### PR TITLE
Refactor/improve full normalise

### DIFF
--- a/characteristic/cfComputeLib.sml
+++ b/characteristic/cfComputeLib.sml
@@ -23,17 +23,11 @@ val add_cf_aux_compset = computeLib.extend_compset
      cfTheory.pat_typechecks_def,
      cfTheory.pat_without_Pref_def,
      cfTheory.validate_pat_def,
-     cfTheory.build_cases_def
-    ]
-  ]
-
-val add_cf_normalize_compset = computeLib.extend_compset
-  [computeLib.Defs
-    [cfNormalizeTheory.exp2v_def,
+     cfTheory.build_cases_def,
+     cfNormalizeTheory.exp2v_def,
      cfNormalizeTheory.exp2v_list_def,
      cfNormalizeTheory.dest_opapp_def
     ]
   ]
-
 
 end

--- a/characteristic/cfNormalizeSyntax.sig
+++ b/characteristic/cfNormalizeSyntax.sig
@@ -1,0 +1,13 @@
+signature cfNormalizeSyntax = sig
+  include Abbrev
+
+  val full_normalise_prog_tm   : term
+  val mk_full_normalise_prog   : term -> term
+  val dest_full_normalise_prog : term -> term
+  val is_full_normalise_prog   : term -> bool
+
+  val full_normalise_tm   : term
+  val mk_full_normalise   : term * term -> term
+  val dest_full_normalise : term -> term * term
+  val is_full_normalise   : term -> bool
+end

--- a/characteristic/cfNormalizeSyntax.sml
+++ b/characteristic/cfNormalizeSyntax.sml
@@ -1,0 +1,16 @@
+structure cfNormalizeSyntax :> cfNormalizeSyntax = struct
+open Abbrev
+
+local
+  open HolKernel boolLib bossLib cfAppTheory
+
+  val s1 = HolKernel.syntax_fns1 "cfNormalize"
+  val s2 = HolKernel.syntax_fns2 "cfNormalize"
+in
+
+val (full_normalise_tm, mk_full_normalise, dest_full_normalise, is_full_normalise) = s2 "full_normalise"
+val (full_normalise_prog_tm, mk_full_normalise_prog, dest_full_normalise_prog, is_full_normalise_prog) = s1 "full_normalise_prog"
+
+end
+
+end

--- a/characteristic/cfTacticsLib.sig
+++ b/characteristic/cfTacticsLib.sig
@@ -2,6 +2,9 @@ signature cfTacticsLib =
 sig
   include Abbrev
 
+  (* Parse and normalise a program consisting of a toplevel declaration *)
+  val process_topdecl : string -> term
+
   (* [xcf name prog_state] is usually the first tactic to call when
      proving a specification.
 
@@ -111,6 +114,9 @@ sig
   val xapply : thm -> tactic
   val xapp_prepare_goal : tactic
   val reduce_tac : tactic
+
+  val normalise_exp : term -> term
+  val normalise_prog : term -> term
 
   val hide_environments : bool -> unit
 end

--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -5,7 +5,7 @@ open preamble
 open ConseqConv match_goal
 open set_sepTheory cfAppTheory cfHeapsTheory cfTheory cfTacticsTheory
 open helperLib cfHeapsBaseLib cfHeapsLib cfTacticsBaseLib evarsConseqConvLib
-open cfAppLib cfSyntax semanticPrimitivesSyntax
+open cfAppLib cfSyntax semanticPrimitivesSyntax cfNormalizeSyntax
 
 fun constant_printer s _ _ _ (ppfns:term_pp_types.ppstream_funs) _ _ _ =
   let
@@ -37,7 +37,6 @@ val () = basicComputeLib.add_basic_compset cs
 val () = semanticsComputeLib.add_semantics_compset cs
 val () = ml_progComputeLib.add_env_compset cs
 val () = cfComputeLib.add_cf_aux_compset cs
-val () = cfComputeLib.add_cf_normalize_compset cs
 
 val _ = (max_print_depth := 15)
 
@@ -62,6 +61,20 @@ in
   val simp_conv = stateful SIMP_CONV let_arith_list
   val simp_rule = stateful SIMP_RULE let_arith_list
 end
+
+(*------------------------------------------------------------------*)
+
+fun normalise_exp tm = let
+    val normalise_tm = mk_full_normalise (listSyntax.mk_nil stringSyntax.string_ty, tm)
+    val eval_th = EVAL normalise_tm
+in rhs (concl eval_th) end
+
+fun normalise_prog prog_tm = let
+    val normalise_prog_tm = mk_full_normalise_prog prog_tm
+    val eval_th = EVAL normalise_prog_tm
+in rhs (concl eval_th) end
+
+fun process_topdecl str = normalise_prog (parse_topdecl str)
 
 (*------------------------------------------------------------------*)
 


### PR DESCRIPTION
This redefines [full_normalise] in the style of CFML's. In particular, it takes care of pulling the introduced let-bindings, and not introducing too many, in order to avoid introducing nested let-bindings, which are annoying to deal with.

The termination proof is cheated for now. 
I'm not sure how morally acceptable it is, but I think using [full_normalise] to certify case studies is for now more important than proving termination.

To prove termination, I think one would have to merge the auxiliary definitions (`protect*`) into `norm`, not inlining them but having an integer argument to dispatch, then having as termination relation a lexicographic order of the expression size and the dispatching index...
(by dispatching I mean having 
```
norm mode other_args =
  if mode = 0 then (
    current code of norm
  ) else if mode = 1 then (
    current code of protect
  ) else if mode = 2 then (
    current code of protect_row
  ) ...
```
)
