### PR TITLE
Exceptions support in CF

### DIFF
--- a/basis/basisProgScript.sml
+++ b/basis/basisProgScript.sml
@@ -104,18 +104,18 @@ fun prove_ref_spec op_name =
 
 val ref_spec = store_thm ("ref_spec",
   ``!xv. app (p:'ffi ffi_proj) ^(fetch_v "op ref" (basis_st())) [xv]
-          emp (\rv. rv ~~> xv)``,
+          emp (POSTv rv. rv ~~> xv)``,
   prove_ref_spec "op ref");
 
 val deref_spec = store_thm ("deref_spec",
   ``!xv. app (p:'ffi ffi_proj) ^(fetch_v "op !" (basis_st())) [rv]
-          (rv ~~> xv) (\yv. cond (xv = yv) * rv ~~> xv)``,
+          (rv ~~> xv) (POSTv yv. cond (xv = yv) * rv ~~> xv)``,
   prove_ref_spec "op !");
 
 val assign_spec = store_thm ("assign_spec",
   ``!rv xv yv.
      app (p:'ffi ffi_proj) ^(fetch_v "op :=" (basis_st())) [rv; yv]
-       (rv ~~> xv) (\v. cond (UNIT_TYPE () v) * rv ~~> yv)``,
+       (rv ~~> xv) (POSTv v. cond (UNIT_TYPE () v) * rv ~~> yv)``,
   prove_ref_spec "op :=");
 
 
@@ -159,20 +159,20 @@ val w8array_alloc_spec = store_thm ("w8array_alloc_spec",
   ``!n nv w wv.
      NUM n nv /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.array" (basis_st())) [nv; wv]
-       emp (\v. W8ARRAY v (REPLICATE n w))``,
+       emp (POSTv v. W8ARRAY v (REPLICATE n w))``,
   prove_array_spec "Word8Array.array");
 
 val w8array_sub_spec = store_thm ("w8array_sub_spec",
   ``!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.sub" (basis_st())) [av; nv]
-       (W8ARRAY av a) (\v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
   prove_array_spec "Word8Array.sub");
 
 val w8array_length_spec = store_thm ("w8array_length_spec",
   ``!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.length" (basis_st())) [av]
-       (W8ARRAY av a) (\v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
   prove_array_spec "Word8Array.length");
 
 val w8array_update_spec = store_thm ("w8array_update_spec",
@@ -181,7 +181,7 @@ val w8array_update_spec = store_thm ("w8array_update_spec",
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.update" (basis_st()))
        [av; nv; wv]
        (W8ARRAY av a)
-       (\v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
+       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
   prove_array_spec "Word8Array.update");
 
 
@@ -216,21 +216,21 @@ val array_alloc_spec = store_thm ("array_alloc_spec",
   ``!n nv v.
      NUM n nv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Array.array" (basis_st())) [nv; v]
-       emp (\av. ARRAY av (REPLICATE n v))``,
+       emp (POSTv av. ARRAY av (REPLICATE n v))``,
   prove_array_spec "Array.array");
 
 val array_sub_spec = store_thm ("array_sub_spec",
   ``!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Array.sub" (basis_st())) [av; nv]
-       (ARRAY av a) (\v. cond (v = EL n a) * ARRAY av a)``,
+       (ARRAY av a) (POSTv v. cond (v = EL n a) * ARRAY av a)``,
   prove_array_spec "Array.sub");
 
 val array_length_spec = store_thm ("array_length_spec",
   ``!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Array.length" (basis_st())) [av]
        (ARRAY av a)
-       (\v. cond (NUM (LENGTH a) v) * ARRAY av a)``,
+       (POSTv v. cond (NUM (LENGTH a) v) * ARRAY av a)``,
   prove_array_spec "Array.length");
 
 val array_update_spec = store_thm ("array_update_spec",
@@ -239,7 +239,7 @@ val array_update_spec = store_thm ("array_update_spec",
      app (p:'ffi ffi_proj) ^(fetch_v "Array.update" (basis_st()))
        [av; nv; v]
        (ARRAY av a)
-       (\uv. cond (UNIT_TYPE () uv) * ARRAY av (LUPDATE v n a))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * ARRAY av (LUPDATE v n a))``,
   prove_array_spec "Array.update");
 
 
@@ -337,19 +337,19 @@ val print_spec = store_thm ("print_spec",
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.print" (basis_st()))
        [cv]
        (CHAR_IO * STDOUT output)
-       (\uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))``,
   xcf "CharIO.print" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
-  \\ xlet `\xv. W8ARRAY print_loc [w] * STDOUT output * & (NUM (ORD c) xv)`
+  \\ xlet `POSTv xv. W8ARRAY print_loc [w] * STDOUT output * & (NUM (ORD c) xv)`
   THEN1 (xapp \\ xsimpl \\ metis_tac [])
-  \\ xlet `\wv. W8ARRAY print_loc [w] * STDOUT output *
-                & (WORD (n2w (ORD c):word8) wv)`
+  \\ xlet `POSTv wv. W8ARRAY print_loc [w] * STDOUT output *
+                     & (WORD (n2w (ORD c):word8) wv)`
   THEN1 (xapp \\ xsimpl \\ metis_tac [])
-  \\ xlet `\zv. STDOUT output * W8ARRAY print_loc [n2w (ORD c)] * & (UNIT_TYPE () zv)`
+  \\ xlet `POSTv zv. STDOUT output * W8ARRAY print_loc [n2w (ORD c)] * & (UNIT_TYPE () zv)`
   THEN1
    (xapp \\ xsimpl \\ fs [CHAR_IO_def,EVAL ``print_loc``]
     \\ instantiate \\ xsimpl \\ EVAL_TAC \\ fs [])
-  \\ xlet `\_. STDOUT (output ++ [c]) * W8ARRAY print_loc [n2w (ORD c)]`
+  \\ xlet `POSTv _. STDOUT (output ++ [c]) * W8ARRAY print_loc [n2w (ORD c)]`
   THEN1
    (xffi
     \\ fs [EVAL ``print_loc``, STDOUT_def]

--- a/characteristic/cfAppLib.sml
+++ b/characteristic/cfAppLib.sml
@@ -29,7 +29,8 @@ fun mk_app_of_Arrow_goal t = let
     mk_cond (
       list_mk_comb (ret_pred, [list_mk_comb (f, xs), post_v])
     )
-  val post_tm = mk_abs (post_v, post_body)
+  fun mk_POSTv Qvtm = (lhs o concl) (SPEC Qvtm cfHeapsBaseTheory.POSTv_def)
+  val post_tm = mk_POSTv (mk_abs (post_v, post_body))
   val app_spec_tm =
     mk_app (
       proj_tm,
@@ -65,6 +66,7 @@ fun app_of_Arrow_rule thm = let
         drule Arrow_IMP_app_basic \\
         disch_then (fn th => mp_tac (MATCH_MP th asm)) \\
         match_mp_tac app_basic_weaken \\
+        Cases THEN_LT REVERSE_LT THEN1 (simp [cfHeapsBaseTheory.POSTv_def]) \\
         fs [cond_def, SEP_EXISTS_THM] \\ rpt strip_tac \\
         qexists_tac `emp` \\ fs [SEP_CLAUSES] \\ tac_acc
       ) all_tac (rev assums)

--- a/characteristic/cfAppScript.sml
+++ b/characteristic/cfAppScript.sml
@@ -126,9 +126,9 @@ val app_weaken = store_thm ("app_weaken",
       app (p:'ffi ffi_proj) f xs H Q ==>
       Q ==+> Q' ==>
       app p f xs H Q'``,
-  rpt strip_tac \\ fs [SEP_IMPPOST_def] \\ irule app_wgframe \\ instantiate \\
-  hsimpl \\ (*fixme*) qexists_tac `emp` \\ simp [GC_def] \\ hsimpl \\
-  gen_tac \\ qexists_tac `emp` \\ hsimpl \\ fs [] (* uhh *)
+  rpt strip_tac \\ irule app_wgframe \\ instantiate \\ fs [SEP_IMPPOST_def] \\
+  rpt (hsimpl \\ TRY hinst) \\ simp [GC_def] \\ hsimpl \\
+  gen_tac \\ qexists_tac `emp` \\ hsimpl \\ fs []
 );
 
 val app_local = store_thm ("app_local",

--- a/characteristic/cfComputeLib.sml
+++ b/characteristic/cfComputeLib.sml
@@ -23,7 +23,6 @@ val add_cf_aux_compset = computeLib.extend_compset
      cfTheory.pat_typechecks_def,
      cfTheory.pat_without_Pref_def,
      cfTheory.validate_pat_def,
-     cfTheory.build_cases_def,
      cfNormalizeTheory.exp2v_def,
      cfNormalizeTheory.exp2v_list_def,
      cfNormalizeTheory.dest_opapp_def

--- a/characteristic/cfHeapsBaseLib.sig
+++ b/characteristic/cfHeapsBaseLib.sig
@@ -20,6 +20,8 @@ sig
   val SEP_IMP_conv : conv -> conv -> conv
   val rearrange_star_conv : term -> term list -> conv
 
+  val heap_clean_conv : conv
+
   (*----------------------------------------------------------------*)
   (* Prove an "easy" goal about sets, involving UNION, DISJOINT,... Useful
     after unfolding the definitions of heap predicates. *)

--- a/characteristic/cfHeapsBaseLib.sig
+++ b/characteristic/cfHeapsBaseLib.sig
@@ -3,7 +3,6 @@ sig
   include Abbrev
   type conseq_conv = ConseqConv.conseq_conv
   type directed_conseq_conv = ConseqConv.directed_conseq_conv
-  type cont_conseq_conv = cfTacticsBaseLib.cont_conseq_conv
 
   (*----------------------------------------------------------------*)
 
@@ -17,8 +16,6 @@ sig
 
   val mk_cond : term -> term
   val emp_tm : term
-
-  val UNFOLD_SEP_IMPPOST_ccc : cont_conseq_conv
 
   val SEP_IMP_conv : conv -> conv -> conv
   val rearrange_star_conv : term -> term list -> conv
@@ -54,9 +51,7 @@ sig
       which it doesn't fail, that is on every [SEP_IMP] and [SEP_IMPPOST].
    *)
   val hsimpl : tactic
-  val hsimpl_top : tactic
   val hsimpl_conseq_conv : directed_conseq_conv
-  val hsimpl_cont_conseq_conv : cont_conseq_conv
 
   (*----------------------------------------------------------------*)
   (** Instantiating existentially quantified variables after calling
@@ -85,8 +80,6 @@ sig
   val hpull_one : tactic
   val hpull_one_conseq_conv : directed_conseq_conv
   val hpull_conseq_conv : directed_conseq_conv
-  val hpull_one_cont_conseq_conv : cont_conseq_conv
-  val hpull_cont_conseq_conv : cont_conseq_conv
 
   (* [hsimpl_cancel_conseq_conv]: on a goal of the form [H1 ==>> H2],
      [hsimpl_cancel_conseq_conv] tries to remove subheaps present both in H1 and
@@ -105,8 +98,6 @@ sig
   val hsimpl_cancel_one : tactic
   val hsimpl_cancel_conseq_conv : directed_conseq_conv
   val hsimpl_cancel_one_conseq_conv : directed_conseq_conv
-  val hsimpl_cancel_cont_conseq_conv : cont_conseq_conv
-  val hsimpl_cancel_one_cont_conseq_conv : cont_conseq_conv
 
   (* [hpullr]: extract pure facts and existential quantifications from the
      right heap (H2).
@@ -122,13 +113,10 @@ sig
   val hpullr_one : tactic
   val hpullr_conseq_conv : directed_conseq_conv
   val hpullr_one_conseq_conv : directed_conseq_conv
-  val hpullr_cont_conseq_conv : cont_conseq_conv
-  val hpullr_one_cont_conseq_conv : cont_conseq_conv
 
   (** [hcancel]: [hsimpl] without [hpull] *)
   val hcancel : tactic
   val hcancel_conseq_conv : directed_conseq_conv
-  val hcancel_cont_conseq_conv : cont_conseq_conv
 
   (** hpullable *)
   val hpullable_rec : term -> unit

--- a/characteristic/cfHeapsBaseLib.sml
+++ b/characteristic/cfHeapsBaseLib.sml
@@ -368,7 +368,9 @@ val hcancel_conseq_conv =
     (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_NO_CONTEXT)
     CONSEQ_CONV_default_cache_opt NONE
     true (* redepth *)
-    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_def))),
+    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_unfold))),
+     (true, NONE, K (SCC (REWR_CONV SEP_IMPPOSTv_def))),
+     (true, NONE, K (SCC (REWR_CONV SEP_IMPPOSTe_def))),
      (true, NONE, K (SCC hcancel_setup_conv)),
      (true, NONE, K hsimpl_cancel_conseq_conv),
      (true, NONE, K hpullr_conseq_conv),
@@ -387,7 +389,9 @@ val hsimpl_conseq_conv =
     (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_NO_CONTEXT)
     CONSEQ_CONV_default_cache_opt NONE
     true (* redepth *)
-    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_def))),
+    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_unfold))),
+     (true, NONE, K (SCC (REWR_CONV SEP_IMPPOSTv_def))),
+     (true, NONE, K (SCC (REWR_CONV SEP_IMPPOSTe_def))),
      (true, NONE, K (SCC hcancel_setup_conv)),
      (true, NONE, K hpull_conseq_conv),
      (true, NONE, K hsimpl_cancel_conseq_conv),

--- a/characteristic/cfHeapsBaseLib.sml
+++ b/characteristic/cfHeapsBaseLib.sml
@@ -28,6 +28,10 @@ val rew_heap_AC = full_simp_tac bool_ss [AC STAR_COMM STAR_ASSOC]
 
 val SEP_CLAUSES = LIST_CONJ [SEP_CLAUSES, STARPOST_def, cond_eq_def]
 
+val heap_clean_conv =
+  SIMP_CONV bool_ss [SEP_CLAUSES] THENC
+  DEPTH_CONV (REWR_CONV SEP_F_to_cond)
+
 (*------------------------------------------------------------------*)
 (** Auxiliary functions *)
 
@@ -154,7 +158,7 @@ fun hpull_one_conseq_conv_core t =
 
 val hpull_setup_conv =
   (* cleanup the left heap a bit (remove ``emp``, pull SEP_EXISTS,...) *)
-  SEP_IMP_conv (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES])) REFL
+  SEP_IMP_conv (QCONV heap_clean_conv) REFL
 
 val hpull_one_conseq_conv =
   STRENGTHEN_CONSEQ_CONV hpull_setup_conv THEN_DCC
