### PR TITLE
Make `closLang.max_app` a parameter.

### DIFF
--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -158,10 +158,11 @@ val compile_eq_to_target = Q.store_thm("compile_eq_to_target",
   unabbrev_all_tac >>
   rpt (CHANGED_TAC (srw_tac[][] >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> rev_full_simp_tac(srw_ss())[])));
 
+(* FIXME:The `max_app` variable for prim_config should probably come from the config *)
 val prim_config_def = Define`
-  prim_config =
+  prim_config max_app =
     FST (to_dec <| source_conf := empty_config; mod_conf := empty_config |> (prim_types_program))
-    with clos_conf := <| start := clos_to_bvl$num_stubs+1; next_loc := clos_to_bvl$num_stubs + 3 |>`;
+    with clos_conf := <| start := (clos_to_bvl$num_stubs max_app) + 1; next_loc := (clos_to_bvl$num_stubs max_app) + 3 |>`;
 
 val from_lab_def = Define`
   from_lab c p =

--- a/compiler/backend/closLangScript.sml
+++ b/compiler/backend/closLangScript.sml
@@ -4,9 +4,6 @@ val _ = new_theory "closLang";
 
 (* compilation from this language removes closures *)
 
-val max_app_def = Define `
-  max_app = 4:num`;
-
 val _ = Datatype `
   op = Global num    (* load global var with index *)
      | SetGlobal num (* assign a value to a global *)

--- a/compiler/backend/semantics/closPropsScript.sml
+++ b/compiler/backend/semantics/closPropsScript.sml
@@ -105,39 +105,39 @@ val code_locs_map = store_thm("code_locs_map",
   \\ ONCE_REWRITE_TAC [code_locs_cons] \\ full_simp_tac(srw_ss())[code_locs_def]);
 
 val contains_App_SOME_def = tDefine "contains_App_SOME" `
