### PR TITLE
Make regression test timeouts more informative.

### DIFF
--- a/developers/regression-test.sh
+++ b/developers/regression-test.sh
@@ -24,6 +24,11 @@ echo
 
 while read i
 do
+  #save the current state
+  if [ -n "$1" ]; then
+      echo $i > $1;
+  fi
+
   [[ $i == '#'* ]] || [[ -z $i ]] && continue
   if [ ! -d $i ]
   then


### PR DESCRIPTION
This patch adds details from the `regression.log` to the mail notification
sent when regression tests timeout.

Fixes #148.