@@ -331,7 +335,7 @@ fun hpullr_conseq_conv_core t =
   end
 
 val hpullr_setup_conv =
-  SEP_IMP_conv REFL (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
+  SEP_IMP_conv REFL (QCONV heap_clean_conv)
 
 val hpullr_one_conseq_conv =
   STRENGTHEN_CONSEQ_CONV hpullr_setup_conv THEN_DCC
@@ -360,8 +364,8 @@ val SCC = STRENGTHEN_CONSEQ_CONV
 
 val hcancel_setup_conv =
   SEP_IMP_conv
-    (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
-    (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
+    (QCONV heap_clean_conv)
+    (QCONV heap_clean_conv)
 
 val hcancel_conseq_conv =
   EXT_DEPTH_CONSEQ_CONV

--- a/characteristic/cfHeapsBaseLib.sml
+++ b/characteristic/cfHeapsBaseLib.sml
@@ -84,14 +84,6 @@ val emp_tm =
   inst [alpha |-> ``:heap_part``]
     (emp_def |> concl |> lhs)
 
-fun UNFOLD_SEP_IMPPOST_ccc tm = let
-  val _ = if not (is_sep_imppost tm) then fail () else ()
-  val th =
-      CONSEQ_TOP_REWRITE_CONV ([], [SEP_IMPPOST_def], [])
-        CONSEQ_CONV_STRENGTHEN_direction tm
-  val cont = (snd o dest_forall, FORALL_CONSEQ_CONV)
-in (th, cont) end
-
 fun SEP_IMP_conv convl convr t =
   let val (l, r) = dest_sep_imp t
       val rew_t = MATCH_MP (MATCH_MP SEP_IMP_rew (convl l)) (convr r)
@@ -127,7 +119,7 @@ fun hpullable tm =
 
 (** hpull *)
 
-fun hpull_cont_conseq_conv_core t =
+fun hpull_one_conseq_conv_core t =
   let
     val (l, r) = dest_sep_imp t
     val ls = list_dest dest_star l
@@ -141,8 +133,7 @@ fun hpull_cont_conseq_conv_core t =
           THEN_CONSEQ_CONV
             (rearrange_conv tm)
             (CONSEQ_TOP_REWRITE_CONV ([], [hpull_prop, hpull_prop_single], [])
-              CONSEQ_CONV_STRENGTHEN_direction),
-          (rand, IMP_CONCL_CONSEQ_CONV)
+              CONSEQ_CONV_STRENGTHEN_direction)
         )
       else if is_sep_exists tm then
         SOME (
@@ -151,38 +142,27 @@ fun hpull_cont_conseq_conv_core t =
             CONSEQ_TOP_REWRITE_CONV ([], [hpull_exists_single], [])
               CONSEQ_CONV_STRENGTHEN_direction,
             REDEPTH_STRENGTHEN_CONSEQ_CONV (REDEPTH_CONV BETA_CONV)
-          ],
-          (snd o strip_forall, STRIP_FORALL_CONSEQ_CONV)
+          ]
         )
       else
         NONE
   in
     case find_map pull ls of
         NONE => raise UNCHANGED