-  (contains_App_SOME [] ⇔ F) /\
-  (contains_App_SOME (x::y::xs) ⇔
-     contains_App_SOME [x] ∨
-     contains_App_SOME (y::xs)) /\
-  (contains_App_SOME [Var v] ⇔ F) /\
-  (contains_App_SOME [If x1 x2 x3] ⇔
-     contains_App_SOME [x1] ∨
-     contains_App_SOME [x2] ∨
-     contains_App_SOME [x3]) /\
-  (contains_App_SOME [Let xs x2] ⇔
-     contains_App_SOME [x2] ∨
-     contains_App_SOME xs) /\
-  (contains_App_SOME [Raise x1] ⇔
-     contains_App_SOME [x1]) /\
-  (contains_App_SOME [Tick x1] ⇔
-     contains_App_SOME [x1]) /\
-  (contains_App_SOME [Op op xs] ⇔
-     contains_App_SOME xs) /\
-  (contains_App_SOME [App loc_opt x1 x2] ⇔
+  (contains_App_SOME max_app [] ⇔ F) /\
+  (contains_App_SOME max_app (x::y::xs) ⇔
+     contains_App_SOME max_app [x] ∨
+     contains_App_SOME max_app (y::xs)) /\
+  (contains_App_SOME max_app [Var v] ⇔ F) /\
+  (contains_App_SOME max_app [If x1 x2 x3] ⇔
+     contains_App_SOME max_app [x1] ∨
+     contains_App_SOME max_app [x2] ∨
+     contains_App_SOME max_app [x3]) /\
+  (contains_App_SOME max_app [Let xs x2] ⇔
+     contains_App_SOME max_app [x2] ∨
+     contains_App_SOME max_app xs) /\
+  (contains_App_SOME max_app [Raise x1] ⇔
+     contains_App_SOME max_app [x1]) /\
+  (contains_App_SOME max_app [Tick x1] ⇔
+     contains_App_SOME max_app [x1]) /\
+  (contains_App_SOME max_app [Op op xs] ⇔
+     contains_App_SOME max_app xs) /\
+  (contains_App_SOME max_app [App loc_opt x1 x2] ⇔
      IS_SOME loc_opt ∨ max_app < LENGTH x2 ∨
-     contains_App_SOME [x1] ∨
-     contains_App_SOME x2) /\
-  (contains_App_SOME [Fn loc vs num_args x1] ⇔
-     contains_App_SOME [x1]) /\
-  (contains_App_SOME [Letrec loc vs fns x1] ⇔
-     contains_App_SOME (MAP SND fns) ∨
-     contains_App_SOME [x1]) /\
-  (contains_App_SOME [Handle x1 x2] ⇔
-     contains_App_SOME [x1] ∨
-     contains_App_SOME [x2]) /\
-  (contains_App_SOME [Call ticks dest xs] ⇔
-     contains_App_SOME xs)`
-  (WF_REL_TAC `measure (exp3_size)`
+     contains_App_SOME max_app [x1] ∨
+     contains_App_SOME max_app x2) /\
+  (contains_App_SOME max_app [Fn loc vs num_args x1] ⇔
+     contains_App_SOME max_app [x1]) /\
+  (contains_App_SOME max_app [Letrec loc vs fns x1] ⇔
+     contains_App_SOME max_app (MAP SND fns) ∨
+     contains_App_SOME max_app [x1]) /\
+  (contains_App_SOME max_app [Handle x1 x2] ⇔
+     contains_App_SOME max_app [x1] ∨
+     contains_App_SOME max_app [x2]) /\
+  (contains_App_SOME max_app [Call ticks dest xs] ⇔
+     contains_App_SOME max_app xs)`
+  (WF_REL_TAC `measure (exp3_size o SND)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
@@ -146,7 +146,7 @@ val contains_App_SOME_def = tDefine "contains_App_SOME" `
    decide_tac);
 
 val contains_App_SOME_EXISTS = store_thm("contains_App_SOME_EXISTS",
-  ``∀ls. contains_App_SOME ls ⇔ EXISTS (λx. contains_App_SOME [x]) ls``,
+  ``∀ls max_app. contains_App_SOME max_app ls ⇔ EXISTS (λx. contains_App_SOME max_app [x]) ls``,
   Induct >> simp[contains_App_SOME_def] >>
   Cases_on`ls`>>full_simp_tac(srw_ss())[contains_App_SOME_def])
 
@@ -554,7 +554,7 @@ val evaluate_app_rw = Q.store_thm ("evaluate_app_rw",
 `(!args loc_opt f s.
   args ≠ [] ⇒
   evaluate_app loc_opt f args s =
-    case dest_closure loc_opt f args of
+    case dest_closure s.max_app loc_opt f args of
        | NONE => (Rerr(Rabort Rtype_error),s)
        | SOME (Partial_app v) =>
            if s.clock < LENGTH args then
@@ -653,9 +653,9 @@ val do_app_cases_type_error = save_thm ("do_app_cases_type_error",
    ALL_CONV));
 
 val dest_closure_none_loc = Q.store_thm ("dest_closure_none_loc",
-`!l cl vs v e env rest.
-  (dest_closure l cl vs = SOME (Partial_app v) ⇒ l = NONE) ∧
-  (dest_closure l cl vs = SOME (Full_app e env rest) ∧ rest ≠ [] ⇒ l = NONE)`,
+`!max_app l cl vs v e env rest.
+  (dest_closure max_app l cl vs = SOME (Partial_app v) ⇒ l = NONE) ∧
+  (dest_closure max_app l cl vs = SOME (Full_app e env rest) ∧ rest ≠ [] ⇒ l = NONE)`,
  rpt gen_tac >>
  simp [dest_closure_def] >>
  Cases_on `cl` >>
@@ -710,8 +710,8 @@ val rec_clo_ok_def = Define `
 val _ = export_rewrites ["rec_clo_ok_def"]
 
 val dest_closure_full_length = Q.store_thm ("dest_closure_full_length",
-`!l v vs e args rest.
-  dest_closure l v vs = SOME (Full_app e args rest)
+`!max_app l v vs e args rest.
+  dest_closure max_app l v vs = SOME (Full_app e args rest)
   ⇒
   LENGTH (clo_to_partial_args v) < clo_to_num_params v ∧
   LENGTH vs + LENGTH (clo_to_partial_args v) = clo_to_num_params v + LENGTH rest ∧
@@ -771,7 +771,7 @@ check_closures cl cl' ⇔
 
 val dest_closure_partial_is_closure = Q.store_thm(
   "dest_closure_partial_is_closure",
-  `dest_closure l v vs = SOME (Partial_app v') ⇒
+  `dest_closure max_app l v vs = SOME (Partial_app v') ⇒
    is_closure v'`,
   dsimp[dest_closure_def, eqs, bool_case_eq, is_closure_def, UNCURRY]);
 
@@ -786,10 +786,10 @@ val evaluate_app_clock0 = Q.store_thm(
    evaluate_app lopt r args s0 ≠ (Rval vs, s)`,
   strip_tac >> `∃a1 args0. args = a1::args0` by (Cases_on `args` >> full_simp_tac(srw_ss())[]) >>
   simp[evaluate_def] >>
-  Cases_on `dest_closure lopt r (a1::args0)` >> simp[] >>
-  rename1 `dest_closure lopt r (a1::args0) = SOME c` >>
+  Cases_on `dest_closure s0.max_app lopt r (a1::args0)` >> simp[] >>
+  rename1 `dest_closure s0.max_app lopt r (a1::args0) = SOME c` >>
   Cases_on `c` >> simp[] >>
-  rename1 `dest_closure lopt r (a1::args0) = SOME (Full_app b env rest)` >>
+  rename1 `dest_closure max_app lopt r (a1::args0) = SOME (Full_app b env rest)` >>
   srw_tac[][] >>
   `SUC (LENGTH args0) ≤ LENGTH rest` by simp[] >>
   imp_res_tac dest_closure_full_length >> lfs[])
@@ -815,15 +815,15 @@ val evaluate_app_clock_drop = Q.store_thm(
 
 val dest_closure_is_closure = Q.store_thm(
   "dest_closure_is_closure",
-  `dest_closure lopt f vs = SOME r ⇒ is_closure f`,
+  `dest_closure max_app lopt f vs = SOME r ⇒ is_closure f`,
   Cases_on `f` >> simp[is_closure_def, dest_closure_def]);
 
 val stage_partial_app = Q.store_thm(
   "stage_partial_app",
   `is_closure c ∧
-   dest_closure NONE v (rest ++ used) =
+   dest_closure max_app NONE v (rest ++ used) =
      SOME (Partial_app (clo_add_partial_args rest c)) ⇒
-   dest_closure NONE c rest =
+   dest_closure max_app NONE c rest =
      SOME (Partial_app (clo_add_partial_args rest c))`,
   Cases_on `v` >> simp[dest_closure_def, eqs, bool_case_eq, UNCURRY] >>
   Cases_on `c` >>
@@ -831,9 +831,9 @@ val stage_partial_app = Q.store_thm(
 
 val dest_closure_full_addargs = Q.store_thm(
   "dest_closure_full_addargs",
-  `dest_closure NONE c vs = SOME (Full_app b env r) ∧
+  `dest_closure max_app NONE c vs = SOME (Full_app b env r) ∧
    LENGTH more + LENGTH vs ≤ max_app ⇒
-   dest_closure NONE c (more ++ vs) = SOME (Full_app b env (more ++ r))`,
+   dest_closure max_app NONE c (more ++ vs) = SOME (Full_app b env (more ++ r))`,
   Cases_on `c` >> csimp[dest_closure_def, bool_case_eq, revdroprev, UNCURRY] >>
   simp[DROP_APPEND1, revdroprev, TAKE_APPEND1, TAKE_APPEND2] >>
   simp[check_loc_def]);
@@ -882,9 +882,9 @@ val evaluate_app_length_imp = Q.store_thm ("evaluate_app_length_imp",
  srw_tac[][]);
 
 val dest_closure_none_append = Q.store_thm ("dest_closure_none_append",
-`!l f args1 args2.
-  dest_closure NONE f args2 = NONE ⇒
-  dest_closure NONE f (args1 ++ args2) = NONE`,
+`!max_app l f args1 args2.
+  dest_closure max_app NONE f args2 = NONE ⇒
+  dest_closure max_app NONE f (args1 ++ args2) = NONE`,
  srw_tac[][dest_closure_def] >>
  Cases_on `f` >>
  full_simp_tac(srw_ss())[check_loc_def] >>
@@ -895,10 +895,10 @@ val dest_closure_none_append = Q.store_thm ("dest_closure_none_append",
  simp []);
 
 val dest_closure_none_append2 = Q.store_thm ("dest_closure_none_append2",
-`!l f args1 args2.
+`!max_app l f args1 args2.
   LENGTH args1 + LENGTH args2 ≤ max_app ∧
-  dest_closure NONE f (args1 ++ args2) = NONE ⇒
-  dest_closure NONE f args2 = NONE`,
+  dest_closure max_app NONE f (args1 ++ args2) = NONE ⇒
+  dest_closure max_app NONE f args2 = NONE`,
  srw_tac[][dest_closure_def] >>
  Cases_on `f` >>
  full_simp_tac(srw_ss())[check_loc_def] >>
@@ -909,7 +909,7 @@ val dest_closure_none_append2 = Q.store_thm ("dest_closure_none_append2",
  simp []);
 
 val dest_closure_rest_length = Q.store_thm ("dest_closure_rest_length",
-`dest_closure NONE f args = SOME (Full_app e l rest) ⇒ LENGTH rest < LENGTH args`,
+`dest_closure max_app NONE f args = SOME (Full_app e l rest) ⇒ LENGTH rest < LENGTH args`,
  simp [dest_closure_def] >>
  Cases_on `f` >>
  simp [check_loc_def]
@@ -918,12 +918,12 @@ val dest_closure_rest_length = Q.store_thm ("dest_closure_rest_length",
  >- (srw_tac[][] >> simp []));
 
 val dest_closure_partial_twice = Q.store_thm ("dest_closure_partial_twice",
-`∀f args1 args2 cl res.
+`∀max_app f args1 args2 cl res.
   LENGTH args1 + LENGTH args2 ≤ max_app ∧
-  dest_closure NONE f (args1 ++ args2) = res ∧
-  dest_closure NONE f args2 = SOME (Partial_app cl)
+  dest_closure max_app NONE f (args1 ++ args2) = res ∧
+  dest_closure max_app NONE f args2 = SOME (Partial_app cl)
   ⇒
-  dest_closure NONE cl args1 = res`,
+  dest_closure max_app NONE cl args1 = res`,
  simp [dest_closure_def] >>
  Cases_on `f` >>
  simp [check_loc_def]
@@ -966,7 +966,7 @@ val dest_closure_partial_twice = Q.store_thm ("dest_closure_partial_twice",
 
 val evaluate_app_append = Q.store_thm ("evaluate_app_append",
 `!args2 f args1 s.
-  LENGTH (args1 ++ args2) ≤ max_app ⇒
+  LENGTH (args1 ++ args2) ≤ s.max_app ⇒
   evaluate_app NONE f (args1 ++ args2) s =
     case evaluate_app NONE f args2 s of
     | (Rval vs1, s1) => evaluate_app NONE (HD vs1) args1 s1
@@ -979,7 +979,8 @@ val evaluate_app_append = Q.store_thm ("evaluate_app_append",
  Cases_on `args2 = []`
  >- full_simp_tac(srw_ss())[evaluate_def, APPEND_eq_NIL] >>
  srw_tac[][evaluate_app_rw] >>
- `dest_closure NONE f args2 = NONE ∨ ?x. dest_closure NONE f args2 = SOME x` by metis_tac [option_nchotomy] >>
+ `dest_closure s.max_app NONE f args2 = NONE ∨
+   ?x. dest_closure s.max_app NONE f args2 = SOME x` by metis_tac [option_nchotomy] >>
  full_simp_tac(srw_ss())[]
  >- (
    imp_res_tac dest_closure_none_append >>
@@ -987,8 +988,8 @@ val evaluate_app_append = Q.store_thm ("evaluate_app_append",
  Cases_on `x` >>
  full_simp_tac(srw_ss())[]
  >- ( (* args2 partial app *)
-   `dest_closure NONE f (args1++args2) = NONE ∨
-    ?x. dest_closure NONE f (args1++args2) = SOME x` by metis_tac [option_nchotomy] >>
+   `dest_closure s.max_app NONE f (args1++args2) = NONE ∨
+    ?x. dest_closure s.max_app NONE f (args1++args2) = SOME x` by metis_tac [option_nchotomy] >>
    simp []
    >- (imp_res_tac dest_closure_none_append2 >> full_simp_tac(srw_ss())[]) >>
    imp_res_tac dest_closure_partial_twice >>
@@ -1027,15 +1028,15 @@ val revnil = Q.prove(`[] = REVERSE l ⇔ l = []`,
 
 val dest_closure_full_maxapp = Q.store_thm(
   "dest_closure_full_maxapp",
-  `dest_closure NONE c vs = SOME (Full_app b env r) ∧ r ≠ [] ⇒
+  `dest_closure max_app NONE c vs = SOME (Full_app b env r) ∧ r ≠ [] ⇒
    LENGTH vs ≤ max_app`,
   Cases_on `c` >> simp[dest_closure_def, check_loc_def, UNCURRY]);
 
 val dest_closure_full_split' = Q.store_thm(
   "dest_closure_full_split'",
-  `dest_closure loc v vs = SOME (Full_app e env rest) ⇒
+  `dest_closure max_app loc v vs = SOME (Full_app e env rest) ⇒
    ∃used.
-    vs = rest ++ used ∧ dest_closure loc v used = SOME (Full_app e env [])`,
+    vs = rest ++ used ∧ dest_closure max_app loc v used = SOME (Full_app e env [])`,
   simp[dest_closure_def] >> Cases_on `v` >>
   simp[bool_case_eq, revnil, DROP_NIL, DECIDE ``0n >= x ⇔ x = 0``, UNCURRY,
        NOT_LESS, DECIDE ``x:num >= y ⇔ y ≤ x``, DECIDE ``¬(x:num ≤ y) ⇔ y < x``]
@@ -1063,12 +1064,12 @@ val dest_closure_full_split' = Q.store_thm(
 
 val dest_closure_partial_split = Q.store_thm (
   "dest_closure_partial_split",
-`!v1 vs v2 n.
-  dest_closure NONE v1 vs = SOME (Partial_app v2) ∧
+`!max_app v1 vs v2 n.
+  dest_closure max_app NONE v1 vs = SOME (Partial_app v2) ∧
   n ≤ LENGTH vs
   ⇒
   ?v3.
-    dest_closure NONE v1 (DROP n vs) = SOME (Partial_app v3) ∧
+    dest_closure max_app NONE v1 (DROP n vs) = SOME (Partial_app v3) ∧
     v2 = clo_add_partial_args (TAKE n vs) v3`,
  srw_tac[][dest_closure_def] >>
  Cases_on `v1` >>
@@ -1090,11 +1091,11 @@ val dest_closure_partial_split = Q.store_thm (
 
 val dest_closure_partial_split' = Q.store_thm(
   "dest_closure_partial_split'",
-  `∀n v vs cl.
-      dest_closure NONE v vs = SOME (Partial_app cl) ∧ n ≤ LENGTH vs ⇒
+  `∀max_app n v vs cl.
+      dest_closure max_app NONE v vs = SOME (Partial_app cl) ∧ n ≤ LENGTH vs ⇒
       ∃cl0 used rest.
          vs = rest ++ used ∧ LENGTH rest = n ∧
-         dest_closure NONE v used = SOME (Partial_app cl0) ∧
+         dest_closure max_app NONE v used = SOME (Partial_app cl0) ∧
          cl = clo_add_partial_args rest cl0`,
   rpt strip_tac >>
   IMP_RES_THEN
@@ -1104,9 +1105,9 @@ val dest_closure_partial_split' = Q.store_thm(
 
 val dest_closure_NONE_Full_to_Partial = Q.store_thm(
   "dest_closure_NONE_Full_to_Partial",
-  `dest_closure NONE v (l1 ++ l2) = SOME (Full_app b env []) ∧ l1 ≠ [] ⇒
-   ∃cl. dest_closure NONE v l2 = SOME (Partial_app cl) ∧
-        dest_closure NONE cl l1 = SOME (Full_app b env [])`,
+  `dest_closure max_app  NONE v (l1 ++ l2) = SOME (Full_app b env []) ∧ l1 ≠ [] ⇒
+   ∃cl. dest_closure max_app NONE v l2 = SOME (Partial_app cl) ∧
+        dest_closure max_app NONE cl l1 = SOME (Full_app b env [])`,
   Cases_on `v` >>
   dsimp[dest_closure_def, bool_case_eq, revnil, DROP_NIL, GREATER_EQ,
         check_loc_def, UNCURRY] >> srw_tac[][] >>

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -25,6 +25,7 @@ val _ = Datatype `
      ; ffi     : 'ffi ffi_state
      ; clock   : num
      ; code    : num |-> (num # closLang$exp)
+     ; max_app : num
     |> `
 
 (* helper functions *)
@@ -264,9 +265,9 @@ val check_clock_lemma = prove(
    defined to evaluate a list of clos_exp expressions. *)
 
 val check_loc_opt_def = Define `
-  (check_loc NONE loc num_params num_args so_far ⇔
+  (check_loc (max_app:num) NONE loc num_params num_args so_far ⇔
     num_args ≤ max_app) /\
-  (check_loc (SOME p) loc num_params num_args so_far ⇔
+  (check_loc max_app (SOME p) loc num_params num_args so_far ⇔
     num_params = num_args ∧ so_far = (0:num) ∧ SOME p = loc)`;
 
 val _ = Datatype `
@@ -275,10 +276,10 @@ val _ = Datatype `
     | Full_app closLang$exp (closSem$v list) (closSem$v list)`;
 
 val dest_closure_def = Define `
-  dest_closure loc_opt f args =
+  dest_closure max_app loc_opt f args =
     case f of
     | Closure loc arg_env clo_env num_args exp =>
-        if check_loc loc_opt loc num_args (LENGTH args) (LENGTH arg_env) ∧ LENGTH arg_env < num_args then
+        if check_loc max_app loc_opt loc num_args (LENGTH args) (LENGTH arg_env) ∧ LENGTH arg_env < num_args then
           if ¬(LENGTH args + LENGTH arg_env < num_args) then
             SOME (Full_app exp
                            (REVERSE (TAKE (num_args - LENGTH arg_env) (REVERSE args))++
@@ -291,7 +292,8 @@ val dest_closure_def = Define `
     | Recclosure loc arg_env clo_env fns i =>
         let (num_args,exp) = EL i fns in
           if LENGTH fns <= i \/
-             ~check_loc loc_opt
+             ~check_loc max_app
+                        loc_opt
                         (OPTION_MAP ((+) (2*i)) loc) num_args
                         (LENGTH args)
                         (LENGTH arg_env) ∨
@@ -309,8 +311,8 @@ val dest_closure_def = Define `
     | _ => NONE`;
 
 val dest_closure_length = Q.prove (
-  `!loc_opt f args exp args1 args2 so_far.
-    dest_closure loc_opt f args = SOME (Full_app exp args1 args2)
+  `!max_app loc_opt f args exp args1 args2 so_far.
+    dest_closure max_app loc_opt f args = SOME (Full_app exp args1 args2)
     ⇒
     LENGTH args2 < LENGTH args`,
   rw [dest_closure_def] >>
@@ -372,7 +374,7 @@ val evaluate_def = tDefine "evaluate" `
                           | Rval (v,s) => (Rval [v],s))
      | res => res) /\
   (evaluate ([Fn loc vsopt num_args exp],env,s) =
-     if num_args ≤ max_app ∧ num_args ≠ 0 then
+     if num_args ≤ s.max_app ∧ num_args ≠ 0 then
        case vsopt of
          | NONE => (Rval [Closure loc [] env num_args exp], s)
          | SOME vs =>
@@ -382,7 +384,7 @@ val evaluate_def = tDefine "evaluate" `
      else
        (Rerr(Rabort Rtype_error), s)) /\
   (evaluate ([Letrec loc namesopt fns exp],env,s) =
-     if EVERY (\(num_args,e). num_args ≤ max_app ∧ num_args ≠ 0) fns then
+     if EVERY (\(num_args,e). num_args ≤ s.max_app ∧ num_args ≠ 0) fns then
        let
          build_rc e = GENLIST (Recclosure loc [] e fns) (LENGTH fns) in
        let
@@ -419,7 +421,7 @@ val evaluate_def = tDefine "evaluate" `
      | res => res) ∧
   (evaluate_app loc_opt f [] s = (Rval [f], s)) ∧
   (evaluate_app loc_opt f args s =
-     case dest_closure loc_opt f args of
+     case dest_closure s.max_app loc_opt f args of
      | NONE => (Rerr(Rabort Rtype_error),s)
      | SOME (Partial_app v) =>
          if s.clock < LENGTH args

--- a/compiler/eval/compilerComputeLib.sml
+++ b/compiler/eval/compilerComputeLib.sml
@@ -158,8 +158,7 @@ val add_compiler_compset = computeLib.extend_compset
     ,``:clos_known$val_approx``
     ]
   ,computeLib.Defs
-    [closLangTheory.max_app_def
-    ,closLangTheory.pure_def
+    [closLangTheory.pure_def
     ,closLangTheory.pure_op_def
       (* ---- pat_to_clos ---- *)
     ,pat_to_closTheory.compile_def


### PR DESCRIPTION
This patch makes `max_app` a parameter.
Thanks to Armaël and Ramana for their help with this patch.

Partially fixes issue #101. Proofs are probably still broken.