-      | SOME (cc, cont) => (cc t, cont)
+      | SOME cc => cc t
   end
 
 val hpull_setup_conv =
   (* cleanup the left heap a bit (remove ``emp``, pull SEP_EXISTS,...) *)
   SEP_IMP_conv (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES])) REFL
 
-val hpull_one_cont_conseq_conv =
-  THEN_CONT_CONSEQ_CONV
-    (INPLACE_CONT_CONSEQ_CONV hpull_setup_conv)
-    hpull_cont_conseq_conv_core
-
 val hpull_one_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hpull_one_cont_conseq_conv)
-
-val hpull_cont_conseq_conv =
-  THEN_CONT_CONSEQ_CONV
-    (INPLACE_CONT_CONSEQ_CONV hpull_setup_conv)
-    (LOOP_CONT_CONSEQ_CONV hpull_cont_conseq_conv_core)
+  STRENGTHEN_CONSEQ_CONV hpull_setup_conv THEN_DCC
+  STRENGTHEN_CONSEQ_CONV hpull_one_conseq_conv_core
 
 val hpull_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hpull_cont_conseq_conv)
+  STRENGTHEN_CONSEQ_CONV hpull_setup_conv THEN_DCC
+  REDEPTH_CONSEQ_CONV (STRENGTHEN_CONSEQ_CONV hpull_one_conseq_conv_core)
 
 val hpull_one = CONSEQ_CONV_TAC hpull_one_conseq_conv
 val hpull = CONSEQ_CONV_TAC hpull_conseq_conv
@@ -205,7 +185,7 @@ val hpull = CONSEQ_CONV_TAC hpull_conseq_conv
 
 (** hsimpl_cancel *)
 
-fun hsimpl_cancel_one_cont_conseq_conv t =
+fun hsimpl_cancel_one_conseq_conv_core t =
   let
     val (l, r) = dest_sep_imp t
     val ls = list_dest dest_star l
@@ -275,33 +255,26 @@ fun hsimpl_cancel_one_cont_conseq_conv t =
   in
     case is of
         tm :: _ =>
-        (THEN_CONSEQ_CONV
-           (rearrange_conv tm tm)
-           (CONSEQ_TOP_REWRITE_CONV ([], frame_thms, [])
-             CONSEQ_CONV_STRENGTHEN_direction) t,
-          (I, I))
+        THEN_CONSEQ_CONV
+          (rearrange_conv tm tm)
+          (CONSEQ_TOP_REWRITE_CONV ([], frame_thms, [])
+            CONSEQ_CONV_STRENGTHEN_direction) t
 
        | [] =>
          case find_matching_cells () of
              SOME (tm1, tm2) =>
-             (THEN_CONSEQ_CONV
-                (rearrange_conv tm1 tm2)
-                (CONSEQ_TOP_REWRITE_CONV ([], frame_cell_thms, [])
-                   CONSEQ_CONV_STRENGTHEN_direction) t,
-              (rand, CONJ2_CONSEQ_CONV))
+             THEN_CONSEQ_CONV
+               (rearrange_conv tm1 tm2)
+               (CONSEQ_TOP_REWRITE_CONV ([], frame_cell_thms, [])
+                  CONSEQ_CONV_STRENGTHEN_direction) t
            | NONE => raise UNCHANGED
   end
 
 val hsimpl_cancel_one_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hsimpl_cancel_one_cont_conseq_conv)
-
-val hsimpl_cancel_cont_conseq_conv =
-  LOOP_CONT_CONSEQ_CONV hsimpl_cancel_one_cont_conseq_conv
+  STRENGTHEN_CONSEQ_CONV hsimpl_cancel_one_conseq_conv_core
 
 val hsimpl_cancel_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hsimpl_cancel_cont_conseq_conv)
+  REDEPTH_CONSEQ_CONV hsimpl_cancel_one_conseq_conv
 
 val hsimpl_cancel_one = CONSEQ_CONV_TAC hsimpl_cancel_one_conseq_conv
 val hsimpl_cancel = CONSEQ_CONV_TAC hsimpl_cancel_conseq_conv
@@ -323,7 +296,7 @@ val hsimpl_cancel = CONSEQ_CONV_TAC hsimpl_cancel_conseq_conv
 
 (** hpullr *)
 
-fun hpullr_cont_conseq_conv_core t =
+fun hpullr_conseq_conv_core t =
   let
     val (l, r) = dest_sep_imp t
     val rs = list_dest dest_star r
@@ -338,8 +311,7 @@ fun hpullr_cont_conseq_conv_core t =
             rearrange_conv tm,
             CONSEQ_TOP_REWRITE_CONV ([], [hsimpl_prop, hsimpl_prop_single], [])
               CONSEQ_CONV_STRENGTHEN_direction
-          ],
-          (rand, CONJ2_CONSEQ_CONV)
+          ]
         )
       else if is_sep_exists tm then
         SOME (
@@ -348,37 +320,26 @@ fun hpullr_cont_conseq_conv_core t =
             CONSEQ_TOP_REWRITE_CONV ([], [hsimpl_exists_single], [])
               CONSEQ_CONV_STRENGTHEN_direction,
             REDEPTH_STRENGTHEN_CONSEQ_CONV (REDEPTH_CONV BETA_CONV)
-          ],
-          (snd o strip_exists, STRIP_EXISTS_CONSEQ_CONV)
+          ]
         )
       else
         NONE
   in
     case find_map simpl rs of
         NONE => raise UNCHANGED
-      | SOME (cc, cont) => (cc t, cont)
+      | SOME cc => cc t
   end
 
 val hpullr_setup_conv =
   SEP_IMP_conv REFL (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
 
-val hpullr_one_cont_conseq_conv =
-  THEN_CONT_CONSEQ_CONV
-    (INPLACE_CONT_CONSEQ_CONV hpullr_setup_conv)
-    hpullr_cont_conseq_conv_core
-
 val hpullr_one_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hpullr_one_cont_conseq_conv)
-
-val hpullr_cont_conseq_conv =
-  THEN_CONT_CONSEQ_CONV
-    (INPLACE_CONT_CONSEQ_CONV hpullr_setup_conv)
-    (LOOP_CONT_CONSEQ_CONV hpullr_cont_conseq_conv_core)
+  STRENGTHEN_CONSEQ_CONV hpullr_setup_conv THEN_DCC
+  STRENGTHEN_CONSEQ_CONV hpullr_conseq_conv_core
 
 val hpullr_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hpullr_cont_conseq_conv)
+  STRENGTHEN_CONSEQ_CONV hpullr_setup_conv THEN_DCC
+  REDEPTH_CONSEQ_CONV (STRENGTHEN_CONSEQ_CONV hpullr_conseq_conv_core)
 
 val hpullr_one = CONSEQ_CONV_TAC hpullr_one_conseq_conv
 val hpullr = CONSEQ_CONV_TAC hpullr_conseq_conv
@@ -395,58 +356,49 @@ val hpullr = CONSEQ_CONV_TAC hpullr_conseq_conv
 
 (** hcancel: hsimpl_cancel + hpullr *)
 
-val hcancel_cont_conseq_conv_core =
-  EVERY_CONT_CONSEQ_CONV [
-    LOOP_CONT_CONSEQ_CONV (
-      THEN_CONT_CONSEQ_CONV
-        (LOOP_CONT_CONSEQ_CONV hsimpl_cancel_cont_conseq_conv)
-        (LOOP_CONT_CONSEQ_CONV hpullr_cont_conseq_conv)
-    ),
-    INPLACE_CONT_CONSEQ_CONV
-      (SIMP_CONV bool_ss [hsimpl_gc, SEP_IMP_REFL])
-  ]
+val SCC = STRENGTHEN_CONSEQ_CONV
 
 val hcancel_setup_conv =
   SEP_IMP_conv
     (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
     (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES]))
 
-val hcancel_cont_conseq_conv =
-  EVERY_CONT_CONSEQ_CONV [
-    TRY_CONT_CONSEQ_CONV UNFOLD_SEP_IMPPOST_ccc,
-    INPLACE_CONT_CONSEQ_CONV hcancel_setup_conv,
-    hcancel_cont_conseq_conv_core
-  ]
-
 val hcancel_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hcancel_cont_conseq_conv) THEN_DCC
-  STRENGTHEN_CONSEQ_CONV
-    (TRY_CONV LIST_FORALL_SIMP_CONV)
+  EXT_DEPTH_CONSEQ_CONV
+    (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_NO_CONTEXT)
+    CONSEQ_CONV_default_cache_opt NONE
+    true (* redepth *)
+    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_def))),
+     (true, NONE, K (SCC hcancel_setup_conv)),
+     (true, NONE, K hsimpl_cancel_conseq_conv),
+     (true, NONE, K hpullr_conseq_conv),
+     (false, NONE, K (SCC (TRY_CONV LIST_FORALL_SIMP_CONV))),
+     (false, NONE, K (SCC (SIMP_CONV bool_ss [hsimpl_gc, SEP_IMP_REFL])))
+    ]
+    []
 
 val hcancel =
   CONSEQ_CONV_TAC hcancel_conseq_conv
 
 (** hsimpl *)
 
-val hsimpl_cont_conseq_conv =
-  EVERY_CONT_CONSEQ_CONV [
-    TRY_CONT_CONSEQ_CONV UNFOLD_SEP_IMPPOST_ccc,
-    hpull_cont_conseq_conv,
-    hcancel_cont_conseq_conv
-  ]
-
 val hsimpl_conseq_conv =
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV hsimpl_cont_conseq_conv) THEN_DCC
-  STRENGTHEN_CONSEQ_CONV
-    (TRY_CONV LIST_FORALL_SIMP_CONV)
-
-val hsimpl_top =
-  CONSEQ_CONV_TAC hsimpl_conseq_conv
+  EXT_DEPTH_CONSEQ_CONV
+    (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_NO_CONTEXT)
+    CONSEQ_CONV_default_cache_opt NONE
+    true (* redepth *)
+    [(true, NONE, K (SCC (REWR_CONV SEP_IMPPOST_def))),
+     (true, NONE, K (SCC hcancel_setup_conv)),
+     (true, NONE, K hpull_conseq_conv),
+     (true, NONE, K hsimpl_cancel_conseq_conv),
+     (true, NONE, K hpullr_conseq_conv),
+     (false, NONE, K (SCC (TRY_CONV LIST_FORALL_SIMP_CONV))),
+     (false, NONE, K (SCC (SIMP_CONV bool_ss [hsimpl_gc, SEP_IMP_REFL])))
+    ]
+    []
 
 val hsimpl =
-  DEPTH_CONSEQ_CONV_TAC hsimpl_conseq_conv
+  CONSEQ_CONV_TAC hsimpl_conseq_conv
 
 (* test goal:
   g `(A:hprop * B * C * l ~~> v * l' ~~> u * D) ==>> (B * Z * l ~~> v' * l' ~~> u' * Y * cond Q * D * A)`;

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -199,7 +199,7 @@ val SPLIT_of_SPLIT3_2u3 = store_thm ("SPLIT_of_SPLIT3_2u3",
 val STARPOST_emp = store_thm ("STARPOST_emp",
   ``!Q. Q *+ emp = Q``,
   strip_tac \\ fs [STARPOST_def] \\ metis_tac [SEP_CLAUSES]
-)
+);
 
 val SEP_IMP_frame_single_l = store_thm ("SEP_IMP_frame_single_l",
   ``!H' R.

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -84,6 +84,12 @@ val POSTe_def = new_binder_definition("POSTe_def",
             | Val v => cond F
             | Exn e => Qe e``)
 
+val POST_def = Define `
+  POST (Qv: v -> hprop) (Qe: v -> hprop) = \r.
+    case r of
+     | Val v => Qv v
+     | Exn e => Qe e`
+
 val POST_F_def = Define `
   POST_F (r: res): hprop = cond F`
 
@@ -363,6 +369,14 @@ val rew_heap_thms =
 val rew_heap = full_simp_tac bool_ss rew_heap_thms
 
 (*------------------------------------------------------------------*)
+(* Workaround because of SEP_CLAUSES turning &F into SEP_F *)
+
+val SEP_F_to_cond = store_thm ("SEP_F_to_cond",
+  ``SEP_F = &F``,
+  irule EQ_EXT \\ fs [SEP_F_def, cond_def]
+);
+
+(*------------------------------------------------------------------*)
 (** Properties of GC *)
 
 val GC_STAR_GC = store_thm ("GC_STAR_GC",
@@ -487,14 +501,14 @@ val POST_Exn = store_thm ("POST_Exn[simp]",
 (*------------------------------------------------------------------*)
 (* Lemmas for ==v> / ==e> *)
 
-val SEP_IMPPOSTv_POSTe = store_thm ("SEP_IMPPOSTv_POSTe",
-  ``!Q1 Q2. $POSTe Q1 ==v> $POSTe Q2``,
-  fs [POSTe_def, SEP_IMPPOSTv_def, SEP_IMP_def]
+val SEP_IMPPOSTv_POSTe_left = store_thm ("SEP_IMPPOSTv_POSTe_left",
+  ``!Qe Q. $POSTe Qe ==v> Q``,
+  fs [POSTe_def, SEP_IMPPOSTv_def, SEP_IMP_def, cond_def]
 );
 
-val SEP_IMPPOSTe_POSTv = store_thm ("SEP_IMPPOSTe_POSTv",
-  ``!Q1 Q2. $POSTv Q1 ==e> $POSTv Q2``,
-  fs [POSTv_def, SEP_IMPPOSTe_def, SEP_IMP_def]
+val SEP_IMPPOSTe_POSTv_left = store_thm ("SEP_IMPPOSTe_POSTv_left",
+  ``!Qv Q. $POSTv Qv ==e> Q``,
+  fs [POSTv_def, SEP_IMPPOSTe_def, SEP_IMP_def, cond_def]
 );
 
 val _ = export_theory()

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -73,13 +73,13 @@ val GC_def = Define `GC: hprop = SEP_EXISTS H. H`
 
 (* Injections for post-conditions *)
 val POSTv_def = new_binder_definition("POSTv_def",
-  ``($POSTv) = \(Qv: v -> hprop).
+  ``($POSTv) (Qv: v -> hprop) =
       \r. case r of
             | Val v => Qv v
             | Exn e => cond F``)
 
 val POSTe_def = new_binder_definition("POSTe_def",
-  ``($POSTe) = \(Qe: v -> hprop).
+  ``($POSTe) (Qe: v -> hprop) =
       \r. case r of
             | Val v => cond F
             | Exn e => Qe e``)
@@ -374,6 +374,18 @@ val GC_STAR_GC = store_thm ("GC_STAR_GC",
 )
 
 (*------------------------------------------------------------------*)
+(* Unfolding + case split lemma for SEP_IMPPOST *)
+
+val SEP_IMPPOST_unfold = store_thm ("SEP_IMPPOST_unfold",
+  ``!Q1 Q2.
+      (Q1 ==+> Q2) <=>
+      (!v. Q1 (Val v) ==>> Q2 (Val v)) /\
+      (!v. Q1 (Exn v) ==>> Q2 (Exn v))``,
+  rpt strip_tac \\ eq_tac \\ rpt strip_tac \\ fs [SEP_IMPPOST_def] \\
+  Cases \\ fs []
+);
+
+(*------------------------------------------------------------------*)
 (** Extraction from H1 in H1 ==>> H2 *)
 
 val hpull_prop = store_thm ("hpull_prop",
@@ -438,5 +450,51 @@ val hsimpl_gc = store_thm ("hsimpl_gc",
   ``!H. H ==>> GC``,
   fs [GC_def, SEP_IMP_def, SEP_EXISTS] \\ metis_tac []
 )
+
+(*------------------------------------------------------------------*)
+(* Automatic rewrites for POSTv/POSTe/POST *)
+
+val POSTv_Val = store_thm ("POSTv_Val[simp]",
+  ``!Qv v. $POSTv Qv (Val v) = Qv v``,
+  fs [POSTv_def]
+);
+
+val POSTv_Exn = store_thm ("POSTv_Exn[simp]",
+  ``!Qv v. $POSTv Qv (Exn v) = &F``,
+  fs [POSTv_def]
+);
+
+val POSTe_Val = store_thm ("POSTe_Val[simp]",
+  ``!Qe v. $POSTe Qe (Val v) = &F``,
+  fs [POSTe_def]
+);
+
+val POSTe_Exn = store_thm ("POSTe_Exn[simp]",
+  ``!Qe v. $POSTe Qe (Exn v) = Qe v``,
+  fs [POSTe_def]
+);
+
+val POST_Val = store_thm ("POST_Val[simp]",
+  ``!Qv Qe v. POST Qv Qe (Val v) = Qv v``,
+  fs [POST_def]
+);
+
+val POST_Exn = store_thm ("POST_Exn[simp]",
+  ``!Qv Qe v. POST Qv Qe (Exn v) = Qe v``,
+  fs [POST_def]
+);
+
+(*------------------------------------------------------------------*)
+(* Lemmas for ==v> / ==e> *)
+
+val SEP_IMPPOSTv_POSTe = store_thm ("SEP_IMPPOSTv_POSTe",
+  ``!Q1 Q2. $POSTe Q1 ==v> $POSTe Q2``,
+  fs [POSTe_def, SEP_IMPPOSTv_def, SEP_IMP_def]
+);
+
+val SEP_IMPPOSTe_POSTv = store_thm ("SEP_IMPPOSTe_POSTv",
+  ``!Q1 Q2. $POSTv Q1 ==e> $POSTv Q2``,
+  fs [POSTv_def, SEP_IMPPOSTe_def, SEP_IMP_def]
+);
 
 val _ = export_theory()

--- a/characteristic/cfHeapsLib.sml
+++ b/characteristic/cfHeapsLib.sml
@@ -84,7 +84,7 @@ fun hclean_one_dcc_core ctx =
   STRENGTHEN_CONSEQ_CONV (hclean_one_conseq_conv_core ctx)
 
 val hclean_setup_conv =
-    F_pre_post_conv (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES])) REFL
+    F_pre_post_conv (QCONV heap_clean_conv) REFL
 
 fun hclean_one_conseq_conv ctx =
   STRENGTHEN_CONSEQ_CONV hclean_setup_conv THEN_DCC
@@ -96,7 +96,7 @@ fun hclean_conseq_conv ctx =
     (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_FULL_CONTEXT)
     CONSEQ_CONV_default_cache_opt NONE true
     [(true, NONE, hclean_one_dcc_core)] ctx
-  
+
 val hclean_one = ASM_CONSEQ_CONV_TAC hclean_one_conseq_conv
 val hclean = ASM_CONSEQ_CONV_TAC hclean_conseq_conv
 

--- a/characteristic/cfHeapsLib.sml
+++ b/characteristic/cfHeapsLib.sml
@@ -36,7 +36,7 @@ fun prove_local_conseq_conv ctx =
           CONSEQ_CONV_STRENGTHEN_direction)) ctx
   in FIRST_CONSEQ_CONV ctx_cc end
 
-fun hclean_cont_conseq_conv ctx t =
+fun hclean_one_conseq_conv_core ctx t =
   let
     val (_, pre, _) = dest_F_pre_post t
     val hs = list_dest dest_star pre
@@ -58,8 +58,7 @@ fun hclean_cont_conseq_conv ctx t =
               ([], [hclean_prop, hclean_prop_single], [])
               CONSEQ_CONV_STRENGTHEN_direction,
             try_prove_local_cc
-          ],
-          (rand, IMP_CONCL_CONSEQ_CONV)
+          ]
         )
       else if is_sep_exists tm then
         SOME (
@@ -71,30 +70,32 @@ fun hclean_cont_conseq_conv ctx t =
             CONJ2_CONSEQ_CONV
               (REDEPTH_STRENGTHEN_CONSEQ_CONV (REDEPTH_CONV BETA_CONV)),
             try_prove_local_cc
-          ],
-          (snd o strip_forall, STRIP_FORALL_CONSEQ_CONV)
+          ]
         )
       else
         NONE
   in
     case find_map pull hs of
         NONE => raise UNCHANGED
-      | SOME (cc, cont) => (cc t, cont)
+      | SOME cc => cc t
   end
+
+fun hclean_one_dcc_core ctx =
+  STRENGTHEN_CONSEQ_CONV (hclean_one_conseq_conv_core ctx)
 
 val hclean_setup_conv =
     F_pre_post_conv (QCONV (SIMP_CONV bool_ss [SEP_CLAUSES])) REFL
 
 fun hclean_one_conseq_conv ctx =
   STRENGTHEN_CONSEQ_CONV hclean_setup_conv THEN_DCC
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV (hclean_cont_conseq_conv ctx))
+  (hclean_one_dcc_core ctx)
 
 fun hclean_conseq_conv ctx =
   STRENGTHEN_CONSEQ_CONV hclean_setup_conv THEN_DCC
-  STRENGTHEN_CONSEQ_CONV
-    (STEP_CONT_CONSEQ_CONV
-      (LOOP_CONT_CONSEQ_CONV (hclean_cont_conseq_conv ctx)))
+  EXT_DEPTH_CONSEQ_CONV
+    (CONSEQ_CONV_get_context_congruences CONSEQ_CONV_FULL_CONTEXT)
+    CONSEQ_CONV_default_cache_opt NONE true
+    [(true, NONE, hclean_one_dcc_core)] ctx
   
 val hclean_one = ASM_CONSEQ_CONV_TAC hclean_one_conseq_conv
 val hclean = ASM_CONSEQ_CONV_TAC hclean_conseq_conv
@@ -114,11 +115,15 @@ val hclean = ASM_CONSEQ_CONV_TAC hclean_conseq_conv
 
    g `CF (H * emp) Q : bool`
    e hclean
+
+   g `CF (cond P * A * cond Q : hprop) (J:v -> hprop) : bool`
+   e hclean
 *)
 
 (** hchange *)
 
 infix then_ecc
+infix THEN_DCC
 
 fun hchange_apply_cc lemma_th cont_ecc1 cont_ecc2 =
   CONSEQ_TOP_REWRITE_CONV ([], [hchange_lemma], []) THEN_DCC
@@ -142,16 +147,12 @@ val hsimpl_cont_ecc =
 val id_cont_ecc =
   lift_conseq_conv_ecc REFL_CONSEQ_CONV
 
-fun hchange_core_cc lemma_th cont_ecc1 cont_ecc2 =
-  STEP_CONT_CONSEQ_CONV (
-    EVERY_CONT_CONSEQ_CONV [
-      hpull_cont_conseq_conv,
-      INPLACE_CONT_CONSEQ_CONV
-        (hchange_apply_cc lemma_th cont_ecc1 cont_ecc2
-         CONSEQ_CONV_STRENGTHEN_direction)
-    ]
-  )
-  |> STRENGTHEN_CONSEQ_CONV
+fun hchange_core_cc lemma_th cont_ecc1 cont_ecc2 dir t = let
+  val _ = cfHeapsBaseLib.dest_sep_imp t
+  val cc =
+    hpull_conseq_conv THEN_DCC
+    DEPTH_CONSEQ_CONV (hchange_apply_cc lemma_th cont_ecc1 cont_ecc2)
+in cc dir t end
 
 fun hchange_conseq_conv th =
   hchange_core_cc th hcancel_cont_ecc id_cont_ecc

--- a/characteristic/cfHeapsScript.sml
+++ b/characteristic/cfHeapsScript.sml
@@ -34,7 +34,7 @@ val hchange_lemma = store_thm ("hchange_lemma",
 (* local = frame rule + consequence rule + garbage collection *)
 
 val local_def = Define `
-  local cf (H: hprop) (Q: v -> hprop) =
+  local cf (H: hprop) (Q: res -> hprop) =
     !(h: heap). H h ==> ?H1 H2 Q1.
       (H1 * H2) h /\
       cf H1 Q1 /\

--- a/characteristic/cfNormalizeScript.sml
+++ b/characteristic/cfNormalizeScript.sml
@@ -221,7 +221,9 @@ val norm_def = tDefine "norm" `
     (let (args', ns, bi) = norm_list F T ns args in
      let b = FLAT (REVERSE bi) in (* right-to-left evaluation *)
      wrap_if_needed as_value ns (Con x args') b) /\
-  norm is_named as_value ns (Raise e) = ARB /\
+  norm is_named as_value ns (Raise e) =
+    (let (e',ns,b) = norm F T ns e in
+     wrap_if_needed as_value ns (Raise e') b) /\
   norm is_named as_value ns (Log l e1 e2) =
     (let (e1', n1, b1) = norm F T ns e1 in
      let (e2', n2, b2) = norm F T n1 e2 in
@@ -251,7 +253,11 @@ val norm_def = tDefine "norm" `
      let (rows', ni) = norm_rows n1 e2 in
      let e' = Mat e1' rows' in
      wrap_if_needed as_value ni e' b1) /\
-  norm is_named as_value ns (Handle e1 e2) = ARB /\
+  norm is_named as_value ns (Handle e1 e2) =
+    (let (e1',n1) = protect F ns e1 in
+     let (rows', ni) = norm_rows n1 e2 in
+     let e' = Handle e1' rows' in
+     wrap_if_needed as_value ni e' []) /\
   norm is_named as_value ns (If e1 e2 e3) =
     (let (e1', ns, b) = norm F T ns e1 in
      let (e2', ns) = protect F ns e2 in

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -1235,9 +1235,8 @@ val cf_var_def = Define `
 
 val cf_let_def = Define `
   cf_let n F1 F2 = \env. local (\H Q.
-    ?Q'. F1 env H Q' /\
-         (!xv. F2 (env with <| v := opt_bind n xv env.v |>) (Q' (Val xv)) Q) /\
-         Q' ==e> Q)`
+    ?Q'. (F1 env H Q' /\ Q' ==e> Q) /\
+         (!xv. F2 (env with <| v := opt_bind n xv env.v |>) (Q' (Val xv)) Q))`
 
 val cf_opn_def = Define `
   cf_opn opn x1 x2 = \env. local (\H Q.

--- a/characteristic/cfTacticsBaseLib.sig
+++ b/characteristic/cfTacticsBaseLib.sig
@@ -115,22 +115,6 @@ sig
   val print_cc : conseq_conv
   val print_dcc : directed_conseq_conv
 
-  type subterm_cont =
-     (term -> term) * (conseq_conv -> conseq_conv)
-
-  type cont_conseq_conv = term -> thm * subterm_cont
-
-  val STEP_CONT_CONSEQ_CONV : cont_conseq_conv -> conseq_conv
-  val THEN_CONT_CONSEQ_CONV :
-    cont_conseq_conv -> cont_conseq_conv -> cont_conseq_conv
-  val ORELSE_CONT_CONSEQ_CONV :
-    cont_conseq_conv -> cont_conseq_conv -> cont_conseq_conv
-  val TRY_CONT_CONSEQ_CONV : cont_conseq_conv -> cont_conseq_conv
-  val EVERY_CONT_CONSEQ_CONV : cont_conseq_conv list -> cont_conseq_conv
-  val LOOP_CONT_CONSEQ_CONV : cont_conseq_conv -> cont_conseq_conv
-  val INPLACE_CONT_CONSEQ_CONV : conseq_conv -> cont_conseq_conv
-  val REFL_CONT_CONSEQ_CONV : cont_conseq_conv
-
   (* -- *)
 
   val MATCH_IMP_STRENGTHEN_CONSEQ_CONV : thm -> conseq_conv

--- a/characteristic/cfTacticsLib.sig
+++ b/characteristic/cfTacticsLib.sig
@@ -109,6 +109,28 @@ sig
   *)
   val xffi : tactic
 
+  (* [xraise] applies on characteristic formulae for raise, of the form
+     [cf_raise ..].
+  *)
+  val xraise : tactic
+
+  (* [xhandle] applies on characteristic formulae for exception handling,
+     of the form [cf_handle ..].
+
+     A post-condition for the evaluation of the body must be provided.
+  *)
+  val xhandle : term quotation -> tactic
+
+  (* [xcases] is somewhat similar to [xmatch]. It applies to characteristic
+     formalue of the form [cf_cases ...], and simplifies them. Such formulae are
+     typically produced by [xhandle].
+
+     [xcases] is not automatically called by [xhandle] as the user is expected
+     to pull facts using [xpull], perform case analysis, unfold representation
+     predicates, ..., before calling [xcases].
+  *)
+  val xcases : tactic
+
   (* low level / debugging *)
   val xlocal : tactic
   val xapply : thm -> tactic

--- a/characteristic/cfTacticsLib.sig
+++ b/characteristic/cfTacticsLib.sig
@@ -32,7 +32,7 @@ sig
      to the value; the introduced name will be deduced from the
      variable of the lambda.
 
-     Example: [xlet `\i. & INT 3 i`]
+     Example: [xlet `POSTv i. & INT 3 i`]
   *)
   val xlet : term quotation -> tactic
 
@@ -104,7 +104,7 @@ sig
   val xmatch : tactic
 
   (* [xffi] applies on characteristic formulae for ffi operations, of the form
-  [cf_ffi ...].
+     [cf_ffi ...].
 
   *)
   val xffi : tactic

--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -213,7 +213,7 @@ fun xlet_core cont0 cont1 cont2 =
   CONJ_TAC THENL [
     CONJ_TAC THENL [
       all_tac,
-      TRY (MATCH_ACCEPT_TAC cfHeapsBaseTheory.SEP_IMPPOSTe_POSTv)
+      TRY (MATCH_ACCEPT_TAC cfHeapsBaseTheory.SEP_IMPPOSTe_POSTv_left)
     ],
     cont1 \\ cont2
   ]

--- a/characteristic/cfTacticsScript.sml
+++ b/characteristic/cfTacticsScript.sml
@@ -6,10 +6,20 @@ open cfTacticsBaseLib cfHeapsLib
 
 val _ = new_theory "cfTactics"
 
+(*
 val xret_lemma = store_thm ("xret_lemma",
   ``!H Q.
     (H ==>> Q v * GC) ==>
     local (\H' Q'. H' ==>> Q' v) H Q``,
+  rpt strip_tac \\ irule (Q.SPEC `GC` local_gc_pre_on) \\
+  fs [local_is_local] \\ first_assum hchanges \\ hinst \\
+  irule local_elim \\ fs [] \\ hsimpl
+)*)
+
+val xret_lemma = store_thm ("xret_lemma",
+  ``!H Q R.
+    H ==>> Q v * GC /\ R Q ==>
+    local (\H' Q'. H' ==>> Q' v /\ R Q') H Q``,
   rpt strip_tac \\ irule (Q.SPEC `GC` local_gc_pre_on) \\
   fs [local_is_local] \\ first_assum hchanges \\ hinst \\
   irule local_elim \\ fs [] \\ hsimpl
@@ -21,10 +31,19 @@ val xret_lemma_unify = store_thm ("xret_lemma_unify",
   rpt strip_tac \\ irule local_elim \\ fs [] \\ hsimpl
 )
 
+(*
 val xret_no_gc_lemma = store_thm ("xret_no_gc_lemma",
   ``!v H Q.
       (H ==>> Q v) ==>
       local (\H' Q'. H' ==>> Q' v) H Q``,
+  fs [local_elim]
+)
+*)
+
+val xret_no_gc_lemma = store_thm ("xret_no_gc_lemma",
+  ``!v H Q R.
+      H ==>> Q v /\ R Q ==>
+      local (\H' Q'. H' ==>> Q' v /\ R Q') H Q``,
   fs [local_elim]
 )
 

--- a/characteristic/examples/cf_examplesScript.sml
+++ b/characteristic/examples/cf_examplesScript.sml
@@ -15,8 +15,8 @@ val st0 = ml_progLib.add_prog example_let0 pick_name basis_st
 
 val example_let0_spec = Q.prove (
   `!nv. app (p:'ffi ffi_proj) ^(fetch_v "example_let0" st0) [nv]
-          emp (\v. & INT 3 v)`,
-  xcf "example_let0" st0 \\ xlet `\a. & INT 3 a`
+          emp (POSTv v. & INT 3 v)`,
+  xcf "example_let0" st0 \\ xlet `POSTv a. & INT 3 a`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
 )
@@ -28,8 +28,8 @@ val st1 = ml_progLib.add_prog example_let1 pick_name basis_st
 
 val example_let1_spec = Q.prove (
   `!uv. app (p:'ffi ffi_proj) ^(fetch_v "example_let1" st1) [uv]
-          emp (\v. & UNIT_TYPE () v)`,
-  xcf "example_let1" st1 \\ xlet `\a. & UNIT_TYPE () a`
+          emp (POSTv v. & UNIT_TYPE () v)`,
+  xcf "example_let1" st1 \\ xlet `POSTv a. & UNIT_TYPE () a`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
 )
@@ -41,8 +41,8 @@ val st2 = ml_progLib.add_prog example_let2 pick_name basis_st
 
 val example_let2_spec = Q.prove (
   `!uv. app (p:'ffi ffi_proj) ^(fetch_v "example_let2" st2) [uv]
-          emp (\v. & (v = uv))`,
-  xcf "example_let2" st2 \\ xlet `\v. & (v = uv)`
+          emp (POSTv v. & (v = uv))`,
+  xcf "example_let2" st2 \\ xlet `POSTv v. & (v = uv)`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
 )
@@ -56,12 +56,12 @@ val example_let_spec = Q.prove (
   `!n nv.
      INT n nv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "example_let" st) [nv]
-       emp (\v. & INT (2 * n) v)`,
+       emp (POSTv v. & INT (2 * n) v)`,
 
   xcf "example_let" st \\
-  xlet `\a. & INT (n+1) a`
+  xlet `POSTv a. & INT (n+1) a`
   THEN1 (xapp \\ fs []) \\
-  xlet `\b. & INT (n-1) b`
+  xlet `POSTv b. & INT (n-1) b`
   THEN1 (xapp \\ fs []) \\
   xapp \\ xsimpl \\ fs [INT_def] \\ intLib.ARITH_TAC
 )
@@ -76,12 +76,12 @@ val alloc_ref2_spec = Q.prove (
      INT a av /\ INT b bv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "alloc_ref2" st) [av; bv]
        emp
-       (\p. SEP_EXISTS r1 r2.
-              & PAIR_TYPE (=) (=) (r1, r2) p *
-              REF r1 av * REF r2 bv)`,
+       (POSTv p. SEP_EXISTS r1 r2.
+                 & PAIR_TYPE (=) (=) (r1, r2) p *
+                 REF r1 av * REF r2 bv)`,
   xcf "alloc_ref2" st \\
-  xlet `\r2. REF r2 bv` THEN1 xapp \\
-  xlet `\r1. REF r1 av * REF r2 bv` THEN1 (xapp \\ xsimpl) \\
+  xlet `POSTv r2. REF r2 bv` THEN1 xapp \\
+  xlet `POSTv r1. REF r1 av * REF r2 bv` THEN1 (xapp \\ xsimpl) \\
   xret \\ fs [PAIR_TYPE_def] \\ xsimpl
 )
 
@@ -94,13 +94,13 @@ val swap_spec = Q.prove (
   `!xv yv r1v r2v.
      app (p:'ffi ffi_proj) ^(fetch_v "swap" st2) [r1v; r2v]
        (REF r1v xv * REF r2v yv)
-       (\v. & UNIT_TYPE () v * REF r1v yv * REF r2v xv)`,
+       (POSTv v. & UNIT_TYPE () v * REF r1v yv * REF r2v xv)`,
   xcf "swap" st2 \\
-  xlet `\xv'. & (xv' = xv) * r1v ~~> xv * r2v ~~> yv`
+  xlet `POSTv xv'. & (xv' = xv) * r1v ~~> xv * r2v ~~> yv`
     THEN1 (xapp \\ xsimpl) \\
-  xlet `\yv'. & (yv' = yv) * r1v ~~> xv * r2v ~~> yv`
+  xlet `POSTv yv'. & (yv' = yv) * r1v ~~> xv * r2v ~~> yv`
     THEN1 (xapp \\ xsimpl) \\
-  xlet `\u. r1v ~~> yv * r2v ~~> yv`
+  xlet `POSTv u. r1v ~~> yv * r2v ~~> yv`
     THEN1 (xapp \\ xsimpl) \\
   xapp \\ xsimpl
 )
@@ -114,9 +114,9 @@ val example_if_spec = Q.prove (
   `!n nv.
      INT n nv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "example_if" st) [nv]
-       emp (\v. &(if n > 0 then INT 1 v else INT 2 v))`,
+       emp (POSTv v. &(if n > 0 then INT 1 v else INT 2 v))`,
 
-  xcf "example_if" st \\ xlet `\bv. & BOOL (n > 0) bv`
+  xcf "example_if" st \\ xlet `POSTv bv. & BOOL (n > 0) bv`
   THEN1 (xapp \\ fs []) \\
   xif \\ xret \\ xsimpl
 )
@@ -130,7 +130,7 @@ val is_nil_spec = Q.prove (
   `!lv a l.
      LIST_TYPE a l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "is_nil" st) [lv]
-       emp (\bv. & BOOL (l = []) bv)`,
+       emp (POSTv bv. & BOOL (l = []) bv)`,
 
   xcf "is_nil" st \\ Cases_on `l` \\ fs [LIST_TYPE_def] \\
   xmatch \\ xret \\ xsimpl
@@ -145,7 +145,7 @@ val example_eq_spec = Q.prove (
   `!x xv.
      INT x xv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "example_eq" st) [xv]
-       emp (\bv. & BOOL (x = 3) bv)`,
+       emp (POSTv bv. & BOOL (x = 3) bv)`,
   xcf "example_eq" st \\ xapp \\
   (* instantiate *) qexists_tac `INT` \\ fs [] \\
   fs [EqualityType_NUM_BOOL]
@@ -160,8 +160,8 @@ val example_and_spec = Q.prove (
   `!uv.
      UNIT_TYPE () uv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "example_and" st) [uv]
-       emp (\bv. & BOOL F bv)`,
-  xcf "example_and" st \\ xlet `\b. & BOOL T b`
+       emp (POSTv bv. & BOOL F bv)`,
+  xcf "example_and" st \\ xlet `POSTv b. & BOOL T b`
   THEN1 (xret \\ xsimpl) \\
   xlog \\ xret \\ xsimpl
 )
@@ -189,7 +189,7 @@ val list_length_spec = store_thm ("list_length_spec",
   ``!a l lv.
      LIST_TYPE a l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "length" st) [lv]
-       emp (\v. & NUM (LENGTH l) v)``,
+       emp (POSTv v. & NUM (LENGTH l) v)``,
   Induct_on `l`
   THEN1 (
     xcf "length" st \\ fs [LIST_TYPE_def] \\
@@ -198,7 +198,7 @@ val list_length_spec = store_thm ("list_length_spec",
   THEN1 (
     xcf "length" st \\ fs [LIST_TYPE_def] \\
     rename1 `a x xv` \\ rename1 `LIST_TYPE a xs xvs` \\
-    xmatch \\ xlet `\xs_len. & NUM (LENGTH xs) xs_len`
+    xmatch \\ xlet `POSTv xs_len. & NUM (LENGTH xs) xs_len`
     THEN1 (xapp \\ metis_tac []) \\
     xapp \\ xsimpl \\ fs [NUM_def] \\ asm_exists_tac \\ fs [] \\
     (* meh? *) fs [INT_def] \\ intLib.ARITH_TAC
@@ -209,11 +209,11 @@ val bytearray_fromlist_spec = Q.prove (
   `!l lv.
      LIST_TYPE WORD l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "fromList" st) [lv]
-       emp (\av. W8ARRAY av l)`,
+       emp (POSTv av. W8ARRAY av l)`,
   xcf "fromList" st \\
-  xlet `\w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
-  xlet `\len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
-  xlet `\av. W8ARRAY av (REPLICATE (LENGTH l) 0w)`
+  xlet `POSTv w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
+  xlet `POSTv len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
+  xlet `POSTv av. W8ARRAY av (REPLICATE (LENGTH l) 0w)`
     THEN1 (xapp \\ fs []) \\
   xfun_spec `f`
     `!ls lvs i iv l_pre rest.
@@ -222,18 +222,18 @@ val bytearray_fromlist_spec = Q.prove (
         ==>
        app p f [lvs; iv]
          (W8ARRAY av (l_pre ++ rest))
-         (\ret. & (ret = av) * W8ARRAY av (l_pre ++ ls))`
+         (POSTv ret. & (ret = av) * W8ARRAY av (l_pre ++ ls))`
   THEN1 (
     Induct_on `ls` \\ fs [LIST_TYPE_def, LENGTH_NIL] \\ rpt strip_tac
     THEN1 (xapp \\ xmatch \\ xret \\ xsimpl)
     THEN1 (
       fs [] \\ last_assum xapp_spec \\ xmatch \\ fs [LENGTH_CONS] \\
       rename1 `rest = rest_h :: rest_t` \\ rw [] \\
-      xlet `\_. W8ARRAY av (l_pre ++ h :: rest_t)` THEN1 (
+      xlet `POSTv _. W8ARRAY av (l_pre ++ h :: rest_t)` THEN1 (
         xapp \\ xsimpl \\ fs [UNIT_TYPE_def] \\ instantiate \\
         fs [lupdate_append]
       ) \\
-      xlet `\ippv. & NUM (LENGTH l_pre + 1) ippv * W8ARRAY av (l_pre ++ h::rest_t)`
+      xlet `POSTv ippv. & NUM (LENGTH l_pre + 1) ippv * W8ARRAY av (l_pre ++ h::rest_t)`
       THEN1 (
         xapp \\ xsimpl \\ fs [NUM_def] \\ instantiate \\
         fs [INT_def] \\ intLib.ARITH_TAC

--- a/characteristic/examples/cf_tutorialScript.sml
+++ b/characteristic/examples/cf_tutorialScript.sml
@@ -68,7 +68,7 @@ val list_length_spec = store_thm ("list_length_spec",
    !x1..xn argv1.. argvm.
      facts_about_xi_argvj x1 .. xn .. argv1 .. argvm ==>
      app (p:'ffi ffi_proj) ^(fetch_v "name" st) [argv1, argv2,...]
-       precondition (\v. postcondition v)
+       precondition postcondition
 
    where:
 
@@ -84,20 +84,36 @@ val list_length_spec = store_thm ("list_length_spec",
      logic, using the predicates defined in ml_translatorTheory,
      and/or contain any necessary logical preconditions;
 
-   - [precondition] and [postcondition v] are heap predicates (of type
-     [hprop]), and describe the memory heap respectively before and
-     after the execution of the function.
+   - [precondition] is a heap predicate (of type [hprop]), and describe
+     the memory heap before the execution of the function.
      The syntax for heap predicates includes:
      - [emp]: the empty heap
      - [H1 * H2]: separating conjunction (H1, H2: hprop)
      - [& P]: a pure fact (P: bool)
      - [H1 ==>> H2]: heap implication (H1, H2: hprop)
-     - [REF r v]: a reference cell (
+     - [REF r v]: a reference cell
      - [ARRAY r lv]: an array
 
      NB: it is always better to put pure preconditions as logical
      preconditions (in [facts_about_xi_argvj]) than in the
      precondition heap.
+
+   - [postcondition] describes the state of the heap after the
+     execution of the function.
+
+     As the function may either return, producing a value, or raise an
+     exception, several helper functions are provided for writing
+     post-conditions:
+
+     - [POSTv v. Q] is a post-condition that asserts that the function
+       will always reduce to a value, here bound to [v], and that the
+       heap predicate [Q] (of type [hprop]) must be satisfied;
+     - [POSTe v. Q] is similar, but for functions that always raise an
+       exception;
+     - [POST Qv Qe] is the general case: [Qv] of type [v -> hprop] is
+       the post-condition for when the function returns a value, and
+       [Qe] (also of type [v -> hprop]) is the post-condition for when
+       the function raises an exception.
 *)
   ``!a l lv.
      LIST_TYPE a l lv ==>

--- a/characteristic/examples/cf_tutorialScript.sml
+++ b/characteristic/examples/cf_tutorialScript.sml
@@ -102,7 +102,7 @@ val list_length_spec = store_thm ("list_length_spec",
   ``!a l lv.
      LIST_TYPE a l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "length" st) [lv]
-       emp (\v. & NUM (LENGTH l) v)``,
+       emp (POSTv v. & NUM (LENGTH l) v)``,
 
   (* Let's reason by induction on [l].
   *)
@@ -151,7 +151,7 @@ val list_length_spec = store_thm ("list_length_spec",
        We get two subgoals, one for proving that this intermediate
        post-condition holds, and one for the rest of the proof.
     *)
-    xlet `\xs_len. & NUM (LENGTH xs) xs_len`
+    xlet `POSTv xs_len. & NUM (LENGTH xs) xs_len`
     THEN1 (
 
       (* [cf_app...] goal: we use [xapp].
@@ -187,11 +187,11 @@ val bytearray_fromlist_spec = Q.prove (
   `!l lv.
      LIST_TYPE WORD l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "fromList" st) [lv]
-       emp (\av. W8ARRAY av l)`,
+       emp (POSTv av. W8ARRAY av l)`,
   xcf "fromList" st \\
-  xlet `\w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
-  xlet `\len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
-  xlet `\av. W8ARRAY av (REPLICATE (LENGTH l) 0w)`
+  xlet `POSTv w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
+  xlet `POSTv len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
+  xlet `POSTv av. W8ARRAY av (REPLICATE (LENGTH l) 0w)`
     THEN1 (xapp \\ fs []) \\
 
   (* [cf_fun] and [cf_fun_rec] goals are handled by [xfun] and
@@ -218,7 +218,7 @@ val bytearray_fromlist_spec = Q.prove (
         ==>
        app p f [lvs; iv]
          (W8ARRAY av (l_pre ++ rest))
-         (\ret. & (ret = av) * W8ARRAY av (l_pre ++ ls))`
+         (POSTv ret. & (ret = av) * W8ARRAY av (l_pre ++ ls))`
   THEN1 (
     (* We get the specification to prove as a first subgoal
     *)
@@ -239,11 +239,11 @@ val bytearray_fromlist_spec = Q.prove (
       rename1 `rest = rest_h :: rest_t` \\ rw [] \\
 
       (* Sequences are encoded as lets, so we can just use [xlet] here *)
-      xlet `\_. W8ARRAY av (l_pre ++ h :: rest_t)` THEN1 (
+      xlet `POSTv _. W8ARRAY av (l_pre ++ h :: rest_t)` THEN1 (
         xapp \\ xsimpl \\ fs [UNIT_TYPE_def] \\ instantiate \\
         fs [lupdate_append]
       ) \\
-      xlet `\ippv. & NUM (LENGTH l_pre + 1) ippv * W8ARRAY av (l_pre ++ h::rest_t)`
+      xlet `POSTv ippv. & NUM (LENGTH l_pre + 1) ippv * W8ARRAY av (l_pre ++ h::rest_t)`
       THEN1 (
         xapp \\ xsimpl \\ fs [NUM_def] \\ instantiate \\
         (* tedious? *) fs [INT_def] \\ intLib.ARITH_TAC


### PR DESCRIPTION
Not finished yet.

Progress:

- [x] Support `raise` and `handle` in the `cf` function
- [x] Update the soundness proof
- [x] Update the existing tactics and specifications of the examples so they still work
- [x] Implement tactics and add examples for `raise` and `handle`
- [x] Be able to use translator representation predicates for exceptions
- Optionally generalize existing cfs (eg for division or array access), to specify the case where an exception is raised (at the moment, the user has to prove that this case cannot happen) **[for later]**

Some questions:
- Does something need to be added to `basisProgramScript` about exceptions?
- please bikeshed about the auxiliary predicates used for post-conditions. At the moment, one writes `POSTv v. Qv v` for writing a "pure" postcondition (meaning that the exception case cannot happen), `POSTe v. Qe v` for a postcondition for the exception case only (the value case cannot happen), and `POST Qv Qe` for specifying one post-condition for each case
- does something else need to be done?