### PR TITLE
Johannes

### DIFF
--- a/basis/basisProgScript.sml
+++ b/basis/basisProgScript.sml
@@ -102,20 +102,20 @@ fun prove_ref_spec op_name =
   reduce_tac \\ fs [app_ref_def, app_deref_def, app_assign_def] \\
   xsimpl \\ fs [UNIT_TYPE_def]
 
-val ref_spec = store_thm ("ref_spec",
-  ``!xv. app (p:'ffi ffi_proj) ^(fetch_v "op ref" (basis_st())) [xv]
-          emp (POSTv rv. rv ~~> xv)``,
+val ref_spec = Q.store_thm ("ref_spec",
+  `!xv. app (p:'ffi ffi_proj) ^(fetch_v "op ref" (basis_st())) [xv]
+          emp (POSTv rv. rv ~~> xv)`,
   prove_ref_spec "op ref");
 
-val deref_spec = store_thm ("deref_spec",
-  ``!xv. app (p:'ffi ffi_proj) ^(fetch_v "op !" (basis_st())) [rv]
-          (rv ~~> xv) (POSTv yv. cond (xv = yv) * rv ~~> xv)``,
+val deref_spec = Q.store_thm ("deref_spec",
+  `!xv. app (p:'ffi ffi_proj) ^(fetch_v "op !" (basis_st())) [rv]
+          (rv ~~> xv) (POSTv yv. cond (xv = yv) * rv ~~> xv)`,
   prove_ref_spec "op !");
 
-val assign_spec = store_thm ("assign_spec",
-  ``!rv xv yv.
+val assign_spec = Q.store_thm ("assign_spec",
+  `!rv xv yv.
      app (p:'ffi ffi_proj) ^(fetch_v "op :=" (basis_st())) [rv; yv]
-       (rv ~~> xv) (POSTv v. cond (UNIT_TYPE () v) * rv ~~> yv)``,
+       (rv ~~> xv) (POSTv v. cond (UNIT_TYPE () v) * rv ~~> yv)`,
   prove_ref_spec "op :=");
 
 
@@ -155,33 +155,33 @@ fun prove_array_spec op_name =
   xsimpl \\ fs [INT_def, NUM_def, WORD_def, w2w_def, UNIT_TYPE_def] \\
   TRY (simp_tac (arith_ss ++ intSimps.INT_ARITH_ss) [])
 
-val w8array_alloc_spec = store_thm ("w8array_alloc_spec",
-  ``!n nv w wv.
+val w8array_alloc_spec = Q.store_thm ("w8array_alloc_spec",
+  `!n nv w wv.
      NUM n nv /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.array" (basis_st())) [nv; wv]
-       emp (POSTv v. W8ARRAY v (REPLICATE n w))``,
+       emp (POSTv v. W8ARRAY v (REPLICATE n w))`,
   prove_array_spec "Word8Array.array");
 
-val w8array_sub_spec = store_thm ("w8array_sub_spec",
-  ``!a av n nv.
+val w8array_sub_spec = Q.store_thm ("w8array_sub_spec",
+  `!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.sub" (basis_st())) [av; nv]
-       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.sub");
 
-val w8array_length_spec = store_thm ("w8array_length_spec",
-  ``!a av.
+val w8array_length_spec = Q.store_thm ("w8array_length_spec",
+  `!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.length" (basis_st())) [av]
-       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.length");
 
-val w8array_update_spec = store_thm ("w8array_update_spec",
-  ``!a av n nv w wv.
+val w8array_update_spec = Q.store_thm ("w8array_update_spec",
+  `!a av n nv w wv.
      NUM n nv /\ n < LENGTH a /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.update" (basis_st()))
        [av; nv; wv]
        (W8ARRAY av a)
-       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
+       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))`,
   prove_array_spec "Word8Array.update");
 
 
@@ -212,34 +212,34 @@ val _ = append_decs
 
 val _ = ml_prog_update (close_module NONE);
 
-val array_alloc_spec = store_thm ("array_alloc_spec",
-  ``!n nv v.
+val array_alloc_spec = Q.store_thm ("array_alloc_spec",
+  `!n nv v.
      NUM n nv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Array.array" (basis_st())) [nv; v]
-       emp (POSTv av. ARRAY av (REPLICATE n v))``,
+       emp (POSTv av. ARRAY av (REPLICATE n v))`,
   prove_array_spec "Array.array");
 
-val array_sub_spec = store_thm ("array_sub_spec",
-  ``!a av n nv.
+val array_sub_spec = Q.store_thm ("array_sub_spec",
+  `!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Array.sub" (basis_st())) [av; nv]
-       (ARRAY av a) (POSTv v. cond (v = EL n a) * ARRAY av a)``,
+       (ARRAY av a) (POSTv v. cond (v = EL n a) * ARRAY av a)`,
   prove_array_spec "Array.sub");
 
-val array_length_spec = store_thm ("array_length_spec",
-  ``!a av.
+val array_length_spec = Q.store_thm ("array_length_spec",
+  `!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Array.length" (basis_st())) [av]
        (ARRAY av a)
-       (POSTv v. cond (NUM (LENGTH a) v) * ARRAY av a)``,
+       (POSTv v. cond (NUM (LENGTH a) v) * ARRAY av a)`,
   prove_array_spec "Array.length");
 
-val array_update_spec = store_thm ("array_update_spec",
-  ``!a av n nv v.
+val array_update_spec = Q.store_thm ("array_update_spec",
+  `!a av n nv v.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Array.update" (basis_st()))
        [av; nv; v]
        (ARRAY av a)
-       (POSTv uv. cond (UNIT_TYPE () uv) * ARRAY av (LUPDATE v n a))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * ARRAY av (LUPDATE v n a))`,
   prove_array_spec "Array.update");
 
 
@@ -331,13 +331,13 @@ val STDOUT_def = Define `
 val CHAR_IO_def = Define `
   CHAR_IO = SEP_EXISTS w. W8ARRAY print_loc [w]`;
 
-val print_spec = store_thm ("print_spec",
-  ``!a av n nv v.
+val print_spec = Q.store_thm ("print_spec",
+  `!a av n nv v.
      CHAR c cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.print" (basis_st()))
        [cv]
        (CHAR_IO * STDOUT output)
-       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))`,
   xcf "CharIO.print" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
   \\ xlet `POSTv xv. W8ARRAY print_loc [w] * STDOUT output * & (NUM (ORD c) xv)`

--- a/candle/set-theory/jrhSetScript.sml
+++ b/candle/set-theory/jrhSetScript.sml
@@ -198,8 +198,8 @@ val universe_IN = Q.prove(
   `universe x ⇔ x ∈ universe`,
   rw[IN_DEF])
 
-val V_bij = store_thm("V_bij",
-  ``∀l e. e ∈ setlevel l ⇔ dest_V(mk_V(l,e)) = (l,e)``,
+val V_bij = Q.store_thm("V_bij",
+  `∀l e. e ∈ setlevel l ⇔ dest_V(mk_V(l,e)) = (l,e)`,
   rw[GSYM(CONJUNCT2 v_bij)] >>
   rw[universe_IN,universe_def])
 
@@ -220,8 +220,8 @@ val ELEMENT_IN_LEVEL = Q.store_thm("ELEMENT_IN_LEVEL",
   `∀x. (element x) ∈ setlevel (level x)`,
   rw[element_def,level_def,V_bij,v_bij])
 
-val SET = store_thm("SET",
-  ``∀x. mk_V(level x,element x) = x``,
+val SET = Q.store_thm("SET",
+  `∀x. mk_V(level x,element x) = x`,
   rw[level_def,element_def,v_bij])
 
 val set_def = Define`
@@ -256,16 +256,16 @@ val LEVEL_SET_EXISTS = Q.store_thm("LEVEL_SET_EXISTS",
   simp[V_bij,level_def] >>
   metis_tac[FST])
 
-val MK_V_CLAUSES = store_thm("MK_V_CLAUSES",
-  ``e ∈ setlevel l ⇒
-      level(mk_V(l,e)) = l ∧ element(mk_V(l,e)) = e``,
+val MK_V_CLAUSES = Q.store_thm("MK_V_CLAUSES",
+  `e ∈ setlevel l ⇒
+      level(mk_V(l,e)) = l ∧ element(mk_V(l,e)) = e`,
   rw[level_def,element_def,V_bij])
 
-val MK_V_SET = store_thm("MK_V_SET",
-  ``s ⊆ setlevel l ⇒
+val MK_V_SET = Q.store_thm("MK_V_SET",
+  `s ⊆ setlevel l ⇒
     set(mk_V(Powerset l,I_SET (setlevel l) s)) = s ∧
     level(mk_V(Powerset l,I_SET (setlevel l) s)) = Powerset l ∧
-    element(mk_V(Powerset l,I_SET (setlevel l) s)) = I_SET (setlevel l) s``,
+    element(mk_V(Powerset l,I_SET (setlevel l) s)) = I_SET (setlevel l) s`,
   strip_tac >>
   `I_SET (setlevel l) s ∈ setlevel (Powerset l)` by (
     rw[setlevel_def,IN_POW] ) >>
@@ -351,13 +351,13 @@ val pair_def = Define`
   pair x y = mk_V(Cartprod (level x) (level y),
                   I_PAIR(element x,element y))`
 
-val PAIR_IN_LEVEL = store_thm("PAIR_IN_LEVEL",
-  ``∀x y l m. x ∈ setlevel l ∧ y ∈ setlevel m
-              ⇒ I_PAIR(x,y) ∈ setlevel (Cartprod l m)``,
+val PAIR_IN_LEVEL = Q.store_thm("PAIR_IN_LEVEL",
+  `∀x y l m. x ∈ setlevel l ∧ y ∈ setlevel m
+              ⇒ I_PAIR(x,y) ∈ setlevel (Cartprod l m)`,
   simp[setlevel_def])
 
-val DEST_MK_PAIR = store_thm("DEST_MK_PAIR",
-  ``dest_V(pair x y) = (Cartprod (level x) (level y), I_PAIR(element x,element y))``,
+val DEST_MK_PAIR = Q.store_thm("DEST_MK_PAIR",
+  `dest_V(pair x y) = (Cartprod (level x) (level y), I_PAIR(element x,element y))`,
   simp[pair_def,GSYM V_bij] >>
   simp[PAIR_IN_LEVEL,ELEMENT_IN_LEVEL])
 

--- a/candle/set-theory/jrhSetScript.sml
+++ b/candle/set-theory/jrhSetScript.sml
@@ -3,8 +3,8 @@ val _ = temp_tight_equality()
 val _ = numLib.prefer_num()
 val _ = new_theory"jrhSet"
 
-val ind_model_exists = prove(
-  ``∃x. (@s:num->bool. s ≠ {} ∧ FINITE s) x``,
+val ind_model_exists = Q.prove(
+  `∃x. (@s:num->bool. s ≠ {} ∧ FINITE s) x`,
     metis_tac[IN_DEF, MEMBER_NOT_EMPTY, IN_SING, FINITE_DEF])
 
 val ind_model_ty =
@@ -16,8 +16,8 @@ val mk_ind_onto   = prove_abs_fn_onto    ind_model_bij
 val dest_ind_11   = prove_rep_fn_one_one ind_model_bij
 val dest_ind_onto = prove_rep_fn_onto    ind_model_bij
 
-val inacc_exists = prove(
-  ``∃x:num. UNIV x``,
+val inacc_exists = Q.prove(
+  `∃x:num. UNIV x`,
   metis_tac[IN_UNIV,IN_DEF])
 
 val inacc_ty =
@@ -29,12 +29,12 @@ val mk_I_onto   = prove_abs_fn_onto    inacc_bij
 val dest_I_11   = prove_rep_fn_one_one inacc_bij
 val dest_I_onto = prove_rep_fn_onto    inacc_bij
 
-val FINITE_CARD_LT = store_thm("FINITE_CARD_LT",
-  ``∀s. FINITE s ⇔ s ≺ 𝕌(:num)``,
+val FINITE_CARD_LT = Q.store_thm("FINITE_CARD_LT",
+  `∀s. FINITE s ⇔ s ≺ 𝕌(:num)`,
   metis_tac[INFINITE_Unum])
 
-val lemma = prove(
-  ``∀s. s ≺ 𝕌(:I) ⇔ FINITE s``,
+val lemma = Q.prove(
+  `∀s. s ≺ 𝕌(:I) ⇔ FINITE s`,
   rw[FINITE_CARD_LT] >>
   match_mp_tac CARDEQ_CARDLEQ >>
   simp[cardeq_REFL] >>
@@ -42,17 +42,17 @@ val lemma = prove(
   simp[cardleq_def,INJ_DEF] >>
   metis_tac[inacc_bij,dest_I_11,mk_I_11,IN_UNIV,IN_DEF])
 
-val I_AXIOM = store_thm("I_AXIOM",
-  ``𝕌(:ind_model) ≺ 𝕌(:I) ∧
-    ∀s. s ≺ 𝕌(:I) ⇒ POW s ≺ 𝕌(:I)``,
+val I_AXIOM = Q.store_thm("I_AXIOM",
+  `𝕌(:ind_model) ≺ 𝕌(:I) ∧
+    ∀s. s ≺ 𝕌(:I) ⇒ POW s ≺ 𝕌(:I)`,
   simp[lemma,FINITE_POW] >>
   `UNIV = IMAGE mk_ind (@s. s ≠ {} ∧ FINITE s)` by (
     simp[Once EXTENSION,IN_DEF,ind_model_bij] >>
     metis_tac[ind_model_bij]) >>
   metis_tac[IMAGE_FINITE,NOT_INSERT_EMPTY,FINITE_EMPTY,FINITE_INSERT])
 
-val I_INFINITE = store_thm("I_INFINITE",
-  ``INFINITE 𝕌(:I)``,
+val I_INFINITE = Q.store_thm("I_INFINITE",
+  `INFINITE 𝕌(:I)`,
   DISCH_TAC >>
   Q.ISPEC_THEN`count (CARD 𝕌(:I) - 1)`mp_tac (CONJUNCT2 I_AXIOM) >>
   simp[] >>
@@ -83,8 +83,8 @@ val I_INFINITE = store_thm("I_INFINITE",
   simp[EXTENSION,IN_POW] >>
   qexists_tac`{}`>>simp[])
 
-val I_PAIR_EXISTS = prove(
-  ``∃f:I#I->I. !x y. (f x = f y) ==> (x = y)``,
+val I_PAIR_EXISTS = Q.prove(
+  `∃f:I#I->I. !x y. (f x = f y) ==> (x = y)`,
   qsuff_tac `𝕌(:I#I) ≼ 𝕌(:I)` >-
     simp[cardleq_def,INJ_DEF] >>
   match_mp_tac CARDEQ_SUBSET_CARDLEQ >>
@@ -98,14 +98,14 @@ val I_PAIR_def =
   new_specification("I_PAIR_def",["I_PAIR"],
     REWRITE_RULE[INJ_LEMMA] I_PAIR_EXISTS)
 
-val CARD_BOOL_LT_I = store_thm("CARD_BOOL_LT_I",
-  ``𝕌(:bool) ≺ 𝕌(:I)``,
+val CARD_BOOL_LT_I = Q.store_thm("CARD_BOOL_LT_I",
+  `𝕌(:bool) ≺ 𝕌(:I)`,
   strip_tac >> mp_tac I_INFINITE >> simp[] >>
   match_mp_tac (INST_TYPE[beta|->``:bool``]CARDLEQ_FINITE) >>
   HINT_EXISTS_TAC >> simp[UNIV_BOOL])
 
-val I_BOOL_EXISTS = prove(
-  ``∃f:bool->I. !x y. (f x = f y) ==> (x = y)``,
+val I_BOOL_EXISTS = Q.prove(
+  `∃f:bool->I. !x y. (f x = f y) ==> (x = y)`,
   `𝕌(:bool) ≼ 𝕌(:I)` by metis_tac[CARD_BOOL_LT_I,cardlt_lenoteq] >>
   fs[cardleq_def,INJ_DEF] >> metis_tac[])
 
@@ -113,8 +113,8 @@ val I_BOOL_def =
   new_specification("I_BOOL_def",["I_BOOL"],
     REWRITE_RULE[INJ_LEMMA] I_BOOL_EXISTS)
 
-val I_IND_EXISTS = prove(
-  ``∃f:ind_model->I. !x y. (f x = f y) ==> (x = y)``,
+val I_IND_EXISTS = Q.prove(
+  `∃f:ind_model->I. !x y. (f x = f y) ==> (x = y)`,
   `𝕌(:ind_model) ≼ 𝕌(:I)` by metis_tac[I_AXIOM,cardlt_lenoteq] >>
   fs[cardleq_def,INJ_DEF] >> metis_tac[])
 
@@ -122,8 +122,8 @@ val I_IND_def =
   new_specification("I_IND_def",["I_IND"],
     REWRITE_RULE[INJ_LEMMA] I_IND_EXISTS)
 
-val I_SET_EXISTS = prove(
-  ``∀s:I->bool. s ≺ 𝕌(:I) ⇒ ∃f:(I->bool)->I. !x y. x ⊆ s ∧ y ⊆ s ∧ (f x = f y) ==> (x = y)``,
+val I_SET_EXISTS = Q.prove(
+  `∀s:I->bool. s ≺ 𝕌(:I) ⇒ ∃f:(I->bool)->I. !x y. x ⊆ s ∧ y ⊆ s ∧ (f x = f y) ==> (x = y)`,
   gen_tac >> disch_then(strip_assume_tac o MATCH_MP(CONJUNCT2 I_AXIOM)) >>
   fs[cardlt_lenoteq] >>
   fs[cardleq_def,INJ_DEF,IN_POW] >>
@@ -147,8 +147,8 @@ val setlevel_def = Define`
   setlevel (Powerset l) =
     IMAGE (I_SET (setlevel l)) (POW (setlevel l))`
 
-val setlevel_CARD = store_thm("setlevel_CARD",
-  ``∀l. setlevel l ≺ 𝕌(:I)``,
+val setlevel_CARD = Q.store_thm("setlevel_CARD",
+  `∀l. setlevel l ≺ 𝕌(:I)`,
   Induct >> simp_tac std_ss [setlevel_def]
   >- (
     strip_tac >>
@@ -171,17 +171,17 @@ val setlevel_CARD = store_thm("setlevel_CARD",
       metis_tac[cardleq_lt_trans,CARDEQ_CROSS_SYM,cardleq_TRANS,cardleq_lteq] >>
     metis_tac[cardleq_dichotomy,CARD_MUL_LT_LEMMA,I_INFINITE]))
 
-val I_SET_SETLEVEL = store_thm("I_SET_SETLEVEL",
-  ``∀l s t. s ⊆ setlevel l ∧ t ⊆ setlevel l ∧
+val I_SET_SETLEVEL = Q.store_thm("I_SET_SETLEVEL",
+  `∀l s t. s ⊆ setlevel l ∧ t ⊆ setlevel l ∧
             (I_SET (setlevel l) s = I_SET (setlevel l) t)
-            ⇒ s = t``,
+            ⇒ s = t`,
   metis_tac[setlevel_CARD,I_SET_def])
 
 val universe_def = Define`
   universe = {(t,x) | x ∈ setlevel t}`
 
-val v_exists = prove(
-  ``∃a. a ∈ universe``,
+val v_exists = Q.prove(
+  `∃a. a ∈ universe`,
   qexists_tac`Ur_bool,I_BOOL T` >>
   rw[universe_def,setlevel_def])
 
@@ -194,8 +194,8 @@ val mk_V_onto   = prove_abs_fn_onto    v_bij
 val dest_V_11   = prove_rep_fn_one_one v_bij
 val dest_V_onto = prove_rep_fn_onto    v_bij
 
-val universe_IN = prove(
-  ``universe x ⇔ x ∈ universe``,
+val universe_IN = Q.prove(
+  `universe x ⇔ x ∈ universe`,
   rw[IN_DEF])
 
 val V_bij = store_thm("V_bij",
@@ -216,8 +216,8 @@ val level_def = Define`
 val element_def = Define`
   element x = SND(dest_V x)`
 
-val ELEMENT_IN_LEVEL = store_thm("ELEMENT_IN_LEVEL",
-  ``∀x. (element x) ∈ setlevel (level x)``,
+val ELEMENT_IN_LEVEL = Q.store_thm("ELEMENT_IN_LEVEL",
+  `∀x. (element x) ∈ setlevel (level x)`,
   rw[element_def,level_def,V_bij,v_bij])
 
 val SET = store_thm("SET",
@@ -241,17 +241,17 @@ val _ = Parse.add_infix("<=:",450,Parse.NONASSOC)
 val subset_def = xDefine"subset"`
   s <=: t ⇔ level s = level t ∧ ∀x. x <: s ⇒ x <: t`
 
-val MEMBERS_ISASET = store_thm("MEMBERS_ISASET",
-  ``∀x s. x <: s ⇒ isaset s``,
+val MEMBERS_ISASET = Q.store_thm("MEMBERS_ISASET",
+  `∀x s. x <: s ⇒ isaset s`,
   rw[inset_def,isaset_def])
 
-val LEVEL_NONEMPTY = store_thm("LEVEL_NONEMPTY",
-  ``∀l. ∃x. x ∈ setlevel l``,
+val LEVEL_NONEMPTY = Q.store_thm("LEVEL_NONEMPTY",
+  `∀l. ∃x. x ∈ setlevel l`,
   simp[MEMBER_NOT_EMPTY] >>
   Induct >> rw[setlevel_def,CROSS_EMPTY_EQN])
 
-val LEVEL_SET_EXISTS = store_thm("LEVEL_SET_EXISTS",
-  ``∀l. ∃s. level s = l``,
+val LEVEL_SET_EXISTS = Q.store_thm("LEVEL_SET_EXISTS",
+  `∀l. ∃s. level s = l`,
   mp_tac LEVEL_NONEMPTY >>
   simp[V_bij,level_def] >>
   metis_tac[FST])
@@ -274,8 +274,8 @@ val MK_V_SET = store_thm("MK_V_SET",
   SELECT_ELIM_TAC >>
   metis_tac[I_SET_SETLEVEL])
 
-val EMPTY_EXISTS = prove(
-  ``∀l. ∃s. level s = l ∧ ∀x. ¬(x <: s)``,
+val EMPTY_EXISTS = Q.prove(
+  `∀l. ∃s. level s = l ∧ ∀x. ¬(x <: s)`,
   Induct >> TRY (
     qexists_tac`mk_V(Powerset l,I_SET(setlevel l){})` >>
     simp[inset_def,MK_V_CLAUSES,MK_V_SET] >> NO_TAC ) >>
@@ -285,8 +285,8 @@ val emptyset_def =
   new_specification("emptyset_def",["emptyset"],
     SIMP_RULE std_ss [SKOLEM_THM] EMPTY_EXISTS)
 
-val COMPREHENSION_EXISTS = prove(
-  ``∀s p. ∃t. level t = level s ∧ ∀x. x <: t ⇔ x <: s ∧ p x``,
+val COMPREHENSION_EXISTS = Q.prove(
+  `∀s p. ∃t. level t = level s ∧ ∀x. x <: t ⇔ x <: s ∧ p x`,
   rpt gen_tac >>
   reverse(Cases_on`isaset s`) >- metis_tac[MEMBERS_ISASET] >>
   fs[isaset_def] >>
@@ -307,17 +307,17 @@ val suchthat_def =
   new_specification("suchthat_def",["suchthat"],
     SIMP_RULE std_ss [SKOLEM_THM] COMPREHENSION_EXISTS)
 
-val SETLEVEL_EXISTS = store_thm("SETLEVEL_EXISTS",
-  ``∀l. ∃s. (level s = Powerset l) ∧
-            ∀x. x <: s ⇔ level x = l ∧ element x ∈ setlevel l``,
+val SETLEVEL_EXISTS = Q.store_thm("SETLEVEL_EXISTS",
+  `∀l. ∃s. (level s = Powerset l) ∧
+            ∀x. x <: s ⇔ level x = l ∧ element x ∈ setlevel l`,
   gen_tac >>
   qexists_tac`mk_V(Powerset l,I_SET (setlevel l) (setlevel l))` >>
   simp[MK_V_SET,inset_def] >> metis_tac[])
 
-val SET_DECOMP = store_thm("SET_DECOMP",
-  ``∀s. isaset s ⇒
+val SET_DECOMP = Q.store_thm("SET_DECOMP",
+  `∀s. isaset s ⇒
         set s ⊆ setlevel(droplevel(level s)) ∧
-        I_SET (setlevel(droplevel(level s))) (set s) = element s``,
+        I_SET (setlevel(droplevel(level s))) (set s) = element s`,
   gen_tac >> simp[isaset_def] >> strip_tac >>
   simp[set_def] >>
   SELECT_ELIM_TAC >>
@@ -326,12 +326,12 @@ val SET_DECOMP = store_thm("SET_DECOMP",
   simp[setlevel_def,IN_POW] >>
   metis_tac[])
 
-val SET_SUBSET_SETLEVEL = store_thm("SET_SUBSET_SETLEVEL",
-  ``∀s. isaset s ⇒ set s ⊆ setlevel(droplevel(level s))``,
+val SET_SUBSET_SETLEVEL = Q.store_thm("SET_SUBSET_SETLEVEL",
+  `∀s. isaset s ⇒ set s ⊆ setlevel(droplevel(level s))`,
   metis_tac[SET_DECOMP])
 
-val POWERSET_EXISTS = prove(
-  ``∀s. ∃t. level t = Powerset(level s) ∧ ∀x. x <: t ⇔ x <=: s``,
+val POWERSET_EXISTS = Q.prove(
+  `∀s. ∃t. level t = Powerset(level s) ∧ ∀x. x <: t ⇔ x <=: s`,
   gen_tac >> Cases_on`isaset s` >- (
     fs[isaset_def] >>
     qspec_then`Powerset l`(Q.X_CHOOSE_THEN`t`strip_assume_tac)
@@ -361,16 +361,16 @@ val DEST_MK_PAIR = store_thm("DEST_MK_PAIR",
   simp[pair_def,GSYM V_bij] >>
   simp[PAIR_IN_LEVEL,ELEMENT_IN_LEVEL])
 
-val PAIR_INJ = store_thm("PAIR_INJ",
-  ``∀x1 y1 x2 y2. (pair x1 y1 = pair x2 y2) ⇔ (x1 = x2) ∧ (y1 = y2)``,
+val PAIR_INJ = Q.store_thm("PAIR_INJ",
+  `∀x1 y1 x2 y2. (pair x1 y1 = pair x2 y2) ⇔ (x1 = x2) ∧ (y1 = y2)`,
   simp[EQ_IMP_THM] >> rpt gen_tac >>
   disch_then(assume_tac o AP_TERM``dest_V``) >>
   fs[DEST_MK_PAIR,I_PAIR_def] >>
   fs[level_def,element_def] >>
   metis_tac[v_bij,PAIR_EQ,FST,SND,pair_CASES])
 
-val LEVEL_PAIR = store_thm("LEVEL_PAIR",
-  ``∀x y. level(pair x y) = Cartprod (level x) (level y)``,
+val LEVEL_PAIR = Q.store_thm("LEVEL_PAIR",
+  `∀x y. level(pair x y) = Cartprod (level x) (level y)`,
   rw[level_def,DEST_MK_PAIR])
 
 val fst_def = Define`
@@ -379,14 +379,14 @@ val fst_def = Define`
 val snd_def = Define`
   snd p = @y. ∃x. p = pair x y`
 
-val PAIR_CLAUSES = store_thm("PAIR_CLAUSES",
-  ``∀x y. (fst(pair x y) = x) ∧ (snd(pair x y) = y)``,
+val PAIR_CLAUSES = Q.store_thm("PAIR_CLAUSES",
+  `∀x y. (fst(pair x y) = x) ∧ (snd(pair x y) = y)`,
   rw[fst_def,snd_def] >> metis_tac[PAIR_INJ])
 
-val CARTESIAN_EXISTS = prove(
-  ``∀s t. ∃u. level u = Powerset(Cartprod (droplevel(level s))
+val CARTESIAN_EXISTS = Q.prove(
+  `∀s t. ∃u. level u = Powerset(Cartprod (droplevel(level s))
                                           (droplevel(level t))) ∧
-              ∀z. z <: u ⇔ ∃x y. (z = pair x y) ∧ x <: s ∧ y <: t``,
+              ∀z. z <: u ⇔ ∃x y. (z = pair x y) ∧ x <: s ∧ y <: t`,
   rpt gen_tac >>
   reverse(Cases_on`isaset s`) >- (
     metis_tac[EMPTY_EXISTS,MEMBERS_ISASET] ) >>
@@ -409,34 +409,34 @@ val PRODUCT_def =
   new_specification("PRODUCT_def",["product"],
     SIMP_RULE std_ss [SKOLEM_THM] CARTESIAN_EXISTS)
 
-val IN_SET_ELEMENT = store_thm("IN_SET_ELEMENT",
-  ``∀s. isaset s ∧ e ∈ set s ⇒
-        ∃x. e = element x ∧ level s = Powerset (level x) ∧ x <: s``,
+val IN_SET_ELEMENT = Q.store_thm("IN_SET_ELEMENT",
+  `∀s. isaset s ∧ e ∈ set s ⇒
+        ∃x. e = element x ∧ level s = Powerset (level x) ∧ x <: s`,
   rw[isaset_def] >>
   qexists_tac`mk_V(l,e)` >>
   simp[inset_def] >>
   qsuff_tac`e ∈ setlevel l` >- simp[MK_V_CLAUSES] >>
   metis_tac[isaset_def,SET_SUBSET_SETLEVEL,SUBSET_DEF,droplevel_def])
 
-val SUBSET_ALT = store_thm("SUBSET_ALT",
-  ``isaset s ∧ isaset t ⇒
-    (s <=: t ⇔ level s = level t ∧ set s SUBSET set t)``,
+val SUBSET_ALT = Q.store_thm("SUBSET_ALT",
+  `isaset s ∧ isaset t ⇒
+    (s <=: t ⇔ level s = level t ∧ set s SUBSET set t)`,
   simp[subset_def,inset_def] >>
   Cases_on`level s = level t` >> simp[SUBSET_DEF] >>
   metis_tac[IN_SET_ELEMENT])
 
-val SUBSET_ANTISYM_LEVEL = store_thm("SUBSET_ANTISYM_LEVEL",
-  ``∀s t. isaset s ∧ isaset t ∧ s <=: t ∧ t <=: s ⇒ s = t``,
+val SUBSET_ANTISYM_LEVEL = Q.store_thm("SUBSET_ANTISYM_LEVEL",
+  `∀s t. isaset s ∧ isaset t ∧ s <=: t ∧ t <=: s ⇒ s = t`,
   rw[] >> rfs[SUBSET_ALT] >>
   imp_res_tac SET_DECOMP >>
   metis_tac[SET,SUBSET_ANTISYM])
 
-val EXTENSIONALITY_LEVEL = store_thm("EXTENSIONALITY_LEVEL",
-  ``∀s t. isaset s ∧ isaset t ∧ level s = level t ∧ (∀x. x <: s ⇔ x <: t) ⇒ s = t``,
+val EXTENSIONALITY_LEVEL = Q.store_thm("EXTENSIONALITY_LEVEL",
+  `∀s t. isaset s ∧ isaset t ∧ level s = level t ∧ (∀x. x <: s ⇔ x <: t) ⇒ s = t`,
   metis_tac[SUBSET_ANTISYM_LEVEL,subset_def])
 
-val EXTENSIONALITY_NONEMPTY = store_thm("EXTENSIONALITY_NONEMPTY",
-  ``∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ∧ (∀x. x <: s ⇔ x <: t) ⇒ s = t``,
+val EXTENSIONALITY_NONEMPTY = Q.store_thm("EXTENSIONALITY_NONEMPTY",
+  `∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ∧ (∀x. x <: s ⇔ x <: t) ⇒ s = t`,
   metis_tac[EXTENSIONALITY_LEVEL,MEMBERS_ISASET,inset_def])
 
 val true_def = Define`
@@ -448,45 +448,45 @@ val false_def = Define`
 val boolset_def = Define`
   boolset = mk_V(Powerset Ur_bool,I_SET (setlevel Ur_bool) (setlevel Ur_bool))`
 
-val setlevel_bool = prove(
-  ``∀b. I_BOOL b ∈ setlevel Ur_bool``,
+val setlevel_bool = Q.prove(
+  `∀b. I_BOOL b ∈ setlevel Ur_bool`,
   simp[setlevel_def,I_BOOL_def])
 
-val IN_BOOL = store_thm("IN_BOOL",
-  ``∀x. x <: boolset ⇔ x = true ∨ x = false``,
+val IN_BOOL = Q.store_thm("IN_BOOL",
+  `∀x. x <: boolset ⇔ x = true ∨ x = false`,
   rw[inset_def,boolset_def,true_def,false_def] >>
   simp[MK_V_SET,setlevel_def] >>
   metis_tac[SET,V_bij,PAIR_EQ,ELEMENT_IN_LEVEL,setlevel_bool])
 
-val TRUE_NE_FALSE = store_thm("TRUE_NE_FALSE",
-  ``true ≠ false``,
+val TRUE_NE_FALSE = Q.store_thm("TRUE_NE_FALSE",
+  `true ≠ false`,
   rw[true_def,false_def] >>
   disch_then(mp_tac o AP_TERM``dest_V``) >> simp[] >>
   metis_tac[V_bij,setlevel_bool,PAIR_EQ,I_BOOL_def])
 
-val BOOLEAN_EQ = store_thm("BOOLEAN_EQ",
-  ``∀x y. x <: boolset ∧ y <: boolset ∧ ((x = true) ⇔ (y = true))
-          ⇒ x = y``,
+val BOOLEAN_EQ = Q.store_thm("BOOLEAN_EQ",
+  `∀x y. x <: boolset ∧ y <: boolset ∧ ((x = true) ⇔ (y = true))
+          ⇒ x = y`,
   metis_tac[TRUE_NE_FALSE,IN_BOOL])
 
 val indset_def = Define`
   indset = mk_V(Powerset Ur_ind,I_SET (setlevel Ur_ind) (setlevel Ur_ind))`
 
-val INDSET_IND_MODEL = store_thm("INDSET_IND_MODEL",
-  ``∃f. (∀i:ind_model. f i <: indset) ∧ (∀i j. f i = f j ⇒ i = j)``,
+val INDSET_IND_MODEL = Q.store_thm("INDSET_IND_MODEL",
+  `∃f. (∀i:ind_model. f i <: indset) ∧ (∀i j. f i = f j ⇒ i = j)`,
   qexists_tac`λi. mk_V(Ur_ind,I_IND i)` >> simp[] >>
   `!i. (I_IND i) ∈ setlevel Ur_ind` by (
     simp[setlevel_def] ) >>
   simp[MK_V_SET,indset_def,inset_def,MK_V_CLAUSES] >>
   metis_tac[V_bij,I_IND_def,ELEMENT_IN_LEVEL,PAIR_EQ])
 
-val INDSET_INHABITED = store_thm("INDSET_INHABITED",
-  ``∃x. x <: indset``,
+val INDSET_INHABITED = Q.store_thm("INDSET_INHABITED",
+  `∃x. x <: indset`,
   metis_tac[INDSET_IND_MODEL])
 
 val ch_def =
   new_specification("ch_def",["ch"],
-    prove(``∃ch. ∀s. (∃x. x <: s) ⇒ ch s <: s``,
+    Q.prove(`∃ch. ∀s. (∃x. x <: s) ⇒ ch s <: s`,
       simp[GSYM SKOLEM_THM] >> metis_tac[]))
 
 val IN_POWERSET = Q.prove
@@ -516,30 +516,30 @@ val abstract_def = Define`
   abstract s t f =
     (product s t suchthat λz. ∀x y. pair x y = z ⇒ y = f x)`
 
-val APPLY_ABSTRACT = store_thm("APPLY_ABSTRACT",
-  ``∀f x s t. x <: s ∧ f x <: t ⇒ apply(abstract s t f) x = f x``,
+val APPLY_ABSTRACT = Q.store_thm("APPLY_ABSTRACT",
+  `∀f x s t. x <: s ∧ f x <: t ⇒ apply(abstract s t f) x = f x`,
   rw[apply_def,abstract_def,IN_PRODUCT,suchthat_def] >>
   SELECT_ELIM_TAC >> rw[PAIR_INJ])
 
-val APPLY_IN_RANSPACE = store_thm("APPLY_IN_RANSPACE",
-  ``∀f x s t. x <: s ∧ f <: funspace s t ⇒ apply f x <: t``,
+val APPLY_IN_RANSPACE = Q.store_thm("APPLY_IN_RANSPACE",
+  `∀f x s t. x <: s ∧ f <: funspace s t ⇒ apply f x <: t`,
   simp[funspace_def,suchthat_def,IN_POWERSET,IN_PRODUCT,subset_def] >>
   rw[apply_def] >> metis_tac[PAIR_INJ])
 
-val ABSTRACT_IN_FUNSPACE = store_thm("ABSTRACT_IN_FUNSPACE",
-  ``∀f x s t. (∀x. x <: s ⇒ f x <: t) ⇒ abstract s t f <: funspace s t``,
+val ABSTRACT_IN_FUNSPACE = Q.store_thm("ABSTRACT_IN_FUNSPACE",
+  `∀f x s t. (∀x. x <: s ⇒ f x <: t) ⇒ abstract s t f <: funspace s t`,
   rw[funspace_def,abstract_def,suchthat_def,IN_POWERSET,IN_PRODUCT,subset_def,PAIR_INJ] >> metis_tac[])
 
-val FUNSPACE_INHABITED = store_thm("FUNSPACE_INHABITED",
-  ``∀s t. ((∃x. x <: s) ⇒ (∃y. y <: t)) ⇒ ∃f. f <: funspace s t``,
+val FUNSPACE_INHABITED = Q.store_thm("FUNSPACE_INHABITED",
+  `∀s t. ((∃x. x <: s) ⇒ (∃y. y <: t)) ⇒ ∃f. f <: funspace s t`,
   rw[] >> qexists_tac`abstract s t (λx. @y. y <: t)` >>
   match_mp_tac ABSTRACT_IN_FUNSPACE >> metis_tac[])
 
-val ABSTRACT_EQ = store_thm("ABSTRACT_EQ",
-  ``∀s t1 t2 f g.
+val ABSTRACT_EQ = Q.store_thm("ABSTRACT_EQ",
+  `∀s t1 t2 f g.
       (∃x. x <: s) ∧
       (∀x. x <: s ⇒ f x <: t1 ∧ g x <: t2 ∧ f x = g x)
-      ⇒ abstract s t1 f = abstract s t2 g``,
+      ⇒ abstract s t1 f = abstract s t2 g`,
   rw[abstract_def] >>
   match_mp_tac EXTENSIONALITY_NONEMPTY >>
   simp[suchthat_def,IN_PRODUCT,PAIR_INJ] >>
@@ -551,17 +551,17 @@ val boolean_def = Define`
 val holds_def = Define`
   holds s x ⇔ apply s x = true`
 
-val BOOLEAN_IN_BOOLSET = store_thm("BOOLEAN_IN_BOOLSET",
-  ``∀b. boolean b <: boolset``,
+val BOOLEAN_IN_BOOLSET = Q.store_thm("BOOLEAN_IN_BOOLSET",
+  `∀b. boolean b <: boolset`,
   metis_tac[boolean_def,IN_BOOL])
 
-val BOOLEAN_EQ_TRUE = store_thm("BOOLEAN_EQ_TRUE",
-  ``∀b. boolean b = true ⇔ b``,
+val BOOLEAN_EQ_TRUE = Q.store_thm("BOOLEAN_EQ_TRUE",
+  `∀b. boolean b = true ⇔ b`,
   metis_tac[boolean_def,TRUE_NE_FALSE])
 
-val in_funspace_abstract = store_thm("in_funspace_abstract",
-  ``∀z s t. z <: funspace s t ∧ (∃z. z <: s) ∧ (∃z. z <: t) ⇒
-    ∃f. z = abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)``,
+val in_funspace_abstract = Q.store_thm("in_funspace_abstract",
+  `∀z s t. z <: funspace s t ∧ (∃z. z <: s) ∧ (∃z. z <: t) ⇒
+    ∃f. z = abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)`,
   rw[funspace_def,suchthat_def,powerset_def] >>
   qexists_tac`λx. @y. pair x y <: z` >>
   conj_tac >- (
@@ -604,8 +604,8 @@ val in_funspace_abstract = store_thm("in_funspace_abstract",
 
 open relationTheory
 
-val WF_inset = store_thm("WF_inset",
-  ``WF $<:``,
+val WF_inset = Q.store_thm("WF_inset",
+  `WF $<:`,
   simp[WF_DEF] >> rw[] >>
   Induct_on`level w` >> TRY (
     rw[] >>

--- a/candle/set-theory/setModelScript.sml
+++ b/candle/set-theory/setModelScript.sml
@@ -12,8 +12,8 @@ val is_set_theory_pred_def = Define`
    (∀x y. is_v_rep x ∧ is_v_rep y ⇒ ∃z. is_v_rep z ∧ (∀a. is_v_rep a ⇒ (in_rep a z ⇔ (a = x ∨ a = y)))) ∧
    (∀x. is_v_rep x ⇒ ∃y. is_v_rep y ∧ (∀a. is_v_rep a ∧ in_rep a x ⇒ in_rep y x))`
 
-val l_model_exists = store_thm("l_model_exists",
-  ``∃(P : α+num -> bool) (mem : α+num -> α+num -> bool). is_set_theory_pred P mem``,
+val l_model_exists = Q.store_thm("l_model_exists",
+  `∃(P : α+num -> bool) (mem : α+num -> α+num -> bool). is_set_theory_pred P mem`,
   qexists_tac`ISR` >>
   REWRITE_TAC[is_set_theory_pred_def] >>
   qexists_tac`λl1 l2. BIT (OUTR l1) (OUTR l2)` >>
@@ -180,8 +180,8 @@ val V_mem_rep_def =
 
 val V_mem_def = Define`V_mem x y = V_mem_rep (dest_V x) (dest_V y)`
 
-val is_set_theory_V = store_thm("is_set_theory_V",
-  ``is_set_theory V_mem``,
+val is_set_theory_V = Q.store_thm("is_set_theory_V",
+  `is_set_theory V_mem`,
   simp[is_set_theory_def] >>
   conj_tac >- (
     simp[extensional_def] >>
@@ -223,8 +223,8 @@ val is_set_theory_V = store_thm("is_set_theory_V",
   simp[V_mem_def] >>
   metis_tac[V_bij] )
 
-val V_choice_exists = prove(
-  ``∃ch. is_choice V_mem ch``,
+val V_choice_exists = Q.prove(
+  `∃ch. is_choice V_mem ch`,
   simp[is_choice_def,GSYM SKOLEM_THM] >>
   rw[] >> simp[V_mem_def] >>
   qspecl_then[`dest_V x`]mp_tac

--- a/candle/set-theory/setModelScript.sml
+++ b/candle/set-theory/setModelScript.sml
@@ -239,9 +239,9 @@ val V_indset_def =
   new_specification("V_indset_def",["V_indset"],
     METIS_PROVE[]``∃i:α V. (∃x:α V. is_infinite V_mem x) ⇒ is_infinite V_mem i``)
 
-val is_model_V = store_thm("is_model_V",
-  ``(∃I:α V. is_infinite V_mem I) ⇒
-    is_model (V_mem,V_indset:α V,V_choice)``,
+val is_model_V = Q.store_thm("is_model_V",
+  `(∃I:α V. is_infinite V_mem I) ⇒
+    is_model (V_mem,V_indset:α V,V_choice)`,
   simp[is_model_def,is_set_theory_V,V_choice_def,V_indset_def])
 
 val _ = export_theory()

--- a/candle/set-theory/setSpecScript.sml
+++ b/candle/set-theory/setSpecScript.sml
@@ -180,9 +180,9 @@ val unit_eq_upair = Q.store_thm("unit_eq_upair",
   fs[extensional_def,mem_unit,mem_upair] >>
   metis_tac[])
 
-val pair_inj = store_thm("pair_inj",
-  ``is_set_theory ^mem ⇒
-    ∀a b c d. (a,b) = (c,d) ⇔ a = c ∧ b = d``,
+val pair_inj = Q.store_thm("pair_inj",
+  `is_set_theory ^mem ⇒
+    ∀a b c d. (a,b) = (c,d) ⇔ a = c ∧ b = d`,
   strip_tac >> fs[pair_def] >> rw[] >>
   simp[upair_inj,unit_inj,unit_eq_upair] >>
   metis_tac[])
@@ -205,9 +205,9 @@ val product_def = Define`
 
 val _ = Parse.overload_on("CROSS",``product ^mem``)
 
-val mem_product = store_thm("mem_product",
-  ``is_set_theory ^mem ⇒
-    ∀a x y. a <: (x × y) ⇔ ∃b c. a = (b,c) ∧ b <: x ∧ c <: y``,
+val mem_product = Q.store_thm("mem_product",
+  `is_set_theory ^mem ⇒
+    ∀a x y. a <: (x × y) ⇔ ∃b c. a = (b,c) ∧ b <: x ∧ c <: y`,
   strip_tac >> fs[product_def] >>
   simp[mem_sub,mem_power,mem_binary_union] >>
   rw[EQ_IMP_THM] >> TRY(metis_tac[]) >>
@@ -399,8 +399,8 @@ val tuple_def = Define`
   (tuple0 ^mem (a::as) = (a, tuple0 ^mem as))`
 val _ = Parse.overload_on("tuple",``tuple0 ^mem``)
 
-val pair_not_empty = store_thm("pair_not_empty",
-  ``is_set_theory ^mem ⇒ (x,y) ≠ ∅``,
+val pair_not_empty = Q.store_thm("pair_not_empty",
+  `is_set_theory ^mem ⇒ (x,y) ≠ ∅`,
   rw[] >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_empty] >>

--- a/candle/set-theory/setSpecScript.sml
+++ b/candle/set-theory/setSpecScript.sml
@@ -35,24 +35,24 @@ val is_set_theory_def = Define`
     (∃union. is_union mem union) ∧
     (∃upair. is_upair mem upair)`
 
-val separation_unique = store_thm("separation_unique",
-  ``extensional ^mem ⇒
-    ∀sub1 sub2. is_separation mem sub1 ∧ is_separation mem sub2 ⇒ sub1 = sub2``,
+val separation_unique = Q.store_thm("separation_unique",
+  `extensional ^mem ⇒
+    ∀sub1 sub2. is_separation mem sub1 ∧ is_separation mem sub2 ⇒ sub1 = sub2`,
   rw[is_separation_def,extensional_def,FUN_EQ_THM])
 
-val power_unique = store_thm("power_unique",
-  ``extensional ^mem ⇒
-    ∀power1 power2. is_power mem power1 ∧ is_power mem power2 ⇒ power1 = power2``,
+val power_unique = Q.store_thm("power_unique",
+  `extensional ^mem ⇒
+    ∀power1 power2. is_power mem power1 ∧ is_power mem power2 ⇒ power1 = power2`,
   rw[is_power_def,extensional_def,FUN_EQ_THM])
 
-val union_unique = store_thm("union_unique",
-  ``extensional ^mem ⇒
-    ∀union1 union2. is_union mem union1 ∧ is_union mem union2 ⇒ union1 = union2``,
+val union_unique = Q.store_thm("union_unique",
+  `extensional ^mem ⇒
+    ∀union1 union2. is_union mem union1 ∧ is_union mem union2 ⇒ union1 = union2`,
   rw[is_union_def,extensional_def,FUN_EQ_THM])
 
-val upair_unique = store_thm("upair_unique",
-  ``extensional ^mem ⇒
-    ∀upair1 upair2. is_upair mem upair1 ∧ is_upair mem upair2 ⇒ upair1 = upair2``,
+val upair_unique = Q.store_thm("upair_unique",
+  `extensional ^mem ⇒
+    ∀upair1 upair2. is_upair mem upair1 ∧ is_upair mem upair2 ⇒ upair1 = upair2`,
   rw[is_upair_def,extensional_def,FUN_EQ_THM])
 
 val sub_def = Define`
@@ -67,24 +67,24 @@ val union_def = Define`
 val upair_def = Define`
   upair ^mem = @upair. is_upair mem upair`
 
-val is_extensional = store_thm("is_extensional",
-  ``is_set_theory ^mem ⇒ extensional mem``,
+val is_extensional = Q.store_thm("is_extensional",
+  `is_set_theory ^mem ⇒ extensional mem`,
   rw[is_set_theory_def])
 
-val is_separation_sub = store_thm("is_separation_sub",
-  ``is_set_theory ^mem ⇒ is_separation mem (sub mem)``,
+val is_separation_sub = Q.store_thm("is_separation_sub",
+  `is_set_theory ^mem ⇒ is_separation mem (sub mem)`,
   rw[sub_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_power_power = store_thm("is_power_power",
-  ``is_set_theory ^mem ⇒ is_power mem (power mem)``,
+val is_power_power = Q.store_thm("is_power_power",
+  `is_set_theory ^mem ⇒ is_power mem (power mem)`,
   rw[power_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_union_union = store_thm("is_union_union",
-  ``is_set_theory ^mem ⇒ is_union mem (union mem)``,
+val is_union_union = Q.store_thm("is_union_union",
+  `is_set_theory ^mem ⇒ is_union mem (union mem)`,
   rw[union_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_upair_upair = store_thm("is_upair_upair",
-  ``is_set_theory ^mem ⇒ is_upair mem (upair mem)``,
+val is_upair_upair = Q.store_thm("is_upair_upair",
+  `is_set_theory ^mem ⇒ is_upair mem (upair mem)`,
   rw[upair_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
 val _ = Parse.add_infix("suchthat",9,Parse.LEFT)
@@ -92,22 +92,22 @@ val _ = Parse.overload_on("suchthat",``sub ^mem``)
 val _ = Parse.overload_on("Pow",``power ^mem``)
 val _ = Parse.overload_on("+",``upair ^mem``)
 
-val mem_sub = store_thm("mem_sub",
-  ``is_set_theory ^mem ⇒ ∀x s P. x <: (s suchthat P) ⇔ x <: s ∧ P x``,
+val mem_sub = Q.store_thm("mem_sub",
+  `is_set_theory ^mem ⇒ ∀x s P. x <: (s suchthat P) ⇔ x <: s ∧ P x`,
   strip_tac >> imp_res_tac is_separation_sub >> fs[is_separation_def])
 
-val mem_power = store_thm("mem_power",
-  ``is_set_theory ^mem ⇒
-    ∀x y. x <: (Pow y) ⇔ (∀b. b <: x ⇒ b <: y)``,
+val mem_power = Q.store_thm("mem_power",
+  `is_set_theory ^mem ⇒
+    ∀x y. x <: (Pow y) ⇔ (∀b. b <: x ⇒ b <: y)`,
   strip_tac >> imp_res_tac is_power_power >> fs[is_power_def])
 
-val mem_union = store_thm("mem_union",
-  ``is_set_theory ^mem ⇒
-    ∀x s. x <: (union mem s) ⇔ ∃a. x <: a ∧ a <: s``,
+val mem_union = Q.store_thm("mem_union",
+  `is_set_theory ^mem ⇒
+    ∀x s. x <: (union mem s) ⇔ ∃a. x <: a ∧ a <: s`,
   strip_tac >> imp_res_tac is_union_union >> fs[is_union_def])
 
-val mem_upair = store_thm("mem_upair",
-  ``is_set_theory ^mem ⇒ ∀a x y. a <: (x + y) ⇔ a = x ∨ a = y``,
+val mem_upair = Q.store_thm("mem_upair",
+  `is_set_theory ^mem ⇒ ∀a x y. a <: (x + y) ⇔ a = x ∨ a = y`,
   strip_tac >> imp_res_tac is_upair_upair >> fs[is_upair_def])
 
 val empty_def = Define`
@@ -115,8 +115,8 @@ val empty_def = Define`
 
 val _ = Parse.overload_on("∅",``empty ^mem``)
 
-val mem_empty = store_thm("mem_empty",
-  ``is_set_theory ^mem ⇒ ∀x. ¬(x <: ∅)``,
+val mem_empty = Q.store_thm("mem_empty",
+  `is_set_theory ^mem ⇒ ∀x. ¬(x <: ∅)`,
   strip_tac >> imp_res_tac is_separation_sub >>
   fs[empty_def,is_separation_def])
 
@@ -125,15 +125,15 @@ val unit_def = Define`
 
 val _ = Parse.overload_on("Unit",``unit ^mem``)
 
-val mem_unit = store_thm("mem_unit",
-  ``is_set_theory ^mem ⇒
-    ∀x y. x <: (Unit y) ⇔ x = y``,
+val mem_unit = Q.store_thm("mem_unit",
+  `is_set_theory ^mem ⇒
+    ∀x y. x <: (Unit y) ⇔ x = y`,
   strip_tac >> imp_res_tac is_upair_upair >>
   fs[is_upair_def,unit_def])
 
-val unit_inj = store_thm("unit_inj",
-  ``is_set_theory ^mem ⇒
-    ∀x y. Unit x = Unit y ⇔ x = y``,
+val unit_inj = Q.store_thm("unit_inj",
+  `is_set_theory ^mem ⇒
+    ∀x y. Unit x = Unit y ⇔ x = y`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_unit] >>
@@ -144,9 +144,9 @@ val one_def = Define`
 
 val _ = Parse.overload_on("One",``one ^mem``)
 
-val mem_one = store_thm("mem_one",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: One ⇔ x = ∅``,
+val mem_one = Q.store_thm("mem_one",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: One ⇔ x = ∅`,
   strip_tac >> simp[mem_unit,one_def])
 
 val two_def = Define`
@@ -154,9 +154,9 @@ val two_def = Define`
 
 val _ = Parse.overload_on("Two",``two ^mem``)
 
-val mem_two = store_thm("mem_two",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: Two ⇔ x = ∅ ∨ x = One``,
+val mem_two = Q.store_thm("mem_two",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: Two ⇔ x = ∅ ∨ x = One`,
   strip_tac >> simp[mem_upair,mem_one,two_def])
 
 val pair_def = Define`
@@ -164,17 +164,17 @@ val pair_def = Define`
 
 val _ = Parse.overload_on(",",``pair ^mem``)
 
-val upair_inj = store_thm("upair_inj",
-  ``is_set_theory ^mem ⇒
-    ∀a b c d. a + b = c + d ⇔ a = c ∧ b = d ∨ a = d ∧ b = c``,
+val upair_inj = Q.store_thm("upair_inj",
+  `is_set_theory ^mem ⇒
+    ∀a b c d. a + b = c + d ⇔ a = c ∧ b = d ∨ a = d ∧ b = c`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_upair] >>
   metis_tac[])
 
-val unit_eq_upair = store_thm("unit_eq_upair",
-  ``is_set_theory ^mem ⇒
-    ∀x y z. Unit x = y + z ⇔ x = y ∧ y = z``,
+val unit_eq_upair = Q.store_thm("unit_eq_upair",
+  `is_set_theory ^mem ⇒
+    ∀x y z. Unit x = y + z ⇔ x = y ∧ y = z`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_unit,mem_upair] >>
@@ -192,9 +192,9 @@ val binary_union_def = Define`
 
 val _ = Parse.overload_on("UNION",``binary_union ^mem``)
 
-val mem_binary_union = store_thm("mem_binary_union",
-  ``is_set_theory ^mem ⇒
-    ∀a x y. a <: (x ∪ y) ⇔ a <: x ∨ a <: y``,
+val mem_binary_union = Q.store_thm("mem_binary_union",
+  `is_set_theory ^mem ⇒
+    ∀a x y. a <: (x ∪ y) ⇔ a <: x ∨ a <: y`,
   strip_tac >> fs[binary_union_def,mem_union,mem_upair] >>
   metis_tac[])
 
@@ -242,17 +242,17 @@ val false_def = Define`
 val _ = Parse.overload_on("True",``true ^mem``)
 val _ = Parse.overload_on("False",``false ^mem``)
 
-val true_neq_false = store_thm("true_neq_false",
-  ``is_set_theory ^mem ⇒ True ≠ False``,
+val true_neq_false = Q.store_thm("true_neq_false",
+  `is_set_theory ^mem ⇒ True ≠ False`,
   strip_tac >>
   imp_res_tac mem_one >>
   imp_res_tac mem_empty >>
   fs[true_def,false_def,is_set_theory_def,extensional_def,one_def] >>
   metis_tac[])
 
-val mem_boolset = store_thm("mem_boolset",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: boolset ⇔ ((x = True) ∨ (x = False))``,
+val mem_boolset = Q.store_thm("mem_boolset",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: boolset ⇔ ((x = True) ∨ (x = False))`,
   strip_tac >> fs[mem_two,true_def,false_def])
 
 val boolean_def = Define`
@@ -260,14 +260,14 @@ val boolean_def = Define`
 
 val _ = Parse.overload_on("Boolean",``boolean ^mem``)
 
-val boolean_in_boolset = store_thm("boolean_in_boolset",
-  ``is_set_theory ^mem ⇒
-    ∀b. Boolean b <: boolset``,
+val boolean_in_boolset = Q.store_thm("boolean_in_boolset",
+  `is_set_theory ^mem ⇒
+    ∀b. Boolean b <: boolset`,
   strip_tac >> imp_res_tac mem_boolset >>
   Cases >> simp[boolean_def])
 
-val boolean_eq_true = store_thm("boolean_eq_true",
-  ``is_set_theory ^mem ⇒ ∀b. Boolean b = True ⇔ b``,
+val boolean_eq_true = Q.store_thm("boolean_eq_true",
+  `is_set_theory ^mem ⇒ ∀b. Boolean b = True ⇔ b`,
   strip_tac >> rw[boolean_def,true_neq_false])
 
 val holds_def = Define`
@@ -280,44 +280,44 @@ val abstract_def = Define`
 
 val _ = Parse.overload_on("Abstract",``abstract ^mem``)
 
-val apply_abstract = store_thm("apply_abstract",
-  ``is_set_theory ^mem ⇒
-    ∀f x s t. x <: s ∧ f x <: t ⇒ (Abstract s t f) ' x = f x``,
+val apply_abstract = Q.store_thm("apply_abstract",
+  `is_set_theory ^mem ⇒
+    ∀f x s t. x <: s ∧ f x <: t ⇒ (Abstract s t f) ' x = f x`,
   strip_tac >>
   rw[apply_def,abstract_def] >>
   SELECT_ELIM_TAC >>
   simp[mem_sub,mem_product,pair_inj])
 
-val apply_abstract_matchable = store_thm("apply_abstract_matchable",
-  ``∀f x s t u. x <: s ∧ f x <: t ∧ is_set_theory ^mem ∧ f x = u ⇒ Abstract s t f ' x = u``,
+val apply_abstract_matchable = Q.store_thm("apply_abstract_matchable",
+  `∀f x s t u. x <: s ∧ f x <: t ∧ is_set_theory ^mem ∧ f x = u ⇒ Abstract s t f ' x = u`,
   metis_tac[apply_abstract])
 
-val apply_in_rng = store_thm("apply_in_rng",
-  ``is_set_theory ^mem ⇒
+val apply_in_rng = Q.store_thm("apply_in_rng",
+  `is_set_theory ^mem ⇒
     ∀f x s t. x <: s ∧ f <: Funspace s t ⇒
-    f ' x <: t``,
+    f ' x <: t`,
   strip_tac >>
   simp[funspace_def,mem_sub,relspace_def,
        mem_power,apply_def,mem_product,EXISTS_UNIQUE_THM] >>
   rw[] >> res_tac >> SELECT_ELIM_TAC >> res_tac >> rfs[pair_inj] >> metis_tac[])
 
-val abstract_in_funspace = store_thm("abstract_in_funspace",
-  ``is_set_theory ^mem ⇒
-    ∀f s t. (∀x. x <: s ⇒ f x <: t) ⇒ Abstract s t f <: Funspace s t``,
+val abstract_in_funspace = Q.store_thm("abstract_in_funspace",
+  `is_set_theory ^mem ⇒
+    ∀f s t. (∀x. x <: s ⇒ f x <: t) ⇒ Abstract s t f <: Funspace s t`,
   strip_tac >>
   simp[funspace_def,relspace_def,abstract_def,mem_power,mem_product,mem_sub] >>
   simp[EXISTS_UNIQUE_THM,pair_inj])
 
-val abstract_in_funspace_matchable = store_thm("abstract_in_funspace_matchable",
-  ``is_set_theory ^mem ⇒
-    ∀f s t fs. (∀x. x <: s ⇒ f x <: t) ∧ fs = Funspace s t ⇒ Abstract s t f <: fs``,
+val abstract_in_funspace_matchable = Q.store_thm("abstract_in_funspace_matchable",
+  `is_set_theory ^mem ⇒
+    ∀f s t fs. (∀x. x <: s ⇒ f x <: t) ∧ fs = Funspace s t ⇒ Abstract s t f <: fs`,
   PROVE_TAC[abstract_in_funspace])
 
-val abstract_eq = store_thm("abstract_eq",
-  ``is_set_theory ^mem ⇒
+val abstract_eq = Q.store_thm("abstract_eq",
+  `is_set_theory ^mem ⇒
     ∀s t1 t2 f g.
     (∀x. x <: s ⇒ f x <: t1 ∧ g x <: t2 ∧ f x = g x)
-    ⇒ Abstract s t1 f = Abstract s t2 g``,
+    ⇒ Abstract s t1 f = Abstract s t2 g`,
   rw[] >>
   imp_res_tac is_extensional >>
   pop_assum mp_tac >>
@@ -326,10 +326,10 @@ val abstract_eq = store_thm("abstract_eq",
   simp[abstract_def,mem_sub,mem_product] >>
   metis_tac[pair_inj])
 
-val in_funspace_abstract = store_thm("in_funspace_abstract",
-  ``is_set_theory ^mem ⇒
+val in_funspace_abstract = Q.store_thm("in_funspace_abstract",
+  `is_set_theory ^mem ⇒
     ∀z s t. z <: Funspace s t ⇒
-    ∃f. z = Abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)``,
+    ∃f. z = Abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)`,
   rw[funspace_def,mem_sub,relspace_def,mem_power] >>
   qexists_tac`λx. @y. (x,y) <: z` >>
   conj_tac >- (
@@ -379,17 +379,17 @@ val is_model_def = Define`
     is_infinite mem indset ∧
     is_choice mem ch`
 
-val is_model_is_set_theory = store_thm("is_model_is_set_theory",
-  ``is_model M ⇒ is_set_theory ^mem``,
+val is_model_is_set_theory = Q.store_thm("is_model_is_set_theory",
+  `is_model M ⇒ is_set_theory ^mem`,
   rw[is_model_def])
 
-val indset_inhabited = store_thm("indset_inhabited",
-  ``is_infinite ^mem indset ⇒ ∃i. i <: indset``,
+val indset_inhabited = Q.store_thm("indset_inhabited",
+  `is_infinite ^mem indset ⇒ ∃i. i <: indset`,
   rw[is_infinite_def] >> imp_res_tac INFINITE_INHAB >>
   fs[] >> metis_tac[])
 
-val funspace_inhabited = store_thm("funspace_inhabited",
-  ``is_set_theory ^mem ⇒ ∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ⇒ ∃f. f <: Funspace s t``,
+val funspace_inhabited = Q.store_thm("funspace_inhabited",
+  `is_set_theory ^mem ⇒ ∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ⇒ ∃f. f <: Funspace s t`,
   rw[] >> qexists_tac`Abstract s t (λx. @x. x <: t)` >>
   match_mp_tac (MP_CANON abstract_in_funspace) >>
   metis_tac[])
@@ -408,14 +408,14 @@ val pair_not_empty = store_thm("pair_not_empty",
   simp[pair_def,mem_upair] >>
   metis_tac[])
 
-val tuple_empty = store_thm("tuple_empty",
-  ``is_set_theory ^mem ⇒ ∀ls. tuple ls = ∅ ⇔ ls = []``,
+val tuple_empty = Q.store_thm("tuple_empty",
+  `is_set_theory ^mem ⇒ ∀ls. tuple ls = ∅ ⇔ ls = []`,
   strip_tac >> Cases >> simp[tuple_def] >>
   simp[pair_not_empty] )
 
-val tuple_inj = store_thm("tuple_inj",
-  ``is_set_theory ^mem ⇒
-    ∀l1 l2. tuple l1 = tuple l2 ⇔ l1 = l2``,
+val tuple_inj = Q.store_thm("tuple_inj",
+  `is_set_theory ^mem ⇒
+    ∀l1 l2. tuple l1 = tuple l2 ⇔ l1 = l2`,
   strip_tac >>
   Induct >> simp[tuple_def] >- metis_tac[tuple_empty] >>
   gen_tac >> Cases >> simp[tuple_def,pair_not_empty] >>
@@ -426,9 +426,9 @@ val bigcross_def = Define`
   (bigcross0 ^mem (a::as) = a × (bigcross0 ^mem as))`
 val _ = Parse.overload_on("bigcross",``bigcross0 ^mem``)
 
-val mem_bigcross = store_thm("mem_bigcross",
-  ``is_set_theory ^mem ⇒
-    ∀ls x. (mem x (bigcross ls) ⇔ ∃xs. x = tuple xs ∧ LIST_REL mem xs ls)``,
+val mem_bigcross = Q.store_thm("mem_bigcross",
+  `is_set_theory ^mem ⇒
+    ∀ls x. (mem x (bigcross ls) ⇔ ∃xs. x = tuple xs ∧ LIST_REL mem xs ls)`,
   strip_tac >> Induct >>
   simp[bigcross_def,tuple_def,mem_one] >>
   simp[mem_product,PULL_EXISTS,tuple_def])

--- a/candle/standard/ml_kernel/ml_hol_initScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_initScript.sml
@@ -5,10 +5,10 @@ open terminationTheory
 
 val _ = new_theory"ml_hol_init"
 
-val kernel_init_thm = store_thm("kernel_init_thm",
-  ``∃refs.
+val kernel_init_thm = Q.store_thm("kernel_init_thm",
+  `∃refs.
       HOL_STORE (candle_init_state ffi).refs refs ∧
-      STATE init_ctxt refs``,
+      STATE init_ctxt refs`,
   qexists_tac`<|
     the_type_constants := init_type_constants;
     the_term_constants := init_term_constants;

--- a/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
@@ -118,8 +118,8 @@ fun derive_case_of ty = let
          ((Pcon xx pats,exp2)::pats2) errv (yyy,y)``
     |> (ONCE_REWRITE_CONV [evaluate_cases] THENC
         SIMP_CONV (srw_ss()) [pmatch_def])
-  val IF_T = prove(``(if T then x else y) = x:'a``,SIMP_TAC std_ss []);
-  val IF_F = prove(``(if F then x else y) = y:'a``,SIMP_TAC std_ss []);
+  val IF_T = Q.prove(`(if T then x else y) = x:'a`,SIMP_TAC std_ss []);
+  val IF_F = Q.prove(`(if F then x else y) = y:'a`,SIMP_TAC std_ss []);
   val init_tac =
         PURE_REWRITE_TAC [CONTAINER_def]
         \\ REPEAT STRIP_TAC \\ STRIP_ASSUME_TAC (Q.SPEC `x` case_th)
@@ -272,7 +272,7 @@ fun inst_case_thm tm m2deep = let
 
 (* PMATCH *)
 
-val IMP_EQ_T = prove(``a ==> (a <=> T)``,fs [])
+val IMP_EQ_T = Q.prove(`a ==> (a <=> T)`,fs [])
 
 val prove_EvalMPatBind_fail = ref T;
 val goal = !prove_EvalMPatBind_fail;
@@ -808,7 +808,7 @@ val res = translate listTheory.APPEND;
 val res = translate mlstringTheory.strcat_def;
 val res = translate stringTheory.string_lt_def
 val res = translate stringTheory.string_le_def
-val res = prove(``mlstring_lt x1 x2 = string_lt (explode x1) (explode x2)``,
+val res = Q.prove(`mlstring_lt x1 x2 = string_lt (explode x1) (explode x2)`,
                 Cases_on`x1`>>Cases_on`x2`>>rw[mlstringTheory.mlstring_lt_def])
           |> translate
 val res = translate totoTheory.TO_of_LinearOrder
@@ -874,9 +874,9 @@ val type_compare_def = tDefine "type_compare" `
                   INR (x,_) => type1_size x
                 | INL (x,_) => type_size x)`)
 
-val type_cmp_thm = prove(
-  ``(type_cmp = type_compare) /\
-    (list_cmp type_cmp = type_list_compare)``,
+val type_cmp_thm = Q.prove(
+  `(type_cmp = type_compare) /\
+    (list_cmp type_cmp = type_list_compare)`,
   fs [FUN_EQ_THM]
   \\ HO_MATCH_MP_TAC (fetch "-" "type_compare_ind")
   \\ REPEAT STRIP_TAC \\ fs []
@@ -927,8 +927,8 @@ val term_compare_def = Define `
          | Equal => term_compare t1' t2'
          | Greater => Greater`;
 
-val term_cmp_thm = prove(
-  ``term_cmp = term_compare``,
+val term_cmp_thm = Q.prove(
+  `term_cmp = term_compare`,
   fs [FUN_EQ_THM]
   \\ HO_MATCH_MP_TAC (fetch "-" "term_compare_ind")
   \\ REPEAT STRIP_TAC \\ fs []

--- a/candle/standard/ml_kernel/ml_monadProgScript.sml
+++ b/candle/standard/ml_kernel/ml_monadProgScript.sml
@@ -29,14 +29,14 @@ val _ = ml_prog_update (open_module "Kernel");
 
 val _ = register_type ``:type``;
 
-val MEM_type_size = prove(
-  ``!ts t. MEM t ts ==> type_size t < type1_size ts``,
+val MEM_type_size = Q.prove(
+  `!ts t. MEM t ts ==> type_size t < type1_size ts`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [] \\ REPEAT STRIP_TAC \\ RES_TAC
   \\ EVAL_TAC \\ FULL_SIMP_TAC std_ss [] \\ DECIDE_TAC);
 
-val type_ind = store_thm("type_ind",
-  ``(!s ts. (!t. MEM t ts ==> P t) ==> P (Tyapp s ts)) /\
-    (!v. P (Tyvar v)) ==> !x. P x``,
+val type_ind = Q.store_thm("type_ind",
+  `(!s ts. (!t. MEM t ts ==> P t) ==> P (Tyapp s ts)) /\
+    (!v. P (Tyvar v)) ==> !x. P x`,
   REPEAT STRIP_TAC \\ completeInduct_on `type_size x`
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [PULL_FORALL]
   \\ Cases_on `x` \\ FULL_SIMP_TAC std_ss []
@@ -46,49 +46,49 @@ val type_ind = store_thm("type_ind",
 
 val TYPE_TYPE_def = fetch "-" "TYPE_TYPE_def"
 
-val LIST_TYPE_NO_CLOSURES = prove(
-  ``!xs v.
+val LIST_TYPE_NO_CLOSURES = Q.prove(
+  `!xs v.
       (!x v. MEM x xs /\ p x v ==> no_closures v) /\
-      LIST_TYPE p xs v ==> no_closures v``,
+      LIST_TYPE p xs v ==> no_closures v`,
   Induct \\ FULL_SIMP_TAC std_ss [LIST_TYPE_def]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [no_closures_def,EVERY_DEF,MEM]
   \\ METIS_TAC []);
 
-val LIST_TYPE_11 = prove(
-  ``!P ts v1 us v2.
+val LIST_TYPE_11 = Q.prove(
+  `!P ts v1 us v2.
       (!x1.
        MEM x1 ts ==>
         !v1 x2 v2.
           P x1 v1 /\ P x2 v2 ==>
           types_match v1 v2 /\ ((v1 = v2) <=> (x1 = x2))) /\
     LIST_TYPE P ts v1 /\ LIST_TYPE P us v2 ==>
-    types_match v1 v2 /\ ((v1 = v2) = (ts = us))``,
+    types_match v1 v2 /\ ((v1 = v2) = (ts = us))`,
   STRIP_TAC \\ Induct \\ Cases_on `us` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ SIMP_TAC (srw_ss()) [LIST_TYPE_def,types_match_def,ctor_same_type_def]
   \\ FULL_SIMP_TAC (srw_ss()) [PULL_EXISTS,types_match_def,ctor_same_type_def]
   \\ METIS_TAC []);
 
-val CHAR_IMP_no_closures = prove(
-  ``CHAR x v ==> no_closures v``,
+val CHAR_IMP_no_closures = Q.prove(
+  `CHAR x v ==> no_closures v`,
   SIMP_TAC std_ss [CHAR_def,no_closures_def]);
 
-val STRING_IMP_no_closures = prove(
-  ``STRING_TYPE x v ==> no_closures v``,
+val STRING_IMP_no_closures = Q.prove(
+  `STRING_TYPE x v ==> no_closures v`,
   SIMP_TAC std_ss [STRING_TYPE_def,no_closures_def]);
 
-val EqualityType_thm = prove(
-  ``EqualityType abs <=>
+val EqualityType_thm = Q.prove(
+  `EqualityType abs <=>
       (!x1 v1. abs x1 v1 ==> no_closures v1) /\
       (!x1 v1 x2 v2. abs x1 v1 /\ abs x2 v2 ==> types_match v1 v2 /\
-                                                (v1 = v2 <=> x1 = x2))``,
+                                                (v1 = v2 <=> x1 = x2))`,
   SIMP_TAC std_ss [EqualityType_def] \\ METIS_TAC []);
 
-val STRING_TYPE_lemma = prove(
-  ``EqualityType (STRING_TYPE)``,
+val STRING_TYPE_lemma = Q.prove(
+  `EqualityType (STRING_TYPE)`,
   METIS_TAC (eq_lemmas ()));
 
-val EqualityType_TYPE = prove(
-  ``EqualityType TYPE_TYPE``,
+val EqualityType_TYPE = Q.prove(
+  `EqualityType TYPE_TYPE`,
   SIMP_TAC std_ss [EqualityType_thm] \\ STRIP_TAC THEN1
    (HO_MATCH_MP_TAC type_ind
     \\ FULL_SIMP_TAC std_ss [TYPE_TYPE_def]
@@ -168,9 +168,9 @@ val HOL_MONAD_def = Define `
 
 (* return *)
 
-val EvalM_return = store_thm("EvalM_return",
-  ``Eval env exp (a x) ==>
-    EvalM env exp (HOL_MONAD a (ex_return x))``,
+val EvalM_return = Q.store_thm("EvalM_return",
+  `Eval env exp (a x) ==>
+    EvalM env exp (HOL_MONAD a (ex_return x))`,
   SIMP_TAC std_ss [Eval_def,EvalM_def,HOL_MONAD_def,ex_return_def]
   \\ REPEAT STRIP_TAC \\ Q.LIST_EXISTS_TAC [`s`,`Rval res`,`refs`]
   \\ IMP_RES_TAC (evaluate_empty_state_IMP
@@ -179,10 +179,10 @@ val EvalM_return = store_thm("EvalM_return",
 
 (* bind *)
 
-val EvalM_bind = store_thm("EvalM_bind",
-  ``EvalM env e1 (HOL_MONAD b (x:'b M)) /\
+val EvalM_bind = Q.store_thm("EvalM_bind",
+  `EvalM env e1 (HOL_MONAD b (x:'b M)) /\
     (!x v. b x v ==> EvalM (write name v env) e2 (HOL_MONAD a ((f x):'a M))) ==>
-    EvalM env (Let (SOME name) e1 e2) (HOL_MONAD a (ex_bind x f))``,
+    EvalM env (Let (SOME name) e1 e2) (HOL_MONAD a (ex_bind x f))`,
   SIMP_TAC std_ss [EvalM_def,HOL_MONAD_def,ex_return_def] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [PULL_EXISTS] \\ RES_TAC
   \\ Cases_on `x refs` \\ Cases_on `q`
@@ -248,10 +248,10 @@ val evaluate_list_cases = let
           (``evaluate_list a5 a6 a7 (x::xs) (a9,Rval a10)``
            |> SIMP_CONV (srw_ss()) [Once lemma]) end
 
-val EvalM_ArrowM = store_thm("EvalM_ArrowM",
-  ``EvalM env x1 ((a -M-> b) f) ==>
+val EvalM_ArrowM = Q.store_thm("EvalM_ArrowM",
+  `EvalM env x1 ((a -M-> b) f) ==>
     EvalM env x2 (a x) ==>
-    EvalM env (App Opapp [x1;x2]) (b (f x))``,
+    EvalM env (App Opapp [x1;x2]) (b (f x))`,
   SIMP_TAC std_ss [EvalM_def,ArrowM_def,ArrowP_def,PURE_def] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [PULL_EXISTS]
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -271,9 +271,9 @@ val EvalM_ArrowM = store_thm("EvalM_ArrowM",
   \\ Q.LIST_EXISTS_TAC [`s3`,`res3`,`refs3`] \\ FULL_SIMP_TAC std_ss []
   \\ DISJ1_TAC \\ FULL_SIMP_TAC std_ss [any_evaluate_closure_def]);
 
-val EvalM_Fun = store_thm("EvalM_Fun",
-  ``(!v x. a x v ==> EvalM (write name v env) body (b (f x))) ==>
-    EvalM env (Fun name body) ((PURE a -M-> b) f)``,
+val EvalM_Fun = Q.store_thm("EvalM_Fun",
+  `(!v x. a x v ==> EvalM (write name v env) body (b (f x))) ==>
+    EvalM env (Fun name body) ((PURE a -M-> b) f)`,
   SIMP_TAC std_ss [EvalM_def,ArrowM_def,ArrowP_def,PURE_def,Eq_def]
   \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -281,9 +281,9 @@ val EvalM_Fun = store_thm("EvalM_Fun",
   \\ FULL_SIMP_TAC (srw_ss())
        [any_evaluate_closure_def,do_app_def,do_opapp_def,write_def]);
 
-val EvalM_Fun_Eq = store_thm("EvalM_Fun_Eq",
-  ``(!v. a x v ==> EvalM (write name v env) body (b (f x))) ==>
-    EvalM env (Fun name body) ((PURE (Eq a x) -M-> b) f)``,
+val EvalM_Fun_Eq = Q.store_thm("EvalM_Fun_Eq",
+  `(!v. a x v ==> EvalM (write name v env) body (b (f x))) ==>
+    EvalM env (Fun name body) ((PURE (Eq a x) -M-> b) f)`,
   SIMP_TAC std_ss [EvalM_def,ArrowM_def,ArrowP_def,PURE_def,Eq_def]
   \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -291,28 +291,28 @@ val EvalM_Fun_Eq = store_thm("EvalM_Fun_Eq",
   \\ FULL_SIMP_TAC (srw_ss())
        [any_evaluate_closure_def,do_app_def,do_opapp_def,write_def]);
 
-val Eval_IMP_PURE = store_thm("Eval_IMP_PURE",
-  ``Eval env exp (P x) ==> EvalM env exp (PURE P x)``,
+val Eval_IMP_PURE = Q.store_thm("Eval_IMP_PURE",
+  `Eval env exp (P x) ==> EvalM env exp (PURE P x)`,
   SIMP_TAC std_ss [Eval_def,EvalM_def,PURE_def,PULL_EXISTS]
   \\ REPEAT STRIP_TAC \\ Q.EXISTS_TAC `res`
   \\ IMP_RES_TAC (evaluate_empty_state_IMP
                   |> INST_TYPE [``:'ffi``|->``:unit``])
   \\ ASM_SIMP_TAC std_ss []);
 
-val TYPE_TYPE_EXISTS = prove(
-  ``?ty v. TYPE_TYPE ty v``,
+val TYPE_TYPE_EXISTS = Q.prove(
+  `?ty v. TYPE_TYPE ty v`,
   Q.EXISTS_TAC `Tyvar (strlit [])`
   \\ fs [fetch "-" "TYPE_TYPE_def", STRING_TYPE_def]);
 
-val TERM_TYPE_EXISTS = prove(
-  ``?tm v. TERM_TYPE tm v``,
+val TERM_TYPE_EXISTS = Q.prove(
+  `?tm v. TERM_TYPE tm v`,
   STRIP_ASSUME_TAC TYPE_TYPE_EXISTS
   \\ Q.EXISTS_TAC `Var (strlit []) ty`
   \\ fs [fetch "-" "TERM_TYPE_def",STRING_TYPE_def]
   \\ Q.EXISTS_TAC `v` \\ FULL_SIMP_TAC std_ss []);
 
-val HOL_STORE_EXISTS = store_thm("HOL_STORE_EXISTS",
-  ``?(s:unit state) refs. HOL_STORE s.refs refs``,
+val HOL_STORE_EXISTS = Q.store_thm("HOL_STORE_EXISTS",
+  `?(s:unit state) refs. HOL_STORE s.refs refs`,
   SIMP_TAC std_ss [HOL_STORE_def]
   \\ Q.EXISTS_TAC `<| refs :=
                    [Refv (Conv (SOME ("nil",TypeId (Short "list"))) []);
@@ -326,32 +326,32 @@ val HOL_STORE_EXISTS = store_thm("HOL_STORE_EXISTS",
                       the_axioms         := [] |>`
   \\ FULL_SIMP_TAC (srw_ss()) [LIST_TYPE_def]);
 
-val LOOKUP_VAR_EvalM_IMP = store_thm("LOOKUP_VAR_EvalM_IMP",
-  ``(!env. LOOKUP_VAR n env v ==> EvalM env (Var (Short n)) (PURE P g)) ==>
-    P g v``,
+val LOOKUP_VAR_EvalM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_IMP",
+  `(!env. LOOKUP_VAR n env v ==> EvalM env (Var (Short n)) (PURE P g)) ==>
+    P g v`,
   fs [LOOKUP_VAR_def,lookup_var_def,EvalM_def,PURE_def,AND_IMP_INTRO,
       Once evaluate_cases,PULL_EXISTS,lookup_var_id_def,PULL_FORALL]
   \\ rw [] \\ pop_assum match_mp_tac
   \\ qexists_tac `<|v := [n,v]|>` \\ fs []
   \\ metis_tac [HOL_STORE_EXISTS]);
 
-val EvalM_Fun_PURE_IMP = store_thm("EvalM_Fun_PURE_IMP",
-  ``EvalM env (Fun n exp) (PURE P f) ==>
-    P f (Closure env n exp)``,
+val EvalM_Fun_PURE_IMP = Q.store_thm("EvalM_Fun_PURE_IMP",
+  `EvalM env (Fun n exp) (PURE P f) ==>
+    P f (Closure env n exp)`,
   fs [EvalM_def,PURE_def,PULL_EXISTS,evaluate_Fun]
   \\ rw [] \\ pop_assum match_mp_tac \\ metis_tac [HOL_STORE_EXISTS])
 
-val EvalM_ArrowM_IMP = store_thm("EvalM_ArrowM_IMP",
-  ``EvalM env (Var x) ((a -M-> b) f) ==>
-    Eval env (Var x) (ArrowP a b f)``,
+val EvalM_ArrowM_IMP = Q.store_thm("EvalM_ArrowM_IMP",
+  `EvalM env (Var x) ((a -M-> b) f) ==>
+    Eval env (Var x) (ArrowP a b f)`,
   SIMP_TAC std_ss [ArrowM_def,EvalM_def,Eval_def,PURE_def,PULL_EXISTS]
   \\ REPEAT STRIP_TAC \\ STRIP_ASSUME_TAC HOL_STORE_EXISTS
   \\ RES_TAC \\ Q.EXISTS_TAC `v` \\ ASM_SIMP_TAC std_ss []
   \\ NTAC 2 (POP_ASSUM MP_TAC) \\ ONCE_REWRITE_TAC [evaluate_cases]
   \\ SIMP_TAC (srw_ss()) []);
 
-val EvalM_PURE_EQ = store_thm("EvalM_PURE_EQ",
-  ``EvalM env (Fun n exp) (PURE P x) = Eval env (Fun n exp) (P x)``,
+val EvalM_PURE_EQ = Q.store_thm("EvalM_PURE_EQ",
+  `EvalM env (Fun n exp) (PURE P x) = Eval env (Fun n exp) (P x)`,
   REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [Eval_IMP_PURE]
   \\ FULL_SIMP_TAC std_ss [Eval_def,EvalM_def,PURE_def,PULL_EXISTS]
@@ -361,10 +361,10 @@ val EvalM_PURE_EQ = store_thm("EvalM_PURE_EQ",
   \\ ONCE_REWRITE_TAC [evaluate_cases]
   \\ SIMP_TAC (srw_ss()) []);
 
-val EvalM_Var_SIMP = store_thm("EvalM_Var_SIMP",
-  ``EvalM (write n x env) (Var (Short y)) p =
+val EvalM_Var_SIMP = Q.store_thm("EvalM_Var_SIMP",
+  `EvalM (write n x env) (Var (Short y)) p =
     if n = y then EvalM (write n x env) (Var (Short y)) p
-             else EvalM env (Var (Short y)) p``,
+             else EvalM env (Var (Short y)) p`,
   SIMP_TAC std_ss [EvalM_def] \\ SRW_TAC [] []
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases,write_def,lookup_var_id_def]);
@@ -392,11 +392,11 @@ val EvalM_Recclosure = store_thm("EvalM_Recclosure",
   \\ FULL_SIMP_TAC (srw_ss()) [build_rec_env_def,FOLDR,
        write_rec_def,write_def]);
 
-val IND_HELP = store_thm("IND_HELP",
-  ``!env cl.
+val IND_HELP = Q.store_thm("IND_HELP",
+  `!env cl.
       LOOKUP_VAR x env cl /\
       EvalM env (Var (Short x)) ((b1 -M-> b2) f) ==>
-      EvalM (write x cl cl_env) (Var (Short x)) ((b1 -M-> b2) f)``,
+      EvalM (write x cl cl_env) (Var (Short x)) ((b1 -M-> b2) f)`,
   SIMP_TAC std_ss [EvalM_def,Eval_def,ArrowM_def,PURE_def,PULL_EXISTS,LOOKUP_VAR_def]
   \\ ONCE_REWRITE_TAC [evaluate_cases]
   \\ SIMP_TAC (srw_ss()) [option_CASE_LEMMA2]
@@ -410,9 +410,9 @@ val write_rec_one = store_thm("write_rec_one",
 
 (* Eq simps *)
 
-val EvalM_FUN_FORALL = store_thm("EvalM_FUN_FORALL",
-  ``(!x. EvalM env exp (PURE (p x) f)) ==>
-    EvalM env exp (PURE (FUN_FORALL x. p x) f)``,
+val EvalM_FUN_FORALL = Q.store_thm("EvalM_FUN_FORALL",
+  `(!x. EvalM env exp (PURE (p x) f)) ==>
+    EvalM env exp (PURE (FUN_FORALL x. p x) f)`,
   SIMP_TAC std_ss [EvalM_def,Eq_def,PURE_def] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [AppReturns_def,FUN_FORALL,PULL_EXISTS]
   \\ RES_TAC \\ POP_ASSUM (STRIP_ASSUME_TAC o Q.SPEC `ARB`)
@@ -422,14 +422,14 @@ val EvalM_FUN_FORALL = store_thm("EvalM_FUN_FORALL",
        METIS_TAC [determTheory.big_exp_determ]
   \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val EvalM_FUN_FORALL_EQ = store_thm("EvalM_FUN_FORALL_EQ",
-  ``(!x. EvalM env exp (PURE (p x) f)) =
-    EvalM env exp (PURE (FUN_FORALL x. p x) f)``,
+val EvalM_FUN_FORALL_EQ = Q.store_thm("EvalM_FUN_FORALL_EQ",
+  `(!x. EvalM env exp (PURE (p x) f)) =
+    EvalM env exp (PURE (FUN_FORALL x. p x) f)`,
   REPEAT STRIP_TAC \\ EQ_TAC \\ FULL_SIMP_TAC std_ss [EvalM_FUN_FORALL]
   \\ fs [EvalM_def,PURE_def,PULL_EXISTS,FUN_FORALL] \\ METIS_TAC []);
 
-val M_FUN_FORALL_PUSH1 = prove(
-  ``(FUN_FORALL x. ArrowP a (PURE (b x))) = (ArrowP a (PURE (FUN_FORALL x. b x)))``,
+val M_FUN_FORALL_PUSH1 = Q.prove(
+  `(FUN_FORALL x. ArrowP a (PURE (b x))) = (ArrowP a (PURE (FUN_FORALL x. b x)))`,
   FULL_SIMP_TAC std_ss [ArrowP_def,FUN_EQ_THM,AppReturns_def,FUN_FORALL,
     Eval_def,any_evaluate_closure_def,PURE_def] \\ REPEAT STRIP_TAC \\ reverse EQ_TAC
   THEN1 METIS_TAC [evaluate_11_Rval]
@@ -444,14 +444,14 @@ val M_FUN_FORALL_PUSH1 = prove(
   \\ REPEAT STRIP_TAC \\ Q.LIST_EXISTS_TAC [`refs3`,`v`]
   \\ FULL_SIMP_TAC std_ss []) |> GEN_ALL;
 
-val M_FUN_FORALL_PUSH2 = prove(
-  ``(FUN_FORALL x. ArrowP ((PURE (a x))) b) =
-    (ArrowP (PURE (FUN_EXISTS x. a x)) b)``,
+val M_FUN_FORALL_PUSH2 = Q.prove(
+  `(FUN_FORALL x. ArrowP ((PURE (a x))) b) =
+    (ArrowP (PURE (FUN_EXISTS x. a x)) b)`,
   FULL_SIMP_TAC std_ss [ArrowP_def,FUN_EQ_THM,AppReturns_def,
     FUN_FORALL,FUN_EXISTS,PURE_def] \\ METIS_TAC []) |> GEN_ALL;
 
-val FUN_EXISTS_Eq = prove(
-  ``(FUN_EXISTS x. Eq a x) = a``,
+val FUN_EXISTS_Eq = Q.prove(
+  `(FUN_EXISTS x. Eq a x) = a`,
   SIMP_TAC std_ss [FUN_EQ_THM,FUN_EXISTS,Eq_def]) |> GEN_ALL;
 
 val M_FUN_QUANT_SIMP = save_thm("M_FUN_QUANT_SIMP",
@@ -570,12 +570,12 @@ val EvalM_handle_clash = store_thm("EvalM_handle_clash",
 
 (* if *)
 
-val EvalM_If = store_thm("EvalM_If",
-  ``(a1 ==> Eval env x1 (BOOL b1)) /\
+val EvalM_If = Q.store_thm("EvalM_If",
+  `(a1 ==> Eval env x1 (BOOL b1)) /\
     (a2 ==> EvalM env x2 (a b2)) /\
     (a3 ==> EvalM env x3 (a b3)) ==>
     (a1 /\ (CONTAINER b1 ==> a2) /\ (~CONTAINER b1 ==> a3) ==>
-     EvalM env (If x1 x2 x3) (a (if b1 then b2 else b3)))``,
+     EvalM env (If x1 x2 x3) (a (if b1 then b2 else b3)))`,
   SIMP_TAC std_ss [EvalM_def,NUM_def,BOOL_def] \\ SIMP_TAC std_ss [CONTAINER_def]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -597,18 +597,18 @@ val EvalM_If = store_thm("EvalM_If",
                     |> INST_TYPE [``:'ffi``|->``:unit``])
     \\ FULL_SIMP_TAC std_ss []));
 
-val Eval_Var_SIMP2 = store_thm("Eval_Var_SIMP2",
-  ``Eval (write x i env) (Var (Short y)) p =
-      if x = y then p i else Eval env (Var (Short y)) p``,
+val Eval_Var_SIMP2 = Q.store_thm("Eval_Var_SIMP2",
+  `Eval (write x i env) (Var (Short y)) p =
+      if x = y then p i else Eval env (Var (Short y)) p`,
   SIMP_TAC (srw_ss()) [Eval_def,Once evaluate_cases] \\ SRW_TAC [] []
   \\ ASM_SIMP_TAC (srw_ss()) [Eval_def,Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [Eval_def,
        Once evaluate_cases,lookup_var_id_def,write_def]);
 
-val EvalM_Let = store_thm("EvalM_Let",
-  ``Eval env exp (a res) /\
+val EvalM_Let = Q.store_thm("EvalM_Let",
+  `Eval env exp (a res) /\
     (!v. a res v ==> EvalM (write name v env) body (b (f res))) ==>
-    EvalM env (Let (SOME name) exp body) (b (LET f res))``,
+    EvalM env (Let (SOME name) exp body) (b (LET f res))`,
   SIMP_TAC std_ss [Eval_def,Arrow_def,EvalM_def] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
   \\ RES_TAC \\ Q.LIST_EXISTS_TAC [`s2`,`res''`,`refs2`]
@@ -621,23 +621,23 @@ val EvalM_Let = store_thm("EvalM_Let",
 
 (* PMATCH *)
 
-val EvalM_PMATCH_NIL = store_thm("EvalM_PMATCH_NIL",
-  ``!b x xv a.
+val EvalM_PMATCH_NIL = Q.store_thm("EvalM_PMATCH_NIL",
+  `!b x xv a.
       Eval env x (a xv) ==>
       CONTAINER F ==>
-      EvalM env (Mat x []) (b (PMATCH xv []))``,
+      EvalM env (Mat x []) (b (PMATCH xv []))`,
   rw[CONTAINER_def]);
 
-val pmatch_ignore_empty_store = prove(
-  ``(pmatch cenv empty_store p r eenv = Match x) ==>
-    (pmatch cenv s p r eenv = Match x)``,
+val pmatch_ignore_empty_store = Q.prove(
+  `(pmatch cenv empty_store p r eenv = Match x) ==>
+    (pmatch cenv s p r eenv = Match x)`,
   REPEAT STRIP_TAC
   \\ IMP_RES_TAC pmatch_empty_store
   \\ fs []);
 
-val pmatch_ignore_empty_store_No_match = prove(
-  ``(pmatch cenv empty_store p r eenv = No_match) ==>
-    (pmatch cenv s p r eenv = No_match)``,
+val pmatch_ignore_empty_store_No_match = Q.prove(
+  `(pmatch cenv empty_store p r eenv = No_match) ==>
+    (pmatch cenv s p r eenv = No_match)`,
   REPEAT STRIP_TAC
   \\ IMP_RES_TAC pmatch_empty_store
   \\ fs []);
@@ -856,30 +856,30 @@ fun read_tac n =
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ fs []
   \\ fs[state_component_equality];
 
-val get_type_constants_thm = store_thm("get_the_type_constants_thm",
-  ``lookup_var_id (Short "the_type_constants") env = SOME the_type_constants ==>
+val get_type_constants_thm = Q.store_thm("get_the_type_constants_thm",
+  `lookup_var_id (Short "the_type_constants") env = SOME the_type_constants ==>
     EvalM env (App Opderef [Var (Short "the_type_constants")])
       (HOL_MONAD (LIST_TYPE (PAIR_TYPE STRING_TYPE NUM))
-                 get_the_type_constants)``,
+                 get_the_type_constants)`,
   read_tac ``0:num``);
 
-val get_term_constants_thm = store_thm("get_the_term_constants_thm",
-  ``lookup_var_id (Short "the_term_constants") env = SOME the_term_constants ==>
+val get_term_constants_thm = Q.store_thm("get_the_term_constants_thm",
+  `lookup_var_id (Short "the_term_constants") env = SOME the_term_constants ==>
     EvalM env (App Opderef [Var (Short "the_term_constants")])
       (HOL_MONAD (LIST_TYPE (PAIR_TYPE STRING_TYPE TYPE_TYPE))
-                 get_the_term_constants)``,
+                 get_the_term_constants)`,
   read_tac ``1:num``);
 
-val get_the_axioms_thm = store_thm("get_the_axioms_thm",
-  ``lookup_var_id (Short "the_axioms") env = SOME the_axioms ==>
+val get_the_axioms_thm = Q.store_thm("get_the_axioms_thm",
+  `lookup_var_id (Short "the_axioms") env = SOME the_axioms ==>
     EvalM env (App Opderef [Var (Short "the_axioms")])
-      (HOL_MONAD (LIST_TYPE THM_TYPE) get_the_axioms)``,
+      (HOL_MONAD (LIST_TYPE THM_TYPE) get_the_axioms)`,
   read_tac ``2:num``);
 
-val get_the_context_thm = store_thm("get_the_context_thm",
-  ``lookup_var_id (Short "the_context") env = SOME the_context ==>
+val get_the_context_thm = Q.store_thm("get_the_context_thm",
+  `lookup_var_id (Short "the_context") env = SOME the_context ==>
     EvalM env (App Opderef [Var (Short "the_context")])
-      (HOL_MONAD (LIST_TYPE UPDATE_TYPE) get_the_context)``,
+      (HOL_MONAD (LIST_TYPE UPDATE_TYPE) get_the_context)`,
   read_tac ``3:num``);
 
 fun update_tac n r =
@@ -913,32 +913,32 @@ fun update_tac n r =
   \\ EVAL_TAC
   \\ simp[state_component_equality];
 
-val set_the_type_constants_thm = store_thm("set_the_type_constants_thm",
-  ``lookup_var_id (Short "the_type_constants") env = SOME the_type_constants ==>
+val set_the_type_constants_thm = Q.store_thm("set_the_type_constants_thm",
+  `lookup_var_id (Short "the_type_constants") env = SOME the_type_constants ==>
     Eval env exp (LIST_TYPE (PAIR_TYPE STRING_TYPE NUM) x) ==>
     EvalM env (App Opassign [Var (Short "the_type_constants"); exp])
-      ((HOL_MONAD UNIT_TYPE) (set_the_type_constants x))``,
+      ((HOL_MONAD UNIT_TYPE) (set_the_type_constants x))`,
   update_tac ``0n`` `refs with the_type_constants := x`);
 
-val set_the_term_constants_thm = store_thm("set_the_term_constants_thm",
-  ``lookup_var_id (Short "the_term_constants") env = SOME the_term_constants ==>
+val set_the_term_constants_thm = Q.store_thm("set_the_term_constants_thm",
+  `lookup_var_id (Short "the_term_constants") env = SOME the_term_constants ==>
     Eval env exp (LIST_TYPE (PAIR_TYPE STRING_TYPE TYPE_TYPE) x) ==>
     EvalM env (App Opassign [Var (Short "the_term_constants"); exp])
-      ((HOL_MONAD UNIT_TYPE) (set_the_term_constants x))``,
+      ((HOL_MONAD UNIT_TYPE) (set_the_term_constants x))`,
   update_tac ``1n`` `refs with the_term_constants := x`);
 
-val set_the_axioms_thm = store_thm("set_the_axioms_thm",
-  ``lookup_var_id (Short "the_axioms") env = SOME the_axioms ==>
+val set_the_axioms_thm = Q.store_thm("set_the_axioms_thm",
+  `lookup_var_id (Short "the_axioms") env = SOME the_axioms ==>
     Eval env exp (LIST_TYPE THM_TYPE x) ==>
     EvalM env (App Opassign [Var (Short "the_axioms"); exp])
-      ((HOL_MONAD UNIT_TYPE) (set_the_axioms x))``,
+      ((HOL_MONAD UNIT_TYPE) (set_the_axioms x))`,
   update_tac ``2n`` `refs with the_axioms := x`);
 
-val set_the_context_thm = store_thm("set_the_context_thm",
-  ``lookup_var_id (Short "the_context") env = SOME the_context ==>
+val set_the_context_thm = Q.store_thm("set_the_context_thm",
+  `lookup_var_id (Short "the_context") env = SOME the_context ==>
     Eval env exp (LIST_TYPE UPDATE_TYPE x) ==>
     EvalM env (App Opassign [Var (Short "the_context"); exp])
-      ((HOL_MONAD UNIT_TYPE) (set_the_context x))``,
+      ((HOL_MONAD UNIT_TYPE) (set_the_context x))`,
   update_tac ``3n`` `refs with the_context := x`);
 
 val _ = (print_asts := true);

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -67,9 +67,9 @@ val tac =
 
 val () = ENABLE_PMATCH_CASES();
 
-val codomain_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL holSyntaxTheory.codomain_raw))) =
-    case ty of Tyapp n (y::x::xs) => x | _ => ty``,
+val codomain_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL holSyntaxTheory.codomain_raw))) =
+    case ty of Tyapp n (y::x::xs) => x | _ => ty`,
   rpt tac)
 val res = fix holSyntaxTheory.codomain_raw "codomain_def" codomain_PMATCH
 
@@ -114,46 +114,46 @@ val raconv_PMATCH = prove(
   rpt tac)
 val res = fix raconv_def "raconv_def" raconv_PMATCH
 
-val is_var_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL is_var_def))) =
-    case x of (Var _ _) => T | _ => F``,
+val is_var_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL is_var_def))) =
+    case x of (Var _ _) => T | _ => F`,
   rpt tac)
 val res = fix is_var_def "is_var_def" is_var_PMATCH
 
-val is_const_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL is_const_def))) =
-    case x of (Const _ _) => T | _ => F``,
+val is_const_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL is_const_def))) =
+    case x of (Const _ _) => T | _ => F`,
   rpt tac)
 val res = fix is_const_def "is_const_def" is_const_PMATCH
 
-val is_abs_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL is_abs_def))) =
-    case x of (Abs _ _) => T | _ => F``,
+val is_abs_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL is_abs_def))) =
+    case x of (Abs _ _) => T | _ => F`,
   rpt tac)
 val res = fix is_abs_def "is_abs_def" is_abs_PMATCH
 
-val is_comb_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL is_comb_def))) =
-    case x of (Comb _ _) => T | _ => F``,
+val is_comb_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL is_comb_def))) =
+    case x of (Comb _ _) => T | _ => F`,
   rpt tac)
 val res = fix is_comb_def "is_comb_def" is_comb_PMATCH
 
-val mk_abs_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL mk_abs_def))) =
+val mk_abs_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL mk_abs_def))) =
     case bvar of Var n ty => return (Abs bvar bod)
-    | _ => failwith (strlit "mk_abs: not a variable")``,
+    | _ => failwith (strlit "mk_abs: not a variable")`,
   rpt tac)
 val res = fix mk_abs_def "mk_abs_def" mk_abs_PMATCH
 
-val mk_comb_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL mk_comb_def))) =
+val mk_comb_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL mk_comb_def))) =
     do tyf <- type_of f ;
        tya <- type_of a ;
        case tyf of
          Tyapp (strlit "fun") [ty;_] => if tya = ty then return (Comb f a) else
                                  failwith (strlit "mk_comb: types do not agree")
        | _ => failwith (strlit "mk_comb: types do not agree")
-    od``,
+    od`,
   monadtac >> rpt tac)
 val res = fix mk_comb_def "mk_comb_def" mk_comb_PMATCH
 
@@ -185,28 +185,28 @@ val dest_abs_PMATCH = prove(
   rpt tac)
 val res = fix dest_abs_def "dest_abs_def" dest_abs_PMATCH
 
-val vfree_in_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL holSyntaxExtraTheory.vfree_in_def))) =
+val vfree_in_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL holSyntaxExtraTheory.vfree_in_def))) =
     case tm of
     | Abs bv bod => v <> bv ∧ vfree_in v bod
     | Comb s t => vfree_in v s ∨ vfree_in v t
-    | _ => tm = v``,
+    | _ => tm = v`,
   rpt tac)
 val res = fix holSyntaxExtraTheory.vfree_in_def "vfree_in_def" vfree_in_PMATCH
 
-val rator_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL rator_def))) =
+val rator_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL rator_def))) =
     case tm of
       Comb l r => return l
-    | _ => failwith (strlit "rator: Not a combination")``,
+    | _ => failwith (strlit "rator: Not a combination")`,
   rpt tac)
 val res = fix rator_def "rator_def" rator_PMATCH
 
-val rand_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL rand_def))) =
+val rand_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL rand_def))) =
     case tm of
       Comb l r => return r
-    | _ => failwith (strlit "rand: Not a combination")``,
+    | _ => failwith (strlit "rand: Not a combination")`,
   rpt tac)
 val res = fix rand_def "rand_def" rand_PMATCH
 
@@ -218,11 +218,11 @@ val dest_eq_PMATCH = prove(
   rpt tac)
 val res = fix dest_eq_def "dest_eq_def" dest_eq_PMATCH
 
-val is_eq_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL is_eq_def))) =
+val is_eq_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL is_eq_def))) =
     case tm of
       Comb (Comb (Const (strlit "=") _) l) r => T
-    | _ => F``,
+    | _ => F`,
   rpt tac)
 val res = fix is_eq_def "is_eq_def" is_eq_PMATCH
 
@@ -273,22 +273,22 @@ val BETA_PMATCH = prove(
   rpt tac)
 val res = fix BETA_def "BETA_def" BETA_PMATCH
 
-val EQ_MP_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL EQ_MP_def))) =
+val EQ_MP_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL EQ_MP_def))) =
     case eq of
       Comb (Comb (Const (strlit "=") _) l) r =>
         if aconv l c then return (Sequent (term_union asl1 asl2) r)
                      else failwith (strlit "EQ_MP")
-    | _ => failwith (strlit "EQ_MP")``,
+    | _ => failwith (strlit "EQ_MP")`,
   rpt tac)
 val res = fix EQ_MP_def "EQ_MP_def" EQ_MP_PMATCH
 
-val SYM_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL SYM_def))) =
+val SYM_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL SYM_def))) =
     case eq of
       Comb (Comb (Const (strlit "=") t) l) r =>
         return (Sequent asl (Comb (Comb (Const (strlit "=") t) r) l))
-    | _ => failwith (strlit "SYM")``,
+    | _ => failwith (strlit "SYM")`,
   rpt tac)
 val res = fix SYM_def "SYM_def" SYM_PMATCH
 

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -14,8 +14,8 @@ val _ = temp_overload_on ("monad_ignore_bind", ``\x y. ex_bind x (\z. y)``);
 val _ = temp_overload_on ("return", ``ex_return``);
 
 (* TODO: stolen from deepMatchesLib.sml; should be exported? *)
-val PAIR_EQ_COLLAPSE = prove (
-``(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))``,
+val PAIR_EQ_COLLAPSE = Q.prove (
+`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
 Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
 
 val pabs_elim_ss =
@@ -73,16 +73,16 @@ val codomain_PMATCH = Q.prove(
   rpt tac)
 val res = fix holSyntaxTheory.codomain_raw "codomain_def" codomain_PMATCH
 
-val rev_assocd_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL rev_assocd_def))) =
+val rev_assocd_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL rev_assocd_def))) =
     case l of
        (x,y)::l1 => if y = a then x else rev_assocd a l1 d
-     | _ => d``,
+     | _ => d`,
   rpt tac)
 val res = fix rev_assocd_def "rev_assocd_def" rev_assocd_PMATCH
 
-val type_of_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL type_of_def))) =
+val type_of_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL type_of_def))) =
     case tm of
     | Var _ ty => return ty
     | Const _ ty => return ty
@@ -94,12 +94,12 @@ val type_of_PMATCH = prove(
            od
     | Abs (Var _ ty) t
         => do x <- type_of t; mk_fun_ty ty x od
-    | _ => failwith (strlit "match")``,
+    | _ => failwith (strlit "match")`,
   monadtac >> rpt tac)
 val res = fix type_of_def "type_of_def" type_of_PMATCH
 
-val raconv_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL raconv_def))) =
+val raconv_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL raconv_def))) =
     case (tm1,tm2) of
     | (Var _ _, Var _ _) => alphavars env tm1 tm2
     | (Const _ _, Const _ _) => (tm1 = tm2)
@@ -110,7 +110,7 @@ val raconv_PMATCH = prove(
             | (Var n1 ty1,Var n2 ty2)
                 => (ty1 = ty2) ∧ raconv ((v1,v2)::env) t1 t2
             | _ => F)
-    | _ => F``,
+    | _ => F`,
   rpt tac)
 val res = fix raconv_def "raconv_def" raconv_PMATCH
 
@@ -157,31 +157,31 @@ val mk_comb_PMATCH = Q.prove(
   monadtac >> rpt tac)
 val res = fix mk_comb_def "mk_comb_def" mk_comb_PMATCH
 
-val dest_var_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL dest_var_def))) =
+val dest_var_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL dest_var_def))) =
     case tm of Var s ty => return (s,ty)
-            | _ => failwith (strlit "dest_var: not a variable")``,
+            | _ => failwith (strlit "dest_var: not a variable")`,
   rpt tac)
 val res = fix dest_var_def "dest_var_def" dest_var_PMATCH
 
-val dest_const_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL dest_const_def))) =
+val dest_const_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL dest_const_def))) =
     case tm of Const s ty => return (s,ty)
-            | _ => failwith (strlit "dest_const: not a constant")``,
+            | _ => failwith (strlit "dest_const: not a constant")`,
   rpt tac)
 val res = fix dest_const_def "dest_const_def" dest_const_PMATCH
 
-val dest_comb_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL dest_comb_def))) =
+val dest_comb_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL dest_comb_def))) =
     case tm of Comb f x => return (f,x)
-            | _ => failwith (strlit "dest_comb: not a combination")``,
+            | _ => failwith (strlit "dest_comb: not a combination")`,
   rpt tac)
 val res = fix dest_comb_def "dest_comb_def" dest_comb_PMATCH
 
-val dest_abs_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL dest_abs_def))) =
+val dest_abs_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL dest_abs_def))) =
     case tm of Abs v b => return (v,b)
-            | _ => failwith (strlit "dest_abs: not an abstraction")``,
+            | _ => failwith (strlit "dest_abs: not an abstraction")`,
   rpt tac)
 val res = fix dest_abs_def "dest_abs_def" dest_abs_PMATCH
 
@@ -210,11 +210,11 @@ val rand_PMATCH = Q.prove(
   rpt tac)
 val res = fix rand_def "rand_def" rand_PMATCH
 
-val dest_eq_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL dest_eq_def))) =
+val dest_eq_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL dest_eq_def))) =
     case tm of
       Comb (Comb (Const (strlit "=") _) l) r => return (l,r)
-    | _ => failwith (strlit "dest_eq")``,
+    | _ => failwith (strlit "dest_eq")`,
   rpt tac)
 val res = fix dest_eq_def "dest_eq_def" dest_eq_PMATCH
 
@@ -226,31 +226,31 @@ val is_eq_PMATCH = Q.prove(
   rpt tac)
 val res = fix is_eq_def "is_eq_def" is_eq_PMATCH
 
-val TRANS_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL TRANS_def))) =
+val TRANS_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL TRANS_def))) =
     case (c1,c2) of
       (Comb (Comb (Const (strlit "=") _) l) m1, Comb (Comb (Const (strlit "=") _) m2) r) =>
         if aconv m1 m2 then do eq <- mk_eq(l,r);
                                return (Sequent (term_union asl1 asl2) eq) od
         else failwith (strlit "TRANS")
-    | _ => failwith (strlit "TRANS")``,
+    | _ => failwith (strlit "TRANS")`,
   rpt tac)
 val res = fix TRANS_def "TRANS_def" TRANS_PMATCH
 
-val MK_COMB_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL MK_COMB_def))) =
+val MK_COMB_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL MK_COMB_def))) =
    case (c1,c2) of
      (Comb (Comb (Const (strlit "=") _) l1) r1, Comb (Comb (Const (strlit "=") _) l2) r2) =>
        do x1 <- mk_comb(l1,l2) ;
           x2 <- mk_comb(r1,r2) ;
           eq <- mk_eq(x1,x2) ;
           return (Sequent(term_union asl1 asl2) eq) od
-   | _ => failwith (strlit "MK_COMB")``,
+   | _ => failwith (strlit "MK_COMB")`,
   rpt tac)
 val res = fix MK_COMB_def "MK_COMB_def" MK_COMB_PMATCH
 
-val ABS_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL ABS_def))) =
+val ABS_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL ABS_def))) =
     case c of
       Comb (Comb (Const (strlit "=") _) l) r =>
         if EXISTS (vfree_in v) asl
@@ -259,17 +259,17 @@ val ABS_PMATCH = prove(
                 a2 <- mk_abs(v,r) ;
                 eq <- mk_eq(a1,a2) ;
                 return (Sequent asl eq) od
-    | _ => failwith (strlit "ABS: not an equation")``,
+    | _ => failwith (strlit "ABS: not an equation")`,
   BasicProvers.CASE_TAC >> rpt tac)
 val res = fix ABS_def "ABS_def" ABS_PMATCH
 
-val BETA_PMATCH = prove(
-  ``^(rhs(concl(SPEC_ALL BETA_def))) =
+val BETA_PMATCH = Q.prove(
+  `^(rhs(concl(SPEC_ALL BETA_def))) =
     case tm of
       Comb (Abs v bod) arg =>
         if arg = v then do eq <- mk_eq(tm,bod) ; return (Sequent [] eq) od
         else failwith (strlit "BETA: not a trivial beta-redex")
-    | _ => failwith (strlit "BETA: not a trivial beta-redex")``,
+    | _ => failwith (strlit "BETA: not a trivial beta-redex")`,
   rpt tac)
 val res = fix BETA_def "BETA_def" BETA_PMATCH
 

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -5,16 +5,16 @@ val _ = new_theory "holKernelProof";
 val _ = temp_overload_on ("monad_bind", ``ex_bind``);
 val _ = temp_overload_on ("return", ``ex_return``);
 
-val rev_assocd_thm = prove(
-  ``rev_assocd = REV_ASSOCD``,
+val rev_assocd_thm = Q.prove(
+  `rev_assocd = REV_ASSOCD`,
   SIMP_TAC std_ss [FUN_EQ_THM] \\ Induct_on `x'`
   \\ ONCE_REWRITE_TAC [rev_assocd_def] \\ SRW_TAC [] [REV_ASSOCD]
   \\ Cases_on `h` \\ SRW_TAC [] [REV_ASSOCD]);
 
 val REPLICATE_GENLIST = rich_listTheory.REPLICATE_GENLIST
 
-val REPLICATE_11 = prove(
-  ``!m n x. (REPLICATE n x = REPLICATE m x) = (m = n)``,
+val REPLICATE_11 = Q.prove(
+  `!m n x. (REPLICATE n x = REPLICATE m x) = (m = n)`,
   Induct \\ Cases \\ SRW_TAC [] [rich_listTheory.REPLICATE]);
 
 val _ = temp_overload_on("impossible_term",``holSyntax$Comb (Var (strlit "x") Bool) (Var (strlit "x") Bool)``);
@@ -45,32 +45,32 @@ val STATE_def = Define `
 (* impossible term lemmas                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val term_ok_impossible_term = prove(
-  ``~(term_ok defs impossible_term)``,
+val term_ok_impossible_term = Q.prove(
+  `~(term_ok defs impossible_term)`,
   simp[term_ok_def])
 
-val impossible_term_thm = prove(
-  ``TERM defs tm ==> tm <> impossible_term``,
+val impossible_term_thm = Q.prove(
+  `TERM defs tm ==> tm <> impossible_term`,
   SIMP_TAC std_ss [TERM_def] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [term_ok_impossible_term])
 
-val Abs_Var = prove(
-  ``TERM defs (Abs v tm) ==> ?s ty. v = Var s ty``,
+val Abs_Var = Q.prove(
+  `TERM defs (Abs v tm) ==> ?s ty. v = Var s ty`,
   simp[TERM_def,term_ok_def] >> rw[])
 
 (* ------------------------------------------------------------------------- *)
 (* invariant lemmas                                                          *)
 (* ------------------------------------------------------------------------- *)
 
-val CONTEXT_ALL_DISTINCT = prove(
-  ``CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
-                   ALL_DISTINCT (MAP FST (const_list defs))``,
+val CONTEXT_ALL_DISTINCT = Q.prove(
+  `CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
+                   ALL_DISTINCT (MAP FST (const_list defs))`,
   rw[CONTEXT_def] >>
   METIS_TAC[extends_ALL_DISTINCT,init_ALL_DISTINCT])
 
-val STATE_ALL_DISTINCT = prove(
-  ``STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
-                   ALL_DISTINCT (MAP FST s.the_term_constants)``,
+val STATE_ALL_DISTINCT = Q.prove(
+  `STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
+                   ALL_DISTINCT (MAP FST s.the_term_constants)`,
   rw[STATE_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`X = const_list Y`(assume_tac o SYM) >> fs[] >>
@@ -86,8 +86,8 @@ val TYPE_Tyapp = prove(
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
   rfs[STATE_def])
 
-val CONTEXT_std_sig = prove(
-  ``CONTEXT defs ⇒ is_std_sig (sigof defs)``,
+val CONTEXT_std_sig = Q.prove(
+  `CONTEXT defs ⇒ is_std_sig (sigof defs)`,
   rw[CONTEXT_def] >>
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
   imp_res_tac theory_ok_sig >> fs[is_std_sig_def])
@@ -102,53 +102,53 @@ val CONTEXT_fun = prove(
   EQ_TAC >> rw[] >> res_tac >> fs[] >>
   imp_res_tac ALOOKUP_MEM)
 
-val TYPE = prove(
-  ``(STATE defs state ==> TYPE defs (Tyvar v)) /\
-    (TYPE defs (Tyapp op tys) ==> EVERY (TYPE defs) tys)``,
+val TYPE = Q.prove(
+  `(STATE defs state ==> TYPE defs (Tyvar v)) /\
+    (TYPE defs (Tyapp op tys) ==> EVERY (TYPE defs) tys)`,
   conj_tac >- (
     simp[STATE_def,TYPE_def,EVERY_MEM] >>
     rw[] >> simp[type_ok_def] ) >>
   rw[EVERY_MEM,TYPE_def] >>
   fs[type_ok_def,EVERY_MAP,EVERY_MEM]);
 
-val TERM = prove(
-  ``(TERM defs (Var n ty) ==> TYPE defs ty) /\
+val TERM = Q.prove(
+  `(TERM defs (Var n ty) ==> TYPE defs ty) /\
     (TERM defs (Const n ty) ==> TYPE defs ty) /\
     (TERM defs (Abs (Var v ty) x) ==> TERM defs x /\ TYPE defs ty) /\
-    (TERM defs (Comb x y) ==> TERM defs x /\ TERM defs y)``,
+    (TERM defs (Comb x y) ==> TERM defs x /\ TERM defs y)`,
   rw[TERM_def,TYPE_def] >> fs[term_ok_def])
 
-val TYPE_Fun = prove(
-  ``CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
-    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])``,
+val TYPE_Fun = Q.prove(
+  `CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
+    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])`,
   rw[TYPE_def,type_ok_def] >>
   imp_res_tac CONTEXT_fun >>
   METIS_TAC[ALOOKUP_ALL_DISTINCT_MEM,CONTEXT_ALL_DISTINCT]);
 
-val TERM_Var_SIMP = prove(
-  ``(TERM defs (Var n ty) = TYPE defs ty)``,
+val TERM_Var_SIMP = Q.prove(
+  `(TERM defs (Var n ty) = TYPE defs ty)`,
   rw[TERM_def,TYPE_def,term_ok_def]);
 
-val TERM_Var = prove(
-  ``TYPE defs ty ==> TERM defs (Var n ty)``,
+val TERM_Var = Q.prove(
+  `TYPE defs ty ==> TERM defs (Var n ty)`,
   METIS_TAC [TERM_Var_SIMP]);
 
-val IMP_TERM_Abs = prove(
-  ``TERM defs (Var str ty) /\ TERM defs bod ==>
-    TERM defs (Abs (Var str ty) bod)``,
+val IMP_TERM_Abs = Q.prove(
+  `TERM defs (Var str ty) /\ TERM defs bod ==>
+    TERM defs (Abs (Var str ty) bod)`,
   fs[TERM_def,term_ok_def]);
 
-val IMP_TERM_Comb = prove(
-  ``TERM defs f /\
+val IMP_TERM_Comb = Q.prove(
+  `TERM defs f /\
     TERM defs a /\
     (typeof a = ty1) /\
     (typeof f = Fun ty1 ty2) ==>
-    TERM defs (Comb f a)``,
+    TERM defs (Comb f a)`,
   rw[TERM_def,term_ok_def] >>
   METIS_TAC[term_ok_welltyped])
 
-val TERM_Abs = prove(
-  ``TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm``,
+val TERM_Abs = Q.prove(
+  `TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm`,
   rw[TERM_def,term_ok_def,TYPE_def]);
 
 val INST_CORE_LEMMA =
@@ -181,8 +181,8 @@ val INST_CORE_EMPTY = prove(
   >> simp[])
   |> Q.SPECL [`tm`,`[]`] |> SIMP_RULE std_ss [EVERY_DEF] |> GEN_ALL;
 
-val THM = prove(
-  ``THM defs (Sequent asl c) ==> EVERY (TERM defs) asl /\ TERM defs c``,
+val THM = Q.prove(
+  `THM defs (Sequent asl c) ==> EVERY (TERM defs) asl /\ TERM defs c`,
   SIMP_TAC std_ss [THM_def] \\ SIMP_TAC std_ss [EVERY_MEM] >>
   strip_tac >> imp_res_tac proves_term_ok >>
   fs[EVERY_MEM,TERM_def,MEM_MAP,PULL_EXISTS])
@@ -193,25 +193,25 @@ val type_IND = type_induction
   |> UNDISCH_ALL |> CONJUNCT1 |> DISCH_ALL
   |> Q.GEN`P`
 
-val type_subst_EMPTY = prove(
-  ``!ty. type_subst [] ty = ty``,
+val type_subst_EMPTY = Q.prove(
+  `!ty. type_subst [] ty = ty`,
   HO_MATCH_MP_TAC type_IND
   \\ REPEAT STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once type_subst_def]
   \\ SIMP_TAC std_ss [rev_assocd_thm,REV_ASSOCD,LET_DEF]
   \\ `MAP (\a. type_subst [] a) l = l` by ALL_TAC \\ FULL_SIMP_TAC std_ss []
   \\ Induct_on `l` \\ FULL_SIMP_TAC std_ss [MAP,EVERY_DEF]);
 
-val MAP_EQ_2 = prove(
-  ``(MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)``,
+val MAP_EQ_2 = Q.prove(
+  `(MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)`,
   Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[])
 
 val sequent_has_type_bool = prove(
   ``(d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)``,
   strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM])
 
-val THM_term_ok_bool = prove(
-  ``THM defs (Sequent asl p) ⇒
-    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)``,
+val THM_term_ok_bool = Q.prove(
+  `THM defs (Sequent asl p) ⇒
+    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)`,
   REPEAT STRIP_TAC
   \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [THM_def]
@@ -252,10 +252,10 @@ val get_type_arity_thm = prove(
     get_the_type_constants_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC assoc_thm);
 
-val mk_vartype_thm = store_thm("mk_vartype_thm",
-  ``!name s.
+val mk_vartype_thm = Q.store_thm("mk_vartype_thm",
+  `!name s.
       STATE s.the_context s ⇒
-      TYPE s.the_context (mk_vartype name)``,
+      TYPE s.the_context (mk_vartype name)`,
   SIMP_TAC (srw_ss()) [mk_vartype_def,TYPE_def,type_ok_def,STATE_def]);
 
 val mk_type_thm = store_thm("mk_type_thm",
@@ -289,16 +289,16 @@ val dest_vartype_thm = store_thm("dest_vartype_thm",
   Cases \\ FULL_SIMP_TAC (srw_ss())
     [dest_vartype_def,failwith_def,ex_return_def]);
 
-val is_type_thm = store_thm("is_type_thm",
-  ``!ty. is_type ty = ?s tys. ty = Tyapp s tys``,
+val is_type_thm = Q.store_thm("is_type_thm",
+  `!ty. is_type ty = ?s tys. ty = Tyapp s tys`,
   Cases \\ SIMP_TAC (srw_ss()) [is_type_def]);
 
-val is_vartype_thm = store_thm("is_vartype_thm",
-  ``!ty. is_vartype ty = ?s. ty = Tyvar s``,
+val is_vartype_thm = Q.store_thm("is_vartype_thm",
+  `!ty. is_vartype ty = ?s. ty = Tyvar s`,
   Cases \\ SIMP_TAC (srw_ss()) [is_vartype_def]);
 
-val tyvars_thm = prove(
-  ``!ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)``,
+val tyvars_thm = Q.prove(
+  `!ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)`,
   HO_MATCH_MP_TAC holKernelTheory.tyvars_ind \\ REPEAT STRIP_TAC
   \\ Cases_on `ty` \\ FULL_SIMP_TAC (srw_ss()) [type_11,type_distinct]
   \\ SIMP_TAC (srw_ss()) [Once holKernelTheory.tyvars_def,
@@ -360,10 +360,10 @@ val term_type_def = Define `
     | Abs (Var _ ty) t => Tyapp (strlit "fun") [ty; term_type t]
     | _ => Tyvar (strlit "")`
 
-val term_type = prove(
-  ``!defs tm. CONTEXT defs ∧ TERM defs tm ==>
+val term_type = Q.prove(
+  `!defs tm. CONTEXT defs ∧ TERM defs tm ==>
     (term_type tm = typeof tm) /\
-    TYPE defs (term_type tm)``,
+    TYPE defs (term_type tm)`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ STRIP_TAC \\ Induct \\ ONCE_REWRITE_TAC [term_type_def]
   \\ SIMP_TAC (srw_ss()) [typeof_def]
@@ -448,20 +448,20 @@ val raconv_thm = prove(
   THEN1 (REPEAT STRIP_TAC \\ MATCH_MP_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [])
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [])
 
-val aconv_thm = store_thm("aconv_thm",
-  ``!tm1 tm2 env.
+val aconv_thm = Q.store_thm("aconv_thm",
+  `!tm1 tm2 env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 ==>
-      (aconv tm1 tm2 = ACONV tm1 tm2)``,
+      (aconv tm1 tm2 = ACONV tm1 tm2)`,
   SIMP_TAC std_ss [aconv_def,ACONV_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC (raconv_thm |> Q.SPECL [`t1`,`t2`,`[]`]
        |> SIMP_RULE std_ss [EVERY_DEF,MAP])
   \\ FULL_SIMP_TAC std_ss []);
 
-val is_term_thm = store_thm("is_term_thm",
-  ``(is_var tm = ?n ty. tm = Var n ty) /\
+val is_term_thm = Q.store_thm("is_term_thm",
+  `(is_var tm = ?n ty. tm = Var n ty) /\
     (is_const tm = ?n ty. tm = Const n ty) /\
     (is_abs tm = ?v x. tm = Abs v x) /\
-    (is_comb tm = ?x y. tm = Comb x y)``,
+    (is_comb tm = ?x y. tm = Comb x y)`,
   Cases_on `tm` \\ EVAL_TAC \\ FULL_SIMP_TAC std_ss []);
 
 val mk_var_thm = store_thm("mk_var_thm",
@@ -548,12 +548,12 @@ val rand_thm = store_thm("rand_thm",
   \\ SIMP_TAC (srw_ss()) [rand_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
 
-val type_subst_bool = prove(
-  ``type_subst i Bool = Bool``,
+val type_subst_bool = Q.prove(
+  `type_subst i Bool = Bool`,
   SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF]);
 
-val type_subst_fun = prove(
-  ``type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)``,
+val type_subst_fun = Q.prove(
+  `type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)`,
   SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []);
 
 val TERM_Const = prove(
@@ -688,38 +688,38 @@ val mk_eq_thm = store_thm("mk_eq_thm",
          ``type_of (Const x y)`` |> SIMP_CONV (srw_ss()) [Once type_of_def],
          ex_bind_def,dest_type_def]);
 
-val TERM_Eq_x = prove(
-  ``STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
-    (Fun (typeof x) (Fun (typeof x) Bool) = ty)``,
+val TERM_Eq_x = Q.prove(
+  `STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
+    (Fun (typeof x) (Fun (typeof x) Bool) = ty)`,
   rw[TERM_def,STATE_def] >>
   fs[term_ok_def] >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >> rw[] >>
   fs[TYPE_SUBST_def])
 
-val TERM_Comb = prove(
-  ``CONTEXT defs ⇒
+val TERM_Comb = Q.prove(
+  `CONTEXT defs ⇒
     (TERM defs (Comb f a) <=>
      TERM defs f /\ TERM defs a /\
-     ?ty. term_type f = Fun (term_type a) ty)``,
+     ?ty. term_type f = Fun (term_type a) ty)`,
   REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC term_type
   \\ FULL_SIMP_TAC std_ss [TERM_def,WELLTYPED_CLAUSES,term_ok_def]
   \\ METIS_TAC[term_ok_welltyped])
 
-val MAP_EQ_2_SYM = prove(
-  ``([x;y] = MAP f l) ⇔ (MAP f l = [x;y])``,METIS_TAC[])
+val MAP_EQ_2_SYM = Q.prove(
+  `([x;y] = MAP f l) ⇔ (MAP f l = [x;y])`,METIS_TAC[])
 
-val Equal_type = prove(
-  ``STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)``,
+val Equal_type = Q.prove(
+  `STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)`,
   rw[STATE_def,TERM_def] >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def,term_ok_def])
 
-val Equal_type_IMP = prove(
-  ``STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
-    (typeof ll = a')``,
+val Equal_type_IMP = Q.prove(
+  `STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
+    (typeof ll = a')`,
   simp[TERM_Comb] >> strip_tac >>
   imp_res_tac TERM_Eq_x >>
   fs[Once term_type_def] >>
@@ -737,10 +737,10 @@ val dest_eq_thm = store_thm("dest_eq_thm",
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC TERM_Eq_x);
 
-val VFREE_IN_IMP = prove(
-  ``!y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
+val VFREE_IN_IMP = Q.prove(
+  `!y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
         VFREE_IN (Var name ty) y ==>
-        vfree_in (Var name ty) y``,
+        vfree_in (Var name ty) y`,
   METIS_TAC [vfree_in_thm]);
 
 val SELECT_LEMMA = prove(
@@ -767,18 +767,18 @@ val SELECT_LEMMA2 = prove(
                             VFREE_IN s tm'` by METIS_TAC []
   \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
 
-val is_var_thm = prove(
-  ``!x. is_var x = ?v ty. x = Var v ty``,
+val is_var_thm = Q.prove(
+  `!x. is_var x = ?v ty. x = Var v ty`,
   Cases \\ FULL_SIMP_TAC (srw_ss()) [is_var_def]);
 
-val VSUBST_EMPTY = prove(
-  ``(!tm. holSyntax$VSUBST [] tm = tm)``,
+val VSUBST_EMPTY = Q.prove(
+  `(!tm. holSyntax$VSUBST [] tm = tm)`,
   Induct
   \\ FULL_SIMP_TAC (srw_ss()) [VSUBST_def,REV_ASSOCD,EVERY_DEF,FILTER,LET_THM]);
 
-val VFREE_IN_TYPE = prove(
-  ``!x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
-        ?ty. (oty = ty) /\ TYPE defs ty``,
+val VFREE_IN_TYPE = Q.prove(
+  `!x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
+        ?ty. (oty = ty) /\ TYPE defs ty`,
   Induct
   THEN1 (SIMP_TAC std_ss [VFREE_IN_def,term_11] \\ METIS_TAC [TERM])
   THEN1 (SRW_TAC [] [VFREE_IN_def,term_11,term_distinct])
@@ -789,9 +789,9 @@ val VFREE_IN_TYPE = prove(
   \\ IMP_RES_TAC TERM
   \\ FULL_SIMP_TAC std_ss [VFREE_IN_def] \\ METIS_TAC []);
 
-val VFREE_IN_IMP_MEM = prove(
-  ``VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
-    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1``,
+val VFREE_IN_IMP_MEM = Q.prove(
+  `VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
+    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1`,
   Induct_on `h0` THEN1 (Q.SPEC_TAC (`oty`,`oty`)
     \\ FULL_SIMP_TAC (srw_ss()) [VFREE_IN_def,term_11,Once frees_def]
     \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [])
@@ -806,8 +806,8 @@ val VFREE_IN_IMP_MEM = prove(
   \\ IMP_RES_TAC VFREE_IN_TYPE \\ FULL_SIMP_TAC std_ss []
   \\ fs[])
 
-val term_type_Var = prove(
-  ``term_type (Var v ty) = ty``,
+val term_type_Var = Q.prove(
+  `term_type (Var v ty) = ty`,
   SIMP_TAC (srw_ss()) [Once term_type_def]);
 
 val vsubst_aux_thm = prove(
@@ -1047,13 +1047,13 @@ val inst_aux_Var = prove(
   SIMP_TAC (srw_ss()) [Once inst_aux_def,rev_assocd_thm,REV_ASSOCD,
        LET_DEF,ex_return_def] \\ METIS_TAC []);
 
-val MEM_subtract = prove(
-  ``!xs ys x. MEM x (subtract xs ys) <=> MEM x xs /\ ~MEM x ys``,
+val MEM_subtract = Q.prove(
+  `!xs ys x. MEM x (subtract xs ys) <=> MEM x xs /\ ~MEM x ys`,
   FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER,MEM] \\ METIS_TAC []);
 
-val MEM_frees = prove(
-  ``!tm y. TERM defs tm /\ MEM y (frees tm) ==>
-           ?v ty. (y = Var v ty) /\ TYPE defs ty``,
+val MEM_frees = Q.prove(
+  `!tm y. TERM defs tm /\ MEM y (frees tm) ==>
+           ?v ty. (y = Var v ty) /\ TYPE defs ty`,
   Induct \\ SIMP_TAC (srw_ss()) [Once frees_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC Abs_Var \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [MEM_union,MEM_subtract]);
@@ -1276,10 +1276,10 @@ val inst_thm = store_thm("inst_thm",
   \\ FULL_SIMP_TAC std_ss [EVERY_MEM,TYPE_def,FORALL_PROD,MEM,IS_RESULT_def]
   \\ METIS_TAC [])
 
-val freesin_IMP = prove(
-  ``!rhs vars.
+val freesin_IMP = Q.prove(
+  `!rhs vars.
        freesin vars rhs /\ TERM defs rhs /\ VFREE_IN (Var x ty) (rhs) ==>
-       MEM (Var x ty) vars``,
+       MEM (Var x ty) vars`,
   Induct \\ SIMP_TAC (srw_ss()) [Once freesin_def]
   THEN1 (REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
          \\ FULL_SIMP_TAC std_ss [CLOSED_def,VFREE_IN_def])
@@ -1292,27 +1292,27 @@ val freesin_IMP = prove(
   \\ FULL_SIMP_TAC std_ss [MEM]
   \\ FULL_SIMP_TAC (srw_ss()) [term_11]);
 
-val ALL_DISTINCT_union = prove(
-  ``!xs. ALL_DISTINCT (holSyntaxExtra$union xs ys) = ALL_DISTINCT ys``,
+val ALL_DISTINCT_union = Q.prove(
+  `!xs. ALL_DISTINCT (holSyntaxExtra$union xs ys) = ALL_DISTINCT ys`,
   Induct \\ SIMP_TAC (srw_ss()) [union_def,Once itlist_def,insert_def]
   \\ SRW_TAC [] [] \\ FULL_SIMP_TAC std_ss [union_def]);
 
-val ALL_DISTINCT_tyvars_ALT = prove(
-  ``!h. ALL_DISTINCT (tyvars (h:type))``,
+val ALL_DISTINCT_tyvars_ALT = Q.prove(
+  `!h. ALL_DISTINCT (tyvars (h:type))`,
   HO_MATCH_MP_TAC type_IND \\ REPEAT STRIP_TAC
   \\ SIMP_TAC (srw_ss()) [Once holKernelTheory.tyvars_def]
   \\ Induct_on `l` \\ SIMP_TAC (srw_ss()) [Once itlist_def,MAP]
   \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_union]);
 
-val ALL_DISTINCT_type_vars_in_term = prove(
-  ``!P. ALL_DISTINCT (type_vars_in_term P)``,
+val ALL_DISTINCT_type_vars_in_term = Q.prove(
+  `!P. ALL_DISTINCT (type_vars_in_term P)`,
   Induct \\ SIMP_TAC (srw_ss()) [Once type_vars_in_term_def]
   \\ FULL_SIMP_TAC std_ss [tyvars_ALL_DISTINCT,ALL_DISTINCT_union]
   \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_tyvars_ALT]);
 
-val MEM_type_vars_in_term = prove(
-  ``!rhs v. TERM defs rhs ==>
-            (MEM v (type_vars_in_term rhs) = MEM v (tvars rhs))``,
+val MEM_type_vars_in_term = Q.prove(
+  `!rhs v. TERM defs rhs ==>
+            (MEM v (type_vars_in_term rhs) = MEM v (tvars rhs))`,
   Induct
   \\ SIMP_TAC (srw_ss()) [Once type_vars_in_term_def,tvars_def,tyvars_thm]
   THEN1 (FULL_SIMP_TAC std_ss [MEM_union,MEM_LIST_UNION] \\ REPEAT STRIP_TAC
@@ -1323,9 +1323,9 @@ val MEM_type_vars_in_term = prove(
        tvars_def,MEM_LIST_UNION]
   \\ IMP_RES_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [pred_setTheory.IN_UNION]);
 
-val QSORT_type_vars_in_term = prove(
-  ``TERM defs P ==>
-    (QSORT $<= (MAP explode (type_vars_in_term P)) = STRING_SORT (MAP explode (tvars P)))``,
+val QSORT_type_vars_in_term = Q.prove(
+  `TERM defs P ==>
+    (QSORT $<= (MAP explode (type_vars_in_term P)) = STRING_SORT (MAP explode (tvars P)))`,
   REPEAT STRIP_TAC \\
   MATCH_MP_TAC (MP_CANON sortingTheory.SORTED_PERM_EQ) \\
   qexists_tac`$<=` >>
@@ -1359,15 +1359,15 @@ val dest_thm_thm = store_thm("dest_thm_thm",
   REPEAT STRIP_TAC \\ Cases_on `th` \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [dest_thm_def] \\ METIS_TAC []);
 
-val hyp_thm = store_thm("hyp_thm",
-  ``THM defs th /\ STATE defs s /\ (hyp th = asl) ==>
-    EVERY (TERM defs) asl``,
+val hyp_thm = Q.store_thm("hyp_thm",
+  `THM defs th /\ STATE defs s /\ (hyp th = asl) ==>
+    EVERY (TERM defs) asl`,
   REPEAT STRIP_TAC \\ Cases_on `th` \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [hyp_def] \\ METIS_TAC []);
 
-val concl_thm = store_thm("concl_thm",
-  ``THM defs th /\ STATE defs s /\ (concl th = c) ==>
-    TERM defs c``,
+val concl_thm = Q.store_thm("concl_thm",
+  `THM defs th /\ STATE defs s /\ (concl th = c) ==>
+    TERM defs c`,
   REPEAT STRIP_TAC \\ Cases_on `th` \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [concl_def] \\ METIS_TAC []);
 
@@ -1828,16 +1828,16 @@ val INST_thm = store_thm("INST_thm",
 (* Verification of definition functions                                      *)
 (* ------------------------------------------------------------------------- *)
 
-val TYPE_CONS_EXTEND = store_thm("TYPE_CONS_EXTEND",
-  ``STATE (d::defs) s /\ TYPE defs ty ==> TYPE (d::defs) ty``,
+val TYPE_CONS_EXTEND = Q.store_thm("TYPE_CONS_EXTEND",
+  `STATE (d::defs) s /\ TYPE defs ty ==> TYPE (d::defs) ty`,
   simp[STATE_def,TYPE_def] >> strip_tac >>
   match_mp_tac type_ok_extend >>
   HINT_EXISTS_TAC >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   Cases_on`d`>>fs[SUBMAP_FUNION])
 
-val TERM_CONS_EXTEND = store_thm("TERM_CONS_EXTEND",
-  ``STATE (d::defs) s /\ TERM defs tm ==> TERM (d::defs) tm``,
+val TERM_CONS_EXTEND = Q.store_thm("TERM_CONS_EXTEND",
+  `STATE (d::defs) s /\ TERM defs tm ==> TERM (d::defs) tm`,
   simp[STATE_def,TERM_def] >> strip_tac >>
   match_mp_tac term_ok_extend >>
   map_every qexists_tac[`tysof(defs)`,`tmsof(defs)`] >>
@@ -1851,16 +1851,16 @@ val TERM_CONS_EXTEND = store_thm("TERM_CONS_EXTEND",
 val STRCAT_SHADOW_def = zDefine`
   STRCAT_SHADOW = STRCAT`
 
-val first_dup_thm = prove(
-  ``∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)``,
+val first_dup_thm = Q.prove(
+  `∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)`,
   Induct >> simp[Once first_dup_def] >>
   rpt gen_tac >>
   BasicProvers.CASE_TAC >>
   strip_tac >> res_tac >>
   fs[MEM] >> METIS_TAC[])
 
-val first_dup_SOME = prove(
-  ``∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)``,
+val first_dup_SOME = Q.prove(
+  `∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)`,
   Induct >> simp[Once first_dup_def] >>
   rw[] >> fs[ALL_DISTINCT_APPEND] >>
   res_tac >> rw[] >> fs[ALL_DISTINCT] >> fs[] >>

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -76,10 +76,10 @@ val STATE_ALL_DISTINCT = Q.prove(
   qpat_x_assum`X = const_list Y`(assume_tac o SYM) >> fs[] >>
   fs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
 
-val TYPE_Tyapp = prove(
-  ``MEM (tyop,LENGTH args) r.the_type_constants /\
+val TYPE_Tyapp = Q.prove(
+  `MEM (tyop,LENGTH args) r.the_type_constants /\
     STATE defs r /\ EVERY (TYPE defs) args ==>
-    TYPE defs (Tyapp tyop args)``,
+    TYPE defs (Tyapp tyop args)`,
   rw[EVERY_MEM,TYPE_def] >>
   imp_res_tac STATE_ALL_DISTINCT >>
   rw[type_ok_def,EVERY_MAP,EVERY_MEM] >>
@@ -92,9 +92,9 @@ val CONTEXT_std_sig = Q.prove(
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
   imp_res_tac theory_ok_sig >> fs[is_std_sig_def])
 
-val CONTEXT_fun = prove(
-  ``CONTEXT defs ⇒
-      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)``,
+val CONTEXT_fun = Q.prove(
+  `CONTEXT defs ⇒
+      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)`,
   rw[] >> imp_res_tac CONTEXT_ALL_DISTINCT >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >>
@@ -155,10 +155,10 @@ val INST_CORE_LEMMA =
   INST_CORE_HAS_TYPE |> Q.SPECL [`holSyntax$sizeof tm`,`tm`,`[]`,`tyin`]
   |> SIMP_RULE std_ss [MEM,REV_ASSOCD] |> Q.GENL [`tm`,`tyin`]
 
-val INST_CORE_EMPTY = prove(
-  ``!tm env.
+val INST_CORE_EMPTY = Q.prove(
+  `!tm env.
       welltyped tm /\ EVERY (\(x,y). x = y) env ==>
-      (holSyntax$INST_CORE env [] tm = Result tm)``,
+      (holSyntax$INST_CORE env [] tm = Result tm)`,
   completeInduct_on `holSyntax$sizeof tm` \\ Cases \\ REPEAT STRIP_TAC
   THEN1 (ONCE_REWRITE_TAC [INST_CORE_def] \\ SIMP_TAC std_ss [TYPE_SUBST_NIL]
     \\ `REV_ASSOCD (Var m t) env (Var m t) = Var m t` by ALL_TAC THEN1
@@ -205,8 +205,8 @@ val MAP_EQ_2 = Q.prove(
   `(MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)`,
   Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[])
 
-val sequent_has_type_bool = prove(
-  ``(d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)``,
+val sequent_has_type_bool = Q.prove(
+  `(d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)`,
   strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM])
 
 val THM_term_ok_bool = Q.prove(
@@ -226,28 +226,28 @@ val THM_term_ok_bool = Q.prove(
 (* Verification of type functions                                            *)
 (* ------------------------------------------------------------------------- *)
 
-val can_thm = prove(
-  ``can f x s = case f x s of (HolRes _,s) => (HolRes T,s) |
-                              (_,s) => (HolRes F,s)``,
+val can_thm = Q.prove(
+  `can f x s = case f x s of (HolRes _,s) => (HolRes T,s) |
+                              (_,s) => (HolRes F,s)`,
   SIMP_TAC std_ss [can_def,ex_bind_def,otherwise_def]
   \\ Cases_on `f x s` \\ Cases_on `q`
   \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def]);
 
-val assoc_thm = prove(
-  ``!xs y z s s'.
+val assoc_thm = Q.prove(
+  `!xs y z s s'.
       (assoc y xs s = (z, s')) ==>
       (s' = s) /\ (!i. (z = HolRes i) ==> MEM (y,i) xs) /\
-                  (!e. (z = HolErr e) ==> !i. ~MEM (y,i) xs)``,
+                  (!e. (z = HolErr e) ==> !i. ~MEM (y,i) xs)`,
   Induct \\ SIMP_TAC (srw_ss()) [Once assoc_def,failwith_def]
   \\ Cases \\ SIMP_TAC (srw_ss()) [] \\ STRIP_TAC
   \\ Cases_on `y = q` \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def]
   \\ METIS_TAC []);
 
-val get_type_arity_thm = prove(
-  ``!name s z s'.
+val get_type_arity_thm = Q.prove(
+  `!name s z s'.
       (get_type_arity name s = (z,s')) ==> (s' = s) /\
       (!i. (z = HolRes i) ==> MEM (name,i) s.the_type_constants) /\
-      (!e. (z = HolErr e) ==> !i. ~MEM (name,i) s.the_type_constants)``,
+      (!e. (z = HolErr e) ==> !i. ~MEM (name,i) s.the_type_constants)`,
   SIMP_TAC (srw_ss()) [get_type_arity_def,ex_bind_def,
     get_the_type_constants_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC assoc_thm);
@@ -258,12 +258,12 @@ val mk_vartype_thm = Q.store_thm("mk_vartype_thm",
       TYPE s.the_context (mk_vartype name)`,
   SIMP_TAC (srw_ss()) [mk_vartype_def,TYPE_def,type_ok_def,STATE_def]);
 
-val mk_type_thm = store_thm("mk_type_thm",
-  ``!tyop args s z s'.
+val mk_type_thm = Q.store_thm("mk_type_thm",
+  `!tyop args s z s'.
       STATE defs s /\ EVERY (TYPE defs) args /\
       (mk_type (tyop,args) s = (z,s')) ==> (s' = s) /\
       ((tyop = (strlit "fun")) /\ (LENGTH args = 2) ==> ?i. z = HolRes i) /\
-      !i. (z = HolRes i) ==> TYPE defs i /\ (i = Tyapp tyop args)``,
+      !i. (z = HolRes i) ==> TYPE defs i /\ (i = Tyapp tyop args)`,
   SIMP_TAC std_ss [mk_type_def,try_def,ex_bind_def,otherwise_def]
   \\ NTAC 3 STRIP_TAC \\ Cases_on `get_type_arity tyop s`
   \\ IMP_RES_TAC get_type_arity_thm
@@ -272,20 +272,20 @@ val mk_type_thm = store_thm("mk_type_thm",
   \\ IMP_RES_TAC TYPE_Tyapp
   \\ fs[STATE_def] >> METIS_TAC[CONTEXT_fun])
 
-val dest_type_thm = store_thm("dest_type_thm",
-  ``!ty s z s'.
+val dest_type_thm = Q.store_thm("dest_type_thm",
+  `!ty s z s'.
       STATE defs s /\
       (dest_type ty s = (z,s')) /\ TYPE defs ty ==> (s' = s) /\
       !i. (z = HolRes i) ==> ?n tys. (ty = Tyapp n tys) /\ (i = (n,tys)) /\
-                                     EVERY (TYPE defs) tys``,
+                                     EVERY (TYPE defs) tys`,
   Cases \\ FULL_SIMP_TAC (srw_ss()) [dest_type_def,failwith_def,ex_return_def]
   \\ FULL_SIMP_TAC std_ss [TYPE_def,EVERY_MEM] \\ SRW_TAC [] []
   >> fs[type_ok_def,EVERY_MAP,EVERY_MEM])
 
-val dest_vartype_thm = store_thm("dest_vartype_thm",
-  ``!ty s z s'.
+val dest_vartype_thm = Q.store_thm("dest_vartype_thm",
+  `!ty s z s'.
       (dest_vartype ty s = (z,s')) ==> (s' = s) /\
-      !i. (z = HolRes i) ==> (ty = Tyvar i)``,
+      !i. (z = HolRes i) ==> (ty = Tyvar i)`,
   Cases \\ FULL_SIMP_TAC (srw_ss())
     [dest_vartype_def,failwith_def,ex_return_def]);
 
@@ -308,11 +308,11 @@ val tyvars_thm = Q.prove(
   \\ SIMP_TAC (srw_ss()) [Once itlist_def,FOLDR,MEM_union,MEM_LIST_UNION]
   \\ METIS_TAC []);
 
-val type_subst_thm = store_thm("type_subst",
-  ``!i ty.
+val type_subst_thm = Q.store_thm("type_subst",
+  `!i ty.
       (type_subst i ty = TYPE_SUBST i ty) /\
       (EVERY (\(x,y). TYPE s x /\ TYPE s y) i /\ TYPE s ty ==>
-       TYPE s (type_subst i ty))``,
+       TYPE s (type_subst i ty))`,
   HO_MATCH_MP_TAC type_subst_ind \\ STRIP_TAC \\ Cases THEN1
    (SIMP_TAC (srw_ss()) [Once type_subst_def] >>
     SIMP_TAC (srw_ss()) [Once type_subst_def]
@@ -327,11 +327,11 @@ val type_subst_thm = store_thm("type_subst",
     rw[MAP_EQ_f] ) >>
   fs[TYPE_def,type_ok_def,EVERY_MAP,EVERY_MEM])
 
-val mk_fun_ty_thm = store_thm("mk_fun_ty_thm",
-  ``!ty1 ty2 s z s'.
+val mk_fun_ty_thm = Q.store_thm("mk_fun_ty_thm",
+  `!ty1 ty2 s z s'.
       STATE defs s /\ EVERY (TYPE defs) [ty1;ty2] /\
       (mk_fun_ty ty1 ty2 s = (z,s')) ==> (s' = s) /\
-      ?i. (z = HolRes i) /\ (i = Tyapp (strlit "fun") [ty1;ty2]) /\ TYPE defs i``,
+      ?i. (z = HolRes i) /\ (i = Tyapp (strlit "fun") [ty1;ty2]) /\ TYPE defs i`,
   SIMP_TAC std_ss [mk_fun_ty_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC mk_type_thm \\ FULL_SIMP_TAC (srw_ss()) []);
 
@@ -341,11 +341,11 @@ val mk_fun_ty_thm = store_thm("mk_fun_ty_thm",
 
 val _ = temp_overload_on("aty",``(Tyvar (strlit "A")):type``);
 
-val get_const_type_thm = prove(
-  ``!name s z s'.
+val get_const_type_thm = Q.prove(
+  `!name s z s'.
       (get_const_type name s = (z,s')) ==> (s' = s) /\
       (!i. (z = HolRes i) ==> MEM (name,i) s.the_term_constants) /\
-      (!e. (z = HolErr e) ==> !i. ~(MEM (name,i) s.the_term_constants))``,
+      (!e. (z = HolErr e) ==> !i. ~(MEM (name,i) s.the_term_constants))`,
   SIMP_TAC (srw_ss()) [get_const_type_def,ex_bind_def,
     get_the_term_constants_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC assoc_thm);
@@ -375,9 +375,9 @@ val term_type = Q.prove(
   imp_res_tac CONTEXT_std_sig >>
   fs[TYPE_def,type_ok_def,is_std_sig_def])
 
-val type_of_thm = prove(
-  ``!tm. TERM defs tm /\ STATE defs s ==>
-         (type_of tm s = (HolRes (term_type tm),s))``,
+val type_of_thm = Q.prove(
+  `!tm. TERM defs tm /\ STATE defs s ==>
+         (type_of tm s = (HolRes (term_type tm),s))`,
   HO_MATCH_MP_TAC type_of_ind \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ `CONTEXT defs` by fs[STATE_def]
@@ -407,20 +407,20 @@ val type_of_thm = prove(
   \\ IMP_RES_TAC mk_fun_ty_thm
   \\ FULL_SIMP_TAC (srw_ss()) [ex_bind_def]);
 
-val alphavars_thm = prove(
-  ``!env.
+val alphavars_thm = Q.prove(
+  `!env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))``,
+      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))`,
   Induct \\ SIMP_TAC (srw_ss()) [Once alphavars_def,ALPHAVARS_def]
   \\ Cases \\ FULL_SIMP_TAC (srw_ss()) []
   \\ METIS_TAC []);
 
-val raconv_thm = prove(
-  ``!tm1 tm2 env.
+val raconv_thm = Q.prove(
+  `!tm1 tm2 env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (raconv env tm1 tm2 = RACONV env (tm1, tm2))``,
+      (raconv env tm1 tm2 = RACONV env (tm1, tm2))`,
   Induct THEN1
    (Cases_on `tm2` >> simp[raconv_def,RACONV] >> rw[] >>
     IMP_RES_TAC alphavars_thm)
@@ -464,23 +464,23 @@ val is_term_thm = Q.store_thm("is_term_thm",
     (is_comb tm = ?x y. tm = Comb x y)`,
   Cases_on `tm` \\ EVAL_TAC \\ FULL_SIMP_TAC std_ss []);
 
-val mk_var_thm = store_thm("mk_var_thm",
-  ``STATE defs s /\ TYPE defs ty ==> TERM defs (mk_var(v,ty))``,
+val mk_var_thm = Q.store_thm("mk_var_thm",
+  `STATE defs s /\ TYPE defs ty ==> TERM defs (mk_var(v,ty))`,
   SIMP_TAC std_ss [mk_var_def] \\ METIS_TAC [TERM_Var]);
 
-val mk_abs_thm = store_thm("mk_abs_thm",
-  ``!res.
+val mk_abs_thm = Q.store_thm("mk_abs_thm",
+  `!res.
       TERM defs bvar /\ TERM defs bod /\ (mk_abs(bvar,bod) s = (res,s1)) ==>
-      (s1 = s) /\ !t. (res = HolRes t) ==> TERM defs t /\ (t = Abs bvar bod)``,
+      (s1 = s) /\ !t. (res = HolRes t) ==> TERM defs t /\ (t = Abs bvar bod)`,
   FULL_SIMP_TAC std_ss [mk_abs_def] \\ Cases_on `bvar`
   \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def,failwith_def,IMP_TERM_Abs]);
 
-val mk_comb_thm = prove(
-  ``TERM defs f /\ TERM defs a /\ STATE defs s /\
+val mk_comb_thm = Q.prove(
+  `TERM defs f /\ TERM defs a /\ STATE defs s /\
     (mk_comb(f,a)s = (res,s1)) ==>
     (s1 = s) /\
     (!t. (res = HolErr t) ==> !ty. term_type f <> Fun (term_type a) ty) /\
-    !t. (res = HolRes t) ==> TERM defs t /\ (t = Comb f a)``,
+    !t. (res = HolRes t) ==> TERM defs t /\ (t = Comb f a)`,
   SIMP_TAC std_ss [mk_comb_def,ex_bind_def] \\ STRIP_TAC
   \\ MP_TAC (type_of_thm |> SIMP_RULE std_ss [] |> Q.SPEC `f`)
   \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC \\ FULL_SIMP_TAC (srw_ss()) []
@@ -498,52 +498,52 @@ val mk_comb_thm = prove(
   \\ FULL_SIMP_TAC std_ss [MAP]
   \\ METIS_TAC [IMP_TERM_Comb,STATE_def]);
 
-val dest_var_thm = store_thm("dest_var_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val dest_var_thm = Q.store_thm("dest_var_thm",
+  `TERM defs v /\ STATE defs s ==>
     (dest_var v s = (res,s')) ==>
-    (s' = s) /\ !n ty. (res = HolRes (n,ty)) ==> TYPE defs ty``,
+    (s' = s) /\ !n ty. (res = HolRes (n,ty)) ==> TYPE defs ty`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [holKernelTheory.dest_var_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
 
-val dest_const_thm = store_thm("dest_const_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val dest_const_thm = Q.store_thm("dest_const_thm",
+  `TERM defs v /\ STATE defs s ==>
     (dest_const v s = (res,s')) ==>
-    (s' = s) /\ !n ty. (res = HolRes (n,ty)) ==> TYPE defs ty``,
+    (s' = s) /\ !n ty. (res = HolRes (n,ty)) ==> TYPE defs ty`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [dest_const_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
 
-val dest_comb_thm = store_thm("dest_comb_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val dest_comb_thm = Q.store_thm("dest_comb_thm",
+  `TERM defs v /\ STATE defs s ==>
     (dest_comb v s = (res,s')) ==>
-    (s' = s) /\ !x y. (res = HolRes (x,y)) ==> TERM defs x /\ TERM defs y``,
+    (s' = s) /\ !x y. (res = HolRes (x,y)) ==> TERM defs x /\ TERM defs y`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [dest_comb_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
 
-val dest_abs_thm = store_thm("dest_abs_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val dest_abs_thm = Q.store_thm("dest_abs_thm",
+  `TERM defs v /\ STATE defs s ==>
     (dest_abs v s = (res,s')) ==>
-    (s' = s) /\ !x y. (res = HolRes (x,y)) ==> TERM defs x /\ TERM defs y``,
+    (s' = s) /\ !x y. (res = HolRes (x,y)) ==> TERM defs x /\ TERM defs y`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [dest_abs_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC Abs_Var
   \\ FULL_SIMP_TAC std_ss [] \\ IMP_RES_TAC TERM
   \\ IMP_RES_TAC TERM_Var \\ FULL_SIMP_TAC std_ss []);
 
-val rator_thm = store_thm("rator_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val rator_thm = Q.store_thm("rator_thm",
+  `TERM defs v /\ STATE defs s ==>
     (rator v s = (res,s')) ==>
-    (s' = s) /\ !x. (res = HolRes x) ==> TERM defs x``,
+    (s' = s) /\ !x. (res = HolRes x) ==> TERM defs x`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [rator_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
 
-val rand_thm = store_thm("rand_thm",
-  ``TERM defs v /\ STATE defs s ==>
+val rand_thm = Q.store_thm("rand_thm",
+  `TERM defs v /\ STATE defs s ==>
     (rand v s = (res,s')) ==>
-    (s' = s) /\ !x. (res = HolRes x) ==> TERM defs x``,
+    (s' = s) /\ !x. (res = HolRes x) ==> TERM defs x`,
   Cases_on `v`
   \\ SIMP_TAC (srw_ss()) [rand_def,ex_return_def,Once EQ_SYM_EQ,failwith_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM);
@@ -556,9 +556,9 @@ val type_subst_fun = Q.prove(
   `type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)`,
   SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []);
 
-val TERM_Const = prove(
-  ``STATE defs r /\ MEM (name,a) r.the_term_constants ==>
-    TERM defs (Const name a)``,
+val TERM_Const = Q.prove(
+  `STATE defs r /\ MEM (name,a) r.the_term_constants ==>
+    TERM defs (Const name a)`,
   rw[STATE_def,TERM_def,term_ok_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`X = Y`(ASSUME_TAC o SYM) >>
@@ -574,9 +574,9 @@ val TERM_Const = prove(
   MATCH_MP_TAC ALOOKUP_IN_FRANGE >>
   simp[ALOOKUP_MAP] >> METIS_TAC[])
 
-val TERM_Const_type_subst = prove(
-  ``EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
-    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))``,
+val TERM_Const_type_subst = Q.prove(
+  `EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
+    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
   \\ IMP_RES_TAC type_subst_thm
   \\ FULL_SIMP_TAC std_ss [type_subst_thm,TERM_def,TYPE_def] >>
@@ -588,11 +588,11 @@ val TERM_Const_type_subst = prove(
   simp[TYPE_SUBST_compose] >>
   METIS_TAC[])
 
-val mk_const_thm = store_thm("mk_const_thm",
-  ``!name theta s z s'.
+val mk_const_thm = Q.store_thm("mk_const_thm",
+  `!name theta s z s'.
       STATE defs s /\ EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
       (mk_const (name,theta) s = (z,s')) ==> (s' = s) /\
-      !i. (z = HolRes i) ==> TERM defs i``,
+      !i. (z = HolRes i) ==> TERM defs i`,
   SIMP_TAC std_ss [mk_const_def,try_def,ex_bind_def,otherwise_def]
   \\ NTAC 3 STRIP_TAC \\ Cases_on `get_const_type name s`
   \\ IMP_RES_TAC get_const_type_thm
@@ -602,9 +602,9 @@ val mk_const_thm = store_thm("mk_const_thm",
   \\ IMP_RES_TAC get_const_type_thm \\ FULL_SIMP_TAC (srw_ss()) []
   \\ IMP_RES_TAC TERM_Const);
 
-val get_const_type_Equal = prove(
-  ``STATE defs s ==>
-    (get_const_type (strlit "=") s = (HolRes (Fun aty (Fun aty Bool)),s))``,
+val get_const_type_Equal = Q.prove(
+  `STATE defs s ==>
+    (get_const_type (strlit "=") s = (HolRes (Fun aty (Fun aty Bool)),s))`,
   SIMP_TAC std_ss [STATE_def]
   \\ Cases_on `get_const_type (strlit "=") s`
   \\ IMP_RES_TAC get_const_type_thm \\ REPEAT STRIP_TAC >>
@@ -618,33 +618,33 @@ val get_const_type_Equal = prove(
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
   rfs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
 
-val mk_const_eq = prove(
-  ``STATE defs s ==>
+val mk_const_eq = Q.prove(
+  `STATE defs s ==>
     (mk_const ((strlit "="),[]) s =
-     (HolRes (Const (strlit "=") (Fun aty (Fun aty Bool))),s))``,
+     (HolRes (Const (strlit "=") (Fun aty (Fun aty Bool))),s))`,
   SIMP_TAC std_ss [mk_const_def,ex_bind_def,try_def,otherwise_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC get_const_type_Equal
   \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def]
   \\ EVAL_TAC);
 
-val mk_eq_lemma = prove(
-  ``inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
+val mk_eq_lemma = Q.prove(
+  `inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
     ex_return
         (Const (strlit "=")
-           (Fun (term_type x) (Fun (term_type x) Bool))) s``,
+           (Fun (term_type x) (Fun (term_type x) Bool))) s`,
   SIMP_TAC (srw_ss()) [inst_def,inst_aux_def,LET_DEF]
   \\ NTAC 50 (SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF,mk_vartype_def,
        rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []);
 
-val mk_eq_thm = store_thm("mk_eq_thm",
-  ``TERM defs x /\ TERM defs y /\ STATE defs s ==>
+val mk_eq_thm = Q.store_thm("mk_eq_thm",
+  `TERM defs x /\ TERM defs y /\ STATE defs s ==>
     (mk_eq(x,y)s = (res,s')) ==>
     (s' = s) /\
     (!t. (res = HolErr t) ==> ((term_type x) <> (term_type y))) /\
     !t. (res = HolRes t) ==>
     (t = Comb (Comb (Const (strlit "=") (Fun (term_type x)
                                (Fun (term_type x) Bool))) x) y) /\
-    TERM defs t``,
+    TERM defs t`,
   STRIP_TAC \\ SIMP_TAC std_ss [mk_eq_def,try_def,ex_bind_def,
     otherwise_def,mk_vartype_def]
   \\ `CONTEXT defs` by fs[STATE_def]
@@ -725,10 +725,10 @@ val Equal_type_IMP = Q.prove(
   fs[Once term_type_def] >>
   rw[] >> imp_res_tac term_type >> simp[])
 
-val dest_eq_thm = store_thm("dest_eq_thm",
-  ``TERM defs tm /\ STATE defs s /\ (dest_eq tm s = (res, s')) ==>
+val dest_eq_thm = Q.store_thm("dest_eq_thm",
+  `TERM defs tm /\ STATE defs s /\ (dest_eq tm s = (res, s')) ==>
     (s' = s) /\ !t1 t2. (res = HolRes (t1,t2)) ==> TERM defs t1 /\ TERM defs t2 /\
-    (tm = Comb (Comb (Equal (typeof t1)) t1) t2)``,
+    (tm = Comb (Comb (Equal (typeof t1)) t1) t2)`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ SIMP_TAC std_ss [dest_eq_def]
   \\ BasicProvers.EVERY_CASE_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [failwith_def,ex_return_def]
@@ -743,20 +743,20 @@ val VFREE_IN_IMP = Q.prove(
         vfree_in (Var name ty) y`,
   METIS_TAC [vfree_in_thm]);
 
-val SELECT_LEMMA = prove(
-  ``(@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)``,
+val SELECT_LEMMA = Q.prove(
+  `(@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)`,
   Q.ABBREV_TAC `p = (@f. !s s'. f (s',s) <=> s <> t)`
   \\ `?f. !s s'. f (s',s) <=> s <> t` by ALL_TAC
   THEN1 (Q.EXISTS_TAC `(\(z,y). y <> t)` \\ FULL_SIMP_TAC std_ss [])
   \\ `!s s'. p (s',s) <=> s <> t` by METIS_TAC []
   \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
 
-val SELECT_LEMMA2 = prove(
-  ``(@f.
+val SELECT_LEMMA2 = Q.prove(
+  `(@f.
        !s s''.
          f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm') =
-    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')``,
+    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')`,
   Q.ABBREV_TAC `p = (@f. !s s''. f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm')`
   \\ `?f. !s s''. f (s'',s) <=>
@@ -810,13 +810,13 @@ val term_type_Var = Q.prove(
   `term_type (Var v ty) = ty`,
   SIMP_TAC (srw_ss()) [Once term_type_def]);
 
-val vsubst_aux_thm = prove(
-  ``!t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
+val vsubst_aux_thm = Q.prove(
+  `!t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
                      (term_type t1 = term_type t2) /\ is_var t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (vsubst_aux theta tm = t) ==>
     TERM defs t /\
-    (t = VSUBST theta tm)``,
+    (t = VSUBST theta tm)`,
   SIMP_TAC std_ss [] \\ Induct THEN1
    (NTAC 4 STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def]
     \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def,VSUBST_def]
@@ -947,10 +947,10 @@ val vsubst_aux_thm = prove(
   Q.PAT_ABBREV_TAC`vv = holSyntax$VARIANT A B Z` >>
   simp[])
 
-val forall_thm = prove(
-  ``!f s (xs:(term # term) list). (forall f xs s = (res,s')) ==>
+val forall_thm = Q.prove(
+  `!f s (xs:(term # term) list). (forall f xs s = (res,s')) ==>
     (!x. ?r. f x s = (r,s)) ==>
-    (s' = s) /\ ((res = HolRes T) ==> EVERY (\x. FST (f x s) = HolRes T) xs)``,
+    (s' = s) /\ ((res = HolRes T) ==> EVERY (\x. FST (f x s) = HolRes T) xs)`,
   STRIP_TAC \\ STRIP_TAC
   \\ Induct \\ ASM_SIMP_TAC (srw_ss()) [Once forall_def,ex_return_def,ex_bind_def]
   \\ STRIP_TAC \\ Cases_on `f h s` \\ SIMP_TAC std_ss [Once EQ_SYM_EQ]
@@ -959,13 +959,13 @@ val forall_thm = prove(
   \\ Cases_on `a` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC [FST,PAIR]);
 
-val assoc_state = prove(
-  ``!xs x. ?r. assoc x xs s = (r,s)``,
+val assoc_state = Q.prove(
+  `!xs x. ?r. assoc x xs s = (r,s)`,
   Induct \\ ONCE_REWRITE_TAC [assoc_def] \\ TRY Cases
   \\ FULL_SIMP_TAC (srw_ss()) [failwith_def,ex_return_def] \\ SRW_TAC [] []);
 
-val type_of_state = prove(
-  ``!tm. ?r. type_of tm s = (r,s)``,
+val type_of_state = Q.prove(
+  `!tm. ?r. type_of tm s = (r,s)`,
   HO_MATCH_MP_TAC type_of_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [Once type_of_def] \\ Cases_on `tm`
   \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def,failwith_def,ex_bind_def]
@@ -986,14 +986,14 @@ val type_of_state = prove(
   \\ Cases_on `r` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ SRW_TAC [] []);
 
-val vsubst_thm = store_thm("vsubst_thm",
-  ``EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2) theta /\
+val vsubst_thm = Q.store_thm("vsubst_thm",
+  `EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (vsubst theta tm s = (res, s')) ==>
     (s' = s) /\ !t. (res = HolRes t) ==> TERM defs t /\
     (t = VSUBST  theta tm) /\
     (EVERY (\(p_1,p_2). ?x ty. (p_2 = Var x ty) /\
-                               (p_1) has_type ty) theta)``,
+                               (p_1) has_type ty) theta)`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ SIMP_TAC std_ss [vsubst_def]
   \\ Cases_on `theta = []`
   \\ FULL_SIMP_TAC (srw_ss()) [MAP,VSUBST_EMPTY,ex_return_def,ex_bind_def]
@@ -1041,9 +1041,9 @@ val vsubst_thm = store_thm("vsubst_thm",
   rfs[STATE_def] >>
   rw[] >> METIS_TAC [WELLTYPED,term_ok_welltyped])
 
-val inst_aux_Var = prove(
-  ``inst_aux [] theta (Var v ty) state =
-      (HolRes (Var v (type_subst theta ty)),state)``,
+val inst_aux_Var = Q.prove(
+  `inst_aux [] theta (Var v ty) state =
+      (HolRes (Var v (type_subst theta ty)),state)`,
   SIMP_TAC (srw_ss()) [Once inst_aux_def,rev_assocd_thm,REV_ASSOCD,
        LET_DEF,ex_return_def] \\ METIS_TAC []);
 
@@ -1058,8 +1058,8 @@ val MEM_frees = Q.prove(
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC Abs_Var \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [MEM_union,MEM_subtract]);
 
-val inst_aux_thm = prove(
-  ``!env theta tm s s' res.
+val inst_aux_thm = Q.prove(
+  `!env theta tm s s' res.
       EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
       EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2) env /\
       TERM defs tm /\ STATE defs s /\
@@ -1068,7 +1068,7 @@ val inst_aux_thm = prove(
       case res of
       | HolRes t => (INST_CORE env theta tm = Result t)
       | HolErr (Fail _) => T
-      | HolErr (Clash v) => (INST_CORE env theta tm = Clash v)``,
+      | HolErr (Clash v) => (INST_CORE env theta tm = Clash v)`,
   HO_MATCH_MP_TAC inst_aux_ind \\ NTAC 4 STRIP_TAC \\ Cases_on `tm`
   \\ FULL_SIMP_TAC (srw_ss()) []
   THEN1
@@ -1230,12 +1230,12 @@ val inst_aux_thm = prove(
   BasicProvers.CASE_TAC >> fs[] >>
   BasicProvers.CASE_TAC >> fs[])
 
-val inst_lemma = prove(
-  ``EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
+val inst_lemma = Q.prove(
+  `EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (inst theta tm s = (res, s')) ==>
     STATE defs s' /\ !t. (res = HolRes t) ==>
-    (t = INST theta (tm))``,
+    (t = INST theta (tm))`,
   SIMP_TAC std_ss [INST_def,inst_def] \\ Cases_on `theta = []`
   \\ ASM_SIMP_TAC std_ss [MAP,EVERY_DEF,ex_return_def] THEN1
    (Q.SPEC_TAC (`res`,`res`) \\ SIMP_TAC (srw_ss()) []
@@ -1259,12 +1259,12 @@ val inst_lemma = prove(
   \\ FULL_SIMP_TAC std_ss [MAP,RESULT_def,result_distinct,result_11]
   \\ Cases_on `res` \\ FULL_SIMP_TAC (srw_ss()) [])
 
-val inst_thm = store_thm("inst_thm",
-  ``EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
+val inst_thm = Q.store_thm("inst_thm",
+  `EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (inst theta tm s = (res, s')) ==>
     STATE defs s' /\ !t. (res = HolRes t) ==> TERM defs t /\
-    (t = INST theta (tm))``,
+    (t = INST theta (tm))`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC inst_lemma
   \\ FULL_SIMP_TAC std_ss [TERM_def] >> imp_res_tac term_ok_welltyped
   \\ IMP_RES_TAC INST_CORE_LEMMA
@@ -1353,9 +1353,9 @@ val QSORT_type_vars_in_term = Q.prove(
 (* Verification of thm functions                                             *)
 (* ------------------------------------------------------------------------- *)
 
-val dest_thm_thm = store_thm("dest_thm_thm",
-  ``THM defs th /\ STATE defs s /\ (dest_thm th = (asl, c)) ==>
-    EVERY (TERM defs) asl /\ TERM defs c``,
+val dest_thm_thm = Q.store_thm("dest_thm_thm",
+  `THM defs th /\ STATE defs s /\ (dest_thm th = (asl, c)) ==>
+    EVERY (TERM defs) asl /\ TERM defs c`,
   REPEAT STRIP_TAC \\ Cases_on `th` \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [dest_thm_def] \\ METIS_TAC []);
 
@@ -1371,9 +1371,9 @@ val concl_thm = Q.store_thm("concl_thm",
   REPEAT STRIP_TAC \\ Cases_on `th` \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [concl_def] \\ METIS_TAC []);
 
-val REFL_thm = store_thm("REFL_thm",
-  ``TERM defs tm /\ STATE defs s /\ (REFL tm s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+val REFL_thm = Q.store_thm("REFL_thm",
+  `TERM defs tm /\ STATE defs s /\ (REFL tm s = (res, s')) ==>
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   SIMP_TAC std_ss [REFL_def,ex_bind_def] \\ Cases_on `mk_eq(tm,tm) s`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC mk_eq_thm
   \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [ex_return_def]
@@ -1386,10 +1386,10 @@ val REFL_thm = store_thm("REFL_thm",
   fs[CONTEXT_def,TERM_def] >>
   METIS_TAC[extends_theory_ok,init_theory_ok])
 
-val TRANS_thm = store_thm("TRANS_thm",
-  ``THM defs th1 /\ THM defs th2 /\ STATE defs s /\
+val TRANS_thm = Q.store_thm("TRANS_thm",
+  `THM defs th1 /\ THM defs th2 /\ STATE defs s /\
     (TRANS th1 th2 s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [TRANS_def]
   \\ BasicProvers.EVERY_CASE_TAC
@@ -1419,10 +1419,10 @@ val TRANS_thm = store_thm("TRANS_thm",
   MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,9)) >>
   METIS_TAC[])
 
-val SYM_thm = store_thm("SYM_thm",
-  ``THM defs th /\ STATE defs s /\
+val SYM_thm = Q.store_thm("SYM_thm",
+  `THM defs th /\ STATE defs s /\
     (SYM th s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on`th`>>rw[EQ_SYM_EQ]>>fs[SYM_def]>>
   every_case_tac >> fs[failwith_def,ex_return_def] >>
   fs[THM_def] >> rw[] >>
@@ -1518,10 +1518,10 @@ val ALPHA_THM_thm = Q.store_thm("ALPHA_THM_thm",
   fs[MEM_MAP,PULL_EXISTS] >>
   METIS_TAC[term_type,STATE_def,TERM_def,WELLTYPED_LEMMA,WELLTYPED,term_ok_welltyped])
 
-val MK_COMB_thm = store_thm("MK_COMB_thm",
-  ``THM defs th1 /\ THM defs th2 /\ STATE defs s /\
+val MK_COMB_thm = Q.store_thm("MK_COMB_thm",
+  `THM defs th1 /\ THM defs th2 /\ STATE defs s /\
     (MK_COMB (th1,th2) s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [MK_COMB_def]
   \\ BasicProvers.EVERY_CASE_TAC
@@ -1562,10 +1562,10 @@ val MK_COMB_thm = store_thm("MK_COMB_thm",
   qpat_x_assum`TERM x (Comb f1 x1)`mp_tac >> simp[TERM_Comb] >> strip_tac >>
   fs[TERM_def] >> imp_res_tac term_ok_welltyped >> simp[])
 
-val ABS_thm = store_thm("ABS_thm",
-  ``TERM defs tm /\ THM defs th1 /\ STATE defs s /\
+val ABS_thm = Q.store_thm("ABS_thm",
+  `TERM defs tm /\ THM defs th1 /\ STATE defs s /\
     (ABS tm th1 s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ SIMP_TAC std_ss [ABS_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [failwith_def]
   \\ Cases_on `t'` \\ FULL_SIMP_TAC (srw_ss()) [failwith_def]
@@ -1617,10 +1617,10 @@ val ABS_thm = store_thm("ABS_thm",
   REPEAT STRIP_TAC \\ RES_TAC
   \\ IMP_RES_TAC TERM \\ IMP_RES_TAC VFREE_IN_IMP)
 
-val BETA_thm = store_thm("BETA_thm",
-  ``TERM defs tm /\ STATE defs s /\
+val BETA_thm = Q.store_thm("BETA_thm",
+  `TERM defs tm /\ STATE defs s /\
     (BETA tm s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   SIMP_TAC std_ss [BETA_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ Cases_on `tm` \\ FULL_SIMP_TAC (srw_ss()) [failwith_def]
   \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [failwith_def]
@@ -1647,10 +1647,10 @@ val BETA_thm = store_thm("BETA_thm",
   fs[CONTEXT_def,TERM_def,TYPE_def] >>
   METIS_TAC[extends_theory_ok,init_theory_ok])
 
-val ASSUME_thm = store_thm("ASSUME_thm",
-  ``TERM defs tm /\ STATE defs s /\
+val ASSUME_thm = Q.store_thm("ASSUME_thm",
+  `TERM defs tm /\ STATE defs s /\
     (ASSUME tm s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   SIMP_TAC std_ss [ASSUME_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ STRIP_TAC \\ MP_TAC (type_of_thm |> Q.SPEC `tm`)
   \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC \\ FULL_SIMP_TAC std_ss []
@@ -1672,10 +1672,10 @@ val ASSUME_thm = store_thm("ASSUME_thm",
   FULL_SIMP_TAC std_ss [WELLTYPED]
   >> METIS_TAC[CONTEXT_def,extends_theory_ok,init_theory_ok])
 
-val EQ_MP_thm = store_thm("EQ_MP_thm",
-  ``THM defs th1 /\ THM defs th2 /\ STATE defs s /\
+val EQ_MP_thm = Q.store_thm("EQ_MP_thm",
+  `THM defs th1 /\ THM defs th2 /\ STATE defs s /\
     (EQ_MP th1 th2 s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [EQ_MP_def]
   \\ BasicProvers.EVERY_CASE_TAC
@@ -1697,10 +1697,10 @@ val EQ_MP_thm = store_thm("EQ_MP_thm",
   fs[TERM_Comb] >>
   METIS_TAC[aconv_thm])
 
-val DEDUCT_ANTISYM_RULE_thm = store_thm("DEDUCT_ANTISYM_RULE_thm",
-  ``THM defs th1 /\ THM defs th2 /\ STATE defs s /\
+val DEDUCT_ANTISYM_RULE_thm = Q.store_thm("DEDUCT_ANTISYM_RULE_thm",
+  `THM defs th1 /\ THM defs th2 /\ STATE defs s /\
     (DEDUCT_ANTISYM_RULE th1 th2 s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [DEDUCT_ANTISYM_RULE_def,LET_DEF,ex_bind_def]
   \\ Cases_on `mk_eq (t,t') s` \\ STRIP_TAC
@@ -1723,13 +1723,13 @@ val DEDUCT_ANTISYM_RULE_thm = store_thm("DEDUCT_ANTISYM_RULE_thm",
   MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,3)) >>
   simp[])
 
-val image_lemma = prove(
-  ``∀f l s g defs res s'.
+val image_lemma = Q.prove(
+  `∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ∃r s'. ((f x s = (r,s'))) ∧ STATE defs s' ∧
                             (∀t. (r = HolRes t) ⇒ (t = g x))) l ⇒
-      STATE defs s' ∧ ∀ts. (res = HolRes ts) ⇒ (ts = term_image g l)``,
+      STATE defs s' ∧ ∀ts. (res = HolRes ts) ⇒ (ts = term_image g l)`,
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[ex_return_def,Once term_image_def] ) >>
   simp[ex_bind_def] >> rpt gen_tac >>
@@ -1744,11 +1744,11 @@ val image_lemma = prove(
   rpt BasicProvers.VAR_EQ_TAC >>
   simp[] >> res_tac >> fs[])
 
-val INST_TYPE_thm = store_thm("INST_TYPE_thm",
-  ``EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
+val INST_TYPE_thm = Q.store_thm("INST_TYPE_thm",
+  `EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
     THM defs th1 /\ STATE defs s /\
     (INST_TYPE theta th1 s = (res, s')) ==>
-    STATE defs s' /\ !th. (res = HolRes th) ==> THM defs th``,
+    STATE defs s' /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [INST_TYPE_def,LET_DEF,ex_bind_def]
   \\ STRIP_TAC \\ IMP_RES_TAC THM
@@ -1774,13 +1774,13 @@ val INST_TYPE_thm = store_thm("INST_TYPE_thm",
   fs[EVERY_MEM,FORALL_PROD,TYPE_def] >>
   METIS_TAC[])
 
-val image_lemma = prove(
-  ``∀f l s g defs res s'.
+val image_lemma = Q.prove(
+  `∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ∃r s'. ((f x s = (r,s))) ∧
                             (∀t. (r = HolRes t) ⇒ (t = g x))) l ⇒
-      (s' = s) ∧ ∀ts. (res = HolRes ts) ⇒ (ts = term_image g l)``,
+      (s' = s) ∧ ∀ts. (res = HolRes ts) ⇒ (ts = term_image g l)`,
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[ex_return_def,Once term_image_def] ) >>
   simp[ex_bind_def] >> rpt gen_tac >>
@@ -1795,11 +1795,11 @@ val image_lemma = prove(
   rpt BasicProvers.VAR_EQ_TAC >>
   simp[] >> res_tac >> fs[])
 
-val INST_thm = store_thm("INST_thm",
-  ``EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2) theta /\
+val INST_thm = Q.store_thm("INST_thm",
+  `EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2) theta /\
     THM defs th1 /\ STATE defs s /\
     (INST theta th1 s = (res, s')) ==>
-    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th``,
+    (s' = s) /\ !th. (res = HolRes th) ==> THM defs th`,
   Cases_on `th1` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [holKernelTheory.INST_def,LET_DEF,ex_bind_def]
   \\ STRIP_TAC \\ IMP_RES_TAC THM
@@ -1866,12 +1866,12 @@ val first_dup_SOME = Q.prove(
   res_tac >> rw[] >> fs[ALL_DISTINCT] >> fs[] >>
   METIS_TAC[])
 
-val add_constants_thm = prove(
-  ``∀ls s res s'. (add_constants ls s = (res,s')) ⇒
+val add_constants_thm = Q.prove(
+  `∀ls s res s'. (add_constants ls s = (res,s')) ⇒
       (∀u. (res = HolRes u) ∧ ALL_DISTINCT (MAP FST s.the_term_constants) ⇒
            ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants) ∧
            (s' = s with the_term_constants := ls++s.the_term_constants)) ∧
-      (∀msg. (res = HolErr msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))``,
+      (∀msg. (res = HolErr msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))`,
   simp_tac std_ss [add_constants_def,GSYM STRCAT_SHADOW_def] >>
   simp[ex_bind_def,get_the_term_constants_def] >>
   rpt gen_tac >>
@@ -1885,12 +1885,12 @@ val add_constants_thm = prove(
   rpt BasicProvers.VAR_EQ_TAC >> simp[] >>
   simp[ALL_DISTINCT_APPEND])
 
-val new_specification_thm = store_thm("new_specification_thm",
-  ``THM defs th /\ STATE defs s ==>
+val new_specification_thm = Q.store_thm("new_specification_thm",
+  `THM defs th /\ STATE defs s ==>
     case new_specification th s of
     | (HolErr exn, s') => (s' = s)
     | (HolRes th, s') => (?d. THM (d::defs) th /\
-                              STATE (d::defs) s')``,
+                              STATE (d::defs) s')`,
   Cases_on`th` >>
   simp_tac std_ss [new_specification_def,GSYM STRCAT_SHADOW_def] >>
   simp[ex_bind_def,ex_return_def] >>
@@ -2119,12 +2119,12 @@ val new_specification_thm = store_thm("new_specification_thm",
 
 val _ = delete_const"STRCAT_SHADOW"
 
-val new_basic_definition_thm = store_thm("new_basic_definition_thm",
-  ``TERM defs tm /\ STATE defs s ==>
+val new_basic_definition_thm = Q.store_thm("new_basic_definition_thm",
+  `TERM defs tm /\ STATE defs s ==>
     case new_basic_definition tm s of
     | (HolErr exn, s') => (s' = s)
     | (HolRes th, s') => (?d. THM (d::defs) th /\
-                              STATE (d::defs) s')``,
+                              STATE (d::defs) s')`,
   rw[] >>
   simp[new_basic_definition_def,ex_bind_def] >>
   Cases_on`ASSUME tm s` >>
@@ -2132,13 +2132,13 @@ val new_basic_definition_thm = store_thm("new_basic_definition_thm",
   Cases_on`q`>>fs[] >>
   imp_res_tac new_specification_thm )
 
-val new_basic_type_definition_thm = store_thm("new_basic_type_definition_thm",
-  ``THM defs th /\ STATE defs s ==>
+val new_basic_type_definition_thm = Q.store_thm("new_basic_type_definition_thm",
+  `THM defs th /\ STATE defs s ==>
     case new_basic_type_definition tyname absname repname th s of
     | (HolErr exn, s') => (s' = s)
     | (HolRes (th1,th2), s') =>
       (?ds. THM (ds++defs) th1 /\ THM (ds++defs) th2 /\
-            STATE (ds++defs) s')``,
+            STATE (ds++defs) s')`,
   Cases_on `th` \\ SIMP_TAC (srw_ss())
      [new_basic_type_definition_def,Once ex_bind_def,ex_return_def,failwith_def,
       can_def |> SIMP_RULE std_ss [otherwise_def,ex_bind_def,ex_return_def]] >>
@@ -2402,11 +2402,11 @@ val new_basic_type_definition_thm = store_thm("new_basic_type_definition_thm",
 (* Verification of context extension functions                               *)
 (* ------------------------------------------------------------------------- *)
 
-val new_type_thm = store_thm("new_type_thm",
-  ``STATE defs s ⇒
+val new_type_thm = Q.store_thm("new_type_thm",
+  `STATE defs s ⇒
     case new_type (name,arity) s of
     | (HolErr exn, s') => (s' = s)
-    | (HolRes (), s') => (?d. STATE (d::defs) s')``,
+    | (HolRes (), s') => (?d. STATE (d::defs) s')`,
   rw[new_type_def,ex_bind_def,add_type_def,can_def,get_type_arity_def,get_the_type_constants_def
     ,otherwise_def,ex_return_def,failwith_def] >>
   BasicProvers.CASE_TAC >>
@@ -2421,11 +2421,11 @@ val new_type_thm = store_thm("new_type_thm",
   disj2_tac >> simp[GSYM extends_def] >>
   rfs[updates_cases,MEM_MAP,EXISTS_PROD] )
 
-val new_constant_thm = store_thm("new_constant_thm",
-  ``STATE defs s ∧ TYPE defs ty ⇒
+val new_constant_thm = Q.store_thm("new_constant_thm",
+  `STATE defs s ∧ TYPE defs ty ⇒
     case new_constant (name,ty) s of
     | (HolErr exn, s') => (s' = s)
-    | (HolRes (), s') => (?d. STATE (d::defs) s')``,
+    | (HolRes (), s') => (?d. STATE (d::defs) s')`,
   rw[new_constant_def,ex_bind_def] >>
   qspecl_then[`[(name,ty)]`,`s`]mp_tac add_constants_thm >>
   Cases_on`add_constants [(name,ty)] s`>>simp[] >>
@@ -2440,11 +2440,11 @@ val new_constant_thm = store_thm("new_constant_thm",
   rfs[updates_cases,MEM_MAP,EXISTS_PROD] >>
   fs[TYPE_def] )
 
-val new_axiom_thm = store_thm("new_axiom_thm",
-  ``STATE defs s ∧ TERM defs p ⇒
+val new_axiom_thm = Q.store_thm("new_axiom_thm",
+  `STATE defs s ∧ TERM defs p ⇒
     case new_axiom p s of
     | (HolErr exn, s') => (s' = s)
-    | (HolRes th, s') => (?d. THM (d::defs) th ∧ STATE (d::defs) s')``,
+    | (HolRes th, s') => (?d. THM (d::defs) th ∧ STATE (d::defs) s')`,
   rw[new_axiom_def,ex_bind_def] >>
   imp_res_tac type_of_thm >> rw[] >>
   qspecl_then[`(strlit "bool")`,`[]`,`s`]mp_tac mk_type_thm >>

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -571,16 +571,16 @@ val _ = Define `
   this a non-failing function to make it pure.
 *)
 
-val EXISTS_IMP = prove(
-  ``!xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x``,
+val EXISTS_IMP = Q.prove(
+  `!xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x`,
   Induct THEN SIMP_TAC (srw_ss()) [EXISTS_DEF] THEN METIS_TAC []);
 
-val MEM_subtract = prove(
-  ``!y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)``,
+val MEM_subtract = Q.prove(
+  `!y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)`,
   FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER] THEN METIS_TAC []);
 
-val vfree_in_IMP = prove(
-  ``!(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)``,
+val vfree_in_IMP = Q.prove(
+  `!(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)`,
   HO_MATCH_MP_TAC (SIMP_RULE std_ss [] (vfree_in_ind))
   THEN REPEAT STRIP_TAC THEN Cases_on `x` THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [vfree_in_def,frees_def]
@@ -670,25 +670,25 @@ val my_term_size_def = Define `
   (my_term_size (Comb s1 s2) = 1 + my_term_size s1 + my_term_size s2) /\
   (my_term_size (Abs s1 s2) = 1 + my_term_size s1 + my_term_size s2)`;
 
-val my_term_size_variant = prove(
-  ``!avoid t. my_term_size (variant avoid t) = my_term_size t``,
+val my_term_size_variant = Q.prove(
+  `!avoid t. my_term_size (variant avoid t) = my_term_size t`,
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
   THEN FULL_SIMP_TAC std_ss [my_term_size_def]);
 
-val is_var_variant = prove(
-  ``!avoid t. is_var (variant avoid t) = is_var t``,
+val is_var_variant = Q.prove(
+  `!avoid t. is_var (variant avoid t) = is_var t`,
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
   THEN FULL_SIMP_TAC (srw_ss()) [my_term_size_def,fetch "-" "is_var_def"]);
 
-val my_term_size_vsubst_aux = prove(
-  ``!t xs. EVERY (\x. is_var (FST x)) xs ==>
-           (my_term_size (vsubst_aux xs t) = my_term_size t)``,
+val my_term_size_vsubst_aux = Q.prove(
+  `!t xs. EVERY (\x. is_var (FST x)) xs ==>
+           (my_term_size (vsubst_aux xs t) = my_term_size t)`,
   Induct THEN1
    (FULL_SIMP_TAC (srw_ss()) [my_term_size_def,Once (fetch "-" "vsubst_aux_def")]
     THEN Induct_on `xs` THEN1 (EVAL_TAC THEN SRW_TAC [] [my_term_size_def])
@@ -708,8 +708,8 @@ val my_term_size_vsubst_aux = prove(
   |> Q.SPECL [`t`,`[(Var v ty,x)]`]
   |> SIMP_RULE (srw_ss()) [EVERY_DEF,fetch "-" "is_var_def"]
 
-val ZERO_LT_term_size = prove(
-  ``!t. 0 < my_term_size t``,
+val ZERO_LT_term_size = Q.prove(
+  `!t. 0 < my_term_size t`,
   Cases THEN EVAL_TAC THEN DECIDE_TAC);
 
 val inst_aux_def = tDefine "inst_aux" `

--- a/candle/standard/monadic/pmatch/pmatchExamplesScript.sml
+++ b/candle/standard/monadic/pmatch/pmatchExamplesScript.sml
@@ -5,8 +5,8 @@ open holKernelTheory
 val _ = new_theory"pmatchExamples"
 
 (* TODO: stolen from deepMatchesLib.sml; should be exported? *)
-val PAIR_EQ_COLLAPSE = prove (
-``(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))``,
+val PAIR_EQ_COLLAPSE = Q.prove (
+`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
 Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
 
 val pabs_elim_ss =
@@ -44,8 +44,8 @@ val static_ss = simpLib.merge_ss
 fun rc_ss gl = srw_ss() ++ simpLib.merge_ss (static_ss :: gl)
 (* -- *)
 
-val raconv_PMATCH_eq = prove(
-  ``^(rhs(concl(SPEC_ALL raconv_def))) =
+val raconv_PMATCH_eq = Q.prove(
+  `^(rhs(concl(SPEC_ALL raconv_def))) =
     CASE (tm1,tm2) OF
     [ ||. (Var _ _, Var _ _) ~> alphavars env tm1 tm2
     ; ||. (Const _ _, Const _ _) ~> (tm1 = tm2)
@@ -58,7 +58,7 @@ val raconv_PMATCH_eq = prove(
            ; ||. _ ~> F
            ]
     ; ||. _ ~> F
-    ]``,
+    ]`,
   rpt (
   BasicProvers.PURE_CASE_TAC >>
   FULL_SIMP_TAC (rc_ss []) [PMATCH_EVAL, PMATCH_ROW_COND_def,
@@ -73,8 +73,8 @@ val raconv_PMATCH =
 
 (* stolen from deepMatchesLib.sml TODO *)
 
-val PAIR_EQ_COLLAPSE = prove (
-``(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))``,
+val PAIR_EQ_COLLAPSE = Q.prove (
+`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
 Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
 
 val pabs_elim_ss =

--- a/candle/standard/semantics/holAxiomsScript.sml
+++ b/candle/standard/semantics/holAxiomsScript.sml
@@ -19,11 +19,11 @@ val _ = Parse.temp_overload_on("FAy",``Forall (strlit "y") B``)
 
 val mem = ``mem:'U->'U->bool``
 
-val eta_has_model = store_thm("eta_has_model",
-  ``is_set_theory ^mem ⇒
+val eta_has_model = Q.store_thm("eta_has_model",
+  `is_set_theory ^mem ⇒
     ∀ctxt. is_std_sig (sigof ctxt) ⇒
       ∀i. i models (thyof ctxt) ⇒
-        i models (thyof (mk_eta_ctxt ctxt))``,
+        i models (thyof (mk_eta_ctxt ctxt))`,
   rw[models_def,mk_eta_ctxt_def,conexts_of_upd_def] >> res_tac >>
   rw[satisfies_def] >>
   `is_structure (sigof ctxt) i v` by simp[is_structure_def] >>
@@ -60,8 +60,8 @@ val good_select_def = xDefine"good_select"`
   good_select0 ^mem select = (∀ty p x. x <: ty ⇒ select ty p <: ty ∧ (p x ⇒ p (select ty p)))`
 val _ = Parse.overload_on("good_select",``good_select0 ^mem``)
 
-val select_has_model_gen = store_thm("select_has_model_gen",
-  ``is_set_theory ^mem ⇒
+val select_has_model_gen = Q.store_thm("select_has_model_gen",
+  `is_set_theory ^mem ⇒
     ∀ctxt.
       (strlit "@") ∉ FDOM (tmsof ctxt) ∧
       is_implies_sig (tmsof ctxt) ∧
@@ -75,7 +75,7 @@ val select_has_model_gen = store_thm("select_has_model_gen",
              i' models (thyof (mk_select_ctxt ctxt)) ∧
              (tmaof i' (strlit "@") =
                 (λls. Abstract (Funspace (HD ls) boolset) (HD ls)
-                        (λp. select (HD ls) (Holds p))))``,
+                        (λp. select (HD ls) (Holds p))))`,
   rw[good_select_def,models_def,mk_select_ctxt_def,conexts_of_upd_def,is_implies_sig_def,is_implies_interpretation_def] >>
   qexists_tac`(tyaof i, (strlit "@" =+ λl. Abstract (Funspace (HD l) boolset) (HD l)
                                       (λp. select (HD l) (Holds p))) (tmaof i))` >>
@@ -184,9 +184,9 @@ val base_select_def = xDefine "base_select"`
     else ARB`
 val _ = Parse.overload_on("base_select",``base_select0 ^mem``)
 
-val good_select_base_select = store_thm("good_select_base_select",
-  ``is_set_theory ^mem ⇒
-    good_select base_select``,
+val good_select_base_select = Q.store_thm("good_select_base_select",
+  `is_set_theory ^mem ⇒
+    good_select base_select`,
   rw[good_select_def,base_select_def] >>
   rw[]>> TRY(metis_tac[]) >>
   TRY (
@@ -201,8 +201,8 @@ val good_select_base_select = store_thm("good_select_base_select",
   simp[Abbr`Z`,Abbr`Q`,Abbr`R`] >>
   metis_tac[] )
 
-val select_has_model = store_thm("select_has_model",
-  ``is_set_theory ^mem ⇒
+val select_has_model = Q.store_thm("select_has_model",
+  `is_set_theory ^mem ⇒
     ∀ctxt.
       (strlit "@") ∉ FDOM (tmsof ctxt) ∧
       is_implies_sig (tmsof ctxt) ∧
@@ -212,7 +212,7 @@ val select_has_model = store_thm("select_has_model",
         i models (thyof ctxt) ∧
         is_implies_interpretation (tmaof i)
       ⇒ ∃i'. equal_on (sigof ctxt) i i' ∧
-             i' models (thyof (mk_select_ctxt ctxt))``,
+             i' models (thyof (mk_select_ctxt ctxt))`,
   rw[] >>
   qspec_then`ctxt`mp_tac(UNDISCH select_has_model_gen) >>
   simp[] >>
@@ -261,8 +261,8 @@ val apply_abstract_tac = rpt ( (
     `tmsof sctx = tmsof (sigof sctx)` by simp[] >> pop_assum SUBST1_TAC >>
     rw[SIMP_RULE std_ss [] termsem_equation,boolean_in_boolset]
 
-val infinity_has_model_gen = store_thm("infinity_has_model_gen",
-  ``is_set_theory ^mem  ⇒
+val infinity_has_model_gen = Q.store_thm("infinity_has_model_gen",
+  `is_set_theory ^mem  ⇒
     ∀ctxt.
       theory_ok (thyof ctxt) ∧
       DISJOINT (FDOM (tmsof ctxt)) {strlit "ONE_ONE";strlit "ONTO"} ∧
@@ -283,7 +283,7 @@ val infinity_has_model_gen = store_thm("infinity_has_model_gen",
           is_infinite ^mem inf
       ⇒ ∃i'. equal_on (sigof ctxt) i i' ∧
              i' models (thyof (mk_infinity_ctxt ctxt)) ∧
-             (tyaof i' (strlit "ind") [] = inf)``,
+             (tyaof i' (strlit "ind") [] = inf)`,
   rw[models_def,is_implies_sig_def,is_and_sig_def,is_forall_sig_def,is_exists_sig_def,is_not_sig_def,
      is_implies_interpretation_def,is_and_interpretation_def,is_forall_interpretation_def,is_exists_interpretation_def,is_not_interpretation_def] >>
   `∃ctxt1 p. mk_infinity_ctxt ctxt = (NewAxiom p)::(NewType (strlit "ind") 0)::ctxt1` by simp[mk_infinity_ctxt_def] >>
@@ -662,8 +662,8 @@ val infinity_has_model_gen = store_thm("infinity_has_model_gen",
     metis_tac[]) >>
   simp[combinTheory.APPLY_UPDATE_THM])
 
-val infinity_has_model = store_thm("infinity_has_model",
-  ``is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
+val infinity_has_model = Q.store_thm("infinity_has_model",
+  `is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
     ∀ctxt.
       theory_ok (thyof ctxt) ∧
       DISJOINT (FDOM (tmsof ctxt)) {strlit"ONE_ONE";strlit"ONTO"} ∧
@@ -682,7 +682,7 @@ val infinity_has_model = store_thm("infinity_has_model",
           is_exists_interpretation (tmaof i) ∧
           is_not_interpretation (tmaof i)
       ⇒ ∃i'. equal_on (sigof ctxt) i i' ∧
-             i' models (thyof (mk_infinity_ctxt ctxt))``,
+             i' models (thyof (mk_infinity_ctxt ctxt))`,
   metis_tac[infinity_has_model_gen])
 
 val _ = export_theory()

--- a/candle/standard/semantics/holBoolScript.sml
+++ b/candle/standard/semantics/holBoolScript.sml
@@ -20,8 +20,8 @@ val _ = Parse.temp_overload_on("FAx",``Forall (strlit "x") A``)
 val sigs = [is_true_sig_def, is_false_sig_def, is_implies_sig_def, is_and_sig_def,
             is_or_sig_def, is_not_sig_def, is_forall_sig_def, is_exists_sig_def]
 
-val bool_sig_instances = store_thm("bool_sig_instances",
-  ``is_bool_sig sig ⇒
+val bool_sig_instances = Q.store_thm("bool_sig_instances",
+  `is_bool_sig sig ⇒
     instance (tmsof sig) (i:'U interpretation) (strlit "T") Bool = (K (tmaof i (strlit "T") [])) ∧
     instance (tmsof sig) i (strlit "F") Bool = (K (tmaof i (strlit "F") [])) ∧
     instance (tmsof sig) i (strlit "==>") (Fun Bool (Fun Bool Bool)) = (K (tmaof i (strlit "==>") [])) ∧
@@ -29,7 +29,7 @@ val bool_sig_instances = store_thm("bool_sig_instances",
     instance (tmsof sig) i (strlit "\\/") (Fun Bool (Fun Bool Bool)) = (K (tmaof i (strlit "\\/") [])) ∧
     instance (tmsof sig) i (strlit "~") (Fun Bool Bool) = (K (tmaof i (strlit "~") [])) ∧
     instance (tmsof sig) i (strlit "!") (Fun (Fun A Bool) Bool) = (λτ. tmaof i (strlit "!") [τ (strlit "A")]) ∧
-    instance (tmsof sig) i (strlit "?") (Fun (Fun A Bool) Bool) = (λτ. tmaof i (strlit "?") [τ (strlit "A")])``,
+    instance (tmsof sig) i (strlit "?") (Fun (Fun A Bool) Bool) = (λτ. tmaof i (strlit "?") [τ (strlit "A")])`,
   rw[is_bool_sig_def] >> fs sigs >> imp_res_tac identity_instance >> rw[FUN_EQ_THM] >>
   rpt AP_TERM_TAC >> rw[FUN_EQ_THM,tyvars_def] >> EVAL_TAC >> metis_tac[])
 
@@ -95,8 +95,8 @@ val is_bool_interpretation_def = xDefine"is_bool_interpretation"`
     is_not_interpretation (tmaof i)`
 val _ = Parse.overload_on("is_bool_interpretation",``is_bool_interpretation0 ^mem``)
 
-val boolrel_in_funspace = store_thm("boolrel_in_funspace",
-  ``is_set_theory ^mem ⇒ Boolrel R <: Funspace boolset (Funspace boolset boolset)``,
+val boolrel_in_funspace = Q.store_thm("boolrel_in_funspace",
+  `is_set_theory ^mem ⇒ Boolrel R <: Funspace boolset (Funspace boolset boolset)`,
   rw[Boolrel_def] >> match_mp_tac (UNDISCH abstract_in_funspace) >> rw[] >>
   match_mp_tac (UNDISCH abstract_in_funspace) >> rw[boolean_in_boolset] )
 val _ = export_rewrites["boolrel_in_funspace"]
@@ -153,10 +153,10 @@ val apply_abstract_tac = rpt ( (
     match_mp_tac (UNDISCH apply_in_rng) >>
     HINT_EXISTS_TAC >> rw[]
 
-val apply_boolrel = store_thm("apply_boolrel",
-  ``is_set_theory ^mem ⇒
+val apply_boolrel = Q.store_thm("apply_boolrel",
+  `is_set_theory ^mem ⇒
     ∀b1 b2 b3. b1 <: boolset ∧ b2 <: boolset ∧ (b3 = Boolean (R (b1 = True) (b2 = True))) ⇒
-      Boolrel R ' b1 ' b2 = b3 ``,
+      Boolrel R ' b1 ' b2 = b3 `,
   rw[] >>
   `Boolrel R ' b1 = Abstract boolset boolset (λb2. Boolean (R (b1 = True) (b2 = True)))` by (
     rw[Boolrel_def] >>
@@ -168,11 +168,11 @@ val apply_boolrel = store_thm("apply_boolrel",
   match_mp_tac apply_abstract_matchable >>
   rw[boolean_in_boolset] )
 
-val bool_has_bool_interpretation = store_thm("bool_has_bool_interpretation",
-  ``is_set_theory ^mem ⇒
+val bool_has_bool_interpretation = Q.store_thm("bool_has_bool_interpretation",
+  `is_set_theory ^mem ⇒
     ∀ctxt i. theory_ok (thyof (mk_bool_ctxt ctxt)) ∧
              i models (thyof (mk_bool_ctxt ctxt)) ⇒
-             is_bool_interpretation i``,
+             is_bool_interpretation i`,
   rw[] >>
   simp[is_bool_interpretation_def] >>
   conj_asm1_tac >- fs[models_def] >>
@@ -492,12 +492,12 @@ val bool_has_bool_interpretation = store_thm("bool_has_bool_interpretation",
   simp[boolean_in_boolset,SIMP_RULE(srw_ss())[]apply_boolrel,combinTheory.APPLY_UPDATE_THM,mem_boolset,boolean_def] >>
   rw[] >> rw[] >> fs[])
 
-val extends_is_bool_interpretation = store_thm("extends_is_bool_interpretation",
-  ``is_set_theory ^mem ∧
+val extends_is_bool_interpretation = Q.store_thm("extends_is_bool_interpretation",
+  `is_set_theory ^mem ∧
     ctxt2 extends (mk_bool_ctxt ctxt) ∧
     theory_ok (thyof (mk_bool_ctxt ctxt)) ∧
     i models (thyof ctxt2) ⇒
-    is_bool_interpretation i``,
+    is_bool_interpretation i`,
   strip_tac >>
   `i models thyof (mk_bool_ctxt ctxt)` by (
     `∃x y z. thyof (mk_bool_ctxt ctxt) = ((x,y),z)` by metis_tac[pairTheory.PAIR] >>
@@ -513,8 +513,8 @@ val extends_is_bool_interpretation = store_thm("extends_is_bool_interpretation",
     fs[theory_ok_def] ) >>
   metis_tac[bool_has_bool_interpretation])
 
-val termsem_implies = store_thm("termsem_implies",
-  ``is_set_theory ^mem ⇒
+val termsem_implies = Q.store_thm("termsem_implies",
+  `is_set_theory ^mem ⇒
     ∀s i v p1 p2.
     is_valuation (tysof s) (tyaof i) v ∧
     is_interpretation s i ∧
@@ -524,7 +524,7 @@ val termsem_implies = store_thm("termsem_implies",
     is_implies_sig (tmsof s) ∧ is_implies_interpretation (tmaof i) ⇒
     termsem (tmsof s) i v (Implies p1 p2) =
     Boolean (termsem (tmsof s) i v p1 = True ⇒
-             termsem (tmsof s) i v p2 = True)``,
+             termsem (tmsof s) i v p2 = True)`,
   rw[termsem_def,is_implies_sig_def,is_implies_interpretation_def] >>
   qspecl_then[`tmsof s`,`i`,`strlit"==>"`]mp_tac instance_def >> simp[] >>
   disch_then(qspec_then`[]`mp_tac) >>
@@ -654,8 +654,8 @@ val termsem_exists = store_thm("termsem_exists",
   fs[is_valuation_def,is_term_valuation_def,combinTheory.APPLY_UPDATE_THM] >>
   rw[] >> rw[] )
 
-val termsem_and = store_thm("termsem_and",
-  ``is_set_theory ^mem ⇒
+val termsem_and = Q.store_thm("termsem_and",
+  `is_set_theory ^mem ⇒
     ∀s i v p1 p2.
     is_valuation (tysof s) (tyaof i) v ∧
     is_interpretation s i ∧
@@ -665,7 +665,7 @@ val termsem_and = store_thm("termsem_and",
     is_and_sig (tmsof s) ∧ is_and_interpretation (tmaof i) ⇒
     termsem (tmsof s) i v (And p1 p2) =
     Boolean (termsem (tmsof s) i v p1 = True ∧
-             termsem (tmsof s) i v p2 = True)``,
+             termsem (tmsof s) i v p2 = True)`,
   rw[termsem_def,is_and_sig_def,is_and_interpretation_def] >>
   qspecl_then[`tmsof s`,`i`,`strlit"/\\"`]mp_tac instance_def >> simp[] >>
   disch_then(qspec_then`[]`mp_tac) >>
@@ -699,8 +699,8 @@ val termsem_and = store_thm("termsem_and",
     imp_res_tac typesem_Bool >> simp[] ) >>
   simp[boolean_in_boolset] )
 
-val termsem_not = store_thm("termsem_not",
-  ``is_set_theory ^mem ⇒
+val termsem_not = Q.store_thm("termsem_not",
+  `is_set_theory ^mem ⇒
     ∀s i v p1.
     is_valuation (tysof s) (tyaof i) v ∧
     is_interpretation s i ∧
@@ -709,7 +709,7 @@ val termsem_not = store_thm("termsem_not",
     typeof p1 = Bool ∧
     is_not_sig (tmsof s) ∧ is_not_interpretation (tmaof i) ⇒
     termsem (tmsof s) i v (Not p1) =
-    Boolean (termsem (tmsof s) i v p1 ≠ True)``,
+    Boolean (termsem (tmsof s) i v p1 ≠ True)`,
   rw[termsem_def,is_not_sig_def,is_not_interpretation_def] >>
   qspecl_then[`tmsof s`,`i`,`strlit"~"`]mp_tac instance_def >> simp[] >>
   disch_then(qspec_then`[]`mp_tac) >>

--- a/candle/standard/semantics/holBoolScript.sml
+++ b/candle/standard/semantics/holBoolScript.sml
@@ -558,8 +558,8 @@ val termsem_implies = Q.store_thm("termsem_implies",
     imp_res_tac typesem_Bool >> simp[] ) >>
   simp[boolean_in_boolset] )
 
-val termsem_forall = store_thm("termsem_forall",
-  ``is_set_theory ^mem ⇒
+val termsem_forall = Q.store_thm("termsem_forall",
+  `is_set_theory ^mem ⇒
     ∀s i v f y b.
     is_valuation (tysof s) (tyaof i) v ∧
     is_interpretation s i ∧
@@ -568,7 +568,7 @@ val termsem_forall = store_thm("termsem_forall",
     is_forall_sig (tmsof s) ∧ is_forall_interpretation (tmaof i) ⇒
     termsem (tmsof s) i v (Forall f y b) =
     Boolean (∀x. x <: typesem (tyaof i) (tyvof v) y ⇒
-                 termsem (tmsof s) i (tyvof v, ((f,y) =+ x) (tmvof v)) b = True)``,
+                 termsem (tmsof s) i (tyvof v, ((f,y) =+ x) (tmvof v)) b = True)`,
   rw[termsem_def,is_forall_sig_def,is_forall_interpretation_def] >>
   qspecl_then[`tmsof s`,`i`,`strlit"!"`]mp_tac instance_def >> simp[] >>
   disch_then(qspec_then`[y,Tyvar(strlit"A")]`mp_tac) >>
@@ -606,8 +606,8 @@ val termsem_forall = store_thm("termsem_forall",
   fs[is_valuation_def,is_term_valuation_def,combinTheory.APPLY_UPDATE_THM] >>
   rw[] >> rw[] )
 
-val termsem_exists = store_thm("termsem_exists",
-  ``is_set_theory ^mem ⇒
+val termsem_exists = Q.store_thm("termsem_exists",
+  `is_set_theory ^mem ⇒
     ∀s i v f y b.
     is_valuation (tysof s) (tyaof i) v ∧
     is_interpretation s i ∧
@@ -616,7 +616,7 @@ val termsem_exists = store_thm("termsem_exists",
     is_exists_sig (tmsof s) ∧ is_exists_interpretation (tmaof i) ⇒
     termsem (tmsof s) i v (Exists f y b) =
     Boolean (∃x. x <: typesem (tyaof i) (tyvof v) y ∧
-                 termsem (tmsof s) i (tyvof v, ((f,y) =+ x) (tmvof v)) b = True)``,
+                 termsem (tmsof s) i (tyvof v, ((f,y) =+ x) (tmvof v)) b = True)`,
   rw[termsem_def,is_exists_sig_def,is_exists_interpretation_def] >>
   qspecl_then[`tmsof s`,`i`,`strlit"?"`]mp_tac instance_def >> simp[] >>
   disch_then(qspec_then`[y,Tyvar(strlit"A")]`mp_tac) >>

--- a/candle/standard/semantics/holConsistencyScript.sml
+++ b/candle/standard/semantics/holConsistencyScript.sml
@@ -11,10 +11,10 @@ val consistent_theory_def = Define`
         (thy,[]) |- (Var (strlit"x") Bool === Var (strlit"x") Bool) ∧
       ¬((thy,[]) |- (Var (strlit"x") Bool === Var (strlit"y") Bool))`
 
-val proves_consistent = store_thm("proves_consistent",
-  ``is_set_theory ^mem ⇒
+val proves_consistent = Q.store_thm("proves_consistent",
+  `is_set_theory ^mem ⇒
     ∀thy. theory_ok thy ∧ (∃i. i models thy) ⇒
-      consistent_theory thy``,
+      consistent_theory thy`,
   rw[consistent_theory_def] >- (
     match_mp_tac (List.nth(CONJUNCTS proves_rules,8)) >>
     simp[term_ok_def,type_ok_def] >>
@@ -45,8 +45,8 @@ val proves_consistent = store_thm("proves_consistent",
     fs[models_def,theory_ok_def] ) >>
   simp[Abbr`s`,Abbr`t`,termsem_def,boolean_eq_true,Abbr`v`,true_neq_false])
 
-val init_ctxt_has_model = store_thm("init_ctxt_has_model",
-  ``is_set_theory ^mem ⇒ ∃i. i models (thyof init_ctxt)``,
+val init_ctxt_has_model = Q.store_thm("init_ctxt_has_model",
+  `is_set_theory ^mem ⇒ ∃i. i models (thyof init_ctxt)`,
   rw[models_def,init_ctxt_def,conexts_of_upd_def] >>
   rw[is_std_interpretation_def,is_std_type_assignment_def,EXISTS_PROD] >>
   qho_match_abbrev_tac`∃f g. P f g ∧ (Q f ∧ f x2 z2 = y2) ∧ (g interprets x3 on z3 as y3)` >>
@@ -64,10 +64,10 @@ val init_ctxt_has_model = store_thm("init_ctxt_has_model",
   match_mp_tac (UNDISCH funspace_inhabited) >>
   metis_tac[])
 
-val min_hol_consistent = store_thm("min_hol_consistent",
-  ``is_set_theory ^mem ⇒
+val min_hol_consistent = Q.store_thm("min_hol_consistent",
+  `is_set_theory ^mem ⇒
     ∀ctxt. ctxt extends init_ctxt ∧ (∀p. MEM (NewAxiom p) ctxt ⇒ MEM (NewAxiom p) init_ctxt) ⇒
-      consistent_theory (thyof ctxt)``,
+      consistent_theory (thyof ctxt)`,
   strip_tac >> gen_tac >> strip_tac >>
   match_mp_tac (UNDISCH proves_consistent) >>
   metis_tac[extends_theory_ok,extends_consistent,init_theory_ok,init_ctxt_has_model])
@@ -75,8 +75,8 @@ val min_hol_consistent = store_thm("min_hol_consistent",
 val fhol_ctxt_def = Define`
   fhol_ctxt = mk_select_ctxt (mk_eta_ctxt (mk_bool_ctxt init_ctxt))`
 
-val fhol_extends_bool = store_thm("fhol_extends_bool",
-  ``fhol_ctxt extends (mk_bool_ctxt init_ctxt)``,
+val fhol_extends_bool = Q.store_thm("fhol_extends_bool",
+  `fhol_ctxt extends (mk_bool_ctxt init_ctxt)`,
   rw[fhol_ctxt_def] >>
   match_mp_tac extends_trans >>
   qexists_tac`mk_eta_ctxt (mk_bool_ctxt init_ctxt)` >>
@@ -132,23 +132,23 @@ fun tac extends_bool unfold =
   impl_tac >- fs[is_bool_interpretation_def] >>
   disch_then(qx_choose_then`i3`strip_assume_tac)
 
-val fhol_has_model = store_thm("fhol_has_model",
-  ``is_set_theory ^mem ⇒
+val fhol_has_model = Q.store_thm("fhol_has_model",
+  `is_set_theory ^mem ⇒
     ∀ctxt.
       ctxt extends fhol_ctxt ∧
       (∀p. MEM (NewAxiom p) ctxt ⇒ MEM (NewAxiom p) fhol_ctxt) ⇒
-      theory_ok (thyof ctxt) ∧ ∃i. i models thyof ctxt``,
+      theory_ok (thyof ctxt) ∧ ∃i. i models thyof ctxt`,
   tac fhol_extends_bool ALL_TAC >>
   fs[GSYM fhol_ctxt_def] >>
   qspecl_then[`fhol_ctxt`,`ctxt`]mp_tac(UNDISCH extends_consistent) >> simp[] >>
   metis_tac[])
 
-val _ = store_thm("fhol_consistent",
-  ``is_set_theory ^mem ⇒
+val _ = Q.store_thm("fhol_consistent",
+  `is_set_theory ^mem ⇒
     ∀ctxt.
       ctxt extends fhol_ctxt ∧
       (∀p. MEM (NewAxiom p) ctxt ⇒ MEM (NewAxiom p) fhol_ctxt) ⇒
-      consistent_theory (thyof ctxt)``,
+      consistent_theory (thyof ctxt)`,
   strip_tac >> gen_tac >> strip_tac >>
   match_mp_tac (UNDISCH proves_consistent) >>
   metis_tac[fhol_has_model])
@@ -156,8 +156,8 @@ val _ = store_thm("fhol_consistent",
 val hol_ctxt_def = Define`
   hol_ctxt = mk_infinity_ctxt fhol_ctxt`
 
-val hol_extends_fhol = store_thm("hol_extends_fhol",
-  ``hol_ctxt extends fhol_ctxt``,
+val hol_extends_fhol = Q.store_thm("hol_extends_fhol",
+  `hol_ctxt extends fhol_ctxt`,
   rw[hol_ctxt_def] >>
   match_mp_tac infinity_extends >>
   reverse conj_tac >- EVAL_TAC >>
@@ -167,17 +167,17 @@ val hol_extends_fhol = store_thm("hol_extends_fhol",
   match_mp_tac (MP_CANON extends_theory_ok) >>
   metis_tac[bool_extends_init,init_theory_ok])
 
-val hol_extends_bool = store_thm("hol_extends_bool",
-  ``hol_ctxt extends (mk_bool_ctxt init_ctxt)``,
+val hol_extends_bool = Q.store_thm("hol_extends_bool",
+  `hol_ctxt extends (mk_bool_ctxt init_ctxt)`,
   match_mp_tac extends_trans >>
   metis_tac[hol_extends_fhol,fhol_extends_bool])
 
-val hol_has_model = store_thm("hol_has_model",
-  ``is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
+val hol_has_model = Q.store_thm("hol_has_model",
+  `is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
     ∀ctxt.
       ctxt extends hol_ctxt ∧
       (∀p. MEM (NewAxiom p) ctxt ⇒ MEM (NewAxiom p) hol_ctxt) ⇒
-      theory_ok (thyof ctxt) ∧ ∃i. i models thyof ctxt``,
+      theory_ok (thyof ctxt) ∧ ∃i. i models thyof ctxt`,
   tac hol_extends_bool (fs[hol_ctxt_def]) >>
   assume_tac(UNDISCH(PROVE[]``is_infinite mem inf ⇒ ∃inf. is_infinite ^mem inf``)) >>
   qspec_then`mk_select_ctxt (mk_eta_ctxt (mk_bool_ctxt init_ctxt))`mp_tac
@@ -208,12 +208,12 @@ val hol_has_model = store_thm("hol_has_model",
   qspecl_then[`hol_ctxt`,`ctxt`]mp_tac(UNDISCH extends_consistent) >> simp[] >>
   metis_tac[])
 
-val _ = store_thm("hol_consistent",
-  ``is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
+val _ = Q.store_thm("hol_consistent",
+  `is_set_theory ^mem ∧ (∃inf. is_infinite ^mem inf) ⇒
     ∀ctxt.
       ctxt extends hol_ctxt ∧
       (∀p. MEM (NewAxiom p) ctxt ⇒ MEM (NewAxiom p) hol_ctxt) ⇒
-      consistent_theory (thyof ctxt)``,
+      consistent_theory (thyof ctxt)`,
   strip_tac >> gen_tac >> strip_tac >>
   match_mp_tac (UNDISCH proves_consistent) >>
   metis_tac[hol_has_model])

--- a/candle/standard/semantics/holExtensionScript.sml
+++ b/candle/standard/semantics/holExtensionScript.sml
@@ -12,13 +12,13 @@ val sound_update_def = xDefine"sound_update"`
            i' models (thyof (upd::ctxt))`
 val _ = Parse.overload_on("sound_update",``sound_update0 ^mem``)
 
-val new_constant_correct = store_thm("new_constant_correct",
-  ``is_set_theory ^mem ⇒
+val new_constant_correct = Q.store_thm("new_constant_correct",
+  `is_set_theory ^mem ⇒
     ∀ctxt name ty.
      theory_ok (thyof ctxt) ∧
      name ∉ (FDOM (tmsof ctxt)) ∧
      type_ok (tysof ctxt) ty ⇒
-     sound_update ctxt (NewConst name ty)``,
+     sound_update ctxt (NewConst name ty)`,
   rw[] >> REWRITE_TAC[sound_update_def,equal_on_def] >>
   gen_tac >> strip_tac >>
   qexists_tac`(tyaof i,
@@ -290,15 +290,15 @@ val new_specification_correct = store_thm("new_specification_correct",
     metis_tac[term_ok_welltyped] ) >>
   rw[Abbr`v4`])
 
-val new_definition_correct = store_thm("new_definition_correct",
-  ``is_set_theory ^mem ⇒
+val new_definition_correct = Q.store_thm("new_definition_correct",
+  `is_set_theory ^mem ⇒
     ∀ctxt name tm.
     theory_ok (thyof ctxt) ∧
     term_ok (sigof ctxt) tm ∧
     name ∉ FDOM (tmsof ctxt) ∧
     CLOSED tm ∧
     set (tvars tm) ⊆ set (tyvars (typeof tm))
-    ⇒ sound_update ctxt (ConstDef name tm)``,
+    ⇒ sound_update ctxt (ConstDef name tm)`,
   rw[] >>
   ho_match_mp_tac (UNDISCH new_specification_correct) >>
   simp[] >> fs[SUBSET_DEF,CLOSED_def,vfree_in_equation] >>
@@ -308,12 +308,12 @@ val new_definition_correct = store_thm("new_definition_correct",
   imp_res_tac term_ok_welltyped >>
   imp_res_tac term_ok_type_ok >> fs[])
 
-val new_type_correct = store_thm("new_type_correct",
-  ``is_set_theory ^mem ⇒
+val new_type_correct = Q.store_thm("new_type_correct",
+  `is_set_theory ^mem ⇒
     ∀ctxt name arity.
      theory_ok (thyof ctxt) ∧
      name ∉ FDOM (tysof ctxt) ⇒
-     sound_update ctxt (NewType name arity)``,
+     sound_update ctxt (NewType name arity)`,
   rw[] >> REWRITE_TAC[sound_update_def,equal_on_def] >>
   gen_tac >> strip_tac >>
   qexists_tac`((name =+ (K boolset)) (tyaof i),tmaof i)` >>
@@ -784,11 +784,11 @@ val new_type_definition_correct = store_thm("new_type_definition_correct",
   metis_tac[mem_boolset])
 val _ = delete_const"eqsh"
 
-val updates_consistent = store_thm("updates_consistent",
-  ``is_set_theory ^mem ⇒
+val updates_consistent = Q.store_thm("updates_consistent",
+  `is_set_theory ^mem ⇒
     ∀upd ctxt. upd updates ctxt ⇒
       theory_ok (thyof ctxt) ∧ (∀p. upd ≠ NewAxiom p) ⇒
-      sound_update ctxt upd``,
+      sound_update ctxt upd`,
   strip_tac >>
   ho_match_mp_tac updates_ind >>
   conj_tac >- simp[] >>
@@ -797,13 +797,13 @@ val updates_consistent = store_thm("updates_consistent",
   conj_tac >- metis_tac[update_distinct,new_type_correct] >>
   metis_tac[update_distinct,new_type_definition_correct])
 
-val extends_consistent = store_thm("extends_consistent",
-  ``is_set_theory ^mem ⇒
+val extends_consistent = Q.store_thm("extends_consistent",
+  `is_set_theory ^mem ⇒
     ∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒
       ∀i. theory_ok (thyof ctxt1) ∧ i models (thyof ctxt1) ∧
           (∀p. MEM (NewAxiom p) ctxt2 ⇒ MEM (NewAxiom p) ctxt1)
         ⇒
-        ∃i'. equal_on (sigof ctxt1) i i' ∧ i' models (thyof ctxt2)``,
+        ∃i'. equal_on (sigof ctxt1) i i' ∧ i' models (thyof ctxt2)`,
   rw[] >>
   Q.ISPEC_THEN
     `λctxt. theory_ok (thyof ctxt) ∧

--- a/candle/standard/semantics/holExtensionScript.sml
+++ b/candle/standard/semantics/holExtensionScript.sml
@@ -400,7 +400,7 @@ val new_type_definition_correct = store_thm("new_type_definition_correct",
   imp_res_tac proves_term_ok >>
   fs[term_ok_def] >>
   `pred has_type Fun rep_type Bool` by (
-    rator_x_assum`$has_type`mp_tac >>
+    qhdtm_x_assum`$has_type`mp_tac >>
     simp[Once has_type_cases] >>
     rw[Abbr`rep_type`] >>
     imp_res_tac WELLTYPED_LEMMA >> fs[] >> rw[] ) >>

--- a/candle/standard/semantics/holExtensionScript.sml
+++ b/candle/standard/semantics/holExtensionScript.sml
@@ -58,8 +58,8 @@ val new_constant_correct = Q.store_thm("new_constant_correct",
   simp[equal_on_def] >>
   metis_tac[])
 
-val new_specification_correct = store_thm("new_specification_correct",
-  ``is_set_theory ^mem ⇒
+val new_specification_correct = Q.store_thm("new_specification_correct",
+  `is_set_theory ^mem ⇒
     ∀ctxt eqs prop.
      theory_ok (thyof ctxt) ∧
      (thyof ctxt, MAP (λ(s,t). Var s (typeof t) === t) eqs) |- prop ∧
@@ -71,7 +71,7 @@ val new_specification_correct = store_thm("new_specification_correct",
                MEM (x,ty) (MAP (λ(s,t). (s,typeof t)) eqs)) ∧
      (∀s. MEM s (MAP FST eqs) ⇒ s ∉ (FDOM (tmsof ctxt))) ∧
      ALL_DISTINCT (MAP FST eqs) ⇒
-    sound_update ctxt (ConstSpec eqs prop)``,
+    sound_update ctxt (ConstSpec eqs prop)`,
   rw[] >> REWRITE_TAC[sound_update_def,equal_on_def] >>
   gen_tac >> strip_tac >>
   qexists_tac`(tyaof i,
@@ -363,8 +363,8 @@ val new_type_correct = Q.store_thm("new_type_correct",
   fs[MEM_MAP,EXISTS_PROD] >> metis_tac[])
 
 val eqsh_def = new_definition("eqsh",``eqsh = $=``)
-val new_type_definition_correct = store_thm("new_type_definition_correct",
-  ``is_set_theory ^mem ⇒
+val new_type_definition_correct = Q.store_thm("new_type_definition_correct",
+  `is_set_theory ^mem ⇒
     ∀ctxt name pred abs rep witness.
     (thyof ctxt,[]) |- Comb pred witness ∧
     CLOSED pred ∧
@@ -372,7 +372,7 @@ val new_type_definition_correct = store_thm("new_type_definition_correct",
     abs ∉ (FDOM (tmsof ctxt)) ∧
     rep ∉ (FDOM (tmsof ctxt)) ∧
     abs ≠ rep ⇒
-    sound_update ctxt (TypeDefn name pred abs rep)``,
+    sound_update ctxt (TypeDefn name pred abs rep)`,
   rw[sound_update_def,equal_on_def,models_def,LET_THM] >>
   Q.PAT_ABBREV_TAC`tys' = tysof ctxt |+ X` >>
   Q.PAT_ABBREV_TAC`tms' = tmsof ctxt |+ X |+ Y` >>

--- a/candle/standard/semantics/holSemanticsExtraScript.sml
+++ b/candle/standard/semantics/holSemanticsExtraScript.sml
@@ -222,8 +222,8 @@ val termsem_equation = Q.store_thm("termsem_equation",
 
 (* aconv *)
 
-val termsem_raconv = store_thm("termsem_raconv",
-  ``∀env tp. RACONV env tp ⇒
+val termsem_raconv = Q.store_thm("termsem_raconv",
+  `∀env tp. RACONV env tp ⇒
       ∀Γ i v1 v2.
         (FST v1 = FST v2) ∧
         (∀x1 ty1 x2 ty2.
@@ -233,7 +233,7 @@ val termsem_raconv = store_thm("termsem_raconv",
         EVERY (λ(x,y). welltyped x ∧ welltyped y ∧ typeof x = typeof y) env ∧
         welltyped (FST tp) ∧ welltyped (SND tp)
         ⇒
-        termsem Γ i v1 (FST tp) = termsem Γ i v2 (SND tp)``,
+        termsem Γ i v1 (FST tp) = termsem Γ i v2 (SND tp)`,
   ho_match_mp_tac RACONV_strongind >>
   rpt conj_tac >> simp[termsem_def] >>
   TRY (metis_tac[]) >>
@@ -258,11 +258,11 @@ val termsem_aconv = Q.store_thm("termsem_aconv",
 
 (* semantics only depends on valuation of free variables *)
 
-val termsem_frees = store_thm("termsem_frees",
-  ``∀Γ i t v1 v2.
+val termsem_frees = Q.store_thm("termsem_frees",
+  `∀Γ i t v1 v2.
       welltyped t ∧ FST v1 = FST v2 ∧
       (∀x ty. VFREE_IN (Var x ty) t ⇒ SND v1 (x,ty) = SND v2 (x,ty))
-      ⇒ termsem Γ i v1 t = termsem Γ i v2 t``,
+      ⇒ termsem Γ i v1 t = termsem Γ i v2 t`,
   ntac 2 gen_tac >> Induct >>
   simp[termsem_def] >- metis_tac[] >>
   rw[] >> rw[termsem_def] >> rpt AP_TERM_TAC >>
@@ -312,8 +312,8 @@ val termsem_tyfrees = Q.store_thm("termsem_tyfrees",
 
 (* semantics of substitution *)
 
-val termsem_simple_subst = store_thm("termsem_simple_subst",
-  ``∀tm ilist.
+val termsem_simple_subst = Q.store_thm("termsem_simple_subst",
+  `∀tm ilist.
       welltyped tm ∧
       DISJOINT (set (bv_names tm)) {y | ∃ty u. VFREE_IN (Var y ty) u ∧ MEM u (MAP FST ilist)} ∧
       (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. s = Var x ty ∧ s' has_type ty)
@@ -324,7 +324,7 @@ val termsem_simple_subst = store_thm("termsem_simple_subst",
           (FST v, SND v =++
                   MAP ((dest_var ## termsem Γ i v) o (λ(s',s). (s,s')))
                       (REVERSE ilist))
-          tm``,
+          tm`,
   Induct >> simp[termsem_def] >- (
     simp[REV_ASSOCD_ALOOKUP,APPLY_UPDATE_LIST_ALOOKUP,rich_listTheory.MAP_REVERSE] >>
     rw[] >> BasicProvers.CASE_TAC >> rw[termsem_def] >- (
@@ -390,8 +390,8 @@ val termsem_simple_subst = store_thm("termsem_simple_subst",
   fs[Abbr`ls`,MEM_MAP,FORALL_PROD,EXISTS_PROD] >>
   metis_tac[welltyped_def])
 
-val termsem_VSUBST = store_thm("termsem_VSUBST",
-  `` ∀tm ilist.
+val termsem_VSUBST = Q.store_thm("termsem_VSUBST",
+  ` ∀tm ilist.
       welltyped tm ∧
       (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. s = Var x ty ∧ s' has_type ty) ⇒
       ∀Γ i v.
@@ -399,7 +399,7 @@ val termsem_VSUBST = store_thm("termsem_VSUBST",
        termsem Γ i (FST v,
                     SND v =++
                     MAP ((dest_var ## termsem Γ i v) o (λ(s',s). (s,s')))
-                      (REVERSE ilist)) tm``,
+                      (REVERSE ilist)) tm`,
   rw[] >>
   Q.ISPECL_THEN[`{y | ∃ty u. VFREE_IN (Var y ty) u ∧ MEM u (MAP FST ilist)}`,`tm`]mp_tac fresh_term_def >>
   simp[] >>
@@ -417,8 +417,8 @@ val termsem_VSUBST = store_thm("termsem_VSUBST",
 
 (* semantics of instantiation *)
 
-val termsem_simple_inst = store_thm("termsem_simple_inst",
-  ``∀Γ tm tyin tmenv.
+val termsem_simple_inst = Q.store_thm("termsem_simple_inst",
+  `∀Γ tm tyin tmenv.
       welltyped tm ∧ term_ok Γ tm ∧
       ALL_DISTINCT (bv_names tm) ∧
       DISJOINT (set (bv_names tm)) {x | ∃ty. VFREE_IN (Var x ty) tm} ∧
@@ -429,7 +429,7 @@ val termsem_simple_inst = store_thm("termsem_simple_inst",
         termsem tmenv i
           ((λx. typesem (FST i) (FST v) (TYPE_SUBST tyin (Tyvar x))),
            (λ(x,ty). SND v (x, TYPE_SUBST tyin ty)))
-          tm``,
+          tm`,
   Cases >> Induct >> simp[termsem_def,term_ok_def] >- (
     rw[] >> rw[TYPE_SUBST_compose] >>
     qmatch_abbrev_tac`instance sig int name (TYPE_SUBST i2 ty0) t1 =
@@ -465,15 +465,15 @@ val termsem_simple_inst = store_thm("termsem_simple_inst",
   rw[combinTheory.APPLY_UPDATE_THM] >>
   metis_tac[])
 
-val termsem_INST = store_thm("termsem_INST",
-  ``∀Γ tm tyin tmenv.
+val termsem_INST = Q.store_thm("termsem_INST",
+  `∀Γ tm tyin tmenv.
       term_ok Γ tm ∧ tmenv = tmsof Γ ⇒
       ∀i v.
         termsem tmenv i v (INST tyin tm) =
         termsem tmenv i
           ((λx. typesem (FST i) (FST v) (TYPE_SUBST tyin (Tyvar x))),
            (λ(x,ty). SND v (x, TYPE_SUBST tyin ty)))
-          tm``,
+          tm`,
   rw[] >> imp_res_tac term_ok_welltyped >>
   Q.ISPECL_THEN[`{x | ∃ty. VFREE_IN (Var x ty) tm}`,`tm`]mp_tac fresh_term_def >>
   simp[] >>
@@ -493,12 +493,12 @@ val termsem_INST = store_thm("termsem_INST",
 
 (* extending the context doesn't change the semantics *)
 
-val termsem_extend = store_thm("termsem_extend",
-  ``∀tyenv tmenv tyenv' tmenv' tm.
+val termsem_extend = Q.store_thm("termsem_extend",
+  `∀tyenv tmenv tyenv' tmenv' tm.
       tmenv ⊑ tmenv' ∧
       term_ok (tyenv,tmenv) tm ⇒
       ∀i v. termsem tmenv' i v tm =
-            termsem tmenv i v tm``,
+            termsem tmenv i v tm`,
   ntac 4 gen_tac >> Induct >> simp[termsem_def,term_ok_def] >>
   rw[] >> simp[termsem_def] >>
   qmatch_abbrev_tac`X = instance sig int name ty t` >>
@@ -516,12 +516,12 @@ val is_valuation_reduce = Q.store_thm("is_valuation_reduce",
   rw[is_valuation_def,is_term_valuation_def] >>
   metis_tac[type_ok_extend])
 
-val satisfies_extend = store_thm("satisfies_extend",
-  ``∀tyenv tmenv tyenv' tmenv' tm i h c.
+val satisfies_extend = Q.store_thm("satisfies_extend",
+  `∀tyenv tmenv tyenv' tmenv' tm i h c.
       tmenv ⊑ tmenv' ∧ tyenv ⊑ tyenv' ∧
       EVERY (term_ok (tyenv,tmenv)) (c::h) ∧
       i satisfies ((tyenv,tmenv),h,c) ⇒
-      i satisfies ((tyenv',tmenv'),h,c)``,
+      i satisfies ((tyenv',tmenv'),h,c)`,
   rw[satisfies_def] >> fs[EVERY_MEM] >>
   metis_tac[term_ok_extend,termsem_extend,is_valuation_reduce])
 
@@ -618,14 +618,14 @@ val termsem_sig = Q.store_thm("termsem_sig",
   unabbrev_all_tac >> fs[] >>
   fs[FORALL_PROD] >> res_tac >> fs[])
 
-val satisfies_sig = store_thm("satisfies_sig",
-  ``∀i i' sig h c.
+val satisfies_sig = Q.store_thm("satisfies_sig",
+  `∀i i' sig h c.
     is_std_sig sig ∧
     EVERY (term_ok sig) (c::h) ∧
     equal_on sig i i' ∧
     i satisfies (sig,h,c)
     ⇒
-    i' satisfies (sig,h,c)``,
+    i' satisfies (sig,h,c)`,
   rw[satisfies_def] >>
   qsuff_tac`termsem (tmsof sig) i v c = True` >- metis_tac[termsem_sig] >>
   first_x_assum match_mp_tac >>
@@ -636,10 +636,10 @@ val satisfies_sig = store_thm("satisfies_sig",
 
 (* valuations exist *)
 
-val term_valuation_exists = store_thm("term_valuation_exists",
-  ``is_set_theory ^mem ⇒
+val term_valuation_exists = Q.store_thm("term_valuation_exists",
+  `is_set_theory ^mem ⇒
     ∀tyenv δ τ. is_type_valuation τ ∧ is_type_assignment tyenv δ ⇒
-      ∃σ. is_valuation tyenv δ (τ,σ)``,
+      ∃σ. is_valuation tyenv δ (τ,σ)`,
   rw[is_valuation_def,is_term_valuation_def] >>
   qexists_tac`λ(x,ty). @v. v <: typesem δ τ ty` >> rw[] >>
   metis_tac[typesem_inhabited])
@@ -657,14 +657,14 @@ val valuation_exists = Q.store_thm("valuation_exists",
   conj_asm1_tac >- simp[is_type_valuation_exists] >>
   fs[is_term_valuation_def] >> metis_tac[typesem_inhabited])
 
-val extend_valuation_exists = store_thm("extend_valuation_exists",
-  ``is_set_theory ^mem ⇒
+val extend_valuation_exists = Q.store_thm("extend_valuation_exists",
+  `is_set_theory ^mem ⇒
     ∀tysig δ v tysig'.
     is_valuation tysig δ v ∧ tysig ⊑ tysig' ∧
     is_type_assignment tysig' δ ⇒
     ∃v'. is_valuation tysig' δ v' ∧
          (tyvof v' = tyvof v) ∧
-         (∀x ty. type_ok tysig ty ⇒ (tmvof v (x,ty) = tmvof v' (x,ty)))``,
+         (∀x ty. type_ok tysig ty ⇒ (tmvof v (x,ty) = tmvof v' (x,ty)))`,
   rw[] >> simp[EXISTS_PROD] >>
   fs[is_valuation_def,is_term_valuation_def] >>
   qexists_tac`λ(x,ty).
@@ -724,17 +724,17 @@ val is_term_assignment_reduce = Q.store_thm("is_term_assignment_reduce",
    rw[is_term_assignment_def] >>
    imp_res_tac FEVERY_SUBMAP)
 
-val is_interpretation_reduce = store_thm("is_interpretation_reduce",
-  ``∀i tyenv tmenv tyenv' tmenv'.
+val is_interpretation_reduce = Q.store_thm("is_interpretation_reduce",
+  `∀i tyenv tmenv tyenv' tmenv'.
      tyenv ⊑ tyenv' ∧ tmenv ⊑ tmenv' ∧
      is_interpretation (tyenv',tmenv') i ⇒
-     is_interpretation (tyenv,tmenv) i``,
+     is_interpretation (tyenv,tmenv) i`,
   Cases >> rw[is_interpretation_def] >>
   imp_res_tac is_type_assignment_reduce >>
   imp_res_tac is_term_assignment_reduce)
 
-val is_valuation_extend_sig = store_thm("is_valuation_extend_sig",
-  ``is_set_theory ^mem ⇒
+val is_valuation_extend_sig = Q.store_thm("is_valuation_extend_sig",
+  `is_set_theory ^mem ⇒
     ∀tyenv tyenv' tyass v.
     is_valuation tyenv tyass v ∧
     is_type_assignment tyenv' tyass ∧
@@ -742,7 +742,7 @@ val is_valuation_extend_sig = store_thm("is_valuation_extend_sig",
     ∃v'.
       (tyvof v' = tyvof v) ∧
       (∀ty. type_ok tyenv ty ⇒ ∀x. tmvof v' (x,ty) = tmvof v (x,ty)) ∧
-      is_valuation tyenv' tyass v'``,
+      is_valuation tyenv' tyass v'`,
   rw[is_valuation_def] >>
   fs[is_term_valuation_def] >>
   simp[EXISTS_PROD] >>
@@ -752,8 +752,8 @@ val is_valuation_extend_sig = store_thm("is_valuation_extend_sig",
   match_mp_tac (UNDISCH typesem_inhabited) >>
   metis_tac[])
 
-val satisfies_reduce = store_thm("satisfies_reduce",
-  ``is_set_theory ^mem ⇒
+val satisfies_reduce = Q.store_thm("satisfies_reduce",
+  `is_set_theory ^mem ⇒
     ∀i tyenv tmenv tyenv' tmenv' h c.
       is_std_sig (tyenv,tmenv) ∧
       tyenv ⊑ tyenv' ∧
@@ -761,7 +761,7 @@ val satisfies_reduce = store_thm("satisfies_reduce",
       EVERY (term_ok (tyenv,tmenv)) (c::h) ∧
       is_type_assignment tyenv' (tyaof i) ∧
       i satisfies ((tyenv',tmenv'),h,c) ⇒
-      i satisfies ((tyenv,tmenv),h,c)``,
+      i satisfies ((tyenv,tmenv),h,c)`,
   rw[satisfies_def] >>
   qspecl_then[`tyenv`,`tyenv'`,`tyaof i`,`v`]mp_tac (UNDISCH is_valuation_extend_sig) >>
   simp[] >> strip_tac >>
@@ -783,15 +783,15 @@ val satisfies_reduce = store_thm("satisfies_reduce",
   impl_tac >- ( fs[EVERY_MEM] ) >>
   simp[])
 
-val models_reduce = store_thm("models_reduce",
-  ``is_set_theory ^mem ⇒
+val models_reduce = Q.store_thm("models_reduce",
+  `is_set_theory ^mem ⇒
     ∀i tyenv tmenv axs tyenv' tmenv' axs'.
      is_std_sig (tyenv,tmenv) ∧
      tyenv ⊑ tyenv' ∧ tmenv ⊑ tmenv' ∧ (axs ⊆ axs') ∧
      i models ((tyenv',tmenv'),axs') ∧
      (∀p. p ∈ axs ⇒ (term_ok (tyenv,tmenv)) p)
      ⇒
-     i models ((tyenv,tmenv),axs)``,
+     i models ((tyenv,tmenv),axs)`,
   strip_tac >>
   Cases >> rw[models_def] >>
   imp_res_tac is_interpretation_reduce >>

--- a/candle/standard/semantics/holSemanticsExtraScript.sml
+++ b/candle/standard/semantics/holSemanticsExtraScript.sml
@@ -4,20 +4,20 @@ val _ = new_theory"holSemanticsExtra"
 
 val mem = ``mem:'U->'U->bool``
 
-val is_std_interpretation_is_type = store_thm("is_std_interpretation_is_type",
-  ``is_std_interpretation i ⇒ is_std_type_assignment (FST i)``,
+val is_std_interpretation_is_type = Q.store_thm("is_std_interpretation_is_type",
+  `is_std_interpretation i ⇒ is_std_type_assignment (FST i)`,
   Cases_on`i` >> simp[is_std_interpretation_def])
 
 (* typesem *)
 
-val typesem_inhabited = store_thm("typesem_inhabited",
-  ``is_set_theory ^mem ⇒
+val typesem_inhabited = Q.store_thm("typesem_inhabited",
+  `is_set_theory ^mem ⇒
     ∀tyenv δ τ ty.
     is_type_valuation τ ∧
     is_type_assignment tyenv δ ∧
     type_ok tyenv ty
     ⇒
-    inhabited (typesem δ τ ty)``,
+    inhabited (typesem δ τ ty)`,
   strip_tac >> gen_tac >> ho_match_mp_tac typesem_ind >>
   simp[typesem_def,is_type_valuation_def,type_ok_def] >>
   rw[is_type_assignment_def,FLOOKUP_DEF] >>
@@ -26,43 +26,43 @@ val typesem_inhabited = store_thm("typesem_inhabited",
   disch_then match_mp_tac >>
   simp[EVERY_MAP] >> fs[EVERY_MEM] >> metis_tac[])
 
-val typesem_Fun = store_thm("typesem_Fun",
-  ``∀δ τ dom rng.
+val typesem_Fun = Q.store_thm("typesem_Fun",
+  `∀δ τ dom rng.
     is_std_type_assignment δ ⇒
     typesem δ τ (Fun dom rng) =
-    Funspace (typesem δ τ dom) (typesem δ τ rng)``,
+    Funspace (typesem δ τ dom) (typesem δ τ rng)`,
   rw[is_std_type_assignment_def,typesem_def])
 
-val typesem_Bool = store_thm("typesem_Bool",
-  ``∀δ τ.
+val typesem_Bool = Q.store_thm("typesem_Bool",
+  `∀δ τ.
     is_std_type_assignment δ ⇒
-    typesem δ τ Bool = boolset``,
+    typesem δ τ Bool = boolset`,
   rw[is_std_type_assignment_def,typesem_def])
 
-val typesem_TYPE_SUBST = store_thm("typesem_TYPE_SUBST",
-  ``∀tyin ty δ τ.
+val typesem_TYPE_SUBST = Q.store_thm("typesem_TYPE_SUBST",
+  `∀tyin ty δ τ.
       typesem δ τ (TYPE_SUBST tyin ty) =
-      typesem δ (λx. typesem δ τ (TYPE_SUBST tyin (Tyvar x))) ty``,
+      typesem δ (λx. typesem δ τ (TYPE_SUBST tyin (Tyvar x))) ty`,
   ho_match_mp_tac TYPE_SUBST_ind >> simp[typesem_def] >>
   rw[] >> rpt AP_TERM_TAC >>
   simp[MAP_MAP_o,MAP_EQ_f])
 
-val typesem_tyvars = store_thm("typesem_tyvars",
-  ``∀δ τ ty τ'.
+val typesem_tyvars = Q.store_thm("typesem_tyvars",
+  `∀δ τ ty τ'.
     (∀x. MEM x (tyvars ty) ⇒ τ' x = τ x) ⇒
-    typesem δ τ' ty = typesem δ τ ty``,
+    typesem δ τ' ty = typesem δ τ ty`,
   ho_match_mp_tac typesem_ind >>
   simp[tyvars_def,MEM_FOLDR_LIST_UNION,typesem_def] >>
   rw[] >> rpt AP_TERM_TAC >> rw[MAP_EQ_f] >>
   metis_tac[])
 
-val typesem_consts = store_thm("typesem_consts",
-  ``∀δ τ ty δ'.
+val typesem_consts = Q.store_thm("typesem_consts",
+  `∀δ τ ty δ'.
     (∀name args. (Tyapp name args) subtype ty ⇒
       δ' name = δ name ∨
       ∃vars. args = MAP Tyvar vars ∧
              δ' name (MAP τ vars) = δ name (MAP τ vars))
-    ⇒ typesem δ' τ ty = typesem δ τ ty``,
+    ⇒ typesem δ' τ ty = typesem δ τ ty`,
   ho_match_mp_tac typesem_ind >>
   conj_tac >- simp[typesem_def] >>
   rw[] >> simp[typesem_def] >>
@@ -74,8 +74,8 @@ val typesem_consts = store_thm("typesem_consts",
 
 (* termsem *)
 
-val termsem_typesem = store_thm("termsem_typesem",
-  ``is_set_theory ^mem ⇒
+val termsem_typesem = Q.store_thm("termsem_typesem",
+  `is_set_theory ^mem ⇒
     ∀sig i tm v δ τ tmenv.
       δ = FST i ∧ τ = FST v ∧
       is_valuation (tysof sig) δ v ∧
@@ -83,7 +83,7 @@ val termsem_typesem = store_thm("termsem_typesem",
       is_std_type_assignment δ ∧
       term_ok sig tm ∧ tmenv = tmsof sig
       ⇒
-      termsem tmenv i v tm <: typesem δ τ (typeof tm)``,
+      termsem tmenv i v tm <: typesem δ τ (typeof tm)`,
   strip_tac >> ntac 2 Cases >> Induct
   >- (
     Cases_on`v`>>
@@ -130,18 +130,18 @@ val termsem_typesem = store_thm("termsem_typesem",
   Cases_on`v`>> fs[is_valuation_def,is_term_valuation_def] >>
   rw[combinTheory.APPLY_UPDATE_THM] >> rw[])
 
-val termsem_typesem_matchable = store_thm("termsem_typesem_matchable",
-  ``is_set_theory ^mem ⇒
+val termsem_typesem_matchable = Q.store_thm("termsem_typesem_matchable",
+  `is_set_theory ^mem ⇒
      ∀sig i tm v δ τ tmenv ty.
        δ = tyaof i ∧ τ = tyvof v ∧ is_valuation (tysof sig) δ v ∧
        is_interpretation sig i ∧ is_std_type_assignment δ ∧
        term_ok sig tm ∧ tmenv = tmsof sig ∧
        ty = typesem δ τ (typeof tm) ⇒
-       termsem tmenv i v tm <: ty``,
+       termsem tmenv i v tm <: ty`,
   PROVE_TAC[termsem_typesem])
 
-val termsem_consts = store_thm("termsem_consts",
-  ``∀tmsig i v tm i'.
+val termsem_consts = Q.store_thm("termsem_consts",
+  `∀tmsig i v tm i'.
       welltyped tm ∧
       (∀name ty. VFREE_IN (Const name ty) tm ⇒
                  instance tmsig i' name ty (tyvof v) =
@@ -150,7 +150,7 @@ val termsem_consts = store_thm("termsem_consts",
          typesem (tyaof i') (tyvof v) (typeof t) =
          typesem (tyaof i ) (tyvof v) (typeof t))
       ⇒
-      termsem tmsig i' v tm = termsem tmsig i v tm``,
+      termsem tmsig i' v tm = termsem tmsig i v tm`,
   Induct_on`tm` >> simp[termsem_def] >> rw[]
   >- (
     fs[subterm_Comb] >>
@@ -165,11 +165,11 @@ val Equalsem =
   |> strip_conj |> last
   |> strip_comb |> snd |> last
 
-val termsem_Equal = store_thm("termsem_Equal",
-  ``is_set_theory ^mem ⇒
+val termsem_Equal = Q.store_thm("termsem_Equal",
+  `is_set_theory ^mem ⇒
     ∀Γ i v ty.
       is_structure Γ i v ∧ type_ok (tysof Γ) ty ⇒
-      termsem (tmsof Γ) i v (Equal ty) = ^Equalsem [typesem (FST i) (FST v) ty]``,
+      termsem (tmsof Γ) i v (Equal ty) = ^Equalsem [typesem (FST i) (FST v) ty]`,
   rw[termsem_def,LET_THM] >> fs[is_structure_def] >>
   qspecl_then[`tmsof Γ`,`i`,`(strlit "=")`]mp_tac instance_def >> fs[is_std_sig_def]>>
   disch_then(qspec_then`[(ty,Tyvar(strlit "A"))]`mp_tac)>>
@@ -192,13 +192,13 @@ val termsem_Equal = store_thm("termsem_Equal",
 
 (* equations *)
 
-val termsem_equation = store_thm("termsem_equation",
-  ``is_set_theory ^mem ⇒
+val termsem_equation = Q.store_thm("termsem_equation",
+  `is_set_theory ^mem ⇒
     ∀sig i v s t tmenv.
     is_structure sig i v ∧
     term_ok sig (s === t) ∧
     tmenv = tmsof sig
-    ⇒ termsem tmenv i v (s === t) = Boolean (termsem tmenv i v s = termsem tmenv i v t)``,
+    ⇒ termsem tmenv i v (s === t) = Boolean (termsem tmenv i v s = termsem tmenv i v t)`,
   rw[] >>
   `is_std_sig sig ∧ is_std_interpretation i` by fs[is_structure_def] >>
   fs[term_ok_equation] >>
@@ -249,8 +249,8 @@ val termsem_raconv = store_thm("termsem_raconv",
   simp[ALPHAVARS_def,combinTheory.APPLY_UPDATE_THM] >>
   rw[] >> fs[])
 
-val termsem_aconv = store_thm("termsem_aconv",
-  ``∀Γ i v t1 t2. ACONV t1 t2 ∧ welltyped t1 ∧ welltyped t2 ⇒ termsem Γ i v t1 = termsem Γ i v t2``,
+val termsem_aconv = Q.store_thm("termsem_aconv",
+  `∀Γ i v t1 t2. ACONV t1 t2 ∧ welltyped t1 ∧ welltyped t2 ⇒ termsem Γ i v t1 = termsem Γ i v t2`,
   rw[ACONV_def] >>
   imp_res_tac termsem_raconv >>
   rfs[ALPHAVARS_def] >>
@@ -271,22 +271,22 @@ val termsem_frees = store_thm("termsem_frees",
   rw[combinTheory.APPLY_UPDATE_THM,FUN_EQ_THM] >>
   first_x_assum match_mp_tac >> fs[])
 
-val typesem_frees = store_thm("typesem_frees",
-  ``∀ty τ1 τ2 δ.
+val typesem_frees = Q.store_thm("typesem_frees",
+  `∀ty τ1 τ2 δ.
       (∀a. MEM a (tyvars ty) ⇒ τ1 a = τ2 a) ⇒
-      typesem δ τ1 ty = typesem δ τ2 ty``,
+      typesem δ τ1 ty = typesem δ τ2 ty`,
   ho_match_mp_tac type_ind >>
   simp[tyvars_def,MEM_FOLDR_LIST_UNION,typesem_def,PULL_EXISTS] >>
   rw[] >> rpt AP_TERM_TAC >> simp[MAP_EQ_f] >>
   fs[EVERY_MEM] >> metis_tac[])
 
-val termsem_tyfrees = store_thm("termsem_tyfrees",
-  ``∀Γ i t v1 v2 tmenv.
+val termsem_tyfrees = Q.store_thm("termsem_tyfrees",
+  `∀Γ i t v1 v2 tmenv.
       term_ok Γ t ∧
       SND v1 = SND v2 ∧
       (∀a. MEM a (tvars t) ⇒ FST v1 a = FST v2 a) ∧
       tmenv = tmsof Γ
-      ⇒ termsem tmenv i v1 t = termsem tmenv i v2 t``,
+      ⇒ termsem tmenv i v1 t = termsem tmenv i v2 t`,
   ntac 2 gen_tac >> Induct >>
   simp[termsem_def,tvars_def,term_ok_def] >- (
     rw[] >>
@@ -510,9 +510,9 @@ val termsem_extend = store_thm("termsem_extend",
   imp_res_tac FLOOKUP_SUBMAP >>
   fs[Abbr`sig`,Abbr`ty`])
 
-val is_valuation_reduce = store_thm("is_valuation_reduce",
-  ``∀tyenv tyenv' δ v. tyenv ⊑ tyenv' ∧ is_valuation tyenv' δ v ⇒
-    is_valuation tyenv δ v``,
+val is_valuation_reduce = Q.store_thm("is_valuation_reduce",
+  `∀tyenv tyenv' δ v. tyenv ⊑ tyenv' ∧ is_valuation tyenv' δ v ⇒
+    is_valuation tyenv δ v`,
   rw[is_valuation_def,is_term_valuation_def] >>
   metis_tac[type_ok_extend])
 
@@ -532,44 +532,44 @@ val equal_on_def = Define`
   (∀name. name ∈ FDOM (tysof sig) ⇒ tyaof i' name = tyaof i name) ∧
   (∀name. name ∈ FDOM (tmsof sig) ⇒ tmaof i' name = tmaof i name)`
 
-val equal_on_refl = store_thm("equal_on_refl",
-  ``∀sig i. equal_on sig i i``,
+val equal_on_refl = Q.store_thm("equal_on_refl",
+  `∀sig i. equal_on sig i i`,
   rw[equal_on_def])
 
-val equal_on_sym = store_thm("equal_on_sym",
-  ``∀sig i i'. equal_on sig i i' ⇒ equal_on sig i' i``,
+val equal_on_sym = Q.store_thm("equal_on_sym",
+  `∀sig i i'. equal_on sig i i' ⇒ equal_on sig i' i`,
   rw[equal_on_def] >> PROVE_TAC[])
 
-val equal_on_trans = store_thm("equal_on_trans",
-  ``∀sig i1 i2 i3. equal_on sig i1 i2 ∧ equal_on sig i2 i3
-    ⇒ equal_on sig i1 i3``,
+val equal_on_trans = Q.store_thm("equal_on_trans",
+  `∀sig i1 i2 i3. equal_on sig i1 i2 ∧ equal_on sig i2 i3
+    ⇒ equal_on sig i1 i3`,
   rw[equal_on_def] >> metis_tac[])
 
-val equal_on_interprets = store_thm("equal_on_interprets",
-  ``∀sig i1 i2 name args ty m.
+val equal_on_interprets = Q.store_thm("equal_on_interprets",
+  `∀sig i1 i2 name args ty m.
       equal_on sig i1 i2 ∧
       tmaof i1 interprets name on args as m ∧
       (FLOOKUP (tmsof sig) name = SOME ty) ∧
       type_ok (tysof sig) ty ∧
       (set (tyvars ty) = set args) ⇒
-      tmaof i2 interprets name on args as m``,
+      tmaof i2 interprets name on args as m`,
   rw[equal_on_def,interprets_def] >>
   qsuff_tac`tmaof i2 name = tmaof i1 name` >- metis_tac[] >>
   first_x_assum match_mp_tac >>
   fs[FLOOKUP_DEF])
 
-val equal_on_reduce = store_thm("equal_on_reduce",
-  ``∀ls ctxt i i'. equal_on (sigof (ls++ctxt)) i i' ∧
+val equal_on_reduce = Q.store_thm("equal_on_reduce",
+  `∀ls ctxt i i'. equal_on (sigof (ls++ctxt)) i i' ∧
                  DISJOINT (FDOM (tysof ls)) (FDOM (tysof ctxt)) ∧
                  DISJOINT (FDOM (tmsof ls)) (FDOM (tmsof ctxt))
-    ⇒ equal_on (sigof ctxt) i i'``,
+    ⇒ equal_on (sigof ctxt) i i'`,
   rw[equal_on_def])
 
 (* semantics only depends on interpretation of things in the term's signature *)
 
-val typesem_sig = store_thm("typesem_sig",
-  ``∀ty τ δ δ' tyenv. type_ok tyenv ty ∧ (∀name. name ∈ FDOM tyenv ⇒ δ' name = δ name) ⇒
-                    typesem δ' τ ty = typesem δ τ ty``,
+val typesem_sig = Q.store_thm("typesem_sig",
+  `∀ty τ δ δ' tyenv. type_ok tyenv ty ∧ (∀name. name ∈ FDOM tyenv ⇒ δ' name = δ name) ⇒
+                    typesem δ' τ ty = typesem δ τ ty`,
   ho_match_mp_tac type_ind >> simp[typesem_def,type_ok_def] >> rw[] >>
   qmatch_abbrev_tac`δ' name args1 = δ name args2` >>
   `args1 = args2` by (
@@ -581,11 +581,11 @@ val typesem_sig = store_thm("typesem_sig",
   first_x_assum match_mp_tac >>
   fs[FLOOKUP_DEF])
 
-val termsem_sig = store_thm("termsem_sig",
-  ``∀tm Γ i v i' tmenv.
+val termsem_sig = Q.store_thm("termsem_sig",
+  `∀tm Γ i v i' tmenv.
       is_std_sig Γ ∧ term_ok Γ tm ∧ tmenv = tmsof Γ ∧ equal_on Γ i i'
       ⇒
-      termsem tmenv i' v tm = termsem tmenv i v tm``,
+      termsem tmenv i' v tm = termsem tmenv i v tm`,
   REWRITE_TAC[equal_on_def] >>
   Induct >> simp[termsem_def] >- (
     rw[term_ok_def] >>
@@ -644,14 +644,14 @@ val term_valuation_exists = store_thm("term_valuation_exists",
   qexists_tac`λ(x,ty). @v. v <: typesem δ τ ty` >> rw[] >>
   metis_tac[typesem_inhabited])
 
-val is_type_valuation_exists = prove(
-  ``is_set_theory ^mem ⇒ is_type_valuation (K boolset)``,
+val is_type_valuation_exists = Q.prove(
+  `is_set_theory ^mem ⇒ is_type_valuation (K boolset)`,
   simp[is_type_valuation_def] >> metis_tac[boolean_in_boolset]) |> UNDISCH
 
-val valuation_exists = store_thm("valuation_exists",
-  ``is_set_theory ^mem ⇒
+val valuation_exists = Q.store_thm("valuation_exists",
+  `is_set_theory ^mem ⇒
     ∀tyenv δ. is_type_assignment tyenv δ ⇒
-      ∃v. is_valuation tyenv δ v``,
+      ∃v. is_valuation tyenv δ v`,
   rw[is_valuation_def] >>
   qexists_tac`K boolset, λ(x,ty). @v. v <: typesem δ (K boolset) ty` >>
   conj_asm1_tac >- simp[is_type_valuation_exists] >>
@@ -672,18 +672,18 @@ val extend_valuation_exists = store_thm("extend_valuation_exists",
     else @m. m <: typesem δ (tyvof v) ty` >>
   rw[] >> metis_tac[typesem_inhabited])
 
-val is_type_valuation_UPDATE_LIST = store_thm("is_type_valuation_UPDATE_LIST",
-  ``∀t ls. is_type_valuation t ∧ EVERY (inhabited o SND) ls ⇒
-           is_type_valuation (t =++ ls)``,
+val is_type_valuation_UPDATE_LIST = Q.store_thm("is_type_valuation_UPDATE_LIST",
+  `∀t ls. is_type_valuation t ∧ EVERY (inhabited o SND) ls ⇒
+           is_type_valuation (t =++ ls)`,
   rw[is_type_valuation_def,APPLY_UPDATE_LIST_ALOOKUP] >>
   BasicProvers.CASE_TAC >> rw[] >> imp_res_tac ALOOKUP_MEM >>
   fs[EVERY_MEM,FORALL_PROD] >> metis_tac[])
 
 (* identity instance *)
 
-val identity_instance = store_thm("identity_instance",
-  ``∀tmenv (i:'U interpretation) name ty τ. FLOOKUP tmenv name = SOME ty ⇒
-      instance tmenv i name ty = λτ. tmaof i name (MAP τ (MAP implode (STRING_SORT (MAP explode (tyvars ty)))))``,
+val identity_instance = Q.store_thm("identity_instance",
+  `∀tmenv (i:'U interpretation) name ty τ. FLOOKUP tmenv name = SOME ty ⇒
+      instance tmenv i name ty = λτ. tmaof i name (MAP τ (MAP implode (STRING_SORT (MAP explode (tyvars ty)))))`,
   rw[] >>
   qspecl_then[`tmenv`,`i`,`name`,`ty`,`ty`,`[]`]mp_tac instance_def >>
   rw[FUN_EQ_THM,typesem_def,combinTheory.o_DEF,ETA_AX])
@@ -695,9 +695,9 @@ val interprets_nil = save_thm("interprets_nil",
   interprets_def |> SPEC_ALL |> Q.GEN`vs` |> Q.SPEC`[]`
   |> SIMP_RULE (std_ss++listSimps.LIST_ss) [rwt] |> GEN_ALL)
 
-val interprets_one = store_thm("interprets_one",
-  ``i interprets name on [v] as f ⇔
-    (∀x. inhabited x ⇒ (i name [x] = f [x]))``,
+val interprets_one = Q.store_thm("interprets_one",
+  `i interprets name on [v] as f ⇔
+    (∀x. inhabited x ⇒ (i name [x] = f [x]))`,
   rw[interprets_def,EQ_IMP_THM] >>
   TRY (
     first_x_assum match_mp_tac >>
@@ -708,19 +708,19 @@ val interprets_one = store_thm("interprets_one",
 
 (* for models, reducing the context *)
 
-val is_type_assignment_reduce = store_thm("is_type_assignment_reduce",
-  ``∀tyenv tyenv' δ.
+val is_type_assignment_reduce = Q.store_thm("is_type_assignment_reduce",
+  `∀tyenv tyenv' δ.
      tyenv ⊑ tyenv' ∧
      is_type_assignment tyenv' δ ⇒
-     is_type_assignment tyenv δ``,
+     is_type_assignment tyenv δ`,
   rw[is_type_assignment_def] >>
   imp_res_tac FEVERY_SUBMAP)
 
-val is_term_assignment_reduce = store_thm("is_term_assignment_reduce",
-  ``∀tmenv tmenv' δ γ.
+val is_term_assignment_reduce = Q.store_thm("is_term_assignment_reduce",
+  `∀tmenv tmenv' δ γ.
      tmenv ⊑ tmenv' ∧
      is_term_assignment tmenv' δ γ ⇒
-     is_term_assignment tmenv δ γ``,
+     is_term_assignment tmenv δ γ`,
    rw[is_term_assignment_def] >>
    imp_res_tac FEVERY_SUBMAP)
 

--- a/candle/standard/semantics/holSemanticsScript.sml
+++ b/candle/standard/semantics/holSemanticsScript.sml
@@ -89,13 +89,13 @@ val _ = Parse.overload_on("is_valuation",``is_valuation0 ^mem``)
 (* term assignment for instances of constants *)
 
 val instance_def = new_specification("instance_def",["instance"],
-  prove(``∃f. ∀tmsig (i:'U interpretation) name ty ty0 tyin.
+  Q.prove(`∃f. ∀tmsig (i:'U interpretation) name ty ty0 tyin.
               FLOOKUP tmsig name = SOME ty0 ∧
               ty = TYPE_SUBST tyin ty0
               ⇒
               f tmsig i name ty =
               λτ. tmaof i name
-                (MAP (typesem (tyaof i) τ o TYPE_SUBST tyin o Tyvar) (MAP implode (STRING_SORT (MAP explode (tyvars ty0)))))``,
+                (MAP (typesem (tyaof i) τ o TYPE_SUBST tyin o Tyvar) (MAP implode (STRING_SORT (MAP explode (tyvars ty0)))))`,
     simp[GSYM SKOLEM_THM] >> rw[] >>
     Cases_on`FLOOKUP tmsig name`>>simp[] >>
     qmatch_assum_rename_tac`FLOOKUP tmsig name = SOME ty0` >>

--- a/candle/standard/semantics/holSoundnessScript.sml
+++ b/candle/standard/semantics/holSoundnessScript.sml
@@ -5,8 +5,8 @@ val _ = new_theory"holSoundness"
 
 val mem = ``mem:'U->'U-> bool``
 
-val binary_inference_rule = store_thm("binary_inference_rule",
-  ``is_set_theory ^mem ⇒
+val binary_inference_rule = Q.store_thm("binary_inference_rule",
+  `is_set_theory ^mem ⇒
     ∀thy h1 h2 p1 p2 q.
     q has_type Bool ∧ term_ok (sigof thy) q ∧
     (∀i v. is_structure (sigof thy) i v ∧
@@ -14,7 +14,7 @@ val binary_inference_rule = store_thm("binary_inference_rule",
            termsem (tmsof thy) i v p2 = True ⇒
            termsem (tmsof thy) i v q = True) ∧
     (thy,h1) |= p1 ∧ (thy,h2) |= p2
-    ⇒ (thy, term_union h1 h2) |= q``,
+    ⇒ (thy, term_union h1 h2) |= q`,
   strip_tac >>
   rpt gen_tac >> strip_tac >>
   fs[entails_def,EVERY_term_union] >> rw[] >>
@@ -28,12 +28,12 @@ val binary_inference_rule = store_thm("binary_inference_rule",
   qspecl_then[`h1`,`h2`,`t`]mp_tac MEM_term_union >> simp[] >> strip_tac >>
   metis_tac[MEM_term_union_imp,termsem_aconv,term_ok_welltyped])
 
-val ABS_correct = store_thm("ABS_correct",
-  ``is_set_theory ^mem ⇒
+val ABS_correct = Q.store_thm("ABS_correct",
+  `is_set_theory ^mem ⇒
     ∀thy x ty h l r.
     ¬EXISTS (VFREE_IN (Var x ty)) h ∧ type_ok (tysof thy) ty ∧
     (thy,h) |= l === r
-    ⇒ (thy,h) |= Abs (Var x ty) l === Abs (Var x ty) r``,
+    ⇒ (thy,h) |= Abs (Var x ty) l === Abs (Var x ty) r`,
   rw[] >> fs[entails_def] >>
   imp_res_tac theory_ok_sig >>
   conj_asm1_tac >- fs[term_ok_equation,term_ok_def] >>
@@ -67,17 +67,17 @@ val ABS_correct = store_thm("ABS_correct",
   simp[Abbr`vv`,combinTheory.APPLY_UPDATE_THM] >>
   rw[] >> metis_tac[term_ok_welltyped])
 
-val ASSUME_correct = store_thm("ASSUME_correct",
-  ``∀thy p.
+val ASSUME_correct = Q.store_thm("ASSUME_correct",
+  `∀thy p.
       theory_ok thy ∧ p has_type Bool ∧ term_ok (sigof thy) p
-      ⇒ (thy,[p]) |= p``,
+      ⇒ (thy,[p]) |= p`,
   rw[entails_def,satisfies_def])
 
-val BETA_correct = store_thm("BETA_correct",
-  ``is_set_theory ^mem ⇒
+val BETA_correct = Q.store_thm("BETA_correct",
+  `is_set_theory ^mem ⇒
     ∀thy x ty t.
       theory_ok thy ∧ type_ok (tysof thy) ty ∧ term_ok (sigof thy) t ⇒
-      (thy,[]) |= Comb (Abs (Var x ty) t) (Var x ty) === t``,
+      (thy,[]) |= Comb (Abs (Var x ty) t) (Var x ty) === t`,
   rw[] >> simp[entails_def] >>
   imp_res_tac theory_ok_sig >>
   imp_res_tac term_ok_welltyped >>
@@ -106,14 +106,14 @@ val BETA_correct = store_thm("BETA_correct",
   simp[Abbr`f`,Abbr`e`] >>
   rw[combinTheory.APPLY_UPDATE_ID])
 
-val DEDUCT_ANTISYM_correct = store_thm("DEDUCT_ANTISYM_correct",
-  ``is_set_theory ^mem ⇒
+val DEDUCT_ANTISYM_correct = Q.store_thm("DEDUCT_ANTISYM_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h1 p1 h2 p2.
       (thy,h1) |= p1 ∧ (thy,h2) |= p2 ⇒
       (thy,
        term_union (term_remove p2 h1)
                   (term_remove p1 h2))
-      |= p1 === p2``,
+      |= p1 === p2`,
   rw[] >> fs[entails_def] >>
   imp_res_tac theory_ok_sig >>
   conj_asm1_tac >- (
@@ -160,11 +160,11 @@ val DEDUCT_ANTISYM_correct = store_thm("DEDUCT_ANTISYM_correct",
     metis_tac[typesem_Bool]) >>
   metis_tac[mem_boolset])
 
-val EQ_MP_correct = store_thm("EQ_MP_correct",
-  ``is_set_theory ^mem ⇒
+val EQ_MP_correct = Q.store_thm("EQ_MP_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h1 h2 p q p'.
       (thy,h1) |= p === q ∧ (thy,h2) |= p' ∧ ACONV p p' ⇒
-      (thy,term_union h1 h2) |= q``,
+      (thy,term_union h1 h2) |= q`,
   rw[] >>
   match_mp_tac (UNDISCH binary_inference_rule) >>
   map_every qexists_tac[`p === q`,`p'`] >>
@@ -176,13 +176,13 @@ val EQ_MP_correct = store_thm("EQ_MP_correct",
   imp_res_tac (UNDISCH termsem_equation) >> rfs[boolean_eq_true] >>
   metis_tac[termsem_aconv,term_ok_welltyped])
 
-val INST_correct = store_thm("INST_correct",
-  ``is_set_theory ^mem ⇒
+val INST_correct = Q.store_thm("INST_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h c.
       (∀s s'. MEM (s',s) ilist ⇒
               ∃x ty. (s = Var x ty) ∧ s' has_type ty ∧ term_ok (sigof thy) s') ∧
       (thy, h) |= c
-    ⇒ (thy, term_image (VSUBST ilist) h) |= VSUBST ilist c``,
+    ⇒ (thy, term_image (VSUBST ilist) h) |= VSUBST ilist c`,
   rw[entails_def,EVERY_MEM,satisfies_def] >>
   TRY ( imp_res_tac MEM_term_image_imp >> rw[] ) >>
   TRY ( match_mp_tac term_ok_VSUBST >> metis_tac[] ) >>
@@ -211,12 +211,12 @@ val INST_correct = store_thm("INST_correct",
   first_x_assum(fn th => first_assum (CHANGED_TAC o SUBST1_TAC o SYM o MATCH_MP th)) >>
   metis_tac[MEM_term_image_imp,termsem_VSUBST,welltyped_def,VSUBST_WELLTYPED,termsem_aconv])
 
-val INST_TYPE_correct = store_thm("INST_TYPE_correct",
-  ``is_set_theory ^mem ⇒
+val INST_TYPE_correct = Q.store_thm("INST_TYPE_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h c.
       EVERY (type_ok (tysof thy)) (MAP FST tyin) ∧
       (thy, h) |= c
-    ⇒ (thy, term_image (INST tyin) h) |= INST tyin c``,
+    ⇒ (thy, term_image (INST tyin) h) |= INST tyin c`,
   rw[entails_def,EVERY_MAP,EVERY_MEM,satisfies_def] >>
   TRY ( match_mp_tac hypset_ok_term_image >> rw[] ) >>
   TRY ( imp_res_tac MEM_term_image_imp >> rw[] ) >>
@@ -246,12 +246,12 @@ val INST_TYPE_correct = store_thm("INST_TYPE_correct",
   metis_tac[MEM_term_image_imp,SIMP_RULE(srw_ss())[]termsem_INST,
             welltyped_def,INST_WELLTYPED,termsem_aconv])
 
-val MK_COMB_correct = store_thm("MK_COMB_correct",
-  ``is_set_theory ^mem ⇒
+val MK_COMB_correct = Q.store_thm("MK_COMB_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h1 h2 l1 r1 l2 r2.
       (thy,h1) |= l1 === r1 ∧ (thy,h2) |= l2 === r2 ∧
       welltyped (Comb l1 l2)
-      ⇒ (thy,term_union h1 h2) |= Comb l1 l2 === Comb r1 r2``,
+      ⇒ (thy,term_union h1 h2) |= Comb l1 l2 === Comb r1 r2`,
   rw[] >>
   match_mp_tac (UNDISCH binary_inference_rule) >>
   map_every qexists_tac[`l1 === r1`,`l2 === r2`] >>
@@ -267,11 +267,11 @@ val MK_COMB_correct = store_thm("MK_COMB_correct",
   rfs[boolean_eq_true] >>
   rw[termsem_def])
 
-val REFL_correct = store_thm("REFL_correct",
-  ``is_set_theory ^mem ⇒
+val REFL_correct = Q.store_thm("REFL_correct",
+  `is_set_theory ^mem ⇒
     ∀thy t.
       theory_ok thy ∧ term_ok (sigof thy) t ⇒
-      (thy,[]) |= t === t``,
+      (thy,[]) |= t === t`,
   rw[] >>
   simp[entails_def,EQUATION_HAS_TYPE_BOOL] >>
   imp_res_tac theory_ok_sig >>
@@ -283,11 +283,11 @@ val REFL_correct = store_thm("REFL_correct",
   imp_res_tac termsem_equation >>
   rw[boolean_def])
 
-val TRANS_correct = store_thm("TRANS_correct",
-  ``is_set_theory ^mem ⇒
+val TRANS_correct = Q.store_thm("TRANS_correct",
+  `is_set_theory ^mem ⇒
     ∀thy h1 h2 l m1 m2 r.
       (thy,h1) |= l === m1 ∧ (thy,h2) |= m2 === r ∧ ACONV m1 m2
-      ⇒ (thy,term_union h1 h2) |= l === r``,
+      ⇒ (thy,term_union h1 h2) |= l === r`,
   strip_tac >>
   rw[] >> match_mp_tac (UNDISCH binary_inference_rule) >>
   map_every qexists_tac[`l === m1`,`m2 === r`] >>

--- a/candle/standard/semantics/holSoundnessScript.sml
+++ b/candle/standard/semantics/holSoundnessScript.sml
@@ -303,8 +303,8 @@ val TRANS_correct = store_thm("TRANS_correct",
   rfs[boolean_eq_true] >> fs[term_ok_equation] >>
   metis_tac[termsem_aconv,ACONV_SYM,term_ok_welltyped])
 
-val proves_sound = store_thm("proves_sound",
-  ``is_set_theory ^mem ⇒ ∀thyh c. thyh |- c ⇒ thyh |= c``,
+val proves_sound = Q.store_thm("proves_sound",
+  `is_set_theory ^mem ⇒ ∀thyh c. thyh |- c ⇒ thyh |= c`,
   strip_tac >> match_mp_tac proves_ind >>
   conj_tac >- metis_tac[ABS_correct] >>
   conj_tac >- metis_tac[ASSUME_correct] >>

--- a/candle/standard/syntax/holAxiomsSyntaxScript.sml
+++ b/candle/standard/syntax/holAxiomsSyntaxScript.sml
@@ -12,8 +12,8 @@ val _ = Parse.temp_overload_on("g",``Var (strlit "f") (Fun A B)``)
 val mk_eta_ctxt_def = Define`
   mk_eta_ctxt ctxt = NewAxiom ((Abs x (Comb g x)) === g)::ctxt`
 
-val eta_extends = store_thm("eta_extends",
-  ``∀ctxt. is_std_sig (sigof ctxt) ⇒ mk_eta_ctxt ctxt extends ctxt``,
+val eta_extends = Q.store_thm("eta_extends",
+  `∀ctxt. is_std_sig (sigof ctxt) ⇒ mk_eta_ctxt ctxt extends ctxt`,
   rw[extends_def] >>
   rw[Once RTC_CASES1] >> disj2_tac >>
   rw[Once RTC_CASES1] >> rw[mk_eta_ctxt_def] >>
@@ -30,11 +30,11 @@ val mk_select_ctxt_def = Define`
     NewConst (strlit "@") (Fun (Fun A Bool) A) ::
     ctxt`
 
-val select_extends = store_thm("select_extends",
-  ``∀ctxt. is_std_sig (sigof ctxt) ∧
+val select_extends = Q.store_thm("select_extends",
+  `∀ctxt. is_std_sig (sigof ctxt) ∧
            (strlit "@") ∉ FDOM (tmsof ctxt) ∧
            (FLOOKUP (tmsof ctxt) (strlit "==>") = SOME (Fun Bool (Fun Bool Bool)))
-    ⇒ mk_select_ctxt ctxt extends ctxt``,
+    ⇒ mk_select_ctxt ctxt extends ctxt`,
   rw[extends_def] >>
   rw[Once RTC_CASES1] >> disj2_tac >>
   rw[Once RTC_CASES1] >> reverse(rw[mk_select_ctxt_def]) >- (
@@ -68,13 +68,13 @@ val mk_infinity_ctxt_def = Define`
       (Abs g (FAx1 (FAx2 (Implies (Comb g x1 === Comb g x2) (x1 === x2))))) ::
     ctxt`
 
-val tyvar_inst_exists = prove(
-  ``∃i. ty = REV_ASSOCD (Tyvar a) i b``,
+val tyvar_inst_exists = Q.prove(
+  `∃i. ty = REV_ASSOCD (Tyvar a) i b`,
   qexists_tac`[(ty,Tyvar a)]` >>
   rw[REV_ASSOCD])
 
-val infinity_extends = store_thm("infinity_extends",
-  ``∀ctxt. theory_ok (thyof ctxt) ∧
+val infinity_extends = Q.store_thm("infinity_extends",
+  `∀ctxt. theory_ok (thyof ctxt) ∧
            DISJOINT (FDOM (tmsof ctxt)) (IMAGE strlit {"ONE_ONE";"ONTO"}) ∧
            (strlit "ind") ∉ FDOM (tysof ctxt) ∧
            (FLOOKUP (tmsof ctxt) (strlit "==>") = SOME (Fun Bool (Fun Bool Bool))) ∧
@@ -82,7 +82,7 @@ val infinity_extends = store_thm("infinity_extends",
            (FLOOKUP (tmsof ctxt) (strlit "!") = SOME (Fun (Fun A Bool) Bool)) ∧
            (FLOOKUP (tmsof ctxt) (strlit "?") = SOME (Fun (Fun A Bool) Bool)) ∧
            (FLOOKUP (tmsof ctxt) (strlit "~") = SOME (Fun Bool Bool))
-       ⇒ mk_infinity_ctxt ctxt extends ctxt``,
+       ⇒ mk_infinity_ctxt ctxt extends ctxt`,
   rw[extends_def] >>
   imp_res_tac theory_ok_sig >>
   `ALOOKUP (type_list ctxt) (strlit "fun") = SOME 2` by fs[is_std_sig_def] >>

--- a/candle/standard/syntax/holBoolSyntaxScript.sml
+++ b/candle/standard/syntax/holBoolSyntaxScript.sml
@@ -83,11 +83,11 @@ fun pull_tac () =
   BETA_TAC >> REWRITE_TAC[CONS_11] >> simp_tac bool_ss [] >>
   conj_asm2_tac
 
-val bool_extends = store_thm("bool_extends",
-  ``∀ctxt.
+val bool_extends = Q.store_thm("bool_extends",
+  `∀ctxt.
       theory_ok (thyof ctxt) ∧
       DISJOINT (FDOM (tmsof ctxt)) (IMAGE strlit {"T";"F";"==>";"/\\";"\\/";"~";"!";"?"}) ⇒
-      mk_bool_ctxt ctxt extends ctxt``,
+      mk_bool_ctxt ctxt extends ctxt`,
   REWRITE_TAC(mk_bool_ctxt_def::Defs) >>
   REWRITE_TAC[extends_def] >>
   ntac 2 strip_tac >>
@@ -101,8 +101,8 @@ val bool_extends = store_thm("bool_extends",
   pull_tac() >- ConstDef_tac >>
   rw[Once RTC_CASES1])
 
-val bool_extends_init = store_thm("bool_extends_init",
-  ``mk_bool_ctxt init_ctxt extends init_ctxt``,
+val bool_extends_init = Q.store_thm("bool_extends_init",
+  `mk_bool_ctxt init_ctxt extends init_ctxt`,
   match_mp_tac bool_extends >> simp[init_theory_ok] >>
   simp[init_ctxt_def])
 
@@ -139,18 +139,18 @@ val is_bool_sig_def = Define`
   is_forall_sig (tmsof sig) ∧
   is_exists_sig (tmsof sig)`
 
-val bool_has_bool_sig = store_thm("bool_has_bool_sig",
-  ``∀ctxt. is_std_sig (sigof ctxt)
-  ⇒ is_bool_sig (sigof (mk_bool_ctxt ctxt))``,
+val bool_has_bool_sig = Q.store_thm("bool_has_bool_sig",
+  `∀ctxt. is_std_sig (sigof ctxt)
+  ⇒ is_bool_sig (sigof (mk_bool_ctxt ctxt))`,
   rw[is_bool_sig_def] >- (
     fs[is_std_sig_def,mk_bool_ctxt_def,FLOOKUP_UPDATE] ) >>
   EVAL_TAC)
 
-val is_bool_sig_std = store_thm("is_bool_sig_std",
-  ``is_bool_sig sig ⇒ is_std_sig sig``, rw[is_bool_sig_def])
+val is_bool_sig_std = Q.store_thm("is_bool_sig_std",
+  `is_bool_sig sig ⇒ is_std_sig sig`, rw[is_bool_sig_def])
 
-val is_bool_sig_extends = store_thm("is_bool_sig_extends",
-  ``∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ is_bool_sig (sigof ctxt1) ⇒ is_bool_sig (sigof ctxt2)``,
+val is_bool_sig_extends = Q.store_thm("is_bool_sig_extends",
+  `∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ is_bool_sig (sigof ctxt1) ⇒ is_bool_sig (sigof ctxt2)`,
   ho_match_mp_tac extends_ind >>
   REWRITE_TAC[GSYM AND_IMP_INTRO] >>
   ho_match_mp_tac updates_ind >>
@@ -185,8 +185,8 @@ val is_bool_sig_extends = store_thm("is_bool_sig_extends",
 
 (* Boolean terms are ok *)
 
-val bool_term_ok = store_thm("bool_term_ok",
-  ``∀sig. is_bool_sig sig ⇒
+val bool_term_ok = Q.store_thm("bool_term_ok",
+  `∀sig. is_bool_sig sig ⇒
     term_ok sig True ∧
     (∀p1 p2. term_ok sig (And p1 p2) ⇔ term_ok sig p1 ∧ term_ok sig p2 ∧ typeof p1 = Bool ∧ typeof p2 = Bool) ∧
     (∀p1 p2. term_ok sig (Implies p1 p2) ⇔ term_ok sig p1 ∧ term_ok sig p2 ∧ typeof p1 = Bool ∧ typeof p2 = Bool) ∧
@@ -194,7 +194,7 @@ val bool_term_ok = store_thm("bool_term_ok",
     (∀z ty p. term_ok sig (Exists z ty p) ⇔ type_ok (tysof sig) ty ∧ term_ok sig p ∧ typeof p = Bool) ∧
     (∀p1 p2. term_ok sig (Or p1 p2) ⇔ term_ok sig p1 ∧ term_ok sig p2 ∧ typeof p1 = Bool ∧ typeof p2 = Bool) ∧
     term_ok sig False ∧
-    (∀p. term_ok sig (Not p) ⇔ term_ok sig p ∧ typeof p = Bool)``,
+    (∀p. term_ok sig (Not p) ⇔ term_ok sig p ∧ typeof p = Bool)`,
   rw[] >> imp_res_tac is_bool_sig_std >> rw[term_ok_clauses] >>
   rw[term_ok_def] >> fs[is_bool_sig_def] >> fs sigs >> rw[term_ok_clauses,tyvar_inst_exists] >>
   PROVE_TAC[term_ok_welltyped])

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -12,13 +12,13 @@ val type_ind = save_thm("type_ind",
   |> DISCH_ALL
   |> Q.GEN`P`)
 
-val type1_size_append = store_thm("type1_size_append",
-  ``∀l1 l2. type1_size (l1 ++ l2) = type1_size l1 + type1_size l2``,
+val type1_size_append = Q.store_thm("type1_size_append",
+  `∀l1 l2. type1_size (l1 ++ l2) = type1_size l1 + type1_size l2`,
   Induct >> simp[type_size_def])
 
-val extends_ind = store_thm("extends_ind",
-  ``∀P. (∀upd ctxt. upd updates ctxt ∧ P ctxt ⇒ P (upd::ctxt)) ⇒
-    ∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ P ctxt1 ⇒ P ctxt2``,
+val extends_ind = Q.store_thm("extends_ind",
+  `∀P. (∀upd ctxt. upd updates ctxt ∧ P ctxt ⇒ P (upd::ctxt)) ⇒
+    ∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ P ctxt1 ⇒ P ctxt2`,
   gen_tac >> strip_tac >>
   simp[extends_def] >>
   CONV_TAC SWAP_FORALL_CONV >>
@@ -38,18 +38,18 @@ val ALOOKUP_MAP_dest_var = store_thm("ALOOKUP_MAP_dest_var",
 
 (* type substitution *)
 
-val TYPE_SUBST_NIL = store_thm("TYPE_SUBST_NIL",
-  ``∀ty. TYPE_SUBST [] ty = ty``,
+val TYPE_SUBST_NIL = Q.store_thm("TYPE_SUBST_NIL",
+  `∀ty. TYPE_SUBST [] ty = ty`,
   ho_match_mp_tac type_ind >>
   rw[REV_ASSOCD,MAP_EQ_ID] >>
   fs[EVERY_MEM])
 val _ = export_rewrites["TYPE_SUBST_NIL"]
 
-val TYPE_SUBST_Bool = store_thm("TYPE_SUBST_Bool",
-  ``∀tyin. TYPE_SUBST tyin Bool = Bool``, rw[TYPE_SUBST_def])
+val TYPE_SUBST_Bool = Q.store_thm("TYPE_SUBST_Bool",
+  `∀tyin. TYPE_SUBST tyin Bool = Bool`, rw[TYPE_SUBST_def])
 
-val is_instance_refl = store_thm("is_instance_refl",
-  ``∀ty. is_instance ty ty``,
+val is_instance_refl = Q.store_thm("is_instance_refl",
+  `∀ty. is_instance ty ty`,
   rw[] >> qexists_tac`[]` >> rw[])
 val _ = export_rewrites["is_instance_refl"]
 
@@ -61,10 +61,10 @@ val ff_def = store_thm("ff_def",
   ``∀f g. (f ## g) = λ(x,y). (f x, g y)``,
   rw[FUN_EQ_THM,FORALL_PROD,PAIR_MAP_THM])
 
-val TYPE_SUBST_compose = store_thm("TYPE_SUBST_compose",
-  ``∀tyin1 ty tyin2.
+val TYPE_SUBST_compose = Q.store_thm("TYPE_SUBST_compose",
+  `∀tyin1 ty tyin2.
     TYPE_SUBST tyin2 (TYPE_SUBST tyin1 ty) =
-    TYPE_SUBST ((MAP (TYPE_SUBST tyin2 ## I) tyin1) ++ tyin2) ty``,
+    TYPE_SUBST ((MAP (TYPE_SUBST tyin2 ## I) tyin1) ++ tyin2) ty`,
   ho_match_mp_tac TYPE_SUBST_ind >>
   rw[TYPE_SUBST_def,MAP_MAP_o,combinTheory.o_DEF,MAP_EQ_f] >>
   rw[REV_ASSOCD_ALOOKUP,ALOOKUP_APPEND] >>
@@ -72,12 +72,12 @@ val TYPE_SUBST_compose = store_thm("TYPE_SUBST_compose",
   simp[ff_def,ALOOKUP_MAP] >>
   BasicProvers.CASE_TAC >> simp[TYPE_SUBST_def,REV_ASSOCD_ALOOKUP])
 
-val TYPE_SUBST_tyvars = store_thm("TYPE_SUBST_tyvars",
-  ``∀ty tyin tyin'.
+val TYPE_SUBST_tyvars = Q.store_thm("TYPE_SUBST_tyvars",
+  `∀ty tyin tyin'.
     (TYPE_SUBST tyin ty = TYPE_SUBST tyin' ty) ⇔
     ∀x. MEM x (tyvars ty) ⇒
         REV_ASSOCD (Tyvar x) tyin' (Tyvar x) =
-        REV_ASSOCD (Tyvar x) tyin  (Tyvar x)``,
+        REV_ASSOCD (Tyvar x) tyin  (Tyvar x)`,
   ho_match_mp_tac type_ind >>
   simp[tyvars_def] >>
   conj_tac >- metis_tac[] >>
@@ -88,22 +88,22 @@ val TYPE_SUBST_tyvars = store_thm("TYPE_SUBST_tyvars",
 
 (* Welltyped terms *)
 
-val WELLTYPED_LEMMA = store_thm("WELLTYPED_LEMMA",
-  ``∀tm ty. tm has_type ty ⇒ (typeof tm = ty)``,
+val WELLTYPED_LEMMA = Q.store_thm("WELLTYPED_LEMMA",
+  `∀tm ty. tm has_type ty ⇒ (typeof tm = ty)`,
   ho_match_mp_tac has_type_ind >>
   simp[typeof_def,has_type_rules,codomain_def])
 
-val WELLTYPED = store_thm("WELLTYPED",
-  ``∀tm. welltyped tm ⇔ tm has_type (typeof tm)``,
+val WELLTYPED = Q.store_thm("WELLTYPED",
+  `∀tm. welltyped tm ⇔ tm has_type (typeof tm)`,
   simp[welltyped_def] >> metis_tac[WELLTYPED_LEMMA])
 
-val WELLTYPED_CLAUSES = store_thm("WELLTYPED_CLAUSES",
- ``(!n ty. welltyped(Var n ty)) /\
+val WELLTYPED_CLAUSES = Q.store_thm("WELLTYPED_CLAUSES",
+ `(!n ty. welltyped(Var n ty)) /\
    (!n ty. welltyped(Const n ty)) /\
    (!s t. welltyped (Comb s t) <=>
             welltyped s /\ welltyped t /\
             ?rty. typeof s = Fun (typeof t) rty) /\
-   (!v t. welltyped (Abs v t) = ∃n ty. v = Var n ty ∧ welltyped t)``,
+   (!v t. welltyped (Abs v t) = ∃n ty. v = Var n ty ∧ welltyped t)`,
   REPEAT STRIP_TAC THEN REWRITE_TAC[welltyped_def] THEN
   rw[Once has_type_cases] >>
   metis_tac[WELLTYPED,WELLTYPED_LEMMA])
@@ -138,8 +138,8 @@ val RACONV_REFL = store_thm("RACONV_REFL",
   ``∀t env. EVERY (UNCURRY $=) env ⇒ RACONV env (t,t)``,
   Induct >> simp[RACONV,ALPHAVARS_REFL])
 
-val ACONV_REFL = store_thm("ACONV_REFL",
-  ``∀t. ACONV t t``,
+val ACONV_REFL = Q.store_thm("ACONV_REFL",
+  `∀t. ACONV t t`,
   simp[ACONV_def,RACONV_REFL])
 val _ = export_rewrites["ACONV_REFL"]
 
@@ -159,8 +159,8 @@ val RACONV_TRANS = store_thm("RACONV_TRANS",
   Cases_on`t`>>fs[RACONV]>>rw[]>>
   metis_tac[LENGTH,ZIP])
 
-val ACONV_TRANS = store_thm("ACONV_TRANS",
-  ``∀t1 t2 t3. ACONV t1 t2 ∧ ACONV t2 t3 ⇒ ACONV t1 t3``,
+val ACONV_TRANS = Q.store_thm("ACONV_TRANS",
+  `∀t1 t2 t3. ACONV t1 t2 ∧ ACONV t2 t3 ⇒ ACONV t1 t3`,
   rw[ACONV_def] >> imp_res_tac RACONV_TRANS >> fs[LENGTH_NIL])
 
 val RACONV_SYM = store_thm("RACONV_SYM",
@@ -172,8 +172,8 @@ val RACONV_SYM = store_thm("RACONV_SYM",
     rw[] >> res_tac >> fs[RACONV]) >>
   simp[RACONV])
 
-val ACONV_SYM = store_thm("ACONV_SYM",
-  ``∀t1 t2. ACONV t1 t2 ⇒ ACONV t2 t1``,
+val ACONV_SYM = Q.store_thm("ACONV_SYM",
+  `∀t1 t2. ACONV t1 t2 ⇒ ACONV t2 t1`,
   rw[ACONV_def] >> imp_res_tac RACONV_SYM >> fs[])
 
 val ALPHAVARS_TYPE = store_thm("ALPHAVARS_TYPE",
@@ -195,8 +195,8 @@ val RACONV_TYPE = store_thm("RACONV_TYPE",
   rw[] >> imp_res_tac ALPHAVARS_TYPE >>
   fs[typeof_def,WELLTYPED_CLAUSES])
 
-val ACONV_TYPE = store_thm("ACONV_TYPE",
-  ``∀s t. ACONV s t ⇒ welltyped s ∧ welltyped t ⇒ (typeof s = typeof t)``,
+val ACONV_TYPE = Q.store_thm("ACONV_TYPE",
+  `∀s t. ACONV s t ⇒ welltyped s ∧ welltyped t ⇒ (typeof s = typeof t)`,
   rw[ACONV_def] >> imp_res_tac RACONV_TYPE >> fs[])
 
 (* subtypes *)
@@ -215,8 +215,8 @@ val subtype_Tyapp = save_thm("subtype_Tyapp",
   |> SIMP_CONV(srw_ss()++boolSimps.DNF_ss)
       [Once relationTheory.RTC_CASES2,subtype1_cases])
 
-val subtype_type_ok = store_thm("subtype_type_ok",
-  ``∀tysig ty1 ty2. type_ok tysig ty2 ∧ ty1 subtype ty2 ⇒ type_ok tysig ty1``,
+val subtype_type_ok = Q.store_thm("subtype_type_ok",
+  `∀tysig ty1 ty2. type_ok tysig ty2 ∧ ty1 subtype ty2 ⇒ type_ok tysig ty1`,
   gen_tac >>
   (relationTheory.RTC_lifts_invariants
     |> Q.GEN`R` |> Q.ISPEC`inv subtype1`
@@ -259,7 +259,7 @@ val subterm_Abs = save_thm("subterm_Abs",
 
 val subterm_welltyped = save_thm("subterm_welltyped",
   let val th =
-    prove(``∀tm ty. tm has_type ty ⇒ ∀t. t subterm tm ⇒ welltyped t``,
+    Q.prove(`∀tm ty. tm has_type ty ⇒ ∀t. t subterm tm ⇒ welltyped t`,
       ho_match_mp_tac has_type_strongind >>
       simp[subterm_Comb,subterm_Abs] >> rw[] >>
       rw[] >> imp_res_tac WELLTYPED_LEMMA >> simp[])
@@ -305,24 +305,24 @@ val term_lt_thm = prove(``
   |> CONJUNCTS |> map GEN_ALL |> LIST_CONJ
   |> curry save_thm "term_lt_thm"
 
-val type_cmp_refl = store_thm("type_cmp_refl[simp]",
-  ``type_cmp t t = EQUAL``,
+val type_cmp_refl = Q.store_thm("type_cmp_refl[simp]",
+  `type_cmp t t = EQUAL`,
   rw[type_cmp_def,TO_of_LinearOrder])
 
-val term_cmp_refl = store_thm("term_cmp_refl[simp]",
-  ``term_cmp t t = EQUAL``,
+val term_cmp_refl = Q.store_thm("term_cmp_refl[simp]",
+  `term_cmp t t = EQUAL`,
   rw[term_cmp_def,TO_of_LinearOrder])
 
-val irreflexive_type_lt = prove(
-  ``irreflexive type_lt``,
+val irreflexive_type_lt = Q.prove(
+  `irreflexive type_lt`,
   mp_tac StrongLinearOrder_mlstring_lt >>
   simp[StrongLinearOrder,StrongOrder,irreflexive_def] >>
   strip_tac >> ho_match_mp_tac type_ind >>
   simp[type_lt_thm,LEX_DEF] >>
   Induct >> simp[])
 
-val trichotomous_type_lt = prove(
-  ``trichotomous type_lt``,
+val trichotomous_type_lt = Q.prove(
+  `trichotomous type_lt`,
   mp_tac StrongLinearOrder_mlstring_lt >>
   simp[StrongLinearOrder,trichotomous] >> strip_tac >>
   ho_match_mp_tac type_ind >>
@@ -338,8 +338,8 @@ val trichotomous_type_lt = prove(
   rw[] >> fs[] >>
   metis_tac[])
 
-val transitive_type_lt = prove(
-  ``∀x y. type_lt x y ⇒ ∀z. type_lt y z ⇒ type_lt x z``,
+val transitive_type_lt = Q.prove(
+  `∀x y. type_lt x y ⇒ ∀z. type_lt y z ⇒ type_lt x z`,
   ho_match_mp_tac type_lt_strongind >>
   rpt conj_tac >> rpt gen_tac >> simp[PULL_FORALL] >>
   Cases_on`z` >> simp[type_lt_thm,LEX_DEF_THM] >-
@@ -403,27 +403,27 @@ val transitive_type_lt = prove(
   `LENGTH args1 ≤ LENGTH l` by DECIDE_TAC >> simp[] >>
   simp[rich_listTheory.EL_TAKE])
 
-val StrongLinearOrder_type_lt = store_thm("StrongLinearOrder_type_lt",
-  ``StrongLinearOrder type_lt``,
+val StrongLinearOrder_type_lt = Q.store_thm("StrongLinearOrder_type_lt",
+  `StrongLinearOrder type_lt`,
   simp[StrongLinearOrder,StrongOrder,irreflexive_type_lt,trichotomous_type_lt] >>
   metis_tac[transitive_type_lt,transitive_def])
 
-val TotOrd_type_cmp = store_thm("TotOrd_type_cmp",
-  ``TotOrd type_cmp``,
+val TotOrd_type_cmp = Q.store_thm("TotOrd_type_cmp",
+  `TotOrd type_cmp`,
   rw[type_cmp_def] >>
   match_mp_tac TotOrd_TO_of_Strong >>
   ACCEPT_TAC StrongLinearOrder_type_lt)
 
-val irreflexive_term_lt = prove(
-  ``irreflexive term_lt``,
+val irreflexive_term_lt = Q.prove(
+  `irreflexive term_lt`,
   mp_tac StrongLinearOrder_mlstring_lt >>
   mp_tac StrongLinearOrder_type_lt >>
   simp[StrongLinearOrder,StrongOrder,irreflexive_def] >>
   ntac 2 strip_tac >> ho_match_mp_tac term_induction >>
   simp[term_lt_thm,LEX_DEF])
 
-val trichotomous_term_lt = prove(
-  ``trichotomous term_lt``,
+val trichotomous_term_lt = Q.prove(
+  `trichotomous term_lt`,
   mp_tac StrongLinearOrder_mlstring_lt >>
   mp_tac StrongLinearOrder_type_lt >>
   simp[StrongLinearOrder,trichotomous] >> ntac 2 strip_tac >>
@@ -432,33 +432,33 @@ val trichotomous_term_lt = prove(
   Cases_on`b` >> simp[term_lt_thm,LEX_DEF_THM] >>
   metis_tac[])
 
-val transitive_term_lt = prove(
-  ``∀x y. term_lt x y ⇒ ∀z. term_lt y z ⇒ term_lt x z``,
+val transitive_term_lt = Q.prove(
+  `∀x y. term_lt x y ⇒ ∀z. term_lt y z ⇒ term_lt x z`,
   ho_match_mp_tac term_lt_strongind >>
   rpt conj_tac >> rpt gen_tac >> simp[PULL_FORALL] >>
   Cases_on`z` >> simp[term_lt_thm,LEX_DEF_THM] >>
   metis_tac[StrongLinearOrder_mlstring_lt,StrongLinearOrder_type_lt,StrongLinearOrder,
             StrongOrder,transitive_def])
 
-val StrongLinearOrder_term_lt = store_thm("StrongLinearOrder_term_lt",
-  ``StrongLinearOrder term_lt``,
+val StrongLinearOrder_term_lt = Q.store_thm("StrongLinearOrder_term_lt",
+  `StrongLinearOrder term_lt`,
   simp[StrongLinearOrder,StrongOrder,irreflexive_term_lt,trichotomous_term_lt] >>
   metis_tac[transitive_term_lt,transitive_def])
 
-val TotOrd_term_cmp = store_thm("TotOrd_term_cmp",
-  ``TotOrd term_cmp``,
+val TotOrd_term_cmp = Q.store_thm("TotOrd_term_cmp",
+  `TotOrd term_cmp`,
   rw[term_cmp_def] >>
   match_mp_tac TotOrd_TO_of_Strong >>
   ACCEPT_TAC StrongLinearOrder_term_lt)
 
-val StrongLinearOrder_irreflexive = prove(
-  ``StrongLinearOrder R ⇒ irreflexive R``,
+val StrongLinearOrder_irreflexive = Q.prove(
+  `StrongLinearOrder R ⇒ irreflexive R`,
   rw[StrongLinearOrder,StrongOrder])
 
 val irreflexive_mlstring_lt = MATCH_MP StrongLinearOrder_irreflexive StrongLinearOrder_mlstring_lt
 
-val LLEX_irreflexive = prove(
-  ``∀R. irreflexive R ⇒ irreflexive (LLEX R)``,
+val LLEX_irreflexive = Q.prove(
+  `∀R. irreflexive R ⇒ irreflexive (LLEX R)`,
   rw[irreflexive_def] >> Induct_on`x`>>rw[])
 
 val irreflexive_LLEX_type_lt = MATCH_MP LLEX_irreflexive (irreflexive_type_lt)
@@ -484,8 +484,8 @@ val type_cmp_thm = store_thm("type_cmp_thm",
        SYM(MATCH_MP TO_of_LinearOrder_LEX (CONJ irreflexive_mlstring_lt irreflexive_LLEX_type_lt))] >>
   simp[TO_of_LinearOrder])
 
-val type_cmp_ind = store_thm("type_cmp_ind",
-  ``∀P.
+val type_cmp_ind = Q.store_thm("type_cmp_ind",
+  `∀P.
       (∀t1 t2.
         (∀x1 a1 x2 a2 x y.
           t1 = Tyapp x1 a1 ∧
@@ -493,7 +493,7 @@ val type_cmp_ind = store_thm("type_cmp_ind",
           MEM x a1 ∧ MEM y a2 ⇒
           P x y)
         ⇒ P t1 t2)
-      ⇒ ∀t1 t2. P t1 t2``,
+      ⇒ ∀t1 t2. P t1 t2`,
   gen_tac >> strip_tac >>
   ho_match_mp_tac type_ind >>
   rpt conj_tac >> TRY (gen_tac >> Cases >> rw[] >> NO_TAC) >>
@@ -542,8 +542,8 @@ val term_cmp_thm = store_thm("term_cmp_thm",
   simp[term_cmp_def, TO_of_LinearOrder,
        SYM(MATCH_MP TO_of_LinearOrder_LEX (CONJ irreflexive_term_lt irreflexive_term_lt))] )
 
-val term_cmp_ind = store_thm("term_cmp_ind",
-  ``∀P.
+val term_cmp_ind = Q.store_thm("term_cmp_ind",
+  `∀P.
       (∀t1 t2.
         (∀x1 y1 x2 y2.
           t1 = Comb x1 y1 ∧ t2 = Comb x2 y2 ⇒
@@ -558,7 +558,7 @@ val term_cmp_ind = store_thm("term_cmp_ind",
           t1 = Abs x1 y1 ∧ t2 = Abs x2 y2 ⇒
             P y1 y2)
         ⇒ P t1 t2)
-      ⇒ ∀t1 t2. P t1 t2``,
+      ⇒ ∀t1 t2. P t1 t2`,
   gen_tac >> strip_tac >>
   ho_match_mp_tac term_induction >>
   rpt conj_tac >>
@@ -567,8 +567,8 @@ val term_cmp_ind = store_thm("term_cmp_ind",
 
 (* alpha ordering *)
 
-val ALPHAVARS_ordav = prove(
-  ``∀env tp. ALPHAVARS env tp ⇒ ordav env (FST tp) (SND tp) = EQUAL``,
+val ALPHAVARS_ordav = Q.prove(
+  `∀env tp. ALPHAVARS env tp ⇒ ordav env (FST tp) (SND tp) = EQUAL`,
   Induct >> rw[ALPHAVARS_def,ordav_def] >>
   Cases_on`h`>>rw[ordav_def] >> fs[] >>
   rfs[term_cmp_def,TO_of_LinearOrder] >>
@@ -585,8 +585,8 @@ val ALPHAVARS_eq_ordav = store_thm("ALPHAVARS_eq_ordav",
   ``∀env t1 t2. ALPHAVARS env (t1,t2) ⇔ ordav env t1 t2 = EQUAL``,
   metis_tac[ALPHAVARS_ordav,ordav_ALPHAVARS,pair_CASES,FST,SND])
 
-val RACONV_orda = prove(
-  ``∀env tp. RACONV env tp ⇒ orda env (FST tp) (SND tp) = EQUAL``,
+val RACONV_orda = Q.prove(
+  `∀env tp. RACONV env tp ⇒ orda env (FST tp) (SND tp) = EQUAL`,
   ho_match_mp_tac RACONV_ind >> rw[ALPHAVARS_eq_ordav]
   >- rw[orda_def] >- rw[orda_def] >- rw[Once orda_def] >>
   rw[Once orda_def])
@@ -615,8 +615,8 @@ val RACONV_eq_orda = store_thm("RACONV_eq_orda",
   ``∀env t1 t2. RACONV env (t1,t2) ⇔ orda env t1 t2 = EQUAL``,
   metis_tac[RACONV_orda,orda_RACONV,pair_CASES,FST,SND])
 
-val ACONV_eq_orda = store_thm("ACONV_eq_orda",
-  ``∀t1 t2. ACONV t1 t2 = (orda [] t1 t2 = EQUAL)``,
+val ACONV_eq_orda = Q.store_thm("ACONV_eq_orda",
+  `∀t1 t2. ACONV t1 t2 = (orda [] t1 t2 = EQUAL)`,
   rw[ACONV_def,RACONV_eq_orda])
 
 val ordav_FILTER = store_thm("ordav_FILTER",
@@ -648,14 +648,14 @@ val orda_sym = store_thm("orda_sym",
   metis_tac[invert_def,TotOrd_type_cmp,TotOrd_term_cmp,
             TotOrd,cpn_nchotomy,cpn_distinct] )
 
-val antisymmetric_alpha_lt = store_thm("antisymmetric_alpha_lt",
-  ``antisymmetric alpha_lt``,
+val antisymmetric_alpha_lt = Q.store_thm("antisymmetric_alpha_lt",
+  `antisymmetric alpha_lt`,
   rw[antisymmetric_def,alpha_lt_def] >>
   qspecl_then[`[]`,`x`,`y`]mp_tac orda_sym >>
   simp[])
 
-val orda_thm = prove(
-  ``∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))``,
+val orda_thm = Q.prove(
+  `∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))`,
   rpt gen_tac >>
   CONV_TAC(LAND_CONV(REWR_CONV orda_def)) >>
   reverse IF_CASES_TAC >- rw[] >> rw[] >>
@@ -786,22 +786,22 @@ val orda_lx_trans = prove(
       [`t1`,`t2`,`t3`,`t4`,`t5`,`t6`]))) >>
   metis_tac[cpn_nchotomy,cpn_distinct])
 
-val transitive_alpha_lt = store_thm("transitive_alpha_lt",
-  ``transitive alpha_lt``,
+val transitive_alpha_lt = Q.store_thm("transitive_alpha_lt",
+  `transitive alpha_lt`,
   rw[transitive_def,alpha_lt_def] >>
   qspecl_then[`[]`,`x`,`y`]mp_tac orda_lx_trans >>
   simp[])
 
-val alpha_lt_trans_ACONV = store_thm("alpha_lt_trans_ACONV",
-  ``∀x y z.
+val alpha_lt_trans_ACONV = Q.store_thm("alpha_lt_trans_ACONV",
+  `∀x y z.
     (ACONV x y ∧ alpha_lt y z ⇒ alpha_lt x z) ∧
-    (alpha_lt x y ∧ ACONV y z ⇒ alpha_lt x z)``,
+    (alpha_lt x y ∧ ACONV y z ⇒ alpha_lt x z)`,
   rw[alpha_lt_def,ACONV_eq_orda] >>
   qspecl_then[`[]`,`x`,`y`]mp_tac orda_lx_trans >>
   simp[])
 
-val alpha_lt_not_refl = store_thm("alpha_lt_not_refl[simp]",
-  ``∀x. ¬alpha_lt x x``,
+val alpha_lt_not_refl = Q.store_thm("alpha_lt_not_refl[simp]",
+  `∀x. ¬alpha_lt x x`,
   metis_tac[alpha_lt_def,ACONV_eq_orda,cpn_distinct,ACONV_REFL])
 
 (* VFREE_IN lemmas *)
@@ -816,39 +816,39 @@ val VFREE_IN_RACONV = store_thm("VFREE_IN_RACONV",
   reverse conj_tac >- metis_tac[] >>
   Induct >> simp[ALPHAVARS_def,FORALL_PROD] >> rw[] >> metis_tac[])
 
-val VFREE_IN_ACONV = store_thm("VFREE_IN_ACONV",
-  ``∀s t x ty. ACONV s t ⇒ (VFREE_IN (Var x ty) s ⇔ VFREE_IN (Var x ty) t)``,
+val VFREE_IN_ACONV = Q.store_thm("VFREE_IN_ACONV",
+  `∀s t x ty. ACONV s t ⇒ (VFREE_IN (Var x ty) s ⇔ VFREE_IN (Var x ty) t)`,
   rw[ACONV_def] >> imp_res_tac VFREE_IN_RACONV >> fs[])
 
-val VFREE_IN_subterm = store_thm("VFREE_IN_subterm",
-  ``∀t1 t2. VFREE_IN t1 t2 ⇒ t1 subterm t2``,
+val VFREE_IN_subterm = Q.store_thm("VFREE_IN_subterm",
+  `∀t1 t2. VFREE_IN t1 t2 ⇒ t1 subterm t2`,
   Induct_on`t2` >> simp[subterm_Comb,subterm_Abs] >>
   metis_tac[])
 
 (* hypset_ok *)
 
-val hypset_ok_nil = store_thm("hypset_ok_nil[simp]",
-  ``hypset_ok []``, rw[hypset_ok_def])
+val hypset_ok_nil = Q.store_thm("hypset_ok_nil[simp]",
+  `hypset_ok []`, rw[hypset_ok_def])
 
-val hypset_ok_sing = store_thm("hypset_ok_sing[simp]",
-  ``∀p. hypset_ok [p]``, rw[hypset_ok_def])
+val hypset_ok_sing = Q.store_thm("hypset_ok_sing[simp]",
+  `∀p. hypset_ok [p]`, rw[hypset_ok_def])
 
-val hypset_ok_cons = store_thm("hypset_ok_cons",
-  ``hypset_ok (h::hs) ⇔
-    EVERY (alpha_lt h) hs ∧ hypset_ok hs``,
+val hypset_ok_cons = Q.store_thm("hypset_ok_cons",
+  `hypset_ok (h::hs) ⇔
+    EVERY (alpha_lt h) hs ∧ hypset_ok hs`,
   rw[hypset_ok_def,MATCH_MP SORTED_EQ transitive_alpha_lt,EVERY_MEM]>>
   metis_tac[])
 
-val hypset_ok_ALL_DISTINCT = store_thm("hypset_ok_ALL_DISTINCT",
-  ``∀h. hypset_ok h ⇒ ALL_DISTINCT h``,
+val hypset_ok_ALL_DISTINCT = Q.store_thm("hypset_ok_ALL_DISTINCT",
+  `∀h. hypset_ok h ⇒ ALL_DISTINCT h`,
   simp[hypset_ok_def] >> Induct >>
   simp[MATCH_MP SORTED_EQ transitive_alpha_lt] >>
   rw[] >> strip_tac >> res_tac >> fs[alpha_lt_def] >>
   metis_tac[cpn_distinct,ACONV_REFL,ACONV_eq_orda])
 
-val hypset_ok_eq = store_thm("hypset_ok_eq",
-  ``∀h1 h2.  hypset_ok h1 ∧ hypset_ok h2 ⇒
-            ((h1 = h2) ⇔ (set h1 = set h2))``,
+val hypset_ok_eq = Q.store_thm("hypset_ok_eq",
+  `∀h1 h2.  hypset_ok h1 ∧ hypset_ok h2 ⇒
+            ((h1 = h2) ⇔ (set h1 = set h2))`,
   rw[EQ_IMP_THM] >> fs[EXTENSION] >>
   metis_tac[
     hypset_ok_ALL_DISTINCT,PERM_ALL_DISTINCT,
@@ -865,20 +865,20 @@ val hypset_ok_el_less = save_thm("hypset_ok_el_less",
 
 (* term_union lemmas *)
 
-val term_union_idem = store_thm("term_union_idem[simp]",
-  ``∀ls. term_union ls ls = ls``,
+val term_union_idem = Q.store_thm("term_union_idem[simp]",
+  `∀ls. term_union ls ls = ls`,
   Induct >- simp[term_union_def] >>
   simp[Once term_union_def])
 
-val term_union_thm = store_thm("term_union_thm",
-  ``(∀l2. term_union [] l2 = l2) ∧
+val term_union_thm = Q.store_thm("term_union_thm",
+  `(∀l2. term_union [] l2 = l2) ∧
     (∀l1. term_union l1 [] = l1) ∧
     (∀h1 t1 h2 t2.
           term_union (h1::t1) (h2::t2) =
           case orda [] h1 h2 of
           | EQUAL =>   h1::term_union t1 t2
           | LESS =>    h1::term_union t1 (h2::t2)
-          | GREATER => h2::term_union (h1::t1) t2)``,
+          | GREATER => h2::term_union (h1::t1) t2)`,
   rw[] >- rw[term_union_def] >- (
     rw[term_union_def] >>
     BasicProvers.CASE_TAC ) >>
@@ -890,17 +890,17 @@ val term_union_thm = store_thm("term_union_thm",
   BasicProvers.CASE_TAC >> fs[] >>
   BasicProvers.CASE_TAC >> fs[])
 
-val MEM_term_union_imp = store_thm("MEM_term_union_imp",
-  ``∀l1 l2 x. MEM x (term_union l1 l2) ⇒ MEM x l1 ∨ MEM x l2``,
+val MEM_term_union_imp = Q.store_thm("MEM_term_union_imp",
+  `∀l1 l2 x. MEM x (term_union l1 l2) ⇒ MEM x l1 ∨ MEM x l2`,
   Induct >> simp[term_union_thm] >>
   CONV_TAC(SWAP_FORALL_CONV) >>
   Induct >> simp[term_union_thm] >> rpt gen_tac >>
   BasicProvers.CASE_TAC >> rw[] >> fs[] >>
   res_tac >> fs[])
 
-val hypset_ok_term_union = store_thm("hypset_ok_term_union[simp]",
-  ``∀l1 l2. hypset_ok l1 ∧ hypset_ok l2 ⇒
-            hypset_ok (term_union l1 l2)``,
+val hypset_ok_term_union = Q.store_thm("hypset_ok_term_union[simp]",
+  `∀l1 l2. hypset_ok l1 ∧ hypset_ok l2 ⇒
+            hypset_ok (term_union l1 l2)`,
   simp[hypset_ok_def] >>
   Induct >- simp[term_union_thm] >> qx_gen_tac`h1` >>
   Induct >- simp[term_union_thm] >> qx_gen_tac`h2` >>
@@ -924,13 +924,13 @@ val hypset_ok_term_union = store_thm("hypset_ok_term_union[simp]",
   qspecl_then[`[]`,`h2`,`h1`]mp_tac orda_lx_trans >>
   simp[])
 
-val EVERY_term_union = store_thm("EVERY_term_union",
-  ``EVERY P l1 ∧ EVERY P l2 ⇒ EVERY P (term_union l1 l2)``,
+val EVERY_term_union = Q.store_thm("EVERY_term_union",
+  `EVERY P l1 ∧ EVERY P l2 ⇒ EVERY P (term_union l1 l2)`,
   metis_tac[EVERY_MEM,MEM_term_union_imp])
 
-val MEM_term_union = store_thm("MEM_term_union",
-  ``∀h1 h2 t. hypset_ok h1 ∧ hypset_ok h2 ∧ (MEM t h1 ∨ MEM t h2) ⇒
-      ∃y. MEM y (term_union h1 h2) ∧ ACONV t y``,
+val MEM_term_union = Q.store_thm("MEM_term_union",
+  `∀h1 h2 t. hypset_ok h1 ∧ hypset_ok h2 ∧ (MEM t h1 ∨ MEM t h2) ⇒
+      ∃y. MEM y (term_union h1 h2) ∧ ACONV t y`,
   Induct >> simp[term_union_thm] >-
     (metis_tac[ACONV_REFL]) >>
   gen_tac >> Induct >> simp[term_union_thm] >-
@@ -942,16 +942,16 @@ val MEM_term_union = store_thm("MEM_term_union",
   fs[GSYM ACONV_eq_orda] >>
   metis_tac[MEM,ACONV_REFL,ACONV_SYM,hypset_ok_cons])
 
-val term_union_sing_lt = prove(
-  ``∀ys x. EVERY (λy. alpha_lt x y) ys ⇒ (term_union [x] ys = x::ys)``,
+val term_union_sing_lt = Q.prove(
+  `∀ys x. EVERY (λy. alpha_lt x y) ys ⇒ (term_union [x] ys = x::ys)`,
   Induct >> simp[term_union_thm] >> rw[] >> fs[] >>
   fs[alpha_lt_def])
 
-val term_union_insert = store_thm("term_union_insert",
-  ``∀ys x zs.
+val term_union_insert = Q.store_thm("term_union_insert",
+  `∀ys x zs.
     EVERY (λy. alpha_lt y x) ys ∧
     EVERY (λz. alpha_lt x z) zs
-    ⇒ (term_union [x] (ys ++ zs) = ys ++ x::zs)``,
+    ⇒ (term_union [x] (ys ++ zs) = ys ++ x::zs)`,
   Induct >> simp[term_union_sing_lt] >> rw[] >>
   simp[term_union_thm] >>
   `orda [] x h = Greater` by (
@@ -960,19 +960,19 @@ val term_union_insert = store_thm("term_union_insert",
     simp[] ) >>
   simp[])
 
-val term_union_replace = store_thm("term_union_replace",
-  ``∀ys x x' zs.
+val term_union_replace = Q.store_thm("term_union_replace",
+  `∀ys x x' zs.
     EVERY (λy. alpha_lt y x) ys ∧ ACONV x x' ∧
     EVERY (λz. alpha_lt x z) zs
     ⇒
-    term_union [x] (ys ++ x'::zs) = ys ++ x::zs``,
+    term_union [x] (ys ++ x'::zs) = ys ++ x::zs`,
   Induct >> rw[term_union_thm,ACONV_eq_orda,alpha_lt_def] >>
   qspecl_then[`[]`,`h`,`x`]mp_tac orda_sym >>
   simp[] >> disch_then(assume_tac o SYM) >> simp[] >>
   fs[GSYM ACONV_eq_orda, GSYM alpha_lt_def])
 
-val MEM_term_union_first = store_thm("MEM_term_union_first",
-  ``∀h1 h2 t. hypset_ok h1 ∧ hypset_ok h2 ∧ MEM t h1 ⇒ MEM t (term_union h1 h2)``,
+val MEM_term_union_first = Q.store_thm("MEM_term_union_first",
+  `∀h1 h2 t. hypset_ok h1 ∧ hypset_ok h2 ∧ MEM t h1 ⇒ MEM t (term_union h1 h2)`,
   Induct >> simp[hypset_ok_cons] >>
   gen_tac >> Induct >> simp[term_union_thm] >>
   rw[hypset_ok_cons] >>
@@ -981,8 +981,8 @@ val MEM_term_union_first = store_thm("MEM_term_union_first",
   first_x_assum match_mp_tac >>
   rw[hypset_ok_cons])
 
-val term_union_insert_mem = store_thm("term_union_insert_mem",
-  ``∀c h. hypset_ok h ∧ MEM c h ⇒ (term_union [c] h = h)``,
+val term_union_insert_mem = Q.store_thm("term_union_insert_mem",
+  `∀c h. hypset_ok h ∧ MEM c h ⇒ (term_union [c] h = h)`,
   gen_tac >> Induct >> simp[hypset_ok_cons,term_union_thm] >>
   rw[] >> fs[] >- (
     `ACONV c c` by simp[] >> fs[ACONV_eq_orda] ) >>
@@ -992,8 +992,8 @@ val term_union_insert_mem = store_thm("term_union_insert_mem",
   disch_then(assume_tac o SYM) >>
   rw[term_union_thm])
 
-val term_union_insert_remove = store_thm("term_union_insert_remove",
-  ``∀c h. hypset_ok h ∧ MEM c h ∧ ACONV c' c ⇒ (term_union [c] (term_remove c' h) = h)``,
+val term_union_insert_remove = Q.store_thm("term_union_insert_remove",
+  `∀c h. hypset_ok h ∧ MEM c h ∧ ACONV c' c ⇒ (term_union [c] (term_remove c' h) = h)`,
   gen_tac >> Induct >> simp[hypset_ok_cons] >> rw[] >> fs[] >- (
     simp[Once term_remove_def] >>
     fs[ACONV_eq_orda] >>
@@ -1013,13 +1013,13 @@ val term_union_insert_remove = store_thm("term_union_insert_remove",
 
 (* term_remove *)
 
-val term_remove_nil = store_thm("term_remove_nil[simp]",
-  ``∀a. term_remove a [] = []``,
+val term_remove_nil = Q.store_thm("term_remove_nil[simp]",
+  `∀a. term_remove a [] = []`,
   rw[Once term_remove_def])
 
-val MEM_term_remove_imp = store_thm("MEM_term_remove_imp",
-  ``∀ls x t. MEM t (term_remove x ls) ⇒
-      MEM t ls ∧ (hypset_ok ls ⇒ ¬ACONV x t)``,
+val MEM_term_remove_imp = Q.store_thm("MEM_term_remove_imp",
+  `∀ls x t. MEM t (term_remove x ls) ⇒
+      MEM t ls ∧ (hypset_ok ls ⇒ ¬ACONV x t)`,
   Induct >> simp[Once term_remove_def] >> rw[] >>
   fs[hypset_ok_def,
      MATCH_MP SORTED_EQ transitive_alpha_lt,
@@ -1033,8 +1033,8 @@ val MEM_term_remove_imp = store_thm("MEM_term_remove_imp",
   qspecl_then[`[]`,`x`,`h`]mp_tac orda_lx_trans >>
   simp[] >> qexists_tac`t` >> simp[])
 
-val hypset_ok_term_remove = store_thm("hypset_ok_term_remove[simp]",
-  ``∀ls. hypset_ok ls ⇒ ∀t. hypset_ok (term_remove t ls)``,
+val hypset_ok_term_remove = Q.store_thm("hypset_ok_term_remove[simp]",
+  `∀ls. hypset_ok ls ⇒ ∀t. hypset_ok (term_remove t ls)`,
   Induct >> simp[Once term_remove_def] >>
   rw[] >> fs[hypset_ok_def] >> rw[] >>
   fs[MATCH_MP SORTED_EQ transitive_alpha_lt,
@@ -1042,41 +1042,41 @@ val hypset_ok_term_remove = store_thm("hypset_ok_term_remove[simp]",
   imp_res_tac MEM_term_remove_imp >>
   rfs[hypset_ok_def])
 
-val EVERY_term_remove = store_thm("EVERY_term_remove",
-  ``EVERY P ls ⇒ EVERY P (term_remove t ls)``,
+val EVERY_term_remove = Q.store_thm("EVERY_term_remove",
+  `EVERY P ls ⇒ EVERY P (term_remove t ls)`,
   metis_tac[EVERY_MEM,MEM_term_remove_imp])
 
-val MEM_term_remove = store_thm("MEM_term_remove",
-  ``∀h x t. MEM t h ∧ ¬ACONV x t ∧ hypset_ok h
-    ⇒ MEM t (term_remove x h)``,
+val MEM_term_remove = Q.store_thm("MEM_term_remove",
+  `∀h x t. MEM t h ∧ ¬ACONV x t ∧ hypset_ok h
+    ⇒ MEM t (term_remove x h)`,
   Induct >> simp[Once term_remove_def] >>
   simp[hypset_ok_cons] >> rw[EVERY_MEM] >>
   res_tac >> fs[alpha_lt_def,GSYM ACONV_eq_orda])
 
-val term_remove_exists = store_thm("term_remove_exists",
-  ``∀c h. term_remove c h ≠ h ⇒ ∃c'. MEM c' h ∧ ACONV c c'``,
+val term_remove_exists = Q.store_thm("term_remove_exists",
+  `∀c h. term_remove c h ≠ h ⇒ ∃c'. MEM c' h ∧ ACONV c c'`,
   gen_tac >> Induct >> simp[] >>
   simp[Once term_remove_def] >> rw[] >> fs[] >>
   fs[GSYM ACONV_eq_orda] >> metis_tac[])
 
 (* term_image *)
 
-val term_image_nil = store_thm("term_image_nil[simp]",
-  ``term_image f [] = []``,
+val term_image_nil = Q.store_thm("term_image_nil[simp]",
+  `term_image f [] = []`,
   simp[Once term_image_def])
 
-val MEM_term_image_imp = store_thm("MEM_term_image_imp",
-  ``∀ls f t. MEM t (term_image f ls) ⇒ ∃x. MEM x ls ∧ t = f x``,
+val MEM_term_image_imp = Q.store_thm("MEM_term_image_imp",
+  `∀ls f t. MEM t (term_image f ls) ⇒ ∃x. MEM x ls ∧ t = f x`,
   Induct >> simp[Once term_image_def] >> rw[] >> fs[] >>
   imp_res_tac MEM_term_union_imp >> fs[] >>
   metis_tac[])
 
-val hypset_ok_term_image = store_thm("hypset_ok_term_image",
-  ``∀ls f. hypset_ok ls ⇒ hypset_ok (term_image f ls)``,
+val hypset_ok_term_image = Q.store_thm("hypset_ok_term_image",
+  `∀ls f. hypset_ok ls ⇒ hypset_ok (term_image f ls)`,
   Induct >> simp[Once term_image_def] >> rw[hypset_ok_cons])
 
-val MEM_term_image = store_thm("MEM_term_image",
-  ``∀ls f t. MEM t ls ∧ hypset_ok ls ⇒ ∃y. MEM y (term_image f ls) ∧ ACONV (f t) y``,
+val MEM_term_image = Q.store_thm("MEM_term_image",
+  `∀ls f t. MEM t ls ∧ hypset_ok ls ⇒ ∃y. MEM y (term_image f ls) ∧ ACONV (f t) y`,
   Induct >> simp[Once term_image_def] >> rw[hypset_ok_cons] >> rw[] >>
   TRY(metis_tac[ACONV_REFL]) >- metis_tac[MEM_term_union,hypset_ok_sing,MEM,hypset_ok_term_image] >>
   first_x_assum(qspecl_then[`f`,`t`]mp_tac) >> rw[] >>
@@ -1114,12 +1114,12 @@ val VSUBST_WELLTYPED = store_thm("VSUBST_WELLTYPED",
       ⇒ welltyped (VSUBST ilist tm)``,
   metis_tac[VSUBST_HAS_TYPE,welltyped_def])
 
-val VFREE_IN_VSUBST = store_thm("VFREE_IN_VSUBST",
-  ``∀tm u uty ilist.
+val VFREE_IN_VSUBST = Q.store_thm("VFREE_IN_VSUBST",
+  `∀tm u uty ilist.
       welltyped tm ⇒
       (VFREE_IN (Var u uty) (VSUBST ilist tm) ⇔
        ∃y ty. VFREE_IN (Var y ty) tm ∧
-              VFREE_IN (Var u uty) (REV_ASSOCD (Var y ty) ilist (Var y ty)))``,
+              VFREE_IN (Var u uty) (REV_ASSOCD (Var y ty) ilist (Var y ty)))`,
   Induct >> simp[VFREE_IN_def,VSUBST_def] >- metis_tac[] >>
   map_every qx_gen_tac[`u`,`uty`,`ilist`] >>
   disch_then(qx_choosel_then[`b`,`bty`]strip_assume_tac) >> simp[] >>
@@ -1162,8 +1162,8 @@ val VFREE_IN_VSUBST = store_thm("VFREE_IN_VSUBST",
   fs[VFREE_IN_def] >>
   metis_tac[])
 
-val VSUBST_NIL = store_thm("VSUBST_NIL[simp]",
-  ``∀tm. VSUBST [] tm = tm``,
+val VSUBST_NIL = Q.store_thm("VSUBST_NIL[simp]",
+  `∀tm. VSUBST [] tm = tm`,
   ho_match_mp_tac term_induction >>
   simp[VSUBST_def,REV_ASSOCD])
 
@@ -1297,28 +1297,28 @@ val INST_CORE_HAS_TYPE = store_thm("INST_CORE_HAS_TYPE",
     simp[Once has_type_cases] >>
     metis_tac[VARIANT_THM,term_11]))
 
-val INST_CORE_NIL_IS_RESULT = store_thm("INST_CORE_NIL_IS_RESULT",
-  ``∀tyin tm. welltyped tm ⇒ IS_RESULT (INST_CORE [] tyin tm)``,
+val INST_CORE_NIL_IS_RESULT = Q.store_thm("INST_CORE_NIL_IS_RESULT",
+  `∀tyin tm. welltyped tm ⇒ IS_RESULT (INST_CORE [] tyin tm)`,
   rw[] >>
   qspecl_then[`sizeof tm`,`tm`,`[]`,`tyin`]mp_tac INST_CORE_HAS_TYPE >>
   simp[] >> rw[] >> rw[] >> fs[REV_ASSOCD])
 
-val INST_HAS_TYPE = store_thm("INST_HAS_TYPE",
-  ``∀tm ty tyin ty'. tm has_type ty ∧ ty' = TYPE_SUBST tyin ty ⇒ INST tyin tm has_type ty'``,
+val INST_HAS_TYPE = Q.store_thm("INST_HAS_TYPE",
+  `∀tm ty tyin ty'. tm has_type ty ∧ ty' = TYPE_SUBST tyin ty ⇒ INST tyin tm has_type ty'`,
   rw[INST_def] >>
   qspecl_then[`tyin`,`tm`]mp_tac INST_CORE_NIL_IS_RESULT >> rw[] >>
   qspecl_then[`sizeof tm`,`tm`,`[]`,`tyin`]mp_tac INST_CORE_HAS_TYPE >>
   `welltyped tm` by metis_tac[welltyped_def] >> fs[] >>
   rw[] >> fs[] >> metis_tac[WELLTYPED_LEMMA])
 
-val INST_WELLTYPED = store_thm("INST_WELLTYPED",
-  ``∀tm tyin.  welltyped tm ⇒ welltyped (INST tyin tm)``,
+val INST_WELLTYPED = Q.store_thm("INST_WELLTYPED",
+  `∀tm tyin.  welltyped tm ⇒ welltyped (INST tyin tm)`,
   metis_tac[INST_HAS_TYPE,WELLTYPED_LEMMA,WELLTYPED])
 
-val INST_CORE_NIL = store_thm("INST_CORE_NIL",
-  ``∀env tyin tm. welltyped tm ∧ tyin = [] ∧
+val INST_CORE_NIL = Q.store_thm("INST_CORE_NIL",
+  `∀env tyin tm. welltyped tm ∧ tyin = [] ∧
       (∀x ty. VFREE_IN (Var x ty) tm ⇒ REV_ASSOCD (Var x (TYPE_SUBST tyin ty)) env (Var x ty) = Var x ty) ⇒
-      INST_CORE env tyin tm = Result tm``,
+      INST_CORE env tyin tm = Result tm`,
   ho_match_mp_tac INST_CORE_ind >>
   simp[INST_CORE_def] >>
   rw[] >> fs[] >>
@@ -1330,50 +1330,50 @@ val INST_CORE_NIL = store_thm("INST_CORE_NIL",
     rw[] >> metis_tac[] ) >>
   simp[])
 
-val INST_nil = store_thm("INST_nil",
-  ``welltyped tm ⇒ (INST [] tm = tm)``,
+val INST_nil = Q.store_thm("INST_nil",
+  `welltyped tm ⇒ (INST [] tm = tm)`,
   rw[INST_def,INST_CORE_def] >>
   qspecl_then[`[]`,`[]`,`tm`]mp_tac INST_CORE_NIL >>
   simp[holSyntaxLibTheory.REV_ASSOCD])
 
 (* tyvars and tvars *)
 
-val tyvars_ALL_DISTINCT = store_thm("tyvars_ALL_DISTINCT",
-  ``∀ty. ALL_DISTINCT (tyvars ty)``,
+val tyvars_ALL_DISTINCT = Q.store_thm("tyvars_ALL_DISTINCT",
+  `∀ty. ALL_DISTINCT (tyvars ty)`,
   ho_match_mp_tac type_ind >>
   rw[tyvars_def] >>
   Induct_on`l` >> simp[] >>
   rw[ALL_DISTINCT_LIST_UNION])
 val _ = export_rewrites["tyvars_ALL_DISTINCT"]
 
-val tvars_ALL_DISTINCT = store_thm("tvars_ALL_DISTINCT",
-  ``∀tm. ALL_DISTINCT (tvars tm)``,
+val tvars_ALL_DISTINCT = Q.store_thm("tvars_ALL_DISTINCT",
+  `∀tm. ALL_DISTINCT (tvars tm)`,
   Induct >> simp[tvars_def,ALL_DISTINCT_LIST_UNION])
 val _ = export_rewrites["tvars_ALL_DISTINCT"]
 
-val tyvars_TYPE_SUBST = store_thm("tyvars_TYPE_SUBST",
-  ``∀ty tyin. set (tyvars (TYPE_SUBST tyin ty)) =
-      { v | ∃x. MEM x (tyvars ty) ∧ MEM v (tyvars (REV_ASSOCD (Tyvar x) tyin (Tyvar x))) }``,
+val tyvars_TYPE_SUBST = Q.store_thm("tyvars_TYPE_SUBST",
+  `∀ty tyin. set (tyvars (TYPE_SUBST tyin ty)) =
+      { v | ∃x. MEM x (tyvars ty) ∧ MEM v (tyvars (REV_ASSOCD (Tyvar x) tyin (Tyvar x))) }`,
   ho_match_mp_tac type_ind >> simp[tyvars_def] >>
   simp[EXTENSION,EVERY_MEM,MEM_FOLDR_LIST_UNION,PULL_EXISTS,MEM_MAP] >> rw[] >>
   metis_tac[] )
 
-val tyvars_typeof_subset_tvars = store_thm("tyvars_typeof_subset_tvars",
-  ``∀tm ty. tm has_type ty ⇒ set (tyvars ty) ⊆ set (tvars tm)``,
+val tyvars_typeof_subset_tvars = Q.store_thm("tyvars_typeof_subset_tvars",
+  `∀tm ty. tm has_type ty ⇒ set (tyvars ty) ⊆ set (tvars tm)`,
   ho_match_mp_tac has_type_ind >>
   simp[tvars_def] >>
   simp[SUBSET_DEF,MEM_LIST_UNION,tyvars_def] >>
   metis_tac[])
 
-val tyvars_Tyapp_MAP_Tyvar = store_thm("tyvars_Tyapp_MAP_Tyvar",
-  ``∀x ls. ALL_DISTINCT ls ⇒ (tyvars (Tyapp x (MAP Tyvar ls)) = LIST_UNION [] ls)``,
+val tyvars_Tyapp_MAP_Tyvar = Q.store_thm("tyvars_Tyapp_MAP_Tyvar",
+  `∀x ls. ALL_DISTINCT ls ⇒ (tyvars (Tyapp x (MAP Tyvar ls)) = LIST_UNION [] ls)`,
   simp[tyvars_def] >>
   Induct >> fs[tyvars_def,LIST_UNION_def] >>
   rw[LIST_INSERT_def])
 
-val STRING_SORT_SET_TO_LIST_set_tvars = store_thm("STRING_SORT_SET_TO_LIST_set_tvars",
-  ``∀tm. STRING_SORT (MAP explode (SET_TO_LIST (set (tvars tm)))) =
-         STRING_SORT (MAP explode (tvars tm))``,
+val STRING_SORT_SET_TO_LIST_set_tvars = Q.store_thm("STRING_SORT_SET_TO_LIST_set_tvars",
+  `∀tm. STRING_SORT (MAP explode (SET_TO_LIST (set (tvars tm)))) =
+         STRING_SORT (MAP explode (tvars tm))`,
   gen_tac >> assume_tac(SPEC_ALL tvars_ALL_DISTINCT) >>
   simp[STRING_SORT_EQ] >>
   match_mp_tac sortingTheory.PERM_MAP >>
@@ -1381,70 +1381,70 @@ val STRING_SORT_SET_TO_LIST_set_tvars = store_thm("STRING_SORT_SET_TO_LIST_set_t
   REWRITE_TAC[sortingTheory.ALL_DISTINCT_PERM_LIST_TO_SET_TO_LIST] >>
   simp[sortingTheory.PERM_SYM])
 
-val mlstring_sort_SET_TO_LIST_set_tvars = store_thm("mlstring_sort_SET_TO_LIST_set_tvars",
-  ``mlstring_sort (SET_TO_LIST (set (tvars tm))) = mlstring_sort (tvars tm)``,
+val mlstring_sort_SET_TO_LIST_set_tvars = Q.store_thm("mlstring_sort_SET_TO_LIST_set_tvars",
+  `mlstring_sort (SET_TO_LIST (set (tvars tm))) = mlstring_sort (tvars tm)`,
   rw[mlstring_sort_def,STRING_SORT_SET_TO_LIST_set_tvars])
 
 (* Equations *)
 
-val EQUATION_HAS_TYPE_BOOL = store_thm("EQUATION_HAS_TYPE_BOOL",
-  ``∀s t. (s === t) has_type Bool
-          ⇔ welltyped s ∧ welltyped t ∧ (typeof s = typeof t)``,
+val EQUATION_HAS_TYPE_BOOL = Q.store_thm("EQUATION_HAS_TYPE_BOOL",
+  `∀s t. (s === t) has_type Bool
+          ⇔ welltyped s ∧ welltyped t ∧ (typeof s = typeof t)`,
   rw[equation_def] >> rw[Ntimes has_type_cases 3] >>
   metis_tac[WELLTYPED_LEMMA,WELLTYPED])
 
-val welltyped_equation = store_thm("welltyped_equation",
-  ``∀s t. welltyped (s === t) ⇔ s === t has_type Bool``,
+val welltyped_equation = Q.store_thm("welltyped_equation",
+  `∀s t. welltyped (s === t) ⇔ s === t has_type Bool`,
   simp[EQUATION_HAS_TYPE_BOOL] >> simp[equation_def])
 
-val typeof_equation = store_thm("typeof_equation",
-  ``welltyped (l === r) ⇒ (typeof (l === r)) = Bool``,
+val typeof_equation = Q.store_thm("typeof_equation",
+  `welltyped (l === r) ⇒ (typeof (l === r)) = Bool`,
   rw[welltyped_equation] >> imp_res_tac WELLTYPED_LEMMA >> rw[])
 
-val vfree_in_equation = store_thm("vfree_in_equation",
-  ``VFREE_IN v (s === t) ⇔ (v = Equal (typeof s)) ∨ VFREE_IN v s ∨ VFREE_IN v t``,
+val vfree_in_equation = Q.store_thm("vfree_in_equation",
+  `VFREE_IN v (s === t) ⇔ (v = Equal (typeof s)) ∨ VFREE_IN v s ∨ VFREE_IN v t`,
   rw[equation_def,VFREE_IN_def] >> metis_tac[])
 
-val equation_intro = store_thm("equation_intro",
-  ``(ty = typeof p) ⇒ (Comb (Comb (Equal ty) p) q = p === q)``,
+val equation_intro = Q.store_thm("equation_intro",
+  `(ty = typeof p) ⇒ (Comb (Comb (Equal ty) p) q = p === q)`,
   rw[equation_def])
 
 (* type_ok *)
 
-val type_ok_TYPE_SUBST = store_thm("type_ok_TYPE_SUBST",
-  ``∀s tyin ty.
+val type_ok_TYPE_SUBST = Q.store_thm("type_ok_TYPE_SUBST",
+  `∀s tyin ty.
       type_ok s ty ∧
       EVERY (type_ok s) (MAP FST tyin)
-    ⇒ type_ok s (TYPE_SUBST tyin ty)``,
+    ⇒ type_ok s (TYPE_SUBST tyin ty)`,
   gen_tac >> ho_match_mp_tac TYPE_SUBST_ind >>
   simp[type_ok_def] >> rw[EVERY_MAP,EVERY_MEM] >>
   fs[FORALL_PROD] >>
   metis_tac[REV_ASSOCD_MEM,type_ok_def])
 
-val type_ok_TYPE_SUBST_imp = store_thm("type_ok_TYPE_SUBST_imp",
-  ``∀s tyin ty. type_ok s (TYPE_SUBST tyin ty) ⇒
-                ∀x. MEM x (tyvars ty) ⇒ type_ok s (TYPE_SUBST tyin (Tyvar x))``,
+val type_ok_TYPE_SUBST_imp = Q.store_thm("type_ok_TYPE_SUBST_imp",
+  `∀s tyin ty. type_ok s (TYPE_SUBST tyin ty) ⇒
+                ∀x. MEM x (tyvars ty) ⇒ type_ok s (TYPE_SUBST tyin (Tyvar x))`,
   gen_tac >> ho_match_mp_tac TYPE_SUBST_ind >>
   simp[tyvars_def,MEM_FOLDR_LIST_UNION,type_ok_def] >> rw[] >>
   fs[EVERY_MAP,EVERY_MEM] >> metis_tac[])
 
 (* term_ok *)
 
-val term_ok_welltyped = store_thm("term_ok_welltyped",
-  ``∀sig t. term_ok sig t ⇒ welltyped t``,
+val term_ok_welltyped = Q.store_thm("term_ok_welltyped",
+  `∀sig t. term_ok sig t ⇒ welltyped t`,
   Cases >> Induct >> simp[term_ok_def] >> rw[])
 
-val term_ok_type_ok = store_thm("term_ok_type_ok",
-  ``∀sig t. is_std_sig sig ∧ term_ok sig t
-          ⇒ type_ok (FST sig) (typeof t)``,
+val term_ok_type_ok = Q.store_thm("term_ok_type_ok",
+  `∀sig t. is_std_sig sig ∧ term_ok sig t
+          ⇒ type_ok (FST sig) (typeof t)`,
   Cases >> Induct >> simp[term_ok_def] >> rw[] >>
   fs[is_std_sig_def,type_ok_def])
 
-val term_ok_equation = store_thm("term_ok_equation",
-  ``is_std_sig sig ⇒
+val term_ok_equation = Q.store_thm("term_ok_equation",
+  `is_std_sig sig ⇒
       (term_ok sig (s === t) ⇔
         term_ok sig s ∧ term_ok sig t ∧
-        typeof t = typeof s)``,
+        typeof t = typeof s)`,
   Cases_on`sig` >> rw[equation_def,term_ok_def] >>
   rw[EQ_IMP_THM] >>
   imp_res_tac term_ok_welltyped >>
@@ -1453,8 +1453,8 @@ val term_ok_equation = store_thm("term_ok_equation",
   qexists_tac`[(typeof s,Tyvar (strlit "A"))]` >>
   rw[holSyntaxLibTheory.REV_ASSOCD_def])
 
-val term_ok_clauses = store_thm("term_ok_clauses",
-  ``is_std_sig sig ⇒
+val term_ok_clauses = Q.store_thm("term_ok_clauses",
+  `is_std_sig sig ⇒
     (term_ok sig (Var s ty) ⇔ type_ok (tysof sig) ty) ∧
     (type_ok (tysof sig) (Tyvar a) ⇔ T) ∧
     (type_ok (tysof sig) Bool ⇔ T) ∧
@@ -1462,7 +1462,7 @@ val term_ok_clauses = store_thm("term_ok_clauses",
     (term_ok sig (Comb t1 t2) ⇔ term_ok sig t1 ∧ term_ok sig t2 ∧ welltyped (Comb t1 t2)) ∧
     (term_ok sig (Equal ty) ⇔ type_ok (tysof sig) ty) ∧
     (term_ok sig (t1 === t2) ⇔ term_ok sig t1 ∧ term_ok sig t2 ∧ typeof t1 = typeof t2) ∧
-    (term_ok sig (Abs (Var s ty) t) ⇔ type_ok (tysof sig) ty ∧ term_ok sig t)``,
+    (term_ok sig (Abs (Var s ty) t) ⇔ type_ok (tysof sig) ty ∧ term_ok sig t)`,
   rw[term_ok_def,type_ok_def,term_ok_equation] >>
   fs[is_std_sig_def] >>
   TRY (
@@ -1525,11 +1525,11 @@ val term_ok_INST_CORE = store_thm("term_ok_INST_CORE",
     metis_tac[] ) >>
   simp[welltyped_def] >> PROVE_TAC[])
 
-val term_ok_INST = store_thm("term_ok_INST",
-  ``∀sig tyin tm.
+val term_ok_INST = Q.store_thm("term_ok_INST",
+  `∀sig tyin tm.
     term_ok sig tm ∧
     EVERY (type_ok (FST sig)) (MAP FST tyin) ⇒
-    term_ok sig (INST tyin tm)``,
+    term_ok sig (INST tyin tm)`,
   rw[INST_def] >>
   metis_tac[INST_CORE_NIL_IS_RESULT,term_ok_welltyped,term_ok_INST_CORE,MEM])
 
@@ -1544,12 +1544,12 @@ val term_ok_raconv = store_thm("term_ok_raconv",
     res_tac >> fs[] >> rw[] ) >>
   rw[] >> fs[])
 
-val term_ok_aconv = store_thm("term_ok_aconv",
-  ``∀sig t1 t2. ACONV t1 t2 ∧ term_ok sig t1 ∧ welltyped t2 ⇒ term_ok sig t2``,
+val term_ok_aconv = Q.store_thm("term_ok_aconv",
+  `∀sig t1 t2. ACONV t1 t2 ∧ term_ok sig t1 ∧ welltyped t2 ⇒ term_ok sig t2`,
   rw[ACONV_def] >> imp_res_tac term_ok_raconv >> fs[])
 
-val term_ok_VFREE_IN = store_thm("term_ok_VFREE_IN",
-  ``∀sig t x. VFREE_IN x t ∧ term_ok sig t ⇒ term_ok sig x``,
+val term_ok_VFREE_IN = Q.store_thm("term_ok_VFREE_IN",
+  `∀sig t x. VFREE_IN x t ∧ term_ok sig t ⇒ term_ok sig x`,
   gen_tac >> Induct >> simp[term_ok_def] >> metis_tac[])
 
 (* de Bruijn terms, for showing alpha-equivalence respect
@@ -1599,17 +1599,17 @@ val dbVFREE_IN_def = Define`
   (dbVFREE_IN v (dbAbs ty t) ⇔ dbVFREE_IN v t)`
 val _ = export_rewrites["dbVFREE_IN_def"]
 
-val bind_not_free = store_thm("bind_not_free",
-  ``∀t n v. ¬dbVFREE_IN (UNCURRY dbVar v) t ⇒ bind v n t = t``,
+val bind_not_free = Q.store_thm("bind_not_free",
+  `∀t n v. ¬dbVFREE_IN (UNCURRY dbVar v) t ⇒ bind v n t = t`,
   Induct >> simp[] >> rw[])
 
-val bind_dbVSUBST = store_thm("bind_dbVSUBST",
-  ``∀tm v n ls.
+val bind_dbVSUBST = Q.store_thm("bind_dbVSUBST",
+  `∀tm v n ls.
     (UNCURRY dbVar v) ∉ set (MAP SND ls) ∧
     (∀k. dbVFREE_IN k tm ∧ MEM k (MAP SND ls) ⇒
         ¬dbVFREE_IN (UNCURRY dbVar v) (REV_ASSOCD k ls k))
     ⇒
-    bind v n (dbVSUBST ls tm) = dbVSUBST ls (bind v n tm)``,
+    bind v n (dbVSUBST ls tm) = dbVSUBST ls (bind v n tm)`,
   Induct >> simp[] >>
   CONV_TAC (RESORT_FORALL_CONV List.rev) >>
   rw[] >- (
@@ -1634,15 +1634,15 @@ val bind_dbVSUBST_cons = store_thm("bind_dbVSUBST_cons",
     Cases_on`x`>>fs[] ) >>
   match_mp_tac bind_not_free >> fs[] )
 
-val dbVSUBST_frees = store_thm("dbVSUBST_frees",
-  ``∀tm ls ls'.
+val dbVSUBST_frees = Q.store_thm("dbVSUBST_frees",
+  `∀tm ls ls'.
     (∀k. dbVFREE_IN k tm ⇒ REV_ASSOCD k ls k = REV_ASSOCD k ls' k)
      ⇒
-      dbVSUBST ls tm = dbVSUBST ls' tm``,
+      dbVSUBST ls tm = dbVSUBST ls' tm`,
   Induct >> simp[])
 
-val dbVFREE_IN_bind = store_thm("dbVFREE_IN_bind",
-  ``∀tm x v n b. dbVFREE_IN x (bind v n tm) ⇔ (x ≠ UNCURRY dbVar v) ∧ dbVFREE_IN x tm``,
+val dbVFREE_IN_bind = Q.store_thm("dbVFREE_IN_bind",
+  `∀tm x v n b. dbVFREE_IN x (bind v n tm) ⇔ (x ≠ UNCURRY dbVar v) ∧ dbVFREE_IN x tm`,
   Induct >> simp[] >> rw[] >- metis_tac[]
   >- (
     Cases_on`x`>>fs[]>>
@@ -1654,8 +1654,8 @@ val dbVFREE_IN_bind = store_thm("dbVFREE_IN_bind",
   Cases_on`v`>>fs[]>>
   Cases_on`x=dbVar q r`>>fs[])
 
-val dbVFREE_IN_VFREE_IN = store_thm("dbVFREE_IN_VFREE_IN",
-  ``∀tm x. welltyped tm ⇒ (dbVFREE_IN (db x) (db tm) ⇔ VFREE_IN x tm)``,
+val dbVFREE_IN_VFREE_IN = Q.store_thm("dbVFREE_IN_VFREE_IN",
+  `∀tm x. welltyped tm ⇒ (dbVFREE_IN (db x) (db tm) ⇔ VFREE_IN x tm)`,
   Induct >> simp[VFREE_IN_def] >- (
     ntac 2 gen_tac >> Cases >> simp[VFREE_IN_def] )
   >- (
@@ -1681,12 +1681,12 @@ val REV_ASSOCD_MAP_db = store_thm("REV_ASSOCD_MAP_db",
   `∃x ty. r = Var x ty` by metis_tac[] >> fs[] >>
   metis_tac[])
 
-val dbVFREE_IN_dbVSUBST = store_thm("dbVFREE_IN_dbVSUBST",
-  ``∀tm u uty ilist.
+val dbVFREE_IN_dbVSUBST = Q.store_thm("dbVFREE_IN_dbVSUBST",
+  `∀tm u uty ilist.
       dbVFREE_IN (dbVar u uty) (dbVSUBST ilist tm) ⇔
       ∃y ty. dbVFREE_IN (dbVar y ty) tm ∧
              dbVFREE_IN (dbVar u uty)
-               (REV_ASSOCD (dbVar y ty) ilist (dbVar y ty))``,
+               (REV_ASSOCD (dbVar y ty) ilist (dbVar y ty))`,
   Induct >> simp[] >> rw[] >> metis_tac[])
 
 val VSUBST_dbVSUBST = store_thm("VSUBST_dbVSUBST",
@@ -1816,8 +1816,8 @@ val dbINST_bind = store_thm("dbINST_bind",
   BasicProvers.CASE_TAC >> fs[] >>
   BasicProvers.CASE_TAC >> fs[])
 
-val dbVSUBST_nil = store_thm("dbVSUBST_nil",
-  ``∀tm. dbVSUBST [] tm = tm``,
+val dbVSUBST_nil = Q.store_thm("dbVSUBST_nil",
+  `∀tm. dbVSUBST [] tm = tm`,
   Induct >> simp[REV_ASSOCD])
 val _ = export_rewrites["dbVSUBST_nil"]
 
@@ -1939,10 +1939,10 @@ val INST_CORE_dbINST = store_thm("INST_CORE_dbINST",
     simp[] ) >>
   simp[])
 
-val INST_dbINST = store_thm("INST_dbINST",
-  ``∀tm tyin.
+val INST_dbINST = Q.store_thm("INST_dbINST",
+  `∀tm tyin.
       welltyped tm ⇒
-      db (INST tyin tm) = dbINST tyin (db tm)``,
+      db (INST tyin tm) = dbINST tyin (db tm)`,
   rw[INST_def] >>
   imp_res_tac INST_CORE_NIL_IS_RESULT >>
   pop_assum(qspec_then`tyin`strip_assume_tac) >>
@@ -1965,15 +1965,15 @@ val bind_list_aux_def = Define`
   bind_list_aux n (v::vs) tm = bind_list_aux (n+1) vs (bind v n tm)`
 val _ = export_rewrites["bind_list_aux_def"]
 
-val bind_list_aux_clauses = store_thm("bind_list_aux_clauses",
-  ``(∀env m. bind_list_aux m env (dbBound n) = dbBound n) ∧
+val bind_list_aux_clauses = Q.store_thm("bind_list_aux_clauses",
+  `(∀env m. bind_list_aux m env (dbBound n) = dbBound n) ∧
     (∀env m. bind_list_aux m env (dbConst x ty) = dbConst x ty) ∧
     (∀env m t1 t2. bind_list_aux m env (dbComb t1 t2) = dbComb (bind_list_aux m env t1) (bind_list_aux m env t2)) ∧
-    (∀env m ty tm. bind_list_aux m env (dbAbs ty tm) = dbAbs ty (bind_list_aux (m+1) env tm))``,
+    (∀env m ty tm. bind_list_aux m env (dbAbs ty tm) = dbAbs ty (bind_list_aux (m+1) env tm))`,
   rpt conj_tac >> Induct >> simp[])
 
-val dbterm_bind = store_thm("dbterm_bind",
-  ``∀tm env. dbterm env tm = bind_list_aux 0 env (db tm)``,
+val dbterm_bind = Q.store_thm("dbterm_bind",
+  `∀tm env. dbterm env tm = bind_list_aux 0 env (db tm)`,
   Induct >> simp[bind_list_aux_clauses] >>
   gen_tac >>
   Q.SPEC_TAC(`0n`,`n`) >>
@@ -1981,8 +1981,8 @@ val dbterm_bind = store_thm("dbterm_bind",
   Cases >> simp[] >>
   rw[] >> rw[bind_list_aux_clauses])
 
-val dbterm_db = store_thm("dbterm_db",
-  ``∀tm. dbterm [] tm = db tm``,
+val dbterm_db = Q.store_thm("dbterm_db",
+  `∀tm. dbterm [] tm = db tm`,
   rw[dbterm_bind])
 
 (* alpha-equivalence on de Bruijn terms *)
@@ -2016,11 +2016,11 @@ val dbterm_RACONV = store_thm("dbterm_RACONV",
     gen_tac >> BasicProvers.CASE_TAC >> simp[] ) >>
   rw[] >> res_tac >> fs[])
 
-val RACONV_dbterm = store_thm("RACONV_dbterm",
-  ``∀env tp. RACONV env tp ⇒
+val RACONV_dbterm = Q.store_thm("RACONV_dbterm",
+  `∀env tp. RACONV env tp ⇒
     welltyped (FST tp) ∧ welltyped (SND tp) ∧
     (∀vp. MEM vp env ⇒ (∃x ty. (FST vp = Var x ty)) ∧ (∃x ty. (SND vp = Var x ty)))
-     ⇒ dbterm (MAP (dest_var o FST) env) (FST tp) = dbterm (MAP (dest_var o SND) env) (SND tp)``,
+     ⇒ dbterm (MAP (dest_var o FST) env) (FST tp) = dbterm (MAP (dest_var o SND) env) (SND tp)`,
   ho_match_mp_tac RACONV_ind >> rw[] >> rw[] >> fs[PULL_EXISTS] >> rw[] >>
   TRY (
     first_x_assum match_mp_tac >>
@@ -2035,15 +2035,15 @@ val RACONV_dbterm = store_thm("RACONV_dbterm",
   simp[Once find_index_shift_0,SimpRHS] >>
   rpt BasicProvers.CASE_TAC >> fs[] >> rw[] >> fs[])
 
-val dbterm_ACONV = store_thm("dbterm_ACONV",
-  ``∀t1 t2. welltyped t1 ∧ welltyped t2 ⇒ (ACONV t1 t2 ⇔ dbterm [] t1 = dbterm [] t2)``,
+val dbterm_ACONV = Q.store_thm("dbterm_ACONV",
+  `∀t1 t2. welltyped t1 ∧ welltyped t2 ⇒ (ACONV t1 t2 ⇔ dbterm [] t1 = dbterm [] t2)`,
   rw[ACONV_def,EQ_IMP_THM] >- (
     qspecl_then[`[]`,`t1,t2`]mp_tac RACONV_dbterm >> simp[] ) >>
   qspecl_then[`t1`,`[]`,`t2`,`[]`]mp_tac dbterm_RACONV >>
   simp[])
 
-val ACONV_db = store_thm("ACONV_db",
-  ``∀t1 t2. welltyped t1 ∧ welltyped t2 ⇒ (ACONV t1 t2 ⇔ db t1 = db t2)``,
+val ACONV_db = Q.store_thm("ACONV_db",
+  `∀t1 t2. welltyped t1 ∧ welltyped t2 ⇒ (ACONV t1 t2 ⇔ db t1 = db t2)`,
   metis_tac[dbterm_ACONV,dbterm_db])
 
 (* respect of alpha-equivalence by VSUBST and INST follows *)
@@ -2059,8 +2059,8 @@ val ACONV_VSUBST = store_thm("ACONV_VSUBST",
   rw[ACONV_db] >>
   metis_tac[ACONV_db,VSUBST_dbVSUBST,welltyped_def])
 
-val ACONV_INST = store_thm("ACONV_INST",
-  ``∀t1 t2 tyin. welltyped t1 ∧ welltyped t2 ∧ ACONV t1 t2 ⇒ ACONV (INST tyin t1) (INST tyin t2)``,
+val ACONV_INST = Q.store_thm("ACONV_INST",
+  `∀t1 t2 tyin. welltyped t1 ∧ welltyped t2 ∧ ACONV t1 t2 ⇒ ACONV (INST tyin t1) (INST tyin t2)`,
   rw[] >>
   imp_res_tac INST_WELLTYPED >>
   rw[ACONV_db] >> imp_res_tac INST_dbINST >>
@@ -2169,13 +2169,13 @@ val INST_CORE_simple_inst = store_thm("INST_CORE_simple_inst",
     metis_tac[dest_var_def,FST] ) >>
   fs[])
 
-val INST_simple_inst = store_thm("INST_simple_inst",
-  ``∀tyin tm.
+val INST_simple_inst = Q.store_thm("INST_simple_inst",
+  `∀tyin tm.
       ALL_DISTINCT (bv_names tm) ∧
       DISJOINT (set (bv_names tm)) {x | ∃ty. VFREE_IN (Var x ty) tm} ∧
       welltyped tm
       ⇒
-      INST tyin tm = simple_inst tyin tm``,
+      INST tyin tm = simple_inst tyin tm`,
   rw[INST_def] >>
   qspecl_then[`[]`,`tyin`,`tm`]mp_tac INST_CORE_simple_inst >>
   simp[])
@@ -2198,8 +2198,8 @@ val simple_subst_has_type = store_thm("simple_subst_has_type",
   first_x_assum match_mp_tac >>
   fs[EVERY_FILTER,EVERY_MEM])
 
-val simple_inst_has_type = store_thm("simple_inst_has_type",
-  ``∀tm tyin. welltyped tm ⇒ simple_inst tyin tm has_type (TYPE_SUBST tyin (typeof tm))``,
+val simple_inst_has_type = Q.store_thm("simple_inst_has_type",
+  `∀tm tyin. welltyped tm ⇒ simple_inst tyin tm has_type (TYPE_SUBST tyin (typeof tm))`,
   Induct >> rw[] >> rw[Once has_type_cases] >> fs[] >> metis_tac[] )
 
 (* rename bound variables from a source of names *)
@@ -2218,8 +2218,8 @@ val rename_bvars_def = Define`
      let (names,tm) = rename_bvars names ((s',dest_var v)::env) tm in
      (names, Abs (Var s' (typeof v)) tm))`
 
-val FST_rename_bvars = store_thm("FST_rename_bvars",
-  ``∀names env tm. LENGTH (bv_names tm) ≤ LENGTH names ⇒ (FST (rename_bvars names env tm) = DROP (LENGTH (bv_names tm)) names)``,
+val FST_rename_bvars = Q.store_thm("FST_rename_bvars",
+  `∀names env tm. LENGTH (bv_names tm) ≤ LENGTH names ⇒ (FST (rename_bvars names env tm) = DROP (LENGTH (bv_names tm)) names)`,
   ho_match_mp_tac (theorem"rename_bvars_ind") >>
   simp[rename_bvars_def] >>
   rw[UNCURRY] >> rw[] >>
@@ -2288,20 +2288,20 @@ val rename_bvars_RACONV = store_thm("rename_bvars_RACONV",
   fs[IN_DISJOINT,ALL_DISTINCT_APPEND] >>
   rfs[] >> metis_tac[])
 
-val rename_bvars_ACONV = store_thm("rename_bvars_ACONV",
-  ``∀names tm.
+val rename_bvars_ACONV = Q.store_thm("rename_bvars_ACONV",
+  `∀names tm.
     LENGTH (bv_names tm) ≤ LENGTH names ∧ ALL_DISTINCT names ∧
     DISJOINT (set names) {x | MEM x (bv_names tm) ∨ ∃ty. VFREE_IN (Var x ty) tm} ∧
     welltyped tm
     ⇒
-    ACONV tm (SND (rename_bvars names [] tm))``,
+    ACONV tm (SND (rename_bvars names [] tm))`,
   rw[ACONV_def] >>
   qspecl_then[`names`,`[]`,`tm`]mp_tac rename_bvars_RACONV >>
   simp[] >> disch_then match_mp_tac >>
   fs[IN_DISJOINT] >> metis_tac[])
 
-val rename_bvars_has_type = store_thm("rename_bvars_has_type",
-  ``∀names env tm ty. tm has_type ty ⇒ SND (rename_bvars names env tm) has_type ty``,
+val rename_bvars_has_type = Q.store_thm("rename_bvars_has_type",
+  `∀names env tm ty. tm has_type ty ⇒ SND (rename_bvars names env tm) has_type ty`,
   ho_match_mp_tac(theorem"rename_bvars_ind") >>
   srw_tac[][rename_bvars_def] >> rw[] >> fs[]
   >- fs[Once has_type_cases] >>
@@ -2309,8 +2309,8 @@ val rename_bvars_has_type = store_thm("rename_bvars_has_type",
   simp[Once has_type_cases] >> strip_tac >>
   simp[Once has_type_cases] >> metis_tac[] )
 
-val rename_bvars_welltyped = store_thm("rename_bvars_welltyped",
-  ``∀names env tm. welltyped tm ⇒ welltyped (SND (rename_bvars names env tm))``,
+val rename_bvars_welltyped = Q.store_thm("rename_bvars_welltyped",
+  `∀names env tm. welltyped tm ⇒ welltyped (SND (rename_bvars names env tm))`,
   metis_tac[rename_bvars_has_type,welltyped_def])
 
 (* appropriate fresh term for using the simple functions above *)
@@ -2323,21 +2323,21 @@ val fresh_def = new_specification("fresh_def",["fresh"],
   |> Q.GEN`s`
   |> SIMP_RULE(srw_ss())[SKOLEM_THM])
 
-val fresh_union = store_thm("fresh_union",
-  ``FINITE s ∧ FINITE t ⇒ fresh (s ∪ t) ∉ s ∧ fresh (s ∪ t) ∉ t``,
+val fresh_union = Q.store_thm("fresh_union",
+  `FINITE s ∧ FINITE t ⇒ fresh (s ∪ t) ∉ s ∧ fresh (s ∪ t) ∉ t`,
   metis_tac[fresh_def,FINITE_UNION,IN_UNION])
 
-val fresh_names_exist = store_thm("fresh_names_exist",
-  ``∀s n. FINITE (s:string set) ⇒ ∃names. LENGTH names = n ∧ ALL_DISTINCT names ∧ DISJOINT (set names) s``,
+val fresh_names_exist = Q.store_thm("fresh_names_exist",
+  `∀s n. FINITE (s:string set) ⇒ ∃names. LENGTH names = n ∧ ALL_DISTINCT names ∧ DISJOINT (set names) s`,
   gen_tac >> Induct >> strip_tac
   >- (qexists_tac`[]`>>simp[]) >> rw[] >> fs[] >>
   qexists_tac`fresh (s ∪ set names)::names` >>
   simp[fresh_union])
 
-val bv_names_rename_bvars = store_thm("bv_names_rename_bvars",
-  ``∀names env tm.
+val bv_names_rename_bvars = Q.store_thm("bv_names_rename_bvars",
+  `∀names env tm.
     LENGTH (bv_names tm) ≤ LENGTH names ⇒
-    bv_names (SND (rename_bvars names env tm)) = TAKE (LENGTH (bv_names tm)) names``,
+    bv_names (SND (rename_bvars names env tm)) = TAKE (LENGTH (bv_names tm)) names`,
   ho_match_mp_tac(theorem"rename_bvars_ind")>>
   simp[rename_bvars_def] >>
   conj_tac >- (
@@ -2352,8 +2352,8 @@ val bv_names_rename_bvars = store_thm("bv_names_rename_bvars",
 
 (* various rewrites for FINITE sets to make this go through *)
 
-val FINITE_VFREE_IN = store_thm("FINITE_VFREE_IN",
-  ``∀tm. FINITE {x | ∃ty. VFREE_IN (Var x ty) tm}``,
+val FINITE_VFREE_IN = Q.store_thm("FINITE_VFREE_IN",
+  `∀tm. FINITE {x | ∃ty. VFREE_IN (Var x ty) tm}`,
   Induct >> simp[] >- (
     qmatch_assum_abbrev_tac`FINITE s1` >>
     qpat_x_assum`FINITE s1`mp_tac >>
@@ -2394,8 +2394,8 @@ val FINITE_VFREE_IN_2 = store_thm("FINITE_VFREE_IN_2",
   metis_tac[])
 val _ = export_rewrites["FINITE_VFREE_IN_2"]
 
-val FINITE_VFREE_IN_list = store_thm("FINITE_VFREE_IN_list",
-  ``∀ls. FINITE {x | ∃ty u. VFREE_IN (Var x ty) u ∧ MEM u ls}``,
+val FINITE_VFREE_IN_list = Q.store_thm("FINITE_VFREE_IN_list",
+  `∀ls. FINITE {x | ∃ty u. VFREE_IN (Var x ty) u ∧ MEM u ls}`,
   Induct >> simp[] >> rw[] >>
   qmatch_assum_abbrev_tac`FINITE s` >>
   qmatch_abbrev_tac`FINITE t` >>
@@ -2420,12 +2420,12 @@ val FINITE_MEM_Var = store_thm("FINITE_MEM_Var",
 val _ = export_rewrites["FINITE_MEM_Var"]
 
 val fresh_term_def = new_specification("fresh_term_def",["fresh_term"],
-  prove(``∃f. ∀s tm. FINITE s ⇒
+  Q.prove(`∃f. ∀s tm. FINITE s ⇒
                      welltyped tm ⇒
                      welltyped (f s tm) ∧
                      ACONV tm (f s tm) ∧
                      ALL_DISTINCT (bv_names (f s tm)) ∧
-                     DISJOINT (set (bv_names (f s tm))) s``,
+                     DISJOINT (set (bv_names (f s tm))) s`,
     simp[GSYM SKOLEM_THM] >> rw[RIGHT_EXISTS_IMP_THM] >>
     qspecl_then[`IMAGE explode (s ∪ set (bv_names tm) ∪ {x | ∃ty. VFREE_IN (Var x ty) tm})`,`LENGTH (bv_names tm)`]
       mp_tac fresh_names_exist >> rw[] >>
@@ -2453,8 +2453,8 @@ val vfree_in_def = Define `
     | Comb s t => vfree_in v s \/ vfree_in v t
     | _ => (tm = v)`;
 
-val vfree_in_thm = store_thm("vfree_in_thm",
-  ``!name ty y. (VFREE_IN (Var name ty) y = vfree_in (Var name ty) y)``,
+val vfree_in_thm = Q.store_thm("vfree_in_thm",
+  `!name ty y. (VFREE_IN (Var name ty) y = vfree_in (Var name ty) y)`,
   ntac 2 gen_tac >> Induct >> simp[VFREE_IN_def,Once vfree_in_def] >>
   simp[Once vfree_in_def,SimpRHS] >>
   BasicProvers.CASE_TAC >>
@@ -2542,14 +2542,14 @@ val itlist_def = Define `
 val union_def = Define `
   union l1 l2 = itlist insert l1 l2`;
 
-val MEM_union = store_thm("MEM_union",
-  ``!xs ys x. MEM x (union xs ys) <=> MEM x xs \/ MEM x ys``,
+val MEM_union = Q.store_thm("MEM_union",
+  `!xs ys x. MEM x (union xs ys) <=> MEM x xs \/ MEM x ys`,
   Induct \\ FULL_SIMP_TAC std_ss [union_def]
   \\ ONCE_REWRITE_TAC [itlist_def] \\ SRW_TAC [] [insert_def]
   \\ METIS_TAC []);
 
-val EXISTS_union = store_thm("EXISTS_union",
-  ``!xs ys. EXISTS P (union xs ys) <=> EXISTS P xs \/ EXISTS P ys``,
+val EXISTS_union = Q.store_thm("EXISTS_union",
+  `!xs ys. EXISTS P (union xs ys) <=> EXISTS P xs \/ EXISTS P ys`,
   SIMP_TAC std_ss [EXISTS_MEM,MEM_MAP,MEM_union] \\ METIS_TAC []);
 
 val frees_def = Define `
@@ -2560,8 +2560,8 @@ val frees_def = Define `
     | Abs bv bod => subtract (frees bod) [bv]
     | Comb s t => union (frees s) (frees t)`
 
-val MEM_frees_EQ = store_thm("MEM_frees_EQ",
-  ``!a x. MEM x (frees a) = ?n ty. (x = Var n ty) /\ MEM (Var n ty) (frees a)``,
+val MEM_frees_EQ = Q.store_thm("MEM_frees_EQ",
+  `!a x. MEM x (frees a) = ?n ty. (x = Var n ty) /\ MEM (Var n ty) (frees a)`,
   Induct \\ SIMP_TAC (srw_ss()) [Once frees_def,MEM_union]
   THEN1 (SIMP_TAC (srw_ss()) [Once frees_def,MEM_union])
   THEN1 (SIMP_TAC (srw_ss()) [Once frees_def,MEM_union])
@@ -2652,18 +2652,18 @@ val INST_CORE_Abs_thm = store_thm("INST_CORE_Abs_thm",
 
 (* provable terms are ok and of type bool *)
 
-val proves_theory_ok = store_thm("proves_theory_ok",
-  ``∀thyh c. thyh |- c ⇒ theory_ok (FST thyh)``,
+val proves_theory_ok = Q.store_thm("proves_theory_ok",
+  `∀thyh c. thyh |- c ⇒ theory_ok (FST thyh)`,
   ho_match_mp_tac proves_ind >> rw[])
 
-val theory_ok_sig = store_thm("theory_ok_sig",
-  ``∀thy. theory_ok thy ⇒ is_std_sig (sigof thy)``,
+val theory_ok_sig = Q.store_thm("theory_ok_sig",
+  `∀thy. theory_ok thy ⇒ is_std_sig (sigof thy)`,
   Cases >> rw[theory_ok_def])
 
-val proves_term_ok = store_thm("proves_term_ok",
-  ``∀thyh c. thyh |- c ⇒
+val proves_term_ok = Q.store_thm("proves_term_ok",
+  `∀thyh c. thyh |- c ⇒
       hypset_ok (SND thyh) ∧
-      EVERY (λp. term_ok (sigof (FST thyh)) p ∧ p has_type Bool) (c::(SND thyh))``,
+      EVERY (λp. term_ok (sigof (FST thyh)) p ∧ p has_type Bool) (c::(SND thyh))`,
   ho_match_mp_tac proves_strongind >>
   strip_tac >- (
     rw[EQUATION_HAS_TYPE_BOOL] >>
@@ -2775,8 +2775,8 @@ val rws = [
   rich_listTheory.EL_DROP,
   rich_listTheory.EL_CONS]
 
-val proves_concl_ACONV = prove(
-  ``∀thyh c c'. thyh |- c ∧ ACONV c c' ∧ welltyped c' ⇒ thyh |- c'``,
+val proves_concl_ACONV = Q.prove(
+  `∀thyh c c'. thyh |- c ∧ ACONV c c' ∧ welltyped c' ⇒ thyh |- c'`,
   rw[] >>
   qspecl_then[`c'`,`FST thyh`]mp_tac refl_equation >>
   imp_res_tac proves_theory_ok >>
@@ -2886,8 +2886,8 @@ val proves_ACONV = store_thm("proves_ACONV",
 
 (* more derived rules *)
 
-val sym_equation = store_thm("sym_equation",
-  ``∀thyh p q. thyh |- p === q ⇒ thyh |- q === p``,
+val sym_equation = Q.store_thm("sym_equation",
+  `∀thyh p q. thyh |- p === q ⇒ thyh |- q === p`,
   rpt strip_tac >>
   imp_res_tac proves_theory_ok >>
   imp_res_tac proves_term_ok >>
@@ -2917,10 +2917,10 @@ val sym_equation = store_thm("sym_equation",
   fs[EQUATION_HAS_TYPE_BOOL] >>
   metis_tac[eqMp_equation,term_union_thm,ACONV_REFL])
 
-val sym = store_thm("sym",
-  ``∀thyh p q ty.
+val sym = Q.store_thm("sym",
+  `∀thyh p q ty.
       thyh |- Comb (Comb (Equal ty) p) q ⇒
-      thyh |- Comb (Comb (Equal ty) q) p``,
+      thyh |- Comb (Comb (Equal ty) q) p`,
   rw[] >>
   imp_res_tac proves_term_ok >> fs[] >>
   imp_res_tac term_ok_welltyped >> fs[] >>
@@ -2997,67 +2997,67 @@ val proveHyp = store_thm("proveHyp",
 
 (* extension is transitive *)
 
-val extends_trans = store_thm("extends_trans",
-  ``∀c1 c2 c3. c1 extends c2 ∧ c2 extends c3 ⇒ c1 extends c3``,
+val extends_trans = Q.store_thm("extends_trans",
+  `∀c1 c2 c3. c1 extends c2 ∧ c2 extends c3 ⇒ c1 extends c3`,
   rw[extends_def] >> metis_tac[RTC_TRANSITIVE,transitive_def])
 
 (* extensions have all distinct names *)
 
-val updates_ALL_DISTINCT = store_thm("updates_ALL_DISTINCT",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val updates_ALL_DISTINCT = Q.store_thm("updates_ALL_DISTINCT",
+  `∀upd ctxt. upd updates ctxt ⇒
       (ALL_DISTINCT (MAP FST (type_list ctxt)) ⇒
        ALL_DISTINCT (MAP FST (type_list (upd::ctxt)))) ∧
       (ALL_DISTINCT (MAP FST (const_list ctxt)) ⇒
-       ALL_DISTINCT (MAP FST (const_list (upd::ctxt))))``,
+       ALL_DISTINCT (MAP FST (const_list (upd::ctxt))))`,
   ho_match_mp_tac updates_ind >> simp[] >>
   rw[ALL_DISTINCT_APPEND,MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
 
-val extends_ALL_DISTINCT = store_thm("extends_ALL_DISTINCT",
-  ``∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒
+val extends_ALL_DISTINCT = Q.store_thm("extends_ALL_DISTINCT",
+  `∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒
       (ALL_DISTINCT (MAP FST (type_list ctxt1)) ⇒
        ALL_DISTINCT (MAP FST (type_list ctxt2))) ∧
       (ALL_DISTINCT (MAP FST (const_list ctxt1)) ⇒
-       ALL_DISTINCT (MAP FST (const_list ctxt2)))``,
+       ALL_DISTINCT (MAP FST (const_list ctxt2)))`,
   simp[IMP_CONJ_THM,FORALL_AND_THM] >> conj_tac >>
   ho_match_mp_tac extends_ind >>
   METIS_TAC[updates_ALL_DISTINCT])
 
-val init_ALL_DISTINCT = store_thm("init_ALL_DISTINCT",
-  ``ALL_DISTINCT (MAP FST (const_list init_ctxt)) ∧
-    ALL_DISTINCT (MAP FST (type_list init_ctxt))``,
+val init_ALL_DISTINCT = Q.store_thm("init_ALL_DISTINCT",
+  `ALL_DISTINCT (MAP FST (const_list init_ctxt)) ∧
+    ALL_DISTINCT (MAP FST (type_list init_ctxt))`,
   EVAL_TAC)
 
-val updates_DISJOINT = store_thm("updates_DISJOINT",
-  ``∀upd ctxt.
+val updates_DISJOINT = Q.store_thm("updates_DISJOINT",
+  `∀upd ctxt.
     upd updates ctxt ⇒
     DISJOINT (FDOM (alist_to_fmap (consts_of_upd upd))) (FDOM (tmsof ctxt)) ∧
-    DISJOINT (FDOM (alist_to_fmap (types_of_upd upd))) (FDOM (tysof ctxt))``,
+    DISJOINT (FDOM (alist_to_fmap (types_of_upd upd))) (FDOM (tysof ctxt))`,
   ho_match_mp_tac updates_ind >>
   simp[IN_DISJOINT] >> rw[] >>
   simp[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX] >>
   PROVE_TAC[])
 
-val updates_upd_ALL_DISTINCT = store_thm("updates_upd_ALL_DISTINCT",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val updates_upd_ALL_DISTINCT = Q.store_thm("updates_upd_ALL_DISTINCT",
+  `∀upd ctxt. upd updates ctxt ⇒
       ALL_DISTINCT (MAP FST (consts_of_upd upd)) ∧
-      ALL_DISTINCT (MAP FST (types_of_upd upd))``,
+      ALL_DISTINCT (MAP FST (types_of_upd upd))`,
   ho_match_mp_tac updates_ind >> rw[] >>
   rw[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
 
-val updates_upd_DISJOINT = store_thm("updates_upd_DISJOINT",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val updates_upd_DISJOINT = Q.store_thm("updates_upd_DISJOINT",
+  `∀upd ctxt. upd updates ctxt ⇒
       DISJOINT (set (MAP FST (types_of_upd upd))) (set (MAP FST (type_list ctxt))) ∧
-      DISJOINT (set (MAP FST (consts_of_upd upd))) (set (MAP FST (const_list ctxt)))``,
+      DISJOINT (set (MAP FST (consts_of_upd upd))) (set (MAP FST (const_list ctxt)))`,
   ho_match_mp_tac updates_ind >> rw[IN_DISJOINT,MEM_MAP,FORALL_PROD,EXISTS_PROD,PULL_EXISTS,LET_THM] >>
   metis_tac[])
 
 (* signature extensions preserve ok *)
 
-val type_ok_extend = store_thm("type_ok_extend",
-  ``∀t tyenv tyenv'.
+val type_ok_extend = Q.store_thm("type_ok_extend",
+  `∀t tyenv tyenv'.
     tyenv ⊑ tyenv' ∧
     type_ok tyenv t ⇒
-    type_ok tyenv' t``,
+    type_ok tyenv' t`,
   ho_match_mp_tac type_ind >>
   rw[type_ok_def,EVERY_MEM] >>
   res_tac >>
@@ -3073,10 +3073,10 @@ val term_ok_extend = store_thm("term_ok_extend",
   imp_res_tac FLOOKUP_SUBMAP >>
   metis_tac[])
 
-val term_ok_updates = store_thm("term_ok_updates",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val term_ok_updates = Q.store_thm("term_ok_updates",
+  `∀upd ctxt. upd updates ctxt ⇒
       term_ok (sigof (thyof ctxt)) tm ⇒
-      term_ok (sigof (thyof (upd::ctxt))) tm``,
+      term_ok (sigof (thyof (upd::ctxt))) tm`,
   rw[] >> match_mp_tac term_ok_extend >>
   map_every qexists_tac[`tysof ctxt`,`tmsof ctxt`] >>
   simp[] >> conj_tac >> match_mp_tac finite_mapTheory.SUBMAP_FUNION >>
@@ -3090,8 +3090,8 @@ val is_std_sig_extend = store_thm("is_std_sig_extend",
 
 (* updates preserve ok *)
 
-val updates_theory_ok = store_thm("updates_theory_ok",
-  ``∀upd ctxt. upd updates ctxt ⇒ theory_ok (thyof ctxt) ⇒ theory_ok (thyof (upd::ctxt))``,
+val updates_theory_ok = Q.store_thm("updates_theory_ok",
+  `∀upd ctxt. upd updates ctxt ⇒ theory_ok (thyof ctxt) ⇒ theory_ok (thyof (upd::ctxt))`,
   ho_match_mp_tac updates_ind >>
   strip_tac >- (
     rw[conexts_of_upd_def] >>
@@ -3197,21 +3197,21 @@ val updates_theory_ok = store_thm("updates_theory_ok",
     fs[is_std_sig_def] ) >>
   metis_tac[term_ok_extend])
 
-val extends_theory_ok = store_thm("extends_theory_ok",
-  ``∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ theory_ok (thyof ctxt1) ⇒ theory_ok (thyof ctxt2)``,
+val extends_theory_ok = Q.store_thm("extends_theory_ok",
+  `∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ theory_ok (thyof ctxt1) ⇒ theory_ok (thyof ctxt2)`,
   ho_match_mp_tac extends_ind >> metis_tac[updates_theory_ok])
 
 (* init_ctxt ok *)
 
-val init_theory_ok = store_thm("init_theory_ok",
-  ``theory_ok (thyof init_ctxt)``,
+val init_theory_ok = Q.store_thm("init_theory_ok",
+  `theory_ok (thyof init_ctxt)`,
   rw[theory_ok_def,init_ctxt_def,type_ok_def,FLOOKUP_UPDATE,conexts_of_upd_def] >>
   rw[is_std_sig_def,FLOOKUP_UPDATE])
 
 (* is_std_sig is preserved *)
 
-val is_std_sig_extends = store_thm("is_std_sig_extends",
-  ``∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ is_std_sig (sigof ctxt1) ⇒ is_std_sig (sigof ctxt2)``,
+val is_std_sig_extends = Q.store_thm("is_std_sig_extends",
+  `∀ctxt1 ctxt2. ctxt2 extends ctxt1 ⇒ is_std_sig (sigof ctxt1) ⇒ is_std_sig (sigof ctxt2)`,
   ho_match_mp_tac extends_ind >>
   REWRITE_TAC[GSYM AND_IMP_INTRO] >>
   ho_match_mp_tac updates_ind >>
@@ -3225,14 +3225,14 @@ val is_std_sig_extends = store_thm("is_std_sig_extends",
 
 val _ = Parse.overload_on("ConstDef",``λx t. ConstSpec [(x,t)] (Var x (typeof t) === t)``)
 
-val ConstDef_updates = store_thm("ConstDef_updates",
-  ``∀name tm ctxt.
+val ConstDef_updates = Q.store_thm("ConstDef_updates",
+  `∀name tm ctxt.
     theory_ok (thyof ctxt) ∧
     term_ok (sigof ctxt) tm ∧
     name ∉ FDOM (tmsof ctxt) ∧
     CLOSED tm ∧
     set (tvars tm) ⊆ set (tyvars (typeof tm))
-    ⇒ ConstDef name tm updates ctxt``,
+    ⇒ ConstDef name tm updates ctxt`,
   rw[] >>
   match_mp_tac(List.nth(CONJUNCTS updates_rules,2)) >>
   simp[EVERY_MAP] >> fs[SUBSET_DEF] >>
@@ -3245,19 +3245,19 @@ val ConstDef_updates = store_thm("ConstDef_updates",
 
 (* lookups in extended contexts *)
 
-val FLOOKUP_tmsof_updates = store_thm("FLOOKUP_tmsof_updates",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val FLOOKUP_tmsof_updates = Q.store_thm("FLOOKUP_tmsof_updates",
+  `∀upd ctxt. upd updates ctxt ⇒
     FLOOKUP (tmsof (thyof ctxt)) name = SOME ty ⇒
-    FLOOKUP (tmsof (thyof (upd::ctxt))) name = SOME ty``,
+    FLOOKUP (tmsof (thyof (upd::ctxt))) name = SOME ty`,
   rw[finite_mapTheory.FLOOKUP_FUNION] >>
   BasicProvers.CASE_TAC >> imp_res_tac updates_DISJOINT >>
   fs[pred_setTheory.IN_DISJOINT,listTheory.MEM_MAP,pairTheory.EXISTS_PROD] >>
   PROVE_TAC[alistTheory.ALOOKUP_MEM])
 
-val FLOOKUP_tysof_updates = store_thm("FLOOKUP_tysof_updates",
-  ``∀upd ctxt. upd updates ctxt ⇒
+val FLOOKUP_tysof_updates = Q.store_thm("FLOOKUP_tysof_updates",
+  `∀upd ctxt. upd updates ctxt ⇒
     FLOOKUP (tysof (thyof ctxt)) name = SOME a ⇒
-    FLOOKUP (tysof (thyof (upd::ctxt))) name = SOME a``,
+    FLOOKUP (tysof (thyof (upd::ctxt))) name = SOME a`,
   rw[finite_mapTheory.FLOOKUP_FUNION] >>
   BasicProvers.CASE_TAC >> imp_res_tac updates_DISJOINT >>
   fs[pred_setTheory.IN_DISJOINT,listTheory.MEM_MAP,pairTheory.EXISTS_PROD] >>
@@ -3292,11 +3292,11 @@ val FLOOKUP_tmsof_extends = Q.store_thm("FLOOKUP_tmsof_extends",
   \\ TRY(qpat_x_assum`_ = SOME _`mp_tac \\ rw[])
   \\ metis_tac[]);
 
-val extends_sub = store_thm("extends_sub",
-  ``∀ctxt2 ctxt1. ctxt2 extends ctxt1 ⇒
+val extends_sub = Q.store_thm("extends_sub",
+  `∀ctxt2 ctxt1. ctxt2 extends ctxt1 ⇒
       tmsof ctxt1 ⊑ tmsof ctxt2 ∧
       tysof ctxt1 ⊑ tysof ctxt2 ∧
-      axsof ctxt1 ⊆ axsof ctxt2``,
+      axsof ctxt1 ⊆ axsof ctxt2`,
   simp[extends_def] >>
   ho_match_mp_tac relationTheory.RTC_INDUCT >>
   simp[PULL_EXISTS] >>
@@ -3461,28 +3461,28 @@ val types_in_def = Define`
   types_in (Abs v t) = types_in v ∪ types_in t`
 val _ = export_rewrites["types_in_def"]
 
-val type_ok_types_in = store_thm("type_ok_types_in",
-  ``∀sig. is_std_sig sig ⇒ ∀tm ty. term_ok sig tm ∧ ty ∈ types_in tm ⇒ type_ok (tysof sig) ty``,
+val type_ok_types_in = Q.store_thm("type_ok_types_in",
+  `∀sig. is_std_sig sig ⇒ ∀tm ty. term_ok sig tm ∧ ty ∈ types_in tm ⇒ type_ok (tysof sig) ty`,
   gen_tac >> strip_tac >> Induct >> simp[] >> rw[] >>
   TRY (imp_res_tac term_ok_def >> NO_TAC) >> fs[term_ok_def])
 
-val VFREE_IN_types_in = store_thm("VFREE_IN_types_in",
-  ``∀t2 t1. VFREE_IN t1 t2 ⇒ typeof t1 ∈ types_in t2``,
+val VFREE_IN_types_in = Q.store_thm("VFREE_IN_types_in",
+  `∀t2 t1. VFREE_IN t1 t2 ⇒ typeof t1 ∈ types_in t2`,
   ho_match_mp_tac term_induction >> rw[] >> rw[])
 
-val Var_subterm_types_in = prove(
-  ``∀t x ty. Var x ty subterm t ⇒ ty ∈ types_in t``,
+val Var_subterm_types_in = Q.prove(
+  `∀t x ty. Var x ty subterm t ⇒ ty ∈ types_in t`,
   ho_match_mp_tac term_induction >> rw[subterm_Comb,subterm_Abs] >>
   metis_tac[])
 
-val Const_subterm_types_in = prove(
-  ``∀t x ty. Const x ty subterm t ⇒ ty ∈ types_in t``,
+val Const_subterm_types_in = Q.prove(
+  `∀t x ty. Const x ty subterm t ⇒ ty ∈ types_in t`,
   ho_match_mp_tac term_induction >> rw[subterm_Comb,subterm_Abs] >>
   metis_tac[])
 
-val subterm_typeof_types_in = store_thm("subterm_typeof_types_in",
-  ``∀t1 t2 name args. (Tyapp name args) subtype (typeof t1) ∧ t1 subterm t2 ∧ welltyped t2 ∧ name ≠ (strlit"fun") ⇒
-      ∃ty2. Tyapp name args subtype ty2 ∧ ty2 ∈ types_in t2``,
+val subterm_typeof_types_in = Q.store_thm("subterm_typeof_types_in",
+  `∀t1 t2 name args. (Tyapp name args) subtype (typeof t1) ∧ t1 subterm t2 ∧ welltyped t2 ∧ name ≠ (strlit"fun") ⇒
+      ∃ty2. Tyapp name args subtype ty2 ∧ ty2 ∈ types_in t2`,
   ho_match_mp_tac term_induction >>
   conj_tac >- ( rw[] >> metis_tac[Var_subterm_types_in] ) >>
   conj_tac >- ( rw[] >> metis_tac[Const_subterm_types_in] ) >>
@@ -3549,23 +3549,23 @@ val arities_match_def = tDefine"arities_match"`
   (WF_REL_TAC`measure (λx. type1_size (FST x) + type1_size (SND x))`)
 val arities_match_ind = theorem "arities_match_ind"
 
-val arities_match_length = store_thm("arities_match_length",
-  ``∀l1 l2. arities_match l1 l2 ⇒ (LENGTH l1 = LENGTH l2)``,
+val arities_match_length = Q.store_thm("arities_match_length",
+  `∀l1 l2. arities_match l1 l2 ⇒ (LENGTH l1 = LENGTH l2)`,
   ho_match_mp_tac arities_match_ind >> simp[arities_match_def])
 
-val arities_match_nil = store_thm("arities_match_nil[simp]",
-  ``(arities_match [] ls = (ls = [])) ∧
-    (arities_match ls [] = (ls = []))``,
+val arities_match_nil = Q.store_thm("arities_match_nil[simp]",
+  `(arities_match [] ls = (ls = [])) ∧
+    (arities_match ls [] = (ls = []))`,
   Cases_on`ls`>> simp[arities_match_def])
 
-val arities_match_Tyvar = store_thm("arities_match_Tyvar[simp]",
-  ``arities_match (Tyvar v::ps) (ty::obs) = arities_match ps obs``,
+val arities_match_Tyvar = Q.store_thm("arities_match_Tyvar[simp]",
+  `arities_match (Tyvar v::ps) (ty::obs) = arities_match ps obs`,
   Cases_on`ty`>>simp[arities_match_def])
 
-val arities_match_append = store_thm("arities_match_append",
-  ``∀l1 l2 l3 l4.
+val arities_match_append = Q.store_thm("arities_match_append",
+  `∀l1 l2 l3 l4.
     arities_match l1 l2 ∧ arities_match l3 l4 ⇒
-    arities_match (l1++l3) (l2++l4)``,
+    arities_match (l1++l3) (l2++l4)`,
   ho_match_mp_tac arities_match_ind >>
   simp[arities_match_def])
 
@@ -3660,9 +3660,9 @@ val tymatch_SOME = store_thm("tymatch_SOME",
 val match_type_def = Define`
   match_type ty1 ty2 = OPTION_MAP FST (tymatch [ty1] [ty2] ([],[]))`
 
-val type_ok_arities_match = store_thm("type_ok_arities_match",
-  ``∀tys ty1 ty2.
-    type_ok tys ty1 ∧ type_ok tys ty2 ⇒ arities_match [ty1] [ty2]``,
+val type_ok_arities_match = Q.store_thm("type_ok_arities_match",
+  `∀tys ty1 ty2.
+    type_ok tys ty1 ∧ type_ok tys ty2 ⇒ arities_match [ty1] [ty2]`,
   gen_tac >> ho_match_mp_tac type_ind >> simp[] >>
   gen_tac >> strip_tac >>
   gen_tac >> Cases >> simp[arities_match_def] >>
@@ -3679,10 +3679,10 @@ val type_ok_arities_match = store_thm("type_ok_arities_match",
   `arities_match [h] [h']` by metis_tac[] >>
   metis_tac[arities_match_append,APPEND])
 
-val match_type_SOME = store_thm("match_type_SOME",
-  ``∀ty1 ty2 s. arities_match [ty1] [ty2] ⇒
+val match_type_SOME = Q.store_thm("match_type_SOME",
+  `∀ty1 ty2 s. arities_match [ty1] [ty2] ⇒
     (match_type ty1 ty2 = SOME s) ⇒
-    (TYPE_SUBST s ty1 = ty2)``,
+    (TYPE_SUBST s ty1 = ty2)`,
   rw[match_type_def] >>
   qspecl_then[`[ty1]`,`[ty2]`,`[],[]`]mp_tac tymatch_SOME >>
   simp[] >>

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -597,7 +597,7 @@ val orda_RACONV = prove(
   reverse(Cases_on`t1 ≠ t2 ∨ env ≠ []`) >- (
     fs[RACONV_REFL] ) >>
   qmatch_assum_abbrev_tac`p` >> fs[] >>
-  rator_x_assum`orda`mp_tac >>
+  qhdtm_x_assum`orda`mp_tac >>
   simp[Once orda_def] >>
   rw[] >- fs[markerTheory.Abbrev_def] >>
   pop_assum mp_tac >>
@@ -605,10 +605,10 @@ val orda_RACONV = prove(
   BasicProvers.CASE_TAC >>
   rw[RACONV,ALPHAVARS_eq_ordav] >>
   TRY (
-    rator_x_assum`term_cmp`mp_tac >>
+    qhdtm_x_assum`term_cmp`mp_tac >>
     rw[term_cmp_def,TO_of_LinearOrder] >>
     NO_TAC) >> fs[] >>
-  rator_x_assum`type_cmp`mp_tac >>
+  qhdtm_x_assum`type_cmp`mp_tac >>
   rw[type_cmp_def,TO_of_LinearOrder])
 
 val RACONV_eq_orda = store_thm("RACONV_eq_orda",

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -28,11 +28,11 @@ val extends_ind = Q.store_thm("extends_ind",
 
 (* deconstructing variables *)
 
-val ALOOKUP_MAP_dest_var = store_thm("ALOOKUP_MAP_dest_var",
-  ``∀ls f x ty.
+val ALOOKUP_MAP_dest_var = Q.store_thm("ALOOKUP_MAP_dest_var",
+  `∀ls f x ty.
       EVERY (λs. ∃x ty. s = Var x ty) (MAP FST ls) ⇒
       ALOOKUP (MAP (dest_var ## f) ls) (x,ty) =
-      OPTION_MAP f (ALOOKUP ls (Var x ty))``,
+      OPTION_MAP f (ALOOKUP ls (Var x ty))`,
   Induct >> simp[] >> Cases >> simp[EVERY_MEM,EVERY_MAP] >>
   rw[] >> fs[])
 
@@ -53,12 +53,12 @@ val is_instance_refl = Q.store_thm("is_instance_refl",
   rw[] >> qexists_tac`[]` >> rw[])
 val _ = export_rewrites["is_instance_refl"]
 
-val swap_ff = store_thm("swap_ff",
-  ``∀f g. (λ(x,y). (y,x)) o (f ## g) = (g ## f) o (λ(x,y). (y,x))``,
+val swap_ff = Q.store_thm("swap_ff",
+  `∀f g. (λ(x,y). (y,x)) o (f ## g) = (g ## f) o (λ(x,y). (y,x))`,
   rw[FUN_EQ_THM,FORALL_PROD])
 
-val ff_def = store_thm("ff_def",
-  ``∀f g. (f ## g) = λ(x,y). (f x, g y)``,
+val ff_def = Q.store_thm("ff_def",
+  `∀f g. (f ## g) = λ(x,y). (f x, g y)`,
   rw[FUN_EQ_THM,FORALL_PROD,PAIR_MAP_THM])
 
 val TYPE_SUBST_compose = Q.store_thm("TYPE_SUBST_compose",
@@ -111,8 +111,8 @@ val _ = export_rewrites["WELLTYPED_CLAUSES"]
 
 (* Alpha-equivalence *)
 
-val RACONV = store_thm("RACONV",
- ``(RACONV env (Var x1 ty1,Var x2 ty2) <=>
+val RACONV = Q.store_thm("RACONV",
+ `(RACONV env (Var x1 ty1,Var x2 ty2) <=>
         ALPHAVARS env (Var x1 ty1,Var x2 ty2)) /\
    (RACONV env (Var x1 ty1,Const x2 ty2) <=> F) /\
    (RACONV env (Var x1 ty1,Comb l2 r2) <=> F) /\
@@ -131,11 +131,11 @@ val RACONV = store_thm("RACONV",
    (RACONV env (Abs v1 t1,Comb l2 r2) <=> F) /\
    (RACONV env (Abs v1 t1,Abs v2 t2) <=>
           typeof v1 = typeof v2 /\
-          RACONV (CONS (v1,v2) env) (t1,t2))``,
+          RACONV (CONS (v1,v2) env) (t1,t2))`,
   REPEAT CONJ_TAC THEN simp[Once RACONV_cases] >> metis_tac[])
 
-val RACONV_REFL = store_thm("RACONV_REFL",
-  ``∀t env. EVERY (UNCURRY $=) env ⇒ RACONV env (t,t)``,
+val RACONV_REFL = Q.store_thm("RACONV_REFL",
+  `∀t env. EVERY (UNCURRY $=) env ⇒ RACONV env (t,t)`,
   Induct >> simp[RACONV,ALPHAVARS_REFL])
 
 val ACONV_REFL = Q.store_thm("ACONV_REFL",
@@ -143,8 +143,8 @@ val ACONV_REFL = Q.store_thm("ACONV_REFL",
   simp[ACONV_def,RACONV_REFL])
 val _ = export_rewrites["ACONV_REFL"]
 
-val RACONV_TRANS = store_thm("RACONV_TRANS",
-  ``∀env tp. RACONV env tp ⇒ ∀vs t. LENGTH vs = LENGTH env ∧ RACONV (ZIP(MAP SND env,vs)) (SND tp,t) ⇒ RACONV (ZIP(MAP FST env,vs)) (FST tp, t)``,
+val RACONV_TRANS = Q.store_thm("RACONV_TRANS",
+  `∀env tp. RACONV env tp ⇒ ∀vs t. LENGTH vs = LENGTH env ∧ RACONV (ZIP(MAP SND env,vs)) (SND tp,t) ⇒ RACONV (ZIP(MAP FST env,vs)) (FST tp, t)`,
   ho_match_mp_tac RACONV_ind >> simp[RACONV] >>
   conj_tac >- (
     Induct >- simp[ALPHAVARS_def] >>
@@ -163,8 +163,8 @@ val ACONV_TRANS = Q.store_thm("ACONV_TRANS",
   `∀t1 t2 t3. ACONV t1 t2 ∧ ACONV t2 t3 ⇒ ACONV t1 t3`,
   rw[ACONV_def] >> imp_res_tac RACONV_TRANS >> fs[LENGTH_NIL])
 
-val RACONV_SYM = store_thm("RACONV_SYM",
-  ``∀env tp. RACONV env tp ⇒ RACONV (MAP (λ(x,y). (y,x)) env) (SND tp,FST tp)``,
+val RACONV_SYM = Q.store_thm("RACONV_SYM",
+  `∀env tp. RACONV env tp ⇒ RACONV (MAP (λ(x,y). (y,x)) env) (SND tp,FST tp)`,
   ho_match_mp_tac RACONV_ind >> simp[] >>
   conj_tac >- (
     Induct >> simp[ALPHAVARS_def,RACONV] >>
@@ -176,20 +176,20 @@ val ACONV_SYM = Q.store_thm("ACONV_SYM",
   `∀t1 t2. ACONV t1 t2 ⇒ ACONV t2 t1`,
   rw[ACONV_def] >> imp_res_tac RACONV_SYM >> fs[])
 
-val ALPHAVARS_TYPE = store_thm("ALPHAVARS_TYPE",
-  ``∀env s t. ALPHAVARS env (s,t) ∧
+val ALPHAVARS_TYPE = Q.store_thm("ALPHAVARS_TYPE",
+  `∀env s t. ALPHAVARS env (s,t) ∧
               EVERY (λ(x,y). welltyped x ∧ welltyped y
                              ∧ (typeof x = typeof y)) env ∧
               welltyped s ∧ welltyped t
-              ⇒ typeof s = typeof t``,
+              ⇒ typeof s = typeof t`,
   Induct >> simp[ALPHAVARS_def,FORALL_PROD] >> rw[] >> rw[])
 
-val RACONV_TYPE = store_thm("RACONV_TYPE",
-  ``∀env p. RACONV env p
+val RACONV_TYPE = Q.store_thm("RACONV_TYPE",
+  `∀env p. RACONV env p
             ⇒ EVERY (λ(x,y). welltyped x ∧ welltyped y
                              ∧ (typeof x = typeof y)) env ∧
               welltyped (FST p) ∧ welltyped (SND p)
-              ⇒ typeof (FST p) = typeof (SND p)``,
+              ⇒ typeof (FST p) = typeof (SND p)`,
   ho_match_mp_tac RACONV_ind >>
   simp[FORALL_PROD,typeof_def,WELLTYPED_CLAUSES] >>
   rw[] >> imp_res_tac ALPHAVARS_TYPE >>
@@ -269,18 +269,18 @@ val subterm_welltyped = save_thm("subterm_welltyped",
 
 (* term ordering *)
 
-val type_lt_thm = prove(
-  ``(type_lt (Tyvar x1) (Tyvar x2) ⇔ mlstring_lt x1 x2) ∧
+val type_lt_thm = Q.prove(
+  `(type_lt (Tyvar x1) (Tyvar x2) ⇔ mlstring_lt x1 x2) ∧
     (type_lt (Tyvar _) (Tyapp _ _) ⇔ T) ∧
     (type_lt (Tyapp _ _) (Tyvar _) ⇔ F) ∧
     (type_lt (Tyapp x1 args1) (Tyapp x2 args2) ⇔
        (mlstring_lt LEX LLEX type_lt)
-         (x1,args1) (x2,args2))``,
+         (x1,args1) (x2,args2))`,
   rw[] >> rw[Once type_lt_cases])
   |> CONJUNCTS |> map GEN_ALL |> LIST_CONJ
   |> curry save_thm "type_lt_thm"
 
-val term_lt_thm = prove(``
+val term_lt_thm = Q.prove(`
   (term_lt (Var x1 ty1) (Var x2 ty2) ⇔
      (mlstring_lt LEX type_lt) (x1,ty1) (x2,ty2)) ∧
   (term_lt (Var _ _) (Const _ _) ⇔ T) ∧
@@ -300,7 +300,7 @@ val term_lt_thm = prove(``
   (term_lt (Abs _ _) (Const _ _) ⇔ F) ∧
   (term_lt (Abs _ _) (Comb _ _) ⇔ F) ∧
   (term_lt (Abs s1 s2) (Abs t1 t2) ⇔
-    (term_lt LEX term_lt) (s1,s2) (t1,t2))``,
+    (term_lt LEX term_lt) (s1,s2) (t1,t2))`,
   rw[] >> rw[Once term_lt_cases])
   |> CONJUNCTS |> map GEN_ALL |> LIST_CONJ
   |> curry save_thm "term_lt_thm"
@@ -463,13 +463,13 @@ val LLEX_irreflexive = Q.prove(
 
 val irreflexive_LLEX_type_lt = MATCH_MP LLEX_irreflexive (irreflexive_type_lt)
 
-val type_cmp_thm = store_thm("type_cmp_thm",
-  ``∀t1 t2.  type_cmp t1 t2 =
+val type_cmp_thm = Q.store_thm("type_cmp_thm",
+  `∀t1 t2.  type_cmp t1 t2 =
     case (t1,t2) of
     | (Tyvar x1, Tyvar x2) => mlstring_cmp x1 x2
     | (Tyvar _, _) => LESS
     | (_, Tyvar _) => GREATER
-    | (Tyapp x1 a1, Tyapp x2 a2) => pair_cmp mlstring_cmp (list_cmp type_cmp) (x1,a1) (x2,a2)``,
+    | (Tyapp x1 a1, Tyapp x2 a2) => pair_cmp mlstring_cmp (list_cmp type_cmp) (x1,a1) (x2,a2)`,
   ho_match_mp_tac type_ind >>
   conj_tac >- (
     gen_tac >> Cases >>
@@ -502,8 +502,8 @@ val type_cmp_ind = Q.store_thm("type_cmp_ind",
   first_x_assum match_mp_tac >> simp[] >>
   fs[EVERY_MEM])
 
-val term_cmp_thm = store_thm("term_cmp_thm",
-  ``∀t1 t2. term_cmp t1 t2 =
+val term_cmp_thm = Q.store_thm("term_cmp_thm",
+  `∀t1 t2. term_cmp t1 t2 =
     case (t1,t2) of
     | (Var x1 ty1, Var x2 ty2) => pair_cmp mlstring_cmp type_cmp (x1,ty1) (x2,ty2)
     | (Var _ _, _) => LESS
@@ -516,7 +516,7 @@ val term_cmp_thm = store_thm("term_cmp_thm",
     | (_, Comb _ _) => GREATER
     | (Abs s1 t1, Abs s2 t2) => pair_cmp term_cmp term_cmp (s1,t1) (s2,t2)
     | (Abs _ _, _) => LESS
-    | (_, Abs _ _) => GREATER``,
+    | (_, Abs _ _) => GREATER`,
   ho_match_mp_tac term_induction >>
   conj_tac >- (
     ntac 2 gen_tac >> Cases >>
@@ -574,15 +574,15 @@ val ALPHAVARS_ordav = Q.prove(
   rfs[term_cmp_def,TO_of_LinearOrder] >>
   ntac 2 (pop_assum mp_tac) >> rw[])
 
-val ordav_ALPHAVARS = prove(
-  ``∀env t1 t2. ordav env t1 t2 = EQUAL ⇒ ALPHAVARS env (t1,t2)``,
+val ordav_ALPHAVARS = Q.prove(
+  `∀env t1 t2. ordav env t1 t2 = EQUAL ⇒ ALPHAVARS env (t1,t2)`,
   ho_match_mp_tac ordav_ind >>
   rw[ALPHAVARS_def,ordav_def] >>
   fs[term_cmp_def,TO_of_LinearOrder] >>
   rpt(pop_assum mp_tac) >> rw[])
 
-val ALPHAVARS_eq_ordav = store_thm("ALPHAVARS_eq_ordav",
-  ``∀env t1 t2. ALPHAVARS env (t1,t2) ⇔ ordav env t1 t2 = EQUAL``,
+val ALPHAVARS_eq_ordav = Q.store_thm("ALPHAVARS_eq_ordav",
+  `∀env t1 t2. ALPHAVARS env (t1,t2) ⇔ ordav env t1 t2 = EQUAL`,
   metis_tac[ALPHAVARS_ordav,ordav_ALPHAVARS,pair_CASES,FST,SND])
 
 val RACONV_orda = Q.prove(
@@ -591,8 +591,8 @@ val RACONV_orda = Q.prove(
   >- rw[orda_def] >- rw[orda_def] >- rw[Once orda_def] >>
   rw[Once orda_def])
 
-val orda_RACONV = prove(
-  ``∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)``,
+val orda_RACONV = Q.prove(
+  `∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)`,
   ho_match_mp_tac orda_ind >> rw[] >>
   reverse(Cases_on`t1 ≠ t2 ∨ env ≠ []`) >- (
     fs[RACONV_REFL] ) >>
@@ -611,31 +611,31 @@ val orda_RACONV = prove(
   qhdtm_x_assum`type_cmp`mp_tac >>
   rw[type_cmp_def,TO_of_LinearOrder])
 
-val RACONV_eq_orda = store_thm("RACONV_eq_orda",
-  ``∀env t1 t2. RACONV env (t1,t2) ⇔ orda env t1 t2 = EQUAL``,
+val RACONV_eq_orda = Q.store_thm("RACONV_eq_orda",
+  `∀env t1 t2. RACONV env (t1,t2) ⇔ orda env t1 t2 = EQUAL`,
   metis_tac[RACONV_orda,orda_RACONV,pair_CASES,FST,SND])
 
 val ACONV_eq_orda = Q.store_thm("ACONV_eq_orda",
   `∀t1 t2. ACONV t1 t2 = (orda [] t1 t2 = EQUAL)`,
   rw[ACONV_def,RACONV_eq_orda])
 
-val ordav_FILTER = store_thm("ordav_FILTER",
-  ``∀env x y. ordav env x y =
+val ordav_FILTER = Q.store_thm("ordav_FILTER",
+  `∀env x y. ordav env x y =
       case FILTER (λ(x',y'). x' = x ∨ y' = y) env of
       | [] => term_cmp x y
-      | ((x',y')::_) => if x' = x then if y' = y then EQUAL else LESS else GREATER``,
+      | ((x',y')::_) => if x' = x then if y' = y then EQUAL else LESS else GREATER`,
   ho_match_mp_tac ordav_ind >> simp[ordav_def] >>
   strip_assume_tac TotOrd_term_cmp >>
   fs[TotOrd] >> rw[])
 
-val ordav_sym = store_thm("ordav_sym",
-  ``∀env v1 v2. invert (ordav env v1 v2) = ordav (MAP (λ(x,y). (y,x)) env) v2 v1``,
+val ordav_sym = Q.store_thm("ordav_sym",
+  `∀env v1 v2. invert (ordav env v1 v2) = ordav (MAP (λ(x,y). (y,x)) env) v2 v1`,
   ho_match_mp_tac ordav_ind >> simp[ordav_def] >>
   conj_tac >- metis_tac[invert_def,TotOrd_term_cmp,TotOrd,cpn_nchotomy,cpn_distinct] >>
   rw[])
 
-val orda_sym = store_thm("orda_sym",
-  ``∀env t1 t2. invert (orda env t1 t2) = orda (MAP (λ(x,y). (y,x)) env) t2 t1``,
+val orda_sym = Q.store_thm("orda_sym",
+  `∀env t1 t2. invert (orda env t1 t2) = orda (MAP (λ(x,y). (y,x)) env) t2 t1`,
   ho_match_mp_tac orda_ind >>
   rpt gen_tac >> rpt strip_tac >>
   ONCE_REWRITE_TAC[orda_def] >>
@@ -662,14 +662,14 @@ val orda_thm = Q.prove(
   BasicProvers.CASE_TAC >> rw[ordav_def] >>
   fs[GSYM RACONV_eq_orda,RACONV_REFL])
 
-val ordav_lx_trans = prove(
-  ``∀t1 t2 t3 env1 env2.
+val ordav_lx_trans = Q.prove(
+  `∀t1 t2 t3 env1 env2.
     ordav env1 t1 t2 ≠ GREATER ∧
     ordav env2 t2 t3 ≠ GREATER ∧
     MAP SND env1 = MAP FST env2
     ⇒ ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 ≠ GREATER ∧
       (ordav env1 t1 t2 = LESS ∨ ordav env2 t2 t3 = LESS ⇒
-       ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)``,
+       ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)`,
   mp_tac TotOrd_term_cmp >> simp[TotOrd] >> strip_tac >>
   ntac 3 gen_tac >> Induct >> simp[ordav_def] >- (
     metis_tac[cpn_nchotomy,cpn_distinct] ) >>
@@ -679,19 +679,19 @@ val ordav_lx_trans = prove(
   rw[ordav_def] >>
   metis_tac[cpn_nchotomy,cpn_distinct] )
 
-val undo_zip_map_fst = prove(
-  ``p::ZIP(MAP FST l1,MAP SND l2) =
-    ZIP (MAP FST ((FST p,v2)::l1), MAP SND ((v2,SND p)::l2))``,
+val undo_zip_map_fst = Q.prove(
+  `p::ZIP(MAP FST l1,MAP SND l2) =
+    ZIP (MAP FST ((FST p,v2)::l1), MAP SND ((v2,SND p)::l2))`,
   Cases_on`p`>>rw[])
 
-val orda_lx_trans = prove(
-  ``∀env1 t1 t2 env2 t3.
+val orda_lx_trans = Q.prove(
+  `∀env1 t1 t2 env2 t3.
     orda env1 t1 t2 ≠ GREATER ∧
     orda env2 t2 t3 ≠ GREATER ∧
     MAP SND env1 = MAP FST env2
     ⇒ orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 ≠ GREATER ∧
       (orda env1 t1 t2 = LESS ∨ orda env2 t2 t3 = LESS ⇒
-       orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)``,
+       orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)`,
   completeInduct_on`term_size t1 + term_size t2 + term_size t3` >>
   rpt gen_tac >> strip_tac >>
   BasicProvers.VAR_EQ_TAC >>
@@ -806,12 +806,12 @@ val alpha_lt_not_refl = Q.store_thm("alpha_lt_not_refl[simp]",
 
 (* VFREE_IN lemmas *)
 
-val VFREE_IN_RACONV = store_thm("VFREE_IN_RACONV",
-  ``∀env p. RACONV env p
+val VFREE_IN_RACONV = Q.store_thm("VFREE_IN_RACONV",
+  `∀env p. RACONV env p
             ⇒ ∀x ty. VFREE_IN (Var x ty) (FST p) ∧
                      ¬(∃y. MEM (Var x ty,y) env) ⇔
                      VFREE_IN (Var x ty) (SND p) ∧
-                     ¬(∃y. MEM (y,Var x ty) env)``,
+                     ¬(∃y. MEM (y,Var x ty) env)`,
   ho_match_mp_tac RACONV_ind >> simp[VFREE_IN_def] >>
   reverse conj_tac >- metis_tac[] >>
   Induct >> simp[ALPHAVARS_def,FORALL_PROD] >> rw[] >> metis_tac[])
@@ -1084,11 +1084,11 @@ val MEM_term_image = Q.store_thm("MEM_term_image",
 
 (* VSUBST lemmas *)
 
-val VSUBST_HAS_TYPE = store_thm("VSUBST_HAS_TYPE",
-  ``∀tm ty ilist.
+val VSUBST_HAS_TYPE = Q.store_thm("VSUBST_HAS_TYPE",
+  `∀tm ty ilist.
       tm has_type ty ∧
       (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. (s = Var x ty) ∧ s' has_type ty)
-      ⇒ (VSUBST ilist tm) has_type ty``,
+      ⇒ (VSUBST ilist tm) has_type ty`,
   Induct >> simp[VSUBST_def]
   >- (
     map_every qx_gen_tac[`x`,`ty`,`tty`] >>
@@ -1107,11 +1107,11 @@ val VSUBST_HAS_TYPE = store_thm("VSUBST_HAS_TYPE",
     simp[MEM_FILTER] >> rw[] >> TRY(metis_tac[]) >>
     simp[Once has_type_cases]))
 
-val VSUBST_WELLTYPED = store_thm("VSUBST_WELLTYPED",
-  ``∀tm ty ilist.
+val VSUBST_WELLTYPED = Q.store_thm("VSUBST_WELLTYPED",
+  `∀tm ty ilist.
       welltyped tm ∧
       (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. (s = Var x ty) ∧ s' has_type ty)
-      ⇒ welltyped (VSUBST ilist tm)``,
+      ⇒ welltyped (VSUBST ilist tm)`,
   metis_tac[VSUBST_HAS_TYPE,welltyped_def])
 
 val VFREE_IN_VSUBST = Q.store_thm("VFREE_IN_VSUBST",
@@ -1169,8 +1169,8 @@ val VSUBST_NIL = Q.store_thm("VSUBST_NIL[simp]",
 
 (* INST lemmas *)
 
-val INST_CORE_HAS_TYPE = store_thm("INST_CORE_HAS_TYPE",
-  ``∀n tm env tyin.
+val INST_CORE_HAS_TYPE = Q.store_thm("INST_CORE_HAS_TYPE",
+  `∀n tm env tyin.
       welltyped tm ∧ (sizeof tm = n) ∧
       (∀s s'. MEM (s,s') env ⇒
               ∃x ty. (s = Var x ty) ∧
@@ -1186,7 +1186,7 @@ val INST_CORE_HAS_TYPE = store_thm("INST_CORE_HAS_TYPE",
                tm' has_type (TYPE_SUBST tyin (typeof tm)) ∧
                (∀u uty. VFREE_IN (Var u uty) tm' ⇔
                         ∃oty. VFREE_IN (Var u oty) tm ∧
-                              uty = TYPE_SUBST tyin oty))``,
+                              uty = TYPE_SUBST tyin oty))`,
   gen_tac >> completeInduct_on`n` >>
   Induct >> simp[Once INST_CORE_def] >>
   TRY (
@@ -1471,12 +1471,12 @@ val term_ok_clauses = Q.store_thm("term_ok_clauses",
     EVAL_TAC >> NO_TAC) >>
   metis_tac[])
 
-val term_ok_VSUBST = store_thm("term_ok_VSUBST",
-  ``∀sig tm ilist.
+val term_ok_VSUBST = Q.store_thm("term_ok_VSUBST",
+  `∀sig tm ilist.
     term_ok sig tm ∧
     (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. s = Var x ty ∧ s' has_type ty ∧ term_ok sig s')
     ⇒
-    term_ok sig (VSUBST ilist tm)``,
+    term_ok sig (VSUBST ilist tm)`,
   Cases >> Induct >> simp[VSUBST_def,term_ok_def] >- (
     ntac 2 gen_tac >> Induct >> simp[REV_ASSOCD,term_ok_def] >>
     Cases >> simp[REV_ASSOCD] >> rw[term_ok_def] >> metis_tac[])
@@ -1491,14 +1491,14 @@ val term_ok_VSUBST = store_thm("term_ok_VSUBST",
   rw[term_ok_def,MEM_FILTER] >>
   simp[Once has_type_cases])
 
-val term_ok_INST_CORE = store_thm("term_ok_INST_CORE",
-  ``∀sig env tyin tm.
+val term_ok_INST_CORE = Q.store_thm("term_ok_INST_CORE",
+  `∀sig env tyin tm.
       term_ok sig tm ∧
       EVERY (type_ok (FST sig)) (MAP FST tyin) ∧
       (∀s s'. MEM (s,s') env ⇒ ∃x ty. s = Var x ty ∧ s' = Var x (TYPE_SUBST tyin ty)) ∧
       IS_RESULT (INST_CORE env tyin tm)
       ⇒
-      term_ok sig (RESULT (INST_CORE env tyin tm))``,
+      term_ok sig (RESULT (INST_CORE env tyin tm))`,
   Cases >> ho_match_mp_tac INST_CORE_ind >>
   simp[term_ok_def,INST_CORE_def] >>
   rw[term_ok_def,type_ok_TYPE_SUBST] >- (
@@ -1533,11 +1533,11 @@ val term_ok_INST = Q.store_thm("term_ok_INST",
   rw[INST_def] >>
   metis_tac[INST_CORE_NIL_IS_RESULT,term_ok_welltyped,term_ok_INST_CORE,MEM])
 
-val term_ok_raconv = store_thm("term_ok_raconv",
-  ``∀env tp. RACONV env tp ⇒
+val term_ok_raconv = Q.store_thm("term_ok_raconv",
+  `∀env tp. RACONV env tp ⇒
       ∀sig.
       EVERY (λ(s,s'). welltyped s ∧ welltyped s' ∧ typeof s = typeof s' ∧ type_ok (FST sig) (typeof s)) env ⇒
-      term_ok sig (FST tp) ∧ welltyped (SND tp) ⇒ term_ok sig (SND tp)``,
+      term_ok sig (FST tp) ∧ welltyped (SND tp) ⇒ term_ok sig (SND tp)`,
   ho_match_mp_tac RACONV_strongind >>
   rw[] >> Cases_on`sig`>>fs[term_ok_def] >- (
     imp_res_tac ALPHAVARS_MEM >> fs[EVERY_MEM,FORALL_PROD] >>
@@ -1621,11 +1621,11 @@ val bind_dbVSUBST = Q.store_thm("bind_dbVSUBST",
   Cases >> simp[REV_ASSOCD] >> strip_tac >>
   rw[] >> metis_tac[bind_not_free])
 
-val bind_dbVSUBST_cons = store_thm("bind_dbVSUBST_cons",
-  ``∀tm z x n ls.
+val bind_dbVSUBST_cons = Q.store_thm("bind_dbVSUBST_cons",
+  `∀tm z x n ls.
     ¬dbVFREE_IN (UNCURRY dbVar z) (dbVSUBST ls (bind x n tm))
     ⇒
-    bind z n (dbVSUBST ((UNCURRY dbVar z,UNCURRY dbVar x)::ls) tm) = dbVSUBST ls (bind x n tm)``,
+    bind z n (dbVSUBST ((UNCURRY dbVar z,UNCURRY dbVar x)::ls) tm) = dbVSUBST ls (bind x n tm)`,
   Induct >> simp[] >>
   CONV_TAC (RESORT_FORALL_CONV List.rev) >>
   rw[REV_ASSOCD] >>fs[] >- (
@@ -1663,17 +1663,17 @@ val dbVFREE_IN_VFREE_IN = Q.store_thm("dbVFREE_IN_VFREE_IN",
   simp[dbVFREE_IN_bind,PULL_EXISTS] >>
   Cases >> simp[] >> metis_tac[] )
 
-val MAP_db_FILTER_neq = store_thm("MAP_db_FILTER_neq",
-  ``∀ls z ty. MAP (λ(x,y). (db x, db y)) (FILTER (λ(x,y). y ≠ Var z ty) ls) = FILTER (λ(x,y). y ≠ dbVar z ty) (MAP (λ(x,y). (db x, db y)) ls)``,
+val MAP_db_FILTER_neq = Q.store_thm("MAP_db_FILTER_neq",
+  `∀ls z ty. MAP (λ(x,y). (db x, db y)) (FILTER (λ(x,y). y ≠ Var z ty) ls) = FILTER (λ(x,y). y ≠ dbVar z ty) (MAP (λ(x,y). (db x, db y)) ls)`,
   Induct >> simp[] >>
   Cases >> simp[] >>
   rw[] >-( Cases_on`r`>>fs[] ) >> fs[])
 
-val REV_ASSOCD_MAP_db = store_thm("REV_ASSOCD_MAP_db",
-  ``∀ls k ky.
+val REV_ASSOCD_MAP_db = Q.store_thm("REV_ASSOCD_MAP_db",
+  `∀ls k ky.
     (∀k v. MEM (v,k) ls ⇒ ∃x ty. k = Var x ty)
     ⇒
-    REV_ASSOCD (dbVar k ky) (MAP (λ(x,y). (db x, db y)) ls) (dbVar k ky) = db (REV_ASSOCD (Var k ky) ls (Var k ky))``,
+    REV_ASSOCD (dbVar k ky) (MAP (λ(x,y). (db x, db y)) ls) (dbVar k ky) = db (REV_ASSOCD (Var k ky) ls (Var k ky))`,
   Induct >> simp[REV_ASSOCD] >>
   Cases >> simp[REV_ASSOCD] >>
   rw[] >> fs[] >- (
@@ -1689,12 +1689,12 @@ val dbVFREE_IN_dbVSUBST = Q.store_thm("dbVFREE_IN_dbVSUBST",
                (REV_ASSOCD (dbVar y ty) ilist (dbVar y ty))`,
   Induct >> simp[] >> rw[] >> metis_tac[])
 
-val VSUBST_dbVSUBST = store_thm("VSUBST_dbVSUBST",
-  ``∀tm ilist.
+val VSUBST_dbVSUBST = Q.store_thm("VSUBST_dbVSUBST",
+  `∀tm ilist.
     welltyped tm ∧
     (∀k v. MEM (v,k) ilist ⇒ welltyped v ∧ ∃x ty. k = Var x ty)
     ⇒
-    db (VSUBST ilist tm) = dbVSUBST (MAP (λ(x,y). (db x, db y)) ilist) (db tm)``,
+    db (VSUBST ilist tm) = dbVSUBST (MAP (λ(x,y). (db x, db y)) ilist) (db tm)`,
   Induct >- (
     simp[VSUBST_def] >>
     ntac 2 gen_tac >> Induct >>
@@ -1806,10 +1806,10 @@ val dbINST_def = Define`
   dbINST tyin (dbAbs ty t) = dbAbs (TYPE_SUBST tyin ty) (dbINST tyin t)`
 val _ = export_rewrites["dbINST_def"]
 
-val dbINST_bind = store_thm("dbINST_bind",
-  ``∀tm v n ls.
+val dbINST_bind = Q.store_thm("dbINST_bind",
+  `∀tm v n ls.
       (∀ty. dbVFREE_IN (dbVar (FST v) ty) tm ∧ (TYPE_SUBST ls ty = TYPE_SUBST ls (SND v)) ⇒ ty = SND v)
-      ⇒ dbINST ls (bind v n tm) = bind (FST v,TYPE_SUBST ls (SND v)) n (dbINST ls tm)``,
+      ⇒ dbINST ls (bind v n tm) = bind (FST v,TYPE_SUBST ls (SND v)) n (dbINST ls tm)`,
   Induct >> simp[] >>
   Cases_on`v`>>simp[] >>
   rpt strip_tac >>
@@ -1821,11 +1821,11 @@ val dbVSUBST_nil = Q.store_thm("dbVSUBST_nil",
   Induct >> simp[REV_ASSOCD])
 val _ = export_rewrites["dbVSUBST_nil"]
 
-val INST_CORE_dbINST = store_thm("INST_CORE_dbINST",
-  ``∀tm tyin env tmi.
+val INST_CORE_dbINST = Q.store_thm("INST_CORE_dbINST",
+  `∀tm tyin env tmi.
       welltyped tm ∧ (∀s s'. MEM (s,s') env ⇒ ∃x ty. s = Var x ty ∧ s' = Var x (TYPE_SUBST tyin ty)) ∧
       INST_CORE env tyin tm = Result tmi ⇒
-        db tmi = dbINST tyin (db tm)``,
+        db tmi = dbINST tyin (db tm)`,
   completeInduct_on`sizeof tm` >> Cases >> simp[] >- (
     strip_tac >>
     simp[INST_CORE_def] >>
@@ -1987,9 +1987,9 @@ val dbterm_db = Q.store_thm("dbterm_db",
 
 (* alpha-equivalence on de Bruijn terms *)
 
-val dbterm_RACONV = store_thm("dbterm_RACONV",
-  ``∀t1 env1 t2 env2. welltyped t1 ∧ welltyped t2 ∧ dbterm env1 t1 = dbterm env2 t2 ∧ LENGTH env1 = LENGTH env2 ⇒
-      RACONV (ZIP(MAP (UNCURRY Var) env1,MAP (UNCURRY Var) env2)) (t1,t2)``,
+val dbterm_RACONV = Q.store_thm("dbterm_RACONV",
+  `∀t1 env1 t2 env2. welltyped t1 ∧ welltyped t2 ∧ dbterm env1 t1 = dbterm env2 t2 ∧ LENGTH env1 = LENGTH env2 ⇒
+      RACONV (ZIP(MAP (UNCURRY Var) env1,MAP (UNCURRY Var) env2)) (t1,t2)`,
   Induct >- (
     ntac 3 gen_tac >> simp[] >>
     Cases >> simp[RACONV] >>
@@ -2048,12 +2048,12 @@ val ACONV_db = Q.store_thm("ACONV_db",
 
 (* respect of alpha-equivalence by VSUBST and INST follows *)
 
-val ACONV_VSUBST = store_thm("ACONV_VSUBST",
-  ``∀t1 t2 ilist.
+val ACONV_VSUBST = Q.store_thm("ACONV_VSUBST",
+  `∀t1 t2 ilist.
     welltyped t1 ∧ welltyped t2 ∧
     (∀k v. MEM (v,k) ilist ⇒ ∃x ty. k = Var x ty ∧ v has_type ty) ∧
     ACONV t1 t2 ⇒
-    ACONV (VSUBST ilist t1) (VSUBST ilist t2)``,
+    ACONV (VSUBST ilist t1) (VSUBST ilist t2)`,
   rw[] >>
   imp_res_tac VSUBST_WELLTYPED >>
   rw[ACONV_db] >>
@@ -2095,11 +2095,11 @@ val simple_inst_def = Define`
   simple_inst tyin (Abs v t) = Abs (simple_inst tyin v) (simple_inst tyin t)`
 val _ = export_rewrites["simple_inst_def"]
 
-val VSUBST_simple_subst = store_thm("VSUBST_simple_subst",
-  ``∀tm ilist. DISJOINT (set (bv_names tm)) {y | ∃ty u. VFREE_IN (Var y ty) u ∧ MEM u (MAP FST ilist)} ∧
+val VSUBST_simple_subst = Q.store_thm("VSUBST_simple_subst",
+  `∀tm ilist. DISJOINT (set (bv_names tm)) {y | ∃ty u. VFREE_IN (Var y ty) u ∧ MEM u (MAP FST ilist)} ∧
                (∀s s'. MEM (s',s) ilist ⇒ ∃x ty. s = Var x ty) ∧
                welltyped tm
-               ⇒ VSUBST ilist tm = simple_subst ilist tm``,
+               ⇒ VSUBST ilist tm = simple_subst ilist tm`,
   Induct
   >- simp[VSUBST_def]
   >- simp[VSUBST_def]
@@ -2119,14 +2119,14 @@ val VSUBST_simple_subst = store_thm("VSUBST_simple_subst",
   fs[MEM_MAP,EXISTS_PROD,IN_DISJOINT] >>
   metis_tac[])
 
-val INST_CORE_simple_inst = store_thm("INST_CORE_simple_inst",
-  ``∀env tyin tm.
+val INST_CORE_simple_inst = Q.store_thm("INST_CORE_simple_inst",
+  `∀env tyin tm.
       ALL_DISTINCT (bv_names tm ++ (MAP (FST o dest_var o SND) env)) ∧
       DISJOINT (set(bv_names tm)) {x | ∃ty. VFREE_IN (Var x ty) tm} ∧
       (∀s s'. MEM (s,s') env ⇒ ∃x ty. s = Var x ty ∧ s' = Var x (TYPE_SUBST tyin ty)) ∧
       (∀x ty ty'. VFREE_IN (Var x ty) tm ∧ MEM (Var x ty') (MAP FST env) ⇒ ty' = ty) ∧
       welltyped tm
-      ⇒ INST_CORE env tyin tm = Result (simple_inst tyin tm)``,
+      ⇒ INST_CORE env tyin tm = Result (simple_inst tyin tm)`,
   ho_match_mp_tac INST_CORE_ind >>
   conj_tac >- (
     simp[INST_CORE_def] >> rpt gen_tac >> strip_tac >> rw[] >>
@@ -2180,12 +2180,12 @@ val INST_simple_inst = Q.store_thm("INST_simple_inst",
   qspecl_then[`[]`,`tyin`,`tm`]mp_tac INST_CORE_simple_inst >>
   simp[])
 
-val simple_subst_has_type = store_thm("simple_subst_has_type",
-  ``∀tm ty.
+val simple_subst_has_type = Q.store_thm("simple_subst_has_type",
+  `∀tm ty.
       tm has_type ty ⇒
       ∀subst.
         EVERY (λ(s',s). s' has_type typeof s) subst ⇒
-        simple_subst subst tm has_type ty``,
+        simple_subst subst tm has_type ty`,
   ho_match_mp_tac has_type_ind >>
   simp[] >> rw[] >- (
     simp[REV_ASSOCD_ALOOKUP] >> BasicProvers.CASE_TAC >-
@@ -2229,14 +2229,14 @@ val FST_rename_bvars = Q.store_thm("FST_rename_bvars",
   match_mp_tac rich_listTheory.DROP_DROP >>
   simp[])
 
-val rename_bvars_RACONV = store_thm("rename_bvars_RACONV",
-  ``∀names env tm.
+val rename_bvars_RACONV = Q.store_thm("rename_bvars_RACONV",
+  `∀names env tm.
     LENGTH (bv_names tm) ≤ LENGTH names ∧
     DISJOINT (set (MAP FST env ++ names)) (set (MAP (FST o SND) env ++ bv_names tm)) ∧
     DISJOINT (set (MAP FST env ++ names)) {x | ∃ty. VFREE_IN (Var x ty) tm} ∧
     ALL_DISTINCT (MAP FST env ++ names) ∧
     welltyped tm
-    ⇒ RACONV (MAP (λ(s',(s,ty)). (Var s ty, Var s' ty)) env) (tm, SND (rename_bvars names env tm))``,
+    ⇒ RACONV (MAP (λ(s',(s,ty)). (Var s ty, Var s' ty)) env) (tm, SND (rename_bvars names env tm))`,
   ho_match_mp_tac (theorem"rename_bvars_ind") >>
   simp[rename_bvars_def,RACONV] >>
   conj_tac >- (
@@ -2370,8 +2370,8 @@ val FINITE_VFREE_IN = Q.store_thm("FINITE_VFREE_IN",
   metis_tac[])
 val _ = export_rewrites["FINITE_VFREE_IN"]
 
-val FINITE_VFREE_IN_2 = store_thm("FINITE_VFREE_IN_2",
-  ``∀tm. FINITE {(x,ty) | VFREE_IN (Var x ty) tm}``,
+val FINITE_VFREE_IN_2 = Q.store_thm("FINITE_VFREE_IN_2",
+  `∀tm. FINITE {(x,ty) | VFREE_IN (Var x ty) tm}`,
   Induct >> simp[] >- (
     rw[] >>
     qmatch_abbrev_tac`FINITE x` >>
@@ -2406,8 +2406,8 @@ val FINITE_VFREE_IN_list = Q.store_thm("FINITE_VFREE_IN_list",
   simp[FINITE_UNION])
 val _ = export_rewrites["FINITE_VFREE_IN_list"]
 
-val FINITE_MEM_Var = store_thm("FINITE_MEM_Var",
-  ``∀ls. FINITE {(x,ty) | MEM (Var x ty) ls}``,
+val FINITE_MEM_Var = Q.store_thm("FINITE_MEM_Var",
+  `∀ls. FINITE {(x,ty) | MEM (Var x ty) ls}`,
   Induct >> simp[] >>
   Cases >> simp[] >>
   qmatch_assum_abbrev_tac`FINITE P` >>
@@ -2619,8 +2619,8 @@ val variant_inst_thm = save_thm("variant_inst_thm",prove(
   \\ RES_TAC \\ FULL_SIMP_TAC std_ss [])
   |> SIMP_RULE std_ss [] |> SPEC_ALL);
 
-val INST_CORE_Abs_thm = store_thm("INST_CORE_Abs_thm",
-  ``∀v t env tyin. welltyped (Abs v t) ⇒
+val INST_CORE_Abs_thm = Q.store_thm("INST_CORE_Abs_thm",
+  `∀v t env tyin. welltyped (Abs v t) ⇒
    INST_CORE env tyin (Abs v t) =
    (let (x,ty) = dest_var v in
     let ty' = TYPE_SUBST tyin ty in
@@ -2643,7 +2643,7 @@ val INST_CORE_Abs_thm = store_thm("INST_CORE_Abs_thm",
               in
                 if IS_RESULT tres' then
                   Result (Abs (Var x' ty') (RESULT tres'))
-                else tres')))``,
+                else tres')))`,
   rw[] >> simp[Once INST_CORE_def] >> rw[] >>
   unabbrev_all_tac >> fs[] >>
   rfs[GSYM INST_def] >>
@@ -2740,9 +2740,9 @@ val appThm_equation = save_thm("appThm_equation",
   proves_rules |> CONJUNCTS |> el 8
   |> REWRITE_RULE[GSYM AND_IMP_INTRO])
 
-val addAssum = store_thm("addAssum",
-  ``∀thy h c a. (thy,h) |- c ∧ term_ok (sigof thy) a ∧ (a has_type Bool) ⇒
-      (thy,term_union [a] h) |- c``,
+val addAssum = Q.store_thm("addAssum",
+  `∀thy h c a. (thy,h) |- c ∧ term_ok (sigof thy) a ∧ (a has_type Bool) ⇒
+      (thy,term_union [a] h) |- c`,
   rw[] >>
   ho_match_mp_tac (MP_CANON eqMp_equation) >>
   map_every qexists_tac[`c`,`c`] >> simp[] >>
@@ -2785,13 +2785,13 @@ val proves_concl_ACONV = Q.prove(
   Cases_on`thyh`>>fs[]>>
   metis_tac[eqMp_equation,term_union_thm,ACONV_SYM] )
 
-val proves_ACONV_lemma = prove(
-  ``∀thy c h' h1 h.
+val proves_ACONV_lemma = Q.prove(
+  `∀thy c h' h1 h.
     (thy,h1++h) |- c ∧
     hypset_ok (h1++h') ∧
     EVERY (λx. EXISTS (ACONV x) h') h ∧
     EVERY (λx. term_ok (sigof thy) x ∧ x has_type Bool) h'
-    ⇒ (thy,h1++h') |- c``,
+    ⇒ (thy,h1++h') |- c`,
   ntac 2 gen_tac >> Induct >> rw[] >> rw[] >>
   imp_res_tac proves_term_ok >> fs[hypset_ok_cons] >>
   Cases_on`EXISTS (ACONV h) h''` >- (
@@ -2871,13 +2871,13 @@ val proves_ACONV_lemma = prove(
     metis_tac[ACONV_SYM] ) >>
   metis_tac[rich_listTheory.CONS_APPEND,APPEND_ASSOC])
 
-val proves_ACONV = store_thm("proves_ACONV",
-  ``∀thy h' c' h c.
+val proves_ACONV = Q.store_thm("proves_ACONV",
+  `∀thy h' c' h c.
       (thy,h) |- c ∧ welltyped c' ∧ ACONV c c' ∧
       hypset_ok h' ∧
       EVERY (λx. EXISTS (ACONV x) h') h ∧
       EVERY (λx. term_ok (sigof thy) x ∧ x has_type Bool) h'
-      ⇒ (thy,h') |- c'``,
+      ⇒ (thy,h') |- c'`,
   rw[] >>
   qsuff_tac`(thy,h') |- c` >- metis_tac[proves_concl_ACONV] >>
   qpat_x_assum`welltyped c'`kall_tac >>
@@ -2927,12 +2927,12 @@ val sym = Q.store_thm("sym",
   metis_tac[equation_def,sym_equation])
 
 (* TODO: Use this to close issue #97 *)
-val trans_equation = store_thm("trans_equation",
-  ``∀thy h1 h2 t1 t2a t2b t3.
+val trans_equation = Q.store_thm("trans_equation",
+  `∀thy h1 h2 t1 t2a t2b t3.
       (thy,h2) |- t2b === t3 ⇒
       (thy,h1) |- t1 === t2a ⇒
       ACONV t2a t2b ⇒
-      (thy,term_union h1 h2) |- t1 === t3``,
+      (thy,term_union h1 h2) |- t1 === t3`,
   rw[] >>
   imp_res_tac proves_theory_ok >> fs[] >>
   imp_res_tac theory_ok_sig >>
@@ -2957,20 +2957,20 @@ val trans_equation = store_thm("trans_equation",
     simp[GSYM ACONV_def] ) >>
   metis_tac[sym_equation])
 
-val trans = store_thm("trans",
-  ``∀thy h1 h2 t1 t2a t2b t3 ty.
+val trans = Q.store_thm("trans",
+  `∀thy h1 h2 t1 t2a t2b t3 ty.
       (thy,h2) |- Comb (Comb (Equal ty) t2b) t3 ⇒
       (thy,h1) |- Comb (Comb (Equal ty) t1) t2a ⇒
       ACONV t2a t2b ⇒
-      (thy,term_union h1 h2) |- Comb (Comb (Equal ty) t1) t3``,
+      (thy,term_union h1 h2) |- Comb (Comb (Equal ty) t1) t3`,
   rw[] >>
   imp_res_tac proves_term_ok >> fs[] >>
   imp_res_tac term_ok_welltyped >> fs[] >>
   metis_tac[trans_equation,equation_def])
 
-val proveHyp = store_thm("proveHyp",
-  ``∀thy h1 c1 h2 c2. (thy,h1) |- c1 ∧ (thy,h2) |- c2 ⇒
-      (thy,term_union h2 (term_remove c2 h1)) |- c1``,
+val proveHyp = Q.store_thm("proveHyp",
+  `∀thy h1 c1 h2 c2. (thy,h1) |- c1 ∧ (thy,h2) |- c2 ⇒
+      (thy,term_union h2 (term_remove c2 h1)) |- c1`,
   rw[] >>
   imp_res_tac proves_term_ok >>
   imp_res_tac proves_theory_ok >> fs[] >>
@@ -3063,11 +3063,11 @@ val type_ok_extend = Q.store_thm("type_ok_extend",
   res_tac >>
   imp_res_tac FLOOKUP_SUBMAP)
 
-val term_ok_extend = store_thm("term_ok_extend",
-  ``∀t tyenv tmenv tyenv' tmenv'.
+val term_ok_extend = Q.store_thm("term_ok_extend",
+  `∀t tyenv tmenv tyenv' tmenv'.
     tyenv ⊑ tyenv' ∧ tmenv ⊑ tmenv' ∧
     term_ok (tyenv,tmenv) t ⇒
-    term_ok (tyenv',tmenv') t``,
+    term_ok (tyenv',tmenv') t`,
   Induct >> simp[term_ok_def] >> rw[] >>
   imp_res_tac type_ok_extend >>
   imp_res_tac FLOOKUP_SUBMAP >>
@@ -3082,10 +3082,10 @@ val term_ok_updates = Q.store_thm("term_ok_updates",
   simp[] >> conj_tac >> match_mp_tac finite_mapTheory.SUBMAP_FUNION >>
   metis_tac[updates_DISJOINT,finite_mapTheory.SUBMAP_REFL,pred_setTheory.DISJOINT_SYM])
 
-val is_std_sig_extend = store_thm("is_std_sig_extend",
-  ``∀tyenv tmenv tyenv' tmenv'.
+val is_std_sig_extend = Q.store_thm("is_std_sig_extend",
+  `∀tyenv tmenv tyenv' tmenv'.
     is_std_sig (tyenv,tmenv) ∧ tyenv ⊑ tyenv' ∧ tmenv ⊑ tmenv' ⇒
-    is_std_sig (tyenv',tmenv')``,
+    is_std_sig (tyenv',tmenv')`,
   rw[is_std_sig_def] >> imp_res_tac FLOOKUP_SUBMAP)
 
 (* updates preserve ok *)
@@ -3445,11 +3445,11 @@ val update_extension = Q.prove (
       >- (Cases_on `ctxt` >>
           fs [])));
 
-val updates_proves = store_thm("updates_proves",
-  ``∀upd ctxt.  upd updates ctxt ⇒
+val updates_proves = Q.store_thm("updates_proves",
+  `∀upd ctxt.  upd updates ctxt ⇒
     ∀h c.
     (thyof ctxt,h) |- c ⇒
-    (thyof (upd::ctxt),h) |- c``,
+    (thyof (upd::ctxt),h) |- c`,
   metis_tac[update_extension])
 
 (* types occurring in a term *)
@@ -3569,8 +3569,8 @@ val arities_match_append = Q.store_thm("arities_match_append",
   ho_match_mp_tac arities_match_ind >>
   simp[arities_match_def])
 
-val tymatch_SOME = store_thm("tymatch_SOME",
-  ``∀ps obs sids s' ids'.
+val tymatch_SOME = Q.store_thm("tymatch_SOME",
+  `∀ps obs sids s' ids'.
      arities_match ps obs ∧
       DISJOINT (set (MAP SND (FST sids))) (set (MAP Tyvar (SND sids))) ∧
       (∀name. ¬MEM (Tyvar name,Tyvar name) (FST sids)) ∧
@@ -3581,7 +3581,7 @@ val tymatch_SOME = store_thm("tymatch_SOME",
          DISJOINT (set (MAP SND s')) (set (MAP Tyvar ids')) ∧
          (∀name. ¬MEM (Tyvar name,Tyvar name) s') ∧
          ALL_DISTINCT (MAP SND s') ∧
-         (MAP (TYPE_SUBST s') ps = obs)``,
+         (MAP (TYPE_SUBST s') ps = obs)`,
   ho_match_mp_tac tymatch_ind >>
   simp[tymatch_def,arities_match_def] >>
   conj_tac >- (

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -14,15 +14,15 @@ val _ = Parse.overload_on("Bool",``Tyapp (strlit "bool") []``)
 val domain_raw = Define `
   domain ty = case ty of Tyapp n (x::xs) => x | _ => ty`;
 
-val domain_def = store_thm("domain_def",
-  ``!t s. domain (Fun s t) = s``,
+val domain_def = Q.store_thm("domain_def",
+  `!t s. domain (Fun s t) = s`,
   REPEAT STRIP_TAC \\ EVAL_TAC);
 
 val codomain_raw = Define `
   codomain ty = case ty of Tyapp n (y::x::xs) => x | _ => ty`;
 
-val codomain_def = store_thm("codomain_def",
-  ``!t s. codomain (Fun s t) = t``,
+val codomain_def = Q.store_thm("codomain_def",
+  `!t s. codomain (Fun s t) = t`,
   REPEAT STRIP_TAC \\ EVAL_TAC);
 
 val _ = save_thm("domain_raw",domain_raw);
@@ -203,8 +203,8 @@ val CLOSED_def = Define`
 (* Producing a variant of a variable, guaranteed
    to not be free in a given term. *)
 
-val VFREE_IN_FINITE = store_thm("VFREE_IN_FINITE",
-  ``∀t. FINITE {x | VFREE_IN x t}``,
+val VFREE_IN_FINITE = Q.store_thm("VFREE_IN_FINITE",
+  `∀t. FINITE {x | VFREE_IN x t}`,
   Induct >> simp[VFREE_IN_def] >- (
     qmatch_abbrev_tac`FINITE z` >>
     qmatch_assum_abbrev_tac`FINITE x` >>
@@ -219,23 +219,23 @@ val VFREE_IN_FINITE = store_thm("VFREE_IN_FINITE",
   simp[Abbr`z`,Abbr`x`,EXTENSION] >>
   metis_tac[IN_SING])
 
-val VFREE_IN_FINITE_ALT = store_thm("VFREE_IN_FINITE_ALT",
-  ``∀t ty. FINITE {x | VFREE_IN (Var (implode x) ty) t}``,
+val VFREE_IN_FINITE_ALT = Q.store_thm("VFREE_IN_FINITE_ALT",
+  `∀t ty. FINITE {x | VFREE_IN (Var (implode x) ty) t}`,
   rw[] >> match_mp_tac (MP_CANON SUBSET_FINITE) >>
   qexists_tac`IMAGE (λt. case t of Var x y => explode x) {x | VFREE_IN x t}` >>
   simp[VFREE_IN_FINITE,IMAGE_FINITE] >>
   simp[SUBSET_DEF] >> rw[] >>
   HINT_EXISTS_TAC >> simp[explode_implode])
 
-val PRIMED_NAME_EXISTS = store_thm("PRIMED_NAME_EXISTS",
-  ``∃n. ¬(VFREE_IN (Var (implode (APPEND x (GENLIST (K #"'") n))) ty) t)``,
+val PRIMED_NAME_EXISTS = Q.store_thm("PRIMED_NAME_EXISTS",
+  `∃n. ¬(VFREE_IN (Var (implode (APPEND x (GENLIST (K #"'") n))) ty) t)`,
   qspecl_then[`t`,`ty`]mp_tac VFREE_IN_FINITE_ALT >>
   disch_then(mp_tac o CONJ PRIMED_INFINITE) >>
   disch_then(mp_tac o MATCH_MP INFINITE_DIFF_FINITE) >>
   simp[GSYM MEMBER_NOT_EMPTY] >> rw[] >> metis_tac[])
 
-val LEAST_EXISTS = prove(
-  ``(∃n:num. P n) ⇒ ∃k. P k ∧ ∀m. m < k ⇒ ¬(P m)``,
+val LEAST_EXISTS = Q.prove(
+  `(∃n:num. P n) ⇒ ∃k. P k ∧ ∀m. m < k ⇒ ¬(P m)`,
   metis_tac[whileTheory.LEAST_EXISTS])
 
 val VARIANT_PRIMES_def = new_specification
@@ -249,8 +249,8 @@ val VARIANT_PRIMES_def = new_specification
 val VARIANT_def = Define`
   VARIANT t x ty = implode (APPEND x (GENLIST (K #"'") (VARIANT_PRIMES t x ty)))`
 
-val VARIANT_THM = store_thm("VARIANT_THM",
-  ``∀t x ty. ¬VFREE_IN (Var (VARIANT t x ty) ty) t``,
+val VARIANT_THM = Q.store_thm("VARIANT_THM",
+  `∀t x ty. ¬VFREE_IN (Var (VARIANT t x ty) ty) t`,
   metis_tac[VARIANT_def,VARIANT_PRIMES_def])
 
 (* Substitution for type variables in a type. *)
@@ -301,8 +301,8 @@ val SIZEOF_VSUBST = store_thm("SIZEOF_VSUBST",
   simp[MEM_FILTER] >>
   rw[] >> res_tac >> fs[] )
 
-val sizeof_positive = store_thm("sizeof_positive",
-  ``∀t. 0 < sizeof t``,
+val sizeof_positive = Q.store_thm("sizeof_positive",
+  `∀t. 0 < sizeof t`,
   Induct >> simp[])
 
 (* Instantiation of type variables in terms *)

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -289,9 +289,9 @@ val sizeof_def = Define`
   sizeof (Abs v t) = 2 + sizeof t`
 val _ = export_rewrites["sizeof_def"]
 
-val SIZEOF_VSUBST = store_thm("SIZEOF_VSUBST",
-  ``∀t ilist. (∀s' s. MEM (s',s) ilist ⇒ ∃x ty. s' = Var x ty)
-              ⇒ sizeof (VSUBST ilist t) = sizeof t``,
+val SIZEOF_VSUBST = Q.store_thm("SIZEOF_VSUBST",
+  `∀t ilist. (∀s' s. MEM (s',s) ilist ⇒ ∃x ty. s' = Var x ty)
+              ⇒ sizeof (VSUBST ilist t) = sizeof t`,
   Induct >> simp[VSUBST_def] >> rw[VSUBST_def] >> simp[] >- (
     Q.ISPECL_THEN[`ilist`,`Var m t`,`Var m t`]mp_tac REV_ASSOCD_MEM >>
     rw[] >> res_tac >> pop_assum SUBST1_TAC >> simp[] )

--- a/candle/syntax-lib/holSyntaxLibScript.sml
+++ b/candle/syntax-lib/holSyntaxLibScript.sml
@@ -13,8 +13,8 @@ val ALPHAVARS_REFL = store_thm("ALPHAVARS_REFL",
   ``∀env t. EVERY (UNCURRY $=) env ==> ALPHAVARS env (t,t)``,
   Induct >> simp[ALPHAVARS_def,FORALL_PROD])
 
-val ALPHAVARS_MEM = store_thm("ALPHAVARS_MEM",
-  ``∀env tp. ALPHAVARS env tp ⇒ MEM tp env ∨ (FST tp = SND tp)``,
+val ALPHAVARS_MEM = Q.store_thm("ALPHAVARS_MEM",
+  `∀env tp. ALPHAVARS env tp ⇒ MEM tp env ∨ (FST tp = SND tp)`,
    Induct >> simp[ALPHAVARS_def] >> rw[] >> res_tac >> simp[])
 
 val REV_ASSOCD_def = Define`
@@ -32,8 +32,8 @@ val REV_ASSOCD_ALOOKUP = store_thm("REV_ASSOCD_ALOOKUP",
   Induct >> simp[REV_ASSOCD] >>
   Cases >> simp[REV_ASSOCD] >> rw[])
 
-val PRIMED_INFINITE = store_thm("PRIMED_INFINITE",
-  ``INFINITE (IMAGE (λn. APPEND x (GENLIST (K #"'") n)) UNIV)``,
+val PRIMED_INFINITE = Q.store_thm("PRIMED_INFINITE",
+  `INFINITE (IMAGE (λn. APPEND x (GENLIST (K #"'") n)) UNIV)`,
   match_mp_tac (MP_CANON IMAGE_11_INFINITE) >>
   simp[] >> Induct >- metis_tac[NULL_EQ,NULL_GENLIST] >>
   simp[GENLIST_CONS] >> qx_gen_tac`y` >>
@@ -51,8 +51,8 @@ val REV_ASSOCD_MEM = store_thm("REV_ASSOCD_MEM",
   ``∀l x d. MEM (REV_ASSOCD x l d,x) l ∨ (REV_ASSOCD x l d = d)``,
   Induct >> simp[REV_ASSOCD,FORALL_PROD] >>rw[]>>fs[])
 
-val tyvar_inst_exists = store_thm("tyvar_inst_exists",
-  ``∃i. ty = REV_ASSOCD tyvar i b``,
+val tyvar_inst_exists = Q.store_thm("tyvar_inst_exists",
+  `∃i. ty = REV_ASSOCD tyvar i b`,
   qexists_tac`[(ty,tyvar)]` >> rw[REV_ASSOCD])
 
 val _ = Hol_datatype`result = Clash of 'a | Result of 'a`
@@ -73,79 +73,79 @@ val CLASH_def = Define`
 
 val _ = export_rewrites["IS_RESULT_def","IS_CLASH_def","RESULT_def","CLASH_def"]
 
-val NOT_IS_CLASH_IS_RESULT = store_thm("NOT_IS_CLASH_IS_RESULT",
-  ``∀x. IS_CLASH x ⇔ ¬IS_RESULT x``,
+val NOT_IS_CLASH_IS_RESULT = Q.store_thm("NOT_IS_CLASH_IS_RESULT",
+  `∀x. IS_CLASH x ⇔ ¬IS_RESULT x`,
   Cases >> simp[])
 
-val RESULT_eq_suff = store_thm("RESULT_eq_suff",
-  ``x = Result y ⇒ RESULT x = y``,
+val RESULT_eq_suff = Q.store_thm("RESULT_eq_suff",
+  `x = Result y ⇒ RESULT x = y`,
   Cases_on`x`>>simp[])
 
-val IS_CLASH_IMP = store_thm("IS_CLASH_IMP",
-  ``!x. IS_CLASH x ==> !tm. ~(x = Result tm)``,
+val IS_CLASH_IMP = Q.store_thm("IS_CLASH_IMP",
+  `!x. IS_CLASH x ==> !tm. ~(x = Result tm)`,
   Cases \\ simp[])
 
-val NOT_IS_CLASH_IMP = store_thm("NOT_IS_CLASH_IMP",
-  ``!x. ~IS_CLASH x ==> !tm. ~(x = Clash tm)``,
+val NOT_IS_CLASH_IMP = Q.store_thm("NOT_IS_CLASH_IMP",
+  `!x. ~IS_CLASH x ==> !tm. ~(x = Clash tm)`,
   Cases \\ simp[])
 
-val IS_RESULT_IMP = store_thm("IS_RESULT_IMP",
-  ``!x. IS_RESULT x ==> (!tm. ~(x = Clash tm))``,
+val IS_RESULT_IMP = Q.store_thm("IS_RESULT_IMP",
+  `!x. IS_RESULT x ==> (!tm. ~(x = Clash tm))`,
   Cases \\ simp[])
 
-val NOT_IS_RESULT_IMP_Clash = store_thm("NOT_IS_RESULT_IMP_Clash",
-  ``!x. ~IS_RESULT x ==> ?var. x = Clash var``,
+val NOT_IS_RESULT_IMP_Clash = Q.store_thm("NOT_IS_RESULT_IMP_Clash",
+  `!x. ~IS_RESULT x ==> ?var. x = Clash var`,
   Cases \\ simp[])
 
-val IS_RESULT_IMP_Result = store_thm("IS_RESULT_IMP_Result",
-  ``!x. IS_RESULT x ==> ?res. x = Result res``,
+val IS_RESULT_IMP_Result = Q.store_thm("IS_RESULT_IMP_Result",
+  `!x. IS_RESULT x ==> ?res. x = Result res`,
   Cases \\ simp[])
 
-val NOT_IS_CLASH_IMP_Result = store_thm("NOT_IS_CLASH_IMP_Result",
-  ``!x. ~IS_CLASH x ==> ?res. x = Result res``,
+val NOT_IS_CLASH_IMP_Result = Q.store_thm("NOT_IS_CLASH_IMP_Result",
+  `!x. ~IS_CLASH x ==> ?res. x = Result res`,
   Cases \\ simp[])
 
 val LIST_INSERT_def = Define`
   LIST_INSERT x xs = if MEM x xs then xs else x::xs`
 
-val MEM_LIST_INSERT = store_thm("MEM_LIST_INSERT",
-  ``∀l x. set (LIST_INSERT x l) = x INSERT set l``,
+val MEM_LIST_INSERT = Q.store_thm("MEM_LIST_INSERT",
+  `∀l x. set (LIST_INSERT x l) = x INSERT set l`,
   Induct >> simp[LIST_INSERT_def] >> rw[] >>
   rw[EXTENSION] >> metis_tac[])
 
 val LIST_UNION_def = Define`
   LIST_UNION xs ys = FOLDR LIST_INSERT ys xs`
 
-val MEM_LIST_UNION = store_thm("MEM_LIST_UNION",
-  ``∀l1 l2. set (LIST_UNION l1 l2) = set l1 ∪ set l2``,
+val MEM_LIST_UNION = Q.store_thm("MEM_LIST_UNION",
+  `∀l1 l2. set (LIST_UNION l1 l2) = set l1 ∪ set l2`,
   Induct >> fs[LIST_UNION_def,MEM_LIST_INSERT] >>
   rw[EXTENSION] >> metis_tac[])
 
-val MEM_FOLDR_LIST_UNION = store_thm("MEM_FOLDR_LIST_UNION",
-  ``∀ls x f b. MEM x (FOLDR (λx y. LIST_UNION (f x) y) b ls) ⇔ MEM x b ∨ ∃y. MEM y ls ∧ MEM x (f y)``,
+val MEM_FOLDR_LIST_UNION = Q.store_thm("MEM_FOLDR_LIST_UNION",
+  `∀ls x f b. MEM x (FOLDR (λx y. LIST_UNION (f x) y) b ls) ⇔ MEM x b ∨ ∃y. MEM y ls ∧ MEM x (f y)`,
   Induct >> simp[MEM_LIST_UNION] >> metis_tac[])
 
-val ALL_DISTINCT_LIST_UNION = store_thm("ALL_DISTINCT_LIST_UNION",
-  ``∀l1 l2. ALL_DISTINCT l2 ⇒ ALL_DISTINCT (LIST_UNION l1 l2)``,
+val ALL_DISTINCT_LIST_UNION = Q.store_thm("ALL_DISTINCT_LIST_UNION",
+  `∀l1 l2. ALL_DISTINCT l2 ⇒ ALL_DISTINCT (LIST_UNION l1 l2)`,
   Induct >> fs[LIST_UNION_def,LIST_INSERT_def] >> rw[])
 
-val LIST_UNION_NIL = store_thm("LIST_UNION_NIL",
-  ``∀l2. (LIST_UNION [] l2 = l2)``,
+val LIST_UNION_NIL = Q.store_thm("LIST_UNION_NIL",
+  `∀l2. (LIST_UNION [] l2 = l2)`,
   simp[LIST_UNION_def] )
 val _ = export_rewrites["LIST_UNION_NIL"]
 
-val set_LIST_UNION = store_thm("set_LIST_UNION",
-  ``∀l1 l2. set (LIST_UNION l1 l2) = set l1 ∪ set l2``,
+val set_LIST_UNION = Q.store_thm("set_LIST_UNION",
+  `∀l1 l2. set (LIST_UNION l1 l2) = set l1 ∪ set l2`,
   rw[EXTENSION,MEM_LIST_UNION])
 val _ = export_rewrites["set_LIST_UNION"]
 
-val LIST_UNION_NIL_2 = store_thm("LIST_UNION_NIL_2",
-  ``∀ls. ALL_DISTINCT ls ⇒ LIST_UNION ls [] = ls``,
+val LIST_UNION_NIL_2 = Q.store_thm("LIST_UNION_NIL_2",
+  `∀ls. ALL_DISTINCT ls ⇒ LIST_UNION ls [] = ls`,
   Induct >> simp[LIST_UNION_def,LIST_INSERT_def] >>
   rw[] >> fs[] >> rfs[LIST_UNION_def])
 
-val LIST_UNION_same = store_thm("LIST_UNION_same",
-  ``∀l1 l2. set l1 ⊆ set l2 ⇒ LIST_UNION l1 l2 = l2``,
+val LIST_UNION_same = Q.store_thm("LIST_UNION_same",
+  `∀l1 l2. set l1 ⊆ set l2 ⇒ LIST_UNION l1 l2 = l2`,
   Induct >> simp[LIST_UNION_def] >>
   fs[pred_setTheory.SUBSET_DEF] >>
   fs[LIST_UNION_def,LIST_INSERT_def])
@@ -155,8 +155,8 @@ val INORDER_INSERT_def = Define`
     APPEND (FILTER (λy. string_lt y x) xs)
    (APPEND [x] (FILTER (λy. string_lt x y) xs))`
 
-val LENGTH_INORDER_INSERT = prove(
-  ``!xs. ALL_DISTINCT (x::xs) ==> (LENGTH (INORDER_INSERT x xs) = SUC (LENGTH xs))``,
+val LENGTH_INORDER_INSERT = Q.prove(
+  `!xs. ALL_DISTINCT (x::xs) ==> (LENGTH (INORDER_INSERT x xs) = SUC (LENGTH xs))`,
   FULL_SIMP_TAC std_ss [INORDER_INSERT_def,LENGTH_APPEND,LENGTH]
   \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [DECIDE ``1 + n = SUC n``]
@@ -168,21 +168,21 @@ val LENGTH_INORDER_INSERT = prove(
   \\ Cases_on `x = y` \\ FULL_SIMP_TAC std_ss []
   \\ METIS_TAC [stringTheory.string_lt_cases,stringTheory.string_lt_antisym]);
 
-val ALL_DISTINCT_INORDER_INSERT = prove(
-  ``!xs h. ALL_DISTINCT xs ==> ALL_DISTINCT (INORDER_INSERT h xs)``,
+val ALL_DISTINCT_INORDER_INSERT = Q.prove(
+  `!xs h. ALL_DISTINCT xs ==> ALL_DISTINCT (INORDER_INSERT h xs)`,
   FULL_SIMP_TAC (srw_ss()) [ALL_DISTINCT,INORDER_INSERT_def,
     ALL_DISTINCT_APPEND,MEM_FILTER] \\ REPEAT STRIP_TAC
   \\ TRY (MATCH_MP_TAC FILTER_ALL_DISTINCT)
   \\ FULL_SIMP_TAC (srw_ss()) [stringTheory.string_lt_nonrefl]
   \\ METIS_TAC [stringTheory.string_lt_antisym]);
 
-val ALL_DISTINCT_FOLDR_INORDER_INSERT = prove(
-  ``!xs. ALL_DISTINCT (FOLDR INORDER_INSERT [] xs)``,
+val ALL_DISTINCT_FOLDR_INORDER_INSERT = Q.prove(
+  `!xs. ALL_DISTINCT (FOLDR INORDER_INSERT [] xs)`,
   Induct \\ SIMP_TAC std_ss [ALL_DISTINCT,FOLDR] \\ REPEAT STRIP_TAC
   \\ MATCH_MP_TAC ALL_DISTINCT_INORDER_INSERT \\ FULL_SIMP_TAC std_ss []);
 
-val MEM_FOLDR_INORDER_INSERT = store_thm("MEM_FOLDR_INORDER_INSERT",
-  ``!xs x. MEM x (FOLDR INORDER_INSERT [] xs) = MEM x xs``,
+val MEM_FOLDR_INORDER_INSERT = Q.store_thm("MEM_FOLDR_INORDER_INSERT",
+  `!xs x. MEM x (FOLDR INORDER_INSERT [] xs) = MEM x xs`,
   Induct \\ FULL_SIMP_TAC std_ss [FOLDR,INORDER_INSERT_def,MEM,MEM_APPEND,
     MEM_FILTER] \\ METIS_TAC [stringTheory.string_lt_cases]);
 val _ = export_rewrites["MEM_FOLDR_INORDER_INSERT"]
@@ -190,8 +190,8 @@ val _ = export_rewrites["MEM_FOLDR_INORDER_INSERT"]
 val STRING_SORT_def = Define`
   STRING_SORT xs = FOLDR INORDER_INSERT [] xs`
 
-val PERM_STRING_SORT = store_thm("PERM_STRING_SORT",
-  ``∀ls. ALL_DISTINCT ls ⇒ PERM ls (STRING_SORT ls)``,
+val PERM_STRING_SORT = Q.store_thm("PERM_STRING_SORT",
+  `∀ls. ALL_DISTINCT ls ⇒ PERM ls (STRING_SORT ls)`,
   Induct >>
   simp[STRING_SORT_def] >>
   simp[INORDER_INSERT_def] >>
@@ -206,20 +206,20 @@ val PERM_STRING_SORT = store_thm("PERM_STRING_SORT",
   simp[Abbr`A`,Abbr`B`,MEM_FILTER] >>
   metis_tac[FILTER_ALL_DISTINCT,ALL_DISTINCT_PERM,string_lt_antisym,string_lt_cases,MEM_PERM] )
 
-val LENGTH_STRING_SORT = store_thm("LENGTH_STRING_SORT",
-  ``∀ls. ALL_DISTINCT ls ⇒ (LENGTH (STRING_SORT ls) = LENGTH ls)``,
+val LENGTH_STRING_SORT = Q.store_thm("LENGTH_STRING_SORT",
+  `∀ls. ALL_DISTINCT ls ⇒ (LENGTH (STRING_SORT ls) = LENGTH ls)`,
   metis_tac[PERM_STRING_SORT,PERM_LENGTH])
 val _ = export_rewrites["LENGTH_STRING_SORT"]
 
-val MEM_STRING_SORT = store_thm("MEM_STRING_SORT",
-  ``∀ls. set (STRING_SORT ls) = set ls``,
+val MEM_STRING_SORT = Q.store_thm("MEM_STRING_SORT",
+  `∀ls. set (STRING_SORT ls) = set ls`,
   Induct >>
   simp[STRING_SORT_def,INORDER_INSERT_def,EXTENSION,MEM_FILTER] >>
   rw[] >> metis_tac[string_lt_cases])
 val _ = export_rewrites["MEM_STRING_SORT"]
 
-val ALL_DISTINCT_STRING_SORT = store_thm("ALL_DISTINCT_STRING_SORT",
-  ``!xs. ALL_DISTINCT (STRING_SORT xs)``,
+val ALL_DISTINCT_STRING_SORT = Q.store_thm("ALL_DISTINCT_STRING_SORT",
+  `!xs. ALL_DISTINCT (STRING_SORT xs)`,
   Induct
   >> FULL_SIMP_TAC std_ss [STRING_SORT_def,FOLDR,ALL_DISTINCT,INORDER_INSERT_def]
   >> FULL_SIMP_TAC std_ss [ALL_DISTINCT_APPEND,MEM_FILTER,MEM,MEM_APPEND,
@@ -231,8 +231,8 @@ val ALL_DISTINCT_STRING_SORT = store_thm("ALL_DISTINCT_STRING_SORT",
         stringTheory.string_lt_cases]);
 val _ = export_rewrites["ALL_DISTINCT_STRING_SORT"]
 
-val STRING_SORT_SORTED = store_thm("STRING_SORT_SORTED",
-  ``∀ls. SORTED $< (STRING_SORT ls)``,
+val STRING_SORT_SORTED = Q.store_thm("STRING_SORT_SORTED",
+  `∀ls. SORTED $< (STRING_SORT ls)`,
   Induct >> simp[STRING_SORT_def,INORDER_INSERT_def] >>
   rw[] >> match_mp_tac SORTED_APPEND >>
   conj_asm1_tac >- METIS_TAC [string_lt_trans,relationTheory.transitive_def] >>
@@ -244,9 +244,9 @@ val STRING_SORT_SORTED = store_thm("STRING_SORT_SORTED",
   rw[] >> fs[relationTheory.transitive_def] >>
   METIS_TAC[])
 
-val STRING_SORT_EQ = store_thm("STRING_SORT_EQ",
-  ``∀l1 l2. ALL_DISTINCT l1 ∧ ALL_DISTINCT l2 ⇒
-      (STRING_SORT l1 = STRING_SORT l2 ⇔ PERM l1 l2)``,
+val STRING_SORT_EQ = Q.store_thm("STRING_SORT_EQ",
+  `∀l1 l2. ALL_DISTINCT l1 ∧ ALL_DISTINCT l2 ⇒
+      (STRING_SORT l1 = STRING_SORT l2 ⇔ PERM l1 l2)`,
   rw[] >>
   imp_res_tac PERM_STRING_SORT >>
   `transitive string_lt ∧ antisymmetric string_lt` by (
@@ -256,20 +256,20 @@ val STRING_SORT_EQ = store_thm("STRING_SORT_EQ",
     by METIS_TAC[STRING_SORT_SORTED] >>
   METIS_TAC[SORTED_PERM_EQ,PERM_REFL,PERM_SYM,PERM_TRANS])
 
-val ALL_DISTINCT_LIST_UNION = store_thm("ALL_DISTINCT_LIST_UNION",
-  ``∀l1 l2. ALL_DISTINCT l2 ⇒ ALL_DISTINCT (LIST_UNION l1 l2)``,
+val ALL_DISTINCT_LIST_UNION = Q.store_thm("ALL_DISTINCT_LIST_UNION",
+  `∀l1 l2. ALL_DISTINCT l2 ⇒ ALL_DISTINCT (LIST_UNION l1 l2)`,
   Induct >> fs[LIST_UNION_def,LIST_INSERT_def] >> rw[])
 
-val set_MAP_implode_STRING_SORT_MAP_explode = store_thm("set_MAP_implode_STRING_SORT_MAP_explode",
-  ``set (MAP implode (STRING_SORT (MAP explode ls))) = set ls``,
+val set_MAP_implode_STRING_SORT_MAP_explode = Q.store_thm("set_MAP_implode_STRING_SORT_MAP_explode",
+  `set (MAP implode (STRING_SORT (MAP explode ls))) = set ls`,
   rw[EXTENSION,MEM_MAP,PULL_EXISTS,mlstringTheory.implode_explode])
 
 val mlstring_sort_def = Define`
   mlstring_sort ls = MAP implode (STRING_SORT (MAP explode ls))`
 
-val mlstring_sort_eq = store_thm("mlstring_sort_eq",
-  ``∀l1 l2. ALL_DISTINCT l1 ∧ ALL_DISTINCT l2 ⇒
-    ((mlstring_sort l1 = mlstring_sort l2) ⇔ PERM l1 l2)``,
+val mlstring_sort_eq = Q.store_thm("mlstring_sort_eq",
+  `∀l1 l2. ALL_DISTINCT l1 ∧ ALL_DISTINCT l2 ⇒
+    ((mlstring_sort l1 = mlstring_sort l2) ⇔ PERM l1 l2)`,
   rw[mlstring_sort_def] >>
   qspecl_then[`l1`,`l2`]mp_tac(MATCH_MP PERM_MAP_BIJ mlstringTheory.explode_BIJ) >>
   disch_then SUBST1_TAC >>

--- a/candle/syntax-lib/holSyntaxLibScript.sml
+++ b/candle/syntax-lib/holSyntaxLibScript.sml
@@ -9,8 +9,8 @@ val ALPHAVARS_def = Define`
     (tmp = tp) ∨
     (FST tp ≠ FST tmp) ∧ (SND tp ≠ SND tmp) ∧ ALPHAVARS oenv tmp)`
 
-val ALPHAVARS_REFL = store_thm("ALPHAVARS_REFL",
-  ``∀env t. EVERY (UNCURRY $=) env ==> ALPHAVARS env (t,t)``,
+val ALPHAVARS_REFL = Q.store_thm("ALPHAVARS_REFL",
+  `∀env t. EVERY (UNCURRY $=) env ==> ALPHAVARS env (t,t)`,
   Induct >> simp[ALPHAVARS_def,FORALL_PROD])
 
 val ALPHAVARS_MEM = Q.store_thm("ALPHAVARS_MEM",
@@ -21,14 +21,14 @@ val REV_ASSOCD_def = Define`
   (REV_ASSOCD a [] d = d) ∧
   (REV_ASSOCD a (p::t) d = if SND p = a then FST p else REV_ASSOCD a t d)`
 
-val REV_ASSOCD = store_thm("REV_ASSOCD",
-  ``(∀a d. REV_ASSOCD a [] d = d) ∧
+val REV_ASSOCD = Q.store_thm("REV_ASSOCD",
+  `(∀a d. REV_ASSOCD a [] d = d) ∧
     (∀a x y t d. REV_ASSOCD a ((x,y)::t) d =
-                 if y = a then x else REV_ASSOCD a t d)``,
+                 if y = a then x else REV_ASSOCD a t d)`,
   rw[REV_ASSOCD_def])
 
-val REV_ASSOCD_ALOOKUP = store_thm("REV_ASSOCD_ALOOKUP",
-  ``∀ls x d. REV_ASSOCD x ls d = case ALOOKUP (MAP (λ(x,y). (y,x)) ls) x of NONE => d | SOME y => y``,
+val REV_ASSOCD_ALOOKUP = Q.store_thm("REV_ASSOCD_ALOOKUP",
+  `∀ls x d. REV_ASSOCD x ls d = case ALOOKUP (MAP (λ(x,y). (y,x)) ls) x of NONE => d | SOME y => y`,
   Induct >> simp[REV_ASSOCD] >>
   Cases >> simp[REV_ASSOCD] >> rw[])
 
@@ -40,15 +40,15 @@ val PRIMED_INFINITE = Q.store_thm("PRIMED_INFINITE",
   Cases_on`GENLIST (K #"'") y`>>simp[]>>rw[]>>
   Cases_on`y`>>fs[GENLIST_CONS])
 
-val REV_ASSOCD_FILTER = store_thm("REV_ASSOCD_FILTER",
-  ``∀l a b d.
+val REV_ASSOCD_FILTER = Q.store_thm("REV_ASSOCD_FILTER",
+  `∀l a b d.
       REV_ASSOCD a (FILTER (λ(y,x). P x) l) b =
-        if P a then REV_ASSOCD a l b else b``,
+        if P a then REV_ASSOCD a l b else b`,
   Induct >> simp[REV_ASSOCD,FORALL_PROD] >>
   rw[] >> fs[FORALL_PROD,REV_ASSOCD] >> rw[] >> fs[])
 
-val REV_ASSOCD_MEM = store_thm("REV_ASSOCD_MEM",
-  ``∀l x d. MEM (REV_ASSOCD x l d,x) l ∨ (REV_ASSOCD x l d = d)``,
+val REV_ASSOCD_MEM = Q.store_thm("REV_ASSOCD_MEM",
+  `∀l x d. MEM (REV_ASSOCD x l d,x) l ∨ (REV_ASSOCD x l d = d)`,
   Induct >> simp[REV_ASSOCD,FORALL_PROD] >>rw[]>>fs[])
 
 val tyvar_inst_exists = Q.store_thm("tyvar_inst_exists",

--- a/characteristic/cfAppScript.sml
+++ b/characteristic/cfAppScript.sml
@@ -223,11 +223,11 @@ val spec_def = Define `
 (*------------------------------------------------------------------*)
 (* Relating [app] to [_ --> _] from the translator *)
 
-val Arrow_IMP_app_basic = store_thm("Arrow_IMP_app_basic",
-  ``(a --> b) f v ==>
+val Arrow_IMP_app_basic = Q.store_thm("Arrow_IMP_app_basic",
+  `(a --> b) f v ==>
     !x v1.
       a x v1 ==>
-      app_basic (p:'ffi ffi_proj) v v1 emp (POSTv v. & b (f x) v)``,
+      app_basic (p:'ffi ffi_proj) v v1 emp (POSTv v. & b (f x) v)`,
   fs [app_basic_def,emp_def,cfHeapsBaseTheory.SPLIT_emp1,
       ml_translatorTheory.Arrow_def,ml_translatorTheory.AppReturns_def,
       ml_translatorTheory.evaluate_closure_def,POSTv_def, PULL_EXISTS]
@@ -245,10 +245,10 @@ val Arrow_IMP_app_basic = store_thm("Arrow_IMP_app_basic",
   THEN1 (fs [st2heap_clock] \\ SPLIT_TAC)
 );
 
-val app_basic_weaken = store_thm("app_basic_weaken",
-  ``(!x v. P x v ==> Q x v) ==>
+val app_basic_weaken = Q.store_thm("app_basic_weaken",
+  `(!x v. P x v ==> Q x v) ==>
     (app_basic p v v1 x P ==>
-     app_basic p v v1 x Q)``,
+     app_basic p v v1 x Q)`,
   fs [app_basic_def] \\ metis_tac []);
 
 val evaluate_list_SING = prove(

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -161,33 +161,33 @@ val _ = add_infix ("~~>", 690, HOLgrammars.NONASSOC)
 (*------------------------------------------------------------------*)
 (** Low level lemmas about SPLIT and SPLIT3 *)
 
-val SPLIT3_of_SPLIT_emp3 = store_thm ("SPLIT3_of_SPLIT_emp3",
-  ``!h h1 h2. SPLIT h (h1, h2) ==> SPLIT3 h (h1, h2, {})``,
+val SPLIT3_of_SPLIT_emp3 = Q.store_thm ("SPLIT3_of_SPLIT_emp3",
+  `!h h1 h2. SPLIT h (h1, h2) ==> SPLIT3 h (h1, h2, {})`,
   SPLIT_TAC
 )
 
-val SPLIT3_of_SPLIT_emp2 = store_thm ("SPLIT3_of_SPLIT_emp2",
-  ``!h h1 h3. SPLIT h (h1, h3) ==> SPLIT3 h (h1, {}, h3)``,
+val SPLIT3_of_SPLIT_emp2 = Q.store_thm ("SPLIT3_of_SPLIT_emp2",
+  `!h h1 h3. SPLIT h (h1, h3) ==> SPLIT3 h (h1, {}, h3)`,
   SPLIT_TAC
 )
 
-val SPLIT3_swap23 = store_thm ("SPLIT3_swap23",
-  ``!h h1 h2 h3. SPLIT3 h (h1, h2, h3) ==> SPLIT3 h (h1, h3, h2)``,
+val SPLIT3_swap23 = Q.store_thm ("SPLIT3_swap23",
+  `!h h1 h2 h3. SPLIT3 h (h1, h2, h3) ==> SPLIT3 h (h1, h3, h2)`,
   SPLIT_TAC
 )
 
-val SPLIT_emp1 = store_thm ("SPLIT_emp1",
-  ``!h h'. SPLIT h ({}, h') = (h' = h)``,
+val SPLIT_emp1 = Q.store_thm ("SPLIT_emp1",
+  `!h h'. SPLIT h ({}, h') = (h' = h)`,
   SPLIT_TAC
 )
 
-val SPLIT_emp2 = store_thm ("SPLIT_emp2",
-  ``!h h'. SPLIT h (h', {}) = (h' = h)``,
+val SPLIT_emp2 = Q.store_thm ("SPLIT_emp2",
+  `!h h'. SPLIT h (h', {}) = (h' = h)`,
   SPLIT_TAC
 )
 
-val SPLIT3_emp1 = store_thm ("SPLIT3_emp1",
-  ``!h h1 h2. SPLIT3 h ({}, h1, h2) = SPLIT h (h1, h2)``,
+val SPLIT3_emp1 = Q.store_thm ("SPLIT3_emp1",
+  `!h h1 h2. SPLIT3 h ({}, h1, h2) = SPLIT h (h1, h2)`,
   SPLIT_TAC
 )
 
@@ -195,173 +195,173 @@ val SPLIT3_emp3 = Q.store_thm("SPLIT3_emp3",
   `!h h1 h2. SPLIT3 h (h1,h2,{}) = SPLIT h (h1,h2)`,
   SPLIT_TAC)
 
-val SPLIT_of_SPLIT3_2u3 = store_thm ("SPLIT_of_SPLIT3_2u3",
-  ``!h h1 h2 h3. SPLIT3 h (h1, h2, h3) ==> SPLIT h (h1, h2 UNION h3)``,
+val SPLIT_of_SPLIT3_2u3 = Q.store_thm ("SPLIT_of_SPLIT3_2u3",
+  `!h h1 h2 h3. SPLIT3 h (h1, h2, h3) ==> SPLIT h (h1, h2 UNION h3)`,
   SPLIT_TAC
 )
 
 (*------------------------------------------------------------------*)
 (** Additionnal properties of STAR *)
 
-val STARPOST_emp = store_thm ("STARPOST_emp",
-  ``!Q. Q *+ emp = Q``,
+val STARPOST_emp = Q.store_thm ("STARPOST_emp",
+  `!Q. Q *+ emp = Q`,
   strip_tac \\ fs [STARPOST_def] \\ metis_tac [SEP_CLAUSES]
 );
 
-val SEP_IMP_frame_single_l = store_thm ("SEP_IMP_frame_single_l",
-  ``!H' R.
+val SEP_IMP_frame_single_l = Q.store_thm ("SEP_IMP_frame_single_l",
+  `!H' R.
      (emp ==>> H') ==>
-     (R ==>> H' * R)``,
+     (R ==>> H' * R)`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_frame_single_r = store_thm ("SEP_IMP_frame_single_r",
-  ``!H R.
+val SEP_IMP_frame_single_r = Q.store_thm ("SEP_IMP_frame_single_r",
+  `!H R.
      (H ==>> emp) ==>
-     (H * R ==>> R)``,
+     (H * R ==>> R)`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_cell_frame = store_thm ("SEP_IMP_cell_frame",
-  ``!H H' l v v'.
+val SEP_IMP_cell_frame = Q.store_thm ("SEP_IMP_cell_frame",
+  `!H H' l v v'.
      (v = v') /\ (H ==>> H') ==>
-     (H * l ~~>> v ==>> H' * l ~~>> v')``,
+     (H * l ~~>> v ==>> H' * l ~~>> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_cell_frame_single_l = store_thm ("SEP_IMP_cell_frame_single_l",
-  ``!H' l v v'.
+val SEP_IMP_cell_frame_single_l = Q.store_thm ("SEP_IMP_cell_frame_single_l",
+  `!H' l v v'.
      (v = v') /\ (emp ==>> H') ==>
-     (l ~~>> v ==>> H' * l ~~>> v')``,
+     (l ~~>> v ==>> H' * l ~~>> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_cell_frame_single_r = store_thm ("SEP_IMP_cell_frame_single_r",
-  ``!H l v v'.
+val SEP_IMP_cell_frame_single_r = Q.store_thm ("SEP_IMP_cell_frame_single_r",
+  `!H l v v'.
      (v = v') /\ (H ==>> emp) ==>
-     (H * l ~~>> v ==>> l ~~>> v')``,
+     (H * l ~~>> v ==>> l ~~>> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_cell_frame_single = store_thm ("SEP_IMP_cell_frame_single",
-  ``!H l v v'.
+val SEP_IMP_cell_frame_single = Q.store_thm ("SEP_IMP_cell_frame_single",
+  `!H l v v'.
      (v = v') /\ (emp ==>> emp) ==>
-     (l ~~>> v ==>> l ~~>> v')``,
+     (l ~~>> v ==>> l ~~>> v')`,
   fs [SEP_IMP_REFL]
 );
 
-val SEP_IMP_REF_frame = store_thm ("SEP_IMP_REF_frame",
-  ``!H H' r v v'.
+val SEP_IMP_REF_frame = Q.store_thm ("SEP_IMP_REF_frame",
+  `!H H' r v v'.
      (v = v') /\ (H ==>> H') ==>
-     (H * r ~~> v ==>> H' * r ~~> v')``,
+     (H * r ~~> v ==>> H' * r ~~> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_REF_frame_single_l = store_thm ("SEP_IMP_REF_frame_single_l",
-  ``!H' r v v'.
+val SEP_IMP_REF_frame_single_l = Q.store_thm ("SEP_IMP_REF_frame_single_l",
+  `!H' r v v'.
      (v = v') /\ (emp ==>> H') ==>
-     (r ~~> v ==>> H' * r ~~> v')``,
+     (r ~~> v ==>> H' * r ~~> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_REF_frame_single_r = store_thm ("SEP_IMP_REF_frame_single_r",
-  ``!H r v v'.
+val SEP_IMP_REF_frame_single_r = Q.store_thm ("SEP_IMP_REF_frame_single_r",
+  `!H r v v'.
      (v = v') /\ (H ==>> emp) ==>
-     (H * r ~~> v ==>> r ~~> v')``,
+     (H * r ~~> v ==>> r ~~> v')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_REF_frame_single = store_thm ("SEP_IMP_REF_frame_single",
-  ``!H r v v'.
+val SEP_IMP_REF_frame_single = Q.store_thm ("SEP_IMP_REF_frame_single",
+  `!H r v v'.
      (v = v') /\ (emp ==>> emp) ==>
-     (r ~~> v ==>> r ~~> v')``,
+     (r ~~> v ==>> r ~~> v')`,
   fs [SEP_IMP_REFL]
 );
 
-val SEP_IMP_ARRAY_frame = store_thm ("SEP_IMP_ARRAY_frame",
-  ``!H H' a vl vl'.
+val SEP_IMP_ARRAY_frame = Q.store_thm ("SEP_IMP_ARRAY_frame",
+  `!H H' a vl vl'.
      (vl = vl') /\ (H ==>> H') ==>
-     (H * ARRAY a vl ==>> H' * ARRAY a vl')``,
+     (H * ARRAY a vl ==>> H' * ARRAY a vl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_ARRAY_frame_single_l = store_thm ("SEP_IMP_ARRAY_frame_single_l",
-  ``!H' a vl vl'.
+val SEP_IMP_ARRAY_frame_single_l = Q.store_thm ("SEP_IMP_ARRAY_frame_single_l",
+  `!H' a vl vl'.
      (vl = vl') /\ (emp ==>> H') ==>
-     (ARRAY a vl ==>> H' * ARRAY a vl')``,
+     (ARRAY a vl ==>> H' * ARRAY a vl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_ARRAY_frame_single_r = store_thm ("SEP_IMP_ARRAY_frame_single_r",
-  ``!H a vl vl'.
+val SEP_IMP_ARRAY_frame_single_r = Q.store_thm ("SEP_IMP_ARRAY_frame_single_r",
+  `!H a vl vl'.
      (vl = vl') /\ (H ==>> emp) ==>
-     (H * ARRAY a vl ==>> ARRAY a vl')``,
+     (H * ARRAY a vl ==>> ARRAY a vl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_ARRAY_frame_single = store_thm ("SEP_IMP_ARRAY_frame_single",
-  ``!H a vl vl'.
+val SEP_IMP_ARRAY_frame_single = Q.store_thm ("SEP_IMP_ARRAY_frame_single",
+  `!H a vl vl'.
      (vl = vl') /\ (emp ==>> emp) ==>
-     (ARRAY a vl ==>> ARRAY a vl')``,
+     (ARRAY a vl ==>> ARRAY a vl')`,
   fs [SEP_IMP_REFL]
 );
 
-val SEP_IMP_W8ARRAY_frame = store_thm ("SEP_IMP_W8ARRAY_frame",
-  ``!H H' a wl wl'.
+val SEP_IMP_W8ARRAY_frame = Q.store_thm ("SEP_IMP_W8ARRAY_frame",
+  `!H H' a wl wl'.
      (wl = wl') /\ (H ==>> H') ==>
-     (H * W8ARRAY a wl ==>> H' * W8ARRAY a wl')``,
+     (H * W8ARRAY a wl ==>> H' * W8ARRAY a wl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_W8ARRAY_frame_single_l = store_thm (
+val SEP_IMP_W8ARRAY_frame_single_l = Q.store_thm (
   "SEP_IMP_W8ARRAY_frame_single_l",
-  ``!H' a wl wl'.
+  `!H' a wl wl'.
      (wl = wl') /\ (emp ==>> H') ==>
-     (W8ARRAY a wl ==>> H' * W8ARRAY a wl')``,
+     (W8ARRAY a wl ==>> H' * W8ARRAY a wl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_W8ARRAY_frame_single_r = store_thm (
+val SEP_IMP_W8ARRAY_frame_single_r = Q.store_thm (
   "SEP_IMP_W8ARRAY_frame_single_r",
-  ``!H a wl wl'.
+  `!H a wl wl'.
      (wl = wl') /\ (H ==>> emp) ==>
-     (H * W8ARRAY a wl ==>> W8ARRAY a wl')``,
+     (H * W8ARRAY a wl ==>> W8ARRAY a wl')`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_W8ARRAY_frame_single = store_thm (
+val SEP_IMP_W8ARRAY_frame_single = Q.store_thm (
   "SEP_IMP_W8ARRAY_frame_single",
-  ``!H a wl wl'.
+  `!H a wl wl'.
      (wl = wl') /\ (emp ==>> emp) ==>
-     (W8ARRAY a wl ==>> W8ARRAY a wl')``,
+     (W8ARRAY a wl ==>> W8ARRAY a wl')`,
   fs [SEP_IMP_REFL]
 );
 
-val SEP_IMP_IO_frame = store_thm ("SEP_IMP_IO_frame",
-  ``!H H' idx st u st' u'.
+val SEP_IMP_IO_frame = Q.store_thm ("SEP_IMP_IO_frame",
+  `!H H' idx st u st' u'.
      (st = st' /\ u = u') /\ (H ==>> H') ==>
-     (H * IO st u idx ==>> H' * IO st' u' idx)``,
+     (H * IO st u idx ==>> H' * IO st' u' idx)`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_IO_frame_single_l = store_thm ("SEP_IMP_IO_frame_single_l",
-  ``!H' idx st u st' u'.
+val SEP_IMP_IO_frame_single_l = Q.store_thm ("SEP_IMP_IO_frame_single_l",
+  `!H' idx st u st' u'.
      (st = st' /\ u = u') /\ (emp ==>> H') ==>
-     (IO st u idx ==>> H' * IO st' u' idx)``,
+     (IO st u idx ==>> H' * IO st' u' idx)`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_IO_frame_singel_r = store_thm ("SEP_IMP_IO_frame_single_r",
-  ``!H idx st u st' u'.
+val SEP_IMP_IO_frame_singel_r = Q.store_thm ("SEP_IMP_IO_frame_single_r",
+  `!H idx st u st' u'.
      (st = st' /\ u = u') /\ (H ==>> emp) ==>
-     (H * IO st u idx ==>> IO st' u' idx)``,
+     (H * IO st u idx ==>> IO st' u' idx)`,
   rpt strip_tac \\ progress SEP_IMP_FRAME \\ fs [SEP_CLAUSES]
 );
 
-val SEP_IMP_IO_frame_single = store_thm ("SEP_IMP_IO_frame_single",
-  ``!idx st u st' u'.
+val SEP_IMP_IO_frame_single = Q.store_thm ("SEP_IMP_IO_frame_single",
+  `!idx st u st' u'.
      (st = st' /\ u = u') /\ (emp ==>> emp) ==>
-     (IO st u idx ==>> IO st' u' idx)``,
+     (IO st u idx ==>> IO st' u' idx)`,
   fs [SEP_IMP_REFL]
 );
 
@@ -378,16 +378,16 @@ val rew_heap = full_simp_tac bool_ss rew_heap_thms
 (*------------------------------------------------------------------*)
 (* Workaround because of SEP_CLAUSES turning &F into SEP_F *)
 
-val SEP_F_to_cond = store_thm ("SEP_F_to_cond",
-  ``SEP_F = &F``,
+val SEP_F_to_cond = Q.store_thm ("SEP_F_to_cond",
+  `SEP_F = &F`,
   irule EQ_EXT \\ fs [SEP_F_def, cond_def]
 );
 
 (*------------------------------------------------------------------*)
 (** Properties of GC *)
 
-val GC_STAR_GC = store_thm ("GC_STAR_GC",
-  ``GC * GC = GC``,
+val GC_STAR_GC = Q.store_thm ("GC_STAR_GC",
+  `GC * GC = GC`,
   fs [GC_def] \\ irule EQ_EXT \\ strip_tac \\ rew_heap \\
   fs [SEP_EXISTS] \\ eq_tac \\ rpt strip_tac
   THENL [all_tac, qexists_tac `emp` \\ rew_heap] \\
@@ -397,11 +397,11 @@ val GC_STAR_GC = store_thm ("GC_STAR_GC",
 (*------------------------------------------------------------------*)
 (* Unfolding + case split lemma for SEP_IMPPOST *)
 
-val SEP_IMPPOST_unfold = store_thm ("SEP_IMPPOST_unfold",
-  ``!Q1 Q2.
+val SEP_IMPPOST_unfold = Q.store_thm ("SEP_IMPPOST_unfold",
+  `!Q1 Q2.
       (Q1 ==+> Q2) <=>
       (!v. Q1 (Val v) ==>> Q2 (Val v)) /\
-      (!v. Q1 (Exn v) ==>> Q2 (Exn v))``,
+      (!v. Q1 (Exn v) ==>> Q2 (Exn v))`,
   rpt strip_tac \\ eq_tac \\ rpt strip_tac \\ fs [SEP_IMPPOST_def] \\
   Cases \\ fs []
 );
@@ -409,32 +409,32 @@ val SEP_IMPPOST_unfold = store_thm ("SEP_IMPPOST_unfold",
 (*------------------------------------------------------------------*)
 (** Extraction from H1 in H1 ==>> H2 *)
 
-val hpull_prop = store_thm ("hpull_prop",
-  ``!H H' P.
+val hpull_prop = Q.store_thm ("hpull_prop",
+  `!H H' P.
      (P ==> H ==>> H') ==>
-     (H * cond P ==>> H')``,
+     (H * cond P ==>> H')`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, cond_def] \\
   SPLIT_TAC
 )
 
-val hpull_prop_single = store_thm ("hpull_prop_single",
-  ``!H' P.
+val hpull_prop_single = Q.store_thm ("hpull_prop_single",
+  `!H' P.
      (P ==> emp ==>> H') ==>
-     (cond P ==>> H')``,
+     (cond P ==>> H')`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, cond_def, emp_def] \\
   SPLIT_TAC
 )
 
-val hpull_exists_single = store_thm ("hpull_exists_single",
-  ``!A H' J.
+val hpull_exists_single = Q.store_thm ("hpull_exists_single",
+  `!A H' J.
      (!x. (J x) ==>> H') ==>
-     ($SEP_EXISTS J ==>> H')``,
+     ($SEP_EXISTS J ==>> H')`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, SEP_EXISTS, emp_def] \\
   SPLIT_TAC
 )
 
-val SEP_IMP_rew = store_thm ("SEP_IMP_rew",
-  ``!H1 H2 H1' H2'. (H1 = H2) ==> (H1' = H2') ==> (H1 ==>> H1') = (H2 ==>> H2')``,
+val SEP_IMP_rew = Q.store_thm ("SEP_IMP_rew",
+  `!H1 H2 H1' H2'. (H1 = H2) ==> (H1' = H2') ==> (H1 ==>> H1') = (H2 ==>> H2')`,
   rew_heap
 )
 
@@ -443,65 +443,65 @@ val SEP_IMP_rew = store_thm ("SEP_IMP_rew",
 
 (** Lemmas *)
 
-val hsimpl_prop = store_thm ("hsimpl_prop",
-  ``!H' H P.
+val hsimpl_prop = Q.store_thm ("hsimpl_prop",
+  `!H' H P.
      P /\ (H' ==>> H) ==>
-     (H' ==>> H * cond P)``,
+     (H' ==>> H * cond P)`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, cond_def] \\
   SPLIT_TAC
 )
 
-val hsimpl_prop_single = store_thm ("hsimpl_prop_single",
-  ``!H' P.
+val hsimpl_prop_single = Q.store_thm ("hsimpl_prop_single",
+  `!H' P.
      P /\ (H' ==>> emp) ==>
-     (H' ==>> cond P)``,
+     (H' ==>> cond P)`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, cond_def, emp_def] \\
   SPLIT_TAC
 )
 
-val hsimpl_exists_single = store_thm ("hsimpl_exists_single",
-  ``!x H' J.
+val hsimpl_exists_single = Q.store_thm ("hsimpl_exists_single",
+  `!x H' J.
      (H' ==>> J x) ==>
-     (H' ==>> $SEP_EXISTS J)``,
+     (H' ==>> $SEP_EXISTS J)`,
   rpt strip_tac \\ fs [SEP_IMP_def, STAR_def, SEP_EXISTS, emp_def] \\
   SPLIT_TAC
 )
 
-val hsimpl_gc = store_thm ("hsimpl_gc",
-  ``!H. H ==>> GC``,
+val hsimpl_gc = Q.store_thm ("hsimpl_gc",
+  `!H. H ==>> GC`,
   fs [GC_def, SEP_IMP_def, SEP_EXISTS] \\ metis_tac []
 )
 
 (*------------------------------------------------------------------*)
 (* Automatic rewrites for POSTv/POSTe/POST *)
 
-val POSTv_Val = store_thm ("POSTv_Val[simp]",
-  ``!Qv v. $POSTv Qv (Val v) = Qv v``,
+val POSTv_Val = Q.store_thm ("POSTv_Val[simp]",
+  `!Qv v. $POSTv Qv (Val v) = Qv v`,
   fs [POSTv_def]
 );
 
-val POSTv_Exn = store_thm ("POSTv_Exn[simp]",
-  ``!Qv v. $POSTv Qv (Exn v) = &F``,
+val POSTv_Exn = Q.store_thm ("POSTv_Exn[simp]",
+  `!Qv v. $POSTv Qv (Exn v) = &F`,
   fs [POSTv_def]
 );
 
-val POSTe_Val = store_thm ("POSTe_Val[simp]",
-  ``!Qe v. $POSTe Qe (Val v) = &F``,
+val POSTe_Val = Q.store_thm ("POSTe_Val[simp]",
+  `!Qe v. $POSTe Qe (Val v) = &F`,
   fs [POSTe_def]
 );
 
-val POSTe_Exn = store_thm ("POSTe_Exn[simp]",
-  ``!Qe v. $POSTe Qe (Exn v) = Qe v``,
+val POSTe_Exn = Q.store_thm ("POSTe_Exn[simp]",
+  `!Qe v. $POSTe Qe (Exn v) = Qe v`,
   fs [POSTe_def]
 );
 
-val POST_Val = store_thm ("POST_Val[simp]",
-  ``!Qv Qe v. POST Qv Qe (Val v) = Qv v``,
+val POST_Val = Q.store_thm ("POST_Val[simp]",
+  `!Qv Qe v. POST Qv Qe (Val v) = Qv v`,
   fs [POST_def]
 );
 
-val POST_Exn = store_thm ("POST_Exn[simp]",
-  ``!Qv Qe v. POST Qv Qe (Exn v) = Qe v``,
+val POST_Exn = Q.store_thm ("POST_Exn[simp]",
+  `!Qv Qe v. POST Qv Qe (Exn v) = Qe v`,
   fs [POST_def]
 );
 
@@ -514,13 +514,13 @@ val POSTv_ignore = Q.store_thm("POSTv_ignore",
 (*------------------------------------------------------------------*)
 (* Lemmas for ==v> / ==e> *)
 
-val SEP_IMPPOSTv_POSTe_left = store_thm ("SEP_IMPPOSTv_POSTe_left",
-  ``!Qe Q. $POSTe Qe ==v> Q``,
+val SEP_IMPPOSTv_POSTe_left = Q.store_thm ("SEP_IMPPOSTv_POSTe_left",
+  `!Qe Q. $POSTe Qe ==v> Q`,
   fs [POSTe_def, SEP_IMPPOSTv_def, SEP_IMP_def, cond_def]
 );
 
-val SEP_IMPPOSTe_POSTv_left = store_thm ("SEP_IMPPOSTe_POSTv_left",
-  ``!Qv Q. $POSTv Qv ==e> Q``,
+val SEP_IMPPOSTe_POSTv_left = Q.store_thm ("SEP_IMPPOSTe_POSTv_left",
+  `!Qv Q. $POSTv Qv ==e> Q`,
   fs [POSTv_def, SEP_IMPPOSTe_def, SEP_IMP_def, cond_def]
 );
 

--- a/characteristic/cfHeapsScript.sml
+++ b/characteristic/cfHeapsScript.sml
@@ -8,22 +8,22 @@ fun sing x = [x]
 (*------------------------------------------------------------------*)
 (* hchange: using a [H1 ==>> H2] theorem modulo frame rule *)
 
-val hchange_lemma' = store_thm ("hchange_lemma'",
-  ``!H1 H1' H H' H2.
+val hchange_lemma' = Q.store_thm ("hchange_lemma'",
+  `!H1 H1' H H' H2.
     H1 ==>> H1' ==>
     H ==>> H1 * H2 /\
     H1' * H2 ==>> H' ==>
-    H ==>> H'``,
+    H ==>> H'`,
   rpt strip_tac \\ irule SEP_IMP_TRANS \\ qexists_tac `H1 * H2` \\ fs [] \\
   irule SEP_IMP_TRANS \\ qexists_tac `H1' * H2` \\ hsimpl \\ fs []
 )
 
-val hchange_lemma = store_thm ("hchange_lemma",
-  ``!H1 H1' H H' H2.
+val hchange_lemma = Q.store_thm ("hchange_lemma",
+  `!H1 H1' H H' H2.
     H1 ==>> H1' /\
     H ==>> H1 * H2 /\
     H1' * H2 ==>> H' ==>
-    H ==>> H'``,
+    H ==>> H'`,
   rpt strip_tac \\ irule SEP_IMP_TRANS \\ qexists_tac `H1 * H2` \\ fs [] \\
   irule SEP_IMP_TRANS \\ qexists_tac `H1' * H2` \\ hsimpl \\ fs []
 )
@@ -45,14 +45,14 @@ val is_local_def = Define `
 
 (* Properties of [local] *)
 
-val local_elim = store_thm ("local_elim",
-  ``!cf H Q. cf H Q ==> local cf H Q``,
+val local_elim = Q.store_thm ("local_elim",
+  `!cf H Q. cf H Q ==> local cf H Q`,
   fs [local_def] \\ rpt strip_tac \\
   Q.LIST_EXISTS_TAC [`H`, `emp`, `Q`] \\ hsimpl \\ rew_heap
 )
 
-val local_local = store_thm ("local_local",
-  ``!cf. local (local cf) = local cf``,
+val local_local = Q.store_thm ("local_local",
+  `!cf. local (local cf) = local cf`,
   qsuff_tac `!cf H Q. local (local cf) H Q = local cf H Q`
   THEN1 (metis_tac []) \\
   rpt strip_tac \\ eq_tac \\
@@ -79,37 +79,37 @@ val local_local = store_thm ("local_local",
   match_mp_tac SEP_IMP_STAR \\ fs [SEP_IMP_REFL]
 )
 
-val local_is_local = store_thm ("local_is_local",
-  ``!F. is_local (local F) = T``,
+val local_is_local = Q.store_thm ("local_is_local",
+  `!F. is_local (local F) = T`,
   metis_tac [is_local_def, local_local]
 )
 
-val is_local_prove = store_thm ("is_local_prove",
-  ``!F. (!H Q. F H Q <=> local F H Q) ==> is_local F``,
+val is_local_prove = Q.store_thm ("is_local_prove",
+  `!F. (!H Q. F H Q <=> local F H Q) ==> is_local F`,
   rpt strip_tac \\ fs [is_local_def] \\
   NTAC 2 (irule EQ_EXT \\ gen_tac) \\ fs []
 );
 
-val local_frame_gc = store_thm ("local_frame_gc",
-  ``!F H H1 H2 Q1 Q.
+val local_frame_gc = Q.store_thm ("local_frame_gc",
+  `!F H H1 H2 Q1 Q.
       is_local F ==>
       F H1 Q1 ==>
       H ==>> H1 * H2 ==>
       Q1 *+ H2 ==+> Q *+ GC ==>
-      F H Q``,
+      F H Q`,
   fs [is_local_def] \\ rpt strip_tac \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   rewrite_tac [local_def] \\ rpt strip_tac \\
   Q.LIST_EXISTS_TAC [`H1`, `H2`, `Q1`] \\ strip_tac \\ fs [SEP_IMP_def]
 )
 
-val local_frame = store_thm ("local_frame",
-  ``!H1 H2 Q1 F H Q.
+val local_frame = Q.store_thm ("local_frame",
+  `!H1 H2 Q1 F H Q.
       is_local F ==>
       F H1 Q1 ==>
       H ==>> H1 * H2 ==>
       Q1 *+ H2 ==+> Q ==>
-      F H Q``,
+      F H Q`,
   fs [is_local_def] \\ rpt strip_tac \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   rewrite_tac [local_def] \\ rpt strip_tac \\
@@ -122,12 +122,12 @@ val local_frame = store_thm ("local_frame",
   )
 )
 
-val local_gc_pre_on = store_thm ("local_gc_pre_on",
-  ``!HG H' F H Q.
+val local_gc_pre_on = Q.store_thm ("local_gc_pre_on",
+  `!HG H' F H Q.
      is_local F ==>
      H ==>> HG * H' ==>
      F H' Q ==>
-     F H Q``,
+     F H Q`,
   rpt strip_tac \\ fs [is_local_def] \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   fs [local_def] \\ rpt strip_tac \\
@@ -137,12 +137,12 @@ val local_gc_pre_on = store_thm ("local_gc_pre_on",
   THEN1 hsimpl
 )
 
-val local_gc_post = store_thm ("local_gc_post",
-  ``!Q' F H Q.
+val local_gc_post = Q.store_thm ("local_gc_post",
+  `!Q' F H Q.
      is_local F ==>
      F H Q' ==>
      Q' ==+> Q *+ GC ==>
-     F H Q``,
+     F H Q`,
   rpt strip_tac \\ fs [is_local_def] \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   fs [local_def] \\ rpt strip_tac \\
@@ -154,11 +154,11 @@ val local_gc_post = store_thm ("local_gc_post",
 
 (* Extraction of premisses from [local] *)
 
-val local_intro_prop = store_thm ("local_intro_prop",
-  ``!F H P Q.
+val local_intro_prop = Q.store_thm ("local_intro_prop",
+  `!F H P Q.
       is_local F ==>
       (P ==> F H Q) ==>
-      F (H * cond P) Q``,
+      F (H * cond P) Q`,
   rpt strip_tac \\ fs [is_local_def] \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   fs [local_def] \\ rpt strip_tac \\
@@ -168,11 +168,11 @@ val local_intro_prop = store_thm ("local_intro_prop",
 
 (** Extraction of existentials from [local] *)
 
-val local_extract_exists = store_thm ("local_extract_exists",
-  ``!F A J Q.
+val local_extract_exists = Q.store_thm ("local_extract_exists",
+  `!F A J Q.
       is_local F ==>
       (!x. F (J x) Q) ==>
-      F ($SEP_EXISTS J) Q``,
+      F ($SEP_EXISTS J) Q`,
   rpt strip_tac \\ fs [is_local_def] \\
   qpat_x_assum `_ = local _` (once_rewrite_tac o sing) \\
   fs [local_def] \\ rpt strip_tac \\ fs [SEP_EXISTS] \\ rename1 `J x _` \\
@@ -182,29 +182,29 @@ val local_extract_exists = store_thm ("local_extract_exists",
 
 (** Auxiliary lemmas for [hclean]. Mostly repackaging of previous lemmas *)
 
-val hclean_prop = store_thm ("hclean_prop",
- ``!F H P Q.
+val hclean_prop = Q.store_thm ("hclean_prop",
+ `!F H P Q.
       is_local F /\
       (P ==> F H Q) ==>
-      F (H * cond P) Q``,
+      F (H * cond P) Q`,
   fs [local_intro_prop]
 )
 
-val hclean_prop_single = store_thm ("hclean_prop_single",
-  ``!F P Q.
+val hclean_prop_single = Q.store_thm ("hclean_prop_single",
+  `!F P Q.
       is_local F /\
       (P ==> F emp Q) ==>
-      F (cond P) Q``,
+      F (cond P) Q`,
   qx_gen_tac `HF` \\
   qspecl_then [`HF`, `emp`] mp_tac local_intro_prop \\
   rew_heap
 )
 
-val hclean_exists_single = store_thm ("hclean_exists_single",
-  ``!F A J Q.
+val hclean_exists_single = Q.store_thm ("hclean_exists_single",
+  `!F A J Q.
       is_local F /\
       (!x. F (J x) Q) ==>
-      F ($SEP_EXISTS J) Q``,
+      F ($SEP_EXISTS J) Q`,
   fs [local_extract_exists]
 )
 

--- a/characteristic/cfNormalizeScript.sml
+++ b/characteristic/cfNormalizeScript.sml
@@ -19,9 +19,9 @@ val exp2v_def = Define `
   exp2v env (Var name) = lookup_var_id name env /\
   exp2v _ _ = NONE`
 
-val exp2v_evaluate = store_thm ("exp2v_evaluate",
-  ``!e env st v. exp2v env e = SOME v ==>
-    evaluate st env [e] = (st, Rval [v])``,
+val exp2v_evaluate = Q.store_thm ("exp2v_evaluate",
+  `!e env st v. exp2v env e = SOME v ==>
+    evaluate st env [e] = (st, Rval [v])`,
   Induct \\ fs [exp2v_def, terminationTheory.evaluate_def]
 );
 
@@ -35,9 +35,9 @@ val exp2v_list_def = Define `
           | NONE => NONE
           | SOME vs => SOME (v :: vs)))`;
 
-val exp2v_list_evaluate = store_thm ("exp2v_list_evaluate",
-  ``!l lv env st. exp2v_list env l = SOME lv ==>
-    evaluate st env l = (st, Rval lv)``,
+val exp2v_list_evaluate = Q.store_thm ("exp2v_list_evaluate",
+  `!l lv env st. exp2v_list env l = SOME lv ==>
+    evaluate st env l = (st, Rval lv)`,
   Induct
   THEN1 (fs [exp2v_list_def, terminationTheory.evaluate_def])
   THEN1 (
@@ -48,11 +48,11 @@ val exp2v_list_evaluate = store_thm ("exp2v_list_evaluate",
   )
 );
 
-val evaluate_list_rcons = store_thm ("evaluate_rcons",
-  ``!env st st' st'' l x lv v.
+val evaluate_list_rcons = Q.store_thm ("evaluate_rcons",
+  `!env st st' st'' l x lv v.
      evaluate st env l = (st', Rval lv) /\
      evaluate st' env [x] = (st'', Rval [v]) ==>
-     evaluate st env (l ++ [x]) = (st'', Rval (lv ++ [v]))``,
+     evaluate st env (l ++ [x]) = (st'', Rval (lv ++ [v]))`,
 
   Induct_on `l`
   THEN1 (
@@ -77,29 +77,29 @@ val evaluate_list_rcons = store_thm ("evaluate_rcons",
   )
 );
 
-val exp2v_list_REVERSE = store_thm ("exp2v_list_REVERSE",
-  ``!l (st: 'ffi semanticPrimitives$state) lv env. exp2v_list env l = SOME lv ==>
-    evaluate st env (REVERSE l) = (st, Rval (REVERSE lv))``,
+val exp2v_list_REVERSE = Q.store_thm ("exp2v_list_REVERSE",
+  `!l (st: 'ffi semanticPrimitives$state) lv env. exp2v_list env l = SOME lv ==>
+    evaluate st env (REVERSE l) = (st, Rval (REVERSE lv))`,
   Induct \\ rpt gen_tac \\ disch_then (assume_tac o GSYM) \\
   fs [exp2v_list_def, terminationTheory.evaluate_def] \\
   every_case_tac \\ fs [] \\ rw [] \\ irule evaluate_list_rcons \\
   metis_tac [exp2v_evaluate]
 );
 
-val exp2v_list_rcons = store_thm ("exp2v_list_rcons",
-  ``!xs x l env.
+val exp2v_list_rcons = Q.store_thm ("exp2v_list_rcons",
+  `!xs x l env.
      exp2v_list env (xs ++ [x]) = SOME l ==>
      ?xvs xv.
        l = xvs ++ [xv] /\
        exp2v_list env xs = SOME xvs /\
-       exp2v env x = SOME xv``,
+       exp2v env x = SOME xv`,
   Induct_on `xs` \\ fs [exp2v_list_def] \\ rpt strip_tac \\
   every_case_tac \\ fs [] \\
   first_assum progress \\ fs [] \\ rw []
 );
 
-val exp2v_list_LENGTH = store_thm ("exp2v_list_LENGTH",
-  ``!l lv env. exp2v_list env l = SOME lv ==> LENGTH l = LENGTH lv``,
+val exp2v_list_LENGTH = Q.store_thm ("exp2v_list_LENGTH",
+  `!l lv env. exp2v_list env l = SOME lv ==> LENGTH l = LENGTH lv`,
   Induct_on `l` \\ fs [exp2v_list_def] \\ rpt strip_tac \\
   every_case_tac \\ res_tac \\ fs [] \\ rw []
 );
@@ -140,8 +140,8 @@ val MEM_exp_size = Q.prove(
   `!args a. MEM a args ==> exp_size a <= exp6_size args`,
   Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []);
 
-val MEM_exp1_size = prove(
-  ``!rs. MEM (v,a,e') rs ==> exp_size e' < exp1_size rs``,
+val MEM_exp1_size = Q.prove(
+  `!rs. MEM (v,a,e') rs ==> exp_size e' < exp1_size rs`,
   Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []
   \\ fs [astTheory.exp_size_def]);
 
@@ -171,10 +171,10 @@ val exp6_size_lemma = Q.prove(
   `!xs ys. exp6_size (xs ++ ys) = exp6_size xs + exp6_size ys`,
   Induct \\ fs [astTheory.exp_size_def]);
 
-val dest_opapp_size = prove(
-  ``!xs p_1 p_2.
+val dest_opapp_size = Q.prove(
+  `!xs p_1 p_2.
       dest_opapp xs = SOME (p_1,p_2) ==>
-      exp_size p_1 + exp6_size p_2 < exp_size xs``,
+      exp_size p_1 + exp6_size p_2 < exp_size xs`,
   recInduct (theorem "dest_opapp_ind") \\ fs [dest_opapp_def]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ fs [astTheory.exp_size_def]
@@ -356,11 +356,11 @@ val norm_state_rel_def = Define `
      s1.defined_mods = s2.defined_mods`
 
 (*
-val full_normalise_correct = store_thm("full_normalise_correct",
-  ``env_rel (free_in e) env1 env2 /\ norm_state_rel s1 s2 /\
+val full_normalise_correct = Q.store_thm("full_normalise_correct",
+  `env_rel (free_in e) env1 env2 /\ norm_state_rel s1 s2 /\
     evaluate ck env1 s1 e1 (rs1,res1) /\ norm_exp_rel e1 e2 ==>
     ?rs2 res2. evaluate ck env2 s2 e2 (rs2,res2) /\
-               norm_state_rel rs1 rs2 /\ norm_res_rel res1 res2``,
+               norm_state_rel rs1 rs2 /\ norm_res_rel res1 res2`,
   ... ); TODO
 *)
 

--- a/characteristic/cfNormalizeScript.sml
+++ b/characteristic/cfNormalizeScript.sml
@@ -110,8 +110,8 @@ val exp2v_list_LENGTH = store_thm ("exp2v_list_LENGTH",
 val normalise_def = Define `
   normalise x = (x:exp)` (* TODO: actually implement this without going into closures *)
 
-val evaluate_normalise = store_thm("evaluate_normalise",
-  ``evaluate s env [normalise exp] = evaluate s env [exp]``,
+val evaluate_normalise = Q.store_thm("evaluate_normalise",
+  `evaluate s env [normalise exp] = evaluate s env [exp]`,
   fs [normalise_def]);
 
 
@@ -136,8 +136,8 @@ val mk_opapp_def = tDefine "mk_opapp" `
  (WF_REL_TAC `measure LENGTH`
   \\ fs [LENGTH_FRONT] \\ Cases \\ fs []);
 
-val MEM_exp_size = prove(
-  ``!args a. MEM a args ==> exp_size a <= exp6_size args``,
+val MEM_exp_size = Q.prove(
+  `!args a. MEM a args ==> exp_size a <= exp6_size args`,
   Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []);
 
 val MEM_exp1_size = prove(
@@ -167,8 +167,8 @@ val Lets_def = Define `
   Lets [] e = e /\
   Lets ((n,x)::xs) e = Let (SOME n) x (Lets xs e)`
 
-val exp6_size_lemma = prove(
-  ``!xs ys. exp6_size (xs ++ ys) = exp6_size xs + exp6_size ys``,
+val exp6_size_lemma = Q.prove(
+  `!xs ys. exp6_size (xs ++ ys) = exp6_size xs + exp6_size ys`,
   Induct \\ fs [astTheory.exp_size_def]);
 
 val dest_opapp_size = prove(
@@ -296,8 +296,8 @@ val norm_def = tDefine "norm" `
 val full_normalise_def = Define `
   full_normalise ns e = FST (protect T ns e)`;
 
-val MEM_v_size = prove(
-  ``!xs. MEM a xs ==> v_size a < v6_size xs``,
+val MEM_v_size = Q.prove(
+  `!xs. MEM a xs ==> v_size a < v6_size xs`,
   Induct  \\ fs [v_size_def] \\ rw [] \\ res_tac \\ fs []);
 
 val norm_exp_rel_def = Define `

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -890,8 +890,8 @@ val htriple_valid_normalise = store_thm ("htriple_valid_normalise",
   fs [htriple_valid_def, evaluate_ck_def, evaluate_normalise]
 );
 
-val sound_normalise = store_thm("sound_normalise",
-  ``sound p (normalise e) R <=> sound p e R``,
+val sound_normalise = Q.store_thm("sound_normalise",
+  `sound p (normalise e) R <=> sound p e R`,
   fs [sound_def, htriple_valid_normalise]);
 
 val star_split = Q.prove (
@@ -1044,8 +1044,8 @@ val SPLIT_SING_2 = store_thm("SPLIT_SING_2",
   ``SPLIT s (x,{y}) <=> (s = y INSERT x) /\ ~(y IN x)``,
   SPLIT_TAC);
 
-val SUBSET_IN = prove(
-  ``!s t x. s SUBSET t /\ x IN s ==> x IN t``,
+val SUBSET_IN = Q.prove(
+  `!s t x. s SUBSET t /\ x IN s ==> x IN t`,
   fs [SUBSET_DEF] \\ metis_tac []);
 
 val SPLIT_FFI_SET_IMP_DISJOINT = store_thm("SPLIT_FFI_SET_IMP_DISJOINT",
@@ -1079,9 +1079,9 @@ val FLOOKUP_FUPDATE_LIST = store_thm("FLOOKUP_FUPDATE_LIST",
   Induct \\ fs [FUPDATE_LIST] \\ rw [] \\ fs []
   \\ fs [FLOOKUP_DEF,FAPPLY_FUPDATE_THM]);
 
-val ALL_DISTINCT_FLAT_MEM_IMP = store_thm("ALL_DISTINCT_FLAT_MEM_IMP",
-  ``!p2. ALL_DISTINCT (FLAT p2) /\ MEM ns' p2 /\ MEM ns p2 /\
-         MEM m ns' /\ MEM m ns ==> ns = ns'``,
+val ALL_DISTINCT_FLAT_MEM_IMP = Q.store_thm("ALL_DISTINCT_FLAT_MEM_IMP",
+  `!p2. ALL_DISTINCT (FLAT p2) /\ MEM ns' p2 /\ MEM ns p2 /\
+         MEM m ns' /\ MEM m ns ==> ns = ns'`,
   Induct \\ fs [ALL_DISTINCT_APPEND] \\ rw [] \\ fs []
   \\ res_tac \\ fs [MEM_FLAT] \\ metis_tac []);
 

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -102,46 +102,46 @@ val letrec_pull_params_def = Define `
        | SOME body' => (f, n::Fun_params body, body')) ::
     (letrec_pull_params funs)`
 
-val letrec_pull_params_names = store_thm ("letrec_pull_params_names",
-  ``!funs P.
+val letrec_pull_params_names = Q.store_thm ("letrec_pull_params_names",
+  `!funs P.
      MAP (\ (f,_,_). P f) (letrec_pull_params funs) =
-     MAP (\ (f,_,_). P f) funs``,
+     MAP (\ (f,_,_). P f) funs`,
   Induct \\ fs [letrec_pull_params_def] \\ rpt strip_tac \\
   rename1 `ftuple::funs` \\ PairCases_on `ftuple` \\
   fs [letrec_pull_params_def] \\ every_case_tac \\ fs []
 )
 
-val letrec_pull_params_LENGTH = store_thm ("letrec_pull_params_LENGTH",
-  ``!funs. LENGTH (letrec_pull_params funs) = LENGTH funs``,
+val letrec_pull_params_LENGTH = Q.store_thm ("letrec_pull_params_LENGTH",
+  `!funs. LENGTH (letrec_pull_params funs) = LENGTH funs`,
   Induct \\ fs [letrec_pull_params_def] \\ rpt strip_tac \\
   rename1 `ftuple::funs` \\ PairCases_on `ftuple` \\
   fs [letrec_pull_params_def] \\ every_case_tac \\ fs []
 )
 
-val letrec_pull_params_append = store_thm ("letrec_pull_params_append",
-  ``!l l'.
+val letrec_pull_params_append = Q.store_thm ("letrec_pull_params_append",
+  `!l l'.
      letrec_pull_params (l ++ l') =
-     letrec_pull_params l ++ letrec_pull_params l'``,
+     letrec_pull_params l ++ letrec_pull_params l'`,
   Induct \\ rpt strip_tac \\ fs [letrec_pull_params_def] \\
   rename1 `ftuple::_` \\ PairCases_on `ftuple` \\ rename1 `(f,n,body)` \\
   fs [letrec_pull_params_def]
 )
 
-val letrec_pull_params_cancel = store_thm ("letrec_pull_params_cancel",
-  ``!funs.
+val letrec_pull_params_cancel = Q.store_thm ("letrec_pull_params_cancel",
+  `!funs.
      MAP (\ (f,ns,body). (f, HD ns, naryFun (TL ns) body))
          (letrec_pull_params funs) =
-     funs``,
+     funs`,
   Induct \\ rpt strip_tac \\ fs [letrec_pull_params_def] \\
   rename1 `ftuple::_` \\ PairCases_on `ftuple` \\ rename1 `(f,n,body)` \\
   fs [letrec_pull_params_def] \\ every_case_tac \\ fs [naryFun_def] \\
   fs [Fun_params_Fun_body_repack]
 )
 
-val letrec_pull_params_nonnil_params = store_thm ("letrec_pull_params_nonnil_params",
-  ``!funs f ns body.
+val letrec_pull_params_nonnil_params = Q.store_thm ("letrec_pull_params_nonnil_params",
+  `!funs f ns body.
      MEM (f,ns,body) (letrec_pull_params funs) ==>
-     ns <> []``,
+     ns <> []`,
   Induct \\ rpt strip_tac \\ fs [letrec_pull_params_def, MEM] \\
   rename1 `ftuple::funs` \\ PairCases_on `ftuple` \\
   rename1 `(f',n',body')::funs` \\
@@ -149,10 +149,10 @@ val letrec_pull_params_nonnil_params = store_thm ("letrec_pull_params_nonnil_par
   metis_tac []
 )
 
-val find_recfun_letrec_pull_params = store_thm ("find_recfun_letrec_pull_params",
-  ``!funs f n ns body.
+val find_recfun_letrec_pull_params = Q.store_thm ("find_recfun_letrec_pull_params",
+  `!funs f n ns body.
      find_recfun f (letrec_pull_params funs) = SOME (n::ns, body) ==>
-     find_recfun f funs = SOME (n, naryFun ns body)``,
+     find_recfun f funs = SOME (n, naryFun ns body)`,
   Induct \\ fs [letrec_pull_params_def]
   THEN1 (fs [Once find_recfun_def]) \\
   rpt strip_tac \\ rename1 `ftuple::funs` \\ PairCases_on `ftuple` \\
@@ -187,11 +187,11 @@ val with_clock_self_eq = Q.prove(
   `!ck. (s with clock := ck) = s <=> ck = s.clock`,
   fs [state_component_equality]);
 
-val app_one_naryClosure = store_thm ("app_one_naryClosure",
-  ``!env n ns x xs body H Q.
+val app_one_naryClosure = Q.store_thm ("app_one_naryClosure",
+  `!env n ns x xs body H Q.
      ns <> [] ==> xs <> [] ==>
      app (p:'ffi ffi_proj) (naryClosure env (n::ns) body) (x::xs) H Q ==>
-     app (p:'ffi ffi_proj) (naryClosure (env with v := (n, x)::env.v) ns body) xs H Q``,
+     app (p:'ffi ffi_proj) (naryClosure (env with v := (n, x)::env.v) ns body) xs H Q`,
 
   rpt strip_tac \\ Cases_on `ns` \\ Cases_on `xs` \\ fs [] \\
   rename1 `app _ (naryClosure _ (n::n'::ns) _) (x::x'::xs) _ _` \\
@@ -213,10 +213,10 @@ val app_one_naryClosure = store_thm ("app_one_naryClosure",
   simp [PULL_EXISTS] \\ instantiate
 );
 
-val curried_naryClosure = store_thm ("curried_naryClosure",
-  ``!env len ns body.
+val curried_naryClosure = Q.store_thm ("curried_naryClosure",
+  `!env len ns body.
      ns <> [] ==> len = LENGTH ns ==>
-     curried (p:'ffi ffi_proj) len (naryClosure env ns body)``,
+     curried (p:'ffi ffi_proj) len (naryClosure env ns body)`,
 
   Induct_on `ns` \\ fs [naryClosure_def, naryFun_def] \\ Cases_on `ns`
   THEN1 (once_rewrite_tac [ONE] \\ fs [Once curried_def])
@@ -248,29 +248,29 @@ val naryRecclosure_def = Define `
 
 (* Properties of [naryRecclosure] *)
 
-val do_opapp_naryRecclosure = store_thm ("do_opapp_naryRecclosure",
-  ``!funs f n ns body x env env' exp.
+val do_opapp_naryRecclosure = Q.store_thm ("do_opapp_naryRecclosure",
+  `!funs f n ns body x env env' exp.
      find_recfun f (letrec_pull_params funs) = SOME (n::ns, body) ==>
      (do_opapp [naryRecclosure env (letrec_pull_params funs) f; x] =
       SOME (env', exp)
      <=>
      (ALL_DISTINCT (MAP (\ (f,_,_). f) funs) /\
       env' = (env with v := (n, x)::build_rec_env funs env env.v) /\
-      exp = naryFun ns body))``,
+      exp = naryFun ns body))`,
   rpt strip_tac \\ progress find_recfun_letrec_pull_params \\
   fs [naryRecclosure_def, do_opapp_def, letrec_pull_params_cancel] \\
   eq_tac \\ every_case_tac \\ fs []
 );
 
-val app_one_naryRecclosure = store_thm ("app_one_naryRecclosure",
-  ``!funs f n ns body x xs env H Q.
+val app_one_naryRecclosure = Q.store_thm ("app_one_naryRecclosure",
+  `!funs f n ns body x xs env H Q.
      ns <> [] ==> xs <> [] ==>
      find_recfun f (letrec_pull_params funs) = SOME (n::ns, body) ==>
      (app (p:'ffi ffi_proj) (naryRecclosure env (letrec_pull_params funs) f) (x::xs) H Q ==>
       app (p:'ffi ffi_proj)
         (naryClosure
           (env with v := (n, x)::build_rec_env funs env env.v)
-          ns body) xs H Q)``,
+          ns body) xs H Q)`,
 
   rpt strip_tac \\ Cases_on `ns` \\ Cases_on `xs` \\ fs [] \\
   rename1 `SOME (n::n'::ns, _)` \\ rename1 `app _ _ (x::x'::xs)` \\
@@ -288,12 +288,12 @@ val app_one_naryRecclosure = store_thm ("app_one_naryRecclosure",
   simp [PULL_EXISTS] \\ instantiate
 );
 
-val curried_naryRecclosure = store_thm ("curried_naryRecclosure",
-  ``!env funs f len ns body.
+val curried_naryRecclosure = Q.store_thm ("curried_naryRecclosure",
+  `!env funs f len ns body.
      ALL_DISTINCT (MAP (\ (f,_,_). f) funs) ==>
      find_recfun f (letrec_pull_params funs) = SOME (ns, body) ==>
      len = LENGTH ns ==>
-     curried (p:'ffi ffi_proj) len (naryRecclosure env (letrec_pull_params funs) f)``,
+     curried (p:'ffi ffi_proj) len (naryRecclosure env (letrec_pull_params funs) f)`,
 
   rpt strip_tac \\ Cases_on `ns` \\ fs []
   THEN1 (
@@ -320,10 +320,10 @@ val curried_naryRecclosure = store_thm ("curried_naryRecclosure",
   )
 );
 
-val letrec_pull_params_repack = store_thm ("letrec_pull_params_repack",
-  ``!funs f env.
+val letrec_pull_params_repack = Q.store_thm ("letrec_pull_params_repack",
+  `!funs f env.
      naryRecclosure env (letrec_pull_params funs) f =
-     Recclosure env funs f``,
+     Recclosure env funs f`,
   Induct \\ rpt strip_tac \\ fs [naryRecclosure_def, letrec_pull_params_def] \\
   rename1 `ftuple::_` \\ PairCases_on `ftuple` \\ rename1 `(f,n,body)` \\
   fs [letrec_pull_params_def] \\ every_case_tac \\ fs [naryFun_def] \\
@@ -341,19 +341,19 @@ val extend_env_v_def = Define `
 val extend_env_def = Define `
   extend_env ns xvs env = (env with v := extend_env_v ns xvs env.v)`;
 
-val extend_env_v_rcons = store_thm ("extend_env_v_rcons",
-  ``!ns xvs n xv env_v.
+val extend_env_v_rcons = Q.store_thm ("extend_env_v_rcons",
+  `!ns xvs n xv env_v.
      LENGTH ns = LENGTH xvs ==>
      extend_env_v (ns ++ [n]) (xvs ++ [xv]) env_v =
-     (n,xv) :: extend_env_v ns xvs env_v``,
+     (n,xv) :: extend_env_v ns xvs env_v`,
   Induct \\ rpt strip_tac \\ first_assum (assume_tac o GSYM) \\
   fs [LENGTH_NIL, LENGTH_CONS, extend_env_v_def]
 );
 
-val extend_env_v_zip = store_thm ("extend_env_v_zip",
-  ``!ns xvs env_v.
+val extend_env_v_zip = Q.store_thm ("extend_env_v_zip",
+  `!ns xvs env_v.
     LENGTH ns = LENGTH xvs ==>
-    extend_env_v ns xvs env_v = ZIP (REVERSE ns, REVERSE xvs) ++ env_v``,
+    extend_env_v ns xvs env_v = ZIP (REVERSE ns, REVERSE xvs) ++ env_v`,
   Induct \\ rpt strip_tac \\ first_assum (assume_tac o GSYM) \\
   fs [LENGTH_NIL, LENGTH_CONS, extend_env_v_def, GSYM ZIP_APPEND]
 );
@@ -377,12 +377,12 @@ val build_rec_env_zip_aux = Q.prove (
   fs [letrec_pull_params_repack]
 );
 
-val build_rec_env_zip = store_thm ("build_rec_env_zip",
-  ``!funs env env_v.
+val build_rec_env_zip = Q.store_thm ("build_rec_env_zip",
+  `!funs env env_v.
      ZIP (MAP (\ (f,_,_). f) funs,
           MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs)
        ++ env_v =
-     build_rec_env funs env env_v``,
+     build_rec_env funs env env_v`,
   fs [build_rec_env_def, build_rec_env_zip_aux]
 );
 
@@ -395,13 +395,13 @@ val extend_env_rec_def = Define `
   extend_env_rec rec_ns rec_xvs ns xvs env =
     env with v := extend_env_v_rec rec_ns rec_xvs ns xvs env.v`;
 
-val extend_env_rec_build_rec_env = store_thm ("extend_env_rec_build_rec_env",
-  ``!funs env env_v.
+val extend_env_rec_build_rec_env = Q.store_thm ("extend_env_rec_build_rec_env",
+  `!funs env env_v.
      extend_env_v_rec
        (MAP (\ (f,_,_). f) funs)
        (MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs)
        [] [] env_v =
-     build_rec_env funs env env_v``,
+     build_rec_env funs env env_v`,
   rpt strip_tac \\ fs [extend_env_v_rec_def, extend_env_v_def, build_rec_env_zip]
 );
 
@@ -472,21 +472,21 @@ val v_of_pat_def = tDefine "v_of_pat" `
 
 val v_of_pat_ind = fetch "-" "v_of_pat_ind";
 
-val v_of_pat_list_length = store_thm ("v_of_pat_list_length",
-  ``!envC pats insts vs rest.
+val v_of_pat_list_length = Q.store_thm ("v_of_pat_list_length",
+  `!envC pats insts vs rest.
       v_of_pat_list envC pats insts = SOME (vs, rest) ==>
-      LENGTH pats = LENGTH vs``,
+      LENGTH pats = LENGTH vs`,
   Induct_on `pats` \\ fs [v_of_pat_def] \\ rpt strip_tac \\
   every_case_tac \\ fs [] \\ rw [] \\ first_assum irule \\ instantiate
 );
 
-val v_of_pat_insts_length = store_thm ("v_of_pat_insts_length",
-  ``(!envC pat insts v insts_rest.
+val v_of_pat_insts_length = Q.store_thm ("v_of_pat_insts_length",
+  `(!envC pat insts v insts_rest.
        v_of_pat envC pat insts = SOME (v, insts_rest) ==>
        (LENGTH insts = LENGTH (pat_bindings pat []) + LENGTH insts_rest)) /\
     (!envC pats insts vs insts_rest.
        v_of_pat_list envC pats insts = SOME (vs, insts_rest) ==>
-       (LENGTH insts = LENGTH (pats_bindings pats []) + LENGTH insts_rest))``,
+       (LENGTH insts = LENGTH (pats_bindings pats []) + LENGTH insts_rest))`,
 
   HO_MATCH_MP_TAC v_of_pat_ind \\ rpt strip_tac \\
   fs [v_of_pat_def, pat_bindings_def, LENGTH_NIL] \\ rw []
@@ -498,13 +498,13 @@ val v_of_pat_insts_length = store_thm ("v_of_pat_insts_length",
   )
 );
 
-val v_of_pat_extend_insts = store_thm ("v_of_pat_extend_insts",
-  ``(!envC pat insts v rest insts'.
+val v_of_pat_extend_insts = Q.store_thm ("v_of_pat_extend_insts",
+  `(!envC pat insts v rest insts'.
        v_of_pat envC pat insts = SOME (v, rest) ==>
        v_of_pat envC pat (insts ++ insts') = SOME (v, rest ++ insts')) /\
     (!envC pats insts vs rest insts'.
        v_of_pat_list envC pats insts = SOME (vs, rest) ==>
-       v_of_pat_list envC pats (insts ++ insts') = SOME (vs, rest ++ insts'))``,
+       v_of_pat_list envC pats (insts ++ insts') = SOME (vs, rest ++ insts'))`,
 
   HO_MATCH_MP_TAC v_of_pat_ind \\ rpt strip_tac \\
   try_finally (fs [v_of_pat_def])
@@ -521,15 +521,15 @@ val v_of_pat_extend_insts = store_thm ("v_of_pat_extend_insts",
   THEN1 (fs [v_of_pat_def] \\ every_case_tac \\ fs [] \\ rw [] \\ fs [])
 );
 
-val v_of_pat_NONE_extend_insts = store_thm ("v_of_pat_NONE_extend_insts",
-  ``(!envC pat insts insts'.
+val v_of_pat_NONE_extend_insts = Q.store_thm ("v_of_pat_NONE_extend_insts",
+  `(!envC pat insts insts'.
        v_of_pat envC pat insts = NONE ==>
        LENGTH insts >= LENGTH (pat_bindings pat []) ==>
        v_of_pat envC pat (insts ++ insts') = NONE) /\
     (!envC pats insts insts'.
        v_of_pat_list envC pats insts = NONE ==>
        LENGTH insts >= LENGTH (pats_bindings pats []) ==>
-       v_of_pat_list envC pats (insts ++ insts') = NONE)``,
+       v_of_pat_list envC pats (insts ++ insts') = NONE)`,
 
   HO_MATCH_MP_TAC v_of_pat_ind \\ rpt strip_tac \\
   try_finally (fs [v_of_pat_def, pat_bindings_def])
@@ -558,8 +558,8 @@ val v_of_pat_NONE_extend_insts = store_thm ("v_of_pat_NONE_extend_insts",
   )
 );
 
-val v_of_pat_remove_rest_insts = store_thm ("v_of_pat_remove_rest_insts",
-  ``(!pat envC insts v rest.
+val v_of_pat_remove_rest_insts = Q.store_thm ("v_of_pat_remove_rest_insts",
+  `(!pat envC insts v rest.
        v_of_pat envC pat insts = SOME (v, rest) ==>
        ?insts'.
          insts = insts' ++ rest /\
@@ -570,7 +570,7 @@ val v_of_pat_remove_rest_insts = store_thm ("v_of_pat_remove_rest_insts",
        ?insts'.
          insts = insts' ++ rest /\
          LENGTH insts' = LENGTH (pats_bindings pats []) /\
-         v_of_pat_list envC pats insts' = SOME (vs, []))``,
+         v_of_pat_list envC pats insts' = SOME (vs, []))`,
 
   HO_MATCH_MP_TAC astTheory.pat_induction \\ rpt strip_tac \\
   try_finally (fs [v_of_pat_def, pat_bindings_def])
@@ -608,13 +608,13 @@ val v_of_pat_remove_rest_insts = store_thm ("v_of_pat_remove_rest_insts",
   )
 );
 
-val v_of_pat_insts_unique = store_thm ("v_of_pat_insts_unique",
-  ``(!envC pat insts rest v.
+val v_of_pat_insts_unique = Q.store_thm ("v_of_pat_insts_unique",
+  `(!envC pat insts rest v.
        v_of_pat envC pat insts = SOME (v, rest) ==>
        (!insts'. v_of_pat envC pat insts' = SOME (v, rest) <=> (insts' = insts))) /\
     (!envC pats insts rest vs.
        v_of_pat_list envC pats insts = SOME (vs, rest) ==>
-       (!insts'. v_of_pat_list envC pats insts' = SOME (vs, rest) <=> (insts' = insts)))``,
+       (!insts'. v_of_pat_list envC pats insts' = SOME (vs, rest) <=> (insts' = insts)))`,
 
   HO_MATCH_MP_TAC v_of_pat_ind \\ rpt strip_tac \\
   try_finally (fs [v_of_pat_def] \\ every_case_tac \\ fs [])
@@ -642,18 +642,18 @@ val v_of_pat_norest_def = Define `
         SOME (v, []) => SOME v
       | _ => NONE`;
 
-val v_of_pat_norest_insts_length = store_thm ("v_of_pat_norest_insts_length",
-  ``!envC pat insts v.
+val v_of_pat_norest_insts_length = Q.store_thm ("v_of_pat_norest_insts_length",
+  `!envC pat insts v.
       v_of_pat_norest envC pat insts = SOME v ==>
-      LENGTH insts = LENGTH (pat_bindings pat [])``,
+      LENGTH insts = LENGTH (pat_bindings pat [])`,
   rpt strip_tac \\ fs [v_of_pat_norest_def] \\ every_case_tac \\ fs [] \\
   rw [] \\ progress (fst (CONJ_PAIR v_of_pat_insts_length)) \\ fs []
 );
 
-val v_of_pat_norest_insts_unique = store_thm ("v_of_pat_norest_insts_unique",
-  ``!envC pat insts v.
+val v_of_pat_norest_insts_unique = Q.store_thm ("v_of_pat_norest_insts_unique",
+  `!envC pat insts v.
       v_of_pat_norest envC pat insts = SOME v ==>
-      (!insts'. v_of_pat_norest envC pat insts' = SOME v <=> (insts' = insts))``,
+      (!insts'. v_of_pat_norest envC pat insts' = SOME v <=> (insts' = insts))`,
   rpt strip_tac \\ fs [v_of_pat_norest_def] \\
   every_case_tac \\ fs [] \\ rw [] \\
   try_finally (strip_tac \\ rw [] \\ fs []) \\
@@ -692,15 +692,15 @@ val validate_pat_def = Define `
    from the semantics.
 *)
 
-val v_of_pat_pmatch = store_thm ("v_of_pat_pmatch",
-  ``(!envC s pat v env_v insts.
+val v_of_pat_pmatch = Q.store_thm ("v_of_pat_pmatch",
+  `(!envC s pat v env_v insts.
       v_of_pat envC pat insts = SOME (v, []) ==>
       pmatch envC s pat v env_v = Match
         (ZIP (pat_bindings pat [], REVERSE insts) ++ env_v)) /\
     (!envC s pats vs env_v insts.
       v_of_pat_list envC pats insts = SOME (vs, []) ==>
       pmatch_list envC s pats vs env_v = Match
-        (ZIP (pats_bindings pats [], REVERSE insts) ++ env_v))``,
+        (ZIP (pats_bindings pats [], REVERSE insts) ++ env_v))`,
 
   HO_MATCH_MP_TAC pmatch_ind \\ rpt strip_tac \\ rw [] \\
   try_finally (
@@ -736,17 +736,17 @@ val v_of_pat_pmatch = store_thm ("v_of_pat_pmatch",
   )
 );
 
-val v_of_pat_norest_pmatch = store_thm ("v_of_pat_norest_pmatch",
-  ``!envC s pat v env_v insts.
+val v_of_pat_norest_pmatch = Q.store_thm ("v_of_pat_norest_pmatch",
+  `!envC s pat v env_v insts.
      v_of_pat_norest envC pat insts = SOME v ==>
      pmatch envC s pat v env_v = Match
-       (ZIP (pat_bindings pat [], REVERSE insts) ++ env_v)``,
+       (ZIP (pat_bindings pat [], REVERSE insts) ++ env_v)`,
   rpt strip_tac \\ fs [v_of_pat_norest_def] \\
   every_case_tac \\ fs [v_of_pat_pmatch]
 );
 
-val pmatch_v_of_pat = store_thm ("pmatch_v_of_pat",
-  ``(!envC s pat v env_v env_v'.
+val pmatch_v_of_pat = Q.store_thm ("pmatch_v_of_pat",
+  `(!envC s pat v env_v env_v'.
       pmatch envC s pat v env_v = Match env_v' ==>
       pat_without_Pref pat ==>
       ?insts.
@@ -757,7 +757,7 @@ val pmatch_v_of_pat = store_thm ("pmatch_v_of_pat",
       EVERY (\pat. pat_without_Pref pat) pats ==>
       ?insts.
         env_v' = ZIP (pats_bindings pats [], REVERSE insts) ++ env_v /\
-        v_of_pat_list envC pats insts = SOME (vs, []))``,
+        v_of_pat_list envC pats insts = SOME (vs, []))`,
 
   HO_MATCH_MP_TAC pmatch_ind \\ rpt strip_tac \\ rw [] \\
   try_finally (fs [pmatch_def, v_of_pat_def, pat_bindings_def])
@@ -803,13 +803,13 @@ val pmatch_v_of_pat = store_thm ("pmatch_v_of_pat",
   )
 );
 
-val pmatch_v_of_pat_norest = store_thm ("pmatch_v_of_pat_norest",
-  ``!envC s pat v env_v env_v'.
+val pmatch_v_of_pat_norest = Q.store_thm ("pmatch_v_of_pat_norest",
+  `!envC s pat v env_v env_v'.
       pmatch envC s pat v env_v = Match env_v' ==>
       pat_without_Pref pat ==>
       ?insts.
         env_v' = ZIP (pat_bindings pat [], REVERSE insts) ++ env_v /\
-        v_of_pat_norest envC pat insts = SOME v``,
+        v_of_pat_norest envC pat insts = SOME v`,
   rpt strip_tac \\ progress (fst (CONJ_PAIR pmatch_v_of_pat)) \\ fs [] \\
   qexists_tac `insts` \\ fs [v_of_pat_norest_def]
 );
@@ -838,9 +838,9 @@ in
     )
 end
 
-val cf_cases_local = store_thm ("cf_cases_local",
-  ``!v nomatch_exn rows env.
-      is_local (cf_cases v nomatch_exn rows env)``,
+val cf_cases_local = Q.store_thm ("cf_cases_local",
+  `!v nomatch_exn rows env.
+      is_local (cf_cases v nomatch_exn rows env)`,
   rpt strip_tac \\
   `cf_cases v nomatch_exn rows env =
    (\H Q. cf_cases v nomatch_exn rows env H Q)` by (
@@ -883,10 +883,10 @@ val sound_def = Define `
       htriple_valid p e env H Q`;
 
 
-val htriple_valid_normalise = store_thm ("htriple_valid_normalise",
-  ``!e env H Q.
+val htriple_valid_normalise = Q.store_thm ("htriple_valid_normalise",
+  `!e env H Q.
       htriple_valid (p:'ffi ffi_proj) (normalise e) env H Q <=>
-      htriple_valid (p:'ffi ffi_proj) e env H Q``,
+      htriple_valid (p:'ffi ffi_proj) e env H Q`,
   fs [htriple_valid_def, evaluate_ck_def, evaluate_normalise]
 );
 
@@ -904,8 +904,8 @@ val star_split = Q.prove (
   metis_tac []
 );
 
-val sound_local = store_thm ("sound_local",
-  ``!e R. sound (p:'ffi ffi_proj) e R ==> sound (p:'ffi ffi_proj) e (\env. local (R env))``,
+val sound_local = Q.store_thm ("sound_local",
+  `!e R. sound (p:'ffi ffi_proj) e R ==> sound (p:'ffi ffi_proj) e (\env. local (R env))`,
   rpt strip_tac \\ rewrite_tac [sound_def, htriple_valid_def] \\
   fs [local_def] \\ rpt strip_tac \\
   res_tac \\ rename1 `(H_i * H_k) h_i` \\ rename1 `R env H_i Q_f` \\
@@ -924,8 +924,8 @@ val sound_local = store_thm ("sound_local",
   SPLIT_TAC
 );
 
-val sound_false = store_thm ("sound_false",
-  ``!e. sound (p:'ffi ffi_proj) e (\env H Q. F)``,
+val sound_false = Q.store_thm ("sound_false",
+  `!e. sound (p:'ffi ffi_proj) e (\env H Q. F)`,
   rewrite_tac [sound_def]
 );
 
@@ -1040,17 +1040,17 @@ val app_rec_of_htriple_valid = Q.prove (
 (*------------------------------------------------------------------*)
 (* Lemmas used in the soundness proof of FFI *)
 
-val SPLIT_SING_2 = store_thm("SPLIT_SING_2",
-  ``SPLIT s (x,{y}) <=> (s = y INSERT x) /\ ~(y IN x)``,
+val SPLIT_SING_2 = Q.store_thm("SPLIT_SING_2",
+  `SPLIT s (x,{y}) <=> (s = y INSERT x) /\ ~(y IN x)`,
   SPLIT_TAC);
 
 val SUBSET_IN = Q.prove(
   `!s t x. s SUBSET t /\ x IN s ==> x IN t`,
   fs [SUBSET_DEF] \\ metis_tac []);
 
-val SPLIT_FFI_SET_IMP_DISJOINT = store_thm("SPLIT_FFI_SET_IMP_DISJOINT",
-  ``SPLIT (st2heap p st) (c,{FFI_part s u ns ts}) ==>
-    !s1 ts1. ~(FFI_part s1 u ns ts1 IN c)``,
+val SPLIT_FFI_SET_IMP_DISJOINT = Q.store_thm("SPLIT_FFI_SET_IMP_DISJOINT",
+  `SPLIT (st2heap p st) (c,{FFI_part s u ns ts}) ==>
+    !s1 ts1. ~(FFI_part s1 u ns ts1 IN c)`,
   fs [SPLIT_def] \\ rw [] \\ fs [EXTENSION,st2heap_def,DISJOINT_DEF]
   \\ CCONTR_TAC \\ fs []
   \\ `FFI_part s1 u ns ts1 IN ffi2heap p st.ffi /\
@@ -1064,18 +1064,18 @@ val SPLIT_FFI_SET_IMP_DISJOINT = store_thm("SPLIT_FFI_SET_IMP_DISJOINT",
   \\ Cases_on `ns` \\ fs []
   \\ metis_tac []);
 
-val SPLIT_IMP_Mem_NOT_IN = store_thm("SPLIT_IMP_Mem_NOT_IN",
-  ``SPLIT (st2heap p st) ({Mem y xs},c) ==>
-    !ys. ~(Mem y ys IN c)``,
+val SPLIT_IMP_Mem_NOT_IN = Q.store_thm("SPLIT_IMP_Mem_NOT_IN",
+  `SPLIT (st2heap p st) ({Mem y xs},c) ==>
+    !ys. ~(Mem y ys IN c)`,
   fs [SPLIT_def] \\ rw [] \\ fs [EXTENSION,st2heap_def]
   \\ CCONTR_TAC \\ fs []
   \\ `Mem y ys ∈ store2heap st.refs` by metis_tac [Mem_NOT_IN_ffi2heap]
   \\ `Mem y xs ∈ store2heap st.refs` by metis_tac [Mem_NOT_IN_ffi2heap]
   \\ imp_res_tac store2heap_IN_unique_key \\ fs []);
 
-val FLOOKUP_FUPDATE_LIST = store_thm("FLOOKUP_FUPDATE_LIST",
-  ``!ns f. FLOOKUP (f |++ MAP (λn. (n,s)) ns) m =
-           if MEM m ns then SOME s else FLOOKUP f m``,
+val FLOOKUP_FUPDATE_LIST = Q.store_thm("FLOOKUP_FUPDATE_LIST",
+  `!ns f. FLOOKUP (f |++ MAP (λn. (n,s)) ns) m =
+           if MEM m ns then SOME s else FLOOKUP f m`,
   Induct \\ fs [FUPDATE_LIST] \\ rw [] \\ fs []
   \\ fs [FLOOKUP_DEF,FAPPLY_FUPDATE_THM]);
 
@@ -1085,9 +1085,9 @@ val ALL_DISTINCT_FLAT_MEM_IMP = Q.store_thm("ALL_DISTINCT_FLAT_MEM_IMP",
   Induct \\ fs [ALL_DISTINCT_APPEND] \\ rw [] \\ fs []
   \\ res_tac \\ fs [MEM_FLAT] \\ metis_tac []);
 
-val ALL_DISTINCT_FLAT_FST_IMP = store_thm("ALL_DISTINCT_FLAT_FST_IMP",
-  ``!p2. ALL_DISTINCT (FLAT (MAP FST p2)) /\
-         MEM (ns,u') p2 /\ MEM (ns,u) p2 /\ ns <> [] ==> u = u'``,
+val ALL_DISTINCT_FLAT_FST_IMP = Q.store_thm("ALL_DISTINCT_FLAT_FST_IMP",
+  `!p2. ALL_DISTINCT (FLAT (MAP FST p2)) /\
+         MEM (ns,u') p2 /\ MEM (ns,u) p2 /\ ns <> [] ==> u = u'`,
   Induct \\ fs [ALL_DISTINCT_APPEND] \\ rw [] \\ fs []
   \\ fs [MEM_FLAT,MEM_MAP,FORALL_PROD]
   \\ Cases_on `ns` \\ fs []
@@ -1635,8 +1635,8 @@ val cf_defs = [
 (** Properties about [cf]. The main result is the proof of soundness,
     [cf_sound] *)
 
-val cf_local = store_thm ("cf_local",
-  ``!e. is_local (cf (p:'ffi ffi_proj) e env)``,
+val cf_local = Q.store_thm ("cf_local",
+  `!e. is_local (cf (p:'ffi ffi_proj) e env)`,
   Q.SPEC_TAC (`p`,`p`) \\
   recInduct cf_ind \\ rpt strip_tac \\
   fs (local_local :: local_is_local :: cf_defs)
@@ -1687,8 +1687,8 @@ val DROP_EL_CONS = Q.prove (
   Cases_on `n` \\ fs []
 );
 
-val FST_rw = prove(
-  ``(\(x,_,_). x) = FST``,
+val FST_rw = Q.prove(
+  `(\(x,_,_). x) = FST`,
   fs [FUN_EQ_THM,FORALL_PROD]);
 
 val cf_letrec_sound_aux = Q.prove (
@@ -2099,8 +2099,8 @@ fun add_to_clock qtm th g =
         th evaluate_match_add_to_clock_lemma g))
   g
 
-val cf_sound = store_thm ("cf_sound",
-  ``!p e. sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e)``,
+val cf_sound = Q.store_thm ("cf_sound",
+  `!p e. sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e)`,
   recInduct cf_ind \\ rpt strip_tac \\
   rewrite_tac cf_defs \\ fs [sound_local, sound_false]
   THEN1 (* Lit *) cf_base_case_tac
@@ -2524,15 +2524,15 @@ val cf_sound = store_thm ("cf_sound",
   )
 );
 
-val cf_sound' = store_thm ("cf_sound'",
-  ``!e env H Q st.
+val cf_sound' = Q.store_thm ("cf_sound'",
+  `!e env H Q st.
      cf (p:'ffi ffi_proj) e env H Q ==> H (st2heap (p:'ffi ffi_proj) st) ==>
      ?st' h_f h_g r ck.
        (case r of
           | Val v => evaluate (st with clock := ck) env [e] = (st', Rval [v])
           | Exn v => evaluate (st with clock := ck) env [e] = (st', Rerr (Rraise v))) /\
        SPLIT (st2heap (p:'ffi ffi_proj) st') (h_f, h_g) /\
-       Q r h_f``,
+       Q r h_f`,
   rpt strip_tac \\ qspecl_then [`(p:'ffi ffi_proj)`, `e`] assume_tac cf_sound \\
   fs [sound_def, evaluate_ck_def, htriple_valid_def] \\
   `SPLIT (st2heap p st) (st2heap p st, {})` by SPLIT_TAC \\
@@ -2540,8 +2540,8 @@ val cf_sound' = store_thm ("cf_sound'",
   `SPLIT (st2heap p st') (h_f, h_g)` by SPLIT_TAC \\ instantiate
 );
 
-val cf_sound_local = store_thm ("cf_sound_local",
-  ``!e env H Q h i st.
+val cf_sound_local = Q.store_thm ("cf_sound_local",
+  `!e env H Q h i st.
      cf (p:'ffi ffi_proj) e env H Q ==>
      SPLIT (st2heap (p:'ffi ffi_proj) st) (h, i) ==>
      H h ==>
@@ -2550,7 +2550,7 @@ val cf_sound_local = store_thm ("cf_sound_local",
           | Val v => evaluate (st with clock := ck) env [e] = (st', Rval [v])
           | Exn v => evaluate (st with clock := ck) env [e] = (st', Rerr (Rraise v))) /\
        SPLIT3 (st2heap (p:'ffi ffi_proj) st') (h', g, i) /\
-       Q r h'``,
+       Q r h'`,
   rpt strip_tac \\
   `sound (p:'ffi ffi_proj) e (\env. (local (cf (p:'ffi ffi_proj) e env)))` by
     (match_mp_tac sound_local \\ fs [cf_sound]) \\
@@ -2560,28 +2560,28 @@ val cf_sound_local = store_thm ("cf_sound_local",
   res_tac \\ progress SPLIT3_swap23 \\ instantiate
 )
 
-val app_basic_of_cf = store_thm ("app_basic_of_cf",
-  ``!clos body x env env' v H Q.
+val app_basic_of_cf = Q.store_thm ("app_basic_of_cf",
+  `!clos body x env env' v H Q.
      do_opapp [clos; x] = SOME (env', body) ==>
      cf (p:'ffi ffi_proj) body env' H Q ==>
-     app_basic (p:'ffi ffi_proj) clos x H Q``,
+     app_basic (p:'ffi ffi_proj) clos x H Q`,
   rpt strip_tac \\ irule app_basic_of_htriple_valid \\
   progress (REWRITE_RULE [sound_def] cf_sound) \\
   instantiate
 )
 
-val app_of_cf = store_thm ("app_of_cf",
-  ``!ns env body xvs env' H Q.
+val app_of_cf = Q.store_thm ("app_of_cf",
+  `!ns env body xvs env' H Q.
      ns <> [] ==>
      LENGTH xvs = LENGTH ns ==>
      cf (p:'ffi ffi_proj) body (extend_env ns xvs env) H Q ==>
-     app (p:'ffi ffi_proj) (naryClosure env ns body) xvs H Q``,
+     app (p:'ffi ffi_proj) (naryClosure env ns body) xvs H Q`,
   rpt strip_tac \\ irule app_of_htriple_valid \\ fs [] \\
   progress (REWRITE_RULE [sound_def] cf_sound)
 )
 
-val app_rec_of_cf = store_thm ("app_rec_of_cf",
-  ``!f params body funs xvs env H Q.
+val app_rec_of_cf = Q.store_thm ("app_rec_of_cf",
+  `!f params body funs xvs env H Q.
      params <> [] ==>
      LENGTH params = LENGTH xvs ==>
      ALL_DISTINCT (MAP (\ (f,_,_). f) funs) ==>
@@ -2592,7 +2592,7 @@ val app_rec_of_cf = store_thm ("app_rec_of_cf",
           (MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs)
           params xvs env)
         H Q ==>
-     app (p:'ffi ffi_proj) (naryRecclosure env (letrec_pull_params funs) f) xvs H Q``,
+     app (p:'ffi ffi_proj) (naryRecclosure env (letrec_pull_params funs) f) xvs H Q`,
   rpt strip_tac \\ irule app_rec_of_htriple_valid \\ fs [] \\
   progress (REWRITE_RULE [sound_def] cf_sound)
 )

--- a/characteristic/cfStoreScript.sml
+++ b/characteristic/cfStoreScript.sml
@@ -117,16 +117,16 @@ val store2heap_IN_unique_key = store_thm ("store2heap_IN_unique_key",
   tac_store2heap_IN
 )
 
-val Mem_NOT_IN_ffi2heap = store_thm("Mem_NOT_IN_ffi2heap",
-  ``~(Mem rv x IN ffi2heap (p:'ffi ffi_proj) f)``,
+val Mem_NOT_IN_ffi2heap = Q.store_thm("Mem_NOT_IN_ffi2heap",
+  `~(Mem rv x IN ffi2heap (p:'ffi ffi_proj) f)`,
   PairCases_on `p` \\ fs [ffi2heap_def] \\ rw []);
 
-val FFI_part_NOT_IN_store2heap_aux = store_thm("FFI_part_NOT_IN_store2heap_aux",
-  ``∀n s. FFI_part x1 x2 x3 ∉ store2heap_aux n s``,
+val FFI_part_NOT_IN_store2heap_aux = Q.store_thm("FFI_part_NOT_IN_store2heap_aux",
+  `∀n s. FFI_part x1 x2 x3 ∉ store2heap_aux n s`,
   Induct_on `s` \\ fs [store2heap_aux_def]);
 
-val FFI_part_NOT_IN_store2heap = store_thm("FFI_part_NOT_IN_store2heap",
-  ``!s. ~(FFI_part x1 x2 x3 ∈ store2heap s)``,
+val FFI_part_NOT_IN_store2heap = Q.store_thm("FFI_part_NOT_IN_store2heap",
+  `!s. ~(FFI_part x1 x2 x3 ∈ store2heap s)`,
   fs [store2heap_def,FFI_part_NOT_IN_store2heap_aux]);
 
 val store2heap_LUPDATE = store_thm ("store2heap_LUPDATE",

--- a/characteristic/cfTacticsBaseLib.sml
+++ b/characteristic/cfTacticsBaseLib.sml
@@ -390,8 +390,8 @@ fun print_dcc direction t = (
   val P_def = Define `P (x : num) (y : bool) = T`
   val Q_def = Define `Q (x : num) (y : num) = T`
 
-  val dummy_imp = prove (``
-    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)``,
+  val dummy_imp = Q.prove (`
+    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)`,
   REWRITE_TAC[P_def]);
 *)
 

--- a/characteristic/cfTacticsScript.sml
+++ b/characteristic/cfTacticsScript.sml
@@ -7,43 +7,43 @@ open cfTacticsBaseLib cfHeapsLib
 val _ = new_theory "cfTactics"
 
 (*
-val xret_lemma = store_thm ("xret_lemma",
-  ``!H Q.
+val xret_lemma = Q.store_thm ("xret_lemma",
+  `!H Q.
     (H ==>> Q v * GC) ==>
-    local (\H' Q'. H' ==>> Q' v) H Q``,
+    local (\H' Q'. H' ==>> Q' v) H Q`,
   rpt strip_tac \\ irule (Q.SPEC `GC` local_gc_pre_on) \\
   fs [local_is_local] \\ first_assum hchanges \\ hinst \\
   irule local_elim \\ fs [] \\ hsimpl
 )*)
 
-val xret_lemma = store_thm ("xret_lemma",
-  ``!H Q R.
+val xret_lemma = Q.store_thm ("xret_lemma",
+  `!H Q R.
     H ==>> Q v * GC /\ R Q ==>
-    local (\H' Q'. H' ==>> Q' v /\ R Q') H Q``,
+    local (\H' Q'. H' ==>> Q' v /\ R Q') H Q`,
   rpt strip_tac \\ irule (Q.SPEC `GC` local_gc_pre_on) \\
   fs [local_is_local] \\ first_assum hchanges \\ hinst \\
   irule local_elim \\ fs [] \\ hsimpl
 )
 
 (* todo: does it even happen? *)
-val xret_lemma_unify = store_thm ("xret_lemma_unify",
-  ``!v H. local (\H' Q'. H' ==>> Q' v) H (\x. cond (x = v) * H)``,
+val xret_lemma_unify = Q.store_thm ("xret_lemma_unify",
+  `!v H. local (\H' Q'. H' ==>> Q' v) H (\x. cond (x = v) * H)`,
   rpt strip_tac \\ irule local_elim \\ fs [] \\ hsimpl
 )
 
 (*
-val xret_no_gc_lemma = store_thm ("xret_no_gc_lemma",
-  ``!v H Q.
+val xret_no_gc_lemma = Q.store_thm ("xret_no_gc_lemma",
+  `!v H Q.
       (H ==>> Q v) ==>
-      local (\H' Q'. H' ==>> Q' v) H Q``,
+      local (\H' Q'. H' ==>> Q' v) H Q`,
   fs [local_elim]
 )
 *)
 
-val xret_no_gc_lemma = store_thm ("xret_no_gc_lemma",
-  ``!v H Q R.
+val xret_no_gc_lemma = Q.store_thm ("xret_no_gc_lemma",
+  `!v H Q R.
       H ==>> Q v /\ R Q ==>
-      local (\H' Q'. H' ==>> Q' v /\ R Q') H Q``,
+      local (\H' Q'. H' ==>> Q' v /\ R Q') H Q`,
   fs [local_elim]
 )
 
@@ -51,53 +51,53 @@ val xret_no_gc_lemma = store_thm ("xret_no_gc_lemma",
 (* Automatic rewrites *)
 
 
-val INT_Litv = store_thm ("INT_Litv[simp]",
-  ``INT i (Litv (IntLit k)) = (i = k)``,
+val INT_Litv = Q.store_thm ("INT_Litv[simp]",
+  `INT i (Litv (IntLit k)) = (i = k)`,
   fs [INT_def] \\ eq_tac \\ fs []
 )
 
-val NUM_Litv = store_thm ("NUM_Litv[simp]",
-  ``NUM n (Litv (IntLit k)) = (k = &n)``,
+val NUM_Litv = Q.store_thm ("NUM_Litv[simp]",
+  `NUM n (Litv (IntLit k)) = (k = &n)`,
   fs [NUM_def] \\ eq_tac \\ fs []
 )
 
-val CHAR_Litv = store_thm ("CHAR_Litv[simp]",
-  ``CHAR c (Litv (Char c')) = (c = c')``,
+val CHAR_Litv = Q.store_thm ("CHAR_Litv[simp]",
+  `CHAR c (Litv (Char c')) = (c = c')`,
   fs [CHAR_def] \\ eq_tac \\ fs []
 )
 
-val STRING_Litv = store_thm ("STRING_Litv[simp]",
-  ``STRING_TYPE s (Litv (StrLit s')) = (s' = explode s)``,
+val STRING_Litv = Q.store_thm ("STRING_Litv[simp]",
+  `STRING_TYPE s (Litv (StrLit s')) = (s' = explode s)`,
   fs [STRING_TYPE_def] \\ eq_tac \\ fs []
 )
 
-val WORD8_Litv = store_thm ("WORD8_Litv[simp]",
-  ``WORD w (Litv (Word8 w')) = (w = w')``,
+val WORD8_Litv = Q.store_thm ("WORD8_Litv[simp]",
+  `WORD w (Litv (Word8 w')) = (w = w')`,
   fs [WORD_def, w2w_def] \\ eq_tac \\ fs []
 )
 
-val WORD64_Litv = store_thm ("WORD64_Litv[simp]",
-  ``WORD w (Litv (Word64 w')) = (w = w')``,
+val WORD64_Litv = Q.store_thm ("WORD64_Litv[simp]",
+  `WORD w (Litv (Word64 w')) = (w = w')`,
   fs [WORD_def, w2w_def] \\ eq_tac \\ fs []
 )
 
-val UNIT_Conv = store_thm ("UNIT_Conv[simp]",
-  ``UNIT_TYPE () (Conv NONE []) = T``,
+val UNIT_Conv = Q.store_thm ("UNIT_Conv[simp]",
+  `UNIT_TYPE () (Conv NONE []) = T`,
   fs [UNIT_TYPE_def]
 )
 
-val BOOL_T_Conv = store_thm ("BOOL_T_Conv[simp]",
-  ``BOOL T (Conv (SOME ("true", TypeId (Short "bool"))) []) = T``,
+val BOOL_T_Conv = Q.store_thm ("BOOL_T_Conv[simp]",
+  `BOOL T (Conv (SOME ("true", TypeId (Short "bool"))) []) = T`,
   fs [BOOL_def, semanticPrimitivesTheory.Boolv_def]
 )
 
-val BOOL_F_Conv = store_thm ("BOOL_F_Conv[simp]",
-  ``BOOL F (Conv (SOME ("false", TypeId (Short "bool"))) []) = T``,
+val BOOL_F_Conv = Q.store_thm ("BOOL_F_Conv[simp]",
+  `BOOL F (Conv (SOME ("false", TypeId (Short "bool"))) []) = T`,
   fs [BOOL_def, semanticPrimitivesTheory.Boolv_def]
 )
 
-val BOOL_Boolv = store_thm ("BOOL_Boolv[simp]",
-  ``BOOL b (Boolv bv) = (b = bv)``,
+val BOOL_Boolv = Q.store_thm ("BOOL_Boolv[simp]",
+  `BOOL b (Boolv bv) = (b = bv)`,
   fs [BOOL_def, semanticPrimitivesTheory.Boolv_def] \\
   every_case_tac \\ fs []
 )
@@ -105,23 +105,23 @@ val BOOL_Boolv = store_thm ("BOOL_Boolv[simp]",
 (*------------------------------------------------------------------*)
 (* Used for cleaning up after unfolding [build_cases] (in cf_match) *)
 
-val exists_v_of_pat_norest_length = store_thm (
+val exists_v_of_pat_norest_length = Q.store_thm (
   "exists_v_of_pat_norest_length",
-  ``!envC pat insts v.
+  `!envC pat insts v.
      (?insts. v_of_pat_norest envC pat insts = SOME v) <=>
      (?insts. LENGTH insts = LENGTH (pat_bindings pat []) /\
-              v_of_pat_norest envC pat insts = SOME v)``,
+              v_of_pat_norest envC pat insts = SOME v)`,
   rpt strip_tac \\ eq_tac \\ fs [] \\ rpt strip_tac \\ instantiate \\
   progress v_of_pat_norest_insts_length
 )
 
-val forall_v_of_pat_norest_length = store_thm (
+val forall_v_of_pat_norest_length = Q.store_thm (
   "forall_v_of_pat_norest_length",
-  ``!envC pat insts v P.
+  `!envC pat insts v P.
      (!insts. v_of_pat_norest envC pat insts = SOME v ==> P insts) <=>
      (!insts. LENGTH insts = LENGTH (pat_bindings pat []) ==>
               v_of_pat_norest envC pat insts = SOME v ==>
-              P insts)``,
+              P insts)`,
   rpt strip_tac \\ eq_tac \\ fs [] \\ rpt strip_tac \\
   progress v_of_pat_norest_insts_length \\ first_assum progress
 )

--- a/characteristic/evarsConseqConvLib.sml
+++ b/characteristic/evarsConseqConvLib.sml
@@ -161,12 +161,12 @@ end
   val P_def = Define `P (x : num) (y : bool) = T`
   val Q_def = Define `Q (x : num) (y : num) = T`
 
-  val dummy_imp = prove (``
-    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)``,
+  val dummy_imp = Q.prove (`
+    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)`,
   REWRITE_TAC[P_def]);
 
-  val dummy_imp2 = prove (``
-    !x y z. P (z + x) (y > x)``,
+  val dummy_imp2 = Q.prove (`
+    !x y z. P (z + x) (y > x)`,
   REWRITE_TAC[P_def]);
 
   val t = ``?(a:'a) x c y. P (5 + (x + 2)) ((c:num) > y)``
@@ -227,12 +227,12 @@ fun (ecc1 then_ecc ecc2) {term, evars} =
   val Q_def = Define `Q (x : num) (y : num) = T`
   val R_def = Define `R (x : num) (y : num) (z: num) (z': num) = T`
 
-  val imp1 = prove (``
-    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)``,
+  val imp1 = Q.prove (`
+    !x y z (z' : num). Q x (z + y + z') ==> P (z + x) (y > x)`,
   REWRITE_TAC[P_def]);
 
-  val imp2 = prove (``
-    !(x:num) y z z'. R x y z z' ==> Q (x + y) (z + z')``,
+  val imp2 = Q.prove (`
+    !(x:num) y z z'. R x y z z' ==> Q (x + y) (z + z')`,
   REWRITE_TAC[Q_def]);
 
   val t = ``?(a:'a) x (c:num) y. P (5 + (x + 2)) (c > y)``

--- a/characteristic/examples/cf_examplesScript.sml
+++ b/characteristic/examples/cf_examplesScript.sml
@@ -274,11 +274,11 @@ val bytearray_fromlist = process_topdecs
 
 val st = ml_progLib.add_prog bytearray_fromlist pick_name basis_st
 
-val list_length_spec = store_thm ("list_length_spec",
-  ``!a l lv.
+val list_length_spec = Q.store_thm ("list_length_spec",
+  `!a l lv.
      LIST_TYPE a l lv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "length" st) [lv]
-       emp (POSTv v. & NUM (LENGTH l) v)``,
+       emp (POSTv v. & NUM (LENGTH l) v)`,
   Induct_on `l`
   THEN1 (
     xcf "length" st \\ fs [LIST_TYPE_def] \\

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -336,10 +336,10 @@ val compile_oracle = Q.store_thm("compile_oracle",`
   rveq>>fs[]>>
   BasicProvers.EVERY_CASE_TAC>>fs[])
 
-val to_livesets_invariant = store_thm("to_livesets_invariant",``
+val to_livesets_invariant = Q.store_thm("to_livesets_invariant",`
   to_livesets (c with word_to_word_conf:=wc) p =
   let (rcm,c,p) = to_livesets c p in
-    (rcm,c with word_to_word_conf:=wc,p)``,
+    (rcm,c with word_to_word_conf:=wc,p)`,
   srw_tac[][FUN_EQ_THM,
      to_data_def,
      to_bvi_def,

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -293,8 +293,8 @@ val from_livesets_def = Define`
   let c = c with word_to_word_conf updated_by (λc. c with col_oracle := col) in
   from_word c p`
 
-val compile_oracle = store_thm("compile_oracle",``
-  from_livesets (to_livesets c p) = compile c p``,
+val compile_oracle = Q.store_thm("compile_oracle",`
+  from_livesets (to_livesets c p) = compile c p`,
   srw_tac[][FUN_EQ_THM,
      to_data_def,
      to_bvi_def,

--- a/compiler/backend/bignum/multiwordScript.sml
+++ b/compiler/backend/bignum/multiwordScript.sml
@@ -36,9 +36,9 @@ val MULT_ADD_LESS_MULT_ADD = Q.prove(
   \\ `m * k + k <= l * k` by ASM_SIMP_TAC bool_ss [LE_MULT_RCANCEL,GSYM MULT]
   \\ DECIDE_TAC);
 
-val SPLIT_LET2 = prove(
-  ``!x y z P. (let (x,y) = z in P x y (x,y)) =
-              (let x = FST z in let y = SND z in P x y (x,y))``,
+val SPLIT_LET2 = Q.prove(
+  `!x y z P. (let (x,y) = z in P x y (x,y)) =
+              (let x = FST z in let y = SND z in P x y (x,y))`,
   Cases_on `z` \\ SIMP_TAC std_ss [LET_THM]);
 
 
@@ -252,8 +252,8 @@ val mw_ok_n2mw = Q.store_thm("mw_ok_n2mw",
   \\ ONCE_REWRITE_TAC [n2mw_def] \\ FULL_SIMP_TAC std_ss [DECIDE ``0<n = ~(n = 0)``]
   \\ FULL_SIMP_TAC std_ss [NOT_NIL_CONS]);
 
-val mw_ok_i2mw = store_thm("mw_ok_i2mw",
-  ``!i x xs. (i2mw i = (x,xs)) ==> mw_ok xs``,
+val mw_ok_i2mw = Q.store_thm("mw_ok_i2mw",
+  `!i x xs. (i2mw i = (x,xs)) ==> mw_ok xs`,
   SIMP_TAC std_ss [i2mw_def,mw_ok_n2mw]);
 
 val n2mw_EQ_k2mw = Q.prove(
@@ -317,8 +317,8 @@ val IMP_EQ_n2mw_ALT = Q.prove(
   `!xs ys. mw_ok xs /\ mw_ok ys /\ (mw2n xs = mw2n ys) ==> (xs = ys)`,
   METIS_TAC [IMP_EQ_n2mw]);
 
-val EXISTS_i2mw = prove(
-  ``!x. mw_ok (SND x) /\ ~(x = (T,[])) ==> ?y. x = i2mw y``,
+val EXISTS_i2mw = Q.prove(
+  `!x. mw_ok (SND x) /\ ~(x = (T,[])) ==> ?y. x = i2mw y`,
   Cases \\ SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC mw_ok_IMP_EXISTS_n2mw THEN1
    (Q.EXISTS_TAC `(& n)` \\ ASM_SIMP_TAC std_ss [i2mw_def,n2mw_11]
@@ -328,8 +328,8 @@ val EXISTS_i2mw = prove(
   \\ Cases_on `q` \\ FULL_SIMP_TAC std_ss [i2mw_def,n2mw_11]
   \\ REPEAT (POP_ASSUM (K ALL_TAC)) \\ intLib.COOPER_TAC);
 
-val mw2i_EQ_IMP_EQ_i2mw = prove(
-  ``!x. mw_ok (SND x) /\ ~(x = (T,[])) /\ (mw2i x = i) ==> (x = i2mw i)``,
+val mw2i_EQ_IMP_EQ_i2mw = Q.prove(
+  `!x. mw_ok (SND x) /\ ~(x = (T,[])) /\ (mw2i x = i) ==> (x = i2mw i)`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC EXISTS_i2mw \\ FULL_SIMP_TAC std_ss [mw2i_i2mw]);
 
 val LENGTH_n2mw_LESS_LENGTH_n2mw = Q.prove(
@@ -389,8 +389,8 @@ val mw2i_mw_zerofix = Q.prove(
   `!x. mw2i (mw_zerofix x) = mw2i x`,
   SRW_TAC [] [mw_zerofix_def,mw2i_def,mw2n_def]);
 
-val mw_zerofix_thm = prove(
-  ``!x b xs. ~(mw_zerofix x = (T,[])) /\ mw_ok (SND (mw_zerofix (b, mw_fix xs)))``,
+val mw_zerofix_thm = Q.prove(
+  `!x b xs. ~(mw_zerofix x = (T,[])) /\ mw_ok (SND (mw_zerofix (b, mw_fix xs)))`,
   SRW_TAC [] [mw_zerofix_def,mw_ok_CLAUSES,mw_ok_mw_fix]);
 
 val mw_fix_NIL = Q.store_thm("mw_fix_NIL",
@@ -476,10 +476,10 @@ val mw_sub_def = Define `
     let (z,c1) = single_sub x y c in
     let (zs,c2) = mw_sub xs ys c1 in (z::zs,c2))`;
 
-val single_add_thm = store_thm("single_add_thm",
-  ``!(x:'a word) y z c d.
+val single_add_thm = Q.store_thm("single_add_thm",
+  `!(x:'a word) y z c d.
       (single_add x y c = (z,d)) ==>
-      (w2n z + dimword (:'a) * b2n d = w2n x + w2n y + b2n c)``,
+      (w2n z + dimword (:'a) * b2n d = w2n x + w2n y + b2n c)`,
   NTAC 2 Cases_word \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ ASM_SIMP_TAC std_ss [single_add_def,w2n_n2w,LESS_MOD,b2w_def] \\ STRIP_TAC
   \\ Cases_on `dimword (:'a) <= n + n' + b2n c`
@@ -495,9 +495,9 @@ val b2n_thm = Q.prove(
   `!c. b2n c = if c then 1 else 0`,
   Cases \\ SIMP_TAC std_ss [b2n_def]);
 
-val single_add_eq = store_thm("single_add_eq",
-  ``single_add x y c = (FST (add_with_carry (x,y:'a word,c)),
-                        FST (SND (add_with_carry (x,y,c))))``,
+val single_add_eq = Q.store_thm("single_add_eq",
+  `single_add x y c = (FST (add_with_carry (x,y:'a word,c)),
+                        FST (SND (add_with_carry (x,y,c))))`,
   SIMP_TAC std_ss [single_add_def,add_with_carry_def,LET_DEF,GSYM b2n_thm]
   \\ SIMP_TAC std_ss [GSYM word_add_n2w,n2w_w2n,b2w_def]
   \\ Cases_on `x` \\ Cases_on `y` \\ ASM_SIMP_TAC std_ss [w2n_n2w,LESS_MOD]
@@ -509,11 +509,11 @@ val single_add_eq = store_thm("single_add_eq",
   \\ SIMP_TAC std_ss [DECIDE ``((m = n + m:num) = (0 = n)) /\ (~(n=0)=0<n)``]
   \\ SIMP_TAC std_ss [X_LT_DIV,ZERO_LT_dimword] \\ DECIDE_TAC);
 
-val mw_add_thm = prove(
-  ``!xs ys c (zs:'a word list) d.
+val mw_add_thm = Q.prove(
+  `!xs ys c (zs:'a word list) d.
       (mw_add xs ys c = (zs,d)) /\ (LENGTH xs = LENGTH ys) ==>
       (mw2n zs + dimwords (LENGTH xs) (:'a) * b2n d =
-       mw2n xs + mw2n ys + b2n c)``,
+       mw2n xs + mw2n ys + b2n c)`,
   Induct \\ Cases_on `ys` \\ SIMP_TAC std_ss
     [mw_add_def,LENGTH,dimwords_thm,mw2n_def,DECIDE ``~(SUC n = 0)``,HD,TL]
   \\ BasicProvers.LET_ELIM_TAC
@@ -525,10 +525,10 @@ val mw_add_thm = prove(
   \\ FULL_SIMP_TAC std_ss [GSYM ADD_ASSOC,GSYM LEFT_ADD_DISTRIB,GSYM MULT_ASSOC]
   \\ DECIDE_TAC);
 
-val single_sub_thm = prove(
-  ``!(x:'a word) y z c d.
+val single_sub_thm = Q.prove(
+  `!(x:'a word) y z c d.
       (single_sub x y c = (z,d)) ==>
-      (w2n z + dimword (:'a) * b2n d + w2n y = w2n x + b2n c + (dimword(:'a) - 1))``,
+      (w2n z + dimword (:'a) * b2n d + w2n y = w2n x + b2n c + (dimword(:'a) - 1))`,
   SIMP_TAC std_ss [single_sub_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC single_add_thm \\ ASM_SIMP_TAC std_ss []
   \\ SIMP_TAC std_ss [DECIDE ``(x+yy+c+y=x+c+d)=(yy+y=d:num)``]
@@ -536,12 +536,12 @@ val single_sub_thm = prove(
   \\ `dimword (:'a) - 1 - n < dimword (:'a)` by DECIDE_TAC
   \\ ASM_SIMP_TAC std_ss [w2n_n2w,word_1comp_n2w] \\ DECIDE_TAC);
 
-val mw_sub_lemma = prove(
-  ``!xs ys c (zs:'a word list) d.
+val mw_sub_lemma = Q.prove(
+  `!xs ys c (zs:'a word list) d.
       (mw_sub xs ys c = (zs,d)) /\ (LENGTH xs = LENGTH ys) ==>
       (mw2n zs + mw2n ys + dimwords (LENGTH xs) (:'a) * b2n d =
        mw2n xs + b2n c + (dimwords (LENGTH xs) (:'a) - 1)) /\
-      (LENGTH zs = LENGTH xs)``,
+      (LENGTH zs = LENGTH xs)`,
   Induct \\ Cases_on `ys` \\ SIMP_TAC std_ss
     [mw_sub_def,LENGTH,dimwords_thm,mw2n_def,DECIDE ``~(SUC n = 0)``,HD,TL]
   \\ BasicProvers.LET_ELIM_TAC \\ IMP_RES_TAC single_sub_thm
@@ -621,13 +621,13 @@ val mw_ok_addv = Q.prove(
   \\ Q.SPEC_TAC (`z`,`z`) \\ Cases
   \\ ASM_SIMP_TAC std_ss [n2w_11,ZERO_LT_dimword,w2n_n2w]);
 
-val mw_addv_EQ_mw_add = store_thm("mw_addv_EQ_mw_add",
-  ``!xs1 xs2 ys c1.
+val mw_addv_EQ_mw_add = Q.store_thm("mw_addv_EQ_mw_add",
+  `!xs1 xs2 ys c1.
       (LENGTH ys = LENGTH xs1) ==>
       (mw_addv (xs1 ++ xs2) ys c1 =
         let (zs1,c2) = mw_add xs1 ys c1 in
         let (zs2,c3) = mw_add xs2 (MAP (\x.0w) xs2) c2 in
-          zs1 ++ zs2 ++ if c3 then [1w] else [])``,
+          zs1 ++ zs2 ++ if c3 then [1w] else [])`,
   Induct THEN1
    (Induct \\ FULL_SIMP_TAC std_ss [APPEND,LENGTH,LENGTH_NIL,mw_addv_def,mw_add_def]
     THEN1 SIMP_TAC std_ss [LET_DEF,APPEND] \\ REPEAT STRIP_TAC
@@ -643,13 +643,13 @@ val mw_addv_EQ_mw_add = store_thm("mw_addv_EQ_mw_add",
   \\ Cases_on `mw_add xs2 (MAP (\x. 0x0w) xs2) r'`
   \\ ASM_SIMP_TAC std_ss [APPEND]);
 
-val mw_sub_APPEND = store_thm("mw_sub_APPEND",
-  ``!xs1 xs2 ys c.
+val mw_sub_APPEND = Q.store_thm("mw_sub_APPEND",
+  `!xs1 xs2 ys c.
       (LENGTH xs1 = LENGTH ys) ==>
       (mw_sub (xs1 ++ xs2) ys c =
        let (ts1,c) = mw_sub xs1 ys c in
        let (ts2,c) = mw_sub xs2 [] c in
-         (ts1 ++ ts2,c))``,
+         (ts1 ++ ts2,c))`,
   Induct \\ Cases_on `ys`
   \\ ASM_SIMP_TAC std_ss [mw_sub_def,APPEND,LET_DEF,LENGTH,ADD1]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
@@ -701,10 +701,10 @@ val mwi_add_def = Define `
 val mwi_sub_def = Define `
   mwi_sub (s,xs) (t,ys) = mwi_add (s,xs) (~t,ys)`;
 
-val mwi_add_lemma = prove(
-  ``!s t xs ys.
+val mwi_add_lemma = Q.prove(
+  `!s t xs ys.
       mw_ok xs /\ mw_ok ys ==>
-      (mw2i (mwi_add (s,xs) (t,ys)) = mw2i (s,xs) + mw2i (t,ys))``,
+      (mw2i (mwi_add (s,xs) (t,ys)) = mw2i (s,xs) + mw2i (t,ys))`,
   REPEAT STRIP_TAC \\ Cases_on `s` \\ Cases_on `t` \\ Cases_on `mw2n ys <= mw2n xs`
   \\ Cases_on `LENGTH ys <= LENGTH xs`
   \\ IMP_RES_TAC (DECIDE ``~(m<=n) ==> n <= m:num``)
@@ -745,10 +745,10 @@ val mwi_add_thm = Q.store_thm("mwi_add_thm",
        LENGTH_n2mw_LESS_LENGTH_n2mw] (Q.SPECL [`n2mw n`,`n2mw m`] mw_subv_thm))
   \\ intLib.COOPER_TAC);
 
-val mwi_sub_lemma = prove(
-  ``!s t xs ys.
+val mwi_sub_lemma = Q.prove(
+  `!s t xs ys.
       mw_ok xs /\ mw_ok ys ==>
-      (mw2i (mwi_sub (s,xs) (t,ys)) = mw2i (s,xs) - mw2i (t,ys))``,
+      (mw2i (mwi_sub (s,xs) (t,ys)) = mw2i (s,xs) - mw2i (t,ys))`,
   ASM_SIMP_TAC std_ss [mwi_add_lemma,mwi_sub_def] \\ Cases_on `t`
   \\ ASM_SIMP_TAC std_ss [mw2i_def,INT_ADD_REDUCE,INT_ADD_CALCULATE,
       INT_SUB_REDUCE,INT_SUB_CALCULATE]);
@@ -806,10 +806,10 @@ val mwi_mul_def = Define `
     if (xs = []) \/ (ys = []) then (F,[]) else
       (~(s = t), mw_fix (mw_mul xs ys (MAP (\x.0w) ys)))`;
 
-val single_mul_thm = prove(
-  ``!(x:'a word) y k z l.
+val single_mul_thm = Q.prove(
+  `!(x:'a word) y k z l.
       (single_mul x y k = (z,l)) ==>
-      (w2n z + dimword (:'a) * w2n l = w2n x * w2n y + w2n k)``,
+      (w2n z + dimword (:'a) * w2n l = w2n x * w2n y + w2n k)`,
   NTAC 3 Cases_word \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ ASM_SIMP_TAC std_ss [single_mul_def,w2n_n2w,LESS_MOD,b2w_def]
   \\ `(n * n' + n'') DIV dimword (:'a) < dimword (:'a)` by
@@ -824,10 +824,10 @@ val ADD_LESS_MULT = Q.prove(
   \\ Cases_on `1<n` \\ RES_TAC THEN1 DECIDE_TAC
   \\ `n = 1` by DECIDE_TAC \\ ASM_SIMP_TAC std_ss []);
 
-val single_mul_add_thm = prove(
-  ``!(p:'a word) q k1 k2 x1 x2.
+val single_mul_add_thm = Q.prove(
+  `!(p:'a word) q k1 k2 x1 x2.
       (single_mul_add p q k1 k2 = (x1,x2)) ==>
-      (w2n x1 + dimword (:'a) * w2n x2 = w2n p * w2n q + w2n k1 + w2n k2)``,
+      (w2n x1 + dimword (:'a) * w2n x2 = w2n p * w2n q + w2n k1 + w2n k2)`,
   SIMP_TAC std_ss [single_mul_add_def] \\ BasicProvers.LET_ELIM_TAC
   \\ POP_ASSUM (ASSUME_TAC o GSYM) \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC mw_add_thm \\ FULL_SIMP_TAC bool_ss [LENGTH,dimwords_thm]
@@ -1149,8 +1149,8 @@ val EQ_M_R_S_i =
 
 val EQT_M_R_S_i = fn x => (MATCH_MP_TAC (Q.SPECL [`xxx`,x,`yyy`] EQ_M_R_S_i))
 
-val EQ_A_S_R_2 = store_thm ("EQ_A_S_R_2",
-  ``!c d a b. d <= c /\ a + c < b + d ==> a < b``,
+val EQ_A_S_R_2 = Q.store_thm ("EQ_A_S_R_2",
+  `!c d a b. d <= c /\ a + c < b + d ==> a < b`,
   REPEAT strip_tac  >> RW_TAC arith_ss[]);
 
 val EQT_A_S_R_2 =
@@ -1193,12 +1193,12 @@ val DIV_thm5 = Q.store_thm( "DIV_thm5",
 
 (* lists *)
 
-val NOT_NIL_EQ_LENGTH_NOT_0 = store_thm ( "NOT_NIL_EQ_LENGTH_NOT_0",
-  ``x <> [] <=> (0 < LENGTH x)``,
+val NOT_NIL_EQ_LENGTH_NOT_0 = Q.store_thm ( "NOT_NIL_EQ_LENGTH_NOT_0",
+  `x <> [] <=> (0 < LENGTH x)`,
   Cases_on `x` >> lrw[]);
 
-val HD_REVERSE = store_thm ("HD_REVERSE",
-  ``!x. x <> [] ==> (HD (REVERSE x) = LAST x)``,
+val HD_REVERSE = Q.store_thm ("HD_REVERSE",
+  `!x. x <> [] ==> (HD (REVERSE x) = LAST x)`,
   REPEAT strip_tac >>
   Induct_on `x` THEN1 fs[] >>
   rw[LAST_DEF] >>
@@ -1217,17 +1217,17 @@ val dimwords_dimword = Q.store_thm("dimwords_dimword",
   Induct_on `n` THEN1 rw[] >>
   METIS_TAC[MULT_COMM,MULT,EXP,EXP_ADD]);
 
-val mw2n_msf = store_thm ("mw2n_msf" ,
-  ``!(x:'a word) xs. mw2n (xs++[x]) = mw2n xs + dimwords (LENGTH xs) (:'a) * w2n x``,
+val mw2n_msf = Q.store_thm ("mw2n_msf" ,
+  `!(x:'a word) xs. mw2n (xs++[x]) = mw2n xs + dimwords (LENGTH xs) (:'a) * w2n x`,
   Induct_on `xs` >>
   lrw[mw2n_def, EXP,dimwords_def,dimword_def,LEFT_ADD_DISTRIB] >>
   REWRITE_TAC[MULT,DECIDE ``z * dimindex (:'a) = dimindex (:'a) * z``] >>
   METIS_TAC[MULT_ASSOC,EXP_ADD,ADD_COMM]);
 
-val mw2n_msf_NIL = store_thm ("mw2n_msf_NIL",
-  ``!(xs:'a word list). (xs <> []) /\
+val mw2n_msf_NIL = Q.store_thm ("mw2n_msf_NIL",
+  `!(xs:'a word list). (xs <> []) /\
                         (mw2n xs < dimwords (LENGTH (FRONT xs)) (:'a)) ==>
-                        (mw2n xs = mw2n (FRONT xs))``,
+                        (mw2n xs = mw2n (FRONT xs))`,
   REPEAT strip_tac >>
   `mw2n xs = mw2n (FRONT xs ++ [LAST xs])` by METIS_TAC[APPEND_FRONT_LAST] >>
   POP_ASSUM (fn x => FULL_SIMP_TAC std_ss [x,mw2n_msf]) >>
@@ -1451,19 +1451,19 @@ val d_word_msb = Q.store_thm( "d_word_msb",
   \\ FULL_SIMP_TAC std_ss [dimword_def] \\ Cases_on `dimindex (:'a)`
   \\ FULL_SIMP_TAC std_ss [EXP] \\ DECIDE_TAC);
 
-val d_lemma1 = store_thm ("d_lemma1",
-``!(v1:'a word) (d:'a word) (x:'a word).
-   calc_d (FST(v1,d),SND(v1,d)*x) = calc_d(v1,d) * x``,
+val d_lemma1 = Q.store_thm ("d_lemma1",
+`!(v1:'a word) (d:'a word) (x:'a word).
+   calc_d (FST(v1,d),SND(v1,d)*x) = calc_d(v1,d) * x`,
   HO_MATCH_MP_TAC calc_d_ind >> REPEAT strip_tac >>
   rw[Once calc_d_def] THEN1 rw[Once calc_d_def] THEN1 rw[Once calc_d_def] >>
   fs[FST,SND] >>
   `!(x1:'a word) (x2:'a word). x1 * x2 = x2 * x1` by rw[] >>
   METIS_TAC[calc_d_def]);
 
-val d_lemma2 = store_thm ("d_lemma2",
-``!(v1:'a word) (d:'a word).
+val d_lemma2 = Q.store_thm ("d_lemma2",
+`!(v1:'a word) (d:'a word).
   FST(v1,d) <> 0w ==>
-  dimword(:'a) DIV 2 <= w2n ((calc_d (FST(v1,d),1w:'a word)) * (FST (v1,d)))``,
+  dimword(:'a) DIV 2 <= w2n ((calc_d (FST(v1,d),1w:'a word)) * (FST (v1,d)))`,
 
   HO_MATCH_MP_TAC calc_d_ind >> REPEAT strip_tac >>
   rw[Once calc_d_def] THEN1 METIS_TAC[d_word_msb] >>
@@ -1478,17 +1478,17 @@ val d_lemma2 = store_thm ("d_lemma2",
   `calc_d(2w *d, 2w) = calc_d(2w*d,1w) * 2w` by METIS_TAC[d_lemma1,FST,SND] >> POP_ASSUM (fn x => REWRITE_TAC[x]) >>
   RES_TAC >>rw[]);
 
-val d_lemma2_bis = store_thm ( "d_lemma2_bis",
-``!(v1:'a word) (d:'a word).
-  FST(v1,d) <> 0w ==> calc_d (FST(v1,d),1w) <> 0w``,
+val d_lemma2_bis = Q.store_thm ( "d_lemma2_bis",
+`!(v1:'a word) (d:'a word).
+  FST(v1,d) <> 0w ==> calc_d (FST(v1,d),1w) <> 0w`,
   REPEAT strip_tac >> IMP_RES_TAC d_lemma2 >>
   `w2n (calc_d (FST (v1,d),1w)) = 0` by METIS_TAC[word_0_n2w] >>
   fs[FST,word_mul_def] >>
   METIS_TAC[TWO,LESS_EQ,ONE_LT_dimword,DECIDE``0<2``,prim_recTheory.LESS_NOT_EQ,DIV_GT0]);
 
-val d_lemma3 = store_thm ("d_lemma3",
-``!(v1:'a word) (d:'a word).
-  w2n (calc_d (FST(v1,d),1w:'a word)) * w2n (FST (v1,d)) < dimword(:'a)``,
+val d_lemma3 = Q.store_thm ("d_lemma3",
+`!(v1:'a word) (d:'a word).
+  w2n (calc_d (FST(v1,d),1w:'a word)) * w2n (FST (v1,d)) < dimword(:'a)`,
 
   HO_MATCH_MP_TAC calc_d_ind >> REPEAT strip_tac >>
   srw_tac[][Once calc_d_def,w2n_lt] >>
@@ -1510,9 +1510,9 @@ val d_lemma3 = store_thm ("d_lemma3",
   `(2 * w2n X) * w2n d < dimword(:'a)` by RW_TAC arith_ss[] >>
   METIS_TAC[MOD_LESS_EQ,ZERO_LT_dimword,LESS_EQ_LESS_TRANS,LESS_MONO_MULT]);
 
-val d_lemma4 = store_thm ("d_lemma4",
-``!(v1:'a word) (d:'a word).
-  ?n. w2n (calc_d (FST(v1,d),1w)) = 2 ** n``,
+val d_lemma4 = Q.store_thm ("d_lemma4",
+`!(v1:'a word) (d:'a word).
+  ?n. w2n (calc_d (FST(v1,d),1w)) = 2 ** n`,
 
   HO_MATCH_MP_TAC calc_d_ind >> REPEAT strip_tac >> srw_tac[][Once calc_d_def] >> RES_TAC >>
   full_simp_tac (srw_ss())[FST] >>
@@ -1547,10 +1547,10 @@ val d_lemma4 = store_thm ("d_lemma4",
   METIS_TAC[LE_MULT_CANCEL_LBARE,LESS_EQ_LESS_TRANS,MULT_COMM,EQ_M_R_S_i,EXP_BASE_LT_MONO,DECIDE ``1 < 2``]) >>
   IMP_RES_TAC TWOEXP_MONO >> srw_tac[][LESS_MOD]);
 
-val d_lemma5 = store_thm ("d_lemma5",
-``!(v1:'a word) (d:'a word).
+val d_lemma5 = Q.store_thm ("d_lemma5",
+`!(v1:'a word) (d:'a word).
   2 <= w2n (calc_d (FST(v1,d),1w:'a word)) ==>
-  w2n (calc_d (FST(v1,d),1w:'a word)) * SUC (w2n (FST (v1,d))) <= dimword(:'a)``,
+  w2n (calc_d (FST(v1,d),1w:'a word)) * SUC (w2n (FST (v1,d))) <= dimword(:'a)`,
 
   REPEAT strip_tac >>
   REWRITE_TAC[dimword_def] >> ASSUME_TAC dimword_def >>  Q.PAT_ABBREV_TAC `m = dimindex(:'a)` >> markerLib.RM_ABBREV_TAC "m" >>
@@ -1563,12 +1563,12 @@ val d_lemma5 = store_thm ("d_lemma5",
   `2 ** p = 2 ** m DIV 2 ** n` by METIS_TAC[EXP_ADD,MULT_COMM,MULT_DIV,ZERO_LT_EXP,DECIDE ``0 < 2``] >>
   METIS_TAC[ZERO_LT_EXP,DECIDE ``0<2``,ADD1,X_LT_DIV,MULT_COMM]);
 
-val d_clauses = store_thm( "d_clauses",
-``!(vs:'a word list) (v1:'a word).
+val d_clauses = Q.store_thm( "d_clauses",
+`!(vs:'a word list) (v1:'a word).
   (0 < w2n v1) ==>
   (0 < w2n (calc_d (v1,1w))) /\
   (mw2n (mw_mul_by_single (calc_d (v1,1w)) (REVERSE (v1::vs))) = mw2n (FRONT (mw_mul_by_single (calc_d (v1,1w)) (REVERSE (v1::vs))))) /\
-  (dimword(:'a) DIV 2 <= w2n (LAST (FRONT (mw_mul_by_single (calc_d (v1,1w)) (REVERSE (v1::vs))))))``,
+  (dimword(:'a) DIV 2 <= w2n (LAST (FRONT (mw_mul_by_single (calc_d (v1,1w)) (REVERSE (v1::vs))))))`,
 
   REPEAT GEN_TAC >> strip_tac >>
   qsuff_tac `0 < w2n (calc_d (v1,1w))`
@@ -1625,10 +1625,10 @@ val d_clauses = store_thm( "d_clauses",
          MATCH_MP_TAC LESS_MONO_MULT >> METIS_TAC[Abbr`Z`,ADD1,d_lemma5,FST,MULT_COMM]) >>
   Cases_on `v1 = 0w` THEN1 full_simp_tac (srw_ss())[] >> METIS_TAC[d_lemma2_bis,FST,NOT_0w_bis])
 
-val LAST_FRONT_mw_mul_by_single_NOT_ZERO = store_thm(
+val LAST_FRONT_mw_mul_by_single_NOT_ZERO = Q.store_thm(
    "LAST_FRONT_mw_mul_by_single_NOT_ZERO",
-  ``mw_ok ys /\ ys <> [] /\ 2 < dimword (:'a)  ==>
-    LAST (FRONT (mw_mul_by_single (calc_d (LAST ys,0x1w:'a word)) ys)) <> 0x0w``,
+  `mw_ok ys /\ ys <> [] /\ 2 < dimword (:'a)  ==>
+    LAST (FRONT (mw_mul_by_single (calc_d (LAST ys,0x1w:'a word)) ys)) <> 0x0w`,
   STRIP_TAC
   \\ MP_TAC (d_clauses |> Q.SPECL [`TL (REVERSE ys)`,`HD (REVERSE ys)`])
   \\ `~(NULL (REVERSE ys))` by FULL_SIMP_TAC std_ss [NULL_EQ,REVERSE_EQ_NIL]
@@ -1644,17 +1644,17 @@ val LAST_FRONT_mw_mul_by_single_NOT_ZERO = store_thm(
 
 (* Single Division: x1x2 / y *)
 
-val single_div_lemma1 = store_thm ( "single_div_lemma1" ,
-`` w2n (x1:'a word) < w2n (y:'a word) ==>
-   (w2n (x2:'a word) +  dimword(:'a) * w2n x1) DIV w2n y < dimword(:'a)``,
+val single_div_lemma1 = Q.store_thm ( "single_div_lemma1" ,
+` w2n (x1:'a word) < w2n (y:'a word) ==>
+   (w2n (x2:'a word) +  dimword(:'a) * w2n x1) DIV w2n y < dimword(:'a)`,
   strip_tac >> MATCH_MP_TAC DIV_thm2 >> strip_tac THEN1 DECIDE_TAC >>
   `w2n x2 < dimword(:'a)` by METIS_TAC[w2n_lt] >>
   `w2n x2 + dimword(:'a) * w2n x1 < dimword(:'a) * SUC (w2n x1)`
   by METIS_TAC[LESS_MONO_ADD,MULT_RIGHT_1,LEFT_ADD_DISTRIB,ADD1,ADD_COMM] >>
   METIS_TAC[LESS_EQ,LESS_LESS_EQ_TRANS,LESS_MONO_MULT,MULT_COMM] );
 
-val single_div_lemma2 = store_thm ( "single_div_lemma2",
-  ``y <> 0w ==> w2n (SND (single_div x1 x2 y)) < w2n y``,
+val single_div_lemma2 = Q.store_thm ( "single_div_lemma2",
+  `y <> 0w ==> w2n (SND (single_div x1 x2 y)) < w2n y`,
   lrw[single_div_def] >>
   ` 0 < w2n y` by PROVE_TAC [NOT_0w_bis] >>
   `0 < dimword(:'a)` by PROVE_TAC[ZERO_LT_dimword] >>
@@ -1664,22 +1664,22 @@ val single_div_lemma2 = store_thm ( "single_div_lemma2",
   `z MOD dimword(:'a) <= z` by PROVE_TAC[MOD_LESS_EQ] >>
   DECIDE_TAC);
 
-val single_div_thm = store_thm ( "single_div_thm",
-  ``!(x1:'a word) (x2:'a word) y q r. (single_div x1 x2 y = (q,r))
+val single_div_thm = Q.store_thm ( "single_div_thm",
+  `!(x1:'a word) (x2:'a word) y q r. (single_div x1 x2 y = (q,r))
     ==>(((w2n x1 * dimword(:'a) + w2n x2) DIV w2n y < dimword(:'a) /\
           y <> 0w)
     ==> ((w2n q = (w2n x1 * dimword(:'a) + w2n x2) DIV w2n y) /\
-         (w2n r = (w2n x1 * dimword(:'a) + w2n x2) MOD w2n y)))``,
+         (w2n r = (w2n x1 * dimword(:'a) + w2n x2) MOD w2n y)))`,
 
   lrw[single_div_def] >> full_simp_tac (srw_ss()) [] >> lrw[w2n_n2w] >>
   `!w. w <> 0w ==> 0 < w2n w` by (Cases_on `w`>> full_simp_tac (srw_ss()) [] >> DECIDE_TAC) >>
   `w2n y < dimword(:'a)` by lrw[w2n_lt] >>
   METIS_TAC[MOD_LESS,LESS_TRANS] );
 
-val single_div_thm_bis = store_thm ( "single_div_thm_bis",
-  ``!(x1:'a word) (x2:'a word) y q r. (single_div x1 x2 y = (q,r)) /\
+val single_div_thm_bis = Q.store_thm ( "single_div_thm_bis",
+  `!(x1:'a word) (x2:'a word) y q r. (single_div x1 x2 y = (q,r)) /\
     (w2n x1 < w2n y) ==>
-    (w2n q * w2n y + w2n r = w2n x1 * dimword(:'a) + w2n x2)``,
+    (w2n q * w2n y + w2n r = w2n x1 * dimword(:'a) + w2n x2)`,
 
     REPEAT strip_tac >> IMP_RES_TAC single_div_lemma1 >>
     qpat_x_assum `!xs. xxx` (fn x => (ASSUME_TAC (RW[Once ADD_COMM,Once MULT_COMM] (SPEC ``x2:'a word`` x)))) >>
@@ -1689,9 +1689,9 @@ val single_div_thm_bis = store_thm ( "single_div_thm_bis",
 
 (* Division by single: x_{1}x_{2}...x_{n} / y  *)
 
-val mw_div_by_single_LENGTH = store_thm ("mw_div_by_single_LENGTH",
-``!x xs y. w2n x < w2n y ==>
-    (LENGTH (mw_div_by_single (x::xs) y) = SUC (LENGTH xs))``,
+val mw_div_by_single_LENGTH = Q.store_thm ("mw_div_by_single_LENGTH",
+`!x xs y. w2n x < w2n y ==>
+    (LENGTH (mw_div_by_single (x::xs) y) = SUC (LENGTH xs))`,
 
   REPEAT GEN_TAC >>
   completeInduct_on `LENGTH (x::xs)`>>
@@ -1705,8 +1705,8 @@ val mw_div_by_single_LENGTH = store_thm ("mw_div_by_single_LENGTH",
          METIS_TAC[DECIDE ``!a. 0 <= a``,LESS_EQ_LESS_TRANS,MOD_LESS_EQ,MOD_LESS,ZERO_LT_dimword]) >>
   METIS_TAC[LENGTH, DECIDE ``n < SUC n``])
 
-val mw_div_by_single_thm = store_thm ( "mw_div_by_single_thm",
-``!xs y. 0 < w2n y ==> (mw2n (REVERSE xs) = mw2n (mw_mul_by_single y (REVERSE (FRONT (mw_div_by_single xs y)))) + w2n (LAST (mw_div_by_single xs y)))``,
+val mw_div_by_single_thm = Q.store_thm ( "mw_div_by_single_thm",
+`!xs y. 0 < w2n y ==> (mw2n (REVERSE xs) = mw2n (mw_mul_by_single y (REVERSE (FRONT (mw_div_by_single xs y)))) + w2n (LAST (mw_div_by_single xs y)))`,
 
 HO_MATCH_MP_TAC mw_div_by_single_ind >>
 REPEAT strip_tac
@@ -1765,10 +1765,10 @@ lrw[mw_mul_by_single_lemma,FRONT_DEF,LAST_DEF,mw2n_msf] >>
 METIS_TAC[mw_div_by_single_LENGTH,DECIDE ``0 < SUC n``,LENGTH,NOT_NIL_EQ_LENGTH_NOT_0,rich_listTheory.LENGTH_BUTLAST,prim_recTheory.PRE] >>
 RW_TAC arith_ss[])
 
-val mw_div_by_single_thm_bis = store_thm ("mw_div_by_single_thm_bis",
-``!xs y. 0 < w2n y ==>
+val mw_div_by_single_thm_bis = Q.store_thm ("mw_div_by_single_thm_bis",
+`!xs y. 0 < w2n y ==>
   (mw2n (REVERSE (FRONT (mw_div_by_single xs y))) = mw2n (REVERSE xs) DIV w2n y) /\
-  (w2n (LAST (mw_div_by_single xs y)) = mw2n (REVERSE xs) MOD w2n y)``,
+  (w2n (LAST (mw_div_by_single xs y)) = mw2n (REVERSE xs) MOD w2n y)`,
 
   qsuff_tac `! (xs:'a word list) (y:'a word). 0 < w2n y ==>
                w2n (LAST (mw_div_by_single xs y)) < w2n y`
@@ -1798,10 +1798,10 @@ val mw_div_by_single_thm_bis = store_thm ("mw_div_by_single_thm_bis",
   srw_tac[][listTheory.LAST_CONS_cond,word_0_n2w] >>
   METIS_TAC[w2n_eq_0])
 
-val mw_simple_div_lemma = prove(
-  ``!xs x y qs (r:'a word) c.
+val mw_simple_div_lemma = Q.prove(
+  `!xs x y qs (r:'a word) c.
       (mw_simple_div x xs y = (qs,r,c)) /\ 0w <+ y /\ x <+ y ==>
-      (mw_div_by_single (x::xs) y = SNOC r qs) /\ c``,
+      (mw_div_by_single (x::xs) y = SNOC r qs) /\ c`,
   Induct THEN1
    (FULL_SIMP_TAC std_ss [mw_simple_div_def,mw_div_by_single_def,WORD_LO]
     \\ REPEAT STRIP_TAC
@@ -1834,11 +1834,11 @@ val mw2n_SNOC_0 = Q.prove(
   `!xs. mw2n (SNOC 0w xs) = mw2n xs`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [mw2n_def,SNOC]);
 
-val mw_simple_div_thm = store_thm("mw_simple_div_thm",
-  ``!xs y qs (r:'a word) c.
+val mw_simple_div_thm = Q.store_thm("mw_simple_div_thm",
+  `!xs y qs (r:'a word) c.
       (mw_simple_div 0w xs y = (qs,r,c)) /\ 0w <+ y ==>
       (mw2n (REVERSE qs) = mw2n (REVERSE xs) DIV w2n y) /\
-      (w2n r = mw2n (REVERSE xs) MOD w2n y) /\ c``,
+      (w2n r = mw2n (REVERSE xs) MOD w2n y) /\ c`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC mw_simple_div_lemma
   \\ FULL_SIMP_TAC (srw_ss()) [WORD_LO]
   \\ IMP_RES_TAC mw_div_by_single_thm_bis
@@ -2464,14 +2464,14 @@ markerLib.UNABBREV_TAC "q3ys" >>
 ASM_REWRITE_TAC[mw_mul_by_single_lemma] >>
 METIS_TAC[DIV_thm4];
 
-val mw_div_loop_thm_bis = store_thm ("mw_div_loop_thm_bis",
-``!(zs:'a word list) (ys:'a word list).
+val mw_div_loop_thm_bis = Q.store_thm ("mw_div_loop_thm_bis",
+`!(zs:'a word list) (ys:'a word list).
   dimword(:'a) DIV 2 <= w2n (HD ys) /\
   LENGTH ys < LENGTH zs /\ 1 < LENGTH ys /\
   ((mw2n (REVERSE (TAKE (SUC (LENGTH ys)) zs)) DIV mw2n (REVERSE ys)) < dimword(:'a) ) ==>
   (let rslt = mw_div_loop zs ys in
    (mw2n (REVERSE( BUTLASTN (LENGTH ys) rslt)) = mw2n (REVERSE zs) DIV mw2n (REVERSE ys)) /\
-   (mw2n (REVERSE (LASTN (LENGTH ys) rslt)) = mw2n (REVERSE zs) MOD mw2n (REVERSE ys)))``,
+   (mw2n (REVERSE (LASTN (LENGTH ys) rslt)) = mw2n (REVERSE zs) MOD mw2n (REVERSE ys)))`,
 
 qsuff_tac `!(zs:'a word list) (ys:'a word list).
            dimword(:'a) DIV 2 <= w2n (HD ys) /\
@@ -2630,8 +2630,8 @@ val mw_div_loop_alt = Q.prove(
 
 val IMP_IMP = METIS_PROVE [] ``b1 /\ (b2 ==> b3) ==> (b1 ==> b2) ==> b3``
 
-val LENGTH_mw_sub = store_thm("LENGTH_mw_sub",
-  ``!xs1 ys c qs1 c1. (mw_sub xs1 ys c = (qs1,c1)) ==> (LENGTH xs1 = LENGTH qs1)``,
+val LENGTH_mw_sub = Q.store_thm("LENGTH_mw_sub",
+  `!xs1 ys c qs1 c1. (mw_sub xs1 ys c = (qs1,c1)) ==> (LENGTH xs1 = LENGTH qs1)`,
   Induct \\ Cases_on `ys`
   \\ FULL_SIMP_TAC std_ss [mw_sub_def,LET_DEF,single_add_def,single_sub_def]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) \\ REPEAT STRIP_TAC THEN1
@@ -2642,12 +2642,12 @@ val LENGTH_mw_sub = store_thm("LENGTH_mw_sub",
   \\ `?x1 x2. mw_sub xs1 t tt = (x1,x2)` by METIS_TAC [PAIR]
   \\ RES_TAC \\ Cases_on `qs1` \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val mw_div_aux_lemma = prove(
-  ``!zs1 zs2 ys qs rs.
+val mw_div_aux_lemma = Q.prove(
+  `!zs1 zs2 ys qs rs.
       (LENGTH zs2 = LENGTH ys) /\ 1 < LENGTH ys /\
       (mw_div_aux zs1 zs2 ys = (qs,rs)) ==>
       (mw_div_loop (REVERSE (zs1 ++ zs2)) (REVERSE ys) =
-         qs ++ REVERSE rs) /\ (LENGTH rs = LENGTH ys)``,
+         qs ++ REVERSE rs) /\ (LENGTH rs = LENGTH ys)`,
   STRIP_TAC \\ completeInduct_on `LENGTH zs1` \\ NTAC 2 STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [PULL_FORALL] \\ NTAC 5 STRIP_TAC
   \\ `(zs1 = []) \/ ?x l. zs1 = SNOC x l` by METIS_TAC [SNOC_CASES] THEN1
@@ -2738,9 +2738,9 @@ val MULT_DIV_MULT_EQ_MULT = Q.prove(
   ONCE_REWRITE_TAC [MULT_COMM]
   \\ SIMP_TAC std_ss [GSYM DIV_DIV_DIV_MULT,RW1 [MULT_COMM] MULT_DIV]);
 
-val LENGTH_mw_simple_div = store_thm("LENGTH_mw_simple_div",
-  ``!xs x ys qs r c.
-      (mw_simple_div x xs ys = (qs,r,c)) ==> (LENGTH xs = LENGTH qs)``,
+val LENGTH_mw_simple_div = Q.store_thm("LENGTH_mw_simple_div",
+  `!xs x ys qs r c.
+      (mw_simple_div x xs ys = (qs,r,c)) ==> (LENGTH xs = LENGTH qs)`,
   Induct \\ SIMP_TAC std_ss [mw_simple_div_def,LET_DEF]
   \\ REPEAT STRIP_TAC \\ Cases_on `single_div x h ys`
   \\ FULL_SIMP_TAC std_ss []
@@ -2749,11 +2749,11 @@ val LENGTH_mw_simple_div = store_thm("LENGTH_mw_simple_div",
   \\ Q.PAT_X_ASSUM `q::qs1 = qs` (ASSUME_TAC o GSYM)
   \\ FULL_SIMP_TAC std_ss [LENGTH]);
 
-val mw_div_thm = store_thm("mw_div_thm",
-  ``!xs ys mod res c.
+val mw_div_thm = Q.store_thm("mw_div_thm",
+  `!xs ys mod res c.
       (mw_div xs ys = (res,mod,c)) /\ mw2n ys <> 0 ==>
       (mw2n res = mw2n xs DIV mw2n ys) /\
-      (mw2n mod = mw2n xs MOD mw2n ys) /\ c /\ (LENGTH mod = LENGTH (mw_fix ys))``,
+      (mw2n mod = mw2n xs MOD mw2n ys) /\ c /\ (LENGTH mod = LENGTH (mw_fix ys))`,
   NTAC 5 STRIP_TAC \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ SIMP_TAC std_ss [LET_DEF,mw_div_def]
   \\ Cases_on `LENGTH (mw_fix xs) < LENGTH (mw_fix ys)`
@@ -2985,10 +2985,10 @@ val n2mw_EQ_NIL = Q.prove(
   Cases_on `n` THEN1 EVAL_TAC \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ SIMP_TAC std_ss [ADD1,NOT_CONS_NIL]);
 
-val mwi_divmod_thm = store_thm("mwi_divmod_thm",
-  ``!i j. j <> 0 ==>
+val mwi_divmod_thm = Q.store_thm("mwi_divmod_thm",
+  `!i j. j <> 0 ==>
       (mwi_divmod (i2mw i) ((i2mw j):bool # 'a word list) =
-         (T,i2mw (i / j),i2mw (i % j)))``,
+         (T,i2mw (i / j),i2mw (i % j)))`,
   NTAC 3 STRIP_TAC \\ SIMP_TAC std_ss [i2mw_def,mwi_divmod_def,n2mw_NIL,Num_ABS_EQ_0]
   \\ `(?r1 r2 r3. mw_div (n2mw (Num (ABS i))) (n2mw (Num (ABS j))) =
                  (r1:'a word list,r2,r3))`
@@ -3055,10 +3055,10 @@ val mwi_to_dec_def = Define `
     let (rest,c) = mw_to_dec xs in
       (sign ++ rest,c)`
 
-val mw_to_dec_thm = store_thm("mw_to_dec_thm",
-  ``!(xs:'a word list).
+val mw_to_dec_thm = Q.store_thm("mw_to_dec_thm",
+  `!(xs:'a word list).
       10 < dimword (:'a) ==>
-      (mw_to_dec xs = (MAP (n2w o ORD) (num_to_dec_string (mw2n xs)),T))``,
+      (mw_to_dec xs = (MAP (n2w o ORD) (num_to_dec_string (mw2n xs)),T))`,
   STRIP_TAC \\ STRIP_ASSUME_TAC (SPEC_ALL k2mw_EXISTS)
   \\ Q.PAT_X_ASSUM `xs = bb` (fn th => ONCE_REWRITE_TAC [th])
   \\ POP_ASSUM MP_TAC \\ Q.SPEC_TAC (`xs`,`xs`)
@@ -3102,10 +3102,10 @@ val mw_to_dec_thm = store_thm("mw_to_dec_thm",
   \\ FULL_SIMP_TAC (srw_ss()) []
   \\ FULL_SIMP_TAC std_ss [AC ADD_COMM ADD_ASSOC]);
 
-val mwi_to_dec_thm = store_thm("mwi_to_dec_thm",
-  ``10 < dimword (:'a) /\ ((xs = []) ==> ~s) /\ mw_ok xs ==>
+val mwi_to_dec_thm = Q.store_thm("mwi_to_dec_thm",
+  `10 < dimword (:'a) /\ ((xs = []) ==> ~s) /\ mw_ok xs ==>
     (mwi_to_dec (s,xs:'a word list) =
-        (MAP (n2w o ORD) (int_to_str (mw2i (s,xs))),T))``,
+        (MAP (n2w o ORD) (int_to_str (mw2i (s,xs))),T))`,
   SIMP_TAC std_ss [mwi_to_dec_def,int_to_str_def,i2mw_def,LET_DEF] \\ STRIP_TAC
   \\ `mw2i (s,xs) < 0 <=> s` by ALL_TAC THEN1
    (Cases_on `xs = []` \\ FULL_SIMP_TAC std_ss [] THEN1 EVAL_TAC
@@ -3167,8 +3167,8 @@ val LESS_EQ_LENGTH = Q.store_thm("LESS_EQ_LENGTH",
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ FULL_SIMP_TAC std_ss []
   \\ Q.LIST_EXISTS_TAC [`h::xs1`,`xs2`] \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val LENGTH_mw_add = store_thm("LENGTH_mw_add",
-  ``!xs1 ys c qs1 c1. (mw_add xs1 ys c = (qs1,c1)) ==> (LENGTH xs1 = LENGTH qs1)``,
+val LENGTH_mw_add = Q.store_thm("LENGTH_mw_add",
+  `!xs1 ys c qs1 c1. (mw_add xs1 ys c = (qs1,c1)) ==> (LENGTH xs1 = LENGTH qs1)`,
   Induct \\ FULL_SIMP_TAC std_ss [mw_add_def,LET_DEF,single_add_def]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) \\ REPEAT STRIP_TAC
   \\ Q.ABBREV_TAC `t = (dimword (:'a) <= w2n h + w2n (HD ys) + b2n c)`
@@ -3187,8 +3187,8 @@ val LENGTH_mw_subv = Q.store_thm("LENGTH_mw_subv",
   \\ Cases_on `mw_sub ys xs T`
   \\ IMP_RES_TAC LENGTH_mw_sub \\ FULL_SIMP_TAC std_ss []);
 
-val mw_add_F = store_thm("mw_add_F",
-  ``!xs2. (mw_add xs2 (MAP (\x. 0x0w) xs2) F = (xs2,F))``,
+val mw_add_F = Q.store_thm("mw_add_F",
+  `!xs2. (mw_add xs2 (MAP (\x. 0x0w) xs2) F = (xs2,F))`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [mw_add_def,MAP,single_add_def,
     LET_DEF,b2w_def,b2n_def,GSYM NOT_LESS,w2n_lt]);
 
@@ -3227,10 +3227,10 @@ val LESS_EQ_LENGTH_ALT = Q.store_thm("LESS_EQ_LENGTH_ALT",
   \\ Q.LIST_EXISTS_TAC [`ys1`,`SNOC x ys2`]
   \\ FULL_SIMP_TAC std_ss [LENGTH_SNOC,SNOC_APPEND]);
 
-val LENGTH_mw_div_aux = store_thm("LENGTH_mw_div_aux",
-  ``!ts1 ts2 ys qs rs.
+val LENGTH_mw_div_aux = Q.store_thm("LENGTH_mw_div_aux",
+  `!ts1 ts2 ys qs rs.
       (mw_div_aux ts1 ts2 ys = (qs,rs)) /\ (LENGTH ts2 = LENGTH ys) ==>
-      (LENGTH rs = LENGTH ys) /\ (LENGTH qs = LENGTH ts1)``,
+      (LENGTH rs = LENGTH ys) /\ (LENGTH qs = LENGTH ts1)`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ STRIP_TAC
   THEN1 (SIMP_TAC std_ss [Once mw_div_aux_def])
   \\ NTAC 7 STRIP_TAC
@@ -3302,10 +3302,10 @@ val k2mw_LENGTH_0 = Q.store_thm("k2mw_LENGTH_0",
   SIMP_TAC std_ss [LEN_LENGTH_LEM,GSYM ADD1,k2mw_def] \\
   FULL_SIMP_TAC std_ss [MATCH_MP ZERO_DIV ZERO_LT_dimword]);
 
-val mw_mul_pass_top_lemma = prove(
-  ``!ys k1 k2 k3 x.
+val mw_mul_pass_top_lemma = Q.prove(
+  `!ys k1 k2 k3 x.
       ((let (x1,x2,x3) = mw_mul_pass_top x ys (k1,k2,k3) in [x1;x2;x3]) =
-       TAKE 3 (REVERSE (mw_mul_pass x ys (MAP (K 0w) ys) k1) ++ [k2;k3]))``,
+       TAKE 3 (REVERSE (mw_mul_pass x ys (MAP (K 0w) ys) k1) ++ [k2;k3]))`,
   Induct THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
   \\ ONCE_REWRITE_TAC [mw_mul_pass_def,mw_mul_pass_top_def]
   \\ FULL_SIMP_TAC std_ss [HD,MAP,TL] \\ REPEAT STRIP_TAC
@@ -3318,12 +3318,12 @@ val mw_mul_pass_top_lemma = prove(
   |> Q.SPECL [`ys`,`0w`] |> GEN_ALL
   |> SIMP_RULE std_ss [GSYM k2mw_LENGTH_0,GSYM mw_mul_by_single_def];
 
-val mw_mul_pass_top_thm = store_thm("mw_mul_pass_top_thm",
-  ``1 < LENGTH ys ==>
+val mw_mul_pass_top_thm = Q.store_thm("mw_mul_pass_top_thm",
+  `1 < LENGTH ys ==>
     (mw_mul_pass_top x ys (0w,0w,0w) =
       (LAST (mw_mul_by_single x ys),
        LAST (BUTLAST (mw_mul_by_single x ys)),
-       LAST (BUTLAST (BUTLAST (mw_mul_by_single x ys)))))``,
+       LAST (BUTLAST (BUTLAST (mw_mul_by_single x ys)))))`,
   STRIP_TAC
   \\ ASSUME_TAC (mw_mul_pass_top_lemma |> Q.SPECL [`ys`,`0w`,`0w`,`x`])
   \\ Cases_on `mw_mul_pass_top x ys (0x0w,0x0w,0x0w)`
@@ -3342,8 +3342,8 @@ val mw_mul_pass_top_thm = store_thm("mw_mul_pass_top_thm",
 
 (* extra lemmas about mw_addv special case *)
 
-val single_add_lemma = prove(
-  ``!h. single_add h 0x0w F = (h,F)``,
+val single_add_lemma = Q.prove(
+  `!h. single_add h 0x0w F = (h,F)`,
   Cases \\ FULL_SIMP_TAC std_ss [single_add_def,word_add_n2w,b2w_def,
      b2n_def,w2n_n2w,ZERO_LT_dimword,GSYM NOT_LESS]);
 
@@ -3380,10 +3380,10 @@ val num_div_loop_def = Define `
         else
           num_div_loop (k-1,n,m+1,i-n)`
 
-val num_div_loop_lemma = prove(
-  ``!k i n m.
+val num_div_loop_lemma = Q.prove(
+  `!k i n m.
       i < n * 2 ** k /\ 0 < n ==>
-      (num_div_loop (k,n * 2 ** k,m,i) = (m * 2 ** k + i DIV n,i MOD n))``,
+      (num_div_loop (k,n * 2 ** k,m,i) = (m * 2 ** k + i DIV n,i MOD n))`,
   Induct
   \\ simp [Once num_div_loop_def,arithmeticTheory.LESS_DIV_EQ_ZERO]
   \\ rw [] \\ fs [EXP,ONCE_REWRITE_RULE [MULT_COMM] MULT_DIV]
@@ -3417,14 +3417,14 @@ fun drule th =
 
 val impl_tac = match_mp_tac IMP_IMP \\ conj_tac
 
-val single_div_loop_thm = prove(
-  ``!k ns m is t qs.
+val single_div_loop_thm = Q.prove(
+  `!k ns m is t qs.
       (single_div_loop (n2w k,ns,m,is) = (t,qs:'a word list)) /\
       k < dimword (:'a) /\
       k <= dimindex (:'a) /\ (w2n m < 2 ** (dimindex (:'a) - k)) /\
       (LENGTH ns = 2) /\ (LENGTH is = 2) ==>
       (num_div_loop (k,mw2n ns,w2n m,mw2n is) = (w2n t, mw2n qs)) /\
-      (LENGTH qs = 2)``,
+      (LENGTH qs = 2)`,
   Induct THEN1 (fs [Once num_div_loop_def,Once single_div_loop_def])
   \\ NTAC 6 strip_tac
   \\ qpat_x_assum `single_div_loop _ = _` mp_tac

--- a/compiler/backend/bignum/multiwordScript.sml
+++ b/compiler/backend/bignum/multiwordScript.sml
@@ -21,16 +21,16 @@ val REV = Tactical.REVERSE;
 val b2n_def = Define `(b2n T = 1) /\ (b2n F = 0:num)`;
 val b2w_def = Define `b2w c = n2w (b2n c)`;
 
-val MULT_ADD_LESS_MULT = prove(
-  ``!m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num``,
+val MULT_ADD_LESS_MULT = Q.prove(
+  `!m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num`,
   REPEAT STRIP_TAC
   \\ `SUC m <= l` by ASM_REWRITE_TAC [GSYM LESS_EQ]
   \\ `m * k + k <= l * k` by ASM_SIMP_TAC bool_ss [LE_MULT_RCANCEL,GSYM MULT]
   \\ `m * j <= m * k` by ASM_SIMP_TAC bool_ss [LE_MULT_LCANCEL]
   \\ DECIDE_TAC);
 
-val MULT_ADD_LESS_MULT_ADD = prove(
-  ``!m n k l p. m < l /\ n < k /\ p < k ==> m * k + n < l * k + p:num``,
+val MULT_ADD_LESS_MULT_ADD = Q.prove(
+  `!m n k l p. m < l /\ n < k /\ p < k ==> m * k + n < l * k + p:num`,
   REPEAT STRIP_TAC
   \\ `SUC m <= l` by ASM_REWRITE_TAC [GSYM LESS_EQ]
   \\ `m * k + k <= l * k` by ASM_SIMP_TAC bool_ss [LE_MULT_RCANCEL,GSYM MULT]
@@ -71,41 +71,41 @@ val i2mw_def = Define `i2mw i = (i < 0,n2mw (Num (ABS i)))`;
 
 val mw_ok_def = Define `mw_ok xs = ~(xs = []) ==> ~(LAST xs = 0w)`;
 
-val n2mw_0 = prove(``(n2mw 0 = [])``,METIS_TAC [n2mw_def]);
-val n2mw_thm = prove(
-  ``~(n = 0) ==> (n2mw n = (n2w (n MOD dimword (:'a)):'a word) ::
-                           n2mw (n DIV dimword(:'a)))``,
+val n2mw_0 = Q.prove(`(n2mw 0 = [])`,METIS_TAC [n2mw_def]);
+val n2mw_thm = Q.prove(
+  `~(n = 0) ==> (n2mw n = (n2w (n MOD dimword (:'a)):'a word) ::
+                           n2mw (n DIV dimword(:'a)))`,
   METIS_TAC [n2mw_def]);
 
 val k2mw_SUC = REWRITE_CONV [k2mw_def] ``k2mw (SUC n) m``;
 
-val ZERO_LT_dimwords = prove(``!k. 0 < dimwords k (:'a)``,
+val ZERO_LT_dimwords = Q.prove(`!k. 0 < dimwords k (:'a)`,
   Cases \\ SIMP_TAC std_ss [dimwords_def,EVAL ``0<2``,ZERO_LT_EXP]);
 
 val dimwords_SUC =
   (REWRITE_CONV [dimwords_def,MULT,EXP_ADD] THENC
    REWRITE_CONV [GSYM dimwords_def,GSYM dimword_def]) ``dimwords (SUC k) (:'a)``;
 
-val dimwords_thm = prove(
-  ``(dimwords 0 (:'a) = 1) /\
-    (dimwords (SUC k) (:'a) = dimword (:'a) * dimwords k (:'a))``,
+val dimwords_thm = Q.prove(
+  `(dimwords 0 (:'a) = 1) /\
+    (dimwords (SUC k) (:'a) = dimword (:'a) * dimwords k (:'a))`,
   FULL_SIMP_TAC std_ss [dimwords_def,MULT,EXP_ADD,dimword_def,AC MULT_COMM MULT_ASSOC]);
 
-val mw_ok_CLAUSES = prove(
-  ``mw_ok [] /\ (mw_ok (x::xs) = ((xs = []) ==> ~(x = 0w)) /\ mw_ok xs)``,
+val mw_ok_CLAUSES = Q.prove(
+  `mw_ok [] /\ (mw_ok (x::xs) = ((xs = []) ==> ~(x = 0w)) /\ mw_ok xs)`,
   SIMP_TAC std_ss [mw_ok_def,NOT_NIL_CONS]
   \\ `(xs = []) \/ ?y ys. xs = SNOC y ys` by METIS_TAC [SNOC_CASES]
   \\ ASM_SIMP_TAC std_ss [LAST_DEF,LAST_SNOC,NOT_SNOC_NIL]);
 
-val k2mw_SNOC = store_thm("k2mw_SNOC",
-  ``!k n. k2mw (SUC k) n = SNOC ((n2w (n DIV dimwords k (:'a))):'a word) (k2mw k n)``,
+val k2mw_SNOC = Q.store_thm("k2mw_SNOC",
+  `!k n. k2mw (SUC k) n = SNOC ((n2w (n DIV dimwords k (:'a))):'a word) (k2mw k n)`,
   Induct THEN1 REWRITE_TAC [k2mw_def,SNOC,dimwords_def,MULT_CLAUSES,EXP,DIV_1]
   \\ ONCE_REWRITE_TAC [k2mw_def] \\ ASM_REWRITE_TAC [SNOC]
   \\ SIMP_TAC bool_ss [dimwords_def,dimword_def,MULT,EXP_ADD,
        AC MULT_COMM MULT_ASSOC,DIV_DIV_DIV_MULT,EVAL ``0<2``,ZERO_LT_EXP,ZERO_LT_dimword]);
 
-val k2mw_mw2n = prove(
-  ``!xs. (k2mw (LENGTH xs) (mw2n xs) = xs)``,
+val k2mw_mw2n = Q.prove(
+  `!xs. (k2mw (LENGTH xs) (mw2n xs) = xs)`,
   Induct THEN1 EVAL_TAC
   \\ FULL_SIMP_TAC std_ss [LENGTH,mw2n_def,k2mw_def,CONS_11]
   \\ FULL_SIMP_TAC (srw_ss()) []
@@ -113,11 +113,11 @@ val k2mw_mw2n = prove(
   \\ ONCE_REWRITE_TAC [ADD_COMM] \\ ONCE_REWRITE_TAC [MULT_COMM]
   \\ FULL_SIMP_TAC std_ss [MOD_MULT,DIV_MULT]);
 
-val LENGTH_k2mw = store_thm("LENGTH_k2mw",
-  ``!k n. LENGTH (k2mw k n) = k``,Induct \\ ASM_REWRITE_TAC [k2mw_def,LENGTH]);
+val LENGTH_k2mw = Q.store_thm("LENGTH_k2mw",
+  `!k n. LENGTH (k2mw k n) = k`,Induct \\ ASM_REWRITE_TAC [k2mw_def,LENGTH]);
 
-val k2mw_mod = prove(
-  ``!k m. k2mw k (m MOD dimwords k (:'a)):('a word) list = k2mw k m``,
+val k2mw_mod = Q.prove(
+  `!k m. k2mw k (m MOD dimwords k (:'a)):('a word) list = k2mw k m`,
   Induct \\ REWRITE_TAC [k2mw_def,dimwords_def,MULT,CONS_11]
   \\ REWRITE_TAC [GSYM dimwords_def,EXP_ADD,GSYM dimword_def]
   \\ ONCE_REWRITE_TAC [MULT_COMM]
@@ -125,14 +125,14 @@ val k2mw_mod = prove(
   \\ ONCE_REWRITE_TAC [GSYM n2w_mod]
   \\ ASM_SIMP_TAC bool_ss [MOD_MULT_MOD,ZERO_LT_dimword,ZERO_LT_dimwords]);
 
-val mw2n_APPEND = prove(
-  ``!xs ys. mw2n (xs ++ ys) = mw2n xs + dimwords (LENGTH xs) (:'a) * mw2n (ys:'a word list)``,
+val mw2n_APPEND = Q.prove(
+  `!xs ys. mw2n (xs ++ ys) = mw2n xs + dimwords (LENGTH xs) (:'a) * mw2n (ys:'a word list)`,
   Induct \\ ASM_SIMP_TAC std_ss [dimwords_thm,LENGTH,APPEND,mw2n_def] \\ DECIDE_TAC);
 
-val k2mw_APPEND = prove(
-  ``!k l m n.
+val k2mw_APPEND = Q.prove(
+  `!k l m n.
       k2mw k m ++ k2mw l n =
-      k2mw (k+l) (m MOD dimwords k (:'a) + dimwords k (:'a) * n) :('a word) list``,
+      k2mw (k+l) (m MOD dimwords k (:'a) + dimwords k (:'a) * n) :('a word) list`,
   Induct
   THEN1 REWRITE_TAC [k2mw_def,APPEND_NIL,ADD_CLAUSES,dimwords_def,MULT_CLAUSES,EXP,MOD_1]
   \\ ASM_REWRITE_TAC [ADD,k2mw_def,APPEND,CONS_11] \\ REPEAT STRIP_TAC THENL [
@@ -148,8 +148,8 @@ val dimwords_ADD =
   (REWRITE_CONV [dimwords_def,RIGHT_ADD_DISTRIB,EXP_ADD] THENC
    REWRITE_CONV [GSYM dimwords_def]) ``dimwords (i+j) (:'a)``;
 
-val TWO_dimwords_LE_dinwords_SUC = prove(
-  ``!i. 2 * dimwords i (:'a) <= dimwords (SUC i) (:'a)``,
+val TWO_dimwords_LE_dinwords_SUC = Q.prove(
+  `!i. 2 * dimwords i (:'a) <= dimwords (SUC i) (:'a)`,
   REWRITE_TAC [dimwords_def,MULT,EXP_ADD] \\ STRIP_TAC
   \\ ASSUME_TAC (MATCH_MP LESS_OR DIMINDEX_GT_0)
   \\ Q.SPEC_TAC (`2 ** (i * dimindex (:'a))`,`x`)
@@ -159,22 +159,22 @@ val TWO_dimwords_LE_dinwords_SUC = prove(
   \\ REWRITE_TAC [RW [MULT_CLAUSES] (Q.SPECL [`m`,`1`] LE_MULT_LCANCEL)]
   \\ DECIDE_TAC);
 
-val k2mw_MOD_ADD = prove(
-  ``!i m n. k2mw i (m MOD dimwords i (:'a) + n) = k2mw i (m + n) :('a word)list``,
+val k2mw_MOD_ADD = Q.prove(
+  `!i m n. k2mw i (m MOD dimwords i (:'a) + n) = k2mw i (m + n) :('a word)list`,
   REPEAT STRIP_TAC
   \\ STRIP_ASSUME_TAC (Q.SPEC `m` (MATCH_MP DA (Q.SPEC `i` ZERO_LT_dimwords)))
   \\ ASM_SIMP_TAC bool_ss [GSYM ADD_ASSOC,MOD_MULT]
   \\ ONCE_REWRITE_TAC [GSYM k2mw_mod]
   \\ ASM_SIMP_TAC bool_ss [MOD_TIMES,ZERO_LT_dimwords]);
 
-val mw2n_lt = prove(
-  ``!xs. mw2n xs < dimwords (LENGTH (xs:'a word list)) (:'a)``,
+val mw2n_lt = Q.prove(
+  `!xs. mw2n xs < dimwords (LENGTH (xs:'a word list)) (:'a)`,
   Induct \\ SIMP_TAC std_ss [NOT_NIL_CONS,LENGTH,dimwords_thm,mw2n_def]
   \\ REPEAT STRIP_TAC \\ ONCE_REWRITE_TAC [ADD_COMM] \\ ONCE_REWRITE_TAC [MULT_COMM]
   \\ MATCH_MP_TAC MULT_ADD_LESS_MULT \\ ASM_SIMP_TAC std_ss [w2n_lt]);
 
-val k2mw_EXISTS = store_thm("k2mw_EXISTS",
-  ``!xs:('a word) list. ?k. (xs = k2mw (LENGTH xs) k) /\ k < dimwords (LENGTH xs) (:'a)``,
+val k2mw_EXISTS = Q.store_thm("k2mw_EXISTS",
+  `!xs:('a word) list. ?k. (xs = k2mw (LENGTH xs) k) /\ k < dimwords (LENGTH xs) (:'a)`,
   Induct \\ REWRITE_TAC [k2mw_def,LENGTH]
   THEN1 (Q.EXISTS_TAC `0` \\ REWRITE_TAC [dimwords_def,EXP,MULT_CLAUSES] \\ EVAL_TAC)
   \\ POP_ASSUM (STRIP_ASSUME_TAC o GSYM) \\ REPEAT STRIP_TAC
@@ -183,15 +183,15 @@ val k2mw_EXISTS = store_thm("k2mw_EXISTS",
   \\ ASM_SIMP_TAC bool_ss [DIV_MULT,w2n_lt,MOD_MULT,n2w_w2n,dimwords_SUC]
   \\ MATCH_MP_TAC MULT_ADD_LESS_MULT \\ ASM_REWRITE_TAC [w2n_lt,LESS_EQ_REFL]);
 
-val mw2n_MAP_ZERO = prove(
-  ``!xs ys. mw2n (xs ++ MAP (\x.0w) ys) = mw2n xs``,
+val mw2n_MAP_ZERO = Q.prove(
+  `!xs ys. mw2n (xs ++ MAP (\x.0w) ys) = mw2n xs`,
   Induct THEN1 (SIMP_TAC std_ss [APPEND] \\ Induct
     \\ FULL_SIMP_TAC std_ss [MAP,mw2n_def,w2n_n2w,ZERO_LT_dimword])
   \\ ASM_SIMP_TAC std_ss [APPEND,mw2n_def]);
 
-val EXISTS_k2mw = prove(
-  ``!(xs:'a word list).
-      ?n k. (xs = k2mw k n) /\ (LENGTH xs = k) /\ n < dimwords k (:'a)``,
+val EXISTS_k2mw = Q.prove(
+  `!(xs:'a word list).
+      ?n k. (xs = k2mw k n) /\ (LENGTH xs = k) /\ n < dimwords k (:'a)`,
   Induct \\ FULL_SIMP_TAC std_ss [k2mw_def,LENGTH,CONS_11] \\ REPEAT STRIP_TAC
   THEN1 (Q.EXISTS_TAC `0` \\ SIMP_TAC std_ss [ZERO_LT_dimwords])
   \\ Q.EXISTS_TAC `n * dimword (:'a) + w2n h`
@@ -203,15 +203,15 @@ val EXISTS_k2mw = prove(
   \\ ONCE_REWRITE_TAC [MULT_COMM] \\ MATCH_MP_TAC MULT_ADD_LESS_MULT
   \\ ASM_SIMP_TAC std_ss [w2n_lt]);
 
-val mw2n_k2mw = prove(
-  ``!k n. n < dimwords k (:'a) ==> (mw2n ((k2mw k n):'a word list) = n)``,
+val mw2n_k2mw = Q.prove(
+  `!k n. n < dimwords k (:'a) ==> (mw2n ((k2mw k n):'a word list) = n)`,
   Induct \\ SIMP_TAC std_ss [dimwords_thm,DECIDE ``n<1 = (n = 0)``,
    k2mw_def,mw2n_def,RW1[MULT_COMM](GSYM DIV_LT_X),ZERO_LT_dimwords,ZERO_LT_dimword]
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ ASM_SIMP_TAC std_ss [w2n_n2w]
   \\ METIS_TAC [DIVISION,ZERO_LT_dimword,ADD_COMM,MULT_COMM]);
 
-val mw2n_gt = prove(
-  ``!xs. mw_ok xs /\ ~(xs = []) ==> dimwords (LENGTH xs - 1) (:'a) <= mw2n (xs:'a word list)``,
+val mw2n_gt = Q.prove(
+  `!xs. mw_ok xs /\ ~(xs = []) ==> dimwords (LENGTH xs - 1) (:'a) <= mw2n (xs:'a word list)`,
   Induct \\ SIMP_TAC std_ss [NOT_NIL_CONS,LENGTH,ADD1,mw2n_def]
   \\ Cases_on `xs` THEN1
    (SIMP_TAC std_ss [mw_ok_def,LAST_CONS,NOT_NIL_CONS,LENGTH,mw2n_def,dimwords_thm]
@@ -224,9 +224,9 @@ val mw2n_gt = prove(
   \\ MATCH_MP_TAC (DECIDE ``m <= k ==> m <= n + k:num``)
   \\ ASM_SIMP_TAC std_ss [LE_MULT_LCANCEL]);
 
-val mw2n_LESS = store_thm("mw2n_LESS",
-  ``!(xs:'a word list) (ys:'a word list).
-       mw_ok xs /\ mw_ok ys /\ mw2n xs <= mw2n ys ==> LENGTH xs <= LENGTH ys``,
+val mw2n_LESS = Q.store_thm("mw2n_LESS",
+  `!(xs:'a word list) (ys:'a word list).
+       mw_ok xs /\ mw_ok ys /\ mw2n xs <= mw2n ys ==> LENGTH xs <= LENGTH ys`,
   REPEAT STRIP_TAC \\ Cases_on `xs = []` \\ ASM_SIMP_TAC std_ss [LENGTH]
   \\ Cases_on `ys = []` THEN1
    (IMP_RES_TAC mw2n_gt
@@ -238,8 +238,8 @@ val mw2n_LESS = store_thm("mw2n_LESS",
   \\ `dimwords (LENGTH xs - 1) (:'a) < dimwords (LENGTH ys) (:'a)` by DECIDE_TAC
   \\ FULL_SIMP_TAC std_ss [dimwords_def] \\ DECIDE_TAC);
 
-val mw_ok_n2mw = store_thm("mw_ok_n2mw",
-  ``!n. mw_ok ((n2mw n):'a word list)``,
+val mw_ok_n2mw = Q.store_thm("mw_ok_n2mw",
+  `!n. mw_ok ((n2mw n):'a word list)`,
   HO_MATCH_MP_TAC n2mw_ind \\ REPEAT STRIP_TAC \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ Cases_on `n = 0` THEN1 ASM_SIMP_TAC std_ss [mw_ok_def] \\ RES_TAC
   \\ Cases_on `n < dimword (:'a)` \\ ASM_SIMP_TAC std_ss [LESS_DIV_EQ_ZERO]
@@ -256,14 +256,14 @@ val mw_ok_i2mw = store_thm("mw_ok_i2mw",
   ``!i x xs. (i2mw i = (x,xs)) ==> mw_ok xs``,
   SIMP_TAC std_ss [i2mw_def,mw_ok_n2mw]);
 
-val n2mw_EQ_k2mw = prove(
-  ``!n. n2mw n = k2mw (LENGTH ((n2mw n):'a word list)) n :'a word list``,
+val n2mw_EQ_k2mw = Q.prove(
+  `!n. n2mw n = k2mw (LENGTH ((n2mw n):'a word list)) n :'a word list`,
   HO_MATCH_MP_TAC n2mw_ind \\ REPEAT STRIP_TAC \\ Cases_on `n = 0`
   \\ FULL_SIMP_TAC std_ss [] \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ ASM_SIMP_TAC std_ss [LENGTH,k2mw_def,CONS_11,n2w_11,MOD_MOD,ZERO_LT_dimword]);
 
-val LESS_dimwords_n2mw = prove(
-  ``!n. n < dimwords (LENGTH ((n2mw n):'a word list)) (:'a)``,
+val LESS_dimwords_n2mw = Q.prove(
+  `!n. n < dimwords (LENGTH ((n2mw n):'a word list)) (:'a)`,
   HO_MATCH_MP_TAC n2mw_ind \\ REPEAT STRIP_TAC \\ Cases_on `n = 0`
   \\ FULL_SIMP_TAC std_ss [ZERO_LT_dimwords] \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ ASM_SIMP_TAC std_ss [LENGTH,dimwords_SUC]
@@ -271,18 +271,18 @@ val LESS_dimwords_n2mw = prove(
   \\ MATCH_MP_TAC MULT_ADD_LESS_MULT
   \\ ASM_SIMP_TAC std_ss [ZERO_LT_dimword,MOD_LESS]);
 
-val mw2n_n2mw = store_thm("mw2n_n2mw",
-  ``!n. mw2n (n2mw n) = n``,
+val mw2n_n2mw = Q.store_thm("mw2n_n2mw",
+  `!n. mw2n (n2mw n) = n`,
   ONCE_REWRITE_TAC [n2mw_EQ_k2mw] \\ REPEAT STRIP_TAC
   \\ MATCH_MP_TAC mw2n_k2mw \\ ASM_SIMP_TAC std_ss [LESS_dimwords_n2mw]);
 
-val mw2i_i2mw = store_thm("mw2i_i2mw",
-  ``!i. mw2i (i2mw i) = i``,
+val mw2i_i2mw = Q.store_thm("mw2i_i2mw",
+  `!i. mw2i (i2mw i) = i`,
   REPEAT STRIP_TAC \\ Cases_on `i < 0` \\ ASM_SIMP_TAC std_ss [mw2i_def,i2mw_def]
   \\ ASM_SIMP_TAC std_ss [INT_ABS,mw2n_n2mw] \\ intLib.COOPER_TAC);
 
-val n2mw_11 = store_thm("n2mw_11",
-  ``!m n. (n2mw m = n2mw n) = (m = n)``,
+val n2mw_11 = Q.store_thm("n2mw_11",
+  `!m n. (n2mw m = n2mw n) = (m = n)`,
   HO_MATCH_MP_TAC n2mw_ind
   \\ REPEAT STRIP_TAC \\ Cases_on `m = 0` \\ Cases_on `n = 0`
   \\ ONCE_REWRITE_TAC [n2mw_def] \\ FULL_SIMP_TAC std_ss [NOT_CONS_NIL,CONS_11]
@@ -290,13 +290,13 @@ val n2mw_11 = store_thm("n2mw_11",
   \\ CCONTR_TAC \\ FULL_SIMP_TAC std_ss [n2w_11,ZERO_LT_dimword]
   \\ METIS_TAC [DIVISION,ZERO_LT_dimword]);
 
-val i2mw_11 = store_thm("i2mw_11",
-  ``!i j. (i2mw i = i2mw j) = (i = j)``,
+val i2mw_11 = Q.store_thm("i2mw_11",
+  `!i j. (i2mw i = i2mw j) = (i = j)`,
   SIMP_TAC std_ss [i2mw_def,n2mw_11] \\ REPEAT STRIP_TAC
   \\ Cases_on `i = j` \\ ASM_SIMP_TAC std_ss [] \\ intLib.COOPER_TAC);
 
-val mw_ok_IMP_EXISTS_n2mw = prove(
-  ``!xs. mw_ok xs ==> ?n. xs = n2mw n``,
+val mw_ok_IMP_EXISTS_n2mw = Q.prove(
+  `!xs. mw_ok xs ==> ?n. xs = n2mw n`,
   Induct THEN1 METIS_TAC [n2mw_def] \\ SIMP_TAC std_ss [mw_ok_CLAUSES]
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ ASM_SIMP_TAC std_ss []
   \\ Q.EXISTS_TAC `n * dimword (:'a) + w2n h`
@@ -308,13 +308,13 @@ val mw_ok_IMP_EXISTS_n2mw = prove(
   \\ Q.PAT_X_ASSUM `h <> 0w` MP_TAC \\ Q.SPEC_TAC (`h`,`h`) \\ Cases
   \\ FULL_SIMP_TAC std_ss [n2w_11,ZERO_LT_dimword,w2n_n2w]);
 
-val IMP_EQ_n2mw = prove(
-  ``!xs i. mw_ok xs /\ (mw2n xs = i) ==> (xs = n2mw i)``,
+val IMP_EQ_n2mw = Q.prove(
+  `!xs i. mw_ok xs /\ (mw2n xs = i) ==> (xs = n2mw i)`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC mw_ok_IMP_EXISTS_n2mw
   \\ FULL_SIMP_TAC std_ss [n2mw_11,mw2n_n2mw]);
 
-val IMP_EQ_n2mw_ALT = prove(
-  ``!xs ys. mw_ok xs /\ mw_ok ys /\ (mw2n xs = mw2n ys) ==> (xs = ys)``,
+val IMP_EQ_n2mw_ALT = Q.prove(
+  `!xs ys. mw_ok xs /\ mw_ok ys /\ (mw2n xs = mw2n ys) ==> (xs = ys)`,
   METIS_TAC [IMP_EQ_n2mw]);
 
 val EXISTS_i2mw = prove(
@@ -332,9 +332,9 @@ val mw2i_EQ_IMP_EQ_i2mw = prove(
   ``!x. mw_ok (SND x) /\ ~(x = (T,[])) /\ (mw2i x = i) ==> (x = i2mw i)``,
   REPEAT STRIP_TAC \\ IMP_RES_TAC EXISTS_i2mw \\ FULL_SIMP_TAC std_ss [mw2i_i2mw]);
 
-val LENGTH_n2mw_LESS_LENGTH_n2mw = prove(
-  ``!m n. m <= n ==>
-          LENGTH (n2mw m:'a word list) <= LENGTH (n2mw n:'a word list)``,
+val LENGTH_n2mw_LESS_LENGTH_n2mw = Q.prove(
+  `!m n. m <= n ==>
+          LENGTH (n2mw m:'a word list) <= LENGTH (n2mw n:'a word list)`,
   HO_MATCH_MP_TAC n2mw_ind
   \\ REPEAT STRIP_TAC \\ Cases_on `m = 0` \\ Cases_on `n = 0`
   \\ ONCE_REWRITE_TAC [n2mw_def] \\ ASM_SIMP_TAC std_ss [LENGTH] THEN1 DECIDE_TAC
@@ -344,8 +344,8 @@ val LENGTH_n2mw_LESS_LENGTH_n2mw = prove(
   \\ Q.EXISTS_TAC `m MOD dimword (:'a)`
   \\ ASM_SIMP_TAC std_ss [GSYM DIVISION,ZERO_LT_dimword]);
 
-val mw2n_EQ_IMP_EQ = prove(
-  ``!xs ys. (LENGTH xs = LENGTH ys) /\ (mw2n xs = mw2n ys) ==> (xs = ys)``,
+val mw2n_EQ_IMP_EQ = Q.prove(
+  `!xs ys. (LENGTH xs = LENGTH ys) /\ (mw2n xs = mw2n ys) ==> (xs = ys)`,
   REPEAT STRIP_TAC
   \\ STRIP_ASSUME_TAC (Q.SPEC `xs` EXISTS_k2mw)
   \\ STRIP_ASSUME_TAC (Q.SPEC `ys` EXISTS_k2mw)
@@ -364,20 +364,20 @@ val mw_fix_ind = fetch "-" "mw_fix_ind"
 val mw_zerofix_def = Define `
   mw_zerofix x = if x = (T,[]) then (F,[]) else x`;
 
-val mw_ok_mw_fix = store_thm("mw_ok_fix",
-  ``!xs. mw_ok (mw_fix xs)``,
+val mw_ok_mw_fix = Q.store_thm("mw_ok_fix",
+  `!xs. mw_ok (mw_fix xs)`,
   HO_MATCH_MP_TAC mw_fix_ind \\ Cases \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [mw_fix_def]
   \\ FULL_SIMP_TAC std_ss [mw_ok_CLAUSES,NOT_CONS_NIL]
   \\ Cases_on `LAST (h::t) = 0w` \\ RES_TAC \\ ASM_SIMP_TAC std_ss []
   \\ ASM_SIMP_TAC std_ss [mw_ok_def]);
 
-val mw_ok_mw_fix_ID = store_thm("mw_ok_mw_fix_ID",
-  ``!xs. mw_ok xs ==> (mw_fix xs = xs)``,
+val mw_ok_mw_fix_ID = Q.store_thm("mw_ok_mw_fix_ID",
+  `!xs. mw_ok xs ==> (mw_fix xs = xs)`,
   Cases \\ ASM_SIMP_TAC std_ss [mw_ok_def,Once mw_fix_def,NOT_NIL_CONS]);
 
-val mw2n_mw_fix = prove(
-  ``!xs. mw2n (mw_fix xs) = mw2n xs``,
+val mw2n_mw_fix = Q.prove(
+  `!xs. mw2n (mw_fix xs) = mw2n xs`,
   HO_MATCH_MP_TAC mw_fix_ind \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [mw_fix_def]
   \\ `(xs = []) \/ ?y ys. xs = SNOC y ys` by METIS_TAC [SNOC_CASES]
@@ -385,16 +385,16 @@ val mw2n_mw_fix = prove(
   \\ Cases_on `y = 0w` \\ ASM_SIMP_TAC std_ss [SNOC_APPEND]
   \\ ASM_SIMP_TAC std_ss [mw2n_APPEND,mw2n_def,w2n_n2w,ZERO_LT_dimword]);
 
-val mw2i_mw_zerofix = prove(
-  ``!x. mw2i (mw_zerofix x) = mw2i x``,
+val mw2i_mw_zerofix = Q.prove(
+  `!x. mw2i (mw_zerofix x) = mw2i x`,
   SRW_TAC [] [mw_zerofix_def,mw2i_def,mw2n_def]);
 
 val mw_zerofix_thm = prove(
   ``!x b xs. ~(mw_zerofix x = (T,[])) /\ mw_ok (SND (mw_zerofix (b, mw_fix xs)))``,
   SRW_TAC [] [mw_zerofix_def,mw_ok_CLAUSES,mw_ok_mw_fix]);
 
-val mw_fix_NIL = store_thm("mw_fix_NIL",
-  ``!xs. (mw_fix xs = []) = (mw2n xs = 0)``,
+val mw_fix_NIL = Q.store_thm("mw_fix_NIL",
+  `!xs. (mw_fix xs = []) = (mw2n xs = 0)`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [mw_fix_def]
   \\ SIMP_TAC std_ss [mw2n_def,NOT_SNOC_NIL,LAST_SNOC,FRONT_SNOC]
@@ -404,35 +404,35 @@ val mw_fix_NIL = store_thm("mw_fix_NIL",
   \\ REPEAT STRIP_TAC THEN1 DECIDE_TAC \\ Cases_on `x`
   \\ FULL_SIMP_TAC std_ss [n2w_11,w2n_n2w,ZERO_LT_dimword]);
 
-val mw_fix_LENGTH_ZERO = prove(
-  ``!xs. (LENGTH (mw_fix xs) = 0) = (mw2n xs = 0)``,
+val mw_fix_LENGTH_ZERO = Q.prove(
+  `!xs. (LENGTH (mw_fix xs) = 0) = (mw2n xs = 0)`,
   FULL_SIMP_TAC std_ss [LENGTH_NIL,mw_fix_NIL]);
 
 val mw_fix_EQ_n2mw =
   Q.SPEC `mw_fix xs` mw_ok_IMP_EXISTS_n2mw |> RW [mw_ok_mw_fix] |> GEN_ALL;
 
-val n2mw_mw2n = prove(
-  ``!xs. (mw_fix xs = n2mw (mw2n xs))``,
+val n2mw_mw2n = Q.prove(
+  `!xs. (mw_fix xs = n2mw (mw2n xs))`,
   REPEAT STRIP_TAC
   \\ `?n. mw_fix xs = n2mw n` by METIS_TAC [mw_fix_EQ_n2mw]
   \\ ONCE_REWRITE_TAC [GSYM mw2n_mw_fix] \\ FULL_SIMP_TAC std_ss [mw2n_n2mw]);
 
-val mw_ok_mw_mw2n = prove(
-  ``!xs. mw_ok xs ==> (xs = n2mw (mw2n xs))``,
+val mw_ok_mw_mw2n = Q.prove(
+  `!xs. mw_ok xs ==> (xs = n2mw (mw2n xs))`,
   METIS_TAC [n2mw_mw2n,mw_ok_mw_fix,mw_ok_mw_fix_ID]);
 
-val LENGTH_mw_fix = store_thm("LENGTH_mw_fix",
-  ``!xs. LENGTH (mw_fix xs) <= LENGTH xs``,
+val LENGTH_mw_fix = Q.store_thm("LENGTH_mw_fix",
+  `!xs. LENGTH (mw_fix xs) <= LENGTH xs`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ REPEAT STRIP_TAC
   \\ SIMP_TAC (srw_ss()) [Once mw_fix_def] \\ SRW_TAC [] []
   \\ DECIDE_TAC);
 
-val REPLICATE_SNOC = store_thm("REPLICATE_SNOC",
-  ``!n x. REPLICATE (SUC n) x = SNOC x (REPLICATE n x)``,
+val REPLICATE_SNOC = Q.store_thm("REPLICATE_SNOC",
+  `!n x. REPLICATE (SUC n) x = SNOC x (REPLICATE n x)`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [REPLICATE]);
 
-val mw_fix_thm = store_thm("mw_fix_thm",
-  ``!xs. mw_fix xs ++ REPLICATE (LENGTH xs - LENGTH (mw_fix xs)) 0x0w = xs``,
+val mw_fix_thm = Q.store_thm("mw_fix_thm",
+  `!xs. mw_fix xs ++ REPLICATE (LENGTH xs - LENGTH (mw_fix xs)) 0x0w = xs`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ STRIP_TAC THEN1 EVAL_TAC
   \\ REPEAT STRIP_TAC \\ ONCE_REWRITE_TAC [mw_fix_def]
   \\ FULL_SIMP_TAC std_ss [NOT_SNOC_NIL,LAST_SNOC,FRONT_SNOC]
@@ -447,8 +447,8 @@ val mw_fix_thm = store_thm("mw_fix_thm",
   \\ FULL_SIMP_TAC std_ss []
   \\ FULL_SIMP_TAC std_ss [SNOC_APPEND,APPEND_ASSOC]);
 
-val mw2n_REPLICATE = prove(
-  ``!n. mw2n (REPLICATE n 0x0w) = 0``,
+val mw2n_REPLICATE = Q.prove(
+  `!n. mw2n (REPLICATE n 0x0w) = 0`,
   Induct THEN1 EVAL_TAC
   \\ ASM_SIMP_TAC std_ss [REPLICATE,mw2n_def,w2n_n2w,ZERO_LT_dimword]);
 
@@ -491,8 +491,8 @@ val single_add_thm = store_thm("single_add_thm",
   \\ `n + n' + b2n c = dimword (:'a) + (n + n' + b2n c - dimword (:'a))` by DECIDE_TAC
   \\ METIS_TAC [bitTheory.DIV_MULT_1]);
 
-val b2n_thm = prove(
-  ``!c. b2n c = if c then 1 else 0``,
+val b2n_thm = Q.prove(
+  `!c. b2n c = if c then 1 else 0`,
   Cases \\ SIMP_TAC std_ss [b2n_def]);
 
 val single_add_eq = store_thm("single_add_eq",
@@ -557,10 +557,10 @@ val mw_sub_lemma = prove(
   \\ Cases_on `dimwords (LENGTH t) (:'a)` \\ FULL_SIMP_TAC std_ss [MULT_CLAUSES]
   \\ `0 < dimword (:'a)` by FULL_SIMP_TAC std_ss [ZERO_LT_dimword] \\ DECIDE_TAC);
 
-val mw_sub_thm = prove(
-  ``!xs ys c zs d.
+val mw_sub_thm = Q.prove(
+  `!xs ys c zs d.
      (LENGTH xs = LENGTH ys) /\ mw2n ys <= mw2n xs ==>
-     (mw2n (FST (mw_sub xs ys T)) = mw2n xs - mw2n ys)``,
+     (mw2n (FST (mw_sub xs ys T)) = mw2n xs - mw2n ys)`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ REPEAT STRIP_TAC
   \\ `?zs d. mw_sub xs ys T = (zs,d)` by METIS_TAC [PAIR]
   \\ IMP_RES_TAC mw_sub_lemma \\ ASM_SIMP_TAC std_ss []
@@ -578,14 +578,14 @@ val mw_addv_def = Define `
     let (z,c1) = single_add x y c in
       z :: mw_addv xs ys2 c1)`;
 
-val WORD_NOT_ZERO_ONE = prove(
-  ``~(0w = 1w)``,
+val WORD_NOT_ZERO_ONE = Q.prove(
+  `~(0w = 1w)`,
   SIMP_TAC std_ss [n2w_11,ZERO_LT_dimword,ONE_LT_dimword]);
 
-val mw_addv_thm = prove(
-  ``!xs (ys:'a word list) c.
+val mw_addv_thm = Q.prove(
+  `!xs (ys:'a word list) c.
       (LENGTH ys <= LENGTH xs) ==>
-      (mw2n (mw_addv xs ys c) = mw2n xs + mw2n ys + b2n c)``,
+      (mw2n (mw_addv xs ys c) = mw2n xs + mw2n ys + b2n c)`,
   Induct \\ Cases_on `ys` \\ SIMP_TAC std_ss [LENGTH] THEN1
    (Cases_on `c` \\ SIMP_TAC std_ss [mw_addv_def,b2n_def,
       mw2n_def,w2n_n2w,ONE_LT_dimword,mw_ok_def,LAST_DEF])
@@ -598,8 +598,8 @@ val mw_addv_thm = prove(
   \\ `?z3 c3. single_add h' h c = (z3,c3)` by METIS_TAC [PAIR]
   \\ IMP_RES_TAC single_add_thm \\ FULL_SIMP_TAC std_ss [mw2n_def] \\ DECIDE_TAC);
 
-val mw_ok_addv = prove(
-  ``!xs ys c. mw_ok xs /\ mw_ok ys ==> mw_ok (mw_addv xs (ys:'a word list) c)``,
+val mw_ok_addv = Q.prove(
+  `!xs ys c. mw_ok xs /\ mw_ok ys ==> mw_ok (mw_addv xs (ys:'a word list) c)`,
   Induct THEN1 (Cases_on `c`
     \\ SIMP_TAC std_ss [mw_addv_def,mw_ok_def,LAST_DEF,WORD_NOT_ZERO_ONE])
   \\ SIMP_TAC std_ss [mw_addv_def,SPLIT_LET2] \\ SIMP_TAC std_ss [LET_DEF]
@@ -658,27 +658,27 @@ val mw_sub_APPEND = store_thm("mw_sub_APPEND",
 val mw_subv_def = Define `
   mw_subv xs ys = mw_fix (FST (mw_sub xs ys T))`;
 
-val mw_sub_SNOC_0 = prove(
-  ``!xs ys c. mw_sub xs (SNOC 0w ys) c = mw_sub xs ys c``,
+val mw_sub_SNOC_0 = Q.prove(
+  `!xs ys c. mw_sub xs (SNOC 0w ys) c = mw_sub xs ys c`,
   Induct \\ SIMP_TAC std_ss [mw_sub_def] \\ Cases_on `ys`
   \\ FULL_SIMP_TAC std_ss [SNOC_APPEND,APPEND,mw_sub_def]);
 
-val mw_sub_APPEND_0 = prove(
-  ``!n xs ys c. mw_sub xs (ys ++ REPLICATE n 0w) c = mw_sub xs ys c``,
+val mw_sub_APPEND_0 = Q.prove(
+  `!n xs ys c. mw_sub xs (ys ++ REPLICATE n 0w) c = mw_sub xs ys c`,
   Induct \\ ASM_SIMP_TAC std_ss [REPLICATE_SNOC,APPEND_SNOC,mw_sub_SNOC_0]
   \\ SIMP_TAC std_ss [REPLICATE,APPEND_NIL]);
 
-val mw_sub_mw_fix = store_thm("mw_sub_mw_fix",
-  ``!xs ys. mw_sub xs (mw_fix ys) c = mw_sub xs (ys:'a word list) c``,
+val mw_sub_mw_fix = Q.store_thm("mw_sub_mw_fix",
+  `!xs ys. mw_sub xs (mw_fix ys) c = mw_sub xs (ys:'a word list) c`,
   METIS_TAC [mw_sub_APPEND_0,mw_fix_thm]);
 
-val mw2n_APPEND_REPLICATE = prove(
-  ``!ys n. mw2n ys = mw2n (ys ++ REPLICATE n 0w)``,
+val mw2n_APPEND_REPLICATE = Q.prove(
+  `!ys n. mw2n ys = mw2n (ys ++ REPLICATE n 0w)`,
   SIMP_TAC std_ss [mw2n_APPEND,mw2n_REPLICATE]);
 
-val mw_subv_thm = prove(
-  ``!xs ys. mw2n ys <= mw2n xs /\ (LENGTH ys <= LENGTH xs) ==>
-            (mw2n (mw_subv xs ys) = mw2n xs - mw2n ys)``,
+val mw_subv_thm = Q.prove(
+  `!xs ys. mw2n ys <= mw2n xs /\ (LENGTH ys <= LENGTH xs) ==>
+            (mw2n (mw_subv xs ys) = mw2n xs - mw2n ys)`,
   SIMP_TAC std_ss [mw_subv_def,mw2n_mw_fix] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [(GSYM mw_sub_APPEND_0)
        |> Q.SPECL [`(LENGTH (xs:'a word list) - LENGTH (ys:'a word list))`,
@@ -716,18 +716,18 @@ val mwi_add_lemma = prove(
 val mwi_add_lemma2 = RW [mw_ok_n2mw,GSYM i2mw_def,mw2i_i2mw]
   (Q.SPECL [`i<0:int`,`j<0:int`,`n2mw (Num (ABS i))`,`n2mw (Num (ABS j))`] mwi_add_lemma);
 
-val mw_addv_IMP_NIL = prove(
-  ``!xs ys. (mw_addv xs ys c = []) ==> (xs = [])``,
+val mw_addv_IMP_NIL = Q.prove(
+  `!xs ys. (mw_addv xs ys c = []) ==> (xs = [])`,
   Induct \\ SIMP_TAC std_ss [mw_addv_def,SPLIT_LET2]
   \\ SIMP_TAC std_ss [LET_DEF,NOT_CONS_NIL]);
 
-val n2mw_NIL = store_thm("n2mw_NIL",
-  ``!n. (n2mw n = []) = (n = 0)``,
+val n2mw_NIL = Q.store_thm("n2mw_NIL",
+  `!n. (n2mw n = []) = (n = 0)`,
   REPEAT STRIP_TAC \\ Cases_on `n = 0` \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ ASM_SIMP_TAC std_ss [NOT_CONS_NIL]);
 
-val mwi_add_thm = store_thm("mwi_add_thm",
-  ``!i j. mwi_add (i2mw i) (i2mw j) = i2mw (i + j)``,
+val mwi_add_thm = Q.store_thm("mwi_add_thm",
+  `!i j. mwi_add (i2mw i) (i2mw j) = i2mw (i + j)`,
   REPEAT STRIP_TAC \\ MATCH_MP_TAC mw2i_EQ_IMP_EQ_i2mw
   \\ FULL_SIMP_TAC std_ss [mwi_add_lemma2]
   \\ SIMP_TAC std_ss [mwi_add_def,i2mw_def,mw2n_n2mw] \\ STRIP_TAC
@@ -757,8 +757,8 @@ val mwi_sub_lemma2 = RW [mw_ok_n2mw,GSYM i2mw_def,mw2i_i2mw]
   (Q.SPECL [`i<0:int`,`j<0:int`,`n2mw (Num (ABS i))`,`n2mw (Num (ABS j))`]
     mwi_sub_lemma);
 
-val mwi_sub_thm = store_thm("mwi_sub_thm",
-  ``!i j. mwi_sub (i2mw i) (i2mw j) = i2mw (i - j)``,
+val mwi_sub_thm = Q.store_thm("mwi_sub_thm",
+  `!i j. mwi_sub (i2mw i) (i2mw j) = i2mw (i - j)`,
   REPEAT STRIP_TAC \\ MATCH_MP_TAC mw2i_EQ_IMP_EQ_i2mw
   \\ FULL_SIMP_TAC std_ss [mwi_sub_lemma2]
   \\ SIMP_TAC std_ss [mwi_sub_def,mwi_add_def,i2mw_def,mw2n_n2mw] \\ STRIP_TAC
@@ -818,8 +818,8 @@ val single_mul_thm = prove(
   \\ ASM_SIMP_TAC std_ss [word_add_n2w,word_mul_n2w,w2n_n2w]
   \\ METIS_TAC [DIVISION,MULT_COMM,ADD_COMM,ZERO_LT_dimword]);
 
-val ADD_LESS_MULT = prove(
-  ``!n. 1 < n ==> n + (n - 1) < n * n``,
+val ADD_LESS_MULT = Q.prove(
+  `!n. 1 < n ==> n + (n - 1) < n * n`,
   Induct \\ SIMP_TAC std_ss [MULT_CLAUSES] \\ REPEAT STRIP_TAC
   \\ Cases_on `1<n` \\ RES_TAC THEN1 DECIDE_TAC
   \\ `n = 1` by DECIDE_TAC \\ ASM_SIMP_TAC std_ss []);
@@ -849,11 +849,11 @@ val single_mul_add_thm = prove(
   \\ ASSUME_TAC (MATCH_MP ADD_LESS_MULT ONE_LT_dimword)
   \\ Q.ABBREV_TAC `d = dimword(:'a)` \\ DECIDE_TAC);
 
-val mw_mul_pass_thm = prove(
-  ``!ys zs (x:'a word) k.
+val mw_mul_pass_thm = Q.prove(
+  `!ys zs (x:'a word) k.
       (LENGTH ys = LENGTH zs) ==>
       (mw2n (mw_mul_pass x ys zs k) = w2n x * mw2n ys + mw2n zs + w2n k) /\
-      (LENGTH (mw_mul_pass x ys zs k) = LENGTH ys + 1)``,
+      (LENGTH (mw_mul_pass x ys zs k) = LENGTH ys + 1)`,
   Induct \\ Cases_on `zs` \\ SIMP_TAC std_ss
     [mw_mul_pass_def,LENGTH,dimwords_thm,mw2n_def,DECIDE ``~(SUC n = 0)``,HD,TL]
   \\ POP_ASSUM (ASSUME_TAC o Q.SPEC `t`) \\ REPEAT STRIP_TAC
@@ -861,10 +861,10 @@ val mw_mul_pass_thm = prove(
   \\ FULL_SIMP_TAC std_ss [mw2n_def,LEFT_ADD_DISTRIB,LENGTH,ADD1,TL]
   \\ IMP_RES_TAC single_mul_add_thm \\ DECIDE_TAC);
 
-val mw_mul_thm = store_thm("mw_mul_thm",
-  ``!xs ys (zs:'a word list).
+val mw_mul_thm = Q.store_thm("mw_mul_thm",
+  `!xs ys (zs:'a word list).
       (LENGTH ys = LENGTH zs) ==>
-      (mw2n (mw_mul xs ys zs) = mw2n xs * mw2n ys + mw2n zs)``,
+      (mw2n (mw_mul xs ys zs) = mw2n xs * mw2n ys + mw2n zs)`,
   Induct \\ SIMP_TAC std_ss [mw_mul_def,mw2n_def] \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [LET_DEF,mw2n_def]
   \\ (STRIP_ASSUME_TAC o UNDISCH o Q.SPECL [`ys`,`zs`,`h`,`0w`]) mw_mul_pass_thm
@@ -873,18 +873,18 @@ val mw_mul_thm = store_thm("mw_mul_thm",
   \\ FULL_SIMP_TAC std_ss [TL,HD,mw2n_def,w2n_n2w,ZERO_LT_dimword]
   \\ DECIDE_TAC);
 
-val Num_ABS_EQ_0 = prove(
-  ``!i. (Num (ABS i) = 0) = (i = 0)``,
+val Num_ABS_EQ_0 = Q.prove(
+  `!i. (Num (ABS i) = 0) = (i = 0)`,
   intLib.COOPER_TAC);
 
-val NUM_EXISTS = prove(
-  ``!i. ?n. ABS i = & n``,
+val NUM_EXISTS = Q.prove(
+  `!i. ?n. ABS i = & n`,
   REPEAT STRIP_TAC \\ Cases_on `i < 0:int` \\ ASM_SIMP_TAC std_ss [INT_ABS]
   THEN1 (Q.EXISTS_TAC `Num (-i)` \\ intLib.COOPER_TAC)
   THEN1 (Q.EXISTS_TAC `Num i` \\ intLib.COOPER_TAC));
 
-val mwi_mul_thm = store_thm("mwi_mul_thm",
-  ``!i j. mwi_mul (i2mw i) (i2mw j) = i2mw (i * j)``,
+val mwi_mul_thm = Q.store_thm("mwi_mul_thm",
+  `!i j. mwi_mul (i2mw i) (i2mw j) = i2mw (i * j)`,
   REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [i2mw_def,mwi_mul_def,n2mw_NIL,Num_ABS_EQ_0]
   \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
@@ -911,16 +911,16 @@ val mw_shift_def = Define `
   (mw_shift ((w:'a word)::x::xs) =
      (w >>> 1 !! x << (dimindex (:'a) - 1)) :: mw_shift (x::xs))`;
 
-val w2n_add = prove(
-  ``!x y. w2n (x + y) = (w2n x + w2n (y:'a word)) MOD dimword (:'a)``,
+val w2n_add = Q.prove(
+  `!x y. w2n (x + y) = (w2n x + w2n (y:'a word)) MOD dimword (:'a)`,
   REPEAT Cases \\ SIMP_TAC std_ss [word_add_n2w,w2n_n2w,MOD_PLUS,ZERO_LT_dimword]);
 
-val word_LSL_n2w = prove(
-  ``!m k. ((n2w m):'a word) << k = n2w (m * 2 ** k)``,
+val word_LSL_n2w = Q.prove(
+  `!m k. ((n2w m):'a word) << k = n2w (m * 2 ** k)`,
   SIMP_TAC std_ss [AC MULT_ASSOC MULT_COMM,WORD_MUL_LSL,word_mul_n2w]);
 
-val mw_shift_thm = store_thm("mw_shift_thm",
-  ``!xs. mw2n (mw_shift xs) = mw2n (xs:'a word list) DIV 2``,
+val mw_shift_thm = Q.store_thm("mw_shift_thm",
+  `!xs. mw2n (mw_shift xs) = mw2n (xs:'a word list) DIV 2`,
   Induct \\ SIMP_TAC std_ss [mw_shift_def,mw2n_def]
   \\ Cases_on `xs` \\ ASM_SIMP_TAC std_ss [mw_shift_def,mw2n_def,w2n_lsr]
   \\ CONV_TAC (RAND_CONV (ALPHA_CONV ``w:'a word``)) \\ REPEAT STRIP_TAC
@@ -950,8 +950,8 @@ val mw_shift_thm = store_thm("mw_shift_thm",
   \\ SIMP_TAC std_ss [LEFT_ADD_DISTRIB,MULT_ASSOC,ADD_ASSOC]
   \\ SIMP_TAC std_ss [AC ADD_COMM ADD_ASSOC, AC MULT_COMM MULT_ASSOC]);
 
-val LENGTH_mw_shift = store_thm("LENGTH_mw_shift",
-  ``!xs. LENGTH (mw_shift xs) = LENGTH xs``,
+val LENGTH_mw_shift = Q.store_thm("LENGTH_mw_shift",
+  `!xs. LENGTH (mw_shift xs) = LENGTH xs`,
   Induct \\ SIMP_TAC std_ss [LENGTH,mw_shift_def]
   \\ Cases_on `xs` \\ ASM_SIMP_TAC std_ss [LENGTH,mw_shift_def]);
 
@@ -985,9 +985,9 @@ val mwi_lt_def = Define `
 val mwi_eq_def = Define `
   mwi_eq s_xs t_ys = (mwi_compare s_xs t_ys = NONE)`;
 
-val LAST_IMP_mw2n_LESS_mw2n = prove(
-  ``!xs ys. (LENGTH xs = LENGTH ys) /\ (LAST xs <+ LAST ys) /\ ~(xs = []) ==>
-            mw2n xs < mw2n ys``,
+val LAST_IMP_mw2n_LESS_mw2n = Q.prove(
+  `!xs ys. (LENGTH xs = LENGTH ys) /\ (LAST xs <+ LAST ys) /\ ~(xs = []) ==>
+            mw2n xs < mw2n ys`,
   STRIP_TAC \\ `(xs = []) \/ ?x xs1. xs = SNOC x xs1` by METIS_TAC [SNOC_CASES]
   \\ STRIP_TAC \\ `(ys = []) \/ ?y ys1. ys = SNOC y ys1` by METIS_TAC [SNOC_CASES]
   \\ ASM_SIMP_TAC std_ss [LENGTH_SNOC,LENGTH,DECIDE ``~(SUC n = 0)``,LAST_SNOC]
@@ -996,10 +996,10 @@ val LAST_IMP_mw2n_LESS_mw2n = prove(
   \\ MATCH_MP_TAC MULT_ADD_LESS_MULT_ADD
   \\ FULL_SIMP_TAC std_ss [mw2n_lt,WORD_LO] \\ METIS_TAC [mw2n_lt]);
 
-val mw_cmp_thm = store_thm("mw_cmp_thm",
-  ``!xs ys. (LENGTH ys = LENGTH xs) ==>
+val mw_cmp_thm = Q.store_thm("mw_cmp_thm",
+  `!xs ys. (LENGTH ys = LENGTH xs) ==>
             (mw_cmp xs ys = if mw2n xs = mw2n ys then NONE else
-                              SOME (mw2n xs < mw2n ys))``,
+                              SOME (mw2n xs < mw2n ys))`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ REPEAT STRIP_TAC \\ ONCE_REWRITE_TAC [mw_cmp_def]
   THEN1 FULL_SIMP_TAC std_ss [LENGTH,LENGTH_NIL]
   \\ `(ys = []) \/ ?z zs. ys = SNOC z zs` by METIS_TAC [SNOC_CASES]
@@ -1014,9 +1014,9 @@ val mw_cmp_thm = store_thm("mw_cmp_thm",
   \\ METIS_TAC [LAST_IMP_mw2n_LESS_mw2n,LENGTH_SNOC,LAST_SNOC,NOT_NIL_SNOC,
                  WORD_LOWER_LOWER_CASES]);
 
-val LENGTH_LESS_IMP_mw2n_LESS = store_thm("LENGTH_LESS_IMP_mw2n_LESS",
-  ``!(xs:'a word list) (ys:'a word list).
-      mw_ok xs /\ mw_ok ys /\ LENGTH xs < LENGTH ys ==> mw2n xs < mw2n ys``,
+val LENGTH_LESS_IMP_mw2n_LESS = Q.store_thm("LENGTH_LESS_IMP_mw2n_LESS",
+  `!(xs:'a word list) (ys:'a word list).
+      mw_ok xs /\ mw_ok ys /\ LENGTH xs < LENGTH ys ==> mw2n xs < mw2n ys`,
   REPEAT STRIP_TAC \\ STRIP_ASSUME_TAC (Q.ISPEC `ys:'a word list` SNOC_CASES)
   \\ FULL_SIMP_TAC std_ss [LENGTH,mw_ok_def,NOT_SNOC_NIL,LAST_SNOC,LENGTH_SNOC]
   \\ SIMP_TAC std_ss [SNOC_APPEND,mw2n_APPEND,mw2n_def]
@@ -1028,16 +1028,16 @@ val LENGTH_LESS_IMP_mw2n_LESS = store_thm("LENGTH_LESS_IMP_mw2n_LESS",
   \\ `0 < dimwords (LENGTH l) (:'a)` by FULL_SIMP_TAC std_ss [ZERO_LT_dimwords]
   \\ Cases_on `n` \\ FULL_SIMP_TAC std_ss [MULT_CLAUSES] \\ DECIDE_TAC);
 
-val mw2n_LESS_IMP_LENGTH_LESS_EQ = store_thm("mw2n_LESS_IMP_LENGTH_LESS_EQ",
-  ``!xs:'a word list ys:'a word list.
-      mw_ok xs /\ mw_ok ys /\ mw2n xs < mw2n ys ==> LENGTH xs <= LENGTH ys``,
+val mw2n_LESS_IMP_LENGTH_LESS_EQ = Q.store_thm("mw2n_LESS_IMP_LENGTH_LESS_EQ",
+  `!xs:'a word list ys:'a word list.
+      mw_ok xs /\ mw_ok ys /\ mw2n xs < mw2n ys ==> LENGTH xs <= LENGTH ys`,
   SIMP_TAC std_ss [GSYM NOT_LESS] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC LENGTH_LESS_IMP_mw2n_LESS \\ DECIDE_TAC);
 
-val mw_compare_thm = store_thm("mw_compare_thm",
-  ``!xs ys. mw_ok xs /\ mw_ok ys ==>
+val mw_compare_thm = Q.store_thm("mw_compare_thm",
+  `!xs ys. mw_ok xs /\ mw_ok ys ==>
             (mw_compare xs ys = if mw2n xs = mw2n ys then NONE else
-                                  SOME (mw2n xs < mw2n ys))``,
+                                  SOME (mw2n xs < mw2n ys))`,
   REPEAT STRIP_TAC \\ ASM_SIMP_TAC std_ss [mw_compare_def]
   \\ Cases_on `LENGTH xs = LENGTH ys` \\ ASM_SIMP_TAC std_ss [mw_cmp_thm]
   \\ `LENGTH xs < LENGTH ys \/ LENGTH ys < LENGTH xs` by DECIDE_TAC
@@ -1045,16 +1045,16 @@ val mw_compare_thm = store_thm("mw_compare_thm",
   \\ IMP_RES_TAC (DECIDE ``m < n ==> ~(n < m) /\ ~(m = n:num)``)
   \\ ASM_SIMP_TAC std_ss []);
 
-val mwi_compare_thm = store_thm("mwi_compare_thm",
-  ``!i j. mwi_compare (i2mw i) (i2mw j) = if i = j then NONE else SOME (i < j)``,
+val mwi_compare_thm = Q.store_thm("mwi_compare_thm",
+  `!i j. mwi_compare (i2mw i) (i2mw j) = if i = j then NONE else SOME (i < j)`,
   SIMP_TAC std_ss [i2mw_def,mwi_compare_def,mw_compare_thm,mw_ok_n2mw,mw2n_n2mw]
   \\ REPEAT STRIP_TAC \\ Cases_on `i = j` \\ ASM_SIMP_TAC std_ss [option_eq_def]
   \\ REV (Cases_on `i < 0 = j < 0`) \\ ASM_SIMP_TAC std_ss [] THEN1 intLib.COOPER_TAC
   \\ Cases_on `i < 0` \\ Cases_on `j < 0` \\ SRW_TAC [] [option_eq_def,INT_ABS]
   \\ intLib.COOPER_TAC);
 
-val mw_subv_NOT_NIL = store_thm("mw_subv_NOT_NIL",
-  ``!xs ys. mw_ok xs /\ mw_ok ys /\ mw2n xs < mw2n ys ==> ~(mw_subv ys xs = [])``,
+val mw_subv_NOT_NIL = Q.store_thm("mw_subv_NOT_NIL",
+  `!xs ys. mw_ok xs /\ mw_ok ys /\ mw2n xs < mw2n ys ==> ~(mw_subv ys xs = [])`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC mw2n_LESS_IMP_LENGTH_LESS_EQ
   \\ `mw2n xs <= mw2n ys` by DECIDE_TAC \\ IMP_RES_TAC mw_subv_thm
   \\ POP_ASSUM MP_TAC \\ ASM_SIMP_TAC std_ss [mw2n_def] \\ DECIDE_TAC);
@@ -1068,11 +1068,11 @@ val mw_cmp_alt_def = Define `
      mw_cmp_alt xs (TL ys) (if x = HD ys then b else
                             if x <+ HD ys then SOME T else SOME F))`
 
-val mw_cmp_CONS = prove(
-  ``!xs ys.
+val mw_cmp_CONS = Q.prove(
+  `!xs ys.
       (LENGTH xs = LENGTH ys) ==>
       (mw_cmp (x::xs) (y::ys) =
-        case mw_cmp xs ys of NONE => mw_cmp [x] [y] | t => t)``,
+        case mw_cmp xs ys of NONE => mw_cmp [x] [y] | t => t)`,
   HO_MATCH_MP_TAC (fetch "-" "mw_cmp_ind") \\ REPEAT STRIP_TAC
   \\ `(xs = []) \/ ?x1 l1. xs = SNOC x1 l1` by METIS_TAC [SNOC_CASES]
   \\ `(ys = []) \/ ?x2 l2. ys = SNOC x2 l2` by METIS_TAC [SNOC_CASES]
@@ -1083,11 +1083,11 @@ val mw_cmp_CONS = prove(
   \\ SIMP_TAC (srw_ss()) [Once mw_cmp_def,LAST_SNOC,FRONT_SNOC]
   \\ Cases_on `x1 = x2` \\ FULL_SIMP_TAC std_ss []);
 
-val mw_cmp_alt_lemma = prove(
-  ``!xs ys res.
+val mw_cmp_alt_lemma = Q.prove(
+  `!xs ys res.
       (LENGTH xs = LENGTH ys) ==>
       (mw_cmp_alt xs ys res =
-         case mw_cmp xs ys of NONE => res | SOME t => SOME t)``,
+         case mw_cmp xs ys of NONE => res | SOME t => SOME t)`,
   Induct \\ Cases_on `ys` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ SIMP_TAC (srw_ss()) [mw_cmp_alt_def,HD,TL]
   THEN1 (STRIP_TAC \\ EVAL_TAC)
@@ -1099,9 +1099,9 @@ val mw_cmp_alt_lemma = prove(
   \\ EVAL_TAC \\ Cases_on `h = h'` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ SRW_TAC [] []);
 
-val mw_cmp_alt_thm = store_thm("mw_cmp_alt_thm",
-  ``(LENGTH xs = LENGTH ys) ==>
-    (mw_cmp xs ys = mw_cmp_alt xs ys NONE)``,
+val mw_cmp_alt_thm = Q.store_thm("mw_cmp_alt_thm",
+  `(LENGTH xs = LENGTH ys) ==>
+    (mw_cmp xs ys = mw_cmp_alt xs ys NONE)`,
   Cases_on `mw_cmp xs ys` \\ ASM_SIMP_TAC std_ss [mw_cmp_alt_lemma]);
 
 
@@ -1126,15 +1126,15 @@ val mw_mul_by_single_def = Define `
   mw_mul_by_single (x:'a word) (ys:'a word list) =
     mw_mul_pass x ys (k2mw (LENGTH ys) 0) 0w`;
 
-val LENGTH_mw_mul_pass = store_thm("LENGTH_mw_mul_pass",
-  ``!ys zs (x:'a word) k.
-      (LENGTH (mw_mul_pass x ys zs k) = LENGTH ys + 1)``,
+val LENGTH_mw_mul_pass = Q.store_thm("LENGTH_mw_mul_pass",
+  `!ys zs (x:'a word) k.
+      (LENGTH (mw_mul_pass x ys zs k) = LENGTH ys + 1)`,
   Induct \\ Cases_on `zs`
   \\ FULL_SIMP_TAC (srw_ss()) [mw_mul_pass_def,single_mul_add_def,LET_DEF,
        single_mul_def,mw_add_def,single_add_def] \\ DECIDE_TAC);
 
-val LENGTH_mw_mul_by_single = store_thm("LENGTH_mw_mul_by_single",
-  ``(LENGTH (mw_mul_by_single x ys) = LENGTH ys + 1)``,
+val LENGTH_mw_mul_by_single = Q.store_thm("LENGTH_mw_mul_by_single",
+  `(LENGTH (mw_mul_by_single x ys) = LENGTH ys + 1)`,
   SIMP_TAC std_ss [LENGTH_mw_mul_pass,mw_mul_by_single_def]);
 
 val PULL_CONJ = METIS_PROVE [] ``!a b c.( a ==> b /\ c) ==>(a ==> b) /\ (a ==> c)``
@@ -1162,33 +1162,33 @@ val EQT_A_S_R_2 =
 
 (* division arithmetic lemmas*)
 
-val DIV_thm2 = store_thm( "DIV_thm2",
-  ``0 < b /\ a < c * b ==> a DIV b < c``,
+val DIV_thm2 = Q.store_thm( "DIV_thm2",
+  `0 < b /\ a < c * b ==> a DIV b < c`,
   strip_tac >> METIS_TAC[DIV_LT_X]);
 
-val DIV_thm3 = store_thm( "DIV_thm3",
-  ``!a b. 0 < b ==> (a DIV b * b <= a)``,
+val DIV_thm3 = Q.store_thm( "DIV_thm3",
+  `!a b. 0 < b ==> (a DIV b * b <= a)`,
   REPEAT strip_tac >> IMP_RES_TAC DIVISION >> METIS_TAC[LESS_EQ_ADD]);
 
-val DIV_thm4 = store_thm( "DIV_thm4",
-  ``!a b. 0 < b ==> (a - a DIV b * b < b)``,
+val DIV_thm4 = Q.store_thm( "DIV_thm4",
+  `!a b. 0 < b ==> (a - a DIV b * b < b)`,
   REPEAT strip_tac >> IMP_RES_TAC DIVISION >>
   METIS_TAC[MOD_LESS_EQ,DIV_thm3,CANCEL_SUB,ADD_SUB,ADD_COMM]);
 
-val DIV_thm4_bis = store_thm( "DIV_thm4_bis",
-  ``!a b. 0 < b ==> a < b + a DIV b * b``, strip_tac >>
+val DIV_thm4_bis = Q.store_thm( "DIV_thm4_bis",
+  `!a b. 0 < b ==> a < b + a DIV b * b`, strip_tac >>
   METIS_TAC[DIV_EQ_X,MULT,ADD_COMM]);
 
-val DIV_thm1 = store_thm( "DIV_thm1",
-  ``0 < b /\ b <= c ==> a DIV c <= a DIV b`` ,
+val DIV_thm1 = Q.store_thm( "DIV_thm1",
+  `0 < b /\ b <= c ==> a DIV c <= a DIV b` ,
   strip_tac >> qsuff_tac `a < (a DIV b + 1) * c` THEN1 (
   strip_tac >> METIS_TAC[LESS_LESS_EQ_TRANS,DIV_LE_X]) >>
   MATCH_MP_TAC LESS_LESS_EQ_TRANS >> EXISTS_TAC ``(a DIV b + 1)*b`` >> strip_tac THEN1
   METIS_TAC[DIV_thm4_bis,RIGHT_ADD_DISTRIB,MULT_LEFT_1,ADD_COMM] >>
   METIS_TAC[MULT_COMM,LESS_MONO_MULT]);
 
-val DIV_thm5 = store_thm( "DIV_thm5",
-  ``0 < b /\ a - q*b < b ==> (q >= a DIV b)``,
+val DIV_thm5 = Q.store_thm( "DIV_thm5",
+  `0 < b /\ a - q*b < b ==> (q >= a DIV b)`,
   rw[GREATER_EQ] >> rw[DIV_LE_X] >> srw_tac[ARITH_ss][]);
 
 (* lists *)
@@ -1207,12 +1207,12 @@ val HD_REVERSE = store_thm ("HD_REVERSE",
 
 (* word & multiWord general *)
 
-val NOT_0w_bis = store_thm("NOT_0w_bis",
-  ``w <> 0w ==> 0 < w2n w``,
+val NOT_0w_bis = Q.store_thm("NOT_0w_bis",
+  `w <> 0w ==> 0 < w2n w`,
   Cases_on `w`>> fs [] >> DECIDE_TAC);
 
-val dimwords_dimword = store_thm("dimwords_dimword",
-  ``!n. dimwords n (:'a) = dimword(:'a) ** n``,
+val dimwords_dimword = Q.store_thm("dimwords_dimword",
+  `!n. dimwords n (:'a) = dimword(:'a) ** n`,
   rw[dimwords_def,dimword_def,Once MULT_COMM] >>
   Induct_on `n` THEN1 rw[] >>
   METIS_TAC[MULT_COMM,MULT,EXP,EXP_ADD]);
@@ -1233,24 +1233,24 @@ val mw2n_msf_NIL = store_thm ("mw2n_msf_NIL",
   POP_ASSUM (fn x => FULL_SIMP_TAC std_ss [x,mw2n_msf]) >>
   METIS_TAC[LESS_EQ_ADD,ADD_COMM,LESS_EQ_LESS_TRANS,LT_MULT_CANCEL_RBARE]);
 
-val mw2n_k2mw_0 = store_thm( "mw2n_k2mw_0",
-  ``!x. mw2n ((k2mw x 0):'a word list) = 0``,
+val mw2n_k2mw_0 = Q.store_thm( "mw2n_k2mw_0",
+  `!x. mw2n ((k2mw x 0):'a word list) = 0`,
   Induct_on `x` THEN1 METIS_TAC[k2mw_def,mw2n_def] >>
   `0 DIV dimword(:'a) = 0` by METIS_TAC[ZERO_LT_dimword,ZERO_DIV] >>
   RW_TAC std_ss [word_0_n2w,k2mw_def,mw2n_def]);
 
-val mw_mul_by_single_lemma = store_thm( "mw_mul_by_single_lemma",
-  ``!(x:'a word) (ys:'a word list).
+val mw_mul_by_single_lemma = Q.store_thm( "mw_mul_by_single_lemma",
+  `!(x:'a word) (ys:'a word list).
     (mw2n (mw_mul_by_single x ys) = w2n x * mw2n ys) /\
-    (LENGTH (mw_mul_by_single x ys) = LENGTH ys + 1)``,
+    (LENGTH (mw_mul_by_single x ys) = LENGTH ys + 1)`,
   REPEAT strip_tac >>
   REWRITE_TAC[mw_mul_by_single_def] >>
   `LENGTH (ys:'a word list) = LENGTH ((k2mw (LENGTH ys) 0): 'a word list)`
   by METIS_TAC[LENGTH_k2mw] >>
   IMP_RES_TAC (SPEC_ALL mw_mul_pass_thm) >> lrw[mw2n_k2mw_0]);
 
-val word_reverse_lsl = prove(
-  ``!w n. word_reverse (w << n) = (word_reverse w >>> n):'a word``,
+val word_reverse_lsl = Q.prove(
+  `!w n. word_reverse (w << n) = (word_reverse w >>> n):'a word`,
   FULL_SIMP_TAC std_ss [word_reverse_def,word_lsl_def,word_lsr_def,
     fcpTheory.CART_EQ,fcpTheory.FCP_BETA] \\ REPEAT STRIP_TAC
   \\ `(dimindex (:'a) - 1 - i) < dimindex (:'a)` by DECIDE_TAC
@@ -1259,8 +1259,8 @@ val word_reverse_lsl = prove(
   \\ `i + n < dimindex (:'a) = n <= dimindex (:'a) - 1 - i` by DECIDE_TAC
   \\ FULL_SIMP_TAC std_ss [fcpTheory.FCP_BETA,SUB_PLUS]);
 
-val word_reverse_EQ_ZERO = prove(
-  ``!w:'a word. (word_reverse w = 0w) = (w = 0w)``,
+val word_reverse_EQ_ZERO = Q.prove(
+  `!w:'a word. (word_reverse w = 0w) = (w = 0w)`,
   FULL_SIMP_TAC std_ss
    [fcpTheory.CART_EQ,fcpTheory.FCP_BETA,word_reverse_def,word_0]
   \\ REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
@@ -1440,8 +1440,8 @@ val mw_div_loop_ind = fetch "-" "mw_div_loop_ind"
 
 (* calc_d Lemmas  *)
 
-val d_word_msb = store_thm( "d_word_msb",
-``!(a:'a word). word_msb a <=> dimword(:'a) DIV 2 <= w2n a``,
+val d_word_msb = Q.store_thm( "d_word_msb",
+`!(a:'a word). word_msb a <=> dimword(:'a) DIV 2 <= w2n a`,
   Cases \\ `0 < dimindex (:'a)` by FULL_SIMP_TAC std_ss [DIMINDEX_GT_0]
   \\ `(dimindex(:'a)) - 1 < (dimindex (:'a))` by DECIDE_TAC
   \\ `2 ** SUC (dimindex(:'a) - 1) = dimword (:'a)` by
@@ -1830,8 +1830,8 @@ val mw_simple_div_lemma = prove(
     \\ DECIDE_TAC)
   \\ IMP_RES_TAC single_div_thm \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val mw2n_SNOC_0 = prove(
-  ``!xs. mw2n (SNOC 0w xs) = mw2n xs``,
+val mw2n_SNOC_0 = Q.prove(
+  `!xs. mw2n (SNOC 0w xs) = mw2n xs`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [mw2n_def,SNOC]);
 
 val mw_simple_div_thm = store_thm("mw_simple_div_thm",
@@ -1851,14 +1851,14 @@ val mw_simple_div_thm = store_thm("mw_simple_div_thm",
 
 (* Following the proof on p.271 *)
 
-val mw_div_range1 = store_thm("mw_div_range1",
-  ``! (u1:'a word) u2 us (v1:'a word) vs.
+val mw_div_range1 = Q.store_thm("mw_div_range1",
+  `! (u1:'a word) u2 us (v1:'a word) vs.
     (LENGTH us = LENGTH vs) /\
     0 < w2n v1 /\
     mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs))
     < dimword(:'a) ==>
     MIN ((w2n u1 * dimword(:'a) + w2n u2) DIV w2n v1) (dimword(:'a)-1)
-    >= mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs))``,
+    >= mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs))`,
 
     REPEAT GEN_TAC >>
     Q.PAT_ABBREV_TAC`Q = (w2n u1 * dimword (:'a) + w2n u2) DIV w2n v1` >>
@@ -1896,14 +1896,14 @@ val mw_div_range1 = store_thm("mw_div_range1",
 
 (* Proof on p.271-272 *)
 
-val mw_div_range2 = store_thm( "mw_div_range2",
-  ``! (u1:'a word) u2 us (v1:'a word) vs.
+val mw_div_range2 = Q.store_thm( "mw_div_range2",
+  `! (u1:'a word) u2 us (v1:'a word) vs.
     (LENGTH us = LENGTH vs) /\
     mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs))
     < dimword(:'a) /\
     dimword(:'a) DIV 2 <= w2n v1 ==>
     MIN ((w2n u1 * dimword(:'a) + w2n u2) DIV w2n v1) (dimword(:'a)-1)
-    <= mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs)) + 2``,
+    <= mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs)) + 2`,
 
     REPEAT GEN_TAC >>
     Q.PAT_ABBREV_TAC`V = mw2n (REVERSE (v1::vs))` >>
@@ -2028,8 +2028,8 @@ val mw_div_range2 = store_thm( "mw_div_range2",
   `(w2n u2 + dimword(:'a) * w2n u1) < w2n v1` by RW_TAC arith_ss[] >> METIS_TAC[LESS_DIV_EQ_ZERO, DECIDE ``0<=1``]) >>
   lrw[]);
 
-val mw_div_test_lemma1 = store_thm( "mw_div_test_lemma1",
-``!q u1 u2 u3 v1 v2. w2n (mw_div_test q u1 u2 u3 v1 v2) <= w2n q``,
+val mw_div_test_lemma1 = Q.store_thm( "mw_div_test_lemma1",
+`!q u1 u2 u3 v1 v2. w2n (mw_div_test q u1 u2 u3 v1 v2) <= w2n q`,
     HO_MATCH_MP_TAC mw_div_test_ind >> REPEAT strip_tac >>
     srw_tac[][Once mw_div_test_def] >>
     `w2n q2 <= w2n q` by
@@ -2037,14 +2037,14 @@ val mw_div_test_lemma1 = store_thm( "mw_div_test_lemma1",
     Cases_on `mw_cmp [u2; u1] (FST (mw_add [FST s; SND s] [0w; 1w] F)) = SOME T`
            >> full_simp_tac (srw_ss())[] >> METIS_TAC[LESS_EQ_TRANS])
 
-val mw_div_test_lemma2 = store_thm( "mw_div_test_lemma2",
-``!(us:'a word list) (vs:'a word list).
+val mw_div_test_lemma2 = Q.store_thm( "mw_div_test_lemma2",
+`!(us:'a word list) (vs:'a word list).
   !q u1 u2 u3 v1 v2.
    (0 < w2n v1) /\ (LENGTH us = LENGTH vs) /\
    (mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs)) < dimword(:'a)) /\
    (mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs)) <= w2n q) ==>
    (mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs))
-    <= w2n (mw_div_test q u1 u2 u3 v1 v2))``,
+    <= w2n (mw_div_test q u1 u2 u3 v1 v2))`,
 
     GEN_TAC >> GEN_TAC >>
     HO_MATCH_MP_TAC mw_div_test_ind >>
@@ -2100,11 +2100,11 @@ val mw_div_test_lemma2 = store_thm( "mw_div_test_lemma2",
             FULL_SIMP_TAC std_ss [mw_cmp_thm]) >>
 full_simp_tac (srw_ss())[Once mw_div_test_def] )
 
-val q_thm = store_thm( "q_thm",
-``!(u1:'a word) u2 us (v1:'a word) vs.
+val q_thm = Q.store_thm( "q_thm",
+`!(u1:'a word) u2 us (v1:'a word) vs.
   (LENGTH us = LENGTH vs) /\ (0 < w2n v1) /\
   (mw2n (REVERSE (u1::u2::us)) DIV mw2n (REVERSE (v1::vs)) < dimword(:'a)) ==>
-  w2n u1 * dimword(:'a) + w2n u2 < dimword(:'a) * (1 + w2n v1)``,
+  w2n u1 * dimword(:'a) + w2n u2 < dimword(:'a) * (1 + w2n v1)`,
 
     REPEAT GEN_TAC >>
     Q.PAT_ABBREV_TAC`U = mw2n (REVERSE (u1::u2::us))` >>
@@ -2126,8 +2126,8 @@ val q_thm = store_thm( "q_thm",
     lrw[Abbr`V`,mw2n_msf,dimwords_dimword] >> REWRITE_TAC[RIGHT_ADD_DISTRIB,MULT_LEFT_1] >>
     METIS_TAC[LENGTH_REVERSE,ADD_COMM,LESS_EQ_MONO_ADD_EQ,mw2n_lt,dimwords_dimword,LESS_IMP_LESS_OR_EQ] );
 
-val mw_div_test_thm = store_thm( "mw_div_test_thm",
-``!(u1:'a word) u2 u3 us (v1:'a word) v2 vs.
+val mw_div_test_thm = Q.store_thm( "mw_div_test_thm",
+`!(u1:'a word) u2 u3 us (v1:'a word) v2 vs.
   (LENGTH us = LENGTH vs) /\ (dimword(:'a) DIV 2 <= w2n v1) /\
   (mw2n (REVERSE (u1::u2::u3::us)) DIV (mw2n (REVERSE (v1::v2::vs))) < dimword(:'a))  ==>
   (let q = if w2n u1 < w2n v1 then FST (single_div u1 u2 v1) else (n2w (dimword(:'a) - 1):'a word) in
@@ -2135,7 +2135,7 @@ val mw_div_test_thm = store_thm( "mw_div_test_thm",
   (w2n (mw_div_test q u1 u2 u3 v1 v2) =
     mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs))) \/
    (w2n (mw_div_test q u1 u2 u3 v1 v2) =
-    SUC (mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs))))))``,
+    SUC (mw2n (REVERSE (u1::u2::u3::us)) DIV mw2n (REVERSE (v1::v2::vs))))))`,
     REPEAT GEN_TAC >>
     Q.PAT_ABBREV_TAC`U = mw2n (REVERSE (u1::u2::u3::us))` >>
     Q.PAT_ABBREV_TAC`V = mw2n (REVERSE (v1::v2::vs))` >>
@@ -2241,12 +2241,12 @@ val mw_div_test_thm = store_thm( "mw_div_test_thm",
     MATCH_MP_TAC LESS_MONO_ADD >>
     METIS_TAC[Abbr`Q`,Abbr`U`,Abbr`V`,DIV_thm4_bis,ADD_COMM,MULT_COMM]);
 
-val mw_div_loop_LENGTH = store_thm( "mw_div_loop_LENGTH",
-``!(zs:'a word list) (ys:'a word list).
+val mw_div_loop_LENGTH = Q.store_thm( "mw_div_loop_LENGTH",
+`!(zs:'a word list) (ys:'a word list).
   dimword(:'a) DIV 2 <= w2n (HD ys) /\
   LENGTH ys < LENGTH zs /\
   1 < LENGTH ys  ==>
-  (LENGTH (mw_div_loop zs ys) = LENGTH zs)``,
+  (LENGTH (mw_div_loop zs ys) = LENGTH zs)`,
 
 HO_MATCH_MP_TAC mw_div_loop_ind >>
 REPEAT strip_tac >>
@@ -2350,14 +2350,14 @@ val tac_div_loop_test =
        FULL_SIMP_TAC std_ss[HD,TL,LENGTH] >>
        METIS_TAC[mw_div_test_thm];
 
-val mw_div_loop_thm = store_thm( "mw_div_loop_thm",
-``!(zs:'a word list) (ys:'a word list).
+val mw_div_loop_thm = Q.store_thm( "mw_div_loop_thm",
+`!(zs:'a word list) (ys:'a word list).
   dimword(:'a) DIV 2 <= w2n (HD ys) /\
   LENGTH ys < LENGTH zs /\ 1 < LENGTH ys /\
   ((mw2n (REVERSE (TAKE (SUC (LENGTH ys)) zs)) DIV mw2n (REVERSE ys)) < dimword(:'a) ) ==>
   (let rslt = mw_div_loop zs ys in
    mw2n (REVERSE( BUTLASTN (LENGTH ys) rslt)) * mw2n (REVERSE ys) + mw2n (REVERSE (LASTN (LENGTH ys) rslt)) =
-   mw2n (REVERSE zs))``,
+   mw2n (REVERSE zs))`,
 
   HO_MATCH_MP_TAC mw_div_loop_ind >> REPEAT strip_tac >>
   srw_tac[][Once mw_div_loop_def] >>
@@ -2585,8 +2585,8 @@ val mw_div_aux_def = tDefine "mw_div_aux" `
 
 val mw_div_aux_ind = fetch "-" "mw_div_aux_ind"
 
-val mw_div_loop_alt_lemma = prove(
-  ``mw_div_loop zs ys =
+val mw_div_loop_alt_lemma = Q.prove(
+  `mw_div_loop zs ys =
      if LENGTH ys < LENGTH zs then
        (let us = TAKE (SUC (LENGTH ys)) zs in
         let q2 = mw_div_guess us ys in
@@ -2606,12 +2606,12 @@ val mw_div_loop_alt_lemma = prove(
                    DROP (SUC (LENGTH ys)) zs
              in
                q2::mw_div_loop zs2 ys))
-     else zs``,
+     else zs`,
   SIMP_TAC std_ss [Once mw_div_loop_def]
   \\ SIMP_TAC std_ss [mw_div_guess_def,LET_DEF]);
 
-val mw_div_loop_alt = prove(
-  ``mw_div_loop zs ys =
+val mw_div_loop_alt = Q.prove(
+  `mw_div_loop zs ys =
      if LENGTH ys < LENGTH zs then
        (let us = TAKE (SUC (LENGTH ys)) zs in
         let q2 = mw_div_guess us ys in
@@ -2620,7 +2620,7 @@ val mw_div_loop_alt = prove(
         let zs2 = REVERSE (FRONT (FST (mw_sub (REVERSE us) q3ys T))) ++
                   DROP (SUC (LENGTH ys)) zs in
           q3::mw_div_loop zs2 ys)
-     else zs``,
+     else zs`,
   SIMP_TAC std_ss [Once mw_div_loop_alt_lemma,mw_div_adjust_def]
   \\ Cases_on `LENGTH ys < LENGTH zs` \\ FULL_SIMP_TAC std_ss []
   \\ SIMP_TAC std_ss [LET_DEF]
@@ -2733,8 +2733,8 @@ val mwi_div_def = Define `
 val mwi_mod_def = Define `
   mwi_mod s_xs t_ys = SND (SND (mwi_divmod s_xs t_ys))`;
 
-val MULT_DIV_MULT_EQ_MULT = prove(
-  ``!n k m. 0 < n /\ 0 < k ==> ((m * n) DIV (k * n) = m DIV k)``,
+val MULT_DIV_MULT_EQ_MULT = Q.prove(
+  `!n k m. 0 < n /\ 0 < k ==> ((m * n) DIV (k * n) = m DIV k)`,
   ONCE_REWRITE_TAC [MULT_COMM]
   \\ SIMP_TAC std_ss [GSYM DIV_DIV_DIV_MULT,RW1 [MULT_COMM] MULT_DIV]);
 
@@ -2891,13 +2891,13 @@ val mw_div_thm = store_thm("mw_div_thm",
   \\ IMP_RES_TAC LENGTH_mw_simple_div
   \\ FULL_SIMP_TAC std_ss [LENGTH_REVERSE]);
 
-val ABS_NEG = prove(
-  ``ABS (-(& n)) = & n``,
+val ABS_NEG = Q.prove(
+  `ABS (-(& n)) = & n`,
   intLib.COOPER_TAC);
 
-val NEG_DIV_LEMMA = prove(
-  ``m <> 0 ==>
-    ((- & n) / & m = - (& (n DIV m + if n MOD m = 0 then 0 else 1)):int)``,
+val NEG_DIV_LEMMA = Q.prove(
+  `m <> 0 ==>
+    ((- & n) / & m = - (& (n DIV m + if n MOD m = 0 then 0 else 1)):int)`,
   STRIP_TAC \\ `& m <> 0i` by intLib.COOPER_TAC
   \\ ASM_SIMP_TAC (srw_ss()) []
   \\ `0i < &m /\ (0 <= -&n = (n = 0))` by intLib.COOPER_TAC
@@ -2909,18 +2909,18 @@ val NEG_DIV_LEMMA = prove(
   \\ Cases_on `n MOD m = 0` \\ FULL_SIMP_TAC std_ss []
   \\ Q.ABBREV_TAC `k = n DIV m` \\ intLib.COOPER_TAC);
 
-val NEG_DIV = prove(
-  ``m <> 0 ==>
+val NEG_DIV = Q.prove(
+  `m <> 0 ==>
     (& n / & m         = (& (n DIV m)):int) /\
     ((- & n) / & m     = - (& (n DIV m + if n MOD m = 0 then 0 else 1)):int) /\
     (& n     / (- & m) = - (& (n DIV m + if n MOD m = 0 then 0 else 1)):int) /\
-    ((- & n) / (- & m) = (& (n DIV m):int))``,
+    ((- & n) / (- & m) = (& (n DIV m):int))`,
   STRIP_TAC \\ `& m <> 0i` by intLib.COOPER_TAC
   \\ ASM_SIMP_TAC (srw_ss()) [NEG_DIV_LEMMA]);
 
-val NEG_MOD_LEMMA = prove(
-  ``m <> 0 ==>
-    (-&n % &m = &(if n MOD m = 0 then 0 else m - n MOD m))``,
+val NEG_MOD_LEMMA = Q.prove(
+  `m <> 0 ==>
+    (-&n % &m = &(if n MOD m = 0 then 0 else m - n MOD m))`,
   STRIP_TAC \\ `& m <> 0i` by intLib.COOPER_TAC
   \\ ASM_SIMP_TAC std_ss [int_mod,NEG_DIV_LEMMA]
   \\ Cases_on `n MOD m = 0` \\ FULL_SIMP_TAC std_ss []
@@ -2941,17 +2941,17 @@ val NEG_MOD_LEMMA = prove(
   \\ Q.ABBREV_TAC `k = n MOD m` \\ POP_ASSUM (K ALL_TAC)
   \\ intLib.COOPER_TAC);
 
-val NEG_MOD = prove(
-  ``m <> 0 ==>
+val NEG_MOD = Q.prove(
+  `m <> 0 ==>
     (& n % & m         = (& (n MOD m)):int) /\
     ((- & n) % & m     = &(if n MOD m = 0 then 0 else m - n MOD m)) /\
     (& n     % (- & m) = - &(if n MOD m = 0 then 0 else m - n MOD m)) /\
-    ((- & n) % (- & m) = - (& (n MOD m):int))``,
+    ((- & n) % (- & m) = - (& (n MOD m):int))`,
   STRIP_TAC \\ `& m <> 0i` by intLib.COOPER_TAC
   \\ ASM_SIMP_TAC (srw_ss()) [NEG_MOD_LEMMA]);
 
-val mw_addv_lemma = prove(
-  ``mw_addv (n2mw n) [] T = n2mw (n + 1)``,
+val mw_addv_lemma = Q.prove(
+  `mw_addv (n2mw n) [] T = n2mw (n + 1)`,
   `mw_ok (mw_addv (n2mw n) [] T)` by ALL_TAC THEN1
     (MATCH_MP_TAC mw_ok_addv
      \\ FULL_SIMP_TAC std_ss [mw_ok_n2mw,EVAL ``mw_ok []``])
@@ -2960,14 +2960,14 @@ val mw_addv_lemma = prove(
   \\ FULL_SIMP_TAC std_ss [mw2n_n2mw,mw_addv_thm,LENGTH]
   \\ AP_TERM_TAC \\ EVAL_TAC);
 
-val Num_ABS_ID = prove(
-  ``Num (ABS (& n)) = n``,
+val Num_ABS_ID = Q.prove(
+  `Num (ABS (& n)) = n`,
   intLib.COOPER_TAC);
 
-val mw_subv_lemma = prove(
-  ``j <> 0 ==>
+val mw_subv_lemma = Q.prove(
+  `j <> 0 ==>
     (mw_subv (n2mw (Num (ABS j))) (n2mw (Num (ABS i) MOD Num (ABS j))) =
-     n2mw (Num (ABS j) - Num (ABS i) MOD Num (ABS j)))``,
+     n2mw (Num (ABS j) - Num (ABS i) MOD Num (ABS j)))`,
   REPEAT STRIP_TAC \\ `0 < Num (ABS j)` by intLib.COOPER_TAC
   \\ Q.ABBREV_TAC `k = Num (ABS j)`
   \\ MATCH_MP_TAC IMP_EQ_n2mw_ALT
@@ -2980,8 +2980,8 @@ val mw_subv_lemma = prove(
   \\ MATCH_MP_TAC mw2n_LESS
   \\ FULL_SIMP_TAC std_ss [mw_ok_n2mw,mw2n_n2mw] \\ DECIDE_TAC);
 
-val n2mw_EQ_NIL = prove(
-  ``(n2mw n = []) <=> (n = 0)``,
+val n2mw_EQ_NIL = Q.prove(
+  `(n2mw n = []) <=> (n = 0)`,
   Cases_on `n` THEN1 EVAL_TAC \\ ONCE_REWRITE_TAC [n2mw_def]
   \\ SIMP_TAC std_ss [ADD1,NOT_CONS_NIL]);
 
@@ -3013,10 +3013,10 @@ val int_to_str_def = Define `
   int_to_str i =
     (if i < 0 then "~" else "") ++ num_to_dec_string (Num (ABS i))`;
 
-val num_to_dec_string_unroll = prove(
-  ``!n. num_to_dec_string n =
+val num_to_dec_string_unroll = Q.prove(
+  `!n. num_to_dec_string n =
           SNOC (CHR (48 + n MOD 10))
-               (if n < 10 then [] else num_to_dec_string (n DIV 10))``,
+               (if n < 10 then [] else num_to_dec_string (n DIV 10))`,
   SIMP_TAC std_ss [num_to_dec_string_def,n2s_def]
   \\ SIMP_TAC std_ss [Once numposrepTheory.n2l_def] \\ SRW_TAC [] []
   THEN1 (Cases_on `(n=0) \/ (n=1) \/ (n=2) \/ (n=3) \/ (n=4) \/
@@ -3146,10 +3146,10 @@ val mwi_op_def = Define `
   (mwi_op Eq s_xs t_ys = i2mw (if mwi_eq s_xs t_ys then 1 else 0)) /\
   (mwi_op Dec s_xs t_ys = (F,[]))`;
 
-val mwi_op_thm = store_thm("mwi_op_thm",
-  ``!op i j.
+val mwi_op_thm = Q.store_thm("mwi_op_thm",
+  `!op i j.
       ((op = Div) \/ (op = Mod) ==> j <> 0) ==>
-      (mwi_op op (i2mw i) (i2mw j) = i2mw (int_op op i j))``,
+      (mwi_op op (i2mw i) (i2mw j) = i2mw (int_op op i j))`,
   Cases \\ FULL_SIMP_TAC (srw_ss()) [int_op_def,mwi_op_def,
     mwi_add_thm,mwi_sub_thm,mwi_mul_thm,mwi_divmod_thm,mwi_lt_def,
     mwi_eq_def,mwi_compare_thm,mwi_div_def,mwi_mod_def] \\ REPEAT STRIP_TAC
@@ -3160,8 +3160,8 @@ val mwi_op_thm = store_thm("mwi_op_thm",
 
 (* extra *)
 
-val LESS_EQ_LENGTH = store_thm("LESS_EQ_LENGTH",
-  ``!xs n. n <= LENGTH xs ==> ?xs1 xs2. (xs = xs1 ++ xs2) /\ (LENGTH xs1 = n)``,
+val LESS_EQ_LENGTH = Q.store_thm("LESS_EQ_LENGTH",
+  `!xs n. n <= LENGTH xs ==> ?xs1 xs2. (xs = xs1 ++ xs2) /\ (LENGTH xs1 = n)`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [LENGTH,LENGTH_NIL]
   \\ Cases_on `n` \\ FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL]
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ FULL_SIMP_TAC std_ss []
@@ -3175,13 +3175,13 @@ val LENGTH_mw_add = store_thm("LENGTH_mw_add",
   \\ `?x1 x2. mw_add xs1 (TL ys) t = (x1,x2)` by METIS_TAC [PAIR]
   \\ RES_TAC \\ Cases_on `qs1` \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val LENGTH_mw_fix_IMP = store_thm("LENGTH_mw_fix_IMP",
-  ``(LENGTH xs = LENGTH ys) ==>
-    LENGTH (mw_fix xs) <= LENGTH ys``,
+val LENGTH_mw_fix_IMP = Q.store_thm("LENGTH_mw_fix_IMP",
+  `(LENGTH xs = LENGTH ys) ==>
+    LENGTH (mw_fix xs) <= LENGTH ys`,
   METIS_TAC [LENGTH_mw_fix]);
 
-val LENGTH_mw_subv = store_thm("LENGTH_mw_subv",
-  ``!ys xs. LENGTH xs <= LENGTH ys ==> (LENGTH (mw_subv ys xs) <= LENGTH ys)``,
+val LENGTH_mw_subv = Q.store_thm("LENGTH_mw_subv",
+  `!ys xs. LENGTH xs <= LENGTH ys ==> (LENGTH (mw_subv ys xs) <= LENGTH ys)`,
   REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [mw_subv_def,LET_DEF]
   \\ MATCH_MP_TAC LENGTH_mw_fix_IMP \\ IMP_RES_TAC LESS_EQ_LENGTH
   \\ Cases_on `mw_sub ys xs T`
@@ -3192,9 +3192,9 @@ val mw_add_F = store_thm("mw_add_F",
   Induct \\ FULL_SIMP_TAC (srw_ss()) [mw_add_def,MAP,single_add_def,
     LET_DEF,b2w_def,b2n_def,GSYM NOT_LESS,w2n_lt]);
 
-val LENGTH_mw_addv = store_thm("LENGTH_mw_addv",
-  ``LENGTH ys <= LENGTH xs ==>
-    LENGTH (mw_addv xs ys F) <= LENGTH xs + LENGTH ys``,
+val LENGTH_mw_addv = Q.store_thm("LENGTH_mw_addv",
+  `LENGTH ys <= LENGTH xs ==>
+    LENGTH (mw_addv xs ys F) <= LENGTH xs + LENGTH ys`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC LESS_EQ_LENGTH
   \\ FULL_SIMP_TAC std_ss [mw_addv_EQ_mw_add,LET_DEF]
   \\ `?ts1 t1. mw_add xs1 ys F = (ts1,t1)` by METIS_TAC [PAIR]
@@ -3207,10 +3207,10 @@ val LENGTH_mw_addv = store_thm("LENGTH_mw_addv",
   \\ IMP_RES_TAC LENGTH_mw_add
   \\ Cases_on `t2` \\ FULL_SIMP_TAC std_ss [LENGTH_APPEND,LENGTH] \\ DECIDE_TAC);
 
-val LENGTH_mw_mul = store_thm("LENGTH_mw_mul",
-  ``!xs ys zs.
+val LENGTH_mw_mul = Q.store_thm("LENGTH_mw_mul",
+  `!xs ys zs.
       (LENGTH zs = LENGTH ys) ==>
-      (LENGTH (mw_mul xs ys zs) = LENGTH xs + LENGTH ys)``,
+      (LENGTH (mw_mul xs ys zs) = LENGTH xs + LENGTH ys)`,
   Induct \\ FULL_SIMP_TAC std_ss [mw_mul_def,LENGTH,LET_DEF]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ `LENGTH (mw_mul_pass h ys zs 0w) = LENGTH ys + 1` by
@@ -3218,8 +3218,8 @@ val LENGTH_mw_mul = store_thm("LENGTH_mw_mul",
   \\ Cases_on `mw_mul_pass h ys zs 0x0w`
   \\ FULL_SIMP_TAC std_ss [LENGTH,TL,ADD1] \\ DECIDE_TAC);
 
-val LESS_EQ_LENGTH_ALT = store_thm("LESS_EQ_LENGTH_ALT",
-  ``!xs n. n <= LENGTH xs ==> ?ys1 ys2. (xs = ys1 ++ ys2) /\ (LENGTH ys2 = n)``,
+val LESS_EQ_LENGTH_ALT = Q.store_thm("LESS_EQ_LENGTH_ALT",
+  `!xs n. n <= LENGTH xs ==> ?ys1 ys2. (xs = ys1 ++ ys2) /\ (LENGTH ys2 = n)`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [LENGTH,LENGTH_NIL,APPEND_NIL,LENGTH_SNOC]
   \\ Cases_on `n` \\ FULL_SIMP_TAC std_ss [LENGTH_NIL,APPEND_NIL]
@@ -3259,22 +3259,22 @@ val mw_mul_by_single2_def = Define `
      let (y2,k2) = single_mul_add x2 y1 k2 0w in
        y2 :: mw_mul_by_single2 x1 x2 ys k1 k2)`;
 
-val k2mw_SUC_0 = prove(
-  ``k2mw (SUC n) 0 = 0w :: k2mw n 0``,
+val k2mw_SUC_0 = Q.prove(
+  `k2mw (SUC n) 0 = 0w :: k2mw n 0`,
   SRW_TAC [] [k2mw_def,ZERO_DIV]);
 
-val mw_mul_pass_NOT_NIL = prove(
-  ``!xs ys r x. mw_mul_pass x xs ys r <> []``,
+val mw_mul_pass_NOT_NIL = Q.prove(
+  `!xs ys r x. mw_mul_pass x xs ys r <> []`,
   Cases \\ SIMP_TAC (srw_ss()) [mw_mul_pass_def,LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ SIMP_TAC (srw_ss()) []);
 
-val mw_mul_by_single2_thm = prove(
-  ``!ys x1 x2 k1 k2.
+val mw_mul_by_single2_thm = Q.prove(
+  `!ys x1 x2 k1 k2.
       mw_mul_by_single2 x1 x2 ys k1 k2 =
         let ys = mw_mul_pass x1 ys (k2mw (LENGTH ys) 0) k1 in
         let ys = mw_mul_pass x2 (FRONT ys) (k2mw (LENGTH (FRONT ys)) 0) k2 in
-          ys``,
+          ys`,
   Induct THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
   \\ FULL_SIMP_TAC std_ss [LET_DEF] \\ REPEAT STRIP_TAC
   \\ SIMP_TAC (srw_ss()) [mw_mul_pass_def,LENGTH,k2mw_SUC_0]
@@ -3296,8 +3296,8 @@ val mw_mul_pass_top_def = Define `
      let (y1,k) = single_mul_add x y k 0w in
        mw_mul_pass_top x ys (k,y1,k1))`;
 
-val k2mw_LENGTH_0 = store_thm("k2mw_LENGTH_0",
-  ``!ys. (k2mw (LENGTH ys) 0) = MAP (K 0w) ys``,
+val k2mw_LENGTH_0 = Q.store_thm("k2mw_LENGTH_0",
+  `!ys. (k2mw (LENGTH ys) 0) = MAP (K 0w) ys`,
   Induct \\ EVAL_TAC \\
   SIMP_TAC std_ss [LEN_LENGTH_LEM,GSYM ADD1,k2mw_def] \\
   FULL_SIMP_TAC std_ss [MATCH_MP ZERO_DIV ZERO_LT_dimword]);
@@ -3347,14 +3347,14 @@ val single_add_lemma = prove(
   Cases \\ FULL_SIMP_TAC std_ss [single_add_def,word_add_n2w,b2w_def,
      b2n_def,w2n_n2w,ZERO_LT_dimword,GSYM NOT_LESS]);
 
-val mw_addv_NIL_F = prove(
-  ``!xs. mw_addv xs [] F = xs``,
+val mw_addv_NIL_F = Q.prove(
+  `!xs. mw_addv xs [] F = xs`,
   Induct THEN1 EVAL_TAC
   \\ ASM_SIMP_TAC std_ss [mw_addv_def,LET_DEF,single_add_lemma,CONS_11]);
 
-val mw_addv_CONS_NIL_T = prove(
-  ``mw_addv (x::xs) [] T =
-      if x = ~0w:word64 then 0w::mw_addv xs [] T else (x+1w)::xs``,
+val mw_addv_CONS_NIL_T = Q.prove(
+  `mw_addv (x::xs) [] T =
+      if x = ~0w:word64 then 0w::mw_addv xs [] T else (x+1w)::xs`,
   Cases_on `x = ~0x0w`
   \\ ASM_SIMP_TAC std_ss [mw_addv_def,LET_DEF,
        EVAL ``single_add (~0x0w) (0x0w:word64) T``]
@@ -3476,25 +3476,25 @@ val single_div_loop_thm = prove(
   \\ match_mp_tac mw_sub_thm
   \\ fs [LENGTH_mw_shift]);
 
-val mw2n_0 = store_thm("mw2n_0",
-  ``(mw2n [] = 0) /\
-    (mw2n (0w::xs:'a word list) = dimword (:'a) * mw2n xs)``,
+val mw2n_0 = Q.store_thm("mw2n_0",
+  `(mw2n [] = 0) /\
+    (mw2n (0w::xs:'a word list) = dimword (:'a) * mw2n xs)`,
   fs [mw2n_def]);
 
-val HD_eq_n2w_mw2n = store_thm("HD_eq_n2w_mw2n",
-  ``LENGTH xs <> 0 /\ mw2n xs < dimword (:'a) ==>
-    (HD xs = n2w (mw2n (xs:'a word list)))``,
+val HD_eq_n2w_mw2n = Q.store_thm("HD_eq_n2w_mw2n",
+  `LENGTH xs <> 0 /\ mw2n xs < dimword (:'a) ==>
+    (HD xs = n2w (mw2n (xs:'a word list)))`,
   Cases_on `xs` \\ fs [mw2n_def]
   \\ Cases_on `mw2n t` \\ fs []
   \\ fs [MULT_CLAUSES]);
 
-val LESS_2_EXP = store_thm("LESS_2_EXP[simp]",
-  ``!n. n < 2 ** n``,
+val LESS_2_EXP = Q.store_thm("LESS_2_EXP[simp]",
+  `!n. n < 2 ** n`,
   Induct \\ fs [EXP]);
 
-val single_div_full_thm = store_thm("single_div_full_thm",
-  ``mw2n [x2;x1] < mw2n [0w;y] ==>
-    (single_div_full x1 x2 y = single_div x1 x2 y)``,
+val single_div_full_thm = Q.store_thm("single_div_full_thm",
+  `mw2n [x2;x1] < mw2n [0w;y] ==>
+    (single_div_full x1 x2 y = single_div x1 x2 y)`,
   fs [single_div_full_def]
   \\ Cases_on `single_div_loop (n2w (dimindex (:'a)),[0w; y],0w,[x2; x1])`
   \\ fs [] \\ strip_tac

--- a/compiler/backend/bvi_letScript.sml
+++ b/compiler/backend/bvi_letScript.sml
@@ -55,8 +55,8 @@ val delete_var_def = Define `
   (delete_var ((Var n):bvi$exp) = Op (Const 0) []) /\
   (delete_var x = x)`;
 
-val exp2_size_APPEND = store_thm("exp2_size_APPEND",
-  ``!xs ys. exp2_size (xs++ys) = exp2_size xs + exp2_size ys``,
+val exp2_size_APPEND = Q.store_thm("exp2_size_APPEND",
+  `!xs ys. exp2_size (xs++ys) = exp2_size xs + exp2_size ys`,
   Induct \\ fs [exp_size_def]);
 
 val compile_def = tDefine "compile" `
@@ -104,8 +104,8 @@ val compile_length = Q.store_thm("compile_length[simp]",
   \\ FULL_SIMP_TAC (srw_ss()) [compile_def,ADD1,LET_DEF]
   \\ every_case_tac \\ SRW_TAC [] [] \\ DECIDE_TAC);
 
-val compile_HD_SING = store_thm("compile_HD_SING",
-  ``[HD (compile n d [x])] = compile n d [x]``,
+val compile_HD_SING = Q.store_thm("compile_HD_SING",
+  `[HD (compile n d [x])] = compile n d [x]`,
   MP_TAC (Q.SPECL [`n`,`d`,`[x]`] compile_length)
   \\ Cases_on `compile n d [x]` \\ fs [LENGTH_NIL]);
 

--- a/compiler/backend/bvi_to_dataScript.sml
+++ b/compiler/backend/bvi_to_dataScript.sml
@@ -91,9 +91,9 @@ val compile_LESS_EQ_lemma = Q.prove(
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);
 
-val compile_LESS_EQ = store_thm("compile_LESS_EQ",
-  ``!n env tail live xs c vs new_var.
-      (compile n env tail live xs = (c,vs,new_var)) ==> n <= new_var``,
+val compile_LESS_EQ = Q.store_thm("compile_LESS_EQ",
+  `!n env tail live xs c vs new_var.
+      (compile n env tail live xs = (c,vs,new_var)) ==> n <= new_var`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL compile_LESS_EQ_lemma)
   \\ FULL_SIMP_TAC std_ss []);
 
@@ -104,14 +104,14 @@ val compile_LENGTH_lemma = Q.prove(
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] []);
 
-val compile_LENGTH = store_thm("compile_LENGTH",
-  ``!n env tail live xs c vs new_var.
-      (compile n env tail live xs = (c,vs,new_var)) ==> (LENGTH vs = LENGTH xs)``,
+val compile_LENGTH = Q.store_thm("compile_LENGTH",
+  `!n env tail live xs c vs new_var.
+      (compile n env tail live xs = (c,vs,new_var)) ==> (LENGTH vs = LENGTH xs)`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL compile_LENGTH_lemma)
   \\ FULL_SIMP_TAC std_ss []);
 
-val compile_SING_IMP = store_thm("compile_SING_IMP",
-  ``(compile n env tail live [x] = (c,vs,new_var)) ==> ?t. vs = [t]``,
+val compile_SING_IMP = Q.store_thm("compile_SING_IMP",
+  `(compile n env tail live [x] = (c,vs,new_var)) ==> ?t. vs = [t]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC compile_LENGTH
   \\ Cases_on `vs` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) []);

--- a/compiler/backend/bvi_to_dataScript.sml
+++ b/compiler/backend/bvi_to_dataScript.sml
@@ -19,9 +19,9 @@ val op_space_reset_def = Define `
 val op_requires_names_def = Define`
   op_requires_names op = (op_space_reset op ∨ (∃n. op = FFI n))`;
 
-val op_requires_names_eqn = store_thm("op_requires_names_eqn",
-  ``∀op. op_requires_names op =
-    (op_space_reset op ∨ (case op of FFI n => T | _ => F))``,
+val op_requires_names_eqn = Q.store_thm("op_requires_names_eqn",
+  `∀op. op_requires_names op =
+    (op_space_reset op ∨ (case op of FFI n => T | _ => F))`,
     Cases>>fs[op_requires_names_def])
 
 val iAssign_def = Define `
@@ -84,9 +84,9 @@ val compile_def = tDefine "compile" `
 
 val compile_ind = theorem"compile_ind";
 
-val compile_LESS_EQ_lemma = prove(
-  ``!n env tail live xs.
-      n <= SND (SND (compile n env tail live xs))``,
+val compile_LESS_EQ_lemma = Q.prove(
+  `!n env tail live xs.
+      n <= SND (SND (compile n env tail live xs))`,
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);
@@ -97,9 +97,9 @@ val compile_LESS_EQ = store_thm("compile_LESS_EQ",
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL compile_LESS_EQ_lemma)
   \\ FULL_SIMP_TAC std_ss []);
 
-val compile_LENGTH_lemma = prove(
-  ``!n env tail live xs.
-      (LENGTH (FST (SND (compile n env tail live xs))) = LENGTH xs)``,
+val compile_LENGTH_lemma = Q.prove(
+  `!n env tail live xs.
+      (LENGTH (FST (SND (compile n env tail live xs))) = LENGTH xs)`,
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] []);

--- a/compiler/backend/bvl_constScript.sml
+++ b/compiler/backend/bvl_constScript.sml
@@ -115,8 +115,8 @@ val compile_length = Q.store_thm("compile_length[simp]",
   \\ FULL_SIMP_TAC (srw_ss()) [compile_def,ADD1,LET_DEF]
   \\ every_case_tac \\ SRW_TAC [] [] \\ DECIDE_TAC);
 
-val compile_HD_SING = store_thm("compile_HD_SING",
-  ``[HD (compile n [x])] = compile n [x]``,
+val compile_HD_SING = Q.store_thm("compile_HD_SING",
+  `[HD (compile n [x])] = compile n [x]`,
   MP_TAC (Q.SPECL [`n`,`[x]`] compile_length)
   \\ Cases_on `compile n [x]` \\ fs [LENGTH_NIL]);
 

--- a/compiler/backend/bvl_handleScript.sml
+++ b/compiler/backend/bvl_handleScript.sml
@@ -109,8 +109,8 @@ val compile_length = Q.store_thm("compile_length[simp]",
   \\ fs [compile_def,ADD1,LET_DEF]
   \\ rpt (pairarg_tac \\ fs []) \\ rw [OptionalLetLet_def]);
 
-val compile_sing = store_thm("compile_sing",
-  ``compile l n [x] = (dx,lx,s) ==> ?y. dx = [y]``,
+val compile_sing = Q.store_thm("compile_sing",
+  `compile l n [x] = (dx,lx,s) ==> ?y. dx = [y]`,
   `LENGTH (FST (compile l n [x])) = LENGTH [x]` by fs []
   \\ rpt strip_tac \\ full_simp_tac std_ss [LENGTH]
   \\ Cases_on `dx` \\ fs [LENGTH_NIL]);

--- a/compiler/backend/bvl_inlineScript.sml
+++ b/compiler/backend/bvl_inlineScript.sml
@@ -108,13 +108,13 @@ val compile_prog_def = Define `
   compile_prog limit prog =
     if limit = 0 then prog else inline_all limit LN prog []`
 
-val LENGTH_inline = store_thm("LENGTH_inline",
-  ``!cs xs. LENGTH (inline cs xs) = LENGTH xs``,
+val LENGTH_inline = Q.store_thm("LENGTH_inline",
+  `!cs xs. LENGTH (inline cs xs) = LENGTH xs`,
   recInduct inline_ind \\ REPEAT STRIP_TAC
   \\ fs [Once inline_def,LET_DEF] \\ rw [] \\ every_case_tac \\ fs []);
 
-val HD_inline = store_thm("HD_inline[simp]",
-  ``[HD (inline cs [x])] = inline cs [x]``,
+val HD_inline = Q.store_thm("HD_inline[simp]",
+  `[HD (inline cs [x])] = inline cs [x]`,
   `LENGTH (inline cs [x]) = LENGTH [x]` by SRW_TAC [] [LENGTH_inline]
   \\ Cases_on `inline cs [x]` \\ FULL_SIMP_TAC std_ss [LENGTH]
   \\ Cases_on `t` \\ FULL_SIMP_TAC std_ss [LENGTH,HD] \\ `F` by DECIDE_TAC);

--- a/compiler/backend/bvl_to_bviScript.sml
+++ b/compiler/backend/bvl_to_bviScript.sml
@@ -199,12 +199,12 @@ val compile_exps_LENGTH_lemma = Q.prove(
   \\ SIMP_TAC std_ss [compile_exps_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);
 
-val compile_exps_LENGTH = store_thm("compile_exps_LENGTH",
-  ``(compile_exps n xs = (ys,aux,n1)) ==> (LENGTH ys = LENGTH xs)``,
+val compile_exps_LENGTH = Q.store_thm("compile_exps_LENGTH",
+  `(compile_exps n xs = (ys,aux,n1)) ==> (LENGTH ys = LENGTH xs)`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL compile_exps_LENGTH_lemma) \\ fs [])
 
-val compile_exps_SING = store_thm("compile_exps_SING",
-  ``(compile_exps n [x] = (c,aux,n1)) ==> ?y. c = [y]``,
+val compile_exps_SING = Q.store_thm("compile_exps_SING",
+  `(compile_exps n [x] = (c,aux,n1)) ==> ?y. c = [y]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC compile_exps_LENGTH
   \\ Cases_on `c` \\ fs [LENGTH_NIL]);
 

--- a/compiler/backend/bvl_to_bviScript.sml
+++ b/compiler/backend/bvl_to_bviScript.sml
@@ -193,8 +193,8 @@ val compile_exps_def = tDefine "compile_exps" `
 
 val compile_exps_ind = theorem"compile_exps_ind";
 
-val compile_exps_LENGTH_lemma = prove(
-  ``!n xs. (LENGTH (FST (compile_exps n xs)) = LENGTH xs)``,
+val compile_exps_LENGTH_lemma = Q.prove(
+  `!n xs. (LENGTH (FST (compile_exps n xs)) = LENGTH xs)`,
   HO_MATCH_MP_TAC compile_exps_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_exps_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);

--- a/compiler/backend/closLangScript.sml
+++ b/compiler/backend/closLangScript.sml
@@ -65,8 +65,8 @@ val _ = Datatype `
 
 val exp_size_def = definition"exp_size_def";
 
-val exp1_size_lemma = store_thm("exp1_size_lemma",
-  ``!fns n x. MEM (n,x) fns ==> exp_size x < exp1_size fns``,
+val exp1_size_lemma = Q.store_thm("exp1_size_lemma",
+  `!fns n x. MEM (n,x) fns ==> exp_size x < exp1_size fns`,
   Induct \\ fs [FORALL_PROD,exp_size_def] \\ REPEAT STRIP_TAC
   \\ RES_TAC \\ SRW_TAC [] [] \\ DECIDE_TAC);
 

--- a/compiler/backend/clos_annotateScript.sml
+++ b/compiler/backend/clos_annotateScript.sml
@@ -74,26 +74,26 @@ val shift_def = tDefine "shift" `
 
 val shift_ind = theorem "shift_ind";
 
-val shift_LENGTH_LEMMA = store_thm("shift_LENGTH_LEMMA",
-  ``!xs m l i. LENGTH (shift xs m l i) = LENGTH xs``,
+val shift_LENGTH_LEMMA = Q.store_thm("shift_LENGTH_LEMMA",
+  `!xs m l i. LENGTH (shift xs m l i) = LENGTH xs`,
   recInduct shift_ind \\ REPEAT STRIP_TAC
   \\ fs [shift_def,LET_DEF,ADD1,AC ADD_COMM ADD_ASSOC])
 
-val shift_SING = store_thm("shift_SING",
-  ``!ys. (shift [x] m l i = ys) ==> ?y. ys = [y]``,
+val shift_SING = Q.store_thm("shift_SING",
+  `!ys. (shift [x] m l i = ys) ==> ?y. ys = [y]`,
   fs [] \\ MP_TAC (Q.SPEC `[x]` shift_LENGTH_LEMMA |> SPEC_ALL)
   \\ Cases_on `shift [x] m l i` \\ fs [LENGTH_NIL])
   |> SIMP_RULE std_ss [];
 
-val shift_CONS = store_thm("shift_CONS",
-  ``shift ((x:closLang$exp)::xs) m l i =
+val shift_CONS = Q.store_thm("shift_CONS",
+  `shift ((x:closLang$exp)::xs) m l i =
       let c1 = shift [x] m l i in
       let c2 = shift xs m l i in
-        (HD c1 :: c2:closLang$exp list)``,
+        (HD c1 :: c2:closLang$exp list)`,
   Cases_on `xs` \\ fs [shift_def,LET_DEF,SING_HD,shift_LENGTH_LEMMA]);
 
-val HD_shift = store_thm("HD_shift[simp]",
-  ``[HD (shift [x] m l i)] = shift [x] m l i``,
+val HD_shift = Q.store_thm("HD_shift[simp]",
+  `[HD (shift [x] m l i)] = shift [x] m l i`,
   STRIP_ASSUME_TAC shift_SING \\ fs []);
 
 (* main functions *)

--- a/compiler/backend/clos_callScript.sml
+++ b/compiler/backend/clos_callScript.sml
@@ -5,8 +5,8 @@ val _ = new_theory "clos_call";
 val closed_def = Define `
   closed x = isEmpty (db_to_set (SND (free [x])))`
 
-val EL_MEM_LEMMA = prove(
-  ``!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs``,
+val EL_MEM_LEMMA = Q.prove(
+  `!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs`,
   Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []);
 
 val insert_each_def = Define `
@@ -23,8 +23,8 @@ val calls_list_def = Define `
   (calls_list loc ((n,_)::xs) =
      (n,Call 0 (loc+1) (GENLIST Var n))::calls_list (loc+2n) xs)`;
 
-val exp3_size_MAP_SND = prove(
-  ``!fns. exp3_size (MAP SND fns) <= exp1_size fns``,
+val exp3_size_MAP_SND = Q.prove(
+  `!fns. exp3_size (MAP SND fns) <= exp1_size fns`,
   Induct \\ fs [exp_size_def,FORALL_PROD]);
 
 val calls_def = tDefine "calls" `

--- a/compiler/backend/clos_freeScript.sml
+++ b/compiler/backend/clos_freeScript.sml
@@ -58,8 +58,8 @@ val free_def = tDefine "free" `
 
 val free_ind = theorem "free_ind";
 
-val free_LENGTH_LEMMA = prove(
-  ``!xs. (case free xs of (ys,s1) => (LENGTH xs = LENGTH ys))``,
+val free_LENGTH_LEMMA = Q.prove(
+  `!xs. (case free xs of (ys,s1) => (LENGTH xs = LENGTH ys))`,
   recInduct free_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [free_def]
   \\ SRW_TAC [] [] \\ SRW_TAC [] []
@@ -68,12 +68,12 @@ val free_LENGTH_LEMMA = prove(
   \\ SRW_TAC [] [] \\ DECIDE_TAC)
   |> SIMP_RULE std_ss [] |> SPEC_ALL;
 
-val free_LENGTH = store_thm("free_LENGTH",
-  ``!xs ys l. (free xs = (ys,l)) ==> (LENGTH ys = LENGTH xs)``,
+val free_LENGTH = Q.store_thm("free_LENGTH",
+  `!xs ys l. (free xs = (ys,l)) ==> (LENGTH ys = LENGTH xs)`,
   REPEAT STRIP_TAC \\ MP_TAC free_LENGTH_LEMMA \\ fs []);
 
-val free_SING = store_thm("free_SING",
-  ``(free [x] = (ys,l)) ==> ?y. ys = [y]``,
+val free_SING = Q.store_thm("free_SING",
+  `(free [x] = (ys,l)) ==> ?y. ys = [y]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC free_LENGTH
   \\ Cases_on `ys` \\ fs [LENGTH_NIL]);
 

--- a/compiler/backend/clos_freeScript.sml
+++ b/compiler/backend/clos_freeScript.sml
@@ -77,17 +77,17 @@ val free_SING = store_thm("free_SING",
   REPEAT STRIP_TAC \\ IMP_RES_TAC free_LENGTH
   \\ Cases_on `ys` \\ fs [LENGTH_NIL]);
 
-val LENGTH_FST_free = store_thm("LENGTH_FST_free",
-  ``LENGTH (FST (free fns)) = LENGTH fns``,
+val LENGTH_FST_free = Q.store_thm("LENGTH_FST_free",
+  `LENGTH (FST (free fns)) = LENGTH fns`,
   Cases_on `free fns` \\ fs [] \\ IMP_RES_TAC free_LENGTH);
 
-val HD_FST_free = store_thm("HD_FST_free",
-  ``[HD (FST (free [x1]))] = FST (free [x1])``,
+val HD_FST_free = Q.store_thm("HD_FST_free",
+  `[HD (FST (free [x1]))] = FST (free [x1])`,
   Cases_on `free [x1]` \\ fs []
   \\ imp_res_tac free_SING \\ fs[]);
 
-val free_CONS = store_thm("free_CONS",
-  ``FST (free (x::xs)) = HD (FST (free [x])) :: FST (free xs)``,
+val free_CONS = Q.store_thm("free_CONS",
+  `FST (free (x::xs)) = HD (FST (free [x])) :: FST (free xs)`,
   Cases_on `xs` \\ fs [free_def,SING_HD,LENGTH_FST_free,LET_DEF]
   \\ Cases_on `free [x]` \\ fs []
   \\ Cases_on `free (h::t)` \\ fs [SING_HD]

--- a/compiler/backend/clos_knownScript.sml
+++ b/compiler/backend/clos_knownScript.sml
@@ -100,8 +100,8 @@ val known_op_def = Define `
      | _ => (Other,g)) /\
   (known_op op as g = (Other,g))`
 
-val EL_MEM_LEMMA = prove(
-  ``!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs``,
+val EL_MEM_LEMMA = Q.prove(
+  `!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs`,
   Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []);
 
 val dest_Clos_def = Define `

--- a/compiler/backend/clos_knownScript.sml
+++ b/compiler/backend/clos_knownScript.sml
@@ -67,8 +67,8 @@ val merge_tup_def = tDefine "merge_tup" `
    simp[] >> rename[`_ < (tag:num) + (_ + _)`] >>
    disch_then (qspec_then `tag` mp_tac) >> simp[])
 
-val merge_alt = store_thm("merge_alt",``
-  ∀x y.merge x y = merge_tup (x,y)``,
+val merge_alt = Q.store_thm("merge_alt",`
+  ∀x y.merge x y = merge_tup (x,y)`,
   HO_MATCH_MP_TAC (fetch "-" "merge_ind")>>rw[merge_tup_def,MAP2_MAP]>>
   match_mp_tac LIST_EQ>>rw[EL_ZIP,EL_MAP]>>
   first_x_assum match_mp_tac>>metis_tac[MEM_EL])

--- a/compiler/backend/clos_numberScript.sml
+++ b/compiler/backend/clos_numberScript.sml
@@ -59,9 +59,9 @@ val renumber_code_locs_def = tDefine "renumber_code_locs" `
 
 val renumber_code_locs_ind = theorem"renumber_code_locs_ind";
 
-val renumber_code_locs_length = store_thm("renumber_code_locs_length",
-  ``(∀x y. LENGTH (SND (renumber_code_locs_list x y)) = LENGTH y) ∧
-    (∀(x:num)(y:closLang$exp). T)``,
+val renumber_code_locs_length = Q.store_thm("renumber_code_locs_length",
+  `(∀x y. LENGTH (SND (renumber_code_locs_list x y)) = LENGTH y) ∧
+    (∀(x:num)(y:closLang$exp). T)`,
     ho_match_mp_tac renumber_code_locs_ind >>
     simp[renumber_code_locs_def,UNCURRY] >> rw[] >>
     METIS_TAC[PAIR,FST,SND]);

--- a/compiler/backend/clos_removeScript.sml
+++ b/compiler/backend/clos_removeScript.sml
@@ -86,8 +86,8 @@ val remove_def = tDefine "remove" `
 
 val remove_ind = theorem "remove_ind";
 
-val remove_LENGTH_LEMMA = prove(
-  ``!xs. (case remove xs of (ys,s1) => (LENGTH xs = LENGTH ys))``,
+val remove_LENGTH_LEMMA = Q.prove(
+  `!xs. (case remove xs of (ys,s1) => (LENGTH xs = LENGTH ys))`,
   recInduct remove_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [remove_def]
   \\ SRW_TAC [] [] \\ SRW_TAC [] []
@@ -96,12 +96,12 @@ val remove_LENGTH_LEMMA = prove(
   \\ SRW_TAC [] [] \\ DECIDE_TAC)
   |> SIMP_RULE std_ss [] |> SPEC_ALL;
 
-val remove_LENGTH = store_thm("remove_LENGTH",
-  ``!xs ys l. (remove xs = (ys,l)) ==> (LENGTH ys = LENGTH xs)``,
+val remove_LENGTH = Q.store_thm("remove_LENGTH",
+  `!xs ys l. (remove xs = (ys,l)) ==> (LENGTH ys = LENGTH xs)`,
   REPEAT STRIP_TAC \\ MP_TAC remove_LENGTH_LEMMA \\ fs []);
 
-val remove_SING = store_thm("remove_SING",
-  ``(remove [x] = (ys,l)) ==> ?y. ys = [y]``,
+val remove_SING = Q.store_thm("remove_SING",
+  `(remove [x] = (ys,l)) ==> ?y. ys = [y]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC remove_LENGTH
   \\ Cases_on `ys` \\ fs [LENGTH_NIL]);
 
@@ -123,7 +123,7 @@ val remove_CONS = Q.store_thm("remove_CONS",
 
 val remove_alt = save_thm ("remove_alt",remove_def |> SIMP_RULE std_ss [MAPi_enumerate_MAP])
 
-val remove_alt_ind = store_thm("remove_alt_ind",``
+val remove_alt_ind = Q.store_thm("remove_alt_ind",`
     ∀P.
      P [] ∧
      (∀x y xs.
@@ -153,7 +153,7 @@ val remove_alt_ind = store_thm("remove_alt_ind",``
      (∀x1 x2.
         (∀c1 l1. (c1,l1) = remove [x1] ⇒ P [x2]) ∧ P [x1] ⇒
         P [Handle x1 x2]) ∧ (∀ticks dest xs. P xs ⇒ P [Call ticks dest xs]) ⇒
-     ∀v. P v``,
+     ∀v. P v`,
   ntac 2 strip_tac>>
   ho_match_mp_tac remove_ind>>
   fs[]>>rw[]>>TRY(metis_tac[])>>

--- a/compiler/backend/clos_removeScript.sml
+++ b/compiler/backend/clos_removeScript.sml
@@ -105,17 +105,17 @@ val remove_SING = store_thm("remove_SING",
   REPEAT STRIP_TAC \\ IMP_RES_TAC remove_LENGTH
   \\ Cases_on `ys` \\ fs [LENGTH_NIL]);
 
-val LENGTH_FST_remove = store_thm("LENGTH_FST_remove",
-  ``LENGTH (FST (remove fns)) = LENGTH fns``,
+val LENGTH_FST_remove = Q.store_thm("LENGTH_FST_remove",
+  `LENGTH (FST (remove fns)) = LENGTH fns`,
   Cases_on `remove fns` \\ fs [] \\ IMP_RES_TAC remove_LENGTH);
 
-val HD_FST_remove = store_thm("HD_FST_remove",
-  ``[HD (FST (remove [x1]))] = FST (remove [x1])``,
+val HD_FST_remove = Q.store_thm("HD_FST_remove",
+  `[HD (FST (remove [x1]))] = FST (remove [x1])`,
   Cases_on `remove [x1]` \\ fs []
   \\ imp_res_tac remove_SING \\ fs[]);
 
-val remove_CONS = store_thm("remove_CONS",
-  ``FST (remove (x::xs)) = HD (FST (remove [x])) :: FST (remove xs)``,
+val remove_CONS = Q.store_thm("remove_CONS",
+  `FST (remove (x::xs)) = HD (FST (remove [x])) :: FST (remove xs)`,
   Cases_on `xs` \\ fs [remove_def,SING_HD,LENGTH_FST_remove,LET_DEF]
   \\ Cases_on `remove [x]` \\ fs []
   \\ Cases_on `remove (h::t)` \\ fs [SING_HD]

--- a/compiler/backend/clos_to_bvlScript.sml
+++ b/compiler/backend/clos_to_bvlScript.sml
@@ -62,15 +62,15 @@ val build_aux_def = Define `
   (build_aux i [] aux = (i:num,aux)) /\
   (build_aux i ((x:num#bvl$exp)::xs) aux = build_aux (i+2) xs ((i,x) :: aux))`;
 
-val build_aux_LENGTH = store_thm("build_aux_LENGTH",
-  ``!l n aux n1 t.
-      (build_aux n l aux = (n1,t)) ==> (n1 = n + 2 * LENGTH l)``,
+val build_aux_LENGTH = Q.store_thm("build_aux_LENGTH",
+  `!l n aux n1 t.
+      (build_aux n l aux = (n1,t)) ==> (n1 = n + 2 * LENGTH l)`,
   Induct \\ fs [build_aux_def] \\ REPEAT STRIP_TAC \\ RES_TAC \\ DECIDE_TAC);
 
-val build_aux_MOVE = store_thm("build_aux_MOVE",
-  ``!xs n aux n1 aux1.
+val build_aux_MOVE = Q.store_thm("build_aux_MOVE",
+  `!xs n aux n1 aux1.
       (build_aux n xs aux = (n1,aux1)) <=>
-      ?aux2. (build_aux n xs [] = (n1,aux2)) /\ (aux1 = aux2 ++ aux)``,
+      ?aux2. (build_aux n xs [] = (n1,aux2)) /\ (aux1 = aux2 ++ aux)`,
   Induct THEN1 (fs [build_aux_def] \\ METIS_TAC [])
   \\ ONCE_REWRITE_TAC [build_aux_def]
   \\ POP_ASSUM (fn th => ONCE_REWRITE_TAC [th])
@@ -80,10 +80,10 @@ val build_aux_acc = Q.store_thm("build_aux_acc",
   `!k n aux. ?aux1. SND (build_aux n k aux) = aux1 ++ aux`,
   METIS_TAC[build_aux_MOVE,SND,PAIR]);
 
-val build_aux_MEM = store_thm("build_aux_MEM",
-  ``!c n aux n7 aux7.
+val build_aux_MEM = Q.store_thm("build_aux_MEM",
+  `!c n aux n7 aux7.
        (build_aux n c aux = (n7,aux7)) ==>
-       !k. k < LENGTH c ==> ?d. MEM (n + 2*k,d) aux7``,
+       !k. k < LENGTH c ==> ?d. MEM (n + 2*k,d) aux7`,
   Induct \\ fs [build_aux_def] \\ REPEAT STRIP_TAC
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`n+2`,`(n,h)::aux`]) \\ fs []
   \\ REPEAT STRIP_TAC
@@ -92,11 +92,11 @@ val build_aux_MEM = store_thm("build_aux_MEM",
          \\ REPEAT STRIP_TAC \\ fs [] \\ METIS_TAC [])
   \\ RES_TAC \\ fs [ADD1,LEFT_ADD_DISTRIB] \\ METIS_TAC []);
 
-val build_aux_APPEND1 = store_thm("build_aux_APPEND1",
-  ``!xs x n aux.
+val build_aux_APPEND1 = Q.store_thm("build_aux_APPEND1",
+  `!xs x n aux.
       build_aux n (xs ++ [x]) aux =
         let (n1,aux1) = build_aux n xs aux in
-          (n1+2,(n1,x)::aux1)``,
+          (n1+2,(n1,x)::aux1)`,
   Induct \\ fs [build_aux_def,LET_DEF]);
 
 val recc_Let_def = Define `
@@ -393,21 +393,21 @@ val compile_exps_SING = Q.store_thm("compile_exps_SING",
   \\ ASSUME_TAC (Q.SPECL [`max_app`,`[x]`,`aux`] compile_exps_acc) \\ rfs [LET_DEF]
   \\ Cases_on `c` \\ fs [] \\ Cases_on `t` \\ fs []);
 
-val compile_exps_CONS = store_thm("compile_exps_CONS",
-  ``!max_app xs x aux.
+val compile_exps_CONS = Q.store_thm("compile_exps_CONS",
+  `!max_app xs x aux.
       compile_exps max_app (x::xs) aux =
       (let (c1,aux1) = compile_exps max_app [x] aux in
        let (c2,aux2) = compile_exps max_app xs aux1 in
-         (c1 ++ c2,aux2))``,
+         (c1 ++ c2,aux2))`,
   Cases_on `xs` \\ fs[compile_exps_def] \\ fs [LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) \\ fs []);
 
-val compile_exps_SNOC = store_thm("compile_exps_SNOC",
-  ``!xs x aux max_app.
+val compile_exps_SNOC = Q.store_thm("compile_exps_SNOC",
+  `!xs x aux max_app.
       compile_exps max_app (SNOC x xs) aux =
       (let (c1,aux1) = compile_exps max_app xs aux in
        let (c2,aux2) = compile_exps max_app [x] aux1 in
-         (c1 ++ c2,aux2))``,
+         (c1 ++ c2,aux2))`,
   Induct THEN1
    (fs [compile_exps_def,LET_DEF]
     \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) \\ fs [])
@@ -453,16 +453,16 @@ val code_merge_def = tDefine "code_merge" `
           y1::code_merge xs ys1`
   (WF_REL_TAC `measure (\(xs,ys). LENGTH xs + LENGTH ys)` \\ rw []);
 
-val code_split_NULL = store_thm("code_split_NULL",
-  ``!ts1 ts2 ts3 xs ys.
+val code_split_NULL = Q.store_thm("code_split_NULL",
+  `!ts1 ts2 ts3 xs ys.
       (xs,ys) = code_split ts1 ts2 ts3 /\ ts2 <> [] /\ ts3 <> [] ==>
-      xs <> [] /\ ys <> []``,
+      xs <> [] /\ ys <> []`,
   Induct \\ fs [code_split_def] \\ rw [] \\ first_x_assum drule \\ fs []);
 
-val code_split_LENGTH = store_thm("code_split_LENGTH",
-  ``!ts1 ts2 ts3 xs ys.
+val code_split_LENGTH = Q.store_thm("code_split_LENGTH",
+  `!ts1 ts2 ts3 xs ys.
       (xs,ys) = code_split ts1 ts2 ts3 ==>
-      LENGTH xs + LENGTH ys = LENGTH ts1 + LENGTH ts2 + LENGTH ts3``,
+      LENGTH xs + LENGTH ys = LENGTH ts1 + LENGTH ts2 + LENGTH ts3`,
   Induct \\ fs [code_split_def] \\ rw [] \\ first_x_assum drule \\ fs []);
 
 val code_sort_def = tDefine "code_sort" `

--- a/compiler/backend/db_varsScript.sml
+++ b/compiler/backend/db_varsScript.sml
@@ -65,12 +65,12 @@ val has_var_def = Define `
   (has_var n (Union d1 d2) <=> has_var n d1 \/ has_var n d2)`;
 val _ = export_rewrites["has_var_def"];
 
-val has_var_mk_Union = store_thm("has_var_mk_Union[simp]",
-  ``has_var n (mk_Union l1 l2) <=> has_var n l1 \/ has_var n l2``,
+val has_var_mk_Union = Q.store_thm("has_var_mk_Union[simp]",
+  `has_var n (mk_Union l1 l2) <=> has_var n l1 \/ has_var n l2`,
   SRW_TAC [] [mk_Union_def,has_var_def]);
 
-val has_var_list_mk_Union = store_thm("has_var_list_mk_Union[simp]",
-  ``!ls. has_var n (list_mk_Union ls) <=> EXISTS (has_var n) ls``,
+val has_var_list_mk_Union = Q.store_thm("has_var_list_mk_Union[simp]",
+  `!ls. has_var n (list_mk_Union ls) <=> EXISTS (has_var n) ls`,
   Induct \\ fs [list_mk_Union_def,has_var_mk_Union,has_var_def]);
 
 val lookup_db_to_set_acc = Q.store_thm("lookup_db_to_set_acc",
@@ -90,26 +90,26 @@ val lookup_db_to_set_Shift = Q.store_thm("lookup_db_to_set_Shift",
   rw[db_to_set_def,db_to_set_acc_def]
   \\ rw[lookup_db_to_set_acc,lookup_def]);
 
-val MEM_vars_to_list = store_thm("MEM_vars_to_list",
-  ``MEM n (vars_to_list d) = has_var n d``,
+val MEM_vars_to_list = Q.store_thm("MEM_vars_to_list",
+  `MEM n (vars_to_list d) = has_var n d`,
   fs [vars_to_list_def,MEM_MAP,EXISTS_PROD,MEM_toAList]
   \\ fs [lookup_db_to_set]);
 
-val has_var_FOLDL_Union = prove(
-  ``!vs n s. has_var n (FOLDL (\s1 v. Union (Var v) s1) s vs) <=>
-             MEM n vs \/ has_var n s``,
+val has_var_FOLDL_Union = Q.prove(
+  `!vs n s. has_var n (FOLDL (\s1 v. Union (Var v) s1) s vs) <=>
+             MEM n vs \/ has_var n s`,
   Induct \\ fs [] \\ rw [] \\ fs [] \\ eq_tac \\ rw [] \\ fs []);
 
-val MEM_vars_from_list = store_thm("MEM_vars_from_list",
-  ``!vs n. has_var n (vars_from_list vs) <=> MEM n vs``,
+val MEM_vars_from_list = Q.store_thm("MEM_vars_from_list",
+  `!vs n. has_var n (vars_from_list vs) <=> MEM n vs`,
   fs [vars_from_list_def,has_var_FOLDL_Union]);
 
-val has_var_vars_flatten = store_thm("has_var_vars_flatten[simp]",
-  ``has_var n (vars_flatten d) = has_var n d``,
+val has_var_vars_flatten = Q.store_thm("has_var_vars_flatten[simp]",
+  `has_var n (vars_flatten d) = has_var n d`,
   fs [vars_flatten_def,MEM_vars_from_list,MEM_vars_to_list]);
 
-val ALL_DISTINCT_vars_to_list = store_thm("ALL_DISTINCT_vars_to_list",
-  ``ALL_DISTINCT (vars_to_list d)``,
+val ALL_DISTINCT_vars_to_list = Q.store_thm("ALL_DISTINCT_vars_to_list",
+  `ALL_DISTINCT (vars_to_list d)`,
   fs [vars_to_list_def,ALL_DISTINCT_MAP_FST_toAList]);
 
 val _ = export_theory();

--- a/compiler/backend/dec_to_exhScript.sml
+++ b/compiler/backend/dec_to_exhScript.sml
@@ -102,8 +102,8 @@ val e2sz_def = Lib.with_flag (computeLib.auto_import_definitions, false) (tDefin
     | INR (INR (INL (pes))) => exp3_size pes
     | INR (INR (INR (funs))) => exp1_size funs)`)
 
-val p2sz_append = prove(
-  ``∀p1 p2. p2sz (p1++p2) = p2sz p1 + p2sz p2``,
+val p2sz_append = Q.prove(
+  `∀p1 p2. p2sz (p1++p2) = p2sz p1 + p2sz p2`,
   Induct >> simp[e2sz_def] >>
   Cases >> simp[e2sz_def])
 

--- a/compiler/backend/dec_to_exhScript.sml
+++ b/compiler/backend/dec_to_exhScript.sml
@@ -176,8 +176,8 @@ val compile_exp_def = tDefine"compile_exp"`
 val _ = map delete_const ["e2sz","p2sz","l2sz","f2sz","e2sz_UNION"]
 val _ = delete_binding "e2sz_ind"
 
-val compile_funs_map = store_thm("compile_funs_map",
-  ``compile_funs exh ls = MAP (λ(x,y,z). (x,y,compile_exp exh z)) ls``,
+val compile_funs_map = Q.store_thm("compile_funs_map",
+  `compile_funs exh ls = MAP (λ(x,y,z). (x,y,compile_exp exh z)) ls`,
   Induct_on`ls`>>simp[compile_exp_def]>>qx_gen_tac`p`>>PairCases_on`p`>>simp[compile_exp_def]);
 
 val compile_exps_map = Q.store_thm ("compile_exps_map",

--- a/compiler/backend/exh_to_patScript.sml
+++ b/compiler/backend/exh_to_patScript.sml
@@ -77,8 +77,8 @@ val pure_def = Define `
   ∧
   (pure_list (e::es) ⇔ pure e ∧ pure_list es)`;
 
-val pure_list_EVERY = store_thm("pure_list_EVERY",
-  ``∀ls. pure_list ls ⇔ EVERY pure ls``,
+val pure_list_EVERY = Q.store_thm("pure_list_EVERY",
+  `∀ls. pure_list ls ⇔ EVERY pure ls`,
   Induct >> simp[pure_def])
 val _ = export_rewrites["pure_list_EVERY"]
 
@@ -115,12 +115,12 @@ val ground_def = Define `
 
 val _ = export_rewrites["pure_op_op_def","pure_op_def","pure_def","ground_def"];
 
-val ground_list_EVERY = store_thm("ground_list_EVERY",
-  ``∀n ls. ground_list n ls ⇔ EVERY (ground n) ls``,
+val ground_list_EVERY = Q.store_thm("ground_list_EVERY",
+  `∀n ls. ground_list n ls ⇔ EVERY (ground n) ls`,
   gen_tac >> Induct >> simp[])
 val _ = export_rewrites["ground_list_EVERY"]
 
-val pure_op_op_eqn = store_thm("pure_op_op_eqn",``
+val pure_op_op_eqn = Q.store_thm("pure_op_op_eqn",`
   pure_op_op op =
   case op of
     Opref => F
@@ -137,7 +137,7 @@ val pure_op_op_eqn = store_thm("pure_op_op_eqn",``
   | Opn Divide => F
   | Opn Modulo => F
   | FFI _ => F
-  | _ => T``,
+  | _ => T`,
   Cases_on`op`>>fs[]>>
   Cases_on`o'`>>fs[])
 
@@ -289,12 +289,12 @@ val compile_funs_map = Q.store_thm("compile_funs_map",
   `∀funs bvs. compile_funs bvs funs = MAP (λ(f,x,e). compile_exp (SOME x::bvs) e) funs`,
   Induct>>simp[pairTheory.FORALL_PROD])
 
-val compile_exps_map = store_thm("compile_exps_map",
-  ``∀es. compile_exps a es = MAP (compile_exp a) es``,
+val compile_exps_map = Q.store_thm("compile_exps_map",
+  `∀es. compile_exps a es = MAP (compile_exp a) es`,
   Induct >> simp[compile_exp_def])
 
-val compile_exps_reverse = store_thm("compile_exps_reverse",
-  ``compile_exps a (REVERSE ls) = REVERSE (compile_exps a ls)``,
+val compile_exps_reverse = Q.store_thm("compile_exps_reverse",
+  `compile_exps a (REVERSE ls) = REVERSE (compile_exps a ls)`,
   rw[compile_exps_map,rich_listTheory.MAP_REVERSE])
 
 val _ = export_theory()

--- a/compiler/backend/gc/copying_gcScript.sml
+++ b/compiler/backend/gc/copying_gcScript.sml
@@ -4,41 +4,41 @@ val _ = new_theory "copying_gc";
 
 (* TODO: move *)
 
-val EVERY2_SPLIT = store_thm("EVERY2_SPLIT",
-  ``!xs1 zs.
+val EVERY2_SPLIT = Q.store_thm("EVERY2_SPLIT",
+  `!xs1 zs.
       EVERY2 P zs (xs1 ++ x::xs2) ==>
       ?ys1 y ys2. (zs = ys1 ++ y::ys2) /\ EVERY2 P ys1 xs1 /\
-                  EVERY2 P ys2 xs2 /\ P y x``,
+                  EVERY2 P ys2 xs2 /\ P y x`,
   Induct \\ full_simp_tac std_ss [APPEND]
   \\ Cases_on `zs` \\ full_simp_tac (srw_ss()) []
   \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss []
   \\ Q.LIST_EXISTS_TAC [`h::ys1`,`y`,`ys2`] \\ full_simp_tac (srw_ss()) []);
 
-val EVERY2_SPLIT_ALT = store_thm("EVERY2_SPLIT_ALT",
-  ``!xs1 zs.
+val EVERY2_SPLIT_ALT = Q.store_thm("EVERY2_SPLIT_ALT",
+  `!xs1 zs.
       EVERY2 P (xs1 ++ x::xs2) zs ==>
       ?ys1 y ys2. (zs = ys1 ++ y::ys2) /\ EVERY2 P xs1 ys1 /\
-                  EVERY2 P xs2 ys2 /\ P x y``,
+                  EVERY2 P xs2 ys2 /\ P x y`,
   Induct \\ full_simp_tac std_ss [APPEND]
   \\ Cases_on `zs` \\ full_simp_tac (srw_ss()) []
   \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss []
   \\ Q.LIST_EXISTS_TAC [`h::ys1`,`y`,`ys2`] \\ full_simp_tac (srw_ss()) []);
 
-val EVERY2_APPEND = store_thm("EVERY2_APPEND",
-  ``!xs ts.
+val EVERY2_APPEND = Q.store_thm("EVERY2_APPEND",
+  `!xs ts.
       (LENGTH xs = LENGTH ts) ==>
-      (EVERY2 P (xs ++ ys) (ts ++ us) = EVERY2 P xs ts /\ EVERY2 P ys us)``,
+      (EVERY2 P (xs ++ ys) (ts ++ us) = EVERY2 P xs ts /\ EVERY2 P ys us)`,
   Induct \\ Cases_on `ts` \\ full_simp_tac (srw_ss()) [LENGTH,CONJ_ASSOC]);
 
-val BIJ_UPDATE = prove(
-  ``BIJ f s t /\ ~(x IN s) /\ ~(y IN t) ==>
-    BIJ ((x =+ y) f) (x INSERT s) (y INSERT t)``,
+val BIJ_UPDATE = Q.prove(
+  `BIJ f s t /\ ~(x IN s) /\ ~(y IN t) ==>
+    BIJ ((x =+ y) f) (x INSERT s) (y INSERT t)`,
   simp_tac std_ss [BIJ_DEF,SURJ_DEF,INJ_DEF,IN_INSERT,APPLY_UPDATE_THM]
   \\ metis_tac []);
 
-val INJ_UPDATE = store_thm("INJ_UPDATE",
-  ``INJ f s t /\ ~(x IN s) /\ ~(y IN t) ==>
-    INJ ((x =+ y) f) (x INSERT s) (y INSERT t)``,
+val INJ_UPDATE = Q.store_thm("INJ_UPDATE",
+  `INJ f s t /\ ~(x IN s) /\ ~(y IN t) ==>
+    INJ ((x =+ y) f) (x INSERT s) (y INSERT t)`,
   simp_tac std_ss [BIJ_DEF,SURJ_DEF,INJ_DEF,IN_INSERT,APPLY_UPDATE_THM]
   \\ metis_tac []);
 
@@ -211,13 +211,13 @@ val gc_inv_def = Define `
 
 (* Invariant maintained *)
 
-val heap_lookup_MEM = store_thm("heap_lookup_MEM",
-  ``!heap n x. (heap_lookup n heap = SOME x) ==> MEM x heap``,
+val heap_lookup_MEM = Q.store_thm("heap_lookup_MEM",
+  `!heap n x. (heap_lookup n heap = SOME x) ==> MEM x heap`,
   Induct \\ full_simp_tac std_ss [heap_lookup_def] \\ SRW_TAC [] []
   \\ res_tac \\ full_simp_tac std_ss []);
 
-val DRESTRICT_heap_map = prove(
-  ``!heap k. n < k ==> (DRESTRICT (heap_map k heap) (COMPL {n}) = heap_map k heap)``,
+val DRESTRICT_heap_map = Q.prove(
+  `!heap k. n < k ==> (DRESTRICT (heap_map k heap) (COMPL {n}) = heap_map k heap)`,
   simp_tac (srw_ss()) [GSYM fmap_EQ_THM,DRESTRICT_DEF,EXTENSION] \\ rpt strip_tac
   \\ Cases_on `x IN FDOM (heap_map k heap)` \\ full_simp_tac std_ss []
   \\ rpt (pop_assum mp_tac)  \\ Q.SPEC_TAC (`k`,`k`) \\ Q.SPEC_TAC (`heap`,`heap`)
@@ -226,15 +226,15 @@ val DRESTRICT_heap_map = prove(
   \\ rpt strip_tac \\ full_simp_tac std_ss []
   \\ metis_tac [DECIDE ``n<k ==> n < k + m:num``,DECIDE ``n<k ==> n < k + m+1:num``]);
 
-val IN_FRANGE = prove(
-  ``!heap n. MEM (ForwardPointer ptr d l) heap ==> ptr IN FRANGE (heap_map n heap)``,
+val IN_FRANGE = Q.prove(
+  `!heap n. MEM (ForwardPointer ptr d l) heap ==> ptr IN FRANGE (heap_map n heap)`,
   Induct \\ full_simp_tac std_ss [MEM] \\ rpt strip_tac
   \\ Cases_on `h` \\ full_simp_tac (srw_ss()) [heap_map_def,FRANGE_FUPDATE]
   \\ `n < n + n0 + 1` by decide_tac \\ full_simp_tac std_ss [DRESTRICT_heap_map]);
 
-val heap_lookup_SPLIT = store_thm("heap_lookup_SPLIT",
-  ``!heap n x. (heap_lookup n heap = SOME x) ==>
-               ?ha hb. (heap = ha ++ x::hb) /\ (n = heap_length ha)``,
+val heap_lookup_SPLIT = Q.store_thm("heap_lookup_SPLIT",
+  `!heap n x. (heap_lookup n heap = SOME x) ==>
+               ?ha hb. (heap = ha ++ x::hb) /\ (n = heap_length ha)`,
   Induct \\ full_simp_tac std_ss [heap_lookup_def] \\ SRW_TAC [] []
   THEN1 (Q.LIST_EXISTS_TAC [`[]`,`heap`] \\ full_simp_tac (srw_ss()) [heap_length_def])
   \\ res_tac \\ Q.LIST_EXISTS_TAC [`h::ha`,`hb`]
@@ -247,10 +247,10 @@ val gc_forward_ptr_thm = store_thm("gc_forward_ptr_thm",
     el_length_def,isDataElement_def,LET_DEF] \\ SRW_TAC [] []
   \\ Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ decide_tac);
 
-val heap_lookup_FLOOKUP = prove(
-  ``!heap n k.
+val heap_lookup_FLOOKUP = Q.prove(
+  `!heap n k.
       (heap_lookup n heap = SOME (ForwardPointer ptr u l)) ==>
-      (FLOOKUP (heap_map k heap) (n+k) = SOME ptr)``,
+      (FLOOKUP (heap_map k heap) (n+k) = SOME ptr)`,
   Induct \\ full_simp_tac std_ss [heap_lookup_def] \\ SRW_TAC [] []
   THEN1 (full_simp_tac (srw_ss()) [heap_map_def,FLOOKUP_DEF])
   \\ res_tac \\ pop_assum (ASSUME_TAC o Q.SPEC `k + el_length h`)
@@ -260,14 +260,14 @@ val heap_lookup_FLOOKUP = prove(
   \\ full_simp_tac (srw_ss()) [FLOOKUP_DEF,ADD_ASSOC,FAPPLY_FUPDATE_THM])
   |> Q.SPECL [`heap`,`n`,`0`] |> SIMP_RULE std_ss [];
 
-val IN_heap_map_IMP = prove(
-  ``!heap n k. n IN FDOM (heap_map k heap) ==> k <= n``,
+val IN_heap_map_IMP = Q.prove(
+  `!heap n k. n IN FDOM (heap_map k heap) ==> k <= n`,
   Induct \\ TRY (Cases_on `h`) \\ full_simp_tac (srw_ss()) [heap_map_def]
   \\ rpt strip_tac \\ res_tac
   \\ full_simp_tac (srw_ss()) [heap_length_def,el_length_def] \\ decide_tac);
 
-val NOT_IN_heap_map = prove(
-  ``!ha n. ~(n + heap_length ha IN FDOM (heap_map n (ha ++ DataElement ys l d::hb)))``,
+val NOT_IN_heap_map = Q.prove(
+  `!ha n. ~(n + heap_length ha IN FDOM (heap_map n (ha ++ DataElement ys l d::hb)))`,
   Induct \\ full_simp_tac (srw_ss()) [heap_map_def,APPEND,heap_length_def]
   \\ rpt strip_tac \\ imp_res_tac IN_heap_map_IMP
   \\ full_simp_tac std_ss [ADD_ASSOC] \\ res_tac
@@ -276,25 +276,25 @@ val NOT_IN_heap_map = prove(
   \\ res_tac \\ full_simp_tac (srw_ss()) [el_length_def,ADD_ASSOC] \\ res_tac
   \\ decide_tac) |> Q.SPECL [`ha`,`0`] |> SIMP_RULE std_ss []
 
-val isSomeDataOrForward_lemma = prove(
-  ``!ha ptr.
+val isSomeDataOrForward_lemma = Q.prove(
+  `!ha ptr.
       isSomeDataOrForward (heap_lookup ptr (ha ++ DataElement ys l d::hb)) <=>
-      isSomeDataOrForward (heap_lookup ptr (ha ++ [ForwardPointer a u l] ++ hb))``,
+      isSomeDataOrForward (heap_lookup ptr (ha ++ [ForwardPointer a u l] ++ hb))`,
   Induct \\ full_simp_tac std_ss [APPEND,heap_lookup_def]
   \\ SRW_TAC [] [] \\ full_simp_tac std_ss []
   \\ EVAL_TAC \\ full_simp_tac std_ss [el_length_def]);
 
-val heaps_similar_IMP_heap_length = prove(
-  ``!xs ys. heaps_similar xs ys ==> (heap_length xs = heap_length ys)``,
+val heaps_similar_IMP_heap_length = Q.prove(
+  `!xs ys. heaps_similar xs ys ==> (heap_length xs = heap_length ys)`,
   Induct \\ Cases_on `ys`
   \\ full_simp_tac (srw_ss()) [heaps_similar_def,heap_length_def]
   \\ rpt strip_tac \\ Cases_on `isForwardPointer h`
   \\ full_simp_tac std_ss []);
 
-val heap_similar_Data_IMP = prove(
-  ``heaps_similar heap0 (ha ++ DataElement ys l d::hb) ==>
+val heap_similar_Data_IMP = Q.prove(
+  `heaps_similar heap0 (ha ++ DataElement ys l d::hb) ==>
     ?ha0 hb0. (heap0 = ha0 ++ DataElement ys l d::hb0) /\
-              (heap_length ha = heap_length ha0)``,
+              (heap_length ha = heap_length ha0)`,
   rpt strip_tac \\ full_simp_tac std_ss [heaps_similar_def]
   \\ imp_res_tac EVERY2_SPLIT \\ full_simp_tac std_ss [isForwardPointer_def]
   \\ pop_assum (ASSUME_TAC o GSYM) \\ full_simp_tac std_ss []
@@ -302,10 +302,10 @@ val heap_similar_Data_IMP = prove(
   \\ `heaps_similar ys1 ha` by full_simp_tac std_ss [heaps_similar_def]
   \\ full_simp_tac std_ss [heaps_similar_IMP_heap_length]);
 
-val heaps_similar_lemma = prove(
-  ``!ha heap0.
+val heaps_similar_lemma = Q.prove(
+  `!ha heap0.
       heaps_similar heap0 (ha ++ DataElement ys l d::hb) ==>
-      heaps_similar heap0 (ha ++ [ForwardPointer (heap_length (h1 ++ h2)) u l] ++ hb)``,
+      heaps_similar heap0 (ha ++ [ForwardPointer (heap_length (h1 ++ h2)) u l] ++ hb)`,
   full_simp_tac std_ss [heaps_similar_def] \\ rpt strip_tac
   \\ imp_res_tac EVERY2_SPLIT \\ full_simp_tac std_ss []
   \\ imp_res_tac LIST_REL_LENGTH
@@ -315,48 +315,48 @@ val heaps_similar_lemma = prove(
   \\ qpat_x_assum `DataElement ys l d = y` (mp_tac o GSYM)
   \\ full_simp_tac (srw_ss()) [el_length_def]);
 
-val heap_addresses_SNOC = prove(
-  ``!xs n x.
+val heap_addresses_SNOC = Q.prove(
+  `!xs n x.
       heap_addresses n (xs ++ [x]) =
-      heap_addresses n xs UNION {heap_length xs + n}``,
+      heap_addresses n xs UNION {heap_length xs + n}`,
   Induct \\ full_simp_tac (srw_ss()) [heap_addresses_def,APPEND,heap_length_def]
   \\ full_simp_tac (srw_ss()) [EXTENSION] \\ rpt strip_tac
   \\ full_simp_tac std_ss [AC ADD_COMM ADD_ASSOC,DISJ_ASSOC]);
 
-val NOT_IN_heap_addresses = prove(
-  ``!xs n. ~(n + heap_length xs IN heap_addresses n xs)``,
+val NOT_IN_heap_addresses = Q.prove(
+  `!xs n. ~(n + heap_length xs IN heap_addresses n xs)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_addresses_def,APPEND,heap_length_def]
   \\ full_simp_tac (srw_ss()) [EXTENSION] \\ rpt strip_tac
   \\ full_simp_tac std_ss [ADD_ASSOC]
   THEN1 (Cases_on `h` \\ EVAL_TAC \\ decide_tac) \\ metis_tac [])
   |> Q.SPECL [`xs`,`0`] |> SIMP_RULE std_ss [];
 
-val heap_lookup_PREFIX = store_thm("heap_lookup_PREFIX",
-  ``!xs. (heap_lookup (heap_length xs) (xs ++ x::ys) = SOME x)``,
+val heap_lookup_PREFIX = Q.store_thm("heap_lookup_PREFIX",
+  `!xs. (heap_lookup (heap_length xs) (xs ++ x::ys) = SOME x)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_lookup_def,APPEND,heap_length_def]
   \\ SRW_TAC [] [] \\ Cases_on `h`
   \\ full_simp_tac std_ss [el_length_def] \\ decide_tac);
 
-val heap_lookup_EXTEND = store_thm("heap_lookup_EXTEND",
-  ``!xs n ys x. (heap_lookup n xs = SOME x) ==>
-                (heap_lookup n (xs ++ ys) = SOME x)``,
+val heap_lookup_EXTEND = Q.store_thm("heap_lookup_EXTEND",
+  `!xs n ys x. (heap_lookup n xs = SOME x) ==>
+                (heap_lookup n (xs ++ ys) = SOME x)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_lookup_def] \\ SRW_TAC [] []);
 
-val ADDR_MAP_EQ = prove(
-  ``!xs. (!p d. MEM (Pointer p d) xs ==> (f p = g p)) ==>
-         (ADDR_MAP f xs = ADDR_MAP g xs)``,
+val ADDR_MAP_EQ = Q.prove(
+  `!xs. (!p d. MEM (Pointer p d) xs ==> (f p = g p)) ==>
+         (ADDR_MAP f xs = ADDR_MAP g xs)`,
   Induct \\ TRY (Cases_on `h`) \\ full_simp_tac (srw_ss()) [ADDR_MAP_def]
   \\ metis_tac []);
 
-val heap_map_APPEND = prove(
-  ``!xs n ys. (heap_map n (xs ++ ys)) =
-              FUNION (heap_map n xs) (heap_map (n + heap_length xs) ys)``,
+val heap_map_APPEND = Q.prove(
+  `!xs n ys. (heap_map n (xs ++ ys)) =
+              FUNION (heap_map n xs) (heap_map (n + heap_length xs) ys)`,
   Induct \\ TRY (Cases_on `h`) \\ full_simp_tac (srw_ss())
      [APPEND,heap_map_def,FUNION_DEF,FUNION_FEMPTY_1,heap_length_def,ADD_ASSOC]
   \\ full_simp_tac std_ss [FUNION_FUPDATE_1,el_length_def,ADD_ASSOC]);
 
-val FDOM_heap_map = prove(
-  ``!xs n. ~(n + heap_length xs IN FDOM (heap_map n xs))``,
+val FDOM_heap_map = Q.prove(
+  `!xs n. ~(n + heap_length xs IN FDOM (heap_map n xs))`,
   Induct \\ TRY (Cases_on `h`)
   \\ full_simp_tac (srw_ss()) [heap_map_def,heap_length_def,ADD_ASSOC]
   \\ rpt strip_tac \\ full_simp_tac std_ss [el_length_def,ADD_ASSOC]
@@ -505,34 +505,34 @@ val gc_move_list_APPEND_lemma = prove(
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ full_simp_tac std_ss [APPEND_ASSOC] \\ metis_tac []);
 
-val heap_addresses_APPEND = prove(
-  ``!xs ys n. heap_addresses n (xs ++ ys) =
-              heap_addresses n xs UNION heap_addresses (n + heap_length xs) ys``,
+val heap_addresses_APPEND = Q.prove(
+  `!xs ys n. heap_addresses n (xs ++ ys) =
+              heap_addresses n xs UNION heap_addresses (n + heap_length xs) ys`,
   Induct \\ full_simp_tac (srw_ss()) [APPEND,heap_addresses_def,heap_length_def]
   \\ full_simp_tac (srw_ss()) [EXTENSION,DISJ_ASSOC,ADD_ASSOC]);
 
-val LESS_IMP_heap_lookup = store_thm("LESS_IMP_heap_lookup",
-  ``!xs j ys. j < heap_length xs ==> (heap_lookup j (xs ++ ys) = heap_lookup j xs)``,
+val LESS_IMP_heap_lookup = Q.store_thm("LESS_IMP_heap_lookup",
+  `!xs j ys. j < heap_length xs ==> (heap_lookup j (xs ++ ys) = heap_lookup j xs)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_length_def,heap_lookup_def]
   \\ SRW_TAC [] [] \\ `j - el_length h < SUM (MAP el_length xs)` by decide_tac
   \\ full_simp_tac std_ss []);
 
-val NOT_LESS_IMP_heap_lookup = store_thm("NOT_LESS_IMP_heap_lookup",
-  ``!xs j ys. ~(j < heap_length xs) ==>
-              (heap_lookup j (xs ++ ys) = heap_lookup (j - heap_length xs) ys)``,
+val NOT_LESS_IMP_heap_lookup = Q.store_thm("NOT_LESS_IMP_heap_lookup",
+  `!xs j ys. ~(j < heap_length xs) ==>
+              (heap_lookup j (xs ++ ys) = heap_lookup (j - heap_length xs) ys)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_length_def,heap_lookup_def]
   \\ SRW_TAC [] [SUB_PLUS]
   THEN1 (Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ `F` by decide_tac)
   THEN1 (Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ `F` by decide_tac));
 
-val heap_length_APPEND = store_thm("heap_length_APPEND",
-  ``heap_length (xs ++ ys) = heap_length xs + heap_length ys``,
+val heap_length_APPEND = Q.store_thm("heap_length_APPEND",
+  `heap_length (xs ++ ys) = heap_length xs + heap_length ys`,
   SRW_TAC [] [heap_length_def,SUM_APPEND]);
 
-val heap_similar_Data_IMP_DataOrForward = prove(
-  ``!heap0 heap1 ptr.
+val heap_similar_Data_IMP_DataOrForward = Q.prove(
+  `!heap0 heap1 ptr.
       heaps_similar heap0 heap1 /\ isSomeDataElement (heap_lookup ptr heap0) ==>
-      isSomeDataOrForward (heap_lookup ptr heap1)``,
+      isSomeDataOrForward (heap_lookup ptr heap1)`,
   Induct \\ Cases_on `heap1` \\ full_simp_tac (srw_ss()) [heaps_similar_def]
   \\ full_simp_tac std_ss [heap_lookup_def]
   THEN1 (full_simp_tac (srw_ss()) [isSomeDataElement_def,isSomeDataOrForward_def])
@@ -617,17 +617,17 @@ val gc_move_loop_thm = prove(
   \\ full_simp_tac std_ss [heap_length_APPEND]
   \\ full_simp_tac (srw_ss()) [heap_length_def,el_length_def]);
 
-val FILTER_LEMMA = prove(
-  ``!heap. (FILTER isForwardPointer heap = []) ==>
-           (FILTER (\h. ~isForwardPointer h) heap = heap)``,
+val FILTER_LEMMA = Q.prove(
+  `!heap. (FILTER isForwardPointer heap = []) ==>
+           (FILTER (\h. ~isForwardPointer h) heap = heap)`,
   Induct \\ full_simp_tac (srw_ss()) [] \\ SRW_TAC [] []);
 
-val heaps_similar_REFL = prove(
-  ``!xs. (FILTER isForwardPointer xs = []) ==> heaps_similar xs xs``,
+val heaps_similar_REFL = Q.prove(
+  `!xs. (FILTER isForwardPointer xs = []) ==> heaps_similar xs xs`,
   Induct \\ full_simp_tac (srw_ss()) [heaps_similar_def] \\ SRW_TAC [] []);
 
-val heap_map_EMPTY = prove(
-  ``!xs n. (FILTER isForwardPointer xs = []) ==> (FDOM (heap_map n xs) = {})``,
+val heap_map_EMPTY = Q.prove(
+  `!xs n. (FILTER isForwardPointer xs = []) ==> (FDOM (heap_map n xs) = {})`,
   Induct \\ TRY (Cases_on `h`)
   \\ full_simp_tac (srw_ss()) [heap_map_def,isForwardPointer_def]);
 
@@ -671,43 +671,43 @@ val full_gc_thm = store_thm("full_gc_thm",
   \\ full_simp_tac std_ss [] \\ rpt strip_tac \\ res_tac
   \\ full_simp_tac std_ss [SUBMAP_DEF,heap_map1_def]);
 
-val MEM_ADDR_MAP = prove(
-  ``!xs f ptr u. MEM (Pointer ptr u) (ADDR_MAP f xs) ==>
-                 ?y. MEM (Pointer y u) xs /\ (f y = ptr)``,
+val MEM_ADDR_MAP = Q.prove(
+  `!xs f ptr u. MEM (Pointer ptr u) (ADDR_MAP f xs) ==>
+                 ?y. MEM (Pointer y u) xs /\ (f y = ptr)`,
   Induct \\ TRY (Cases_on `h`) \\ full_simp_tac (srw_ss()) [ADDR_MAP_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [] \\ res_tac \\ metis_tac []);
 
-val heap_length_heap_expand = store_thm("heap_length_heap_expand",
-  ``!n. heap_length (heap_expand n) = n``,
+val heap_length_heap_expand = Q.store_thm("heap_length_heap_expand",
+  `!n. heap_length (heap_expand n) = n`,
   Cases \\ EVAL_TAC \\ full_simp_tac (srw_ss()) [el_length_def,ADD1,SUM_ACC_DEF]);
 
-val EVERY_isDataElement_IMP_LEMMA = prove(
-  ``!heap2. EVERY isDataElement heap2 ==> (FILTER isForwardPointer heap2 = [])``,
+val EVERY_isDataElement_IMP_LEMMA = Q.prove(
+  `!heap2. EVERY isDataElement heap2 ==> (FILTER isForwardPointer heap2 = [])`,
   Induct \\ full_simp_tac (srw_ss()) [isDataElement_def] \\ rpt strip_tac
   \\ full_simp_tac (srw_ss()) [isForwardPointer_def]);
 
-val heap_lookup_LESS = store_thm("heap_lookup_LESS",
-  ``!xs n. (heap_lookup n xs = SOME x) ==> n < heap_length xs``,
+val heap_lookup_LESS = Q.store_thm("heap_lookup_LESS",
+  `!xs n. (heap_lookup n xs = SOME x) ==> n < heap_length xs`,
   Induct \\ full_simp_tac std_ss [heap_lookup_def] \\ SRW_TAC [] []
   \\ res_tac \\ Cases_on `h` \\ full_simp_tac (srw_ss())
       [heap_length_def,el_length_def] \\ decide_tac);
 
-val isSome_heap_looukp_IMP_APPEND = prove(
-  ``!xs ptr. isSomeDataElement (heap_lookup ptr xs) ==>
-             isSomeDataElement (heap_lookup ptr (xs ++ ys))``,
+val isSome_heap_looukp_IMP_APPEND = Q.prove(
+  `!xs ptr. isSomeDataElement (heap_lookup ptr xs) ==>
+             isSomeDataElement (heap_lookup ptr (xs ++ ys))`,
   full_simp_tac std_ss [isSomeDataElement_def] \\ rpt strip_tac
   \\ imp_res_tac heap_lookup_LESS \\ imp_res_tac LESS_IMP_heap_lookup
   \\ full_simp_tac (srw_ss()) []);
 
-val MEM_IMP_heap_lookup = store_thm("MEM_IMP_heap_lookup",
-  ``!xs x. MEM x xs ==> ?j. (heap_lookup j xs = SOME x)``,
+val MEM_IMP_heap_lookup = Q.store_thm("MEM_IMP_heap_lookup",
+  `!xs x. MEM x xs ==> ?j. (heap_lookup j xs = SOME x)`,
   Induct \\ full_simp_tac std_ss [MEM,heap_lookup_def,heap_addresses_def]
   \\ SRW_TAC [] [] \\ res_tac THEN1 metis_tac []
   \\ qexists_tac `j + el_length h` \\ full_simp_tac std_ss [] \\ SRW_TAC [] []
   \\ Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ `F` by decide_tac);
 
-val heap_lookup_IMP_heap_addresses = prove(
-  ``!xs n x j. (heap_lookup j xs = SOME x) ==> n + j IN heap_addresses n xs``,
+val heap_lookup_IMP_heap_addresses = Q.prove(
+  `!xs n x j. (heap_lookup j xs = SOME x) ==> n + j IN heap_addresses n xs`,
   Induct \\ full_simp_tac std_ss [MEM,heap_lookup_def,heap_addresses_def]
   \\ SRW_TAC [] [] \\ res_tac
   \\ pop_assum (mp_tac o Q.SPEC `n + el_length h`)

--- a/compiler/backend/gc/copying_gcScript.sml
+++ b/compiler/backend/gc/copying_gcScript.sml
@@ -240,9 +240,9 @@ val heap_lookup_SPLIT = Q.store_thm("heap_lookup_SPLIT",
   \\ res_tac \\ Q.LIST_EXISTS_TAC [`h::ha`,`hb`]
   \\ full_simp_tac (srw_ss()) [heap_length_def] \\ decide_tac);
 
-val gc_forward_ptr_thm = store_thm("gc_forward_ptr_thm",
-  ``!ha. gc_forward_ptr (heap_length ha) (ha ++ DataElement ys l d::hb) a u c =
-         (ha ++ ForwardPointer a u l::hb,c)``,
+val gc_forward_ptr_thm = Q.store_thm("gc_forward_ptr_thm",
+  `!ha. gc_forward_ptr (heap_length ha) (ha ++ DataElement ys l d::hb) a u c =
+         (ha ++ ForwardPointer a u l::hb,c)`,
   Induct \\ full_simp_tac (srw_ss()) [gc_forward_ptr_def,heap_length_def,APPEND,
     el_length_def,isDataElement_def,LET_DEF] \\ SRW_TAC [] []
   \\ Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ decide_tac);
@@ -363,8 +363,8 @@ val FDOM_heap_map = Q.prove(
   \\ TRY decide_tac \\ metis_tac [])
   |> Q.SPECL [`xs`,`0`] |> SIMP_RULE std_ss [];
 
-val gc_move_thm = prove(
-  ``gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 /\
+val gc_move_thm = Q.prove(
+  `gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 /\
     (!ptr u. (x = Pointer ptr u) ==> isSomeDataOrForward (heap_lookup ptr heap)) ==>
     ?x3 h23 a3 n3 heap3 c3.
       (gc_move (x:'a heap_address,h2,a,n,heap,c,limit) = (ADDR_APPLY (heap_map1 heap3) x,h23,a3,n3,heap3,c3)) /\
@@ -372,7 +372,7 @@ val gc_move_thm = prove(
       (!ptr. isSomeDataOrForward (heap_lookup ptr heap) =
              isSomeDataOrForward (heap_lookup ptr heap3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0``,
+      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0`,
   Cases_on `x` \\ simp_tac (srw_ss()) [gc_move_def,ADDR_APPLY_def]
   \\ simp_tac std_ss [Once isSomeDataOrForward_def] \\ rpt strip_tac
   \\ full_simp_tac (srw_ss()) [isSomeForwardPointer_def] THEN1
@@ -447,8 +447,8 @@ val gc_move_thm = prove(
   \\ match_mp_tac ADDR_MAP_EQ
   \\ full_simp_tac std_ss [FAPPLY_FUPDATE_THM] \\ metis_tac []);
 
-val gc_move_list_thm = prove(
-  ``!xs h2 a n heap c.
+val gc_move_list_thm = Q.prove(
+  `!xs h2 a n heap c.
     gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 /\
     (!ptr u. MEM (Pointer ptr u) (xs:'a heap_address list) ==> isSomeDataOrForward (heap_lookup ptr heap)) ==>
     ?h23 a3 n3 heap3 c3.
@@ -457,7 +457,7 @@ val gc_move_list_thm = prove(
       (!ptr. isSomeDataOrForward (heap_lookup ptr heap) =
              isSomeDataOrForward (heap_lookup ptr heap3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0``,
+      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0`,
   Induct THEN1 (full_simp_tac std_ss [gc_move_list_def,ADDR_MAP_def,MEM,SUBMAP_REFL])
   \\ full_simp_tac std_ss [MEM,gc_move_list_def,LET_DEF] \\ rpt strip_tac
   \\ Q.ABBREV_TAC `x = h` \\ pop_assum (K all_tac)
@@ -475,21 +475,21 @@ val gc_move_list_thm = prove(
 
 val APPEND_NIL_LEMMA = METIS_PROVE [APPEND_NIL] ``?xs1. xs = xs ++ xs1:'a list``
 
-val gc_move_ALT = store_thm("gc_move_ALT",
-  ``gc_move (ys,xs,a,n,heap,c,limit) =
+val gc_move_ALT = Q.store_thm("gc_move_ALT",
+  `gc_move (ys,xs,a,n,heap,c,limit) =
       let (ys,xs1,x) = gc_move (ys,[],a,n,heap,c,limit) in
-        (ys,xs++xs1,x)``,
+        (ys,xs++xs1,x)`,
   Cases_on `ys` \\ simp_tac (srw_ss()) [gc_move_def] \\ rpt strip_tac
   \\ Cases_on `heap_lookup n' heap` \\ simp_tac (srw_ss()) [LET_DEF]
   \\ Cases_on `x` \\ simp_tac (srw_ss()) [LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ full_simp_tac std_ss []);
 
-val gc_move_list_ALT = store_thm("gc_move_list_ALT",
-  ``!ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
+val gc_move_list_ALT = Q.store_thm("gc_move_list_ALT",
+  `!ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
       gc_move_list (ys,xs,a,n,heap,c,limit) =
         let (ys,xs1,x) = gc_move_list (ys,[],a,n,heap,c,limit) in
-          (ys,xs++xs1,x)``,
+          (ys,xs++xs1,x)`,
   Induct \\ simp_tac std_ss [gc_move_list_def,LET_DEF,APPEND_NIL]
   \\ simp_tac std_ss [Once gc_move_ALT,LET_DEF]
   \\ pop_assum (fn th => once_rewrite_tac [th])
@@ -497,10 +497,10 @@ val gc_move_list_ALT = store_thm("gc_move_list_ALT",
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ full_simp_tac std_ss [APPEND_ASSOC]);
 
-val gc_move_list_APPEND_lemma = prove(
-  ``!ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
+val gc_move_list_APPEND_lemma = Q.prove(
+  `!ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
       (gc_move_list (ys,xs,a,n,heap,c,limit) = (ys3,xs3,a3,n3,heap3,c3)) ==>
-      (?xs1. xs3 = xs ++ xs1)``,
+      (?xs1. xs3 = xs ++ xs1)`,
   once_rewrite_tac [gc_move_list_ALT] \\ full_simp_tac std_ss [LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ full_simp_tac std_ss [APPEND_ASSOC] \\ metis_tac []);
@@ -546,13 +546,13 @@ val heap_similar_Data_IMP_DataOrForward = Q.prove(
   THEN1 full_simp_tac std_ss [isSomeDataElement_def]
   \\ full_simp_tac std_ss [] \\ res_tac);
 
-val gc_move_loop_thm = prove(
-  ``!h1 h2 a n heap c.
+val gc_move_loop_thm = Q.prove(
+  `!h1 h2 a n heap c.
       gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 ==>
       ?h13 a3 n3 heap3 c3.
         (gc_move_loop (h1,h2,a,n,heap,c,limit) = (h13,a3,n3,heap3,c3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h13,[],a3,n3,heap3,c3,limit) heap0``,
+      gc_inv (h13,[],a3,n3,heap3,c3,limit) heap0`,
   completeInduct_on `limit - heap_length h1` \\ rpt strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `h2`
   \\ full_simp_tac std_ss [gc_move_loop_def,SUBMAP_REFL]
@@ -631,8 +631,8 @@ val heap_map_EMPTY = Q.prove(
   Induct \\ TRY (Cases_on `h`)
   \\ full_simp_tac (srw_ss()) [heap_map_def,isForwardPointer_def]);
 
-val gc_inv_init = prove(
-  ``gc_inv ([],[],0,limit,heap,T,limit) heap = heap_ok heap limit``,
+val gc_inv_init = Q.prove(
+  `gc_inv ([],[],0,limit,heap,T,limit) heap = heap_ok heap limit`,
   full_simp_tac std_ss [gc_inv_def] \\ Cases_on `heap_ok heap limit`
   \\ full_simp_tac (srw_ss()) [heap_addresses_def,heap_length_def]
   \\ full_simp_tac std_ss [heap_ok_def]
@@ -640,13 +640,13 @@ val gc_inv_init = prove(
   \\ full_simp_tac (srw_ss()) [heaps_similar_REFL,heap_map_EMPTY,FLOOKUP_DEF]
   \\ full_simp_tac (srw_ss()) [BIJ_DEF,INJ_DEF,SURJ_DEF]);
 
-val full_gc_thm = store_thm("full_gc_thm",
-  ``roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
+val full_gc_thm = Q.store_thm("full_gc_thm",
+  `roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
     ?heap2 a2 heap3.
       (full_gc (roots:'a heap_address list,heap,limit) =
          (ADDR_MAP (heap_map1 heap3) roots,heap2,a2,T)) /\
       (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM (heap_map 0 heap3)) /\
-      gc_inv (heap2,[],a2,limit - a2,heap3,T,limit) heap``,
+      gc_inv (heap2,[],a2,limit - a2,heap3,T,limit) heap`,
   simp_tac std_ss [Once (GSYM gc_inv_init)]
   \\ rpt strip_tac \\ full_simp_tac std_ss [full_gc_def]
   \\ mp_tac (Q.SPECL [`roots`,`[]`,`0`,`limit`,`heap`,`T`] gc_move_list_thm |> Q.INST [`h1`|->`[]`,`heap0`|->`heap`])
@@ -714,20 +714,20 @@ val heap_lookup_IMP_heap_addresses = Q.prove(
   \\ `n + el_length h + (j - el_length h) = n + j` by decide_tac
   \\ metis_tac []) |> Q.SPECL [`xs`,`0`] |> SIMP_RULE std_ss [] |> GEN_ALL;
 
-val full_gc_LENGTH = store_thm("full_gc_LENGTH",
-  ``roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
+val full_gc_LENGTH = Q.store_thm("full_gc_LENGTH",
+  `roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
     ?roots2 heap2 a2.
       (full_gc (roots:'a heap_address list,heap,limit) =
-      (roots2,heap2,heap_length heap2,T))``,
+      (roots2,heap2,heap_length heap2,T))`,
   rpt strip_tac \\ mp_tac full_gc_thm \\ full_simp_tac std_ss []
   \\ rpt strip_tac \\ full_simp_tac std_ss [gc_inv_def,APPEND_NIL]);
 
-val full_gc_ok = store_thm("full_gc_ok",
-  ``roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
+val full_gc_ok = Q.store_thm("full_gc_ok",
+  `roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
     ?roots2 heap2 a2.
       (full_gc (roots:'a heap_address list,heap,limit) = (roots2,heap2,a2,T)) /\
       a2 <= limit /\ roots_ok roots2 (heap2 ++ heap_expand (limit - a2)) /\
-      heap_ok (heap2 ++ heap_expand (limit - a2)) limit``,
+      heap_ok (heap2 ++ heap_expand (limit - a2)) limit`,
   rpt strip_tac \\ mp_tac full_gc_thm \\ full_simp_tac std_ss [] \\ strip_tac
   \\ full_simp_tac std_ss [] \\ full_simp_tac std_ss [gc_inv_def]
   \\ full_simp_tac std_ss [APPEND_NIL] \\ strip_tac THEN1 decide_tac
@@ -774,13 +774,13 @@ val gc_related_def = Define `
       (heap_lookup (f ' i) heap2 = SOME (DataElement (ADDR_MAP (FAPPLY f) xs) l d)) /\
       !ptr u. MEM (Pointer ptr u) xs ==> ptr IN FDOM f`;
 
-val full_gc_related = store_thm("full_gc_related",
-  ``roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
+val full_gc_related = Q.store_thm("full_gc_related",
+  `roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>
     ?heap2 a2 f.
       (full_gc (roots:'a heap_address list,heap,limit) =
          (ADDR_MAP (FAPPLY f) roots,heap2,a2,T)) /\
       (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM f) /\
-      gc_related f heap (heap2 ++ heap_expand (limit - a2))``,
+      gc_related f heap (heap2 ++ heap_expand (limit - a2))`,
   strip_tac \\ mp_tac full_gc_thm \\ asm_simp_tac std_ss []
   \\ rpt strip_tac \\ full_simp_tac std_ss []
   \\ qexists_tac `heap_map 0 heap3`
@@ -805,8 +805,8 @@ val full_gc_related = store_thm("full_gc_related",
 
 (* Lemmas about ok and a *)
 
-val gc_forward_ptr_ok = store_thm("gc_forward_ptr_ok",
-  ``!heap n a c x. (gc_forward_ptr n heap a d c = (x,T)) ==> c``,
+val gc_forward_ptr_ok = Q.store_thm("gc_forward_ptr_ok",
+  `!heap n a c x. (gc_forward_ptr n heap a d c = (x,T)) ==> c`,
   Induct \\ simp_tac std_ss [Once gc_forward_ptr_def] \\ rpt strip_tac
   \\ Cases_on `n = 0` \\ full_simp_tac std_ss []
   \\ Cases_on `n < el_length h` \\ full_simp_tac std_ss []
@@ -814,10 +814,10 @@ val gc_forward_ptr_ok = store_thm("gc_forward_ptr_ok",
   \\ full_simp_tac std_ss [LET_DEF] \\ Cases_on `r`
   \\ full_simp_tac std_ss [] \\ res_tac);
 
-val gc_move_ok = store_thm("gc_move_ok",
-  ``(gc_move (x,h2,a,n,heap,c,limit) = (x',h2',a',n',heap',T)) ==>
+val gc_move_ok = Q.store_thm("gc_move_ok",
+  `(gc_move (x,h2,a,n,heap,c,limit) = (x',h2',a',n',heap',T)) ==>
     c /\
-    ((a = b + heap_length h2) ==> (a' = b + heap_length h2'))``,
+    ((a = b + heap_length h2) ==> (a' = b + heap_length h2'))`,
   simp_tac std_ss [Once EQ_SYM_EQ] \\ Cases_on `x`
   \\ full_simp_tac std_ss [gc_move_def]
   \\ Cases_on `heap_lookup n'' heap` \\ full_simp_tac (srw_ss()) []
@@ -830,11 +830,11 @@ val gc_move_ok = store_thm("gc_move_ok",
   \\ full_simp_tac (srw_ss()) [heap_length_APPEND,heap_length_def,
        el_length_def,ADD_ASSOC]);
 
-val gc_move_list_ok = store_thm("gc_move_list_ok",
-  ``!xs h2 a n heap c limit xs' h2' a' n' heap' c'.
+val gc_move_list_ok = Q.store_thm("gc_move_list_ok",
+  `!xs h2 a n heap c limit xs' h2' a' n' heap' c'.
       (gc_move_list (xs,h2,a,n,heap,c,limit) = (xs',h2',a',n',heap',T)) ==>
       c /\
-      ((a = b + heap_length h2) ==> (a' = b + heap_length h2'))``,
+      ((a = b + heap_length h2) ==> (a' = b + heap_length h2'))`,
   Induct \\ simp_tac std_ss [gc_move_list_def] \\ rpt strip_tac
   THENL [all_tac, pop_assum mp_tac]
   \\ pop_assum mp_tac
@@ -877,18 +877,18 @@ val th = MP th lemma |> SIMP_RULE std_ss []
 
 val gc_move_loop_ok = save_thm("gc_move_loop_ok",th);
 
-val gc_move_list_IMP_LENGTH = store_thm("gc_move_list_IMP_LENGTH",
-  ``!l5 h a n heap c k xs ys a1 xs1 heap1 c1.
+val gc_move_list_IMP_LENGTH = Q.store_thm("gc_move_list_IMP_LENGTH",
+  `!l5 h a n heap c k xs ys a1 xs1 heap1 c1.
       (gc_move_list (l5,h,a,n,heap,c,k) =
-        (xs,ys,a1,xs1,heap1,c1)) ==> (LENGTH xs = LENGTH l5)``,
+        (xs,ys,a1,xs1,heap1,c1)) ==> (LENGTH xs = LENGTH l5)`,
   Induct \\ fs [gc_move_list_def,LET_THM] \\ rw []
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[] \\ rw []
   \\ res_tac \\ fs []);
 
-val full_gc_IMP_LENGTH = store_thm("full_gc_IMP_LENGTH",
-  ``(full_gc (xs,heap,limit) = (roots2,heap2,h,T)) ==>
-    (LENGTH roots2 = LENGTH xs)``,
+val full_gc_IMP_LENGTH = Q.store_thm("full_gc_IMP_LENGTH",
+  `(full_gc (xs,heap,limit) = (roots2,heap2,h,T)) ==>
+    (LENGTH roots2 = LENGTH xs)`,
   fs [full_gc_def,LET_THM]
   \\ rpt (pairarg_tac \\ fs []) \\ rw []
   \\ imp_res_tac gc_move_list_IMP_LENGTH \\ fs []);

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -1346,7 +1346,7 @@ val compile_correct = Q.store_thm("compile_correct",
     rw[] >> EVAL_TAC >>
     srw_tac[QUANT_INST_ss[std_qp]][]) >>
   disch_then drule >> strip_tac >>
-  rator_x_assum`from_mod`mp_tac >>
+  qhdtm_x_assum`from_mod`mp_tac >>
   srw_tac[][from_mod_def,Abbr`c''`,mod_to_conTheory.compile_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   qmatch_assum_abbrev_tac`semantics_prog s env prog sem2` >>
@@ -1369,7 +1369,7 @@ val compile_correct = Q.store_thm("compile_correct",
   impl_tac >- (
     rw[Abbr`s`,prim_config_eq] >>
     fs[prim_config_eq] >>
-    rator_x_assum`next_inv`mp_tac >>
+    qhdtm_x_assum`next_inv`mp_tac >>
     rpt(pop_assum kall_tac) >>
     REWRITE_TAC[FRANGE_FUPDATE,DRESTRICT_FUPDATE,DOMSUB_FUPDATE_THM] >>
     EVAL_TAC >> rw[SUBSET_DEF] >> fs[PULL_EXISTS] >>
@@ -1380,14 +1380,14 @@ val compile_correct = Q.store_thm("compile_correct",
   strip_tac >>
   pop_assum(assume_tac o SYM) >> simp[] >>
   qunabbrev_tac`c'''`>>
-  rator_x_assum`from_con`mp_tac >>
+  qhdtm_x_assum`from_con`mp_tac >>
   srw_tac[][from_con_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   rfs[] >> fs[] >>
   drule(GEN_ALL(MATCH_MP SWAP_IMP (REWRITE_RULE[GSYM AND_IMP_INTRO]con_to_decProofTheory.compile_semantics))) >>
   simp[] >>
   impl_tac >- (
-    rator_x_assum`mod_to_con$compile_prog`mp_tac >>
+    qhdtm_x_assum`mod_to_con$compile_prog`mp_tac >>
     simp[prim_config_eq] >> EVAL_TAC >>
     `semantics env2 s2 p ≠ Fail` by simp[] >>
     pop_assum mp_tac >>
@@ -1406,9 +1406,9 @@ val compile_correct = Q.store_thm("compile_correct",
     qexists_tac`st`>>simp[Abbr`st`,mod_to_conTheory.get_exh_def] >>
     simp[FLOOKUP_UPDATE]) >>
   disch_then(strip_assume_tac o SYM) >> fs[] >>
-  rator_x_assum`from_dec`mp_tac >> srw_tac[][from_dec_def] >>
+  qhdtm_x_assum`from_dec`mp_tac >> srw_tac[][from_dec_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
-  rator_x_assum`con_to_dec$compile`mp_tac >>
+  qhdtm_x_assum`con_to_dec$compile`mp_tac >>
   `c'.next_global = 0` by (
     fs[source_to_modTheory.compile_def,LET_THM] >>
     pairarg_tac >> fs[] >>
@@ -1427,7 +1427,7 @@ val compile_correct = Q.store_thm("compile_correct",
   CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss()++QUANT_INST_ss[record_default_qp,pair_default_qp])[])) >>
   simp[Abbr`es3`,dec_to_exhTheory.compile_exp_def] >>
   disch_then(strip_assume_tac o SYM) >> fs[] >>
-  rator_x_assum`from_exh`mp_tac >>
+  qhdtm_x_assum`from_exh`mp_tac >>
   srw_tac[][from_exh_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   fs[exh_to_patTheory.compile_def] >>
@@ -1438,7 +1438,7 @@ val compile_correct = Q.store_thm("compile_correct",
   simp[Abbr`es3`,Abbr`env3`] >>
   fs[exh_to_patProofTheory.compile_state_def,Abbr`st3`] >>
   disch_then(strip_assume_tac o SYM) >> fs[] >>
-  rator_x_assum`from_pat`mp_tac >>
+  qhdtm_x_assum`from_pat`mp_tac >>
   srw_tac[][from_pat_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   qmatch_abbrev_tac`_ ⊆ _ { patSem$semantics env3 st3 es3 }` >>
@@ -1449,7 +1449,7 @@ val compile_correct = Q.store_thm("compile_correct",
   first_assum(fn th => disch_then(mp_tac o C MATCH_MP th)) >>
   fs[pat_to_closProofTheory.compile_state_def,Abbr`st3`] >>
   disch_then(strip_assume_tac o SYM) >> fs[] >>
-  rator_x_assum`from_clos`mp_tac >>
+  qhdtm_x_assum`from_clos`mp_tac >>
   srw_tac[][from_clos_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   qmatch_abbrev_tac`_ ⊆ _ { closSem$semantics [] st3 [e3] }` >>
@@ -1472,7 +1472,7 @@ val compile_correct = Q.store_thm("compile_correct",
   simp[Abbr`e3`] >>
   fs[Abbr`st3`] >>
   disch_then(strip_assume_tac o SYM) >> fs[] >>
-  rator_x_assum`from_bvl`mp_tac >>
+  qhdtm_x_assum`from_bvl`mp_tac >>
   srw_tac[][from_bvl_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   Q.ISPEC_THEN`s2.ffi`drule(Q.GEN`ffi0` bvl_to_bviProofTheory.compile_semantics) >>
@@ -1486,7 +1486,7 @@ val compile_correct = Q.store_thm("compile_correct",
     EVAL_TAC >>
     simp[EVEN_ADD,EVEN_EXP_IFF])>>
   disch_then(SUBST_ALL_TAC o SYM) >>
-  rator_x_assum`from_bvi`mp_tac >>
+  qhdtm_x_assum`from_bvi`mp_tac >>
   srw_tac[][from_bvi_def] >>
   pop_assum mp_tac >> BasicProvers.LET_ELIM_TAC >>
   qmatch_abbrev_tac`_ ⊆ _ { bviSem$semantics ffi (fromAList p3) s3 }` >>

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -62,11 +62,11 @@ val from_word = let
     |> INST_TYPE [``:'b``|->``:'a``]
   in simple_match_mp (MATCH_MP implements_trans lemma1) from_stack end
 
-val full_make_init_ffi = prove(
-  ``(full_make_init
+val full_make_init_ffi = Q.prove(
+  `(full_make_init
          (bitmaps,c1,code,f,k,max_heap,regs,
           make_init mc_conf ffi save_regs io_regs t m dm ms code2,
-          save_regs)).ffi = ffi``,
+          save_regs)).ffi = ffi`,
   fs [full_make_init_def,stack_allocProofTheory.make_init_def,
       stack_removeProofTheory.make_init_any_ffi] \\ EVAL_TAC);
 
@@ -145,27 +145,27 @@ val machine_sem_implements_data_sem = save_thm("machine_sem_implements_data_sem"
 
 val data_to_word_precond_def = fetch "-" "data_to_word_precond_def" |> SPEC_ALL
 
-val full_make_init_gc_fun = prove(
-  ``(full_make_init
+val full_make_init_gc_fun = Q.prove(
+  `(full_make_init
          (bitmaps,c1,code,f,k,max_heap,regs, xx,
-          save_regs)).gc_fun = word_gc_fun c1``,
+          save_regs)).gc_fun = word_gc_fun c1`,
   fs [full_make_init_def,stack_allocProofTheory.make_init_def]);
 
-val full_make_init_bitmaps = prove(
-  ``full_init_pre
+val full_make_init_bitmaps = Q.prove(
+  `full_init_pre
          (bitmaps,c1,SND (compile asm_conf code3),f,k,max_heap,regs,
           make_init mc_conf ffi save_regs io_regs t m dm ms code2,
           save_regs) ==>
     (full_make_init
          (bitmaps,c1,SND (compile asm_conf code3),f,k,max_heap,regs,
           make_init mc_conf ffi save_regs io_regs t m dm ms code2,
-          save_regs)).bitmaps = bitmaps``,
+          save_regs)).bitmaps = bitmaps`,
   fs [full_make_init_def,stack_allocProofTheory.make_init_def,
       stack_removeProofTheory.make_init_any_bitmaps]
   \\ every_case_tac \\ fs [] \\ fs [full_init_pre_def]);
 
-val full_init_pre_IMP_init_store_ok = prove(
-  ``max_heap = 2 * max_heap_limit (:'a) c1 -1 ==>
+val full_init_pre_IMP_init_store_ok = Q.prove(
+  `max_heap = 2 * max_heap_limit (:'a) c1 -1 ==>
     init_store_ok c1
       ((full_make_init
           (bitmaps,c1,code3,f,k,max_heap,regs,(s:('a,'ffi)labSem$state),
@@ -173,7 +173,7 @@ val full_init_pre_IMP_init_store_ok = prove(
        (full_make_init
           (bitmaps,c1,code3,f,k,max_heap,regs,s,save_regs)).memory
        (full_make_init
-          (bitmaps,c1,code3,f,k,max_heap,regs,s,save_regs)).mdomain``,
+          (bitmaps,c1,code3,f,k,max_heap,regs,s,save_regs)).mdomain`,
   fs [full_make_init_def,stack_allocProofTheory.make_init_def,
       stack_removeProofTheory.make_init_any_def]
   \\ CASE_TAC \\ fs [] THEN1
@@ -191,14 +191,14 @@ val full_init_pre_IMP_init_store_ok = prove(
   \\ qexists_tac`len`
   \\ fs [FLOOKUP_DEF,DOMSUB_FAPPLY_THM,FAPPLY_FUPDATE_THM]);
 
-val full_init_pre_IMP_init_state_ok = prove(
-  ``2 < asm_conf.reg_count − (LENGTH asm_conf.avoid_regs + 5) /\
+val full_init_pre_IMP_init_state_ok = Q.prove(
+  `2 < asm_conf.reg_count − (LENGTH asm_conf.avoid_regs + 5) /\
     (case bitmaps of [] => F | h::_ => 4w = h) /\
     good_dimindex (:α) ==>
     init_state_ok
       (asm_conf.reg_count − (LENGTH (asm_conf:'a asm_config).avoid_regs + 5))
       (full_make_init
-        (bitmaps:'a word list,c1,code3,f,k,max_heap,regs,s,save_regs))``,
+        (bitmaps:'a word list,c1,code3,f,k,max_heap,regs,s,save_regs))`,
   fs [full_make_init_def,stack_allocProofTheory.make_init_def,
       stack_removeProofTheory.make_init_any_def] \\ strip_tac
   \\ CASE_TAC \\ fs [] THEN1
@@ -375,8 +375,8 @@ val word_to_stack_sl_gs = Q.prove(`
     match_mp_tac stack_move_sl_gs>>fs convs))
   >- (rpt(pairarg_tac>>fs[sl_gs_def])>>rveq>>fs[sl_gs_def]));
 
-val data_to_word_compile_imp = prove(
-  ``(LENGTH mc_conf.target.config.avoid_regs + 5) < mc_conf.target.config.reg_count ∧
+val data_to_word_compile_imp = Q.prove(
+  `(LENGTH mc_conf.target.config.avoid_regs + 5) < mc_conf.target.config.reg_count ∧
     EVERY (λn. data_num_stubs ≤ n) (MAP FST prog) ∧
     compile (c:'a backend$config).word_to_word_conf mc_conf.target.config
         (stubs(:'a) c.data_conf ++ MAP (compile_part c.data_conf) prog) = (col,p) ==>
@@ -396,7 +396,7 @@ val data_to_word_compile_imp = prove(
      EVERY (\p. stack_to_labProof$good_syntax p 1 2 0) (MAP SND prog1) /\
      EVERY stack_allocProof$good_syntax (MAP SND prog1) /\
      EVERY (\p. stack_removeProof$good_syntax p (mc_conf.target.config.reg_count - (LENGTH mc_conf.target.config.avoid_regs +3)))
-       (MAP SND prog1))``,
+       (MAP SND prog1))`,
   fs[code_rel_def,code_rel_ext_def]>>strip_tac>>
   CONJ_TAC>-
     (fs[lookup_fromAList]
@@ -537,9 +537,9 @@ val stack_alloc_syntax = Q.prove(
     BasicProvers.EVERY_CASE_TAC)>>
   rpt(pairarg_tac>>fs convs));
 
-val word_to_stack_compile_imp = prove(
-  ``word_to_stack$compile c p = (c2,prog1) ==>
-    (case c2.bitmaps of [] => F | h::v1 => 4w = h)``,
+val word_to_stack_compile_imp = Q.prove(
+  `word_to_stack$compile c p = (c2,prog1) ==>
+    (case c2.bitmaps of [] => F | h::v1 => 4w = h)`,
   fs [word_to_stackTheory.compile_def] \\ pairarg_tac \\ fs [] \\ rw [] \\ fs []
   \\ imp_res_tac compile_word_to_stack_isPREFIX
   \\ Cases_on `bitmaps` \\ fs []);
@@ -552,16 +552,16 @@ val make_init_opt_imp_bitmaps_limit = Q.prove(
   \\ fs [stack_removeProofTheory.init_prop_def,
          stack_removeProofTheory.init_reduce_def]);
 
-val data_to_word_names = prove(
-  ``word_to_word$compile c1 c2 (stubs(:α)c.data_conf ++ MAP (compile_part c3) prog) = (col,p) ==>
-    MAP FST p = (MAP FST (stubs(:α)c.data_conf))++MAP FST prog``,
+val data_to_word_names = Q.prove(
+  `word_to_word$compile c1 c2 (stubs(:α)c.data_conf ++ MAP (compile_part c3) prog) = (col,p) ==>
+    MAP FST p = (MAP FST (stubs(:α)c.data_conf))++MAP FST prog`,
   rw[]>>assume_tac(GEN_ALL word_to_wordProofTheory.compile_to_word_conventions)>>
   pop_assum (qspecl_then [`c1`,`stubs(:α)c.data_conf++(MAP (compile_part c3) prog)`,`c2`] assume_tac)>>rfs[]>>
   fs[MAP_MAP_o,MAP_EQ_f,FORALL_PROD,data_to_wordTheory.compile_part_def]);
 
-val word_to_stack_names = prove(
-  ``word_to_stack$compile c1 p = (c2,prog1) ==>
-    MAP FST prog1 = raise_stub_location::MAP FST p``,
+val word_to_stack_names = Q.prove(
+  `word_to_stack$compile c1 p = (c2,prog1) ==>
+    MAP FST prog1 = raise_stub_location::MAP FST p`,
   fs [word_to_stackTheory.compile_def] \\ pairarg_tac \\ fs []
   \\ rw [] \\ fs []>>
   pop_assum mp_tac>>
@@ -669,11 +669,11 @@ val code_installed_prog_to_section_lemma = Q.prove(
   \\ res_tac \\ fs [stack_to_labTheory.prog_to_section_def] \\ pairarg_tac
   \\ fs [loc_to_pc_skip_section,code_installed_cons]);
 
-val labs_correct_hd = prove(``
+val labs_correct_hd = Q.prove(`
   ∀extra l.
   ALL_DISTINCT (extract_labels (extra++l)) ∧
   EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) (extract_labels (extra++l)) ⇒
-  labs_correct (LENGTH (FILTER (\x. ~(is_Label x)) extra)) l (Section n (extra++l) ::code)``,
+  labs_correct (LENGTH (FILTER (\x. ~(is_Label x)) extra)) l (Section n (extra++l) ::code)`,
   Induct_on`l`>>fs[labs_correct_def]>>rw[]
   >-
     (first_x_assum(qspec_then `extra++[h]` mp_tac)>>
@@ -838,8 +838,8 @@ val stack_names_syntax_pres = Q.prove(
   fs convs>>
   BasicProvers.EVERY_CASE_TAC>>fs[]);
 
-val MEM_pair_IMP = prove(
-  ``!xs. MEM (x,y) xs ==> MEM x (MAP FST xs) /\ MEM y (MAP SND xs)``,
+val MEM_pair_IMP = Q.prove(
+  `!xs. MEM (x,y) xs ==> MEM x (MAP FST xs) /\ MEM y (MAP SND xs)`,
   Induct \\ fs [FORALL_PROD] \\ metis_tac []);
 
 val IS_SOME_EQ_CASE = Q.prove(
@@ -863,10 +863,10 @@ val BIJ_FLOOKUP_MAPKEYS = Q.prove(
   \\ `INJ (LINV bij UNIV) (FDOM f) UNIV` by fs [INJ_DEF,IN_UNIV,BIJ_DEF]
   \\ fs [MAP_KEYS_def] \\ metis_tac [BIJ_LINV_INV,BIJ_DEF,IN_UNIV,LINV_DEF]);
 
-val word_list_exists_imp = prove(
-  ``dm = addresses a n /\
+val word_list_exists_imp = Q.prove(
+  `dm = addresses a n /\
     dimindex (:'a) DIV 8 * n < dimword (:'a) ∧ good_dimindex (:'a) ⇒
-    word_list_exists a n (fun2set (m1,dm:'a word set))``,
+    word_list_exists a n (fun2set (m1,dm:'a word set))`,
   metis_tac [stack_removeProofTheory.word_list_exists_addresses]);
 
 val addresses_thm = Q.store_thm("addresses_thm",
@@ -936,8 +936,8 @@ val LESS_MULT_LEMMA = Q.prove(
   \\ fs []);
 
 local
-val lemma = prove(
-  ``(from_data c prog = SOME (bytes,ffi_limit) /\
+val lemma = Q.prove(
+  `(from_data c prog = SOME (bytes,ffi_limit) /\
      EVERY (\n. data_num_stubs ≤ n) (MAP FST prog) /\ ALL_DISTINCT (MAP FST prog) /\
      byte_aligned (t.regs (find_name c.stack_conf.reg_names 2)) /\
      byte_aligned (t.regs (find_name c.stack_conf.reg_names 4)) /\
@@ -970,7 +970,7 @@ val lemma = prove(
     10 ≤ ra_regs +2 /\
     (LENGTH mc_conf.target.config.avoid_regs + 5) <
       (mc_conf:('a,'b,'c) machine_config).target.config.reg_count) ==>
-    data_to_word_precond (bytes,c,ffi:'ffi ffi_state,ffi_limit,mc_conf,ms,prog)``,
+    data_to_word_precond (bytes,c,ffi:'ffi ffi_state,ffi_limit,mc_conf,ms,prog)`,
   strip_tac \\ fs [data_to_word_precond_def,lab_to_targetProofTheory.good_syntax_def]
   \\ `ffi.final_event = NONE /\ byte_aligned (t.regs mc_conf.ptr_reg)` by
         fs [good_init_state_def] \\ fs [EXISTS_PROD]
@@ -1246,11 +1246,11 @@ val from_data_ignore = Q.prove(
   fs [from_data_def,from_word_def,from_stack_def,from_lab_def]
   \\ rpt (pairarg_tac \\ fs []));
 
-val clos_to_data_names = store_thm("clos_to_data_names",
-  ``clos_to_bvl$compile c e4 = (c2,p2) /\
+val clos_to_data_names = Q.store_thm("clos_to_data_names",
+  `clos_to_bvl$compile c e4 = (c2,p2) /\
     bvl_to_bvi$compile n1 n limit p2 = (k,p3,n2) ==>
     EVERY (λn. data_num_stubs ≤ n) (MAP FST (bvi_to_data$compile_prog p3)) /\
-    ALL_DISTINCT (MAP FST (bvi_to_data$compile_prog p3))``,
+    ALL_DISTINCT (MAP FST (bvi_to_data$compile_prog p3))`,
   fs[Once (GSYM bvi_to_dataProofTheory.MAP_FST_compile_prog)]>>
   fs[bvl_to_bviTheory.compile_def,bvl_to_bviTheory.compile_prog_def]>>
   strip_tac>>

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -233,15 +233,15 @@ val code_and_locs = [
   wordLangTheory.raise_stub_location_def
   ]
 
-val stack_move_sa_gs = prove(``
+val stack_move_sa_gs = Q.prove(`
   ∀n st off i p.
   good_syntax p ⇒
-  good_syntax (stack_move n st off i p)``,
+  good_syntax (stack_move n st off i p)`,
   Induct>>rw[stack_move_def,sa_gs_def])
 
-val word_to_stack_sa_gs = prove(``
+val word_to_stack_sa_gs = Q.prove(`
   ∀p n args.
-  good_syntax (FST(word_to_stack$comp p n args))``,
+  good_syntax (FST(word_to_stack$comp p n args))`,
   recInduct comp_ind >>fs[comp_def,sa_gs_def,FORALL_PROD,wRegWrite1_def,wLive_def]>>rw[]>>fs convs
   >-
     (fs[wMove_def]>>qpat_abbrev_tac`ls = MAP f A`>>
@@ -278,18 +278,18 @@ val word_to_stack_sa_gs = prove(``
   >>
     rpt(pairarg_tac>>fs[sa_gs_def])>>rveq>>fs[sa_gs_def]);
 
-val stack_move_sr_gs = prove(``
+val stack_move_sr_gs = Q.prove(`
   ∀n st off i p k.
   i < k ∧
   good_syntax p k ⇒
-  good_syntax (stack_move n st off i p) k``,
+  good_syntax (stack_move n st off i p) k`,
   Induct>>rw[stack_move_def,sr_gs_def])
 
-val word_to_stack_sr_gs = prove(``
+val word_to_stack_sr_gs = Q.prove(`
   ∀p n args.
   post_alloc_conventions (FST args) p ∧
   1 ≤ FST args ⇒
-  good_syntax (FST(word_to_stack$comp p n args)) (FST args+2)``,
+  good_syntax (FST(word_to_stack$comp p n args)) (FST args+2)`,
   recInduct comp_ind >>fs[comp_def,sa_gs_def,FORALL_PROD,wRegWrite1_def,wLive_def]>>rw[]>> fs convs
   >-
     (fs[wMove_def]>>
@@ -329,16 +329,16 @@ val word_to_stack_sr_gs = prove(``
     match_mp_tac stack_move_sr_gs>>fs convs))
   >- (rpt(pairarg_tac>>fs[sr_gs_def])>>rveq>>fs[sr_gs_def]))
 
-val stack_move_sl_gs = prove(``
+val stack_move_sl_gs = Q.prove(`
   ∀n st off i p.
   good_syntax p 1 2 0 ⇒
-  good_syntax (stack_move n st off i p) 1 2 0``,
+  good_syntax (stack_move n st off i p) 1 2 0`,
   Induct>>rw[stack_move_def,sl_gs_def])
 
-val word_to_stack_sl_gs = prove(``
+val word_to_stack_sl_gs = Q.prove(`
   ∀p n args.
   post_alloc_conventions (FST args) p ⇒
-  good_syntax (FST(word_to_stack$comp p n args)) 1 2 0``,
+  good_syntax (FST(word_to_stack$comp p n args)) 1 2 0`,
   ho_match_mp_tac comp_ind >>fs[comp_def,sl_gs_def,FORALL_PROD,wRegWrite1_def,wLive_def]>>rw[]>>fs convs
   >-
     (fs[wMove_def]>>
@@ -510,14 +510,14 @@ val data_to_word_compile_imp = prove(
     fs convs>>
     unabbrev_all_tac>>fs[]);
 
-val stack_alloc_syntax = prove(
-  ``10 ≤ sp ∧ (* I think 10 has to do with the number of vars used by the gc implementation *)
+val stack_alloc_syntax = Q.prove(
+  `10 ≤ sp ∧ (* I think 10 has to do with the number of vars used by the gc implementation *)
     EVERY (λp. good_syntax p 1 2 0) (MAP SND prog1) /\
     EVERY (\p. stack_removeProof$good_syntax p sp)
        (MAP SND prog1) ==>
     EVERY (λp. good_syntax p 1 2 0) (MAP SND (compile c.data_conf prog1)) /\
     EVERY (\p. stack_removeProof$good_syntax p sp)
-       (MAP SND (compile c.data_conf prog1))``,
+       (MAP SND (compile c.data_conf prog1))`,
   fs[stack_allocTheory.compile_def]>>
   EVAL_TAC>>fs[]>>
   qid_spec_tac`prog1`>>Induct>>
@@ -544,9 +544,9 @@ val word_to_stack_compile_imp = prove(
   \\ imp_res_tac compile_word_to_stack_isPREFIX
   \\ Cases_on `bitmaps` \\ fs []);
 
-val make_init_opt_imp_bitmaps_limit = prove(
-  ``make_init_opt max_heap bitmaps k code s = SOME x ==>
-    LENGTH (bitmaps:'a word list) < dimword (:'a) − 1``,
+val make_init_opt_imp_bitmaps_limit = Q.prove(
+  `make_init_opt max_heap bitmaps k code s = SOME x ==>
+    LENGTH (bitmaps:'a word list) < dimword (:'a) − 1`,
   fs [stack_removeProofTheory.make_init_opt_def]
   \\ every_case_tac \\ fs [] \\ rw []
   \\ fs [stack_removeProofTheory.init_prop_def,
@@ -572,9 +572,9 @@ val word_to_stack_names = prove(
   rveq>>fs[]>>
   metis_tac[]);
 
-val stack_alloc_names = prove(
-  ``stack_alloc$compile c1 p = prog1 ==>
-    MAP FST prog1 = gc_stub_location::MAP FST p``,
+val stack_alloc_names = Q.prove(
+  `stack_alloc$compile c1 p = prog1 ==>
+    MAP FST prog1 = gc_stub_location::MAP FST p`,
   fs [stack_allocTheory.compile_def,stack_allocTheory.stubs_def] \\ rw []
   \\ fs [MAP_MAP_o,MAP_EQ_f,FORALL_PROD,stack_allocTheory.prog_comp_def]);
 
@@ -584,45 +584,45 @@ val code_installed'_def = Define `
      if is_Label x then code_installed' n xs code
      else asm_fetch_aux n code = SOME x ∧ code_installed' (n + 1) xs code)`
 
-val code_installed'_cons_label = prove(
-  ``!lines pos.
+val code_installed'_cons_label = Q.prove(
+  `!lines pos.
       is_Label h ==>
       code_installed' pos lines (Section n (h::xs)::other) =
-      code_installed' pos lines (Section n xs::other)``,
+      code_installed' pos lines (Section n xs::other)`,
   Induct \\ fs [code_installed'_def]
   \\ rw [] \\ fs [labSemTheory.asm_fetch_aux_def]);
 
-val code_installed'_cons_non_label = prove(
-  ``!lines pos.
+val code_installed'_cons_non_label = Q.prove(
+  `!lines pos.
       ~is_Label h ==>
       code_installed' (pos+1) lines (Section n (h::xs)::other) =
-      code_installed' pos lines (Section n xs::other)``,
+      code_installed' pos lines (Section n xs::other)`,
   Induct \\ fs [code_installed'_def]
   \\ rw [] \\ fs [labSemTheory.asm_fetch_aux_def])
   |> Q.SPECL [`lines`,`0`] |> SIMP_RULE std_ss [];
 
-val code_installed'_simp = store_thm("code_installed'_simp",
-  ``!lines. code_installed' 0 lines (Section n (lines ++ rest)::other)``,
+val code_installed'_simp = Q.store_thm("code_installed'_simp",
+  `!lines. code_installed' 0 lines (Section n (lines ++ rest)::other)`,
   Induct \\ fs [code_installed'_def]
   \\ fs [labSemTheory.asm_fetch_aux_def]
   \\ rpt strip_tac \\ IF_CASES_TAC
   \\ fs [code_installed'_cons_label,code_installed'_cons_non_label]);
 
-val loc_to_pc_skip_section = prove(
-  ``!lines.
+val loc_to_pc_skip_section = Q.prove(
+  `!lines.
       n <> p ==>
       loc_to_pc n 0 (Section p lines :: xs) =
       case loc_to_pc n 0 xs of
       | NONE => NONE
-      | SOME k => SOME (k + LENGTH (FILTER (\x. ~(is_Label x)) lines))``,
+      | SOME k => SOME (k + LENGTH (FILTER (\x. ~(is_Label x)) lines))`,
   Induct \\ once_rewrite_tac [labSemTheory.loc_to_pc_def] \\ fs []
   THEN1 (every_case_tac \\ fs [])
   \\ strip_tac \\ IF_CASES_TAC \\ fs [] \\ CASE_TAC \\ fs []);
 
-val asm_fetch_aux_add = prove(
-  ``!ys pc rest.
+val asm_fetch_aux_add = Q.prove(
+  `!ys pc rest.
       asm_fetch_aux (pc + LENGTH (FILTER (λx. ¬is_Label x) ys))
-        (Section pos ys::rest) = asm_fetch_aux pc rest``,
+        (Section pos ys::rest) = asm_fetch_aux pc rest`,
   Induct \\ fs [labSemTheory.asm_fetch_aux_def,ADD1]);
 
 val labs_correct_def = Define `
@@ -634,10 +634,10 @@ val labs_correct_def = Define `
         | _ => T)
      else labs_correct (n + 1) xs code)`
 
-val code_installed_eq = prove(
-  ``!pc xs code.
+val code_installed_eq = Q.prove(
+  `!pc xs code.
       code_installed pc xs code <=>
-      code_installed' pc xs code /\ labs_correct pc xs code``,
+      code_installed' pc xs code /\ labs_correct pc xs code`,
   Induct_on `xs`
   \\ fs [code_installed_def,code_installed'_def,labs_correct_def]
   \\ ntac 3 strip_tac \\ fs []
@@ -645,22 +645,22 @@ val code_installed_eq = prove(
   \\ Cases_on `h` \\ fs [lab_to_targetTheory.is_Label_def]
   \\ rw [] \\ eq_tac \\ fs []);
 
-val code_installed_cons = prove(
-  ``!xs ys pos pc.
+val code_installed_cons = Q.prove(
+  `!xs ys pos pc.
       code_installed' pc xs rest ==>
       code_installed' (pc + LENGTH (FILTER (λx. ¬is_Label x) ys)) xs
-        (Section pos ys :: rest)``,
+        (Section pos ys :: rest)`,
   Induct \\ fs [] \\ fs [code_installed'_def]
   \\ ntac 4 strip_tac \\ IF_CASES_TAC \\ fs []
   \\ rw [] \\ res_tac \\ fs [asm_fetch_aux_add]);
 
-val code_installed_prog_to_section_lemma = prove(
-  ``!prog4 n prog3.
+val code_installed_prog_to_section_lemma = Q.prove(
+  `!prog4 n prog3.
       ALOOKUP prog4 n = SOME prog3 ==>
       ?pc.
         code_installed' pc (append (FST (flatten prog3 n (next_lab prog3))))
           (MAP prog_to_section prog4) /\
-        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc``,
+        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc`,
   Induct_on `prog4` \\ fs [] \\ Cases \\ fs [ALOOKUP_def] \\ rw []
   THEN1
    (fs [stack_to_labTheory.prog_to_section_def] \\ pairarg_tac \\ fs []
@@ -698,13 +698,13 @@ val labs_correct_hd = prove(``
     Cases_on`h`>>fs[extract_labels_def,FILTER_APPEND]>>
     metis_tac[APPEND_ASSOC,APPEND])
 
-val labels_ok_labs_correct = prove(``
+val labels_ok_labs_correct = Q.prove(`
   ∀code.
   labels_ok code ⇒
   EVERY ( λs. case s of Section n lines =>
       case loc_to_pc n 0 code of
        SOME pc => labs_correct pc lines code
-      | _ => T) code``,
+      | _ => T) code`,
   Induct>>fs[labels_ok_def]>>Cases_on`h`>>fs[]>>
   rw[]
   >-
@@ -766,20 +766,20 @@ val labels_ok_labs_correct = prove(``
       >>
        fs[]);
 
-val labs_correct_append = prove(``
+val labs_correct_append = Q.prove(`
   ∀ls pc.
   labs_correct pc (ls ++ rest) code ⇒
-  labs_correct pc ls code``,
+  labs_correct pc ls code`,
   Induct>>fs[labs_correct_def]>>rw[]);
 
-val code_installed_prog_to_section = prove(
-  ``!prog4 n prog3.
+val code_installed_prog_to_section = Q.prove(
+  `!prog4 n prog3.
       labels_ok (MAP prog_to_section prog4) ∧
       ALOOKUP prog4 n = SOME prog3 ==>
       ?pc.
         code_installed pc (append (FST (flatten prog3 n (next_lab prog3))))
           (MAP prog_to_section prog4) /\
-        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc``,
+        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc`,
   rpt strip_tac \\ fs [code_installed_eq]
   \\ drule code_installed_prog_to_section_lemma \\ strip_tac
   \\ asm_exists_tac \\ fs []
@@ -792,10 +792,10 @@ val code_installed_prog_to_section = prove(
   \\ pairarg_tac>>fs[]>>rveq>>fs[]
   \\ metis_tac[labs_correct_append]);
 
-val stack_remove_syntax_pres = prove(
-  ``Abbrev (prog3 = compile n bitmaps k pos prog2) /\
+val stack_remove_syntax_pres = Q.prove(
+  `Abbrev (prog3 = compile n bitmaps k pos prog2) /\
     EVERY (λp. good_syntax p 1 2 0) (MAP SND prog2) ==>
-    EVERY (λp. good_syntax p 1 2 0) (MAP SND prog3)``,
+    EVERY (λp. good_syntax p 1 2 0) (MAP SND prog3)`,
   rw[]>>
   unabbrev_all_tac>>fs[]>>
   EVAL_TAC>>
@@ -821,12 +821,12 @@ val stack_remove_syntax_pres = prove(
     EVAL_TAC>>fs[])
   >- EVAL_TAC));
 
-val stack_names_syntax_pres = prove(
-  ``Abbrev (prog4 = stack_names$compile f prog3) /\
+val stack_names_syntax_pres = Q.prove(
+  `Abbrev (prog4 = stack_names$compile f prog3) /\
     EVERY (λp. good_syntax p 1 2 0) (MAP SND prog3) ==>
     EVERY (λp. good_syntax p (find_name f 1)
                              (find_name f 2)
-                             (find_name f 0)) (MAP SND prog4)``,
+                             (find_name f 0)) (MAP SND prog4)`,
   rw[]>>
   unabbrev_all_tac>>fs[stack_namesTheory.compile_def]>>
   fs[EVERY_MAP,EVERY_MEM,FORALL_PROD,stack_namesTheory.prog_comp_def]>>
@@ -842,18 +842,18 @@ val MEM_pair_IMP = prove(
   ``!xs. MEM (x,y) xs ==> MEM x (MAP FST xs) /\ MEM y (MAP SND xs)``,
   Induct \\ fs [FORALL_PROD] \\ metis_tac []);
 
-val IS_SOME_EQ_CASE = prove(
-  ``IS_SOME x <=> case x of NONE => F | SOME _ => T``,
+val IS_SOME_EQ_CASE = Q.prove(
+  `IS_SOME x <=> case x of NONE => F | SOME _ => T`,
   Cases_on `x` \\ fs []);
 
-val compile_eq_imp = prove(
-  ``x = x' /\ y = y' ==>
-    lab_to_target$compile x y = lab_to_target$compile x' y'``,
+val compile_eq_imp = Q.prove(
+  `x = x' /\ y = y' ==>
+    lab_to_target$compile x y = lab_to_target$compile x' y'`,
   fs []);
 
-val BIJ_FLOOKUP_MAPKEYS = prove(
-  ``BIJ bij UNIV UNIV ==>
-    FLOOKUP (MAP_KEYS (LINV bij UNIV) f) n = FLOOKUP f (bij n)``,
+val BIJ_FLOOKUP_MAPKEYS = Q.prove(
+  `BIJ bij UNIV UNIV ==>
+    FLOOKUP (MAP_KEYS (LINV bij UNIV) f) n = FLOOKUP f (bij n)`,
   fs [FLOOKUP_DEF,MAP_KEYS_def,BIJ_DEF] \\ strip_tac
   \\ match_mp_tac (METIS_PROVE []
       ``x=x'/\(x /\ x' ==> y=y') ==> (if x then y else z) = (if x' then y' else z)``)
@@ -869,8 +869,8 @@ val word_list_exists_imp = prove(
     word_list_exists a n (fun2set (m1,dm:'a word set))``,
   metis_tac [stack_removeProofTheory.word_list_exists_addresses]);
 
-val addresses_thm = store_thm("addresses_thm",
-  ``!n a. addresses a n = { a + n2w i * bytes_in_word | i < n }``,
+val addresses_thm = Q.store_thm("addresses_thm",
+  `!n a. addresses a n = { a + n2w i * bytes_in_word | i < n }`,
   Induct \\ fs [stack_removeProofTheory.addresses_def]
   \\ rw [EXTENSION] \\ eq_tac \\ rw []
   THEN1 (qexists_tac `0` \\ fs [])
@@ -881,18 +881,18 @@ val addresses_thm = store_thm("addresses_thm",
   \\ asm_exists_tac \\ fs []
   \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val IMP_MULT_DIV_LESS = prove(
-  ``m <> 0 /\ d < k ==> m * (d DIV m) < k``,
+val IMP_MULT_DIV_LESS = Q.prove(
+  `m <> 0 /\ d < k ==> m * (d DIV m) < k`,
   strip_tac \\ `0 < m` by decide_tac
   \\ drule DIVISION
   \\ disch_then (qspec_then `d` assume_tac)
   \\ decide_tac);
 
-val WORD_LS_IMP = prove(
-  ``a <=+ b ==>
+val WORD_LS_IMP = Q.prove(
+  `a <=+ b ==>
     ?k. Abbrev (b = a + n2w k) /\
         w2n (b - a) = k /\
-        (!w. a <=+ w /\ w <+ b <=> ?i. w = a + n2w i /\ i < k)``,
+        (!w. a <=+ w /\ w <+ b <=> ?i. w = a + n2w i /\ i < k)`,
   Cases_on `a` \\ Cases_on `b` \\ fs [WORD_LS]
   \\ fs [markerTheory.Abbrev_def]
   \\ full_simp_tac std_ss [GSYM word_sub_def,addressTheory.word_arith_lemma2]
@@ -904,32 +904,32 @@ val WORD_LS_IMP = prove(
   \\ eq_tac \\ rw [] \\ fs []
   \\ rename1 `k < m:num` \\ qexists_tac `k - n` \\ fs [])
 
-val byte_aligned_mult = prove(
-  ``good_dimindex (:'a) ==>
-    byte_aligned (a + bytes_in_word * n2w i) = byte_aligned (a:'a word)``,
+val byte_aligned_mult = Q.prove(
+  `good_dimindex (:'a) ==>
+    byte_aligned (a + bytes_in_word * n2w i) = byte_aligned (a:'a word)`,
   fs [alignmentTheory.byte_aligned_def,labPropsTheory.good_dimindex_def]
   \\ rw [] \\ fs [bytes_in_word_def,word_mul_n2w]
   \\ once_rewrite_tac [MULT_COMM]
   \\ rewrite_tac [GSYM (EVAL ``2n**2``),GSYM (EVAL ``2n**3``),
         data_to_wordPropsTheory.aligned_add_pow]);
 
-val DIV_LESS_DIV = prove(
-  ``n MOD k = 0 /\ m MOD k = 0 /\ n < m /\ 0 < k ==> n DIV k < m DIV k``,
+val DIV_LESS_DIV = Q.prove(
+  `n MOD k = 0 /\ m MOD k = 0 /\ n < m /\ 0 < k ==> n DIV k < m DIV k`,
   strip_tac
   \\ drule DIVISION \\ disch_then (qspec_then `n` (strip_assume_tac o GSYM))
   \\ drule DIVISION \\ disch_then (qspec_then `m` (strip_assume_tac o GSYM))
   \\ rfs [] \\ metis_tac [LT_MULT_LCANCEL]);
 
-val MOD_SUB_LEMMA = prove(
-  ``n MOD k = 0 /\ m MOD k = 0 /\ 0 < k ==> (n - m) MOD k = 0``,
+val MOD_SUB_LEMMA = Q.prove(
+  `n MOD k = 0 /\ m MOD k = 0 /\ 0 < k ==> (n - m) MOD k = 0`,
   Cases_on `m <= n` \\ fs []
   \\ imp_res_tac LESS_EQ_EXISTS \\ rw []
   \\ qpat_x_assum `(m + _) MOD k = 0` mp_tac
   \\ drule MOD_PLUS
   \\ disch_then (fn th => once_rewrite_tac [GSYM th]) \\ fs []);
 
-val LESS_MULT_LEMMA = prove(
-  ``n1 < n2 /\ d < k ==> k * n1 + d < k * n2:num``,
+val LESS_MULT_LEMMA = Q.prove(
+  `n1 < n2 /\ d < k ==> k * n1 + d < k * n2:num`,
   Cases_on `n2` \\ fs [MULT_CLAUSES] \\ rw []
   \\ fs [DECIDE ``n1 < SUC k <=> n1 <= k``]
   \\ match_mp_tac (DECIDE ``n < n' /\ m <= m' ==> n + m < n' + m':num``)
@@ -1240,9 +1240,9 @@ val COND_eq_SOME = Q.store_thm("COND_eq_SOME",
   `((if t then SOME a else b) = SOME x) ⇔ ((t ∧ (a = x)) ∨ (¬t ∧ b = SOME x))`,
   rw[]);
 
-val from_data_ignore = prove(
-  ``from_data (c with <|source_conf := x; mod_conf := y; clos_conf := z|>) prog =
-    from_data c prog``,
+val from_data_ignore = Q.prove(
+  `from_data (c with <|source_conf := x; mod_conf := y; clos_conf := z|>) prog =
+    from_data c prog`,
   fs [from_data_def,from_word_def,from_stack_def,from_lab_def]
   \\ rpt (pairarg_tac \\ fs []));
 

--- a/compiler/backend/proofs/bvi_letProofScript.sml
+++ b/compiler/backend/proofs/bvi_letProofScript.sml
@@ -42,20 +42,20 @@ val env_rel_LOOKUP_SOME = Q.prove(
   \\ first_x_assum match_mp_tac
   \\ Cases_on `h'` \\ fs [env_rel_def]);
 
-val evaluate_delete_var_Rerr_SING = store_thm("evaluate_delete_var_Rerr_SING",
-  ``!x s r e env2.
+val evaluate_delete_var_Rerr_SING = Q.store_thm("evaluate_delete_var_Rerr_SING",
+  `!x s r e env2.
       evaluate ([x],env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate ([delete_var x],env2,s) = (Rerr e,r)``,
+      evaluate ([delete_var x],env2,s) = (Rerr e,r)`,
   Cases \\ fs [delete_var_def]
   \\ fs [evaluate_def,do_app_def] \\ rw []
   \\ CCONTR_TAC \\ fs [] \\ rw []);
 
-val evaluate_delete_var_Rerr = prove(
-  ``!xs s r e env2.
+val evaluate_delete_var_Rerr = Q.prove(
+  `!xs s r e env2.
       evaluate (xs,env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate (MAP delete_var xs,env2,s) = (Rerr e,r)``,
+      evaluate (MAP delete_var xs,env2,s) = (Rerr e,r)`,
   Induct \\ fs [] \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ TRY (drule evaluate_delete_var_Rerr_SING \\ fs [])
@@ -65,12 +65,12 @@ val evaluate_delete_var_Rerr = prove(
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs [] \\ rw []
   \\ pop_assum mp_tac \\ EVAL_TAC);
 
-val evaluate_delete_var_Rval = prove(
-  ``!xs env2 s a r ax env d.
+val evaluate_delete_var_Rval = Q.prove(
+  `!xs env2 s a r ax env d.
       evaluate (xs,env2,s:'a bviSem$state) = (Rval a,r) /\
       env_rel ax d env env2 ==>
       ?b. evaluate (MAP delete_var xs,env2,s) = (Rval b,r) /\
-          env_rel (extract_list xs ++ ax) d (a ++ env) (b ++ env2)``,
+          env_rel (extract_list xs ++ ax) d (a ++ env) (b ++ env2)`,
   Induct \\ fs [env_rel_def,extract_list_def]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ Cases_on `evaluate ([h],env2,s)` \\ fs []
@@ -92,12 +92,12 @@ val evaluate_delete_var_Rval = prove(
   \\ imp_res_tac evaluate_SING_IMP \\ rw [] \\ fs []
   \\ fs [v_rel_def,env_rel_def,LLOOKUP_def]);
 
-val evaluate_SNOC_Rval = store_thm("evaluate_SNOC_Rval",
-  ``evaluate (SNOC x y,env,s) = (Rval a,r) ==>
+val evaluate_SNOC_Rval = Q.store_thm("evaluate_SNOC_Rval",
+  `evaluate (SNOC x y,env,s) = (Rval a,r) ==>
     ?a1 a2 r1.
       a = SNOC a1 a2 /\ LENGTH y = LENGTH a2 /\
       evaluate (y,env,s) = (Rval a2,r1) /\
-      evaluate ([x],env,r1) = (Rval [a1],r)``,
+      evaluate ([x],env,r1) = (Rval [a1],r)`,
   fs [evaluate_SNOC]
   \\ every_case_tac \\ fs []
   \\ imp_res_tac evaluate_SING_IMP \\ rw []
@@ -139,12 +139,12 @@ val env_rel_MAP = Q.store_thm("env_rel_MAP",
   \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
   \\ fs [EL_APPEND2]);
 
-val evaluate_env_rel = store_thm("evaluate_env_rel",
-  ``!xs env1 (s1:'a bviSem$state) ax env2 res s2 ys d.
+val evaluate_env_rel = Q.store_thm("evaluate_env_rel",
+  `!xs env1 (s1:'a bviSem$state) ax env2 res s2 ys d.
       (evaluate (xs,env1,s1) = (res,s2)) /\
       env_rel ax d env1 env2 /\
       res <> Rerr (Rabort Rtype_error) ==>
-      (evaluate (compile ax d xs,env2,s1) = (res,s2))``,
+      (evaluate (compile ax d xs,env2,s1) = (res,s2))`,
   strip_tac \\ completeInduct_on `exp2_size xs`
   \\ rw [] \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs[compile_def,evaluate_def]
@@ -276,10 +276,10 @@ val compile_thm = save_thm("compile_thm",
   |> Q.SPECL [`xs`,`env`,`s1`,`[]`,`env`,`res`,`s2`,`ys`,`0`] |> GEN_ALL
   |> SIMP_RULE (srw_ss()) [env_rel_def])
 
-val evaluate_compile_exp = store_thm("evaluate_compile_exp",
-  ``evaluate ([d],env,s) = (r,t) /\
+val evaluate_compile_exp = Q.store_thm("evaluate_compile_exp",
+  `evaluate ([d],env,s) = (r,t) /\
     r <> Rerr (Rabort Rtype_error) ==>
-    evaluate ([bvi_let$compile_exp d],env,s) = (r,t)``,
+    evaluate ([bvi_let$compile_exp d],env,s) = (r,t)`,
   fs [compile_exp_def]
   \\ `LENGTH (compile [] 0 [d]) = LENGTH [d]` by fs [compile_length]
   \\ Cases_on `compile [] 0 [d]` \\ fs [LENGTH_NIL] \\ rw []

--- a/compiler/backend/proofs/bvi_letProofScript.sml
+++ b/compiler/backend/proofs/bvi_letProofScript.sml
@@ -13,29 +13,29 @@ val env_rel_def = Define `
      v_rel a x y (x::e1) (y::e2) /\ env_rel rest d e1 e2) /\
   (env_rel _ _ _ _ = F)`
 
-val env_rel_length = store_thm("env_rel_length",
-  ``!ax env env2. env_rel ax d env env2 ==> LENGTH env <= LENGTH env2``,
+val env_rel_length = Q.store_thm("env_rel_length",
+  `!ax env env2. env_rel ax d env env2 ==> LENGTH env <= LENGTH env2`,
   Induct \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ rw [] \\ Cases_on `d` \\ fs []
   \\ imp_res_tac (METIS_PROVE [] ``x=y ==> LENGTH x = LENGTH y``) \\ fs []);
 
-val env_rel_LLOOKUP_NONE = prove(
-  ``!ax env env2 n d.
+val env_rel_LLOOKUP_NONE = Q.prove(
+  `!ax env env2 n d.
       env_rel ax d env env2 /\
       LLOOKUP ax n = NONE /\
       n < LENGTH env ==>
       n+d < LENGTH env2 /\
-      EL (n+d) env2 = EL n env``,
+      EL (n+d) env2 = EL n env`,
   Induct THEN1 (fs [env_rel_def,LLOOKUP_def,EL_DROP])
   \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ rw [] \\ Cases_on `n` \\ fs []
   \\ res_tac \\ fs [LLOOKUP_def] \\ rfs [] \\ fs[ADD_CLAUSES]);
 
-val env_rel_LOOKUP_SOME = prove(
-  ``!env env2 ax x n d.
+val env_rel_LOOKUP_SOME = Q.prove(
+  `!env env2 ax x n d.
       env_rel ax d env env2 /\
       LLOOKUP ax n = SOME x ==>
-      v_rel x (EL n env) (EL n env2) (DROP n env) (DROP n env2)``,
+      v_rel x (EL n env) (EL n env2) (DROP n env) (DROP n env2)`,
   Induct \\ Cases_on `env2` \\ Cases_on `ax` \\ fs [env_rel_def,LLOOKUP_def]
   \\ rw [] \\ fs [env_rel_def] \\ res_tac \\ fs []
   \\ Cases_on `n` \\ fs [env_rel_def]
@@ -103,27 +103,27 @@ val evaluate_SNOC_Rval = store_thm("evaluate_SNOC_Rval",
   \\ imp_res_tac evaluate_SING_IMP \\ rw []
   \\ imp_res_tac evaluate_IMP_LENGTH \\ fs []);
 
-val compile_CONS = store_thm("compile_CONS",
-  ``compile ax d (x::xs) = compile ax d [x] ++ compile ax d xs``,
+val compile_CONS = Q.store_thm("compile_CONS",
+  `compile ax d (x::xs) = compile ax d [x] ++ compile ax d xs`,
   Cases_on `xs` \\ fs [compile_def]);
 
-val compile_APPEND = store_thm("compile_APPEND",
-  ``!xs ys ax d. compile ax d (xs ++ ys) = compile ax d xs ++ compile ax d ys``,
+val compile_APPEND = Q.store_thm("compile_APPEND",
+  `!xs ys ax d. compile ax d (xs ++ ys) = compile ax d xs ++ compile ax d ys`,
   Induct \\ fs [compile_def]
   \\ once_rewrite_tac [compile_CONS] \\ fs []);
 
-val IMP_COMM = store_thm("IMP_COMM",
-  ``(b1 ==> b2 ==> b3) <=> (b2 ==> b1 ==> b3)``,
+val IMP_COMM = Q.store_thm("IMP_COMM",
+  `(b1 ==> b2 ==> b3) <=> (b2 ==> b1 ==> b3)`,
   metis_tac []);
 
-val exp_size_APPEND = store_thm("exp_size_APPEND",
-  ``!xs ys. exp2_size (xs ++ ys) = exp2_size xs + exp2_size ys``,
+val exp_size_APPEND = Q.store_thm("exp_size_APPEND",
+  `!xs ys. exp2_size (xs ++ ys) = exp2_size xs + exp2_size ys`,
   Induct \\ fs [bviTheory.exp_size_def]);
 
-val env_rel_MAP = store_thm("env_rel_MAP",
-  ``!ax env1 env2 d a.
+val env_rel_MAP = Q.store_thm("env_rel_MAP",
+  `!ax env1 env2 d a.
       env_rel ax d env1 env2 ==>
-      env_rel (MAP ($+ (LENGTH a)) ax) (d + LENGTH a) env1 (a ++ env2)``,
+      env_rel (MAP ($+ (LENGTH a)) ax) (d + LENGTH a) env1 (a ++ env2)`,
   Induct \\ fs [env_rel_def]
   THEN1 (once_rewrite_tac [EQ_SYM_EQ] \\ Induct_on `a` \\ fs [ADD1])
   \\ Cases_on `env1` \\ Cases_on `env2` \\ fs [env_rel_def]

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -32,10 +32,10 @@ val state_rel_def = Define `
 val find_code_def = bvlSemTheory.find_code_def;
 val _ = temp_bring_to_front_overload"find_code"{Name="find_code",Thy="bvlSem"};
 
-val find_code_lemma = prove(
-  ``state_rel r t2 /\
+val find_code_lemma = Q.prove(
+  `state_rel r t2 /\
     (find_code dest a r.code = SOME (args,exp)) ==>
-    (find_code dest a t2.code = SOME (args,compile_exp (LENGTH args) exp))``,
+    (find_code dest a t2.code = SOME (args,compile_exp (LENGTH args) exp))`,
   reverse (Cases_on `dest`) \\ SIMP_TAC std_ss [find_code_def]
   \\ FULL_SIMP_TAC (srw_ss()) [state_rel_def,code_rel_def]
   \\ REPEAT STRIP_TAC THEN1
@@ -51,10 +51,10 @@ val find_code_lemma = prove(
   \\ `?t1 t2. a = SNOC t1 t2` by METIS_TAC [SNOC_CASES]
   \\ FULL_SIMP_TAC std_ss [FRONT_SNOC,LENGTH_SNOC,ADD1]);
 
-val do_app_data_to_bvi = prove(
-  ``(do_app op a s1 = Rval (x0,s2)) /\ state_rel s1 t1 ==>
+val do_app_data_to_bvi = Q.prove(
+  `(do_app op a s1 = Rval (x0,s2)) /\ state_rel s1 t1 ==>
     (do_app op a (data_to_bvi t1) =
-      Rval (x0,s2 with code := map (K ARB) t1.code))``,
+      Rval (x0,s2 with code := map (K ARB) t1.code))`,
   full_simp_tac(srw_ss())[state_rel_def]
   \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[bviSemTheory.do_app_def] \\ REPEAT STRIP_TAC
@@ -106,8 +106,8 @@ val compile_RANGE_lemma = Q.prove(
   \\ IMP_RES_TAC compile_LESS_EQ
   \\ TRY (Cases_on `tail`) \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC);
 
-val compile_RANGE = prove(
-  ``(compile n env tail live xs = (ys,vs,k)) ==> EVERY (\v.  v < k) vs``,
+val compile_RANGE = Q.prove(
+  `(compile n env tail live xs = (ys,vs,k)) ==> EVERY (\v.  v < k) vs`,
   REPEAT STRIP_TAC \\ MP_TAC (compile_RANGE_lemma |> SPEC_ALL) \\ full_simp_tac(srw_ss())[]);
 
 val _ = temp_overload_on("res_list",``map_result (λv. [v]) I``);
@@ -969,11 +969,11 @@ val compile_exp_lemma = compile_correct
   |> SIMP_RULE std_ss [LENGTH,GSYM compile_exp_def,option_case_NONE_F,
        PULL_EXISTS,EVERY_DEF];
 
-val compile_exp_correct = store_thm("compile_exp_correct",
-  ``^(compile_exp_lemma |> concl |> dest_imp |> fst) ==>
+val compile_exp_correct = Q.store_thm("compile_exp_correct",
+  `^(compile_exp_lemma |> concl |> dest_imp |> fst) ==>
     ?t2 prog vs next_var r.
       evaluate (compile_exp n exp,t1) = (SOME r,t2) /\
-      state_rel s2 t2 /\ res_list r = res``,
+      state_rel s2 t2 /\ res_list r = res`,
   REPEAT STRIP_TAC \\ MP_TAC compile_exp_lemma \\ full_simp_tac(srw_ss())[]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[compile_exp_def,LET_DEF]
   \\ MP_TAC (Q.SPECL [`prog`,`t1`] optimise_correct) \\ full_simp_tac(srw_ss())[]

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -1057,7 +1057,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
     qx_gen_tac`res`>>srw_tac[][]>>
     simp[dataSemTheory.semantics_def] >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`bviSem$evaluate`kall_tac >>
+      qhdtm_x_assum`bviSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >>
@@ -1085,7 +1085,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
           impl_tac >- (
             full_simp_tac(srw_ss())[] >> strip_tac >> full_simp_tac(srw_ss())[] >> rveq >> full_simp_tac(srw_ss())[] ) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`dataSem$evaluate`mp_tac >>
+          qhdtm_x_assum`dataSem$evaluate`mp_tac >>
           drule dataPropsTheory.evaluate_add_clock >>
           impl_tac >- (
             full_simp_tac(srw_ss())[] >> strip_tac >> full_simp_tac(srw_ss())[] ) >>
@@ -1101,7 +1101,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
           last_x_assum(qspec_then`k+k'`mp_tac)>>
           rpt strip_tac >> fsrw_tac[ARITH_ss][] >> rev_full_simp_tac(srw_ss())[] ) >>
         strip_tac >>
-        rator_x_assum`bviSem$evaluate`mp_tac >>
+        qhdtm_x_assum`bviSem$evaluate`mp_tac >>
         drule bviPropsTheory.evaluate_add_clock >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
         disch_then(qspec_then`k'`mp_tac)>>simp[inc_clock_def] >>
@@ -1117,7 +1117,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
       fsrw_tac[ARITH_ss][] >>
       reverse(Cases_on`s'.ffi.final_event`)>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]>- (
         full_simp_tac(srw_ss())[state_rel_def] >> rev_full_simp_tac(srw_ss())[] ) >>
-      rator_x_assum`dataSem$evaluate`mp_tac >>
+      qhdtm_x_assum`dataSem$evaluate`mp_tac >>
       drule dataPropsTheory.evaluate_add_clock >>
       impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
       disch_then(qspec_then`k`mp_tac)>>simp[inc_clock_def] >>

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -92,10 +92,10 @@ val optimise_correct = Q.store_thm("optimise_correct",
   full_simp_tac(srw_ss())[optimise_def] \\ REPEAT STRIP_TAC \\ Cases_on `evaluate (c,s)` \\ full_simp_tac(srw_ss())[]
   \\ METIS_TAC [simp_correct,data_liveProofTheory.compile_correct,data_spaceProofTheory.compile_correct,FST]);
 
-val compile_RANGE_lemma = prove(
-  ``!n env tail live xs.
+val compile_RANGE_lemma = Q.prove(
+  `!n env tail live xs.
       EVERY (\v. v < (SND (SND (compile n env tail live xs))))
-        (FST (SND (compile n env tail live xs)))``,
+        (FST (SND (compile n env tail live xs)))`,
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) []

--- a/compiler/backend/proofs/bvl_constProofScript.sml
+++ b/compiler/backend/proofs/bvl_constProofScript.sml
@@ -17,25 +17,25 @@ val env_rel_def = Define `
      v_rel (:'a) a x y (x::e1) (y::e2) /\ env_rel (:'a) rest e1 e2) /\
   (env_rel _ _ _ _ = F)`
 
-val env_rel_length = store_thm("env_rel_length",
-  ``!ax env env2. env_rel (:α) ax env env2 ==> LENGTH env2 = LENGTH env``,
+val env_rel_length = Q.store_thm("env_rel_length",
+  `!ax env env2. env_rel (:α) ax env env2 ==> LENGTH env2 = LENGTH env`,
   Induct \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ Cases \\ fs [env_rel_def]);
 
-val env_rel_LLOOKUP_NONE = prove(
-  ``!ax env env2 n.
+val env_rel_LLOOKUP_NONE = Q.prove(
+  `!ax env env2 n.
       env_rel (:α) ax env env2 /\
       (LLOOKUP ax n = NONE \/ LLOOKUP ax n = SOME NONE) ==>
-      EL n env2 = EL n env``,
+      EL n env2 = EL n env`,
   Induct \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ Cases \\ fs [env_rel_def,LLOOKUP_def]
   \\ rw [] \\ fs [] \\ Cases_on `n` \\ fs [EL]);
 
-val env_rel_LOOKUP_SOME = prove(
-  ``!env env2 ax x n.
+val env_rel_LOOKUP_SOME = Q.prove(
+  `!env env2 ax x n.
       env_rel (:α) ax env env2 /\
       LLOOKUP ax n = SOME (SOME x) ==>
-      v_rel (:'a) x (EL n env) (EL n env2) (DROP n env) (DROP n env2)``,
+      v_rel (:'a) x (EL n env) (EL n env2) (DROP n env) (DROP n env2)`,
   Induct \\ Cases_on `env2` \\ Cases_on `ax` \\ fs [env_rel_def,LLOOKUP_def]
   \\ rw [] \\ fs [env_rel_def] \\ res_tac \\ fs []
   \\ Cases_on `n` \\ fs [env_rel_def]
@@ -96,8 +96,8 @@ val evaluate_delete_var_Rval = prove(
   \\ fs [v_rel_def,NULL_EQ,evaluate_def,do_app_def]
   \\ every_case_tac \\ fs []);
 
-val IS_SOME_dest_Op_Const = store_thm("IS_SOME_dest_Op_Const[simp]",
-  ``IS_SOME (dest_Op_Const h) = ?i. h = Op (Const i) []``,
+val IS_SOME_dest_Op_Const = Q.store_thm("IS_SOME_dest_Op_Const[simp]",
+  `IS_SOME (dest_Op_Const h) = ?i. h = Op (Const i) []`,
   Cases_on `h` \\ fs [dest_Op_Const_def]
   \\ Cases_on `o'` \\ fs [dest_Op_Const_def]
   \\ rw [] \\ fs [NULL_EQ]);
@@ -109,8 +109,8 @@ val evaluate_EQ_NIL = store_thm("evaluate_EQ_NIL",
   \\ rw [] \\ TRY eq_tac \\ fs [] \\ rw [] \\ fs [LENGTH_NIL]
   \\ CCONTR_TAC \\ fs [] \\ fs [evaluate_def]);
 
-val is_simple_thm = store_thm("is_simple_thm",
-  ``is_simple v <=> (?t. v = Op (Cons t) []) \/ (?i. v = Op (Const i) [])``,
+val is_simple_thm = Q.store_thm("is_simple_thm",
+  `is_simple v <=> (?t. v = Op (Cons t) []) \/ (?i. v = Op (Const i) [])`,
   Cases_on `v` \\ fs [is_simple_def]
   \\ Cases_on `o'` \\ fs [is_simple_def,NULL_EQ]);
 

--- a/compiler/backend/proofs/bvl_constProofScript.sml
+++ b/compiler/backend/proofs/bvl_constProofScript.sml
@@ -42,20 +42,20 @@ val env_rel_LOOKUP_SOME = Q.prove(
   \\ first_x_assum match_mp_tac
   \\ Cases_on `h'` \\ fs [env_rel_def]);
 
-val evaluate_delete_var_Rerr_SING = store_thm("evaluate_delete_var_Rerr_SING",
-  ``!x s r e env2.
+val evaluate_delete_var_Rerr_SING = Q.store_thm("evaluate_delete_var_Rerr_SING",
+  `!x s r e env2.
       evaluate ([x],env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate ([bvl_const$delete_var x],env2,s) = (Rerr e,r)``,
+      evaluate ([bvl_const$delete_var x],env2,s) = (Rerr e,r)`,
   Cases \\ fs [delete_var_def]
   \\ fs [evaluate_def,do_app_def] \\ rw []
   \\ CCONTR_TAC \\ fs [] \\ rw []);
 
-val evaluate_delete_var_Rerr = prove(
-  ``!xs s r e env2.
+val evaluate_delete_var_Rerr = Q.prove(
+  `!xs s r e env2.
       evaluate (xs,env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate (MAP bvl_const$delete_var xs,env2,s) = (Rerr e,r)``,
+      evaluate (MAP bvl_const$delete_var xs,env2,s) = (Rerr e,r)`,
   Induct \\ fs [] \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ TRY (drule evaluate_delete_var_Rerr_SING \\ fs [])
@@ -65,12 +65,12 @@ val evaluate_delete_var_Rerr = prove(
   \\ fs [evaluate_def,do_app_def] \\ rw []
   \\ every_case_tac \\ fs [] \\ rw []);
 
-val evaluate_delete_var_Rval = prove(
-  ``!xs env2 s a r ax env.
+val evaluate_delete_var_Rval = Q.prove(
+  `!xs env2 s a r ax env.
       evaluate (xs,env2,s:'a bvlSem$state) = (Rval a,r) /\
       env_rel (:'a) ax env env2 ==>
       ?b. evaluate (MAP delete_var xs,env2,s) = (Rval b,r) /\
-          env_rel (:'a) (extract_list xs ++ ax) (a ++ env) (b ++ env2)``,
+          env_rel (:'a) (extract_list xs ++ ax) (a ++ env) (b ++ env2)`,
   Induct \\ fs [env_rel_def,extract_list_def]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ Cases_on `evaluate ([h],env2,s)` \\ fs []
@@ -102,8 +102,8 @@ val IS_SOME_dest_Op_Const = Q.store_thm("IS_SOME_dest_Op_Const[simp]",
   \\ Cases_on `o'` \\ fs [dest_Op_Const_def]
   \\ rw [] \\ fs [NULL_EQ]);
 
-val evaluate_EQ_NIL = store_thm("evaluate_EQ_NIL",
-  ``bvlSem$evaluate (xs,env,s) = (Rval [],t) <=> xs = [] /\ s = t``,
+val evaluate_EQ_NIL = Q.store_thm("evaluate_EQ_NIL",
+  `bvlSem$evaluate (xs,env,s) = (Rval [],t) <=> xs = [] /\ s = t`,
   mp_tac (Q.SPECL [`xs`,`env`,`s`] evaluate_LENGTH)
   \\ every_case_tac \\ fs []
   \\ rw [] \\ TRY eq_tac \\ fs [] \\ rw [] \\ fs [LENGTH_NIL]
@@ -114,10 +114,10 @@ val is_simple_thm = Q.store_thm("is_simple_thm",
   Cases_on `v` \\ fs [is_simple_def]
   \\ Cases_on `o'` \\ fs [is_simple_def,NULL_EQ]);
 
-val SmartOp_thm = store_thm("SmartOp_thm",
-  ``evaluate ([Op op xs],env,s) = (res,s2) /\
+val SmartOp_thm = Q.store_thm("SmartOp_thm",
+  `evaluate ([Op op xs],env,s) = (res,s2) /\
     res ≠ Rerr (Rabort Rtype_error) ==>
-    evaluate ([SmartOp op xs],env,s) = (res,s2)``,
+    evaluate ([SmartOp op xs],env,s) = (res,s2)`,
   full_simp_tac std_ss [SmartOp_def]
   \\ reverse (Cases_on `op`) \\ fs [] \\ every_case_tac \\ fs []
   \\ fs [quantHeuristicsTheory.LIST_LENGTH_7] \\ rw []
@@ -127,12 +127,12 @@ val SmartOp_thm = store_thm("SmartOp_thm",
   \\ fs [dest_Op_Const_def,evaluate_def,do_app_def] \\ rw []
   \\ eq_tac \\ rw []);
 
-val evaluate_env_rel = store_thm("evaluate_env_rel",
-  ``!xs env1 (s1:'a bvlSem$state) ax env2 res s2 ys.
+val evaluate_env_rel = Q.store_thm("evaluate_env_rel",
+  `!xs env1 (s1:'a bvlSem$state) ax env2 res s2 ys.
       (evaluate (xs,env1,s1) = (res,s2)) /\
       env_rel (:'a) ax env1 env2 /\
       res <> Rerr (Rabort Rtype_error) ==>
-      (evaluate (compile ax xs,env2,s1) = (res,s2))``,
+      (evaluate (compile ax xs,env2,s1) = (res,s2))`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [compile_def,evaluate_def,compile_HD_SING]
   THEN1
@@ -195,10 +195,10 @@ val compile_thm = save_thm("compile_thm",
   |> Q.SPECL [`xs`,`env`,`s1`,`[]`,`env`] |> GEN_ALL
   |> SIMP_RULE std_ss [env_rel_def])
 
-val evaluate_compile_exp = store_thm("evaluate_compile_exp",
-  ``evaluate ([d],env,s) = (r,t) /\
+val evaluate_compile_exp = Q.store_thm("evaluate_compile_exp",
+  `evaluate ([d],env,s) = (r,t) /\
     r <> Rerr (Rabort Rtype_error) ==>
-    evaluate ([bvl_const$compile_exp d],env,s) = (r,t)``,
+    evaluate ([bvl_const$compile_exp d],env,s) = (r,t)`,
   fs [compile_exp_def]
   \\ `LENGTH (compile [] [d]) = LENGTH [d]` by fs [compile_length]
   \\ Cases_on `compile [] [d]` \\ fs [LENGTH_NIL] \\ rw []

--- a/compiler/backend/proofs/bvl_handleProofScript.sml
+++ b/compiler/backend/proofs/bvl_handleProofScript.sml
@@ -45,21 +45,21 @@ val env_rel_def = Define `
   env_rel l env env1 =
     LIST_RELi (\i v1 v2. has_var i l ==> v1 = v2) env env1`
 
-val env_rel_mk_Union = store_thm("env_rel_mk_Union",
-  ``!env env1. env_rel (mk_Union lx ly) env env1 <=>
-               env_rel lx env env1 /\ env_rel ly env env1``,
+val env_rel_mk_Union = Q.store_thm("env_rel_mk_Union",
+  `!env env1. env_rel (mk_Union lx ly) env env1 <=>
+               env_rel lx env env1 /\ env_rel ly env env1`,
   fs [LIST_RELi_EL_EQN,env_rel_def] \\ metis_tac []);
 
-val env_rel_length = store_thm("env_rel_length",
-  ``env_rel l env env1 ==> LENGTH env1 = LENGTH env``,
+val env_rel_length = Q.store_thm("env_rel_length",
+  `env_rel l env env1 ==> LENGTH env1 = LENGTH env`,
   fs [LIST_RELi_EL_EQN,env_rel_def]);
 
-val env_rel_MAPi = store_thm("env_rel_MAPi",
-  ``env_rel l1 env (MAPi (\i v. if has_var i l1 then v else Number 0) env)``,
+val env_rel_MAPi = Q.store_thm("env_rel_MAPi",
+  `env_rel l1 env (MAPi (\i v. if has_var i l1 then v else Number 0) env)`,
   fs [LIST_RELi_EL_EQN,env_rel_def]);
 
-val IMP_EL_SING = store_thm("IMP_EL_SING",
-  ``k = LENGTH xs ==> EL k (xs ++ [x] ++ ys) = x``,
+val IMP_EL_SING = Q.store_thm("IMP_EL_SING",
+  `k = LENGTH xs ==> EL k (xs ++ [x] ++ ys) = x`,
   rw [] \\ fs [] \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
   \\ fs [EL_APPEND2]);
 
@@ -76,8 +76,8 @@ val ALOOKUP_MAPi_APPEND2 = store_thm("ALOOKUP_MAPi_APPEND2",
       ALOOKUP (MAPi (λi x. (x,i+z)) (xs ++ [k])) k = SOME (LENGTH xs + z)``,
   Induct_on `xs` \\ fs [o_DEF,ADD1]) |> Q.SPEC `0` |> SIMP_RULE std_ss [];
 
-val IS_SOME_lookup_db_to_set = store_thm("IS_SOME_lookup_db_to_set",
-  ``!n. IS_SOME (lookup n (db_to_set l)) = has_var n l``,
+val IS_SOME_lookup_db_to_set = Q.store_thm("IS_SOME_lookup_db_to_set",
+  `!n. IS_SOME (lookup n (db_to_set l)) = has_var n l`,
   fs [db_varsTheory.lookup_db_to_set,IS_SOME_EXISTS]);
 
 val evaluate_LetLet = store_thm("evaluate_LetLet",
@@ -138,12 +138,12 @@ val evaluate_LetLet = store_thm("evaluate_LetLet",
   \\ fs [evaluate_def,do_app_def,MAPi_def,MAPi_APPEND]
   \\ fs [EL_APPEND2] \\ match_mp_tac IMP_EL_SING \\ fs []);
 
-val env_rel_refl = store_thm("env_rel_refl",
-  ``env_rel l env env``,
+val env_rel_refl = Q.store_thm("env_rel_refl",
+  `env_rel l env env`,
   fs [LIST_RELi_EL_EQN,env_rel_def]);
 
-val opt_lemma = prove(
-  ``x = y <=> (x = SOME () <=> y = SOME ())``,
+val opt_lemma = Q.prove(
+  `x = y <=> (x = SOME () <=> y = SOME ())`,
   Cases_on `x` \\ Cases_on `y` \\ fs []);
 
 val OptionalLetLet_IMP = prove(
@@ -357,20 +357,20 @@ val compile_IMP_LENGTH = store_thm("compile_IMP_LENGTH",
   ``compile l n xs = (ys,l1,s1) ==> LENGTH ys = LENGTH xs``,
   rw [] \\ mp_tac (SPEC_ALL compile_length) \\ asm_simp_tac std_ss []);
 
-val bVarBound_CONS = store_thm("bVarBound_CONS",
-  ``bVarBound m [x] /\ bVarBound m xs ==> bVarBound m (x::xs)``,
+val bVarBound_CONS = Q.store_thm("bVarBound_CONS",
+  `bVarBound m [x] /\ bVarBound m xs ==> bVarBound m (x::xs)`,
   Cases_on `xs` \\ fs []);
 
-val bVarBound_MEM = store_thm("bVarBound_MEM",
-  ``bVarBound n xs <=> !x. MEM x xs ==> bVarBound n [x]``,
+val bVarBound_MEM = Q.store_thm("bVarBound_MEM",
+  `bVarBound n xs <=> !x. MEM x xs ==> bVarBound n [x]`,
   fs [Once bVarBound_EVERY,EVERY_MEM]);
 
-val bEvery_MEM = store_thm("bEvery_MEM",
-  ``bEvery p xs = !x. MEM x xs ==> bEvery p [x]``,
+val bEvery_MEM = Q.store_thm("bEvery_MEM",
+  `bEvery p xs = !x. MEM x xs ==> bEvery p [x]`,
   fs [Once bEvery_EVERY,EVERY_MEM]);
 
-val bVarBound_LESS_EQ = store_thm("bVarBound_LESS_EQ",
-  ``!m xs n. bVarBound m xs /\ m <= n ==> bVarBound n xs``,
+val bVarBound_LESS_EQ = Q.store_thm("bVarBound_LESS_EQ",
+  `!m xs n. bVarBound m xs /\ m <= n ==> bVarBound n xs`,
   HO_MATCH_MP_TAC bVarBound_ind \\ rw [] \\ fs []);
 
 val ALOOKUP_MAPi = store_thm("ALOOKUP_MAPi",
@@ -380,12 +380,12 @@ val ALOOKUP_MAPi = store_thm("ALOOKUP_MAPi",
   \\ fs [SNOC_APPEND,MAPi_APPEND,ALOOKUP_APPEND]
   \\ every_case_tac \\ fs []);
 
-val bVarBound_SmartLet = store_thm("bVarBound_SmartLet[simp]",
-  ``bVarBound m [SmartLet x xs] = bVarBound m [Let x xs]``,
+val bVarBound_SmartLet = Q.store_thm("bVarBound_SmartLet[simp]",
+  `bVarBound m [SmartLet x xs] = bVarBound m [Let x xs]`,
   rw [SmartLet_def] \\ fs [NULL_EQ]);
 
-val bVarBound_LetLet = store_thm("bVarBound_LetLet",
-  ``bVarBound m [y] /\ n <= m ==> bVarBound m [LetLet n (l1:num_set) y]``,
+val bVarBound_LetLet = Q.store_thm("bVarBound_LetLet",
+  `bVarBound m [y] /\ n <= m ==> bVarBound m [LetLet n (l1:num_set) y]`,
   fs [LetLet_def] \\ strip_tac
   \\ once_rewrite_tac [bVarBound_MEM]
   \\ fs [MEM_MAP,MEM_GENLIST,PULL_EXISTS,MEM_FILTER]
@@ -395,9 +395,9 @@ val bVarBound_LetLet = store_thm("bVarBound_LetLet",
   \\ qabbrev_tac `xs = FILTER (λn. IS_SOME (lookup n l1)) (GENLIST I n)`
   \\ imp_res_tac ALOOKUP_MAPi \\ fs []);
 
-val bVarBound_OptionalLetLet = store_thm("bVarBound_OptionalLetLet",
-  ``bVarBound m [e] /\ n <= m ==>
-    bVarBound m (FST (OptionalLetLet e n l s limit nr))``,
+val bVarBound_OptionalLetLet = Q.store_thm("bVarBound_OptionalLetLet",
+  `bVarBound m [e] /\ n <= m ==>
+    bVarBound m (FST (OptionalLetLet e n l s limit nr))`,
   rw [OptionalLetLet_def,bVarBound_LetLet]);
 
 val bVarBound_compile = Q.store_thm("bVarBound_compile",
@@ -415,8 +415,8 @@ val compile_IMP_bVarBound = store_thm("compile_IMP_bVarBound",
   ``compile l n xs = (ys,l2,s2) ==> bVarBound n ys``,
   rw [] \\ mp_tac (Q.INST [`m`|->`n`] (SPEC_ALL bVarBound_compile)) \\ fs []);
 
-val compile_exp_bVarBound = store_thm("compile_exp_bVarBound",
-  ``bVarBound n [compile_exp l n x]``,
+val compile_exp_bVarBound = Q.store_thm("compile_exp_bVarBound",
+  `bVarBound n [compile_exp l n x]`,
   fs [compile_exp_def]
   \\ Cases_on `compile l n [bvl_const$compile_exp x]`
   \\ Cases_on `r` \\ fs []
@@ -425,10 +425,10 @@ val compile_exp_bVarBound = store_thm("compile_exp_bVarBound",
   \\ Cases_on `q` \\ fs []
   \\ Cases_on `t` \\ fs []);
 
-val compile_seqs_bVarBound = store_thm("compile_seqs_bVarBound",
-  ``!l x acc.
+val compile_seqs_bVarBound = Q.store_thm("compile_seqs_bVarBound",
+  `!l x acc.
       (!y. acc = SOME y ==> bVarBound 0 [y]) ==>
-      bVarBound 0 [compile_seqs l x acc]``,
+      bVarBound 0 [compile_seqs l x acc]`,
   HO_MATCH_MP_TAC compile_seqs_ind \\ rw []
   \\ once_rewrite_tac [compile_seqs_def]
   \\ Cases_on `dest_Seq x` \\ fs []
@@ -439,22 +439,22 @@ val compile_seqs_bVarBound = store_thm("compile_seqs_bVarBound",
   \\ rename1 `dest_Seq x = SOME y` \\ PairCases_on `y`
   \\ fs [] \\ first_x_assum match_mp_tac \\ fs []);
 
-val bEvery_CONS = store_thm("bEvery_CONS",
-  ``bEvery p [x] /\ bEvery p xs ==> bEvery p (x::xs)``,
+val bEvery_CONS = Q.store_thm("bEvery_CONS",
+  `bEvery p [x] /\ bEvery p xs ==> bEvery p (x::xs)`,
   Cases_on `xs` \\ fs []);
 
-val handle_ok_Var_Const_list = store_thm("handle_ok_Var_Const_list",
-  ``EVERY (\x. ?v i. x = Var v \/ x = Op (Const i) []) xs ==> handle_ok xs``,
+val handle_ok_Var_Const_list = Q.store_thm("handle_ok_Var_Const_list",
+  `EVERY (\x. ?v i. x = Var v \/ x = Op (Const i) []) xs ==> handle_ok xs`,
   Induct_on `xs` \\ fs [handle_ok_def,PULL_EXISTS] \\ rw []
   \\ Cases_on `xs` \\ fs [handle_ok_def]);
 
-val handle_ok_SmartLet = store_thm("handle_ok_SmartLet",
-  ``handle_ok [SmartLet xs x] <=> handle_ok xs /\ handle_ok [x]``,
+val handle_ok_SmartLet = Q.store_thm("handle_ok_SmartLet",
+  `handle_ok [SmartLet xs x] <=> handle_ok xs /\ handle_ok [x]`,
   rw [SmartLet_def,handle_ok_def] \\ fs [NULL_EQ,LENGTH_NIL,handle_ok_def]);
 
-val handle_ok_OptionalLetLet = store_thm("handle_ok_OptionalLetLet",
-  ``handle_ok [e] /\ bVarBound n [e] ==>
-    handle_ok (FST (OptionalLetLet e n lx s l nr))``,
+val handle_ok_OptionalLetLet = Q.store_thm("handle_ok_OptionalLetLet",
+  `handle_ok [e] /\ bVarBound n [e] ==>
+    handle_ok (FST (OptionalLetLet e n lx s l nr))`,
   rw [OptionalLetLet_def] \\ fs [handle_ok_def]
   \\ reverse conj_tac THEN1
    (fs [LetLet_def,handle_ok_SmartLet]
@@ -469,8 +469,8 @@ val handle_ok_OptionalLetLet = store_thm("handle_ok_OptionalLetLet",
       \\ imp_res_tac ALOOKUP_MAPi \\ fs [])
   \\ match_mp_tac bVarBound_LESS_EQ \\ asm_exists_tac \\ fs []);
 
-val compile_handle_ok = store_thm("compile_handle_ok",
-  ``∀l n xs. handle_ok (FST (compile l n xs))``,
+val compile_handle_ok = Q.store_thm("compile_handle_ok",
+  `∀l n xs. handle_ok (FST (compile l n xs))`,
   ho_match_mp_tac compile_ind \\ rw []
   \\ fs [compile_def,handle_ok_def]
   \\ rpt (pairarg_tac \\ fs []) \\ rveq
@@ -500,8 +500,8 @@ val compile_handle_ok = store_thm("compile_handle_ok",
   \\ fs [EVERY_GENLIST]
   \\ rw [] \\ every_case_tac \\ fs []);
 
-val compile_exp_handle_ok = store_thm("compile_exp_handle_ok",
-  ``handle_ok [compile_exp l n x]``,
+val compile_exp_handle_ok = Q.store_thm("compile_exp_handle_ok",
+  `handle_ok [compile_exp l n x]`,
   fs [bvl_handleTheory.compile_exp_def]
   \\ Cases_on `compile l n [bvl_const$compile_exp x]`
   \\ fs [] \\ PairCases_on `r`
@@ -509,10 +509,10 @@ val compile_exp_handle_ok = store_thm("compile_exp_handle_ok",
   \\ qspecl_then [`l`,`n`,`[bvl_const$compile_exp x]`] mp_tac compile_handle_ok
   \\ fs []);
 
-val compile_seqs_handle_ok = store_thm("compile_seqs_handle_ok",
-  ``!l x acc.
+val compile_seqs_handle_ok = Q.store_thm("compile_seqs_handle_ok",
+  `!l x acc.
       (!y. acc = SOME y ==> handle_ok [y] /\ bVarBound 0 [y]) ==>
-      handle_ok [compile_seqs l x acc]``,
+      handle_ok [compile_seqs l x acc]`,
   HO_MATCH_MP_TAC compile_seqs_ind \\ rw []
   \\ once_rewrite_tac [compile_seqs_def]
   \\ Cases_on `dest_Seq x` \\ fs []
@@ -524,8 +524,8 @@ val compile_seqs_handle_ok = store_thm("compile_seqs_handle_ok",
   \\ fs [] \\ first_x_assum match_mp_tac \\ fs []
   \\ match_mp_tac compile_seqs_bVarBound \\ fs []);
 
-val compile_any_handle_ok = store_thm("compile_any_handle_ok",
-  ``handle_ok [compile_any split_seq l n x]``,
+val compile_any_handle_ok = Q.store_thm("compile_any_handle_ok",
+  `handle_ok [compile_any split_seq l n x]`,
   rw [compile_any_def,compile_exp_handle_ok]
   \\ match_mp_tac compile_seqs_handle_ok \\ fs []);
 

--- a/compiler/backend/proofs/bvl_handleProofScript.sml
+++ b/compiler/backend/proofs/bvl_handleProofScript.sml
@@ -2,8 +2,8 @@ open preamble bvl_handleTheory bvlSemTheory bvlPropsTheory;
 
 val _ = new_theory"bvl_handleProof";
 
-val evaluate_SmartLet = store_thm("evaluate_SmartLet[simp]",
-  ``bvlSem$evaluate ([SmartLet xs x],env,s) = evaluate ([Let xs x],env,s)``,
+val evaluate_SmartLet = Q.store_thm("evaluate_SmartLet[simp]",
+  `bvlSem$evaluate ([SmartLet xs x],env,s) = evaluate ([Let xs x],env,s)`,
   rw [SmartLet_def] \\ fs [NULL_EQ,evaluate_def]);
 
 val let_ok_def = Define `
@@ -63,28 +63,28 @@ val IMP_EL_SING = Q.store_thm("IMP_EL_SING",
   rw [] \\ fs [] \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
   \\ fs [EL_APPEND2]);
 
-val ALOOKUP_MAPi_SWAP = store_thm("ALOOKUP_MAPi_SWAP",
-  ``!z n k xs.
+val ALOOKUP_MAPi_SWAP = Q.store_thm("ALOOKUP_MAPi_SWAP",
+  `!z n k xs.
       n <> k ==>
       ALOOKUP (MAPi (λi x. (x,i+z)) (xs ++ [k])) n =
-      ALOOKUP (MAPi (λi x. (x,i+z)) xs) n``,
+      ALOOKUP (MAPi (λi x. (x,i+z)) xs) n`,
   Induct_on `xs` \\ fs [o_DEF,ADD1]) |> Q.SPEC `0` |> SIMP_RULE std_ss [];
 
-val ALOOKUP_MAPi_APPEND2 = store_thm("ALOOKUP_MAPi_APPEND2",
-  ``!z xs k.
+val ALOOKUP_MAPi_APPEND2 = Q.store_thm("ALOOKUP_MAPi_APPEND2",
+  `!z xs k.
       ~MEM k xs ==>
-      ALOOKUP (MAPi (λi x. (x,i+z)) (xs ++ [k])) k = SOME (LENGTH xs + z)``,
+      ALOOKUP (MAPi (λi x. (x,i+z)) (xs ++ [k])) k = SOME (LENGTH xs + z)`,
   Induct_on `xs` \\ fs [o_DEF,ADD1]) |> Q.SPEC `0` |> SIMP_RULE std_ss [];
 
 val IS_SOME_lookup_db_to_set = Q.store_thm("IS_SOME_lookup_db_to_set",
   `!n. IS_SOME (lookup n (db_to_set l)) = has_var n l`,
   fs [db_varsTheory.lookup_db_to_set,IS_SOME_EXISTS]);
 
-val evaluate_LetLet = store_thm("evaluate_LetLet",
-  ``(∀env2 extra.
+val evaluate_LetLet = Q.store_thm("evaluate_LetLet",
+  `(∀env2 extra.
        env_rel l1 env env2 ==> evaluate ([y],env2 ++ extra,s1) = res) /\
     env_rel l1 env env1 ==>
-    evaluate ([LetLet (LENGTH env) (db_to_set l1) y],env1 ++ extra,s1) = res``,
+    evaluate ([LetLet (LENGTH env) (db_to_set l1) y],env1 ++ extra,s1) = res`,
   fs [LetLet_def] \\ rw [o_DEF] \\ fs [Once evaluate_def]
   \\ qabbrev_tac `qs = (FILTER (λn. has_var n l1) (GENLIST I (LENGTH env)))`
   \\ `evaluate
@@ -146,12 +146,12 @@ val opt_lemma = Q.prove(
   `x = y <=> (x = SOME () <=> y = SOME ())`,
   Cases_on `x` \\ Cases_on `y` \\ fs []);
 
-val OptionalLetLet_IMP = prove(
-  ``(ys,l,s',nr') = OptionalLetLet y (LENGTH env) lx s1 limit nr /\
+val OptionalLetLet_IMP = Q.prove(
+  `(ys,l,s',nr') = OptionalLetLet y (LENGTH env) lx s1 limit nr /\
     (∀env2 extra.
       env_rel l env env2 ⇒ evaluate ([y],env2 ++ extra,s) = res) /\
     env_rel l env env1 /\ b ==>
-    evaluate (ys,env1 ++ extra,s) = res /\ b``,
+    evaluate (ys,env1 ++ extra,s) = res /\ b`,
   rw [OptionalLetLet_def,evaluate_def]
   \\ drule evaluate_LetLet \\ fs []
   \\ fs [GSYM db_varsTheory.vars_flatten_def,GSYM db_varsTheory.vars_to_list_def]
@@ -161,24 +161,24 @@ val OptionalLetLet_IMP = prove(
   \\ rewrite_tac [GSYM db_varsTheory.lookup_db_to_set]
   \\ fs []);
 
-val OptionalLetLet_limit = store_thm("OptionalLetLet_limit",
-  ``(ys,l,s',nr') = OptionalLetLet e (LENGTH env) lx s1 limit nr /\
-    env_rel l env env1 ==> env_rel lx env env1``,
+val OptionalLetLet_limit = Q.store_thm("OptionalLetLet_limit",
+  `(ys,l,s',nr') = OptionalLetLet e (LENGTH env) lx s1 limit nr /\
+    env_rel l env env1 ==> env_rel lx env env1`,
   rw [OptionalLetLet_def,GSYM db_varsTheory.vars_to_list_def,
       GSYM db_varsTheory.vars_flatten_def,env_rel_def] \\ fs []);
 
-val OptionalLetLet_nr = store_thm("OptionalLetLet_nr",
-  ``(ys,l,s',nr') = OptionalLetLet e (LENGTH env) lx s1 limit nr ==>
-    nr' = nr``,
+val OptionalLetLet_nr = Q.store_thm("OptionalLetLet_nr",
+  `(ys,l,s',nr') = OptionalLetLet e (LENGTH env) lx s1 limit nr ==>
+    nr' = nr`,
   rw [OptionalLetLet_def,GSYM db_varsTheory.vars_to_list_def,
       GSYM db_varsTheory.vars_flatten_def,env_rel_def] \\ fs []);
 
-val compile_correct = store_thm("compile_correct",
-  ``!xs env s1 ys env1 res s2 extra l s nr.
+val compile_correct = Q.store_thm("compile_correct",
+  `!xs env s1 ys env1 res s2 extra l s nr.
       compile limit (LENGTH env) xs = (ys,l,s,nr) /\ env_rel l env env1 /\
       (evaluate (xs,env,s1) = (res,s2)) /\ res <> Rerr(Rabort Rtype_error) ==>
       (evaluate (ys,env1 ++ extra,s1) = (res,s2)) /\
-      (nr ==> !e. res <> Rerr (Rraise e))``,
+      (nr ==> !e. res <> Rerr (Rraise e))`,
   SIMP_TAC std_ss [Once EQ_SYM_EQ]
   \\ recInduct evaluate_ind \\ rpt conj_tac \\ rpt gen_tac \\ strip_tac
   \\ FULL_SIMP_TAC std_ss [compile_def,evaluate_def]
@@ -287,10 +287,10 @@ val compile_correct = store_thm("compile_correct",
 
 val _ = save_thm("compile_correct",compile_correct);
 
-val compile_correct = store_thm("compile_correct",
-  ``(evaluate ([x],env,s1) = (res,s2)) /\ res <> Rerr(Rabort Rtype_error) /\
+val compile_correct = Q.store_thm("compile_correct",
+  `(evaluate ([x],env,s1) = (res,s2)) /\ res <> Rerr(Rabort Rtype_error) /\
     k = LENGTH env ==>
-    (evaluate ([compile_exp l k x],env,s1) = (res,s2))``,
+    (evaluate ([compile_exp l k x],env,s1) = (res,s2))`,
   fs [compile_exp_def]
   \\ Cases_on `compile l (LENGTH env) [bvl_const$compile_exp x]`
   \\ PairCases_on `r` \\ rw []
@@ -298,14 +298,14 @@ val compile_correct = store_thm("compile_correct",
   \\ drule compile_sing \\ rw []
   \\ drule compile_correct \\ fs []);
 
-val dest_Seq_thm = store_thm("dest_Seq_thm",
-  ``!x. dest_Seq x = SOME (y0,y1) <=>
-        x = Let [y0;y1] (Var 1)``,
+val dest_Seq_thm = Q.store_thm("dest_Seq_thm",
+  `!x. dest_Seq x = SOME (y0,y1) <=>
+        x = Let [y0;y1] (Var 1)`,
   ho_match_mp_tac dest_Seq_ind \\ fs [] \\ rw [] \\ EVAL_TAC
   \\ rw [] \\ eq_tac \\ rw []);
 
-val compile_seqs_correct = store_thm("compile_seqs_correct",
-  ``!l x acc s1 s2 s3 res res3.
+val compile_seqs_correct = Q.store_thm("compile_seqs_correct",
+  `!l x acc s1 s2 s3 res res3.
       evaluate ([x],[],s1) = (res,s2) /\
       (!y r. acc = SOME y /\ res = Rval r ==>
              res3 <> Rerr (Rabort Rtype_error) /\
@@ -313,7 +313,7 @@ val compile_seqs_correct = store_thm("compile_seqs_correct",
       res <> Rerr (Rabort Rtype_error) ==>
       evaluate ([compile_seqs l x acc],[],s1) =
         if acc = NONE then (res,s2) else
-          case res of Rval _ => (res3,s3) | _ => (res,s2)``,
+          case res of Rval _ => (res3,s3) | _ => (res,s2)`,
   HO_MATCH_MP_TAC compile_seqs_ind \\ rpt strip_tac
   \\ once_rewrite_tac [compile_seqs_def]
   \\ Cases_on `dest_Seq x` \\ fs []
@@ -345,16 +345,16 @@ val compile_seqs_correct = store_thm("compile_seqs_correct",
   \\ first_x_assum drule \\ fs []
   \\ Cases_on `acc` \\ fs []);
 
-val compile_any_correct = store_thm("compile_any_correct",
-  ``(evaluate ([x],env,s1) = (res,s2)) /\ res <> Rerr(Rabort Rtype_error) /\
+val compile_any_correct = Q.store_thm("compile_any_correct",
+  `(evaluate ([x],env,s1) = (res,s2)) /\ res <> Rerr(Rabort Rtype_error) /\
     k = LENGTH env ==>
-    (evaluate ([compile_any split_seq l k x],env,s1) = (res,s2))``,
+    (evaluate ([compile_any split_seq l k x],env,s1) = (res,s2))`,
   rw [compile_any_def,compile_correct] \\ fs [LENGTH_NIL] \\ rw []
   \\ drule compile_seqs_correct
   \\ disch_then (qspecl_then [`l`,`NONE`] mp_tac) \\ fs []);
 
-val compile_IMP_LENGTH = store_thm("compile_IMP_LENGTH",
-  ``compile l n xs = (ys,l1,s1) ==> LENGTH ys = LENGTH xs``,
+val compile_IMP_LENGTH = Q.store_thm("compile_IMP_LENGTH",
+  `compile l n xs = (ys,l1,s1) ==> LENGTH ys = LENGTH xs`,
   rw [] \\ mp_tac (SPEC_ALL compile_length) \\ asm_simp_tac std_ss []);
 
 val bVarBound_CONS = Q.store_thm("bVarBound_CONS",
@@ -373,9 +373,9 @@ val bVarBound_LESS_EQ = Q.store_thm("bVarBound_LESS_EQ",
   `!m xs n. bVarBound m xs /\ m <= n ==> bVarBound n xs`,
   HO_MATCH_MP_TAC bVarBound_ind \\ rw [] \\ fs []);
 
-val ALOOKUP_MAPi = store_thm("ALOOKUP_MAPi",
-  ``!xs i x.
-      ALOOKUP (MAPi (λi x. (x,i)) xs) n = SOME x ==> x < LENGTH xs``,
+val ALOOKUP_MAPi = Q.store_thm("ALOOKUP_MAPi",
+  `!xs i x.
+      ALOOKUP (MAPi (λi x. (x,i)) xs) n = SOME x ==> x < LENGTH xs`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ rw []
   \\ fs [SNOC_APPEND,MAPi_APPEND,ALOOKUP_APPEND]
   \\ every_case_tac \\ fs []);
@@ -411,8 +411,8 @@ val bVarBound_compile = Q.store_thm("bVarBound_compile",
   \\ imp_res_tac bVarBound_LetLet \\ fs []
   \\ match_mp_tac bVarBound_OptionalLetLet \\ fs []);
 
-val compile_IMP_bVarBound = store_thm("compile_IMP_bVarBound",
-  ``compile l n xs = (ys,l2,s2) ==> bVarBound n ys``,
+val compile_IMP_bVarBound = Q.store_thm("compile_IMP_bVarBound",
+  `compile l n xs = (ys,l2,s2) ==> bVarBound n ys`,
   rw [] \\ mp_tac (Q.INST [`m`|->`n`] (SPEC_ALL bVarBound_compile)) \\ fs []);
 
 val compile_exp_bVarBound = Q.store_thm("compile_exp_bVarBound",

--- a/compiler/backend/proofs/bvl_inlineProofScript.sml
+++ b/compiler/backend/proofs/bvl_inlineProofScript.sml
@@ -14,14 +14,14 @@ val code_rel_def = Define `
              evaluate ([e1],env,s with code := c1) = (res,t with code := c1) ==>
              evaluate ([e2],env,s with code := c2) = (res,t with code := c2)`
 
-val code_rel_refl = store_thm("code_rel_refl",
-  ``!c. code_rel (:'ffi) c c``,
+val code_rel_refl = Q.store_thm("code_rel_refl",
+  `!c. code_rel (:'ffi) c c`,
   fs [code_rel_def]);
 
-val code_rel_trans = store_thm("code_rel_trans",
-  ``!c1 c2 c3.
+val code_rel_trans = Q.store_thm("code_rel_trans",
+  `!c1 c2 c3.
       code_rel (:'ffi) c1 c2 /\ code_rel (:'ffi) c2 c3 ==>
-      code_rel (:'ffi) c1 c3``,
+      code_rel (:'ffi) c1 c3`,
   fs [code_rel_def] \\ rw [] \\ res_tac
   \\ first_x_assum drule \\ rw [] \\ fs []);
 
@@ -187,8 +187,8 @@ val evaluate_inline = Q.store_thm("evaluate_inline",
      \\ split_tac `evaluate ([x],env,s)` \\ split_tac `evaluate (y::xs,env,r)`
      \\ IMP_RES_TAC evaluate_code \\ FULL_SIMP_TAC (srw_ss()) []));
 
-val exp_rel_inline = store_thm("exp_rel_inline",
-  ``subspt cs c ==> exp_rel (:'ffi) c e (HD (inline cs [e]))``,
+val exp_rel_inline = Q.store_thm("exp_rel_inline",
+  `subspt cs c ==> exp_rel (:'ffi) c e (HD (inline cs [e]))`,
   fs [exp_rel_def] \\ rw []
   \\ qpat_x_assum `_ = (_,_)` (fn th => assume_tac th THEN
         once_rewrite_tac [GSYM th])
@@ -211,33 +211,33 @@ val code_rel_insert_insert_inline = store_thm("code_rel_insert_insert_inline",
   \\ pop_assum (fn th => once_rewrite_tac [th]) \\ rw []
   \\ match_mp_tac code_rel_insert_inline \\ fs []);
 
-val inline_all_acc = store_thm("inline_all_acc",
-  ``!xs ys cs limit.
-      inline_all limit cs xs ys = REVERSE ys ++ inline_all limit cs xs []``,
+val inline_all_acc = Q.store_thm("inline_all_acc",
+  `!xs ys cs limit.
+      inline_all limit cs xs ys = REVERSE ys ++ inline_all limit cs xs []`,
   Induct \\ fs [inline_all_def] \\ strip_tac \\ PairCases_on `h` \\ fs []
   \\ once_rewrite_tac [inline_all_def] \\ simp_tac std_ss [LET_THM]
   \\ rpt strip_tac \\ IF_CASES_TAC
   \\ qpat_x_assum `!x._` (fn th => once_rewrite_tac [th]) \\ fs []);
 
-val fromAList_SWAP = prove(
-  ``!xs x ys.
+val fromAList_SWAP = Q.prove(
+  `!xs x ys.
       ALL_DISTINCT (FST x::MAP FST xs) ==>
-      fromAList (xs ++ x::ys) = fromAList (x::(xs ++ ys))``,
+      fromAList (xs ++ x::ys) = fromAList (x::(xs ++ ys))`,
   Induct \\ fs [] \\ rw []
   \\ PairCases_on `h` \\ fs [fromAList_def]
   \\ PairCases_on `x` \\ fs [fromAList_def]
   \\ fs [spt_eq_thm,wf_insert,wf_fromAList]
   \\ rw [lookup_insert]);
 
-val code_rel_rearrange_lemma = store_thm("code_rel_rearrange_lemma",
-  ``ALL_DISTINCT (FST x::MAP FST xs) /\
+val code_rel_rearrange_lemma = Q.store_thm("code_rel_rearrange_lemma",
+  `ALL_DISTINCT (FST x::MAP FST xs) /\
     MAP FST zs = MAP FST xs /\
     code_rel (:'ffi) (fromAList (xs++x::ys)) (fromAList (zs++x::ys)) ==>
-    code_rel (:'ffi) (fromAList (x::(xs++ys))) (fromAList (x::(zs++ys))) ``,
+    code_rel (:'ffi) (fromAList (x::(xs++ys))) (fromAList (x::(zs++ys))) `,
   metis_tac [fromAList_SWAP,APPEND]);
 
-val MAP_FST_inline_all = store_thm("MAP_FST_inline_all",
-  ``!xs cs. MAP FST (inline_all limit cs xs []) = MAP FST xs``,
+val MAP_FST_inline_all = Q.store_thm("MAP_FST_inline_all",
+  `!xs cs. MAP FST (inline_all limit cs xs []) = MAP FST xs`,
   Induct \\ fs [inline_all_def] \\ strip_tac
   \\ PairCases_on `h` \\ fs [inline_all_def] \\ rw []
   \\ once_rewrite_tac [inline_all_acc] \\ fs []);
@@ -286,16 +286,16 @@ val code_rel_inline_all = store_thm("code_rel_inline_all",
   \\ Cases_on `y'` \\ fs [])
   |> Q.SPECL [`xs`,`[]`] |> SIMP_RULE std_ss [APPEND_NIL];
 
-val code_rel_compile_prog = store_thm("code_rel_compile_prog",
-  ``ALL_DISTINCT (MAP FST prog) ==>
-    code_rel (:'ffi) (fromAList prog) (fromAList (compile_prog limit prog))``,
+val code_rel_compile_prog = Q.store_thm("code_rel_compile_prog",
+  `ALL_DISTINCT (MAP FST prog) ==>
+    code_rel (:'ffi) (fromAList prog) (fromAList (compile_prog limit prog))`,
   fs [compile_prog_def] \\ rw [code_rel_refl]
   \\ match_mp_tac code_rel_inline_all \\ fs [lookup_def]);
 
-val code_rel_IMP_semantics_EQ = store_thm("code_rel_IMP_semantics_EQ",
-  ``!(ffi:'ffi ffi_state) c1 c2 start.
+val code_rel_IMP_semantics_EQ = Q.store_thm("code_rel_IMP_semantics_EQ",
+  `!(ffi:'ffi ffi_state) c1 c2 start.
       code_rel (:'ffi) c1 c2 /\ semantics ffi c1 start <> Fail ==>
-      semantics ffi c2 start = semantics ffi c1 start``,
+      semantics ffi c2 start = semantics ffi c1 start`,
   rewrite_tac [GSYM AND_IMP_INTRO]
   \\ ntac 5 strip_tac \\ simp[bvlSemTheory.semantics_def]
   \\ IF_CASES_TAC >> full_simp_tac(srw_ss())[] >>
@@ -373,8 +373,8 @@ val compile_prog_semantics = save_thm("compile_prog_semantics",
    (code_rel_compile_prog |> UNDISCH) |> SPEC_ALL
   |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO]);
 
-val MAP_FST_compile_prog = store_thm("MAP_FST_compile_prog",
-  ``MAP FST (bvl_inline$compile_prog limit prog) = MAP FST prog``,
+val MAP_FST_compile_prog = Q.store_thm("MAP_FST_compile_prog",
+  `MAP FST (bvl_inline$compile_prog limit prog) = MAP FST prog`,
   fs [bvl_inlineTheory.compile_prog_def] \\ rw [MAP_FST_inline_all]);
 
 val _ = export_theory();

--- a/compiler/backend/proofs/bvl_inlineProofScript.sml
+++ b/compiler/backend/proofs/bvl_inlineProofScript.sml
@@ -32,15 +32,15 @@ val exp_rel_def = Define `
       res <> Rerr (Rabort Rtype_error) ==>
       evaluate ([e2],env,s) = (res,t)`
 
-val evaluate_code_insert = store_thm("evaluate_code_insert",
-  ``!xs env (s:'ffi bvlSem$state) res t e1 e2 n arity c.
+val evaluate_code_insert = Q.store_thm("evaluate_code_insert",
+  `!xs env (s:'ffi bvlSem$state) res t e1 e2 n arity c.
       evaluate (xs,env,s) = (res,t) /\
       exp_rel (:'ffi) (insert n (arity,e2) c) e1 e2 /\
       res ≠ Rerr (Rabort Rtype_error) /\
       lookup n c = SOME (arity,e1) /\
       s.code = c ==>
       evaluate (xs,env,s with code := insert n (arity,e2) c) =
-                  (res,t with code := insert n (arity,e2) c)``,
+                  (res,t with code := insert n (arity,e2) c)`,
   recInduct bvlSemTheory.evaluate_ind \\ reverse (rw [])
   \\ fs [bvlSemTheory.evaluate_def]
   THEN1 (* Call *)
@@ -129,10 +129,10 @@ val evaluate_code_insert = store_thm("evaluate_code_insert",
     \\ imp_res_tac evaluate_code \\ fs []
     \\ Cases_on `q` \\ fs [] \\ rveq \\ fs []));
 
-val code_rel_insert = store_thm("code_rel_insert",
-  ``lookup n c = SOME (arity,e1) /\
+val code_rel_insert = Q.store_thm("code_rel_insert",
+  `lookup n c = SOME (arity,e1) /\
     exp_rel (:'ffi) (insert n (arity,e2) c) e1 e2 ==>
-    code_rel (:'ffi) c (insert n (arity,e2) c)``,
+    code_rel (:'ffi) c (insert n (arity,e2) c)`,
   fs [code_rel_def] \\ rw [lookup_insert] \\ rw [] \\ fs [] \\ rw []
   \\ TRY (drule evaluate_code_insert \\ fs [] \\ NO_TAC)
   \\ drule evaluate_code_insert \\ fs []
@@ -194,18 +194,18 @@ val exp_rel_inline = Q.store_thm("exp_rel_inline",
         once_rewrite_tac [GSYM th])
   \\ match_mp_tac evaluate_inline \\ fs []);
 
-val code_rel_insert_inline = store_thm("code_rel_insert_inline",
-  ``lookup n c = SOME (arity,e1) /\ subspt cs c /\ ~(n IN domain cs) ==>
-    code_rel (:'ffi) c (insert n (arity,(HD (inline cs [e1]))) c)``,
+val code_rel_insert_inline = Q.store_thm("code_rel_insert_inline",
+  `lookup n c = SOME (arity,e1) /\ subspt cs c /\ ~(n IN domain cs) ==>
+    code_rel (:'ffi) c (insert n (arity,(HD (inline cs [e1]))) c)`,
   rw [] \\ match_mp_tac code_rel_insert \\ fs []
   \\ match_mp_tac exp_rel_inline
   \\ fs [subspt_def,domain_lookup,PULL_EXISTS,lookup_insert]
   \\ rw [] \\ res_tac \\ fs []);
 
-val code_rel_insert_insert_inline = store_thm("code_rel_insert_insert_inline",
-  ``subspt cs (insert n (arity,e1) c) /\ ~(n IN domain cs) ==>
+val code_rel_insert_insert_inline = Q.store_thm("code_rel_insert_insert_inline",
+  `subspt cs (insert n (arity,e1) c) /\ ~(n IN domain cs) ==>
     code_rel (:'ffi) (insert n (arity,e1) c)
-                     (insert n (arity,(HD (inline cs [e1]))) c)``,
+                     (insert n (arity,(HD (inline cs [e1]))) c)`,
   `insert n (arity,HD (inline cs [e1])) c =
    insert n (arity,HD (inline cs [e1])) (insert n (arity,e1) c)` by fs [insert_shadow]
   \\ pop_assum (fn th => once_rewrite_tac [th]) \\ rw []
@@ -242,20 +242,20 @@ val MAP_FST_inline_all = Q.store_thm("MAP_FST_inline_all",
   \\ PairCases_on `h` \\ fs [inline_all_def] \\ rw []
   \\ once_rewrite_tac [inline_all_acc] \\ fs []);
 
-val MEM_IMP_ALOOKUP_SOME = store_thm("MEM_IMP_ALOOKUP_SOME",
-  ``!xs x y.
+val MEM_IMP_ALOOKUP_SOME = Q.store_thm("MEM_IMP_ALOOKUP_SOME",
+  `!xs x y.
       ALL_DISTINCT (MAP FST xs) /\ MEM (x,y) xs ==>
-      ALOOKUP xs x = SOME y``,
+      ALOOKUP xs x = SOME y`,
   Induct \\ fs [FORALL_PROD] \\ rw []
   \\ res_tac \\ fs [MEM_MAP,FORALL_PROD] \\ rfs []);
 
-val code_rel_inline_all = store_thm("code_rel_inline_all",
-  ``!xs ys cs.
+val code_rel_inline_all = Q.store_thm("code_rel_inline_all",
+  `!xs ys cs.
       (!x y. lookup x cs = SOME y ==> MEM (x,y) ys /\ !y. ~MEM (x,y) xs) /\
       ALL_DISTINCT (MAP FST (ys ++ xs)) ==>
       code_rel (:'ffi)
         (fromAList (xs ++ ys))
-        (fromAList (inline_all limit cs xs [] ++ ys))``,
+        (fromAList (inline_all limit cs xs [] ++ ys))`,
   Induct \\ fs [inline_all_def,code_rel_refl]
   \\ strip_tac \\ PairCases_on `h` \\ fs []
   \\ reverse (rw [inline_all_def])

--- a/compiler/backend/proofs/bvl_jumpProofScript.sml
+++ b/compiler/backend/proofs/bvl_jumpProofScript.sml
@@ -2,11 +2,11 @@ open preamble bvl_jumpTheory bvlSemTheory bvlPropsTheory;
 
 val _ = new_theory"bvl_jumpProof";
 
-val evaluate_JumpList = prove(
-  ``!n xs k.
+val evaluate_JumpList = Q.prove(
+  `!n xs k.
       k < LENGTH xs ==>
       (evaluate ([JumpList n xs],Number (&(n+k))::env,s) =
-       evaluate ([EL k xs],Number (&(n+k))::env,s))``,
+       evaluate ([EL k xs],Number (&(n+k))::env,s))`,
   recInduct JumpList_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ SIMP_TAC std_ss [Once JumpList_def,LET_DEF]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
@@ -23,11 +23,11 @@ val evaluate_JumpList = prove(
   \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[NOT_LESS]
   \\ IMP_RES_TAC EL_APPEND2 \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_Jump = store_thm("evaluate_Jump",
-  ``(evaluate ([x],env,s) = (Rval [Number (&n)],t)) /\
+val evaluate_Jump = Q.store_thm("evaluate_Jump",
+  `(evaluate ([x],env,s) = (Rval [Number (&n)],t)) /\
     n < LENGTH xs ==>
     (evaluate ([Jump x xs],env,s) =
-     evaluate ([EL n xs],Number (&n) :: env,t))``,
+     evaluate ([EL n xs],Number (&n) :: env,t))`,
   full_simp_tac(srw_ss())[evaluate_def,Jump_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC evaluate_JumpList
   \\ POP_ASSUM (ASSUME_TAC o Q.SPECL [`t`,`0`]) \\ full_simp_tac(srw_ss())[]);

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -665,7 +665,7 @@ val do_app_adjust = Q.prove(
     conj_asm1_tac >- (
       simp[INJ_INSERT] >>
       conj_tac >- (
-        rator_x_assum`INJ`mp_tac >>
+        qhdtm_x_assum`INJ`mp_tac >>
         simp[INJ_DEF] ) >>
       `n ∈ FDOM s5.refs` by full_simp_tac(srw_ss())[FLOOKUP_DEF] >>
       metis_tac[INJ_DEF]) >>
@@ -1664,7 +1664,7 @@ val compile_exps_correct = Q.prove(
          imp_res_tac evaluate_global_mono >>
          BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
          simp[bEvalOp_def] >>
-         rator_x_assum`state_rel`mp_tac >>
+         qhdtm_x_assum`state_rel`mp_tac >>
          simp[Once state_rel_def] >> strip_tac >>
          simp[ADD1,LENGTH_REPLICATE] >>
          reverse IF_CASES_TAC >>
@@ -2346,7 +2346,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
       first_assum(subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) o concl) >>
       drule bviPropsTheory.evaluate_add_clock >>
       impl_tac >- full_simp_tac(srw_ss())[] >> strip_tac >>
-      rator_x_assum`bvlSem$evaluate`kall_tac >>
+      qhdtm_x_assum`bvlSem$evaluate`kall_tac >>
       last_assum(qspec_then`SUC k'`mp_tac)>>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       drule (GEN_ALL compile_prog_evaluate) >>
@@ -2387,7 +2387,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
             CASE_TAC >> full_simp_tac(srw_ss())[] >>
             CASE_TAC >> full_simp_tac(srw_ss())[] ) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[bviPropsTheory.inc_clock_def]>>
-          rator_x_assum`bviSem$evaluate`mp_tac >>
+          qhdtm_x_assum`bviSem$evaluate`mp_tac >>
           drule bviPropsTheory.evaluate_add_clock >>
           impl_tac >- ( strip_tac >> full_simp_tac(srw_ss())[] ) >>
           disch_then(qspec_then`ck+k`mp_tac)>>simp[bviPropsTheory.inc_clock_def]>>
@@ -2407,7 +2407,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
           rveq >> full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def] >>
           every_case_tac >> full_simp_tac(srw_ss())[] >> rveq >> full_simp_tac(srw_ss())[]) >>
         strip_tac >>
-        rator_x_assum`bvlSem$evaluate`mp_tac >>
+        qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
         drule bvlPropsTheory.evaluate_add_clock >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
         disch_then(qspec_then`k'`mp_tac)>>simp[bvlPropsTheory.inc_clock_def] >>
@@ -2429,7 +2429,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
         first_x_assum(qspec_then`ck+SUC k`mp_tac) >>
         fsrw_tac[ARITH_ss][ADD1] >> strip_tac >>
         full_simp_tac(srw_ss())[state_rel_def] >> rev_full_simp_tac(srw_ss())[] ) >>
-      rator_x_assum`bviSem$evaluate`mp_tac >>
+      qhdtm_x_assum`bviSem$evaluate`mp_tac >>
       drule bviPropsTheory.evaluate_add_clock >>
       impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
       disch_then(qspec_then`ck+SUC k`mp_tac)>>simp[bviPropsTheory.inc_clock_def] >>
@@ -2449,7 +2449,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
     strip_tac >>
     asm_exists_tac >>
     every_case_tac >> full_simp_tac(srw_ss())[] >> rveq >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`bvlSem$evaluate`mp_tac >>
+      qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
       drule bvlPropsTheory.evaluate_add_clock >>
       impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
       disch_then(qspec_then`1`mp_tac)>>simp[bvlPropsTheory.inc_clock_def] ) >>
@@ -2500,14 +2500,14 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
     qpat_x_assum`∀x y. ¬z`mp_tac >> simp[] >>
     qexists_tac`SUC k`>>simp[] >>
     reverse(Cases_on`s.ffi.final_event`)>>full_simp_tac(srw_ss())[]>-(
-      rator_x_assum`bviSem$evaluate`mp_tac >>
+      qhdtm_x_assum`bviSem$evaluate`mp_tac >>
       qmatch_assum_abbrev_tac`bviSem$evaluate (exps,[],ss) = _` >>
       qspecl_then[`exps`,`[]`,`ss`]mp_tac bviPropsTheory.evaluate_add_to_clock_io_events_mono >>
       disch_then(qspec_then`SUC ck`mp_tac)>>
       fsrw_tac[ARITH_ss][ADD1,bviPropsTheory.inc_clock_def,Abbr`ss`] >>
       rpt strip_tac >> full_simp_tac(srw_ss())[] >>
       full_simp_tac(srw_ss())[state_rel_def] >> rev_full_simp_tac(srw_ss())[] ) >>
-    rator_x_assum`bviSem$evaluate`mp_tac >>
+    qhdtm_x_assum`bviSem$evaluate`mp_tac >>
     drule bviPropsTheory.evaluate_add_clock >>
     impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
     disch_then(qspec_then`SUC ck`mp_tac) >>

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -33,8 +33,8 @@ val adjust_bv_Unit = Q.store_thm("adjust_bv_Unit[simp]",
   `adjust_bv x Unit = Unit`,
   EVAL_TAC);
 
-val adjust_bv_Boolv = store_thm("adjust_bv_Boolv[simp]",
-  ``adjust_bv x (Boolv b) = Boolv b``,
+val adjust_bv_Boolv = Q.store_thm("adjust_bv_Boolv[simp]",
+  `adjust_bv x (Boolv b) = Boolv b`,
   Cases_on`b`>>EVAL_TAC)
 
 val aux_code_installed_def = Define `
@@ -43,11 +43,11 @@ val aux_code_installed_def = Define `
      (sptree$lookup name t = SOME (arg_count,body)) /\
      aux_code_installed rest t)`
 
-val aux_code_installed_APPEND = prove(
-  ``!xs ys.
+val aux_code_installed_APPEND = Q.prove(
+  `!xs ys.
       aux_code_installed (xs++ys) code ==>
       aux_code_installed xs code /\
-      aux_code_installed ys code``,
+      aux_code_installed ys code`,
   Induct \\ full_simp_tac(srw_ss())[APPEND,aux_code_installed_def,FORALL_PROD] \\ METIS_TAC []);
 
 val state_rel_def = Define `
@@ -88,9 +88,9 @@ val bv_ok_def = tDefine "bv_ok" `
 
 val bv_ok_ind = theorem"bv_ok_ind";
 
-val bv_ok_SUBSET_IMP = prove(
-  ``!refs x refs2.
-      bv_ok refs x /\ FDOM refs SUBSET FDOM refs2 ==> bv_ok refs2 x``,
+val bv_ok_SUBSET_IMP = Q.prove(
+  `!refs x refs2.
+      bv_ok refs x /\ FDOM refs SUBSET FDOM refs2 ==> bv_ok refs2 x`,
   HO_MATCH_MP_TAC bv_ok_ind \\ full_simp_tac(srw_ss())[bv_ok_def]
   \\ full_simp_tac(srw_ss())[SUBSET_DEF,EVERY_MEM]);
 
@@ -102,11 +102,11 @@ val bv_ok_Boolv = Q.store_thm("bv_ok_Boolv[simp]",
   `bv_ok refs (Boolv b)`,
   EVAL_TAC)
 
-val bv_ok_IMP_adjust_bv_eq = prove(
-  ``!b2 a1 b3.
+val bv_ok_IMP_adjust_bv_eq = Q.prove(
+  `!b2 a1 b3.
       bv_ok (s5:'ffi bvlSem$state).refs a1 /\
       (!a. a IN FDOM s5.refs ==> b2 a = b3 a) ==>
-      (adjust_bv b2 a1 = adjust_bv b3 a1)``,
+      (adjust_bv b2 a1 = adjust_bv b3 a1)`,
   HO_MATCH_MP_TAC adjust_bv_ind
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[adjust_bv_def,bv_ok_def]
   \\ full_simp_tac(srw_ss())[MAP_EQ_f,EVERY_MEM]);
@@ -120,9 +120,9 @@ val state_ok_def = Define `
 
 (* evaluate preserves state_ok *)
 
-val evaluate_ok_lemma = prove(
-  ``(state_ok (dec_clock n s) = state_ok s) /\
-    ((dec_clock n s).refs = s.refs)``,
+val evaluate_ok_lemma = Q.prove(
+  `(state_ok (dec_clock n s) = state_ok s) /\
+    ((dec_clock n s).refs = s.refs)`,
   full_simp_tac(srw_ss())[state_ok_def,bvlSemTheory.dec_clock_def]);
 
 val evaluate_IMP_bv_ok = prove(

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -125,10 +125,10 @@ val evaluate_ok_lemma = Q.prove(
     ((dec_clock n s).refs = s.refs)`,
   full_simp_tac(srw_ss())[state_ok_def,bvlSemTheory.dec_clock_def]);
 
-val evaluate_IMP_bv_ok = prove(
-  ``(bvlSem$evaluate (xs,env,s) = (res,t)) ==>
+val evaluate_IMP_bv_ok = Q.prove(
+  `(bvlSem$evaluate (xs,env,s) = (res,t)) ==>
     (bv_ok s.refs a1 ==> bv_ok t.refs a1) /\
-    (EVERY (bv_ok s.refs) as ==> EVERY (bv_ok t.refs) as)``,
+    (EVERY (bv_ok s.refs) as ==> EVERY (bv_ok t.refs) as)`,
   REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[EVERY_MEM] \\ REPEAT STRIP_TAC \\ RES_TAC
   \\ IMP_RES_TAC evaluate_refs_SUBSET \\ IMP_RES_TAC bv_ok_SUBSET_IMP);
 
@@ -140,10 +140,10 @@ val v_to_list_ok = Q.prove(
   simp[v_to_list_def,bv_ok_def] >> srw_tac[][] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][])
 
-val do_app_ok_lemma = prove(
-  ``state_ok r /\ EVERY (bv_ok r.refs) a /\
+val do_app_ok_lemma = Q.prove(
+  `state_ok r /\ EVERY (bv_ok r.refs) a /\
     (do_app op a r = Rval (q,t)) ==>
-    state_ok t /\ bv_ok t.refs q``,
+    state_ok t /\ bv_ok t.refs q`,
   Cases_on `op` \\ full_simp_tac(srw_ss())[bvlSemTheory.do_app_def] \\ BasicProvers.EVERY_CASE_TAC
   \\ TRY (full_simp_tac(srw_ss())[] \\ SRW_TAC [] [bv_ok_def]
     \\ full_simp_tac(srw_ss())[closSemTheory.get_global_def]
@@ -245,18 +245,18 @@ val do_app_ok_lemma = prove(
     \\ Q.ISPEC_THEN`r.refs`match_mp_tac bv_ok_SUBSET_IMP
     \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[SUBSET_DEF,FLOOKUP_DEF]));
 
-val do_app_ok = prove(
-  ``state_ok r /\ EVERY (bv_ok r.refs) a /\
+val do_app_ok = Q.prove(
+  `state_ok r /\ EVERY (bv_ok r.refs) a /\
     (do_app op a r = Rval (q,t)) ==>
     state_ok t /\ bv_ok t.refs q /\
-    (EVERY (bv_ok r.refs) env ==> EVERY (bv_ok t.refs) env)``,
+    (EVERY (bv_ok r.refs) env ==> EVERY (bv_ok t.refs) env)`,
   STRIP_TAC \\ IMP_RES_TAC do_app_ok_lemma \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[EVERY_MEM] \\ REPEAT STRIP_TAC \\ RES_TAC
   \\ IMP_RES_TAC do_app_refs_SUBSET
   \\ IMP_RES_TAC bv_ok_SUBSET_IMP);
 
-val evaluate_ok = prove(
-  ``!xs env s res t.
+val evaluate_ok = Q.prove(
+  `!xs env s res t.
       (evaluate (xs,env,s) = (res,t)) /\
       state_ok s /\ EVERY (bv_ok s.refs) env ==>
       state_ok t /\
@@ -264,7 +264,7 @@ val evaluate_ok = prove(
        | Rval vs => EVERY (bv_ok t.refs) vs
        | Rerr(Rraise v) => bv_ok t.refs v
        | _ => T) /\
-      EVERY (bv_ok t.refs) env``,
+      EVERY (bv_ok t.refs) env`,
   recInduct bvlSemTheory.evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def]
   \\ SRW_TAC [] []
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[evaluate_ok_lemma]
@@ -289,11 +289,11 @@ val evaluate_ok = prove(
 
 (* semantics lemmas *)
 
-val evaluate_MAP_Var = prove(
-  ``!l env vs b s.
+val evaluate_MAP_Var = Q.prove(
+  `!l env vs b s.
       EVERY isVar l /\ (get_vars (MAP destVar l) env = SOME vs) ==>
         (evaluate (MAP (Var o destVar) l,MAP (adjust_bv b) env,s) =
-          (Rval (MAP (adjust_bv b) vs),s))``,
+          (Rval (MAP (adjust_bv b) vs),s))`,
   Induct THEN1 (EVAL_TAC \\ SRW_TAC [] [])
   \\ Cases \\ full_simp_tac(srw_ss())[isVar_def,destVar_def,get_vars_def]
   \\ Cases_on `l` \\ full_simp_tac(srw_ss())[bviSemTheory.evaluate_def,get_vars_def,EL_MAP]
@@ -304,22 +304,22 @@ val evaluate_MAP_Var = prove(
   \\ Q.PAT_X_ASSUM `!xx.bb` (MP_TAC o Q.SPEC `env`) \\ full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[EL_MAP]) |> INST_TYPE[alpha|->``:'ffi``];
 
-val evaluate_MAP_Var2 = prove(
-  ``!args.
+val evaluate_MAP_Var2 = Q.prove(
+  `!args.
       bVarBound (LENGTH vs) args /\ EVERY isVar args ==>
       ?ts.
         bviSem$evaluate (MAP (Var o destVar) args,vs ++ env,s) = (Rval ts,s) /\
-        evaluate (MAP (Var o destVar) args,vs,s) = (Rval ts,s)``,
+        evaluate (MAP (Var o destVar) args,vs,s) = (Rval ts,s)`,
   Induct \\ full_simp_tac(srw_ss())[MAP,bviSemTheory.evaluate_def] \\ Cases \\ full_simp_tac(srw_ss())[isVar_def]
   \\ Cases_on `args` \\ full_simp_tac(srw_ss())[MAP,bviSemTheory.evaluate_def,destVar_def,bVarBound_def]
   \\ REPEAT STRIP_TAC
   \\ `n < LENGTH vs + LENGTH env` by DECIDE_TAC \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[rich_listTheory.EL_APPEND1]) |> SPEC_ALL |> INST_TYPE[alpha|->``:'ffi``];
 
-val bEval_bVarBound = prove(
-  ``!xs vs s env.
+val bEval_bVarBound = Q.prove(
+  `!xs vs s env.
       bVarBound (LENGTH vs) xs ==>
-      (bvlSem$evaluate (xs,vs ++ env,s) = evaluate (xs,vs,s))``,
+      (bvlSem$evaluate (xs,vs ++ env,s) = evaluate (xs,vs,s))`,
   recInduct bvlSemTheory.evaluate_ind \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def,bVarBound_def]
   \\ TRY (BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[ADD1] \\ NO_TAC)
@@ -440,13 +440,13 @@ val evaluate_AllocGlobal_code = Q.prove(
   \\ AP_THM_TAC \\ AP_TERM_TAC
   \\ intLib.COOPER_TAC)
 
-val evaluate_ListLength_code = store_thm("evaluate_ListLength_code",
-  ``!lv vs n.
+val evaluate_ListLength_code = Q.store_thm("evaluate_ListLength_code",
+  `!lv vs n.
       lookup ListLength_location s.code = SOME (2,SND ListLength_code) /\
       v_to_list lv = SOME vs ==>
       ∃p1 c.
         evaluate ([SND ListLength_code],[lv;Number (&n)],inc_clock c s) =
-          (Rval [Number (&(n + LENGTH vs))],s)``,
+          (Rval [Number (&(n + LENGTH vs))],s)`,
   HO_MATCH_MP_TAC v_to_list_ind \\ rw [] \\ fs [v_to_list_def] \\ rveq
   \\ fs [ListLength_code_def] THEN1
    (fs [bviSemTheory.evaluate_def,EVAL ``Boolv T``,
@@ -474,15 +474,15 @@ val evaluate_ListLength_code = store_thm("evaluate_ListLength_code",
 val bEval_def = bvlSemTheory.evaluate_def;
 val iEval_append = bviPropsTheory.evaluate_APPEND;
 
-val compile_exps_Var_list = prove(
-  ``!l n. EVERY isVar l ==> (∃aux. compile_exps n l = (MAP (Var o destVar) l ,aux,n) ∧ append aux = [])``,
+val compile_exps_Var_list = Q.prove(
+  `!l n. EVERY isVar l ==> (∃aux. compile_exps n l = (MAP (Var o destVar) l ,aux,n) ∧ append aux = [])`,
   Induct \\ fs[compile_exps_def] \\ Cases \\ rw[isVar_def] \\ fs[]
   \\ Cases_on`l` \\ fs[compile_exps_def,destVar_def]
   \\ qmatch_goalsub_rename_tac`bvl_to_bvi$compile_exps a`
   \\ first_x_assum(qspec_then`a`strip_assume_tac) \\ fs[]);
 
-val compile_int_thm = prove(
-  ``!i env s. evaluate ([compile_int i],env,s) = (Rval [Number i],s)``,
+val compile_int_thm = Q.prove(
+  `!i env s. evaluate ([compile_int i],env,s) = (Rval [Number i],s)`,
   STRIP_TAC \\ completeInduct_on `Num (ABS i)`
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[PULL_FORALL] \\ POP_ASSUM (K ALL_TAC)
   \\ reverse (Cases_on `i`) \\ full_simp_tac(srw_ss())[] THEN1 EVAL_TAC
@@ -802,8 +802,8 @@ val do_app_adjust = Q.prove(
     \\ every_case_tac >> full_simp_tac(srw_ss())[bvl_to_bvi_id] >> srw_tac[][]
     \\ EVAL_TAC )) |> INST_TYPE[alpha|->``:'ffi``];
 
-val eval_ind_alt = store_thm("eval_ind_alt",
-  ``∀P.
+val eval_ind_alt = Q.store_thm("eval_ind_alt",
+  `∀P.
      (∀env s. P ([],env,s)) ∧
      (∀x y xs env s.
         (∀v3 s1 v1.
@@ -849,7 +849,7 @@ val eval_ind_alt = store_thm("eval_ind_alt",
            ¬(s.clock < ticks + 1) ⇒
            P ([exp],args,dec_clock (ticks + 1) s)) ∧ P (xs,env,s1) ⇒
         P ([Call ticks dest xs],env,s1)) ⇒
-     ∀v v1 v2. P (v,v1,v2:'ffi bvlSem$state)``,
+     ∀v v1 v2. P (v,v1,v2:'ffi bvlSem$state)`,
   rpt strip_tac
   \\ HO_MATCH_MP_TAC (MP_CANON WF_INDUCTION_THM)
   \\ WF_REL_TAC `(inv_image (measure I LEX measure exp1_size)
@@ -867,10 +867,10 @@ val eval_ind_alt = store_thm("eval_ind_alt",
   \\ fs [LESS_OR_EQ,bvlTheory.exp_size_def]
   \\ fs [bvlSemTheory.dec_clock_def]);
 
-val EVERY_isVar_evaluate_Rval_MEM = store_thm("EVERY_isVar_evaluate_Rval_MEM",
-  ``!l env a s r.
+val EVERY_isVar_evaluate_Rval_MEM = Q.store_thm("EVERY_isVar_evaluate_Rval_MEM",
+  `!l env a s r.
       EVERY isVar l /\ bvlSem$evaluate (l,env,s) = (Rval a,r) ==>
-      EVERY (\x. MEM x env) a /\ s = r``,
+      EVERY (\x. MEM x env) a /\ s = r`,
   Induct \\ fs [bvlSemTheory.evaluate_def]
   \\ Cases_on `h` \\ fs[isVar_def]
   \\ Cases_on `l` \\ fs [bvlSemTheory.evaluate_def] \\ rw []
@@ -1879,10 +1879,10 @@ val ALOOKUP_optimise_lookup = Q.store_thm("ALOOKUP_optimise_lookup",
   fs [optimise_def,MEM_MAP,PULL_EXISTS,EXISTS_PROD,MEM_toAList] >>
   full_simp_tac(srw_ss())[]);
 
-val evaluate_IMP_optimise = store_thm("evaluate_IMP_optimise",
-  ``evaluate ([r],zenv,zs) = (res,s') /\ res <> Rerr (Rabort Rtype_error) /\
+val evaluate_IMP_optimise = Q.store_thm("evaluate_IMP_optimise",
+  `evaluate ([r],zenv,zs) = (res,s') /\ res <> Rerr (Rabort Rtype_error) /\
     LENGTH zenv = q ==>
-    evaluate ([bvl_handle$compile_any split_seq x q r],zenv,zs) = (res,s')``,
+    evaluate ([bvl_handle$compile_any split_seq x q r],zenv,zs) = (res,s')`,
   rw [] \\ match_mp_tac bvl_handleProofTheory.compile_any_correct \\ fs []
   \\ drule (GEN_ALL bvl_constProofTheory.evaluate_compile_exp) \\ fs []);
 
@@ -2037,9 +2037,9 @@ val compile_single_evaluate = Q.store_thm("compile_single_evaluate",
   Cases_on`res`>>simp[] >- METIS_TAC[] >>
   Cases_on`e`>>simp[] >> METIS_TAC[]);
 
-val evaluate_REPLICATE_0 = prove(
-  ``!n. evaluate (REPLICATE n (Op (Const 0) []),env,s) =
-          (Rval (REPLICATE n (Number 0)),s)``,
+val evaluate_REPLICATE_0 = Q.prove(
+  `!n. evaluate (REPLICATE n (Op (Const 0) []),env,s) =
+          (Rval (REPLICATE n (Number 0)),s)`,
   Induct \\ fs [evaluate_def,REPLICATE]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ fs [evaluate_def,REPLICATE,do_app_def,do_app_aux_def]

--- a/compiler/backend/proofs/clos_annotateProofScript.sml
+++ b/compiler/backend/proofs/clos_annotateProofScript.sml
@@ -72,22 +72,22 @@ val v_rel_simp = let
             ``v_rel y (Recclosure x1 x2 x3 x4 x5)``] |> LIST_CONJ end
   |> curry save_thm "v_rel_simp";
 
-val v_rel_Boolv = store_thm("v_rel_Boolv[simp]",
-  ``(v_rel x (Boolv b) ⇔ (x = Boolv b)) ∧
-    (v_rel (Boolv b) x ⇔ (x = Boolv b))``,
+val v_rel_Boolv = Q.store_thm("v_rel_Boolv[simp]",
+  `(v_rel x (Boolv b) ⇔ (x = Boolv b)) ∧
+    (v_rel (Boolv b) x ⇔ (x = Boolv b))`,
   Cases_on`b`>>EVAL_TAC>>ntac 2(simp[Once v_rel_cases]))
 
-val v_rel_Unit = store_thm("v_rel_Unit[simp]",
-  ``(v_rel x Unit ⇔ (x = Unit)) ∧
-    (v_rel Unit x ⇔ (x = Unit))``,
+val v_rel_Unit = Q.store_thm("v_rel_Unit[simp]",
+  `(v_rel x Unit ⇔ (x = Unit)) ∧
+    (v_rel Unit x ⇔ (x = Unit))`,
   EVAL_TAC>>ntac 2(simp[Once v_rel_cases]))
 
 val env_ok_def = v_rel_cases |> CONJUNCT2
 
-val env_ok_EXTEND = prove(
-  ``EVERY2 v_rel env1 env2 /\ (l1 = LENGTH env1) /\
+val env_ok_EXTEND = Q.prove(
+  `EVERY2 v_rel env1 env2 /\ (l1 = LENGTH env1) /\
     (l1 <= n ==> env_ok m l i env1' env2' (n - l1)) ==>
-    env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n``,
+    env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n`,
   SRW_TAC [] [] \\ SIMP_TAC std_ss [env_ok_def]
   \\ Cases_on `n < LENGTH env1` \\ full_simp_tac(srw_ss())[] THEN1
    (DISJ2_TAC \\ DISJ1_TAC \\ REPEAT STRIP_TAC
@@ -150,19 +150,19 @@ val state_rel_max_app = Q.store_thm("state_rel_max_app",
 
 (* semantic functions respect relation *)
 
-val list_to_v = prove(
-  ``!l' l. LIST_REL v_rel l' l ==>
-           v_rel (list_to_v l') (list_to_v l)``,
+val list_to_v = Q.prove(
+  `!l' l. LIST_REL v_rel l' l ==>
+           v_rel (list_to_v l') (list_to_v l)`,
   Induct \\ Cases_on `l` \\ full_simp_tac(srw_ss())[list_to_v_def,v_rel_simp]);
 
-val v_to_list = prove(
-  ``!h h'.
+val v_to_list = Q.prove(
+  `!h h'.
       v_rel h h' ==>
       (v_to_list h = NONE /\
        v_to_list h' = NONE) \/
       ?x x'. (v_to_list h = SOME x) /\
              (v_to_list h' = SOME x') /\
-             EVERY2 v_rel x x'``,
+             EVERY2 v_rel x x'`,
   HO_MATCH_MP_TAC v_to_list_ind
   \\ full_simp_tac(srw_ss())[v_rel_simp]
   \\ full_simp_tac(srw_ss())[v_to_list_def]
@@ -173,13 +173,13 @@ val v_to_list = prove(
   \\ CCONTR_TAC \\ RES_TAC \\ full_simp_tac(srw_ss())[]
   \\ RES_TAC \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
 
-val do_eq = prove(
-  ``(!h1 u1 h2 u2.
+val do_eq = Q.prove(
+  `(!h1 u1 h2 u2.
        v_rel h1 h2 /\ v_rel u1 u2 ==>
        (do_eq h1 u1 = do_eq h2 u2)) /\
     (!h1 u1 h2 u2.
       EVERY2 v_rel h1 h2 /\ EVERY2 v_rel u1 u2 ==>
-      (do_eq_list h1 u1 = do_eq_list h2 u2))``,
+      (do_eq_list h1 u1 = do_eq_list h2 u2))`,
   HO_MATCH_MP_TAC do_eq_ind
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ ONCE_REWRITE_TAC [do_eq_def]
@@ -189,9 +189,9 @@ val do_eq = prove(
   \\ Q.PAT_X_ASSUM `xx = do_eq y y'` (ASSUME_TAC o GSYM)
   \\ full_simp_tac(srw_ss())[]) |> CONJUNCT1 ;
 
-val do_app_IMP_case = prove(
-  ``(do_app UpdateByte xs s1 = Rval x) ==>
-    ?x1 x2 x3. xs = [RefPtr x1; Number x2; Number x3]``,
+val do_app_IMP_case = Q.prove(
+  `(do_app UpdateByte xs s1 = Rval x) ==>
+    ?x1 x2 x3. xs = [RefPtr x1; Number x2; Number x3]`,
   full_simp_tac(srw_ss())[do_app_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]);
 
@@ -508,18 +508,18 @@ val do_app_err_thm = Q.prove(
 
 (* compiler correctness *)
 
-val lookup_EL_shifted_env = prove(
-  ``!y n k. n < LENGTH y /\ ALL_DISTINCT y ==>
-            (lookup (EL n y) (shifted_env k y) = SOME (k + n))``,
+val lookup_EL_shifted_env = Q.prove(
+  `!y n k. n < LENGTH y /\ ALL_DISTINCT y ==>
+            (lookup (EL n y) (shifted_env k y) = SOME (k + n))`,
   Induct \\ full_simp_tac(srw_ss())[] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[shifted_env_def,lookup_insert]
   \\ SRW_TAC [] [ADD1,AC ADD_COMM ADD_ASSOC]
   \\ full_simp_tac(srw_ss())[MEM_EL] \\ METIS_TAC []);
 
-val env_ok_shifted_env = prove(
-  ``env_ok m l i env env2 k /\ MEM k live /\ ALL_DISTINCT live /\
+val env_ok_shifted_env = Q.prove(
+  `env_ok m l i env env2 k /\ MEM k live /\ ALL_DISTINCT live /\
     (lookup_vars (MAP (get_var m l i) (FILTER (\n. n < m + l) live)) env2 =
       SOME x) ==>
-    env_ok (m + l) 0 (shifted_env 0 (FILTER (\n. n < m + l) live)) env x k``,
+    env_ok (m + l) 0 (shifted_env 0 (FILTER (\n. n < m + l) live)) env x k`,
   REPEAT STRIP_TAC
   \\ Q.ABBREV_TAC `y = FILTER (\n. n < m + l) live`
   \\ `ALL_DISTINCT y` by
@@ -545,11 +545,11 @@ val env_ok_shifted_env = prove(
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[lookup_EL_shifted_env]
   \\ IMP_RES_TAC lookup_vars_SOME \\ full_simp_tac(srw_ss())[]);
 
-val EL_shift_free = prove(
-  ``!fns index.
+val EL_shift_free = Q.prove(
+  `!fns index.
      index < LENGTH fns ==>
      ([EL index (shift (FST (free fns)) l m i)] =
-      (shift (FST (free [EL index fns])) l m i))``,
+      (shift (FST (free [EL index fns])) l m i))`,
   Induct \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [free_CONS]
   \\ SIMP_TAC std_ss [Once shift_CONS]
@@ -1105,8 +1105,8 @@ val shift_correct = Q.prove(
     \\ MATCH_MP_TAC rich_listTheory.EVERY2_APPEND_suff \\ full_simp_tac(srw_ss())[]
     \\ MATCH_MP_TAC EVERY2_REVERSE \\ full_simp_tac(srw_ss())[]));
 
-val env_set_default = prove(
-  ``x SUBSET env_ok 0 0 LN [] env'``,
+val env_set_default = Q.prove(
+  `x SUBSET env_ok 0 0 LN [] env'`,
   full_simp_tac(srw_ss())[SUBSET_DEF,IN_DEF,env_ok_def]);
 
 val annotate_correct = save_thm("annotate_correct",
@@ -1164,8 +1164,8 @@ val every_Fn_SOME_annotate = Q.store_thm("every_Fn_SOME_annotate[simp]",
 
 val IF_MAP_EQ = MAP_EQ_f |> SPEC_ALL |> EQ_IMP_RULE |> snd;
 
-val shift_code_locs = prove(
-  ``!xs env s1 env'. code_locs (shift xs env s1 env') = code_locs xs``,
+val shift_code_locs = Q.prove(
+  `!xs env s1 env'. code_locs (shift xs env s1 env') = code_locs xs`,
   ho_match_mp_tac shift_ind
   \\ simp[shift_def,code_locs_def,shift_LENGTH_LEMMA]
   \\ srw_tac[][code_locs_append]
@@ -1173,8 +1173,8 @@ val shift_code_locs = prove(
   \\ ONCE_REWRITE_TAC [code_locs_map]
   \\ AP_TERM_TAC \\ MATCH_MP_TAC IF_MAP_EQ \\ full_simp_tac(srw_ss())[FORALL_PROD])
 
-val free_code_locs = prove(
-  ``!xs. code_locs (FST (free xs)) = code_locs xs``,
+val free_code_locs = Q.prove(
+  `!xs. code_locs (FST (free xs)) = code_locs xs`,
   ho_match_mp_tac free_ind >>
   simp[free_def,code_locs_def,UNCURRY] >> srw_tac[][]
   \\ Cases_on `free [x]` \\ full_simp_tac(srw_ss())[code_locs_append,HD_FST_free]
@@ -1186,8 +1186,8 @@ val free_code_locs = prove(
   \\ MATCH_MP_TAC IF_MAP_EQ \\ full_simp_tac(srw_ss())[FORALL_PROD,HD_FST_free]
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ full_simp_tac(srw_ss())[])
 
-val annotate_code_locs = store_thm("annotate_code_locs",
-  ``!n ls. code_locs (annotate n ls) = code_locs ls``,
+val annotate_code_locs = Q.store_thm("annotate_code_locs",
+  `!n ls. code_locs (annotate n ls) = code_locs ls`,
   srw_tac[][annotate_def,shift_code_locs,free_code_locs])
 
 val _ = export_theory()

--- a/compiler/backend/proofs/clos_callProofScript.sml
+++ b/compiler/backend/proofs/clos_callProofScript.sml
@@ -7,8 +7,8 @@ val _ = new_theory"clos_callProof";
 
 (* TODO: move *)
 
-val MEM_REPLICATE_EQ = store_thm("MEM_REPLICATE_EQ",
-  ``!n x y. MEM x (REPLICATE n y) <=> x = y /\ n <> 0``,
+val MEM_REPLICATE_EQ = Q.store_thm("MEM_REPLICATE_EQ",
+  `!n x y. MEM x (REPLICATE n y) <=> x = y /\ n <> 0`,
   Induct \\ fs [REPLICATE] \\ rw [] \\ eq_tac \\ rw []);
 
 val PUSH_EXISTS_IMP = SPEC_ALL RIGHT_EXISTS_IMP_THM;
@@ -27,8 +27,8 @@ val ALL_DISTINCT_FLAT_EVERY = Q.store_thm("ALL_DISTINCT_FLAT_EVERY",
 
 val IN_EVEN = SIMP_CONV std_ss [IN_DEF] ``x ∈ EVEN``;
 
-val v_size_lemma = prove(
-  ``MEM (v:closSem$v) vl ⇒ v_size v < v1_size vl``,
+val v_size_lemma = Q.prove(
+  `MEM (v:closSem$v) vl ⇒ v_size v < v1_size vl`,
   Induct_on `vl` >> dsimp[v_size_def] >> rpt strip_tac >>
   res_tac >> simp[]);
 
@@ -53,18 +53,18 @@ val evaluate_add_clock =
   |> CONJUNCT1 |> GEN_ALL
   |> REWRITE_RULE[GSYM AND_IMP_INTRO]
 
-val DISJOINT_IMAGE_SUC = store_thm("DISJOINT_IMAGE_SUC",
-  ``DISJOINT (IMAGE SUC x) (IMAGE SUC y) <=> DISJOINT x y``,
+val DISJOINT_IMAGE_SUC = Q.store_thm("DISJOINT_IMAGE_SUC",
+  `DISJOINT (IMAGE SUC x) (IMAGE SUC y) <=> DISJOINT x y`,
   fs [IN_DISJOINT] \\ metis_tac [DECIDE ``(SUC n = SUC m) <=> (m = n)``]);
 
-val IMAGE_SUC_SUBSET_UNION = store_thm("IMAGE_SUC_SUBSET_UNION",
-  ``IMAGE SUC x SUBSET IMAGE SUC y UNION IMAGE SUC z <=>
-    x SUBSET y UNION z``,
+val IMAGE_SUC_SUBSET_UNION = Q.store_thm("IMAGE_SUC_SUBSET_UNION",
+  `IMAGE SUC x SUBSET IMAGE SUC y UNION IMAGE SUC z <=>
+    x SUBSET y UNION z`,
   fs [SUBSET_DEF] \\ metis_tac [DECIDE ``(SUC n = SUC m) <=> (m = n)``]);
 
-val ALL_DISTINCT_APPEND_APPEND_IMP = store_thm("ALL_DISTINCT_APPEND_APPEND_IMP",
-  ``ALL_DISTINCT (xs ++ ys ++ zs) ==>
-    ALL_DISTINCT (xs ++ ys) /\ ALL_DISTINCT (xs ++ zs) /\ ALL_DISTINCT (ys ++ zs)``,
+val ALL_DISTINCT_APPEND_APPEND_IMP = Q.store_thm("ALL_DISTINCT_APPEND_APPEND_IMP",
+  `ALL_DISTINCT (xs ++ ys ++ zs) ==>
+    ALL_DISTINCT (xs ++ ys) /\ ALL_DISTINCT (xs ++ zs) /\ ALL_DISTINCT (ys ++ zs)`,
   fs [ALL_DISTINCT_APPEND]);
 
 val is_Recclosure_def = Define`
@@ -1223,19 +1223,19 @@ val wfv_subg = Q.store_thm("wfv_subg",
 
 (* semantic functions respect relation *)
 
-val v_rel_Unit = store_thm("v_rel_Unit[simp]",
-  ``v_rel g1 l1 Unit Unit``,
+val v_rel_Unit = Q.store_thm("v_rel_Unit[simp]",
+  `v_rel g1 l1 Unit Unit`,
   EVAL_TAC \\ fs []);
 
-val do_eq_thm = store_thm("do_eq_thm",
-  ``(!h1 h1a b h2 h2a.
+val do_eq_thm = Q.store_thm("do_eq_thm",
+  `(!h1 h1a b h2 h2a.
        do_eq h1 h1a = Eq_val b /\ v_rel g1 l1 h1 h2 /\ v_rel g1 l1 h1a h2a ==>
        do_eq h2 h2a = Eq_val b) /\
     (!h1 h1a b h2 h2a.
        do_eq_list h1 h1a = Eq_val b /\
        LIST_REL (v_rel g1 l1) h1 h2 /\
        LIST_REL (v_rel g1 l1) h1a h2a ==>
-       do_eq_list h2 h2a = Eq_val b)``,
+       do_eq_list h2 h2a = Eq_val b)`,
   HO_MATCH_MP_TAC do_eq_ind \\ fs [] \\ rw []
   THEN1
    (Cases_on `h1` \\ Cases_on `h1a` \\ fs [v_rel_def,do_eq_def]
@@ -1245,33 +1245,33 @@ val do_eq_thm = store_thm("do_eq_thm",
   \\ fs [v_rel_def,do_eq_def |> CONJUNCT2] \\ every_case_tac \\ fs []
   \\ res_tac \\ fs [])
 
-val v_to_list_thm = store_thm("v_to_list_thm",
-  ``!h h' x.
+val v_to_list_thm = Q.store_thm("v_to_list_thm",
+  `!h h' x.
       v_to_list h = SOME x /\ v_rel g1 l1 h h' ==>
-      ?x'. v_to_list h' = SOME x' /\ LIST_REL (v_rel g1 l1) x x'``,
+      ?x'. v_to_list h' = SOME x' /\ LIST_REL (v_rel g1 l1) x x'`,
   recInduct v_to_list_ind \\ rw [] \\ fs [v_to_list_def] \\ rw []
   \\ fs [v_rel_def,v_to_list_def] \\ rw []
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs []
   \\ res_tac \\ fs [] \\ rw []);
 
-val v_to_list_wfv = store_thm("v_to_list_wfv",
-  ``!h x. v_to_list h = SOME x /\ wfv g1 l1 h ==> EVERY (wfv g1 l1) x``,
+val v_to_list_wfv = Q.store_thm("v_to_list_wfv",
+  `!h x. v_to_list h = SOME x /\ wfv g1 l1 h ==> EVERY (wfv g1 l1) x`,
   recInduct v_to_list_ind \\ rw [] \\ fs [v_to_list_def] \\ rw []
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs []
   \\ res_tac \\ fs [] \\ rw []);
 
-val v_rel_list_to_v = store_thm("v_rel_list_to_v",
-  ``!l1 l2.
+val v_rel_list_to_v = Q.store_thm("v_rel_list_to_v",
+  `!l1 l2.
       LIST_REL (v_rel g1 l) l1 l2 ==>
-      v_rel g1 l (list_to_v l1) (list_to_v l2)``,
+      v_rel g1 l (list_to_v l1) (list_to_v l2)`,
   Induct \\ fs [v_rel_def,list_to_v_def,PULL_EXISTS]);
 
-val wfv_list_to_v = store_thm("wfv_list_to_v",
-  ``!l. EVERY (wfv g1 l1) l ==> wfv g1 l1 (list_to_v l)``,
+val wfv_list_to_v = Q.store_thm("wfv_list_to_v",
+  `!l. EVERY (wfv g1 l1) l ==> wfv g1 l1 (list_to_v l)`,
   Induct \\ fs [wfv_def,list_to_v_def,PULL_EXISTS]);
 
-val wfv_Boolv = store_thm("wfv_Boolv",
-  ``wfv g1 l1 (Boolv b) /\ wfv g1 l1 Unit``,
+val wfv_Boolv = Q.store_thm("wfv_Boolv",
+  `wfv g1 l1 (Boolv b) /\ wfv g1 l1 Unit`,
   Cases_on `b` \\ EVAL_TAC);
 
 val do_app_thm = prove(
@@ -1495,8 +1495,8 @@ val NOT_IN_domain_FST_g = store_thm("NOT_IN_domain_FST_g",
   \\ rfs [wfg_def,SUBSET_DEF,EXTENSION] \\ rveq \\ fs []
   \\ fs [ALL_DISTINCT_APPEND] \\ res_tac);
 
-val v_rel_Boolv = store_thm("v_rel_Boolv[simp]",
-  ``v_rel g1 l1 (Boolv b) v <=> (v = Boolv b)``,
+val v_rel_Boolv = Q.store_thm("v_rel_Boolv[simp]",
+  `v_rel g1 l1 (Boolv b) v <=> (v = Boolv b)`,
   Cases_on `b` \\ Cases_on `v` \\ fs [v_rel_def,Boolv_def]);
 
 val s0 = ``s0:'ffi closSem$state``;
@@ -3322,24 +3322,24 @@ val calls_correct = Q.store_thm("calls_correct",
   \\ disch_then(qspec_then`ck'`assume_tac)
   \\ qexists_tac`ck+ck'+1` \\ simp[]);
 
-val code_locs_calls_list = prove(``
-  ∀ls n. code_locs (MAP SND (calls_list n ls)) = []``,
+val code_locs_calls_list = Q.prove(`
+  ∀ls n. code_locs (MAP SND (calls_list n ls)) = []`,
   Induct>>fs[calls_list_def,FORALL_PROD,Once code_locs_cons]>>EVAL_TAC>>
   fs[])
 
-val code_locs_code_list_MEM = prove(``
+val code_locs_code_list_MEM = Q.prove(`
   ∀ls n rest x.
   MEM x (code_locs (MAP (SND o SND) (SND (code_list n ls rest)))) ⇔
-  MEM x (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))``,
+  MEM x (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))`,
   Induct>>fs[code_list_def,FORALL_PROD,Once code_locs_cons,code_locs_append]>>
   rw[]>>EVAL_TAC>>
   rw[EQ_IMP_THM]>>
   fs[Once code_locs_cons,code_locs_def])
 
-val code_locs_code_list_ALL_DISTINCT = prove(``
+val code_locs_code_list_ALL_DISTINCT = Q.prove(`
   ∀ls n rest.
   ALL_DISTINCT (code_locs (MAP (SND o SND) (SND (code_list n ls rest)))) ⇔
-  ALL_DISTINCT (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))``,
+  ALL_DISTINCT (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))`,
   Induct>>fs[code_list_def,FORALL_PROD,Once code_locs_cons,code_locs_append]>>
   rw[]>>EVAL_TAC>>
   fs[ALL_DISTINCT_APPEND]>>

--- a/compiler/backend/proofs/clos_callProofScript.sml
+++ b/compiler/backend/proofs/clos_callProofScript.sml
@@ -1140,8 +1140,8 @@ val env_rel_DROP_args = Q.store_thm("env_rel_DROP_args",
   \\ simp[] \\ strip_tac
   \\ rfs[EL_DROP]);
 
-val subg_insert_each' = store_thm("subg_insert_each'",
-  ``!gb fns1 es g1.
+val subg_insert_each' = Q.store_thm("subg_insert_each'",
+  `!gb fns1 es g1.
       subg gb (FST new_g,l ++ SND (insert_each' g1 loc (LENGTH fns1) g)) /\
       SND new_g = l ++ SND g /\ LENGTH fns1 = LENGTH es
       ∧ wfg g ∧
@@ -1150,7 +1150,7 @@ val subg_insert_each' = store_thm("subg_insert_each'",
       (∀i. i < LENGTH fns1 ⇒ ALOOKUP g1 (2*i+loc+1) = SOME (FST (EL i fns1), EL i es))
       ==>
       subg (FST new_g,l ++ SND (insert_each' g1 loc (LENGTH fns1) g))
-        (code_list loc (ZIP (MAP FST fns1,es)) new_g)``,
+        (code_list loc (ZIP (MAP FST fns1,es)) new_g)`,
   Cases_on `new_g` \\ fs [] \\ PairCases_on `g` \\ fs []
   \\ rw [] \\ rveq \\ fs [subg_def]
   \\ fs[ALL_DISTINCT_APPEND,MAP_FST_code_list,MEM_GENLIST,PULL_EXISTS,
@@ -1274,8 +1274,8 @@ val wfv_Boolv = Q.store_thm("wfv_Boolv",
   `wfv g1 l1 (Boolv b) /\ wfv g1 l1 Unit`,
   Cases_on `b` \\ EVAL_TAC);
 
-val do_app_thm = prove(
-  ``case do_app op (REVERSE a) (r:'ffi closSem$state) of
+val do_app_thm = Q.prove(
+  `case do_app op (REVERSE a) (r:'ffi closSem$state) of
       Rerr (Rraise _) => F
     | Rerr (Rabort e) => (e = Rtype_error)
     | Rval (w,s) =>
@@ -1283,7 +1283,7 @@ val do_app_thm = prove(
         wfv_state g1 l1 s /\ wfv g1 l1 w) /\
        (LIST_REL (v_rel g1 l1) a v /\ state_rel g1 l1 r t ==>
         ?w' s'. (do_app op (REVERSE v) t = Rval (w',s')) /\
-                v_rel g1 l1 w w' /\ state_rel g1 l1 s s')``,
+                v_rel g1 l1 w w' /\ state_rel g1 l1 s s')`,
   once_rewrite_tac [GSYM REVERSE_REVERSE]
   \\ qspec_tac (`REVERSE a`,`xs`)
   \\ qspec_tac (`REVERSE v`,`ys`)
@@ -1480,13 +1480,13 @@ val do_app_thm = prove(
     \\ first_x_assum drule \\ fs [])
   \\ Cases_on `op` \\ fs []);
 
-val NOT_IN_domain_FST_g = store_thm("NOT_IN_domain_FST_g",
-  ``ALL_DISTINCT (code_locs xs ++ code_locs ys) ⇒
+val NOT_IN_domain_FST_g = Q.store_thm("NOT_IN_domain_FST_g",
+  `ALL_DISTINCT (code_locs xs ++ code_locs ys) ⇒
     calls ys g' = (e2,g) ⇒
     wfg g' ⇒
     MEM x (code_locs xs) ⇒
     x ∉ domain (FST g') ⇒
-    x ∉ domain (FST g)``,
+    x ∉ domain (FST g)`,
   rw [] \\ imp_res_tac calls_domain
   \\ fs [SUBSET_DEF,DISJOINT_DEF,EXTENSION] \\ rw []
   \\ CCONTR_TAC \\ fs [] \\ res_tac \\ rveq \\ fs []

--- a/compiler/backend/proofs/clos_freeProofScript.sml
+++ b/compiler/backend/proofs/clos_freeProofScript.sml
@@ -4,9 +4,9 @@ open preamble
 
 val _ = new_theory"clos_freeProof";
 
-val IMP_EXISTS_IFF = prove(
-  ``!xs. (!x. MEM x xs ==> (P x <=> Q x)) ==>
-         (EXISTS P xs <=> EXISTS Q xs)``,
+val IMP_EXISTS_IFF = Q.prove(
+  `!xs. (!x. MEM x xs ==> (P x <=> Q x)) ==>
+         (EXISTS P xs <=> EXISTS Q xs)`,
   Induct \\ fs []);
 
 val free_thm = Q.store_thm("free_thm",

--- a/compiler/backend/proofs/clos_knownProofScript.sml
+++ b/compiler/backend/proofs/clos_knownProofScript.sml
@@ -678,23 +678,23 @@ val known_op_correct_approx = Q.store_thm(
           pop_assum (fn th => fs[th])))
   >- (rveq >> fs[LIST_REL_EL_EQN]));
 
-val LENGTH_clos_gen = prove(``
+val LENGTH_clos_gen = Q.prove(`
   ∀ls x c.
-  LENGTH (clos_gen x c ls) = LENGTH ls``,
+  LENGTH (clos_gen x c ls) = LENGTH ls`,
   Induct>>fs[FORALL_PROD,clos_gen_def])
 
-val clos_gen_eq = prove(``
+val clos_gen_eq = Q.prove(`
   ∀n c fns.
   clos_gen n c fns =
-  GENLIST (λi. Clos (2* (i+c) +n ) (FST (EL i fns))) (LENGTH fns)``,
+  GENLIST (λi. Clos (2* (i+c) +n ) (FST (EL i fns))) (LENGTH fns)`,
   Induct_on`fns`>>fs[FORALL_PROD,clos_gen_def,GENLIST_CONS]>>rw[]>>
   simp[o_DEF,ADD1])
 
-val letrec_case_eq = prove(``
+val letrec_case_eq = Q.prove(`
   (case loc of
     NONE => REPLICATE (LENGTH fns) Other
   | SOME n => clos_gen n 0 fns) =
-  GENLIST (case loc of NONE => K Other | SOME n => λi. Clos (n+ 2*i) (FST (EL i fns))) (LENGTH fns)``,
+  GENLIST (case loc of NONE => K Other | SOME n => λi. Clos (n+ 2*i) (FST (EL i fns))) (LENGTH fns)`,
   Cases_on`loc`>>fs[clos_gen_eq,REPLICATE_GENLIST])
 
 val say = say0 "known_correct_approx"

--- a/compiler/backend/proofs/clos_mtiProofScript.sml
+++ b/compiler/backend/proofs/clos_mtiProofScript.sml
@@ -159,8 +159,8 @@ val dest_addarg_Fn_EQ_SOME = Q.store_thm(
 
 val app_rw_closure = save_thm(
   "app_rw_closure",
-  Q.prove(
-    mk_imp(`0n < numargs ∧ LENGTH (cargs:closSem$v list) < numargs`,
+  prove(
+    mk_imp(``0n < numargs ∧ LENGTH (cargs:closSem$v list) < numargs``,
            concl evaluate_app_rw
                  |> strip_forall |> #2 |> rand
                  |> Term.subst [``f:closSem$v`` |->

--- a/compiler/backend/proofs/clos_mtiProofScript.sml
+++ b/compiler/backend/proofs/clos_mtiProofScript.sml
@@ -159,8 +159,8 @@ val dest_addarg_Fn_EQ_SOME = Q.store_thm(
 
 val app_rw_closure = save_thm(
   "app_rw_closure",
-  prove(
-    mk_imp(``0n < numargs ∧ LENGTH (cargs:closSem$v list) < numargs``,
+  Q.prove(
+    mk_imp(`0n < numargs ∧ LENGTH (cargs:closSem$v list) < numargs`,
            concl evaluate_app_rw
                  |> strip_forall |> #2 |> rand
                  |> Term.subst [``f:closSem$v`` |->

--- a/compiler/backend/proofs/clos_numberProofScript.sml
+++ b/compiler/backend/proofs/clos_numberProofScript.sml
@@ -37,13 +37,13 @@ val renumber_code_locs_inc = Q.store_thm("renumber_code_locs_inc",
   tac >> full_simp_tac(srw_ss())[] >> simp[] >>
   pairarg_tac \\ fs[] \\ pairarg_tac \\ fs[]);
 
-val renumber_code_locs_imp_inc = store_thm("renumber_code_locs_imp_inc",
-  ``(renumber_code_locs_list n es = (m,vs) ⇒ n ≤ m) ∧
-    (renumber_code_locs n e = (z,v) ⇒ n ≤ z)``,
+val renumber_code_locs_imp_inc = Q.store_thm("renumber_code_locs_imp_inc",
+  `(renumber_code_locs_list n es = (m,vs) ⇒ n ≤ m) ∧
+    (renumber_code_locs n e = (z,v) ⇒ n ≤ z)`,
   metis_tac[pairTheory.pair_CASES,pairTheory.FST,renumber_code_locs_inc])
 
-val renumber_code_locs_list_length = prove(
-  ``∀ls n x y. renumber_code_locs_list n ls = (x,y) ⇒ LENGTH y = LENGTH ls``,
+val renumber_code_locs_list_length = Q.prove(
+  `∀ls n x y. renumber_code_locs_list n ls = (x,y) ⇒ LENGTH y = LENGTH ls`,
   Induct >> simp[renumber_code_locs_def,LENGTH_NIL] >> srw_tac[][] >>
   Cases_on`renumber_code_locs n h`>>full_simp_tac(srw_ss())[]>>
   Cases_on`renumber_code_locs_list q ls`>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>
@@ -113,10 +113,10 @@ val renumber_code_locs_distinct = Q.store_thm("renumber_code_locs_distinct",
   qexists_tac`$<` >> simp[] >>
   simp[relationTheory.irreflexive_def])
 
-val renumber_code_locs_list_els = prove(
-  ``∀ls ls' n n'. renumber_code_locs_list n ls = (n',ls') ⇒
+val renumber_code_locs_list_els = Q.prove(
+  `∀ls ls' n n'. renumber_code_locs_list n ls = (n',ls') ⇒
       ∀x. x < LENGTH ls ⇒
-        ∃m. EL x ls' = SND (renumber_code_locs m (EL x ls))``,
+        ∃m. EL x ls' = SND (renumber_code_locs m (EL x ls))`,
   Induct >> simp[renumber_code_locs_def] >>
   simp[UNCURRY] >> srw_tac[][] >>
   Cases_on`x`>>full_simp_tac(srw_ss())[] >- METIS_TAC[] >>
@@ -370,15 +370,15 @@ val do_eq = Q.prove(
   match_mp_tac do_eq_list_rel >> srw_tac[][] >>
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN,EL_ZIP])
 
-val do_app = prove(
-  ``state_rel s1 s2 ∧
+val do_app = Q.prove(
+  `state_rel s1 s2 ∧
     LIST_REL (v_rel s1.max_app) x1 x2 ⇒
     (∀err.
       do_app op x1 s1 = (Rerr err) ⇒
       do_app op x2 s2 = (Rerr err)) ∧
     (∀v1 w1. do_app op x1 s1 = Rval(v1,w1) ⇒
              ∃v2 w2. do_app op x2 s2 = Rval(v2,w2) ∧
-                     v_rel s1.max_app v1 v2 ∧ state_rel w1 w2)``,
+                     v_rel s1.max_app v1 v2 ∧ state_rel w1 w2)`,
   strip_tac >>
   simp[do_app_def] >>
   Cases_on`op`>>simp[v_rel_simp]>>

--- a/compiler/backend/proofs/clos_numberProofScript.sml
+++ b/compiler/backend/proofs/clos_numberProofScript.sml
@@ -3,9 +3,9 @@ open preamble closLangTheory clos_numberTheory closSemTheory closPropsTheory;
 val _ = new_theory"clos_numberProof";
 
 (* properties of renumber_code_locs *)
-val option_case_eq = prove(
-  ``(option_CASE opt n s = v) ⇔
-      (opt = NONE ∧ v = n) ∨ (∃x. opt = SOME x ∧ v = s x)``,
+val option_case_eq = Q.prove(
+  `(option_CASE opt n s = v) ⇔
+      (opt = NONE ∧ v = n) ∨ (∃x. opt = SOME x ∧ v = s x)`,
   Cases_on `opt` >> simp[EQ_SYM_EQ]);
 
 
@@ -27,9 +27,9 @@ fun tac (g as (asl,w)) =
     map_every (fn tm => Cases_on [ANTIQUOTE tm]) tms g
   end
 
-val renumber_code_locs_inc = store_thm("renumber_code_locs_inc",
-  ``(∀n es. n ≤ FST (renumber_code_locs_list n es)) ∧
-    (∀n e. n ≤ FST (renumber_code_locs n e))``,
+val renumber_code_locs_inc = Q.store_thm("renumber_code_locs_inc",
+  `(∀n es. n ≤ FST (renumber_code_locs_list n es)) ∧
+    (∀n e. n ≤ FST (renumber_code_locs n e))`,
   ho_match_mp_tac renumber_code_locs_ind >>
   simp[renumber_code_locs_def] >> srw_tac[][] >>
   tac >> full_simp_tac(srw_ss())[] >>
@@ -49,13 +49,13 @@ val renumber_code_locs_list_length = prove(
   Cases_on`renumber_code_locs_list q ls`>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>
   res_tac)
 
-val renumber_code_locs_distinct_lemma = prove(
-  ``(∀n es. SORTED $< (code_locs (SND (renumber_code_locs_list n es))) ∧
+val renumber_code_locs_distinct_lemma = Q.prove(
+  `(∀n es. SORTED $< (code_locs (SND (renumber_code_locs_list n es))) ∧
             EVERY ($<= n) (code_locs (SND (renumber_code_locs_list n es))) ∧
             EVERY ($> (FST (renumber_code_locs_list n es))) (code_locs (SND (renumber_code_locs_list n es)))) ∧
     (∀n e. SORTED $< (code_locs [SND (renumber_code_locs n e)]) ∧
             EVERY ($<= n) (code_locs [SND (renumber_code_locs n e)]) ∧
-            EVERY ($> (FST (renumber_code_locs n e))) (code_locs [SND (renumber_code_locs n e)]))``,
+            EVERY ($> (FST (renumber_code_locs n e))) (code_locs [SND (renumber_code_locs n e)]))`,
   ho_match_mp_tac renumber_code_locs_ind >>
   simp[renumber_code_locs_def,code_locs_def,pairTheory.UNCURRY] >>
   srw_tac[][] >> rpt (CHANGED_TAC tac >> full_simp_tac(srw_ss())[]) >> srw_tac[][] >>
@@ -103,10 +103,10 @@ val renumber_code_locs_distinct_lemma = prove(
   rev_full_simp_tac(srw_ss())[MAP_ZIP] >>
   srw_tac[][] >> full_simp_tac(srw_ss())[EVERY_MEM] >> res_tac >> fsrw_tac[ARITH_ss][MAP_ZIP]);
 
-val renumber_code_locs_distinct = store_thm("renumber_code_locs_distinct",
-  ``∀n e. ALL_DISTINCT (code_locs [SND (renumber_code_locs n e)]) ∧
+val renumber_code_locs_distinct = Q.store_thm("renumber_code_locs_distinct",
+  `∀n e. ALL_DISTINCT (code_locs [SND (renumber_code_locs n e)]) ∧
           EVERY ($<= n) (code_locs [SND (renumber_code_locs n e)]) ∧
-          EVERY ($> (FST (renumber_code_locs n e))) (code_locs [SND (renumber_code_locs n e)])``,
+          EVERY ($> (FST (renumber_code_locs n e))) (code_locs [SND (renumber_code_locs n e)])`,
   srw_tac[][] >>
   qspecl_then[`n`,`e`]strip_assume_tac (CONJUNCT2 renumber_code_locs_distinct_lemma) >> simp[] >>
   match_mp_tac (MP_CANON (GEN_ALL SORTED_ALL_DISTINCT)) >>
@@ -169,14 +169,14 @@ val state_rel_clock = Q.prove (
   `!s t. state_rel s t ⇒ state_rel (s with clock := x) (t with clock := x)`,
    srw_tac[][state_rel_def] \\ rfs[]);
 
-val state_rel_globals = prove(
-  ``state_rel s t ⇒
-    LIST_REL (OPTREL (v_rel s.max_app)) s.globals t.globals``,
+val state_rel_globals = Q.prove(
+  `state_rel s t ⇒
+    LIST_REL (OPTREL (v_rel s.max_app)) s.globals t.globals`,
   srw_tac[][state_rel_def])
 
-val state_rel_refs = prove(
-  ``state_rel s t ⇒
-    fmap_rel (ref_rel (v_rel t.max_app)) s.refs t.refs``,
+val state_rel_refs = Q.prove(
+  `state_rel s t ⇒
+    fmap_rel (ref_rel (v_rel t.max_app)) s.refs t.refs`,
   srw_tac[][state_rel_def])
 
 val v_rel_simp = let
@@ -194,15 +194,15 @@ val v_rel_simp = let
             ``v_rel max_app y (Recclosure x1 x2 x3 x4 x5)``] |> LIST_CONJ end
   |> curry save_thm"v_rel_simp"
 
-val v_rel_Boolv = store_thm("v_rel_Boolv[simp]",
-  ``(v_rel max_app x (Boolv b) ⇔ (x = Boolv b)) ∧
-    (v_rel max_app (Boolv b) x ⇔ (x = Boolv b))``,
+val v_rel_Boolv = Q.store_thm("v_rel_Boolv[simp]",
+  `(v_rel max_app x (Boolv b) ⇔ (x = Boolv b)) ∧
+    (v_rel max_app (Boolv b) x ⇔ (x = Boolv b))`,
   Cases_on`b`>>srw_tac[][Boolv_def,Once v_rel_cases] >>
   srw_tac[][Once v_rel_cases])
 
-val v_rel_Unit = store_thm("v_rel_Unit[simp]",
-  ``(v_rel max_app x Unit ⇔ (x = Unit)) ∧
-    (v_rel max_app Unit x ⇔ (x = Unit))``,
+val v_rel_Unit = Q.store_thm("v_rel_Unit[simp]",
+  `(v_rel max_app x Unit ⇔ (x = Unit)) ∧
+    (v_rel max_app Unit x ⇔ (x = Unit))`,
   EVAL_TAC >> simp[v_rel_simp])
 
 (* semantic functions respect relation *)
@@ -341,28 +341,28 @@ val helper = Q.prove (
   `SND ((λ(n',x'). (n',[x'])) x) = [SND x]`,
   Cases_on `x` >> full_simp_tac(srw_ss())[]);
 
-val list_to_v = prove(
-  ``∀l1 l2. LIST_REL (v_rel max_app) l1 l2 ⇒
-    v_rel max_app (list_to_v l1) (list_to_v l2)``,
+val list_to_v = Q.prove(
+  `∀l1 l2. LIST_REL (v_rel max_app) l1 l2 ⇒
+    v_rel max_app (list_to_v l1) (list_to_v l2)`,
   Induct >> simp[list_to_v_def,v_rel_simp] >>
   srw_tac[][PULL_EXISTS,list_to_v_def])
 
-val v_rel_Boolv_mono = prove(
-  ``(x ⇔ y) ⇒ (v_rel max_app (Boolv x) (Boolv y))``,
+val v_rel_Boolv_mono = Q.prove(
+  `(x ⇔ y) ⇒ (v_rel max_app (Boolv x) (Boolv y))`,
   Cases_on`x`>>simp[Boolv_def,v_rel_simp])
 
-val v_to_list = prove(
-  ``∀x y. v_rel max_app x y ⇒
-          OPTREL (LIST_REL (v_rel max_app)) (v_to_list x) (v_to_list y)``,
+val v_to_list = Q.prove(
+  `∀x y. v_rel max_app x y ⇒
+          OPTREL (LIST_REL (v_rel max_app)) (v_to_list x) (v_to_list y)`,
   ho_match_mp_tac v_to_list_ind >>
   simp[v_rel_simp,v_to_list_def,PULL_EXISTS] >>
   srw_tac[][] >> TRY(srw_tac[][optionTheory.OPTREL_def]>>NO_TAC) >>
   first_x_assum(fn th => first_x_assum(STRIP_ASSUME_TAC o MATCH_MP th)) >>
   full_simp_tac(srw_ss())[optionTheory.OPTREL_def])
 
-val do_eq = prove(
-  ``∀x1 y1. v_rel max_app x1 y1 ⇒
-      ∀x2 y2. v_rel max_app x2 y2 ⇒ (do_eq x1 x2 = do_eq y1 y2)``,
+val do_eq = Q.prove(
+  `∀x1 y1. v_rel max_app x1 y1 ⇒
+      ∀x2 y2. v_rel max_app x2 y2 ⇒ (do_eq x1 x2 = do_eq y1 y2)`,
   ho_match_mp_tac v_rel_ind >> srw_tac[][] >>
   Cases_on`x2`>>full_simp_tac(srw_ss())[v_rel_simp]>>TRY(full_simp_tac(srw_ss())[do_eq_def]>>NO_TAC)>> srw_tac[][] >>
   simp[do_eq_def] >>

--- a/compiler/backend/proofs/clos_to_bvlProofScript.sml
+++ b/compiler/backend/proofs/clos_to_bvlProofScript.sml
@@ -3601,7 +3601,7 @@ val compile_exps_correct = Q.store_thm("compile_exps_correct",
     >- ((* Enough arguments to do something *)
          `SUC (LENGTH v43) = LENGTH args` by metis_tac [LENGTH] >>
          `every_Fn_SOME [e] ∧ every_Fn_vs_SOME [e]` by (
-           rator_x_assum`dest_closure`mp_tac >>
+           qhdtm_x_assum`dest_closure`mp_tac >>
            simp[dest_closure_def] >>
            BasicProvers.CASE_TAC >> srw_tac[][] >>
            full_simp_tac(srw_ss())[v_rel_cases,cl_rel_cases] >>
@@ -3754,7 +3754,7 @@ val compile_exps_correct = Q.store_thm("compile_exps_correct",
                      rpt var_eq_tac >>
                      simp_tac(srw_ss())[inc_clock_def] >>
                      disch_then kall_tac >>
-                     rator_x_assum`evaluate`mp_tac >>
+                     qhdtm_x_assum`evaluate`mp_tac >>
                      simp_tac(srw_ss()++ARITH_ss)[] >>
                      strip_tac >>
                      Cases_on`res''''`>> full_simp_tac(srw_ss())[] >>
@@ -4329,7 +4329,7 @@ val compile_evaluate = Q.store_thm("compile_evaluate",
   first_assum(match_exists_tac o concl) >> simp[] >>
 
   (* Stuff to carry along *)
-  rator_x_assum`renumber_code_locs_list`mp_tac >>
+  qhdtm_x_assum`renumber_code_locs_list`mp_tac >>
   specl_args_of_then``renumber_code_locs_list``
     (CONJUNCT1 clos_numberProofTheory.renumber_code_locs_every_Fn_vs_NONE)
     assume_tac >>
@@ -4672,7 +4672,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
       first_assum(subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) o concl) >>
       drule bvlPropsTheory.evaluate_add_clock >>
       impl_tac >- full_simp_tac(srw_ss())[] >> strip_tac >>
-      rator_x_assum`closSem$evaluate`kall_tac >>
+      qhdtm_x_assum`closSem$evaluate`kall_tac >>
       last_assum(qspec_then`k'`mp_tac)>>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       drule (GEN_ALL compile_evaluate) >> fs[] >>
@@ -4704,7 +4704,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
           impl_tac >- (
             PROVE_TAC[FST,full_result_rel_abort] ) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[bvlPropsTheory.inc_clock_def]>>
-          rator_x_assum`bvlSem$evaluate`mp_tac >>
+          qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
           drule bvlPropsTheory.evaluate_add_clock >>
           impl_tac >- ( strip_tac >> full_simp_tac(srw_ss())[] ) >>
           disch_then(qspec_then`ck+k`mp_tac)>>simp[bvlPropsTheory.inc_clock_def]>>
@@ -4723,7 +4723,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM,GSYM AND_IMP_INTRO])) >>
         rpt (disch_then drule)>>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[LET_THM])) >> strip_tac >>
-        rator_x_assum`closSem$evaluate`mp_tac >>
+        qhdtm_x_assum`closSem$evaluate`mp_tac >>
         drule (Q.GEN`extra`(SIMP_RULE std_ss [] (CONJUNCT1 closPropsTheory.evaluate_add_to_clock))) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
@@ -4751,7 +4751,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
         full_simp_tac(srw_ss())[state_rel_def] >> rev_full_simp_tac(srw_ss())[] >>
         imp_res_tac full_result_rel_ffi >>
         full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]) >>
-      rator_x_assum`bvlSem$evaluate`mp_tac >>
+      qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
       drule bvlPropsTheory.evaluate_add_clock >>
       impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
       disch_then(qspec_then`ck+k`mp_tac)>>simp[bvlPropsTheory.inc_clock_def] >>
@@ -4803,14 +4803,14 @@ val compile_semantics = Q.store_thm("compile_semantics",
     spose_not_then strip_assume_tac >>
     last_x_assum(qspec_then`k`strip_assume_tac) >> rev_full_simp_tac(srw_ss())[] >>
     reverse(Cases_on`s'.ffi.final_event`)>>full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`bvlSem$evaluate`mp_tac >>
+      qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
       qmatch_assum_abbrev_tac`bvlSem$evaluate (exps,[],ss) = _` >>
       qspecl_then[`exps`,`[]`,`ss`]mp_tac (INST_TYPE[alpha|->``:'ffi``]bvlPropsTheory.evaluate_add_to_clock_io_events_mono) >>
       disch_then(qspec_then`ck`mp_tac)>>
       fsrw_tac[ARITH_ss][ADD1,bvlPropsTheory.inc_clock_def,Abbr`ss`] >>
       rpt strip_tac >> full_simp_tac(srw_ss())[] >>
       imp_res_tac full_result_rel_ffi >> full_simp_tac(srw_ss())[]) >>
-    rator_x_assum`bvlSem$evaluate`mp_tac >>
+    qhdtm_x_assum`bvlSem$evaluate`mp_tac >>
     drule bvlPropsTheory.evaluate_add_clock >>
     impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
     disch_then(qspec_then`ck`mp_tac) >>

--- a/compiler/backend/proofs/clos_to_bvlProofScript.sml
+++ b/compiler/backend/proofs/clos_to_bvlProofScript.sml
@@ -35,10 +35,10 @@ val SUM_REPLICATE = Q.store_thm("SUM_REPLICATE",
 
 val EVERY2_GENLIST = LIST_REL_GENLIST |> EQ_IMP_RULE |> snd |> Q.GEN`l`
 
-val EVERY_ZIP_GENLIST = prove(
-  ``!xs.
+val EVERY_ZIP_GENLIST = Q.prove(
+  `!xs.
       (!i. i < LENGTH xs ==> P (EL i xs,f i)) ==>
-      EVERY P (ZIP (xs,GENLIST f (LENGTH xs)))``,
+      EVERY P (ZIP (xs,GENLIST f (LENGTH xs)))`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ full_simp_tac(srw_ss())[GENLIST] \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[ZIP_SNOC,EVERY_SNOC] \\ REPEAT STRIP_TAC
   THEN1
@@ -895,9 +895,9 @@ val cl_rel_NEW_REF = Q.prove (
   \\ full_simp_tac(srw_ss())[FDIFF_def,SUBMAP_DEF,DRESTRICT_DEF,FLOOKUP_DEF]
   \\ full_simp_tac(srw_ss())[FAPPLY_FUPDATE_THM] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
 
-val v_rel_NEW_REF = prove(
-  ``!x y. v_rel max_app f1 refs1 code x y ==> ~(r IN FDOM refs1) ==>
-          v_rel max_app f1 (refs1 |+ (r,t)) code x y``,
+val v_rel_NEW_REF = Q.prove(
+  `!x y. v_rel max_app f1 refs1 code x y ==> ~(r IN FDOM refs1) ==>
+          v_rel max_app f1 (refs1 |+ (r,t)) code x y`,
   HO_MATCH_MP_TAC v_rel_ind \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [v_rel_cases] \\ full_simp_tac(srw_ss())[]
   THEN1 (REPEAT (POP_ASSUM MP_TAC) \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[])
@@ -911,10 +911,10 @@ val v_rel_NEW_REF = prove(
          metis_tac [] ))
   |> SPEC_ALL |> MP_CANON;
 
-val cl_rel_UPDATE_REF = prove(
-  ``!x y. cl_rel max_app f1 refs1 code (env,ys) x y ==>
+val cl_rel_UPDATE_REF = Q.prove(
+  `!x y. cl_rel max_app f1 refs1 code (env,ys) x y ==>
           (r IN f1) ==>
-          cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y``,
+          cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y`,
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
@@ -925,10 +925,10 @@ val cl_rel_UPDATE_REF = prove(
   \\ full_simp_tac(srw_ss())[FAPPLY_FUPDATE_THM] \\ SRW_TAC [] []
   \\ full_simp_tac(srw_ss())[FRANGE_DEF] \\ METIS_TAC []);
 
-val v_rel_UPDATE_REF = prove(
-  ``!x y. v_rel max_app f1 refs1 code x y ==>
+val v_rel_UPDATE_REF = Q.prove(
+  `!x y. v_rel max_app f1 refs1 code x y ==>
           (r IN FRANGE f1) ==>
-          v_rel max_app f1 (refs1 |+ (r,t)) code x y``,
+          v_rel max_app f1 (refs1 |+ (r,t)) code x y`,
   HO_MATCH_MP_TAC v_rel_ind \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [v_rel_cases] \\ full_simp_tac(srw_ss())[]
   THEN1 (REPEAT (POP_ASSUM MP_TAC) \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[])
@@ -942,40 +942,40 @@ val v_rel_UPDATE_REF = prove(
          metis_tac [] ))
   |> SPEC_ALL |> MP_CANON;
 
-val OPTREL_v_rel_NEW_REF = prove(
-  ``OPTREL (v_rel max_app f1 refs1 code) x y /\ ~(r IN FDOM refs1) ==>
-    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y``,
+val OPTREL_v_rel_NEW_REF = Q.prove(
+  `OPTREL (v_rel max_app f1 refs1 code) x y /\ ~(r IN FDOM refs1) ==>
+    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y`,
   Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_NEW_REF]);
 
-val OPTREL_v_rel_UPDATE_REF = prove(
-  ``OPTREL (v_rel max_app f1 refs1 code) x y /\ r IN FRANGE f1 ==>
-    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y``,
+val OPTREL_v_rel_UPDATE_REF = Q.prove(
+  `OPTREL (v_rel max_app f1 refs1 code) x y /\ r IN FRANGE f1 ==>
+    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y`,
   Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_UPDATE_REF]);
 
-val env_rel_NEW_REF = prove(
-  ``!x y.
+val env_rel_NEW_REF = Q.prove(
+  `!x y.
       env_rel max_app f1 refs1 code x y /\ ~(r IN FDOM refs1) ==>
-      env_rel max_app f1 (refs1 |+ (r,t)) code x y``,
+      env_rel max_app f1 (refs1 |+ (r,t)) code x y`,
   Induct \\ Cases_on `y` \\ full_simp_tac(srw_ss())[env_rel_def] \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC v_rel_NEW_REF \\ full_simp_tac(srw_ss())[]);
 
-val cl_rel_NEW_F = prove(
-  ``!x y.
+val cl_rel_NEW_F = Q.prove(
+  `!x y.
       cl_rel max_app f2 t2.refs t2.code (env,ys) x y ==>
       ~(qq IN FDOM t2.refs) ==>
-      cl_rel max_app (qq INSERT f2) t2.refs t2.code (env,ys) x y``,
+      cl_rel max_app (qq INSERT f2) t2.refs t2.code (env,ys) x y`,
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
   \\ DISJ2_TAC \\ Q.LIST_EXISTS_TAC [`exps_ps`,`r`] \\ full_simp_tac(srw_ss())[]
   \\ strip_tac >> full_simp_tac(srw_ss())[FLOOKUP_DEF])
 
-val v_rel_NEW_F = prove(
-  ``!x y.
+val v_rel_NEW_F = Q.prove(
+  `!x y.
       v_rel max_app f2 t2.refs t2.code x y ==>
       ~(pp IN FDOM f2) ==>
       ~(qq IN FDOM t2.refs) ==>
-      v_rel max_app (f2 |+ (pp,qq)) t2.refs t2.code x y``,
+      v_rel max_app (f2 |+ (pp,qq)) t2.refs t2.code x y`,
   HO_MATCH_MP_TAC v_rel_ind \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [v_rel_cases] \\ full_simp_tac(srw_ss())[]
   THEN1 (REPEAT (POP_ASSUM MP_TAC) \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[])
@@ -990,11 +990,11 @@ val v_rel_NEW_F = prove(
          metis_tac [] ))
   |> SPEC_ALL |> MP_CANON;
 
-val OPTREL_v_rel_NEW_F = prove(
-  ``OPTREL (v_rel max_app f2 t2.refs t2.code) x y ==>
+val OPTREL_v_rel_NEW_F = Q.prove(
+  `OPTREL (v_rel max_app f2 t2.refs t2.code) x y ==>
     ~(pp IN FDOM f2) ==>
     ~(qq IN FDOM t2.refs) ==>
-    OPTREL (v_rel max_app (f2 |+ (pp,qq)) t2.refs t2.code) x y``,
+    OPTREL (v_rel max_app (f2 |+ (pp,qq)) t2.refs t2.code) x y`,
   Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def]
   \\ METIS_TAC [v_rel_NEW_F]) |> MP_CANON;
 
@@ -1517,13 +1517,13 @@ val EXISTS_NOT_IN_refs = Q.prove(
   `?x. ~(x IN FDOM (t1:'ffi bvlSem$state).refs)`,
   METIS_TAC [NUM_NOT_IN_FDOM])
 
-val lookup_vars_IMP2 = prove(
-  ``!vs env xs env2.
+val lookup_vars_IMP2 = Q.prove(
+  `!vs env xs env2.
       (lookup_vars vs env = SOME xs) /\
       env_rel max_app f refs code env env2 ==>
       ?ys. (!t1. (evaluate (MAP Var vs,env2,t1) = (Rval ys,t1))) /\
            EVERY2 (v_rel max_app f refs code) xs ys /\
-           (LENGTH vs = LENGTH xs)``,
+           (LENGTH vs = LENGTH xs)`,
   Induct \\ full_simp_tac(srw_ss())[lookup_vars_def,evaluate_def]
   \\ REPEAT STRIP_TAC
   \\ Cases_on `lookup_vars vs env` \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] []
@@ -1532,27 +1532,27 @@ val lookup_vars_IMP2 = prove(
   \\ RES_TAC \\ IMP_RES_TAC LESS_LENGTH_env_rel_IMP \\ full_simp_tac(srw_ss())[])
   |> INST_TYPE[alpha|->``:'ffi``];
 
-val lookup_vars_IMP = prove(
-  ``!vs env xs env2.
+val lookup_vars_IMP = Q.prove(
+  `!vs env xs env2.
       (lookup_vars vs env = SOME xs) /\
       env_rel max_app f refs code env env2 ==>
       ?ys. (evaluate (MAP Var vs,env2,t1) = (Rval ys,t1)) /\
            EVERY2 (v_rel max_app f refs code) xs ys /\
-           (LENGTH vs = LENGTH xs)``,
+           (LENGTH vs = LENGTH xs)`,
   (* TODO: metis_tac is not VALID here *)
     PROVE_TAC[lookup_vars_IMP2])
   |> INST_TYPE[alpha|->``:'ffi``];
 
-val compile_exps_IMP_code_installed = prove(
-  ``(compile_exps max_app xs aux = (c,aux1)) /\
+val compile_exps_IMP_code_installed = Q.prove(
+  `(compile_exps max_app xs aux = (c,aux1)) /\
     code_installed aux1 code ==>
-    code_installed aux code``,
+    code_installed aux code`,
   REPEAT STRIP_TAC
   \\ MP_TAC (SPEC_ALL compile_exps_acc) \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[code_installed_def]);
 
-val compile_exps_LIST_IMP_compile_exps_EL = prove(
-  ``!exps aux1 c7 aux7 i n8 n4 aux5 num_args e.
+val compile_exps_LIST_IMP_compile_exps_EL = Q.prove(
+  `!exps aux1 c7 aux7 i n8 n4 aux5 num_args e.
       EL i exps = (num_args, e) ∧
       (compile_exps max_app (MAP SND exps) aux1 = (c7,aux7)) /\ i < LENGTH exps /\
       (build_aux n8 (MAP2 (code_for_recc_case k) (MAP FST exps) c7) aux7 = (n4,aux5)) /\
@@ -1560,7 +1560,7 @@ val compile_exps_LIST_IMP_compile_exps_EL = prove(
       ?aux c aux1'.
         compile_exps max_app [e] aux = ([c],aux1') /\
         lookup (n8 + 2*i) t1.code = SOME (num_args + 1,SND (code_for_recc_case k num_args c)) /\
-        code_installed aux1' t1.code``,
+        code_installed aux1' t1.code`,
   HO_MATCH_MP_TAC SNOC_INDUCT \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ Cases_on `i = LENGTH exps` \\ full_simp_tac(srw_ss())[] THEN1
    (full_simp_tac(srw_ss())[SNOC_APPEND,EL_LENGTH_APPEND]
@@ -1613,8 +1613,8 @@ val compile_exps_LIST_IMP_compile_exps_EL = prove(
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[code_installed_def]);
 
-val evaluate_recc_Lets = prove(
-  ``!(ll:(num#'a) list) n7 rr env' t1 ys c8 (x:(num#'a)) (x':(num#'a)) ck.
+val evaluate_recc_Lets = Q.prove(
+  `!(ll:(num#'a) list) n7 rr env' t1 ys c8 (x:(num#'a)) (x':(num#'a)) ck.
      EVERY (\n. n7 + ns + 2* n IN domain t1.code) (GENLIST I (LENGTH ll)) ==>
      (evaluate
        ([recc_Lets (n7 + ns) (REVERSE (MAP FST ll)) (LENGTH ll) (HD c8)],
@@ -1630,7 +1630,7 @@ val evaluate_recc_Lets = prove(
         t1 with <| refs := t1.refs |+ (rr,
                ValueArray
                (MAP2 (\n args. Block closure_tag [CodePtr (n7 + ns + 2* n); Number &(args-1); RefPtr rr])
-                  (GENLIST I (LENGTH ll + 1)) (MAP FST ll ++ [FST x']) ++ ys)); clock := ck |>))``,
+                  (GENLIST I (LENGTH ll + 1)) (MAP FST ll ++ [FST x']) ++ ys)); clock := ck |>))`,
   recInduct SNOC_INDUCT \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [recc_Lets_def] \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def,recc_Let_def,bvlSemTheory.do_app_def]
@@ -3873,10 +3873,10 @@ val compile_exps_correct = Q.store_thm("compile_exps_correct",
 
 (* more correctness properties *)
 
-val build_aux_thm = prove(
-  ``∀c n aux n7 aux7.
+val build_aux_thm = Q.prove(
+  `∀c n aux n7 aux7.
     build_aux n c aux = (n7,aux7++aux) ⇒
-    (MAP FST aux7) = (REVERSE (GENLIST ($+ n o $* 2) (LENGTH c)))``,
+    (MAP FST aux7) = (REVERSE (GENLIST ($+ n o $* 2) (LENGTH c)))`,
   Induct >> simp[build_aux_def] >> srw_tac[][] >>
   qmatch_assum_abbrev_tac`build_aux nn kk auxx = Z` >>
   qspecl_then[`kk`,`nn`,`auxx`]strip_assume_tac build_aux_acc >>
@@ -3912,10 +3912,10 @@ fun tac (g as (asl,w)) =
     rev_full_simp_tac(srw_ss())[]
   end g
 
-val compile_exps_code_locs = store_thm("compile_exps_code_locs",
-  ``∀max_app xs aux ys aux2.
+val compile_exps_code_locs = Q.store_thm("compile_exps_code_locs",
+  `∀max_app xs aux ys aux2.
     compile_exps max_app xs aux = (ys,aux2++aux) ⇒
-    MAP FST aux2 = MAP ((+) (num_stubs max_app)) (REVERSE(code_locs xs))``,
+    MAP FST aux2 = MAP ((+) (num_stubs max_app)) (REVERSE(code_locs xs))`,
   ho_match_mp_tac compile_exps_ind >> rpt conj_tac >>
   TRY (
     srw_tac[][compile_exps_def] >>
@@ -4013,10 +4013,10 @@ val compile_prog_code_locs = Q.store_thm("compile_prog_code_locs",
 (* TODO: Gets rid of the annoying ZIP in clos_remove$compile,
   should probably be the definition instead, but this might translate worse
 *)
-val remove_compile_alt = prove(``
+val remove_compile_alt = Q.prove(`
   ∀b prog.
   clos_remove$compile b prog =
-  MAP (λ(n,args,exp). (n,args, if b then HD(FST(remove [exp])) else exp)) prog``,
+  MAP (λ(n,args,exp). (n,args, if b then HD(FST(remove [exp])) else exp)) prog`,
   Cases>>
   Induct>>fs[clos_removeTheory.compile_def]>-EVAL_TAC>>
   simp[FORALL_PROD]>>rw[Once clos_removeTheory.remove_CONS]);
@@ -4051,10 +4051,10 @@ val IMP_PERM_code_merge = Q.store_thm("IMP_PERM_code_merge",
   \\ simp [Once sortingTheory.PERM_CONS_EQ_APPEND]
   \\ metis_tac []);
 
-val code_split_IMP_PERM = store_thm("code_split_IMP_PERM",
-  ``!xs1 xs2 xs3 ts1 ts2.
+val code_split_IMP_PERM = Q.store_thm("code_split_IMP_PERM",
+  `!xs1 xs2 xs3 ts1 ts2.
       code_split xs1 xs2 xs3 = (ts1,ts2) ==>
-      PERM (ts1 ++ ts2) (xs2 ++ xs3 ++ xs1)``,
+      PERM (ts1 ++ ts2) (xs2 ++ xs3 ++ xs1)`,
   Induct \\ fs [code_split_def] \\ rw [] \\ res_tac
   \\ match_mp_tac PERM_TRANS \\ asm_exists_tac \\ fs []
   \\ fs [sortingTheory.PERM_NIL,sortingTheory.PERM_CONS_EQ_APPEND]
@@ -4251,13 +4251,13 @@ val code_installed_fromAList_strong = Q.prove(`
   srw_tac[][code_installed_def,EVERY_MEM,FORALL_PROD,lookup_fromAList] >>
   metis_tac[ALOOKUP_ALL_DISTINCT_MEM,IS_SUBLIST_MEM])
 
-val compile_prog_stubs = prove(``
+val compile_prog_stubs = Q.prove(`
   ∀ls ls' n m e new_e aux.
   MEM (n,m,e) ls ∧
   compile_prog max_app ls = ls' ∧
   compile_exps max_app [e] [] = (new_e,aux) ⇒
   MEM (n+(num_stubs max_app),m,HD new_e) ls' ∧
-  IS_SUBLIST ls' aux``,
+  IS_SUBLIST ls' aux`,
   Induct>>fs[FORALL_PROD,compile_prog_def]>>
   rw[]>>rpt(pairarg_tac>>fs[])>>
   imp_res_tac compile_exps_SING>>fs[]>>rveq>>fs[]>>

--- a/compiler/backend/proofs/clos_to_bvlProofScript.sml
+++ b/compiler/backend/proofs/clos_to_bvlProofScript.sml
@@ -56,30 +56,30 @@ val ODD_SUB = Q.store_thm("ODD_SUB",
   `∀m n. m ≤ n ⇒ (ODD (n - m) ⇔ ¬(ODD n ⇔ ODD m))`,
   rw[ODD_EVEN,EVEN_SUB]);
 
-val IS_SUBLIST_MEM = prove(``
+val IS_SUBLIST_MEM = Q.prove(`
   ∀ls ls' x.
   MEM x ls ∧ IS_SUBLIST ls' ls ⇒
-  MEM x ls'``,
+  MEM x ls'`,
   Induct>>Induct_on`ls'`>>rw[IS_SUBLIST]>>
   metis_tac[MEM,IS_PREFIX_IS_SUBLIST])
 
-val IS_SUBLIST_APPEND1 = prove(``
+val IS_SUBLIST_APPEND1 = Q.prove(`
   ∀A B C.
   IS_SUBLIST A C ⇒
-  IS_SUBLIST (A++B) C``,
+  IS_SUBLIST (A++B) C`,
   rw[]>>match_mp_tac (snd(EQ_IMP_RULE (SPEC_ALL IS_SUBLIST_APPEND)))>>
   fs[IS_SUBLIST_APPEND]>>
   metis_tac[APPEND_ASSOC])
 
-val IS_SUBLIST_APPEND2 = prove(``
+val IS_SUBLIST_APPEND2 = Q.prove(`
   ∀A B C.
   IS_SUBLIST B C ⇒
-  IS_SUBLIST (A++B) C``,
+  IS_SUBLIST (A++B) C`,
   Induct_on`A`>>Induct_on`B`>>Induct_on`C`>>fs[IS_SUBLIST])
 
-val IS_SUBLIST_REFL = prove(``
+val IS_SUBLIST_REFL = Q.prove(`
   ∀ls.
-  IS_SUBLIST ls ls``,
+  IS_SUBLIST ls ls`,
   Induct>>fs[IS_SUBLIST])
 
 val map2_snoc = Q.prove (
@@ -770,30 +770,30 @@ val env_rel_def = Define `
   (env_rel max_app f refs code (x::xs) (y::ys) <=>
      v_rel max_app f refs code x y /\ env_rel max_app f refs code xs ys)`;
 
-val env_rel_APPEND = prove(
-  ``!xs1 xs2.
+val env_rel_APPEND = Q.prove(
+  `!xs1 xs2.
       EVERY2 (v_rel max_app f1 refs code) xs1 xs2 /\
       env_rel max_app f1 refs code ys1 ys2 ==>
-      env_rel max_app f1 refs code (xs1 ++ ys1) (xs2 ++ ys2)``,
+      env_rel max_app f1 refs code (xs1 ++ ys1) (xs2 ++ ys2)`,
   Induct \\ Cases_on `xs2` \\ full_simp_tac(srw_ss())[env_rel_def]);
 
-val list_rel_IMP_env_rel = prove(
-  ``!xs ys.
+val list_rel_IMP_env_rel = Q.prove(
+  `!xs ys.
       LIST_REL (v_rel max_app f refs code) xs ys ==>
-      env_rel max_app f refs code xs (ys ++ ts)``,
+      env_rel max_app f refs code xs (ys ++ ts)`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[env_rel_def]
   \\ Cases_on `ts` \\ full_simp_tac(srw_ss())[env_rel_def]);
 
-val env_rel_IMP_LENGTH = prove(
-  ``!env1 env2.
+val env_rel_IMP_LENGTH = Q.prove(
+  `!env1 env2.
       env_rel max_app f refs code env1 env2 ==>
-      LENGTH env1 <= LENGTH env2``,
+      LENGTH env1 <= LENGTH env2`,
   Induct \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]);
 
-val LESS_LENGTH_env_rel_IMP = prove(
-  ``!env env2 n.
+val LESS_LENGTH_env_rel_IMP = Q.prove(
+  `!env env2 n.
       n < LENGTH env /\ env_rel max_app f refs code env env2 ==>
-      n < LENGTH env2 /\ v_rel max_app f refs code (EL n env) (EL n env2)``,
+      n < LENGTH env2 /\ v_rel max_app f refs code (EL n env) (EL n env2)`,
   Induct \\ full_simp_tac(srw_ss())[LENGTH] \\ REPEAT STRIP_TAC
   \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]
   \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]);
@@ -833,9 +833,9 @@ val state_rel_def = Define `
 val _ = temp_overload_on ("ksrel", ``clos_knownProof$state_rel``)
 
 
-val state_rel_globals = prove(
-  ``state_rel f s t ⇒
-    LIST_REL (OPTREL (v_rel s.max_app f t.refs t.code)) s.globals t.globals``,
+val state_rel_globals = Q.prove(
+  `state_rel f s t ⇒
+    LIST_REL (OPTREL (v_rel s.max_app f t.refs t.code)) s.globals t.globals`,
   srw_tac[][state_rel_def]);
 
 val state_rel_clock = Q.store_thm ("state_rel_clock[simp]",
@@ -856,10 +856,10 @@ val cl_rel_SUBMAP = Q.prove (
   \\ full_simp_tac(srw_ss())[FDIFF_def,SUBMAP_DEF,DRESTRICT_DEF,FLOOKUP_DEF]
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `r`) \\ full_simp_tac(srw_ss())[]);
 
-val v_rel_SUBMAP = prove(
-  ``!x y. v_rel max_app f1 refs1 code x y ==>
+val v_rel_SUBMAP = Q.prove(
+  `!x y. v_rel max_app f1 refs1 code x y ==>
       f1 SUBMAP f2 /\ FDIFF refs1 (FRANGE f1) SUBMAP FDIFF refs2 (FRANGE f2) ==>
-      v_rel max_app f2 refs2 code x y``,
+      v_rel max_app f2 refs2 code x y`,
   HO_MATCH_MP_TAC v_rel_ind \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [v_rel_cases] \\ full_simp_tac(srw_ss())[]
   THEN1 (REPEAT (POP_ASSUM MP_TAC) \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[])
@@ -875,11 +875,11 @@ val v_rel_SUBMAP = prove(
          metis_tac [SUBMAP_FRANGE_SUBSET] ))
   |> SPEC_ALL |> MP_CANON;
 
-val env_rel_SUBMAP = prove(
-  ``!env1 env2.
+val env_rel_SUBMAP = Q.prove(
+  `!env1 env2.
       env_rel max_app f1 refs1 code env1 env2 /\
       f1 SUBMAP f2 /\ FDIFF refs1 (FRANGE f1) SUBMAP FDIFF refs2 (FRANGE f2) ==>
-      env_rel max_app f2 refs2 code env1 env2``,
+      env_rel max_app f2 refs2 code env1 env2`,
   Induct \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC v_rel_SUBMAP) |> GEN_ALL;
 
@@ -1294,8 +1294,8 @@ val do_eq_def = tDefine"do_eq"`
   (WF_REL_TAC `measure (\x. case x of INL (v1,v2) => v_size v1 | INR (vs1,vs2) => v1_size vs1)`);
 val _ = export_rewrites["do_eq_def"];
 
-val do_eq = prove(
-  ``INJ ($' f) (FDOM f) (FRANGE f) ⇒
+val do_eq = Q.prove(
+  `INJ ($' f) (FDOM f) (FRANGE f) ⇒
     (∀x y x1 y1.
            v_rel max_app f r c x x1 ∧
            v_rel max_app f r c y y1 ⇒
@@ -1303,7 +1303,7 @@ val do_eq = prove(
     (∀x y x1 y1.
            LIST_REL (v_rel max_app f r c) x x1 ∧
            LIST_REL (v_rel max_app f r c) y y1 ⇒
-           do_eq_list x y = do_eq_list x1 y1)``,
+           do_eq_list x y = do_eq_list x1 y1)`,
    strip_tac >>
    HO_MATCH_MP_TAC closSemTheory.do_eq_ind >>
    srw_tac[][]
@@ -1513,8 +1513,8 @@ val equality = Q.prove(
 
 (* compiler correctness *)
 
-val EXISTS_NOT_IN_refs = prove(
-  ``?x. ~(x IN FDOM (t1:'ffi bvlSem$state).refs)``,
+val EXISTS_NOT_IN_refs = Q.prove(
+  `?x. ~(x IN FDOM (t1:'ffi bvlSem$state).refs)`,
   METIS_TAC [NUM_NOT_IN_FDOM])
 
 val lookup_vars_IMP2 = prove(
@@ -4021,16 +4021,16 @@ val remove_compile_alt = prove(``
   Induct>>fs[clos_removeTheory.compile_def]>-EVAL_TAC>>
   simp[FORALL_PROD]>>rw[Once clos_removeTheory.remove_CONS]);
 
-val remove_FST = prove(``
-  ∀ls b.MAP FST (clos_remove$compile b ls) = MAP FST ls``,
+val remove_FST = Q.prove(`
+  ∀ls b.MAP FST (clos_remove$compile b ls) = MAP FST ls`,
   Induct>>Cases_on`b`>>fs[clos_removeTheory.compile_def,FORALL_PROD]
   >-
     EVAL_TAC>>
   first_x_assum(qspec_then`T` assume_tac)>>fs[clos_removeTheory.compile_def]>>
   rw[Once clos_removeTheory.remove_CONS])
 
-val IMP_PERM_code_merge = store_thm("IMP_PERM_code_merge",
-  ``!xs ys zs. PERM (xs ++ ys) zs ==> PERM (code_merge xs ys) zs``,
+val IMP_PERM_code_merge = Q.store_thm("IMP_PERM_code_merge",
+  `!xs ys zs. PERM (xs ++ ys) zs ==> PERM (code_merge xs ys) zs`,
   HO_MATCH_MP_TAC code_merge_ind \\ rw []
   \\ once_rewrite_tac [code_merge_def]
   \\ fs [] \\ Cases_on `xs` \\ fs []
@@ -4061,8 +4061,8 @@ val code_split_IMP_PERM = store_thm("code_split_IMP_PERM",
   \\ qexists_tac `xs2 ++ xs3` \\ fs [sortingTheory.PERM_APPEND_IFF]
   \\ fs [PERM_APPEND]);
 
-val PERM_code_sort = store_thm("PERM_code_sort",
-  ``!xs. PERM (code_sort xs) xs``,
+val PERM_code_sort = Q.store_thm("PERM_code_sort",
+  `!xs. PERM (code_sort xs) xs`,
   HO_MATCH_MP_TAC code_sort_ind \\ rw [code_sort_def]
   \\ pairarg_tac \\ fs []
   \\ match_mp_tac IMP_PERM_code_merge
@@ -4071,15 +4071,15 @@ val PERM_code_sort = store_thm("PERM_code_sort",
   \\ once_rewrite_tac [CONJ_COMM] \\ asm_exists_tac \\ fs []
   \\ match_mp_tac sortingTheory.PERM_CONG \\ fs []);
 
-val ALL_DISTINCT_code_sort = store_thm("ALL_DISTINCT_code_sort",
-  ``ALL_DISTINCT (MAP FST (code_sort xs)) <=> ALL_DISTINCT (MAP FST xs)``,
+val ALL_DISTINCT_code_sort = Q.store_thm("ALL_DISTINCT_code_sort",
+  `ALL_DISTINCT (MAP FST (code_sort xs)) <=> ALL_DISTINCT (MAP FST xs)`,
   match_mp_tac sortingTheory.ALL_DISTINCT_PERM
   \\ match_mp_tac sortingTheory.PERM_MAP \\ fs [PERM_code_sort]);
 
-val PERM_IMP_fromAList_EQ_fromAList = store_thm("PERM_IMP_fromAList_EQ_fromAList",
-  ``!xs ys.
+val PERM_IMP_fromAList_EQ_fromAList = Q.store_thm("PERM_IMP_fromAList_EQ_fromAList",
+  `!xs ys.
       PERM xs ys ==> ALL_DISTINCT (MAP FST xs) ==>
-      fromAList xs = fromAList ys``,
+      fromAList xs = fromAList ys`,
   Induct \\ fs [sortingTheory.PERM_NIL,sortingTheory.PERM_CONS_EQ_APPEND]
   \\ rw [] \\ res_tac
   \\ fs [ALL_DISTINCT_APPEND]
@@ -4088,9 +4088,9 @@ val PERM_IMP_fromAList_EQ_fromAList = store_thm("PERM_IMP_fromAList_EQ_fromAList
   \\ rw [] \\ fs [GSYM alistTheory.ALOOKUP_NONE]
   \\ every_case_tac \\ fs []);
 
-val fromAList_code_sort = store_thm("fromAList_code_sort",
-  ``ALL_DISTINCT (MAP FST xs) ==>
-    fromAList (code_sort xs) = fromAList xs``,
+val fromAList_code_sort = Q.store_thm("fromAList_code_sort",
+  `ALL_DISTINCT (MAP FST xs) ==>
+    fromAList (code_sort xs) = fromAList xs`,
   rw [] \\ match_mp_tac (MP_CANON PERM_IMP_fromAList_EQ_fromAList)
   \\ fs [PERM_code_sort,ALL_DISTINCT_code_sort]);
 
@@ -4243,11 +4243,11 @@ val clos_init_with_clock = Q.store_thm("clos_init_with_clock[simp]",
   EVAL_TAC);
 
 (* actually, this can be made even stronger *)
-val code_installed_fromAList_strong = prove(``
+val code_installed_fromAList_strong = Q.prove(`
   ∀ls ls'.
   ALL_DISTINCT(MAP FST ls) ∧
   IS_SUBLIST ls ls' ⇒
-  code_installed ls' (fromAList ls)``,
+  code_installed ls' (fromAList ls)`,
   srw_tac[][code_installed_def,EVERY_MEM,FORALL_PROD,lookup_fromAList] >>
   metis_tac[ALOOKUP_ALL_DISTINCT_MEM,IS_SUBLIST_MEM])
 

--- a/compiler/backend/proofs/con_to_decProofScript.sml
+++ b/compiler/backend/proofs/con_to_decProofScript.sml
@@ -58,11 +58,11 @@ val compile_env_exh = Q.store_thm("compile_env_exh[simp]",
 
 (* semantic functions are equivalent *)
 
-val do_app = prove(
-  ``∀st op vs res.
+val do_app = Q.prove(
+  `∀st op vs res.
       conSem$do_app st op vs = SOME res ⇒
       ∀s. s.refs = FST st ∧ s.ffi = SND st ⇒
-        decSem$do_app s op vs = SOME (s with <|refs := FST(FST res); ffi := SND(FST res)|>,SND res)``,
+        decSem$do_app s op vs = SOME (s with <|refs := FST(FST res); ffi := SND(FST res)|>,SND res)`,
   Cases >> rw[conSemTheory.do_app_def,decSemTheory.do_app_def] >>
   Cases_on`op`>>fs[] >>
   rpt(BasicProvers.CASE_TAC >> fs[LET_THM,store_alloc_def]))

--- a/compiler/backend/proofs/con_to_decProofScript.sml
+++ b/compiler/backend/proofs/con_to_decProofScript.sml
@@ -413,9 +413,9 @@ val compile_semantics = Q.store_thm("compile_semantics",
   rpt var_eq_tac >>
   fs[dec_result_rel_cases,compile_state_def]);
 
-val set_globals_esgc = prove(``
+val set_globals_esgc = Q.prove(`
   (∀e. set_globals e = {||} ⇒ conProps$esgc_free e) ∧
-  (∀es. elist_globals es = {||} ⇒ EVERY conProps$esgc_free es)``,
+  (∀es. elist_globals es = {||} ⇒ EVERY conProps$esgc_free es)`,
   ho_match_mp_tac set_globals_ind>>rw[])
 
 val no_set_globals_imp_esgc_free = Q.store_thm("no_set_globals_imp_esgc_free",

--- a/compiler/backend/proofs/con_to_decProofScript.sml
+++ b/compiler/backend/proofs/con_to_decProofScript.sml
@@ -275,7 +275,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     rw[] >>
     simp[decSemTheory.semantics_def] >>
     IF_CASES_TAC >> fs[] >- (
-      rator_x_assum`conSem$evaluate_prog`kall_tac >>
+      qhdtm_x_assum`conSem$evaluate_prog`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       pop_assum mp_tac >>
@@ -309,7 +309,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
           simp[RIGHT_FORALL_IMP_THM] >>
           impl_tac >- (strip_tac >> fs[dec_result_rel_cases]) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`decSem$evaluate`mp_tac >>
+          qhdtm_x_assum`decSem$evaluate`mp_tac >>
           drule (GEN_ALL (CONJUNCT1 decPropsTheory.evaluate_add_to_clock)) >>
           simp[] >>
           disch_then(qspec_then`k`mp_tac)>>simp[]>>
@@ -326,7 +326,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
         impl_tac >- fs[] >>
         (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
         strip_tac >> fs[] >>
-        rator_x_assum`conSem$evaluate_prog`mp_tac >>
+        qhdtm_x_assum`conSem$evaluate_prog`mp_tac >>
         drule (GEN_ALL conPropsTheory.evaluate_prog_add_to_clock) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
         impl_tac >- (strip_tac >> fs[]) >>
@@ -348,7 +348,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
       strip_tac >> fs[] >> rveq >>
       reverse(Cases_on`s''.ffi.final_event`)>>fs[]>>rfs[]>- (
         fsrw_tac[ARITH_ss][] >> rfs[compile_state_def,dec_result_rel_cases] >> fs[] >> rfs[]) >>
-      rator_x_assum`decSem$evaluate`mp_tac >>
+      qhdtm_x_assum`decSem$evaluate`mp_tac >>
       drule (GEN_ALL(CONJUNCT1 decPropsTheory.evaluate_add_to_clock)) >>
       CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
       impl_tac >- fs[] >>

--- a/compiler/backend/proofs/data_liveProofScript.sml
+++ b/compiler/backend/proofs/data_liveProofScript.sml
@@ -5,8 +5,8 @@ val _ = new_theory"data_liveProof";
 val _ = temp_bring_to_front_overload"get_vars"{Name="get_vars",Thy="dataSem"};
 val _ = temp_bring_to_front_overload"cut_env"{Name="cut_env",Thy="dataSem"};
 
-val SPLIT_PAIR = prove(
-  ``!x y z. (x = (y,z)) <=> (y = FST x) /\ (z = SND x)``,
+val SPLIT_PAIR = Q.prove(
+  `!x y z. (x = (y,z)) <=> (y = FST x) /\ (z = SND x)`,
   Cases \\ SRW_TAC [] [] \\ METIS_TAC []);
 
 val state_rel_def = Define `
@@ -31,13 +31,13 @@ val jump_exc_IMP_state_rel = Q.prove(
   \\ every_case_tac >> fs[]
   \\ SRW_TAC [] [] \\ fs [state_rel_def]);
 
-val state_rel_IMP_do_app = prove(
-  ``(do_app op args s1 = Rval (v,s2)) /\
+val state_rel_IMP_do_app = Q.prove(
+  `(do_app op args s1 = Rval (v,s2)) /\
     state_rel s1 t1 anything ==>
     (s1.handler = s2.handler) /\ (s1.stack = s2.stack) /\
     (do_app op args t1 = Rval (v,s2 with <| locals := t1.locals ;
                                              stack := t1.stack ;
-                                             handler := t1.handler |>))``,
+                                             handler := t1.handler |>))`,
   STRIP_TAC
   \\ IMP_RES_TAC do_app_const
   \\ fs [do_app_def,do_space_def]
@@ -85,8 +85,8 @@ val is_pure_do_app_Rerr_IMP = Q.prove(
   \\ EVAL_TAC \\ every_case_tac \\ fs []
   \\ fs [state_component_equality]);
 
-val is_pure_do_app_Rval_IMP = prove(
-  ``is_pure op /\ do_app op x s = Rval (q,r) ==> r = s``,
+val is_pure_do_app_Rval_IMP = Q.prove(
+  `is_pure op /\ do_app op x s = Rval (q,r) ==> r = s`,
   Cases_on `op` \\ fs [is_pure_def,do_app_def]
   \\ EVAL_TAC \\ every_case_tac \\ fs [data_spaceTheory.op_space_req_def]
   \\ fs [state_component_equality,is_pure_def]);

--- a/compiler/backend/proofs/data_liveProofScript.sml
+++ b/compiler/backend/proofs/data_liveProofScript.sml
@@ -16,16 +16,16 @@ val state_rel_def = Define `
     s1.handler = t1.handler /\ (LENGTH s1.stack = LENGTH t1.stack) /\
     (!x. x IN domain live ==> (lookup x s1.locals = lookup x t1.locals))`;
 
-val state_rel_ID = prove(
-  ``!s live. state_rel s s live``,
+val state_rel_ID = Q.prove(
+  `!s live. state_rel s s live`,
   fs [state_rel_def]);
 
-val jump_exc_IMP_state_rel = prove(
-  ``!s1 t1 s2 t2.
+val jump_exc_IMP_state_rel = Q.prove(
+  `!s1 t1 s2 t2.
       (jump_exc s1 = SOME s2) /\ (jump_exc t1 = SOME t2) /\
       state_rel s1 t1 LN /\ (LENGTH s2.stack = LENGTH t2.stack) ==>
       state_rel (s2 with handler := s1.handler)
-                (t2 with handler := t1.handler) LN``,
+                (t2 with handler := t1.handler) LN`,
   REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [jump_exc_def]
   \\ every_case_tac >> fs[]
@@ -51,9 +51,9 @@ val state_rel_IMP_do_app = prove(
   \\ ASM_SIMP_TAC (srw_ss()) [dataSemTheory.state_component_equality]
   \\ SRW_TAC [] [] \\ fs[]);
 
-val state_rel_IMP_do_app_err = prove(
-  ``(do_app op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
-    (do_app op args t1 = Rerr e)``,
+val state_rel_IMP_do_app_err = Q.prove(
+  `(do_app op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
+    (do_app op args t1 = Rerr e)`,
   STRIP_TAC
   \\ fs [do_app_def,do_space_def]
   \\ fs [state_rel_def,consume_space_def]
@@ -65,11 +65,11 @@ val state_rel_IMP_do_app_err = prove(
   \\ fs [bvi_to_data_def]
   \\ ASM_SIMP_TAC (srw_ss()) [dataSemTheory.state_component_equality]);
 
-val state_rel_IMP_get_vars = prove(
-  ``!args s1 t1 t xs.
+val state_rel_IMP_get_vars = Q.prove(
+  `!args s1 t1 t xs.
       state_rel s1 t1 (list_insert args t) /\
       (get_vars args s1.locals = SOME xs) ==>
-      (get_vars args t1.locals = SOME xs)``,
+      (get_vars args t1.locals = SOME xs)`,
   Induct \\ fs [get_vars_def] \\ REPEAT STRIP_TAC
   \\ `state_rel s1 t1 (list_insert args t) /\
       (get_var h s1.locals = get_var h t1.locals)` by ALL_TAC THEN1
@@ -78,9 +78,9 @@ val state_rel_IMP_get_vars = prove(
   \\ every_case_tac >> fs[]
   \\ RES_TAC \\ fs [] \\ SRW_TAC [] []);
 
-val is_pure_do_app_Rerr_IMP = prove(
-  ``is_pure op /\ do_app op xs s = Rerr e ==>
-    Rabort Rtype_error = e``,
+val is_pure_do_app_Rerr_IMP = Q.prove(
+  `is_pure op /\ do_app op xs s = Rerr e ==>
+    Rabort Rtype_error = e`,
   Cases_on `op` \\ fs [is_pure_def,do_app_def]
   \\ EVAL_TAC \\ every_case_tac \\ fs []
   \\ fs [state_component_equality]);

--- a/compiler/backend/proofs/data_simpProofScript.sml
+++ b/compiler/backend/proofs/data_simpProofScript.sml
@@ -4,17 +4,17 @@ val _ = new_theory"data_simpProof";
 
 val _ = temp_bring_to_front_overload"evaluate"{Name="evaluate",Thy="dataSem"};
 
-val evaluate_Seq_Skip = prove(
-  ``!c s. evaluate (Seq c Skip,s) = evaluate (c,s)``,
+val evaluate_Seq_Skip = Q.prove(
+  `!c s. evaluate (Seq c Skip,s) = evaluate (c,s)`,
   fs [evaluate_def,LET_DEF] \\ REPEAT STRIP_TAC
   \\ Cases_on `evaluate (c,s)` \\ fs [] \\ SRW_TAC [] []);
 
-val evaluate_pSeq = prove(
-  ``evaluate (pSeq c1 c2, s) = evaluate (Seq c1 c2, s)``,
+val evaluate_pSeq = Q.prove(
+  `evaluate (pSeq c1 c2, s) = evaluate (Seq c1 c2, s)`,
   SRW_TAC [] [pSeq_def] \\ fs [evaluate_Seq_Skip]);
 
-val evaluate_simp = prove(
-  ``!c1 s c2. evaluate (simp c1 c2,s) = evaluate (Seq c1 c2,s)``,
+val evaluate_simp = Q.prove(
+  `!c1 s c2. evaluate (simp c1 c2,s) = evaluate (Seq c1 c2,s)`,
   recInduct evaluate_ind \\ reverse (REPEAT STRIP_TAC) THEN1
    (Cases_on `handler` \\ fs [simp_def,evaluate_pSeq]
     \\ Cases_on `x` \\ fs [simp_def,evaluate_pSeq]
@@ -30,8 +30,8 @@ val evaluate_simp = prove(
   \\ CONV_TAC (DEPTH_CONV (PairRules.PBETA_CONV))
   \\ every_case_tac >> fs[evaluate_def]);
 
-val simp_correct = store_thm("simp_correct",
-  ``!c s. evaluate (simp c Skip,s) = evaluate (c,s)``,
+val simp_correct = Q.store_thm("simp_correct",
+  `!c s. evaluate (simp c Skip,s) = evaluate (c,s)`,
   SIMP_TAC std_ss [evaluate_simp,evaluate_Seq_Skip]);
 
 val _ = export_theory();

--- a/compiler/backend/proofs/data_spaceProofScript.sml
+++ b/compiler/backend/proofs/data_spaceProofScript.sml
@@ -342,11 +342,11 @@ val evaluate_compile = Q.prove(
            dec_clock_def] \\ METIS_TAC [])
     \\ full_simp_tac(srw_ss())[] \\ METIS_TAC [locals_ok_refl,with_same_locals]));
 
-val compile_correct = store_thm("compile_correct",
-  ``!c s.
+val compile_correct = Q.store_thm("compile_correct",
+  `!c s.
       FST (evaluate (c,s)) <> NONE /\
       FST (evaluate (c,s)) <> SOME (Rerr(Rabort Rtype_error)) ==>
-      (evaluate (compile c, s) = evaluate (c,s))``,
+      (evaluate (compile c, s) = evaluate (c,s))`,
   REPEAT STRIP_TAC \\ Cases_on `evaluate (c,s)` \\ full_simp_tac(srw_ss())[]
   \\ MP_TAC (Q.SPECL [`c`,`s`] evaluate_compile)
   \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC

--- a/compiler/backend/proofs/data_spaceProofScript.sml
+++ b/compiler/backend/proofs/data_spaceProofScript.sml
@@ -6,16 +6,16 @@ val _ = temp_bring_to_front_overload"get_vars"{Name="get_vars",Thy="dataSem"};
 val _ = temp_bring_to_front_overload"cut_env"{Name="cut_env",Thy="dataSem"};
 val _ = temp_bring_to_front_overload"evaluate"{Name="evaluate",Thy="dataSem"};
 
-val IMP_sptree_eq = prove(
-  ``wf x /\ wf y /\ (!a. lookup a x = lookup a y) ==> (x = y)``,
+val IMP_sptree_eq = Q.prove(
+  `wf x /\ wf y /\ (!a. lookup a x = lookup a y) ==> (x = y)`,
   METIS_TAC [spt_eq_thm]);
 
-val mk_wf_inter = prove(
-  ``!t1 t2. inter t1 t2 = mk_wf (inter t1 t2)``,
+val mk_wf_inter = Q.prove(
+  `!t1 t2. inter t1 t2 = mk_wf (inter t1 t2)`,
   full_simp_tac(srw_ss())[]);
 
-val get_vars_IMP_LENGTH = store_thm("get_vars_IMP_LENGTH",
-  ``!xs s l. get_vars xs s = SOME l ==> (LENGTH l = LENGTH xs)``,
+val get_vars_IMP_LENGTH = Q.store_thm("get_vars_IMP_LENGTH",
+  `!xs s l. get_vars xs s = SOME l ==> (LENGTH l = LENGTH xs)`,
   Induct \\ fs [get_vars_def] \\ rw [] \\ every_case_tac \\ fs []
   \\ rw [] \\ fs [] \\ res_tac \\ fs []);
 

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -7270,23 +7270,23 @@ val data_to_word_compile_lab_pres = Q.store_thm("data_to_word_compile_lab_pres",
     pop_assum (qspec_then `p_1,p_2` assume_tac)>>fs[MEM_EL,EQ_IMP_THM]>>
     metis_tac[]);
 
-val StoreEach_no_inst = prove(``
+val StoreEach_no_inst = Q.prove(`
   ∀a ls off.
-  every_inst (inst_ok_less ac) (StoreEach a ls off)``,
+  every_inst (inst_ok_less ac) (StoreEach a ls off)`,
   Induct_on`ls`>>rw[StoreEach_def,every_inst_def])
 
-val assign_no_inst = prove(``
+val assign_no_inst = Q.prove(`
   addr_offset_ok 0w ac ⇒
-  every_inst (inst_ok_less ac) (FST(assign a b c d e f g))``,
+  every_inst (inst_ok_less ac) (FST(assign a b c d e f g))`,
   fs[assign_def]>>Cases_on`e`>>fs[every_inst_def]>>
   rw[]>>fs[every_inst_def,GiveUp_def]>>
   every_case_tac>>fs[every_inst_def,list_Seq_def,StoreEach_no_inst,inst_ok_less_def]>>
   Cases_on`o'`>>fs[])
 
-val comp_no_inst = prove(``
+val comp_no_inst = Q.prove(`
   ∀c n m p.
   addr_offset_ok 0w ac ⇒
-  every_inst (inst_ok_less ac) (FST(comp c n m p))``,
+  every_inst (inst_ok_less ac) (FST(comp c n m p))`,
   ho_match_mp_tac comp_ind>>Cases_on`p`>>rw[]>>
   simp[Once comp_def,every_inst_def]>>
   every_case_tac>>fs[]>>
@@ -7294,13 +7294,13 @@ val comp_no_inst = prove(``
   fs[assign_no_inst]>>
   EVAL_TAC>>fs[])
 
-val data_to_word_compile_conventions = store_thm("data_to_word_compile_conventions",``
+val data_to_word_compile_conventions = Q.store_thm("data_to_word_compile_conventions",`
   let (c,p) = compile data_conf wc ac prog in
   EVERY (λ(n,m,prog).
     flat_exp_conventions prog ∧
     post_alloc_conventions (ac.reg_count - (5+LENGTH ac.avoid_regs)) prog ∧
     (addr_offset_ok 0w ac ⇒ full_inst_ok_less ac prog) ∧
-    (ac.two_reg_arith ⇒ every_inst two_reg_inst prog)) p``,
+    (ac.two_reg_arith ⇒ every_inst two_reg_inst prog)) p`,
  fs[compile_def]>>
  qpat_abbrev_tac`p= stubs(:'a) data_conf ++B`>>
  pairarg_tac>>fs[]>>

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -2044,7 +2044,7 @@ val state_rel_get_var_Block = Q.store_thm("state_rel_get_var_Block",
   \\ fs[abs_ml_inv_def]
   \\ fs[bc_stack_ref_inv_def]
   \\ fs[v_inv_def]
-  \\ rator_x_assum`COND`mp_tac
+  \\ qhdtm_x_assum`COND`mp_tac
   \\ IF_CASES_TAC \\ simp[word_addr_def]
   \\ strip_tac \\ rveq
   \\ simp[word_addr_def]);
@@ -6881,7 +6881,7 @@ val compile_semantics_lemma = Q.store_thm("compile_semantics_lemma",
     simp[wordSemTheory.semantics_def] >>
     IF_CASES_TAC >- (
       full_simp_tac(srw_ss())[] >> rveq >> full_simp_tac(srw_ss())[] >>
-      rator_x_assum`dataSem$evaluate`kall_tac >>
+      qhdtm_x_assum`dataSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       strip_tac >>
@@ -6924,7 +6924,7 @@ val compile_semantics_lemma = Q.store_thm("compile_semantics_lemma",
           every_case_tac >> full_simp_tac(srw_ss())[]>>
           Cases_on`res1=SOME NotEnoughSpace`>>full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[] >>
           full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[] ) >>
-        rator_x_assum`wordSem$evaluate`mp_tac >>
+        qhdtm_x_assum`wordSem$evaluate`mp_tac >>
         drule(GEN_ALL wordPropsTheory.evaluate_add_clock) >>
         simp[] >>
         disch_then(qspec_then`ck+k`mp_tac) >>
@@ -6962,7 +6962,7 @@ val compile_semantics_lemma = Q.store_thm("compile_semantics_lemma",
         rveq>>full_simp_tac(srw_ss())[]>>
         last_x_assum(qspec_then`k+k'`mp_tac) >> simp[]) >>
       Cases_on`r`>>full_simp_tac(srw_ss())[]>>
-      rator_x_assum`wordSem$evaluate`mp_tac >>
+      qhdtm_x_assum`wordSem$evaluate`mp_tac >>
       drule(GEN_ALL wordPropsTheory.evaluate_add_clock) >>
       simp[RIGHT_FORALL_IMP_THM] >>
       impl_tac >- ( strip_tac >> full_simp_tac(srw_ss())[] ) >>
@@ -7032,7 +7032,7 @@ val compile_semantics_lemma = Q.store_thm("compile_semantics_lemma",
     first_assum(qspec_then`k`mp_tac) >>
     first_x_assum(qspec_then`k+ck`mp_tac) >>
     fsrw_tac[ARITH_ss][inc_clock_def] >>
-    rator_x_assum`wordSem$evaluate`mp_tac >>
+    qhdtm_x_assum`wordSem$evaluate`mp_tac >>
     drule(GEN_ALL wordPropsTheory.evaluate_add_clock)>>
     simp[]>>
     disch_then(qspec_then`ck`mp_tac)>>

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -9,8 +9,8 @@ val _ = new_theory "data_to_wordProof";
 (* TODO: move *)
 val _ = type_abbrev("state", ``:('a,'b)wordSem$state``)
 
-val WORD_MUL_BIT0 = store_thm("WORD_MUL_BIT0",
-  ``!a b. (a * b) ' 0 <=> a ' 0 /\ b ' 0``,
+val WORD_MUL_BIT0 = Q.store_thm("WORD_MUL_BIT0",
+  `!a b. (a * b) ' 0 <=> a ' 0 /\ b ' 0`,
   fs [word_mul_def,word_index,bitTheory.BIT0_ODD,ODD_MULT]
   \\ Cases \\ Cases \\ fs [word_index,bitTheory.BIT0_ODD]);
 
@@ -36,20 +36,20 @@ val lsr_lsl = Q.store_thm("lsr_lsl",
   \\ last_x_assum(mp_tac o Q.AP_TERM`combin$C $' x`)
   \\ simp[fcpTheory.FCP_BETA,word_0]);
 
-val word_index_test = store_thm("word_index_test",
-  ``n < dimindex (:'a) ==> (w ' n <=> ((w && n2w (2 ** n)) <> 0w:'a word))``,
+val word_index_test = Q.store_thm("word_index_test",
+  `n < dimindex (:'a) ==> (w ' n <=> ((w && n2w (2 ** n)) <> 0w:'a word))`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
 
-val word_and_one_eq_0_iff = store_thm("word_and_one_eq_0_iff", (* same in stack_alloc *)
-  ``!w. ((w && 1w) = 0w) <=> ~(w ' 0)``,
+val word_and_one_eq_0_iff = Q.store_thm("word_and_one_eq_0_iff", (* same in stack_alloc *)
+  `!w. ((w && 1w) = 0w) <=> ~(w ' 0)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index])
 
-val get_var_set_var = store_thm("get_var_set_var[simp]",
-  ``get_var n (set_var n w s) = SOME w``,
+val get_var_set_var = Q.store_thm("get_var_set_var[simp]",
+  `get_var n (set_var n w s) = SOME w`,
   full_simp_tac(srw_ss())[wordSemTheory.get_var_def,wordSemTheory.set_var_def]);
 
-val set_var_set_var = store_thm("set_var_set_var[simp]",
-  ``set_var n v (set_var n w s) = set_var n v s``,
+val set_var_set_var = Q.store_thm("set_var_set_var[simp]",
+  `set_var n v (set_var n w s) = set_var n v s`,
   fs[wordSemTheory.state_component_equality,wordSemTheory.set_var_def,
       insert_shadow]);
 
@@ -66,15 +66,15 @@ val ALOOKUP_SKIP_LEMMA = prove(
     ALOOKUP (xs ++ [(n,d)] ++ ys) n = SOME e``,
   full_simp_tac(srw_ss())[ALOOKUP_APPEND] \\ fs[GSYM ALOOKUP_NONE])
 
-val LAST_EQ = prove(
-  ``(LAST (x::xs) = if xs = [] then x else LAST xs) /\
-    (FRONT (x::xs) = if xs = [] then [] else x::FRONT xs)``,
+val LAST_EQ = Q.prove(
+  `(LAST (x::xs) = if xs = [] then x else LAST xs) /\
+    (FRONT (x::xs) = if xs = [] then [] else x::FRONT xs)`,
   Cases_on `xs` \\ full_simp_tac(srw_ss())[]);
 
-val LASTN_LIST_REL_LEMMA = prove(
-  ``!xs1 ys1 xs n y ys x P.
+val LASTN_LIST_REL_LEMMA = Q.prove(
+  `!xs1 ys1 xs n y ys x P.
       LASTN n xs1 = x::xs /\ LIST_REL P xs1 ys1 ==>
-      ?y ys. LASTN n ys1 = y::ys /\ P x y /\ LIST_REL P xs ys``,
+      ?y ys. LASTN n ys1 = y::ys /\ P x y /\ LIST_REL P xs ys`,
   Induct \\ Cases_on `ys1` \\ full_simp_tac(srw_ss())[LASTN_ALT] \\ rpt strip_tac
   \\ imp_res_tac LIST_REL_LENGTH \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
@@ -82,33 +82,33 @@ val LASTN_LIST_REL_LEMMA = prove(
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ `F` by decide_tac);
 
-val LASTN_CONS_IMP_LENGTH = store_thm("LASTN_CONS_IMP_LENGTH",
-  ``!xs n y ys.
+val LASTN_CONS_IMP_LENGTH = Q.store_thm("LASTN_CONS_IMP_LENGTH",
+  `!xs n y ys.
       n <= LENGTH xs ==>
-      (LASTN n xs = y::ys) ==> LENGTH (y::ys) = n``,
+      (LASTN n xs = y::ys) ==> LENGTH (y::ys) = n`,
   Induct \\ full_simp_tac(srw_ss())[LASTN_ALT]
   \\ srw_tac[][] THEN1 decide_tac \\ full_simp_tac(srw_ss())[GSYM NOT_LESS]);
 
-val LASTN_IMP_APPEND = store_thm("LASTN_IMP_APPEND",
-  ``!xs n ys.
+val LASTN_IMP_APPEND = Q.store_thm("LASTN_IMP_APPEND",
+  `!xs n ys.
       n <= LENGTH xs /\ (LASTN n xs = ys) ==>
-      ?zs. xs = zs ++ ys /\ LENGTH ys = n``,
+      ?zs. xs = zs ++ ys /\ LENGTH ys = n`,
   Induct \\ full_simp_tac(srw_ss())[LASTN_ALT] \\ srw_tac[][] THEN1 decide_tac
   \\ `n <= LENGTH xs` by decide_tac \\ res_tac \\ full_simp_tac(srw_ss())[]
   \\ qpat_x_assum `xs = zs ++ LASTN n xs` (fn th => simp [Once th]));
 
-val NOT_NIL_IMP_LAST = prove(
-  ``!xs x. xs <> [] ==> LAST (x::xs) = LAST xs``,
+val NOT_NIL_IMP_LAST = Q.prove(
+  `!xs x. xs <> [] ==> LAST (x::xs) = LAST xs`,
   Cases \\ full_simp_tac(srw_ss())[]);
 
-val IS_SOME_IF = prove(
-  ``IS_SOME (if b then x else y) = if b then IS_SOME x else IS_SOME y``,
+val IS_SOME_IF = Q.prove(
+  `IS_SOME (if b then x else y) = if b then IS_SOME x else IS_SOME y`,
   Cases_on `b` \\ full_simp_tac(srw_ss())[]);
 
-val PERM_ALL_DISTINCT_MAP = prove(
-  ``!xs ys. PERM xs ys ==>
+val PERM_ALL_DISTINCT_MAP = Q.prove(
+  `!xs ys. PERM xs ys ==>
             ALL_DISTINCT (MAP f xs) ==>
-            ALL_DISTINCT (MAP f ys) /\ !x. MEM x ys <=> MEM x xs``,
+            ALL_DISTINCT (MAP f ys) /\ !x. MEM x ys <=> MEM x xs`,
   full_simp_tac(srw_ss())[MEM_PERM] \\ srw_tac[][]
   \\ `PERM (MAP f xs) (MAP f ys)` by full_simp_tac(srw_ss())[PERM_MAP]
   \\ metis_tac [ALL_DISTINCT_PERM])
@@ -121,8 +121,8 @@ val ALL_DISTINCT_EL = ``ALL_DISTINCT xs``
   |> ONCE_REWRITE_CONV [GSYM GENLIST_I]
   |> SIMP_RULE std_ss [ALL_DISTINCT_GENLIST]
 
-val PERM_list_rearrange = prove(
-  ``!f xs. ALL_DISTINCT xs ==> PERM xs (list_rearrange f xs)``,
+val PERM_list_rearrange = Q.prove(
+  `!f xs. ALL_DISTINCT xs ==> PERM xs (list_rearrange f xs)`,
   srw_tac[][] \\ match_mp_tac PERM_ALL_DISTINCT
   \\ full_simp_tac(srw_ss())[mem_list_rearrange]
   \\ full_simp_tac(srw_ss())[wordSemTheory.list_rearrange_def] \\ srw_tac[][]
@@ -137,8 +137,8 @@ val ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME = prove(
   \\ res_tac \\ full_simp_tac(srw_ss())[MEM_MAP,FORALL_PROD]
   \\ rev_full_simp_tac(srw_ss())[]) |> SPEC_ALL;
 
-val IS_SOME_ALOOKUP_EQ = prove(
-  ``!l x. IS_SOME (ALOOKUP l x) = MEM x (MAP FST l)``,
+val IS_SOME_ALOOKUP_EQ = Q.prove(
+  `!l x. IS_SOME (ALOOKUP l x) = MEM x (MAP FST l)`,
   Induct \\ full_simp_tac(srw_ss())[]
   \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def] \\ srw_tac[][]);
 
@@ -146,12 +146,12 @@ val MEM_IMP_IS_SOME_ALOOKUP = prove(
   ``!l x y. MEM (x,y) l ==> IS_SOME (ALOOKUP l x)``,
   full_simp_tac(srw_ss())[IS_SOME_ALOOKUP_EQ,MEM_MAP,EXISTS_PROD] \\ metis_tac []);
 
-val SUBSET_INSERT_EQ_SUBSET = prove(
-  ``~(x IN s) ==> (s SUBSET (x INSERT t) <=> s SUBSET t)``,
+val SUBSET_INSERT_EQ_SUBSET = Q.prove(
+  `~(x IN s) ==> (s SUBSET (x INSERT t) <=> s SUBSET t)`,
   full_simp_tac(srw_ss())[EXTENSION]);
 
-val EVERY2_IMP_EL = prove(
-  ``!xs ys P n. EVERY2 P xs ys /\ n < LENGTH ys ==> P (EL n xs) (EL n ys)``,
+val EVERY2_IMP_EL = Q.prove(
+  `!xs ys P n. EVERY2 P xs ys /\ n < LENGTH ys ==> P (EL n xs) (EL n ys)`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]);
 
@@ -159,10 +159,10 @@ val FST_PAIR_EQ = prove(
   ``!x v. (FST x,v) = x <=> v = SND x``,
   Cases \\ full_simp_tac(srw_ss())[]);
 
-val EVERY2_APPEND_IMP = prove(
-  ``!xs1 xs2 zs P.
+val EVERY2_APPEND_IMP = Q.prove(
+  `!xs1 xs2 zs P.
       EVERY2 P (xs1 ++ xs2) zs ==>
-      ?zs1 zs2. zs = zs1 ++ zs2 /\ EVERY2 P xs1 zs1 /\ EVERY2 P xs2 zs2``,
+      ?zs1 zs2. zs = zs1 ++ zs2 /\ EVERY2 P xs1 zs1 /\ EVERY2 P xs2 zs2`,
   Induct \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ res_tac \\ full_simp_tac(srw_ss())[]
   \\ Q.LIST_EXISTS_TAC [`y::zs1`,`zs2`] \\ full_simp_tac(srw_ss())[]);
@@ -187,14 +187,14 @@ val FOLDL_LENGTH_LEMMA = prove(
       q = LENGTH xs * d + k``,
   Induct \\ fs [FOLDL] \\ rw [] \\ res_tac \\ fs [MULT_CLAUSES]);
 
-val fromList_SNOC = store_thm("fromList_SNOC",
- ``!xs y. fromList (SNOC y xs) = insert (LENGTH xs) y (fromList xs)``,
+val fromList_SNOC = Q.store_thm("fromList_SNOC",
+ `!xs y. fromList (SNOC y xs) = insert (LENGTH xs) y (fromList xs)`,
   fs [fromList_def,FOLDL_APPEND,SNOC_APPEND] \\ rw []
   \\ Cases_on `FOLDL (λ(i,t) a. (i + 1,insert i a t)) (0,LN) xs`
   \\ fs [] \\ imp_res_tac FOLDL_LENGTH_LEMMA \\ fs []);
 
-val fromList2_SNOC = store_thm("fromList2_SNOC",
- ``!xs y. fromList2 (SNOC y xs) = insert (2 * LENGTH xs) y (fromList2 xs)``,
+val fromList2_SNOC = Q.store_thm("fromList2_SNOC",
+ `!xs y. fromList2 (SNOC y xs) = insert (2 * LENGTH xs) y (fromList2 xs)`,
   fs [fromList2_def,FOLDL_APPEND,SNOC_APPEND] \\ rw []
   \\ Cases_on `FOLDL (λ(i,t) a. (i + 2,insert i a t)) (0,LN) xs`
   \\ fs [] \\ imp_res_tac FOLDL_LENGTH_LEMMA \\ fs []);
@@ -217,46 +217,46 @@ val flat_def = Define `
      join_env env vs ++ flat xs ys) /\
   (flat _ _ = [])`
 
-val flat_APPEND = prove(
-  ``!xs ys xs1 ys1.
+val flat_APPEND = Q.prove(
+  `!xs ys xs1 ys1.
       LENGTH xs = LENGTH ys ==>
-      flat (xs ++ xs1) (ys ++ ys1) = flat xs ys ++ flat xs1 ys1``,
+      flat (xs ++ xs1) (ys ++ ys1) = flat xs ys ++ flat xs1 ys1`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[flat_def] \\ srw_tac[][]
   \\ Cases_on `h'` \\ Cases_on `h`
   \\ TRY (Cases_on `o'`) \\ full_simp_tac(srw_ss())[flat_def]);
 
-val adjust_var_DIV_2 = prove(
-  ``(adjust_var n - 2) DIV 2 = n``,
+val adjust_var_DIV_2 = Q.prove(
+  `(adjust_var n - 2) DIV 2 = n`,
   full_simp_tac(srw_ss())[ONCE_REWRITE_RULE[MULT_COMM]adjust_var_def,MULT_DIV]);
 
-val adjust_var_DIV_2_ANY = prove(
-  ``(adjust_var n) DIV 2 = n + 1``,
+val adjust_var_DIV_2_ANY = Q.prove(
+  `(adjust_var n) DIV 2 = n + 1`,
   fs [adjust_var_def,ONCE_REWRITE_RULE[MULT_COMM]ADD_DIV_ADD_DIV]);
 
-val EVEN_adjust_var = prove(
-  ``EVEN (adjust_var n)``,
+val EVEN_adjust_var = Q.prove(
+  `EVEN (adjust_var n)`,
   full_simp_tac(srw_ss())[adjust_var_def,EVEN_MOD2,
     ONCE_REWRITE_RULE[MULT_COMM]MOD_TIMES]);
 
-val adjust_var_NEQ_0 = prove(
-  ``adjust_var n <> 0``,
+val adjust_var_NEQ_0 = Q.prove(
+  `adjust_var n <> 0`,
   rpt strip_tac \\ full_simp_tac(srw_ss())[adjust_var_def]);
 
-val adjust_var_NEQ_1 = prove(
-  ``adjust_var n <> 1``,
+val adjust_var_NEQ_1 = Q.prove(
+  `adjust_var n <> 1`,
   rpt strip_tac
   \\ `EVEN (adjust_var n) = EVEN 1` by full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[EVEN_adjust_var]);
 
-val adjust_var_NEQ = store_thm("adjust_var_NEQ[simp]",
-  ``adjust_var n <> 0 /\
+val adjust_var_NEQ = Q.store_thm("adjust_var_NEQ[simp]",
+  `adjust_var n <> 0 /\
     adjust_var n <> 1 /\
     adjust_var n <> 3 /\
     adjust_var n <> 5 /\
     adjust_var n <> 7 /\
     adjust_var n <> 9 /\
     adjust_var n <> 11 /\
-    adjust_var n <> 13``,
+    adjust_var n <> 13`,
   rpt strip_tac \\ fs [adjust_var_NEQ_0]
   \\ `EVEN (adjust_var n) = EVEN 1` by full_simp_tac(srw_ss())[]
   \\ `EVEN (adjust_var n) = EVEN 3` by full_simp_tac(srw_ss())[]
@@ -267,32 +267,32 @@ val adjust_var_NEQ = store_thm("adjust_var_NEQ[simp]",
   \\ `EVEN (adjust_var n) = EVEN 13` by full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[EVEN_adjust_var]);
 
-val unit_opt_eq = prove(
-  ``(x = y:unit option) <=> (IS_SOME x <=> IS_SOME y)``,
+val unit_opt_eq = Q.prove(
+  `(x = y:unit option) <=> (IS_SOME x <=> IS_SOME y)`,
   Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[]);
 
-val adjust_var_11 = prove(
-  ``(adjust_var n = adjust_var m) <=> n = m``,
+val adjust_var_11 = Q.prove(
+  `(adjust_var n = adjust_var m) <=> n = m`,
   full_simp_tac(srw_ss())[adjust_var_def,EQ_MULT_LCANCEL]);
 
-val lookup_adjust_var_adjust_set = prove(
-  ``lookup (adjust_var n) (adjust_set s) = lookup n s``,
+val lookup_adjust_var_adjust_set = Q.prove(
+  `lookup (adjust_var n) (adjust_set s) = lookup n s`,
   full_simp_tac(srw_ss())[lookup_def,adjust_set_def,lookup_fromAList,unit_opt_eq,adjust_var_NEQ_0]
   \\ full_simp_tac(srw_ss())[IS_SOME_ALOOKUP_EQ,MEM_MAP,PULL_EXISTS,EXISTS_PROD,adjust_var_11]
   \\ full_simp_tac(srw_ss())[MEM_toAList] \\ Cases_on `lookup n s` \\ full_simp_tac(srw_ss())[]);
 
-val none_opt_eq = prove(
-  ``((x = NONE) = (y = NONE)) <=> (IS_SOME x <=> IS_SOME y)``,
+val none_opt_eq = Q.prove(
+  `((x = NONE) = (y = NONE)) <=> (IS_SOME x <=> IS_SOME y)`,
   Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[]);
 
-val lookup_adjust_var_adjust_set_NONE = prove(
-  ``lookup (adjust_var n) (adjust_set s) = NONE <=> lookup n s = NONE``,
+val lookup_adjust_var_adjust_set_NONE = Q.prove(
+  `lookup (adjust_var n) (adjust_set s) = NONE <=> lookup n s = NONE`,
   full_simp_tac(srw_ss())[lookup_def,adjust_set_def,lookup_fromAList,adjust_var_NEQ_0,none_opt_eq]
   \\ full_simp_tac(srw_ss())[IS_SOME_ALOOKUP_EQ,MEM_MAP,PULL_EXISTS,EXISTS_PROD,adjust_var_11]
   \\ full_simp_tac(srw_ss())[MEM_toAList] \\ Cases_on `lookup n s` \\ full_simp_tac(srw_ss())[]);
 
-val lookup_adjust_var_adjust_set_SOME_UNIT = prove(
-  ``lookup (adjust_var n) (adjust_set s) = SOME () <=> IS_SOME (lookup n s)``,
+val lookup_adjust_var_adjust_set_SOME_UNIT = Q.prove(
+  `lookup (adjust_var n) (adjust_set s) = SOME () <=> IS_SOME (lookup n s)`,
   Cases_on `lookup (adjust_var n) (adjust_set s) = NONE`
   \\ pop_assum (fn th => assume_tac th THEN
        assume_tac (SIMP_RULE std_ss [lookup_adjust_var_adjust_set_NONE] th))
@@ -353,14 +353,14 @@ val word_ml_inv_get_vars_IMP = store_thm("word_ml_inv_get_vars_IMP",
   \\ match_mp_tac word_ml_inv_rearrange
   \\ full_simp_tac(srw_ss())[MEM] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]) |> SPEC_ALL;
 
-val IMP_adjust_var = prove(
-  ``n <> 0 /\ EVEN n ==> adjust_var ((n - 2) DIV 2) = n``,
+val IMP_adjust_var = Q.prove(
+  `n <> 0 /\ EVEN n ==> adjust_var ((n - 2) DIV 2) = n`,
   full_simp_tac(srw_ss())[EVEN_EXISTS] \\ srw_tac[][] \\ Cases_on `m` \\ full_simp_tac(srw_ss())[MULT_CLAUSES]
   \\ once_rewrite_tac [MULT_COMM] \\ full_simp_tac(srw_ss())[MULT_DIV]
   \\ full_simp_tac(srw_ss())[adjust_var_def] \\ decide_tac);
 
-val unit_some_eq_IS_SOME = prove(
-  ``!x. (x = SOME ()) <=> IS_SOME x``,
+val unit_some_eq_IS_SOME = Q.prove(
+  `!x. (x = SOME ()) <=> IS_SOME x`,
   Cases \\ full_simp_tac(srw_ss())[]);
 
 val word_ml_inv_insert = store_thm("word_ml_inv_insert",
@@ -490,61 +490,61 @@ val word_gc_fun_def = Define `
                      (Globals, HD roots1)] in
        if c /\ c2 then SOME (TL roots1,m1,s1) else NONE`
 
-val one_and_or_1 = prove(
-  ``(1w && (w || 1w)) = 1w``,
+val one_and_or_1 = Q.prove(
+  `(1w && (w || 1w)) = 1w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val one_and_or_3 = prove(
-  ``(3w && (w || 3w)) = 3w``,
+val one_and_or_3 = Q.prove(
+  `(3w && (w || 3w)) = 3w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val ODD_not_zero = prove(
-  ``ODD n ==> n2w n <> 0w``,
+val ODD_not_zero = Q.prove(
+  `ODD n ==> n2w n <> 0w`,
   CCONTR_TAC \\ full_simp_tac std_ss []
   \\ `((n2w n):'a word) ' 0 = (0w:'a word) ' 0` by metis_tac []
   \\ full_simp_tac(srw_ss())[wordsTheory.word_index,bitTheory.BIT_def,bitTheory.BITS_THM]
   \\ full_simp_tac(srw_ss())[dimword_def,bitTheory.ODD_MOD2_LEM])
 
-val three_not_0 = store_thm("three_not_0[simp]",
-  ``3w <> 0w``,
+val three_not_0 = Q.store_thm("three_not_0[simp]",
+  `3w <> 0w`,
   match_mp_tac ODD_not_zero \\ full_simp_tac(srw_ss())[]);
 
 val DISJ_EQ_IMP = METIS_PROVE [] ``(~b \/ c) <=> (b ==> c)``
 
-val three_and_shift_2 = prove(
-  ``(3w && (w << 2)) = 0w``,
+val three_and_shift_2 = Q.prove(
+  `(3w && (w << 2)) = 0w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val shift_to_zero = prove(
-  ``3w >>> 2 = 0w``,
+val shift_to_zero = Q.prove(
+  `3w >>> 2 = 0w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val shift_around_under_big_shift = prove(
-  ``!w n k. n <= k ==> (w << n >>> n << k = w << k)``,
+val shift_around_under_big_shift = Q.prove(
+  `!w n k. n <= k ==> (w << n >>> n << k = w << k)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val select_shift_out = prove(
-  ``n <> 0 ==> ((n - 1 -- 0) (w || v << n) = (n - 1 -- 0) w)``,
+val select_shift_out = Q.prove(
+  `n <> 0 ==> ((n - 1 -- 0) (w || v << n) = (n - 1 -- 0) w)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val shift_length_NOT_ZERO = store_thm("shift_length_NOT_ZERO[simp]",
-  ``shift_length conf <> 0``,
+val shift_length_NOT_ZERO = Q.store_thm("shift_length_NOT_ZERO[simp]",
+  `shift_length conf <> 0`,
   full_simp_tac(srw_ss())[shift_length_def] \\ decide_tac);
 
-val get_addr_and_1_not_0 = prove(
-  ``(1w && get_addr conf k a) <> 0w``,
+val get_addr_and_1_not_0 = Q.prove(
+  `(1w && get_addr conf k a) <> 0w`,
   Cases_on `a` \\ full_simp_tac(srw_ss())[get_addr_def,get_lowerbits_def]
   \\ rewrite_tac [one_and_or_1,GSYM WORD_OR_ASSOC] \\ full_simp_tac(srw_ss())[]);
 
-val one_lsr_shift_length = prove(
-  ``1w >>> shift_length conf = 0w``,
+val one_lsr_shift_length = Q.prove(
+  `1w >>> shift_length conf = 0w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss]
     [word_index, shift_length_def])
 
-val ptr_to_addr_get_addr = prove(
-  ``k * 2 ** shift_length conf < dimword (:'a) ==>
+val ptr_to_addr_get_addr = Q.prove(
+  `k * 2 ** shift_length conf < dimword (:'a) ==>
     ptr_to_addr conf curr (get_addr conf k a) =
-    curr + n2w k * bytes_in_word:'a word``,
+    curr + n2w k * bytes_in_word:'a word`,
   strip_tac
   \\ full_simp_tac(srw_ss())[ptr_to_addr_def,bytes_in_word_def,WORD_MUL_LSL,get_addr_def]
   \\ simp_tac std_ss [Once WORD_MULT_COMM] \\ AP_THM_TAC \\ AP_TERM_TAC
@@ -556,26 +556,26 @@ val ptr_to_addr_get_addr = prove(
   \\ Cases_on `n` \\ full_simp_tac(srw_ss())[MULT_CLAUSES]
   \\ decide_tac);
 
-val is_fws_ptr_OR_3 = prove(
-  ``is_fwd_ptr (Word (w << 2)) /\ ~is_fwd_ptr (Word (w || 3w))``,
+val is_fws_ptr_OR_3 = Q.prove(
+  `is_fwd_ptr (Word (w << 2)) /\ ~is_fwd_ptr (Word (w || 3w))`,
   full_simp_tac(srw_ss())[is_fwd_ptr_def] \\ rewrite_tac [one_and_or_3,three_and_shift_2]
   \\ full_simp_tac(srw_ss())[]);
 
-val is_fws_ptr_OR_15 = prove(
-  ``~is_fwd_ptr (Word (w || 15w))``,
+val is_fws_ptr_OR_15 = Q.prove(
+  `~is_fwd_ptr (Word (w || 15w))`,
   full_simp_tac(srw_ss())[is_fwd_ptr_def]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index, get_lowerbits_def]
   \\ qexists_tac `0` \\ fs []);
 
-val is_fws_ptr_OR_31 = prove(
-  ``~is_fwd_ptr (Word (w || 31w))``,
+val is_fws_ptr_OR_31 = Q.prove(
+  `~is_fwd_ptr (Word (w || 31w))`,
   full_simp_tac(srw_ss())[is_fwd_ptr_def]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index, get_lowerbits_def]
   \\ qexists_tac `0` \\ fs []);
 
-val select_get_lowerbits = prove(
-  ``(shift_length conf − 1 -- 0) (get_lowerbits conf a) =
-    get_lowerbits conf a``,
+val select_get_lowerbits = Q.prove(
+  `(shift_length conf − 1 -- 0) (get_lowerbits conf a) =
+    get_lowerbits conf a`,
   Cases_on `a`
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index, get_lowerbits_def]
   \\ eq_tac
@@ -583,42 +583,42 @@ val select_get_lowerbits = prove(
   \\ fs []
   )
 
-val LE_DIV_LT_IMP = prove(
-  ``n <= l DIV 2 ** m /\ k < n ==> k * 2 ** m < l``,
+val LE_DIV_LT_IMP = Q.prove(
+  `n <= l DIV 2 ** m /\ k < n ==> k * 2 ** m < l`,
   srw_tac[][] \\ `k < l DIV 2 ** m` by decide_tac
   \\ full_simp_tac(srw_ss())[X_LT_DIV,MULT_CLAUSES,GSYM ADD1]
   \\ Cases_on `2 ** m` \\ full_simp_tac(srw_ss())[]
   \\ decide_tac);
 
-val word_bits_eq_slice_shift = store_thm("word_bits_eq_slice_shift",
-  ``((k -- n) w) = (((k '' n) w) >>> n)``,
+val word_bits_eq_slice_shift = Q.store_thm("word_bits_eq_slice_shift",
+  `((k -- n) w) = (((k '' n) w) >>> n)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index]
   \\ Cases_on `i + n < dimindex (:'a)`
   \\ fs []
   )
 
-val word_slice_or = prove(
-  ``(k '' n) (w || v) = ((k '' n) w || (k '' n) v)``,
+val word_slice_or = Q.prove(
+  `(k '' n) (w || v) = ((k '' n) w || (k '' n) v)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index]
   \\ eq_tac
   \\ rw []
   \\ fs []
   )
 
-val word_slice_lsl_eq_0 = prove(
-  ``(k '' n) (w << (k + 1)) = 0w``,
+val word_slice_lsl_eq_0 = Q.prove(
+  `(k '' n) (w << (k + 1)) = 0w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
-val word_slice_2_3_eq_0 = prove(
-  ``(n '' 2) 3w = 0w``,
+val word_slice_2_3_eq_0 = Q.prove(
+  `(n '' 2) 3w = 0w`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [word_index])
 
 val can_select_def = Define `
   can_select k n w <=> ((k - 1 -- n) (w << n) = w)`
 
-val read_length_lemma = prove(
-  ``can_select (n+2) 2 (n2w k :'a word) ==>
-    (((n + 1 -- 2) (h ≪ (2 + n) ‖ n2w k ≪ 2 ‖ 3w)) = n2w k :'a word)``,
+val read_length_lemma = Q.prove(
+  `can_select (n+2) 2 (n2w k :'a word) ==>
+    (((n + 1 -- 2) (h ≪ (2 + n) ‖ n2w k ≪ 2 ‖ 3w)) = n2w k :'a word)`,
   full_simp_tac(srw_ss())[word_bits_eq_slice_shift,word_slice_or,can_select_def,DECIDE ``n+2-1=n+1n``]
   \\ full_simp_tac(srw_ss())[DECIDE ``2+n=n+1+1n``,word_slice_lsl_eq_0,word_slice_2_3_eq_0]);
 
@@ -651,8 +651,8 @@ val memcpy_thm = prove(
   \\ full_simp_tac(srw_ss())[] \\ imp_res_tac (DECIDE ``n+1n<k ==> n<k``) \\ full_simp_tac(srw_ss())[]
   \\ rpt var_eq_tac \\ SEP_R_TAC \\ full_simp_tac(srw_ss())[WORD_LEFT_ADD_DISTRIB]);
 
-val LESS_EQ_IMP_APPEND = prove(
-  ``!n xs. n <= LENGTH xs ==> ?ys zs. xs = ys ++ zs /\ LENGTH ys = n``,
+val LESS_EQ_IMP_APPEND = Q.prove(
+  `!n xs. n <= LENGTH xs ==> ?ys zs. xs = ys ++ zs /\ LENGTH ys = n`,
   Induct_on `xs` \\ full_simp_tac(srw_ss())[] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[LENGTH_NIL]
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ qexists_tac `h::ys` \\ full_simp_tac(srw_ss())[]);
@@ -1057,8 +1057,8 @@ val word_full_gc_thm = prove(
   \\ qexists_tac `xs1'` \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[AC STAR_ASSOC STAR_COMM]);
 
-val LIST_REL_EQ_MAP = store_thm("LIST_REL_EQ_MAP",
-  ``!vs ws f. LIST_REL (λv w. f v = w) vs ws <=> ws = MAP f vs``,
+val LIST_REL_EQ_MAP = Q.store_thm("LIST_REL_EQ_MAP",
+  `!vs ws f. LIST_REL (λv w. f v = w) vs ws <=> ws = MAP f vs`,
   Induct \\ full_simp_tac(srw_ss())[]);
 
 val full_gc_IMP = prove(
@@ -1194,8 +1194,8 @@ val state_rel_with_clock = Q.store_thm("state_rel_with_clock",
     init
    ------------------------------------------------------- *)
 
-val flat_NIL = prove(
-  ``flat [] xs = []``,
+val flat_NIL = Q.prove(
+  `flat [] xs = []`,
   Cases_on `xs` \\ fs [flat_def]);
 
 val conf_ok_def = Define `
@@ -1268,35 +1268,35 @@ val state_rel_init = store_thm("state_rel_init",
     compiler proof
    ------------------------------------------------------- *)
 
-val adjust_var_NOT_0 = store_thm("adjust_var_NOT_0[simp]",
-  ``adjust_var n <> 0``,
+val adjust_var_NOT_0 = Q.store_thm("adjust_var_NOT_0[simp]",
+  `adjust_var n <> 0`,
   full_simp_tac(srw_ss())[adjust_var_def]);
 
-val state_rel_get_var_IMP = prove(
-  ``state_rel c l1 l2 s t v1 locs ==>
+val state_rel_get_var_IMP = Q.prove(
+  `state_rel c l1 l2 s t v1 locs ==>
     (get_var n s.locals = SOME x) ==>
-    ?w. get_var (adjust_var n) t = SOME w``,
+    ?w. get_var (adjust_var n) t = SOME w`,
   full_simp_tac(srw_ss())[dataSemTheory.get_var_def,wordSemTheory.get_var_def]
   \\ full_simp_tac(srw_ss())[state_rel_def] \\ rpt strip_tac
   \\ `IS_SOME (lookup n s.locals)` by full_simp_tac(srw_ss())[] \\ res_tac
   \\ Cases_on `lookup (adjust_var n) t.locals` \\ full_simp_tac(srw_ss())[]);
 
-val state_rel_get_vars_IMP = prove(
-  ``!n xs.
+val state_rel_get_vars_IMP = Q.prove(
+  `!n xs.
       state_rel c l1 l2 s t [] locs ==>
       (get_vars n s.locals = SOME xs) ==>
-      ?ws. get_vars (MAP adjust_var n) t = SOME ws /\ (LENGTH xs = LENGTH ws)``,
+      ?ws. get_vars (MAP adjust_var n) t = SOME ws /\ (LENGTH xs = LENGTH ws)`,
   Induct \\ full_simp_tac(srw_ss())[dataSemTheory.get_vars_def,wordSemTheory.get_vars_def]
   \\ rpt strip_tac
   \\ Cases_on `get_var h s.locals` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `get_vars n s.locals` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac state_rel_get_var_IMP \\ full_simp_tac(srw_ss())[]);
 
-val state_rel_0_get_vars_IMP = prove(
-  ``state_rel c l1 l2 s t [] locs ==>
+val state_rel_0_get_vars_IMP = Q.prove(
+  `state_rel c l1 l2 s t [] locs ==>
     (get_vars n s.locals = SOME xs) ==>
     ?ws. get_vars (0::MAP adjust_var n) t = SOME ((Loc l1 l2)::ws) /\
-         (LENGTH xs = LENGTH ws)``,
+         (LENGTH xs = LENGTH ws)`,
   rpt strip_tac
   \\ imp_res_tac state_rel_get_vars_IMP
   \\ full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
@@ -1325,10 +1325,10 @@ val get_var_T_OR_F = prove(
 val mk_loc_def = Define `
   mk_loc (SOME (t1,d1,d2)) = Loc d1 d2`;
 
-val cut_env_IMP_cut_env = prove(
-  ``state_rel c l1 l2 s t [] locs /\
+val cut_env_IMP_cut_env = Q.prove(
+  `state_rel c l1 l2 s t [] locs /\
     dataSem$cut_env r s.locals = SOME x ==>
-    ?y. wordSem$cut_env (adjust_set r) t.locals = SOME y``,
+    ?y. wordSem$cut_env (adjust_set r) t.locals = SOME y`,
   full_simp_tac(srw_ss())[dataSemTheory.cut_env_def,wordSemTheory.cut_env_def]
   \\ full_simp_tac(srw_ss())[adjust_set_def,domain_fromAList,SUBSET_DEF,MEM_MAP,
          PULL_EXISTS,sptreeTheory.domain_lookup,lookup_fromAList] \\ srw_tac[][]
@@ -1342,12 +1342,12 @@ val cut_env_IMP_cut_env = prove(
   \\ Cases_on `lookup (adjust_var q) t.locals` \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[MEM_toAList,unit_some_eq_IS_SOME] \\ res_tac \\ full_simp_tac(srw_ss())[]);
 
-val jump_exc_call_env = prove(
-  ``wordSem$jump_exc (call_env x s) = jump_exc s``,
+val jump_exc_call_env = Q.prove(
+  `wordSem$jump_exc (call_env x s) = jump_exc s`,
   full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def,wordSemTheory.call_env_def]);
 
-val jump_exc_dec_clock = prove(
-  ``mk_loc (wordSem$jump_exc (dec_clock s)) = mk_loc (jump_exc s)``,
+val jump_exc_dec_clock = Q.prove(
+  `mk_loc (wordSem$jump_exc (dec_clock s)) = mk_loc (jump_exc s)`,
   full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def,wordSemTheory.dec_clock_def]
   \\ srw_tac[][] \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[mk_loc_def]);
 
@@ -1469,13 +1469,13 @@ val state_rel_jump_exc = prove(
   \\ full_simp_tac(srw_ss())[MEM_toAList,lookup_fromAList,lookup_inter_alt]
   \\ imp_res_tac alistTheory.ALOOKUP_MEM \\ metis_tac []);
 
-val get_vars_IMP_LENGTH = prove(
-  ``!x t s. dataSem$get_vars x s = SOME t ==> LENGTH x = LENGTH t``,
+val get_vars_IMP_LENGTH = Q.prove(
+  `!x t s. dataSem$get_vars x s = SOME t ==> LENGTH x = LENGTH t`,
   Induct \\ full_simp_tac(srw_ss())[dataSemTheory.get_vars_def] \\ srw_tac[][]
   \\ every_case_tac \\ res_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val lookup_adjust_var_fromList2 = prove(
-  ``lookup (adjust_var n) (fromList2 (w::ws)) = lookup n (fromList ws)``,
+val lookup_adjust_var_fromList2 = Q.prove(
+  `lookup (adjust_var n) (fromList2 (w::ws)) = lookup n (fromList ws)`,
   full_simp_tac(srw_ss())[lookup_fromList2,EVEN_adjust_var,lookup_fromList]
   \\ full_simp_tac(srw_ss())[adjust_var_def]
   \\ once_rewrite_tac [MULT_COMM]
@@ -1514,19 +1514,19 @@ val state_rel_call_env = prove(
   \\ simp [MATCH_MP ADD_DIV_RWT (DECIDE ``0<2:num``)]
   \\ full_simp_tac(srw_ss())[GSYM ADD1,EL]);
 
-val data_get_vars_SNOC_IMP = prove(
-  ``!x2 x. dataSem$get_vars (SNOC x1 x2) s = SOME x ==>
+val data_get_vars_SNOC_IMP = Q.prove(
+  `!x2 x. dataSem$get_vars (SNOC x1 x2) s = SOME x ==>
            ?y1 y2. x = SNOC y1 y2 /\
                    dataSem$get_var x1 s = SOME y1 /\
-                   dataSem$get_vars x2 s = SOME y2``,
+                   dataSem$get_vars x2 s = SOME y2`,
   Induct \\ full_simp_tac(srw_ss())[dataSemTheory.get_vars_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]) |> SPEC_ALL;
 
-val word_get_vars_SNOC_IMP = prove(
-  ``!x2 x. wordSem$get_vars (SNOC x1 x2) s = SOME x ==>
+val word_get_vars_SNOC_IMP = Q.prove(
+  `!x2 x. wordSem$get_vars (SNOC x1 x2) s = SOME x ==>
            ?y1 y2. x = SNOC y1 y2 /\
               wordSem$get_var x1 s = SOME y1 /\
-              wordSem$get_vars x2 s = SOME y2``,
+              wordSem$get_vars x2 s = SOME y2`,
   Induct \\ full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]) |> SPEC_ALL;
 
@@ -1537,12 +1537,12 @@ val word_ml_inv_CodePtr = prove(
   \\ full_simp_tac(srw_ss())[abs_ml_inv_def,bc_stack_ref_inv_def,v_inv_def]
   \\ srw_tac[][word_addr_def]);
 
-val state_rel_CodePtr = prove(
-  ``state_rel c l1 l2 s t [] locs /\
+val state_rel_CodePtr = Q.prove(
+  `state_rel c l1 l2 s t [] locs /\
     get_vars args s.locals = SOME x /\
     get_vars (MAP adjust_var args) t = SOME y /\
     LAST x = CodePtr n /\ x <> [] ==>
-    y <> [] /\ LAST y = Loc n 0``,
+    y <> [] /\ LAST y = Loc n 0`,
   rpt strip_tac
   \\ imp_res_tac wordPropsTheory.get_vars_length_lemma
   \\ imp_res_tac get_vars_IMP_LENGTH \\ full_simp_tac(srw_ss())[]
@@ -1620,42 +1620,42 @@ val env_to_list_lookup_equiv = prove(
   \\ UNABBREV_ALL_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[MEM_toAList]
   \\ Cases_on `lookup n y` \\ full_simp_tac(srw_ss())[]);
 
-val cut_env_adjust_set_lookup_0 = prove(
-  ``wordSem$cut_env (adjust_set r) x = SOME y ==> lookup 0 y = lookup 0 x``,
+val cut_env_adjust_set_lookup_0 = Q.prove(
+  `wordSem$cut_env (adjust_set r) x = SOME y ==> lookup 0 y = lookup 0 x`,
   full_simp_tac(srw_ss())[wordSemTheory.cut_env_def,SUBSET_DEF,domain_lookup,adjust_set_def,
       lookup_fromAList] \\ srw_tac[][lookup_inter]
   \\ pop_assum (qspec_then `0` mp_tac) \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_fromAList,lookup_inter]);
 
-val cut_env_IMP_MEM = prove(
-  ``dataSem$cut_env s r = SOME x ==>
-    (IS_SOME (lookup n x) <=> IS_SOME (lookup n s))``,
+val cut_env_IMP_MEM = Q.prove(
+  `dataSem$cut_env s r = SOME x ==>
+    (IS_SOME (lookup n x) <=> IS_SOME (lookup n s))`,
   full_simp_tac(srw_ss())[cut_env_def,SUBSET_DEF,domain_lookup]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter] \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ res_tac \\ full_simp_tac(srw_ss())[]);
 
-val cut_env_IMP_lookup = prove(
-  ``wordSem$cut_env s r = SOME x /\ lookup n x = SOME q ==>
-    lookup n r = SOME q``,
+val cut_env_IMP_lookup = Q.prove(
+  `wordSem$cut_env s r = SOME x /\ lookup n x = SOME q ==>
+    lookup n r = SOME q`,
   full_simp_tac(srw_ss())[wordSemTheory.cut_env_def,SUBSET_DEF,domain_lookup]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter] \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val cut_env_IMP_lookup_EQ = prove(
-  ``dataSem$cut_env r y = SOME x /\ n IN domain r ==>
-    lookup n x = lookup n y``,
+val cut_env_IMP_lookup_EQ = Q.prove(
+  `dataSem$cut_env r y = SOME x /\ n IN domain r ==>
+    lookup n x = lookup n y`,
   full_simp_tac(srw_ss())[dataSemTheory.cut_env_def,SUBSET_DEF,domain_lookup]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter] \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val cut_env_res_IS_SOME_IMP = prove(
-  ``wordSem$cut_env r x = SOME y /\ IS_SOME (lookup k y) ==>
-    IS_SOME (lookup k x) /\ IS_SOME (lookup k r)``,
+val cut_env_res_IS_SOME_IMP = Q.prove(
+  `wordSem$cut_env r x = SOME y /\ IS_SOME (lookup k y) ==>
+    IS_SOME (lookup k x) /\ IS_SOME (lookup k r)`,
   full_simp_tac(srw_ss())[wordSemTheory.cut_env_def,SUBSET_DEF,domain_lookup]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter] \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val adjust_var_cut_env_IMP_MEM = prove(
-  ``wordSem$cut_env (adjust_set s) r = SOME x ==>
+val adjust_var_cut_env_IMP_MEM = Q.prove(
+  `wordSem$cut_env (adjust_set s) r = SOME x ==>
     domain x SUBSET EVEN /\
-    (IS_SOME (lookup (adjust_var n) x) <=> IS_SOME (lookup n s))``,
+    (IS_SOME (lookup (adjust_var n) x) <=> IS_SOME (lookup n s))`,
   full_simp_tac(srw_ss())[wordSemTheory.cut_env_def,SUBSET_DEF,domain_lookup]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter_alt] THEN1
    (full_simp_tac(srw_ss())[domain_lookup,unit_some_eq_IS_SOME,adjust_set_def]
@@ -1819,12 +1819,12 @@ val bvl_find_code = store_thm("bvl_find_code",
   Cases_on`dest`>>
   full_simp_tac(srw_ss())[bvlSemTheory.find_code_def,wordSemTheory.bad_dest_args_def])
 
-val s_key_eq_LENGTH = prove(
-  ``!xs ys. s_key_eq xs ys ==> (LENGTH xs = LENGTH ys)``,
+val s_key_eq_LENGTH = Q.prove(
+  `!xs ys. s_key_eq xs ys ==> (LENGTH xs = LENGTH ys)`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[s_key_eq_def]);
 
-val s_key_eq_LASTN = prove(
-  ``!xs ys n. s_key_eq xs ys ==> s_key_eq (LASTN n xs) (LASTN n ys)``,
+val s_key_eq_LASTN = Q.prove(
+  `!xs ys n. s_key_eq xs ys ==> s_key_eq (LASTN n xs) (LASTN n ys)`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[s_key_eq_def,LASTN_ALT]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[s_key_eq_def,LASTN_ALT] \\ res_tac
   \\ imp_res_tac s_key_eq_LENGTH \\ full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
@@ -1909,21 +1909,21 @@ val mk_loc_jump_exc = prove(
 val inc_clock_def = Define `
   inc_clock n (t:('a,'ffi) wordSem$state) = t with clock := t.clock + n`;
 
-val inc_clock_0 = store_thm("inc_clock_0[simp]",
-  ``!t. inc_clock 0 t = t``,
+val inc_clock_0 = Q.store_thm("inc_clock_0[simp]",
+  `!t. inc_clock 0 t = t`,
   full_simp_tac(srw_ss())[inc_clock_def,wordSemTheory.state_component_equality]);
 
-val inc_clock_inc_clock = store_thm("inc_clock_inc_clock[simp]",
-  ``!t. inc_clock n (inc_clock m t) = inc_clock (n+m) t``,
+val inc_clock_inc_clock = Q.store_thm("inc_clock_inc_clock[simp]",
+  `!t. inc_clock n (inc_clock m t) = inc_clock (n+m) t`,
   full_simp_tac(srw_ss())[inc_clock_def,wordSemTheory.state_component_equality,AC ADD_ASSOC ADD_COMM]);
 
-val mk_loc_jmup_exc_inc_clock = store_thm("mk_loc_jmup_exc_inc_clock[simp]",
-  ``mk_loc (jump_exc (inc_clock ck t)) = mk_loc (jump_exc t)``,
+val mk_loc_jmup_exc_inc_clock = Q.store_thm("mk_loc_jmup_exc_inc_clock[simp]",
+  `mk_loc (jump_exc (inc_clock ck t)) = mk_loc (jump_exc t)`,
   full_simp_tac(srw_ss())[mk_loc_def,wordSemTheory.jump_exc_def,inc_clock_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[mk_loc_def]);
 
-val jump_exc_inc_clock_EQ_NONE = prove(
-  ``jump_exc (inc_clock n s) = NONE <=> jump_exc s = NONE``,
+val jump_exc_inc_clock_EQ_NONE = Q.prove(
+  `jump_exc (inc_clock n s) = NONE <=> jump_exc s = NONE`,
   full_simp_tac(srw_ss())[mk_loc_def,wordSemTheory.jump_exc_def,inc_clock_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[mk_loc_def]);
 
@@ -1956,10 +1956,10 @@ val state_rel_lookup_globals = Q.store_thm("state_rel_lookup_globals",
   \\ simp_tac(srw_ss())[word_addr_def]
   \\ metis_tac[]);
 
-val state_rel_cut_env = store_thm("state_rel_cut_env",
-  ``state_rel c l1 l2 s t [] locs /\
+val state_rel_cut_env = Q.store_thm("state_rel_cut_env",
+  `state_rel c l1 l2 s t [] locs /\
     dataSem$cut_env names s.locals = SOME x ==>
-    state_rel c l1 l2 (s with locals := x) t [] locs``,
+    state_rel c l1 l2 (s with locals := x) t [] locs`,
   full_simp_tac(srw_ss())[state_rel_def,dataSemTheory.cut_env_def] \\ srw_tac[][]
   THEN1 (full_simp_tac(srw_ss())[lookup_inter] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   \\ asm_exists_tac \\ full_simp_tac(srw_ss())[]
@@ -2062,10 +2062,10 @@ val state_rel_cut_state_opt_get_var = Q.store_thm("state_rel_cut_state_opt_get_v
   \\ imp_res_tac state_rel_cut_env
   \\ metis_tac[] );
 
-val jump_exc_push_env_NONE_simp = prove(
-  ``(jump_exc (dec_clock t) = NONE <=> jump_exc t = NONE) /\
+val jump_exc_push_env_NONE_simp = Q.prove(
+  `(jump_exc (dec_clock t) = NONE <=> jump_exc t = NONE) /\
     (jump_exc (push_env y NONE t) = NONE <=> jump_exc t = NONE) /\
-    (jump_exc (call_env args s) = NONE <=> jump_exc s = NONE)``,
+    (jump_exc (call_env args s) = NONE <=> jump_exc s = NONE)`,
   full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def,wordSemTheory.call_env_def,
       wordSemTheory.dec_clock_def] \\ srw_tac[][] THEN1 every_case_tac
   \\ full_simp_tac(srw_ss())[wordSemTheory.push_env_def]
@@ -2082,9 +2082,9 @@ val jump_exc_push_env_NONE_simp = prove(
   \\ imp_res_tac (LASTN_LENGTH_LESS_EQ |> Q.SPEC `x::xs`
        |> SIMP_RULE std_ss [LENGTH]) \\ full_simp_tac(srw_ss())[]);
 
-val s_key_eq_handler_eq_IMP = prove(
-  ``s_key_eq t.stack t1.stack /\ t.handler = t1.handler ==>
-    (jump_exc t1 <> NONE <=> jump_exc t <> NONE)``,
+val s_key_eq_handler_eq_IMP = Q.prove(
+  `s_key_eq t.stack t1.stack /\ t.handler = t1.handler ==>
+    (jump_exc t1 <> NONE <=> jump_exc t <> NONE)`,
   full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def] \\ srw_tac[][]
   \\ imp_res_tac s_key_eq_LENGTH \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `t1.handler < LENGTH t1.stack` \\ full_simp_tac(srw_ss())[]
@@ -2147,66 +2147,66 @@ val alloc_size_def = Define `
                     n2w (k * (dimindex (:'a) DIV 8))
                   else (-1w)):'a word`
 
-val NOT_1_domain = prove(
-  ``~(1 IN domain (adjust_set names))``,
+val NOT_1_domain = Q.prove(
+  `~(1 IN domain (adjust_set names))`,
   full_simp_tac(srw_ss())[domain_fromAList,adjust_set_def,MEM_MAP,MEM_toAList,
       FORALL_PROD,adjust_var_def] \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ decide_tac)
 
-val cut_env_adjust_set_insert_1 = prove(
-  ``cut_env (adjust_set names) (insert 1 w l) = cut_env (adjust_set names) l``,
+val cut_env_adjust_set_insert_1 = Q.prove(
+  `cut_env (adjust_set names) (insert 1 w l) = cut_env (adjust_set names) l`,
   full_simp_tac(srw_ss())[wordSemTheory.cut_env_def,MATCH_MP SUBSET_INSERT_EQ_SUBSET NOT_1_domain]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[lookup_inter,lookup_insert]
   \\ Cases_on `x = 1` \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[SIMP_RULE std_ss [domain_lookup] NOT_1_domain]);
 
-val case_EQ_SOME_IFF = prove(
-  ``(case p of NONE => NONE | SOME x => g x) = SOME y <=>
-    ?x. p = SOME x /\ g x = SOME y``,
+val case_EQ_SOME_IFF = Q.prove(
+  `(case p of NONE => NONE | SOME x => g x) = SOME y <=>
+    ?x. p = SOME x /\ g x = SOME y`,
   Cases_on `p` \\ full_simp_tac(srw_ss())[]);
 
-val state_rel_set_store_AllocSize = prove(
-  ``state_rel c l1 l2 s (set_store AllocSize (Word w) t) v locs =
-    state_rel c l1 l2 s t v locs``,
+val state_rel_set_store_AllocSize = Q.prove(
+  `state_rel c l1 l2 s (set_store AllocSize (Word w) t) v locs =
+    state_rel c l1 l2 s t v locs`,
   full_simp_tac(srw_ss())[state_rel_def,wordSemTheory.set_store_def]
   \\ eq_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[heap_in_memory_store_def,FLOOKUP_DEF,FAPPLY_FUPDATE_THM]
   \\ metis_tac []);
 
-val inter_insert = store_thm("inter_insert",
-  ``inter (insert n x t1) t2 =
-    if n IN domain t2 then insert n x (inter t1 t2) else inter t1 t2``,
+val inter_insert = Q.store_thm("inter_insert",
+  `inter (insert n x t1) t2 =
+    if n IN domain t2 then insert n x (inter t1 t2) else inter t1 t2`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[spt_eq_thm,wf_inter,wf_insert,lookup_inter_alt,lookup_insert]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val lookup_1_adjust_set = prove(
-  ``lookup 1 (adjust_set l) = NONE``,
+val lookup_1_adjust_set = Q.prove(
+  `lookup 1 (adjust_set l) = NONE`,
   full_simp_tac(srw_ss())[adjust_set_def,lookup_fromAList,ALOOKUP_NONE,MEM_MAP,FORALL_PROD]
   \\ full_simp_tac(srw_ss())[adjust_var_def] \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ decide_tac);
 
-val lookup_3_adjust_set = prove(
-  ``lookup 3 (adjust_set l) = NONE``,
+val lookup_3_adjust_set = Q.prove(
+  `lookup 3 (adjust_set l) = NONE`,
   full_simp_tac(srw_ss())[adjust_set_def,lookup_fromAList,ALOOKUP_NONE,MEM_MAP,FORALL_PROD]
   \\ full_simp_tac(srw_ss())[adjust_var_def] \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ decide_tac);
 
-val state_rel_insert_1 = prove(
-  ``state_rel c l1 l2 s (t with locals := insert 1 x t.locals) v locs =
-    state_rel c l1 l2 s t v locs``,
+val state_rel_insert_1 = Q.prove(
+  `state_rel c l1 l2 s (t with locals := insert 1 x t.locals) v locs =
+    state_rel c l1 l2 s t v locs`,
   full_simp_tac(srw_ss())[state_rel_def] \\ eq_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[lookup_insert,adjust_var_NEQ_1]
   \\ full_simp_tac(srw_ss())[inter_insert,domain_lookup,lookup_1_adjust_set]
   \\ metis_tac []);
 
-val state_rel_insert_3 = prove(
-  ``state_rel c l1 l2 s (t with locals := insert 3 x t.locals) v locs =
-    state_rel c l1 l2 s t v locs``,
+val state_rel_insert_3 = Q.prove(
+  `state_rel c l1 l2 s (t with locals := insert 3 x t.locals) v locs =
+    state_rel c l1 l2 s t v locs`,
   full_simp_tac(srw_ss())[state_rel_def] \\ eq_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[lookup_insert,adjust_var_NEQ_1]
   \\ asm_exists_tac \\ fs []
   \\ full_simp_tac(srw_ss())[inter_insert,domain_lookup,lookup_3_adjust_set]);
 
-val state_rel_insert_3_1 = prove(
-  ``state_rel c l1 l2 s (t with locals := insert 3 x (insert 1 y t.locals)) v locs =
-    state_rel c l1 l2 s t v locs``,
+val state_rel_insert_3_1 = Q.prove(
+  `state_rel c l1 l2 s (t with locals := insert 3 x (insert 1 y t.locals)) v locs =
+    state_rel c l1 l2 s t v locs`,
   full_simp_tac(srw_ss())[state_rel_def] \\ eq_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[lookup_insert,adjust_var_NEQ_1]
   \\ asm_exists_tac \\ fs []
@@ -2219,9 +2219,9 @@ val state_rel_inc_clock = prove(
                       (t with clock := t.clock + 1) [] locs``,
   full_simp_tac(srw_ss())[state_rel_def]);
 
-val dec_clock_inc_clock = prove(
-  ``(dataSem$dec_clock (s with clock := s.clock + 1) = s) /\
-    (wordSem$dec_clock (t with clock := t.clock + 1) = t)``,
+val dec_clock_inc_clock = Q.prove(
+  `(dataSem$dec_clock (s with clock := s.clock + 1) = s) /\
+    (wordSem$dec_clock (t with clock := t.clock + 1) = t)`,
   full_simp_tac(srw_ss())[dataSemTheory.dec_clock_def,wordSemTheory.dec_clock_def]
   \\ full_simp_tac(srw_ss())[dataSemTheory.state_component_equality]
   \\ full_simp_tac(srw_ss())[wordSemTheory.state_component_equality])
@@ -2267,8 +2267,8 @@ val loc_merge_def = Define `
   (loc_merge (Word w::xs) (y::ys) = y::loc_merge xs ys) /\
   (loc_merge (Word w::xs) [] = Word w::xs)`
 
-val LENGTH_loc_merge = prove(
-  ``!xs ys. LENGTH (loc_merge xs ys) = LENGTH xs``,
+val LENGTH_loc_merge = Q.prove(
+  `!xs ys. LENGTH (loc_merge xs ys) = LENGTH xs`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[loc_merge_def]
   \\ Cases_on `h` \\ full_simp_tac(srw_ss())[loc_merge_def]
   \\ Cases_on `h'` \\ full_simp_tac(srw_ss())[loc_merge_def]);
@@ -2342,8 +2342,8 @@ val word_gc_fun_LENGTH = store_thm("word_gc_fun_LENGTH",
   ``word_gc_fun c (xs,m,dm,s) = SOME (zs,m1,s1) ==> LENGTH xs = LENGTH zs``,
   srw_tac[][] \\ drule word_gc_IMP_EVERY2 \\ srw_tac[][] \\ imp_res_tac EVERY2_LENGTH);
 
-val gc_fun_ok_word_gc_fun = store_thm("gc_fun_ok_word_gc_fun",
-  ``gc_fun_ok (word_gc_fun c1)``,
+val gc_fun_ok_word_gc_fun = Q.store_thm("gc_fun_ok_word_gc_fun",
+  `gc_fun_ok (word_gc_fun c1)`,
   fs [gc_fun_ok_def] \\ rpt gen_tac \\ strip_tac
   \\ imp_res_tac word_gc_fun_LENGTH \\ fs []
   \\ imp_res_tac word_gc_fun_IMP
@@ -2369,29 +2369,29 @@ val word_gc_fun_APPEND_IMP = prove(
   \\ full_simp_tac(srw_ss())[ADD_CLAUSES] \\ res_tac
   \\ full_simp_tac(srw_ss())[] \\ Q.LIST_EXISTS_TAC [`h::zs1`,`zs2`] \\ full_simp_tac(srw_ss())[]);
 
-val IMP_loc_merge_APPEND = prove(
-  ``!ts qs xs ys.
+val IMP_loc_merge_APPEND = Q.prove(
+  `!ts qs xs ys.
       LENGTH (FILTER isWord ts) = LENGTH qs ==>
-      loc_merge (ts ++ xs) (qs ++ ys) = loc_merge ts qs ++ loc_merge xs ys``,
+      loc_merge (ts ++ xs) (qs ++ ys) = loc_merge ts qs ++ loc_merge xs ys`,
   Induct \\ full_simp_tac(srw_ss())[] THEN1 (Cases_on `qs` \\ full_simp_tac(srw_ss())[LENGTH,loc_merge_def])
   \\ Cases \\ full_simp_tac(srw_ss())[isWord_def,loc_merge_def]
   \\ Cases \\ full_simp_tac(srw_ss())[loc_merge_def]) |> SPEC_ALL;
 
-val TAKE_DROP_loc_merge_APPEND = prove(
-  ``TAKE (LENGTH q) (loc_merge (MAP SND q) xs ++ ys) = loc_merge (MAP SND q) xs /\
-    DROP (LENGTH q) (loc_merge (MAP SND q) xs ++ ys) = ys``,
+val TAKE_DROP_loc_merge_APPEND = Q.prove(
+  `TAKE (LENGTH q) (loc_merge (MAP SND q) xs ++ ys) = loc_merge (MAP SND q) xs /\
+    DROP (LENGTH q) (loc_merge (MAP SND q) xs ++ ys) = ys`,
   `LENGTH q = LENGTH (loc_merge (MAP SND q) xs)` by full_simp_tac(srw_ss())[LENGTH_loc_merge]
   \\ full_simp_tac(srw_ss())[TAKE_LENGTH_APPEND,DROP_LENGTH_APPEND]);
 
-val loc_merge_NIL = prove(
-  ``!xs. loc_merge xs [] = xs``,
+val loc_merge_NIL = Q.prove(
+  `!xs. loc_merge xs [] = xs`,
   Induct \\ full_simp_tac(srw_ss())[loc_merge_def] \\ Cases \\ full_simp_tac(srw_ss())[loc_merge_def]);
 
-val loc_merge_APPEND = prove(
-  ``!xs1 xs2 ys.
+val loc_merge_APPEND = Q.prove(
+  `!xs1 xs2 ys.
       ?zs1 zs2. loc_merge (xs1 ++ xs2) ys = zs1 ++ zs2 /\
                 LENGTH zs1 = LENGTH xs1 /\ LENGTH xs2 = LENGTH xs2 /\
-                ?ts. loc_merge xs2 ts = zs2``,
+                ?ts. loc_merge xs2 ts = zs2`,
   Induct \\ full_simp_tac(srw_ss())[loc_merge_def,LENGTH_NIL,LENGTH_loc_merge] THEN1 (metis_tac [])
   \\ Cases THEN1
    (Cases_on `ys` \\ full_simp_tac(srw_ss())[loc_merge_def] \\ srw_tac[][]
@@ -2403,15 +2403,15 @@ val loc_merge_APPEND = prove(
   \\ pop_assum (qspecl_then [`xs2`,`ys`] strip_assume_tac)
   \\ full_simp_tac(srw_ss())[] \\ Q.LIST_EXISTS_TAC [`Loc n n0::zs1`,`zs2`] \\ full_simp_tac(srw_ss())[] \\ metis_tac [])
 
-val EVERY2_loc_merge = prove(
-  ``!xs ys. EVERY2 (\x y. (isWord y ==> isWord x) /\
-                          (~isWord x ==> x = y)) xs (loc_merge xs ys)``,
+val EVERY2_loc_merge = Q.prove(
+  `!xs ys. EVERY2 (\x y. (isWord y ==> isWord x) /\
+                          (~isWord x ==> x = y)) xs (loc_merge xs ys)`,
   Induct \\ full_simp_tac(srw_ss())[loc_merge_def,LENGTH_NIL,LENGTH_loc_merge] \\ Cases
   \\ full_simp_tac(srw_ss())[loc_merge_def] \\ Cases_on `ys`
   \\ full_simp_tac(srw_ss())[loc_merge_def,GSYM EVERY2_refl,isWord_def])
 
-val dec_stack_loc_merge_enc_stack = prove(
-  ``!xs ys. ?ss. dec_stack (loc_merge (enc_stack xs) ys) xs = SOME ss``,
+val dec_stack_loc_merge_enc_stack = Q.prove(
+  `!xs ys. ?ss. dec_stack (loc_merge (enc_stack xs) ys) xs = SOME ss`,
   Induct \\ full_simp_tac(srw_ss())[wordSemTheory.enc_stack_def,
     loc_merge_def,wordSemTheory.dec_stack_def]
   \\ Cases \\ Cases_on `o'` \\ full_simp_tac(srw_ss())[] \\ TRY (PairCases_on `x`)
@@ -2432,11 +2432,11 @@ val ALOOKUP_ZIP = prove(
   Induct \\ full_simp_tac(srw_ss())[] \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def,PULL_EXISTS]
   \\ Cases_on `q' = 0` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[isWord_def] \\ srw_tac[][]);
 
-val stack_rel_dec_stack_IMP_stack_rel = prove(
-  ``!xs ys ts stack locs.
+val stack_rel_dec_stack_IMP_stack_rel = Q.prove(
+  `!xs ys ts stack locs.
       LIST_REL stack_rel ts xs /\ LIST_REL contains_loc xs locs /\
       dec_stack (loc_merge (enc_stack xs) ys) xs = SOME stack ==>
-      LIST_REL stack_rel ts stack /\ LIST_REL contains_loc stack locs``,
+      LIST_REL stack_rel ts stack /\ LIST_REL contains_loc stack locs`,
   Induct_on `ts` \\ Cases_on `xs` \\ full_simp_tac(srw_ss())[]
   THEN1 (full_simp_tac(srw_ss())[wordSemTheory.enc_stack_def,loc_merge_def,wordSemTheory.dec_stack_def])
   \\ full_simp_tac(srw_ss())[PULL_EXISTS] \\ srw_tac[][]
@@ -2469,8 +2469,8 @@ val stack_rel_dec_stack_IMP_stack_rel = prove(
   \\ full_simp_tac(srw_ss())[FST_PAIR_EQ]
   \\ imp_res_tac EVERY2_IMP_EL \\ rev_full_simp_tac(srw_ss())[EL_MAP]);
 
-val join_env_NIL = prove(
-  ``join_env s [] = []``,
+val join_env_NIL = Q.prove(
+  `join_env s [] = []`,
   full_simp_tac(srw_ss())[join_env_def]);
 
 val join_env_CONS = prove(
@@ -2480,11 +2480,11 @@ val join_env_CONS = prove(
     else join_env s xs``,
   full_simp_tac(srw_ss())[join_env_def] \\ srw_tac[][]);
 
-val FILTER_enc_stack_lemma = prove(
-  ``!xs ys.
+val FILTER_enc_stack_lemma = Q.prove(
+  `!xs ys.
       LIST_REL stack_rel xs ys ==>
       FILTER isWord (MAP SND (flat xs ys)) =
-      FILTER isWord (enc_stack ys)``,
+      FILTER isWord (enc_stack ys)`,
   Induct \\ Cases_on `ys`
   \\ full_simp_tac(srw_ss())[stack_rel_def,wordSemTheory.enc_stack_def,flat_def]
   \\ Cases \\ Cases_on `h` \\ full_simp_tac(srw_ss())[] \\ Cases_on `o'`
@@ -2535,7 +2535,7 @@ val LENGTH_MAP_SND_join_env_IMP = prove(
   \\ full_simp_tac(srw_ss())[] \\ Cases_on `q <> 0 /\ EVEN q`
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ metis_tac [])
 
-val lemma1 = prove(``(y1 = y2) /\ (x1 = x2) ==> (f x1 y1 = f x2 y2)``,full_simp_tac(srw_ss())[]);
+val lemma1 = Q.prove(`(y1 = y2) /\ (x1 = x2) ==> (f x1 y1 = f x2 y2)`,full_simp_tac(srw_ss())[]);
 
 val word_gc_fun_EL_lemma = prove(
   ``!xs ys stack1 m dm st m1 s1 stack.
@@ -2696,17 +2696,17 @@ val evaluate_IMP_inc_clock_Ex = prove(
   srw_tac[][inc_clock_def] \\ match_mp_tac evaluate_add_clock
   \\ full_simp_tac(srw_ss())[]);
 
-val get_var_inc_clock = prove(
-  ``get_var n (inc_clock k s) = get_var n s``,
+val get_var_inc_clock = Q.prove(
+  `get_var n (inc_clock k s) = get_var n s`,
   full_simp_tac(srw_ss())[wordSemTheory.get_var_def,inc_clock_def]);
 
-val get_vars_inc_clock = prove(
-  ``get_vars n (inc_clock k s) = get_vars n s``,
+val get_vars_inc_clock = Q.prove(
+  `get_vars n (inc_clock k s) = get_vars n s`,
   Induct_on `n` \\ full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[get_var_inc_clock]);
 
-val set_var_inc_clock = store_thm("set_var_inc_clock",
-  ``set_var n x (inc_clock ck t) = inc_clock ck (set_var n x t)``,
+val set_var_inc_clock = Q.store_thm("set_var_inc_clock",
+  `set_var n x (inc_clock ck t) = inc_clock ck (set_var n x t)`,
   full_simp_tac(srw_ss())[wordSemTheory.set_var_def,inc_clock_def]);
 
 val do_app = LIST_CONJ [dataSemTheory.do_app_def,do_space_def,
@@ -2714,16 +2714,16 @@ val do_app = LIST_CONJ [dataSemTheory.do_app_def,do_space_def,
   bvi_to_dataTheory.op_space_reset_def, bviSemTheory.do_app_def,
   bviSemTheory.do_app_aux_def, bvlSemTheory.do_app_def]
 
-val w2n_minus_1_LESS_EQ = store_thm("w2n_minus_1_LESS_EQ",
-  ``(w2n (-1w:'a word) <= w2n (w:'a word)) <=> w + 1w = 0w``,
+val w2n_minus_1_LESS_EQ = Q.store_thm("w2n_minus_1_LESS_EQ",
+  `(w2n (-1w:'a word) <= w2n (w:'a word)) <=> w + 1w = 0w`,
   fs [word_2comp_n2w]
   \\ Cases_on `w` \\ fs [word_add_n2w]
   \\ `n + 1 <= dimword (:'a)` by decide_tac
   \\ Cases_on `dimword (:'a) = n + 1` \\ fs []);
 
-val bytes_in_word_ADD_1_NOT_ZERO = prove(
-  ``good_dimindex (:'a) ==>
-    bytes_in_word * w + 1w <> 0w:'a word``,
+val bytes_in_word_ADD_1_NOT_ZERO = Q.prove(
+  `good_dimindex (:'a) ==>
+    bytes_in_word * w + 1w <> 0w:'a word`,
   rpt strip_tac
   \\ `(bytes_in_word * w + 1w) ' 0 = (0w:'a word) ' 0` by metis_tac []
   \\ fs [WORD_ADD_BIT0,word_index,WORD_MUL_BIT0]
@@ -2805,17 +2805,17 @@ val evaluate_GiveUp = store_thm("evaluate_GiveUp",
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
   \\ rfs [] \\ fs []);
 
-val state_rel_cut_IMP = store_thm("state_rel_cut_IMP",
-  ``state_rel c l1 l2 s t [] locs /\ cut_state_opt names_opt s = SOME x ==>
-    state_rel c l1 l2 x t [] locs``,
+val state_rel_cut_IMP = Q.store_thm("state_rel_cut_IMP",
+  `state_rel c l1 l2 s t [] locs /\ cut_state_opt names_opt s = SOME x ==>
+    state_rel c l1 l2 x t [] locs`,
   Cases_on `names_opt` \\ fs [dataSemTheory.cut_state_opt_def]
   THEN1 (rw [] \\ fs [])
   \\ fs [dataSemTheory.cut_state_def]
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs []
   \\ imp_res_tac state_rel_cut_env);
 
-val get_vars_SING = store_thm("get_vars_SING",
-  ``dataSem$get_vars args s = SOME [w] ==> ?y. args = [y]``,
+val get_vars_SING = Q.store_thm("get_vars_SING",
+  `dataSem$get_vars args s = SOME [w] ==> ?y. args = [y]`,
   Cases_on `args` \\ fs [get_vars_def]
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs []
   \\ Cases_on `t` \\ fs [get_vars_def]
@@ -2832,21 +2832,21 @@ val eval_tac = fs [wordSemTheory.evaluate_def,
   wordLangTheory.word_op_def, wordSemTheory.word_sh_def,
   wordLangTheory.num_exp_def]
 
-val INT_EQ_NUM_LEMMA = store_thm("INT_EQ_NUM_LEMMA",
-  ``0 <= (i:int) <=> ?index. i = & index``,
+val INT_EQ_NUM_LEMMA = Q.store_thm("INT_EQ_NUM_LEMMA",
+  `0 <= (i:int) <=> ?index. i = & index`,
   Cases_on `i` \\ fs []);
 
-val get_vars_2_IMP = store_thm("get_vars_2_IMP",
-  ``(wordSem$get_vars [x1;x2] s = SOME [v1;v2]) ==>
+val get_vars_2_IMP = Q.store_thm("get_vars_2_IMP",
+  `(wordSem$get_vars [x1;x2] s = SOME [v1;v2]) ==>
     get_var x1 s = SOME v1 /\
-    get_var x2 s = SOME v2``,
+    get_var x2 s = SOME v2`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val get_vars_3_IMP = store_thm("get_vars_3_IMP",
-  ``(wordSem$get_vars [x1;x2;x3] s = SOME [v1;v2;v3]) ==>
+val get_vars_3_IMP = Q.store_thm("get_vars_3_IMP",
+  `(wordSem$get_vars [x1;x2;x3] s = SOME [v1;v2;v3]) ==>
     get_var x1 s = SOME v1 /\
     get_var x2 s = SOME v2 /\
-    get_var x3 s = SOME v3``,
+    get_var x3 s = SOME v3`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
 val memory_rel_get_vars_IMP = prove(
@@ -2873,23 +2873,23 @@ val memory_rel_insert = prove(
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ match_mp_tac word_ml_inv_insert \\ fs []);
 
-val get_real_addr_lemma = store_thm("get_real_addr_lemma",
-  ``shift_length c < dimindex (:'a) /\
+val get_real_addr_lemma = Q.store_thm("get_real_addr_lemma",
+  `shift_length c < dimindex (:'a) /\
     good_dimindex (:'a) /\
     get_var v t = SOME (Word ptr_w) /\
     get_real_addr c t.store ptr_w = SOME x ==>
-    word_exp t (real_addr c v) = SOME (Word (x:'a word))``,
+    word_exp t (real_addr c v) = SOME (Word (x:'a word))`,
   fs [get_real_addr_def] \\ every_case_tac \\ fs []
   \\ fs [wordSemTheory.get_var_def,real_addr_def] \\ eval_tac \\ fs []
   \\ rpt strip_tac \\ fs []
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
   \\ rfs [shift_def]);
 
-val get_real_offset_lemma = store_thm("get_real_offset_lemma",
-  ``get_var v t = SOME (Word i_w) /\
+val get_real_offset_lemma = Q.store_thm("get_real_offset_lemma",
+  `get_var v t = SOME (Word i_w) /\
     good_dimindex (:'a) /\
     get_real_offset i_w = SOME y ==>
-    word_exp t (real_offset c v) = SOME (Word (y:'a word))``,
+    word_exp t (real_offset c v) = SOME (Word (y:'a word))`,
   fs [get_real_offset_def] \\ every_case_tac \\ fs []
   \\ fs [wordSemTheory.get_var_def,real_offset_def] \\ eval_tac \\ fs []
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []);
@@ -2900,9 +2900,9 @@ val get_real_byte_offset_lemma = Q.store_thm("get_real_byte_offset_lemma",
   rw[real_byte_offset_def,wordSemTheory.get_var_def]
   \\ eval_tac \\ fs[good_dimindex_def]);
 
-val reorder_lemma = prove(
-  ``memory_rel c be x.refs x.space t.store t.memory t.mdomain (x1::x2::x3::xs) ==>
-    memory_rel c be x.refs x.space t.store t.memory t.mdomain (x3::x1::x2::xs)``,
+val reorder_lemma = Q.prove(
+  `memory_rel c be x.refs x.space t.store t.memory t.mdomain (x1::x2::x3::xs) ==>
+    memory_rel c be x.refs x.space t.store t.memory t.mdomain (x3::x1::x2::xs)`,
   match_mp_tac memory_rel_rearrange \\ fs [] \\ rw [] \\ fs []);
 
 val evaluate_StoreEach = store_thm("evaluate_StoreEach",
@@ -2933,43 +2933,43 @@ val evaluate_StoreEach = store_thm("evaluate_StoreEach",
   \\ rw [] \\ every_case_tac \\ fs [])
   |> Q.SPECL [`xs`,`ys`,`t`,`0w`] |> SIMP_RULE (srw_ss()) [] |> GEN_ALL;
 
-val domain_adjust_set_EVEN = store_thm("domain_adjust_set_EVEN",
-  ``k IN domain (adjust_set s) ==> EVEN k``,
+val domain_adjust_set_EVEN = Q.store_thm("domain_adjust_set_EVEN",
+  `k IN domain (adjust_set s) ==> EVEN k`,
   fs [adjust_set_def,domain_lookup,lookup_fromAList] \\ rw [] \\ fs []
   \\ imp_res_tac ALOOKUP_MEM \\ fs [MEM_MAP]
   \\ pairarg_tac \\ fs [EVEN_adjust_var]);
 
-val inter_insert_ODD_adjust_set = store_thm("inter_insert_ODD_adjust_set",
-  ``!k. ODD k ==>
+val inter_insert_ODD_adjust_set = Q.store_thm("inter_insert_ODD_adjust_set",
+  `!k. ODD k ==>
       inter (insert (adjust_var dest) w (insert k v s)) (adjust_set t) =
-      inter (insert (adjust_var dest) w s) (adjust_set t)``,
+      inter (insert (adjust_var dest) w s) (adjust_set t)`,
   fs [spt_eq_thm,wf_inter,lookup_inter_alt,lookup_insert]
   \\ rw [] \\ rw [] \\ fs []
   \\ imp_res_tac domain_adjust_set_EVEN \\ fs [EVEN_ODD]);
 
-val inter_insert_ODD_adjust_set_alt = store_thm("inter_insert_ODD_adjust_set_alt",
-  ``!k. ODD k ==>
+val inter_insert_ODD_adjust_set_alt = Q.store_thm("inter_insert_ODD_adjust_set_alt",
+  `!k. ODD k ==>
       inter (insert k v s) (adjust_set t) =
-      inter s (adjust_set t)``,
+      inter s (adjust_set t)`,
   fs [spt_eq_thm,wf_inter,lookup_inter_alt,lookup_insert]
   \\ rw [] \\ rw [] \\ fs []
   \\ imp_res_tac domain_adjust_set_EVEN \\ fs [EVEN_ODD]);
 
-val get_vars_adjust_var = prove(
-  ``ODD k ==>
+val get_vars_adjust_var = Q.prove(
+  `ODD k ==>
     get_vars (MAP adjust_var args) (t with locals := insert k w s) =
-    get_vars (MAP adjust_var args) (t with locals := s)``,
+    get_vars (MAP adjust_var args) (t with locals := s)`,
   Induct_on `args`
   \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def,lookup_insert]
   \\ rw [] \\ fs [ODD_EVEN,EVEN_adjust_var]);
 
-val get_vars_with_store = store_thm("get_vars_with_store",
-  ``!args. get_vars args (t with <| locals := t.locals ; store := s |>) =
-           get_vars args t``,
+val get_vars_with_store = Q.store_thm("get_vars_with_store",
+  `!args. get_vars args (t with <| locals := t.locals ; store := s |>) =
+           get_vars args t`,
   Induct \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]);
 
-val word_less_lemma1 = prove(
-  ``v2 < (v1:'a word) <=> ~(v1 <= v2)``,
+val word_less_lemma1 = Q.prove(
+  `v2 < (v1:'a word) <=> ~(v1 <= v2)`,
   metis_tac [WORD_NOT_LESS]);
 
 val heap_in_memory_store_IMP_UPDATE = prove(
@@ -2977,19 +2977,19 @@ val heap_in_memory_store_IMP_UPDATE = prove(
     heap_in_memory_store heap a sp c (st |+ (Globals,h)) m dm l``,
   fs [heap_in_memory_store_def,FLOOKUP_UPDATE]);
 
-val get_vars_2_imp = prove(
-  ``wordSem$get_vars [x1;x2] s = SOME [y1;y2] ==>
+val get_vars_2_imp = Q.prove(
+  `wordSem$get_vars [x1;x2] s = SOME [y1;y2] ==>
     wordSem$get_var x1 s = SOME y1 /\
-    wordSem$get_var x2 s = SOME y2``,
+    wordSem$get_var x2 s = SOME y2`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val get_vars_1_imp = prove(
-  ``wordSem$get_vars [x1] s = SOME [y1] ==>
-    wordSem$get_var x1 s = SOME y1``,
+val get_vars_1_imp = Q.prove(
+  `wordSem$get_vars [x1] s = SOME [y1] ==>
+    wordSem$get_var x1 s = SOME y1`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val LESS_DIV_16_IMP = prove(
-  ``n < k DIV 16 ==> 16 * n + 2 < k:num``,
+val LESS_DIV_16_IMP = Q.prove(
+  `n < k DIV 16 ==> 16 * n + 2 < k:num`,
   fs [X_LT_DIV]);
 
 val word_exp_real_addr = prove(
@@ -3012,8 +3012,8 @@ val word_exp_real_addr_2 = prove(
   rpt strip_tac \\ match_mp_tac (GEN_ALL get_real_addr_lemma)
   \\ fs [wordSemTheory.get_var_def,lookup_insert])
 
-val encode_header_IMP_BIT0 = prove(
-  ``encode_header c tag l = SOME w ==> w ' 0``,
+val encode_header_IMP_BIT0 = Q.prove(
+  `encode_header c tag l = SOME w ==> w ' 0`,
   fs [encode_header_def,make_header_def] \\ rw []
   \\ fs [word_or_def,fcpTheory.FCP_BETA,word_index]);
 
@@ -3070,13 +3070,13 @@ val IMP_read_bytearray_GENLIST = Q.store_thm("IMP_read_bytearray_GENLIST",
   \\ first_x_assum(qspec_then`0`mp_tac)
   \\ simp[]);
 
-val domain_adjust_set_NOT_EMPTY = store_thm("domain_adjust_set_NOT_EMPTY[simp]",
-  ``domain (adjust_set s) <> EMPTY``,
+val domain_adjust_set_NOT_EMPTY = Q.store_thm("domain_adjust_set_NOT_EMPTY[simp]",
+  `domain (adjust_set s) <> EMPTY`,
   fs [EXTENSION,domain_lookup,adjust_set_def] \\ EVAL_TAC
   \\ fs [lookup_insert] \\ metis_tac []);
 
-val get_vars_termdep = store_thm("get_vars_termdep[simp]",
-  ``!xs. get_vars xs (t with termdep := t.termdep - 1) = get_vars xs t``,
+val get_vars_termdep = Q.store_thm("get_vars_termdep[simp]",
+  `!xs. get_vars xs (t with termdep := t.termdep - 1) = get_vars xs t`,
   Induct \\ EVAL_TAC \\ rw [] \\ every_case_tac \\ fs []);
 
 val lookup_RefByte_location = prove(
@@ -3096,22 +3096,22 @@ val word_exp_rw = LIST_CONJ
    wordSemTheory.the_words_def,
    lookup_insert]
 
-val get_vars_SOME_IFF_data = prove(
-  ``(get_vars [] t = SOME [] <=> T) /\
+val get_vars_SOME_IFF_data = Q.prove(
+  `(get_vars [] t = SOME [] <=> T) /\
     (get_vars (x::xs) t = SOME (y::ys) <=>
      dataSem$get_var x t = SOME y /\
-     get_vars xs t = SOME ys)``,
+     get_vars xs t = SOME ys)`,
   fs [dataSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val get_vars_SOME_IFF = prove(
-  ``(get_vars [] t = SOME [] <=> T) /\
+val get_vars_SOME_IFF = Q.prove(
+  `(get_vars [] t = SOME [] <=> T) /\
     (get_vars (x::xs) t = SOME (y::ys) <=>
      get_var x t = SOME y /\
-     wordSem$get_vars xs t = SOME ys)``,
+     wordSem$get_vars xs t = SOME ys)`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val get_vars_sing = store_thm("get_vars_sing",
-  ``get_vars [n] t = SOME x <=> ?x1. get_vars [n] t = SOME [x1] /\ x = [x1]``,
+val get_vars_sing = Q.store_thm("get_vars_sing",
+  `get_vars [n] t = SOME x <=> ?x1. get_vars [n] t = SOME [x1] /\ x = [x1]`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs [] \\ EQ_TAC \\ fs []);
 
 val word_ml_inv_get_var_IMP = save_thm("word_ml_inv_get_var_IMP",
@@ -3120,12 +3120,12 @@ val word_ml_inv_get_var_IMP = save_thm("word_ml_inv_get_var_IMP",
   |> REWRITE_RULE [get_vars_SOME_IFF,get_vars_SOME_IFF_data,MAP]
   |> SIMP_RULE std_ss [Once get_vars_sing,PULL_EXISTS,get_vars_SOME_IFF,ZIP,APPEND]);
 
-val get_var_set_var_thm = store_thm("get_var_set_var_thm",
-  ``wordSem$get_var n (set_var m x y) = if n = m then SOME x else get_var n y``,
+val get_var_set_var_thm = Q.store_thm("get_var_set_var_thm",
+  `wordSem$get_var n (set_var m x y) = if n = m then SOME x else get_var n y`,
   fs[wordSemTheory.get_var_def,wordSemTheory.set_var_def,lookup_insert]);
 
-val lookup_IMP_insert_EQ = store_thm("lookup_IMP_insert_EQ",
-  ``!t x y. lookup x t = SOME y ==> insert x y t = t``,
+val lookup_IMP_insert_EQ = Q.store_thm("lookup_IMP_insert_EQ",
+  `!t x y. lookup x t = SOME y ==> insert x y t = t`,
   Induct \\ fs [lookup_def,Once insert_def] \\ rw []);
 
 val alloc_alt =
@@ -3135,13 +3135,13 @@ val alloc_alt =
         ([],[],[prove(``alloc_size k ≠ -1w ==> T``,fs [])]))
   |> GEN_ALL
 
-val insert_insert_3_1 = prove(
-  ``insert 3 x (insert 1 y t) = insert 1 y (insert 3 x t)``,
+val insert_insert_3_1 = Q.prove(
+  `insert 3 x (insert 1 y t) = insert 1 y (insert 3 x t)`,
   Cases_on `t` \\ EVAL_TAC \\ Cases_on `s0` \\ EVAL_TAC);
 
-val alloc_size_dimword = store_thm("alloc_size_dimword",
-  ``good_dimindex (:'a) ==>
-    alloc_size (dimword (:'a)) = -1w:'a word``,
+val alloc_size_dimword = Q.store_thm("alloc_size_dimword",
+  `good_dimindex (:'a) ==>
+    alloc_size (dimword (:'a)) = -1w:'a word`,
   fs [alloc_size_def,EVAL ``good_dimindex (:'a)``] \\ rw [] \\ fs []);
 
 val alloc_fail = alloc_lemma
@@ -3149,8 +3149,8 @@ val alloc_fail = alloc_lemma
   |> SIMP_RULE std_ss [UNDISCH alloc_size_dimword]
   |> DISCH_ALL |> MP_CANON
 
-val shift_lsl = store_thm("shift_lsl",
-  ``good_dimindex (:'a) ==> w << shift (:'a) = w * bytes_in_word:'a word``,
+val shift_lsl = Q.store_thm("shift_lsl",
+  `good_dimindex (:'a) ==> w << shift (:'a) = w * bytes_in_word:'a word`,
   rw [labPropsTheory.good_dimindex_def,shift_def,bytes_in_word_def]
   \\ fs [WORD_MUL_LSL]);
 
@@ -3226,8 +3226,8 @@ val AllocVar_thm = store_thm("AllocVar_thm",
   \\ qpat_assum `_ = (q,r)` (fn th => fs [GSYM th])
   \\ simp [insert_insert_3_1]);
 
-val set_vars_sing = store_thm("set_vars_sing",
-  ``set_vars [n] [w] t = set_var n w t``,
+val set_vars_sing = Q.store_thm("set_vars_sing",
+  `set_vars [n] [w] t = set_var n w t`,
   EVAL_TAC);
 
 val memory_rel_lookup = store_thm("memory_rel_lookup",
@@ -3277,24 +3277,24 @@ val Replicate_code_thm = store_thm("Replicate_code_thm",
            asmSemTheory.word_cmp_def,wordSemTheory.dec_clock_def]
   \\ rfs [] \\ fs [MULT_CLAUSES,GSYM word_add_n2w] \\ fs [ADD1]);
 
-val NONNEG_INT = store_thm("NONNEG_INT",
-  ``0 <= (i:int) ==> ?j. i = & j``,
+val NONNEG_INT = Q.store_thm("NONNEG_INT",
+  `0 <= (i:int) ==> ?j. i = & j`,
   Cases_on `i` \\ fs []);
 
-val BIT_X_1 = store_thm("BIT_X_1",
-  ``BIT i 1 = (i = 0)``,
+val BIT_X_1 = Q.store_thm("BIT_X_1",
+  `BIT i 1 = (i = 0)`,
   EQ_TAC \\ rw []);
 
-val minus_2_word_and_id = store_thm("minus_2_word_and_id",
-  ``~(w ' 0) ==> (-2w && w) = w``,
+val minus_2_word_and_id = Q.store_thm("minus_2_word_and_id",
+  `~(w ' 0) ==> (-2w && w) = w`,
   fs [fcpTheory.CART_EQ,word_and_def,fcpTheory.FCP_BETA]
   \\ rewrite_tac [GSYM (SIMP_CONV (srw_ss()) [] ``~1w``)]
   \\ Cases_on `w`
   \\ simp_tac std_ss [word_1comp_def,fcpTheory.FCP_BETA,word_index,
         DIMINDEX_GT_0,BIT_X_1] \\ metis_tac []);
 
-val FOUR_MUL_LSL = store_thm("FOUR_MUL_LSL",
-  ``n2w (4 * i) << k = n2w i << (k + 2)``,
+val FOUR_MUL_LSL = Q.store_thm("FOUR_MUL_LSL",
+  `n2w (4 * i) << k = n2w i << (k + 2)`,
   fs [WORD_MUL_LSL,EXP_ADD,word_mul_n2w]);
 
 val RefArray_thm = store_thm("RefArray_thm",
@@ -3487,12 +3487,12 @@ val RefArray_thm = store_thm("RefArray_thm",
   \\ AP_THM_TAC \\ AP_TERM_TAC \\ fs []
   \\ fs [GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val word_exp_SmallLsr = store_thm("word_exp_SmallLsr",
-  ``word_exp s (SmallLsr e n) =
+val word_exp_SmallLsr = Q.store_thm("word_exp_SmallLsr",
+  `word_exp s (SmallLsr e n) =
       if dimindex (:'a) <= n then NONE else
         case word_exp s e of
         | SOME (Word w) => SOME (Word ((w:'a word) >>> n))
-        | res => (if n = 0 then res else NONE)``,
+        | res => (if n = 0 then res else NONE)`,
   rw [SmallLsr_def] \\ assume_tac DIMINDEX_GT_0
   \\ TRY (`F` by decide_tac \\ NO_TAC)
   THEN1
@@ -3515,8 +3515,8 @@ val evaluate_MakeBytes = store_thm("evaluate_MakeBytes",
   \\ fs [wordSemTheory.set_var_def,lookup_insert,word_of_byte_def,
          insert_shadow,wordSemTheory.evaluate_def,word_exp_rw]);
 
-val w2w_shift_shift = store_thm("w2w_shift_shift",
-  ``good_dimindex (:'a) ==> ((w2w (w:word8) ≪ 2 ⋙ 2) : 'a word) = w2w w``,
+val w2w_shift_shift = Q.store_thm("w2w_shift_shift",
+  `good_dimindex (:'a) ==> ((w2w (w:word8) ≪ 2 ⋙ 2) : 'a word) = w2w w`,
   fs [labPropsTheory.good_dimindex_def,fcpTheory.CART_EQ,
       word_lsl_def,word_lsr_def,fcpTheory.FCP_BETA,w2w]
   \\ rw [] \\ fs [] \\ EQ_TAC \\ rw [] \\ rfs [fcpTheory.FCP_BETA,w2w]);
@@ -3843,10 +3843,10 @@ val state_rel_IMP_test_zero = store_thm("state_rel_IMP_test_zero",
   \\ strip_tac \\ fs [Smallnum_def]
   \\ eq_tac \\ rw [] \\ fs []);
 
-val state_rel_get_var_Number_IMP = store_thm("state_rel_get_var_Number_IMP",
-  ``state_rel c l1 l2 s t vs locs /\
+val state_rel_get_var_Number_IMP = Q.store_thm("state_rel_get_var_Number_IMP",
+  `state_rel c l1 l2 s t vs locs /\
     get_var i s.locals = SOME (Number (&n)) /\ small_int (:'a) (&n) ==>
-    ?w. get_var (adjust_var i) t = SOME (Word (Smallnum (&n):'a word))``,
+    ?w. get_var (adjust_var i) t = SOME (Word (Smallnum (&n):'a word))`,
   strip_tac
   \\ rpt_drule state_rel_get_var_IMP
   \\ strip_tac \\ fs []
@@ -3865,8 +3865,8 @@ val state_rel_get_var_Number_IMP = store_thm("state_rel_get_var_Number_IMP",
   \\ match_mp_tac minus_2_word_and_id
   \\ fs [word_index,word_mul_n2w,bitTheory.BIT0_ODD,ODD_MULT]);
 
-val EXP_LEMMA1 = prove(
-  ``4n * n * (2 ** k) = n * 2 ** (k + 2)``,
+val EXP_LEMMA1 = Q.prove(
+  `4n * n * (2 ** k) = n * 2 ** (k + 2)`,
   fs [EXP_ADD]);
 
 val evaluate_Maxout_bits_code = prove(
@@ -4063,27 +4063,27 @@ val FromList_thm = store_thm("FromList_thm",
   \\ match_mp_tac memory_rel_rearrange
   \\ fs [] \\ rw [] \\ fs []);
 
-val MAP_FST_EQ_IMP_IS_SOME_ALOOKUP = store_thm("MAP_FST_EQ_IMP_IS_SOME_ALOOKUP",
-  ``!xs ys.
+val MAP_FST_EQ_IMP_IS_SOME_ALOOKUP = Q.store_thm("MAP_FST_EQ_IMP_IS_SOME_ALOOKUP",
+  `!xs ys.
       MAP FST xs = MAP FST ys ==>
-      IS_SOME (ALOOKUP xs n) = IS_SOME (ALOOKUP ys n)``,
+      IS_SOME (ALOOKUP xs n) = IS_SOME (ALOOKUP ys n)`,
   Induct \\ fs [] \\ Cases \\ Cases_on `ys` \\ fs []
   \\ Cases_on `h` \\ fs [] \\ rw []);
 
-val cut_env_adjust_set_insert_1 = store_thm("cut_env_adjust_set_insert_1",
-  ``cut_env (adjust_set x) (insert 1 w l) =
-    cut_env (adjust_set x) l``,
+val cut_env_adjust_set_insert_1 = Q.store_thm("cut_env_adjust_set_insert_1",
+  `cut_env (adjust_set x) (insert 1 w l) =
+    cut_env (adjust_set x) l`,
   fs [wordSemTheory.cut_env_def] \\ rw []
   \\ fs [lookup_inter_alt,lookup_insert]
   \\ rw [] \\ fs [SUBSET_DEF]
   \\ res_tac \\ fs [NOT_1_domain]);
 
-val state_rel_IMP_Number_arg = store_thm("state_rel_IMP_Number_arg",
-  ``state_rel c l1 l2 (call_env xs s) (call_env ys t) [] locs /\
+val state_rel_IMP_Number_arg = Q.store_thm("state_rel_IMP_Number_arg",
+  `state_rel c l1 l2 (call_env xs s) (call_env ys t) [] locs /\
     n < dimword (:'a) DIV 16 /\ LENGTH ys = LENGTH xs + 1 ==>
     state_rel c l1 l2
       (call_env (xs ++ [Number (& n)]) s)
-      (call_env (ys ++ [Word (n2w (4 * n):'a word)]) t) [] locs``,
+      (call_env (ys ++ [Word (n2w (4 * n):'a word)]) t) [] locs`,
   fs [state_rel_thm,call_env_def,wordSemTheory.call_env_def] \\ rw []
   THEN1 (Cases_on `ys` \\ fs [lookup_fromList,lookup_fromList2])
   THEN1
@@ -6856,9 +6856,9 @@ val compile_correct = store_thm("compile_correct",
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val state_rel_ext_with_clock = prove(
-  ``state_rel_ext a b c s1 s2 ==>
-    state_rel_ext a b c (s1 with clock := k) (s2 with clock := k)``,
+val state_rel_ext_with_clock = Q.prove(
+  `state_rel_ext a b c s1 s2 ==>
+    state_rel_ext a b c (s1 with clock := k) (s2 with clock := k)`,
   full_simp_tac(srw_ss())[state_rel_ext_def] \\ srw_tac[][]
   \\ drule state_rel_with_clock
   \\ strip_tac \\ asm_exists_tac \\ full_simp_tac(srw_ss())[]
@@ -7146,10 +7146,10 @@ fun define_abbrev name tm = let
   val n = mk_var(name,mk_type("fun",[type_of vars, type_of tm]))
   in Define `^n ^vars = ^tm` end
 
-val code_termdep_equiv = prove(
-  ``t' with <|code := l; termdep := 0|> = t <=>
+val code_termdep_equiv = Q.prove(
+  `t' with <|code := l; termdep := 0|> = t <=>
     ?x1 x2.
-      t.code = l /\ t.termdep = 0 /\ t' = t with <|code := x1; termdep := x2|>``,
+      t.code = l /\ t.termdep = 0 /\ t' = t with <|code := x1; termdep := x2|>`,
   fs [wordSemTheory.state_component_equality] \\ rw [] \\ eq_tac \\ rw [] \\ fs []);
 
 val compile_semantics = save_thm("compile_semantics",let

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -61,9 +61,9 @@ val adjust_set_LN = Q.store_thm("adjust_set_LN[simp]",
   `adjust_set LN = insert 0 () LN`,
   srw_tac[][adjust_set_def,fromAList_def]);
 
-val ALOOKUP_SKIP_LEMMA = prove(
-  ``¬MEM n (MAP FST xs) /\ d = e ==>
-    ALOOKUP (xs ++ [(n,d)] ++ ys) n = SOME e``,
+val ALOOKUP_SKIP_LEMMA = Q.prove(
+  `¬MEM n (MAP FST xs) /\ d = e ==>
+    ALOOKUP (xs ++ [(n,d)] ++ ys) n = SOME e`,
   full_simp_tac(srw_ss())[ALOOKUP_APPEND] \\ fs[GSYM ALOOKUP_NONE])
 
 val LAST_EQ = Q.prove(
@@ -130,8 +130,8 @@ val PERM_list_rearrange = Q.prove(
   \\ full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF,SURJ_DEF]
   \\ full_simp_tac(srw_ss())[ALL_DISTINCT_EL]);
 
-val ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME = prove(
-  ``!xs x y. ALL_DISTINCT (MAP FST xs) /\ MEM (x,y) xs ==> ALOOKUP xs x = SOME y``,
+val ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME = Q.prove(
+  `!xs x y. ALL_DISTINCT (MAP FST xs) /\ MEM (x,y) xs ==> ALOOKUP xs x = SOME y`,
   Induct \\ full_simp_tac(srw_ss())[]
   \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def] \\ srw_tac[][]
   \\ res_tac \\ full_simp_tac(srw_ss())[MEM_MAP,FORALL_PROD]
@@ -142,8 +142,8 @@ val IS_SOME_ALOOKUP_EQ = Q.prove(
   Induct \\ full_simp_tac(srw_ss())[]
   \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def] \\ srw_tac[][]);
 
-val MEM_IMP_IS_SOME_ALOOKUP = prove(
-  ``!l x y. MEM (x,y) l ==> IS_SOME (ALOOKUP l x)``,
+val MEM_IMP_IS_SOME_ALOOKUP = Q.prove(
+  `!l x y. MEM (x,y) l ==> IS_SOME (ALOOKUP l x)`,
   full_simp_tac(srw_ss())[IS_SOME_ALOOKUP_EQ,MEM_MAP,EXISTS_PROD] \\ metis_tac []);
 
 val SUBSET_INSERT_EQ_SUBSET = Q.prove(
@@ -155,8 +155,8 @@ val EVERY2_IMP_EL = Q.prove(
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]);
 
-val FST_PAIR_EQ = prove(
-  ``!x v. (FST x,v) = x <=> v = SND x``,
+val FST_PAIR_EQ = Q.prove(
+  `!x v. (FST x,v) = x <=> v = SND x`,
   Cases \\ full_simp_tac(srw_ss())[]);
 
 val EVERY2_APPEND_IMP = Q.prove(
@@ -167,8 +167,8 @@ val EVERY2_APPEND_IMP = Q.prove(
   \\ res_tac \\ full_simp_tac(srw_ss())[]
   \\ Q.LIST_EXISTS_TAC [`y::zs1`,`zs2`] \\ full_simp_tac(srw_ss())[]);
 
-val ZIP_ID = prove(
-  ``!xs. ZIP (MAP FST xs, MAP SND xs) = xs``,
+val ZIP_ID = Q.prove(
+  `!xs. ZIP (MAP FST xs, MAP SND xs) = xs`,
   Induct \\ full_simp_tac(srw_ss())[]);
 
 val write_bytearray_isWord = Q.store_thm("write_bytearray_isWord",
@@ -181,10 +181,10 @@ val write_bytearray_isWord = Q.store_thm("write_bytearray_isWord",
   \\ simp[APPLY_UPDATE_THM]
   \\ rw[isWord_def]);
 
-val FOLDL_LENGTH_LEMMA = prove(
-  ``!xs k l d q r.
+val FOLDL_LENGTH_LEMMA = Q.prove(
+  `!xs k l d q r.
       FOLDL (λ(i,t) a. (i + d,insert i a t)) (k,l) xs = (q,r) ==>
-      q = LENGTH xs * d + k``,
+      q = LENGTH xs * d + k`,
   Induct \\ fs [FOLDL] \\ rw [] \\ res_tac \\ fs [MULT_CLAUSES]);
 
 val fromList_SNOC = Q.store_thm("fromList_SNOC",
@@ -299,13 +299,13 @@ val lookup_adjust_var_adjust_set_SOME_UNIT = Q.prove(
   \\ full_simp_tac(srw_ss())[] \\ Cases_on `lookup n s`
   \\ Cases_on `lookup (adjust_var n) (adjust_set s)` \\ full_simp_tac(srw_ss())[]);
 
-val word_ml_inv_lookup = prove(
-  ``word_ml_inv (heap,be,a,sp) limit c refs
+val word_ml_inv_lookup = Q.prove(
+  `word_ml_inv (heap,be,a,sp) limit c refs
       (ys ++ join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs) /\
     lookup n l1 = SOME x /\
     lookup (adjust_var n) l2 = SOME w ==>
     word_ml_inv (heap,be,a,sp) limit c refs
-      (ys ++ [(x,w)] ++ join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs)``,
+      (ys ++ [(x,w)] ++ join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs)`,
   full_simp_tac(srw_ss())[toAList_def,foldi_def,LET_DEF]
   \\ full_simp_tac(srw_ss())[GSYM toAList_def] \\ srw_tac[][]
   \\ `MEM (x,w) (join_env l1 (toAList (inter l2 (adjust_set l1))))` by
@@ -317,20 +317,20 @@ val word_ml_inv_lookup = prove(
   \\ qpat_x_assum `word_ml_inv yyy limit c refs xxx` mp_tac
   \\ match_mp_tac word_ml_inv_rearrange \\ full_simp_tac(srw_ss())[MEM] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val word_ml_inv_get_var_IMP = store_thm("word_ml_inv_get_var_IMP",
-  ``word_ml_inv (heap,be,a,sp) limit c refs
+val word_ml_inv_get_var_IMP = Q.store_thm("word_ml_inv_get_var_IMP",
+  `word_ml_inv (heap,be,a,sp) limit c refs
       (join_env s.locals (toAList (inter t.locals (adjust_set s.locals)))++envs) /\
     get_var n s.locals = SOME x /\
     get_var (adjust_var n) t = SOME w ==>
     word_ml_inv (heap,be,a,sp) limit c refs
       ([(x,w)]++join_env s.locals
-          (toAList (inter t.locals (adjust_set s.locals)))++envs)``,
+          (toAList (inter t.locals (adjust_set s.locals)))++envs)`,
   srw_tac[][] \\ match_mp_tac (word_ml_inv_lookup
              |> Q.INST [`ys`|->`[]`] |> SIMP_RULE std_ss [APPEND])
   \\ full_simp_tac(srw_ss())[get_var_def,wordSemTheory.get_var_def]);
 
-val word_ml_inv_get_vars_IMP = store_thm("word_ml_inv_get_vars_IMP",
-  ``!n x w envs.
+val word_ml_inv_get_vars_IMP = Q.store_thm("word_ml_inv_get_vars_IMP",
+  `!n x w envs.
       word_ml_inv (heap,be,a,sp) limit c refs
         (join_env s.locals
            (toAList (inter t.locals (adjust_set s.locals)))++envs) /\
@@ -338,7 +338,7 @@ val word_ml_inv_get_vars_IMP = store_thm("word_ml_inv_get_vars_IMP",
       get_vars (MAP adjust_var n) t = SOME w ==>
       word_ml_inv (heap,be,a,sp) limit c refs
         (ZIP(x,w)++join_env s.locals
-           (toAList (inter t.locals (adjust_set s.locals)))++envs)``,
+           (toAList (inter t.locals (adjust_set s.locals)))++envs)`,
   Induct \\ full_simp_tac(srw_ss())[get_vars_def,wordSemTheory.get_vars_def] \\ rpt strip_tac
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac word_ml_inv_get_var_IMP
@@ -363,13 +363,13 @@ val unit_some_eq_IS_SOME = Q.prove(
   `!x. (x = SOME ()) <=> IS_SOME x`,
   Cases \\ full_simp_tac(srw_ss())[]);
 
-val word_ml_inv_insert = store_thm("word_ml_inv_insert",
-  ``word_ml_inv (heap,be,a,sp) limit c refs
+val word_ml_inv_insert = Q.store_thm("word_ml_inv_insert",
+  `word_ml_inv (heap,be,a,sp) limit c refs
       ([(x,w)]++join_env d (toAList (inter l (adjust_set d)))++xs) ==>
     word_ml_inv (heap,be,a,sp) limit c refs
       (join_env (insert dest x d)
         (toAList (inter (insert (adjust_var dest) w l)
-                           (adjust_set (insert dest x d))))++xs)``,
+                           (adjust_set (insert dest x d))))++xs)`,
   match_mp_tac word_ml_inv_rearrange \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[join_env_def,MEM_MAP,MEM_FILTER,EXISTS_PROD]
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[MEM_toAList]
@@ -622,13 +622,13 @@ val read_length_lemma = Q.prove(
   full_simp_tac(srw_ss())[word_bits_eq_slice_shift,word_slice_or,can_select_def,DECIDE ``n+2-1=n+1n``]
   \\ full_simp_tac(srw_ss())[DECIDE ``2+n=n+1+1n``,word_slice_lsl_eq_0,word_slice_2_3_eq_0]);
 
-val memcpy_thm = prove(
-  ``!xs a:'a word c b m m1 dm b1 ys frame.
+val memcpy_thm = Q.prove(
+  `!xs a:'a word c b m m1 dm b1 ys frame.
       memcpy (n2w (LENGTH xs):'a word) a b m dm = (b1,m1,c) /\
       (LENGTH ys = LENGTH xs) /\ LENGTH xs < dimword(:'a) /\
       (frame * word_list a xs * word_list b ys) (fun2set (m,dm)) ==>
       (frame * word_list a xs * word_list b xs) (fun2set (m1,dm)) /\
-      b1 = b + n2w (LENGTH xs) * bytes_in_word /\ c``,
+      b1 = b + n2w (LENGTH xs) * bytes_in_word /\ c`,
   Induct_on `xs` \\ Cases_on `ys`
   THEN1 (simp [LENGTH,Once memcpy_def,LENGTH])
   THEN1 (simp [LENGTH,Once memcpy_def,LENGTH])
@@ -657,14 +657,14 @@ val LESS_EQ_IMP_APPEND = Q.prove(
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ qexists_tac `h::ys` \\ full_simp_tac(srw_ss())[]);
 
-val NOT_is_fwd_ptr = prove(
-  ``word_payload addrs ll tag tt1 conf = (h,ts,c5) ==> ~is_fwd_ptr (Word h)``,
+val NOT_is_fwd_ptr = Q.prove(
+  `word_payload addrs ll tag tt1 conf = (h,ts,c5) ==> ~is_fwd_ptr (Word h)`,
   Cases_on `tag` \\ fs [word_payload_def] \\ rw []
   \\ full_simp_tac std_ss [GSYM WORD_OR_ASSOC,is_fws_ptr_OR_3,is_fws_ptr_OR_15,
       is_fws_ptr_OR_31,isWord_def,theWord_def,make_header_def,LET_DEF,make_byte_header_def]);
 
-val word_gc_move_thm = prove(
-  ``(gc_move (x,[],a,n,heap,T,limit) = (x1,h1,a1,n1,heap1,T)) /\
+val word_gc_move_thm = Q.prove(
+  `(gc_move (x,[],a,n,heap,T,limit) = (x1,h1,a1,n1,heap1,T)) /\
     heap_length heap <= dimword (:'a) DIV 2 ** shift_length conf /\
     (word_heap curr heap conf * word_list pa xs * frame) (fun2set (m,dm)) /\
     (word_gc_move conf (word_addr conf x,n2w a,pa,curr,m,dm) =
@@ -677,7 +677,7 @@ val word_gc_move_thm = prove(
       (w = word_addr conf x1) /\
       heap_length heap1 = heap_length heap /\
       c1 /\ (i1 = n2w a1) /\ n1 = LENGTH xs1 /\
-      pa1 = pa + bytes_in_word * n2w (heap_length h1)``,
+      pa1 = pa + bytes_in_word * n2w (heap_length h1)`,
   reverse (Cases_on `x`) \\ full_simp_tac(srw_ss())[gc_move_def] THEN1
    (srw_tac[][] \\ full_simp_tac(srw_ss())[word_heap_def,SEP_CLAUSES]
     \\ Cases_on `a'` \\ full_simp_tac(srw_ss())[word_addr_def,word_gc_move_def]
@@ -751,8 +751,8 @@ val word_gc_move_thm = prove(
   \\ srw_tac[][] \\ qexists_tac `ts`
   \\ full_simp_tac(srw_ss())[AC STAR_ASSOC STAR_COMM,SEP_CLAUSES]);
 
-val word_gc_move_roots_thm = prove(
-  ``!x a n heap limit pa x1 h1 a1 n1 heap1 pa1 m m1 xs i1 c1 w frame.
+val word_gc_move_roots_thm = Q.prove(
+  `!x a n heap limit pa x1 h1 a1 n1 heap1 pa1 m m1 xs i1 c1 w frame.
       (gc_move_list (x,[],a,n,heap,T,limit) = (x1,h1,a1,n1,heap1,T)) /\
       heap_length heap <= dimword (:'a) DIV 2 ** shift_length conf /\
       (word_heap curr heap conf * word_list pa xs * frame) (fun2set (m,dm)) /\
@@ -766,7 +766,7 @@ val word_gc_move_roots_thm = prove(
         (w = MAP (word_addr conf) x1) /\
         heap_length heap1 = heap_length heap /\
         c1 /\ (i1 = n2w a1) /\ n1 = LENGTH xs1 /\
-        pa1 = pa + n2w (heap_length h1) * bytes_in_word``,
+        pa1 = pa + n2w (heap_length h1) * bytes_in_word`,
   Induct THEN1
    (full_simp_tac(srw_ss())[gc_move_list_def,word_gc_move_roots_def,word_heap_def,SEP_CLAUSES]
     \\ srw_tac[][] \\ qexists_tac `xs` \\ full_simp_tac(srw_ss())[heap_length_def])
@@ -802,8 +802,8 @@ val word_gc_move_roots_thm = prove(
   \\ full_simp_tac(srw_ss())[AC STAR_COMM STAR_ASSOC]
   \\ full_simp_tac(srw_ss())[WORD_LEFT_ADD_DISTRIB,heap_length_def,SUM_APPEND,GSYM word_add_n2w]);
 
-val word_gc_move_list_thm = prove(
-  ``!x a n heap limit pa x1 h1 a1 n1 heap1 pa1 m m1 xs i1 c1 frame k k1.
+val word_gc_move_list_thm = Q.prove(
+  `!x a n heap limit pa x1 h1 a1 n1 heap1 pa1 m m1 xs i1 c1 frame k k1.
       (gc_move_list (x,[],a,n,heap,T,limit) = (x1,h1,a1,n1,heap1,T)) /\
       heap_length heap <= dimword (:'a) DIV 2 ** shift_length conf /\
       (word_gc_move_list conf (k,n2w (LENGTH x),n2w a,pa,curr,m,dm) =
@@ -819,7 +819,7 @@ val word_gc_move_list_thm = prove(
         heap_length heap1 = heap_length heap /\
         c1 /\ (i1 = n2w a1) /\ n1 = LENGTH xs1 /\
         k1 = k + n2w (LENGTH x) * bytes_in_word /\
-        pa1 = pa + n2w (heap_length h1) * bytes_in_word``,
+        pa1 = pa + n2w (heap_length h1) * bytes_in_word`,
   Induct THEN1
    (full_simp_tac(srw_ss())[gc_move_list_def,Once word_gc_move_list_def,word_heap_def,SEP_CLAUSES]
     \\ srw_tac[][] \\ qexists_tac `xs` \\ full_simp_tac(srw_ss())[heap_length_def])
@@ -863,15 +863,15 @@ val word_gc_move_list_thm = prove(
   \\ full_simp_tac(srw_ss())[WORD_LEFT_ADD_DISTRIB,heap_length_def,
         SUM_APPEND,GSYM word_add_n2w]);
 
-val word_payload_swap = prove(
-  ``word_payload l5 (LENGTH l5) tag r conf = (h,MAP (word_addr conf) l5,T) /\
+val word_payload_swap = Q.prove(
+  `word_payload l5 (LENGTH l5) tag r conf = (h,MAP (word_addr conf) l5,T) /\
     LENGTH xs' = LENGTH l5 ==>
-    word_payload xs' (LENGTH l5) tag r conf = (h,MAP (word_addr conf) xs',T)``,
+    word_payload xs' (LENGTH l5) tag r conf = (h,MAP (word_addr conf) xs',T)`,
   Cases_on `tag` \\ full_simp_tac(srw_ss())[word_payload_def]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[LENGTH_NIL]);
 
-val word_gc_move_loop_thm = prove(
-  ``!h1 h2 a n heap c0 limit h11 a1 n1 heap1 i1 pa1 m1 c1 xs frame m k.
+val word_gc_move_loop_thm = Q.prove(
+  `!h1 h2 a n heap c0 limit h11 a1 n1 heap1 i1 pa1 m1 c1 xs frame m k.
       (gc_move_loop (h1,h2,a,n,heap,c0,limit) = (h11,a1,n1,heap1,T)) /\ c0 /\
       heap_length heap <= dimword (:'a) DIV 2 ** shift_length conf /\
       heap_length heap * (dimindex (:'a) DIV 8) < dimword (:'a) /\
@@ -891,7 +891,7 @@ val word_gc_move_loop_thm = prove(
          word_list pa1 xs1 * frame) (fun2set (m1,dm)) /\
         heap_length heap1 = heap_length heap /\
         c1 /\ (i1 = n2w a1) /\ n1 = LENGTH xs1 /\
-        pa1 = new + bytes_in_word * n2w (heap_length h11)``,
+        pa1 = new + bytes_in_word * n2w (heap_length h11)`,
   recInduct gc_move_loop_ind \\ rpt strip_tac
   THEN1
    (full_simp_tac(srw_ss())[gc_move_loop_def] \\ rpt var_eq_tac
@@ -1002,8 +1002,8 @@ val word_gc_move_loop_thm = prove(
   \\ full_simp_tac(srw_ss())[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB,SEP_CLAUSES]
   \\ full_simp_tac(srw_ss())[AC STAR_ASSOC STAR_COMM,word_heap_APPEND]);
 
-val word_full_gc_thm = prove(
-  ``(full_gc (roots,heap,limit) = (roots1,heap1,a1,T)) /\
+val word_full_gc_thm = Q.prove(
+  `(full_gc (roots,heap,limit) = (roots1,heap1,a1,T)) /\
     heap_length heap <= dimword (:'a) DIV 2 ** shift_length conf /\
     heap_length heap * (dimindex (:'a) DIV 8) < dimword (:'a) /\
     conf.len_size + 2 < dimindex (:'a) /\
@@ -1016,7 +1016,7 @@ val word_full_gc_thm = prove(
      word_heap curr (heap_expand limit) conf * frame) (fun2set (m1,dm)) /\
     c1 /\ i1 = n2w a1 /\
     rs1 = MAP (word_addr conf) roots1 /\
-    pa1 = new + bytes_in_word * n2w a1``,
+    pa1 = new + bytes_in_word * n2w a1`,
   strip_tac \\ full_simp_tac(srw_ss())[full_gc_def,LET_THM]
   \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
@@ -1061,16 +1061,16 @@ val LIST_REL_EQ_MAP = Q.store_thm("LIST_REL_EQ_MAP",
   `!vs ws f. LIST_REL (λv w. f v = w) vs ws <=> ws = MAP f vs`,
   Induct \\ full_simp_tac(srw_ss())[]);
 
-val full_gc_IMP = prove(
-  ``full_gc (xs,heap,limit) = (t,heap2,n,T) ==>
-    n <= limit /\ limit = heap_length heap``,
+val full_gc_IMP = Q.prove(
+  `full_gc (xs,heap,limit) = (t,heap2,n,T) ==>
+    n <= limit /\ limit = heap_length heap`,
   full_simp_tac(srw_ss())[full_gc_def,LET_THM]
   \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val word_gc_fun_lemma = prove(
-  ``good_dimindex (:'a) /\
+val word_gc_fun_lemma = Q.prove(
+  `good_dimindex (:'a) /\
     heap_in_memory_store heap a sp c s m dm limit /\
     abs_ml_inv c (v::MAP FST stack) refs (hs,heap,be,a,sp) limit /\
     LIST_REL (\v w. word_addr c v = w) hs (s ' Globals::MAP SND stack) /\
@@ -1082,7 +1082,7 @@ val word_gc_fun_lemma = prove(
           (limit - heap_length heap2) c s1 m1 dm limit /\
         LIST_REL (λv w. word_addr c v = (w:'a word_loc)) roots2
           (s1 ' Globals::MAP SND (ZIP (MAP FST stack,stack1))) /\
-        LENGTH stack1 = LENGTH stack``,
+        LENGTH stack1 = LENGTH stack`,
   strip_tac
   \\ rewrite_tac [word_gc_fun_def] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[heap_in_memory_store_def,FLOOKUP_DEF,theWord_def,LET_THM]
@@ -1114,15 +1114,15 @@ val word_gc_fun_lemma = prove(
   \\ fs [word_gc_fun_assum_def,isWord_def]) |> GEN_ALL
   |> SIMP_RULE (srw_ss()) [LET_DEF,PULL_EXISTS,GSYM CONJ_ASSOC] |> SPEC_ALL;
 
-val word_gc_fun_correct = prove(
-  ``good_dimindex (:'a) /\
+val word_gc_fun_correct = Q.prove(
+  `good_dimindex (:'a) /\
     heap_in_memory_store heap a sp c s m dm limit /\
     word_ml_inv (heap:'a ml_heap,be,a,sp) limit c refs ((v,s ' Globals)::stack) ==>
     ?stack1 m1 s1 heap1 a1 sp1.
       word_gc_fun c (MAP SND stack,m,dm,s) = SOME (stack1,m1,s1) /\
       heap_in_memory_store heap1 a1 sp1 c s1 m1 dm limit /\
       word_ml_inv (heap1,be,a1,sp1) limit c refs
-        ((v,s1 ' Globals)::ZIP (MAP FST stack,stack1))``,
+        ((v,s1 ' Globals)::ZIP (MAP FST stack,stack1))`,
   full_simp_tac(srw_ss())[word_ml_inv_def] \\ srw_tac[][] \\ imp_res_tac full_gc_thm
   \\ full_simp_tac(srw_ss())[PULL_EXISTS] \\ srw_tac[][]
   \\ mp_tac word_gc_fun_lemma \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -1219,15 +1219,15 @@ val init_store_ok_def = Define `
       (word_list_exists curr (limit + limit)) (fun2set (m,dm)) ∧
       byte_aligned curr`
 
-val state_rel_init = store_thm("state_rel_init",
-  ``t.ffi = ffi ∧ t.handler = 0 ∧ t.gc_fun = word_gc_fun c ∧
+val state_rel_init = Q.store_thm("state_rel_init",
+  `t.ffi = ffi ∧ t.handler = 0 ∧ t.gc_fun = word_gc_fun c ∧
     code_rel c code t.code ∧
     good_dimindex (:α) ∧
     lookup 0 t.locals = SOME (Loc l1 l2) ∧
     t.stack = [] /\
     conf_ok (:'a) c /\
     init_store_ok c t.store t.memory t.mdomain ==>
-    state_rel c l1 l2 (initial_state ffi code t.clock) (t:('a,'ffi) state) [] []``,
+    state_rel c l1 l2 (initial_state ffi code t.clock) (t:('a,'ffi) state) [] []`,
   simp_tac std_ss [word_list_exists_ADD,conf_ok_def,init_store_ok_def]
   \\ fs [state_rel_thm,dataSemTheory.initial_state_def,
     join_env_def,lookup_def,the_global_def,
@@ -1302,13 +1302,13 @@ val state_rel_0_get_vars_IMP = Q.prove(
   \\ full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ full_simp_tac(srw_ss())[state_rel_def,wordSemTheory.get_var_def]);
 
-val get_var_T_OR_F = prove(
-  ``state_rel c l1 l2 s (t:('a,'ffi) state) [] locs /\
+val get_var_T_OR_F = Q.prove(
+  `state_rel c l1 l2 s (t:('a,'ffi) state) [] locs /\
     get_var n s.locals = SOME x /\
     get_var (adjust_var n) t = SOME w ==>
     18 MOD dimword (:'a) <> 2 MOD dimword (:'a) /\
     ((x = Boolv T) ==> (w = Word 2w)) /\
-    ((x = Boolv F) ==> (w = Word 18w))``,
+    ((x = Boolv F) ==> (w = Word 18w))`,
   full_simp_tac(srw_ss())[state_rel_def,get_var_def,wordSemTheory.get_var_def]
   \\ strip_tac \\ strip_tac THEN1 (full_simp_tac(srw_ss())[good_dimindex_def] \\ full_simp_tac(srw_ss())[dimword_def])
   \\ full_simp_tac bool_ss [GSYM APPEND_ASSOC]
@@ -1354,9 +1354,9 @@ val jump_exc_dec_clock = Q.prove(
 val LASTN_ADD1 = LASTN_LENGTH_ID
   |> Q.SPEC `x::xs` |> SIMP_RULE (srw_ss()) [ADD1]
 
-val jump_exc_push_env_NONE = prove(
-  ``mk_loc (jump_exc (push_env y NONE s)) =
-    mk_loc (jump_exc (s:('a,'b) wordSem$state))``,
+val jump_exc_push_env_NONE = Q.prove(
+  `mk_loc (jump_exc (push_env y NONE s)) =
+    mk_loc (jump_exc (s:('a,'b) wordSem$state))`,
   full_simp_tac(srw_ss())[wordSemTheory.push_env_def,wordSemTheory.jump_exc_def]
   \\ Cases_on `env_to_list y s.permute` \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ Cases_on `s.handler = LENGTH s.stack` \\ full_simp_tac(srw_ss())[LASTN_ADD1]
@@ -1368,12 +1368,12 @@ val jump_exc_push_env_NONE = prove(
   \\ every_case_tac \\ srw_tac[][mk_loc_def]
   \\ `F` by decide_tac);
 
-val state_rel_pop_env_IMP = prove(
-  ``state_rel c q l s1 t1 xs locs /\
+val state_rel_pop_env_IMP = Q.prove(
+  `state_rel c q l s1 t1 xs locs /\
     pop_env s1 = SOME s2 ==>
     ?t2 l8 l9 ll.
       pop_env t1 = SOME t2 /\ locs = (l8,l9)::ll /\
-      state_rel c l8 l9 s2 t2 xs ll``,
+      state_rel c l8 l9 s2 t2 xs ll`,
   full_simp_tac(srw_ss())[pop_env_def]
   \\ Cases_on `s1.stack` \\ full_simp_tac(srw_ss())[] \\ Cases_on `h` \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[state_rel_def]
@@ -1392,12 +1392,12 @@ val state_rel_pop_env_IMP = prove(
   \\ full_simp_tac(srw_ss())[MEM_toAList,lookup_fromAList,lookup_inter_alt]
   \\ imp_res_tac alistTheory.ALOOKUP_MEM \\ metis_tac []);
 
-val state_rel_pop_env_set_var_IMP = prove(
-  ``state_rel c q l s1 t1 [(a,w)] locs /\
+val state_rel_pop_env_set_var_IMP = Q.prove(
+  `state_rel c q l s1 t1 [(a,w)] locs /\
     pop_env s1 = SOME s2 ==>
     ?t2 l8 l9 ll.
       pop_env t1 = SOME t2 /\ locs = (l8,l9)::ll /\
-      state_rel c l8 l9 (set_var q1 a s2) (set_var (adjust_var q1) w t2) [] ll``,
+      state_rel c l8 l9 (set_var q1 a s2) (set_var (adjust_var q1) w t2) [] ll`,
   full_simp_tac(srw_ss())[pop_env_def]
   \\ Cases_on `s1.stack` \\ full_simp_tac(srw_ss())[] \\ Cases_on `h` \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -1428,15 +1428,15 @@ val state_rel_pop_env_set_var_IMP = prove(
   \\ full_simp_tac(srw_ss())[MEM_toAList,lookup_fromAList,lookup_inter_alt]
   \\ imp_res_tac alistTheory.ALOOKUP_MEM \\ metis_tac []);
 
-val state_rel_jump_exc = prove(
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
+val state_rel_jump_exc = Q.prove(
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
     get_var n s.locals = SOME x /\
     get_var (adjust_var n) t = SOME w /\
     jump_exc s = SOME s1 ==>
     ?t1 d1 d2 l5 l6 ll.
       jump_exc t = SOME (t1,d1,d2) /\
       LASTN (LENGTH s1.stack + 1) locs = (l5,l6)::ll /\
-      !i. state_rel c l5 l6 (set_var i x s1) (set_var (adjust_var i) w t1) [] ll``,
+      !i. state_rel c l5 l6 (set_var i x s1) (set_var (adjust_var i) w t1) [] ll`,
   full_simp_tac(srw_ss())[jump_exc_def] \\ rpt CASE_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[state_rel_def]
   \\ full_simp_tac(srw_ss())[wordSemTheory.set_var_def,set_var_def]
   \\ full_simp_tac bool_ss [GSYM APPEND_ASSOC]
@@ -1481,12 +1481,12 @@ val lookup_adjust_var_fromList2 = Q.prove(
   \\ once_rewrite_tac [MULT_COMM]
   \\ full_simp_tac(srw_ss())[GSYM MULT_CLAUSES,MULT_DIV]);
 
-val state_rel_call_env = prove(
-  ``get_vars args s.locals = SOME q /\
+val state_rel_call_env = Q.prove(
+  `get_vars args s.locals = SOME q /\
     get_vars (MAP adjust_var args) (t:('a,'ffi) wordSem$state) = SOME ws /\
     state_rel c l5 l6 s t [] locs ==>
     state_rel c l1 l2 (call_env q (dec_clock s))
-      (call_env (Loc l1 l2::ws) (dec_clock t)) [] locs``,
+      (call_env (Loc l1 l2::ws) (dec_clock t)) [] locs`,
   full_simp_tac(srw_ss())[state_rel_def,call_env_def,wordSemTheory.call_env_def,
       dec_clock_def,wordSemTheory.dec_clock_def,lookup_adjust_var_fromList2]
   \\ srw_tac[][lookup_fromList2,lookup_fromList] \\ srw_tac[][]
@@ -1530,9 +1530,9 @@ val word_get_vars_SNOC_IMP = Q.prove(
   Induct \\ full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]) |> SPEC_ALL;
 
-val word_ml_inv_CodePtr = prove(
-  ``word_ml_inv (heap,be,a,sp) limit c s.refs ((CodePtr n,v)::xs) ==>
-    (v = Loc n 0)``,
+val word_ml_inv_CodePtr = Q.prove(
+  `word_ml_inv (heap,be,a,sp) limit c s.refs ((CodePtr n,v)::xs) ==>
+    (v = Loc n 0)`,
   full_simp_tac(srw_ss())[word_ml_inv_def,PULL_EXISTS] \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[abs_ml_inv_def,bc_stack_ref_inv_def,v_inv_def]
   \\ srw_tac[][word_addr_def]);
@@ -1558,8 +1558,8 @@ val state_rel_CodePtr = Q.prove(
   \\ imp_res_tac word_ml_inv_get_var_IMP \\ full_simp_tac(srw_ss())[]
   \\ imp_res_tac word_ml_inv_CodePtr);
 
-val find_code_thm = prove(
-  ``!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
+val find_code_thm = Q.prove(
+  `!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
       state_rel c l1 l2 s t [] locs /\
       get_vars args s.locals = SOME x /\
       get_vars (0::MAP adjust_var args) t = SOME (Loc l1 l2::ws) /\
@@ -1567,7 +1567,7 @@ val find_code_thm = prove(
       ?args1 n1 n2.
         find_code dest (Loc l1 l2::ws) t.code = SOME (args1,FST (comp c n1 n2 r)) /\
         state_rel c l1 l2 (call_env q (dec_clock s))
-          (call_env args1 (dec_clock t)) [] locs``,
+          (call_env args1 (dec_clock t)) [] locs`,
   Cases_on `dest` \\ srw_tac[][] \\ full_simp_tac(srw_ss())[find_code_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[wordSemTheory.find_code_def] \\ srw_tac[][]
   \\ `code_rel c s.code t.code` by full_simp_tac(srw_ss())[state_rel_def]
@@ -1593,10 +1593,10 @@ val find_code_thm = prove(
         full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ imp_res_tac state_rel_call_env \\ full_simp_tac(srw_ss())[]) |> SPEC_ALL;
 
-val env_to_list_lookup_equiv = prove(
-  ``env_to_list y f = (q,r) ==>
+val env_to_list_lookup_equiv = Q.prove(
+  `env_to_list y f = (q,r) ==>
     (!n. ALOOKUP q n = lookup n y) /\
-    (!x1 x2. MEM (x1,x2) q ==> lookup x1 y = SOME x2)``,
+    (!x1 x2. MEM (x1,x2) q ==> lookup x1 y = SOME x2)`,
   full_simp_tac(srw_ss())[wordSemTheory.env_to_list_def,LET_DEF] \\ srw_tac[][]
   \\ `ALL_DISTINCT (MAP FST (toAList y))` by full_simp_tac(srw_ss())[ALL_DISTINCT_MAP_FST_toAList]
   \\ imp_res_tac (MATCH_MP PERM_ALL_DISTINCT_MAP
@@ -1666,8 +1666,8 @@ val adjust_var_cut_env_IMP_MEM = Q.prove(
   \\ full_simp_tac(srw_ss())[domain_lookup,lookup_adjust_var_adjust_set_SOME_UNIT] \\ srw_tac[][]
   \\ metis_tac [lookup_adjust_var_adjust_set_SOME_UNIT,IS_SOME_DEF]);
 
-val state_rel_call_env_push_env = prove(
-  ``!opt:(num # 'a wordLang$prog # num # num) option.
+val state_rel_call_env_push_env = Q.prove(
+  `!opt:(num # 'a wordLang$prog # num # num) option.
       state_rel c l1 l2 s (t:('a,'ffi)wordSem$state) [] locs /\
       get_vars args s.locals = SOME xs /\
       get_vars (MAP adjust_var args) t = SOME ws /\
@@ -1675,7 +1675,7 @@ val state_rel_call_env_push_env = prove(
       wordSem$cut_env (adjust_set r) t.locals = SOME y ==>
       state_rel c q l (call_env xs (push_env x (IS_SOME opt) (dec_clock s)))
        (call_env (Loc q l::ws) (push_env y opt (dec_clock t))) []
-       ((l1,l2)::locs)``,
+       ((l1,l2)::locs)`,
   Cases \\ TRY (PairCases_on `x'`) \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[state_rel_def,call_env_def,push_env_def,dec_clock_def,
          wordSemTheory.call_env_def,wordSemTheory.push_env_def,
@@ -1738,8 +1738,8 @@ val state_rel_call_env_push_env = prove(
   \\ full_simp_tac(srw_ss())[dataSemTheory.cut_env_def,SUBSET_DEF,domain_lookup]
   \\ res_tac \\ full_simp_tac(srw_ss())[MEM_toAList]);
 
-val find_code_thm_ret = prove(
-  ``!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
+val find_code_thm_ret = Q.prove(
+  `!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
       state_rel c l1 l2 s t [] locs /\
       get_vars args s.locals = SOME xs /\
       get_vars (MAP adjust_var args) t = SOME ws /\
@@ -1751,7 +1751,7 @@ val find_code_thm_ret = prove(
         state_rel c q l (call_env ys (push_env x F (dec_clock s)))
           (call_env args1 (push_env y
              (NONE:(num # ('a wordLang$prog) # num # num) option)
-          (dec_clock t))) [] ((l1,l2)::locs)``,
+          (dec_clock t))) [] ((l1,l2)::locs)`,
   reverse (Cases_on `dest`) \\ srw_tac[][] \\ full_simp_tac(srw_ss())[find_code_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[wordSemTheory.find_code_def] \\ srw_tac[][]
   \\ `code_rel c s.code t.code` by full_simp_tac(srw_ss())[state_rel_def]
@@ -1775,8 +1775,8 @@ val find_code_thm_ret = prove(
                    |> SIMP_RULE std_ss [] |> GEN_ALL)
   \\ full_simp_tac(srw_ss())[] \\ metis_tac []) |> SPEC_ALL;
 
-val find_code_thm_handler = prove(
-  ``!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
+val find_code_thm_handler = Q.prove(
+  `!(s:'ffi dataSem$state) (t:('a,'ffi)wordSem$state).
       state_rel c l1 l2 s t [] locs /\
       get_vars args s.locals = SOME xs /\
       get_vars (MAP adjust_var args) t = SOME ws /\
@@ -1788,7 +1788,7 @@ val find_code_thm_handler = prove(
         state_rel c q l (call_env ys (push_env x T (dec_clock s)))
           (call_env args1 (push_env y
              (SOME (adjust_var x0,(prog1:'a wordLang$prog),nn,l + 1))
-          (dec_clock t))) [] ((l1,l2)::locs)``,
+          (dec_clock t))) [] ((l1,l2)::locs)`,
   reverse (Cases_on `dest`) \\ srw_tac[][] \\ full_simp_tac(srw_ss())[find_code_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[wordSemTheory.find_code_def] \\ srw_tac[][]
   \\ `code_rel c s.code t.code` by full_simp_tac(srw_ss())[state_rel_def]
@@ -1813,9 +1813,9 @@ val find_code_thm_handler = prove(
                    |> SIMP_RULE std_ss [] |> GEN_ALL)
   \\ full_simp_tac(srw_ss())[] \\ metis_tac []) |> SPEC_ALL;
 
-val bvl_find_code = store_thm("bvl_find_code",
-  ``bvlSem$find_code dest xs code = SOME(ys,prog) ⇒
-  ¬bad_dest_args dest xs``,
+val bvl_find_code = Q.store_thm("bvl_find_code",
+  `bvlSem$find_code dest xs code = SOME(ys,prog) ⇒
+  ¬bad_dest_args dest xs`,
   Cases_on`dest`>>
   full_simp_tac(srw_ss())[bvlSemTheory.find_code_def,wordSemTheory.bad_dest_args_def])
 
@@ -1829,9 +1829,9 @@ val s_key_eq_LASTN = Q.prove(
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[s_key_eq_def,LASTN_ALT] \\ res_tac
   \\ imp_res_tac s_key_eq_LENGTH \\ full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
 
-val evaluate_mk_loc_EQ = prove(
-  ``evaluate (q,t) = (NONE,t1:('a,'b) state) ==>
-    mk_loc (jump_exc t1) = ((mk_loc (jump_exc t)):'a word_loc)``,
+val evaluate_mk_loc_EQ = Q.prove(
+  `evaluate (q,t) = (NONE,t1:('a,'b) state) ==>
+    mk_loc (jump_exc t1) = ((mk_loc (jump_exc t)):'a word_loc)`,
   qspecl_then [`q`,`t`] mp_tac wordPropsTheory.evaluate_stack_swap \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def]
   \\ imp_res_tac s_key_eq_LENGTH \\ full_simp_tac(srw_ss())[]
@@ -1839,12 +1839,12 @@ val evaluate_mk_loc_EQ = prove(
   \\ pop_assum (qspec_then `t.handler + 1` mp_tac)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def,mk_loc_def])
 
-val mk_loc_eq_push_env_exc_Exception = prove(
-  ``evaluate
+val mk_loc_eq_push_env_exc_Exception = Q.prove(
+  `evaluate
       (c:'a wordLang$prog, call_env args1
             (push_env y (SOME (x0,prog1:'a wordLang$prog,x1,l))
                (dec_clock t))) = (SOME (Exception xx w),(t1:('a,'b) state)) ==>
-    mk_loc (jump_exc t1) = mk_loc (jump_exc t) :'a word_loc``,
+    mk_loc (jump_exc t1) = mk_loc (jump_exc t) :'a word_loc`,
   qspecl_then [`c`,`call_env args1
     (push_env y (SOME (x0,prog1:'a wordLang$prog,x1,l)) (dec_clock t))`]
        mp_tac wordPropsTheory.evaluate_stack_swap \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -1858,10 +1858,10 @@ val mk_loc_eq_push_env_exc_Exception = prove(
   \\ pop_assum (qspec_then `t.handler+1` mp_tac) \\ srw_tac[][]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def,mk_loc_def]);
 
-val evaluate_IMP_domain_EQ = prove(
-  ``evaluate (c,call_env (args1:'a word_loc list) (push_env y (opt:(num # ('a wordLang$prog) # num # num) option) (dec_clock t))) =
+val evaluate_IMP_domain_EQ = Q.prove(
+  `evaluate (c,call_env (args1:'a word_loc list) (push_env y (opt:(num # ('a wordLang$prog) # num # num) option) (dec_clock t))) =
       (SOME (Result ll w),t1) /\ pop_env t1 = SOME t2 ==>
-    domain t2.locals = domain y``,
+    domain t2.locals = domain y`,
   qspecl_then [`c`,`call_env args1 (push_env y opt (dec_clock t))`] mp_tac
       wordPropsTheory.evaluate_stack_swap \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[wordSemTheory.call_env_def]
@@ -1875,11 +1875,11 @@ val evaluate_IMP_domain_EQ = prove(
   \\ full_simp_tac(srw_ss())[EXTENSION,MEM_MAP,EXISTS_PROD,mem_list_rearrange,QSORT_MEM,
          domain_lookup,MEM_toAList]);
 
-val evaluate_IMP_domain_EQ_Exc = prove(
-  ``evaluate (c,call_env args1 (push_env y
+val evaluate_IMP_domain_EQ_Exc = Q.prove(
+  `evaluate (c,call_env args1 (push_env y
       (SOME (x0,prog1:'a wordLang$prog,x1,l))
       (dec_clock (t:('a,'b) state)))) = (SOME (Exception ll w),t1) ==>
-    domain t1.locals = domain y``,
+    domain t1.locals = domain y`,
   qspecl_then [`c`,`call_env args1
      (push_env y (SOME (x0,prog1:'a wordLang$prog,x1,l)) (dec_clock t))`]
      mp_tac wordPropsTheory.evaluate_stack_swap \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -1895,12 +1895,12 @@ val evaluate_IMP_domain_EQ_Exc = prove(
   \\ full_simp_tac(srw_ss())[EXTENSION,MEM_MAP,EXISTS_PROD,mem_list_rearrange,QSORT_MEM,
          domain_lookup,MEM_toAList]);
 
-val mk_loc_jump_exc = prove(
-  ``mk_loc
+val mk_loc_jump_exc = Q.prove(
+  `mk_loc
        (jump_exc
           (call_env args1
              (push_env y (SOME (adjust_var n,prog1,x0,l))
-                (dec_clock t)))) = Loc x0 l``,
+                (dec_clock t)))) = Loc x0 l`,
   full_simp_tac(srw_ss())[wordSemTheory.push_env_def,wordSemTheory.call_env_def,
       wordSemTheory.jump_exc_def]
   \\ Cases_on `env_to_list y (dec_clock t).permute`
@@ -2092,31 +2092,31 @@ val s_key_eq_handler_eq_IMP = Q.prove(
   \\ pop_assum (qspec_then `t1.handler + 1` mp_tac)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def]);
 
-val eval_NONE_IMP_jump_exc_NONE_EQ = prove(
-  ``evaluate (q,t) = (NONE,t1) ==> (jump_exc t1 = NONE <=> jump_exc t = NONE)``,
+val eval_NONE_IMP_jump_exc_NONE_EQ = Q.prove(
+  `evaluate (q,t) = (NONE,t1) ==> (jump_exc t1 = NONE <=> jump_exc t = NONE)`,
   srw_tac[][] \\ mp_tac (wordPropsTheory.evaluate_stack_swap |> Q.SPECL [`q`,`t`])
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ imp_res_tac s_key_eq_handler_eq_IMP \\ metis_tac []);
 
-val jump_exc_push_env_SOME = prove(
-  ``jump_exc (push_env y (SOME (x,prog1,l1,l2)) t) <> NONE``,
+val jump_exc_push_env_SOME = Q.prove(
+  `jump_exc (push_env y (SOME (x,prog1,l1,l2)) t) <> NONE`,
   full_simp_tac(srw_ss())[wordSemTheory.jump_exc_def,wordSemTheory.push_env_def]
   \\ Cases_on `env_to_list y t.permute` \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ full_simp_tac(srw_ss())[LASTN_ADD1]);
 
-val eval_push_env_T_Raise_IMP_stack_length = prove(
-  ``evaluate (p,call_env ys (push_env x T (dec_clock s))) =
+val eval_push_env_T_Raise_IMP_stack_length = Q.prove(
+  `evaluate (p,call_env ys (push_env x T (dec_clock s))) =
        (SOME (Rerr (Rraise a)),r') ==>
-    LENGTH r'.stack = LENGTH s.stack``,
+    LENGTH r'.stack = LENGTH s.stack`,
   qspecl_then [`p`,`call_env ys (push_env x T (dec_clock s))`]
     mp_tac dataPropsTheory.evaluate_stack_swap
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[call_env_def,jump_exc_def,push_env_def,dec_clock_def,LASTN_ADD1]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val eval_push_env_SOME_exc_IMP_s_key_eq = prove(
-  ``evaluate (p, call_env args1 (push_env y (SOME (x1,x2,x3,x4)) (dec_clock t))) =
+val eval_push_env_SOME_exc_IMP_s_key_eq = Q.prove(
+  `evaluate (p, call_env args1 (push_env y (SOME (x1,x2,x3,x4)) (dec_clock t))) =
       (SOME (Exception l w),t1) ==>
-    s_key_eq t1.stack t.stack /\ t.handler = t1.handler``,
+    s_key_eq t1.stack t.stack /\ t.handler = t1.handler`,
   qspecl_then [`p`,`call_env args1 (push_env y (SOME (x1,x2,x3,x4)) (dec_clock t))`]
     mp_tac wordPropsTheory.evaluate_stack_swap
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -2126,10 +2126,10 @@ val eval_push_env_SOME_exc_IMP_s_key_eq = prove(
   \\ Cases_on `env_to_list y t.permute` \\ full_simp_tac(srw_ss())[LET_DEF,LASTN_ADD1]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val eval_exc_stack_shorter = prove(
-  ``evaluate (c,call_env ys (push_env x F (dec_clock s))) =
+val eval_exc_stack_shorter = Q.prove(
+  `evaluate (c,call_env ys (push_env x F (dec_clock s))) =
       (SOME (Rerr (Rraise a)),r') ==>
-    LENGTH r'.stack < LENGTH s.stack``,
+    LENGTH r'.stack < LENGTH s.stack`,
   srw_tac[][] \\ qspecl_then [`c`,`call_env ys (push_env x F (dec_clock s))`]
              mp_tac dataPropsTheory.evaluate_stack_swap
   \\ full_simp_tac(srw_ss())[] \\ once_rewrite_tac [EQ_SYM_EQ] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -2213,10 +2213,10 @@ val state_rel_insert_3_1 = Q.prove(
   \\ full_simp_tac(srw_ss())[inter_insert,domain_lookup,
         lookup_3_adjust_set,lookup_1_adjust_set]);
 
-val state_rel_inc_clock = prove(
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
+val state_rel_inc_clock = Q.prove(
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
     state_rel c l1 l2 (s with clock := s.clock + 1)
-                      (t with clock := t.clock + 1) [] locs``,
+                      (t with clock := t.clock + 1) [] locs`,
   full_simp_tac(srw_ss())[state_rel_def]);
 
 val dec_clock_inc_clock = Q.prove(
@@ -2226,17 +2226,17 @@ val dec_clock_inc_clock = Q.prove(
   \\ full_simp_tac(srw_ss())[dataSemTheory.state_component_equality]
   \\ full_simp_tac(srw_ss())[wordSemTheory.state_component_equality])
 
-val word_gc_move_IMP_isWord = prove(
-  ``word_gc_move c' (Word c,i,pa,old,m,dm) = (w1,i1,pa1,m1,c1) ==> isWord w1``,
+val word_gc_move_IMP_isWord = Q.prove(
+  `word_gc_move c' (Word c,i,pa,old,m,dm) = (w1,i1,pa1,m1,c1) ==> isWord w1`,
   full_simp_tac(srw_ss())[word_gc_move_def,LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[isWord_def]);
 
-val word_gc_move_roots_IMP_FILTER = prove(
-  ``!ws i pa old m dm ws2 i2 pa2 m2 c2 c.
+val word_gc_move_roots_IMP_FILTER = Q.prove(
+  `!ws i pa old m dm ws2 i2 pa2 m2 c2 c.
       word_gc_move_roots c (ws,i,pa,old,m,dm) = (ws2,i2,pa2,m2,c2) ==>
       word_gc_move_roots c (FILTER isWord ws,i,pa,old,m,dm) =
-                           (FILTER isWord ws2,i2,pa2,m2,c2)``,
+                           (FILTER isWord ws2,i2,pa2,m2,c2)`,
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def] \\ Cases \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_gc_move_roots_def]
   THEN1
@@ -2249,9 +2249,9 @@ val word_gc_move_roots_IMP_FILTER = prove(
 
 val IMP_EQ_DISJ = METIS_PROVE [] ``(b1 ==> b2) <=> ~b1 \/ b2``
 
-val word_gc_fun_IMP_FILTER = prove(
-  ``word_gc_fun c (xs,m,dm,s) = SOME (stack1,m1,s1) ==>
-    word_gc_fun c (FILTER isWord xs,m,dm,s) = SOME (FILTER isWord stack1,m1,s1)``,
+val word_gc_fun_IMP_FILTER = Q.prove(
+  `word_gc_fun c (xs,m,dm,s) = SOME (stack1,m1,s1) ==>
+    word_gc_fun c (FILTER isWord xs,m,dm,s) = SOME (FILTER isWord stack1,m1,s1)`,
   full_simp_tac(srw_ss())[word_gc_fun_def,LET_THM,word_gc_fun_def,word_full_gc_def]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
@@ -2273,11 +2273,11 @@ val LENGTH_loc_merge = Q.prove(
   \\ Cases_on `h` \\ full_simp_tac(srw_ss())[loc_merge_def]
   \\ Cases_on `h'` \\ full_simp_tac(srw_ss())[loc_merge_def]);
 
-val word_gc_move_roots_IMP_FILTER = prove(
-  ``!ws i pa old m dm ws2 i2 pa2 m2 c2 c.
+val word_gc_move_roots_IMP_FILTER = Q.prove(
+  `!ws i pa old m dm ws2 i2 pa2 m2 c2 c.
       word_gc_move_roots c (FILTER isWord ws,i,pa,old,m,dm) = (ws2,i2,pa2,m2,c2) ==>
       word_gc_move_roots c (ws,i,pa,old,m,dm) =
-                           (loc_merge ws ws2,i2,pa2,m2,c2)``,
+                           (loc_merge ws ws2,i2,pa2,m2,c2)`,
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def,loc_merge_def]
   \\ reverse Cases \\ full_simp_tac(srw_ss())[isWord_def,loc_merge_def,LET_DEF]
   THEN1
@@ -2291,9 +2291,9 @@ val word_gc_move_roots_IMP_FILTER = prove(
   \\ PairCases_on `r` \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[LET_DEF] \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[loc_merge_def]);
 
-val word_gc_fun_loc_merge = prove(
-  ``word_gc_fun c (FILTER isWord xs,m,dm,s) = SOME (ys,m1,s1) ==>
-    word_gc_fun c (xs,m,dm,s) = SOME (loc_merge xs ys,m1,s1)``,
+val word_gc_fun_loc_merge = Q.prove(
+  `word_gc_fun c (FILTER isWord xs,m,dm,s) = SOME (ys,m1,s1) ==>
+    word_gc_fun c (xs,m,dm,s) = SOME (loc_merge xs ys,m1,s1)`,
   full_simp_tac(srw_ss())[word_gc_fun_def,LET_THM,word_gc_fun_def,word_full_gc_def]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
@@ -2303,20 +2303,20 @@ val word_gc_fun_loc_merge = prove(
   \\ imp_res_tac word_gc_move_roots_IMP_FILTER
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]);
 
-val word_gc_fun_IMP = prove(
-  ``word_gc_fun c (xs,m,dm,s) = SOME (ys,m1,s1) ==>
+val word_gc_fun_IMP = Q.prove(
+  `word_gc_fun c (xs,m,dm,s) = SOME (ys,m1,s1) ==>
     FLOOKUP s1 AllocSize = FLOOKUP s AllocSize /\
     FLOOKUP s1 Handler = FLOOKUP s Handler /\
-    Globals IN FDOM s1``,
+    Globals IN FDOM s1`,
   full_simp_tac(srw_ss())[IMP_EQ_DISJ,word_gc_fun_def] \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[GSYM IMP_EQ_DISJ,word_gc_fun_def] \\ srw_tac[][]
   \\ UNABBREV_ALL_TAC \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ EVAL_TAC)
 
-val word_gc_move_roots_IMP_EVERY2 = prove(
-  ``!xs ys pa m i c1 m1 pa1 i1 old dm c.
+val word_gc_move_roots_IMP_EVERY2 = Q.prove(
+  `!xs ys pa m i c1 m1 pa1 i1 old dm c.
       word_gc_move_roots c (xs,i,pa,old,m,dm) = (ys,i1,pa1,m1,c1) ==>
-      EVERY2 (\x y. (isWord x <=> isWord y) /\ (~isWord x ==> x = y)) xs ys``,
+      EVERY2 (\x y. (isWord x <=> isWord y) /\ (~isWord x ==> x = y)) xs ys`,
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def]
   \\ full_simp_tac(srw_ss())[IMP_EQ_DISJ,word_gc_fun_def] \\ srw_tac[][]
   \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
@@ -2327,9 +2327,9 @@ val word_gc_move_roots_IMP_EVERY2 = prove(
   \\ UNABBREV_ALL_TAC \\ srw_tac[][] \\ pop_assum mp_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[isWord_def]);
 
-val word_gc_IMP_EVERY2 = prove(
-  ``word_gc_fun c (xs,m,dm,st) = SOME (ys,m1,s1) ==>
-    EVERY2 (\x y. (isWord x <=> isWord y) /\ (~isWord x ==> x = y)) xs ys``,
+val word_gc_IMP_EVERY2 = Q.prove(
+  `word_gc_fun c (xs,m,dm,st) = SOME (ys,m1,s1) ==>
+    EVERY2 (\x y. (isWord x <=> isWord y) /\ (~isWord x ==> x = y)) xs ys`,
   full_simp_tac(srw_ss())[word_gc_fun_def,LET_THM,word_gc_fun_def,word_full_gc_def]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
@@ -2338,8 +2338,8 @@ val word_gc_IMP_EVERY2 = prove(
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ imp_res_tac word_gc_move_roots_IMP_EVERY2);
 
-val word_gc_fun_LENGTH = store_thm("word_gc_fun_LENGTH",
-  ``word_gc_fun c (xs,m,dm,s) = SOME (zs,m1,s1) ==> LENGTH xs = LENGTH zs``,
+val word_gc_fun_LENGTH = Q.store_thm("word_gc_fun_LENGTH",
+  `word_gc_fun c (xs,m,dm,s) = SOME (zs,m1,s1) ==> LENGTH xs = LENGTH zs`,
   srw_tac[][] \\ drule word_gc_IMP_EVERY2 \\ srw_tac[][] \\ imp_res_tac EVERY2_LENGTH);
 
 val gc_fun_ok_word_gc_fun = Q.store_thm("gc_fun_ok_word_gc_fun",
@@ -2358,9 +2358,9 @@ val gc_fun_ok_word_gc_fun = Q.store_thm("gc_fun_ok_word_gc_fun",
   \\ fs [FAPPLY_FUPDATE_THM,DOMSUB_FAPPLY_THM]
   \\ rw [] \\ fs []);
 
-val word_gc_fun_APPEND_IMP = prove(
-  ``word_gc_fun c (xs ++ ys,m,dm,s) = SOME (zs,m1,s1) ==>
-    ?zs1 zs2. zs = zs1 ++ zs2 /\ LENGTH xs = LENGTH zs1 /\ LENGTH ys = LENGTH zs2``,
+val word_gc_fun_APPEND_IMP = Q.prove(
+  `word_gc_fun c (xs ++ ys,m,dm,s) = SOME (zs,m1,s1) ==>
+    ?zs1 zs2. zs = zs1 ++ zs2 /\ LENGTH xs = LENGTH zs1 /\ LENGTH ys = LENGTH zs2`,
   srw_tac[][] \\ imp_res_tac word_gc_fun_LENGTH \\ full_simp_tac(srw_ss())[LENGTH_APPEND]
   \\ pop_assum mp_tac \\ pop_assum (K all_tac)
   \\ qspec_tac (`zs`,`zs`) \\ qspec_tac (`ys`,`ys`) \\ qspec_tac (`xs`,`xs`)
@@ -2423,12 +2423,12 @@ val dec_stack_loc_merge_enc_stack = Q.prove(
   \\ first_assum (qspec_then `ts` strip_assume_tac) \\ full_simp_tac(srw_ss())[]
   \\ decide_tac);
 
-val ALOOKUP_ZIP = prove(
-  ``!l zs1.
+val ALOOKUP_ZIP = Q.prove(
+  `!l zs1.
       ALOOKUP l (0:num) = SOME (Loc q r) /\
       LIST_REL (λx y. (isWord y ⇒ isWord x) ∧
         (¬isWord x ⇒ x = y)) (MAP SND l) zs1 ==>
-      ALOOKUP (ZIP (MAP FST l,zs1)) 0 = SOME (Loc q r)``,
+      ALOOKUP (ZIP (MAP FST l,zs1)) 0 = SOME (Loc q r)`,
   Induct \\ full_simp_tac(srw_ss())[] \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def,PULL_EXISTS]
   \\ Cases_on `q' = 0` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[isWord_def] \\ srw_tac[][]);
 
@@ -2473,11 +2473,11 @@ val join_env_NIL = Q.prove(
   `join_env s [] = []`,
   full_simp_tac(srw_ss())[join_env_def]);
 
-val join_env_CONS = prove(
-  ``join_env s ((n,v)::xs) =
+val join_env_CONS = Q.prove(
+  `join_env s ((n,v)::xs) =
     if n <> 0 /\ EVEN n then
       (THE (lookup ((n - 2) DIV 2) s),v)::join_env s xs
-    else join_env s xs``,
+    else join_env s xs`,
   full_simp_tac(srw_ss())[join_env_def] \\ srw_tac[][]);
 
 val FILTER_enc_stack_lemma = Q.prove(
@@ -2495,24 +2495,24 @@ val FILTER_enc_stack_lemma = Q.prove(
   \\ Induct_on `l` \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[join_env_NIL]
   \\ Cases \\ full_simp_tac(srw_ss())[join_env_CONS] \\ srw_tac[][]);
 
-val stack_rel_simp = prove(
-  ``(stack_rel (Env s) y <=>
+val stack_rel_simp = Q.prove(
+  `(stack_rel (Env s) y <=>
      ?vs. stack_rel (Env s) y /\ (y = StackFrame vs NONE)) /\
     (stack_rel (Exc s n) y <=>
-     ?vs x1 x2 x3. stack_rel (Exc s n) y /\ (y = StackFrame vs (SOME (x1,x2,x3))))``,
+     ?vs x1 x2 x3. stack_rel (Exc s n) y /\ (y = StackFrame vs (SOME (x1,x2,x3))))`,
   Cases_on `y` \\ full_simp_tac(srw_ss())[stack_rel_def] \\ Cases_on `o'`
   \\ full_simp_tac(srw_ss())[stack_rel_def] \\ PairCases_on `x`
   \\ full_simp_tac(srw_ss())[stack_rel_def,CONJ_ASSOC]);
 
-val join_env_EQ_ZIP = prove(
-  ``!vs s zs1.
+val join_env_EQ_ZIP = Q.prove(
+  `!vs s zs1.
       EVERY (\(x1,x2). isWord x2 ==> x1 <> 0 /\ EVEN x1) vs /\
       LENGTH (join_env s vs) = LENGTH zs1 /\
       LIST_REL (\x y. isWord x = isWord y /\ (~isWord x ==> x = y))
          (MAP SND (join_env s vs)) zs1 ==>
       join_env s
         (ZIP (MAP FST vs,loc_merge (MAP SND vs) (FILTER isWord zs1))) =
-      ZIP (MAP FST (join_env s vs),zs1)``,
+      ZIP (MAP FST (join_env s vs),zs1)`,
   Induct \\ simp [join_env_NIL,loc_merge_def] \\ rpt strip_tac
   \\ Cases_on `h` \\ simp [] \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `r` \\ full_simp_tac(srw_ss())[isWord_def]
@@ -2520,13 +2520,13 @@ val join_env_EQ_ZIP = prove(
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ rev_full_simp_tac(srw_ss())[isWord_def] \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `y` \\ full_simp_tac(srw_ss())[loc_merge_def,join_env_CONS,isWord_def]);
 
-val LENGTH_MAP_SND_join_env_IMP = prove(
-  ``!vs zs1 s.
+val LENGTH_MAP_SND_join_env_IMP = Q.prove(
+  `!vs zs1 s.
       LIST_REL (\x y. (isWord x = isWord y) /\ (~isWord x ==> x = y))
         (MAP SND (join_env s vs)) zs1 /\
       EVERY (\(x1,x2). isWord x2 ==> x1 <> 0 /\ EVEN x1) vs /\
       LENGTH (join_env s vs) = LENGTH zs1 ==>
-      LENGTH (FILTER isWord (MAP SND vs)) = LENGTH (FILTER isWord zs1)``,
+      LENGTH (FILTER isWord (MAP SND vs)) = LENGTH (FILTER isWord zs1)`,
   Induct \\ rpt strip_tac THEN1
    (pop_assum mp_tac \\ simp [join_env_NIL]
     \\ Cases_on `zs1` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][])
@@ -2537,15 +2537,15 @@ val LENGTH_MAP_SND_join_env_IMP = prove(
 
 val lemma1 = Q.prove(`(y1 = y2) /\ (x1 = x2) ==> (f x1 y1 = f x2 y2)`,full_simp_tac(srw_ss())[]);
 
-val word_gc_fun_EL_lemma = prove(
-  ``!xs ys stack1 m dm st m1 s1 stack.
+val word_gc_fun_EL_lemma = Q.prove(
+  `!xs ys stack1 m dm st m1 s1 stack.
       LIST_REL stack_rel xs stack /\
       EVERY2 (\x y. isWord x = isWord y /\ (~isWord x ==> x = y))
          (MAP SND (flat xs ys)) stack1 /\
       dec_stack (loc_merge (enc_stack ys) (FILTER isWord stack1)) ys =
         SOME stack /\ LIST_REL stack_rel xs ys ==>
       (flat xs stack =
-       ZIP (MAP FST (flat xs ys),stack1))``,
+       ZIP (MAP FST (flat xs ys),stack1))`,
   Induct THEN1 (EVAL_TAC \\ full_simp_tac(srw_ss())[] \\ EVAL_TAC \\ srw_tac[][] \\ srw_tac[][flat_def])
   \\ Cases_on `h` \\ full_simp_tac(srw_ss())[] \\ once_rewrite_tac [stack_rel_simp]
   \\ full_simp_tac(srw_ss())[PULL_EXISTS,stack_rel_def,flat_def,wordSemTheory.enc_stack_def]
@@ -2564,8 +2564,8 @@ val word_gc_fun_EL_lemma = prove(
   \\ rpt strip_tac \\ TRY (first_x_assum match_mp_tac \\ full_simp_tac(srw_ss())[])
   \\ TRY (match_mp_tac join_env_EQ_ZIP) \\ full_simp_tac(srw_ss())[]) |> SPEC_ALL;
 
-val state_rel_gc = prove(
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
+val state_rel_gc = Q.prove(
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
     FLOOKUP t.store AllocSize = SOME (Word (alloc_size k)) /\
     s.locals = LN /\
     t.locals = LS (Loc l1 l2) ==>
@@ -2575,7 +2575,7 @@ val state_rel_gc = prove(
       dec_stack wl t.stack = SOME stack /\
       FLOOKUP st AllocSize = SOME (Word (alloc_size k)) /\
       state_rel c l1 l2 (s with space := 0)
-        (t with <|stack := stack; store := st; memory := m|>) [] locs``,
+        (t with <|stack := stack; store := st; memory := m|>) [] locs`,
   full_simp_tac(srw_ss())[state_rel_def] \\ srw_tac[][] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[lookup_def] \\ srw_tac[][]
   \\ qhdtm_x_assum `word_ml_inv` mp_tac
   \\ Q.PAT_ABBREV_TAC `pat = join_env LN _` \\ srw_tac[][]
@@ -2602,8 +2602,8 @@ val state_rel_gc = prove(
   \\ match_mp_tac (GEN_ALL word_gc_fun_EL_lemma)
   \\ imp_res_tac word_gc_IMP_EVERY2 \\ full_simp_tac(srw_ss())[]);
 
-val gc_lemma = prove(
-  ``let t0 = call_env [Loc l1 l2] (push_env y
+val gc_lemma = Q.prove(
+  `let t0 = call_env [Loc l1 l2] (push_env y
         (NONE:(num # 'a wordLang$prog # num # num) option) t) in
       dataSem$cut_env names (s:'ffi dataSem$state).locals = SOME x /\
       state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
@@ -2615,7 +2615,7 @@ val gc_lemma = prove(
         dec_stack wl t0.stack = SOME stack /\
         pop_env (t0 with <|stack := stack; store := st; memory := m|>) = SOME t2 /\
         FLOOKUP t2.store AllocSize = SOME (Word (alloc_size k)) /\
-        state_rel c l1 l2 (s with <| locals := x; space := 0 |>) t2 [] locs``,
+        state_rel c l1 l2 (s with <| locals := x; space := 0 |>) t2 [] locs`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ Q.UNABBREV_TAC `t0` \\ full_simp_tac(srw_ss())[]
   \\ imp_res_tac (state_rel_call_env_push_env
@@ -2646,8 +2646,8 @@ val gc_lemma = prove(
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val gc_add_call_env = prove(
-  ``(case gc (push_env y NONE t5) of
+val gc_add_call_env = Q.prove(
+  `(case gc (push_env y NONE t5) of
      | NONE => (SOME Error,x)
      | SOME s' => case pop_env s' of
                   | NONE => (SOME Error, call_env [] s')
@@ -2656,7 +2656,7 @@ val gc_add_call_env = prove(
      | NONE => (SOME Error,x)
      | SOME s' => case pop_env s' of
                   | NONE => (SOME Error, call_env [] s')
-                  | SOME s' => f s') = (res,t)``,
+                  | SOME s' => f s') = (res,t)`,
   full_simp_tac(srw_ss())[wordSemTheory.gc_def,wordSemTheory.call_env_def,LET_DEF,
       wordSemTheory.push_env_def]
   \\ Cases_on `env_to_list y t5.permute` \\ full_simp_tac(srw_ss())[LET_DEF]
@@ -2664,10 +2664,10 @@ val gc_add_call_env = prove(
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[wordSemTheory.pop_env_def]);
 
-val has_space_state_rel = prove(
-  ``has_space (Word ((alloc_size k):'a word)) (r:('a,'ffi) state) = SOME T /\
+val has_space_state_rel = Q.prove(
+  `has_space (Word ((alloc_size k):'a word)) (r:('a,'ffi) state) = SOME T /\
     state_rel c l1 l2 s r [] locs ==>
-    state_rel c l1 l2 (s with space := k) r [] locs``,
+    state_rel c l1 l2 (s with space := k) r [] locs`,
   full_simp_tac(srw_ss())[state_rel_def] \\ srw_tac[][]
   \\ asm_exists_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[heap_in_memory_store_def,wordSemTheory.has_space_def]
@@ -2684,15 +2684,15 @@ val has_space_state_rel = prove(
   \\ full_simp_tac(srw_ss())[w2n_minus1] \\ rev_full_simp_tac(srw_ss())[]
   \\ `F` by decide_tac);
 
-val evaluate_IMP_inc_clock = prove(
-  ``evaluate (q,t) = (NONE,t1) ==>
-    evaluate (q,inc_clock ck t) = (NONE,inc_clock ck t1)``,
+val evaluate_IMP_inc_clock = Q.prove(
+  `evaluate (q,t) = (NONE,t1) ==>
+    evaluate (q,inc_clock ck t) = (NONE,inc_clock ck t1)`,
   srw_tac[][inc_clock_def] \\ match_mp_tac evaluate_add_clock
   \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_IMP_inc_clock_Ex = prove(
-  ``evaluate (q,t) = (SOME (Exception x y),t1) ==>
-    evaluate (q,inc_clock ck t) = (SOME (Exception x y),inc_clock ck t1)``,
+val evaluate_IMP_inc_clock_Ex = Q.prove(
+  `evaluate (q,t) = (SOME (Exception x y),t1) ==>
+    evaluate (q,inc_clock ck t) = (SOME (Exception x y),inc_clock ck t1)`,
   srw_tac[][inc_clock_def] \\ match_mp_tac evaluate_add_clock
   \\ full_simp_tac(srw_ss())[]);
 
@@ -2730,8 +2730,8 @@ val bytes_in_word_ADD_1_NOT_ZERO = Q.prove(
   \\ rfs [bytes_in_word_def,EVAL ``good_dimindex (:α)``,word_index]
   \\ rfs [bytes_in_word_def,EVAL ``good_dimindex (:α)``,word_index]);
 
-val alloc_lemma = store_thm("alloc_lemma",
-  ``state_rel c l1 l2 s (t:('a,'ffi)wordSem$state) [] locs /\
+val alloc_lemma = Q.store_thm("alloc_lemma",
+  `state_rel c l1 l2 s (t:('a,'ffi)wordSem$state) [] locs /\
     dataSem$cut_env names s.locals = SOME x /\
     alloc (alloc_size k) (adjust_set names)
         (t with locals := insert 1 (Word (alloc_size k)) t.locals) =
@@ -2740,7 +2740,7 @@ val alloc_lemma = store_thm("alloc_lemma",
     (q ≠ SOME NotEnoughSpace ⇒
      state_rel c l1 l2 (s with <|locals := x; space := k|>) r [] locs ∧
      alloc_size k <> -1w:'a word /\
-     q = NONE)``,
+     q = NONE)`,
   strip_tac
   \\ full_simp_tac(srw_ss())[wordSemTheory.alloc_def,
        LET_DEF,addressTheory.CONTAINER_def]
@@ -2780,10 +2780,10 @@ val alloc_lemma = store_thm("alloc_lemma",
   \\ rfs [WORD_LEFT_ADD_DISTRIB,GSYM word_add_n2w,w2n_minus_1_LESS_EQ]
   \\ rfs [bytes_in_word_ADD_1_NOT_ZERO])
 
-val evaluate_GiveUp = store_thm("evaluate_GiveUp",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
+val evaluate_GiveUp = Q.store_thm("evaluate_GiveUp",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ==>
     ?r. evaluate (GiveUp,t) = (SOME NotEnoughSpace,r) /\
-        r.ffi = s.ffi /\ t.ffi = s.ffi``,
+        r.ffi = s.ffi /\ t.ffi = s.ffi`,
   fs [GiveUp_def,wordSemTheory.evaluate_def,wordSemTheory.word_exp_def]
   \\ strip_tac
   \\ Cases_on `alloc (-1w) (insert 0 () LN) (set_var 1 (Word (-1w)) t)
@@ -2849,8 +2849,8 @@ val get_vars_3_IMP = Q.store_thm("get_vars_3_IMP",
     get_var x3 s = SOME v3`,
   fs [wordSemTheory.get_vars_def] \\ every_case_tac \\ fs []);
 
-val memory_rel_get_vars_IMP = prove(
-  ``memory_rel c be s.refs sp st m dm
+val memory_rel_get_vars_IMP = Q.prove(
+  `memory_rel c be s.refs sp st m dm
      (join_env s.locals
         (toAList (inter t.locals (adjust_set s.locals))) ++ envs) ∧
     get_vars n (s:'ffi dataSem$state).locals = SOME x ∧
@@ -2858,18 +2858,18 @@ val memory_rel_get_vars_IMP = prove(
     memory_rel c be s.refs sp st m dm
       (ZIP (x,w) ++
        join_env s.locals
-         (toAList (inter t.locals (adjust_set s.locals))) ++ envs)``,
+         (toAList (inter t.locals (adjust_set s.locals))) ++ envs)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ drule word_ml_inv_get_vars_IMP \\ fs []);
 
-val memory_rel_insert = prove(
-  ``memory_rel c be refs sp st m dm
+val memory_rel_insert = Q.prove(
+  `memory_rel c be refs sp st m dm
      ([(x,w)] ++ join_env d (toAList (inter l (adjust_set d))) ++ xs) ⇒
     memory_rel c be refs sp st m dm
      (join_env (insert dest x d)
         (toAList
            (inter (insert (adjust_var dest) w l)
-              (adjust_set (insert dest x d)))) ++ xs)``,
+              (adjust_set (insert dest x d)))) ++ xs)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ match_mp_tac word_ml_inv_insert \\ fs []);
 
@@ -2905,12 +2905,12 @@ val reorder_lemma = Q.prove(
     memory_rel c be x.refs x.space t.store t.memory t.mdomain (x3::x1::x2::xs)`,
   match_mp_tac memory_rel_rearrange \\ fs [] \\ rw [] \\ fs []);
 
-val evaluate_StoreEach = store_thm("evaluate_StoreEach",
-  ``!xs ys t offset m1.
+val evaluate_StoreEach = Q.store_thm("evaluate_StoreEach",
+  `!xs ys t offset m1.
       store_list (a + offset) ys t.memory t.mdomain = SOME m1 /\
       get_vars xs t = SOME ys /\
       get_var i t = SOME (Word a) ==>
-      evaluate (StoreEach i xs offset, t) = (NONE,t with memory := m1)``,
+      evaluate (StoreEach i xs offset, t) = (NONE,t with memory := m1)`,
   Induct
   \\ fs [store_list_def,StoreEach_def] \\ eval_tac
   \\ fs [wordSemTheory.state_component_equality,
@@ -2972,9 +2972,9 @@ val word_less_lemma1 = Q.prove(
   `v2 < (v1:'a word) <=> ~(v1 <= v2)`,
   metis_tac [WORD_NOT_LESS]);
 
-val heap_in_memory_store_IMP_UPDATE = prove(
-  ``heap_in_memory_store heap a sp c st m dm l ==>
-    heap_in_memory_store heap a sp c (st |+ (Globals,h)) m dm l``,
+val heap_in_memory_store_IMP_UPDATE = Q.prove(
+  `heap_in_memory_store heap a sp c st m dm l ==>
+    heap_in_memory_store heap a sp c (st |+ (Globals,h)) m dm l`,
   fs [heap_in_memory_store_def,FLOOKUP_UPDATE]);
 
 val get_vars_2_imp = Q.prove(
@@ -2992,23 +2992,23 @@ val LESS_DIV_16_IMP = Q.prove(
   `n < k DIV 16 ==> 16 * n + 2 < k:num`,
   fs [X_LT_DIV]);
 
-val word_exp_real_addr = prove(
-  ``get_real_addr c t.store ptr_w = SOME a /\
+val word_exp_real_addr = Q.prove(
+  `get_real_addr c t.store ptr_w = SOME a /\
     shift_length c < dimindex (:α) ∧ good_dimindex (:α) /\
     lookup (adjust_var a1) (t:('a,'ffi) wordSem$state).locals = SOME (Word ptr_w) ==>
     !w. word_exp (t with locals := insert 1 (Word (w:'a word)) t.locals)
-          (real_addr c (adjust_var a1)) = SOME (Word a)``,
+          (real_addr c (adjust_var a1)) = SOME (Word a)`,
   rpt strip_tac \\ match_mp_tac (GEN_ALL get_real_addr_lemma)
   \\ fs [wordSemTheory.get_var_def,lookup_insert])
 
-val word_exp_real_addr_2 = prove(
-  ``get_real_addr c (t:('a,'ffi) wordSem$state).store ptr_w = SOME a /\
+val word_exp_real_addr_2 = Q.prove(
+  `get_real_addr c (t:('a,'ffi) wordSem$state).store ptr_w = SOME a /\
     shift_length c < dimindex (:α) ∧ good_dimindex (:α) /\
     lookup (adjust_var a1) t.locals = SOME (Word ptr_w) ==>
     !w1 w2.
       word_exp
         (t with locals := insert 3 (Word (w1:'a word)) (insert 1 (Word w2) t.locals))
-        (real_addr c (adjust_var a1)) = SOME (Word a)``,
+        (real_addr c (adjust_var a1)) = SOME (Word a)`,
   rpt strip_tac \\ match_mp_tac (GEN_ALL get_real_addr_lemma)
   \\ fs [wordSemTheory.get_var_def,lookup_insert])
 
@@ -3079,12 +3079,12 @@ val get_vars_termdep = Q.store_thm("get_vars_termdep[simp]",
   `!xs. get_vars xs (t with termdep := t.termdep - 1) = get_vars xs t`,
   Induct \\ EVAL_TAC \\ rw [] \\ every_case_tac \\ fs []);
 
-val lookup_RefByte_location = prove(
-  ``state_rel c l1 l2 x t [] locs ==>
+val lookup_RefByte_location = Q.prove(
+  `state_rel c l1 l2 x t [] locs ==>
     lookup RefByte_location t.code = SOME (3,RefByte_code c) /\
     lookup RefArray_location t.code = SOME (3,RefArray_code c) /\
     lookup FromList_location t.code = SOME (4,FromList_code c) /\
-    lookup Replicate_location t.code = SOME (5,Replicate_code)``,
+    lookup Replicate_location t.code = SOME (5,Replicate_code)`,
   fs [state_rel_def,code_rel_def,stubs_def]);
 
 val word_exp_rw = LIST_CONJ
@@ -3154,8 +3154,8 @@ val shift_lsl = Q.store_thm("shift_lsl",
   rw [labPropsTheory.good_dimindex_def,shift_def,bytes_in_word_def]
   \\ fs [WORD_MUL_LSL]);
 
-val AllocVar_thm = store_thm("AllocVar_thm",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ∧
+val AllocVar_thm = Q.store_thm("AllocVar_thm",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs ∧
     dataSem$cut_env names s.locals = SOME x ∧
     get_var 1 t = SOME (Word w) /\
     evaluate (AllocVar limit names,t) = (q,r) /\
@@ -3164,7 +3164,7 @@ val AllocVar_thm = store_thm("AllocVar_thm",
     (q ≠ SOME NotEnoughSpace ⇒
       w2n w DIV 4 < limit /\
       state_rel c l1 l2 (s with <|locals := x; space := w2n w DIV 4 + 1|>) r [] locs ∧
-      q = NONE)``,
+      q = NONE)`,
   fs [wordSemTheory.evaluate_def,AllocVar_def,list_Seq_def] \\ strip_tac
   \\ `limit < dimword (:'a)` by
         (rfs [EVAL ``good_dimindex (:'a)``,state_rel_def,dimword_def])
@@ -3230,18 +3230,18 @@ val set_vars_sing = Q.store_thm("set_vars_sing",
   `set_vars [n] [w] t = set_var n w t`,
   EVAL_TAC);
 
-val memory_rel_lookup = store_thm("memory_rel_lookup",
-  ``memory_rel c be refs s st m dm
+val memory_rel_lookup = Q.store_thm("memory_rel_lookup",
+  `memory_rel c be refs s st m dm
       (join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs) ∧
     lookup n l1 = SOME x ∧ lookup (adjust_var n) l2 = SOME w ⇒
     memory_rel c be refs s st m dm
-     ((x,w)::(join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs))``,
+     ((x,w)::(join_env l1 (toAList (inter l2 (adjust_set l1))) ++ xs))`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ rpt_drule (Q.INST [`ys`|->`[]`] word_ml_inv_lookup
         |> SIMP_RULE std_ss [APPEND]));
 
-val Replicate_code_thm = store_thm("Replicate_code_thm",
-  ``!n a r m1 a1 a2 a3 a4 a5.
+val Replicate_code_thm = Q.store_thm("Replicate_code_thm",
+  `!n a r m1 a1 a2 a3 a4 a5.
       lookup Replicate_location r.code = SOME (5,Replicate_code) /\
       store_list (a + bytes_in_word) (REPLICATE n v)
         (r:('a,'ffi) wordSem$state).memory r.mdomain = SOME m1 /\
@@ -3254,7 +3254,7 @@ val Replicate_code_thm = store_thm("Replicate_code_thm",
       n < r.clock ==>
       evaluate (Call NONE (SOME Replicate_location) [a1;a2;a3;a4;a5] NONE,r) =
         (SOME (Result (Loc l1 l2) ret_val),
-         r with <| memory := m1 ; clock := r.clock - n - 1; locals := LN |>)``,
+         r with <| memory := m1 ; clock := r.clock - n - 1; locals := LN |>)`,
   Induct \\ rw [] \\ simp [wordSemTheory.evaluate_def]
   \\ simp [wordSemTheory.get_vars_def,wordSemTheory.bad_dest_args_def,
         wordSemTheory.find_code_def,wordSemTheory.add_ret_loc_def]
@@ -3297,8 +3297,8 @@ val FOUR_MUL_LSL = Q.store_thm("FOUR_MUL_LSL",
   `n2w (4 * i) << k = n2w i << (k + 2)`,
   fs [WORD_MUL_LSL,EXP_ADD,word_mul_n2w]);
 
-val RefArray_thm = store_thm("RefArray_thm",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
+val RefArray_thm = Q.store_thm("RefArray_thm",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
     get_vars [0;1] s.locals = SOME vals /\
     t.clock = dimword (:'a) - 1 /\
     do_app RefArray vals s = Rval (v,s2) ==>
@@ -3309,7 +3309,7 @@ val RefArray_thm = store_thm("RefArray_thm",
       else
         ?rv. q = SOME (Result (Loc l1 l2) rv) /\
              state_rel c r1 r2 (s2 with <| locals := LN; clock := new_c |>)
-                r [(v,rv)] locs``,
+                r [(v,rv)] locs`,
   fs [RefArray_code_def]
   \\ fs [do_app_def,do_space_def,EVAL ``op_space_reset RefArray``,
          bviSemTheory.do_app_def,bvlSemTheory.do_app_def,
@@ -3501,12 +3501,12 @@ val word_exp_SmallLsr = Q.store_thm("word_exp_SmallLsr",
     \\ Cases_on `x` \\ fs [])
   \\ fs [word_exp_rw] \\ every_case_tac \\ fs []  );
 
-val evaluate_MakeBytes = store_thm("evaluate_MakeBytes",
-  ``good_dimindex (:'a) ==>
+val evaluate_MakeBytes = Q.store_thm("evaluate_MakeBytes",
+  `good_dimindex (:'a) ==>
     evaluate (MakeBytes n,s) =
       case get_var n s of
       | SOME (Word w) => (NONE,set_var n (Word (word_of_byte ((w:'a word) >>> 2))) s)
-      | _ => (SOME Error,s)``,
+      | _ => (SOME Error,s)`,
   fs [MakeBytes_def,list_Seq_def,wordSemTheory.evaluate_def,word_exp_rw,
       wordSemTheory.get_var_def] \\ strip_tac
   \\ Cases_on `lookup n s.locals` \\ fs []
@@ -3521,8 +3521,8 @@ val w2w_shift_shift = Q.store_thm("w2w_shift_shift",
       word_lsl_def,word_lsr_def,fcpTheory.FCP_BETA,w2w]
   \\ rw [] \\ fs [] \\ EQ_TAC \\ rw [] \\ rfs [fcpTheory.FCP_BETA,w2w]);
 
-val RefByte_thm = store_thm("RefByte_thm",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
+val RefByte_thm = Q.store_thm("RefByte_thm",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
     get_vars [0;1] s.locals = SOME vals /\
     t.clock = dimword (:'a) - 1 /\
     do_app RefByte vals s = Rval (v,s2) ==>
@@ -3533,7 +3533,7 @@ val RefByte_thm = store_thm("RefByte_thm",
       else
         ?rv. q = SOME (Result (Loc l1 l2) rv) /\
              state_rel c r1 r2 (s2 with <| locals := LN; clock := new_c |>)
-                r [(v,rv)] locs``,
+                r [(v,rv)] locs`,
   fs [RefByte_code_def]
   \\ fs [do_app_def,do_space_def,EVAL ``op_space_reset RefByte``,
          bviSemTheory.do_app_def,bvlSemTheory.do_app_def,
@@ -3749,8 +3749,8 @@ val RefByte_thm = store_thm("RefByte_thm",
   \\ fs [GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ fs [WORD_MUL_LSL,word_mul_n2w]);
 
-val FromList1_code_thm = store_thm("Replicate_code_thm",
-  ``!k a b r x m1 a1 a2 a3 a4 a5 a6.
+val FromList1_code_thm = Q.store_thm("Replicate_code_thm",
+  `!k a b r x m1 a1 a2 a3 a4 a5 a6.
       lookup FromList1_location r.code = SOME (6,FromList1_code c) /\
       copy_list c r.store k (a,x,b,(r:('a,'ffi) wordSem$state).memory,
         r.mdomain) = SOME (b1,m1) /\
@@ -3766,7 +3766,7 @@ val FromList1_code_thm = store_thm("Replicate_code_thm",
       evaluate (Call NONE (SOME FromList1_location) [a1;a2;a3;a4;a5;a6] NONE,r) =
         (SOME (Result (Loc l1 l2) ret_val),
          r with <| memory := m1 ; clock := r.clock - k - 1; locals := LN ;
-                   store := r.store |+ (NextFree, Word b1) |>)``,
+                   store := r.store |+ (NextFree, Word b1) |>)`,
   Induct \\ rw [] \\ simp [wordSemTheory.evaluate_def]
   \\ simp [wordSemTheory.get_vars_def,wordSemTheory.bad_dest_args_def,
         wordSemTheory.find_code_def,wordSemTheory.add_ret_loc_def]
@@ -3820,10 +3820,10 @@ val FromList1_code_thm = store_thm("Replicate_code_thm",
   \\ fs [wordSemTheory.get_var_def,lookup_insert]
   \\ fs [MULT_CLAUSES,GSYM word_add_n2w]);
 
-val state_rel_IMP_test_zero = store_thm("state_rel_IMP_test_zero",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) vs locs /\
+val state_rel_IMP_test_zero = Q.store_thm("state_rel_IMP_test_zero",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) vs locs /\
     get_var i s.locals = SOME (Number n) ==>
-    ?w. get_var (adjust_var i) t = SOME (Word w) /\ (w = 0w <=> (n = 0))``,
+    ?w. get_var (adjust_var i) t = SOME (Word w) /\ (w = 0w <=> (n = 0))`,
   strip_tac
   \\ rpt_drule state_rel_get_var_IMP
   \\ strip_tac \\ fs []
@@ -3869,20 +3869,20 @@ val EXP_LEMMA1 = Q.prove(
   `4n * n * (2 ** k) = n * 2 ** (k + 2)`,
   fs [EXP_ADD]);
 
-val evaluate_Maxout_bits_code = prove(
-  ``n_reg <> dest /\ n < dimword (:'a) /\ rep_len < dimindex (:α) /\
+val evaluate_Maxout_bits_code = Q.prove(
+  `n_reg <> dest /\ n < dimword (:'a) /\ rep_len < dimindex (:α) /\
     k < dimindex (:'a) /\
     lookup n_reg (t:('a,'ffi) wordSem$state).locals = SOME (Word (n2w n:'a word)) ==>
     evaluate (Maxout_bits_code rep_len k dest n_reg,set_var dest (Word w) t) =
-      (NONE,set_var dest (Word (w || maxout_bits n rep_len k)) t)``,
+      (NONE,set_var dest (Word (w || maxout_bits n rep_len k)) t)`,
   fs [Maxout_bits_code_def,wordSemTheory.evaluate_def,wordSemTheory.get_var_def,
       wordSemTheory.set_var_def,wordSemTheory.get_var_imm_def,
       asmSemTheory.word_cmp_def,lookup_insert,WORD_LO,word_exp_rw,
       maxout_bits_def] \\ rw [] \\ fs [insert_shadow]
   \\ `2 ** rep_len < dimword (:α)` by all_tac \\ fs [] \\ fs [dimword_def]);
 
-val Make_ptr_bits_thm = store_thm("Make_ptr_bits_thm",
-  ``tag_reg ≠ dest ∧ tag1 < dimword (:α) ∧ c.tag_bits < dimindex (:α) ∧
+val Make_ptr_bits_thm = Q.store_thm("Make_ptr_bits_thm",
+  `tag_reg ≠ dest ∧ tag1 < dimword (:α) ∧ c.tag_bits < dimindex (:α) ∧
     len_reg ≠ dest ∧ len1 < dimword (:α) ∧ c.len_bits < dimindex (:α) ∧
     c.len_bits + 1 < dimindex (:α) /\
     FLOOKUP (t:('a,'ffi) wordSem$state).store NextFree = SOME (Word f) /\
@@ -3892,7 +3892,7 @@ val Make_ptr_bits_thm = store_thm("Make_ptr_bits_thm",
     shift_length c < dimindex (:α) + shift (:α) ==>
     ?t1.
       evaluate (Make_ptr_bits_code c tag_reg len_reg dest,t) =
-        (NONE,set_var dest (make_cons_ptr c (f-d) tag1 len1:'a word_loc) t)``,
+        (NONE,set_var dest (make_cons_ptr c (f-d) tag1 len1:'a word_loc) t)`,
   fs [Make_ptr_bits_code_def,list_Seq_def,wordSemTheory.evaluate_def,word_exp_rw]
   \\ fs [make_cons_ptr_thm] \\ strip_tac
   \\ pairarg_tac \\ fs []
@@ -3905,8 +3905,8 @@ val Make_ptr_bits_thm = store_thm("Make_ptr_bits_thm",
   \\ pop_assum (qspec_then `len1` mp_tac) \\ fs [] \\ rw []
   \\ fs [ptr_bits_def]);
 
-val FromList_thm = store_thm("FromList_thm",
-  ``state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
+val FromList_thm = Q.store_thm("FromList_thm",
+  `state_rel c l1 l2 s (t:('a,'ffi) wordSem$state) [] locs /\
     encode_header c (4 * tag) 0 <> (NONE:'a word option) /\
     get_vars [0; 1; 2] s.locals = SOME [v1; v2; Number (&(4 * tag))] /\
     t.clock = dimword (:'a) - 1 /\
@@ -3918,7 +3918,7 @@ val FromList_thm = store_thm("FromList_thm",
       else
         ?rv. q = SOME (Result (Loc l1 l2) rv) /\
              state_rel c r1 r2 (s2 with <| locals := LN; clock := new_c |>)
-                r [(v,rv)] locs``,
+                r [(v,rv)] locs`,
   fs [dataSemTheory.do_app_def,bviSemTheory.do_app_def,
       bviSemTheory.do_app_aux_def,dataSemTheory.do_space_def,
       bvi_to_dataTheory.op_space_reset_def]
@@ -6452,8 +6452,8 @@ val assign_thm = Q.store_thm("assign_thm",
 
 val none = ``NONE:(num # ('a wordLang$prog) # num # num) option``
 
-val data_compile_correct = store_thm("data_compile_correct",
-  ``!prog (s:'ffi dataSem$state) c n l l1 l2 res s1 (t:('a,'ffi)wordSem$state) locs.
+val data_compile_correct = Q.store_thm("data_compile_correct",
+  `!prog (s:'ffi dataSem$state) c n l l1 l2 res s1 (t:('a,'ffi)wordSem$state) locs.
       (dataSem$evaluate (prog,s) = (res,s1)) /\
       res <> SOME (Rerr (Rabort Rtype_error)) /\
       state_rel c l1 l2 s t [] locs /\
@@ -6477,7 +6477,7 @@ val data_compile_correct = store_thm("data_compile_correct",
                 LASTN (LENGTH s1.stack + 1) locs = (l5,l6)::ll /\
                 !i. state_rel c l5 l6 (set_var i v s1)
                        (set_var (adjust_var i) w t1) [] ll)
-         | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)``,
+         | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)`,
   recInduct dataSemTheory.evaluate_ind \\ rpt strip_tac \\ full_simp_tac(srw_ss())[]
   THEN1 (* Skip *)
    (full_simp_tac(srw_ss())[comp_def,dataSemTheory.evaluate_def,wordSemTheory.evaluate_def]
@@ -6781,8 +6781,8 @@ val data_compile_correct = store_thm("data_compile_correct",
     \\ imp_res_tac s_key_eq_handler_eq_IMP
     \\ full_simp_tac(srw_ss())[jump_exc_inc_clock_EQ_NONE] \\ metis_tac []));
 
-val compile_correct_lemma = store_thm("compile_correct_lemma",
-  ``!(s:'ffi dataSem$state) c l1 l2 res s1 (t:('a,'ffi)wordSem$state) start.
+val compile_correct_lemma = Q.store_thm("compile_correct_lemma",
+  `!(s:'ffi dataSem$state) c l1 l2 res s1 (t:('a,'ffi)wordSem$state) start.
       (dataSem$evaluate (Call NONE (SOME start) [] NONE,s) = (res,s1)) /\
       res <> SOME (Rerr (Rabort Rtype_error)) /\
       t.termdep > 0 /\
@@ -6798,7 +6798,7 @@ val compile_correct_lemma = store_thm("compile_correct_lemma",
         | SOME (Rval v) => t1.ffi = s1.ffi /\
                            ?w. (res1 = SOME (Result (Loc l1 l2) w))
         | SOME (Rerr (Rraise v)) => (?v w. res1 = SOME (Exception v w))
-        | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)``,
+        | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)`,
   rpt strip_tac
   \\ drule data_compile_correct \\ full_simp_tac(srw_ss())[]
   \\ ntac 2 (disch_then drule) \\ full_simp_tac(srw_ss())[comp_def]
@@ -6819,8 +6819,8 @@ val state_rel_ext_def = Define `
              lookup n l = SOME (SND (full_compile_single t' k' a' c' ((n,v),col)))) /\
       u = t with <|code := l;termdep:=0|>`
 
-val compile_correct = store_thm("compile_correct",
-  ``!x (s:'ffi dataSem$state) l1 l2 res s1 (t:('a,'ffi)wordSem$state) start.
+val compile_correct = Q.store_thm("compile_correct",
+  `!x (s:'ffi dataSem$state) l1 l2 res s1 (t:('a,'ffi)wordSem$state) start.
       (dataSem$evaluate (Call NONE (SOME start) [] NONE,s) = (res,s1)) /\
       res <> SOME (Rerr (Rabort Rtype_error)) /\
       state_rel_ext x l1 l2 s t ==>
@@ -6836,7 +6836,7 @@ val compile_correct = store_thm("compile_correct",
          | SOME (Rval v) => t1.ffi = s1.ffi /\
                             ?w. (res1 = SOME (Result (Loc l1 l2) w))
          | SOME (Rerr (Rraise v)) => (?v w. res1 = SOME (Exception v w))
-         | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)``,
+         | SOME (Rerr (Rabort e)) => (res1 = SOME TimeOut) /\ t1.ffi = s1.ffi)`,
   gen_tac
   \\ full_simp_tac(srw_ss())[state_rel_ext_def,PULL_EXISTS] \\ srw_tac[][]
   \\ rename1 `state_rel x0 l1 l2 s t [] []`
@@ -7179,13 +7179,13 @@ val compile_semantics = save_thm("compile_semantics",let
          |> UNDISCH
          |> REWRITE_RULE [AND_IMP_INTRO,GSYM CONJ_ASSOC] end);
 
-val data_to_word_lab_pres_lem = prove(``
+val data_to_word_lab_pres_lem = Q.prove(`
   ∀c n l p.
   l ≠ 0 ⇒
   let (cp,l') = comp c n l p in
   l ≤ l' ∧
   EVERY (λ(l1,l2). l1 = n ∧ l ≤ l2 ∧ l2 < l') (extract_labels cp) ∧
-  ALL_DISTINCT (extract_labels cp)``,
+  ALL_DISTINCT (extract_labels cp)`,
   HO_MATCH_MP_TAC comp_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac[comp_def]>>fs[extract_labels_def]
   >-
@@ -7213,13 +7213,13 @@ val data_to_word_lab_pres_lem = prove(``
 
 open match_goal
 
-val data_to_word_compile_lab_pres = store_thm("data_to_word_compile_lab_pres",``
+val data_to_word_compile_lab_pres = Q.store_thm("data_to_word_compile_lab_pres",`
   let (c,p) = compile data_conf word_conf asm_conf prog in
     MAP FST p = MAP FST (stubs(:α) data_conf) ++ MAP FST prog ∧
     EVERY (λn,m,(p:α wordLang$prog).
       let labs = extract_labels p in
       EVERY (λ(l1,l2).l1 = n ∧ l2 ≠ 0) labs ∧
-      ALL_DISTINCT labs) p``,
+      ALL_DISTINCT labs) p`,
   fs[compile_def]>>
   qpat_abbrev_tac`datap = _ ++ MAP (A B) prog`>>
   assume_tac (compile_to_word_conventions |>GEN_ALL |> Q.SPECL [`word_conf`,`datap`,`asm_conf`])>>

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -7112,7 +7112,7 @@ val compile_semantics_lemma = Q.store_thm("compile_semantics_lemma",
     strip_tac >> full_simp_tac(srw_ss())[] >>
     rveq >>
     rpt(first_x_assum(qspec_then`k+ck`mp_tac)>>simp[]) ) >>
-  (fn g => subterm (fn tm => Cases_on`^(replace_term(#1(dest_exists(#2 g)))(``k:num``)(assert(has_pair_type)tm))`) (#2 g) g) >>
+    (fn g => subterm (fn tm => Cases_on`^(Term.subst [{redex = #1(dest_exists(#2 g)), residue = ``k:num``}] (assert(has_pair_type)tm))`) (#2 g) g) >>
   drule compile_correct >>
   simp[GSYM AND_IMP_INTRO,RIGHT_FORALL_IMP_THM] >>
   impl_tac >- (

--- a/compiler/backend/proofs/data_to_wordPropsScript.sml
+++ b/compiler/backend/proofs/data_to_wordPropsScript.sml
@@ -105,8 +105,8 @@ val Word64Rep_DataElement = Q.store_thm("Word64Rep_DataElement",
   `∀a w. ∃ws. (Word64Rep a w:'a ml_el) = DataElement [] (LENGTH ws) (Word64Tag,ws)`,
   Cases \\ rw[Word64Rep_def]);
 
-val v_size_LEMMA = prove(
-  ``!vs v. MEM v vs ==> v_size v <= v1_size vs``,
+val v_size_LEMMA = Q.prove(
+  `!vs v. MEM v vs ==> v_size v <= v1_size vs`,
   Induct \\ full_simp_tac (srw_ss()) [v_size_def]
   \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss [] \\ DECIDE_TAC);
 
@@ -201,45 +201,45 @@ val theWord_def = Define `
 val isWord_def = Define `
   (isWord (Word w) = T) /\ (isWord _ = F)`;
 
-val word_bit_test = store_thm("word_bit_test",
-  ``word_bit n w <=> ((w && n2w (2 ** n)) <> 0w:'a word)``,
+val word_bit_test = Q.store_thm("word_bit_test",
+  `word_bit n w <=> ((w && n2w (2 ** n)) <> 0w:'a word)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss]
     [wordsTheory.word_index, DECIDE ``0n < d ==> (n <= d - 1) = (n < d)``])
 
-val MOD_EQ_0_0 = store_thm("MOD_EQ_0_0",
-  ``∀n b. 0 < b ⇒ (n MOD b = 0) ⇒ n < b ⇒ (n = 0)``,
+val MOD_EQ_0_0 = Q.store_thm("MOD_EQ_0_0",
+  `∀n b. 0 < b ⇒ (n MOD b = 0) ⇒ n < b ⇒ (n = 0)`,
   rw[MOD_EQ_0_DIVISOR] >> Cases_on`d`>>fs[])
 
 val EVERY2_IMP_EVERY = store_thm("EVERY2_IMP_EVERY",
   ``!xs ys. EVERY2 P xs ys ==> EVERY (\(x,y). P y x) (ZIP(ys,xs))``,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[]);
 
-val EVERY2_IMP_EVERY2 = store_thm("EVERY2_IMP_EVERY2",
-  ``!xs ys P1 P2.
+val EVERY2_IMP_EVERY2 = Q.store_thm("EVERY2_IMP_EVERY2",
+  `!xs ys P1 P2.
       (!x y. MEM x xs /\ MEM y ys /\ P1 x y ==> P2 x y) ==>
-      EVERY2 P1 xs ys ==> EVERY2 P2 xs ys``,
+      EVERY2 P1 xs ys ==> EVERY2 P2 xs ys`,
   Induct \\ Cases_on `ys` \\ full_simp_tac (srw_ss()) []
   \\ rpt strip_tac \\ metis_tac []);
 
-val EVERY2_APPEND_IMP = store_thm("EVERY2_APPEND_IMP",
-  ``!xs1 xs2 ys.
+val EVERY2_APPEND_IMP = Q.store_thm("EVERY2_APPEND_IMP",
+  `!xs1 xs2 ys.
       EVERY2 P (xs1 ++ xs2) ys ==>
-      ?ys1 ys2. (ys = ys1 ++ ys2) /\ EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2``,
+      ?ys1 ys2. (ys = ys1 ++ ys2) /\ EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2`,
   Induct \\ full_simp_tac (srw_ss()) []
   \\ Cases_on `ys` \\ full_simp_tac (srw_ss()) [] \\ rpt strip_tac
   \\ res_tac \\ metis_tac [LIST_REL_def,APPEND]);
 
-val MEM_EVERY2_IMP = store_thm("MEM_EVERY2_IMP",
-  ``!l x zs P. MEM x l /\ EVERY2 P zs l ==> ?z. MEM z zs /\ P z x``,
+val MEM_EVERY2_IMP = Q.store_thm("MEM_EVERY2_IMP",
+  `!l x zs P. MEM x l /\ EVERY2 P zs l ==> ?z. MEM z zs /\ P z x`,
   Induct \\ Cases_on `zs` \\ full_simp_tac (srw_ss()) [] \\ metis_tac []);
 
 val EVERY2_LENGTH = LIST_REL_LENGTH
 val EVERY2_IMP_LENGTH = EVERY2_LENGTH
 
-val EVERY2_APPEND_CONS = store_thm("EVERY2_APPEND_CONS",
-  ``!xs y ys zs P. EVERY2 P (xs ++ y::ys) zs ==>
+val EVERY2_APPEND_CONS = Q.store_thm("EVERY2_APPEND_CONS",
+  `!xs y ys zs P. EVERY2 P (xs ++ y::ys) zs ==>
                    ?t1 t t2. (zs = t1 ++ t::t2) /\ (LENGTH t1 = LENGTH xs) /\
-                             EVERY2 P xs t1 /\ P y t /\ EVERY2 P ys t2``,
+                             EVERY2 P xs t1 /\ P y t /\ EVERY2 P ys t2`,
   Induct \\ full_simp_tac (srw_ss()) []
   \\ Cases_on `zs` \\ full_simp_tac (srw_ss()) []
   \\ rpt strip_tac
@@ -247,14 +247,14 @@ val EVERY2_APPEND_CONS = store_thm("EVERY2_APPEND_CONS",
   \\ Q.LIST_EXISTS_TAC [`h::t1`,`t'`,`t2`]
   \\ full_simp_tac (srw_ss()) []);
 
-val EVERY2_SWAP = store_thm("EVERY2_SWAP",
-  ``!xs ys. EVERY2 P xs ys ==> EVERY2 (\y x. P x y) ys xs``,
+val EVERY2_SWAP = Q.store_thm("EVERY2_SWAP",
+  `!xs ys. EVERY2 P xs ys ==> EVERY2 (\y x. P x y) ys xs`,
   Induct \\ Cases_on `ys` \\ full_simp_tac (srw_ss()) []);
 
-val EVERY2_APPEND_IMP_APPEND = store_thm("EVERY2_APPEND_IMP_APPEND",
-  ``!xs1 xs2 ys P.
+val EVERY2_APPEND_IMP_APPEND = Q.store_thm("EVERY2_APPEND_IMP_APPEND",
+  `!xs1 xs2 ys P.
       EVERY2 P (xs1 ++ xs2) ys ==>
-      ?ys1 ys2. (ys = ys1 ++ ys2) /\ EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2``,
+      ?ys1 ys2. (ys = ys1 ++ ys2) /\ EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2`,
   Induct \\ Cases_on `ys` \\ full_simp_tac (srw_ss()) [] \\ rpt strip_tac
   \\ res_tac \\ full_simp_tac std_ss []
   \\ Q.LIST_EXISTS_TAC [`h::ys1`,`ys2`]
@@ -272,47 +272,47 @@ val EVERY2_MAP_FST_SND = prove(
   ``!xs. EVERY2 P (MAP FST xs) (MAP SND xs) = EVERY (\(x,y). P x y) xs``,
   Induct \\ srw_tac [] [LIST_REL_def] \\ Cases_on `h` \\ srw_tac [] []);
 
-val fapply_fupdate_update = store_thm("fapply_fupdate_update",
-  ``$' (f |+ p) = (FST p =+ SND p) ($' f)``,
+val fapply_fupdate_update = Q.store_thm("fapply_fupdate_update",
+  `$' (f |+ p) = (FST p =+ SND p) ($' f)`,
   Cases_on`p`>>
   simp[FUN_EQ_THM,FAPPLY_FUPDATE_THM,APPLY_UPDATE_THM] >> rw[])
 
-val heap_lookup_APPEND1 = prove(
-  ``∀h1 z h2.
+val heap_lookup_APPEND1 = Q.prove(
+  `∀h1 z h2.
     heap_length h1 ≤ z ⇒
-    (heap_lookup z (h1 ++ h2) = heap_lookup (z - heap_length h1) h2)``,
+    (heap_lookup z (h1 ++ h2) = heap_lookup (z - heap_length h1) h2)`,
   Induct >>fs[heap_lookup_def,heap_length_def] >> rw[] >> simp[]
   >> fsrw_tac[ARITH_ss][] >> Cases_on`h`>>fs[el_length_def])
 
-val heap_lookup_APPEND2 = prove(
-  ``∀h1 z h2.
+val heap_lookup_APPEND2 = Q.prove(
+  `∀h1 z h2.
     z < heap_length h1 ⇒
-    (heap_lookup z (h1 ++ h2) = heap_lookup z h1)``,
+    (heap_lookup z (h1 ++ h2) = heap_lookup z h1)`,
   Induct >> fs[heap_lookup_def,heap_length_def] >> rw[] >>
   simp[])
 
-val heap_lookup_APPEND = store_thm("heap_lookup_APPEND",
-  ``heap_lookup a (h1 ++ h2) =
+val heap_lookup_APPEND = Q.store_thm("heap_lookup_APPEND",
+  `heap_lookup a (h1 ++ h2) =
     if a < heap_length h1 then
     heap_lookup a h1 else
-    heap_lookup (a-heap_length h1) h2``,
+    heap_lookup (a-heap_length h1) h2`,
   rw[heap_lookup_APPEND2] >>
   simp[heap_lookup_APPEND1])
 
 (* Prove refinement is maintained past GC calls *)
 
-val LENGTH_ADDR_MAP = prove(
-  ``!xs f. LENGTH (ADDR_MAP f xs) = LENGTH xs``,
+val LENGTH_ADDR_MAP = Q.prove(
+  `!xs f. LENGTH (ADDR_MAP f xs) = LENGTH xs`,
   Induct \\ TRY (Cases_on `h`) \\ srw_tac [] [ADDR_MAP_def]);
 
-val MEM_IMP_v_size = prove(
-  ``!l a. MEM a l ==> v_size a < 1 + v1_size l``,
+val MEM_IMP_v_size = Q.prove(
+  `!l a. MEM a l ==> v_size a < 1 + v1_size l`,
   Induct \\ full_simp_tac std_ss [MEM,v_size_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [] \\ res_tac \\ DECIDE_TAC);
 
-val EL_ADDR_MAP = prove(
-  ``!xs n f.
-      n < LENGTH xs ==> (EL n (ADDR_MAP f xs) = ADDR_APPLY f (EL n xs))``,
+val EL_ADDR_MAP = Q.prove(
+  `!xs n f.
+      n < LENGTH xs ==> (EL n (ADDR_MAP f xs) = ADDR_APPLY f (EL n xs))`,
   Induct \\ full_simp_tac (srw_ss()) [] \\ Cases_on `n` \\ Cases_on `h`
   \\ full_simp_tac (srw_ss()) [ADDR_MAP_def,ADDR_APPLY_def]);
 
@@ -377,9 +377,9 @@ val v_inv_related = prove(
      \\ `n IN FDOM (g f_o_f f)` by ALL_TAC \\ asm_simp_tac std_ss []
      \\ full_simp_tac (srw_ss()) [f_o_f_DEF,get_refs_def]));
 
-val EVERY2_ADDR_MAP = prove(
-  ``!zs l. EVERY2 P (ADDR_MAP g zs) l <=>
-           EVERY2 (\x y. P (ADDR_APPLY g x) y) zs l``,
+val EVERY2_ADDR_MAP = Q.prove(
+  `!zs l. EVERY2 P (ADDR_MAP g zs) l <=>
+           EVERY2 (\x y. P (ADDR_APPLY g x) y) zs l`,
   Induct \\ Cases_on `l`
   \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def] \\ Cases
   \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def,ADDR_APPLY_def]);
@@ -544,26 +544,26 @@ val heap_store_rel_def = Define `
     (!ptr. isSomeDataElement (heap_lookup ptr heap) ==>
            (heap_lookup ptr heap2 = heap_lookup ptr heap))`;
 
-val isSomeDataElement_heap_lookup_lemma1 = prove(
-  ``isSomeDataElement (heap_lookup n (Unused k :: xs)) <=>
-    k < n /\ isSomeDataElement (heap_lookup (n-(k+1)) xs)``,
+val isSomeDataElement_heap_lookup_lemma1 = Q.prove(
+  `isSomeDataElement (heap_lookup n (Unused k :: xs)) <=>
+    k < n /\ isSomeDataElement (heap_lookup (n-(k+1)) xs)`,
   srw_tac [] [heap_lookup_def,isSomeDataElement_def,el_length_def,NOT_LESS]
   THEN1 (DISJ1_TAC \\ DECIDE_TAC)
   \\ `k < n` by DECIDE_TAC \\ full_simp_tac std_ss []);
 
-val isSomeDataElement_heap_lookup_lemma2 = prove(
-  ``isSomeDataElement (heap_lookup n (heap_expand k ++ xs)) <=>
-    k <= n /\ isSomeDataElement (heap_lookup (n-k) xs)``,
+val isSomeDataElement_heap_lookup_lemma2 = Q.prove(
+  `isSomeDataElement (heap_lookup n (heap_expand k ++ xs)) <=>
+    k <= n /\ isSomeDataElement (heap_lookup (n-k) xs)`,
   srw_tac [] [heap_expand_def,isSomeDataElement_heap_lookup_lemma1]
   \\ imp_res_tac (DECIDE ``sp <> 0 ==> (sp - 1 + 1 = sp:num)``)
   \\ full_simp_tac std_ss []
   \\ Cases_on `isSomeDataElement (heap_lookup (n - k) xs)`
   \\ full_simp_tac std_ss [] \\ DECIDE_TAC);
 
-val isSomeDataElement_heap_lookup_lemma3 = prove(
-  ``n <> 0 ==>
+val isSomeDataElement_heap_lookup_lemma3 = Q.prove(
+  `n <> 0 ==>
     (isSomeDataElement (heap_lookup n (x::xs)) <=>
-     el_length x <= n /\ isSomeDataElement (heap_lookup (n - el_length x) xs))``,
+     el_length x <= n /\ isSomeDataElement (heap_lookup (n - el_length x) xs))`,
   srw_tac [] [heap_expand_def,heap_lookup_def,isSomeDataElement_def]
   \\ Cases_on`n < el_length x` THEN srw_tac[][]
   THEN1 (DISJ1_TAC \\ DECIDE_TAC)
@@ -775,9 +775,9 @@ val IMP_heap_store_unused_alt = prove(
   \\ rveq \\ fs []
   \\ rfs [GSYM SUB_PLUS]);
 
-val heap_store_rel_lemma = prove(
-  ``heap_store_rel h1 h2 /\ (heap_lookup n h1 = SOME (DataElement ys l d)) ==>
-    (heap_lookup n h2 = SOME (DataElement ys l d))``,
+val heap_store_rel_lemma = Q.prove(
+  `heap_store_rel h1 h2 /\ (heap_lookup n h1 = SOME (DataElement ys l d)) ==>
+    (heap_lookup n h2 = SOME (DataElement ys l d))`,
   simp_tac std_ss [heap_store_rel_def,isSomeDataElement_def] \\ metis_tac []);
 
 (* cons *)
@@ -1142,15 +1142,15 @@ val heap_store_RefBlock_thm = store_thm("heap_store_RefBlock_thm",
        (Cases_on `h` \\ full_simp_tac std_ss [el_length_def] \\ DECIDE_TAC)
   \\ full_simp_tac std_ss [LET_DEF]);
 
-val heap_lookup_RefBlock_lemma = prove(
-  ``(heap_lookup n (ha ++ RefBlock y::hb) = SOME x) =
+val heap_lookup_RefBlock_lemma = Q.prove(
+  `(heap_lookup n (ha ++ RefBlock y::hb) = SOME x) =
       if n < heap_length ha then
         (heap_lookup n ha = SOME x)
       else if n = heap_length ha then
         (x = RefBlock y)
       else if heap_length ha + (LENGTH y + 1) <= n then
         (heap_lookup (n - heap_length ha - (LENGTH y + 1)) hb = SOME x)
-      else F``,
+      else F`,
   Cases_on `n < heap_length ha` \\ full_simp_tac std_ss [LESS_IMP_heap_lookup]
   \\ full_simp_tac std_ss [NOT_LESS_IMP_heap_lookup]
   \\ full_simp_tac std_ss [heap_lookup_def]
@@ -1396,18 +1396,18 @@ val update_ref_thm1 = store_thm("update_ref_thm1",
 
 (* update byte ref *)
 
-val LENGTH_write_bytes = store_thm("LENGTH_write_bytes[simp]",
-  ``!ws bs be. LENGTH (write_bytes bs ws be) = LENGTH ws``,
+val LENGTH_write_bytes = Q.store_thm("LENGTH_write_bytes[simp]",
+  `!ws bs be. LENGTH (write_bytes bs ws be) = LENGTH ws`,
   Induct \\ fs [write_bytes_def]);
 
-val LIST_REL_IMP_LIST_REL = prove(
-  ``!xs ys.
+val LIST_REL_IMP_LIST_REL = Q.prove(
+  `!xs ys.
       (!x y. MEM x xs ==> P x y ==> Q x y) ==>
-      LIST_REL P xs ys ==> LIST_REL Q xs ys``,
+      LIST_REL P xs ys ==> LIST_REL Q xs ys`,
   Induct \\ fs [PULL_EXISTS]);
 
-val v_size_LESS_EQ = prove(
-  ``!l x. MEM x l ==> v_size x <= v1_size l``,
+val v_size_LESS_EQ = Q.prove(
+  `!l x. MEM x l ==> v_size x <= v1_size l`,
   Induct \\ fs [v_size_def] \\ rw [] \\ fs [] \\ res_tac \\ fs []);
 
 val v_inv_IMP = prove(
@@ -1855,25 +1855,25 @@ val num_eq_thm = store_thm("num_eq_thm",
   \\ Cases_on `i1` \\ Cases_on `i2`
   \\ fs [small_int_def,X_LT_DIV,X_LE_DIV] \\ fs [word_2comp_n2w]);
 
-val Smallnum_i2w = store_thm("Smallnum_i2w",
-  ``Smallnum i = i2w (4 * i)``,
+val Smallnum_i2w = Q.store_thm("Smallnum_i2w",
+  `Smallnum i = i2w (4 * i)`,
   fs [Smallnum_def,integer_wordTheory.i2w_def]
   \\ Cases_on `i` \\ fs []
   \\ reverse IF_CASES_TAC \\ fs [WORD_EQ_NEG]
   THEN1 (`F` by intLib.COOPER_TAC)
   \\ AP_THM_TAC \\ AP_TERM_TAC \\ intLib.COOPER_TAC);
 
-val small_int_IMP_MIN_MAX = store_thm("small_int_IMP_MIN_MAX",
-  ``good_dimindex (:'a) /\ small_int (:'a) i ==>
-    INT_MIN (:'a) <= 4 * i ∧ 4 * i <= INT_MAX (:'a)``,
+val small_int_IMP_MIN_MAX = Q.store_thm("small_int_IMP_MIN_MAX",
+  `good_dimindex (:'a) /\ small_int (:'a) i ==>
+    INT_MIN (:'a) <= 4 * i ∧ 4 * i <= INT_MAX (:'a)`,
   fs [labPropsTheory.good_dimindex_def] \\ rw []
   \\ rfs [small_int_def,dimword_def,
        wordsTheory.INT_MIN_def,wordsTheory.INT_MAX_def]
   \\ intLib.COOPER_TAC);
 
-val num_less_thm = store_thm("num_less_thm",
-  ``good_dimindex (:'a) /\ small_int (:'a) i1 /\ small_int (:'a) i2 ==>
-    ((i1 < i2) <=> (Smallnum i1 < Smallnum i2:'a word))``,
+val num_less_thm = Q.store_thm("num_less_thm",
+  `good_dimindex (:'a) /\ small_int (:'a) i1 /\ small_int (:'a) i2 ==>
+    ((i1 < i2) <=> (Smallnum i1 < Smallnum i2:'a word))`,
   fs [integer_wordTheory.WORD_LTi,Smallnum_i2w] \\ strip_tac
   \\ imp_res_tac small_int_IMP_MIN_MAX
   \\ fs [integer_wordTheory.w2i_i2w]
@@ -1915,9 +1915,9 @@ val duplicate1_thm = save_thm("duplicate1_thm",
 
 (* move *)
 
-val EVERY2_APPEND_IMP = prove(
-  ``EVERY2 P (xs1 ++ xs2) (ys1 ++ ys2) ==>
-    (LENGTH xs1 = LENGTH ys1) ==> EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2``,
+val EVERY2_APPEND_IMP = Q.prove(
+  `EVERY2 P (xs1 ++ xs2) (ys1 ++ ys2) ==>
+    (LENGTH xs1 = LENGTH ys1) ==> EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2`,
   rpt strip_tac \\ imp_res_tac EVERY2_LENGTH \\ imp_res_tac EVERY2_APPEND);
 
 val move_thm = store_thm("move_thm",
@@ -1942,11 +1942,11 @@ val move_thm = store_thm("move_thm",
 
 (* splits *)
 
-val EVERY2_APPEND1 = prove(
-  ``!xs1 xs2 ys.
+val EVERY2_APPEND1 = Q.prove(
+  `!xs1 xs2 ys.
       EVERY2 P (xs1 ++ xs2) ys ==>
       ?ys1 ys2. (ys = ys1 ++ ys2) /\
-                (LENGTH xs1 = LENGTH ys1) /\ EVERY2 P xs2 ys2``,
+                (LENGTH xs1 = LENGTH ys1) /\ EVERY2 P xs2 ys2`,
   Induct THEN1
    (full_simp_tac (srw_ss()) [] \\ rpt strip_tac
     \\ qexists_tac `[]` \\ full_simp_tac (srw_ss()) [])
@@ -1975,16 +1975,16 @@ val split3_thm = store_thm("split3_thm",
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def,GSYM APPEND_ASSOC]
   \\ rpt strip_tac \\ NTAC 5 (imp_res_tac EVERY2_APPEND1) \\ metis_tac []);
 
-val LESS_EQ_LENGTH = store_thm("LESS_EQ_LENGTH",
-  ``!xs k. k <= LENGTH xs ==> ?ys1 ys2. (xs = ys1 ++ ys2) /\ (LENGTH ys1 = k)``,
+val LESS_EQ_LENGTH = Q.store_thm("LESS_EQ_LENGTH",
+  `!xs k. k <= LENGTH xs ==> ?ys1 ys2. (xs = ys1 ++ ys2) /\ (LENGTH ys1 = k)`,
   Induct \\ Cases_on `k` \\ full_simp_tac std_ss [LENGTH,ADD1,LENGTH_NIL,APPEND]
   \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss []
   \\ qexists_tac `h::ys1` \\ full_simp_tac std_ss [LENGTH,APPEND]
   \\ srw_tac [] [ADD1]);
 
-val LESS_LENGTH = store_thm("LESS_LENGTH",
-  ``!xs k. k < LENGTH xs ==>
-           ?ys1 y ys2. (xs = ys1 ++ y::ys2) /\ (LENGTH ys1 = k)``,
+val LESS_LENGTH = Q.store_thm("LESS_LENGTH",
+  `!xs k. k < LENGTH xs ==>
+           ?ys1 y ys2. (xs = ys1 ++ y::ys2) /\ (LENGTH ys1 = k)`,
   Induct \\ Cases_on `k` \\ full_simp_tac std_ss [LENGTH,ADD1,LENGTH_NIL,APPEND]
   \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss [CONS_11]
   \\ qexists_tac `h::ys1` \\ full_simp_tac std_ss [LENGTH,APPEND]
@@ -2141,8 +2141,8 @@ val word_ml_inv_def = Define `
     ?hs. abs_ml_inv c (MAP FST stack) refs (hs,heap,be,a,sp) limit /\
          EVERY2 (\v w. word_addr c v = w) hs (MAP SND stack)`
 
-val IMP_THE_EQ = store_thm("IMP_THE_EQ",
-  ``x = SOME w ==> THE x = w``,
+val IMP_THE_EQ = Q.store_thm("IMP_THE_EQ",
+  `x = SOME w ==> THE x = w`,
   full_simp_tac(srw_ss())[]);
 
 val memory_rel_def = Define `
@@ -2152,15 +2152,15 @@ val memory_rel_def = Define `
        word_ml_inv (heap,be,a,sp) limit c refs vars ∧
        limit * (dimindex (:α) DIV 8) + 1 < dimword (:α) ∧ space ≤ sp`
 
-val EVERY2_MAP_MAP = store_thm("EVERY2_MAP_MAP",
-  ``!xs. EVERY2 P (MAP f xs) (MAP g xs) = EVERY (\x. P (f x) (g x)) xs``,
+val EVERY2_MAP_MAP = Q.store_thm("EVERY2_MAP_MAP",
+  `!xs. EVERY2 P (MAP f xs) (MAP g xs) = EVERY (\x. P (f x) (g x)) xs`,
   Induct \\ full_simp_tac(srw_ss())[]);
 
-val MEM_FIRST_EL = store_thm("MEM_FIRST_EL",
-  ``!xs x.
+val MEM_FIRST_EL = Q.store_thm("MEM_FIRST_EL",
+  `!xs x.
       MEM x xs <=>
       ?n. n < LENGTH xs /\ (EL n xs = x) /\
-          !m. m < n ==> (EL m xs <> EL n xs)``,
+          !m. m < n ==> (EL m xs <> EL n xs)`,
   srw_tac[][] \\ eq_tac
   THEN1 (srw_tac[][] \\ qexists_tac `LEAST n. EL n xs = x /\ n < LENGTH xs`
     \\ mp_tac (Q.SPEC `\n. EL n xs = x /\ n < LENGTH xs` (GEN_ALL FULL_LEAST_INTRO))
@@ -2228,17 +2228,17 @@ val word_ml_inv_rearrange = store_thm("word_ml_inv_rearrange",
   \\ qpat_x_assum `EL n' xs = (p_1,p_2')` (fn th => full_simp_tac(srw_ss())[GSYM th])
   \\ match_mp_tac ALOOKUP_ZIP_EL \\ full_simp_tac(srw_ss())[]);
 
-val memory_rel_rearrange = store_thm("memory_rel_rearrange",
-  ``(∀x. MEM x ys ⇒ MEM x xs) ⇒
+val memory_rel_rearrange = Q.store_thm("memory_rel_rearrange",
+  `(∀x. MEM x ys ⇒ MEM x xs) ⇒
     memory_rel c be refs sp st m dm xs ==>
-    memory_rel c be refs sp st m dm ys``,
+    memory_rel c be refs sp st m dm ys`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ qpat_x_assum `word_ml_inv _ _ _ _ _` mp_tac
   \\ match_mp_tac word_ml_inv_rearrange \\ fs []);
 
-val memory_rel_tl = store_thm("memory_rel_tl",
-  ``memory_rel c be refs sp st m dm (x::xs) ==>
-    memory_rel c be refs sp st m dm xs``,
+val memory_rel_tl = Q.store_thm("memory_rel_tl",
+  `memory_rel c be refs sp st m dm (x::xs) ==>
+    memory_rel c be refs sp st m dm xs`,
   match_mp_tac memory_rel_rearrange \\ fs []);
 
 val word_ml_inv_Unit = store_thm("word_ml_inv_Unit",
@@ -2261,8 +2261,8 @@ val memory_rel_Unit = store_thm("memory_rel_Unit",
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ match_mp_tac word_ml_inv_Unit \\ fs []);
 
-val get_lowerbits_LSL_shift_length = store_thm("get_lowerbits_LSL_shift_length",
-  ``get_lowerbits conf a >>> shift_length conf = 0w``,
+val get_lowerbits_LSL_shift_length = Q.store_thm("get_lowerbits_LSL_shift_length",
+  `get_lowerbits conf a >>> shift_length conf = 0w`,
   Cases_on `a`
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss]
        [word_index, get_lowerbits_def, shift_length_def])
@@ -2280,12 +2280,12 @@ val get_real_offset_def = Define `
     if dimindex (:'a) = 32
     then SOME (w + bytes_in_word) else SOME (w << 1 + bytes_in_word)`
 
-val get_real_addr_get_addr = store_thm("get_real_addr_get_addr",
-  ``heap_length heap <= dimword (:'a) DIV 2 ** shift_length c /\
+val get_real_addr_get_addr = Q.store_thm("get_real_addr_get_addr",
+  `heap_length heap <= dimword (:'a) DIV 2 ** shift_length c /\
     heap_lookup n heap = SOME anything /\
     FLOOKUP st CurrHeap = SOME (Word (curr:'a word)) /\
     good_dimindex (:'a) ==>
-    get_real_addr c st (get_addr c n w) = SOME (curr + n2w n * bytes_in_word)``,
+    get_real_addr c st (get_addr c n w) = SOME (curr + n2w n * bytes_in_word)`,
   fs [X_LE_DIV] \\ fs [get_addr_def,get_real_addr_def] \\ strip_tac
   \\ imp_res_tac copying_gcTheory.heap_lookup_LESS \\ fs []
   \\ `w2n ((n2w n):'a word) * 2 ** shift_length c < dimword (:'a)` by
@@ -2300,29 +2300,29 @@ val get_real_addr_get_addr = store_thm("get_real_addr_get_addr",
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
   \\ rfs [WORD_MUL_LSL,word_mul_n2w,shift_def,bytes_in_word_def])
 
-val get_real_offset_thm = store_thm("get_real_offset_thm",
-  ``good_dimindex (:'a) ==>
+val get_real_offset_thm = Q.store_thm("get_real_offset_thm",
+  `good_dimindex (:'a) ==>
     get_real_offset (n2w (4 * index)) =
-      SOME (bytes_in_word + n2w index * bytes_in_word:'a word)``,
+      SOME (bytes_in_word + n2w index * bytes_in_word:'a word)`,
   fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
   \\ fs [get_real_offset_def,bytes_in_word_def,word_mul_n2w,WORD_MUL_LSL]);
 
-val word_heap_APPEND = store_thm("word_heap_APPEND",
-  ``!xs ys a.
+val word_heap_APPEND = Q.store_thm("word_heap_APPEND",
+  `!xs ys a.
       word_heap a (xs ++ ys) conf =
       word_heap a xs conf *
-      word_heap (a + bytes_in_word * n2w (heap_length xs)) ys conf``,
+      word_heap (a + bytes_in_word * n2w (heap_length xs)) ys conf`,
   Induct \\ full_simp_tac(srw_ss())[word_heap_def,heap_length_def,
               SEP_CLAUSES,STAR_ASSOC]
   \\ full_simp_tac(srw_ss())[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val FORALL_WORD = store_thm("FORALL_WORD",
-  ``(!v:'a word. P v) <=> !n. n < dimword (:'a) ==> P (n2w n)``,
+val FORALL_WORD = Q.store_thm("FORALL_WORD",
+  `(!v:'a word. P v) <=> !n. n < dimword (:'a) ==> P (n2w n)`,
   eq_tac \\ rw [] \\ Cases_on `v` \\ fs []);
 
-val BlockNil_and_lemma = store_thm("BlockNil_and_lemma",
-  ``good_dimindex (:'a) ==>
-    (-2w && 16w * tag + 2w) = 16w * tag + 2w:'a word``,
+val BlockNil_and_lemma = Q.store_thm("BlockNil_and_lemma",
+  `good_dimindex (:'a) ==>
+    (-2w && 16w * tag + 2w) = 16w * tag + 2w:'a word`,
   `!w:word64. (-2w && 16w * w + 2w) = 16w * w + 2w` by blastLib.BBLAST_TAC
   \\ `!w:word32. (-2w && 16w * w + 2w) = 16w * w + 2w` by blastLib.BBLAST_TAC
   \\ fs [GSYM word_mul_n2w,GSYM word_add_n2w]
@@ -2331,8 +2331,8 @@ val BlockNil_and_lemma = store_thm("BlockNil_and_lemma",
   \\ fs [word_mul_n2w,word_add_n2w,word_2comp_n2w,word_and_n2w]
   \\ rfs [dimword_def] \\ fs []);
 
-val word_ml_inv_num_lemma = store_thm("word_ml_inv_num_lemma",
-  ``good_dimindex (:'a) ==> (-2w && 4w * v) = 4w * v:'a word``,
+val word_ml_inv_num_lemma = Q.store_thm("word_ml_inv_num_lemma",
+  `good_dimindex (:'a) ==> (-2w && 4w * v) = 4w * v:'a word`,
   `!w:word64. (-2w && 4w * w) = 4w * w` by blastLib.BBLAST_TAC
   \\ `!w:word32. (-2w && 4w * w) = 4w * w` by blastLib.BBLAST_TAC
   \\ rfs [dimword_def,FORALL_WORD]
@@ -2360,8 +2360,8 @@ val word_ml_inv_num = store_thm("word_ml_inv_num",
 val word_ml_inv_zero = save_thm("word_ml_inv_zero",
   word_ml_inv_num |> Q.INST [`n`|->`0`] |> SIMP_RULE (srw_ss()) [])
 
-val word_ml_inv_neg_num_lemma = store_thm("word_ml_inv_neg_num_lemma",
-  ``good_dimindex (:'a) ==> (-2w && -4w * v) = -4w * v:'a word``,
+val word_ml_inv_neg_num_lemma = Q.store_thm("word_ml_inv_neg_num_lemma",
+  `good_dimindex (:'a) ==> (-2w && -4w * v) = -4w * v:'a word`,
   `!w:word64. (-2w && -4w * w) = -4w * w` by blastLib.BBLAST_TAC
   \\ `!w:word32. (-2w && -4w * w) = -4w * w` by blastLib.BBLAST_TAC
   \\ rfs [dimword_def,FORALL_WORD]
@@ -2386,9 +2386,9 @@ val word_ml_inv_neg_num = store_thm("word_ml_inv_neg_num",
   \\ fs [word_addr_def,Smallnum_def,GSYM word_mul_n2w]
   \\ match_mp_tac word_ml_inv_neg_num_lemma \\ fs []);
 
-val word_list_APPEND = store_thm("word_list_APPEND",
-  ``!xs ys a. word_list a (xs ++ ys) =
-              word_list a xs * word_list (a + n2w (LENGTH xs) * bytes_in_word) ys``,
+val word_list_APPEND = Q.store_thm("word_list_APPEND",
+  `!xs ys a. word_list a (xs ++ ys) =
+              word_list a xs * word_list (a + n2w (LENGTH xs) * bytes_in_word) ys`,
   Induct \\ full_simp_tac(srw_ss())[word_list_def,SEP_CLAUSES,STAR_ASSOC,ADD1,
                 GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
@@ -2505,22 +2505,22 @@ val memory_rel_Deref = store_thm("memory_rel_Deref",
   \\ fs [word_list_def,word_list_APPEND,SEP_CLAUSES] \\ fs [SEP_F_def]
   \\ SEP_R_TAC \\ fs []);
 
-val LENGTH_EQ_1 = store_thm("LENGTH_EQ_1",
-  ``(LENGTH xs = 1 <=> ?a1. xs = [a1]) /\
-    (1 = LENGTH xs <=> ?a1. xs = [a1])``,
+val LENGTH_EQ_1 = Q.store_thm("LENGTH_EQ_1",
+  `(LENGTH xs = 1 <=> ?a1. xs = [a1]) /\
+    (1 = LENGTH xs <=> ?a1. xs = [a1])`,
   rw [] \\ eq_tac \\ rw [] \\ fs []
   \\ Cases_on `xs` \\ fs [LENGTH_NIL]);
 
-val LENGTH_EQ_2 = store_thm("LENGTH_EQ_2",
-  ``(LENGTH xs = 2 <=> ?a1 a2. xs = [a1;a2]) /\
-    (2 = LENGTH xs <=> ?a1 a2. xs = [a1;a2])``,
+val LENGTH_EQ_2 = Q.store_thm("LENGTH_EQ_2",
+  `(LENGTH xs = 2 <=> ?a1 a2. xs = [a1;a2]) /\
+    (2 = LENGTH xs <=> ?a1 a2. xs = [a1;a2])`,
   rw [] \\ eq_tac \\ rw [] \\ fs []
   \\ Cases_on `xs` \\ fs []
   \\ Cases_on `t` \\ fs [LENGTH_NIL]);
 
-val LENGTH_EQ_3 = store_thm("LENGTH_EQ_3",
-  ``(LENGTH xs = 3 <=> ?a1 a2 a3. xs = [a1;a2;a3]) /\
-    (3 = LENGTH xs <=> ?a1 a2 a3. xs = [a1;a2;a3])``,
+val LENGTH_EQ_3 = Q.store_thm("LENGTH_EQ_3",
+  `(LENGTH xs = 3 <=> ?a1 a2 a3. xs = [a1;a2;a3]) /\
+    (3 = LENGTH xs <=> ?a1 a2 a3. xs = [a1;a2;a3])`,
   rw [] \\ eq_tac \\ rw [] \\ fs []
   \\ Cases_on `xs` \\ fs []
   \\ Cases_on `t` \\ fs [LENGTH_NIL]
@@ -2612,47 +2612,47 @@ val store_list_def = Define `
        store_list (a + bytes_in_word) ws ((a =+ w) m) dm
      else NONE)`
 
-val minus_lemma = prove(
-  ``-1w * (bytes_in_word * w) = bytes_in_word * -w``,
+val minus_lemma = Q.prove(
+  `-1w * (bytes_in_word * w) = bytes_in_word * -w`,
   fs []);
 
-val bytes_in_word_mul_eq_shift = store_thm("bytes_in_word_mul_eq_shift",
-  ``good_dimindex (:'a) ==>
-    (bytes_in_word * w = (w << shift (:'a)):'a word)``,
+val bytes_in_word_mul_eq_shift = Q.store_thm("bytes_in_word_mul_eq_shift",
+  `good_dimindex (:'a) ==>
+    (bytes_in_word * w = (w << shift (:'a)):'a word)`,
   fs [bytes_in_word_def,shift_def,WORD_MUL_LSL,word_mul_n2w]
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw [] \\ rfs []);
 
-val n2w_lsr_eq_0 = store_thm("n2w_lsr_eq_0",
-  ``n DIV 2 ** k = 0 /\ n < dimword (:'a) ==> n2w n >>> k = 0w:'a word``,
+val n2w_lsr_eq_0 = Q.store_thm("n2w_lsr_eq_0",
+  `n DIV 2 ** k = 0 /\ n < dimword (:'a) ==> n2w n >>> k = 0w:'a word`,
   rw [] \\ simp_tac std_ss [GSYM w2n_11,w2n_lsr] \\ fs []);
 
-val LESS_EXO_SUB = prove(
-  ``n < 2 ** (k - m) ==> n < 2n ** k``,
+val LESS_EXO_SUB = Q.prove(
+  `n < 2 ** (k - m) ==> n < 2n ** k`,
   rw [] \\ match_mp_tac LESS_LESS_EQ_TRANS
   \\ asm_exists_tac \\ fs []);
 
-val LESS_EXO_SUB_ALT = prove(
-  ``m <= k ==> n < 2 ** (k - m) ==> n * 2 ** m < 2n ** k``,
+val LESS_EXO_SUB_ALT = Q.prove(
+  `m <= k ==> n < 2 ** (k - m) ==> n * 2 ** m < 2n ** k`,
   rw [] \\ match_mp_tac LESS_LESS_EQ_TRANS
   \\ qexists_tac `2 ** (k - m) * 2 ** m`
   \\ fs [GSYM EXP_ADD]);
 
-val less_pow_dimindex_sub_imp = prove(
-  ``n < 2 ** (dimindex (:'a) - k) ==> n < dimword (:'a)``,
+val less_pow_dimindex_sub_imp = Q.prove(
+  `n < 2 ** (dimindex (:'a) - k) ==> n < dimword (:'a)`,
   fs [dimword_def] \\ metis_tac [LESS_EXO_SUB]);
 
-val encode_header_NEQ_0 = store_thm("encode_header_NEQ_0",
-  ``encode_header c n k = SOME w ==> w <> 0w``,
+val encode_header_NEQ_0 = Q.store_thm("encode_header_NEQ_0",
+  `encode_header c n k = SOME w ==> w <> 0w`,
   fs [encode_header_def] \\ rw []
   \\ fs [make_header_def,LET_DEF]
   \\ full_simp_tac (srw_ss()++wordsLib.WORD_BIT_EQ_ss) []
   \\ qexists_tac `0` \\ fs [] \\ EVAL_TAC);
 
-val encode_header_IMP = prove(
-  ``encode_header c tag len = SOME (hd:'a word) /\
+val encode_header_IMP = Q.prove(
+  `encode_header c tag len = SOME (hd:'a word) /\
     c.len_size + 5 < dimindex (:'a) /\ good_dimindex (:'a) ==>
     len < 2 ** (dimindex (:'a) - 4) /\
-    decode_length c hd = n2w len``,
+    decode_length c hd = n2w len`,
   fs [encode_header_def] \\ rw [make_header_def] \\ fs [decode_length_def]
   \\ `3w >>> (dimindex (:α) − c.len_size) = 0w:'a word` by
       (match_mp_tac n2w_lsr_eq_0
@@ -2696,11 +2696,11 @@ val word_list_exists_thm = store_thm("word_list_exists_thm",
   \\ qexists_tac `w::xs`
   \\ full_simp_tac(srw_ss())[word_list_def,ADD1,STAR_ASSOC,cond_STAR]);
 
-val word_list_exists_ADD = store_thm("word_list_exists_ADD",
-  ``!m n a.
+val word_list_exists_ADD = Q.store_thm("word_list_exists_ADD",
+  `!m n a.
       word_list_exists a (m + n) =
       word_list_exists a m *
-      word_list_exists (a + bytes_in_word * n2w m) n``,
+      word_list_exists (a + bytes_in_word * n2w m) n`,
   Induct \\ full_simp_tac(srw_ss())[word_list_exists_thm,SEP_CLAUSES,ADD_CLAUSES]
   \\ full_simp_tac(srw_ss())[STAR_ASSOC,ADD1,
         GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
@@ -2720,10 +2720,10 @@ val word_payload_IMP = store_thm("word_payload_IMP",
   ``word_payload addrs ll tags tt1 conf = (h,ts,T) ==> LENGTH ts = ll``,
   Cases_on `tags` \\ full_simp_tac(srw_ss())[word_payload_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val word_el_IMP_word_list_exists = store_thm("word_el_IMP_word_list_exists",
-  ``!temp p curr.
+val word_el_IMP_word_list_exists = Q.store_thm("word_el_IMP_word_list_exists",
+  `!temp p curr.
       (p * word_el curr temp conf) s ==>
-      (p * word_list_exists curr (el_length temp)) s``,
+      (p * word_list_exists curr (el_length temp)) s`,
   Cases \\ fs[word_el_def,el_length_def,GSYM ADD1,word_list_exists_thm]
   THEN1 (full_simp_tac(srw_ss())[SEP_CLAUSES,SEP_EXISTS_THM] \\ metis_tac [])
   \\ Cases_on `b`
@@ -2734,10 +2734,10 @@ val word_el_IMP_word_list_exists = store_thm("word_el_IMP_word_list_exists",
   \\ full_simp_tac (std_ss++sep_cond_ss) [cond_STAR]
   \\ imp_res_tac word_payload_IMP \\ asm_exists_tac \\ fs [] \\ metis_tac []);
 
-val word_heap_IMP_word_list_exists = store_thm("word_heap_IMP_word_list_exists",
-  ``!temp p curr.
+val word_heap_IMP_word_list_exists = Q.store_thm("word_heap_IMP_word_list_exists",
+  `!temp p curr.
       (p * word_heap curr temp conf) s ==>
-      (p * word_list_exists curr (heap_length temp)) s``,
+      (p * word_list_exists curr (heap_length temp)) s`,
   Induct \\ full_simp_tac(srw_ss())[heap_length_def,
               word_heap_def,word_list_exists_thm]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_el_def,word_list_exists_ADD]
@@ -2746,18 +2746,18 @@ val word_heap_IMP_word_list_exists = store_thm("word_heap_IMP_word_list_exists",
   \\ once_rewrite_tac [STAR_COMM] \\ full_simp_tac(srw_ss())[STAR_ASSOC]
   \\ metis_tac [word_el_IMP_word_list_exists]);
 
-val EVERY2_f_EQ = prove(
-  ``!rs ws f. EVERY2 (\v w. f v = w) rs ws <=> MAP f rs = ws``,
+val EVERY2_f_EQ = Q.prove(
+  `!rs ws f. EVERY2 (\v w. f v = w) rs ws <=> MAP f rs = ws`,
   Induct \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []);
 
-val word_heap_heap_expand = store_thm("word_heap_heap_expand",
-  ``word_heap a (heap_expand n) conf = word_list_exists a n``,
+val word_heap_heap_expand = Q.store_thm("word_heap_heap_expand",
+  `word_heap a (heap_expand n) conf = word_list_exists a n`,
   Cases_on `n` \\ full_simp_tac(srw_ss())[heap_expand_def]
   \\ fs [word_heap_def,word_list_exists_def,LENGTH_NIL,FUN_EQ_THM,ADD1,
          SEP_EXISTS_THM,cond_STAR,word_list_def,word_el_def,SEP_CLAUSES])
 
-val get_lowerbits_or_1 = prove(
-  ``get_lowerbits c v = (get_lowerbits c v || 1w)``,
+val get_lowerbits_or_1 = Q.prove(
+  `get_lowerbits c v = (get_lowerbits c v || 1w)`,
   Cases_on `v` \\ fs [get_lowerbits_def]);
 
 val memory_rel_Word64 = Q.store_thm("memory_rel_Word64",
@@ -3000,14 +3000,14 @@ val memory_rel_Ref = store_thm("memory_rel_Ref",
   \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ fs [AC STAR_ASSOC STAR_COMM] \\ fs [STAR_ASSOC]);
 
-val memory_rel_write = store_thm("memory_rel_write",
-  ``memory_rel c be refs sp st m dm vars ==>
+val memory_rel_write = Q.store_thm("memory_rel_write",
+  `memory_rel c be refs sp st m dm vars ==>
     ?(free:'a word).
       FLOOKUP st NextFree = SOME (Word free) /\
       !n.
         n < sp ==>
         let a = free + bytes_in_word * n2w n in
-          a IN dm /\ memory_rel c be refs sp st ((a =+ w) m) dm vars``,
+          a IN dm /\ memory_rel c be refs sp st ((a =+ w) m) dm vars`,
   fs [LET_THM,memory_rel_def,heap_in_memory_store_def]
   \\ strip_tac \\ fs [word_ml_inv_def,abs_ml_inv_def]
   \\ fs [unused_space_inv_def]
@@ -3173,9 +3173,9 @@ val ADD_DIV_EQ = save_thm("ADD_DIV_EQ",LIST_CONJ
   [GSYM ADD_DIV_ADD_DIV,
    ONCE_REWRITE_RULE [ADD_COMM] (GSYM ADD_DIV_ADD_DIV)])
 
-val set_byte_word_of_byte = prove(
-  ``good_dimindex (:'a) ==>
-    set_byte a w (word_of_byte ((w2w w):'a word)) be = word_of_byte (w2w w)``,
+val set_byte_word_of_byte = Q.prove(
+  `good_dimindex (:'a) ==>
+    set_byte a w (word_of_byte ((w2w w):'a word)) be = word_of_byte (w2w w)`,
   fs [set_byte_def,labPropsTheory.good_dimindex_def] \\ rw [] \\ fs []
   \\ fs [word_of_byte_def]
   \\ `?k. byte_index a be = 8 * k /\ k < (dimindex (:'a) DIV 8)` by
@@ -3187,11 +3187,11 @@ val set_byte_word_of_byte = prove(
   \\ fs [fcpTheory.CART_EQ,word_or_def,word_lsl_def,fcpTheory.FCP_BETA,
         word_slice_alt_def,w2w] \\ rw [] \\ EQ_TAC \\ rw [] \\ fs []);
 
-val write_bytes_REPLICATE = prove(
-  ``!n m.
+val write_bytes_REPLICATE = Q.prove(
+  `!n m.
       good_dimindex (:'a) ==>
       write_bytes (REPLICATE m w) (REPLICATE n (word_of_byte (w2w w))) be =
-      REPLICATE n (word_of_byte ((w2w w):'a word))``,
+      REPLICATE n (word_of_byte ((w2w w):'a word))`,
   Induct \\ fs [write_bytes_def,REPLICATE,DROP_REPLICATE] \\ rw []
   \\ qspec_tac (`m`,`m`)
   \\ qspec_tac (`0w:'a word`,`a`)
@@ -3200,14 +3200,14 @@ val write_bytes_REPLICATE = prove(
   \\ fs [bytes_to_word_def,REPLICATE] \\ Cases_on `m`
   \\ fs [bytes_to_word_def,REPLICATE,set_byte_word_of_byte]);
 
-val IMP_EXP_LESS = store_thm("IMP_EXP_LESS",
-  ``m <= l ==> 2n ** m <= 2 ** l``,
+val IMP_EXP_LESS = Q.store_thm("IMP_EXP_LESS",
+  `m <= l ==> 2n ** m <= 2 ** l`,
   simp [Once LESS_EQ_EXISTS] \\ rw []);
 
-val shift_shift_lemma = prove(
-  ``l = k + shift (:'a) /\ t < k /\ n DIV i < 2 ** t /\ l = dimindex (:'a) /\
+val shift_shift_lemma = Q.prove(
+  `l = k + shift (:'a) /\ t < k /\ n DIV i < 2 ** t /\ l = dimindex (:'a) /\
     i = 2 ** shift (:'a) /\ n < dimword (:'a) ==>
-    n2w n << (k - t) >>> (l - t) = (n2w (n DIV i)):'a word``,
+    n2w n << (k - t) >>> (l - t) = (n2w (n DIV i)):'a word`,
   rw [] \\ `k + shift (:α) − t = (k - t) + shift (:'a)` by decide_tac
   \\ pop_assum (fn th => rewrite_tac [th,GSYM LSR_ADD])
   \\ qsuff_tac `w2n ((n2w n):'a word) * 2 ** (k - t) < dimword (:'a)`
@@ -3331,14 +3331,14 @@ val memory_rel_RefByte = store_thm("memory_rel_RefByte",
   \\ fs [GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ fs [AC STAR_ASSOC STAR_COMM] \\ fs [STAR_ASSOC]);
 
-val memory_rel_tail = store_thm("memory_rel_tail",
-  ``memory_rel c be refs sp st m dm (v::vars) ==>
-    memory_rel c be refs sp st m dm vars``,
+val memory_rel_tail = Q.store_thm("memory_rel_tail",
+  `memory_rel c be refs sp st m dm (v::vars) ==>
+    memory_rel c be refs sp st m dm vars`,
   match_mp_tac memory_rel_rearrange \\ fs []);
 
-val memory_rel_drop = store_thm("memory_rel_drop",
-  ``memory_rel c be refs sp st m dm (vs ++ vars) ==>
-    memory_rel c be refs sp st m dm vars``,
+val memory_rel_drop = Q.store_thm("memory_rel_drop",
+  `memory_rel c be refs sp st m dm (vs ++ vars) ==>
+    memory_rel c be refs sp st m dm vars`,
   match_mp_tac memory_rel_rearrange \\ fs []);
 
 val memory_rel_IMP_word_list_exists = store_thm("memory_rel_IMP_word_list_exists",
@@ -3367,13 +3367,13 @@ val memory_rel_IMP_word_list_exists = store_thm("memory_rel_IMP_word_list_exists
   \\ fs [SEP_IMP_REFL]
   \\ fs [SEP_IMP_def,SEP_T_def]);
 
-val get_addr_0 = store_thm("get_addr_0",
-  ``get_addr c n u ' 0``,
+val get_addr_0 = Q.store_thm("get_addr_0",
+  `get_addr c n u ' 0`,
   Cases_on `u` \\ fs [get_addr_def,get_lowerbits_def,
      word_or_def,fcpTheory.FCP_BETA,word_index]);
 
-val word_addr_eq_Loc = store_thm("word_addr_eq_Loc",
-  ``word_addr c v = Loc l1 l2 <=> v = Data (Loc l1 l2)``,
+val word_addr_eq_Loc = Q.store_thm("word_addr_eq_Loc",
+  `word_addr c v = Loc l1 l2 <=> v = Data (Loc l1 l2)`,
   Cases_on `v` \\ fs [word_addr_def]
   \\ Cases_on `a` \\ fs [word_addr_def]);
 
@@ -3567,9 +3567,9 @@ val memory_rel_FromList = store_thm("memory_rel_FromList",
   \\ rpt_drule memory_rel_Cons_alt
   \\ strip_tac \\ fs []);
 
-val make_header_tag_mask = prove(
-  ``k < 2 ** (dimindex (:α) − (c.len_size + 2)) ==>
-    (tag_mask c && make_header c ((n2w k):'a word) n) = n2w (4 * k)``,
+val make_header_tag_mask = Q.prove(
+  `k < 2 ** (dimindex (:α) − (c.len_size + 2)) ==>
+    (tag_mask c && make_header c ((n2w k):'a word) n) = n2w (4 * k)`,
   srw_tac [wordsLib.WORD_MUL_LSL_ss, boolSimps.LET_ss]
        [tag_mask_def, make_header_def, GSYM wordsTheory.word_mul_n2w]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index]
@@ -3587,16 +3587,16 @@ val make_header_tag_mask = prove(
   \\ metis_tac [bitTheory.NOT_BIT_GT_TWOEXP, bitTheory.TWOEXP_MONO2,
                 arithmeticTheory.LESS_LESS_EQ_TRANS]);
 
-val make_header_and_2 = prove(
-  ``(2w && make_header c w n) = 2w``,
+val make_header_and_2 = Q.prove(
+  `(2w && make_header c w n) = 2w`,
   fs [make_header_def]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index]
   \\ Cases_on `i=1` \\ fs []);
 
-val encode_header_tag_mask = store_thm("encode_header_tag_mask",
-  ``encode_header c (4 * tag) n = SOME (w:'a word) /\ good_dimindex (:'a) ==>
+val encode_header_tag_mask = Q.store_thm("encode_header_tag_mask",
+  `encode_header c (4 * tag) n = SOME (w:'a word) /\ good_dimindex (:'a) ==>
     tag < dimword (:α) DIV 16 /\
-    (w && (tag_mask c ‖ 2w)) = n2w (16 * tag + 2)``,
+    (w && (tag_mask c ‖ 2w)) = n2w (16 * tag + 2)`,
   strip_tac \\ fs [encode_header_def,WORD_LEFT_AND_OVER_OR]
   \\ rw [make_header_and_2]
   \\ drule (GEN_ALL make_header_tag_mask)
@@ -3616,12 +3616,12 @@ val memory_rel_tag_limit = store_thm("memory_rel_tag_limit",
   \\ every_case_tac \\ fs []
   \\ imp_res_tac encode_header_tag_mask \\ fs []);
 
-val LESS_DIV_16_IMP = prove(
-  ``n < k DIV 16 ==> 16 * n + 2 < k:num``,
+val LESS_DIV_16_IMP = Q.prove(
+  `n < k DIV 16 ==> 16 * n + 2 < k:num`,
   fs [X_LT_DIV]);
 
-val MULT_BIT0 = prove(
-  ``BIT 0 (m * n) <=> BIT 0 m /\ BIT 0 n``,
+val MULT_BIT0 = Q.prove(
+  `BIT 0 (m * n) <=> BIT 0 m /\ BIT 0 n`,
   fs [bitTheory.BIT0_ODD,ODD_MULT]);
 
 val memory_rel_test_nil_eq = store_thm("memory_rel_test_nil_eq",
@@ -3649,11 +3649,11 @@ val not_bit_lt_2exp = Q.prove(
 
 val not_bit_lt_2 = not_bit_lt_2exp |> Q.SPEC `0` |> SIMP_RULE (srw_ss()) []
 
-val encode_header_EQ = store_thm("encode_header_EQ",
-  ``encode_header c t1 l1 = SOME (w1:'a word) /\
+val encode_header_EQ = Q.store_thm("encode_header_EQ",
+  `encode_header c t1 l1 = SOME (w1:'a word) /\
     encode_header c t2 l2 = SOME (w2:'a word) /\
     c.len_size + 2 < dimindex (:'a) ==>
-    (w1 = w2 <=> t1 = t2 /\ l1 = l2)``,
+    (w1 = w2 <=> t1 = t2 /\ l1 = l2)`,
   fs [encode_header_def] \\ rw [] \\ fs [make_header_def,LET_THM]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index]
   \\ Tactical.REVERSE EQ_TAC >- rw []
@@ -3733,16 +3733,16 @@ val memory_rel_ValueArray_IMP = store_thm("memory_rel_ValueArray_IMP",
   \\ fs [labPropsTheory.good_dimindex_def]
   \\ fs [fcpTheory.FCP_BETA,word_lsl_def,word_index])
 
-val LESS_LENGTH_IMP = prove(
-  ``!xs n. n < LENGTH xs ==> ?ys t ts. xs = ys ++ t::ts /\ LENGTH ys = n``,
+val LESS_LENGTH_IMP = Q.prove(
+  `!xs n. n < LENGTH xs ==> ?ys t ts. xs = ys ++ t::ts /\ LENGTH ys = n`,
   Induct \\ fs [] \\ Cases_on `n` \\ fs [LENGTH_NIL] \\ rw []
   \\ res_tac \\ clean_tac \\ qexists_tac `h::ys` \\ fs []);
 
-val write_bytes_APPEND = store_thm("write_bytes_APPEND",
-  ``!xs ys vals be.
+val write_bytes_APPEND = Q.store_thm("write_bytes_APPEND",
+  `!xs ys vals be.
       write_bytes vals (xs ++ (ys:'a word list)) be =
       write_bytes vals xs be ++
-      write_bytes (DROP ((dimindex (:α) DIV 8) * LENGTH xs) vals) ys be``,
+      write_bytes (DROP ((dimindex (:α) DIV 8) * LENGTH xs) vals) ys be`,
   Induct \\ fs [write_bytes_def,ADD1,RIGHT_ADD_DISTRIB,DROP_DROP_T]);
 
 val LESS_4 = DECIDE ``i < 4 <=> (i = 0) \/ (i = 1) \/ (i = 2) \/ (i = 3n)``
@@ -3753,17 +3753,17 @@ val expand_num =
   DECIDE ``4 = SUC 3 /\ 3 = SUC 2 /\ 2 = SUC 1 /\ 1 = SUC 0 /\
            5 = SUC 4 /\ 6 = SUC 5 /\ 7 = SUC 6 /\ 8 = SUC 7``
 
-val get_byte_set_byte_alt = store_thm("get_byte_set_byte_alt",
-  ``good_dimindex (:'a) /\ w <> v /\ byte_align w = byte_align v /\
+val get_byte_set_byte_alt = Q.store_thm("get_byte_set_byte_alt",
+  `good_dimindex (:'a) /\ w <> v /\ byte_align w = byte_align v /\
     get_byte w s be = x ==>
-    get_byte w (set_byte v b (s:'a word) be) be = x``,
+    get_byte w (set_byte v b (s:'a word) be) be = x`,
   rw [] \\ rpt_drule labPropsTheory.get_byte_set_byte_diff \\ fs []);
 
-val get_byte_bytes_to_word = store_thm("get_byte_bytes_to_word",
-  ``∀zs (t:'a word).
+val get_byte_bytes_to_word = Q.store_thm("get_byte_bytes_to_word",
+  `∀zs (t:'a word).
       i < LENGTH zs /\ i < 2 ** k /\
       2 ** k = dimindex(:'a) DIV 8 /\ good_dimindex (:'a) ⇒
-      get_byte (n2w i) (bytes_to_word (2 ** k) 0w zs t be) be = EL i zs``,
+      get_byte (n2w i) (bytes_to_word (2 ** k) 0w zs t be) be = EL i zs`,
   rw [] \\ fs [] \\ Cases_on `dimindex (:α) = 32` \\ fs [] THEN1
    (fs [LESS_4] \\ fs []
     \\ Cases_on `zs` \\ fs []
@@ -3794,24 +3794,24 @@ val get_byte_bytes_to_word = store_thm("get_byte_bytes_to_word",
              alignmentTheory.align_w2n]))
   \\ rfs [labPropsTheory.good_dimindex_def]);
 
-val pow_eq_0 = store_thm("pow_eq_0",
-  ``dimindex (:'a) <= k ==> (n2w (2 ** k) = 0w:'a word)``,
+val pow_eq_0 = Q.store_thm("pow_eq_0",
+  `dimindex (:'a) <= k ==> (n2w (2 ** k) = 0w:'a word)`,
   fs [dimword_def] \\ fs [LESS_EQ_EXISTS]
   \\ rw [] \\ fs [EXP_ADD,MOD_EQ_0]);
 
-val aligned_pow = store_thm("aligned_pow",
-  ``aligned k (n2w (2 ** k))``,
+val aligned_pow = Q.store_thm("aligned_pow",
+  `aligned k (n2w (2 ** k))`,
   Cases_on `k < dimindex (:'a)`
   \\ fs [NOT_LESS,pow_eq_0,aligned_0]
   \\ `2 ** k < dimword (:'a)` by fs [dimword_def]
   \\ fs [aligned_def,align_w2n])
 
 local
-  val aligned_add_mult_lemma = prove(
-    ``aligned k (w + n2w (2 ** k)) = aligned k w``,
+  val aligned_add_mult_lemma = Q.prove(
+    `aligned k (w + n2w (2 ** k)) = aligned k w`,
     fs [aligned_add_sub,aligned_pow]) |> GEN_ALL
-  val aligned_add_mult_any = prove(
-    ``!n w. aligned k (w + n2w (n * 2 ** k)) = aligned k w``,
+  val aligned_add_mult_any = Q.prove(
+    `!n w. aligned k (w + n2w (n * 2 ** k)) = aligned k w`,
     Induct \\ fs [MULT_CLAUSES,GSYM word_add_n2w] \\ rw []
     \\ pop_assum (qspec_then `w + n2w (2 ** k)` mp_tac)
     \\ fs [aligned_add_mult_lemma]) |> GEN_ALL
@@ -3820,19 +3820,19 @@ in
     CONJ aligned_add_mult_lemma aligned_add_mult_any)
 end
 
-val MOD_MULT_MOD_LEMMA = prove(
-  ``k MOD n = 0 /\ x MOD n = t /\ 0 < k /\ 0 < n /\ n <= k ==>
-    x MOD k MOD n = t``,
+val MOD_MULT_MOD_LEMMA = Q.prove(
+  `k MOD n = 0 /\ x MOD n = t /\ 0 < k /\ 0 < n /\ n <= k ==>
+    x MOD k MOD n = t`,
   rw [] \\ drule DIVISION
   \\ disch_then (qspec_then `k` mp_tac) \\ strip_tac
   \\ qpat_x_assum `_ = _` (fn th => once_rewrite_tac [th])
   \\ fs [] \\ Cases_on `0 < k DIV n` \\ fs [MOD_MULT_MOD]
   \\ fs [DIV_EQ_X] \\ rfs [DIV_EQ_X]);
 
-val w2n_add_byte_align_lemma = store_thm("w2n_add_byte_align_lemma",
-  ``good_dimindex (:'a) ==>
+val w2n_add_byte_align_lemma = Q.store_thm("w2n_add_byte_align_lemma",
+  `good_dimindex (:'a) ==>
     w2n (a' + byte_align (a:'a word)) MOD (dimindex (:'a) DIV 8) =
-    w2n a' MOD (dimindex (:'a) DIV 8)``,
+    w2n a' MOD (dimindex (:'a) DIV 8)`,
   Cases_on `a'` \\ Cases_on `a`
   \\ fs [byte_align_def,align_w2n]
   \\ fs [labPropsTheory.good_dimindex_def] \\ rw []
@@ -3842,15 +3842,15 @@ val w2n_add_byte_align_lemma = store_thm("w2n_add_byte_align_lemma",
   \\ once_rewrite_tac [ADD_COMM]
   \\ fs [MOD_TIMES]);
 
-val get_byte_byte_align = store_thm("get_byte_byte_align",
-  ``good_dimindex (:'a) ==>
-    get_byte (a' + byte_align a) w be = get_byte a' (w:'a word) be``,
+val get_byte_byte_align = Q.store_thm("get_byte_byte_align",
+  `good_dimindex (:'a) ==>
+    get_byte (a' + byte_align a) w be = get_byte a' (w:'a word) be`,
   fs [wordSemTheory.get_byte_def] \\ rw [] \\ rpt AP_TERM_TAC
   \\ fs [wordSemTheory.byte_index_def,w2n_add_byte_align_lemma]);
 
-val get_byte_eq = store_thm("get_byte_eq",
-  ``good_dimindex (:'a) /\ a = byte_align a + a' ==>
-    get_byte a w be = get_byte a' (w:'a word) be``,
+val get_byte_eq = Q.store_thm("get_byte_eq",
+  `good_dimindex (:'a) /\ a = byte_align a + a' ==>
+    get_byte a w be = get_byte a' (w:'a word) be`,
   rw [] \\ pop_assum (fn th => once_rewrite_tac [th])
   \\ fs [get_byte_byte_align]);
 
@@ -3959,14 +3959,14 @@ val write_bytes_same = Q.store_thm("write_bytes_same",
   \\ first_x_assum(qspec_then`n+bw`mp_tac)
   \\ simp[EL_DROP]);
 
-val bytes_to_word_simp = store_thm("bytes_to_word_simp",
-  ``(bytes_to_word k a [] w be = w) /\
+val bytes_to_word_simp = Q.store_thm("bytes_to_word_simp",
+  `(bytes_to_word k a [] w be = w) /\
     (bytes_to_word k a (b::bs) w be =
-     if k = 0 then w else set_byte a b (bytes_to_word (k-1) (a+1w) bs w be) be)``,
+     if k = 0 then w else set_byte a b (bytes_to_word (k-1) (a+1w) bs w be) be)`,
   Cases_on `k` \\ fs [bytes_to_word_def]);
 
-val set_byte_sort = store_thm("set_byte_sort",
-  ``!n1 n2.
+val set_byte_sort = Q.store_thm("set_byte_sort",
+  `!n1 n2.
       set_byte (n2w n1) b1 (set_byte (n2w n2:'a word) b2 w be) be =
       if n1 = n2 then set_byte (n2w n1) b1 w be else
       if n1 < dimindex(:α) DIV 8 /\ n2 < dimindex(:α) DIV 8 /\
@@ -3974,7 +3974,7 @@ val set_byte_sort = store_thm("set_byte_sort",
       then
         set_byte (n2w n2) b2 (set_byte (n2w n1) b1 w be) be
       else
-        set_byte (n2w n1) b1 (set_byte (n2w n2) b2 w be) be``,
+        set_byte (n2w n1) b1 (set_byte (n2w n2) b2 w be) be`,
   rw [] THEN1
    (fs [set_byte_def]
     \\ full_simp_tac (std_ss++wordsLib.WORD_BIT_EQ_ss) [word_slice_alt_def]
@@ -4002,8 +4002,8 @@ val (set_byte_sort_dec,set_byte_sort_asc) = let
   val ts2 = filter (fn (x,y) => y < x) ys
   in (LIST_CONJ (map f ts1), LIST_CONJ (map f ts2)) end
 
-val set_byte_eq_ARB = store_thm("set_byte_eq_ARB",
-  ``good_dimindex (:α) ==>
+val set_byte_eq_ARB = Q.store_thm("set_byte_eq_ARB",
+  `good_dimindex (:α) ==>
     !x h h'.
       (set_byte 0w x h be = set_byte 0w x (h':'a word) be <=>
        set_byte 0w ARB h be = set_byte 0w ARB h' be) /\
@@ -4020,18 +4020,18 @@ val set_byte_eq_ARB = store_thm("set_byte_eq_ARB",
       (set_byte 6w x h be = set_byte 6w x (h':'a word) be <=>
        set_byte 6w ARB h be = set_byte 6w ARB h' be) /\
       (set_byte 7w x h be = set_byte 7w x (h':'a word) be <=>
-       set_byte 7w ARB h be = set_byte 7w ARB h' be)``,
+       set_byte 7w ARB h be = set_byte 7w ARB h' be)`,
   rw [labPropsTheory.good_dimindex_def]
   \\ Cases_on `be` \\ fs [set_byte_def,LET_THM,byte_index_def,dimword_def]
   \\ full_simp_tac (std_ss++wordsLib.WORD_BIT_EQ_ss)
         [word_slice_alt_def,set_byte_def,LET_THM,dimword_def]);
 
-val bytes_to_word_eq_lemma = store_thm("bytes_to_word_eq_lemma",
-  ``good_dimindex (:α) /\ LENGTH bs' = LENGTH bs /\
+val bytes_to_word_eq_lemma = Q.store_thm("bytes_to_word_eq_lemma",
+  `good_dimindex (:α) /\ LENGTH bs' = LENGTH bs /\
     bytes_to_word (dimindex (:α) DIV 8) 0w bs (h:'a word) be =
     bytes_to_word (dimindex (:α) DIV 8) 0w bs h' be ==>
     bytes_to_word (dimindex (:α) DIV 8) 0w bs' h be =
-    bytes_to_word (dimindex (:α) DIV 8) 0w bs' h' be``,
+    bytes_to_word (dimindex (:α) DIV 8) 0w bs' h' be`,
   fs[labPropsTheory.good_dimindex_def] \\ rfs[dimword_def]
   \\ rw [] \\ rfs [] \\ pop_assum mp_tac
   \\ `good_dimindex (:α)` by fs[labPropsTheory.good_dimindex_def]
@@ -4671,9 +4671,9 @@ val memory_rel_Number_LESS_EQ = store_thm("memory_rel_Number_LESS_EQ",
   \\ drule memory_rel_Number_EQ \\ fs [] \\ rw [] \\ fs []
   \\ fs [WORD_LESS_OR_EQ,integerTheory.INT_LE_LT]);
 
-val memory_rel_RefPtr_EQ_lemma = prove(
-  ``n * 2 ** k < dimword (:'a) /\ m * 2 ** k < dimword (:'a) /\ 0 < k /\
-    (n2w n << k || 1w) = (n2w m << k || 1w:'a word) ==> n = m``,
+val memory_rel_RefPtr_EQ_lemma = Q.prove(
+  `n * 2 ** k < dimword (:'a) /\ m * 2 ** k < dimword (:'a) /\ 0 < k /\
+    (n2w n << k || 1w) = (n2w m << k || 1w:'a word) ==> n = m`,
   `!n a b. 0n < n ==> (a * n = b * n) = (a = b)`
   by (Cases \\ simp [])
   \\ rw []
@@ -4739,15 +4739,15 @@ val memory_rel_Boolv_F = store_thm("memory_rel_Boolv_F",
   \\ asm_exists_tac \\ fs [] \\ fs [word_addr_def,BlockNil_def]
   \\ EVAL_TAC \\ fs [labPropsTheory.good_dimindex_def,dimword_def]);
 
-val Smallnum_bits = store_thm("Smallnum_bits",
-  ``(1w && Smallnum i) = 0w /\ (2w && Smallnum i) = 0w``,
+val Smallnum_bits = Q.store_thm("Smallnum_bits",
+  `(1w && Smallnum i) = 0w /\ (2w && Smallnum i) = 0w`,
   Cases_on `i`
   \\ srw_tac [wordsLib.WORD_MUL_LSL_ss]
              [Smallnum_def, GSYM wordsTheory.word_mul_n2w]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
 
-val IsBlock_word_lemma = store_thm("IsBlock_word_lemma",
-  ``good_dimindex (:'a) ==> (2w && 16w * n2w n' + 2w) <> 0w :'a word``,
+val IsBlock_word_lemma = Q.store_thm("IsBlock_word_lemma",
+  `good_dimindex (:'a) ==> (2w && 16w * n2w n' + 2w) <> 0w :'a word`,
   `!a : 'a word. (a << 4 + 2w) = (a << 4 || 2w)`
   by (strip_tac \\ match_mp_tac wordsTheory.WORD_ADD_OR
       \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
@@ -4763,18 +4763,18 @@ val word_ml_inv_SP_LIMIT = store_thm("word_ml_inv_SP_LIMIT",
   \\ full_simp_tac(srw_ss())[heap_length_APPEND,
         heap_length_def,el_length_def] \\ decide_tac);
 
-val word_or_eq_0 = prove(
-  ``((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)``,
+val word_or_eq_0 = Q.prove(
+  `((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [] \\ metis_tac [])
 
 val lt8 =
   DECIDE ``(n < 8n) = (n = 0 \/ n = 1 \/ n = 2 \/ n = 3 \/
                        n = 4 \/ n = 5 \/ n = 6 \/ n = 7)``
 
-val Smallnum_test = prove(
-  ``((Smallnum i && -1w ≪ (dimindex (:'a) − 2)) = 0w:'a word) /\
+val Smallnum_test = Q.prove(
+  `((Smallnum i && -1w ≪ (dimindex (:'a) − 2)) = 0w:'a word) /\
     good_dimindex (:'a) /\ small_int (:'a) i ==>
-    ~(i < 0) /\ i < 2 ** (dimindex (:'a) - 4)``,
+    ~(i < 0) /\ i < 2 ** (dimindex (:'a) - 4)`,
   Tactical.REVERSE (Cases_on `i`)
   \\ srw_tac [wordsLib.WORD_MUL_LSL_ss]
       [Smallnum_def, small_int_def, labPropsTheory.good_dimindex_def,
@@ -4870,8 +4870,8 @@ val memory_rel_Add = store_thm("memory_rel_Add",
   \\ rfs [dimword_def]
   \\ intLib.COOPER_TAC);
 
-val exists_num = prove(
-  ``~(i < 0i) <=> ?n. i = &n``,
+val exists_num = Q.prove(
+  `~(i < 0i) <=> ?n. i = &n`,
   Cases_on `i` \\ fs []);
 
 val memory_rel_Sub = store_thm("memory_rel_Sub",
@@ -4995,9 +4995,9 @@ val memory_rel_Number_IMP_Word_2 = store_thm("memory_rel_Number_IMP_Word_2",
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def] \\ rw [] \\ fs [word_addr_def]);
 
-val memory_rel_zero_space = store_thm("memory_rel_zero_space",
-  ``memory_rel c be refs sp st m dm vars ==>
-    memory_rel c be refs 0 st m dm vars``,
+val memory_rel_zero_space = Q.store_thm("memory_rel_zero_space",
+  `memory_rel c be refs sp st m dm vars ==>
+    memory_rel c be refs 0 st m dm vars`,
   fs [memory_rel_def,heap_in_memory_store_def]
   \\ rw [] \\ fs [] \\ rpt (asm_exists_tac \\ fs []) \\ metis_tac []);
 
@@ -5006,8 +5006,8 @@ val memory_rel_less_space = Q.store_thm("memory_rel_less_space",
    memory_rel c be refs sp' st m dm vars`,
   rw[memory_rel_def] \\ asm_exists_tac \\ simp[]);
 
-val maxout_bits_IMP = store_thm("maxout_bits_IMP",
-  ``i < dimindex (:'a) /\ (maxout_bits tag k n:'a word) ' i ==> i <= n + k``,
+val maxout_bits_IMP = Q.store_thm("maxout_bits_IMP",
+  `i < dimindex (:'a) /\ (maxout_bits tag k n:'a word) ' i ==> i <= n + k`,
   rw [maxout_bits_def] \\ rfs [word_lsl_def,fcpTheory.FCP_BETA,n2w_def]
   THEN1
    (CCONTR_TAC \\ fs [GSYM NOT_LESS]
@@ -5018,10 +5018,10 @@ val maxout_bits_IMP = store_thm("maxout_bits_IMP",
     \\ asm_exists_tac \\ fs [])
   \\ rfs [all_ones_def,word_bits_def,fcpTheory.FCP_BETA]);
 
-val make_cons_ptr_thm = store_thm("make_cons_ptr_thm",
-  ``make_cons_ptr conf (f:'a word) tag len =
+val make_cons_ptr_thm = Q.store_thm("make_cons_ptr_thm",
+  `make_cons_ptr conf (f:'a word) tag len =
      Word ((f << (shift_length conf − shift (:'a)) || 1w ||
-            ptr_bits conf tag len))``,
+            ptr_bits conf tag len))`,
   fs [make_cons_ptr_def]
   \\ `get_lowerbits conf (Word (ptr_bits conf tag len)) =
       (ptr_bits conf tag len || 1w)` by all_tac \\ fs []

--- a/compiler/backend/proofs/data_to_wordPropsScript.sml
+++ b/compiler/backend/proofs/data_to_wordPropsScript.sml
@@ -9,8 +9,8 @@ val _ = new_theory "data_to_wordProps";
 val clean_tac = rpt var_eq_tac \\ rpt (qpat_x_assum `T` kall_tac)
 fun rpt_drule th = drule (th |> GEN_ALL) \\ rpt (disch_then drule \\ fs [])
 
-val ZIP_REPLICATE = store_thm("ZIP_REPLICATE",
-  ``!n. ZIP (REPLICATE n x, REPLICATE n y) = REPLICATE n (x,y)``,
+val ZIP_REPLICATE = Q.store_thm("ZIP_REPLICATE",
+  `!n. ZIP (REPLICATE n x, REPLICATE n y) = REPLICATE n (x,y)`,
   Induct \\ fs [REPLICATE]);
 
 (* -- *)
@@ -210,8 +210,8 @@ val MOD_EQ_0_0 = Q.store_thm("MOD_EQ_0_0",
   `∀n b. 0 < b ⇒ (n MOD b = 0) ⇒ n < b ⇒ (n = 0)`,
   rw[MOD_EQ_0_DIVISOR] >> Cases_on`d`>>fs[])
 
-val EVERY2_IMP_EVERY = store_thm("EVERY2_IMP_EVERY",
-  ``!xs ys. EVERY2 P xs ys ==> EVERY (\(x,y). P y x) (ZIP(ys,xs))``,
+val EVERY2_IMP_EVERY = Q.store_thm("EVERY2_IMP_EVERY",
+  `!xs ys. EVERY2 P xs ys ==> EVERY (\(x,y). P y x) (ZIP(ys,xs))`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[]);
 
 val EVERY2_IMP_EVERY2 = Q.store_thm("EVERY2_IMP_EVERY2",
@@ -268,8 +268,8 @@ val EVERY2_EQ_EL = LIST_REL_EL_EQN
 val EVERY2_IMP_EL = METIS_PROVE[EVERY2_EQ_EL]
   ``!xs ys P. EVERY2 P xs ys ==> !n. n < LENGTH ys ==> P (EL n xs) (EL n ys)``
 
-val EVERY2_MAP_FST_SND = prove(
-  ``!xs. EVERY2 P (MAP FST xs) (MAP SND xs) = EVERY (\(x,y). P x y) xs``,
+val EVERY2_MAP_FST_SND = Q.prove(
+  `!xs. EVERY2 P (MAP FST xs) (MAP SND xs) = EVERY (\(x,y). P x y) xs`,
   Induct \\ srw_tac [] [LIST_REL_def] \\ Cases_on `h` \\ srw_tac [] []);
 
 val fapply_fupdate_update = Q.store_thm("fapply_fupdate_update",
@@ -318,13 +318,13 @@ val EL_ADDR_MAP = Q.prove(
 
 val _ = augment_srw_ss [rewrites [LIST_REL_def]];
 
-val v_inv_related = prove(
-  ``!w x f.
+val v_inv_related = Q.prove(
+  `!w x f.
       gc_related g heap1 (heap2:'a ml_heap) /\
       (!ptr u. (x = Pointer ptr u) ==> ptr IN FDOM g) /\
       v_inv conf w (x,f,heap1) ==>
       v_inv conf w (ADDR_APPLY (FAPPLY g) x,g f_o_f f,heap2) /\
-      EVERY (\n. f ' n IN FDOM g) (get_refs w)``,
+      EVERY (\n. f ' n IN FDOM g) (get_refs w)`,
   completeInduct_on `v_size w` \\ NTAC 5 strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `w` THEN1
    (full_simp_tac std_ss [v_inv_def,get_refs_def,EVERY_DEF]
@@ -384,10 +384,10 @@ val EVERY2_ADDR_MAP = Q.prove(
   \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def] \\ Cases
   \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def,ADDR_APPLY_def]);
 
-val bc_ref_inv_related = prove(
-  ``gc_related g heap1 heap2 /\
+val bc_ref_inv_related = Q.prove(
+  `gc_related g heap1 heap2 /\
     bc_ref_inv conf n refs (f,heap1,be) /\ (f ' n) IN FDOM g ==>
-    bc_ref_inv conf n refs (g f_o_f f,heap2,be)``,
+    bc_ref_inv conf n refs (g f_o_f f,heap2,be)`,
   full_simp_tac std_ss [bc_ref_inv_def] \\ strip_tac \\ full_simp_tac std_ss []
   \\ MP_TAC v_inv_related \\ asm_simp_tac std_ss []
   \\ full_simp_tac (srw_ss()) [f_o_f_DEF,gc_related_def,RefBlock_def] \\ res_tac
@@ -403,11 +403,11 @@ val bc_ref_inv_related = prove(
   \\ Cases_on `x'` \\ full_simp_tac (srw_ss()) [ADDR_APPLY_def]
   \\ res_tac \\ fs [ADDR_APPLY_def]);
 
-val RTC_lemma = prove(
-  ``!r n. RTC (ref_edge refs) r n ==>
+val RTC_lemma = Q.prove(
+  `!r n. RTC (ref_edge refs) r n ==>
           (!m. RTC (ref_edge refs) r m ==> bc_ref_inv conf m refs (f,heap,be)) /\
           gc_related g heap heap2 /\
-          f ' r IN FDOM g ==> f ' n IN FDOM g``,
+          f ' r IN FDOM g ==> f ' n IN FDOM g`,
   ho_match_mp_tac RTC_INDUCT \\ full_simp_tac std_ss [] \\ rpt strip_tac
   \\ full_simp_tac std_ss []
   \\ qpat_x_assum `bb ==> bbb` match_mp_tac \\ full_simp_tac std_ss []
@@ -437,12 +437,12 @@ val RTC_lemma = prove(
   \\ imp_res_tac MEM_EVERY2_IMP \\ fs []
   \\ fs [] \\ metis_tac []);
 
-val reachable_refs_lemma = prove(
-  ``gc_related g heap heap2 /\
+val reachable_refs_lemma = Q.prove(
+  `gc_related g heap heap2 /\
     EVERY2 (\v x. v_inv conf v (x,f,heap)) stack roots /\
     (!n. reachable_refs stack refs n ==> bc_ref_inv conf n refs (f,heap,be)) /\
     (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM g) ==>
-    (!n. reachable_refs stack refs n ==> n IN FDOM f /\ (f ' n) IN FDOM g)``,
+    (!n. reachable_refs stack refs n ==> n IN FDOM f /\ (f ' n) IN FDOM g)`,
   NTAC 3 strip_tac \\ full_simp_tac std_ss [reachable_refs_def,PULL_EXISTS]
   \\ `?xs1 xs2. stack = xs1 ++ x::xs2` by metis_tac [MEM_SPLIT]
   \\ full_simp_tac std_ss [] \\ imp_res_tac EVERY2_SPLIT_ALT
@@ -457,11 +457,11 @@ val reachable_refs_lemma = prove(
            bc_ref_inv conf m refs (f,heap,be))` by ALL_TAC
   THEN1 metis_tac [] \\ imp_res_tac RTC_lemma);
 
-val bc_stack_ref_inv_related = prove(
-  ``gc_related g heap1 heap2 /\
+val bc_stack_ref_inv_related = Q.prove(
+  `gc_related g heap1 heap2 /\
     bc_stack_ref_inv conf stack refs (roots,heap1,be) /\
     (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM g) ==>
-    bc_stack_ref_inv conf stack refs (ADDR_MAP (FAPPLY g) roots,heap2,be)``,
+    bc_stack_ref_inv conf stack refs (ADDR_MAP (FAPPLY g) roots,heap2,be)`,
   rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ qexists_tac `g f_o_f f` \\ rpt strip_tac
   THEN1 (full_simp_tac (srw_ss()) [INJ_DEF,gc_related_def,f_o_f_DEF])
@@ -477,13 +477,13 @@ val bc_stack_ref_inv_related = prove(
   \\ match_mp_tac bc_ref_inv_related \\ full_simp_tac std_ss []
   \\ metis_tac [reachable_refs_lemma]);
 
-val full_gc_thm = store_thm("full_gc_thm",
-  ``abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit ==>
+val full_gc_thm = Q.store_thm("full_gc_thm",
+  `abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit ==>
     ?roots2 heap2 a2.
       (full_gc (roots,heap,limit) = (roots2,heap2,a2,T)) /\
       abs_ml_inv conf stack refs
         (roots2,heap2 ++ heap_expand (limit - a2),be,a2,limit - a2) limit /\
-      (heap_length heap2 = a2)``,
+      (heap_length heap2 = a2)`,
   simp_tac std_ss [abs_ml_inv_def,GSYM CONJ_ASSOC]
   \\ rpt strip_tac \\ imp_res_tac full_gc_related
   \\ NTAC 3 (POP_ASSUM (K ALL_TAC))
@@ -529,10 +529,10 @@ val heap_store_unused_alt_def = Define `
       heap_store a ([x] ++ heap_expand (sp - el_length x)) xs
     else (xs,F)`;
 
-val heap_store_lemma = store_thm("heap_store_lemma",
-  ``!xs y x ys.
+val heap_store_lemma = Q.store_thm("heap_store_lemma",
+  `!xs y x ys.
       heap_store (heap_length xs) y (xs ++ x::ys) =
-      (xs ++ y ++ ys, heap_length y = el_length x)``,
+      (xs ++ y ++ ys, heap_length y = el_length x)`,
   Induct \\ full_simp_tac (srw_ss()) [heap_length_def,heap_store_def,LET_DEF]
   THEN1 DECIDE_TAC \\ rpt strip_tac
   \\ `el_length h <> 0` by (Cases_on `h` \\ full_simp_tac std_ss [el_length_def])
@@ -569,8 +569,8 @@ val isSomeDataElement_heap_lookup_lemma3 = Q.prove(
   THEN1 (DISJ1_TAC \\ DECIDE_TAC)
   \\ `el_length x <= n` by DECIDE_TAC \\ full_simp_tac std_ss []);
 
-val IMP_heap_store_unused = prove(
-  ``unused_space_inv a sp (heap:('a,'b) heap_element list) /\
+val IMP_heap_store_unused = Q.prove(
+  `unused_space_inv a sp (heap:('a,'b) heap_element list) /\
     el_length x <= sp ==>
     ?heap2. (heap_store_unused a sp x heap = (heap2,T)) /\
             unused_space_inv a (sp - el_length x) heap2 /\
@@ -587,7 +587,7 @@ val IMP_heap_store_unused = prove(
              ({a | isSomeDataElement (heap_lookup a heap2)} =
                a + sp - el_length x
                  INSERT {a | isSomeDataElement (heap_lookup a heap)})) /\
-            heap_store_rel heap heap2``,
+            heap_store_rel heap heap2`,
   rpt strip_tac \\ asm_simp_tac std_ss [heap_store_unused_def,heap_store_rel_def]
   \\ `sp <> 0` by (Cases_on `x` \\ full_simp_tac std_ss [el_length_def] \\ DECIDE_TAC)
   \\ full_simp_tac std_ss [unused_space_inv_def]
@@ -684,8 +684,8 @@ val IMP_heap_store_unused = prove(
       el_length_def,heap_length_def] \\ DECIDE_TAC)
   \\ full_simp_tac std_ss []);
 
-val IMP_heap_store_unused_alt = prove(
-  ``unused_space_inv a sp (heap:('a,'b) heap_element list) /\
+val IMP_heap_store_unused_alt = Q.prove(
+  `unused_space_inv a sp (heap:('a,'b) heap_element list) /\
     el_length x <= sp ==>
     ?heap2. (heap_store_unused_alt a sp x heap = (heap2,T)) /\
             unused_space_inv (a + el_length x) (sp - el_length x) heap2 /\
@@ -701,7 +701,7 @@ val IMP_heap_store_unused_alt = prove(
             (isDataElement x ==>
              ({a | isSomeDataElement (heap_lookup a heap2)} =
                a INSERT {a | isSomeDataElement (heap_lookup a heap)})) /\
-            heap_store_rel heap heap2``,
+            heap_store_rel heap heap2`,
   rpt strip_tac \\ asm_simp_tac std_ss [heap_store_unused_alt_def,heap_store_rel_def]
   \\ `sp <> 0` by (Cases_on `x` \\ full_simp_tac std_ss [el_length_def] \\ DECIDE_TAC)
   \\ full_simp_tac std_ss [unused_space_inv_def]
@@ -782,11 +782,11 @@ val heap_store_rel_lemma = Q.prove(
 
 (* cons *)
 
-val v_inv_SUBMAP = prove(
-  ``!w x.
+val v_inv_SUBMAP = Q.prove(
+  `!w x.
       f SUBMAP f1 /\ heap_store_rel heap heap1 /\
       v_inv conf w (x,f,heap) ==>
-      v_inv conf w (x,f1,heap1) ``,
+      v_inv conf w (x,f1,heap1) `,
   completeInduct_on `v_size w` \\ NTAC 3 strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `w` THEN1
    (full_simp_tac std_ss [v_inv_def,Bignum_def] \\ srw_tac [] []
@@ -814,8 +814,8 @@ val v_inv_SUBMAP = prove(
   THEN1 (full_simp_tac std_ss [v_inv_def] \\ metis_tac [])
   THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF] \\ rw []));
 
-val cons_thm = store_thm("cons_thm",
-  ``abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
+val cons_thm = Q.store_thm("cons_thm",
+  `abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
     LENGTH xs < sp /\ xs <> [] ==>
     ?rs roots2 heap2.
       (roots = rs ++ roots2) /\ (LENGTH rs = LENGTH xs) /\
@@ -825,7 +825,7 @@ val cons_thm = store_thm("cons_thm",
         (Pointer (a + sp - el_length (BlockRep tag rs))
            (Word (ptr_bits conf tag (LENGTH xs)))::roots2,
          heap2,be,a,
-         sp-el_length (BlockRep tag rs)) limit``,
+         sp-el_length (BlockRep tag rs)) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def,LIST_REL_def]
   \\ imp_res_tac EVERY2_APPEND_IMP \\ full_simp_tac std_ss []
@@ -883,8 +883,8 @@ val cons_thm = store_thm("cons_thm",
   \\ fs[Bytes_def,LET_THM] >> imp_res_tac heap_store_rel_lemma
   \\ metis_tac [])
 
-val cons_thm_alt = store_thm("cons_thm_alt",
-  ``abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
+val cons_thm_alt = Q.store_thm("cons_thm_alt",
+  `abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
     LENGTH xs < sp /\ xs <> [] ==>
     ?rs roots2 heap2.
       (roots = rs ++ roots2) /\ (LENGTH rs = LENGTH xs) /\
@@ -893,7 +893,7 @@ val cons_thm_alt = store_thm("cons_thm_alt",
         ((Block tag xs)::stack) refs
         (Pointer a (Word (ptr_bits conf tag (LENGTH xs)))::roots2,
          heap2,be,a+el_length (BlockRep tag rs),
-         sp-el_length (BlockRep tag rs)) limit``,
+         sp-el_length (BlockRep tag rs)) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def,LIST_REL_def]
   \\ imp_res_tac EVERY2_APPEND_IMP \\ full_simp_tac std_ss []
@@ -953,11 +953,11 @@ val cons_thm_alt = store_thm("cons_thm_alt",
   \\ fs[Bytes_def,LET_THM] >> imp_res_tac heap_store_rel_lemma
   \\ metis_tac [])
 
-val cons_thm_EMPTY = store_thm("cons_thm_EMPTY",
-  ``abs_ml_inv conf stack refs (roots,heap:'a ml_heap,be,a,sp) limit /\
+val cons_thm_EMPTY = Q.store_thm("cons_thm_EMPTY",
+  `abs_ml_inv conf stack refs (roots,heap:'a ml_heap,be,a,sp) limit /\
     tag < dimword (:'a) DIV 16 ==>
     abs_ml_inv conf ((Block tag [])::stack) refs
-                     (Data (Word (BlockNil tag))::roots,heap,be,a,sp) limit``,
+                     (Data (Word (BlockNil tag))::roots,heap,be,a,sp) limit`,
   simp_tac std_ss [abs_ml_inv_def] \\ rpt strip_tac
   \\ full_simp_tac std_ss [bc_stack_ref_inv_def,LIST_REL_def]
   \\ full_simp_tac (srw_ss()) [roots_ok_def,MEM]
@@ -1050,18 +1050,18 @@ val word64_thm = Q.store_thm("word64_thm",
 
 (* update ref *)
 
-val ref_edge_ValueArray = prove(
-  ``ref_edge (refs |+ (ptr,ValueArray xs)) x y =
-    if x = ptr then MEM y (get_refs (Block ARB xs)) else ref_edge refs x y``,
+val ref_edge_ValueArray = Q.prove(
+  `ref_edge (refs |+ (ptr,ValueArray xs)) x y =
+    if x = ptr then MEM y (get_refs (Block ARB xs)) else ref_edge refs x y`,
   simp_tac std_ss [FUN_EQ_THM,ref_edge_def] \\ rpt strip_tac
   \\ full_simp_tac (srw_ss()) [FLOOKUP_DEF,FAPPLY_FUPDATE_THM]
   \\ Cases_on `x = ptr` \\ full_simp_tac (srw_ss()) []
   \\ Cases_on `ptr IN FDOM refs` \\ full_simp_tac (srw_ss()) []
   \\ Cases_on `refs ' ptr` \\ full_simp_tac (srw_ss()) []);
 
-val reachable_refs_UPDATE = prove(
-  ``reachable_refs (xs ++ RefPtr ptr::stack) (refs |+ (ptr,ValueArray xs)) n ==>
-    reachable_refs (xs ++ RefPtr ptr::stack) refs n``,
+val reachable_refs_UPDATE = Q.prove(
+  `reachable_refs (xs ++ RefPtr ptr::stack) (refs |+ (ptr,ValueArray xs)) n ==>
+    reachable_refs (xs ++ RefPtr ptr::stack) refs n`,
   full_simp_tac std_ss [reachable_refs_def] \\ rpt strip_tac
   \\ Cases_on `?m. MEM m (get_refs (Block ARB xs)) /\
         RTC (ref_edge refs) m n` THEN1
@@ -1081,10 +1081,10 @@ val reachable_refs_UPDATE = prove(
   \\ reverse (Cases_on `r = ptr`)
   \\ full_simp_tac std_ss [] \\ res_tac);
 
-val reachable_refs_UPDATE1 = prove(
-  ``reachable_refs (xs ++ RefPtr ptr::stack) (refs |+ (ptr,ValueArray xs1)) n ==>
+val reachable_refs_UPDATE1 = Q.prove(
+  `reachable_refs (xs ++ RefPtr ptr::stack) (refs |+ (ptr,ValueArray xs1)) n ==>
     (!v. MEM v xs1 ==> ~MEM v xs ==> ?xs2. (FLOOKUP refs ptr = SOME (ValueArray xs2)) /\ MEM v xs2) ==>
-    reachable_refs (xs ++ RefPtr ptr::stack) refs n``,
+    reachable_refs (xs ++ RefPtr ptr::stack) refs n`,
   full_simp_tac std_ss [reachable_refs_def] \\ rpt strip_tac
   \\ pop_assum mp_tac \\ last_x_assum mp_tac \\ last_x_assum mp_tac
   \\ map_every qid_spec_tac[`stack`,`xs`,`x`]
@@ -1131,10 +1131,10 @@ val RefBlock_inv_def = Define `
     (!n x. (heap_lookup n heap2 = SOME x) /\ ~(isRefBlock x) ==>
            (heap_lookup n heap = SOME x))`;
 
-val heap_store_RefBlock_thm = store_thm("heap_store_RefBlock_thm",
-  ``!ha. (LENGTH x = LENGTH y) ==>
+val heap_store_RefBlock_thm = Q.store_thm("heap_store_RefBlock_thm",
+  `!ha. (LENGTH x = LENGTH y) ==>
          (heap_store (heap_length ha) [RefBlock x] (ha ++ RefBlock y::hb) =
-           (ha ++ RefBlock x::hb,T))``,
+           (ha ++ RefBlock x::hb,T))`,
   Induct \\ full_simp_tac (srw_ss()) [heap_store_def,heap_length_def]
   THEN1 full_simp_tac std_ss [RefBlock_def,el_length_def] \\ strip_tac
   \\ rpt strip_tac \\ full_simp_tac std_ss []
@@ -1163,8 +1163,8 @@ val heap_lookup_RefBlock_lemma = Q.prove(
   \\ full_simp_tac std_ss [el_length_def,RefBlock_def,NOT_LESS]
   \\ DISJ1_TAC \\ DECIDE_TAC);
 
-val heap_store_RefBlock = prove(
-  ``(LENGTH y = LENGTH h) /\
+val heap_store_RefBlock = Q.prove(
+  `(LENGTH y = LENGTH h) /\
     (heap_lookup n heap = SOME (RefBlock y)) ==>
     ?heap2. (heap_store n [RefBlock h] heap = (heap2,T)) /\
             RefBlock_inv heap heap2 /\
@@ -1177,7 +1177,7 @@ val heap_store_RefBlock = prove(
             (!a. isSomeDataElement (heap_lookup a heap2) =
                  isSomeDataElement (heap_lookup a heap)) /\
             !m x. m <> n /\ (heap_lookup m heap = SOME x) ==>
-                  (heap_lookup m heap2 = SOME x)``,
+                  (heap_lookup m heap2 = SOME x)`,
   rpt strip_tac \\ imp_res_tac heap_lookup_SPLIT
   \\ full_simp_tac std_ss [heap_store_RefBlock_thm]
   \\ strip_tac THEN1
@@ -1197,16 +1197,16 @@ val heap_store_RefBlock = prove(
   \\ full_simp_tac std_ss [isSomeDataElement_def,heap_lookup_RefBlock_lemma]
   \\ metis_tac []);
 
-val NOT_isRefBlock = prove(
-  ``~(isRefBlock (Bignum x)) /\
+val NOT_isRefBlock = Q.prove(
+  `~(isRefBlock (Bignum x)) /\
     ~(isRefBlock (Word64Rep a w)) /\
-    ~(isRefBlock (DataElement xs (LENGTH xs) (BlockTag n,[])))``,
+    ~(isRefBlock (DataElement xs (LENGTH xs) (BlockTag n,[])))`,
   simp_tac (srw_ss()) [isRefBlock_def,RefBlock_def,Bignum_def]
   \\ Cases_on`a` \\ EVAL_TAC \\ rw[]);
 
-val v_inv_Ref = prove(
-  ``RefBlock_inv heap heap2 ==>
-    !x h f. (v_inv conf x (h,f,heap2) = v_inv conf x (h,f,heap))``,
+val v_inv_Ref = Q.prove(
+  `RefBlock_inv heap heap2 ==>
+    !x h f. (v_inv conf x (h,f,heap2) = v_inv conf x (h,f,heap))`,
   strip_tac \\ completeInduct_on `v_size x` \\ NTAC 3 strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `x` THEN1
    (full_simp_tac std_ss [v_inv_def] \\ srw_tac [] []
@@ -1253,14 +1253,14 @@ val v_inv_Ref = prove(
   THEN1 (full_simp_tac std_ss [v_inv_def])
   THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF]));
 
-val update_ref_thm = store_thm("update_ref_thm",
-  ``abs_ml_inv conf (xs ++ (RefPtr ptr)::stack) refs (roots,heap,be,a,sp) limit /\
+val update_ref_thm = Q.store_thm("update_ref_thm",
+  `abs_ml_inv conf (xs ++ (RefPtr ptr)::stack) refs (roots,heap,be,a,sp) limit /\
     (FLOOKUP refs ptr = SOME (ValueArray xs1)) /\ (LENGTH xs = LENGTH xs1) ==>
     ?p rs roots2 heap2 u.
       (roots = rs ++ Pointer p u :: roots2) /\
       (heap_store p [RefBlock rs] heap = (heap2,T)) /\
       abs_ml_inv conf (xs ++ (RefPtr ptr)::stack) (refs |+ (ptr,ValueArray xs))
-        (roots,heap2,be,a,sp) limit``,
+        (roots,heap2,be,a,sp) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ imp_res_tac EVERY2_APPEND_CONS
@@ -1318,8 +1318,8 @@ val heap_deref_def = Define `
     | SOME (DataElement xs l (RefTag,[])) => SOME xs
     | _ => NONE)`;
 
-val update_ref_thm1 = store_thm("update_ref_thm1",
-  ``abs_ml_inv conf (xs ++ RefPtr ptr::stack) refs (roots,heap,be,a,sp) limit /\
+val update_ref_thm1 = Q.store_thm("update_ref_thm1",
+  `abs_ml_inv conf (xs ++ RefPtr ptr::stack) refs (roots,heap,be,a,sp) limit /\
     (FLOOKUP refs ptr = SOME (ValueArray xs1)) /\ i < LENGTH xs1 /\ 0 < LENGTH xs
     ==>
     ?p rs roots2 vs1 heap2 u.
@@ -1327,7 +1327,7 @@ val update_ref_thm1 = store_thm("update_ref_thm1",
       (heap_deref p heap = SOME vs1) /\ LENGTH vs1 = LENGTH xs1 /\
       (heap_store p [RefBlock (LUPDATE (HD rs) i vs1)] heap = (heap2,T)) /\
       abs_ml_inv conf (xs ++ (RefPtr ptr)::stack) (refs |+ (ptr,ValueArray (LUPDATE (HD xs) i xs1)))
-        (roots,heap2,be,a,sp) limit``,
+        (roots,heap2,be,a,sp) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ imp_res_tac EVERY2_APPEND_CONS
@@ -1410,10 +1410,10 @@ val v_size_LESS_EQ = Q.prove(
   `!l x. MEM x l ==> v_size x <= v1_size l`,
   Induct \\ fs [v_size_def] \\ rw [] \\ fs [] \\ res_tac \\ fs []);
 
-val v_inv_IMP = prove(
-  ``∀y x f ha.
+val v_inv_IMP = Q.prove(
+  `∀y x f ha.
       v_inv conf y (x,f,ha ++ [Bytes be xs ws] ++ hb) ⇒
-      v_inv conf y (x,f,ha ++ [Bytes be ys ws] ++ hb)``,
+      v_inv conf y (x,f,ha ++ [Bytes be ys ws] ++ hb)`,
   completeInduct_on `v_size y` \\ rw [] \\ fs [PULL_FORALL]
   \\ Cases_on `y` \\ fs [v_inv_def] \\ rw [] \\ fs []
   >- (
@@ -1432,15 +1432,15 @@ val v_inv_IMP = prove(
          heap_length_APPEND,heap_length_def,SUM_APPEND,el_length_def]
   \\ rw [] \\ fs []);
 
-val update_byte_ref_thm = store_thm("update_byte_ref_thm",
-  ``abs_ml_inv conf ((RefPtr ptr)::stack) refs (roots,heap,be,a,sp) limit /\
+val update_byte_ref_thm = Q.store_thm("update_byte_ref_thm",
+  `abs_ml_inv conf ((RefPtr ptr)::stack) refs (roots,heap,be,a,sp) limit /\
     (FLOOKUP refs ptr = SOME (ByteArray xs)) /\ (LENGTH xs = LENGTH ys) ==>
     ?roots2 h1 h2 ws.
       (roots = Pointer (heap_length h1) ((Word 0w):'a word_loc) :: roots2) /\
       heap = h1 ++ [Bytes be xs ws] ++ h2 /\
       (* LENGTH ws = LENGTH xs DIV (dimindex (:α) DIV 8) + 1 /\ *)
       abs_ml_inv conf ((RefPtr ptr)::stack) (refs |+ (ptr,ByteArray ys))
-        (roots,h1 ++ [Bytes be ys ws] ++ h2,be,a,sp) limit``,
+        (roots,h1 ++ [Bytes be ys ws] ++ h2,be,a,sp) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ Cases_on `roots` \\ fs [v_inv_def] \\ rpt var_eq_tac \\ fs []
@@ -1508,15 +1508,15 @@ val update_byte_ref_thm = store_thm("update_byte_ref_thm",
 
 (* new ref *)
 
-val new_ref_thm = store_thm("new_ref_thm",
-  ``abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
+val new_ref_thm = Q.store_thm("new_ref_thm",
+  `abs_ml_inv conf (xs ++ stack) refs (roots,heap,be,a,sp) limit /\
     ~(ptr IN FDOM refs) /\ LENGTH xs + 1 <= sp ==>
     ?p rs roots2 heap2.
       (roots = rs ++ roots2) /\ LENGTH rs = LENGTH xs /\
       (heap_store_unused a sp (RefBlock rs) heap = (heap2,T)) /\
       abs_ml_inv conf (xs ++ (RefPtr ptr)::stack) (refs |+ (ptr,ValueArray xs))
                  (rs ++ Pointer (a+sp-(LENGTH xs + 1)) (Word 0w)::roots2,heap2,be,a,
-                  sp - (LENGTH xs + 1)) limit``,
+                  sp - (LENGTH xs + 1)) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ imp_res_tac EVERY2_APPEND_IMP_APPEND
@@ -1633,8 +1633,8 @@ val heap_el_def = Define `
     | _ => (ARB,F)) /\
   (heap_el _ _ _ = (ARB,F))`;
 
-val deref_thm = store_thm("deref_thm",
-  ``abs_ml_inv conf (RefPtr ptr::stack) refs (roots,heap,be,a,sp) limit ==>
+val deref_thm = Q.store_thm("deref_thm",
+  `abs_ml_inv conf (RefPtr ptr::stack) refs (roots,heap,be,a,sp) limit ==>
     ?r roots2.
       (roots = r::roots2) /\ ptr IN FDOM refs /\
       case refs ' ptr of
@@ -1643,7 +1643,7 @@ val deref_thm = store_thm("deref_thm",
       !n. n < LENGTH ts ==>
           ?y. (heap_el r n heap = (y,T)) /\
                 abs_ml_inv conf (EL n ts::RefPtr ptr::stack) refs
-                  (y::roots,heap,be,a,sp) limit``,
+                  (y::roots,heap,be,a,sp) limit`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def]
   \\ rpt strip_tac \\ Cases_on `roots` \\ full_simp_tac (srw_ss()) [LIST_REL_def]
   \\ full_simp_tac std_ss [v_inv_def]
@@ -1686,13 +1686,13 @@ val deref_thm = store_thm("deref_thm",
 
 (* el *)
 
-val el_thm = store_thm("el_thm",
-  ``abs_ml_inv conf (Block n xs::stack) refs (roots,heap,be,a,sp) limit /\
+val el_thm = Q.store_thm("el_thm",
+  `abs_ml_inv conf (Block n xs::stack) refs (roots,heap,be,a,sp) limit /\
     i < LENGTH xs ==>
     ?r roots2 y.
       (roots = r :: roots2) /\ (heap_el r i heap = (y,T)) /\
       abs_ml_inv conf (EL i xs::Block n xs::stack) refs
-                      (y::roots,heap,be,a,sp) limit``,
+                      (y::roots,heap,be,a,sp) limit`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def]
   \\ rpt strip_tac \\ Cases_on `roots` \\ full_simp_tac (srw_ss()) [LIST_REL_def]
   \\ full_simp_tac std_ss [v_inv_def]
@@ -1724,8 +1724,8 @@ val el_thm = store_thm("el_thm",
 
 (* new byte array *)
 
-val new_byte_thm = store_thm("new_byte_thm",
-  ``abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit /\
+val new_byte_thm = Q.store_thm("new_byte_thm",
+  `abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit /\
     LENGTH bs ≤ LENGTH (ws:'a word list) * (dimindex (:α) DIV 8) ∧
     LENGTH ws ≤ LENGTH bs DIV (dimindex (:α) DIV 8) + 1 /\
     ~(ptr IN FDOM refs) /\ LENGTH ws + 1 <= sp ==>
@@ -1733,7 +1733,7 @@ val new_byte_thm = store_thm("new_byte_thm",
       (heap_store_unused a sp (Bytes be bs (ws:'a word list)) heap = (heap2,T)) /\
       abs_ml_inv conf ((RefPtr ptr)::stack) (refs |+ (ptr,ByteArray bs))
                  (Pointer (a+sp-(LENGTH ws + 1)) (Word 0w)::roots,heap2,be,a,
-                  sp - (LENGTH ws + 1)) limit``,
+                  sp - (LENGTH ws + 1)) limit`,
   simp_tac std_ss [abs_ml_inv_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ imp_res_tac EVERY2_APPEND_IMP_APPEND
@@ -1821,10 +1821,10 @@ val new_byte_thm = store_thm("new_byte_thm",
 
 (* pop *)
 
-val pop_thm = store_thm("pop_thm",
-  ``abs_ml_inv conf (xs ++ stack) refs (rs ++ roots,heap,be,a,sp) limit /\
+val pop_thm = Q.store_thm("pop_thm",
+  `abs_ml_inv conf (xs ++ stack) refs (rs ++ roots,heap,be,a,sp) limit /\
     (LENGTH xs = LENGTH rs) ==>
-    abs_ml_inv conf (stack) refs (roots,heap,be,a,sp) limit``,
+    abs_ml_inv conf (stack) refs (roots,heap,be,a,sp) limit`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ full_simp_tac std_ss [roots_ok_def,MEM_APPEND]
   THEN1 (rw [] \\ res_tac \\ fs [])
@@ -1835,21 +1835,21 @@ val pop_thm = store_thm("pop_thm",
 
 (* equality *)
 
-val ref_eq_thm = store_thm("ref_eq_thm",
-  ``abs_ml_inv conf (RefPtr p1::RefPtr p2::stack) refs
+val ref_eq_thm = Q.store_thm("ref_eq_thm",
+  `abs_ml_inv conf (RefPtr p1::RefPtr p2::stack) refs
       (r1::r2::roots,heap,be,a,sp) limit ==>
     ((p1 = p2) <=> (r1 = r2)) /\
-    ?p1 p2. r1 = Pointer p1 (Word 0w) /\ r2 = Pointer p2 (Word 0w)``,
+    ?p1 p2. r1 = Pointer p1 (Word 0w) /\ r2 = Pointer p2 (Word 0w)`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ fs [v_inv_def,INJ_DEF] \\ res_tac \\ fs [] \\ fs []
   \\ eq_tac \\ rw [] \\ fs []);
 
-val num_eq_thm = store_thm("num_eq_thm",
-  ``abs_ml_inv conf (Number i1::Number i2::stack) refs
+val num_eq_thm = Q.store_thm("num_eq_thm",
+  `abs_ml_inv conf (Number i1::Number i2::stack) refs
       (r1::r2::roots,heap,be,a,sp) limit ==>
     ((i1 = i2) <=> (r1 = r2)) /\
     r1 = Data (Word (Smallnum i1)) /\
-    r2 = Data (Word (Smallnum i2))``,
+    r2 = Data (Word (Smallnum i2))`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ fs [v_inv_def,INJ_DEF] \\ fs [Smallnum_def]
   \\ Cases_on `i1` \\ Cases_on `i2`
@@ -1881,11 +1881,11 @@ val num_less_thm = Q.store_thm("num_less_thm",
 
 (* permute stack *)
 
-val abs_ml_inv_stack_permute = store_thm("abs_ml_inv_stack_permute",
-  ``!xs ys.
+val abs_ml_inv_stack_permute = Q.store_thm("abs_ml_inv_stack_permute",
+  `!xs ys.
       abs_ml_inv conf (MAP FST xs ++ stack) refs (MAP SND xs ++ roots,heap,be,a,sp) limit /\
       set ys SUBSET set xs ==>
-      abs_ml_inv conf (MAP FST ys ++ stack) refs (MAP SND ys ++ roots,heap,be,a,sp) limit``,
+      abs_ml_inv conf (MAP FST ys ++ stack) refs (MAP SND ys ++ roots,heap,be,a,sp) limit`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ full_simp_tac std_ss [roots_ok_def]
   THEN1 (full_simp_tac std_ss [MEM_APPEND,SUBSET_DEF,MEM_MAP] \\ metis_tac [])
@@ -1898,10 +1898,10 @@ val abs_ml_inv_stack_permute = store_thm("abs_ml_inv_stack_permute",
 
 (* duplicate *)
 
-val duplicate_thm = store_thm("duplicate_thm",
-  ``abs_ml_inv conf (xs ++ stack) refs (rs ++ roots,heap,be,a,sp) limit /\
+val duplicate_thm = Q.store_thm("duplicate_thm",
+  `abs_ml_inv conf (xs ++ stack) refs (rs ++ roots,heap,be,a,sp) limit /\
     (LENGTH xs = LENGTH rs) ==>
-    abs_ml_inv conf (xs ++ xs ++ stack) refs (rs ++ rs ++ roots,heap,be,a,sp) limit``,
+    abs_ml_inv conf (xs ++ xs ++ stack) refs (rs ++ rs ++ roots,heap,be,a,sp) limit`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ full_simp_tac std_ss [roots_ok_def] THEN1 metis_tac [MEM_APPEND]
   \\ qexists_tac `f` \\ full_simp_tac std_ss []
@@ -1920,15 +1920,15 @@ val EVERY2_APPEND_IMP = Q.prove(
     (LENGTH xs1 = LENGTH ys1) ==> EVERY2 P xs1 ys1 /\ EVERY2 P xs2 ys2`,
   rpt strip_tac \\ imp_res_tac EVERY2_LENGTH \\ imp_res_tac EVERY2_APPEND);
 
-val move_thm = store_thm("move_thm",
-  ``!xs1 rs1 xs2 rs2 xs3 rs3.
+val move_thm = Q.store_thm("move_thm",
+  `!xs1 rs1 xs2 rs2 xs3 rs3.
       abs_ml_inv conf (xs1 ++ xs2 ++ xs3 ++ stack) refs
                       (rs1 ++ rs2 ++ rs3 ++ roots,heap,be,a,sp) limit /\
       (LENGTH xs1 = LENGTH rs1) /\
       (LENGTH xs2 = LENGTH rs2) /\
       (LENGTH xs3 = LENGTH rs3) ==>
       abs_ml_inv conf (xs1 ++ xs3 ++ xs2 ++ stack) refs
-                      (rs1 ++ rs3 ++ rs2 ++ roots,heap,be,a,sp) limit``,
+                      (rs1 ++ rs3 ++ rs2 ++ roots,heap,be,a,sp) limit`,
   REPEAT GEN_TAC
   \\ full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def] \\ rpt strip_tac
   \\ full_simp_tac std_ss [roots_ok_def] THEN1 metis_tac [MEM_APPEND]
@@ -1954,24 +1954,24 @@ val EVERY2_APPEND1 = Q.prove(
   \\ res_tac \\ full_simp_tac std_ss []
   \\ Q.LIST_EXISTS_TAC [`h::ys1`,`ys2`] \\ full_simp_tac (srw_ss()) []);
 
-val split1_thm = store_thm("split1_thm",
-  ``abs_ml_inv conf (xs1 ++ stack) refs (roots,heap,be,a,sp) limit ==>
-    ?rs1 roots1. (roots = rs1 ++ roots1) /\ (LENGTH rs1 = LENGTH xs1)``,
+val split1_thm = Q.store_thm("split1_thm",
+  `abs_ml_inv conf (xs1 ++ stack) refs (roots,heap,be,a,sp) limit ==>
+    ?rs1 roots1. (roots = rs1 ++ roots1) /\ (LENGTH rs1 = LENGTH xs1)`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def,GSYM APPEND_ASSOC]
   \\ rpt strip_tac \\ NTAC 5 (imp_res_tac EVERY2_APPEND1) \\ metis_tac []);
 
-val split2_thm = store_thm("split2_thm",
-  ``abs_ml_inv conf (xs1 ++ xs2 ++ stack) refs (roots,heap,be,a,sp) limit ==>
+val split2_thm = Q.store_thm("split2_thm",
+  `abs_ml_inv conf (xs1 ++ xs2 ++ stack) refs (roots,heap,be,a,sp) limit ==>
     ?rs1 rs2 roots1. (roots = rs1 ++ rs2 ++ roots1) /\
-      (LENGTH rs1 = LENGTH xs1) /\ (LENGTH rs2 = LENGTH xs2)``,
+      (LENGTH rs1 = LENGTH xs1) /\ (LENGTH rs2 = LENGTH xs2)`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def,GSYM APPEND_ASSOC]
   \\ rpt strip_tac \\ NTAC 5 (imp_res_tac EVERY2_APPEND1) \\ metis_tac []);
 
-val split3_thm = store_thm("split3_thm",
-  ``abs_ml_inv conf (xs1 ++ xs2 ++ xs3 ++ stack) refs (roots,heap,be,a,sp) limit ==>
+val split3_thm = Q.store_thm("split3_thm",
+  `abs_ml_inv conf (xs1 ++ xs2 ++ xs3 ++ stack) refs (roots,heap,be,a,sp) limit ==>
     ?rs1 rs2 rs3 roots1. (roots = rs1 ++ rs2 ++ rs3 ++ roots1) /\
       (LENGTH rs1 = LENGTH xs1) /\ (LENGTH rs2 = LENGTH xs2) /\
-      (LENGTH rs3 = LENGTH xs3)``,
+      (LENGTH rs3 = LENGTH xs3)`,
   full_simp_tac std_ss [abs_ml_inv_def,bc_stack_ref_inv_def,GSYM APPEND_ASSOC]
   \\ rpt strip_tac \\ NTAC 5 (imp_res_tac EVERY2_APPEND1) \\ metis_tac []);
 
@@ -1990,27 +1990,27 @@ val LESS_LENGTH = Q.store_thm("LESS_LENGTH",
   \\ qexists_tac `h::ys1` \\ full_simp_tac std_ss [LENGTH,APPEND]
   \\ srw_tac [] [ADD1]);
 
-val abs_ml_inv_Num = store_thm("abs_ml_inv_Num",
-  ``abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit /\ small_int (:α) i ==>
+val abs_ml_inv_Num = Q.store_thm("abs_ml_inv_Num",
+  `abs_ml_inv conf stack refs (roots,heap,be,a,sp) limit /\ small_int (:α) i ==>
     abs_ml_inv conf (Number i::stack) refs
-      (Data (Word ((Smallnum i):'a word))::roots,heap,be,a,sp) limit``,
+      (Data (Word ((Smallnum i):'a word))::roots,heap,be,a,sp) limit`,
   fs [abs_ml_inv_def,roots_ok_def,bc_stack_ref_inv_def,v_inv_def]
   \\ fs [reachable_refs_def]
   \\ rw [] \\ fs [] \\ res_tac \\ fs []
   \\ qexists_tac `f` \\ fs []
   \\ rw [] \\ fs [get_refs_def] \\ metis_tac []);
 
-val heap_store_unused_IMP_length = store_thm("heap_store_unused_IMP_length",
-  ``heap_store_unused a sp' x heap = (heap2,T) ==>
-    heap_length heap2 = heap_length heap``,
+val heap_store_unused_IMP_length = Q.store_thm("heap_store_unused_IMP_length",
+  `heap_store_unused a sp' x heap = (heap2,T) ==>
+    heap_length heap2 = heap_length heap`,
   fs [heap_store_unused_def] \\ IF_CASES_TAC \\ fs []
   \\ imp_res_tac heap_lookup_SPLIT \\ fs []
   \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND,heap_store_lemma]
   \\ rw [] \\ fs [] \\ fs [heap_length_APPEND,el_length_def,heap_length_def]);
 
-val heap_store_unused_alt_IMP_length = store_thm("heap_store_unused_alt_IMP_length",
-  ``heap_store_unused_alt a sp' x heap = (heap2,T) ==>
-    heap_length heap2 = heap_length heap``,
+val heap_store_unused_alt_IMP_length = Q.store_thm("heap_store_unused_alt_IMP_length",
+  `heap_store_unused_alt a sp' x heap = (heap2,T) ==>
+    heap_length heap2 = heap_length heap`,
   fs [heap_store_unused_alt_def] \\ IF_CASES_TAC \\ fs []
   \\ imp_res_tac heap_lookup_SPLIT \\ fs []
   \\ full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND,heap_store_lemma]
@@ -2086,11 +2086,11 @@ val word_payload_def = Define `
           let k = if dimindex(:'a) = 32 then 2 else 3 in
           n + (2 ** k - 1) < 2 ** (conf.len_size + k)))`;
 
-val word_payload_T_IMP = store_thm("word_payload_T_IMP",
-  ``word_payload l5 n5 tag r conf = (h:'a word,ts,T) /\
+val word_payload_T_IMP = Q.store_thm("word_payload_T_IMP",
+  `word_payload l5 n5 tag r conf = (h:'a word,ts,T) /\
     good_dimindex (:'a) /\ conf.len_size + 2 < dimindex (:'a) ==>
     n5 = LENGTH ts /\
-    if word_bit 2 h then l5 = [] else ts = MAP (word_addr conf) l5``,
+    if word_bit 2 h then l5 = [] else ts = MAP (word_addr conf) l5`,
   Cases_on `tag`
   \\ full_simp_tac(srw_ss())[word_payload_def,make_header_def,
        make_byte_header_def,LET_THM]
@@ -2171,11 +2171,11 @@ val MEM_FIRST_EL = Q.store_thm("MEM_FIRST_EL",
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[MEM_EL]
   \\ qexists_tac `n` \\ full_simp_tac(srw_ss())[]);
 
-val ALOOKUP_ZIP_EL = store_thm("ALOOKUP_ZIP_EL",
-  ``!xs hs n.
+val ALOOKUP_ZIP_EL = Q.store_thm("ALOOKUP_ZIP_EL",
+  `!xs hs n.
       n < LENGTH xs /\ LENGTH hs = LENGTH xs /\
       (∀m. m < n ⇒ EL m xs ≠ EL n xs) ==>
-      ALOOKUP (ZIP (xs,hs)) (EL n xs) = SOME (EL n hs)``,
+      ALOOKUP (ZIP (xs,hs)) (EL n xs) = SOME (EL n hs)`,
   Induct \\ Cases_on `hs` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]
   \\ rpt strip_tac \\ first_assum (qspec_then `0` assume_tac)
@@ -2184,10 +2184,10 @@ val ALOOKUP_ZIP_EL = store_thm("ALOOKUP_ZIP_EL",
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ first_x_assum (qspec_then `SUC m` mp_tac) \\ full_simp_tac(srw_ss())[]);
 
-val word_ml_inv_rearrange = store_thm("word_ml_inv_rearrange",
-  ``(!x. MEM x ys ==> MEM x xs) ==>
+val word_ml_inv_rearrange = Q.store_thm("word_ml_inv_rearrange",
+  `(!x. MEM x ys ==> MEM x xs) ==>
     word_ml_inv (heap,be,a,sp) limit c refs xs ==>
-    word_ml_inv (heap,be,a,sp) limit c refs ys``,
+    word_ml_inv (heap,be,a,sp) limit c refs ys`,
   full_simp_tac(srw_ss())[word_ml_inv_def] \\ srw_tac[][]
   \\ qexists_tac `MAP (\y. THE (ALOOKUP (ZIP(xs,hs)) y)) ys`
   \\ full_simp_tac(srw_ss())[EVERY2_MAP_MAP,EVERY_MEM]
@@ -2241,11 +2241,11 @@ val memory_rel_tl = Q.store_thm("memory_rel_tl",
     memory_rel c be refs sp st m dm xs`,
   match_mp_tac memory_rel_rearrange \\ fs []);
 
-val word_ml_inv_Unit = store_thm("word_ml_inv_Unit",
-  ``word_ml_inv (heap,be,a,sp) limit c refs ws /\
+val word_ml_inv_Unit = Q.store_thm("word_ml_inv_Unit",
+  `word_ml_inv (heap,be,a,sp) limit c refs ws /\
     good_dimindex (:'a) ==>
     word_ml_inv (heap,be,a,sp) limit c refs
-      ((Unit,Word (2w:'a word))::ws)``,
+      ((Unit,Word (2w:'a word))::ws)`,
   fs [word_ml_inv_def,PULL_EXISTS] \\ rw []
   \\ qexists_tac `Data (Word 2w)`
   \\ qexists_tac `hs` \\ fs [word_addr_def]
@@ -2255,9 +2255,9 @@ val word_ml_inv_Unit = store_thm("word_ml_inv_Unit",
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def]
   \\ fs [BlockNil_def]);
 
-val memory_rel_Unit = store_thm("memory_rel_Unit",
-  ``memory_rel c be refs sp st m dm xs /\ good_dimindex (:'a) ==>
-    memory_rel c be refs sp st m dm ((Unit,Word (2w:'a word))::xs)``,
+val memory_rel_Unit = Q.store_thm("memory_rel_Unit",
+  `memory_rel c be refs sp st m dm xs /\ good_dimindex (:'a) ==>
+    memory_rel c be refs sp st m dm ((Unit,Word (2w:'a word))::xs)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ match_mp_tac word_ml_inv_Unit \\ fs []);
 
@@ -2340,12 +2340,12 @@ val word_ml_inv_num_lemma = Q.store_thm("word_ml_inv_num_lemma",
   \\ Cases_on `v` \\ fs [word_mul_n2w,word_and_n2w,word_2comp_n2w]
   \\ rfs [dimword_def]);
 
-val word_ml_inv_num = store_thm("word_ml_inv_num",
-  ``word_ml_inv (heap,be,a,sp) limit c s.refs ws /\
+val word_ml_inv_num = Q.store_thm("word_ml_inv_num",
+  `word_ml_inv (heap,be,a,sp) limit c s.refs ws /\
     good_dimindex (:'a) /\
     small_enough_int (&n) ==>
     word_ml_inv (heap,be,a,sp) limit c s.refs
-      ((Number (&n),Word (n2w (4 * n):'a word))::ws)``,
+      ((Number (&n),Word (n2w (4 * n):'a word))::ws)`,
   fs [word_ml_inv_def,PULL_EXISTS] \\ rw []
   \\ qexists_tac `Data (Word (Smallnum (&n)))`
   \\ qexists_tac `hs` \\ fs [] \\ conj_tac
@@ -2369,12 +2369,12 @@ val word_ml_inv_neg_num_lemma = Q.store_thm("word_ml_inv_neg_num_lemma",
   \\ Cases_on `v` \\ fs [word_mul_n2w,word_and_n2w,word_2comp_n2w]
   \\ rfs [dimword_def]);
 
-val word_ml_inv_neg_num = store_thm("word_ml_inv_neg_num",
-  ``word_ml_inv (heap,be,a,sp) limit c s.refs ws /\
+val word_ml_inv_neg_num = Q.store_thm("word_ml_inv_neg_num",
+  `word_ml_inv (heap,be,a,sp) limit c s.refs ws /\
     good_dimindex (:'a) /\
     small_enough_int (-&n) /\ n <> 0 ==>
     word_ml_inv (heap,be,a,sp) limit c s.refs
-      ((Number (-&n),Word (-n2w (4 * n):'a word))::ws)``,
+      ((Number (-&n),Word (-n2w (4 * n):'a word))::ws)`,
   fs [word_ml_inv_def,PULL_EXISTS] \\ rw []
   \\ qexists_tac `Data (Word (Smallnum (-&n)))`
   \\ qexists_tac `hs` \\ fs [] \\ conj_tac
@@ -2392,8 +2392,8 @@ val word_list_APPEND = Q.store_thm("word_list_APPEND",
   Induct \\ full_simp_tac(srw_ss())[word_list_def,SEP_CLAUSES,STAR_ASSOC,ADD1,
                 GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val memory_rel_El = store_thm("memory_rel_El",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_El = Q.store_thm("memory_rel_El",
+  `memory_rel c be refs sp st m dm
      ((Block tag vals,ptr)::(Number (&index),i)::vars) /\
     good_dimindex (:'a) /\
     index < LENGTH vals ==>
@@ -2404,7 +2404,7 @@ val memory_rel_El = store_thm("memory_rel_El",
       (x + y) IN dm /\
       memory_rel c be refs sp st m dm
         ((EL index vals,m (x + y))::
-         (Block tag vals,ptr)::(Number (&index),i)::vars)``,
+         (Block tag vals,ptr)::(Number (&index),i)::vars)`,
   rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
   \\ fs [memory_rel_def,PULL_EXISTS] \\ rw []
@@ -2445,8 +2445,8 @@ val memory_rel_El = store_thm("memory_rel_El",
   \\ fs [word_list_def,word_list_APPEND]
   \\ SEP_R_TAC \\ fs []);
 
-val memory_rel_Deref = store_thm("memory_rel_Deref",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Deref = Q.store_thm("memory_rel_Deref",
+  `memory_rel c be refs sp st m dm
      ((RefPtr nn,ptr)::(Number (&index),i)::vars) /\
     FLOOKUP refs nn = SOME (ValueArray vals) /\
     good_dimindex (:'a) /\
@@ -2458,7 +2458,7 @@ val memory_rel_Deref = store_thm("memory_rel_Deref",
       (x + y) IN dm /\
       memory_rel c be refs sp st m dm
         ((EL index vals,m (x + y))::
-         (RefPtr nn,ptr)::(Number (&index),i)::vars)``,
+         (RefPtr nn,ptr)::(Number (&index),i)::vars)`,
   rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
   \\ fs [memory_rel_def,PULL_EXISTS] \\ rw []
@@ -2527,8 +2527,8 @@ val LENGTH_EQ_3 = Q.store_thm("LENGTH_EQ_3",
   \\ Cases_on `t'` \\ fs [LENGTH_NIL]
   \\ Cases_on `t` \\ fs [LENGTH_NIL]);
 
-val memory_rel_Update = store_thm("memory_rel_Update",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Update = Q.store_thm("memory_rel_Update",
+  `memory_rel c be refs sp st m dm
      ((h,w)::(RefPtr nn,ptr)::(Number (&index),i)::vars) /\
     FLOOKUP refs nn = SOME (ValueArray vals) /\
     good_dimindex (:'a) /\
@@ -2540,7 +2540,7 @@ val memory_rel_Update = store_thm("memory_rel_Update",
       (x + y) IN dm /\
       memory_rel c be (refs |+ (nn,ValueArray (LUPDATE h index vals))) sp st
         ((x + y =+ w) m) dm
-        ((h,w)::(RefPtr nn,ptr)::(Number (&index),i)::vars)``,
+        ((h,w)::(RefPtr nn,ptr)::(Number (&index),i)::vars)`,
   rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
   \\ fs [memory_rel_def,PULL_EXISTS] \\ rw []
@@ -2680,10 +2680,10 @@ val encode_header_IMP = Q.prove(
         suffices_by fs []
   \\ fs [GSYM EXP_ADD,dimword_def]);
 
-val word_list_exists_thm = store_thm("word_list_exists_thm",
-  ``(word_list_exists a 0 = emp) /\
+val word_list_exists_thm = Q.store_thm("word_list_exists_thm",
+  `(word_list_exists a 0 = emp) /\
     (word_list_exists a (SUC n) =
-     SEP_EXISTS w. one (a,w) * word_list_exists (a + bytes_in_word) n)``,
+     SEP_EXISTS w. one (a,w) * word_list_exists (a + bytes_in_word) n)`,
   full_simp_tac(srw_ss())[word_heap_def,word_list_exists_def,
           LENGTH_NIL,FUN_EQ_THM,ADD1,
           SEP_EXISTS_THM,cond_STAR,word_list_def,word_el_def,SEP_CLAUSES]
@@ -2705,19 +2705,19 @@ val word_list_exists_ADD = Q.store_thm("word_list_exists_ADD",
   \\ full_simp_tac(srw_ss())[STAR_ASSOC,ADD1,
         GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val store_list_thm = store_thm("store_list_thm",
-  ``!xs a frame m dm.
+val store_list_thm = Q.store_thm("store_list_thm",
+  `!xs a frame m dm.
       (word_list_exists a (LENGTH xs) * frame) (fun2set (m,dm)) ==>
       ?m1.
         store_list a xs m dm = SOME m1 /\
-        (word_list a xs * frame) (fun2set (m1,dm))``,
+        (word_list a xs * frame) (fun2set (m1,dm))`,
   Induct \\ fs [store_list_def,word_list_exists_thm,word_list_def,SEP_CLAUSES]
   \\ fs [SEP_EXISTS_THM,PULL_EXISTS] \\ rpt strip_tac
   \\ SEP_R_TAC \\ fs [] \\ SEP_W_TAC
   \\ SEP_F_TAC \\ rw [] \\ fs [AC STAR_COMM STAR_ASSOC])
 
-val word_payload_IMP = store_thm("word_payload_IMP",
-  ``word_payload addrs ll tags tt1 conf = (h,ts,T) ==> LENGTH ts = ll``,
+val word_payload_IMP = Q.store_thm("word_payload_IMP",
+  `word_payload addrs ll tags tt1 conf = (h,ts,T) ==> LENGTH ts = ll`,
   Cases_on `tags` \\ full_simp_tac(srw_ss())[word_payload_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
 val word_el_IMP_word_list_exists = Q.store_thm("word_el_IMP_word_list_exists",
@@ -2856,8 +2856,8 @@ val memory_rel_WordFromInt =
   |> CONV_RULE(LAND_CONV(SIMP_CONV(srw_ss())[]))
   |> curry save_thm"memory_rel_WordFromInt"
 
-val memory_rel_Cons = store_thm("memory_rel_Cons",
-  ``memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
+val memory_rel_Cons = Q.store_thm("memory_rel_Cons",
+  `memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
     LENGTH vals = LENGTH (ws:'a word_loc list) /\ vals <> [] /\
     encode_header c (4 * tag) (LENGTH ws) = SOME hd /\
     LENGTH ws < sp /\ good_dimindex (:'a) ==>
@@ -2868,7 +2868,7 @@ val memory_rel_Cons = store_thm("memory_rel_Cons",
         store_list w (Word hd::ws) m dm = SOME m1 /\
         memory_rel c be refs (sp - (LENGTH ws + 1))
           (st |+ (EndOfHeap,Word w)) m1 dm
-          ((Block tag vals,make_cons_ptr c (w - curr) tag (LENGTH ws))::vars)``,
+          ((Block tag vals,make_cons_ptr c (w - curr) tag (LENGTH ws))::vars)`,
   simp_tac std_ss [LET_THM]
   \\ rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
@@ -2924,11 +2924,11 @@ val memory_rel_Cons = store_thm("memory_rel_Cons",
   \\ rpt strip_tac
   \\ simp [Once get_lowerbits_or_1]);
 
-val memory_rel_Cons_empty = store_thm("memory_rel_Cons_empty",
-  ``memory_rel c be refs sp st m (dm:'a word set) vars /\
+val memory_rel_Cons_empty = Q.store_thm("memory_rel_Cons_empty",
+  `memory_rel c be refs sp st m (dm:'a word set) vars /\
     tag < dimword (:α) DIV 16 /\ good_dimindex (:'a) ==>
     memory_rel c be refs sp st m dm
-      ((Block tag [],Word (BlockNil tag))::vars)``,
+      ((Block tag [],Word (BlockNil tag))::vars)`,
   fs [memory_rel_def] \\ rw []
   \\ asm_exists_tac \\ fs []
   \\ fs [word_ml_inv_def]
@@ -2938,8 +2938,8 @@ val memory_rel_Cons_empty = store_thm("memory_rel_Cons_empty",
   \\ fs [GSYM word_mul_n2w]
   \\ match_mp_tac BlockNil_and_lemma \\ fs []);
 
-val memory_rel_Ref = store_thm("memory_rel_Ref",
-  ``memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
+val memory_rel_Ref = Q.store_thm("memory_rel_Ref",
+  `memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
     LENGTH vals = LENGTH (ws:'a word_loc list) /\
     encode_header c 2 (LENGTH ws) = SOME hd /\ ~(new IN FDOM refs) /\
     LENGTH ws < sp /\ good_dimindex (:'a) ==>
@@ -2950,7 +2950,7 @@ val memory_rel_Ref = store_thm("memory_rel_Ref",
         store_list w (Word hd::ws) m dm = SOME m1 /\
         memory_rel c be (refs |+ (new,ValueArray vals)) (sp - (LENGTH ws + 1))
           (st |+ (EndOfHeap,Word w)) m1 dm
-          ((RefPtr new,make_ptr c (w - curr) 0w (LENGTH ws))::vars)``,
+          ((RefPtr new,make_ptr c (w - curr) 0w (LENGTH ws))::vars)`,
   simp_tac std_ss [LET_THM]
   \\ rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
@@ -3032,15 +3032,15 @@ val memory_rel_write = Q.store_thm("memory_rel_write",
   \\ fs [word_list_def,word_list_APPEND]
   \\ SEP_WRITE_TAC);
 
-val word_list_AND_word_list_exists_IMP = store_thm(
+val word_list_AND_word_list_exists_IMP = Q.store_thm(
   "word_list_AND_word_list_exists_IMP",
-  ``!ws aa frame n.
+  `!ws aa frame n.
       (word_list aa ws * SEP_T) (fun2set (m,dm)) /\
       (word_list_exists aa n * frame) (fun2set (m,dm)) /\
       LENGTH ws <= n ==>
       (word_list aa ws *
        word_list_exists (aa + bytes_in_word * n2w (LENGTH ws)) (n - LENGTH ws) *
-       frame) (fun2set (m,dm))``,
+       frame) (fun2set (m,dm))`,
   Induct \\ fs [word_list_def,SEP_CLAUSES] \\ rw []
   \\ Cases_on `n` \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ qsuff_tac
@@ -3064,8 +3064,8 @@ val word_list_AND_word_list_exists_IMP = store_thm(
   \\ fs [GSYM ADD1,word_list_exists_thm,SEP_CLAUSES,SEP_EXISTS_THM]
   \\ SEP_WRITE_TAC);
 
-val memory_rel_Cons_alt = store_thm("memory_rel_Cons_alt",
-  ``memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
+val memory_rel_Cons_alt = Q.store_thm("memory_rel_Cons_alt",
+  `memory_rel c be refs sp st m dm (ZIP (vals,ws) ++ vars) /\
     LENGTH vals = LENGTH (ws:'a word_loc list) /\ vals <> [] /\
     encode_header c (4 * tag) (LENGTH ws) = SOME hd /\
     LENGTH ws < sp /\ good_dimindex (:'a) ==>
@@ -3075,7 +3075,7 @@ val memory_rel_Cons_alt = store_thm("memory_rel_Cons_alt",
       ((word_list free (Word hd::ws) * SEP_T) (fun2set(m,dm)) ==>
        memory_rel c be refs (sp - (LENGTH ws + 1))
          (st |+ (NextFree,Word (free + bytes_in_word * n2w (LENGTH ws + 1)))) m dm
-         ((Block tag vals,make_cons_ptr c (free - curr) tag (LENGTH ws))::vars))``,
+         ((Block tag vals,make_cons_ptr c (free - curr) tag (LENGTH ws))::vars))`,
   simp_tac std_ss [LET_THM]
   \\ rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
@@ -3144,9 +3144,9 @@ val memory_rel_Cons_alt = store_thm("memory_rel_Cons_alt",
   \\ CONV_TAC (DEPTH_CONV ETA_CONV)
   \\ fs [AC STAR_ASSOC STAR_COMM] \\ fs [STAR_ASSOC]);
 
-val memory_rel_REPLICATE = store_thm("memory_rel_REPLICATE",
-  ``memory_rel c be refs sp st m dm ((v,w)::vars) ==>
-    memory_rel c be refs sp st m dm (REPLICATE n (v,w) ++ vars)``,
+val memory_rel_REPLICATE = Q.store_thm("memory_rel_REPLICATE",
+  `memory_rel c be refs sp st m dm ((v,w)::vars) ==>
+    memory_rel c be refs sp st m dm (REPLICATE n (v,w) ++ vars)`,
   match_mp_tac memory_rel_rearrange \\ fs [] \\ rw [] \\ fs []
   \\ Induct_on `n` \\ fs [REPLICATE] \\ rw [] \\ fs [])
 
@@ -3226,8 +3226,8 @@ val shift_shift_lemma = Q.prove(
   \\ simp_tac bool_ss [Once MULT_COMM]
   \\ rewrite_tac [LT_MULT_LCANCEL,GSYM MULT_ASSOC] \\ fs []);
 
-val memory_rel_RefByte = store_thm("memory_rel_RefByte",
- ``memory_rel c be refs sp st m dm vars ∧
+val memory_rel_RefByte = Q.store_thm("memory_rel_RefByte",
+ `memory_rel c be refs sp st m dm vars ∧
    new ∉ FDOM refs ∧ byte_len (:'a) n < sp ∧
    byte_len (:'a) n < 2 ** (dimindex (:α) − 4) /\
    byte_len (:'a) n < 2 ** c.len_size /\
@@ -3242,7 +3242,7 @@ val memory_rel_RefByte = store_thm("memory_rel_RefByte",
             (Word (word_of_byte (w2w w)))) m dm = SOME m1 ∧
         memory_rel c be (refs |+ (new,ByteArray (REPLICATE n w)))
           (sp − (byte_len (:'a) n + 1)) (st |+ (EndOfHeap,Word w')) m1 dm
-          ((RefPtr new,make_ptr c (w' − curr) 0w (byte_len (:'a) n))::vars))``,
+          ((RefPtr new,make_ptr c (w' − curr) 0w (byte_len (:'a) n))::vars))`,
   simp_tac std_ss [LET_THM]
   \\ rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
@@ -3341,10 +3341,10 @@ val memory_rel_drop = Q.store_thm("memory_rel_drop",
     memory_rel c be refs sp st m dm vars`,
   match_mp_tac memory_rel_rearrange \\ fs []);
 
-val memory_rel_IMP_word_list_exists = store_thm("memory_rel_IMP_word_list_exists",
-  ``memory_rel c be refs sp st m dm vars /\ n <= sp /\
+val memory_rel_IMP_word_list_exists = Q.store_thm("memory_rel_IMP_word_list_exists",
+  `memory_rel c be refs sp st m dm vars /\ n <= sp /\
     FLOOKUP st NextFree = SOME (Word f) ==>
-    (word_list_exists f n * SEP_T) (fun2set (m,dm))``,
+    (word_list_exists f n * SEP_T) (fun2set (m,dm))`,
   fs [memory_rel_def,heap_in_memory_store_def] \\ rw [] \\ fs []
   \\ fs [word_ml_inv_def,abs_ml_inv_def,unused_space_inv_def]
   \\ Cases_on `n = 0`
@@ -3377,9 +3377,9 @@ val word_addr_eq_Loc = Q.store_thm("word_addr_eq_Loc",
   Cases_on `v` \\ fs [word_addr_def]
   \\ Cases_on `a` \\ fs [word_addr_def]);
 
-val memory_rel_CodePtr = store_thm("memory_rel_CodePtr",
-  ``memory_rel c be refs sp st m dm vars ==>
-    memory_rel c be refs sp st m dm ((CodePtr lab,Loc lab 0)::vars)``,
+val memory_rel_CodePtr = Q.store_thm("memory_rel_CodePtr",
+  `memory_rel c be refs sp st m dm vars ==>
+    memory_rel c be refs sp st m dm ((CodePtr lab,Loc lab 0)::vars)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [word_ml_inv_def,PULL_EXISTS,word_addr_eq_Loc]
   \\ once_rewrite_tac [CONJ_COMM] \\ asm_exists_tac \\ fs []
@@ -3389,8 +3389,8 @@ val memory_rel_CodePtr = store_thm("memory_rel_CodePtr",
   \\ asm_exists_tac \\ fs [PULL_EXISTS] \\ rw [] \\ fs []
   \\ fs [get_refs_def] \\ res_tac);
 
-val memory_rel_Block_IMP = store_thm("memory_rel_Block_IMP",
-  ``memory_rel c be refs sp st m dm ((Block tag vals,v:'a word_loc)::vars) /\
+val memory_rel_Block_IMP = Q.store_thm("memory_rel_Block_IMP",
+  `memory_rel c be refs sp st m dm ((Block tag vals,v:'a word_loc)::vars) /\
     good_dimindex (:'a) ==>
     ?w. v = Word w /\
         if vals = [] then
@@ -3401,7 +3401,7 @@ val memory_rel_Block_IMP = store_thm("memory_rel_Block_IMP",
             get_real_addr c st w = SOME a /\ m a = Word x /\ a IN dm /\
             decode_length c x = n2w (LENGTH vals) /\
             LENGTH vals < 2 ** (dimindex (:'a) − 4) /\
-            encode_header c (4 * tag) (LENGTH vals) = SOME x``,
+            encode_header c (4 * tag) (LENGTH vals) = SOME x`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def]
   \\ CASE_TAC \\ fs [] \\ rw []
@@ -3423,11 +3423,11 @@ val memory_rel_Block_IMP = store_thm("memory_rel_Block_IMP",
   \\ fs [labPropsTheory.good_dimindex_def]
   \\ fs [fcpTheory.FCP_BETA,word_lsl_def,word_index])
 
-val IMP_memory_rel_Number = store_thm("IMP_memory_rel_Number",
-  ``good_dimindex (:'a) /\ small_int (:'a) i /\
+val IMP_memory_rel_Number = Q.store_thm("IMP_memory_rel_Number",
+  `good_dimindex (:'a) /\ small_int (:'a) i /\
     memory_rel c be refs sp st m dm vars ==>
     memory_rel c be refs sp st m dm
-     ((Number i,(Word (Smallnum i):'a word_loc))::vars)``,
+     ((Number i,(Word (Smallnum i):'a word_loc))::vars)`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS] \\ rpt strip_tac
   \\ asm_exists_tac \\ fs []
   \\ rpt_drule abs_ml_inv_Num
@@ -3448,8 +3448,8 @@ val copy_list_def = Define `
           let a = m (a + 2w * bytes_in_word) in
             if c then copy_list c' st (k-1) (a,x,b,m,dm) else NONE`
 
-val copy_list_thm = store_thm("copy_list_thm",
-  ``!v k vs b m vars a x frame.
+val copy_list_thm = Q.store_thm("copy_list_thm",
+  `!v k vs b m vars a x frame.
       memory_rel c be refs sp st m dm ((v,a:'a word_loc)::vars) /\
       v_to_list v = SOME vs /\
       (word_list_exists (b + bytes_in_word * n2w k) (SUC (LENGTH vs)) * frame)
@@ -3462,7 +3462,7 @@ val copy_list_thm = store_thm("copy_list_thm",
            SOME (b + bytes_in_word * n2w (k + LENGTH vs + 1),m1) /\
         LENGTH vs = LENGTH xs /\
         memory_rel c be refs sp st m1 dm (ZIP (vs,xs) ++ vars) /\
-        (word_list (b + bytes_in_word * n2w k) (x::xs) * frame) (fun2set (m1,dm))``,
+        (word_list (b + bytes_in_word * n2w k) (x::xs) * frame) (fun2set (m1,dm))`,
   Induct_on `vs`
   THEN1
    (rewrite_tac [LENGTH,word_list_exists_thm]
@@ -3544,8 +3544,8 @@ val copy_list_thm = store_thm("copy_list_thm",
   |> Q.SPECL [`v`,`0`]
   |> SIMP_RULE (srw_ss()) [WORD_MULT_CLAUSES] |> Q.GEN `v`;
 
-val memory_rel_FromList = store_thm("memory_rel_FromList",
-  ``v_to_list v = SOME vs /\ vs <> [] /\
+val memory_rel_FromList = Q.store_thm("memory_rel_FromList",
+  `v_to_list v = SOME vs /\ vs <> [] /\
     memory_rel c be refs sp st m dm ((v,a:'a word_loc)::vars) /\
     encode_header c (4 * tag) (LENGTH vs) = SOME hd ∧ LENGTH vs < sp ∧
     good_dimindex (:α) ==>
@@ -3555,7 +3555,7 @@ val memory_rel_FromList = store_thm("memory_rel_FromList",
       copy_list c st (LENGTH vs) (a,Word hd,free,m,dm) = SOME (f1,m1) /\
       memory_rel c be refs (sp − (LENGTH vs + 1)) (st |+ (NextFree,Word f1)) m1 dm
         ((Block tag vs,
-          make_cons_ptr c (free − curr) tag (LENGTH vs))::vars)``,
+          make_cons_ptr c (free − curr) tag (LENGTH vs))::vars)`,
   strip_tac
   \\ `?f. FLOOKUP st NextFree = SOME (Word f)` by
        fs [memory_rel_def,heap_in_memory_store_def]
@@ -3608,10 +3608,10 @@ val encode_header_tag_mask = Q.store_thm("encode_header_tag_mask",
   \\ rewrite_tac [DECIDE ``16 * n = (8 * n) * 2n``,
         MATCH_MP MULT_DIV (DECIDE ``0<2n``),ODD_MULT] \\ fs []);
 
-val memory_rel_tag_limit = store_thm("memory_rel_tag_limit",
-  ``memory_rel c be refs sp st m dm ((Block tag l,(w:'a word_loc))::rest) /\
+val memory_rel_tag_limit = Q.store_thm("memory_rel_tag_limit",
+  `memory_rel c be refs sp st m dm ((Block tag l,(w:'a word_loc))::rest) /\
     good_dimindex (:'a) ==>
-    tag < dimword (:'a) DIV 16``,
+    tag < dimword (:'a) DIV 16`,
   strip_tac \\ drule memory_rel_Block_IMP \\ fs [] \\ rw []
   \\ every_case_tac \\ fs []
   \\ imp_res_tac encode_header_tag_mask \\ fs []);
@@ -3624,21 +3624,21 @@ val MULT_BIT0 = Q.prove(
   `BIT 0 (m * n) <=> BIT 0 m /\ BIT 0 n`,
   fs [bitTheory.BIT0_ODD,ODD_MULT]);
 
-val memory_rel_test_nil_eq = store_thm("memory_rel_test_nil_eq",
-  ``memory_rel c be refs sp st m dm ((Block tag l,w:'a word_loc)::rest) /\
+val memory_rel_test_nil_eq = Q.store_thm("memory_rel_test_nil_eq",
+  `memory_rel c be refs sp st m dm ((Block tag l,w:'a word_loc)::rest) /\
     n < dimword (:'a) DIV 16 /\ good_dimindex (:'a) ==>
-    ?v. w = Word v /\ (v = n2w (16 * n + 2) <=> tag = n /\ l = [])``,
+    ?v. w = Word v /\ (v = n2w (16 * n + 2) <=> tag = n /\ l = [])`,
   strip_tac \\ drule memory_rel_Block_IMP \\ fs [] \\ rw []
   \\ reverse every_case_tac \\ fs []
   THEN1 (CCONTR_TAC \\ rw [] \\ fs [word_index,bitTheory.ADD_BIT0,MULT_BIT0])
   \\ fs [word_mul_n2w,word_add_n2w]
   \\ imp_res_tac LESS_DIV_16_IMP \\ fs []);
 
-val memory_rel_test_none_eq = store_thm("memory_rel_test_none_eq",
-  ``encode_header c (4 * n) len = (NONE:'a word option) /\
+val memory_rel_test_none_eq = Q.store_thm("memory_rel_test_none_eq",
+  `encode_header c (4 * n) len = (NONE:'a word option) /\
     memory_rel c be refs sp st m dm ((Block tag l,w:'a word_loc)::rest) /\
     len <> 0 /\ good_dimindex (:'a) ==>
-    ~(tag = n /\ LENGTH l = len)``,
+    ~(tag = n /\ LENGTH l = len)`,
   strip_tac \\ drule memory_rel_Block_IMP \\ fs [] \\ rw []
   \\ CCONTR_TAC \\ fs [] \\ rw [] \\ rfs [LENGTH_NIL,PULL_EXISTS]);
 
@@ -3707,14 +3707,14 @@ val encode_header_EQ = Q.store_thm("encode_header_EQ",
   \\ rfs [not_bit_lt_2exp]
   );
 
-val memory_rel_ValueArray_IMP = store_thm("memory_rel_ValueArray_IMP",
-  ``memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) /\
+val memory_rel_ValueArray_IMP = Q.store_thm("memory_rel_ValueArray_IMP",
+  `memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) /\
     FLOOKUP refs p = SOME (ValueArray vals) /\ good_dimindex (:'a) ==>
     ?w a x.
       v = Word w /\ w ' 0 /\ word_bit 3 x /\ ~word_bit 2 x /\ ~word_bit 4 x /\
       get_real_addr c st w = SOME a /\ m a = Word x /\ a IN dm /\
       decode_length c x = n2w (LENGTH vals) /\
-      LENGTH vals < 2 ** (dimindex (:'a) − 4)``,
+      LENGTH vals < 2 ** (dimindex (:'a) − 4)`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def,word_addr_def] \\ rw [get_addr_0]
   \\ `bc_ref_inv c p refs (f,heap,be)` by
@@ -4551,9 +4551,9 @@ val memory_rel_ByteArray_IMP = Q.store_thm("memory_rel_ByteArray_IMP",
     \\ `y' < y` by simp[Abbr`y`,Abbr`y'`]
     \\ decide_tac));
 
-val memory_rel_RefPtr_IMP_lemma = store_thm("memory_rel_RefPtr_IMP_lemma",
-  ``memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) ==>
-    ?res. FLOOKUP refs p = SOME res``,
+val memory_rel_RefPtr_IMP_lemma = Q.store_thm("memory_rel_RefPtr_IMP_lemma",
+  `memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) ==>
+    ?res. FLOOKUP refs p = SOME res`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def,word_addr_def] \\ rw []
   \\ `bc_ref_inv c p refs (f,heap,be)` by
@@ -4562,21 +4562,21 @@ val memory_rel_RefPtr_IMP_lemma = store_thm("memory_rel_RefPtr_IMP_lemma",
   \\ pop_assum mp_tac \\ simp [bc_ref_inv_def]
   \\ fs [FLOOKUP_DEF] \\ rw []);
 
-val memory_rel_RefPtr_IMP = store_thm("memory_rel_RefPtr_IMP",
-  ``memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) /\
+val memory_rel_RefPtr_IMP = Q.store_thm("memory_rel_RefPtr_IMP",
+  `memory_rel c be refs sp st m dm ((RefPtr p,v:'a word_loc)::vars) /\
     good_dimindex (:'a) ==>
     ?w a x.
       v = Word w /\ w ' 0 /\ word_bit 3 x /\ (word_bit 2 x <=> word_bit 4 x) /\
-      get_real_addr c st w = SOME a /\ m a = Word x /\ a IN dm``,
+      get_real_addr c st w = SOME a /\ m a = Word x /\ a IN dm`,
   strip_tac \\ drule memory_rel_RefPtr_IMP_lemma \\ strip_tac
   \\ Cases_on `res` \\ fs []
   THEN1 (rpt_drule memory_rel_ValueArray_IMP \\ rw [] \\ fs [])
   THEN1 (rpt_drule memory_rel_ByteArray_IMP \\ rw [] \\ fs []));
 
-val memory_rel_Number_IMP = store_thm("memory_rel_Number_IMP",
-  ``good_dimindex (:'a) /\
+val memory_rel_Number_IMP = Q.store_thm("memory_rel_Number_IMP",
+  `good_dimindex (:'a) /\
     memory_rel c be refs sp st m dm ((Number i,v:'a word_loc)::vars) ==>
-    v = Word (Smallnum i) /\ small_int (:'a) i``,
+    v = Word (Smallnum i) /\ small_int (:'a) i`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def] \\ rw []
   \\ fs [word_addr_def,Smallnum_def,integer_wordTheory.i2w_def]
@@ -4620,32 +4620,32 @@ val memory_rel_Word64_IMP = Q.store_thm("memory_rel_Word64_IMP",
   \\ fs[word_payload_def,word_list_def,LSL_ONE]
   \\ SEP_R_TAC \\ fs[]);
 
-val IMP_memory_rel_Number_num3 = store_thm("IMP_memory_rel_Number_num3",
-  ``good_dimindex (:'a) /\ n < 2 ** (dimindex (:'a) - 3) /\
+val IMP_memory_rel_Number_num3 = Q.store_thm("IMP_memory_rel_Number_num3",
+  `good_dimindex (:'a) /\ n < 2 ** (dimindex (:'a) - 3) /\
     memory_rel c be refs sp st m dm vars ==>
     memory_rel c be refs sp st m dm
-     ((Number (&n),Word ((n2w n << 2):'a word))::vars)``,
+     ((Number (&n),Word ((n2w n << 2):'a word))::vars)`,
   strip_tac \\ mp_tac (IMP_memory_rel_Number |> Q.INST [`i`|->`&n`]) \\ fs []
   \\ fs [Smallnum_def,WORD_MUL_LSL,word_mul_n2w]
   \\ disch_then match_mp_tac
   \\ fs [small_int_def,dimword_def]
   \\ fs [labPropsTheory.good_dimindex_def] \\ rfs [])
 
-val IMP_memory_rel_Number_num = store_thm("IMP_memory_rel_Number_num",
-  ``good_dimindex (:'a) /\ n < 2 ** (dimindex (:'a) - 4) /\
+val IMP_memory_rel_Number_num = Q.store_thm("IMP_memory_rel_Number_num",
+  `good_dimindex (:'a) /\ n < 2 ** (dimindex (:'a) - 4) /\
     memory_rel c be refs sp st m dm vars ==>
     memory_rel c be refs sp st m dm
-     ((Number (&n),Word ((n2w n << 2):'a word))::vars)``,
+     ((Number (&n),Word ((n2w n << 2):'a word))::vars)`,
   strip_tac \\ mp_tac (IMP_memory_rel_Number |> Q.INST [`i`|->`&n`]) \\ fs []
   \\ fs [Smallnum_def,WORD_MUL_LSL,word_mul_n2w]
   \\ disch_then match_mp_tac
   \\ fs [small_int_def,dimword_def]
   \\ fs [labPropsTheory.good_dimindex_def] \\ rfs [])
 
-val memory_rel_Number_EQ = store_thm("memory_rel_Number_EQ",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Number_EQ = Q.store_thm("memory_rel_Number_EQ",
+  `memory_rel c be refs sp st m dm
       ((Number i1,w1)::(Number i2,w2)::vars) /\ good_dimindex (:'a) ==>
-      ?v1 v2. w1 = Word v1 /\ w2 = Word (v2:'a word) /\ (v1 = v2 <=> i1 = i2)``,
+      ?v1 v2. w1 = Word v1 /\ w2 = Word (v2:'a word) /\ (v1 = v2 <=> i1 = i2)`,
   strip_tac
   \\ imp_res_tac memory_rel_Number_IMP
   \\ drule memory_rel_tail \\ strip_tac
@@ -4653,20 +4653,20 @@ val memory_rel_Number_EQ = store_thm("memory_rel_Number_EQ",
   \\ fs [] \\ fs [memory_rel_def] \\ rw [] \\ fs [word_ml_inv_def] \\ clean_tac
   \\ drule num_eq_thm \\ rw []);
 
-val memory_rel_Number_LESS = store_thm("memory_rel_Number_LESS",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Number_LESS = Q.store_thm("memory_rel_Number_LESS",
+  `memory_rel c be refs sp st m dm
       ((Number i1,w1)::(Number i2,w2)::vars) /\ good_dimindex (:'a) ==>
-      ?v1 v2. w1 = Word v1 /\ w2 = Word v2 /\ (v1 < (v2:'a word) <=> i1 < i2)``,
+      ?v1 v2. w1 = Word v1 /\ w2 = Word v2 /\ (v1 < (v2:'a word) <=> i1 < i2)`,
   strip_tac
   \\ imp_res_tac memory_rel_Number_IMP
   \\ drule memory_rel_tail \\ strip_tac
   \\ imp_res_tac memory_rel_Number_IMP
   \\ fs [] \\ fs [memory_rel_def] \\ rw [] \\ fs [num_less_thm]);
 
-val memory_rel_Number_LESS_EQ = store_thm("memory_rel_Number_LESS_EQ",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Number_LESS_EQ = Q.store_thm("memory_rel_Number_LESS_EQ",
+  `memory_rel c be refs sp st m dm
       ((Number i1,w1)::(Number i2,w2)::vars) /\ good_dimindex (:'a) ==>
-      ?v1 v2. w1 = Word v1 /\ w2 = Word v2 /\ (v1 <= (v2:'a word) <=> i1 <= i2)``,
+      ?v1 v2. w1 = Word v1 /\ w2 = Word v2 /\ (v1 <= (v2:'a word) <=> i1 <= i2)`,
   rw [] \\ drule memory_rel_Number_LESS \\ fs [] \\ rw [] \\ fs []
   \\ drule memory_rel_Number_EQ \\ fs [] \\ rw [] \\ fs []
   \\ fs [WORD_LESS_OR_EQ,integerTheory.INT_LE_LT]);
@@ -4687,10 +4687,10 @@ val memory_rel_RefPtr_EQ_lemma = Q.prove(
   \\ rfs []
   )
 
-val memory_rel_RefPtr_EQ = store_thm("memory_rel_RefPtr_EQ",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_RefPtr_EQ = Q.store_thm("memory_rel_RefPtr_EQ",
+  `memory_rel c be refs sp st m dm
       ((RefPtr i1,w1)::(RefPtr i2,w2)::vars) /\ good_dimindex (:'a) ==>
-      ?v1 v2. w1 = Word v1 /\ w2 = Word (v2:'a word) /\ (v1 = v2 <=> i1 = i2)``,
+      ?v1 v2. w1 = Word v1 /\ w2 = Word (v2:'a word) /\ (v1 = v2 <=> i1 = i2)`,
   fs [memory_rel_def] \\ rw [] \\ fs [word_ml_inv_def] \\ clean_tac
   \\ drule ref_eq_thm \\ rw [] \\ clean_tac
   \\ fs [word_addr_def,get_addr_def]
@@ -4717,9 +4717,9 @@ val memory_rel_RefPtr_EQ = store_thm("memory_rel_RefPtr_EQ",
      \\ Cases_on `2 ** shift_length c` \\ fs []) \\ fs []
   \\ imp_res_tac memory_rel_RefPtr_EQ_lemma \\ rfs[]);
 
-val memory_rel_Boolv_T = store_thm("memory_rel_Boolv_T",
-  ``memory_rel c be refs sp st m dm vars /\ good_dimindex (:'a) ==>
-    memory_rel c be refs sp st m dm ((Boolv T,Word (2w:'a word))::vars)``,
+val memory_rel_Boolv_T = Q.store_thm("memory_rel_Boolv_T",
+  `memory_rel c be refs sp st m dm vars /\ good_dimindex (:'a) ==>
+    memory_rel c be refs sp st m dm ((Boolv T,Word (2w:'a word))::vars)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [word_ml_inv_def,PULL_EXISTS,EVAL ``Boolv F``,EVAL ``Boolv T``]
   \\ rpt_drule cons_thm_EMPTY \\ disch_then (qspec_then `0` assume_tac)
@@ -4728,9 +4728,9 @@ val memory_rel_Boolv_T = store_thm("memory_rel_Boolv_T",
   \\ asm_exists_tac \\ fs [] \\ fs [word_addr_def,BlockNil_def]
   \\ EVAL_TAC \\ fs [labPropsTheory.good_dimindex_def,dimword_def]);
 
-val memory_rel_Boolv_F = store_thm("memory_rel_Boolv_F",
-  ``memory_rel c be refs sp st m dm vars /\ good_dimindex (:'a) ==>
-    memory_rel c be refs sp st m dm ((Boolv F,Word (18w:'a word))::vars)``,
+val memory_rel_Boolv_F = Q.store_thm("memory_rel_Boolv_F",
+  `memory_rel c be refs sp st m dm vars /\ good_dimindex (:'a) ==>
+    memory_rel c be refs sp st m dm ((Boolv F,Word (18w:'a word))::vars)`,
   fs [memory_rel_def] \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [word_ml_inv_def,PULL_EXISTS,EVAL ``Boolv F``,EVAL ``Boolv T``]
   \\ rpt_drule cons_thm_EMPTY \\ disch_then (qspec_then `1` assume_tac)
@@ -4754,8 +4754,8 @@ val IsBlock_word_lemma = Q.store_thm("IsBlock_word_lemma",
   \\ srw_tac [wordsLib.WORD_MUL_LSL_ss] [labPropsTheory.good_dimindex_def]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
 
-val word_ml_inv_SP_LIMIT = store_thm("word_ml_inv_SP_LIMIT",
-  ``word_ml_inv (heap,be,a,sp) limit c refs stack ==> sp <= limit``,
+val word_ml_inv_SP_LIMIT = Q.store_thm("word_ml_inv_SP_LIMIT",
+  `word_ml_inv (heap,be,a,sp) limit c refs stack ==> sp <= limit`,
   srw_tac[][] \\ Cases_on `sp = 0`
   \\ full_simp_tac(srw_ss())[word_ml_inv_def,abs_ml_inv_def,
         heap_ok_def,unused_space_inv_def]
@@ -4842,13 +4842,13 @@ val Smallnum_test = Q.prove(
                bitTheory.BITSLT_THM2 |> Q.SPEC `59` |> numLib.REDUCE_RULE])
   )
 
-val memory_rel_Add = store_thm("memory_rel_Add",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Add = Q.store_thm("memory_rel_Add",
+  `memory_rel c be refs sp st m dm
       ((Number i,Word wi)::(Number j,Word wj)::vars) /\
     good_dimindex (:'a) /\
     (((wi || wj) && (~0w << (dimindex (:'a)-2))) = 0w) ==>
     memory_rel c be refs sp st m dm
-      ((Number (i + j),Word (wi + wj:'a word))::vars)``,
+      ((Number (i + j),Word (wi + wj:'a word))::vars)`,
   rw [] \\ imp_res_tac memory_rel_Number_IMP \\ fs []
   \\ fs [WORD_LEFT_AND_OVER_OR]
   \\ drule memory_rel_tail \\ strip_tac
@@ -4874,13 +4874,13 @@ val exists_num = Q.prove(
   `~(i < 0i) <=> ?n. i = &n`,
   Cases_on `i` \\ fs []);
 
-val memory_rel_Sub = store_thm("memory_rel_Sub",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Sub = Q.store_thm("memory_rel_Sub",
+  `memory_rel c be refs sp st m dm
        ((Number i,Word wi)::(Number j,Word wj)::vars) /\
     good_dimindex (:'a) /\
     (((wi || wj) && (~0w << (dimindex (:'a)-2))) = 0w) ==>
     memory_rel c be refs sp st m dm
-       ((Number (i - j),Word (wi - wj:'a word))::vars)``,
+       ((Number (i - j),Word (wi - wj:'a word))::vars)`,
   rw [] \\ imp_res_tac memory_rel_Number_IMP \\ fs []
   \\ fs [WORD_LEFT_AND_OVER_OR]
   \\ drule memory_rel_tail \\ strip_tac
@@ -4906,12 +4906,12 @@ val memory_rel_Sub = store_thm("memory_rel_Sub",
   \\ rfs [dimword_def]
   \\ intLib.COOPER_TAC);
 
-val memory_rel_And = store_thm("memory_rel_And",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_And = Q.store_thm("memory_rel_And",
+  `memory_rel c be refs sp st m dm
       ((Number (&(w2n (i:word8))),Word wi)::(Number (&(w2n j)),Word wj)::vars) /\
     good_dimindex (:'a) ==>
     memory_rel c be refs sp st m dm
-      ((Number (&w2n(i && j)),Word (wi && wj:'a word))::vars)``,
+      ((Number (&w2n(i && j)),Word (wi && wj:'a word))::vars)`,
   rw [] \\ imp_res_tac memory_rel_Number_IMP \\ fs []
   \\ fs [WORD_LEFT_AND_OVER_OR]
   \\ drule memory_rel_tail \\ strip_tac
@@ -4932,12 +4932,12 @@ val memory_rel_And = store_thm("memory_rel_And",
   \\ Q.ISPEC_THEN`i && j`strip_assume_tac w2n_lt
   \\ fs[labPropsTheory.good_dimindex_def]);
 
-val memory_rel_Or = store_thm("memory_rel_Or",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Or = Q.store_thm("memory_rel_Or",
+  `memory_rel c be refs sp st m dm
       ((Number (&(w2n (i:word8))),Word wi)::(Number (&(w2n j)),Word wj)::vars) /\
     good_dimindex (:'a) ==>
     memory_rel c be refs sp st m dm
-      ((Number (&w2n(i || j)),Word (wi || wj:'a word))::vars)``,
+      ((Number (&w2n(i || j)),Word (wi || wj:'a word))::vars)`,
   rw [] \\ imp_res_tac memory_rel_Number_IMP \\ fs []
   \\ fs [WORD_LEFT_AND_OVER_OR]
   \\ drule memory_rel_tail \\ strip_tac
@@ -4958,12 +4958,12 @@ val memory_rel_Or = store_thm("memory_rel_Or",
   \\ Q.ISPEC_THEN`i || j`strip_assume_tac w2n_lt
   \\ fs[labPropsTheory.good_dimindex_def]);
 
-val memory_rel_Xor = store_thm("memory_rel_Xor",
-  ``memory_rel c be refs sp st m dm
+val memory_rel_Xor = Q.store_thm("memory_rel_Xor",
+  `memory_rel c be refs sp st m dm
       ((Number (&(w2n (i:word8))),Word wi)::(Number (&(w2n j)),Word wj)::vars) /\
     good_dimindex (:'a) ==>
     memory_rel c be refs sp st m dm
-      ((Number (&w2n(word_xor i j)),Word (word_xor wi wj:'a word))::vars)``,
+      ((Number (&w2n(word_xor i j)),Word (word_xor wi wj:'a word))::vars)`,
   rw [] \\ imp_res_tac memory_rel_Number_IMP \\ fs []
   \\ fs [WORD_LEFT_AND_OVER_OR]
   \\ drule memory_rel_tail \\ strip_tac
@@ -4984,14 +4984,14 @@ val memory_rel_Xor = store_thm("memory_rel_Xor",
   \\ Q.ISPEC_THEN`i ⊕ j`strip_assume_tac w2n_lt
   \\ fs[labPropsTheory.good_dimindex_def]);
 
-val memory_rel_Number_IMP_Word = store_thm("memory_rel_Number_IMP_Word",
-  ``memory_rel c be refs sp st m dm ((Number i,v)::vars) ==> ?w. v = Word w``,
+val memory_rel_Number_IMP_Word = Q.store_thm("memory_rel_Number_IMP_Word",
+  `memory_rel c be refs sp st m dm ((Number i,v)::vars) ==> ?w. v = Word w`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def] \\ rw [] \\ fs [word_addr_def]);
 
-val memory_rel_Number_IMP_Word_2 = store_thm("memory_rel_Number_IMP_Word_2",
-  ``memory_rel c be refs sp st m dm ((Number i,v)::(Number j,w)::vars) ==>
-    ?w1 w2. v = Word w1 /\ w = Word w2``,
+val memory_rel_Number_IMP_Word_2 = Q.store_thm("memory_rel_Number_IMP_Word_2",
+  `memory_rel c be refs sp st m dm ((Number i,v)::(Number j,w)::vars) ==>
+    ?w1 w2. v = Word w1 /\ w = Word w2`,
   fs [memory_rel_def,word_ml_inv_def,PULL_EXISTS,abs_ml_inv_def,
       bc_stack_ref_inv_def,v_inv_def] \\ rw [] \\ fs [word_addr_def]);
 

--- a/compiler/backend/proofs/dec_to_exhProofScript.sml
+++ b/compiler/backend/proofs/dec_to_exhProofScript.sml
@@ -16,8 +16,8 @@ val find_recfun_compile_funs = prove(
   every_case_tac >>
   simp[] >> full_simp_tac(srw_ss())[compile_funs_map]);
 
-val exhaustive_match_submap = prove(
-  ``exhaustive_match exh pes ∧ exh ⊑ exh2 ⇒ exhaustive_match exh2 pes``,
+val exhaustive_match_submap = Q.prove(
+  `exhaustive_match exh pes ∧ exh ⊑ exh2 ⇒ exhaustive_match exh2 pes`,
   srw_tac[][exhaustive_match_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >>
   imp_res_tac FLOOKUP_SUBMAP >> full_simp_tac(srw_ss())[] >> srw_tac[][])
@@ -102,8 +102,8 @@ val v_rel_eqn = Q.prove (
    srw_tac[][Once v_rel_cases] >>
    metis_tac []);
 
-val vs_rel_LIST_REL = prove(
-  ``∀vs vs' exh. vs_rel exh vs vs' = LIST_REL (v_rel exh) vs vs'``,
+val vs_rel_LIST_REL = Q.prove(
+  `∀vs vs' exh. vs_rel exh vs vs' = LIST_REL (v_rel exh) vs vs'`,
   Induct >> simp[v_rel_eqn])
 
 val env_rel_LIST_REL = Q.prove(
@@ -111,22 +111,22 @@ val env_rel_LIST_REL = Q.prove(
   Induct_on`env`>>simp[v_rel_eqn]>>Cases>>simp[v_rel_eqn] >>
   srw_tac[][EXISTS_PROD]);
 
-val env_rel_MAP = store_thm("env_rel_MAP",
-  ``∀exh env1 env2. env_rel exh env1 env2 ⇔ MAP FST env1 = MAP FST env2 ∧
-      LIST_REL (v_rel exh) (MAP SND env1) (MAP SND env2)``,
+val env_rel_MAP = Q.store_thm("env_rel_MAP",
+  `∀exh env1 env2. env_rel exh env1 env2 ⇔ MAP FST env1 = MAP FST env2 ∧
+      LIST_REL (v_rel exh) (MAP SND env1) (MAP SND env2)`,
   Induct_on`env1`>>simp[Once v_rel_cases] >>
   Cases >> Cases_on`env2` >> srw_tac[][] >>
   Cases_on`h`>>srw_tac[][] >> metis_tac[])
 
 val _ = augment_srw_ss[rewrites[vs_rel_LIST_REL,find_recfun_compile_funs]]
 
-val v_rel_lit_loc = store_thm("v_rel_lit_loc[simp]",
-  ``(v_rel exh (Litv l) lh ⇔ lh = Litv l) ∧
+val v_rel_lit_loc = Q.store_thm("v_rel_lit_loc[simp]",
+  `(v_rel exh (Litv l) lh ⇔ lh = Litv l) ∧
     (v_rel exh l2 (Litv l) ⇔ l2 = Litv l) ∧
     (v_rel exh (Loc n) lh ⇔ lh = Loc n) ∧
     (v_rel exh l2 (Loc n) ⇔ l2 = Loc n) ∧
     (v_rel exh (Conv t []) lh ⇔ lh = Conv (get_tag t) []) ∧
-    (v_rel exh (Boolv b) lh ⇔ lh = Boolv b)``,
+    (v_rel exh (Boolv b) lh ⇔ lh = Boolv b)`,
   srw_tac[][] >> srw_tac[][Once v_rel_cases, conSemTheory.Boolv_def, exhSemTheory.Boolv_def])
 
 val state_rel_def = Define`
@@ -283,9 +283,9 @@ val pmatch = Q.prove (
       full_simp_tac(srw_ss())[match_result_rel_def] >>
       metis_tac []));
 
-val pat_bindings = prove(
-  ``(∀p ls. pat_bindings (compile_pat p) ls = pat_bindings p ls) ∧
-    (∀ps ls. pats_bindings (MAP compile_pat ps) ls = pats_bindings ps ls)``,
+val pat_bindings = Q.prove(
+  `(∀p ls. pat_bindings (compile_pat p) ls = pat_bindings p ls) ∧
+    (∀ps ls. pats_bindings (MAP compile_pat ps) ls = pats_bindings ps ls)`,
   ho_match_mp_tac(TypeBase.induction_of(``:conLang$pat``)) >>
   simp[conSemTheory.pat_bindings_def,exhSemTheory.pat_bindings_def,compile_pat_def] >>
   srw_tac[][] >> cases_on`o'` >>
@@ -310,8 +310,8 @@ val v_to_list = Q.prove (
   srw_tac[][] >>
   metis_tac [NOT_SOME_NONE, SOME_11]);
 
-val char_list_to_v = prove(
-  ``∀ls. v_rel exh (char_list_to_v ls) (char_list_to_v ls)``,
+val char_list_to_v = Q.prove(
+  `∀ls. v_rel exh (char_list_to_v ls) (char_list_to_v ls)`,
   Induct >> simp[conSemTheory.char_list_to_v_def,exhSemTheory.char_list_to_v_def] >>
   simp[v_rel_eqn])
 
@@ -489,8 +489,8 @@ val exists_match_def = Define `
   exists_match exh s ps v ⇔
     !env. ?p. MEM p ps ∧ pmatch exh s p v env ≠ No_match`;
 
-val is_unconditional_thm = prove(
-  ``∀p a b c d. is_unconditional p ⇒ pmatch a b p c d ≠ No_match``,
+val is_unconditional_thm = Q.prove(
+  `∀p a b c d. is_unconditional p ⇒ pmatch a b p c d ≠ No_match`,
   ho_match_mp_tac is_unconditional_ind >>
   Cases >> srw_tac[][] >>
   Cases_on`c`>>srw_tac[][conSemTheory.pmatch_def]
@@ -515,8 +515,8 @@ val is_unconditional_thm = prove(
     BasicProvers.EVERY_CASE_TAC >>
     metis_tac[]))
 
-val is_unconditional_list_thm = prove(
-  ``∀l1 l2 a b c. EVERY is_unconditional l1 ⇒ pmatch_list a b l1 l2 c ≠ No_match``,
+val is_unconditional_list_thm = Q.prove(
+  `∀l1 l2 a b c. EVERY is_unconditional l1 ⇒ pmatch_list a b l1 l2 c ≠ No_match`,
   Induct >> Cases_on`l2` >> simp[conSemTheory.pmatch_def] >>
   srw_tac[][] >>
   BasicProvers.CASE_TAC >>

--- a/compiler/backend/proofs/dec_to_exhProofScript.sml
+++ b/compiler/backend/proofs/dec_to_exhProofScript.sml
@@ -5,9 +5,9 @@ open preamble
 
 val _ = new_theory "dec_to_exhProof";
 
-val find_recfun_compile_funs = prove(
-  ``∀ls f exh. find_recfun f (dec_to_exh$compile_funs exh ls) =
-               OPTION_MAP (λ(x,y). (x,compile_exp exh y)) (find_recfun f ls)``,
+val find_recfun_compile_funs = Q.prove(
+  `∀ls f exh. find_recfun f (dec_to_exh$compile_funs exh ls) =
+               OPTION_MAP (λ(x,y). (x,compile_exp exh y)) (find_recfun f ls)`,
   Induct >> simp[compile_funs_map] >- (
     simp[semanticPrimitivesTheory.find_recfun_def] ) >>
   simp[Once semanticPrimitivesTheory.find_recfun_def] >>
@@ -434,14 +434,14 @@ val do_app_lem = Q.prove (
        `l = l'` by metis_tac[semanticPrimitivesPropsTheory.sv_rel_def] >>
        full_simp_tac(srw_ss())[])) |> INST_TYPE[alpha|->``:'ffi``];
 
-val do_app = prove(
-  ``∀s1 op vs s2 res exh s1_exh vs_exh.
+val do_app = Q.prove(
+  `∀s1 op vs s2 res exh s1_exh vs_exh.
       do_app (s1:'ffi decSem$state) op vs = SOME (s2,res) ∧
       state_rel exh s1 s1_exh ∧
       vs_rel exh vs vs_exh ⇒
       ∃s2_exh res_exh.
         do_app s1_exh op vs_exh = SOME (s2_exh,res_exh) ∧
-        result_rel v_rel exh (s2,res) (s2_exh,res_exh)``,
+        result_rel v_rel exh (s2,res) (s2_exh,res_exh)`,
   rpt gen_tac >>
   srw_tac[][decSemTheory.do_app_def] >>
   Cases_on`op`>>full_simp_tac(srw_ss())[] >- (
@@ -457,15 +457,15 @@ val do_app = prove(
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN,OPTREL_def,EL_LUPDATE,semanticPrimitivesPropsTheory.sv_rel_cases] >>
   srw_tac[][] >> metis_tac[NOT_SOME_NONE]);
 
-val do_opapp = prove(
-  ``∀vs env e exh vs_exh.
+val do_opapp = Q.prove(
+  `∀vs env e exh vs_exh.
     do_opapp vs = SOME (env,e) ∧
     vs_rel exh vs vs_exh
     ⇒
     ∃exh' env_exh.
       env_rel exh env env_exh ∧
       exh' ⊑ exh ∧
-      do_opapp vs_exh = SOME (env_exh,compile_exp exh' e)``,
+      do_opapp vs_exh = SOME (env_exh,compile_exp exh' e)`,
   srw_tac[][conSemTheory.do_opapp_def,exhSemTheory.do_opapp_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   TRY (full_simp_tac(srw_ss())[Once v_rel_cases]>>NO_TAC) >>
@@ -560,8 +560,8 @@ val get_tags_thm = Q.prove(
     metis_tac[] ) >>
   metis_tac[])
 
-val pmatch_Pcon_No_match = prove(
-  ``EVERY is_unconditional ps ⇒
+val pmatch_Pcon_No_match = Q.prove(
+  `EVERY is_unconditional ps ⇒
     ((pmatch exh s (Pcon (SOME(c,TypeId t)) ps) v env = No_match) ⇔
      ∃cv vs tags max maxv.
        v = Conv (SOME(cv,TypeId t)) vs ∧
@@ -569,7 +569,7 @@ val pmatch_Pcon_No_match = prove(
        lookup (LENGTH ps) tags = SOME max ∧
        lookup (LENGTH vs) tags = SOME maxv ∧
        c < max ∧ cv < maxv ∧
-       (LENGTH ps = LENGTH vs ⇒ c ≠ cv))``,
+       (LENGTH ps = LENGTH vs ⇒ c ≠ cv))`,
   Cases_on`v`>>srw_tac[][conSemTheory.pmatch_def]>>
   Cases_on`o'`>>simp[conSemTheory.pmatch_def] >>
   PairCases_on`x`>>simp[conSemTheory.pmatch_def]>>

--- a/compiler/backend/proofs/dec_to_exhProofScript.sml
+++ b/compiler/backend/proofs/dec_to_exhProofScript.sml
@@ -866,7 +866,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
     srw_tac[][] >>
     simp[exhSemTheory.semantics_def] >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`decSem$evaluate`kall_tac >>
+      qhdtm_x_assum`decSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >>
@@ -906,7 +906,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
           simp[RIGHT_FORALL_IMP_THM] >>
           impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[result_rel_cases]) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`exhSem$evaluate`mp_tac >>
+          qhdtm_x_assum`exhSem$evaluate`mp_tac >>
           drule (GEN_ALL (CONJUNCT1 exhPropsTheory.evaluate_add_to_clock)) >>
           simp[] >>
           disch_then(qspec_then`k`mp_tac)>>simp[]>>
@@ -926,7 +926,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
           rpt strip_tac >> fsrw_tac[ARITH_ss][] >> rev_full_simp_tac(srw_ss())[] ) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[EXISTS_PROD])) >>
         strip_tac >>
-        rator_x_assum`decSem$evaluate`mp_tac >>
+        qhdtm_x_assum`decSem$evaluate`mp_tac >>
         drule (GEN_ALL (CONJUNCT1 decPropsTheory.evaluate_add_to_clock)) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
@@ -951,7 +951,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
       strip_tac >> rveq >>
       reverse(Cases_on`s'.ffi.final_event`)>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]>- (
         fsrw_tac[ARITH_ss][] >> rev_full_simp_tac(srw_ss())[state_rel_def,result_rel_cases] >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]) >>
-      rator_x_assum`exhSem$evaluate`mp_tac >>
+      qhdtm_x_assum`exhSem$evaluate`mp_tac >>
       drule (GEN_ALL(CONJUNCT1 exhPropsTheory.evaluate_add_to_clock)) >>
       CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
       impl_tac >- full_simp_tac(srw_ss())[] >>

--- a/compiler/backend/proofs/exh_to_patProofScript.sml
+++ b/compiler/backend/proofs/exh_to_patProofScript.sml
@@ -37,8 +37,8 @@ val compile_v_def = save_thm("compile_v_def",
   compile_v_def |> SIMP_RULE (srw_ss()++ETA_ss) [MAP_MAP_o])
 val _ = export_rewrites["compile_v_def"]
 
-val compile_vs_map = store_thm("compile_vs_map",
-  ``∀vs. compile_vs vs = MAP compile_v vs``,
+val compile_vs_map = Q.store_thm("compile_vs_map",
+  `∀vs. compile_vs vs = MAP compile_v vs`,
   Induct >> simp[])
 val _ = export_rewrites["compile_vs_map"]
 
@@ -63,9 +63,9 @@ val compile_state_with_clock = Q.prove(
 
 (* semantic functions obey translation *)
 
-val do_eq = prove(
-  ``(∀v1 v2. do_eq v1 v2 = do_eq (compile_v v1) (compile_v v2)) ∧
-    (∀vs1 vs2. do_eq_list vs1 vs2 = do_eq_list (compile_vs vs1) (compile_vs vs2))``,
+val do_eq = Q.prove(
+  `(∀v1 v2. do_eq v1 v2 = do_eq (compile_v v1) (compile_v v2)) ∧
+    (∀vs1 vs2. do_eq_list vs1 vs2 = do_eq_list (compile_vs vs1) (compile_vs vs2))`,
   ho_match_mp_tac exhSemTheory.do_eq_ind >>
   simp[exhSemTheory.do_eq_def,patSemTheory.do_eq_def] >>
   srw_tac[][] >> BasicProvers.CASE_TAC >> srw_tac[][])
@@ -110,8 +110,8 @@ val v_to_list = Q.prove (
   srw_tac[][] >>
   metis_tac [optionTheory.NOT_SOME_NONE, optionTheory.SOME_11]);
 
-val char_list_to_v = prove(
-  ``∀ls. char_list_to_v ls = compile_v (char_list_to_v ls)``,
+val char_list_to_v = Q.prove(
+  `∀ls. char_list_to_v ls = compile_v (char_list_to_v ls)`,
   Induct >> simp[exhSemTheory.char_list_to_v_def,patSemTheory.char_list_to_v_def])
 
 val v_to_char_list = Q.prove (
@@ -205,11 +205,11 @@ val do_app = prove(
 
 (* pattern compiler correctness *)
 
-val sIf_correct = store_thm("sIf_correct",
-  ``∀env s e1 e2 e3 res.
+val sIf_correct = Q.store_thm("sIf_correct",
+  `∀env s e1 e2 e3 res.
     evaluate env s [If e1 e2 e3] = res ∧
     (SND res ≠ Rerr (Rabort Rtype_error)) ⇒
-    evaluate env s [sIf e1 e2 e3] = res``,
+    evaluate env s [sIf e1 e2 e3] = res`,
   rpt gen_tac >>
   Cases_on`e2=(Bool T) ∧ e3=(Bool F)` >- (
     simp[sIf_def] >>
@@ -243,8 +243,8 @@ val v_to_list_no_closures = Q.prove (
   full_simp_tac(srw_ss())[compile_v_def, patSemTheory.v_to_list_def] >>
   srw_tac[][]);
 
-val char_list_to_v_no_closures = prove(
-  ``∀ls. no_closures (char_list_to_v ls)``,
+val char_list_to_v_no_closures = Q.prove(
+  `∀ls. no_closures (char_list_to_v ls)`,
   Induct >> simp[patSemTheory.char_list_to_v_def])
 
 val s = mk_var("s",
@@ -293,8 +293,8 @@ val pure_correct = Q.store_thm("pure_correct",
   REWRITE_TAC[evaluate_append_Rval_iff,evaluate_append_Rerr] >>
   metis_tac lemmas)
 
-val ground_correct = store_thm("ground_correct",
-  ``(∀e n. ground n e ⇒
+val ground_correct = Q.store_thm("ground_correct",
+  `(∀e n. ground n e ⇒
       (∀env1 env2 ^s res.
           n ≤ LENGTH env1 ∧ n ≤ LENGTH env2 ∧
           (TAKE n env2 = TAKE n env1) ∧
@@ -307,7 +307,7 @@ val ground_correct = store_thm("ground_correct",
           (evaluate env1 s es = res ⇒
            evaluate env2 s es = res) ∧
           (evaluate env1 s (REVERSE es) = res ⇒
-           evaluate env2 s (REVERSE es) = res)))``,
+           evaluate env2 s (REVERSE es) = res)))`,
   ho_match_mp_tac(TypeBase.induction_of(``:patLang$exp``)) >>
   srw_tac[][patSemTheory.evaluate_def] >>
   res_tac >> rev_full_simp_tac(srw_ss())[] >> srw_tac[][] >>
@@ -327,11 +327,11 @@ val ground_correct = store_thm("ground_correct",
   REWRITE_TAC[evaluate_append] >>
   simp[]);
 
-val sLet_correct = store_thm("sLet_correct",
-  ``∀env ^s e1 e2 res.
+val sLet_correct = Q.store_thm("sLet_correct",
+  `∀env ^s e1 e2 res.
     evaluate env s [Let e1 e2] = res ∧
     SND res ≠ Rerr (Rabort Rtype_error) ⇒
-    evaluate env s [sLet e1 e2] = res``,
+    evaluate env s [sLet e1 e2] = res`,
   srw_tac[][sLet_def] >- (
     last_x_assum mp_tac >>
     simp[patSemTheory.evaluate_def] >>
@@ -355,12 +355,12 @@ val sLet_intro = Q.store_thm("sLet_intro",
    ⇒ P (evaluate env s [sLet e1 e2])`,
   metis_tac[sLet_correct])
 
-val Let_Els_correct = prove(
-  ``∀n k e tag vs env ^s res us.
+val Let_Els_correct = Q.prove(
+  `∀n k e tag vs env ^s res us.
     LENGTH us = n ∧ k ≤ LENGTH vs ∧
     evaluate (TAKE k vs ++ us ++ (Conv tag vs::env)) s [e] = res ∧
     SND res ≠ Rerr (Rabort Rtype_error) ⇒
-    evaluate (us ++ (Conv tag vs::env)) s [Let_Els n k e] = res``,
+    evaluate (us ++ (Conv tag vs::env)) s [Let_Els n k e] = res`,
   ho_match_mp_tac Let_Els_ind >> srw_tac[][Let_Els_def] >>
   match_mp_tac sLet_correct >>
   srw_tac[][patSemTheory.evaluate_def] >>
@@ -378,13 +378,13 @@ val Let_Els_correct = prove(
   srw_tac[][] >>
   rpt (AP_TERM_TAC ORELSE AP_THM_TAC) >> simp[] >>
   metis_tac[SNOC_APPEND,SNOC_EL_TAKE])
-val Let_Els_correct = prove(
-  ``∀n k e tag vs env ^s res us enve.
+val Let_Els_correct = Q.prove(
+  `∀n k e tag vs env ^s res us enve.
     LENGTH us = n ∧ k ≤ LENGTH vs ∧
     evaluate (TAKE k vs ++ us ++ (Conv tag vs::env)) s [e] = res ∧
     (enve = us ++ (Conv tag vs::env)) ∧ SND res ≠ Rerr (Rabort Rtype_error)
     ⇒
-    evaluate enve s [Let_Els n k e] = res``,
+    evaluate enve s [Let_Els n k e] = res`,
   metis_tac[Let_Els_correct]);
 
 val s = mk_var("s",
@@ -640,33 +640,33 @@ val bind_def = Define`
   (bind V (SUC n1) (SUC n2) ⇔ V n1 n2) ∧
   (bind V _ _ ⇔ F)`
 
-val bind_mono = store_thm("bind_mono",
-  ``(∀x y. V1 x y ⇒ V2 x y) ⇒ bind V1 x y ⇒ bind V2 x y``,
+val bind_mono = Q.store_thm("bind_mono",
+  `(∀x y. V1 x y ⇒ V2 x y) ⇒ bind V1 x y ⇒ bind V2 x y`,
   Cases_on`x`>>Cases_on`y`>>srw_tac[][bind_def])
 val _ = export_mono"bind_mono"
 
 val bindn_def = Define`bindn = FUNPOW bind`
 
-val bind_thm = store_thm("bind_thm",
-  ``∀V x y. bind V x y =
+val bind_thm = Q.store_thm("bind_thm",
+  `∀V x y. bind V x y =
       if x = 0 then y = 0 else
       if y = 0 then x = 0 else
-      V (x-1) (y-1)``,
+      V (x-1) (y-1)`,
   gen_tac >> Cases >> Cases >> srw_tac[][bind_def])
 
-val bindn_mono = store_thm("bindn_mono",
-  ``(∀x y. R1 x y ⇒ R2 x y) ⇒
-    bindn n R1 x y ⇒ bindn n R2 x y``,
+val bindn_mono = Q.store_thm("bindn_mono",
+  `(∀x y. R1 x y ⇒ R2 x y) ⇒
+    bindn n R1 x y ⇒ bindn n R2 x y`,
   srw_tac[][bindn_def] >>
   match_mp_tac (MP_CANON FUNPOW_mono) >>
   simp[] >> metis_tac[bind_mono] )
 val _ = export_mono"bindn_mono"
 
-val bindn_thm = store_thm("bindn_thm",
-  ``∀n k1 k2.
+val bindn_thm = Q.store_thm("bindn_thm",
+  `∀n k1 k2.
     bindn n R k1 k2 ⇔
     if k1 < n ∧ k2 < n then k1 = k2
-    else n ≤ k1 ∧ n ≤ k2 ∧ R (k1-n) (k2-n)``,
+    else n ≤ k1 ∧ n ≤ k2 ∧ R (k1-n) (k2-n)`,
   Induct>>simp[bindn_def,arithmeticTheory.FUNPOW_SUC] >>
   Cases>>Cases>>simp[bind_def,GSYM bindn_def])
 
@@ -696,9 +696,9 @@ val (exp_rel_rules,exp_rel_ind,exp_rel_cases) = Hol_reln`
    ⇒ exp_rel z1 z2 V (Letrec es1 e1) (Letrec es2 e2)) ∧
   (exp_rel z1 z2 V (Extend_global n) (Extend_global n))`;
 
-val exp_rel_refl = store_thm("exp_rel_refl",
-  ``(∀e z V. (∀k. k < z ⇒ V k k) ⇒ exp_rel z z V e e) ∧
-    (∀es z V. (∀k. k < z ⇒ V k k) ⇒ LIST_REL (exp_rel z z V) es es)``,
+val exp_rel_refl = Q.store_thm("exp_rel_refl",
+  `(∀e z V. (∀k. k < z ⇒ V k k) ⇒ exp_rel z z V e e) ∧
+    (∀es z V. (∀k. k < z ⇒ V k k) ⇒ LIST_REL (exp_rel z z V) es es)`,
   ho_match_mp_tac(TypeBase.induction_of``:patLang$exp``) >> srw_tac[][] >>
   TRY (first_x_assum match_mp_tac) >>
   srw_tac[][Once exp_rel_cases] >>
@@ -710,10 +710,10 @@ val exp_rel_refl = store_thm("exp_rel_refl",
   Cases_on`k < SUC (LENGTH es)` >> simp[] >>
   Cases_on`k < LENGTH es` >> simp[])
 
-val exp_rel_mono = store_thm("exp_rel_mono",
-  ``(∀x y. V1 x y ⇒ V2 x y) ⇒
+val exp_rel_mono = Q.store_thm("exp_rel_mono",
+  `(∀x y. V1 x y ⇒ V2 x y) ⇒
     exp_rel z1 z2 V1 e1 e2 ⇒
-    exp_rel z1 z2 V2 e1 e2``,
+    exp_rel z1 z2 V2 e1 e2`,
   strip_tac >> strip_tac >> last_x_assum mp_tac >>
   qid_spec_tac`V2` >> pop_assum mp_tac >>
   map_every qid_spec_tac[`e2`,`e1`,`V1`,`z2`,`z1`] >>
@@ -758,17 +758,17 @@ val exp_rel_mono = store_thm("exp_rel_mono",
   ( srw_tac[][] >> srw_tac[][Once exp_rel_cases] ))
 val _ = export_mono"exp_rel_mono";
 
-val exp_rel_lit = store_thm("exp_rel_lit",
-  ``(exp_rel z1 z2 V (Lit l) e2 ⇔ (e2 = Lit l)) ∧
+val exp_rel_lit = Q.store_thm("exp_rel_lit",
+  `(exp_rel z1 z2 V (Lit l) e2 ⇔ (e2 = Lit l)) ∧
     (exp_rel z1 z2 V e1 (Lit l) ⇔ (e1 = Lit l)) ∧
     (exp_rel z1 z2 V (Bool b) e2 ⇔ (e2 = Bool b)) ∧
-    (exp_rel z1 z2 V e1 (Bool b) ⇔ (e1 = Bool b))``,
+    (exp_rel z1 z2 V e1 (Bool b) ⇔ (e1 = Bool b))`,
   srw_tac[][Once exp_rel_cases] >>
   srw_tac[][Once exp_rel_cases,Bool_def] )
 val _ = export_rewrites["exp_rel_lit"];
 
-val bind_O = store_thm("bind_O",
-  ``∀R1 R2. bind (R2 O R1) = bind R2 O bind R1``,
+val bind_O = Q.store_thm("bind_O",
+  `∀R1 R2. bind (R2 O R1) = bind R2 O bind R1`,
   srw_tac[][] >> simp[FUN_EQ_THM] >>
   simp[relationTheory.O_DEF] >>
   srw_tac[][bind_thm,relationTheory.O_DEF,EQ_IMP_THM] >> rev_full_simp_tac(srw_ss())[] >- (
@@ -776,8 +776,8 @@ val bind_O = store_thm("bind_O",
   qexists_tac`y-1` >> simp[])
 val _ = export_rewrites["bind_O"];
 
-val bindn_O = store_thm("bindn_O",
-  ``∀R1 R2 n. bindn n (R2 O R1) = bindn n R2 O bindn n R1``,
+val bindn_O = Q.store_thm("bindn_O",
+  `∀R1 R2 n. bindn n (R2 O R1) = bindn n R2 O bindn n R1`,
   srw_tac[][FUN_EQ_THM,bindn_thm,relationTheory.O_DEF] >>
   srw_tac[][EQ_IMP_THM] >> simp[] >> fsrw_tac[ARITH_ss][] >>
   rev_full_simp_tac(srw_ss()++ARITH_ss)[]>>fsrw_tac[ARITH_ss][]
@@ -785,9 +785,9 @@ val bindn_O = store_thm("bindn_O",
   (qexists_tac`y-n` >> simp[]))
 val _ = export_rewrites["bindn_O"];
 
-val exp_rel_trans = prove(
-  ``∀z1 z2 V1 e1 e2. exp_rel z1 z2 V1 e1 e2 ⇒
-      ∀z3 V2 e3. exp_rel z2 z3 V2 e2 e3 ⇒ exp_rel z1 z3 (V2 O V1) e1 e3``,
+val exp_rel_trans = Q.prove(
+  `∀z1 z2 V1 e1 e2. exp_rel z1 z2 V1 e1 e2 ⇒
+      ∀z3 V2 e3. exp_rel z2 z3 V2 e2 e3 ⇒ exp_rel z1 z3 (V2 O V1) e1 e3`,
    ho_match_mp_tac (theorem"exp_rel_strongind") >>
    strip_tac >- ( srw_tac[][] >> pop_assum mp_tac >> ntac 2 (srw_tac[][Once exp_rel_cases]) ) >>
    strip_tac >- ( srw_tac[][] >> pop_assum mp_tac >> ntac 2 (srw_tac[][Once exp_rel_cases]) ) >>
@@ -813,29 +813,29 @@ val exp_rel_trans = prove(
      rev_full_simp_tac(srw_ss())[EVERY2_EVERY,EVERY_MEM] >>
      full_simp_tac(srw_ss())[MEM_ZIP,PULL_EXISTS,MEM_EL] ) >>
    strip_tac >- ( srw_tac[][] >> pop_assum mp_tac >> ntac 2 (srw_tac[][Once exp_rel_cases]) ))
-val exp_rel_trans = store_thm("exp_rel_trans",
-  ``∀z1 z2 z3 V1 V2 V3 e1 e2 e3.
+val exp_rel_trans = Q.store_thm("exp_rel_trans",
+  `∀z1 z2 z3 V1 V2 V3 e1 e2 e3.
       exp_rel z1 z2 V1 e1 e2 ∧
       exp_rel z2 z3 V2 e2 e3 ∧
       (V3 = V2 O V1) ⇒
-      exp_rel z1 z3 V3 e1 e3``,
+      exp_rel z1 z3 V3 e1 e3`,
   metis_tac[exp_rel_trans])
 
 val env_rel_def = Define`
   env_rel R env1 env2 k1 k2 ⇔
     k1 < LENGTH env1 ∧ k2 < LENGTH env2 ∧ R (EL k1 env1) (EL k2 env2)`
 
-val env_rel_mono = store_thm("env_rel_mono",
-  ``(∀x y. R1 x y ⇒ R2 x y) ⇒
+val env_rel_mono = Q.store_thm("env_rel_mono",
+  `(∀x y. R1 x y ⇒ R2 x y) ⇒
     env_rel R1 env1 env2 k1 k2 ⇒
-    env_rel R2 env1 env2 k1 k2``,
+    env_rel R2 env1 env2 k1 k2`,
   srw_tac[][env_rel_def])
 val _ = export_mono"env_rel_mono";
 
-val env_rel_cons = prove(
-  ``R v1 v2 ∧
+val env_rel_cons = Q.prove(
+  `R v1 v2 ∧
     bind (env_rel R env1 env2) k1 k2
-    ⇒ env_rel R (v1::env1) (v2::env2) k1 k2``,
+    ⇒ env_rel R (v1::env1) (v2::env2) k1 k2`,
   Cases_on`k1`>>Cases_on`k2`>>srw_tac[][env_rel_def,bind_def])
 
 val (v_rel_rules,v_rel_ind,v_rel_cases) = Hol_reln`
@@ -853,22 +853,22 @@ val (v_rel_rules,v_rel_ind,v_rel_cases) = Hol_reln`
   (LIST_REL v_rel vs1 vs2
    ⇒ v_rel (Vectorv vs1) (Vectorv vs2))`;
 
-val v_rel_lit = store_thm("v_rel_lit",
-  ``(v_rel (Litv l) v2 ⇔ (v2 = Litv l)) ∧
+val v_rel_lit = Q.store_thm("v_rel_lit",
+  `(v_rel (Litv l) v2 ⇔ (v2 = Litv l)) ∧
     (v_rel v1 (Litv l) ⇔ (v1 = Litv l)) ∧
     (v_rel (Boolv b) v2 ⇔ (v2 = Boolv b)) ∧
-    (v_rel v1 (Boolv b) ⇔ (v1 = Boolv b))``,
+    (v_rel v1 (Boolv b) ⇔ (v1 = Boolv b))`,
   srw_tac[][Once v_rel_cases] >> srw_tac[][Once v_rel_cases,patSemTheory.Boolv_def] )
 val _ = export_rewrites["v_rel_lit"]
 
-val v_rel_loc = store_thm("v_rel_loc",
-  ``(v_rel (Loc l) v2 ⇔ (v2 = Loc l)) ∧
-    (v_rel v1 (Loc l) ⇔ (v1 = Loc l))``,
+val v_rel_loc = Q.store_thm("v_rel_loc",
+  `(v_rel (Loc l) v2 ⇔ (v2 = Loc l)) ∧
+    (v_rel v1 (Loc l) ⇔ (v1 = Loc l))`,
   srw_tac[][Once v_rel_cases] >> srw_tac[][Once v_rel_cases] )
 val _ = export_rewrites["v_rel_loc"]
 
-val v_rel_refl = store_thm("v_rel_refl",
-  ``∀v. v_rel v v``,
+val v_rel_refl = Q.store_thm("v_rel_refl",
+  `∀v. v_rel v v`,
   qsuff_tac`(∀v. v_rel v v) ∧ (∀vs. LIST_REL v_rel vs vs)`>-srw_tac[][]>>
   ho_match_mp_tac(TypeBase.induction_of``:patSem$v``)>>
   srw_tac[][] >> srw_tac[][Once v_rel_cases] >>
@@ -884,8 +884,8 @@ val v_rel_refl = store_thm("v_rel_refl",
   simp[])
 val _ = export_rewrites["v_rel_refl"]
 
-val v_rel_trans = store_thm("v_rel_trans",
-  ``∀v1 v2. v_rel v1 v2 ⇒ ∀v3. v_rel v2 v3 ⇒ v_rel v1 v3``,
+val v_rel_trans = Q.store_thm("v_rel_trans",
+  `∀v1 v2. v_rel v1 v2 ⇒ ∀v3. v_rel v2 v3 ⇒ v_rel v1 v3`,
   ho_match_mp_tac (theorem"v_rel_strongind") >> simp[] >>
   strip_tac >- (
     rpt gen_tac >> strip_tac >>
@@ -938,27 +938,27 @@ val v_rel_trans = store_thm("v_rel_trans",
   rev_full_simp_tac(srw_ss())[EVERY2_EVERY,EVERY_MEM] >>
   full_simp_tac(srw_ss())[MEM_ZIP,PULL_EXISTS,MEM_EL] );
 
-val bind_inv = store_thm("bind_inv",
-  ``∀V. bind (inv V) = inv (bind V)``,
+val bind_inv = Q.store_thm("bind_inv",
+  `∀V. bind (inv V) = inv (bind V)`,
   srw_tac[][FUN_EQ_THM,bind_thm,relationTheory.inv_DEF] >>
   srw_tac[][])
 val _ = export_rewrites["bind_inv"]
 
-val bindn_inv = store_thm("bindn_inv",
-  ``∀V n. bindn n (inv V) = inv (bindn n V)``,
+val bindn_inv = Q.store_thm("bindn_inv",
+  `∀V n. bindn n (inv V) = inv (bindn n V)`,
   srw_tac[][FUN_EQ_THM,bindn_thm,relationTheory.inv_DEF] >>
   srw_tac[][] >> simp[] >> full_simp_tac(srw_ss())[] >> simp[])
 val _ = export_rewrites["bindn_inv"]
 
-val exp_rel_sym = store_thm("exp_rel_sym",
-  ``∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒ exp_rel z2 z1 (inv V) e2 e1``,
+val exp_rel_sym = Q.store_thm("exp_rel_sym",
+  `∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒ exp_rel z2 z1 (inv V) e2 e1`,
   ho_match_mp_tac exp_rel_ind >> srw_tac[][] >>
   simp[Once exp_rel_cases] >>
   rev_full_simp_tac(srw_ss())[EVERY2_EVERY,EVERY_MEM] >>
   full_simp_tac(srw_ss())[MEM_ZIP,PULL_EXISTS,relationTheory.inv_DEF] )
 
-val v_rel_sym = store_thm("v_rel_sym",
-  ``∀v1 v2. v_rel v1 v2 ⇒ v_rel v2 v1``,
+val v_rel_sym = Q.store_thm("v_rel_sym",
+  `∀v1 v2. v_rel v1 v2 ⇒ v_rel v2 v1`,
   ho_match_mp_tac v_rel_ind >> srw_tac[][] >>
   simp[Once v_rel_cases] >>
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN] >> srw_tac[][] >> rev_full_simp_tac(srw_ss())[] >>
@@ -1052,8 +1052,8 @@ val state_rel_trans = Q.prove(
 
 val do_eq_def = patSemTheory.do_eq_def
 
-val do_eq_v_rel = store_thm("do_eq_v_rel",
-  ``∀v1 v2. v_rel v1 v2 ⇒ ∀v3 v4. v_rel v3 v4 ⇒ do_eq v1 v3 = do_eq v2 v4``,
+val do_eq_v_rel = Q.store_thm("do_eq_v_rel",
+  `∀v1 v2. v_rel v1 v2 ⇒ ∀v3 v4. v_rel v3 v4 ⇒ do_eq v1 v3 = do_eq v2 v4`,
   ho_match_mp_tac v_rel_ind >>
   simp[do_eq_def] >> srw_tac[][] >>
   Cases_on`v3`>>Cases_on`v4`>>full_simp_tac(srw_ss())[do_eq_def] >>
@@ -1106,23 +1106,23 @@ val do_opapp_v_rel = store_thm("do_opapp_v_rel",
   full_simp_tac(srw_ss())[MEM_ZIP,PULL_EXISTS,arithmeticTheory.ADD1,Abbr`z1`,Abbr`z2`] >>
   simp[])
 
-val v_to_list_SOME = prove(
-  ``∀v ls.
+val v_to_list_SOME = Q.prove(
+  `∀v ls.
     v_to_list v = SOME ls ⇒
          (v = Conv nil_tag []) ∨
          (∃v1 v2 t.
            v = Conv cons_tag [v1;v2] ∧
            v_to_list v2 = SOME t ∧
-           ls = v1::t)``,
+           ls = v1::t)`,
   ho_match_mp_tac patSemTheory.v_to_list_ind >>
   simp[patSemTheory.v_to_list_def] >> srw_tac[][] >>
   BasicProvers.EVERY_CASE_TAC >> full_simp_tac(srw_ss())[])
 
-val v_to_list_v_rel = prove(
-  ``∀l1 l2 n l3.
+val v_to_list_v_rel = Q.prove(
+  `∀l1 l2 n l3.
     v_rel l1 l2 ∧ v_to_list l1 = SOME l3 ⇒
     ∃l4. v_to_list l2 = SOME l4 ∧
-         LIST_REL v_rel l3 l4``,
+         LIST_REL v_rel l3 l4`,
   ho_match_mp_tac patSemTheory.v_to_list_ind >>
   simp[patSemTheory.v_to_list_def] >> srw_tac[][] >- (
     full_simp_tac(srw_ss())[Once v_rel_cases]>>
@@ -1134,10 +1134,10 @@ val v_to_list_v_rel = prove(
   BasicProvers.CASE_TAC >> srw_tac[][] >>
   res_tac >> simp[])
 
-val v_to_char_list_v_rel = prove(
-  ``∀l1 l2 n l3.
+val v_to_char_list_v_rel = Q.prove(
+  `∀l1 l2 n l3.
     v_rel l1 l2 ∧ v_to_char_list l1 = SOME l3 ⇒
-    v_to_char_list l2 = SOME l3``,
+    v_to_char_list l2 = SOME l3`,
   ho_match_mp_tac patSemTheory.v_to_char_list_ind >>
   simp[patSemTheory.v_to_char_list_def] >> srw_tac[][] >- (
     full_simp_tac(srw_ss())[Once v_rel_cases]>>
@@ -1452,10 +1452,10 @@ val bvs_V_def = Define`
       find_index (SOME x) bvs2 0 = SOME k2
       ⇒ V k1 k2`
 
-val bind_bvs_V_NONE = prove(
-  ``∀bvs1 bvs2 V.
+val bind_bvs_V_NONE = Q.prove(
+  `∀bvs1 bvs2 V.
     bvs_V bvs1 bvs2 V ⇒
-    bvs_V (NONE::bvs1) (NONE::bvs2) (bind V)``,
+    bvs_V (NONE::bvs1) (NONE::bvs2) (bind V)`,
   srw_tac[][bvs_V_def,bind_thm] >>
   imp_res_tac find_index_is_MEM >>
   imp_res_tac find_index_MEM >>
@@ -1469,10 +1469,10 @@ val bind_bvs_V_NONE = prove(
   full_simp_tac(srw_ss())[Once find_index_shift_0] >>
   metis_tac[])
 
-val bind_bvs_V_SOME = prove(
-  ``∀bvs1 bvs2 V.
+val bind_bvs_V_SOME = Q.prove(
+  `∀bvs1 bvs2 V.
     bvs_V bvs1 bvs2 V ⇒
-    bvs_V (SOME x::bvs1) (SOME x::bvs2) (bind V)``,
+    bvs_V (SOME x::bvs1) (SOME x::bvs2) (bind V)`,
   srw_tac[][bvs_V_def,bind_thm] >>
   imp_res_tac find_index_is_MEM >>
   imp_res_tac find_index_MEM >>
@@ -1489,25 +1489,25 @@ val bind_bvs_V_SOME = prove(
   full_simp_tac(srw_ss())[Once find_index_shift_0] >>
   metis_tac[])
 
-val bind_bvs_V = store_thm("bind_bvs_V",
-  ``∀x bvs1 bvs2 V.
+val bind_bvs_V = Q.store_thm("bind_bvs_V",
+  `∀x bvs1 bvs2 V.
     bvs_V bvs1 bvs2 V ⇒
-    bvs_V (x::bvs1) (x::bvs2) (bind V)``,
+    bvs_V (x::bvs1) (x::bvs2) (bind V)`,
   Cases >> metis_tac[bind_bvs_V_NONE,bind_bvs_V_SOME])
 
-val bindn_bvs_V = store_thm("bindn_bvs_V",
-  ``∀ls n bvs1 bvs2 V.
+val bindn_bvs_V = Q.store_thm("bindn_bvs_V",
+  `∀ls n bvs1 bvs2 V.
      bvs_V bvs1 bvs2 V ∧ n = LENGTH ls ⇒
-     bvs_V (ls++bvs1) (ls++bvs2) (bindn n V)``,
+     bvs_V (ls++bvs1) (ls++bvs2) (bindn n V)`,
   Induct >> simp[bindn_def,arithmeticTheory.FUNPOW_SUC] >>
   metis_tac[bind_bvs_V,bindn_def])
 
 val exp_rel_Con =
   SIMP_RULE(srw_ss())[](Q.SPECL[`z1`,`z2`,`V`,`Con X Y`]exp_rel_cases)
 
-val exp_rel_sIf = store_thm("exp_rel_sIf",
-  ``exp_rel z1 z2 V (If e1 e2 e3) (If f1 f2 f3) ⇒
-    exp_rel z1 z2 V (sIf e1 e2 e3) (sIf f1 f2 f3)``,
+val exp_rel_sIf = Q.store_thm("exp_rel_sIf",
+  `exp_rel z1 z2 V (If e1 e2 e3) (If f1 f2 f3) ⇒
+    exp_rel z1 z2 V (sIf e1 e2 e3) (sIf f1 f2 f3)`,
   srw_tac[][sIf_def] >> pop_assum mp_tac >>
   simp[Once exp_rel_cases] >> srw_tac[][] >>
   FULL_SIMP_TAC std_ss [GSYM Bool_eqns] >> full_simp_tac(srw_ss())[] >>
@@ -1528,9 +1528,9 @@ val exp_rel_sIf = store_thm("exp_rel_sIf",
     pop_assum mp_tac >> simp[Once exp_rel_cases]) >>
   simp[Once exp_rel_cases])
 
-val exp_rel_pure = store_thm("exp_rel_pure",
-  ``∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
-    (pure e1 ⇔ pure e2)``,
+val exp_rel_pure = Q.store_thm("exp_rel_pure",
+  `∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
+    (pure e1 ⇔ pure e2)`,
   ho_match_mp_tac (theorem"exp_rel_strongind") >>
   simp[pure_def] >>
   srw_tac[][EVERY_MEM,EVERY2_EVERY,EQ_IMP_THM] >>
@@ -1538,9 +1538,9 @@ val exp_rel_pure = store_thm("exp_rel_pure",
   rev_full_simp_tac(srw_ss())[MEM_EL,PULL_EXISTS] >>
   full_simp_tac(srw_ss())[] >> srw_tac[][] >> metis_tac[])
 
-val exp_rel_imp_ground = store_thm("exp_rel_imp_ground",
-  ``∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
-      ∀n. (∀k1 k2. k1 ≤ n ⇒ (V k1 k2 ⇔ (k1 = k2))) ∧ ground n e1 ⇒ ground n e2``,
+val exp_rel_imp_ground = Q.store_thm("exp_rel_imp_ground",
+  `∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
+      ∀n. (∀k1 k2. k1 ≤ n ⇒ (V k1 k2 ⇔ (k1 = k2))) ∧ ground n e1 ⇒ ground n e2`,
   ho_match_mp_tac exp_rel_ind >>
   simp[] >> srw_tac[][] >>
   TRY (
@@ -1554,26 +1554,26 @@ val exp_rel_imp_ground = store_thm("exp_rel_imp_ground",
   full_simp_tac(srw_ss())[arithmeticTheory.LESS_OR_EQ] >>
   res_tac >> srw_tac[][])
 
-val bindn_0 = store_thm("bindn_0",
-  ``∀V. bindn 0 V = V``,
+val bindn_0 = Q.store_thm("bindn_0",
+  `∀V. bindn 0 V = V`,
   srw_tac[][bindn_def])
 val _ = export_rewrites["bindn_0"]
 
-val bind_bindn = store_thm("bind_bindn",
-  ``(bind (bindn n V) = bindn (SUC n) V) ∧
-    (bindn n (bind V) = bindn (SUC n) V)``,
+val bind_bindn = Q.store_thm("bind_bindn",
+  `(bind (bindn n V) = bindn (SUC n) V) ∧
+    (bindn n (bind V) = bindn (SUC n) V)`,
   conj_tac >- simp[bindn_def,arithmeticTheory.FUNPOW_SUC] >>
   simp[bindn_def,arithmeticTheory.FUNPOW])
 val _ = export_rewrites["bind_bindn"]
 
-val exp_rel_unbind = store_thm("exp_rel_unbind",
-  ``∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
+val exp_rel_unbind = Q.store_thm("exp_rel_unbind",
+  `∀z1 z2 V e1 e2. exp_rel z1 z2 V e1 e2 ⇒
       ∀k n m U.
         V = bindn n U ∧ n ≤ z1 ∧ n ≤ z2 ∧
         ground k e1 ∧ ground k e2 ∧
         k ≤ n-m ∧ m ≤ n
         ⇒
-        exp_rel (z1-m) (z2-m) (bindn (n-m) U) e1 e2``,
+        exp_rel (z1-m) (z2-m) (bindn (n-m) U) e1 e2`,
   ho_match_mp_tac exp_rel_ind >>
   simp[] >> srw_tac[][] >>
   simp[Once exp_rel_cases] >> full_simp_tac(srw_ss())[] >>
@@ -1594,9 +1594,9 @@ val exp_rel_unbind = store_thm("exp_rel_unbind",
   qpat_x_assum`bindn n U k1 k2`mp_tac >>
   simp[bindn_thm] >> srw_tac[][])
 
-val exp_rel_sLet = store_thm("exp_rel_sLet",
-  ``exp_rel z1 z2 V (Let e1 e2) (Let f1 f2) ⇒
-    exp_rel z1 z2 V (sLet e1 e2) (sLet f1 f2)``,
+val exp_rel_sLet = Q.store_thm("exp_rel_sLet",
+  `exp_rel z1 z2 V (Let e1 e2) (Let f1 f2) ⇒
+    exp_rel z1 z2 V (sLet e1 e2) (sLet f1 f2)`,
   srw_tac[][sLet_def] >>
   qpat_x_assum`exp_rel z1 z2 V X Y`mp_tac >>
   simp[Once exp_rel_cases] >> strip_tac >>
@@ -1619,33 +1619,33 @@ val exp_rel_sLet = store_thm("exp_rel_sLet",
   disch_then(qspecl_then[`0`,`1`,`1`,`V`]mp_tac) >>
   simp[bindn_def] )
 
-val ground_sIf = store_thm("ground_sIf",
-  ``ground n (If e1 e2 e3) ⇒
-    ground n (sIf e1 e2 e3)``,
+val ground_sIf = Q.store_thm("ground_sIf",
+  `ground n (If e1 e2 e3) ⇒
+    ground n (sIf e1 e2 e3)`,
   srw_tac[][sIf_def] >>
   Cases_on`e1`>> full_simp_tac(srw_ss())[] >>
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >> srw_tac[][] )
 
-val ground_inc = store_thm("ground_inc",
-  ``(∀e n. ground n e ⇒ ∀m. n ≤ m ⇒ ground m e) ∧
-    (∀es n. ground_list n es ⇒ ∀m. n ≤ m ⇒ ground_list m es)``,
+val ground_inc = Q.store_thm("ground_inc",
+  `(∀e n. ground n e ⇒ ∀m. n ≤ m ⇒ ground m e) ∧
+    (∀es n. ground_list n es ⇒ ∀m. n ≤ m ⇒ ground_list m es)`,
   ho_match_mp_tac(TypeBase.induction_of(``:patLang$exp``)) >>
   simp[] >> srw_tac[][] >>
   first_x_assum (match_mp_tac o MP_CANON) >>
   metis_tac[arithmeticTheory.LE_ADD_RCANCEL])
 
-val ground_sLet = store_thm("ground_sLet",
-  ``ground n (Let e1 e2) ⇒
-    ground n (sLet e1 e2)``,
+val ground_sLet = Q.store_thm("ground_sLet",
+  `ground n (Let e1 e2) ⇒
+    ground n (sLet e1 e2)`,
   srw_tac[][sLet_def] >>
   match_mp_tac(MP_CANON(CONJUNCT1 ground_inc))>>
   qexists_tac`0`>>simp[])
 
-val ground_Let_Els = store_thm("ground_Let_Els",
-  ``∀k m n e.
+val ground_Let_Els = Q.store_thm("ground_Let_Els",
+  `∀k m n e.
     ground (n+k) e ∧ m < n ⇒
-    ground n (Let_Els m k e)``,
+    ground n (Let_Els m k e)`,
   Induct >> simp[Let_Els_def] >>
   srw_tac[][] >>
   match_mp_tac ground_sLet >>
@@ -1653,9 +1653,9 @@ val ground_Let_Els = store_thm("ground_Let_Els",
   first_x_assum match_mp_tac >>
   fsrw_tac[ARITH_ss][arithmeticTheory.ADD1])
 
-val compile_pat_ground = store_thm("compile_pat_ground",
-  ``(∀p. ground 1 (compile_pat p)) ∧
-    (∀n ps. ground (n + LENGTH ps) (compile_pats n ps))``,
+val compile_pat_ground = Q.store_thm("compile_pat_ground",
+  `(∀p. ground 1 (compile_pat p)) ∧
+    (∀n ps. ground (n + LENGTH ps) (compile_pats n ps))`,
   ho_match_mp_tac compile_pat_ind >>
   simp[compile_pat_def] >>
   strip_tac >- (
@@ -1678,11 +1678,11 @@ val compile_pat_ground = store_thm("compile_pat_ground",
   match_mp_tac (MP_CANON(CONJUNCT1 ground_inc)) >>
   HINT_EXISTS_TAC >> simp[])
 
-val ground_exp_rel_refl = store_thm("ground_exp_rel_refl",
-  ``(∀e n. ground n e ⇒
+val ground_exp_rel_refl = Q.store_thm("ground_exp_rel_refl",
+  `(∀e n. ground n e ⇒
        ∀z1 z2 V. n ≤ z1 ∧ n ≤ z2 ⇒ exp_rel z1 z2 (bindn n V) e e) ∧
     (∀es n. ground_list n es ⇒
-       ∀z1 z2 V. n ≤ z1 ∧ n ≤ z2 ⇒ EVERY2 (exp_rel z1 z2 (bindn n V)) es es)``,
+       ∀z1 z2 V. n ≤ z1 ∧ n ≤ z2 ⇒ EVERY2 (exp_rel z1 z2 (bindn n V)) es es)`,
   ho_match_mp_tac(TypeBase.induction_of(``:patLang$exp``)) >>
   simp[] >> srw_tac[][] >>
   simp[Once exp_rel_cases] >> TRY (
@@ -1841,8 +1841,8 @@ val compile_row_shift = store_thm("compile_row_shift",
   full_simp_tac(srw_ss())[bindn_def,GSYM arithmeticTheory.FUNPOW_ADD,arithmeticTheory.ADD1] >>
   fsrw_tac[ARITH_ss][])
 
-val compile_exp_shift = store_thm("compile_exp_shift",
-  ``(∀bvs1 e z1 z2 bvs2 V.
+val compile_exp_shift = Q.store_thm("compile_exp_shift",
+  `(∀bvs1 e z1 z2 bvs2 V.
        (set (FILTER IS_SOME bvs1) = set (FILTER IS_SOME bvs2)) ∧
        (z1 = LENGTH bvs1) ∧ (z2 = LENGTH bvs2) ∧ (bvs_V bvs1 bvs2 V)
        ⇒
@@ -1865,7 +1865,7 @@ val compile_exp_shift = store_thm("compile_exp_shift",
        (set (FILTER IS_SOME bvs1) = set (FILTER IS_SOME bvs2)) ∧
        (z1 = SUC(LENGTH bvs1)) ∧ (z2 = SUC(LENGTH bvs2)) ∧ (bvs_V bvs1 bvs2 V)
        ⇒
-       exp_rel z1 z2 (bind V) (compile_pes (NONE::bvs1) pes) (compile_pes (NONE::bvs2) pes))``,
+       exp_rel z1 z2 (bind V) (compile_pes (NONE::bvs1) pes) (compile_pes (NONE::bvs2) pes))`,
   ho_match_mp_tac compile_exp_ind >>
   strip_tac >- ( srw_tac[][] >> simp[Once exp_rel_cases] ) >>
   strip_tac >- (
@@ -1999,10 +1999,10 @@ val compile_exp_shift = store_thm("compile_exp_shift",
     fsrw_tac[ARITH_ss][arithmeticTheory.ADD1]) >>
    srw_tac[][])
 
-val lookup_find_index_SOME = prove(
-  ``∀env. ALOOKUP env n = SOME v ⇒
+val lookup_find_index_SOME = Q.prove(
+  `∀env. ALOOKUP env n = SOME v ⇒
       ∀m. ∃i. (find_index (SOME n) (MAP (SOME o FST) env) m = SOME (m+i)) ∧
-          (v = EL i (MAP SND env))``,
+          (v = EL i (MAP SND env))`,
   Induct >> simp[] >> Cases >> srw_tac[][find_index_def] >-
     (qexists_tac`0`>>simp[]) >> full_simp_tac(srw_ss())[] >>
   first_x_assum(qspec_then`m+1`mp_tac)>>srw_tac[][]>>srw_tac[][]>>
@@ -2535,15 +2535,15 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
   specl_args_of_then``exhSem$evaluate``(CONJUNCT1 compile_exp_evaluate) mp_tac >>
   simp[state_rel_def,compile_state_def])
 
-val set_globals_let_els = prove(``
+val set_globals_let_els = Q.prove(`
   ∀n m e.
-  set_globals (Let_Els n m e) = set_globals e``,
+  set_globals (Let_Els n m e) = set_globals e`,
   ho_match_mp_tac Let_Els_ind>>rw[Let_Els_def,sLet_def,op_gbag_def]>>
   pop_assum sym_sub_tac>>fs[])
 
-val compile_pat_empty = prove(``
+val compile_pat_empty = Q.prove(`
   (∀p. set_globals (compile_pat p) = {||}) ∧
-  (∀n ps. set_globals (compile_pats n ps) = {||})``,
+  (∀n ps. set_globals (compile_pats n ps) = {||})`,
   ho_match_mp_tac compile_pat_ind>>
   rw[compile_pat_def,op_gbag_def,sIf_def,sLet_def,set_globals_let_els]>>
   every_case_tac>>fs[])
@@ -2586,15 +2586,15 @@ val set_globals_eq = Q.store_thm("set_globals_eq",
     imp_res_tac compile_row_set_globals>>
     fs[bagTheory.SUB_BAG_UNION])
 
-val esgc_free_let_els = prove(``
+val esgc_free_let_els = Q.prove(`
   ∀n m e.
   esgc_free e ⇒
-  esgc_free (Let_Els n m e)``,
+  esgc_free (Let_Els n m e)`,
   ho_match_mp_tac Let_Els_ind>>rw[Let_Els_def,sLet_def,op_gbag_def])
 
-val compile_pat_esgc_free = prove(``
+val compile_pat_esgc_free = Q.prove(`
   (∀p. esgc_free (compile_pat p)) ∧
-  (∀n ps. esgc_free (compile_pats n ps))``,
+  (∀n ps. esgc_free (compile_pats n ps))`,
   ho_match_mp_tac compile_pat_ind>>
   rw[compile_pat_def,op_gbag_def,sIf_def,sLet_def,esgc_free_let_els]>>
   every_case_tac>>fs[])
@@ -2637,11 +2637,11 @@ val compile_esgc_free = Q.store_thm("compile_esgc_free",
     imp_res_tac compile_row_esgc_free)
 
 (* TODO: Move to HOL *)
-val BAG_ALL_DISTINCT_LT = prove(``
+val BAG_ALL_DISTINCT_LT = Q.prove(`
   ∀s t.
   s ≤ t ∧
   BAG_ALL_DISTINCT t ⇒
-  BAG_ALL_DISTINCT s``,
+  BAG_ALL_DISTINCT s`,
   fs[bagTheory.BAG_ALL_DISTINCT,bagTheory.SUB_BAG,bagTheory.BAG_INN]>>
   rw[]>>
   CCONTR_TAC>>

--- a/compiler/backend/proofs/exh_to_patProofScript.sml
+++ b/compiler/backend/proofs/exh_to_patProofScript.sml
@@ -70,11 +70,11 @@ val do_eq = Q.prove(
   simp[exhSemTheory.do_eq_def,patSemTheory.do_eq_def] >>
   srw_tac[][] >> BasicProvers.CASE_TAC >> srw_tac[][])
 
-val do_opapp = prove(
-  ``∀vs env exp.
+val do_opapp = Q.prove(
+  `∀vs env exp.
     do_opapp vs = SOME (env,exp) ⇒
     do_opapp (compile_vs vs) =
-      SOME (MAP (compile_v o SND) env, compile_exp (MAP (SOME o FST) env) exp)``,
+      SOME (MAP (compile_v o SND) env, compile_exp (MAP (SOME o FST) env) exp)`,
   rpt gen_tac >> simp[exhSemTheory.do_opapp_def] >>
   BasicProvers.CASE_TAC >>
   Cases_on`t`>>simp[]>>
@@ -145,12 +145,12 @@ val tac =
   full_simp_tac(srw_ss())[] >>
   srw_tac[][exhSemTheory.prim_exn_def, compile_v_def];
 
-val do_app = prove(
-  ``∀op vs s0 s0_pat env s res.
+val do_app = Q.prove(
+  `∀op vs s0 s0_pat env s res.
      do_app s0 op vs = SOME (s,res)
      ⇒
      do_app (compile_state s0) (Op op) (compile_vs vs) =
-       SOME (compile_state s,map_result compile_v compile_v res)``,
+       SOME (compile_state s,map_result compile_v compile_v res)`,
   srw_tac[][compile_state_def] >>
   imp_res_tac exhSemTheory.do_app_cases >>
   full_simp_tac(srw_ss())[exhSemTheory.do_app_def]
@@ -391,8 +391,8 @@ val s = mk_var("s",
   ``exhSem$evaluate`` |> type_of |> strip_fun |> #1 |> el 2
   |> type_subst[alpha |-> ``:'ffi``])
 
-val compile_pat_correct = prove(
-  ``(∀p v ^s env res env4.
+val compile_pat_correct = Q.prove(
+  `(∀p v ^s env res env4.
        pmatch s.refs p v env = res ∧ res ≠ Match_type_error ⇒
        evaluate
          (compile_v v::env4)
@@ -409,7 +409,7 @@ val compile_pat_correct = prove(
          (compile_state s)
          [compile_pats n ps] =
          (compile_state s
-         ,Rval [Boolv (∃env'. res = Match env')]))``,
+         ,Rval [Boolv (∃env'. res = Match env')]))`,
   ho_match_mp_tac compile_pat_ind >>
   srw_tac[][exhSemTheory.pmatch_def,compile_pat_def] >>
   srw_tac[][patSemTheory.evaluate_def]
@@ -1070,14 +1070,14 @@ val do_eq_v_rel = Q.store_thm("do_eq_v_rel",
   BasicProvers.CASE_TAC >> srw_tac[][] >>
   res_tac >> full_simp_tac(srw_ss())[])
 
-val do_opapp_v_rel = store_thm("do_opapp_v_rel",
-  ``∀vs vs'.
+val do_opapp_v_rel = Q.store_thm("do_opapp_v_rel",
+  `∀vs vs'.
     LIST_REL v_rel vs vs' ⇒
     OPTION_REL
       (λ(env1,e1) (env2,e2).
         exp_rel (LENGTH env1) (LENGTH env2) (env_rel v_rel env1 env2) e1 e2)
       (do_opapp vs)
-      (do_opapp vs')``,
+      (do_opapp vs')`,
   srw_tac[][patSemTheory.do_opapp_def] >>
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[quotient_optionTheory.OPTION_REL_def] >> srw_tac[][] >>
   Cases_on`t`>>full_simp_tac(srw_ss())[quotient_optionTheory.OPTION_REL_def] >> srw_tac[][] >>
@@ -1160,8 +1160,8 @@ in
   val s = mk_var("s",ty)
 end
 
-val do_app_v_rel = store_thm("do_app_v_rel",
-  ``∀^s op s' vs vs'.
+val do_app_v_rel = Q.store_thm("do_app_v_rel",
+  `∀^s op s' vs vs'.
       LIST_REL v_rel vs vs' ⇒
       state_rel s s' ⇒
       OPTION_REL
@@ -1169,7 +1169,7 @@ val do_app_v_rel = store_thm("do_app_v_rel",
           state_rel s1 s2 ∧
           result_rel v_rel v_rel res1 res2)
         (do_app s op vs)
-        (do_app s' op vs')``,
+        (do_app s' op vs')`,
   srw_tac[][] >>
   srw_tac[][optionTheory.OPTREL_def] >>
   Cases_on`do_app s op vs`>>srw_tac[][]>-(
@@ -1293,15 +1293,15 @@ val do_app_v_rel = store_thm("do_app_v_rel",
     simp[EL_LUPDATE] >> srw_tac[][] >> srw_tac[][] >> NO_TAC) >>
   metis_tac[sv_rel_def,optionTheory.NOT_SOME_NONE,optionTheory.SOME_11,PAIR_EQ])
 
-val evaluate_exp_rel = store_thm("evaluate_exp_rel",
-  ``(∀env1 ^s1 es1 s'1 r1. evaluate env1 s1 es1 = (s'1,r1) ⇒
+val evaluate_exp_rel = Q.store_thm("evaluate_exp_rel",
+  `(∀env1 ^s1 es1 s'1 r1. evaluate env1 s1 es1 = (s'1,r1) ⇒
        ∀env2 s2 es2.
          LIST_REL (exp_rel (LENGTH env1) (LENGTH env2) (env_rel v_rel env1 env2)) es1 es2 ∧
          state_rel s1 s2 ⇒
          ∃s'2 r2.
            evaluate env2 s2 es2 = (s'2,r2) ∧
            state_rel s'1 s'2 ∧
-           result_rel (LIST_REL v_rel) v_rel r1 r2)``,
+           result_rel (LIST_REL v_rel) v_rel r1 r2)`,
   ho_match_mp_tac patSemTheory.evaluate_ind >>
   strip_tac >- ( srw_tac[][patSemTheory.evaluate_def] >> srw_tac[][]) >>
   strip_tac >- (
@@ -1691,8 +1691,8 @@ val ground_exp_rel_refl = Q.store_thm("ground_exp_rel_refl",
     NO_TAC) >>
   simp[bindn_thm])
 
-val compile_row_acc = store_thm("compile_row_acc",
-  ``(∀Nbvs p bvs1 N. Nbvs = N::bvs1 ⇒
+val compile_row_acc = Q.store_thm("compile_row_acc",
+  `(∀Nbvs p bvs1 N. Nbvs = N::bvs1 ⇒
        ∀bvs2 r1 n1 f1 r2 n2 f2.
          compile_row (N::bvs1) p = (r1,n1,f1) ∧
          compile_row (N::bvs2) p = (r2,n2,f2) ⇒
@@ -1708,7 +1708,7 @@ val compile_row_acc = store_thm("compile_row_acc",
         n1 = n2 ∧ f1 = f2 ∧
         ∃ls. r1 = ls ++ bvsk ++ (N::bvs1) ∧
              r2 = ls ++ bvsk ++ (N::bvs2) ∧
-             LENGTH ls = n1)``,
+             LENGTH ls = n1)`,
   ho_match_mp_tac compile_row_ind >>
   strip_tac >- (
     rpt gen_tac >> strip_tac >> full_simp_tac(srw_ss())[] >>
@@ -1786,8 +1786,8 @@ val compile_row_acc = store_thm("compile_row_acc",
   rpt BasicProvers.VAR_EQ_TAC >>
   simp[])
 
-val compile_row_shift = store_thm("compile_row_shift",
-  ``(∀bvs p bvs1 n1 f z1 z2 V e1 e2.
+val compile_row_shift = Q.store_thm("compile_row_shift",
+  `(∀bvs p bvs1 n1 f z1 z2 V e1 e2.
        compile_row bvs p = (bvs1,n1,f) ∧ 0 < z1 ∧ 0 < z2 ∧ V 0 0 ∧ bvs ≠ [] ∧
        exp_rel (z1 + n1) (z2 + n1) (bindn n1 V) e1 e2
        ⇒
@@ -1797,7 +1797,7 @@ val compile_row_shift = store_thm("compile_row_shift",
        n < z1 ∧ n < z2 ∧ V n n ∧
        exp_rel (z1 + n1) (z2 + n1) (bindn (n1) V) e1 e2
        ⇒
-       exp_rel z1 z2 V (f e1) (f e2))``,
+       exp_rel z1 z2 V (f e1) (f e2))`,
   ho_match_mp_tac compile_row_ind >>
   simp[compile_row_def] >>
   strip_tac >- (
@@ -2548,10 +2548,10 @@ val compile_pat_empty = Q.prove(`
   rw[compile_pat_def,op_gbag_def,sIf_def,sLet_def,set_globals_let_els]>>
   every_case_tac>>fs[])
 
-val compile_row_set_globals = prove(``
+val compile_row_set_globals = Q.prove(`
   (∀bvs p a b f exp.
   compile_row bvs p = (a,b,f) ⇒ set_globals (f exp) = set_globals exp) ∧
-  (∀bvs n k ps a b f exp. compile_cols bvs n k ps = (a,b,f) ⇒ set_globals (f exp) = set_globals exp)``,
+  (∀bvs n k ps a b f exp. compile_cols bvs n k ps = (a,b,f) ⇒ set_globals (f exp) = set_globals exp)`,
   ho_match_mp_tac compile_row_ind>>rw[compile_row_def]>>fs[]>>
   rpt (pairarg_tac>>fs[sLet_def])>>
   qpat_x_assum `A=f` sym_sub_tac>>rw[op_gbag_def]>>
@@ -2599,13 +2599,13 @@ val compile_pat_esgc_free = Q.prove(`
   rw[compile_pat_def,op_gbag_def,sIf_def,sLet_def,esgc_free_let_els]>>
   every_case_tac>>fs[])
 
-val compile_row_esgc_free = prove(``
+val compile_row_esgc_free = Q.prove(`
   (∀bvs p a b f exp.
   compile_row bvs p = (a,b,f) ∧ esgc_free exp ⇒
   esgc_free (f exp)) ∧
   (∀bvs n k ps a b f exp.
   compile_cols bvs n k ps = (a,b,f) ∧ esgc_free exp ⇒
-  esgc_free (f exp))``,
+  esgc_free (f exp))`,
   ho_match_mp_tac compile_row_ind>>rw[compile_row_def]>>fs[]>>
   rpt (pairarg_tac>>fs[sLet_def])>>
   qpat_x_assum `A=f` sym_sub_tac>>rw[op_gbag_def])

--- a/compiler/backend/proofs/exh_to_patProofScript.sml
+++ b/compiler/backend/proofs/exh_to_patProofScript.sml
@@ -1277,11 +1277,11 @@ val do_app_v_rel = store_thm("do_app_v_rel",
   full_simp_tac(srw_ss())[optionTheory.OPTREL_def] >>
   TRY(
     qmatch_assum_rename_tac`v_rel (Conv t1 v1) (Conv t2 v2)` >>
-    rator_x_assum`v_rel`mp_tac >>
+    qhdtm_x_assum`v_rel`mp_tac >>
     simp[Once v_rel_cases,LIST_REL_EL_EQN] >> NO_TAC) >>
   TRY(
     qmatch_assum_rename_tac`v_rel (Vectorv l1) (Vectorv l2)` >>
-    rator_x_assum`v_rel`mp_tac >>
+    qhdtm_x_assum`v_rel`mp_tac >>
     simp[Once v_rel_cases,LIST_REL_EL_EQN] >> NO_TAC) >>
   TRY (
     CHANGED_TAC(full_simp_tac(srw_ss())[store_v_same_type_def]) >>
@@ -2065,7 +2065,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
     var_eq_tac >>
     split_pair_case_tac >> full_simp_tac(srw_ss())[] >>
     simp[Once evaluate_cons] >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
     simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
     full_simp_tac(srw_ss())[PULL_EXISTS] >>
@@ -2099,7 +2099,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
     Cases_on`r`>>full_simp_tac(srw_ss())[] >>
     qmatch_assum_rename_tac`er ≠ Rabort Rtype_error ⇒ _` >>
     Cases_on`er`>>full_simp_tac(srw_ss())[] >> rpt var_eq_tac >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
     simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
     full_simp_tac(srw_ss())[PULL_EXISTS] >>
@@ -2163,7 +2163,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
       first_assum(split_uncurry_arg_tac o concl) >> full_simp_tac(srw_ss())[] >>
       IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- ( full_simp_tac(srw_ss())[state_rel_def,compile_state_def] ) >>
       strip_tac >> full_simp_tac(srw_ss())[] >>
-      rator_x_assum`result_rel`mp_tac >>
+      qhdtm_x_assum`result_rel`mp_tac >>
       specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
       simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
       full_simp_tac(srw_ss())[PULL_EXISTS] >> strip_tac >>
@@ -2198,7 +2198,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
     split_pair_case_tac >> full_simp_tac(srw_ss())[] >>
     qmatch_assum_rename_tac`r ≠ Rerr (Rabort Rtype_error) ⇒ _` >>
     reverse(Cases_on`r`)>>full_simp_tac(srw_ss())[] >- ( strip_tac >> full_simp_tac(srw_ss())[] ) >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
     simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
     full_simp_tac(srw_ss())[PULL_EXISTS] >>
@@ -2229,7 +2229,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
       simp[patSemTheory.evaluate_def] >>
       split_pair_case_tac >> full_simp_tac(srw_ss())[] >>
       reverse(Cases_on`r`)>>full_simp_tac(srw_ss())[]>>
-      rator_x_assum`result_rel`mp_tac >>
+      qhdtm_x_assum`result_rel`mp_tac >>
       specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
       simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
       full_simp_tac(srw_ss())[PULL_EXISTS] >>
@@ -2240,7 +2240,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
     simp[patSemTheory.evaluate_def] >>
     split_pair_case_tac >> full_simp_tac(srw_ss())[] >>
     reverse(Cases_on`r`)>>full_simp_tac(srw_ss())[]>- ( strip_tac >> full_simp_tac(srw_ss())[] ) >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     specl_args_of_then``patSem$evaluate``evaluate_exp_rel mp_tac >>
     simp[pair_lemma] >> (fn (g as (_,w)) => split_uncurry_arg_tac (rand(rator w)) g) >>
     full_simp_tac(srw_ss())[PULL_EXISTS] >>
@@ -2329,7 +2329,7 @@ val compile_exp_evaluate = Q.store_thm("compile_exp_evaluate",
       qpat_abbrev_tac`xx = evaluate _ _ _` >>
       qmatch_assum_abbrev_tac`Abbrev(xx = evaluate (v4::env4) s4 [f (compile_exp bvss exp)])` >>
       qunabbrev_tac`xx` >>
-      rator_x_assum`state_rel`mp_tac >>
+      qhdtm_x_assum`state_rel`mp_tac >>
       qpat_abbrev_tac`xx = evaluate _ _ _` >>
       qmatch_assum_abbrev_tac`Abbrev(xx = evaluate env3 s4 [exp3])` >>
       qunabbrev_tac`xx` >> strip_tac >>
@@ -2424,7 +2424,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
     srw_tac[][] >>
     simp[patSemTheory.semantics_def] >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`exhSem$evaluate`kall_tac >>
+      qhdtm_x_assum`exhSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >>
@@ -2452,7 +2452,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
           simp[RIGHT_FORALL_IMP_THM] >>
           impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`patSem$evaluate`mp_tac >>
+          qhdtm_x_assum`patSem$evaluate`mp_tac >>
           drule (GEN_ALL patPropsTheory.evaluate_add_to_clock) >>
           simp[] >>
           disch_then(qspec_then`k`mp_tac)>>simp[]>>
@@ -2469,7 +2469,7 @@ val compile_exp_semantics = Q.store_thm("compile_exp_semantics",
           rpt strip_tac >> fsrw_tac[ARITH_ss][] >> rev_full_simp_tac(srw_ss())[] ) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[EXISTS_PROD])) >>
         strip_tac >>
-        rator_x_assum`exhSem$evaluate`mp_tac >>
+        qhdtm_x_assum`exhSem$evaluate`mp_tac >>
         drule (GEN_ALL (CONJUNCT1 exhPropsTheory.evaluate_add_to_clock)) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>

--- a/compiler/backend/proofs/lab_filterProofScript.sml
+++ b/compiler/backend/proofs/lab_filterProofScript.sml
@@ -25,8 +25,8 @@ val all_skips_def = Define`
     ∃x y.
     asm_fetch_aux (pc+i) code = SOME(Asm (Inst Skip) x y)`
 
-val is_Label_not_skip = prove(``
-  is_Label y ⇒ not_skip y``,
+val is_Label_not_skip = Q.prove(`
+  is_Label y ⇒ not_skip y`,
   Cases_on`y`>>full_simp_tac(srw_ss())[is_Label_def,not_skip_def])
 
 (*
@@ -49,11 +49,11 @@ evaluate pc code with k for a clock = evaluate (pc+k) code
 
 (* 1)
 There is probably a neater way to prove this*)
-val asm_fetch_aux_eq = prove(``
+val asm_fetch_aux_eq = Q.prove(`
   ∀pc code.
   ∃k.
     asm_fetch_aux (pc+k) code = asm_fetch_aux (adjust_pc pc code) (filter_skip code) ∧
-    all_skips pc code k``,
+    all_skips pc code k`,
   Induct_on`code`
   >-
     (simp[Once adjust_pc_def,filter_skip_def,asm_fetch_aux_def,all_skips_def]>>
@@ -110,10 +110,10 @@ val asm_fetch_aux_eq = prove(``
 
 (*For any adjusted fetch, the original fetch is either equal or is a skip
 This is probably the wrong direction*)
-val asm_fetch_not_skip_adjust_pc = prove(
-  ``∀pc code inst.
+val asm_fetch_not_skip_adjust_pc = Q.prove(
+  `∀pc code inst.
   (∀x y.asm_fetch_aux pc code ≠ SOME (Asm (Inst Skip) x y)) ⇒
-  asm_fetch_aux pc code = asm_fetch_aux (adjust_pc pc code) (filter_skip code)``,
+  asm_fetch_aux pc code = asm_fetch_aux (adjust_pc pc code) (filter_skip code)`,
   ho_match_mp_tac asm_fetch_aux_ind>>srw_tac[][]
   >-
     simp[asm_fetch_aux_def,filter_skip_def]
@@ -144,20 +144,20 @@ val asm_fetch_not_skip_adjust_pc = prove(
     IF_CASES_TAC>>full_simp_tac(srw_ss())[filter_skip_def]>>
     simp[asm_fetch_aux_def])
 
-val state_rw = prove(``
+val state_rw = Q.prove(`
   s with clock := s.clock = s ∧
   s with pc := s.pc = s ∧
-  s with <|pc := s.pc; clock:= s.clock+k'|> = s with clock:=s.clock+k'``,
+  s with <|pc := s.pc; clock:= s.clock+k'|> = s with clock:=s.clock+k'`,
   full_simp_tac(srw_ss())[state_component_equality])
 
 (* 2) all_skips allow swapping pc for clock*)
-val all_skips_evaluate = prove(``
+val all_skips_evaluate = Q.prove(`
   ∀k s.
   all_skips s.pc s.code k ∧
   ¬s.failed ⇒
   ∀k'.
   evaluate (s with clock:= s.clock +k' + k) =
-  evaluate (s with <|pc := s.pc +k; clock:= s.clock +k'|>)``,
+  evaluate (s with <|pc := s.pc +k; clock:= s.clock +k'|>)`,
   Induct>>full_simp_tac(srw_ss())[all_skips_def]
   >-
     metis_tac[state_rw]
@@ -184,10 +184,10 @@ val state_rel_def = Define `
                      pc := adjust_pc t1.pc t1.code |>) ∧
     ¬t1.failed`
 
-val adjust_pc_all_skips = prove(``
+val adjust_pc_all_skips = Q.prove(`
   ∀k pc code.
   all_skips pc code k ⇒
-  adjust_pc pc code +1 = adjust_pc (pc+k+1) code``,
+  adjust_pc pc code +1 = adjust_pc (pc+k+1) code`,
   Induct>>full_simp_tac(srw_ss())[all_skips_def]>>simp[]>>
   ho_match_mp_tac asm_fetch_aux_ind
   >>
@@ -223,20 +223,20 @@ val adjust_pc_all_skips = prove(``
     first_assum match_mp_tac>>full_simp_tac(srw_ss())[]>>
     full_simp_tac(srw_ss())[])
 
-val asm_fetch_aux_eq2 = prove(
-``asm_fetch_aux (adjust_pc pc code) (filter_skip code) = x ⇒
+val asm_fetch_aux_eq2 = Q.prove(
+`asm_fetch_aux (adjust_pc pc code) (filter_skip code) = x ⇒
   ∃k.
   asm_fetch_aux (pc+k) code = x ∧
-  all_skips pc code k``,
+  all_skips pc code k`,
   metis_tac[asm_fetch_aux_eq])
 
 val all_skips_evaluate_0 = all_skips_evaluate |>SIMP_RULE std_ss [PULL_FORALL]|>(Q.SPECL[`k`,`s`,`0`])|>GEN_ALL|>SIMP_RULE std_ss[]
 
-val all_skips_evaluate_rw = prove(``
+val all_skips_evaluate_rw = Q.prove(`
   all_skips s.pc s.code k ∧ ¬s.failed ∧
   s.clock = clk + k ∧
   t = s with <| pc:= s.pc +k ; clock := clk |> ⇒
-  evaluate s = evaluate t``,
+  evaluate s = evaluate t`,
   srw_tac[][]>>
   qabbrev_tac`s' = s with clock := clk`>>
   `s = s' with clock := s'.clock +k` by
@@ -248,9 +248,9 @@ val all_skips_evaluate_rw = prove(``
    full_simp_tac(srw_ss())[state_component_equality])
 
 (*For all initial code there is some all_skips*)
-val all_skips_initial_adjust = prove(``
+val all_skips_initial_adjust = Q.prove(`
   ∀code.
-  ∃k. all_skips 0 code k ∧ adjust_pc k code = 0``,
+  ∃k. all_skips 0 code k ∧ adjust_pc k code = 0`,
   Induct>>full_simp_tac(srw_ss())[all_skips_def]
   >-
     (qexists_tac`0`>>full_simp_tac(srw_ss())[adjust_pc_def,asm_fetch_aux_def])
@@ -275,10 +275,10 @@ val all_skips_initial_adjust = prove(``
     >> (qexists_tac`0`>>full_simp_tac(srw_ss())[]))
 
 (*May need strengthening*)
-val loc_to_pc_eq_NONE = prove(``
+val loc_to_pc_eq_NONE = Q.prove(`
   ∀n1 n2 code.
   loc_to_pc n1 n2 (filter_skip code) = NONE ⇒
-  loc_to_pc n1 n2 code = NONE``,
+  loc_to_pc n1 n2 code = NONE`,
   ho_match_mp_tac loc_to_pc_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[filter_skip_def]>>
   full_simp_tac(srw_ss())[Once loc_to_pc_def]>>IF_CASES_TAC>>full_simp_tac(srw_ss())[]>>
@@ -293,12 +293,12 @@ val loc_to_pc_eq_NONE = prove(``
     EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>NO_TAC)>>
   full_simp_tac(srw_ss())[not_skip_def])
 
-val loc_to_pc_eq_SOME = prove(``
+val loc_to_pc_eq_SOME = Q.prove(`
   ∀n1 n2 code pc.
   loc_to_pc n1 n2 (filter_skip code) = SOME pc ⇒
   ∃pc'.
   loc_to_pc n1 n2 code = SOME pc' ∧
-  adjust_pc pc' code = pc``,
+  adjust_pc pc' code = pc`,
   ho_match_mp_tac loc_to_pc_ind>>srw_tac[][]
   >-
     (full_simp_tac(srw_ss())[filter_skip_def,adjust_pc_def]>>
@@ -362,18 +362,18 @@ val loc_to_pc_eq_SOME = prove(``
         simp[Once loc_to_pc_def]>>
         simp[Once adjust_pc_def])))
 
-val next_label_filter_skip = prove(``
+val next_label_filter_skip = Q.prove(`
   ∀code.
-  next_label code = next_label (filter_skip code)``,
+  next_label code = next_label (filter_skip code)`,
   ho_match_mp_tac next_label_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[next_label_def,filter_skip_def,not_skip_def]>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[next_label_def])
 
-val all_skips_get_lab_after = prove(``
+val all_skips_get_lab_after = Q.prove(`
   ∀code k.
   all_skips 0 code k ⇒
   get_lab_after k code =
-  get_lab_after 0 (filter_skip code)``,
+  get_lab_after 0 (filter_skip code)`,
   Induct>>full_simp_tac(srw_ss())[get_lab_after_def,filter_skip_def]>>
   Induct>>Induct_on`l`>>srw_tac[][]>>full_simp_tac(srw_ss())[filter_skip_def,get_lab_after_def]
   >-
@@ -408,10 +408,10 @@ val all_skips_get_lab_after = prove(``
     res_tac>>
     full_simp_tac(srw_ss())[])
 
-val get_lab_after_adjust = prove(``
+val get_lab_after_adjust = Q.prove(`
   ∀pc code k.
   all_skips pc code k ⇒
-  get_lab_after (pc+k) code = get_lab_after (adjust_pc pc code) (filter_skip code)``,
+  get_lab_after (pc+k) code = get_lab_after (adjust_pc pc code) (filter_skip code)`,
   ho_match_mp_tac get_lab_after_ind>>
   srw_tac[][]
   >-
@@ -657,8 +657,8 @@ val filter_correct = prove(
       EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>
       same_inst_tac)
 
-val state_rel_IMP_sem_EQ_sem = prove(
-  ``!s t. state_rel s t ==> semantics s = semantics t``,
+val state_rel_IMP_sem_EQ_sem = Q.prove(
+  `!s t. state_rel s t ==> semantics s = semantics t`,
   srw_tac[][labSemTheory.semantics_def] >- (
     DEEP_INTRO_TAC some_intro >>
     full_simp_tac(srw_ss())[FST_EQ_EQUIV] >>
@@ -763,9 +763,9 @@ val state_rel_IMP_sem_EQ_sem = prove(
       qexists_tac`k+k'`>>simp[EL_APPEND1] ) >>
     metis_tac[build_lprefix_lub_thm,unique_lprefix_lub,lprefix_lub_new_chain]));
 
-val filter_skip_semantics = store_thm("filter_skip_semantics",
-  ``!s t. (s.pc = 0) ∧ ¬s.failed /\ (t = s with code := filter_skip s.code) ==>
-          semantics t = semantics s``,
+val filter_skip_semantics = Q.store_thm("filter_skip_semantics",
+  `!s t. (s.pc = 0) ∧ ¬s.failed /\ (t = s with code := filter_skip s.code) ==>
+          semantics t = semantics s`,
   srw_tac[][] \\ match_mp_tac state_rel_IMP_sem_EQ_sem
   \\ full_simp_tac(srw_ss())[state_rel_def,state_component_equality,Once adjust_pc_def]);
 

--- a/compiler/backend/proofs/lab_filterProofScript.sml
+++ b/compiler/backend/proofs/lab_filterProofScript.sml
@@ -497,12 +497,12 @@ val inc_pc_tac =
   `∀x.x + t1.clock -1 = x + (t1.clock -1)` by DECIDE_TAC>>rev_full_simp_tac(srw_ss())[]>>
   metis_tac[arithmeticTheory.ADD_COMM,arithmeticTheory.ADD_ASSOC];
 
-val filter_correct = prove(
-  ``!(s1:('a,'ffi) labSem$state) t1 res s2.
+val filter_correct = Q.prove(
+  `!(s1:('a,'ffi) labSem$state) t1 res s2.
       (evaluate s1 = (res,s2)) /\ state_rel s1 t1 /\ ~t1.failed ==>
       ?k t2.
         (evaluate (t1 with clock := s1.clock + k) = (res,t2)) /\
-        (s2.ffi = t2.ffi)``,
+        (s2.ffi = t2.ffi)`,
   ho_match_mp_tac evaluate_ind>>srw_tac[][]>>
   qpat_x_assum`evaluate s1 = A` mp_tac>>
   simp[Once evaluate_def]>>

--- a/compiler/backend/proofs/lab_filterProofScript.sml
+++ b/compiler/backend/proofs/lab_filterProofScript.sml
@@ -684,7 +684,7 @@ val state_rel_IMP_sem_EQ_sem = Q.prove(
       DEEP_INTRO_TAC some_intro >> full_simp_tac(srw_ss())[] >>
       conj_tac >- (
         srw_tac[][] >>
-        rator_x_assum`evaluate`mp_tac >>
+        qhdtm_x_assum`evaluate`mp_tac >>
         drule filter_correct >>
         disch_then(qspec_then`t with clock := k`mp_tac) >>
         impl_tac >- full_simp_tac(srw_ss())[state_rel_def] >>

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -79,9 +79,9 @@ val enc_with_nop_def = Define `
         let n = (LENGTH bytes - LENGTH init) DIV LENGTH step in
           bytes = init ++ FLAT (REPLICATE n step)`
 
-val enc_with_nop_thm = prove(
-  ``enc_with_nop enc (b:'a asm) bytes =
-      ?n. bytes = enc b ++ FLAT (REPLICATE n (enc (asm$Inst Skip)))``,
+val enc_with_nop_thm = Q.prove(
+  `enc_with_nop enc (b:'a asm) bytes =
+      ?n. bytes = enc b ++ FLAT (REPLICATE n (enc (asm$Inst Skip)))`,
   fs [enc_with_nop_def,LENGTH_NIL]
   \\ IF_CASES_TAC \\ fs [FLAT_REPLICATE_NIL]
   \\ EQ_TAC \\ rw [] THEN1 metis_tac []
@@ -142,22 +142,22 @@ val evaluate_nop_step =
     |> SIMP_RULE (srw_ss()) [asm_def,inst_def,asm_ok_def,inst_ok_def,
          Once upd_pc_def,GSYM CONJ_ASSOC]
 
-val shift_interfer_0 = prove(
-  ``shift_interfer 0 = I``,
+val shift_interfer_0 = Q.prove(
+  `shift_interfer 0 = I`,
   full_simp_tac(srw_ss())[shift_interfer_def,FUN_EQ_THM,shift_seq_def,
       machine_config_component_equality]);
 
-val upd_pc_with_pc = prove(
-  ``upd_pc s1.pc s1 = s1:'a asm_state``,
+val upd_pc_with_pc = Q.prove(
+  `upd_pc s1.pc s1 = s1:'a asm_state`,
   full_simp_tac(srw_ss())[asm_state_component_equality,upd_pc_def]);
 
-val shift_interfer_twice = store_thm("shift_interfer_twice[simp]",
-  ``shift_interfer l' (shift_interfer l c) =
-    shift_interfer (l + l') c``,
+val shift_interfer_twice = Q.store_thm("shift_interfer_twice[simp]",
+  `shift_interfer l' (shift_interfer l c) =
+    shift_interfer (l + l') c`,
   full_simp_tac(srw_ss())[shift_interfer_def,shift_seq_def,AC ADD_COMM ADD_ASSOC]);
 
-val evaluate_nop_steps = prove(
-  ``!n s1 ms1 c.
+val evaluate_nop_steps = Q.prove(
+  `!n s1 ms1 c.
       backend_correct c.target /\
       c.prog_addresses = s1.mem_domain /\
       interference_ok c.next_interfer (c.target.proj s1.mem_domain) /\
@@ -176,7 +176,7 @@ val evaluate_nop_steps = prove(
             (upd_pc
               (s1.pc +
                n2w (n * LENGTH (c.target.config.encode (Inst Skip)))) s1)
-            ms2``,
+            ms2`,
   Induct \\ full_simp_tac(srw_ss())[] THEN1
    (rpt strip_tac \\ Q.LIST_EXISTS_TAC [`0`,`ms1`]
     \\ full_simp_tac(srw_ss())[shift_interfer_0,upd_pc_with_pc])
@@ -200,8 +200,8 @@ val evaluate_nop_steps = prove(
   \\ first_x_assum (mp_tac o Q.SPEC `k+l'`)
   \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]);
 
-val asm_step_IMP_evaluate_step_nop = prove(
-  ``!c s1 ms1 io i s2 bytes.
+val asm_step_IMP_evaluate_step_nop = Q.prove(
+  `!c s1 ms1 io i s2 bytes.
       backend_correct c.target /\
       c.prog_addresses = s1.mem_domain /\
       interference_ok c.next_interfer (c.target.proj s1.mem_domain) /\
@@ -214,7 +214,7 @@ val asm_step_IMP_evaluate_step_nop = prove(
         !k.
           evaluate c io (k + l) ms1 =
           evaluate (shift_interfer l c) io k ms2 /\
-          target_state_rel c.target s2 ms2 /\ l <> 0``,
+          target_state_rel c.target s2 ms2 /\ l <> 0`,
   full_simp_tac(srw_ss())[asm_step_nop_def] \\ rpt strip_tac
   \\ (asm_step_IMP_evaluate_step
       |> SIMP_RULE std_ss [asm_step_def] |> SPEC_ALL |> mp_tac) \\ full_simp_tac(srw_ss())[]
@@ -266,19 +266,19 @@ val asm_step_IMP_evaluate_step_nop = prove(
 
 val _ = Parse.temp_overload_on("option_ldrop",``λn l. OPTION_JOIN (OPTION_MAP (LDROP n) l)``)
 
-val option_ldrop_0 = prove(
-  ``!ll. option_ldrop 0 ll = ll``,
+val option_ldrop_0 = Q.prove(
+  `!ll. option_ldrop 0 ll = ll`,
   Cases \\ full_simp_tac(srw_ss())[]);
 
-val option_ldrop_SUC = prove(
-  ``!k1 ll. option_ldrop (SUC k1) ll = option_ldrop 1 (option_ldrop k1 ll)``,
+val option_ldrop_SUC = Q.prove(
+  `!k1 ll. option_ldrop (SUC k1) ll = option_ldrop 1 (option_ldrop k1 ll)`,
   Cases_on `ll` \\ full_simp_tac(srw_ss())[]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[ADD1] \\ full_simp_tac(srw_ss())[LDROP_ADD]
   \\ Cases_on `LDROP k1 x` \\ full_simp_tac(srw_ss())[]);
 
-val option_ldrop_option_ldrop = prove(
-  ``!k1 ll k2.
-      option_ldrop k1 (option_ldrop k2 ll) = option_ldrop (k1 + k2) ll``,
+val option_ldrop_option_ldrop = Q.prove(
+  `!k1 ll k2.
+      option_ldrop k1 (option_ldrop k2 ll) = option_ldrop (k1 + k2) ll`,
   Induct \\ full_simp_tac(srw_ss())[option_ldrop_0]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[option_ldrop_SUC,ADD_CLAUSES]);
 
@@ -301,9 +301,9 @@ val lab_lookup_def = Define `
     | NONE => NONE
     | SOME f => lookup k2 f`
 
-val lab_lookup_IMP = prove(
-  ``(lab_lookup l1 l2 labs = SOME x) ==>
-    (find_pos (Lab l1 l2) labs = x)``,
+val lab_lookup_IMP = Q.prove(
+  `(lab_lookup l1 l2 labs = SOME x) ==>
+    (find_pos (Lab l1 l2) labs = x)`,
   full_simp_tac(srw_ss())[lab_lookup_def,find_pos_def,lookup_any_def]
   \\ BasicProvers.EVERY_CASE_TAC);
 
@@ -350,8 +350,8 @@ val bytes_in_mem_def = Define `
      a IN md /\ ~(a IN k) /\ (m a = b) /\
      bytes_in_mem (a+1w) bs m md k)`
 
-val bytes_in_mem_IMP = prove(
-  ``!xs p. bytes_in_mem p xs m dm dm1 ==> bytes_in_memory p xs m dm``,
+val bytes_in_mem_IMP = Q.prove(
+  `!xs p. bytes_in_mem p xs m dm dm1 ==> bytes_in_memory p xs m dm`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def,bytes_in_memory_def]);
 
 val has_io_index_def = Define `
@@ -422,9 +422,9 @@ val state_rel_def = Define `
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     code_similar s1.code code2`
 
-val pos_val_0 = prove(
-  ``!xs c enc labs pos.
-      all_enc_ok c labs pos xs ==> (pos_val 0 pos xs = pos)``,
+val pos_val_0 = Q.prove(
+  `!xs c enc labs pos.
+      all_enc_ok c labs pos xs ==> (pos_val 0 pos xs = pos)`,
   Induct \\ full_simp_tac(srw_ss())[pos_val_def] \\ Cases_on `h`
   \\ Induct_on `l` \\ full_simp_tac(srw_ss())[pos_val_def,all_enc_ok_def]
   \\ rpt strip_tac  \\ res_tac  \\ srw_tac[][]
@@ -487,11 +487,11 @@ val prog_to_bytes_lemma = prog_to_bytes_lemma
   |> Q.SPECL [`code2`,`code1`,`pc`,`i`,`0`]
   |> SIMP_RULE std_ss [];
 
-val bytes_in_mem_APPEND = prove(
-  ``!xs ys a m md md1.
+val bytes_in_mem_APPEND = Q.prove(
+  `!xs ys a m md md1.
       bytes_in_mem a (xs ++ ys) m md md1 <=>
       bytes_in_mem a xs m md md1 /\
-      bytes_in_mem (a + n2w (LENGTH xs)) ys m md md1``,
+      bytes_in_mem (a + n2w (LENGTH xs)) ys m md md1`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def,ADD1,GSYM word_add_n2w,CONJ_ASSOC]);
 
 val s1 = ``s1:('a,'ffi) labSem$state``;
@@ -720,15 +720,15 @@ val IMP_bytes_in_memory_Halt = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND]);
 
-val ADD_MODULUS_LEMMA = prove(
-  ``!k m n. 0 < n ==> (m + k * n) MOD n = m MOD n``,
+val ADD_MODULUS_LEMMA = Q.prove(
+  `!k m n. 0 < n ==> (m + k * n) MOD n = m MOD n`,
   Induct \\ full_simp_tac(srw_ss())[MULT_CLAUSES,ADD_ASSOC,ADD_MODULUS]);
 
-val line_length_MOD_0 = prove(
-  ``backend_correct mc_conf.target /\
+val line_length_MOD_0 = Q.prove(
+  `backend_correct mc_conf.target /\
     (~EVEN p ==> (mc_conf.target.config.code_alignment = 0)) /\
     line_ok mc_conf.target.config labs p h ==>
-    (line_length h MOD 2 ** mc_conf.target.config.code_alignment = 0)``,
+    (line_length h MOD 2 ** mc_conf.target.config.code_alignment = 0)`,
   Cases_on `h` \\ TRY (Cases_on `a`) \\ full_simp_tac(srw_ss())[line_ok_def,line_length_def]
   \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[backend_correct_def,target_ok_def,enc_ok_def]
@@ -737,18 +737,18 @@ val line_length_MOD_0 = prove(
   \\ full_simp_tac(srw_ss())[LET_DEF,map_replicate,SUM_REPLICATE] \\ srw_tac[][]
   \\ res_tac \\ full_simp_tac(srw_ss())[ADD_MODULUS_LEMMA]);
 
-val pos_val_MOD_0_lemma = prove(
-  ``(0 MOD 2 ** mc_conf.target.config.code_alignment = 0)``,
+val pos_val_MOD_0_lemma = Q.prove(
+  `(0 MOD 2 ** mc_conf.target.config.code_alignment = 0)`,
   full_simp_tac(srw_ss())[]);
 
-val pos_val_MOD_0 = prove(
-  ``!x pos code2.
+val pos_val_MOD_0 = Q.prove(
+  `!x pos code2.
       backend_correct mc_conf.target /\
       (has_odd_inst code2 ==> (mc_conf.target.config.code_alignment = 0)) /\
       (~EVEN pos ==> (mc_conf.target.config.code_alignment = 0)) /\
       (pos MOD 2 ** mc_conf.target.config.code_alignment = 0) /\
       all_enc_ok mc_conf.target.config labs pos code2 ==>
-      (pos_val x pos code2 MOD 2 ** mc_conf.target.config.code_alignment = 0)``,
+      (pos_val x pos code2 MOD 2 ** mc_conf.target.config.code_alignment = 0)`,
   reverse (Cases_on `backend_correct mc_conf.target`)
   \\ asm_simp_tac pure_ss [] THEN1 full_simp_tac(srw_ss())[]
   \\ HO_MATCH_MP_TAC pos_val_ind
@@ -791,9 +791,9 @@ val read_bytearray_state_rel = prove(
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[word_loc_val_def]
   \\ rev_full_simp_tac(srw_ss())[word_loc_val_byte_def,word_loc_val_def]);
 
-val IMP_has_io_index = prove(
-  ``(asm_fetch s1 = SOME (LabAsm (CallFFI index) l bytes n)) ==>
-    has_io_index index s1.code``,
+val IMP_has_io_index = Q.prove(
+  `(asm_fetch s1 = SOME (LabAsm (CallFFI index) l bytes n)) ==>
+    has_io_index index s1.code`,
   full_simp_tac(srw_ss())[asm_fetch_def]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`)
   \\ Q.SPEC_TAC (`s1.code`,`code`)
@@ -803,11 +803,11 @@ val IMP_has_io_index = prove(
   THEN1 (Cases_on `y` \\ full_simp_tac(srw_ss())[is_Label_def] \\ res_tac)
   \\ Cases_on `pc = 0` \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[]);
 
-val bytes_in_mem_asm_write_bytearray_lemma = prove(
-  ``!xs p.
+val bytes_in_mem_asm_write_bytearray_lemma = Q.prove(
+  `!xs p.
       (!a. ~(a IN k) ==> (m1 a = m2 a)) ==>
       bytes_in_mem p xs m1 d k ==>
-      bytes_in_mem p xs m2 d k``,
+      bytes_in_mem p xs m2 d k`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def]);
 
 val bytes_in_mem_asm_write_bytearray = prove(
@@ -834,18 +834,18 @@ val bytes_in_mem_asm_write_bytearray = prove(
   \\ srw_tac[][combinTheory.APPLY_UPDATE_THM]
   \\ full_simp_tac(srw_ss())[state_rel_def] \\ res_tac);
 
-val write_bytearray_NOT_Loc = prove(
-  ``!xs c1 s1 a c.
+val write_bytearray_NOT_Loc = Q.prove(
+  `!xs c1 s1 a c.
       (s1.mem a = Word c) ==>
-      (write_bytearray c1 xs s1.mem s1.mem_domain s1.be) a <> Loc n n0``,
+      (write_bytearray c1 xs s1.mem s1.mem_domain s1.be) a <> Loc n n0`,
   Induct \\ full_simp_tac(srw_ss())[write_bytearray_def,mem_store_byte_aux_def]
   \\ rpt strip_tac \\ res_tac
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[labSemTheory.upd_mem_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[]);
 
-val CallFFI_bytearray_lemma = prove(
-  ``byte_align (a:'a word) IN s1.mem_domain /\ good_dimindex (:'a) /\
+val CallFFI_bytearray_lemma = Q.prove(
+  `byte_align (a:'a word) IN s1.mem_domain /\ good_dimindex (:'a) /\
     a IN t1.mem_domain /\
     a IN s1.mem_domain /\
     (s1.be = mc_conf.target.config.big_endian) /\
@@ -854,7 +854,7 @@ val CallFFI_bytearray_lemma = prove(
        SOME (t1.mem a)) ==>
     (word_loc_val_byte p labs (write_bytearray c1 new_bytes s1.mem s1.mem_domain s1.be) a
        mc_conf.target.config.big_endian =
-     SOME (asm_write_bytearray c1 new_bytes t1.mem a))``,
+     SOME (asm_write_bytearray c1 new_bytes t1.mem a))`,
   Q.SPEC_TAC (`s1`,`s1`) \\ Q.SPEC_TAC (`t1`,`t1`) \\ Q.SPEC_TAC (`c1`,`c1`)
   \\ Q.SPEC_TAC (`x`,`x`) \\ Q.SPEC_TAC (`new_bytes`,`xs`) \\ Induct
   \\ full_simp_tac(srw_ss())[asm_write_bytearray_def,write_bytearray_def,read_bytearray_def]
@@ -897,11 +897,11 @@ val word_cmp_lemma = prove(
   \\ rpt (qpat_x_assum `p + n2w xxx = t1.regs rr` (fn th => full_simp_tac(srw_ss())[GSYM th]))
   \\ res_tac \\ full_simp_tac(srw_ss())[]);
 
-val bytes_in_mem_IMP_memory = prove(
-  ``!xs a.
+val bytes_in_mem_IMP_memory = Q.prove(
+  `!xs a.
       (!a. ~(a IN dm1) ==> m a = m1 a) ==>
       bytes_in_mem a xs m dm dm1 ==>
-      bytes_in_memory a xs m1 dm``,
+      bytes_in_memory a xs m1 dm`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_memory_def,bytes_in_mem_def]);
 
 val state_rel_shift_interfer = prove(
@@ -911,9 +911,9 @@ val state_rel_shift_interfer = prove(
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ res_tac
   \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]);
 
-val state_rel_clock = prove(
-  ``state_rel x s1 t1 ms ==>
-    state_rel x (s1 with clock := k) (t1) ms``,
+val state_rel_clock = Q.prove(
+  `state_rel x s1 t1 ms ==>
+    state_rel x (s1 with clock := k) (t1) ms`,
   PairCases_on `x`
   \\ full_simp_tac(srw_ss())[state_rel_def]
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -967,17 +967,17 @@ val arith_upd_lemma = Q.prove(
     Fix on asm_ok branch *)
     );
 
-val MULT_ADD_LESS_MULT = prove(
-  ``!m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num``,
+val MULT_ADD_LESS_MULT = Q.prove(
+  `!m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num`,
   rpt strip_tac
   \\ `SUC m <= l` by asm_rewrite_tac [GSYM LESS_EQ]
   \\ `m * k + k <= l * k` by asm_simp_tac bool_ss [LE_MULT_RCANCEL,GSYM MULT]
   \\ `m * j <= m * k` by asm_simp_tac bool_ss [LE_MULT_LCANCEL]
   \\ decide_tac);
 
-val aligned_IMP_ADD_LESS_dimword = prove(
-  ``aligned k (x:'a word) /\ k <= dimindex (:'a) ==>
-    w2n x + (2 ** k - 1) < dimword (:'a)``,
+val aligned_IMP_ADD_LESS_dimword = Q.prove(
+  `aligned k (x:'a word) /\ k <= dimindex (:'a) ==>
+    w2n x + (2 ** k - 1) < dimword (:'a)`,
   Cases_on `x` \\ fs [aligned_w2n,dimword_def] \\ rw []
   \\ full_simp_tac std_ss [ONCE_REWRITE_RULE [ADD_COMM]LESS_EQ_EXISTS]
   \\ pop_assum (fn th => full_simp_tac std_ss [th])
@@ -986,27 +986,27 @@ val aligned_IMP_ADD_LESS_dimword = prove(
   \\ full_simp_tac std_ss [EXP_ADD]
   \\ match_mp_tac MULT_ADD_LESS_MULT \\ fs []);
 
-val aligned_2_imp = store_thm("aligned_2_imp",
-  ``aligned 2 (x:'a word) /\ dimindex (:'a) = 32 ==>
+val aligned_2_imp = Q.store_thm("aligned_2_imp",
+  `aligned 2 (x:'a word) /\ dimindex (:'a) = 32 ==>
     byte_align x = x ∧
     byte_align (x + 1w) = x ∧
     byte_align (x + 2w) = x ∧
-    byte_align (x + 3w) = x``,
+    byte_align (x + 3w) = x`,
   rw [alignmentTheory.byte_align_def, GSYM alignmentTheory.aligned_def]
   \\ match_mp_tac alignmentTheory.align_add_aligned
   \\ simp [wordsTheory.dimword_def])
 
-val aligned_2_not_eq = store_thm("aligned_2_not_eq",
-  ``aligned 2 (x:'a word) ∧ dimindex(:'a) = 32 ∧
+val aligned_2_not_eq = Q.store_thm("aligned_2_not_eq",
+  `aligned 2 (x:'a word) ∧ dimindex(:'a) = 32 ∧
     x ≠ byte_align a ⇒
     x ≠ a ∧
     x+1w ≠ a ∧
     x+2w ≠ a ∧
-    x+3w ≠ a``,
+    x+3w ≠ a`,
   metis_tac[aligned_2_imp])
 
-val aligned_3_imp = store_thm("aligned_3_imp",
-  ``aligned 3 (x:'a word) /\ dimindex (:'a) = 64 ==>
+val aligned_3_imp = Q.store_thm("aligned_3_imp",
+  `aligned 3 (x:'a word) /\ dimindex (:'a) = 64 ==>
     byte_align x = x ∧
     byte_align (x + 1w) = x ∧
     byte_align (x + 2w) = x ∧
@@ -1014,13 +1014,13 @@ val aligned_3_imp = store_thm("aligned_3_imp",
     byte_align (x + 4w) = x ∧
     byte_align (x + 5w) = x ∧
     byte_align (x + 6w) = x ∧
-    byte_align (x + 7w) = x``,
+    byte_align (x + 7w) = x`,
   rw [alignmentTheory.byte_align_def, GSYM alignmentTheory.aligned_def]
   \\ match_mp_tac alignmentTheory.align_add_aligned
   \\ simp [wordsTheory.dimword_def])
 
-val aligned_3_not_eq = store_thm("aligned_3_not_eq",
-  ``aligned 3 (x:'a word) ∧ dimindex(:'a) = 64 ∧
+val aligned_3_not_eq = Q.store_thm("aligned_3_not_eq",
+  `aligned 3 (x:'a word) ∧ dimindex(:'a) = 64 ∧
     x ≠ byte_align a ⇒
     x ≠ a ∧
     x+1w ≠ a ∧
@@ -1029,27 +1029,27 @@ val aligned_3_not_eq = store_thm("aligned_3_not_eq",
     x+4w ≠ a ∧
     x+5w ≠ a ∧
     x+6w ≠ a ∧
-    x+7w ≠ a``,
+    x+7w ≠ a`,
     metis_tac[aligned_3_imp])
 
-val ADD_MOD_EQ_LEMMA = prove(
-  ``k MOD d = 0 /\ n < d ==> (k + n) MOD d = n``,
+val ADD_MOD_EQ_LEMMA = Q.prove(
+  `k MOD d = 0 /\ n < d ==> (k + n) MOD d = n`,
   rw [] \\ `0 < d` by decide_tac
   \\ fs [MOD_EQ_0_DIVISOR]
   \\ pop_assum kall_tac
   \\ drule MOD_MULT
   \\ fs []);
 
-val dimword_eq_32_imp_or_bytes = prove(
-  ``dimindex (:'a) = 32 ==>
+val dimword_eq_32_imp_or_bytes = Q.prove(
+  `dimindex (:'a) = 32 ==>
     (w2w ((w2w (x:'a word)):word8) ‖
      w2w ((w2w (x ⋙ 8)):word8) ≪ 8 ‖
      w2w ((w2w (x ⋙ 16)):word8) ≪ 16 ‖
-     w2w ((w2w (x ⋙ 24)):word8) ≪ 24) = x``,
+     w2w ((w2w (x ⋙ 24)):word8) ≪ 24) = x`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [])
 
-val dimword_eq_64_imp_or_bytes = prove(
-  ``dimindex (:'a) = 64 ==>
+val dimword_eq_64_imp_or_bytes = Q.prove(
+  `dimindex (:'a) = 64 ==>
     (w2w ((w2w (x:'a word)):word8) ‖
      w2w ((w2w (x ⋙ 8)):word8) ≪ 8 ‖
      w2w ((w2w (x ⋙ 16)):word8) ≪ 16 ‖
@@ -1057,12 +1057,12 @@ val dimword_eq_64_imp_or_bytes = prove(
      w2w ((w2w (x ⋙ 32)):word8) ≪ 32 ‖
      w2w ((w2w (x ⋙ 40)):word8) ≪ 40 ‖
      w2w ((w2w (x ⋙ 48)):word8) ≪ 48 ‖
-     w2w ((w2w (x ⋙ 56)):word8) ≪ 56) = x``,
+     w2w ((w2w (x ⋙ 56)):word8) ≪ 56) = x`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [])
 
-val byte_align_32_eq = prove(``
+val byte_align_32_eq = Q.prove(`
   dimindex (:'a) = 32 ⇒
-  byte_align (a:'a word) +n2w (w2n a MOD 4) = a``,
+  byte_align (a:'a word) +n2w (w2n a MOD 4) = a`,
   Cases_on`a`>>
   rw[alignmentTheory.byte_align_def]>>
   fs[alignmentTheory.align_w2n,word_add_n2w]>>rfs[dimword_def]>>
@@ -1070,9 +1070,9 @@ val byte_align_32_eq = prove(``
   fs[]>>disch_then (Q.SPEC_THEN`n` assume_tac)>>
   simp[])
 
-val byte_align_64_eq = prove(``
+val byte_align_64_eq = Q.prove(`
   dimindex (:'a) = 64 ⇒
-  byte_align (a:'a word) +n2w (w2n a MOD 8) = a``,
+  byte_align (a:'a word) +n2w (w2n a MOD 8) = a`,
   Cases_on`a`>>
   rw[alignmentTheory.byte_align_def]>>
   fs[alignmentTheory.align_w2n,word_add_n2w]>>rfs[dimword_def]>>
@@ -1080,12 +1080,12 @@ val byte_align_64_eq = prove(``
   fs[]>>disch_then (Q.SPEC_THEN`n` assume_tac)>>
   simp[])
 
-val byte_align_32_IMP = prove(``
+val byte_align_32_IMP = Q.prove(`
   dimindex(:'a) = 32 ⇒
   (byte_align a = a ⇒ w2n a MOD 4 = 0) ∧
   (byte_align a + (1w:'a word) = a ⇒ w2n a MOD 4 = 1) ∧
   (byte_align a + (2w:'a word) = a ⇒ w2n a MOD 4 = 2) ∧
-  (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 4 = 3)``,
+  (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 4 = 3)`,
   rw[]>>imp_res_tac byte_align_32_eq>>fs[]>>
   qpat_x_assum`A=a` mp_tac>>
   qabbrev_tac`ba = byte_align a`>>
@@ -1098,34 +1098,34 @@ val byte_align_32_IMP = prove(``
   Q.ISPECL_THEN [`w2n a`,`4n`] assume_tac MOD_LESS>>
   DECIDE_TAC)
 
-val MOD4_CASES = prove(``
-  ∀n. n MOD 4 = 0 ∨ n MOD 4 = 1 ∨ n MOD 4 = 2 ∨ n MOD 4 = 3``,
+val MOD4_CASES = Q.prove(`
+  ∀n. n MOD 4 = 0 ∨ n MOD 4 = 1 ∨ n MOD 4 = 2 ∨ n MOD 4 = 3`,
   rw[]>>`n MOD 4 < 4` by fs []
   \\ IMP_RES_TAC (DECIDE
        ``n < 4 ==> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num)``)
   \\ fs [])
 
-val byte_align_32_CASES = prove(``
+val byte_align_32_CASES = Q.prove(`
   dimindex(:'a) = 32 ⇒
   byte_align a + (3w:'a word) = a ∨
   byte_align a + (2w:'a word) = a ∨
   byte_align a + (1w:'a word) = a ∨
-  byte_align a = a``,
+  byte_align a = a`,
   rw[]>>imp_res_tac byte_align_32_eq>>
   pop_assum(qspec_then`a` assume_tac)>>
   Q.SPEC_THEN `w2n a` mp_tac MOD4_CASES>>rw[]>>
   fs[])
 
-val MOD8_CASES = prove(``
+val MOD8_CASES = Q.prove(`
   ∀n. n MOD 8 = 0 ∨ n MOD 8 = 1 ∨ n MOD 8 = 2 ∨ n MOD 8 = 3 ∨
-      n MOD 8 = 4 ∨ n MOD 8 = 5 ∨ n MOD 8 = 6 ∨ n MOD 8 = 7``,
+      n MOD 8 = 4 ∨ n MOD 8 = 5 ∨ n MOD 8 = 6 ∨ n MOD 8 = 7`,
   rw[]>>`n MOD 8 < 8` by fs []
   \\ IMP_RES_TAC (DECIDE
        ``n < 8 ==> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num) \/
                    (n = 4) \/ (n = 5) \/ (n = 6) \/ (n = 7)``)
   \\ fs [])
 
-val byte_align_64_CASES = prove(``
+val byte_align_64_CASES = Q.prove(`
   dimindex(:'a) = 64 ⇒
   byte_align a + (7w:'a word) = a ∨
   byte_align a + (6w:'a word) = a ∨
@@ -1134,13 +1134,13 @@ val byte_align_64_CASES = prove(``
   byte_align a + (3w:'a word) = a ∨
   byte_align a + (2w:'a word) = a ∨
   byte_align a + (1w:'a word) = a ∨
-  byte_align a = a``,
+  byte_align a = a`,
   rw[]>>imp_res_tac byte_align_64_eq>>
   pop_assum(qspec_then`a` assume_tac)>>
   Q.SPEC_THEN `w2n a` mp_tac MOD8_CASES>>rw[]>>
   fs[])
 
-val byte_align_64_IMP = prove(``
+val byte_align_64_IMP = Q.prove(`
   dimindex(:'a) = 64 ⇒
   (byte_align a + (7w:'a word) = a ⇒ w2n a MOD 8 = 7) ∧
   (byte_align a + (6w:'a word) = a ⇒ w2n a MOD 8 = 6) ∧
@@ -1149,7 +1149,7 @@ val byte_align_64_IMP = prove(``
   (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 8 = 3) ∧
   (byte_align a + (2w:'a word) = a ⇒ w2n a MOD 8 = 2) ∧
   (byte_align a + (1w:'a word) = a ⇒ w2n a MOD 8 = 1) ∧
-  (byte_align a = a ⇒ w2n a MOD 8 = 0)``,
+  (byte_align a = a ⇒ w2n a MOD 8 = 0)`,
   rw[]>>imp_res_tac byte_align_64_eq>>fs[]>>
   qpat_x_assum`A=a` mp_tac>>
   qabbrev_tac`ba = byte_align a`>>
@@ -2086,8 +2086,8 @@ val machine_sem_EQ_sem = Q.store_thm("machine_sem_EQ_sem",
 val good_syntax_def = Define `
   good_syntax mc_conf (code:'a sec list) (l:num_set) = T`
 
-val good_syntax_filter_skip = store_thm("good_syntax_filter_skip[simp]",
-  ``good_syntax c (filter_skip prog) l = good_syntax c prog l``,
+val good_syntax_filter_skip = Q.store_thm("good_syntax_filter_skip[simp]",
+  `good_syntax c (filter_skip prog) l = good_syntax c prog l`,
   srw_tac[][good_syntax_def]);
 
 val lines_ok_def = Define`
@@ -2123,17 +2123,17 @@ val line_similar_refl = Q.store_thm("line_similar_refl[simp]",
   `∀l. line_similar l l`,
   Cases >> EVAL_TAC);
 
-val line_similar_trans = prove(
-  ``line_similar x y /\ line_similar y z ==> line_similar x z``,
+val line_similar_trans = Q.prove(
+  `line_similar x y /\ line_similar y z ==> line_similar x z`,
   Cases_on `x` \\ Cases_on `y` \\ Cases_on `z` \\ fs[line_similar_def]);
 
-val EVERY2_TRANS = prove(
-  ``!xs ys zs. EVERY2 P xs ys /\ EVERY2 P ys zs /\
-               (!x y z. P x y /\ P y z ==> P x z) ==> EVERY2 P xs zs``,
+val EVERY2_TRANS = Q.prove(
+  `!xs ys zs. EVERY2 P xs ys /\ EVERY2 P ys zs /\
+               (!x y z. P x y /\ P y z ==> P x z) ==> EVERY2 P xs zs`,
   Induct \\ fs [PULL_EXISTS] \\ rw [] \\ res_tac \\ fs []);
 
-val code_similar_trans = store_thm("code_similar_trans",
-  ``!c1 c2 c3. code_similar c1 c2 /\ code_similar c2 c3 ==> code_similar c1 c3``,
+val code_similar_trans = Q.store_thm("code_similar_trans",
+  `!c1 c2 c3. code_similar c1 c2 /\ code_similar c2 c3 ==> code_similar c1 c3`,
   HO_MATCH_MP_TAC code_similar_ind \\ fs [] \\ rw []
   \\ Cases_on `c3` \\ fs [code_similar_def] \\ rw []
   \\ Cases_on `h` \\ fs [code_similar_def] \\ rw []
@@ -2145,10 +2145,10 @@ val code_similar_refl = Q.store_thm("code_similar_refl[simp]",
   Cases >> simp[code_similar_def] >>
   match_mp_tac EVERY2_refl >> simp[]);
 
-val line_similar_add_nop = prove(``
+val line_similar_add_nop = Q.prove(`
   ∀ls ls' h.
   LIST_REL line_similar ls ls' ⇒
-  LIST_REL line_similar ls (add_nop h ls')``,
+  LIST_REL line_similar ls (add_nop h ls')`,
   Induct_on`ls`>>rw[add_nop_def]>>
   Cases_on`y`>>Cases_on`h`>>fs[add_nop_def,line_similar_def])
 
@@ -2194,10 +2194,10 @@ val code_similar_pad_code = Q.store_thm("code_similar_pad_code",
   match_mp_tac line_similar_pad_section>>
   simp[]);
 
-val LIST_REL_enc_line = prove(``
+val LIST_REL_enc_line = Q.prove(`
   ∀ls ls'.
   LIST_REL line_similar ls ls' ⇔
-  LIST_REL line_similar (MAP (enc_line enc len) ls) ls'`` ,
+  LIST_REL line_similar (MAP (enc_line enc len) ls) ls'` ,
   Induct>>rw[]>>Cases_on`h`>>rw[enc_line_def,EQ_IMP_THM]>>Cases_on`y`>>
   fs[line_similar_def])
 
@@ -2231,10 +2231,10 @@ val pos_val_0_0 = Q.store_thm("pos_val_0_0",
   >> Cases_on`h`>>full_simp_tac(srw_ss())[]
   >> srw_tac[][line_length_def]);
 
-val add_nop_label_zero = prove(``
+val add_nop_label_zero = Q.prove(`
   ∀ls.
   EVERY label_zero ls ⇒
-  EVERY label_zero (add_nop nop ls)``,
+  EVERY label_zero (add_nop nop ls)`,
   Induct>>fs[add_nop_def]>>rw[]>>
   Cases_on`h`>>fs[add_nop_def]);
 
@@ -2247,8 +2247,8 @@ val EVERY_label_zero_pad_section = Q.store_thm("EVERY_label_zero_pad_section[sim
   >> srw_tac[][EVERY_REVERSE]>>
   first_assum match_mp_tac>>fs[add_nop_label_zero]);
 
-val EVERY_label_zero_add_nop = prove(
-  ``!xs. EVERY label_zero (add_nop nop xs) = EVERY label_zero xs``,
+val EVERY_label_zero_add_nop = Q.prove(
+  `!xs. EVERY label_zero (add_nop nop xs) = EVERY label_zero xs`,
   Induct \\ fs [add_nop_def,EVERY_REVERSE]
   \\ Cases \\ fs [add_nop_def,EVERY_REVERSE]);
 
@@ -2364,27 +2364,27 @@ val enc_secs_again_IMP_similar = prove(
   imp_res_tac enc_lines_again_IMP_similar>>
   fs[]);
 
-val lines_upd_lab_len_AUX = prove(
-  ``!l aux pos.
+val lines_upd_lab_len_AUX = Q.prove(
+  `!l aux pos.
       REVERSE aux ++ lines_upd_lab_len pos l [] =
-      lines_upd_lab_len pos l aux``,
+      lines_upd_lab_len pos l aux`,
   Induct \\ fs [lines_upd_lab_len_def]
   \\ Cases \\ simp_tac std_ss [lines_upd_lab_len_def,LET_DEF]
   \\ pop_assum (fn th => once_rewrite_tac [GSYM th]) \\ fs []) |> GSYM
 
-val line_similar_lines_upd_lab_len = prove(
-  ``!l aux pos l1.
+val line_similar_lines_upd_lab_len = Q.prove(
+  `!l aux pos l1.
       LIST_REL line_similar (lines_upd_lab_len pos l []) l1 =
-      LIST_REL line_similar l l1``,
+      LIST_REL line_similar l l1`,
   Induct \\ fs [lines_upd_lab_len_def]
   \\ Cases \\ fs [lines_upd_lab_len_def]
   \\ once_rewrite_tac [lines_upd_lab_len_AUX]
   \\ fs [] \\ rw [] \\ eq_tac \\ rw []
   \\ Cases_on `y` \\ fs [line_similar_def]);
 
-val code_similar_upd_lab_len = prove(
-  ``!code pos code1.
-      code_similar (upd_lab_len pos code) code1 = code_similar code code1``,
+val code_similar_upd_lab_len = Q.prove(
+  `!code pos code1.
+      code_similar (upd_lab_len pos code) code1 = code_similar code code1`,
   Induct \\ fs [code_similar_def] \\ Cases
   \\ Cases_on `code1` \\ fs [upd_lab_len_def,code_similar_def]
   \\ Cases_on `h` \\ fs [upd_lab_len_def,code_similar_def]
@@ -2466,9 +2466,9 @@ val enc_secs_again_T_IMP = prove(``
   fs[])
 *)
 
-val lab_lookup_insert = store_thm("lab_lookup_insert",
-  ``lab_lookup l1 l2 (lab_insert k1 k2 pos labs) =
-    if k1 = l1 /\ k2 = l2 then SOME pos else lab_lookup l1 l2 labs``,
+val lab_lookup_insert = Q.store_thm("lab_lookup_insert",
+  `lab_lookup l1 l2 (lab_insert k1 k2 pos labs) =
+    if k1 = l1 /\ k2 = l2 then SOME pos else lab_lookup l1 l2 labs`,
   fs [lab_lookup_def,lab_insert_def,lookup_insert]
   \\ Cases_on `l1 = k1` \\ fs [lookup_insert] \\ rw []
   \\ every_case_tac \\ fs [] \\ fs [lookup_def]);
@@ -2482,14 +2482,14 @@ val compute_labels_simp_def = Define`
     let result = compute_labels_simp new_pos' rest in
       insert k labs result)`
 
-val compute_labels_simp_EQ = prove(``
+val compute_labels_simp_EQ = Q.prove(`
   ∀pos ls acc.
    wf acc ⇒
   let res = compute_labels pos ls acc in
   let res' = (compute_labels_simp pos ls) in
   wf res ∧
   wf res' ∧
-  res = union acc res'``,
+  res = union acc res'`,
   HO_MATCH_MP_TAC compute_labels_ind>>fs[compute_labels_simp_def,compute_labels_def,wf_def]>>
   ntac 7 strip_tac>>
   pairarg_tac>>fs[]>>
@@ -2510,22 +2510,22 @@ val all_bytes_len_match_def = Define`
   (all_bytes_len_match (Section k ls ::xs) ⇔
   EVERY bytes_len_match ls ∧ all_bytes_len_match xs)`
 
-val all_bytes_len_match_pos_val_0 = prove(``
+val all_bytes_len_match_pos_val_0 = Q.prove(`
   ∀ls pos.
   all_bytes_len_match ls ⇒
-  pos_val 0 pos ls = pos``,
+  pos_val 0 pos ls = pos`,
   Induct>>fs[pos_val_def]>>Induct>>Induct_on`l`>>fs[pos_val_def,all_bytes_len_match_def]>>rw[]>>
   Cases_on`h`>>
   fs[line_length_def,bytes_len_match_def,is_Label_def])
 
 (*
 
-val lab_lookup_compute_labels_simp_lemma = prove(``
+val lab_lookup_compute_labels_simp_lemma = Q.prove(`
   ∀l1 l2 sec_list x2 conf enc labs nop pos l.
   all_bytes_len_match sec_list ∧
   loc_to_pc l1 l2 sec_list = SOME x2 ==>
   lab_lookup l1 l2 (compute_labels_simp pos sec_list) =
-  SOME (pos_val x2 pos sec_list)``,
+  SOME (pos_val x2 pos sec_list)`,
   ho_match_mp_tac loc_to_pc_ind>>fs[Once loc_to_pc_def]>>
   rw[]>>
   pop_assum mp_tac>>
@@ -2535,12 +2535,12 @@ val lab_lookup_compute_labels_simp_lemma = prove(``
   \\ pairarg_tac \\ fs []
   \\ ...)
 
-val lab_lookup_compute_labels = prove(
-  ``∀l1 l2 sec_list x2 conf enc labs nop pos.
+val lab_lookup_compute_labels = Q.prove(
+  `∀l1 l2 sec_list x2 conf enc labs nop pos.
    (* all_enc_ok conf enc labs pos (pad_code nop sec_list) ∧ *)
       loc_to_pc l1 l2 sec_list = SOME x2 ==>
       lab_lookup l1 l2 (compute_labels pos sec_list LN) =
-      SOME (pos_val x2 pos sec_list)``,
+      SOME (pos_val x2 pos sec_list)`,
   ...)
 
 *)
@@ -2562,21 +2562,21 @@ val has_label_def = Define `
      l2 ≠ 0 ∧ ?x. MEM (Label l1 l2 x) xs)`
 
 (*
-val sec_names_compute_labels_simp = prove(``
+val sec_names_compute_labels_simp = Q.prove(`
   ∀n ls x.
   MEM x (sec_names ls) ⇔
-  x ∈ domain (compute_labels_simp n ls)``,
+  x ∈ domain (compute_labels_simp n ls)`,
   ho_match_mp_tac (theorem "compute_labels_simp_ind")>>
   rw[compute_labels_simp_def,sec_names_def]>>
   pairarg_tac>>fs[])
 *)
 (*
 
-val compute_labels_simp_has_label = prove(``
+val compute_labels_simp_has_label = Q.prove(`
   ∀pos sec_list l1 l2.
   ALL_DISTINCT(sec_names sec_list) ∧
   has_label l1 l2 sec_list ⇒
-  IS_SOME (lab_lookup l1 l2 (compute_labels_simp pos sec_list))``,
+  IS_SOME (lab_lookup l1 l2 (compute_labels_simp pos sec_list))`,
   ho_match_mp_tac (theorem "compute_labels_simp_ind")>>
   rw[compute_labels_simp_def,sec_names_def,has_label_def]>>
   pairarg_tac>>fs[lab_lookup_def,sec_labs_def]>>
@@ -2600,12 +2600,12 @@ val compute_labels_simp_has_label = prove(``
 
 *)
 
-val lab_lookup_sec_labels = prove(
-  ``!lines pos labs l1 l2.
+val lab_lookup_sec_labels = Q.prove(
+  `!lines pos labs l1 l2.
       lab_lookup l1 l2 (section_labels pos lines labs) =
       case lab_lookup l1 l2 (section_labels pos lines LN) of
       | SOME x => SOME x
-      | NONE => lab_lookup l1 l2 labs``,
+      | NONE => lab_lookup l1 l2 labs`,
   once_rewrite_tac [EQ_SYM_EQ]
   \\ Induct \\ fs [] \\ fs [section_labels_def]
   THEN1 (fs [lab_lookup_def,lookup_def])
@@ -2616,10 +2616,10 @@ val lab_lookup_sec_labels = prove(
   \\ TRY IF_CASES_TAC \\ asm_rewrite_tac [] \\ fs []
   \\ simp_tac std_ss [section_labels_def,lab_lookup_insert]);
 
-val compute_labels_has_label = prove(
-  ``!sec_list pos l1 l2.
+val compute_labels_has_label = Q.prove(
+  `!sec_list pos l1 l2.
       has_label l1 l2 sec_list ==>
-      IS_SOME (lab_lookup l1 l2 (compute_labels_alt pos sec_list))``,
+      IS_SOME (lab_lookup l1 l2 (compute_labels_alt pos sec_list))`,
   Induct THEN1 (fs [has_label_def])
   \\ Cases \\ fs [has_label_def] \\ rpt gen_tac
   \\ Cases_on `l2 = 0` \\ fs [] THEN1
@@ -2640,9 +2640,9 @@ val compute_labels_has_label = prove(
   \\ rw [] \\ fs[lab_lookup_insert]
   \\ rw[]);
 
-val loc_to_pc_has_label = prove(
-  ``!l1 l2 sec_list.
-      IS_SOME (loc_to_pc l1 l2 sec_list) ==> has_label l1 l2 sec_list``,
+val loc_to_pc_has_label = Q.prove(
+  `!l1 l2 sec_list.
+      IS_SOME (loc_to_pc l1 l2 sec_list) ==> has_label l1 l2 sec_list`,
   ho_match_mp_tac loc_to_pc_ind \\ rpt strip_tac \\ fs []
   \\ pop_assum mp_tac
   \\ once_rewrite_tac [loc_to_pc_def] \\ fs []
@@ -2659,17 +2659,17 @@ val loc_to_pc_has_label = prove(
   \\ Cases_on `h` \\ fs [is_Label_def]
   \\ every_case_tac \\ fs [] \\ metis_tac []);
 
-val IS_SOME_lab_lookup_compute_labels = prove(
-  ``ALL_DISTINCT (sec_names sec_list) ∧
+val IS_SOME_lab_lookup_compute_labels = Q.prove(
+  `ALL_DISTINCT (sec_names sec_list) ∧
     IS_SOME (loc_to_pc l1 l2 sec_list) ==>
-    IS_SOME (lab_lookup l1 l2 (compute_labels_alt pos sec_list))``,
+    IS_SOME (lab_lookup l1 l2 (compute_labels_alt pos sec_list))`,
   metis_tac [compute_labels_has_label,loc_to_pc_has_label]);
 
 (*
 
-val IS_SOME_lab_lookup_compute_labels = prove(
-  ``IS_SOME (lab_lookup l1 l2 (compute_labels pos sec_list LN)) <=>
-    IS_SOME (loc_to_pc l1 l2 sec_list)``,
+val IS_SOME_lab_lookup_compute_labels = Q.prove(
+  `IS_SOME (lab_lookup l1 l2 (compute_labels pos sec_list LN)) <=>
+    IS_SOME (loc_to_pc l1 l2 sec_list)`,
   qspecl_then[`pos`,`sec_list`,`LN`]mp_tac compute_labels_simp_EQ
   \\ rw[CONJUNCT1 wf_def]
   \\ rpt (pop_assum kall_tac)
@@ -2716,9 +2716,9 @@ val MEM_all_labels = prove(
   rw[lab_lookup_def,all_labels_def,MEM_FLAT,MEM_MAP,PULL_EXISTS,MEM_toAList,EXISTS_PROD]
   \\ CASE_TAC);
 
-val loc_to_pc_comp_thm = prove(
-  ``!l1 l2 sec_list.
-      loc_to_pc_comp l1 l2 sec_list = loc_to_pc l1 l2 sec_list``,
+val loc_to_pc_comp_thm = Q.prove(
+  `!l1 l2 sec_list.
+      loc_to_pc_comp l1 l2 sec_list = loc_to_pc l1 l2 sec_list`,
   recInduct loc_to_pc_comp_ind \\ rw []
   \\ once_rewrite_tac [loc_to_pc_def,loc_to_pc_comp_def] \\ fs []
   \\ IF_CASES_TAC \\ fs []
@@ -2726,12 +2726,12 @@ val loc_to_pc_comp_thm = prove(
   \\ TOP_CASE_TAC \\ fs [CONJ_ASSOC]
   \\ TOP_CASE_TAC \\ fs [CONJ_ASSOC])
 
-val lab_lookup_compute_labels_test = prove(
-  ``∀pos sec_list l1 l2 x2 c labs nop.
+val lab_lookup_compute_labels_test = Q.prove(
+  `∀pos sec_list l1 l2 x2 c labs nop.
       all_enc_ok c labs pos sec_list /\
       loc_to_pc l1 l2 sec_list = SOME x2 ==>
       lab_lookup l1 l2 (compute_labels_alt pos sec_list) =
-      SOME (pos_val x2 pos sec_list)``,
+      SOME (pos_val x2 pos sec_list)`,
   ho_match_mp_tac compute_labels_alt_ind>>fs[]>>
   CONJ_TAC
   >-
@@ -2877,12 +2877,12 @@ val lab_lookup_compute_labels_test = prove(
         simp[]);
 
 (*For a single section*)
-val all_enc_ok_lab_lookup_even_lem = prove(``
+val all_enc_ok_lab_lookup_even_lem = Q.prove(`
   ∀lines c labs pos l1 l2 x lab k.
   all_enc_ok c labs pos [Section k lines] ∧
   (∀l1 l2 x. lab_lookup l1 l2 lab = SOME x ⇒ EVEN x) ∧
   lab_lookup l1 l2 (section_labels pos lines lab) = SOME x ⇒
-  EVEN x``,
+  EVEN x`,
   Induct>>rw[section_labels_def]
   >-
     metis_tac[]
@@ -2896,19 +2896,19 @@ val all_enc_ok_lab_lookup_even_lem = prove(``
     (rveq>>fs[]>>
     metis_tac[]))
 
-val all_enc_ok_split = prove(``
+val all_enc_ok_split = Q.prove(`
   ∀c labs pos k lines xs.
   all_enc_ok c labs pos (Section k lines::xs) ⇒
   all_enc_ok c labs pos [Section k lines] ∧
-  all_enc_ok c labs (pos + sec_length lines 0) xs``,
+  all_enc_ok c labs (pos + sec_length lines 0) xs`,
   Induct_on`lines`>>rw[all_enc_ok_def,sec_length_def,all_enc_ok_def]>>
   Cases_on`h`>>TRY(Cases_on`a`)>>fs[sec_length_def,sec_length_add,line_length_def,line_ok_def]>>rveq>>rfs[]>>
   metis_tac[ADD_ASSOC])
 
-val all_enc_ok_even = prove(``
+val all_enc_ok_even = Q.prove(`
   ∀lines pos.
   all_enc_ok c labs pos [Section k lines] ⇒
-  EVEN (sec_length lines pos)``,
+  EVEN (sec_length lines pos)`,
   Induct>>fs[all_enc_ok_def,sec_length_def]>>Cases>>
   TRY(Cases_on`a`)>>
   rw[]>>fs[line_ok_def,line_length_def,sec_length_add,sec_length_def]>>
@@ -2917,12 +2917,12 @@ val all_enc_ok_even = prove(``
     metis_tac[sec_length_add,ADD_COMM]>>
   fs[])
 
-val all_enc_ok_lab_lookup_even = prove(
-  ``∀c labs pos sec_list l1 l2 x.
+val all_enc_ok_lab_lookup_even = Q.prove(
+  `∀c labs pos sec_list l1 l2 x.
       all_enc_ok c labs pos sec_list ∧
       lab_lookup l1 l2 (compute_labels_alt pos sec_list) = SOME x ∧
       EVEN pos ⇒
-      EVEN x``,
+      EVEN x`,
   Induct_on`sec_list`>>
   fs[all_enc_ok_def,compute_labels_alt_def,lab_lookup_insert]>>
   rw[]
@@ -4730,14 +4730,14 @@ val good_init_state_def = Define `
       word_loc_val_byte (mc_conf.target.get_pc ms) labs m a
         mc_conf.target.config.big_endian = SOME (t.mem a)`
 
-val LESS_find_ffi_index_limit = store_thm("LESS_find_ffi_index_limit",
-  ``!code i. has_io_index i code ==> i < find_ffi_index_limit code``,
+val LESS_find_ffi_index_limit = Q.store_thm("LESS_find_ffi_index_limit",
+  `!code i. has_io_index i code ==> i < find_ffi_index_limit code`,
   recInduct find_ffi_index_limit_ind
   \\ fs [find_ffi_index_limit_def,has_io_index_def]
   \\ rpt strip_tac \\ CASE_TAC \\ fs [] \\ CASE_TAC \\ fs []);
 
-val aligned_1_intro = prove(
-  ``((1w && w) = 0w) <=> aligned 1 w``,
+val aligned_1_intro = Q.prove(
+  `((1w && w) = 0w) <=> aligned 1 w`,
   fs [alignmentTheory.aligned_bitwise_and]);
 
 val IMP_state_rel_make_init = prove(
@@ -4780,20 +4780,20 @@ val semantics_make_init = save_thm("semantics_make_init",
   |> UNDISCH |> MATCH_MP (MATCH_MP IMP_LEMMA IMP_state_rel_make_init)
   |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO,GSYM CONJ_ASSOC]);
 
-val make_init_filter_skip = store_thm("make_init_filter_skip",
-  ``semantics (make_init mc_conf ffi save_regs io_regs t m dm ms (filter_skip code)) =
-    semantics (make_init mc_conf ffi save_regs io_regs t m dm ms code)``,
+val make_init_filter_skip = Q.store_thm("make_init_filter_skip",
+  `semantics (make_init mc_conf ffi save_regs io_regs t m dm ms (filter_skip code)) =
+    semantics (make_init mc_conf ffi save_regs io_regs t m dm ms code)`,
   match_mp_tac filter_skip_semantics \\ full_simp_tac(srw_ss())[make_init_def]);
 
-val find_ffi_index_limit_filter_skip = store_thm("find_ffi_index_limit_filter_skip",
-  ``!code. find_ffi_index_limit (filter_skip code) = find_ffi_index_limit code``,
+val find_ffi_index_limit_filter_skip = Q.store_thm("find_ffi_index_limit_filter_skip",
+  `!code. find_ffi_index_limit (filter_skip code) = find_ffi_index_limit code`,
   recInduct find_ffi_index_limit_ind
   \\ fs [lab_filterTheory.filter_skip_def,find_ffi_index_limit_def]
   \\ rpt strip_tac \\ every_case_tac
   \\ fs [lab_filterTheory.not_skip_def,find_ffi_index_limit_def]);
 
-val implements_intro_gen = store_thm("implements_intro_gen",
-  ``(b /\ x <> Fail ==> y = {x}) ==> b ==> implements y {x}``,
+val implements_intro_gen = Q.store_thm("implements_intro_gen",
+  `(b /\ x <> Fail ==> y = {x}) ==> b ==> implements y {x}`,
   full_simp_tac(srw_ss())[semanticsPropsTheory.implements_def]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[semanticsPropsTheory.extend_with_resource_limit_def]);

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -32,9 +32,9 @@ val LIST_REL_SNOC = Q.store_thm("LIST_REL_SNOC",
   \\ Cases_on`n = LENGTH xs`
   \\ fs[EL_APPEND2,EL_APPEND1,EL_LENGTH_SNOC,EL_SNOC] )
 
-val call_FFI_LENGTH = prove(
-  ``(call_FFI st index x = (new_st,new_bytes)) ==>
-    (LENGTH x = LENGTH new_bytes)``,
+val call_FFI_LENGTH = Q.prove(
+  `(call_FFI st index x = (new_st,new_bytes)) ==>
+    (LENGTH x = LENGTH new_bytes)`,
   full_simp_tac(srw_ss())[call_FFI_def] \\ BasicProvers.EVERY_CASE_TAC
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[listTheory.LENGTH_MAP]);
 
@@ -283,9 +283,9 @@ val option_ldrop_option_ldrop = Q.prove(
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[option_ldrop_SUC,ADD_CLAUSES]);
 
 (*
-val option_ldrop_lemma = prove(
-  ``(call_FFI index x io = (new_bytes,new_io)) /\ new_io <> NONE ==>
-    (new_io = option_ldrop 1 io)``,
+val option_ldrop_lemma = Q.prove(
+  `(call_FFI index x io = (new_bytes,new_io)) /\ new_io <> NONE ==>
+    (new_io = option_ldrop 1 io)`,
   full_simp_tac(srw_ss())[call_FFI_def] \\ BasicProvers.EVERY_CASE_TAC
   \\ srw_tac[][]
   \\ Q.MATCH_ASSUM_RENAME_TAC `LTL ll <> NONE`
@@ -496,8 +496,8 @@ val bytes_in_mem_APPEND = Q.prove(
 
 val s1 = ``s1:('a,'ffi) labSem$state``;
 
-val IMP_bytes_in_memory = prove(
-  ``code_similar code1 code2 /\
+val IMP_bytes_in_memory = Q.prove(
+  `code_similar code1 code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     (asm_fetch_aux pc code1 = SOME i) /\
     bytes_in_mem p (prog_to_bytes code2) m (dm:'a word set) dm1 ==>
@@ -506,20 +506,20 @@ val IMP_bytes_in_memory = prove(
       line_ok (mc_conf:('a,'state,'b) machine_config).target.config
         labs (pos_val pc 0 code2) j /\
       (pos_val (pc+1) 0 code2 = pos_val pc 0 code2 + LENGTH (line_bytes j)) /\
-      line_similar i j``,
+      line_similar i j`,
   rpt strip_tac
   \\ mp_tac prog_to_bytes_lemma \\ fs[] \\ rpt strip_tac
   \\ fs[bytes_in_mem_APPEND]
   \\ Q.EXISTS_TAC `j` \\ fs[] \\ decide_tac);
 
-val IMP_bytes_in_memory_JumpReg = prove(
-  ``code_similar s1.code code2 /\
+val IMP_bytes_in_memory_JumpReg = Q.prove(
+  `code_similar s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (Asm (JumpReg r1) l n)) ==>
     bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
       (mc_conf.target.config.encode (JumpReg r1)) t1.mem t1.mem_domain /\
-    asm_ok (JumpReg r1) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+    asm_ok (JumpReg r1) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -531,8 +531,8 @@ val IMP_bytes_in_memory_JumpReg = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND]);
 
-val IMP_bytes_in_memory_Jump = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_Jump = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (Jump jtarget) l bytes n)) ==>
@@ -542,7 +542,7 @@ val IMP_bytes_in_memory_Jump = prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -555,8 +555,8 @@ val IMP_bytes_in_memory_Jump = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND]);
 
-val IMP_bytes_in_memory_JumpCmp = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_JumpCmp = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)) ==>
@@ -566,7 +566,7 @@ val IMP_bytes_in_memory_JumpCmp = prove(
       (enc = mc_conf.target.config.encode (JumpCmp cmp rr ri tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -579,8 +579,8 @@ val IMP_bytes_in_memory_JumpCmp = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND]);
 
-val IMP_bytes_in_memory_JumpCmp_1 = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_JumpCmp_1 = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)) ==>
@@ -591,7 +591,7 @@ val IMP_bytes_in_memory_JumpCmp_1 = prove(
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -606,22 +606,22 @@ val IMP_bytes_in_memory_JumpCmp_1 = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND] \\ srw_tac[][]);
 
-val IMP_bytes_in_memory_Call = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_Call = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok
       (mc_conf: ('a,'state,'b) machine_config).target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem
       (t1:'a asm_state).mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (Call ww) l bytes n)) ==>
-    F``,
+    F`,
   rpt strip_tac
   \\ full_simp_tac(srw_ss())[asm_fetch_def,LET_DEF]
   \\ imp_res_tac IMP_bytes_in_memory
   \\ Cases_on `j` \\ full_simp_tac(srw_ss())[line_similar_def] \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[line_ok_def] \\ rev_full_simp_tac(srw_ss())[]);
 
-val IMP_bytes_in_memory_LocValue = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_LocValue = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (LocValue reg (Lab l1 l2)) l bytes n)) ==>
@@ -632,7 +632,7 @@ val IMP_bytes_in_memory_LocValue = prove(
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (Loc reg tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (Loc reg tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -647,8 +647,8 @@ val IMP_bytes_in_memory_LocValue = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND] \\ srw_tac[][]);
 
-val IMP_bytes_in_memory_Inst = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_Inst = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (Asm (Inst i) bytes len)) ==>
@@ -659,7 +659,7 @@ val IMP_bytes_in_memory_Inst = prove(
       bytes_in_mem ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain s1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (Inst i) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (Inst i) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -674,8 +674,8 @@ val IMP_bytes_in_memory_Inst = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND] \\ srw_tac[][]);
 
-val IMP_bytes_in_memory_CallFFI = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_CallFFI = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (CallFFI index) l bytes n)) ==>
@@ -684,7 +684,7 @@ val IMP_bytes_in_memory_CallFFI = prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -697,8 +697,8 @@ val IMP_bytes_in_memory_CallFFI = prove(
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
          bytes_in_memory_APPEND]);
 
-val IMP_bytes_in_memory_Halt = prove(
-  ``code_similar ^s1.code code2 /\
+val IMP_bytes_in_memory_Halt = Q.prove(
+  `code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm Halt l bytes n)) ==>
@@ -707,7 +707,7 @@ val IMP_bytes_in_memory_Halt = prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config``,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -768,18 +768,18 @@ val pos_val_MOD_0 = Q.prove(
   |> SIMP_RULE std_ss [pos_val_MOD_0_lemma]
   |> REWRITE_RULE [AND_IMP_INTRO,GSYM CONJ_ASSOC];
 
-val state_rel_weaken = prove(
-  ``state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 ==>
-    state_rel (mc_conf,code2,labs,p,F) s1 t1 ms1``,
+val state_rel_weaken = Q.prove(
+  `state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 ==>
+    state_rel (mc_conf,code2,labs,p,F) s1 t1 ms1`,
   full_simp_tac(srw_ss())[state_rel_def] \\ rpt strip_tac \\ full_simp_tac(srw_ss())[] \\ metis_tac []);
 
-val read_bytearray_state_rel = prove(
-  ``!n a x.
+val read_bytearray_state_rel = Q.prove(
+  `!n a x.
       state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 /\
       (read_bytearray a n (mem_load_byte_aux s1.mem s1.mem_domain s1.be) = SOME x) ==>
       (read_bytearray a n
         (\a. if a IN mc_conf.prog_addresses then SOME (t1.mem a) else NONE) =
-       SOME x)``,
+       SOME x)`,
   Induct
   \\ full_simp_tac(srw_ss())[read_bytearray_def]
   \\ rpt strip_tac
@@ -810,12 +810,12 @@ val bytes_in_mem_asm_write_bytearray_lemma = Q.prove(
       bytes_in_mem p xs m2 d k`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def]);
 
-val bytes_in_mem_asm_write_bytearray = prove(
-  ``state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,p,T) s1 t1 ms1 /\
+val bytes_in_mem_asm_write_bytearray = Q.prove(
+  `state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,p,T) s1 t1 ms1 /\
     (read_bytearray c1 (LENGTH new_bytes) (mem_load_byte_aux s1.mem s1.mem_domain s1.be) = SOME x) ==>
     bytes_in_mem p xs t1.mem t1.mem_domain s1.mem_domain ==>
     bytes_in_mem p xs
-      (asm_write_bytearray c1 new_bytes t1.mem) t1.mem_domain s1.mem_domain``,
+      (asm_write_bytearray c1 new_bytes t1.mem) t1.mem_domain s1.mem_domain`,
   STRIP_TAC \\ match_mp_tac bytes_in_mem_asm_write_bytearray_lemma
   \\ POP_ASSUM MP_TAC
   \\ Q.SPEC_TAC (`c1`,`a`)
@@ -879,10 +879,10 @@ val CallFFI_bytearray_lemma = Q.prove(
   \\ Cases_on `byte_align c1 = byte_align a` \\ full_simp_tac(srw_ss())[word_loc_val_def]
   \\ full_simp_tac(srw_ss())[get_byte_set_byte_diff]);
 
-val word_cmp_lemma = prove(
-  ``state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 /\
+val word_cmp_lemma = Q.prove(
+  `state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 /\
     (word_cmp cmp (read_reg rr s1) (reg_imm ri s1) = SOME x) ==>
-    (x = word_cmp cmp (read_reg rr t1) (reg_imm ri t1))``,
+    (x = word_cmp cmp (read_reg rr t1) (reg_imm ri t1))`,
   Cases_on `ri` \\ full_simp_tac(srw_ss())[labSemTheory.reg_imm_def,asmSemTheory.reg_imm_def]
   \\ full_simp_tac(srw_ss())[asmSemTheory.read_reg_def]
   \\ Cases_on `s1.regs rr` \\ full_simp_tac(srw_ss())[]
@@ -904,9 +904,9 @@ val bytes_in_mem_IMP_memory = Q.prove(
       bytes_in_memory a xs m1 dm`,
   Induct \\ full_simp_tac(srw_ss())[bytes_in_memory_def,bytes_in_mem_def]);
 
-val state_rel_shift_interfer = prove(
-  ``state_rel (mc_conf,code2,labs,p,T) s1 t1 x ==>
-    state_rel (shift_interfer l mc_conf,code2,labs,p,T) s1 t1 x``,
+val state_rel_shift_interfer = Q.prove(
+  `state_rel (mc_conf,code2,labs,p,T) s1 t1 x ==>
+    state_rel (shift_interfer l mc_conf,code2,labs,p,T) s1 t1 x`,
   full_simp_tac(srw_ss())[state_rel_def,shift_interfer_def]
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ res_tac
   \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]);
@@ -1425,9 +1425,9 @@ val Inst_lemma = Q.prove(
       rw[APPLY_UPDATE_THM]>>
       rfs[])))
 
-val state_rel_ignore_io_events = prove(
-  ``state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 ==>
-    state_rel (mc_conf,code2,labs,p,T) (s1 with ffi := io) t1 ms1``,
+val state_rel_ignore_io_events = Q.prove(
+  `state_rel (mc_conf,code2,labs,p,T) s1 t1 ms1 ==>
+    state_rel (mc_conf,code2,labs,p,T) (s1 with ffi := io) t1 ms1`,
   full_simp_tac(srw_ss())[state_rel_def] \\ rpt strip_tac
   \\ res_tac \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]);
 
@@ -1936,10 +1936,10 @@ val init_ok_def = Define `
     ?code2 labs t1.
       state_rel (mc_conf,code2,labs,p,T) s t1 ms`
 
-val evaluate_ignore_clocks = prove(
-  ``evaluate mc_conf ffi k ms = (r1,ms1,st1) /\ r1 <> TimeOut /\
+val evaluate_ignore_clocks = Q.prove(
+  `evaluate mc_conf ffi k ms = (r1,ms1,st1) /\ r1 <> TimeOut /\
     evaluate mc_conf ffi k' ms = (r2,ms2,st2) /\ r2 <> TimeOut ==>
-    (r1,ms1,st1) = (r2,ms2,st2)``,
+    (r1,ms1,st1) = (r2,ms2,st2)`,
   srw_tac[][] \\ imp_res_tac evaluate_add_clock \\ full_simp_tac(srw_ss())[]
   \\ pop_assum (qspec_then `k'` mp_tac)
   \\ pop_assum (qspec_then `k` mp_tac)
@@ -2342,11 +2342,11 @@ val has_odd_inst_alignment = Q.store_thm("has_odd_inst_alignment",
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ metis_tac[line_ok_alignment,ODD_EVEN]);
 
-val enc_lines_again_IMP_similar = prove(``
+val enc_lines_again_IMP_similar = Q.prove(`
   ∀labs pos enc lines acc ok lines' ok' curr.
   enc_lines_again labs pos enc lines (acc,ok) = (lines',ok') ⇒
   LIST_REL line_similar curr (REVERSE acc) ⇒
-  LIST_REL line_similar (curr++lines) lines'``,
+  LIST_REL line_similar (curr++lines) lines'`,
   Induct_on`lines`>>fs[enc_lines_again_def]>>rw[]>>
   fs[AND_IMP_INTRO]>>
   `curr ++ h ::lines = SNOC h curr ++ lines` by fs[]>>
@@ -2355,9 +2355,9 @@ val enc_lines_again_IMP_similar = prove(``
   Cases_on`h`>>fs[enc_lines_again_def]>>EVERY_CASE_TAC>>
   asm_exists_tac>>fs[SNOC_APPEND,line_similar_def])
 
-val enc_secs_again_IMP_similar = prove(
-  ``∀pos labs enc code code1 ok.
-  enc_secs_again pos labs enc code = (code1,ok) ==> code_similar code code1``,
+val enc_secs_again_IMP_similar = Q.prove(
+  `∀pos labs enc code code1 ok.
+  enc_secs_again pos labs enc code = (code1,ok) ==> code_similar code code1`,
   ho_match_mp_tac enc_secs_again_ind>>fs[enc_secs_again_def]>>rw[]>>
   ntac 2 (pairarg_tac>>fs[])>>
   rveq>>fs[code_similar_def]>>
@@ -2413,31 +2413,31 @@ val enc_lines_again_simp_def = Define`
 
 val enc_lines_again_simp_ind = theorem"enc_lines_again_simp_ind";
 
-val enc_lines_again_simp_EQ = prove(``
+val enc_lines_again_simp_EQ = Q.prove(`
   ∀labs pos enc ls acc b.
   let (ls',flag) = enc_lines_again_simp labs pos enc ls in
-  enc_lines_again labs pos enc ls (acc,b) = (REVERSE acc ++ ls',b ∧ flag)``,
+  enc_lines_again labs pos enc ls (acc,b) = (REVERSE acc ++ ls',b ∧ flag)`,
   ho_match_mp_tac enc_lines_again_simp_ind >>
   fs[enc_lines_again_simp_def,enc_lines_again_def]>>rw[]>>
   rpt(pairarg_tac>>fs[])>>
   rw[EQ_IMP_THM]>>fs[])
 
 (*
-val enc_lines_again_simp_lemma = prove(``
+val enc_lines_again_simp_lemma = Q.prove(`
   ∀labs pos enc lines lines' acc n.
   enc_lines_again_simp labs pos enc lines = (lines',T) ⇒
   asm_line_labs pos lines acc = asm_line_labs pos lines' acc ∧
-  sec_length lines n = sec_length lines' n``,
+  sec_length lines n = sec_length lines' n`,
   ho_match_mp_tac enc_lines_again_simp_ind >>
   fs[enc_lines_again_simp_def]>>rw[]>>
   pairarg_tac>>fs[]>>
   rveq>>fs[asm_line_labs_def,full_sec_length_def]>>
   fs[sec_length_def])
 
-val enc_lines_again_T_IMP = prove(``
+val enc_lines_again_T_IMP = Q.prove(`
   enc_lines_again labs pos enc lines ([],T) = (lines',T) ⇒
   sec_labs pos lines = sec_labs pos lines' ∧
-  full_sec_length lines = full_sec_length lines'``,
+  full_sec_length lines = full_sec_length lines'`,
   strip_tac>>
   Q.ISPECL_THEN[`labs`,`pos`,`enc`,`lines`,`[]:'a line list`,`T`] assume_tac enc_lines_again_simp_EQ>>
   fs[]>>pairarg_tac>>fs[]>>
@@ -2448,10 +2448,10 @@ val enc_lines_again_T_IMP = prove(``
 *)
 
 (*
-val enc_secs_again_T_IMP = prove(``
+val enc_secs_again_T_IMP = Q.prove(`
   ∀pos code enc labs sec_list acc.
   enc_secs_again pos labs enc code = (sec_list,T) ⇒
-  compute_labels pos code acc = compute_labels pos sec_list acc``,
+  compute_labels pos code acc = compute_labels pos sec_list acc`,
   Induct_on`code`>>fs[enc_secs_again_def]>>rw[]>>
   Cases_on`h`>>fs[compute_labels_def]>>
   pairarg_tac>>fs[enc_secs_again_def]>>
@@ -2711,8 +2711,8 @@ val IS_SOME_lab_lookup_compute_labels = Q.prove(
 
 *)
 
-val MEM_all_labels = prove(
-  ``MEM (l1,l2,pos) (all_labels labs) <=> lab_lookup l1 l2 labs = SOME pos``,
+val MEM_all_labels = Q.prove(
+  `MEM (l1,l2,pos) (all_labels labs) <=> lab_lookup l1 l2 labs = SOME pos`,
   rw[lab_lookup_def,all_labels_def,MEM_FLAT,MEM_MAP,PULL_EXISTS,MEM_toAList,EXISTS_PROD]
   \\ CASE_TAC);
 
@@ -4740,8 +4740,8 @@ val aligned_1_intro = Q.prove(
   `((1w && w) = 0w) <=> aligned 1 w`,
   fs [alignmentTheory.aligned_bitwise_and]);
 
-val IMP_state_rel_make_init = prove(
-  ``good_syntax mc_conf code LN /\
+val IMP_state_rel_make_init = Q.prove(
+  `good_syntax mc_conf code LN /\
     EVERY sec_ends_with_label code /\
     enc_ok mc_conf.target.config /\
     remove_labels clock mc_conf.target.config code =
@@ -4752,7 +4752,7 @@ val IMP_state_rel_make_init = prove(
     state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,
         mc_conf.target.get_pc ms,T)
       (make_init mc_conf (ffi:'ffi ffi_state)
-         save_regs io_regs t m dm ms code) t ms``,
+         save_regs io_regs t m dm ms code) t ms`,
   srw_tac[][] \\ drule remove_labels_thm
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[state_rel_def,make_init_def,
@@ -4798,8 +4798,8 @@ val implements_intro_gen = Q.store_thm("implements_intro_gen",
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[semanticsPropsTheory.extend_with_resource_limit_def]);
 
-val semantics_compile_lemma = store_thm("semantics_compile_lemma",
-  ``ffi.final_event = NONE /\
+val semantics_compile_lemma = Q.store_thm("semantics_compile_lemma",
+  `ffi.final_event = NONE /\
     backend_correct mc_conf.target /\
     good_syntax mc_conf code LN /\
     EVERY sec_ends_with_label code /\
@@ -4809,7 +4809,7 @@ val semantics_compile_lemma = store_thm("semantics_compile_lemma",
     good_init_state mc_conf t m ms ffi ffi_limit bytes io_regs save_regs dm /\
     semantics (make_init mc_conf ffi save_regs io_regs t m dm ms code) <> Fail ==>
     machine_sem mc_conf ffi ms =
-    {semantics (make_init mc_conf ffi save_regs io_regs t m dm ms code)}``,
+    {semantics (make_init mc_conf ffi save_regs io_regs t m dm ms code)}`,
   full_simp_tac(srw_ss())[compile_def,compile_lab_def,GSYM AND_IMP_INTRO]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]

--- a/compiler/backend/proofs/mod_to_conProofScript.sml
+++ b/compiler/backend/proofs/mod_to_conProofScript.sml
@@ -138,8 +138,8 @@ val weakened_exh_def = Define`
       (case FLOOKUP exh t of NONE => LN | SOME tags => tags))
       { t | ∃cn. (cn, TypeId t) ∈ FDOM gtagenv' }`
 
-val FINITE_weakened_exh_dom = prove(
-  ``FINITE {t | ∃cn. (cn,TypeId t) ∈ FDOM ^gtagenv'}``,
+val FINITE_weakened_exh_dom = Q.prove(
+  `FINITE {t | ∃cn. (cn,TypeId t) ∈ FDOM ^gtagenv'}`,
   qmatch_abbrev_tac`FINITE P` >>
   qsuff_tac`∃f. P ⊆ IMAGE f (FDOM gtagenv')` >-
     metis_tac[IMAGE_FINITE,SUBSET_FINITE,FDOM_FINITE] >>
@@ -147,14 +147,14 @@ val FINITE_weakened_exh_dom = prove(
   qexists_tac`λx. @y. SND x = TypeId y` >>
   srw_tac[][EXISTS_PROD] >> metis_tac[tid_or_exn_11]);
 
-val FDOM_weakened_exh = prove(
-  ``FDOM (weakened_exh ^gtagenv' exh) = { t | ∃cn. (cn, TypeId t) ∈ FDOM gtagenv' }``,
+val FDOM_weakened_exh = Q.prove(
+  `FDOM (weakened_exh ^gtagenv' exh) = { t | ∃cn. (cn, TypeId t) ∈ FDOM gtagenv' }`,
   srw_tac[][weakened_exh_def] >>
   (FUN_FMAP_DEF |> SPEC_ALL |> UNDISCH |> CONJUNCT1 |> DISCH_ALL |> GEN_ALL |> match_mp_tac) >>
   srw_tac[][FINITE_weakened_exh_dom]);
 
-val FLOOKUP_weakened_exh_imp = prove(
-  ``(∀tags. tags ∈ FRANGE exh ⇒ wf tags) ∧
+val FLOOKUP_weakened_exh_imp = Q.prove(
+  `(∀tags. tags ∈ FRANGE exh ⇒ wf tags) ∧
     (FLOOKUP (weakened_exh ^gtagenv' exh) t = SOME tags) ⇒
     wf tags ∧
     (∀a max. lookup a tags = SOME max ⇒
@@ -162,7 +162,7 @@ val FLOOKUP_weakened_exh_imp = prove(
              (∃tags'. FLOOKUP exh t = SOME tags'  ∧ lookup a tags' = SOME max)) ∧
     (∀cn tag a.
       FLOOKUP gtagenv' (cn, TypeId t) = SOME (tag,a) ⇒
-      ∃max. lookup a tags = SOME max ∧ tag < max)``,
+      ∃max. lookup a tags = SOME max ∧ tag < max)`,
   simp[Once FLOOKUP_DEF,FDOM_weakened_exh] >>
   strip_tac >> BasicProvers.VAR_EQ_TAC >>
   simp[weakened_exh_def] >>
@@ -1609,8 +1609,8 @@ val compile_decs_next_weak = Q.store_thm("compile_decs_next_weak",
   srw_tac[][] >>
   simp[Abbr`tag`])
 
-val alloc_tag_cenv_inv = prove(
-  ``cenv_inv envC (get_exh (FST st)) (get_tagenv st) gtagenv ∧
+val alloc_tag_cenv_inv = Q.prove(
+  `cenv_inv envC (get_exh (FST st)) (get_tagenv st) gtagenv ∧
     next_inv tids (FST (FST st)) gtagenv ∧
     (cn,tn) ∉ FDOM gtagenv ∧
     (∀x. tn = TypeExn x ⇒ cn = id_to_n x) ⇒
@@ -1621,7 +1621,7 @@ val alloc_tag_cenv_inv = prove(
         gtagenv' ∧
       next_inv (tn INSERT tids) (FST (FST (alloc_tag tn cn arity st))) gtagenv' ∧
       gtagenv ⊑ gtagenv' ∧
-      FDOM gtagenv' = FDOM gtagenv ∪ {(cn,tn)}``,
+      FDOM gtagenv' = FDOM gtagenv ∪ {(cn,tn)}`,
   `∃next tagenv exh acc. st = ((next,tagenv,exh),acc)` by metis_tac[PAIR] >>
   `∃env menv. envC = (menv,env)` by metis_tac[PAIR] >>
   simp[merge_alist_mod_env_def] >> strip_tac >>
@@ -1777,8 +1777,8 @@ val alloc_tag_cenv_inv = prove(
     res_tac >> full_simp_tac(srw_ss())[same_tid_def] >> srw_tac[][] >> full_simp_tac(srw_ss())[]) >>
   srw_tac[][] >> metis_tac[])
 
-val FOLDL_alloc_tag_cenv_inv = prove(
-  ``∀(constrs:(conN # t list) list) envC st gtagenv tids.
+val FOLDL_alloc_tag_cenv_inv = Q.prove(
+  `∀(constrs:(conN # t list) list) envC st gtagenv tids.
     cenv_inv envC (get_exh (FST st)) (get_tagenv st) gtagenv ∧
     next_inv tids (FST (FST st)) gtagenv ∧
     (∀cn. MEM cn (MAP FST constrs) ⇒ (cn,TypeId(mk_id mn tn)) ∉ FDOM gtagenv) ∧
@@ -1793,7 +1793,7 @@ val FOLDL_alloc_tag_cenv_inv = prove(
       gtagenv' ∧
     next_inv (TypeId(mk_id mn tn) INSERT tids) (FST (FST st')) gtagenv' ∧
     gtagenv ⊑ gtagenv' ∧
-    FDOM gtagenv' = FDOM gtagenv ∪ { (cn,TypeId(mk_id mn tn)) | MEM cn (MAP FST constrs) }``,
+    FDOM gtagenv' = FDOM gtagenv ∪ { (cn,TypeId(mk_id mn tn)) | MEM cn (MAP FST constrs) }`,
   ho_match_mp_tac SNOC_INDUCT >>
   conj_tac >- (
     simp[merge_alist_mod_env_empty] >>
@@ -1823,8 +1823,8 @@ val union_insert_lem = Q.prove(
   `a ∪ (b INSERT c) = (a ∪ {b}) ∪ c`,
   srw_tac[][EXTENSION] >> metis_tac[])
 
-val alloc_tags_cenv_inv = prove(
-  ``∀mn st (ls:(tvarN list # typeN # (conN # t list) list) list) envC gtagenv tids.
+val alloc_tags_cenv_inv = Q.prove(
+  `∀mn st (ls:(tvarN list # typeN # (conN # t list) list) list) envC gtagenv tids.
     cenv_inv envC (get_exh (FST st)) (get_tagenv st) gtagenv ∧
     next_inv tids (FST (FST st)) gtagenv ∧
     (* new types only *)
@@ -1841,7 +1841,7 @@ val alloc_tags_cenv_inv = prove(
     gtagenv_weak gtagenv gtagenv' ∧
     IMAGE SND (FDOM gtagenv') = IMAGE SND (FDOM gtagenv)
       ∪ IMAGE (TypeId o mk_id mn o FST o SND)
-        (set (FILTER ($~ o NULL o SND o SND) ls))``,
+        (set (FILTER ($~ o NULL o SND o SND) ls))`,
   ho_match_mp_tac alloc_tags_ind >>
   conj_tac >- (
     simp[alloc_tags_def,build_tdefs_def,merge_alist_mod_env_empty,get_exh_def,get_tagenv_def,type_defs_to_new_tdecs_def] >>
@@ -1913,8 +1913,8 @@ val recfun_helper = Q.prove (
   srw_tac[][Once v_rel_cases, v_rel_eqns] >>
   metis_tac []);
 
-val compile_decs_correct = store_thm("compile_decs_correct",
-  ``∀env s ds r.
+val compile_decs_correct = Q.store_thm("compile_decs_correct",
+  `∀env s ds r.
       evaluate_decs env s ds = r ⇒
     ∀res s1_i2 tagenv_st ds_i2 tagenv_st' genv' envC' s' gtagenv.
       r = (s', envC', genv', res) ∧
@@ -1940,7 +1940,7 @@ val compile_decs_correct = store_thm("compile_decs_correct",
          (∃err err_i2.
            res = SOME err ∧ res_i2 = SOME err_i2 ∧
            s_rel gtagenv' s' s'_i2 ∧
-           result_rel v_rel gtagenv' (Rerr err) (Rerr err_i2)))``,
+           result_rel v_rel gtagenv' (Rerr err) (Rerr err_i2)))`,
   Induct_on`ds` >- (
     simp[modSemTheory.evaluate_decs_def,compile_decs_def,conSemTheory.evaluate_decs_def] >>
     simp[FDOM_EQ_EMPTY,vs_rel_list_rel,flat_envC_tagged_def] >>
@@ -2252,10 +2252,10 @@ val alloc_tags_exh_FDOM = Q.prove(
   full_simp_tac(srw_ss())[SUBSET_DEF] >>
   metis_tac[])
 
-val FDOM_compile_decs_exh = prove(
-  ``∀ds (st:tagenv_state_acc) st' ds'.
+val FDOM_compile_decs_exh = Q.prove(
+  `∀ds (st:tagenv_state_acc) st' ds'.
     compile_decs st ds = (st',ds') ⇒
-    FDOM (get_exh (FST st')) ⊆ FDOM (get_exh (FST st)) ∪ tids_of_decs ds``,
+    FDOM (get_exh (FST st')) ⊆ FDOM (get_exh (FST st)) ∪ tids_of_decs ds`,
   Induct >> simp[compile_decs_def,modPropsTheory.tids_of_decs_thm] >>
   rpt gen_tac >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
@@ -2285,8 +2285,8 @@ val compile_decs_dummy_env_num_defs =prove(
   srw_tac[][] >>
   simp[modSemTheory.dec_to_dummy_env_def,conLangTheory.num_defs_def,compile_funs_map]);
 
-val compile_prompt_correct = store_thm("compile_prompt_correct",
-  ``!env s prompt s_i2 tagenv_st prompt_i2 genv' envC' s' res gtagenv tagenv_st'.
+val compile_prompt_correct = Q.store_thm("compile_prompt_correct",
+  `!env s prompt s_i2 tagenv_st prompt_i2 genv' envC' s' res gtagenv tagenv_st'.
     evaluate_prompt env s prompt = (s', envC', genv', res) ∧
     res ≠ SOME (Rabort Rtype_error) ∧
     invariant env.c tagenv_st gtagenv s s_i2 ∧
@@ -2300,7 +2300,7 @@ val compile_prompt_correct = store_thm("compile_prompt_correct",
       (res = NONE ∧ res_i2 = NONE ∧ new_envC = (merge_alist_mod_env envC' env.c) ∨
        ?err err_i2. res = SOME err ∧ res_i2 = SOME err_i2 ∧ new_envC = env.c ∧
                     s_rel gtagenv' s' s'_i2 ∧
-                    result_rel v_rel gtagenv' (Rerr err) (Rerr err_i2))``,
+                    result_rel v_rel gtagenv' (Rerr err) (Rerr err_i2))`,
   srw_tac[][compile_prompt_def, LET_THM] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   rename1`Prompt mn ds` >>

--- a/compiler/backend/proofs/mod_to_conProofScript.sml
+++ b/compiler/backend/proofs/mod_to_conProofScript.sml
@@ -1167,7 +1167,7 @@ val evaluate_decs_exh_weak = Q.prove(
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_dec_exh_weak >> full_simp_tac(srw_ss())[] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> strip_tac >>
-  rator_x_assum`evaluate_decs`mp_tac >>
+  qhdtm_x_assum`evaluate_decs`mp_tac >>
   qmatch_assum_abbrev_tac`evaluate_decs env1 s1 _ = _` >>
   strip_tac >>
   first_x_assum(qspecl_then[`env1`,`s1`,`exh'`]mp_tac) >>
@@ -1999,7 +1999,7 @@ val compile_decs_correct = store_thm("compile_decs_correct",
   split_pair_case_tac >> simp[] >>
   srw_tac[][] >>
   imp_res_tac modPropsTheory.no_dup_types_cons_imp >>
-  rator_x_assum`mod_to_con$compile_decs`mp_tac >>
+  qhdtm_x_assum`mod_to_con$compile_decs`mp_tac >>
   simp[compile_decs_def] >>
   BasicProvers.CASE_TAC >> strip_tac >>
   first_assum(split_uncurry_arg_tac o lhs o concl) >> full_simp_tac(srw_ss())[] >>
@@ -2532,7 +2532,7 @@ val compile_prog_correct = Q.store_thm ("compile_prog_correct",
     spose_not_then strip_assume_tac >> srw_tac[][] >>
     first_x_assum(qspec_then`(Short tn)`mp_tac) >> simp[] >>
     reverse conj_tac >- metis_tac[] >>
-    rator_x_assum`prompt_mods_ok`mp_tac >>
+    qhdtm_x_assum`prompt_mods_ok`mp_tac >>
     simp[modSemTheory.prompt_mods_ok_def] >>
     BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >- (
       simp[modPropsTheory.tids_of_decs_def,MEM_FLAT,MEM_MAP,PULL_EXISTS,PULL_FORALL] >>
@@ -2600,7 +2600,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
     srw_tac[][] >>
     simp[conSemTheory.semantics_def] >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`modSem$evaluate_prog`kall_tac >>
+      qhdtm_x_assum`modSem$evaluate_prog`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >> full_simp_tac(srw_ss())[] >>
@@ -2641,7 +2641,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
           simp[RIGHT_FORALL_IMP_THM] >>
           impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[OPTREL_def,result_rel_cases]) >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`conSem$evaluate_prog`mp_tac >>
+          qhdtm_x_assum`conSem$evaluate_prog`mp_tac >>
           drule (GEN_ALL conPropsTheory.evaluate_prog_add_to_clock) >>
           simp[] >>
           disch_then(qspec_then`k`mp_tac)>>simp[]>>
@@ -2661,7 +2661,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
         disch_then drule >>
         PairCases_on`tagenv_st'` >>
         simp[] >> spose_not_then strip_assume_tac >>
-        rator_x_assum`modSem$evaluate_prog`mp_tac >>
+        qhdtm_x_assum`modSem$evaluate_prog`mp_tac >>
         drule (GEN_ALL modPropsTheory.evaluate_prog_add_to_clock) >>
         CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
@@ -2686,7 +2686,7 @@ val compile_prog_semantics = Q.store_thm("compile_prog_semantics",
       full_simp_tac(srw_ss())[] >> rveq >>
       reverse(Cases_on`s''.ffi.final_event`)>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]>- (
         fsrw_tac[ARITH_ss][get_exh_def] >> full_simp_tac(srw_ss())[s_rel_cases] >> rev_full_simp_tac(srw_ss())[]) >>
-      rator_x_assum`conSem$evaluate_prog`mp_tac >>
+      qhdtm_x_assum`conSem$evaluate_prog`mp_tac >>
       drule (GEN_ALL conPropsTheory.evaluate_prog_add_to_clock) >>
       CONV_TAC(LAND_CONV(SIMP_CONV(srw_ss())[RIGHT_FORALL_IMP_THM])) >>
       impl_tac >- full_simp_tac(srw_ss())[] >>

--- a/compiler/backend/proofs/mod_to_conProofScript.sml
+++ b/compiler/backend/proofs/mod_to_conProofScript.sml
@@ -71,8 +71,8 @@ val next_inv_def = Define`
        ∃max. lookup a next = SOME max ∧ tag < max)
     ∧ IMAGE SND (FDOM gtagenv) ⊆ tids`
 
-val next_inv_tids_subset = prove(
-  ``s1 ⊆ s2 ∧ next_inv s1 st g ⇒ next_inv s2 st g``,
+val next_inv_tids_subset = Q.prove(
+  `s1 ⊆ s2 ∧ next_inv s1 st g ⇒ next_inv s2 st g`,
   srw_tac[][next_inv_def] >>
   metis_tac[SUBSET_TRANS])
 
@@ -270,8 +270,8 @@ val next_weak_def = Define`
     ∀a max1. lookup a next1 = SOME (max1:num) ⇒
       ∃max2. lookup a next2 = SOME max2 ∧ max1 ≤ max2`
 
-val next_weak_trans = store_thm("next_weak_trans",
-  ``next_weak n1 n2 ∧ next_weak n2 n3 ⇒ next_weak n1 n3``,
+val next_weak_trans = Q.store_thm("next_weak_trans",
+  `next_weak n1 n2 ∧ next_weak n2 n3 ⇒ next_weak n1 n3`,
   srw_tac[][next_weak_def] >> res_tac >> srw_tac[][] >>
   res_tac >> srw_tac[][] >> simp[])
 
@@ -282,12 +282,12 @@ val exh_weak_def = Define`
         ∀a x. lookup a m = SOME x ⇒
            ∃y. lookup a m' = SOME y ∧ x ≤ y`
 
-val exh_weak_refl = store_thm("exh_weak_refl[simp]",
-  ``exh_weak exh exh``,
+val exh_weak_refl = Q.store_thm("exh_weak_refl[simp]",
+  `exh_weak exh exh`,
   srw_tac[][exh_weak_def])
 
-val exh_weak_trans = store_thm("exh_weak_trans",
-  ``exh_weak exh1 exh2 ∧ exh_weak exh2 exh3 ⇒ exh_weak exh1 exh3``,
+val exh_weak_trans = Q.store_thm("exh_weak_trans",
+  `exh_weak exh1 exh2 ∧ exh_weak exh2 exh3 ⇒ exh_weak exh1 exh3`,
   srw_tac[][exh_weak_def] >>
   res_tac >> res_tac >> srw_tac[][] >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   res_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> res_tac >> srw_tac[][] >> simp[])
@@ -295,24 +295,24 @@ val exh_weak_trans = store_thm("exh_weak_trans",
 val exh_wf_def = Define`
   exh_wf exh = ∀t. t ∈ FRANGE exh ⇒ wf t`
 
-val exhaustive_env_correct_exh_weak = store_thm("exhaustive_env_correct_exh_weak",
-  ``exhaustive_env_correct exh gtagenv ∧
+val exhaustive_env_correct_exh_weak = Q.store_thm("exhaustive_env_correct_exh_weak",
+  `exhaustive_env_correct exh gtagenv ∧
     exh_weak exh exh' ∧ exh_wf exh' (* ∧ FDOM exh' ⊆ { t | TypeId t ∈ IMAGE SND (FDOM gtagenv) } *) ⇒
-    exhaustive_env_correct exh' gtagenv``,
+    exhaustive_env_correct exh' gtagenv`,
   srw_tac[][exhaustive_env_correct_def] >>
   full_simp_tac(srw_ss())[PULL_EXISTS,exh_weak_def,exh_wf_def] >>
   res_tac >> res_tac >> srw_tac[][] >>
   res_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   res_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> simp[])
 
-val envC_tagged_extend = prove(
-  ``envC_tagged envC tagenv gtagenv ∧
+val envC_tagged_extend = Q.prove(
+  `envC_tagged envC tagenv gtagenv ∧
     flat_envC_tagged cenv acc gtagenv' ∧
     FDOM acc = set (MAP FST cenv) ∧
     gtagenv_weak gtagenv gtagenv'
     ⇒
     envC_tagged (merge_alist_mod_env (mod_cenv mn cenv) envC)
-      (mod_tagenv mn acc tagenv) gtagenv'``,
+      (mod_tagenv mn acc tagenv) gtagenv'`,
   PairCases_on`envC` >>
   PairCases_on`tagenv` >>
   simp[envC_tagged_def] >>
@@ -845,9 +845,9 @@ val v_to_list = Q.prove (
   full_simp_tac(srw_ss())[] >>
   metis_tac [NOT_SOME_NONE, SOME_11]);
 
-val char_list_to_v = prove(
-  ``gtagenv_wf gtagenv ⇒
-    ∀ls. v_rel gtagenv (char_list_to_v ls) (char_list_to_v ls)``,
+val char_list_to_v = Q.prove(
+  `gtagenv_wf gtagenv ⇒
+    ∀ls. v_rel gtagenv (char_list_to_v ls) (char_list_to_v ls)`,
   strip_tac >>
   Induct >> simp[modSemTheory.char_list_to_v_def,conSemTheory.char_list_to_v_def,v_rel_eqns] >>
   full_simp_tac(srw_ss())[gtagenv_wf_def,has_lists_def])
@@ -1146,22 +1146,22 @@ val evaluate_exh_weak = Q.prove (
   res_tac >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   metis_tac [pmatch_exh_weak, match_result_distinct, match_result_11]);
 
-val evaluate_dec_exh_weak = prove(
-  ``∀env ^s d res.
+val evaluate_dec_exh_weak = Q.prove(
+  `∀env ^s d res.
       evaluate_dec env s d = res ⇒
       ∀exh'. exh_weak env.exh exh' ∧ SND res ≠ Rerr (Rabort Rtype_error)
-        ⇒ evaluate_dec (env with exh := exh') s d = res``,
+        ⇒ evaluate_dec (env with exh := exh') s d = res`,
   Cases_on`d`>>srw_tac[][conSemTheory.evaluate_dec_def] >>
   pop_assum mp_tac >> BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_exh_weak >> full_simp_tac(srw_ss())[] >>
   res_tac >> every_case_tac >> full_simp_tac(srw_ss())[]);
 
-val evaluate_decs_exh_weak = prove(
- ``∀env ^s ds res.
+val evaluate_decs_exh_weak = Q.prove(
+ `∀env ^s ds res.
      evaluate_decs env s ds = res
      ⇒
      ∀exh'. exh_weak env.exh exh' ∧ SND (SND res) ≠ SOME (Rabort Rtype_error) ⇒
-       evaluate_decs (env with exh := exh') s ds = res``,
+       evaluate_decs (env with exh := exh') s ds = res`,
   Induct_on`ds`>>srw_tac[][conSemTheory.evaluate_decs_def] >>
   pop_assum mp_tac >>
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
@@ -1507,16 +1507,16 @@ val tagacc_accumulates = Q.prove (
   res_tac >> srw_tac[][]
   >> metis_tac[alloc_tag_accumulates,alloc_tags_accumulates,FUNION_ASSOC])
 
-val alloc_tag_exh_weak = store_thm("alloc_tag_exh_weak",
-  ``exh_weak (get_exh (FST st)) (get_exh (FST (alloc_tag a b c st)))``,
+val alloc_tag_exh_weak = Q.store_thm("alloc_tag_exh_weak",
+  `exh_weak (get_exh (FST st)) (get_exh (FST (alloc_tag a b c st)))`,
   `∃next menv env exh acc. st = ((next,(menv,env),exh),acc)` by metis_tac[PAIR] >>
   simp[alloc_tag_def]>>
   every_case_tac >> simp[UNCURRY,get_exh_def,exh_weak_def] >> srw_tac[][] >>
   simp[FLOOKUP_UPDATE] >> srw_tac[][] >>
   srw_tac[][sptreeTheory.lookup_insert] >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> full_simp_tac(srw_ss())[])
 
-val alloc_tags_exh_weak = store_thm("alloc_tags_exh_weak",
-  ``∀ls mn ta. exh_weak (get_exh (FST ta)) (get_exh (FST (alloc_tags mn ta ls)))``,
+val alloc_tags_exh_weak = Q.store_thm("alloc_tags_exh_weak",
+  `∀ls mn ta. exh_weak (get_exh (FST ta)) (get_exh (FST (alloc_tags mn ta ls)))`,
   Induct >> srw_tac[][alloc_tags_def] >>
   PairCases_on`h`>>simp[alloc_tags_def]>>
   qmatch_abbrev_tac`exh_weak X (get_exh (FST (alloc_tags mn ta' ls)))` >>
@@ -1532,15 +1532,15 @@ val alloc_tags_exh_weak = store_thm("alloc_tags_exh_weak",
   srw_tac[][Abbr`ta'`] >>
   metis_tac[alloc_tag_exh_weak,exh_weak_trans])
 
-val compile_decs_exh_weak = store_thm("compile_decs_exh_weak",
-  ``∀ds (st:tagenv_state_acc).
-      exh_weak (get_exh (FST st)) (get_exh (FST (FST (compile_decs st ds))))``,
+val compile_decs_exh_weak = Q.store_thm("compile_decs_exh_weak",
+  `∀ds (st:tagenv_state_acc).
+      exh_weak (get_exh (FST st)) (get_exh (FST (FST (compile_decs st ds))))`,
   Induct >> simp[compile_decs_def] >> srw_tac[][] >>
   every_case_tac >> simp[UNCURRY] >>
   metis_tac[exh_weak_trans,alloc_tag_exh_weak,alloc_tags_exh_weak])
 
-val alloc_tag_exh_wf = store_thm("alloc_tag_exh_wf",
-  ``exh_wf (get_exh (FST st)) ⇒ exh_wf (get_exh (FST (alloc_tag a b c st)))``,
+val alloc_tag_exh_wf = Q.store_thm("alloc_tag_exh_wf",
+  `exh_wf (get_exh (FST st)) ⇒ exh_wf (get_exh (FST (alloc_tag a b c st)))`,
   `∃next menv env exh acc. st = ((next,(menv,env),exh),acc)` by metis_tac[PAIR] >>
   simp[alloc_tag_def]>>
   every_case_tac >> simp[UNCURRY,get_exh_def,exh_wf_def] >> srw_tac[][] >>
@@ -1549,8 +1549,8 @@ val alloc_tag_exh_wf = store_thm("alloc_tag_exh_wf",
   match_mp_tac sptreeTheory.wf_insert >>
   simp[sptreeTheory.wf_def])
 
-val alloc_tags_exh_wf = store_thm("alloc_tags_exh_wf",
-  ``∀ls mn ta. exh_wf (get_exh (FST ta)) ⇒ exh_wf (get_exh (FST (alloc_tags mn ta ls)))``,
+val alloc_tags_exh_wf = Q.store_thm("alloc_tags_exh_wf",
+  `∀ls mn ta. exh_wf (get_exh (FST ta)) ⇒ exh_wf (get_exh (FST (alloc_tags mn ta ls)))`,
   Induct >> srw_tac[][alloc_tags_def] >>
   PairCases_on`h`>>simp[alloc_tags_def]>>
   qmatch_abbrev_tac`exh_wf (get_exh (FST (alloc_tags mn ta' ls)))` >>
@@ -1566,15 +1566,15 @@ val alloc_tags_exh_wf = store_thm("alloc_tags_exh_wf",
   srw_tac[][Abbr`ta'`] >>
   metis_tac[alloc_tag_exh_wf])
 
-val compile_decs_exh_wf = store_thm("compile_decs_exh_wf",
-  ``∀ds st.
-      exh_wf (get_exh (FST st)) ⇒ exh_wf (get_exh (FST (FST (compile_decs st ds))))``,
+val compile_decs_exh_wf = Q.store_thm("compile_decs_exh_wf",
+  `∀ds st.
+      exh_wf (get_exh (FST st)) ⇒ exh_wf (get_exh (FST (FST (compile_decs st ds))))`,
   Induct >> simp[compile_decs_def] >> srw_tac[][] >>
   every_case_tac >> simp[UNCURRY] >>
   metis_tac[alloc_tag_exh_wf,alloc_tags_exh_wf])
 
-val alloc_tags_next = store_thm("alloc_tags_next",
-  ``∀x st z. FST (FST (alloc_tags x st z)) = FST (FST st)``,
+val alloc_tags_next = Q.store_thm("alloc_tags_next",
+  `∀x st z. FST (FST (alloc_tags x st z)) = FST (FST st)`,
   ho_match_mp_tac alloc_tags_ind >>
   srw_tac[][alloc_tags_def] >> srw_tac[][] >>
   srw_tac[][Abbr`st'`] >>
@@ -1586,8 +1586,8 @@ val alloc_tags_next = store_thm("alloc_tags_next",
   PairCases_on`st`>>srw_tac[][alloc_tag_def] >>
   simp[UNCURRY])
 
-val compile_decs_next_weak = store_thm("compile_decs_next_weak",
-  ``next_weak (FST(FST st)) (FST(FST(FST (compile_decs (st:tagenv_state_acc) ds))))``,
+val compile_decs_next_weak = Q.store_thm("compile_decs_next_weak",
+  `next_weak (FST(FST st)) (FST(FST(FST (compile_decs (st:tagenv_state_acc) ds))))`,
   qid_spec_tac`st`>>Induct_on`ds`>>
   srw_tac[][compile_decs_def] >- srw_tac[][next_weak_def] >>
   Cases_on`h`>>simp[UNCURRY] >- (
@@ -1819,8 +1819,8 @@ val FOLDL_alloc_tag_cenv_inv = prove(
   simp[EXTENSION] >>
   metis_tac[SUBMAP_TRANS] )
 
-val union_insert_lem = prove(
-  ``a ∪ (b INSERT c) = (a ∪ {b}) ∪ c``,
+val union_insert_lem = Q.prove(
+  `a ∪ (b INSERT c) = (a ∪ {b}) ∪ c`,
   srw_tac[][EXTENSION] >> metis_tac[])
 
 val alloc_tags_cenv_inv = prove(
@@ -2446,16 +2446,16 @@ val compile_prompt_correct = store_thm("compile_prompt_correct",
     simp[result_rel_cases] >>
     full_simp_tac(srw_ss())[s_rel_cases]))
 
-val compile_prompt_exh_weak = store_thm("compile_prompt_exh_weak",
-  ``exh_weak (get_exh st) (get_exh (FST (compile_prompt st pr)))``,
+val compile_prompt_exh_weak = Q.store_thm("compile_prompt_exh_weak",
+  `exh_weak (get_exh st) (get_exh (FST (compile_prompt st pr)))`,
   srw_tac[][compile_prompt_def] >>
   every_case_tac >> simp[] >>
   simp[UNCURRY,get_exh_def] >>
   qspecl_then[`l`,`st,FEMPTY`]strip_assume_tac compile_decs_exh_weak >>
   metis_tac[get_exh_def,SND,FST,PAIR])
 
-val compile_prog_exh_weak = store_thm("compile_prog_exh_weak",
-  ``∀p st. exh_weak (get_exh st) (get_exh (FST (compile_prog st p)))``,
+val compile_prog_exh_weak = Q.store_thm("compile_prog_exh_weak",
+  `∀p st. exh_weak (get_exh st) (get_exh (FST (compile_prog st p)))`,
   Induct >> simp[compile_prog_def] >>
   srw_tac[][UNCURRY] >>
   match_mp_tac (GEN_ALL exh_weak_trans) >>
@@ -2846,17 +2846,17 @@ val compile_prog_exh_unchanged = Q.store_thm("compile_prog_exh_unchanged",
   match_mp_tac compile_prompt_exh_unchanged >>
   Cases_on`h`>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>full_simp_tac(srw_ss())[]);
 
-val compile_exp_no_set_globals = prove(``
+val compile_exp_no_set_globals = Q.prove(`
   (∀c e. set_globals (mod_to_con$compile_exp c e) = {||}) ∧
   (∀c es. elist_globals (mod_to_con$compile_exps c es) = {||}) ∧
   (∀c pes. elist_globals (MAP SND (mod_to_con$compile_pes c pes)) = {||}) ∧
-  (∀c funs. elist_globals (MAP (SND o SND) (mod_to_con$compile_funs c funs)) = {||})``,
+  (∀c funs. elist_globals (MAP (SND o SND) (mod_to_con$compile_funs c funs)) = {||})`,
   ho_match_mp_tac compile_exp_ind>>rw[compile_exp_def]>>
   Cases_on`op`>>fs[op_gbag_def])
 
-val compile_decs_no_set_globals = prove(``
+val compile_decs_no_set_globals = Q.prove(`
   ∀ds c.
-  decs_set_globals (Prompt (SND (compile_decs c ds))) = {||}``,
+  decs_set_globals (Prompt (SND (compile_decs c ds))) = {||}`,
   Induct>>fs[compile_decs_def,dec_set_globals_def]>>
   Cases>>fs[]>>
   rw[]>>

--- a/compiler/backend/proofs/pat_to_closProofScript.sml
+++ b/compiler/backend/proofs/pat_to_closProofScript.sml
@@ -56,11 +56,11 @@ val compile_state_with_clock = Q.store_thm("compile_state_with_clock[simp]",
 
 (* semantic functions respect translation *)
 
-val do_eq = store_thm("do_eq",
-  ``(∀v1 v2. do_eq v1 v2 ≠ Eq_type_error ⇒
+val do_eq = Q.store_thm("do_eq",
+  `(∀v1 v2. do_eq v1 v2 ≠ Eq_type_error ⇒
       (do_eq v1 v2 = do_eq (compile_v v1) (compile_v v2))) ∧
     (∀vs1 vs2. do_eq_list vs1 vs2 ≠ Eq_type_error ⇒
-      (do_eq_list vs1 vs2 = do_eq_list (MAP compile_v vs1) (MAP compile_v vs2)))``,
+      (do_eq_list vs1 vs2 = do_eq_list (MAP compile_v vs1) (MAP compile_v vs2)))`,
   ho_match_mp_tac patSemTheory.do_eq_ind >>
   simp[patSemTheory.do_eq_def,closSemTheory.do_eq_def] >>
   conj_tac >- (
@@ -82,16 +82,16 @@ val do_eq = store_thm("do_eq",
   rw[]>>fs[]>>
   BasicProvers.CASE_TAC>>fs[]);
 
-val list_to_v = store_thm("list_to_v",
-  ``∀ls. list_to_v (MAP (Number o $& o ORD) ls) =
-         compile_v (char_list_to_v ls)``,
+val list_to_v = Q.store_thm("list_to_v",
+  `∀ls. list_to_v (MAP (Number o $& o ORD) ls) =
+         compile_v (char_list_to_v ls)`,
   Induct >> simp[list_to_v_def,char_list_to_v_def])
 
 val v_to_list_def = closSemTheory.v_to_list_def;
 
-val v_to_char_list = store_thm("v_to_char_list",
-  ``∀v ls. (v_to_char_list v = SOME ls) ⇒
-           (v_to_list (compile_v v) = SOME (MAP (Number o $& o ORD) ls))``,
+val v_to_char_list = Q.store_thm("v_to_char_list",
+  `∀v ls. (v_to_char_list v = SOME ls) ⇒
+           (v_to_list (compile_v v) = SOME (MAP (Number o $& o ORD) ls))`,
   ho_match_mp_tac v_to_char_list_ind >>
   simp[v_to_char_list_def,v_to_list_def] >>
   rw[] >>
@@ -105,15 +105,15 @@ val v_to_char_list = store_thm("v_to_char_list",
   rw[]>>fs[]>>
   Cases_on`v_to_char_list h`>>fs[]>> rw[])
 
-val v_to_list = store_thm("v_to_list",
-  ``∀v ls. (v_to_list v = SOME ls) ⇒
-           (v_to_list (compile_v v) = SOME (MAP compile_v ls))``,
+val v_to_list = Q.store_thm("v_to_list",
+  `∀v ls. (v_to_list v = SOME ls) ⇒
+           (v_to_list (compile_v v) = SOME (MAP compile_v ls))`,
   ho_match_mp_tac patSemTheory.v_to_list_ind >>
   simp[patSemTheory.v_to_list_def,v_to_list_def] >>
   rw[] >> Cases_on`v_to_list v`>>fs[]>> rw[])
 
-val Boolv = store_thm("Boolv[simp]",
-  ``compile_v (Boolv b) = Boolv b``,
+val Boolv = Q.store_thm("Boolv[simp]",
+  `compile_v (Boolv b) = Boolv b`,
   Cases_on`b`>>EVAL_TAC)
 
 (* compiler correctness *)
@@ -724,8 +724,8 @@ val compile_semantics = Q.store_thm("compile_semantics",
 
 (* more correctness properties *)
 
-val compile_contains_App_SOME = store_thm("compile_contains_App_SOME",
-  ``0 < max_app ⇒ ∀e. ¬contains_App_SOME max_app [compile e]``,
+val compile_contains_App_SOME = Q.store_thm("compile_contains_App_SOME",
+  `0 < max_app ⇒ ∀e. ¬contains_App_SOME max_app [compile e]`,
   strip_tac >>
   ho_match_mp_tac compile_ind >>
   simp[compile_def,contains_App_SOME_def] >>

--- a/compiler/backend/proofs/pat_to_closProofScript.sml
+++ b/compiler/backend/proofs/pat_to_closProofScript.sml
@@ -620,7 +620,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     rw[] >>
     simp[closSemTheory.semantics_def] >>
     IF_CASES_TAC >> fs[] >- (
-      rator_x_assum`patSem$evaluate`kall_tac >>
+      qhdtm_x_assum`patSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >>
@@ -646,7 +646,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
           drule (GEN_ALL(SIMP_RULE std_ss [](CONJUNCT1 closPropsTheory.evaluate_add_to_clock))) >>
           simp[] >>
           disch_then(qspec_then`k'`mp_tac)>>simp[]>>
-          rator_x_assum`closSem$evaluate`mp_tac >>
+          qhdtm_x_assum`closSem$evaluate`mp_tac >>
           drule (GEN_ALL(SIMP_RULE std_ss [](CONJUNCT1 closPropsTheory.evaluate_add_to_clock))) >>
           simp[] >>
           disch_then(qspec_then`k`mp_tac)>>simp[]>>
@@ -660,7 +660,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
           last_x_assum(qspec_then`k+k'`mp_tac)>>
           rpt strip_tac >> fsrw_tac[ARITH_ss][] >> rfs[] ) >>
         strip_tac >>
-        rator_x_assum`patSem$evaluate`mp_tac >>
+        qhdtm_x_assum`patSem$evaluate`mp_tac >>
         drule (GEN_ALL patPropsTheory.evaluate_add_to_clock) >>
         simp[] >>
         disch_then(qspec_then`k'`mp_tac)>>simp[] >>
@@ -677,7 +677,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
       fsrw_tac[ARITH_ss][] >>
       reverse(Cases_on`s'.ffi.final_event`)>>fs[]>>rfs[]>- (
         fs[] >> rfs[compile_state_def] ) >>
-      rator_x_assum`closSem$evaluate`mp_tac >>
+      qhdtm_x_assum`closSem$evaluate`mp_tac >>
       drule (GEN_ALL(SIMP_RULE std_ss [](CONJUNCT1 closPropsTheory.evaluate_add_to_clock))) >>
       simp[] >>
       disch_then(qspec_then`k`mp_tac)>>simp[] >>

--- a/compiler/backend/proofs/source_to_modProofScript.sml
+++ b/compiler/backend/proofs/source_to_modProofScript.sml
@@ -1291,7 +1291,7 @@ val compile_exp_correct' = Q.prove (
     imp_res_tac evaluate_globals >>
     pop_assum (assume_tac o SYM) >> full_simp_tac(srw_ss())[] >>
     FIRST_X_ASSUM drule >> simp[] >> strip_tac >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     simp[Once result_rel_cases] >> strip_tac >>
     imp_res_tac evaluatePropsTheory.evaluate_length >> full_simp_tac(srw_ss())[] >>
     Cases_on`a`>>full_simp_tac(srw_ss())[LENGTH_NIL] >> rveq >>
@@ -1313,7 +1313,7 @@ val compile_exp_correct' = Q.prove (
     srw_tac[][] >> rev_full_simp_tac(srw_ss())[] >>
     imp_res_tac evaluate_globals >>
     pop_assum (assume_tac o SYM) >> full_simp_tac(srw_ss())[] >>
-    rator_x_assum`result_rel`mp_tac >>
+    qhdtm_x_assum`result_rel`mp_tac >>
     simp[Once result_rel_cases] >> strip_tac >>
     Cases_on`xo`>> srw_tac[][compile_exp_def,evaluate_def] >- (
       first_x_assum match_mp_tac >>
@@ -1383,11 +1383,11 @@ val compile_exp_correct' = Q.prove (
       drule (CONJUNCT1 pmatch) >>
       ONCE_REWRITE_TAC[CONJ_COMM] >>
       simp[GSYM CONJ_ASSOC] >>
-      rator_x_assum`s_rel`mp_tac >>
+      qhdtm_x_assum`s_rel`mp_tac >>
       simp[Once s_rel_cases] >> strip_tac >>
       disch_then drule >>
       disch_then drule >>
-      rator_x_assum`env_all_rel`mp_tac >>
+      qhdtm_x_assum`env_all_rel`mp_tac >>
       simp[Once env_all_rel_cases] >> strip_tac >>
       disch_then drule >> simp[] >> strip_tac >>
       qmatch_assum_abbrev_tac`match_result_rel _ _ _ mm` >>
@@ -1403,11 +1403,11 @@ val compile_exp_correct' = Q.prove (
     drule (CONJUNCT1 pmatch) >>
     ONCE_REWRITE_TAC[CONJ_COMM] >>
     simp[GSYM CONJ_ASSOC] >>
-    rator_x_assum`s_rel`mp_tac >>
+    qhdtm_x_assum`s_rel`mp_tac >>
     simp[Once s_rel_cases] >> strip_tac >>
     disch_then drule >>
     disch_then drule >>
-    rator_x_assum`env_all_rel`mp_tac >>
+    qhdtm_x_assum`env_all_rel`mp_tac >>
     simp[Once env_all_rel_cases] >> strip_tac >>
     disch_then drule >> simp[] >> strip_tac >>
     qmatch_assum_abbrev_tac`match_result_rel _ _ _ mm` >>
@@ -1801,13 +1801,13 @@ val compile_decs_correct = Q.prove (
       \\ simp[] \\ metis_tac[v_rel_weakening])
     \\ rw[Abbr`cx`]
     \\ qmatch_asmsub_abbrev_tac`evaluate_decs cc1 _ ds'`
-    \\ rator_x_assum`modSem$evaluate_decs`mp_tac
+    \\ qhdtm_x_assum`modSem$evaluate_decs`mp_tac
     \\ qmatch_asmsub_abbrev_tac`evaluate_decs cc2 _ ds'`
     \\ `cc1 = cc2`
     by (
       unabbrev_all_tac
       \\ simp[environment_component_equality]
-      \\ rator_x_assum`env_all_rel`mp_tac
+      \\ qhdtm_x_assum`env_all_rel`mp_tac
       \\ simp[env_all_rel_cases] \\ strip_tac
       \\ simp[]
       \\ rfs[env_rel_list_rel] )
@@ -2159,7 +2159,7 @@ val compile_prog_correct = Q.store_thm ("compile_prog_correct",
   \\ pairarg_tac \\ fs[]
   \\ rw[]
   \\ fs[evaluate_prompt_def]
-  \\ rator_x_assum`COND`mp_tac
+  \\ qhdtm_x_assum`COND`mp_tac
   \\ imp_res_tac no_dup_types
   \\ reverse IF_CASES_TAC
   >- (
@@ -2249,7 +2249,7 @@ val compile_prog_correct = Q.store_thm ("compile_prog_correct",
       strip_tac \\ fs[]
       \\ every_case_tac \\ fs[]
       \\ rw[] \\ fs[combine_mod_result_def] )
-    \\ rator_x_assum`invariant`mp_tac
+    \\ qhdtm_x_assum`invariant`mp_tac
     \\ simp[extend_top_env_def,invariant_def]
     \\ fs[Abbr`s2`]
     \\ imp_res_tac evaluatePropsTheory.evaluate_decs_state_unchanged \\ fs[]

--- a/compiler/backend/proofs/source_to_modProofScript.sml
+++ b/compiler/backend/proofs/source_to_modProofScript.sml
@@ -444,8 +444,8 @@ val do_con_check = Q.prove (
   induct_on `es` >>
   srw_tac[][compile_exp_def]);
 
-val char_list_to_v = prove(
-  ``∀ls. v_rel genv (char_list_to_v ls) (char_list_to_v ls)``,
+val char_list_to_v = Q.prove(
+  `∀ls. v_rel genv (char_list_to_v ls) (char_list_to_v ls)`,
   Induct >> simp[semanticPrimitivesTheory.char_list_to_v_def,
                  modSemTheory.char_list_to_v_def,
                  v_rel_eqns])

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -1804,7 +1804,7 @@ val comp_correct = Q.store_thm("comp_correct",
     \\ first_x_assum (qspecl_then[`m'`,`n`,`c`,`regs1`]mp_tac)
     \\ match_mp_tac IMP_IMP \\ conj_tac
     THEN1 (srw_tac[][] \\ imp_res_tac evaluate_consts \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[])
-    \\ strip_tac \\ rator_x_assum`evaluate`mp_tac
+    \\ strip_tac \\ qhdtm_x_assum`evaluate`mp_tac
     \\ drule (GEN_ALL evaluate_add_clock) \\ simp []
     \\ disch_then (qspec_then `ck'`assume_tac) \\ strip_tac
     \\ qexists_tac `ck + ck'` \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]
@@ -1902,7 +1902,7 @@ val comp_correct = Q.store_thm("comp_correct",
     \\ once_rewrite_tac [comp_def] \\ full_simp_tac(srw_ss())[LET_THM]
     \\ strip_tac \\ full_simp_tac(srw_ss())[]
     \\ qexists_tac `ck+ck'`
-    \\ rator_x_assum`evaluate` mp_tac
+    \\ qhdtm_x_assum`evaluate` mp_tac
     \\ drule (GEN_ALL evaluate_add_clock) \\ full_simp_tac(srw_ss())[]
     \\ disch_then (qspec_then `ck'` assume_tac)
     \\ full_simp_tac(srw_ss())[dec_clock_def] \\ strip_tac
@@ -2022,7 +2022,7 @@ val comp_correct = Q.store_thm("comp_correct",
       \\ Cases_on `handler` \\ full_simp_tac(srw_ss())[]
       \\ TRY (PairCases_on `x'` \\ fs[] \\ pairarg_tac \\ full_simp_tac(srw_ss())[])
       \\ full_simp_tac(srw_ss())[evaluate_def,dec_clock_def,set_var_def]
-      \\ rator_x_assum`evaluate`mp_tac
+      \\ qhdtm_x_assum`evaluate`mp_tac
       \\ first_assum (mp_tac o Q.SPEC `ck'` o
              MATCH_MP (REWRITE_RULE [GSYM AND_IMP_INTRO]
              (evaluate_add_clock |> GEN_ALL))) \\ full_simp_tac(srw_ss())[]
@@ -2061,7 +2061,7 @@ val comp_correct = Q.store_thm("comp_correct",
     >- (
       imp_res_tac evaluate_consts \\ full_simp_tac(srw_ss())[]
       \\ rw[] \\ res_tac \\ fs[] \\ NO_TAC) \\ srw_tac[][]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ first_assum (mp_tac o Q.SPEC `ck'` o
              MATCH_MP (REWRITE_RULE [GSYM AND_IMP_INTRO]
              (evaluate_add_clock |> GEN_ALL))) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
@@ -2160,7 +2160,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
         simp[Abbr`e`,comp_def] >>
         strip_tac >>
         Cases_on`t'.ffi.final_event`>>full_simp_tac(srw_ss())[] >- (
-          ntac 2 (rator_x_assum`evaluate`mp_tac) >>
+          ntac 2 (qhdtm_x_assum`evaluate`mp_tac) >>
           drule (GEN_ALL evaluate_add_clock) >>
           disch_then(qspec_then`ck+k`mp_tac) >>
           simp[] >>
@@ -2171,14 +2171,14 @@ val compile_semantics = Q.store_thm("compile_semantics",
           full_simp_tac(srw_ss())[] >>
           Cases_on`t.ffi.final_event`>>full_simp_tac(srw_ss())[] >>
           rev_full_simp_tac(srw_ss())[] ) >>
-        rator_x_assum`evaluate`mp_tac >>
+        qhdtm_x_assum`evaluate`mp_tac >>
         qmatch_assum_abbrev_tac`evaluate (e,ss) = (_,t')` >>
         qspecl_then[`ck+k`,`e`,`ss`]mp_tac(GEN_ALL evaluate_add_clock_io_events_mono)>>
         simp[Abbr`ss`] >>
         ntac 2 strip_tac >> full_simp_tac(srw_ss())[] >>
         Cases_on`t.ffi.final_event`>>full_simp_tac(srw_ss())[] >>
         rev_full_simp_tac(srw_ss())[] ) >>
-      rator_x_assum`evaluate`mp_tac >>
+      qhdtm_x_assum`evaluate`mp_tac >>
       drule (GEN_ALL evaluate_add_clock) >>
       disch_then(qspec_then`k'`mp_tac) >>
       simp[] >> strip_tac >>
@@ -2248,7 +2248,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
       Cases_on`t.ffi.final_event`>>full_simp_tac(srw_ss())[] >>
       rpt strip_tac >> full_simp_tac(srw_ss())[] >>
       spose_not_then strip_assume_tac \\ fs[]) >>
-    rator_x_assum`evaluate`mp_tac >>
+    qhdtm_x_assum`evaluate`mp_tac >>
     drule (GEN_ALL evaluate_add_clock) >>
     disch_then(qspec_then`ck`mp_tac)>>simp[] ) >>
   srw_tac[][] >>
@@ -2294,7 +2294,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     qexists_tac`ck+k`>>simp[] ) >>
   srw_tac[][] >>
   qexists_tac`k`>>simp[] >>
-  ntac 2 (rator_x_assum`evaluate`mp_tac) >>
+  ntac 2 (qhdtm_x_assum`evaluate`mp_tac) >>
   qmatch_assum_abbrev_tac`evaluate (e,ss) = _` >>
   qspecl_then[`ck`,`e`,`ss`]mp_tac(GEN_ALL evaluate_add_clock_io_events_mono)>>
   simp[Abbr`ss`] >>

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -2391,11 +2391,11 @@ val stack_alloc_lab_pres = Q.store_thm("stack_alloc_lab_pres",`
   >>
     res_tac>>fs[]));
 
-val sa_comp_stack_asm_name = prove(``
+val sa_comp_stack_asm_name = Q.prove(`
   ∀n m p.
   stack_asm_name c p ∧ stack_asm_remove (c:'a asm_config) p ⇒
   let (p',m') = comp n m p in
-  stack_asm_name c p' ∧ stack_asm_remove (c:'a asm_config) p'``,
+  stack_asm_name c p' ∧ stack_asm_remove (c:'a asm_config) p'`,
   ho_match_mp_tac comp_ind>>Cases_on`p`>>rw[]>>
   simp[Once comp_def]
   >-
@@ -2411,7 +2411,7 @@ val sa_comp_stack_asm_name = prove(``
     rpt(pairarg_tac>>fs[])>>rw[]>>
     fs[stack_asm_name_def,stack_asm_remove_def])
 
-val sa_compile_stack_asm_convs = store_thm("sa_compile_stack_asm_convs",``
+val sa_compile_stack_asm_convs = Q.store_thm("sa_compile_stack_asm_convs",`
   EVERY (λ(n,p). stack_asm_name c p) prog ∧
   EVERY (λ(n,p). (stack_asm_remove (c:'a asm_config) p)) prog ∧
   (* conf_ok is too strong, but we already have it anyway *)
@@ -2424,7 +2424,7 @@ val sa_compile_stack_asm_convs = store_thm("sa_compile_stack_asm_convs",``
   c.valid_imm (INL Sub) 1w
   ⇒
   EVERY (λ(n,p). stack_asm_name c p) (compile conf prog) ∧
-  EVERY (λ(n,p). stack_asm_remove c p) (compile conf prog)``,
+  EVERY (λ(n,p). stack_asm_remove c p) (compile conf prog)`,
   fs[compile_def]>>rw[]>>
   TRY
     (EVAL_TAC>>fs[reg_name_def,labPropsTheory.good_dimindex_def,asmTheory.offset_ok_def,data_to_wordProofTheory.conf_ok_def,data_to_wordTheory.shift_length_def]>>

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -93,8 +93,8 @@ val get_var_imm_case = Q.prove(
     | Imm w => SOME (Word w)`,
   Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def]);
 
-val prog_comp_lemma = prove(
-  ``prog_comp = \(n,p). (n,FST (comp n (next_lab p) p))``,
+val prog_comp_lemma = Q.prove(
+  `prog_comp = \(n,p). (n,FST (comp n (next_lab p) p))`,
   full_simp_tac(srw_ss())[FUN_EQ_THM,FORALL_PROD,prog_comp_def]);
 
 val lookup_IMP_lookup_compile = Q.prove(
@@ -115,8 +115,8 @@ val word_gc_fun_lemma = word_gc_fun_def
   |> SIMP_RULE std_ss [Once LET_THM]
   |> SIMP_RULE std_ss [Once LET_THM,word_gc_move_roots_def]
 
-val word_gc_fun_thm = prove(
-  ``word_gc_fun conf (roots,m,dm,s) =
+val word_gc_fun_thm = Q.prove(
+  `word_gc_fun conf (roots,m,dm,s) =
       let (w1,i1:'a word,pa1,m1,c1) =
             word_gc_move conf
               (s ' Globals,0w,theWord (s ' OtherHeap),
@@ -138,7 +138,7 @@ val word_gc_fun_thm = prove(
                 (theWord (s ' OtherHeap) +
                  theWord (s ' HeapLength))); (Globals,w1)]
       in
-        if word_gc_fun_assum conf s /\ c2 then SOME (ws2,m1,s1) else NONE``,
+        if word_gc_fun_assum conf s /\ c2 then SOME (ws2,m1,s1) else NONE`,
   full_simp_tac(srw_ss())[word_gc_fun_lemma,LET_THM]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[])
@@ -161,20 +161,20 @@ val word_gc_move_roots_bitmaps_def = Define `
           | NONE => (ARB,ARB,ARB,ARB,F)
           | SOME stack => (stack,i2,pa2,m2,c2)`
 
-val word_gc_move_loop_F = store_thm("word_gc_move_loop_F",
-  ``!k conf pb i pa old m dm i1 pa1 m1 c1.
-      word_gc_move_loop k conf (pb,i,pa,old,m,dm,F) = (i1,pa1,m1,c1) ==> ~c1``,
+val word_gc_move_loop_F = Q.store_thm("word_gc_move_loop_F",
+  `!k conf pb i pa old m dm i1 pa1 m1 c1.
+      word_gc_move_loop k conf (pb,i,pa,old,m,dm,F) = (i1,pa1,m1,c1) ==> ~c1`,
   Induct \\ once_rewrite_tac [word_gc_move_loop_def] \\ fs [] \\ rw []
   \\ pairarg_tac \\ fs []
   \\ IF_CASES_TAC \\ fs []
   \\ pairarg_tac \\ fs []);
 
-val word_gc_move_loop_ok = store_thm("word_gc_move_loop_ok",
-  ``word_gc_move_loop k conf (pb,i,pa,old,m,dm,c) = (i1,pa1,m1,c1) ==> c1 ==> c``,
+val word_gc_move_loop_ok = Q.store_thm("word_gc_move_loop_ok",
+  `word_gc_move_loop k conf (pb,i,pa,old,m,dm,c) = (i1,pa1,m1,c1) ==> c1 ==> c`,
   Cases_on `c` \\ fs [] \\ rw [] \\ imp_res_tac word_gc_move_loop_F \\ fs []);
 
-val gc_thm = prove(
-  ``s.gc_fun = word_gc_fun conf ⇒
+val gc_thm = Q.prove(
+  `s.gc_fun = word_gc_fun conf ⇒
    gc (s:('a,'b)stackSem$state) =
    if LENGTH s.stack < s.stack_space then NONE else
      let unused = TAKE s.stack_space s.stack in
@@ -205,7 +205,7 @@ val gc_thm = prove(
             (Globals,w1)] in
        if word_gc_fun_assum conf s.store /\ c2 then SOME (s with
                        <|stack := unused ++ stack; store := s1;
-                         regs := FEMPTY; memory := m1|>) else NONE``,
+                         regs := FEMPTY; memory := m1|>) else NONE`,
   strip_tac \\ drule gc_lemma
   \\ disch_then (fn th => full_simp_tac(srw_ss())[th])
   \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
@@ -240,12 +240,12 @@ val word_gc_move_bitmaps_def = Define `
           | SOME (hd,ts1,ws') =>
               SOME (hd,ws,i2,pa2,m2,c2)`
 
-val word_gc_move_roots_APPEND = prove(
-  ``!xs ys i1 pa1 m.
+val word_gc_move_roots_APPEND = Q.prove(
+  `!xs ys i1 pa1 m.
       word_gc_move_roots conf (xs++ys,i1,pa1,curr,m,dm) =
         let (ws1,i1,pa1,m1,c1) = word_gc_move_roots conf (xs,i1,pa1,curr,m,dm) in
         let (ws2,i2,pa2,m2,c2) = word_gc_move_roots conf (ys,i1,pa1,curr,m1,dm) in
-          (ws1++ws2,i2,pa2,m2,c1 /\ c2)``,
+          (ws1++ws2,i2,pa2,m2,c1 /\ c2)`,
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def,LET_THM]
   \\ srw_tac[][] \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ fs[]
@@ -255,14 +255,14 @@ val word_gc_move_roots_APPEND = prove(
   \\ rveq \\ fs[]
   \\ EQ_TAC \\ fs[] \\ rw[]);
 
-val map_bitmap_APPEND = prove(
-  ``!x q stack p0 p1.
+val map_bitmap_APPEND = Q.prove(
+  `!x q stack p0 p1.
       filter_bitmap x stack = SOME (p0,p1) /\
       LENGTH q = LENGTH p0 ==>
       map_bitmap x (q ++ q') stack =
       case map_bitmap x q stack of
       | NONE => NONE
-      | SOME (hd,ts,ws) => SOME (hd,ts++q',ws)``,
+      | SOME (hd,ts,ws) => SOME (hd,ts++q',ws)`,
   Induct \\ full_simp_tac(srw_ss())[map_bitmap_def]
   \\ reverse (Cases \\ Cases_on `stack`)
   \\ full_simp_tac(srw_ss())[map_bitmap_def,filter_bitmap_def]
@@ -272,20 +272,20 @@ val map_bitmap_APPEND = prove(
   \\ Cases \\ full_simp_tac(srw_ss())[map_bitmap_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val word_gc_move_roots_IMP_LENGTH = store_thm("word_gc_move_roots_IMP_LENGTH",
-  ``!xs r0 r1 curr r2 dm ys i2 pa2 m2 c conf.
+val word_gc_move_roots_IMP_LENGTH = Q.store_thm("word_gc_move_roots_IMP_LENGTH",
+  `!xs r0 r1 curr r2 dm ys i2 pa2 m2 c conf.
       word_gc_move_roots conf (xs,r0,r1,curr,r2,dm) = (ys,i2,pa2,m2,c) ==>
-      LENGTH ys = LENGTH xs``,
+      LENGTH ys = LENGTH xs`,
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def,LET_THM] \\ srw_tac[][]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[] \\ res_tac);
 
-val filter_bitmap_map_bitmap = store_thm("filter_bitmap_map_bitmap",
-  ``!x t q xs xs1 z ys ys1.
+val filter_bitmap_map_bitmap = Q.store_thm("filter_bitmap_map_bitmap",
+  `!x t q xs xs1 z ys ys1.
       filter_bitmap x t = SOME (xs,xs1) /\
       LENGTH q = LENGTH xs /\
       map_bitmap x q t = SOME (ys,z,ys1) ==>
-      z = [] /\ ys1 = xs1``,
+      z = [] /\ ys1 = xs1`,
   Induct
   THEN1 (Cases_on `q` \\ Cases_on `t`
          \\ full_simp_tac(srw_ss())[filter_bitmap_def,map_bitmap_def])
@@ -310,8 +310,8 @@ val filter_bitmap_map_bitmap = store_thm("filter_bitmap_map_bitmap",
   \\ qexists_tac `t'` \\ full_simp_tac(srw_ss())[]
   \\ qexists_tac `h'::t` \\ full_simp_tac(srw_ss())[]);
 
-val word_gc_move_roots_bitmaps = prove(
-  ``!stack i1 pa1 m stack2 i2 pa2 m2.
+val word_gc_move_roots_bitmaps = Q.prove(
+  `!stack i1 pa1 m stack2 i2 pa2 m2.
       (word_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,curr,m,dm) =
         (stack2,i2,pa2,m2,T)) ==>
       word_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,curr,m,dm) =
@@ -324,7 +324,7 @@ val word_gc_move_roots_bitmaps = prove(
           | SOME (new,stack,i2,pa2,m2,c2) =>
               let (stack,i,pa,m,c3) =
                 word_gc_move_roots_bitmaps conf (stack,bitmaps,i2,pa2,curr,m2,dm) in
-                  (w::new++stack,i,pa,m,c2 /\ c3)``,
+                  (w::new++stack,i,pa,m,c2 /\ c3)`,
   Cases THEN1 (full_simp_tac(srw_ss())[word_gc_move_roots_bitmaps_def,
                  enc_stack_def])
   \\ rpt strip_tac \\ pop_assum mp_tac \\ full_simp_tac(srw_ss())[]
@@ -415,23 +415,23 @@ val get_bits_intro = Q.prove(
     GENLIST (\i. h ' i) (dimindex (:'a) - 1) = get_bits h`,
   full_simp_tac(srw_ss())[get_bits_def,word_msb_IMP_bit_length]);
 
-val filter_bitmap_APPEND = prove(
-  ``!xs stack ys.
+val filter_bitmap_APPEND = Q.prove(
+  `!xs stack ys.
       filter_bitmap (xs ++ ys) stack =
       case filter_bitmap xs stack of
       | NONE => NONE
       | SOME (zs,rs) =>
         case filter_bitmap ys rs of
         | NONE => NONE
-        | SOME (zs2,rs) => SOME (zs ++ zs2,rs)``,
+        | SOME (zs2,rs) => SOME (zs ++ zs2,rs)`,
   Induct \\ Cases_on `stack` \\ full_simp_tac(srw_ss())[filter_bitmap_def]
   THEN1 (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   THEN1 (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   \\ Cases \\ full_simp_tac(srw_ss())[filter_bitmap_def] \\ srw_tac[][]
   \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
 
-val map_bitmap_APPEND_APPEND = prove(
-  ``!vs1 stack x0 x1 ws2 vs2 ws1.
+val map_bitmap_APPEND_APPEND = Q.prove(
+  `!vs1 stack x0 x1 ws2 vs2 ws1.
       filter_bitmap vs1 stack = SOME (x0,x1) /\
       LENGTH x0 = LENGTH ws1 ==>
       map_bitmap (vs1 ++ vs2) (ws1 ++ ws2) stack =
@@ -440,7 +440,7 @@ val map_bitmap_APPEND_APPEND = prove(
       | SOME (ts1,ts2,ts3) =>
         case map_bitmap vs2 ws2 ts3 of
         | NONE => NONE
-        | SOME (us1,us2,us3) => SOME (ts1++us1,ts2++us2,us3)``,
+        | SOME (us1,us2,us3) => SOME (ts1++us1,ts2++us2,us3)`,
   Induct \\ full_simp_tac(srw_ss())[map_bitmap_def] THEN1
    (Cases \\ full_simp_tac(srw_ss())[filter_bitmap_def]
     \\ once_rewrite_tac [EQ_SYM_EQ] \\ full_simp_tac(srw_ss())[LENGTH_NIL]
@@ -458,8 +458,8 @@ val word_gc_move_bitmaps_Loc =
   ``word_gc_move_bitmaps conf (Loc l1 l2,stack,bitmaps,i1,pa1,curr,m,dm)``
   |> SIMP_CONV std_ss [word_gc_move_bitmaps_def,full_read_bitmap_def];
 
-val word_gc_move_bitmaps_unroll = prove(
-  ``word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) = SOME x /\
+val word_gc_move_bitmaps_unroll = Q.prove(
+  `word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) = SOME x /\
     LENGTH bitmaps < dimword (:'a) - 1 /\ good_dimindex (:'a) ==>
     word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) =
     case DROP (w2n (w - 1w:'a word)) bitmaps of
@@ -472,7 +472,7 @@ val word_gc_move_bitmaps_unroll = prove(
             case word_gc_move_bitmaps conf (Word (w+1w),ws,bitmaps,i2,pa2,curr,m2,dm) of
             | NONE => NONE
             | SOME (hd3,ws3,i3,pa3,m3,c3) =>
-                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)``,
+                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)`,
   full_simp_tac(srw_ss())[word_gc_move_bitmaps_def,full_read_bitmap_def]
   \\ Cases_on `w = 0w` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `DROP (w2n (w + -1w)) bitmaps`
@@ -553,8 +553,8 @@ val word_and_one_eq_0_iff = Q.store_thm("word_and_one_eq_0_iff",
   `!w. ((w && 1w) = 0w) <=> ~(w ' 0)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
 
-val word_gc_move_bitmap_unroll = prove(
-  ``word_gc_move_bitmap conf (w,stack,i1,pa1,curr,m,dm) =
+val word_gc_move_bitmap_unroll = Q.prove(
+  `word_gc_move_bitmap conf (w,stack,i1,pa1,curr,m,dm) =
     if w = 0w:'a word then SOME ([],stack,i1,pa1,m,T) else
     if w = 1w then SOME ([],stack,i1,pa1,m,T) else
       case stack of
@@ -568,7 +568,7 @@ val word_gc_move_bitmap_unroll = prove(
           let (x1,i1,pa1,m1,c1) = word_gc_move conf (x,i1,pa1,curr,m,dm) in
           case word_gc_move_bitmap conf (w >>> 1,xs,i1,pa1,curr,m1,dm) of
           | NONE => NONE
-          | SOME (new,stack,i1,pa1,m,c) => SOME (x1::new,stack,i1,pa1,m,c1 /\ c)``,
+          | SOME (new,stack,i1,pa1,m,c) => SOME (x1::new,stack,i1,pa1,m,c1 /\ c)`,
   simp [word_and_one_eq_0_iff]
   \\ simp [Once word_gc_move_bitmap_def,get_bits_def]
   \\ IF_CASES_TAC
@@ -628,8 +628,8 @@ val tac = simp [list_Seq_def,evaluate_def,inst_def,word_exp_def,get_var_def,
        labSemTheory.word_cmp_def,GREATER_EQ,GSYM NOT_LESS,FUPDATE_LIST,
        wordSemTheory.word_sh_def,word_shift_not_0,FLOOKUP_UPDATE]
 
-val memcpy_code_thm = prove(
-  ``!n a b m dm b1 m1 s.
+val memcpy_code_thm = Q.prove(
+  `!n a b m dm b1 m1 s.
       memcpy ((n2w n):'a word) a b m dm = (b1:'a word,m1,T) /\
       n < dimword (:'a) /\
       s.memory = m /\ s.mdomain = dm /\
@@ -643,7 +643,7 @@ val memcpy_code_thm = prove(
                           regs := s.regs |++ [(0,Word 0w);
                                               (1,r1);
                                               (2,Word (a + n2w n * bytes_in_word));
-                                              (3,Word b1)] |>)``,
+                                              (3,Word b1)] |>)`,
   Induct THEN1
    (simp [Once memcpy_def]
     \\ srw_tac[][] \\ full_simp_tac(srw_ss())[memcpy_code_def,evaluate_def,get_var_def,get_var_imm_def]
@@ -678,8 +678,8 @@ val memcpy_code_thm = prove(
   \\ once_rewrite_tac [split_num_forall_to_10] \\ full_simp_tac(srw_ss())[nine_less]
   \\ full_simp_tac(srw_ss())[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB])
 
-val memcpy_code_thm = store_thm("memcpy_code_thm",
-  ``!w a b m dm b1 m1 s.
+val memcpy_code_thm = Q.store_thm("memcpy_code_thm",
+  `!w a b m dm b1 m1 s.
       memcpy (w:'a word) a b m dm = (b1:'a word,m1,T) /\
       s.memory = m /\ s.mdomain = dm /\
       get_var 0 s = SOME (Word w) /\
@@ -692,7 +692,7 @@ val memcpy_code_thm = store_thm("memcpy_code_thm",
                           regs := s.regs |++ [(0,Word 0w);
                                               (1,r1);
                                               (2,Word (a + w * bytes_in_word));
-                                              (3,Word b1)] |>)``,
+                                              (3,Word b1)] |>)`,
   Cases \\ full_simp_tac(srw_ss())[] \\ pop_assum mp_tac \\ qspec_tac (`n`,`n`) \\ full_simp_tac(srw_ss())[PULL_FORALL]
   \\ rpt strip_tac
   \\ match_mp_tac (memcpy_code_thm |> SIMP_RULE (srw_ss()) [])
@@ -717,8 +717,8 @@ val isWord_thm = Q.prove(
   `!w. isWord w = ?v. w = Word v`,
   Cases \\ full_simp_tac(srw_ss())[isWord_def]);
 
-val word_gc_move_code_thm = store_thm("word_gc_move_code_thm",
-  ``word_gc_move conf (w,i,pa,old,m,dm) = (w1,i1,pa1,m1,T) /\
+val word_gc_move_code_thm = Q.store_thm("word_gc_move_code_thm",
+  `word_gc_move conf (w,i,pa,old,m,dm) = (w1,i1,pa1,m1,T) /\
     shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
     2 < dimindex (:'a) /\ conf.len_size <> 0 /\
     (!w:'a word. w << word_shift (:'a) = w * bytes_in_word) /\
@@ -740,7 +740,7 @@ val word_gc_move_code_thm = store_thm("word_gc_move_code_thm",
                                             (3,Word pa1);
                                             (4,Word i1);
                                             (5,w1);
-                                            (6,r6)] |>)``,
+                                            (6,r6)] |>)`,
   reverse (Cases_on `w`) \\ full_simp_tac(srw_ss())[word_gc_move_def] THEN1
    (srw_tac[][word_gc_move_code_def,evaluate_def]
     \\ full_simp_tac(srw_ss())[get_var_def] \\ tac
@@ -803,8 +803,8 @@ val word_gc_move_code_thm = store_thm("word_gc_move_code_thm",
   \\ full_simp_tac(srw_ss())[select_lower_lemma,
         DECIDE ``n<>0 ==> m-(n-1)-1=m-n:num``]);
 
-val word_gc_move_list_code_thm = store_thm("word_gc_move_list_code_thm",
-  ``!l a (s:('a,'b)stackSem$state) pa1 pa old m1 m i1 i dm conf a1.
+val word_gc_move_list_code_thm = Q.store_thm("word_gc_move_list_code_thm",
+  `!l a (s:('a,'b)stackSem$state) pa1 pa old m1 m i1 i dm conf a1.
       word_gc_move_list conf (a:'a word,l,i,pa,old,m,dm) = (a1,i1,pa1,m1,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
       2 < dimindex (:'a) /\ conf.len_size <> 0 /\
@@ -831,7 +831,7 @@ val word_gc_move_list_code_thm = store_thm("word_gc_move_list_code_thm",
                                               (5,r5);
                                               (6,r6);
                                               (7,Word 0w);
-                                              (8,Word a1)] |>)``,
+                                              (8,Word a1)] |>)`,
   Cases \\ Induct_on `n` \\ simp [] THEN1
    (fs [Once word_gc_move_list_def] \\ rw []
     \\ qexists_tac `0`
@@ -888,8 +888,8 @@ val word_gc_move_list_code_thm = store_thm("word_gc_move_list_code_thm",
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less])
 
-val word_gc_move_loop_code_thm = prove(
-  ``!k pb1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'b)stackSem$state).
+val word_gc_move_loop_code_thm = Q.prove(
+  `!k pb1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'b)stackSem$state).
       word_gc_move_loop k conf (pb1,i1,pa1,old1,m1,dm1,c1) = (i2,pa2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
       2 < dimindex (:'a) /\ conf.len_size <> 0 /\
@@ -917,7 +917,7 @@ val word_gc_move_loop_code_thm = prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,Word pa2)] |>)``,
+                                              (8,Word pa2)] |>)`,
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gc_move_loop _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gc_move_loop_def]
@@ -1026,8 +1026,8 @@ val bytes_in_word_word_shift_n2w = Q.store_thm("bytes_in_word_word_shift_n2w",
        (rfs [labPropsTheory.good_dimindex_def,dimword_def] \\ rfs [])
   \\ fs []);
 
-val word_gc_move_bitmap_code_thm = store_thm("word_gc_move_bitmap_code_thm",
-  ``!w stack (s:('a,'b)stackSem$state) i pa curr m dm new stack1 a1 i1 pa1 m1 old.
+val word_gc_move_bitmap_code_thm = Q.store_thm("word_gc_move_bitmap_code_thm",
+  `!w stack (s:('a,'b)stackSem$state) i pa curr m dm new stack1 a1 i1 pa1 m1 old.
       word_gc_move_bitmap conf (w,stack,i,pa,curr,m,dm) =
         SOME (new,stack1,i1,pa1,m1,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -1059,7 +1059,7 @@ val word_gc_move_bitmap_code_thm = store_thm("word_gc_move_bitmap_code_thm",
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                      (8,Word (bytes_in_word * n2w (LENGTH (old ++ new))))] |>)``,
+                      (8,Word (bytes_in_word * n2w (LENGTH (old ++ new))))] |>)`,
   recInduct bit_length_ind \\ rpt strip_tac \\ fs []
   \\ qpat_x_assum `word_gc_move_bitmap _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gc_move_bitmap_unroll]
@@ -1165,34 +1165,34 @@ val word_msb_IFF_lsr_EQ_0 = Q.store_thm("word_msb_IFF_lsr_EQ_0",
   `word_msb h <=> (h >>> (dimindex (:'a) - 1) <> 0w:'a word)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [])
 
-val map_bitmap_IMP_LENGTH = store_thm("map_bitmap_IMP_LENGTH",
-  ``!x wl stack xs ys.
+val map_bitmap_IMP_LENGTH = Q.store_thm("map_bitmap_IMP_LENGTH",
+  `!x wl stack xs ys.
       map_bitmap x wl stack = SOME (xs,ys) ==>
-      LENGTH xs = LENGTH x``,
+      LENGTH xs = LENGTH x`,
   recInduct map_bitmap_ind \\ fs [map_bitmap_def]
   \\ rw [] \\ res_tac \\ fs []
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs []);
 
-val filter_bitmap_IMP_LENGTH = store_thm("filter_bitmap_IMP_LENGTH",
-  ``!x stack q r.
+val filter_bitmap_IMP_LENGTH = Q.store_thm("filter_bitmap_IMP_LENGTH",
+  `!x stack q r.
       filter_bitmap x stack = SOME (q,r) ==>
-      LENGTH stack = LENGTH x + LENGTH r``,
+      LENGTH stack = LENGTH x + LENGTH r`,
   recInduct filter_bitmap_ind \\ fs [filter_bitmap_def]
   \\ rw [] \\ res_tac \\ fs []
   \\ every_case_tac \\ fs []);
 
-val word_gc_move_bitmaps_LENGTH = store_thm("word_gc_move_bitmaps_LENGTH",
-  ``word_gc_move_bitmaps conf (w,stack,bitmaps,i,pa,curr,m,dm) =
+val word_gc_move_bitmaps_LENGTH = Q.store_thm("word_gc_move_bitmaps_LENGTH",
+  `word_gc_move_bitmaps conf (w,stack,bitmaps,i,pa,curr,m,dm) =
        SOME (xs,stack1,i1,pa1,m1,T) ==>
-    LENGTH stack = LENGTH xs + LENGTH stack1``,
+    LENGTH stack = LENGTH xs + LENGTH stack1`,
   fs [word_gc_move_bitmaps_def]
   \\ every_case_tac \\ fs [] \\ pairarg_tac \\ fs []
   \\ every_case_tac \\ fs [] \\ rw []
   \\ imp_res_tac map_bitmap_IMP_LENGTH \\ fs []
   \\ imp_res_tac filter_bitmap_IMP_LENGTH \\ fs []);
 
-val word_gc_move_bitmaps_code_thm = store_thm("word_gc_move_bitmap_code_thm",
-  ``!w bitmaps z stack (s:('a,'b)stackSem$state) i pa curr m dm new
+val word_gc_move_bitmaps_code_thm = Q.store_thm("word_gc_move_bitmap_code_thm",
+  `!w bitmaps z stack (s:('a,'b)stackSem$state) i pa curr m dm new
          stack1 a1 i1 pa1 m1 old.
       word_gc_move_bitmaps conf (Word w,stack,bitmaps,i,pa,curr,m,dm) =
         SOME (new,stack1,i1,pa1,m1,T) /\
@@ -1229,7 +1229,7 @@ val word_gc_move_bitmaps_code_thm = store_thm("word_gc_move_bitmap_code_thm",
                                               (6,r6);
                                               (7,r7);
                       (8,Word (bytes_in_word * n2w (LENGTH (old ++ new))));
-                                              (9,r9)] |>)``,
+                                              (9,r9)] |>)`,
   ntac 2 strip_tac \\ completeInduct_on `LENGTH bitmaps - w2n (w - 1w)`
   \\ rpt strip_tac \\ fs [] \\ rpt var_eq_tac \\ fs [PULL_FORALL]
   \\ qpat_x_assum `word_gc_move_bitmaps _ _ = _`
@@ -1310,8 +1310,8 @@ val EL_LENGTH_ADD_LEMMA = Q.prove(
   fs [EL_LENGTH_APPEND]);
 
 val word_gc_move_roots_bitmaps_code_thm =
-        store_thm("word_gc_move_roots_bitmaps_code_thm",
-  ``!bitmaps (s:('a,'b)stackSem$state) i pa curr m dm new
+        Q.store_thm("word_gc_move_roots_bitmaps_code_thm",
+  `!bitmaps (s:('a,'b)stackSem$state) i pa curr m dm new
          stack1 a1 i1 pa1 m1 old.
       word_gc_move_roots_bitmaps conf (stack,bitmaps,i,pa,curr,m,dm) =
         (stack1,i1,pa1,m1,T) /\
@@ -1349,7 +1349,7 @@ val word_gc_move_roots_bitmaps_code_thm =
                                               (6,r6);
                                               (7,r7);
                                               (8,r8);
-                                              (9,Word 0w)] |>)``,
+                                              (9,Word 0w)] |>)`,
   completeInduct_on `LENGTH stack`
   \\ rpt strip_tac \\ fs [PULL_FORALL]
   \\ rpt var_eq_tac \\ fs []
@@ -1449,8 +1449,8 @@ fun abbrev_under_exists tm tac =
   (fn state => (`?^(tm). ^(hd (fst (hd (fst (tac state)))))` by
         (fs [markerTheory.Abbrev_def] \\ NO_TAC)) state)
 
-val alloc_correct_lemma = store_thm("alloc_correct_lemma",
-  ``alloc w (s:('a,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
+val alloc_correct_lemma = Q.store_thm("alloc_correct_lemma",
+  `alloc w (s:('a,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
     s.gc_fun = word_gc_fun conf /\
     LENGTH s.bitmaps < dimword (:'a) - 1 /\
     LENGTH s.stack * (dimindex (:'a) DIV 8) < dimword (:'a) /\
@@ -1470,7 +1470,7 @@ val alloc_correct_lemma = store_thm("alloc_correct_lemma",
               regs := l2; gc_fun := anything |>) /\
        (r <> NONE ==> r = SOME (Halt (Word 1w))) /\
        t.regs SUBMAP l2 /\
-       (r = NONE ==> FLOOKUP l2 0 = SOME ret)``,
+       (r = NONE ==> FLOOKUP l2 0 = SOME ret)`,
   Cases_on `s.gc_fun = word_gc_fun conf` \\ fs [] \\ fs [alloc_def]
   \\ `(set_store AllocSize (Word w) s).gc_fun = word_gc_fun conf` by
         (fs [set_store_def] \\ NO_TAC)
@@ -1575,8 +1575,8 @@ val alloc_correct_lemma = store_thm("alloc_correct_lemma",
   \\ rw [] \\ fs [FAPPLY_FUPDATE_THM]
   \\ fs [SUBMAP_DEF] \\ rw [] \\ fs [] \\ eq_tac \\ strip_tac \\ fs [])
 
-val alloc_correct = prove(
-  ``alloc w (s:('a,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
+val alloc_correct = Q.prove(
+  `alloc w (s:('a,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
     s.gc_fun = word_gc_fun c /\
     LENGTH s.bitmaps < dimword (:'a) - 1 /\
     LENGTH s.stack * (dimindex (:'a) DIV 8) < dimword (:'a) /\
@@ -1592,7 +1592,7 @@ val alloc_correct = prove(
           t with
            <| use_store := T; use_stack := T; use_alloc := F;
               use_alloc := F; code := fromAList (compile c (toAList s.code));
-              regs := l2; gc_fun := anything|>) /\ t.regs SUBMAP l2``,
+              regs := l2; gc_fun := anything|>) /\ t.regs SUBMAP l2`,
   `find_code (INL gc_stub_location) (l \\ 0) (fromAList (compile c (toAList s.code))) =
       SOME (Seq (word_gc_code c) (Return 0 0))` by
      simp[find_code_def,lookup_fromAList,compile_def,ALOOKUP_APPEND,stubs_def]
@@ -1640,10 +1640,10 @@ val get_labels_comp = Q.store_thm("get_labels_comp",
   \\ TRY pairarg_tac \\ fs [get_labels_def,SUBSET_DEF]
   \\ rw [] \\ fs []);
 
-val loc_check_compile = store_thm("loc_check_compile",
-  ``loc_check s.code (l1,l2) /\
+val loc_check_compile = Q.store_thm("loc_check_compile",
+  `loc_check s.code (l1,l2) /\
     (!k prog. lookup k s.code = SOME prog ==> k ≠ gc_stub_location) ==>
-    loc_check (fromAList (compile c (toAList s.code))) (l1,l2)``,
+    loc_check (fromAList (compile c (toAList s.code))) (l1,l2)`,
   fs [loc_check_def,domain_lookup] \\ rw [] \\ fs []
   \\ fs [compile_def,lookup_fromAList,ALOOKUP_def,stubs_def]
   THEN1
@@ -2343,7 +2343,7 @@ val extract_labels_next_lab = Q.store_thm("extract_labels_next_lab",`
   fs[extract_labels_def]>>
   BasicProvers.EVERY_CASE_TAC>>fs[MAX_DEF]);
 
-val stack_alloc_lab_pres = store_thm("stack_alloc_lab_pres",``
+val stack_alloc_lab_pres = Q.store_thm("stack_alloc_lab_pres",`
   ∀n nl p.
   EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) (extract_labels p) ∧
   ALL_DISTINCT (extract_labels p) ∧
@@ -2352,7 +2352,7 @@ val stack_alloc_lab_pres = store_thm("stack_alloc_lab_pres",``
   EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) (extract_labels cp) ∧
   ALL_DISTINCT (extract_labels cp) ∧
   (∀lab. MEM lab (extract_labels cp) ⇒ MEM lab (extract_labels p) ∨ (nl ≤ SND lab ∧ SND lab < nl')) ∧
-  nl ≤ nl'``,
+  nl ≤ nl'`,
   HO_MATCH_MP_TAC comp_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [comp_def]>>fs[extract_labels_def]
   >-

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -20,19 +20,19 @@ val SUBMAP_DRESTRICT = Q.store_thm("SUBMAP_DRESTRICT",
    DRESTRICT f1 s1 ⊑ DRESTRICT f2 s2`,
   rw[SUBMAP_DEF,FDOM_DRESTRICT,SUBSET_DEF,DRESTRICT_DEF]);
 
-val DROP_IMP_LESS_LENGTH = prove(
-  ``!xs n y ys. DROP n xs = y::ys ==> n < LENGTH xs``,
+val DROP_IMP_LESS_LENGTH = Q.prove(
+  `!xs n y ys. DROP n xs = y::ys ==> n < LENGTH xs`,
   Induct \\ full_simp_tac(srw_ss())[DROP_def] \\ srw_tac[][]
   \\ res_tac \\ decide_tac);
 
-val DROP_EQ_CONS_IMP_DROP_SUC = prove(
-  ``!xs n y ys. DROP n xs = y::ys ==> DROP (SUC n) xs = ys``,
+val DROP_EQ_CONS_IMP_DROP_SUC = Q.prove(
+  `!xs n y ys. DROP n xs = y::ys ==> DROP (SUC n) xs = ys`,
   Induct \\ full_simp_tac(srw_ss())[DROP_def] \\ srw_tac[][]
   \\ res_tac \\ full_simp_tac(srw_ss())[ADD1]
   \\ `n - 1 + 1 = n` by decide_tac \\ full_simp_tac(srw_ss())[]);
 
-val DROP_IMP_EL = store_thm("DROP_IMP_EL",
-  ``!xs n h t. DROP n xs = h::t ==> (EL n xs = h)``,
+val DROP_IMP_EL = Q.store_thm("DROP_IMP_EL",
+  `!xs n h t. DROP n xs = h::t ==> (EL n xs = h)`,
   Induct \\ fs [DROP_def] \\ Cases_on `n` \\ fs []);
 
 (* -- *)
@@ -86,21 +86,21 @@ val good_syntax_def = Define `
      (case x2 of SOME (y,_,_) => good_syntax y | NONE => T)) /\
   (good_syntax _ <=> T)`
 
-val get_var_imm_case = prove(
-  ``get_var_imm ri s =
+val get_var_imm_case = Q.prove(
+  `get_var_imm ri s =
     case ri of
     | Reg n => get_var n s
-    | Imm w => SOME (Word w)``,
+    | Imm w => SOME (Word w)`,
   Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def]);
 
 val prog_comp_lemma = prove(
   ``prog_comp = \(n,p). (n,FST (comp n (next_lab p) p))``,
   full_simp_tac(srw_ss())[FUN_EQ_THM,FORALL_PROD,prog_comp_def]);
 
-val lookup_IMP_lookup_compile = prove(
-  ``lookup dest s.code = SOME x /\ dest ≠ gc_stub_location ==>
+val lookup_IMP_lookup_compile = Q.prove(
+  `lookup dest s.code = SOME x /\ dest ≠ gc_stub_location ==>
     ?m1 n1. lookup dest (fromAList (compile c (toAList s.code))) =
-            SOME (FST (comp m1 n1 x))``,
+            SOME (FST (comp m1 n1 x))`,
   full_simp_tac(srw_ss())[lookup_fromAList,compile_def] \\ srw_tac[][ALOOKUP_APPEND]
   \\ `ALOOKUP (stubs c) dest = NONE` by
     (full_simp_tac(srw_ss())[stubs_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ decide_tac) \\ full_simp_tac(srw_ss())[]
@@ -372,8 +372,8 @@ val word_gc_move_bitmap_def = Define `
            | NONE => NONE
            | SOME (hd,v2) => SOME (hd,ws,i2,pa2,m2,c2)`
 
-val bit_length_thm = store_thm("bit_length_thm",
-  ``!w. ((w >>> bit_length w) = 0w) /\ !n. n < bit_length w ==> (w >>> n) <> 0w``,
+val bit_length_thm = Q.store_thm("bit_length_thm",
+  `!w. ((w >>> bit_length w) = 0w) /\ !n. n < bit_length w ==> (w >>> n) <> 0w`,
   HO_MATCH_MP_TAC bit_length_ind \\ srw_tac[][]
   \\ once_rewrite_tac [bit_length_def]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]
@@ -383,18 +383,18 @@ val bit_length_thm = store_thm("bit_length_thm",
   \\ once_rewrite_tac [bit_length_def]
   \\ full_simp_tac(srw_ss())[ADD1] \\ srw_tac[][]);
 
-val word_lsr_dimindex = prove(
-  ``(w:'a word) >>> dimindex (:'a) = 0w``,
+val word_lsr_dimindex = Q.prove(
+  `(w:'a word) >>> dimindex (:'a) = 0w`,
   full_simp_tac(srw_ss())[]);
 
-val bit_length_LESS_EQ_dimindex = store_thm("bit_length_LESS_EQ_dimindex",
-  ``bit_length (w:'a word) <= dimindex (:'a)``,
+val bit_length_LESS_EQ_dimindex = Q.store_thm("bit_length_LESS_EQ_dimindex",
+  `bit_length (w:'a word) <= dimindex (:'a)`,
   CCONTR_TAC \\ full_simp_tac(srw_ss())[GSYM NOT_LESS]
   \\ imp_res_tac bit_length_thm
   \\ full_simp_tac(srw_ss())[word_lsr_dimindex]);
 
-val shift_to_zero_word_msb = store_thm("shift_to_zero_word_msb",
-  ``(w:'a word) >>> n = 0w /\ word_msb w ==> dimindex (:'a) <= n``,
+val shift_to_zero_word_msb = Q.store_thm("shift_to_zero_word_msb",
+  `(w:'a word) >>> n = 0w /\ word_msb w ==> dimindex (:'a) <= n`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ CCONTR_TAC
   \\ qpat_x_assum `!xx.bb` mp_tac
@@ -402,17 +402,17 @@ val shift_to_zero_word_msb = store_thm("shift_to_zero_word_msb",
   \\ qexists_tac `dimindex (:α) - 1 - n`
   \\ simp [])
 
-val word_msb_IMP_bit_length = prove(
-  ``!h. word_msb (h:'a word) ==> (bit_length h = dimindex (:'a))``,
+val word_msb_IMP_bit_length = Q.prove(
+  `!h. word_msb (h:'a word) ==> (bit_length h = dimindex (:'a))`,
   srw_tac[][] \\ imp_res_tac shift_to_zero_word_msb \\ CCONTR_TAC
   \\ imp_res_tac (DECIDE ``n<>m ==> n < m \/ m < n:num``)
   \\ qspec_then `h` mp_tac bit_length_thm
   \\ strip_tac \\ res_tac \\ full_simp_tac(srw_ss())[word_lsr_dimindex]
   \\ decide_tac);
 
-val get_bits_intro = prove(
-  ``word_msb (h:'a word) ==>
-    GENLIST (\i. h ' i) (dimindex (:'a) - 1) = get_bits h``,
+val get_bits_intro = Q.prove(
+  `word_msb (h:'a word) ==>
+    GENLIST (\i. h ' i) (dimindex (:'a) - 1) = get_bits h`,
   full_simp_tac(srw_ss())[get_bits_def,word_msb_IMP_bit_length]);
 
 val filter_bitmap_APPEND = prove(
@@ -533,12 +533,12 @@ val word_gc_move_bitmaps_unroll = prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]);
 
-val bit_length_minus_1 = store_thm("bit_length_minus_1",
-  ``w <> 0w ==> bit_length w − 1 = bit_length (w >>> 1)``,
+val bit_length_minus_1 = Q.store_thm("bit_length_minus_1",
+  `w <> 0w ==> bit_length w − 1 = bit_length (w >>> 1)`,
   simp [Once bit_length_def]);
 
-val bit_length_eq_1 = store_thm("bit_length_eq_1",
-  ``bit_length w = 1 <=> w = 1w``,
+val bit_length_eq_1 = Q.store_thm("bit_length_eq_1",
+  `bit_length w = 1 <=> w = 1w`,
   Cases_on `w = 1w` \\ full_simp_tac(srw_ss())[] THEN1 (EVAL_TAC \\ full_simp_tac(srw_ss())[])
   \\ once_rewrite_tac [bit_length_def] \\ srw_tac[][]
   \\ once_rewrite_tac [bit_length_def] \\ srw_tac[][]
@@ -549,8 +549,8 @@ val bit_length_eq_1 = store_thm("bit_length_eq_1",
   \\ Cases_on `n'` \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[DIV_EQ_X] \\ decide_tac);
 
-val word_and_one_eq_0_iff = store_thm("word_and_one_eq_0_iff",
-  ``!w. ((w && 1w) = 0w) <=> ~(w ' 0)``,
+val word_and_one_eq_0_iff = Q.store_thm("word_and_one_eq_0_iff",
+  `!w. ((w && 1w) = 0w) <=> ~(w ' 0)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
 
 val word_gc_move_bitmap_unroll = prove(
@@ -603,9 +603,9 @@ val word_gc_move_bitmap_unroll = prove(
   \\ full_simp_tac(srw_ss())[map_bitmap_def]
   \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
 
-val split_num_forall_to_10 = prove(
-  ``($! P) <=> P 0 /\ P 1 /\ P 2 /\ P 3 /\ P 4 /\ P 5 /\
-               P 6 /\ P 7 /\ P 8 /\ P 9 /\ !x. 9 < x ==> P (x:num)``,
+val split_num_forall_to_10 = Q.prove(
+  `($! P) <=> P 0 /\ P 1 /\ P 2 /\ P 3 /\ P 4 /\ P 5 /\
+               P 6 /\ P 7 /\ P 8 /\ P 9 /\ !x. 9 < x ==> P (x:num)`,
   full_simp_tac(srw_ss())[GSYM (RAND_CONV ETA_CONV ``!x. P x``)]
   \\ eq_tac \\ srw_tac[][]
   \\ Cases_on `x` \\ full_simp_tac(srw_ss())[]
@@ -617,8 +617,8 @@ val nine_less = DECIDE
   ``9 < n ==> n <> 0 /\ n <> 1 /\ n <> 2 /\ n <> 3 /\ n <> 4 /\
               n <> 5 /\ n <> 6 /\ n <> 7 /\ n <> 8 /\ n <> 9n``
 
-val word_shift_not_0 = store_thm("word_shift_not_0",
-  ``word_shift (:'a) <> 0``,
+val word_shift_not_0 = Q.store_thm("word_shift_not_0",
+  `word_shift (:'a) <> 0`,
   srw_tac[][stackLangTheory.word_shift_def] \\ full_simp_tac(srw_ss())[]);
 
 val tac = simp [list_Seq_def,evaluate_def,inst_def,word_exp_def,get_var_def,
@@ -698,23 +698,23 @@ val memcpy_code_thm = store_thm("memcpy_code_thm",
   \\ match_mp_tac (memcpy_code_thm |> SIMP_RULE (srw_ss()) [])
   \\ metis_tac [])
 
-val select_lower_lemma = store_thm("select_lower_lemma",
-  ``(n -- 0) w = ((w:'a word) << (dimindex(:'a)-n-1)) >>> (dimindex(:'a)-n-1)``,
+val select_lower_lemma = Q.store_thm("select_lower_lemma",
+  `(n -- 0) w = ((w:'a word) << (dimindex(:'a)-n-1)) >>> (dimindex(:'a)-n-1)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [wordsTheory.word_index]
   \\ Cases_on `i + (dimindex (:α) - n - 1) < dimindex (:α)`
   \\ fs []
   )
 
-val select_eq_select_0 = store_thm("select_eq_select_0",
-  ``k <= n ==> (n -- k) w = (n - k -- 0) (w >>> k)``,
+val select_eq_select_0 = Q.store_thm("select_eq_select_0",
+  `k <= n ==> (n -- k) w = (n - k -- 0) (w >>> k)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [] \\ eq_tac \\ rw [])
 
-val is_fwd_ptr_iff = prove(
-  ``!w. is_fwd_ptr w <=> ?v. w = Word v /\ (v && 3w) = 0w``,
+val is_fwd_ptr_iff = Q.prove(
+  `!w. is_fwd_ptr w <=> ?v. w = Word v /\ (v && 3w) = 0w`,
   Cases \\ full_simp_tac(srw_ss())[is_fwd_ptr_def]);
 
-val isWord_thm = prove(
-  ``!w. isWord w = ?v. w = Word v``,
+val isWord_thm = Q.prove(
+  `!w. isWord w = ?v. w = Word v`,
   Cases \\ full_simp_tac(srw_ss())[isWord_def]);
 
 val word_gc_move_code_thm = store_thm("word_gc_move_code_thm",
@@ -1002,24 +1002,24 @@ val word_gc_move_loop_code_thm = prove(
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less]);
 
-val lower_2w_eq = prove(
-  ``!w:'a word. good_dimindex (:'a) ==> (w <+ 2w <=> w = 0w \/ w = 1w)``,
+val lower_2w_eq = Q.prove(
+  `!w:'a word. good_dimindex (:'a) ==> (w <+ 2w <=> w = 0w \/ w = 1w)`,
   Cases \\ fs [labPropsTheory.good_dimindex_def,WORD_LO,dimword_def]
   \\ rw [] \\ rw []);
 
-val EL_LENGTH_ADD_LEMMA = prove(
-  ``EL (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) = x``,
+val EL_LENGTH_ADD_LEMMA = Q.prove(
+  `EL (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) = x`,
   mp_tac (EL_LENGTH_APPEND |> Q.SPECL [`[x] ++ st1`,`init++old`])
   \\ fs []);
 
-val LUPDATE_LENGTH_ADD_LEMMA = prove(
-  ``LUPDATE w (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) =
-       init ++ old ++ [w] ++ st1``,
+val LUPDATE_LENGTH_ADD_LEMMA = Q.prove(
+  `LUPDATE w (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) =
+       init ++ old ++ [w] ++ st1`,
   mp_tac (LUPDATE_LENGTH |> Q.SPECL [`init++old`]) \\ fs []);
 
-val bytes_in_word_word_shift_n2w = store_thm("bytes_in_word_word_shift_n2w",
-  ``good_dimindex (:α) ∧ (dimindex(:'a) DIV 8) * n < dimword (:α) ⇒
-    (bytes_in_word * n2w n) ⋙ word_shift (:α) = (n2w n):'a word``,
+val bytes_in_word_word_shift_n2w = Q.store_thm("bytes_in_word_word_shift_n2w",
+  `good_dimindex (:α) ∧ (dimindex(:'a) DIV 8) * n < dimword (:α) ⇒
+    (bytes_in_word * n2w n) ⋙ word_shift (:α) = (n2w n):'a word`,
   strip_tac \\ match_mp_tac bytes_in_word_word_shift
   \\ fs [bytes_in_word_def]
   \\ `(dimindex (:α) DIV 8) < dimword (:α) /\ n < dimword (:α)` by
@@ -1161,8 +1161,8 @@ val word_gc_move_bitmap_code_thm = store_thm("word_gc_move_bitmap_code_thm",
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less] \\ fs [])
 
-val word_msb_IFF_lsr_EQ_0 = store_thm("word_msb_IFF_lsr_EQ_0",
-  ``word_msb h <=> (h >>> (dimindex (:'a) - 1) <> 0w:'a word)``,
+val word_msb_IFF_lsr_EQ_0 = Q.store_thm("word_msb_IFF_lsr_EQ_0",
+  `word_msb h <=> (h >>> (dimindex (:'a) - 1) <> 0w:'a word)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [])
 
 val map_bitmap_IMP_LENGTH = store_thm("map_bitmap_IMP_LENGTH",
@@ -1305,8 +1305,8 @@ val word_gc_move_bitmaps_code_thm = store_thm("word_gc_move_bitmap_code_thm",
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less] \\ fs [])
 
-val EL_LENGTH_ADD_LEMMA = prove(
-  ``!n xs y ys. LENGTH xs = n ==> EL n (xs ++ y::ys) = y``,
+val EL_LENGTH_ADD_LEMMA = Q.prove(
+  `!n xs y ys. LENGTH xs = n ==> EL n (xs ++ y::ys) = y`,
   fs [EL_LENGTH_APPEND]);
 
 val word_gc_move_roots_bitmaps_code_thm =
@@ -1603,10 +1603,10 @@ val alloc_correct = prove(
   \\ qexists_tac `ck+1` \\ fs []
   \\ Cases_on `r` \\ fs [state_component_equality]);
 
-val find_code_IMP_lookup = prove(
-  ``find_code dest regs (s:'a num_map) = SOME x ==>
+val find_code_IMP_lookup = Q.prove(
+  `find_code dest regs (s:'a num_map) = SOME x ==>
     ?k. lookup k s = SOME x /\
-        (find_code dest regs = ((lookup k):'a num_map -> 'a option))``,
+        (find_code dest regs = ((lookup k):'a num_map -> 'a option))`,
   Cases_on `dest` \\ full_simp_tac(srw_ss())[find_code_def,FUN_EQ_THM]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ metis_tac []);
 
@@ -1630,8 +1630,8 @@ val find_code_regs_SUBMAP = Q.store_thm("find_code_regs_SUBMAP",
   \\ every_case_tac \\ fs[] \\ res_tac \\ fs[]
   \\ rw[] );
 
-val get_labels_comp = store_thm("get_labels_comp",
-  ``!n p e. get_labels e SUBSET get_labels (FST (comp n p e))``,
+val get_labels_comp = Q.store_thm("get_labels_comp",
+  `!n p e. get_labels e SUBSET get_labels (FST (comp n p e))`,
   recInduct comp_ind \\ rw []
   \\ Cases_on `p` \\ fs []
   \\ once_rewrite_tac [comp_def] \\ fs []
@@ -2334,10 +2334,10 @@ val make_init_semantics = Q.store_thm("make_init_semantics",
   \\ simp[prog_comp_lambda,ALOOKUP_MAP_gen]
   \\ simp[ALOOKUP_toAList,lookup_fromAList]);
 
-val extract_labels_next_lab = store_thm("extract_labels_next_lab",``
+val extract_labels_next_lab = Q.store_thm("extract_labels_next_lab",`
   ∀p e.
   MEM e (extract_labels p) ⇒
-  SND e < next_lab p``,
+  SND e < next_lab p`,
   ho_match_mp_tac next_lab_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [next_lab_def]>>fs[extract_labels_def]>>
   fs[extract_labels_def]>>

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -42,9 +42,9 @@ val mem_store_rename_state = Q.store_thm("mem_store_rename_state[simp]",
   `mem_store x y (rename_state f s) = OPTION_MAP (rename_state f) (mem_store x y s)`,
   EVAL_TAC >> rw[] >> EVAL_TAC);
 
-val get_var_find_name = store_thm("get_var_find_name[simp]",
-  ``BIJ (find_name f) UNIV UNIV ==>
-    get_var (find_name f v) (rename_state f s) = get_var v s``,
+val get_var_find_name = Q.store_thm("get_var_find_name[simp]",
+  `BIJ (find_name f) UNIV UNIV ==>
+    get_var (find_name f v) (rename_state f s) = get_var v s`,
   fs [get_var_def,rename_state_def,FLOOKUP_DEF,MAP_KEYS_def]
   \\ rpt strip_tac \\ imp_res_tac BIJ_IMP_11 \\ fs []
   \\ rw [] \\ fs [] \\ once_rewrite_tac [EQ_SYM_EQ]
@@ -138,13 +138,13 @@ val domain_rename_state_code = Q.store_thm("domain_rename_state_code[simp]",
   `domain (rename_state f s).code = domain s.code`,
   rw[rename_state_def,domain_fromAList,toAList_domain,EXTENSION]);
 
-val comp_STOP_While = prove(
-  ``comp f (STOP (While cmp r1 ri c1)) =
-    STOP (While cmp (find_name f r1) (ri_find_name f ri) (comp f c1))``,
+val comp_STOP_While = Q.prove(
+  `comp f (STOP (While cmp r1 ri c1)) =
+    STOP (While cmp (find_name f r1) (ri_find_name f ri) (comp f c1))`,
   simp [Once comp_def] \\ fs [STOP_def]);
 
-val get_labels_comp = prove(
-  ``!f p. get_labels (comp f p) = get_labels p``,
+val get_labels_comp = Q.prove(
+  `!f p. get_labels (comp f p) = get_labels p`,
   HO_MATCH_MP_TAC stack_namesTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [comp_def] \\ fs [get_labels_def]
   \\ every_case_tac \\ fs []);
@@ -316,10 +316,10 @@ val comp_correct = Q.prove(
     simp[Once comp_def] >> fs[evaluate_def] >>
     simp[Once rename_state_def] >> rveq >> simp[] ));
 
-val compile_semantics = store_thm("compile_semantics",
-  ``BIJ (find_name f) UNIV UNIV /\
+val compile_semantics = Q.store_thm("compile_semantics",
+  `BIJ (find_name f) UNIV UNIV /\
     ~s.use_alloc /\ ~s.use_store /\ ~s.use_stack ==>
-    semantics start (rename_state f s) = semantics start s``,
+    semantics start (rename_state f s) = semantics start s`,
   simp[GSYM AND_IMP_INTRO] >> ntac 4 strip_tac >>
   simp[semantics_def] >>
   simp[
@@ -333,11 +333,11 @@ val compile_semantics = store_thm("compile_semantics",
   simp[rename_state_def] >>
   srw_tac[QUANT_INST_ss[pair_default_qp]][]);
 
-val compile_semantics_alt = prove(
-  ``!s t.
+val compile_semantics_alt = Q.prove(
+  `!s t.
       BIJ (find_name f) UNIV UNIV /\ (rename_state f s = t) /\
       ~s.use_alloc /\ ~s.use_store /\ ~s.use_stack ==>
-      semantics start t = semantics start s``,
+      semantics start t = semantics start s`,
   fs [compile_semantics]);
 
 val make_init_def = Define `
@@ -361,9 +361,9 @@ val make_init_semantics = Q.store_thm("make_init_semantics",
   \\ fs [spt_eq_thm,wf_fromAList,lookup_fromAList,compile_def]
   \\ rw[prog_comp_eta,ALOOKUP_MAP_gen,ALOOKUP_toAList,lookup_fromAList]);
 
-val stack_names_lab_pres = store_thm("stack_names_lab_pres",``
+val stack_names_lab_pres = Q.store_thm("stack_names_lab_pres",`
   ∀f p.
-  extract_labels p = extract_labels (comp f p)``,
+  extract_labels p = extract_labels (comp f p)`,
   HO_MATCH_MP_TAC comp_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [comp_def]>>fs[extract_labels_def]>>
   BasicProvers.EVERY_CASE_TAC>>fs[])

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -149,9 +149,9 @@ val get_labels_comp = Q.prove(
   \\ Cases_on `p` \\ once_rewrite_tac [comp_def] \\ fs [get_labels_def]
   \\ every_case_tac \\ fs []);
 
-val loc_check_rename_state = prove(
-  ``loc_check (rename_state f s).code (l1,l2) =
-    loc_check s.code (l1,l2)``,
+val loc_check_rename_state = Q.prove(
+  `loc_check (rename_state f s).code (l1,l2) =
+    loc_check s.code (l1,l2)`,
   fs [loc_check_def,rename_state_def,lookup_fromAList,compile_def,prog_comp_def]
   \\ simp[lookup_fromAList,compile_def,prog_comp_eta,ALOOKUP_MAP,ALOOKUP_toAList]
   \\ fs [PULL_EXISTS,get_labels_comp]);

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -368,25 +368,25 @@ val stack_names_lab_pres = Q.store_thm("stack_names_lab_pres",`
   once_rewrite_tac [comp_def]>>fs[extract_labels_def]>>
   BasicProvers.EVERY_CASE_TAC>>fs[])
 
-val names_ok_imp = prove(``
+val names_ok_imp = Q.prove(`
   names_ok f c.reg_count c.avoid_regs ⇒
   ∀n. reg_name n c ⇒
-  reg_ok (find_name f n) c``,
+  reg_ok (find_name f n) c`,
   fs[names_ok_def,EVERY_GENLIST,reg_name_def,asmTheory.reg_ok_def])
 
-val names_ok_imp2 = prove(``
+val names_ok_imp2 = Q.prove(`
   names_ok f c.reg_count c.avoid_regs ∧
   n ≠ n' ∧
   reg_name n c ∧ reg_name n' c ⇒
-  find_name f n ≠ find_name f n'``,
+  find_name f n ≠ find_name f n'`,
   rw[names_ok_def]>>fs[ALL_DISTINCT_GENLIST,reg_name_def]>>
   metis_tac[])
 
-val sn_comp_imp_stack_asm_ok = prove(``
+val sn_comp_imp_stack_asm_ok = Q.prove(`
   ∀f p.
   stack_asm_name c p ∧ names_ok f c.reg_count c.avoid_regs ∧
   fixed_names f c ⇒
-  stack_asm_ok c (stack_names$comp f p)``,
+  stack_asm_ok c (stack_names$comp f p)`,
   ho_match_mp_tac comp_ind>>
   Cases_on`p`>>rw[]>>
   simp[Once comp_def]>>fs[stack_asm_ok_def,stack_asm_name_def]
@@ -415,11 +415,11 @@ val sn_comp_imp_stack_asm_ok = prove(``
   >>
   metis_tac[names_ok_imp,asmTheory.reg_ok_def])
 
-val sn_compile_imp_stack_asm_ok = store_thm("sn_compile_imp_stack_asm_ok",``
+val sn_compile_imp_stack_asm_ok = Q.store_thm("sn_compile_imp_stack_asm_ok",`
   EVERY (λ(n,p). stack_asm_name c p) prog ∧
   names_ok f c.reg_count c.avoid_regs ∧
   fixed_names f c ⇒
-  EVERY (λ(n,p). stack_asm_ok c p) (compile f prog)``,
+  EVERY (λ(n,p). stack_asm_ok c p) (compile f prog)`,
   fs[EVERY_MAP,EVERY_MEM,FORALL_PROD,prog_comp_def,compile_def,MEM_MAP,EXISTS_PROD]>>
   rw[]>>
   metis_tac[sn_comp_imp_stack_asm_ok])

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -30,10 +30,10 @@ val aligned_w2n = Q.store_thm("aligned_w2n",
   \\ `(n DIV 2 ** k * 2 ** k) < dimword (:α)` by decide_tac
   \\ asm_simp_tac std_ss [] \\ decide_tac);
 
-val word_list_exists_thm = store_thm("word_list_exists_thm",
-  ``(word_list_exists a 0 = emp) /\
+val word_list_exists_thm = Q.store_thm("word_list_exists_thm",
+  `(word_list_exists a 0 = emp) /\
     (word_list_exists a (SUC n) =
-     SEP_EXISTS w. one (a,w) * word_list_exists (a + bytes_in_word) n)``,
+     SEP_EXISTS w. one (a,w) * word_list_exists (a + bytes_in_word) n)`,
   full_simp_tac(srw_ss())[word_list_exists_def,LENGTH_NIL,FUN_EQ_THM,ADD1,
           SEP_EXISTS_THM,cond_STAR,word_list_def,SEP_CLAUSES]
   \\ srw_tac[][] \\ eq_tac \\ srw_tac[][]
@@ -323,13 +323,13 @@ val state_rel_set_var = Q.store_thm("state_rel_set_var[simp]",
   full_simp_tac(srw_ss())[state_rel_def,set_var_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[FLOOKUP_UPDATE]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
 
-val word_store_CurrHeap = prove(
-  ``word_store base (s.store |+ (CurrHeap,x)) = word_store base s.store``,
+val word_store_CurrHeap = Q.prove(
+  `word_store base (s.store |+ (CurrHeap,x)) = word_store base s.store`,
   full_simp_tac(srw_ss())[word_store_def,store_list_def,FLOOKUP_UPDATE]);
 
-val memory_fun2set_IMP_read = prove(
-  ``(memory m d * p) (fun2set (m1,d1)) /\ a IN d ==>
-    a IN d1 /\ m1 a = m a``,
+val memory_fun2set_IMP_read = Q.prove(
+  `(memory m d * p) (fun2set (m1,d1)) /\ a IN d ==>
+    a IN d1 /\ m1 a = m a`,
   simp [Once STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
   \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS]);
 
@@ -400,12 +400,12 @@ val write_bytearray_EQ = Q.prove(
     (first_x_assum match_mp_tac \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[])
   \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][]);
 
-val write_bytearray_lemma = prove(
-  ``!new_bytes a m1 d1 be x p m d.
+val write_bytearray_lemma = Q.prove(
+  `!new_bytes a m1 d1 be x p m d.
       (memory m1 d1 * p) (fun2set (m,d)) /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME x ==>
       (memory (write_bytearray a new_bytes m1 d1 be) d1 * p)
-        (fun2set (write_bytearray a new_bytes m d be,d))``,
+        (fun2set (write_bytearray a new_bytes m d be,d))`,
   simp [STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
   \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS] \\ srw_tac[][]
   \\ `d1 SUBSET d` by full_simp_tac(srw_ss())[SUBSET_DEF]
@@ -839,8 +839,8 @@ val get_labels_comp = Q.store_thm("get_labels_comp",
   \\ fs [get_labels_def,list_Seq_def]
   \\ every_case_tac \\ fs [get_labels_stack_alloc]);
 
-val code_rel_loc_check = store_thm("code_rel_loc_check",
-  ``code_rel k c1 c2 /\ loc_check c1 (l1,l2) ==> loc_check c2 (l1,l2)``,
+val code_rel_loc_check = Q.store_thm("code_rel_loc_check",
+  `code_rel k c1 c2 /\ loc_check c1 (l1,l2) ==> loc_check c2 (l1,l2)`,
   fs [loc_check_def,code_rel_def,domain_lookup,PULL_EXISTS] \\ rw []
   \\ res_tac \\ fs [] \\ disj2_tac
   \\ asm_exists_tac \\ fs [get_labels_comp]);
@@ -1719,8 +1719,8 @@ val mem_val_def = Define `
   (mem_val regs (INL w) = Word w) /\
   (mem_val (regs:num |-> 'a word_loc) (INR n) = regs ' n)`
 
-val store_list_code_thm = store_thm("store_list_code_thm",
-  ``!xs s w frame ys m dm.
+val store_list_code_thm = Q.store_thm("store_list_code_thm",
+  `!xs s w frame ys m dm.
       (word_list w ys * frame) (fun2set (m,dm)) /\
       m = s.memory /\ dm = s.mdomain /\
       (LENGTH ys = LENGTH xs) /\ a <> t /\
@@ -1731,7 +1731,7 @@ val store_list_code_thm = store_thm("store_list_code_thm",
         evaluate (store_list_code a t xs,s) =
           (NONE,s with <| memory := m1;
                           regs := s.regs |++
-            [(a,Word (w + bytes_in_word * n2w (LENGTH xs)));(t,r1)] |>)``,
+            [(a,Word (w + bytes_in_word * n2w (LENGTH xs)));(t,r1)] |>)`,
   simp_tac std_ss []
   \\ Induct \\ fs [] THEN1
    (fs [word_list_def,SEP_CLAUSES,store_list_code_def,LENGTH_NIL]
@@ -1896,10 +1896,10 @@ val word_list_and_rev_join_lemma = Q.prove(
   \\ fs [word_list_EQ_rev] \\ rw []
   \\ fs [AC STAR_COMM STAR_ASSOC,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
 
-val word_list_IMP_read_mem = prove(
-  ``!xs a p.
+val word_list_IMP_read_mem = Q.prove(
+  `!xs a p.
       (p * word_list a xs) (fun2set (m,dm)) ==>
-      read_mem a m (LENGTH xs) = xs``,
+      read_mem a m (LENGTH xs) = xs`,
   Induct \\ fs [read_mem_def,word_list_def,STAR_ASSOC]
   \\ rw [] \\ res_tac \\ SEP_R_TAC);
 
@@ -1907,10 +1907,10 @@ val INSERT_DELETE_EQ_DELETE = Q.prove(
   `(x INSERT s) DELETE x = s DELETE x`,
   fs [EXTENSION] \\ metis_tac []);
 
-val word_list_exists_addresses = store_thm("word_list_exists_addresses",
-  ``!n a. (dimindex(:'a) DIV 8) * n < dimword (:'a) /\
+val word_list_exists_addresses = Q.store_thm("word_list_exists_addresses",
+  `!n a. (dimindex(:'a) DIV 8) * n < dimword (:'a) /\
           good_dimindex (:'a) ==>
-          word_list_exists a n (fun2set (m1,addresses (a:'a word) n))``,
+          word_list_exists a n (fun2set (m1,addresses (a:'a word) n))`,
   Induct
   THEN1 (fs [word_list_exists_thm,fun2set_def,emp_def,addresses_def])
   \\ fs [word_list_exists_thm,emp_def,addresses_def,INSERT_DELETE_EQ_DELETE,
@@ -2000,15 +2000,15 @@ val byte_aligned_bytes_in_word_MULT = Q.prove(
   \\ qspecl_then [`3`,`w`] mp_tac alignmentTheory.aligned_mul_shift_1
   \\ fs [WORD_MUL_LSL]);
 
-val init_code_thm = store_thm("init_code_thm",
-  ``init_code_pre k s /\ code_rel k code s.code /\
+val init_code_thm = Q.store_thm("init_code_thm",
+  `init_code_pre k s /\ code_rel k code s.code /\
     lookup stack_err_lab s.code = SOME (halt_inst 2w) ==>
     case evaluate (init_code max_heap bitmaps k,s) of
     | (SOME res,t) =>
          ?w. (res = Halt (Word w)) /\ w <> 0w /\ t.ffi = s.ffi
     | (NONE,t) =>
          state_rel k (init_reduce k code bitmaps t) t /\ t.ffi = s.ffi /\
-         init_prop max_heap (init_reduce k code bitmaps t)``,
+         init_prop max_heap (init_reduce k code bitmaps t)`,
   simp_tac std_ss [init_code_pre_def] \\ strip_tac
   \\ `k <> 3 /\ k <> 4 /\ k <> 5` by decide_tac
   \\ full_simp_tac std_ss [init_code_def,LET_DEF]
@@ -2240,8 +2240,8 @@ val init_pre_def = Define `
     (* TODO: remove: *) s.ffi.final_event = NONE /\
     init_code_pre k s`
 
-val evaluate_init_code = store_thm("evaluate_init_code",
-  ``init_pre max_heap bitmaps k start s /\
+val evaluate_init_code = Q.store_thm("evaluate_init_code",
+  `init_pre max_heap bitmaps k start s /\
     lookup stack_err_lab s.code = SOME (halt_inst 2w) /\
     code_rel k code s.code ==>
     case evaluate (init_code max_heap bitmaps k,s) of
@@ -2249,7 +2249,7 @@ val evaluate_init_code = store_thm("evaluate_init_code",
         w <> 0w /\ t.ffi = s.ffi /\ make_init_opt max_heap bitmaps k code s = NONE
     | (NONE,t) => ?r. make_init_opt max_heap bitmaps k code s = SOME r /\
                       state_rel k r t /\ t.ffi = s.ffi
-    | _ => F``,
+    | _ => F`,
   strip_tac \\ fs [init_pre_def]
   \\ drule init_code_thm \\ fs []
   \\ CASE_TAC \\ CASE_TAC
@@ -2261,26 +2261,26 @@ val clock_neutral_store_list_code = Q.store_thm("clock_neutral_store_list_code",
   Induct \\ fs [clock_neutral_def,store_list_code_def]
   \\ Cases \\ fs [clock_neutral_def,store_list_code_def,list_Seq_def]);
 
-val evaluate_init_code_clock = prove(
-  ``evaluate (init_code max_heap bitmaps k,s) = (res,t) ==>
+val evaluate_init_code_clock = Q.prove(
+  `evaluate (init_code max_heap bitmaps k,s) = (res,t) ==>
     evaluate (init_code max_heap bitmaps k,s with clock := c) =
-      (res,t with clock := c)``,
+      (res,t with clock := c)`,
   srw_tac[][] \\ match_mp_tac evaluate_clock_neutral \\ fs []
   \\ fs [clock_neutral_def,init_code_def] \\ rw []
   \\ fs [clock_neutral_def,init_code_def,halt_inst_def,
          list_Seq_def,init_memory_def,clock_neutral_store_list_code]);
 
-val evaluate_init_code_ffi = prove(
-  ``evaluate (init_code max_heap bitmaps k,(s:('a,'ffi) stackSem$state)) = (res,t) ==>
+val evaluate_init_code_ffi = Q.prove(
+  `evaluate (init_code max_heap bitmaps k,(s:('a,'ffi) stackSem$state)) = (res,t) ==>
     evaluate (init_code max_heap bitmaps k,s with ffi := c) =
-      (res,(t with ffi := c):('a,'ffi) stackSem$state)``,
+      (res,(t with ffi := c):('a,'ffi) stackSem$state)`,
   srw_tac[][] \\ match_mp_tac evaluate_ffi_neutral \\ fs []
   \\ fs [clock_neutral_def,init_code_def] \\ rw []
   \\ fs [clock_neutral_def,init_code_def,halt_inst_def,
          list_Seq_def,init_memory_def,clock_neutral_store_list_code]);
 
-val init_semantics = store_thm("init_semantics",
-  ``lookup stack_err_lab s.code = SOME (halt_inst 2w) /\
+val init_semantics = Q.store_thm("init_semantics",
+  `lookup stack_err_lab s.code = SOME (halt_inst 2w) /\
     code_rel k code s.code /\
     init_pre max_heap bitmaps k start s ==>
     case evaluate (init_code max_heap bitmaps k,s) of
@@ -2290,7 +2290,7 @@ val init_semantics = store_thm("init_semantics",
     | (NONE,t) =>
         (semantics 0 s = semantics start t) /\
         ?r. make_init_opt max_heap bitmaps k code s = SOME r /\ state_rel k r t
-    | _ => F``,
+    | _ => F`,
   srw_tac[][]
   \\ pop_assum (fn th => assume_tac th \\ mp_tac th)
   \\ simp_tac std_ss [init_pre_def] \\ rw []
@@ -2404,14 +2404,14 @@ val make_init_any_def = Define `
                       ; store := FEMPTY |++ (MAP (\x. (x,Word 0w))
                                    (CurrHeap::store_list)) |>`
 
-val make_init_semantics = store_thm("make_init_semantics",
-  ``init_pre max_heap bitmaps k start s2 /\
+val make_init_semantics = Q.store_thm("make_init_semantics",
+  `init_pre max_heap bitmaps k start s2 /\
     EVERY (\(n,p). good_syntax p k /\ num_stubs ≤ n+1) code /\
     s2.code = fromAList (compile max_heap bitmaps k start code) /\
     IS_SOME (make_init_opt max_heap bitmaps k (fromAList code) s2) /\
     make_init_any max_heap bitmaps k (fromAList code) s2 = s1 /\
     semantics start s1 <> Fail ==>
-    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}``,
+    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}`,
   fs [make_init_any_def]
   \\ Cases_on `make_init_opt max_heap bitmaps k (fromAList code) s2` \\ fs []
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
@@ -2422,21 +2422,21 @@ val make_init_semantics = store_thm("make_init_semantics",
   \\ qexists_tac `fromAList code` \\ fs [] \\ rfs []
   \\ fs [compile_def,init_stubs_def,lookup_fromAList,stack_err_lab_def]);
 
-val make_init_semantics_fail = store_thm("make_init_semantics_fail",
-  ``init_pre max_heap bitmaps k start s2 /\
+val make_init_semantics_fail = Q.store_thm("make_init_semantics_fail",
+  `init_pre max_heap bitmaps k start s2 /\
     EVERY (\(n,p). good_syntax p k /\ num_stubs ≤ n+1) code /\
     s2.code = fromAList (compile max_heap bitmaps k start code) /\
     make_init_opt max_heap bitmaps k (fromAList code) s2 = NONE ==>
-    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events``,
+    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events`,
   rw [] \\ drule (GEN_ALL make_init_opt_NONE_semantics)
   \\ disch_then match_mp_tac \\ fs []
   \\ qexists_tac `fromAList code` \\ fs [] \\ rfs []
   \\ imp_res_tac IMP_code_rel \\ rfs []
   \\ fs [compile_def,init_stubs_def,lookup_fromAList,stack_err_lab_def]);
 
-val make_init_any_ffi = store_thm("make_init_any_ffi",
-  ``(make_init_any max_heap bitmaps k code s).ffi =
-    (s:('a,'ffi) stackSem$state).ffi``,
+val make_init_any_ffi = Q.store_thm("make_init_any_ffi",
+  `(make_init_any max_heap bitmaps k code s).ffi =
+    (s:('a,'ffi) stackSem$state).ffi`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []
   \\ imp_res_tac evaluate_init_code_ffi

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -14,14 +14,14 @@ val _ = temp_overload_on ("num_stubs", ``stack_num_stubs``)
 
 (* TODO: move *)
 
-val aligned_or = store_thm("aligned_or", (* TODO: move *)
-  ``aligned n (w || v) <=> aligned n w /\ aligned n v``,
+val aligned_or = Q.store_thm("aligned_or", (* TODO: move *)
+  `aligned n (w || v) <=> aligned n w /\ aligned n v`,
   Cases_on `n = 0`
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [alignmentTheory.aligned_extract]
   \\ metis_tac [])
 
-val aligned_w2n = store_thm("aligned_w2n",
-  ``aligned k w <=> w2n (w:'a word) MOD 2 ** k = 0``,
+val aligned_w2n = Q.store_thm("aligned_w2n",
+  `aligned k w <=> w2n (w:'a word) MOD 2 ** k = 0`,
   Cases_on `w`
   \\ fs [alignmentTheory.aligned_def,alignmentTheory.align_w2n]
   \\ `0n < 2 ** k` by simp []
@@ -45,19 +45,19 @@ val word_list_exists_thm = store_thm("word_list_exists_thm",
   \\ qexists_tac `w::xs`
   \\ full_simp_tac(srw_ss())[word_list_def,ADD1,STAR_ASSOC,cond_STAR]);
 
-val word_list_exists_ADD = store_thm("word_list_exists_ADD",
-  ``!m n a.
+val word_list_exists_ADD = Q.store_thm("word_list_exists_ADD",
+  `!m n a.
       word_list_exists a (m + n) =
       word_list_exists a m *
-      word_list_exists (a + bytes_in_word * n2w m) n``,
+      word_list_exists (a + bytes_in_word * n2w m) n`,
   Induct \\ full_simp_tac(srw_ss())[word_list_exists_thm,SEP_CLAUSES,ADD_CLAUSES]
   \\ full_simp_tac(srw_ss())[STAR_ASSOC,ADD1,GSYM word_add_n2w,
        WORD_LEFT_ADD_DISTRIB]);
 
-val word_list_APPEND = store_thm("word_list_APPEND",
-  ``!xs ys a.
+val word_list_APPEND = Q.store_thm("word_list_APPEND",
+  `!xs ys a.
       word_list a (xs ++ ys) =
-      word_list a xs * word_list (a + bytes_in_word * n2w (LENGTH xs)) ys``,
+      word_list a xs * word_list (a + bytes_in_word * n2w (LENGTH xs)) ys`,
   Induct \\ full_simp_tac(srw_ss())[word_list_def,SEP_CLAUSES,STAR_ASSOC,ADD1,GSYM word_add_n2w]
   \\ full_simp_tac(srw_ss())[WORD_LEFT_ADD_DISTRIB]);
 
@@ -145,8 +145,8 @@ val bytes_in_word_word_shift = Q.store_thm("bytes_in_word_word_shift",
   \\ Cases_on`n`\\full_simp_tac(srw_ss())[word_lsl_n2w]
   \\ full_simp_tac(srw_ss())[dimword_def]);
 
-val word_offset_eq = store_thm("word_offset_eq",
-  ``word_offset n = bytes_in_word * n2w n``,
+val word_offset_eq = Q.store_thm("word_offset_eq",
+  `word_offset n = bytes_in_word * n2w n`,
   full_simp_tac(srw_ss())[word_offset_def,word_mul_n2w,bytes_in_word_def]);
 
 (* --- *)
@@ -279,37 +279,37 @@ val state_rel_def = Define `
         (fun2set (s2.memory,s2.mdomain))
     | _ => F`
 
-val state_rel_get_var = prove(
-  ``state_rel k s t /\ n < k ==> (get_var n s = get_var n t)``,
+val state_rel_get_var = Q.prove(
+  `state_rel k s t /\ n < k ==> (get_var n s = get_var n t)`,
   full_simp_tac(srw_ss())[state_rel_def,get_var_def]);
 
-val state_rel_IMP = prove(
-  ``state_rel k s t1 ==>
-    state_rel k (dec_clock s) (dec_clock t1)``,
+val state_rel_IMP = Q.prove(
+  `state_rel k s t1 ==>
+    state_rel k (dec_clock s) (dec_clock t1)`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
 
-val state_rel_with_clock = prove(
-  ``state_rel k s t1 ==>
-    state_rel k (s with clock := c) (t1 with clock := c)``,
+val state_rel_with_clock = Q.prove(
+  `state_rel k s t1 ==>
+    state_rel k (s with clock := c) (t1 with clock := c)`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
 
-val find_code_lemma = prove(
-  ``state_rel k s t1 /\
+val find_code_lemma = Q.prove(
+  `state_rel k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest s.regs s.code = SOME x ==>
-    find_code dest t1.regs t1.code = SOME (comp k x) /\ good_syntax x k``,
+    find_code dest t1.regs t1.code = SOME (comp k x) /\ good_syntax x k`,
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
 
-val find_code_lemma2 = prove(
-  ``state_rel k s t1 /\
+val find_code_lemma2 = Q.prove(
+  `state_rel k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest (s.regs \\ x1) s.code = SOME x ==>
-    find_code dest (t1.regs \\ x1) t1.code = SOME (comp k x) /\ good_syntax x k``,
+    find_code dest (t1.regs \\ x1) t1.code = SOME (comp k x) /\ good_syntax x k`,
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ fs[DOMSUB_FLOOKUP_THM]
@@ -317,9 +317,9 @@ val find_code_lemma2 = prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
 
-val state_rel_set_var = store_thm("state_rel_set_var[simp]",
-  ``state_rel k s t1 /\ v < k ==>
-    state_rel k (set_var v x s) (set_var v x t1)``,
+val state_rel_set_var = Q.store_thm("state_rel_set_var[simp]",
+  `state_rel k s t1 /\ v < k ==>
+    state_rel k (set_var v x s) (set_var v x t1)`,
   full_simp_tac(srw_ss())[state_rel_def,set_var_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[FLOOKUP_UPDATE]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
 
@@ -333,44 +333,44 @@ val memory_fun2set_IMP_read = prove(
   simp [Once STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
   \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS]);
 
-val state_rel_read = prove(
-  ``state_rel k s t /\ a IN s.mdomain ==>
-    a IN t.mdomain /\ (t.memory a = s.memory a)``,
+val state_rel_read = Q.prove(
+  `state_rel k s t /\ a IN s.mdomain ==>
+    a IN t.mdomain /\ (t.memory a = s.memory a)`,
   full_simp_tac(srw_ss())[state_rel_def] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ strip_tac
   \\ full_simp_tac(srw_ss())[GSYM STAR_ASSOC] \\ metis_tac [memory_fun2set_IMP_read]);
 
-val mem_load_byte_aux_IMP = prove(
-  ``state_rel k s t /\
+val mem_load_byte_aux_IMP = Q.prove(
+  `state_rel k s t /\
     mem_load_byte_aux s.memory s.mdomain s.be a = SOME x ==>
-    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x``,
+    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x`,
   full_simp_tac(srw_ss())[wordSemTheory.mem_load_byte_aux_def] \\ srw_tac[][]
   \\ `s.be = t.be` by full_simp_tac(srw_ss())[state_rel_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac state_rel_read
   \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val read_bytearray_IMP_read_bytearray = prove(
-  ``!n a k s t x.
+val read_bytearray_IMP_read_bytearray = Q.prove(
+  `!n a k s t x.
       state_rel k s t /\
       read_bytearray a n (mem_load_byte_aux s.memory s.mdomain s.be) = SOME x ==>
-      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x``,
+      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x`,
   Induct \\ full_simp_tac(srw_ss())[read_bytearray_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ res_tac \\ srw_tac[][]
   \\ imp_res_tac mem_load_byte_aux_IMP \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val write_bytearray_IGNORE_non_aligned = prove(
-  ``!new_bytes a.
+val write_bytearray_IGNORE_non_aligned = Q.prove(
+  `!new_bytes a.
       (!x. b <> byte_align x) ==>
-      write_bytearray a new_bytes m d be b = m b``,
+      write_bytearray a new_bytes m d be b = m b`,
   Induct \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[wordSemTheory.mem_store_byte_aux_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]);
 
-val write_bytearray_IGNORE = prove(
-  ``!new_bytes a x xx.
+val write_bytearray_IGNORE = Q.prove(
+  `!new_bytes a x xx.
       d1 SUBSET d /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME x /\ xx ∉ d1 ==>
-      write_bytearray a new_bytes m d be xx = m xx``,
+      write_bytearray a new_bytes m d be xx = m xx`,
   Induct_on `new_bytes`
   \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def,read_bytearray_def]
   \\ full_simp_tac(srw_ss())[wordSemTheory.mem_load_byte_aux_def]
@@ -379,12 +379,12 @@ val write_bytearray_IGNORE = prove(
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val write_bytearray_EQ = prove(
-  ``!new_bytes a m1 m y x.
+val write_bytearray_EQ = Q.prove(
+  `!new_bytes a m1 m y x.
       d1 SUBSET d /\ (!a. a IN d1 ==> m1 a = m a /\ a IN d) /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME y /\ m1 x = m x ==>
       write_bytearray a new_bytes m1 d1 be x =
-      write_bytearray a new_bytes m d be x``,
+      write_bytearray a new_bytes m d be x`,
   Induct_on `new_bytes`
   \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def,read_bytearray_def]
   \\ rpt gen_tac \\ ntac 2 BasicProvers.TOP_CASE_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -820,20 +820,20 @@ val state_rel_stack_store = Q.store_thm("state_rel_stack_store",
   \\ match_mp_tac stack_write
   \\ fsrw_tac[star_ss][AC ADD_COMM ADD_ASSOC]);
 
-val lsl_word_shift = store_thm("lsl_word_shift",
-  ``good_dimindex (:'a) ==>
-    w ≪ word_shift (:α) = w * bytes_in_word:'a word``,
+val lsl_word_shift = Q.store_thm("lsl_word_shift",
+  `good_dimindex (:'a) ==>
+    w ≪ word_shift (:α) = w * bytes_in_word:'a word`,
   srw_tac[][WORD_MUL_LSL,word_shift_def,bytes_in_word_def,
       labPropsTheory.good_dimindex_def]);
 
-val get_labels_stack_alloc = prove(
-  ``!k n. get_labels (stack_alloc k n) = {}``,
+val get_labels_stack_alloc = Q.prove(
+  `!k n. get_labels (stack_alloc k n) = {}`,
   recInduct stack_alloc_ind \\ rw []
   \\ once_rewrite_tac [stack_alloc_def] \\ rw []
   \\ fs [get_labels_def,single_stack_alloc_def]);
 
-val get_labels_comp = store_thm("get_labels_comp",
-  ``!k e. get_labels (comp k e) = get_labels e``,
+val get_labels_comp = Q.store_thm("get_labels_comp",
+  `!k e. get_labels (comp k e) = get_labels e`,
   recInduct comp_ind \\ rw [] \\ Cases_on `p`
   \\ once_rewrite_tac [comp_def] \\ fs [get_labels_def] \\ rw []
   \\ fs [get_labels_def,list_Seq_def]
@@ -1808,12 +1808,12 @@ val halt_tac =
   tac \\ fs [labPropsTheory.good_dimindex_def]
   \\ rw [] \\ fs [dimword_def]
 
-val MOD_EQ_IMP_MULT = prove(
-  ``!n d. n MOD d = 0 /\ d <> 0 ==> ?k. n = d * k``,
+val MOD_EQ_IMP_MULT = Q.prove(
+  `!n d. n MOD d = 0 /\ d <> 0 ==> ?k. n = d * k`,
   rw [] \\ fs [MOD_EQ_0_DIVISOR] \\ metis_tac []);
 
-val star_move_lemma = prove(
-  ``p1 * p2 * p3 * p4 = p2 * (p1 * STAR p3 p4)``,
+val star_move_lemma = Q.prove(
+  `p1 * p2 * p3 * p4 = p2 * (p1 * STAR p3 p4)`,
   fs [AC STAR_COMM STAR_ASSOC]);
 
 (* TODO: let's not repeat these everywhere *)
@@ -1829,13 +1829,13 @@ val addresses_def = Define `
   (addresses a 0 = {}) /\
   (addresses a (SUC n) = a INSERT addresses (a + bytes_in_word) n)`
 
-val LENGTH_read_mem = prove(
-  ``!n a m. LENGTH (read_mem a m n) = n``,
+val LENGTH_read_mem = Q.prove(
+  `!n a m. LENGTH (read_mem a m n) = n`,
   Induct \\ fs [read_mem_def]);
 
-val IN_addresses = prove(
-  ``!n a x. x IN addresses a n <=>
-            ?i. i < n /\ x = a + n2w i * bytes_in_word``,
+val IN_addresses = Q.prove(
+  `!n a x. x IN addresses a n <=>
+            ?i. i < n /\ x = a + n2w i * bytes_in_word`,
   Induct \\ fs [addresses_def]
   \\ rw [] \\ eq_tac \\ rw []
   THEN1 (qexists_tac `0` \\ fs [])
@@ -1845,10 +1845,10 @@ val IN_addresses = prove(
   \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ metis_tac []);
 
-val memory_addresses = prove(
-  ``!n (a:'a word) (m:'a word -> 'a word_loc).
+val memory_addresses = Q.prove(
+  `!n (a:'a word) (m:'a word -> 'a word_loc).
       n * (dimindex (:'a) DIV 8) < dimword (:'a) /\ good_dimindex (:'a) ==>
-      memory m (addresses a n) = word_list a (read_mem a m n)``,
+      memory m (addresses a n) = word_list a (read_mem a m n)`,
   once_rewrite_tac [EQ_SYM_EQ]
   \\ Induct \\ fs [addresses_def,read_mem_def,word_list_def]
   THEN1 (fs [memory_def,FUN_EQ_THM,fun2set_def,emp_def])
@@ -1872,26 +1872,26 @@ val memory_addresses = prove(
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def]
   \\ fs [labPropsTheory.good_dimindex_def,dimword_def]);
 
-val MOD_LESS_EQ_MOD_IMP = prove(
-  ``m MOD k <= n MOD k /\ m < k /\ n < k ==> m <= n``,
+val MOD_LESS_EQ_MOD_IMP = Q.prove(
+  `m MOD k <= n MOD k /\ m < k /\ n < k ==> m <= n`,
   rw [] \\ fs [])
 
-val MAP_mem_val_MAP_INL = prove(
-  ``!ws f. MAP (mem_val f) (MAP INL ws) = MAP Word ws``,
+val MAP_mem_val_MAP_INL = Q.prove(
+  `!ws f. MAP (mem_val f) (MAP INL ws) = MAP Word ws`,
   Induct \\ fs [mem_val_def]);
 
-val word_list_EQ_rev = store_thm("word_list_EQ_rev",
-  ``!xs a. word_list a xs =
-           word_list_rev (a + n2w (LENGTH xs) * bytes_in_word) (REVERSE xs)``,
+val word_list_EQ_rev = Q.store_thm("word_list_EQ_rev",
+  `!xs a. word_list a xs =
+           word_list_rev (a + n2w (LENGTH xs) * bytes_in_word) (REVERSE xs)`,
   recInduct SNOC_INDUCT \\ fs [REVERSE_SNOC]
   \\ fs [SNOC_APPEND,word_list_APPEND,word_list_rev_def,word_list_def]
   \\ rw [SEP_CLAUSES,ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ fs [AC STAR_COMM STAR_ASSOC])
 
-val word_list_and_rev_join_lemma = prove(
-  ``(b = a + n2w (LENGTH xs + LENGTH ys) * bytes_in_word) /\
+val word_list_and_rev_join_lemma = Q.prove(
+  `(b = a + n2w (LENGTH xs + LENGTH ys) * bytes_in_word) /\
     (p * word_list a (xs ++ REVERSE ys) * q) ss /\ b1 ==>
-    (p * word_list a xs * word_list_rev b ys * q) ss /\ b1``,
+    (p * word_list a xs * word_list_rev b ys * q) ss /\ b1`,
   fs [word_list_APPEND,WORD_LEFT_ADD_DISTRIB]
   \\ fs [word_list_EQ_rev] \\ rw []
   \\ fs [AC STAR_COMM STAR_ASSOC,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
@@ -1903,8 +1903,8 @@ val word_list_IMP_read_mem = prove(
   Induct \\ fs [read_mem_def,word_list_def,STAR_ASSOC]
   \\ rw [] \\ res_tac \\ SEP_R_TAC);
 
-val INSERT_DELETE_EQ_DELETE = prove(
-  ``(x INSERT s) DELETE x = s DELETE x``,
+val INSERT_DELETE_EQ_DELETE = Q.prove(
+  `(x INSERT s) DELETE x = s DELETE x`,
   fs [EXTENSION] \\ metis_tac []);
 
 val word_list_exists_addresses = store_thm("word_list_exists_addresses",
@@ -1948,9 +1948,9 @@ val init_reduce_def = Define `
                                        | INR i => (n,s.regs ' i))
                                (CurrHeap::store_list)) |>`
 
-val init_reduce_stack_space = prove(
-  ``(init_reduce k code bitmaps s8).stack_space <=
-    LENGTH (init_reduce k code bitmap s8).stack``,
+val init_reduce_stack_space = Q.prove(
+  `(init_reduce k code bitmaps s8).stack_space <=
+    LENGTH (init_reduce k code bitmap s8).stack`,
   fs [init_reduce_def,LENGTH_read_mem]);
 
 val init_prop_def = Define `
@@ -1991,9 +1991,9 @@ val init_code_pre_def = Define `
       (word_list_exists ptr2 (w2n (ptr4 - ptr2) DIV w2n (bytes_in_word:'a word)))
         (fun2set (s.memory,s.mdomain))`
 
-val byte_aligned_bytes_in_word_MULT = prove(
-  ``good_dimindex (:'a) ==>
-    byte_aligned (bytes_in_word * w:'a word)``,
+val byte_aligned_bytes_in_word_MULT = Q.prove(
+  `good_dimindex (:'a) ==>
+    byte_aligned (bytes_in_word * w:'a word)`,
   fs [labPropsTheory.good_dimindex_def] \\ rw []
   \\ fs [alignmentTheory.byte_aligned_def,bytes_in_word_def]
   \\ qspecl_then [`2`,`w`] mp_tac alignmentTheory.aligned_mul_shift_1
@@ -2256,8 +2256,8 @@ val evaluate_init_code = store_thm("evaluate_init_code",
   \\ fs [make_init_opt_def]
   \\ strip_tac \\ fs[]);
 
-val clock_neutral_store_list_code = store_thm("clock_neutral_store_list_code",
-  ``!xs n k. clock_neutral (store_list_code n k xs)``,
+val clock_neutral_store_list_code = Q.store_thm("clock_neutral_store_list_code",
+  `!xs n k. clock_neutral (store_list_code n k xs)`,
   Induct \\ fs [clock_neutral_def,store_list_code_def]
   \\ Cases \\ fs [clock_neutral_def,store_list_code_def,list_Seq_def]);
 
@@ -2352,22 +2352,22 @@ val init_semantics = store_thm("init_semantics",
          \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val make_init_opt_SOME_semantics = store_thm("make_init_opt_SOME_semantics",
-  ``init_pre max_heap bitmaps k start s2 /\ code_rel k code s2.code /\
+val make_init_opt_SOME_semantics = Q.store_thm("make_init_opt_SOME_semantics",
+  `init_pre max_heap bitmaps k start s2 /\ code_rel k code s2.code /\
     lookup stack_err_lab s2.code = SOME (halt_inst 2w) /\
     make_init_opt max_heap bitmaps k code s2 = SOME s1 /\
     semantics start s1 <> Fail ==>
-    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}``,
+    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}`,
   srw_tac[][] \\ imp_res_tac init_semantics \\ pop_assum (assume_tac o SPEC_ALL)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ match_mp_tac (GEN_ALL compile_semantics)
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ metis_tac []);
 
-val make_init_opt_NONE_semantics = store_thm("make_init_opt_NONE_semantics",
-  ``init_pre max_heap bitmaps k start s2 /\ code_rel k code s2.code /\
+val make_init_opt_NONE_semantics = Q.store_thm("make_init_opt_NONE_semantics",
+  `init_pre max_heap bitmaps k start s2 /\ code_rel k code s2.code /\
     lookup stack_err_lab s2.code = SOME (halt_inst 2w) /\
     make_init_opt max_heap bitmaps k code s2 = NONE ==>
-    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events``,
+    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events`,
   srw_tac[][] \\ imp_res_tac init_semantics \\ pop_assum (assume_tac o SPEC_ALL)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]);
@@ -2444,36 +2444,36 @@ val make_init_any_ffi = store_thm("make_init_any_ffi",
   \\ `s with ffi := s.ffi = s` by fs [state_component_equality]
   \\ fs [] \\ fs [state_component_equality]);
 
-val make_init_any_bitmaps = store_thm("make_init_any_bitmaps",
-  ``(make_init_any max_heap bitmaps k code s).bitmaps =
+val make_init_any_bitmaps = Q.store_thm("make_init_any_bitmaps",
+  `(make_init_any max_heap bitmaps k code s).bitmaps =
        if IS_SOME (make_init_opt max_heap bitmaps k code s)
-       then bitmaps else [4w]``,
+       then bitmaps else [4w]`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []);
 
-val make_init_any_use_stack = store_thm("make_init_any_use_stack",
-  ``(make_init_any max_heap bitmaps k code s).use_stack``,
+val make_init_any_use_stack = Q.store_thm("make_init_any_use_stack",
+  `(make_init_any max_heap bitmaps k code s).use_stack`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []);
 
-val make_init_any_use_store = store_thm("make_init_any_use_store",
-  ``(make_init_any max_heap bitmaps k code s).use_store``,
+val make_init_any_use_store = Q.store_thm("make_init_any_use_store",
+  `(make_init_any max_heap bitmaps k code s).use_store`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []);
 
-val make_init_any_use_alloc = store_thm("make_init_any_use_alloc",
-  ``~(make_init_any max_heap bitmaps k code s).use_alloc``,
+val make_init_any_use_alloc = Q.store_thm("make_init_any_use_alloc",
+  `~(make_init_any max_heap bitmaps k code s).use_alloc`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []);
 
-val make_init_any_code = store_thm("make_init_any_code",
-  ``(make_init_any max_heap bitmaps k code s).code = code``,
+val make_init_any_code = Q.store_thm("make_init_any_code",
+  `(make_init_any max_heap bitmaps k code s).code = code`,
   fs [make_init_any_def,make_init_opt_def,init_reduce_def]
   \\ every_case_tac \\ fs []);
 
-val make_init_any_stack_limit = store_thm("make_init_any_stack_limit",
-  ``LENGTH ((make_init_any max_heap (bitmaps:'a word list) k code s).stack) *
-      (dimindex (:'a) DIV 8) < dimword (:'a)``,
+val make_init_any_stack_limit = Q.store_thm("make_init_any_stack_limit",
+  `LENGTH ((make_init_any max_heap (bitmaps:'a word list) k code s).stack) *
+      (dimindex (:'a) DIV 8) < dimword (:'a)`,
   fs [make_init_any_def]
   \\ reverse (every_case_tac \\ fs [LENGTH_read_mem])
   \\ fs [make_init_opt_def]
@@ -2483,9 +2483,9 @@ val make_init_any_stack_limit = store_thm("make_init_any_stack_limit",
   \\ qexists_tac `8 * dimindex (:'a)` \\ fs []
   \\ fs [X_LT_EXP_X_IFF]);
 
-val stack_remove_lab_pres = store_thm("stack_remove_lab_pres",``
+val stack_remove_lab_pres = Q.store_thm("stack_remove_lab_pres",`
   ∀k p.
-  extract_labels p = extract_labels (comp k p)``,
+  extract_labels p = extract_labels (comp k p)`,
   ho_match_mp_tac comp_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [comp_def]>>fs[extract_labels_def]>>
   TRY(IF_CASES_TAC)>>

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -280,37 +280,37 @@ val state_rel_def = Define `
         (fun2set (s2.memory,s2.mdomain))
     | _ => F`
 
-val state_rel_get_var = prove(
-  ``state_rel off k s t /\ n < k ==> (get_var n s = get_var n t)``,
+val state_rel_get_var = Q.prove(
+  `state_rel off k s t /\ n < k ==> (get_var n s = get_var n t)`,
   full_simp_tac(srw_ss())[state_rel_def,get_var_def]);
 
-val state_rel_IMP = prove(
-  ``state_rel off k s t1 ==>
-    state_rel off k (dec_clock s) (dec_clock t1)``,
+val state_rel_IMP = Q.prove(
+  `state_rel off k s t1 ==>
+    state_rel off k (dec_clock s) (dec_clock t1)`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
 
-val state_rel_with_clock = prove(
-  ``state_rel off k s t1 ==>
-    state_rel off k (s with clock := c) (t1 with clock := c)``,
+val state_rel_with_clock = Q.prove(
+  `state_rel off k s t1 ==>
+    state_rel off k (s with clock := c) (t1 with clock := c)`,
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
 
-val find_code_lemma = prove(
-  ``state_rel off k s t1 /\
+val find_code_lemma = Q.prove(
+  `state_rel off k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest s.regs s.code = SOME x ==>
-    find_code dest t1.regs t1.code = SOME (comp off k x) /\ good_syntax x k``,
+    find_code dest t1.regs t1.code = SOME (comp off k x) /\ good_syntax x k`,
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
 
-val find_code_lemma2 = prove(
-  ``state_rel off k s t1 /\
+val find_code_lemma2 = Q.prove(
+  `state_rel off k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest (s.regs \\ x1) s.code = SOME x ==>
-    find_code dest (t1.regs \\ x1) t1.code = SOME (comp off k x) /\ good_syntax x k``,
+    find_code dest (t1.regs \\ x1) t1.code = SOME (comp off k x) /\ good_syntax x k`,
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ fs[DOMSUB_FLOOKUP_THM]
@@ -318,9 +318,9 @@ val find_code_lemma2 = prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
 
-val state_rel_set_var = store_thm("state_rel_set_var[simp]",
-  ``state_rel off k s t1 /\ v < k ==>
-    state_rel off k (set_var v x s) (set_var v x t1)``,
+val state_rel_set_var = Q.store_thm("state_rel_set_var[simp]",
+  `state_rel off k s t1 /\ v < k ==>
+    state_rel off k (set_var v x s) (set_var v x t1)`,
   full_simp_tac(srw_ss())[state_rel_def,set_var_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[FLOOKUP_UPDATE]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
 
@@ -334,27 +334,27 @@ val memory_fun2set_IMP_read = Q.prove(
   simp [Once STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
   \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS]);
 
-val state_rel_read = prove(
-  ``state_rel off k s t /\ a IN s.mdomain ==>
-    a IN t.mdomain /\ (t.memory a = s.memory a)``,
+val state_rel_read = Q.prove(
+  `state_rel off k s t /\ a IN s.mdomain ==>
+    a IN t.mdomain /\ (t.memory a = s.memory a)`,
   full_simp_tac(srw_ss())[state_rel_def] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ strip_tac
   \\ full_simp_tac(srw_ss())[GSYM STAR_ASSOC] \\ metis_tac [memory_fun2set_IMP_read]);
 
-val mem_load_byte_aux_IMP = prove(
-  ``state_rel off k s t /\
+val mem_load_byte_aux_IMP = Q.prove(
+  `state_rel off k s t /\
     mem_load_byte_aux s.memory s.mdomain s.be a = SOME x ==>
-    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x``,
+    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x`,
   full_simp_tac(srw_ss())[wordSemTheory.mem_load_byte_aux_def] \\ srw_tac[][]
   \\ `s.be = t.be` by full_simp_tac(srw_ss())[state_rel_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac state_rel_read
   \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val read_bytearray_IMP_read_bytearray = prove(
-  ``!n a k s t x.
+val read_bytearray_IMP_read_bytearray = Q.prove(
+  `!n a k s t x.
       state_rel off k s t /\
       read_bytearray a n (mem_load_byte_aux s.memory s.mdomain s.be) = SOME x ==>
-      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x``,
+      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x`,
   Induct \\ full_simp_tac(srw_ss())[read_bytearray_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ res_tac \\ srw_tac[][]
   \\ imp_res_tac mem_load_byte_aux_IMP \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
@@ -827,32 +827,32 @@ val lsl_word_shift = Q.store_thm("lsl_word_shift",
   srw_tac[][WORD_MUL_LSL,word_shift_def,bytes_in_word_def,
       labPropsTheory.good_dimindex_def]);
 
-val get_labels_stack_free = prove(
-  ``!k n. get_labels (stack_free k n) = {}``,
+val get_labels_stack_free = Q.prove(
+  `!k n. get_labels (stack_free k n) = {}`,
   recInduct stack_free_ind \\ rw []
   \\ once_rewrite_tac [stack_free_def] \\ rw []
   \\ fs [get_labels_def,single_stack_free_def]);
 
-val get_labels_stack_alloc = prove(
-  ``!k n. get_labels (stack_alloc k n) = {}``,
+val get_labels_stack_alloc = Q.prove(
+  `!k n. get_labels (stack_alloc k n) = {}`,
   recInduct stack_alloc_ind \\ rw []
   \\ once_rewrite_tac [stack_alloc_def] \\ rw []
   \\ fs [get_labels_def,single_stack_alloc_def]);
 
-val get_labels_upshift = prove(
-  ``!n n0. get_labels (upshift n n0) = {}``,
+val get_labels_upshift = Q.prove(
+  `!n n0. get_labels (upshift n n0) = {}`,
   recInduct upshift_ind \\ rw []
   \\ once_rewrite_tac [upshift_def] \\ rw []
   \\ fs [get_labels_def]);
 
-val get_labels_downshift = prove(
-  ``!n n0. get_labels (downshift n n0) = {}``,
+val get_labels_downshift = Q.prove(
+  `!n n0. get_labels (downshift n n0) = {}`,
   recInduct downshift_ind \\ rw []
   \\ once_rewrite_tac [downshift_def] \\ rw []
   \\ fs [get_labels_def]);
 
-val get_labels_comp = store_thm("get_labels_comp",
-  ``!off k e. get_labels (comp off k e) = get_labels e``,
+val get_labels_comp = Q.store_thm("get_labels_comp",
+  `!off k e. get_labels (comp off k e) = get_labels e`,
   recInduct comp_ind \\ rw [] \\ Cases_on `p`
   \\ once_rewrite_tac [comp_def] \\ fs [get_labels_def] \\ rw []
   \\ fs [get_labels_def,list_Seq_def]
@@ -860,8 +860,8 @@ val get_labels_comp = store_thm("get_labels_comp",
   \\ fs [get_labels_stack_alloc,get_labels_stack_free,stack_store_def,stack_load_def,get_labels_def]
   \\ metis_tac[get_labels_upshift,get_labels_downshift])
 
-val code_rel_loc_check = store_thm("code_rel_loc_check",
-  ``code_rel off k c1 c2 /\ loc_check c1 (l1,l2) ==> loc_check c2 (l1,l2)``,
+val code_rel_loc_check = Q.store_thm("code_rel_loc_check",
+  `code_rel off k c1 c2 /\ loc_check c1 (l1,l2) ==> loc_check c2 (l1,l2)`,
   fs [loc_check_def,code_rel_def,domain_lookup,PULL_EXISTS] \\ rw []
   \\ res_tac \\ fs [] \\ disj2_tac
   \\ asm_exists_tac \\ fs [get_labels_comp]);
@@ -931,10 +931,10 @@ val evaluate_stack_free = Q.store_thm("evaluate_stack_free",
   \\ ntac 2 strip_tac
   \\ qexists_tac`ck+ck'`\\simp[]);
 
-val evaluate_upshift = prove(``
+val evaluate_upshift = Q.prove(`
   ∀r n st w.
   FLOOKUP st.regs r = SOME (Word w) ⇒
-  evaluate(upshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w + word_offset n)))``,
+  evaluate(upshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w + word_offset n)))`,
   ho_match_mp_tac upshift_ind>>rw[]>>
   simp[Once upshift_def]>>IF_CASES_TAC>>
   simp[evaluate_def,inst_def,assign_def,word_exp_def,wordLangTheory.word_op_def,set_var_def]>>
@@ -947,10 +947,10 @@ val evaluate_upshift = prove(``
   FULL_SIMP_TAC std_ss [GSYM RIGHT_ADD_DISTRIB]>>
   simp[])
 
-val evaluate_downshift = prove(``
+val evaluate_downshift = Q.prove(`
   ∀r n st w.
   FLOOKUP st.regs r = SOME (Word w) ⇒
-  evaluate(downshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w - word_offset n)))``,
+  evaluate(downshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w - word_offset n)))`,
   ho_match_mp_tac downshift_ind>>rw[]>>
   simp[Once downshift_def]>>IF_CASES_TAC>>
   simp[evaluate_def,inst_def,assign_def,word_exp_def,wordLangTheory.word_op_def,set_var_def]>>
@@ -2166,15 +2166,15 @@ val byte_aligned_bytes_in_word_MULT = Q.prove(
   \\ qspecl_then [`3`,`w`] mp_tac alignmentTheory.aligned_mul_shift_1
   \\ fs [WORD_MUL_LSL]);
 
-val init_code_thm = store_thm("init_code_thm",
-  ``init_code_pre k s /\ code_rel off k code s.code /\
+val init_code_thm = Q.store_thm("init_code_thm",
+  `init_code_pre k s /\ code_rel off k code s.code /\
     lookup stack_err_lab s.code = SOME (halt_inst 2w) ==>
     case evaluate (init_code max_heap bitmaps k,s) of
     | (SOME res,t) =>
          ?w. (res = Halt (Word w)) /\ w <> 0w /\ t.ffi = s.ffi
     | (NONE,t) =>
          state_rel off k (init_reduce k code bitmaps t) t /\ t.ffi = s.ffi /\
-         init_prop max_heap (init_reduce k code bitmaps t)``,
+         init_prop max_heap (init_reduce k code bitmaps t)`,
   simp_tac std_ss [init_code_pre_def] \\ strip_tac
   \\ `k <> 3 /\ k <> 4 /\ k <> 5` by decide_tac
   \\ full_simp_tac std_ss [init_code_def,LET_DEF]
@@ -2445,8 +2445,8 @@ val evaluate_init_code_ffi = Q.prove(
   \\ fs [clock_neutral_def,init_code_def,halt_inst_def,
          list_Seq_def,init_memory_def,clock_neutral_store_list_code]);
 
-val init_semantics = store_thm("init_semantics",
-  ``lookup stack_err_lab s.code = SOME (halt_inst 2w) /\
+val init_semantics = Q.store_thm("init_semantics",
+  `lookup stack_err_lab s.code = SOME (halt_inst 2w) /\
     code_rel off k code s.code /\
     init_pre max_heap bitmaps k start s ==>
     case evaluate (init_code max_heap bitmaps k,s) of
@@ -2456,7 +2456,7 @@ val init_semantics = store_thm("init_semantics",
     | (NONE,t) =>
         (semantics 0 s = semantics start t) /\
         ?r. make_init_opt max_heap bitmaps k code s = SOME r /\ state_rel off k r t
-    | _ => F``,
+    | _ => F`,
   srw_tac[][]
   \\ pop_assum (fn th => assume_tac th \\ mp_tac th)
   \\ simp_tac std_ss [init_pre_def] \\ rw []
@@ -2518,22 +2518,22 @@ val init_semantics = store_thm("init_semantics",
          \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val make_init_opt_SOME_semantics = store_thm("make_init_opt_SOME_semantics",
-  ``init_pre max_heap bitmaps k start s2 /\ code_rel off k code s2.code /\
+val make_init_opt_SOME_semantics = Q.store_thm("make_init_opt_SOME_semantics",
+  `init_pre max_heap bitmaps k start s2 /\ code_rel off k code s2.code /\
     lookup stack_err_lab s2.code = SOME (halt_inst 2w) /\
     make_init_opt max_heap bitmaps k code s2 = SOME s1 /\
     semantics start s1 <> Fail ==>
-    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}``,
+    semantics 0 s2 IN extend_with_resource_limit {semantics start s1}`,
   srw_tac[][] \\ imp_res_tac init_semantics \\ pop_assum (assume_tac o SPEC_ALL)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ match_mp_tac (GEN_ALL compile_semantics)
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ metis_tac []);
 
-val make_init_opt_NONE_semantics = store_thm("make_init_opt_NONE_semantics",
-  ``init_pre max_heap bitmaps k start s2 /\ code_rel off k code s2.code /\
+val make_init_opt_NONE_semantics = Q.store_thm("make_init_opt_NONE_semantics",
+  `init_pre max_heap bitmaps k start s2 /\ code_rel off k code s2.code /\
     lookup stack_err_lab s2.code = SOME (halt_inst 2w) /\
     make_init_opt max_heap bitmaps k code s2 = NONE ==>
-    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events``,
+    semantics 0 s2 = Terminate Resource_limit_hit s2.ffi.io_events`,
   srw_tac[][] \\ imp_res_tac init_semantics \\ pop_assum (assume_tac o SPEC_ALL)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]);

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -523,7 +523,7 @@ val evaluate_single_stack_alloc = Q.store_thm("evaluate_single_stack_alloc",
   \\ BasicProvers.TOP_CASE_TAC \\ full_simp_tac(srw_ss())[]
   >- (
     srw_tac[][find_code_def]
-    \\ rator_x_assum`state_rel`mp_tac
+    \\ qhdtm_x_assum`state_rel`mp_tac
     \\ simp[Once state_rel_def]
     \\ strip_tac
     \\ simp[halt_inst_def,evaluate_def,inst_def,assign_def,word_exp_def,set_var_def,dec_clock_def,get_var_def,FLOOKUP_UPDATE]
@@ -601,12 +601,12 @@ val evaluate_stack_alloc = Q.store_thm("evaluate_stack_alloc",
     \\ asm_exists_tac
     \\ simp[]
     \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[Abbr`s'`] )
-  \\ rator_x_assum`evaluate`mp_tac
+  \\ qhdtm_x_assum`evaluate`mp_tac
   \\ drule (GEN_ALL evaluate_add_clock)
   \\ disch_then(qspec_then`ck'`mp_tac)
   \\ simp[] \\ ntac 2 strip_tac
   \\ qexists_tac`ck+ck'`\\simp[]
-  \\ rator_x_assum`COND`mp_tac
+  \\ qhdtm_x_assum`COND`mp_tac
   \\ simp[Abbr`s'`]
   \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
   \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
@@ -1075,7 +1075,7 @@ val comp_correct = Q.prove(
       \\ rev_full_simp_tac(srw_ss()++ARITH_ss)[dec_clock_def])
     \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[good_syntax_def]
     \\ simp[Once comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[Once evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ fs[]
     \\ drule (GEN_ALL find_code_lemma2)
@@ -1140,7 +1140,7 @@ val comp_correct = Q.prove(
       \\ first_x_assum drule \\ simp[] \\ strip_tac
       \\ first_x_assum drule \\ simp[] \\ strip_tac
       \\ fs[dec_clock_def]
-      \\ rator_x_assum`evaluate`mp_tac
+      \\ qhdtm_x_assum`evaluate`mp_tac
       \\ qmatch_goalsub_rename_tac`ck2 + t2.clock`
       \\ drule (GEN_ALL evaluate_add_clock)
       \\ disch_then(qspec_then`ck2`mp_tac)
@@ -1177,7 +1177,7 @@ val comp_correct = Q.prove(
     \\ first_x_assum drule \\ simp[] \\ strip_tac
     \\ first_x_assum drule \\ simp[] \\ strip_tac
     \\ fs[dec_clock_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ qmatch_goalsub_rename_tac`ck2 + t2.clock`
     \\ drule (GEN_ALL evaluate_add_clock)
     \\ disch_then(qspec_then`ck2`mp_tac)
@@ -1227,7 +1227,7 @@ val comp_correct = Q.prove(
     \\ simp[wordLangTheory.word_op_def]
     \\ full_simp_tac(srw_ss())[evaluate_def]
     \\ every_case_tac \\ full_simp_tac(srw_ss())[]
-    \\ rator_x_assum`state_rel`mp_tac
+    \\ qhdtm_x_assum`state_rel`mp_tac
     \\ simp[state_rel_def,set_var_def,FLOOKUP_UPDATE]
     \\ strip_tac
     \\ rveq
@@ -1238,7 +1238,7 @@ val comp_correct = Q.prove(
     \\ metis_tac[])
   THEN1 (* StackLoad *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
@@ -1260,7 +1260,7 @@ val comp_correct = Q.prove(
     \\ full_simp_tac(srw_ss())[good_syntax_def])
   THEN1 (* StackLoadAny *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
@@ -1290,7 +1290,7 @@ val comp_correct = Q.prove(
     \\ simp[GSYM set_var_def])
   THEN1 (* StackStore *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
@@ -1316,7 +1316,7 @@ val comp_correct = Q.prove(
     \\ simp[])
   THEN1 (* StackStoreAny *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
@@ -1353,7 +1353,7 @@ val comp_correct = Q.prove(
     \\ SEP_WRITE_TAC)
   THEN1 (* StackGetSize *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ strip_tac \\ rveq
@@ -1374,7 +1374,7 @@ val comp_correct = Q.prove(
     \\ ONCE_REWRITE_TAC[GSYM set_var_with_const]
     \\ REWRITE_TAC[with_same_clock]
     \\ dep_rewrite.DEP_REWRITE_TAC[bytes_in_word_word_shift]
-    \\ rator_x_assum`good_syntax`mp_tac \\simp[good_syntax_def]
+    \\ qhdtm_x_assum`good_syntax`mp_tac \\simp[good_syntax_def]
     \\ strip_tac
     \\ qpat_x_assum`¬_`kall_tac
     \\ full_simp_tac(srw_ss())[state_rel_def,FLOOKUP_UPDATE]
@@ -1394,7 +1394,7 @@ val comp_correct = Q.prove(
     \\ decide_tac)
   THEN1 (* StackSetSize *) (
     simp[comp_def]
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp[evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
@@ -1518,14 +1518,14 @@ val compile_semantics = Q.store_thm("compile_semantics",
         Cases_on`t'.ffi.final_event`>>full_simp_tac(srw_ss())[] >- (
           rveq
           \\ `t2.ffi = r''.ffi` by (every_case_tac \\ full_simp_tac(srw_ss())[state_rel_def])
-          \\ ntac 2 (rator_x_assum`evaluate`mp_tac) >>
+          \\ ntac 2 (qhdtm_x_assum`evaluate`mp_tac) >>
           drule (GEN_ALL evaluate_add_clock) >>
           disch_then(qspec_then`ck+k'`mp_tac) >>
           simp[] >>
           impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
           simp[] >> ntac 3 strip_tac >>
           rveq >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]) >>
-        rator_x_assum`evaluate`mp_tac >>
+        qhdtm_x_assum`evaluate`mp_tac >>
         qmatch_assum_abbrev_tac`evaluate (e,ss) = (_,t')` >>
         qspecl_then[`ck+k'`,`e`,`ss`]mp_tac(GEN_ALL evaluate_add_clock_io_events_mono)>>
         simp[Abbr`ss`] >>
@@ -1533,7 +1533,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
         `t2.ffi = r''.ffi` by (every_case_tac \\ full_simp_tac(srw_ss())[state_rel_def])
         \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[]
         \\ simp[extend_with_resource_limit_def]) >>
-      rator_x_assum`evaluate`mp_tac >>
+      qhdtm_x_assum`evaluate`mp_tac >>
       drule (GEN_ALL evaluate_add_clock) >>
       disch_then(qspec_then`k''`mp_tac) >>
       simp[] >> strip_tac >>
@@ -1603,7 +1603,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     \\ BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
     \\ BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
     \\ BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
-    \\ ntac 2 (rator_x_assum`evaluate`mp_tac)
+    \\ ntac 2 (qhdtm_x_assum`evaluate`mp_tac)
     \\ drule (GEN_ALL evaluate_add_clock)
     \\ simp[] )
   \\ DEEP_INTRO_TAC some_intro \\ full_simp_tac(srw_ss())[]
@@ -1624,7 +1624,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     \\ simp[good_syntax_def,comp_def]
     \\ strip_tac
     \\ qpat_x_assum`∀k. _ ∨ _`(fn th => assume_tac th >> qspec_then`ck+k'`mp_tac th)
-    \\ rator_x_assum`evaluate`mp_tac
+    \\ qhdtm_x_assum`evaluate`mp_tac
     \\ simp_tac(srw_ss())[]
     \\ strip_tac
     \\ qpat_x_assum`option_CASE _ _ _`mp_tac
@@ -1697,7 +1697,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
     qexists_tac`ck+k'`>>simp[] ) >>
   srw_tac[][] >>
   qexists_tac`k'`>>simp[] >>
-  ntac 2 (rator_x_assum`evaluate`mp_tac) >>
+  ntac 2 (qhdtm_x_assum`evaluate`mp_tac) >>
   qmatch_assum_abbrev_tac`evaluate (e,ss) = _` >>
   qspecl_then[`ck`,`e`,`ss`]mp_tac(GEN_ALL evaluate_add_clock_io_events_mono)>>
   simp[Abbr`ss`] >>

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -232,7 +232,7 @@ val inst_correct = Q.store_thm("inst_correct",
     \\ fs[]
     \\ fs[get_var_def]
     \\ drule (GEN_ALL state_rel_read_reg_FLOOKUP_regs)
-    \\ rator_x_assum`FLOOKUP`mp_tac
+    \\ qhdtm_x_assum`FLOOKUP`mp_tac
     \\ match_mp_tac SWAP_IMP
     \\ disch_then drule
     \\ disch_then (assume_tac o SYM)
@@ -248,7 +248,7 @@ val inst_correct = Q.store_thm("inst_correct",
     \\ simp[stackSemTheory.state_component_equality]
     \\ rveq \\ simp[]) >>
   TRY (
-    rator_x_assum`mem_load_byte_aux`mp_tac
+    qhdtm_x_assum`mem_load_byte_aux`mp_tac
     \\ fs[wordSemTheory.mem_load_byte_aux_def,labSemTheory.mem_load_byte_def,labSemTheory.addr_def]
     \\ BasicProvers.TOP_CASE_TAC \\ fs[]
     \\ fs[word_exp_def,wordLangTheory.word_op_def]
@@ -260,7 +260,7 @@ val inst_correct = Q.store_thm("inst_correct",
     \\ disch_then (assume_tac o SYM) \\ fs[]
     \\ fs[get_var_def]
     \\ drule (GEN_ALL state_rel_read_reg_FLOOKUP_regs)
-    \\ rator_x_assum`FLOOKUP`mp_tac
+    \\ qhdtm_x_assum`FLOOKUP`mp_tac
     \\ match_mp_tac SWAP_IMP
     \\ TRY (
          disch_then drule
@@ -488,11 +488,11 @@ val flatten_correct = Q.store_thm("flatten_correct",
   (* Seq *)
   conj_tac >- (
     srw_tac[][] >>
-    rator_x_assum`evaluate`mp_tac >>
+    qhdtm_x_assum`evaluate`mp_tac >>
     simp[Once stackSemTheory.evaluate_def] >>
     strip_tac >>
     pairarg_tac >> full_simp_tac(srw_ss())[] >>
-    rator_x_assum`code_installed`mp_tac >>
+    qhdtm_x_assum`code_installed`mp_tac >>
     simp[Once flatten_def] >>
     simp[UNCURRY] >> strip_tac >>
     imp_res_tac code_installed_append_imp >>
@@ -878,7 +878,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
     \\ reverse BasicProvers.TOP_CASE_TAC \\ full_simp_tac(srw_ss())[]
     >- (
       strip_tac \\ rveq \\ full_simp_tac(srw_ss())[]
-      \\ rator_x_assum`code_installed`mp_tac
+      \\ qhdtm_x_assum`code_installed`mp_tac
       \\ simp[Once flatten_def]
       \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
       \\ simp[code_installed_def] \\ strip_tac
@@ -905,7 +905,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
     >- (
       strip_tac \\ rveq \\ full_simp_tac(srw_ss())[]
       \\ rev_full_simp_tac(srw_ss())[]
-      \\ rator_x_assum`code_installed`mp_tac
+      \\ qhdtm_x_assum`code_installed`mp_tac
       \\ simp[Once flatten_def]
       \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
       \\ simp[code_installed_def]
@@ -932,7 +932,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
     \\ BasicProvers.TOP_CASE_TAC \\ full_simp_tac(srw_ss())[]
     >- (
       strip_tac \\ rveq \\ full_simp_tac(srw_ss())[]
-      \\ rator_x_assum`code_installed`mp_tac
+      \\ qhdtm_x_assum`code_installed`mp_tac
       \\ simp[Once flatten_def]
       \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
       \\ simp[code_installed_def] \\ strip_tac
@@ -956,7 +956,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
       \\ full_simp_tac(srw_ss())[state_rel_def] )
     \\ strip_tac \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[]
     \\ full_simp_tac(srw_ss())[STOP_def]
-    \\ rator_x_assum`code_installed`mp_tac
+    \\ qhdtm_x_assum`code_installed`mp_tac
     \\ simp[Once flatten_def]
     \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
     \\ simp[code_installed_def] \\ strip_tac
@@ -1006,7 +1006,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
   conj_tac >- (
     srw_tac[][] >>
     full_simp_tac(srw_ss())[Q.SPEC`JumpLower _ _ _`flatten_def] >>
-    rator_x_assum`evaluate`mp_tac >>
+    qhdtm_x_assum`evaluate`mp_tac >>
     simp[Once stackSemTheory.evaluate_def] >>
     Cases_on`get_var r1 s`>>full_simp_tac(srw_ss())[]>> Cases_on`x`>>full_simp_tac(srw_ss())[]>>
     Cases_on`get_var r2 s`>>full_simp_tac(srw_ss())[]>> Cases_on`x`>>full_simp_tac(srw_ss())[]>>
@@ -1055,9 +1055,9 @@ val flatten_correct = Q.store_thm("flatten_correct",
   (* Call *)
   conj_tac >- (
     srw_tac[][] >>
-    rator_x_assum`code_installed`mp_tac >>
+    qhdtm_x_assum`code_installed`mp_tac >>
     simp[Once flatten_def] >> strip_tac >>
-    rator_x_assum`evaluate`mp_tac >>
+    qhdtm_x_assum`evaluate`mp_tac >>
     simp[Once stackSemTheory.evaluate_def] >>
     BasicProvers.TOP_CASE_TAC>>full_simp_tac(srw_ss())[]>-(
       reverse (Cases_on `handler`)
@@ -1077,7 +1077,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
         first_assum(fn th => first_assum(
           tryfind (strip_assume_tac o C MATCH_MP th) o CONJUNCTS o CONV_RULE (REWR_CONV state_rel_def))) >>
         drule state_rel_with_pc >>
-        rator_x_assum`state_rel`kall_tac >>
+        qhdtm_x_assum`state_rel`kall_tac >>
         strip_tac >>
         first_x_assum drule >>
         simp[] >>
@@ -1098,7 +1098,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
       first_assum(fn th => first_assum(
         tryfind (strip_assume_tac o C MATCH_MP th) o CONJUNCTS o CONV_RULE (REWR_CONV state_rel_def))) >>
       drule state_rel_with_pc >>
-      rator_x_assum`state_rel`kall_tac >>
+      qhdtm_x_assum`state_rel`kall_tac >>
       strip_tac >>
       first_x_assum drule >>
       simp[] >>
@@ -1146,7 +1146,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
     `dest_to_loc (s.regs \\ t1.link_reg) dest = dest_to_loc' t1.regs dest` by (
       EVAL_TAC >>
       CASE_TAC >> full_simp_tac(srw_ss())[] >>
-      rator_x_assum`state_rel`mp_tac >>
+      qhdtm_x_assum`state_rel`mp_tac >>
       simp[DOMSUB_FAPPLY_THM] >>
       simp[state_rel_def,FLOOKUP_DEF] ) >>
     full_simp_tac(srw_ss())[] >>
@@ -1159,7 +1159,7 @@ val flatten_correct = Q.store_thm("flatten_correct",
     `loc_to_pc (dest_to_loc' regs dest) 0 t1.code = SOME pc` by (
       ntac 2 (last_x_assum(qspec_then`ARB`kall_tac))>>
       qpat_x_assum`_ ⇒ ∀x. _`kall_tac >>
-      rator_x_assum`loc_to_pc`mp_tac >>
+      qhdtm_x_assum`loc_to_pc`mp_tac >>
       simp[dest_to_loc'_def] >>
       CASE_TAC >> simp[] >>
       full_simp_tac(srw_ss())[Abbr`regs`,APPLY_UPDATE_THM] ) >>
@@ -1509,7 +1509,7 @@ val flatten_semantics = Q.store_thm("flatten_semantics",
     srw_tac[][] >>
     simp[labSemTheory.semantics_def] >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >- (
-      rator_x_assum`stackSem$evaluate`kall_tac >>
+      qhdtm_x_assum`stackSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k'+1`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       spose_not_then strip_assume_tac >> full_simp_tac(srw_ss())[] >>
@@ -1552,7 +1552,7 @@ val flatten_semantics = Q.store_thm("flatten_semantics",
             last_x_assum(qspec_then`k`mp_tac)>>simp[] >>
             strip_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] ) >>
           simp[] >>
-          rator_x_assum`labSem$evaluate`mp_tac >>
+          qhdtm_x_assum`labSem$evaluate`mp_tac >>
           drule labPropsTheory.evaluate_ADD_clock >>
           disch_then(qspec_then`k-1+ck`mp_tac) >>
           simp[]  >>
@@ -1575,7 +1575,7 @@ val flatten_semantics = Q.store_thm("flatten_semantics",
           last_x_assum(qspec_then`k'+1+k`mp_tac) >>
           simp[] >> srw_tac[][] ) >>
         strip_tac >>
-        rator_x_assum`stackSem$evaluate`mp_tac >>
+        qhdtm_x_assum`stackSem$evaluate`mp_tac >>
         drule (GEN_ALL stackPropsTheory.evaluate_add_clock) >>
         disch_then(qspec_then`k'+1`mp_tac) >>
         impl_tac >- (strip_tac >> full_simp_tac(srw_ss())[]) >>
@@ -1599,7 +1599,7 @@ val flatten_semantics = Q.store_thm("flatten_semantics",
         qpat_x_assum`∀extra. _ ∧ _`(qspec_then`ck+k`mp_tac) >>
         fsrw_tac[ARITH_ss][ADD1] >> strip_tac >>
         full_simp_tac(srw_ss())[state_rel_def] >> rev_full_simp_tac(srw_ss())[] ) >>
-      rator_x_assum`labSem$evaluate`mp_tac >>
+      qhdtm_x_assum`labSem$evaluate`mp_tac >>
       drule labPropsTheory.evaluate_ADD_clock >>
       disch_then(qspec_then`ck+k`mp_tac)>>simp[] >>
       ntac 2 strip_tac >> rveq >>
@@ -1677,7 +1677,7 @@ val flatten_semantics = Q.store_thm("flatten_semantics",
       qispl_then[`ck`,`s2 with clock := k`]mp_tac(GEN_ALL labPropsTheory.evaluate_add_clock_io_events_mono) >>
       simp[] >>
       spose_not_then strip_assume_tac >> full_simp_tac(srw_ss())[] ) >>
-    rator_x_assum`labSem$evaluate`mp_tac >>
+    qhdtm_x_assum`labSem$evaluate`mp_tac >>
     drule(labPropsTheory.evaluate_ADD_clock)>>
     disch_then(qspec_then`ck`mp_tac)>>simp[]) >>
   strip_tac >>

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -304,11 +304,11 @@ val compile_jump_correct = Q.store_thm("compile_jump_correct",
   simp[Once labSemTheory.evaluate_def,asm_fetch_def,get_pc_value_def] >>
   CASE_TAC >> full_simp_tac(srw_ss())[]);
 
-val code_installed_get_labels_IMP = prove(
-  ``!e n q pc.
+val code_installed_get_labels_IMP = Q.prove(
+  `!e n q pc.
       code_installed pc (append (FST (flatten e n q))) c /\
       (l1,l2) ∈ get_labels e ==>
-      ?v. loc_to_pc l1 l2 c = SOME v``,
+      ?v. loc_to_pc l1 l2 c = SOME v`,
   recInduct flatten_ind \\ rw []
   \\ ntac 2 (pop_assum mp_tac)
   \\ once_rewrite_tac [flatten_def]
@@ -332,9 +332,9 @@ val code_installed_get_labels_IMP = prove(
   \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []
   \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []);
 
-val loc_check_IMP_loc_to_pc = store_thm("loc_check_IMP_loc_to_pc",
-  ``loc_check s.code (l1,l2) /\ state_rel s t1 ==>
-    ?v. loc_to_pc l1 l2 t1.code = SOME v``,
+val loc_check_IMP_loc_to_pc = Q.store_thm("loc_check_IMP_loc_to_pc",
+  `loc_check s.code (l1,l2) /\ state_rel s t1 ==>
+    ?v. loc_to_pc l1 l2 t1.code = SOME v`,
   rw [loc_check_def] \\ fs [state_rel_def]
   \\ fs [domain_lookup] \\ res_tac \\ fs []
   \\ imp_res_tac code_installed_get_labels_IMP \\ fs []);
@@ -1809,15 +1809,15 @@ fun define_abbrev name tm = let
   val n = mk_var(name,mk_type("fun",[type_of vars, type_of tm]))
   in Define `^n ^vars = ^tm` end;
 
-val FLOOKUP_regs = prove(
-  ``!regs n v f s.
+val FLOOKUP_regs = Q.prove(
+  `!regs n v f s.
       FLOOKUP (FEMPTY |++ MAP (λr. (r,read_reg r s)) regs) n = SOME v ==>
-      read_reg n s = v``,
+      read_reg n s = v`,
   recInduct SNOC_INDUCT \\ fs [FUPDATE_LIST,FOLDL_SNOC,MAP_SNOC]
   \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs []);
 
-val state_rel_make_init = store_thm("state_rel_make_init",
-  ``state_rel (make_init code regs save_regs s) (s:('a,'ffi) labSem$state) <=>
+val state_rel_make_init = Q.store_thm("state_rel_make_init",
+  `state_rel (make_init code regs save_regs s) (s:('a,'ffi) labSem$state) <=>
     (∀n prog.
      lookup n code = SOME (prog) ⇒
      good_syntax prog s.ptr_reg s.len_reg s.link_reg ∧
@@ -1826,7 +1826,7 @@ val state_rel_make_init = store_thm("state_rel_make_init",
        loc_to_pc n 0 s.code = SOME pc) ∧ ¬s.failed ∧
     s.link_reg ≠ s.len_reg ∧ s.link_reg ≠ s.ptr_reg ∧
     s.link_reg ∉ save_regs ∧ (∀k n. k ∈ save_regs ⇒ s.io_regs n k = NONE) ∧
-    (∀x. x ∈ s.mem_domain ⇒ w2n x MOD (dimindex (:α) DIV 8) = 0)``,
+    (∀x. x ∈ s.mem_domain ⇒ w2n x MOD (dimindex (:α) DIV 8) = 0)`,
   fs [state_rel_def,make_init_def,FLOOKUP_regs]
   \\ eq_tac \\ strip_tac \\ fs []
   \\ metis_tac [FLOOKUP_regs]);
@@ -1914,7 +1914,7 @@ val next_lab_non_zero = Q.store_thm("next_lab_non_zero",`
   rw[]>>once_rewrite_tac[next_lab_def]>>fs[]>>
   BasicProvers.EVERY_CASE_TAC>>fs[]);
 
-val stack_to_lab_lab_pres = store_thm("stack_to_lab_lab_pres",``
+val stack_to_lab_lab_pres = Q.store_thm("stack_to_lab_lab_pres",`
   ∀p n nl.
   EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) (extract_labels p) ∧
   ALL_DISTINCT (extract_labels p) ∧
@@ -1923,7 +1923,7 @@ val stack_to_lab_lab_pres = store_thm("stack_to_lab_lab_pres",``
   EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) (extract_labels (append cp)) ∧
   ALL_DISTINCT (extract_labels (append cp)) ∧
   (∀lab. MEM lab (extract_labels (append cp)) ⇒ MEM lab (extract_labels p) ∨ (nl ≤ SND lab ∧ SND lab < nl')) ∧
-  nl ≤ nl'``,
+  nl ≤ nl'`,
   HO_MATCH_MP_TAC flatten_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [flatten_def]>>fs[extract_labels_def,sextract_labels_def]
   >-
@@ -1985,14 +1985,14 @@ val extract_label_store_list_code = Q.prove(`
   ho_match_mp_tac stack_removeTheory.store_list_code_ind>>
   EVAL_TAC>>fs[]);
 
-val stack_to_lab_compile_lab_pres = store_thm("stack_to_lab_compile_lab_pres",``
+val stack_to_lab_compile_lab_pres = Q.store_thm("stack_to_lab_compile_lab_pres",`
   EVERY (λn. n ≠ 0 ∧ n ≠ 1 ∧ n ≠ 2 ∧ n ≠ gc_stub_location) (MAP FST prog) ∧
   EVERY (λn,p.
     let labs = extract_labels p in
     EVERY (λ(l1,l2).l1 = n ∧ l2 ≠ 0) labs ∧
     ALL_DISTINCT labs) prog ∧
   ALL_DISTINCT (MAP FST prog) ⇒
-  labels_ok (compile c c2 c3 sp prog)``,
+  labels_ok (compile c c2 c3 sp prog)`,
   rw[labels_ok_def,stack_to_labTheory.compile_def]
   >-
     (fs[MAP_prog_to_section_FST,MAP_FST_compile_compile]>>

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -1831,9 +1831,9 @@ val state_rel_make_init = store_thm("state_rel_make_init",
   \\ eq_tac \\ strip_tac \\ fs []
   \\ metis_tac [FLOOKUP_regs]);
 
-val halt_assum_lemma = prove(
-  ``halt_assum (:'ffi)
-     (fromAList (stack_names$compile f (compile max_heap bitmaps k l code)))``,
+val halt_assum_lemma = Q.prove(
+  `halt_assum (:'ffi)
+     (fromAList (stack_names$compile f (compile max_heap bitmaps k l code)))`,
   fs [halt_assum_def] \\ rw []
   \\ fs [stackSemTheory.evaluate_def,
          stackSemTheory.find_code_def]
@@ -1846,10 +1846,10 @@ val halt_assum_lemma = prove(
   \\ fs [stackSemTheory.evaluate_def,EVAL ``inst (Const n 0w) (dec_clock s)``,
          get_var_def,FLOOKUP_UPDATE]);
 
-val MAP_FST_compile_compile = prove(
-  ``MAP FST (compile max_heap bitmaps k InitGlobals_location
+val MAP_FST_compile_compile = Q.prove(
+  `MAP FST (compile max_heap bitmaps k InitGlobals_location
               (stack_alloc$compile c code)) =
-    0::1::2::gc_stub_location::MAP FST code``,
+    0::1::2::gc_stub_location::MAP FST code`,
   fs [stack_removeTheory.compile_def,stack_removeTheory.init_stubs_def,
       stack_allocTheory.compile_def,
       stack_allocTheory.stubs_def,stack_removeTheory.prog_comp_def]
@@ -1901,15 +1901,15 @@ val extract_labels_def = Define`
   (extract_labels ((Label l1 l2 _)::xs) = (l1,l2):: extract_labels xs) ∧
   (extract_labels (x::xs) = extract_labels xs)`
 
-val extract_labels_append = store_thm("extract_labels_append",``
+val extract_labels_append = Q.store_thm("extract_labels_append",`
   ∀A B.
-  extract_labels (A++B) = extract_labels A ++ extract_labels B``,
+  extract_labels (A++B) = extract_labels A ++ extract_labels B`,
   Induct>>fs[extract_labels_def]>>Cases_on`h`>>rw[extract_labels_def]);
 
 val sextract_labels_def = stackPropsTheory.extract_labels_def
 
-val next_lab_non_zero = store_thm("next_lab_non_zero",``
-  ∀p. 1 ≤ next_lab p``,
+val next_lab_non_zero = Q.store_thm("next_lab_non_zero",`
+  ∀p. 1 ≤ next_lab p`,
   ho_match_mp_tac next_lab_ind>>Cases_on`p`>>
   rw[]>>once_rewrite_tac[next_lab_def]>>fs[]>>
   BasicProvers.EVERY_CASE_TAC>>fs[]);
@@ -1973,15 +1973,15 @@ val labels_ok_def = Define`
     EVERY (λ(l1,l2). l1 = n ∧ l2 ≠ 0) labs ∧
     ALL_DISTINCT labs) code`;
 
-val MAP_prog_to_section_FST = prove(``
+val MAP_prog_to_section_FST = Q.prove(`
   MAP (λs. case s of Section n v => n) (MAP prog_to_section prog) =
-  MAP FST prog``,
+  MAP FST prog`,
   match_mp_tac LIST_EQ>>rw[EL_MAP]>>Cases_on`EL x prog`>>fs[prog_to_section_def]>>
   pairarg_tac>>fs[]);
 
-val extract_label_store_list_code = prove(``
+val extract_label_store_list_code = Q.prove(`
   ∀a t ls.
-  extract_labels (store_list_code a t ls) = []``,
+  extract_labels (store_list_code a t ls) = []`,
   ho_match_mp_tac stack_removeTheory.store_list_code_ind>>
   EVAL_TAC>>fs[]);
 

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -8,22 +8,22 @@ val _ = bring_to_front_overload"get_vars"{Name="get_vars",Thy="wordSem"};
 val _ = bring_to_front_overload"prog_size"{Name="prog_size",Thy="wordLang"};
 
 (*TODO: Move?*)
-val SUBSET_OF_INSERT = store_thm("SUBSET_OF_INSERT",
-``!s x. s ⊆ x INSERT s``,
+val SUBSET_OF_INSERT = Q.store_thm("SUBSET_OF_INSERT",
+`!s x. s ⊆ x INSERT s`,
   srw_tac[][SUBSET_DEF]);
 
-val INJ_UNION = prove(
-``!f A B.
+val INJ_UNION = Q.prove(
+`!f A B.
   INJ f (A ∪ B) UNIV ⇒
   INJ f A UNIV ∧
-  INJ f B UNIV``,
+  INJ f B UNIV`,
   srw_tac[][]>>
   metis_tac[INJ_SUBSET,SUBSET_DEF,SUBSET_UNION]);
 
-val INJ_less = prove(``
+val INJ_less = Q.prove(`
   INJ f s' UNIV ∧ s ⊆ s'
   ⇒
-  INJ f s UNIV``,
+  INJ f s UNIV`,
   metis_tac[INJ_DEF,SUBSET_DEF])
 
 val list_max_max = Q.store_thm("list_max_max",
@@ -35,24 +35,24 @@ val list_max_max = Q.store_thm("list_max_max",
 val hide_def = Define`
   hide x = x`;
 
-val INJ_IMP_IMAGE_DIFF = prove(``
+val INJ_IMP_IMAGE_DIFF = Q.prove(`
   INJ f (s ∪ t) UNIV ⇒
-  IMAGE f (s DIFF t) = (IMAGE f s) DIFF (IMAGE f t)``,
+  IMAGE f (s DIFF t) = (IMAGE f s) DIFF (IMAGE f t)`,
   rw[EXTENSION,EQ_IMP_THM]>> TRY (metis_tac[])>>
   fs[INJ_DEF]>>
   metis_tac[]);
 
-val INJ_IMP_IMAGE_DIFF_single = prove(``
+val INJ_IMP_IMAGE_DIFF_single = Q.prove(`
   INJ f (s ∪ {n}) UNIV ⇒
-  (IMAGE f s) DIFF {f n} = IMAGE f (s DIFF {n})``,
+  (IMAGE f s) DIFF {f n} = IMAGE f (s DIFF {n})`,
   rw[]>>
   `{f n} = IMAGE f {n}` by fs[]>>
   fs[INJ_IMP_IMAGE_DIFF]);
 
-val INJ_ALL_DISTINCT_MAP = prove(``
+val INJ_ALL_DISTINCT_MAP = Q.prove(`
   ∀ls.
   ALL_DISTINCT (MAP f ls) ⇒
-  INJ f (set ls) UNIV``,
+  INJ f (set ls) UNIV`,
   Induct>>full_simp_tac(srw_ss())[INJ_DEF]>>srw_tac[][]>>
   metis_tac[MEM_MAP]);
 
@@ -129,36 +129,36 @@ val strong_locals_rel_def = Define`
     n ∈ ls ∧ lookup n slocs = SOME v ⇒
     lookup (f n) tlocs = SOME v`;
 
-val domain_numset_list_insert = store_thm("domain_numset_list_insert",``
+val domain_numset_list_insert = Q.store_thm("domain_numset_list_insert",`
   ∀ls locs.
-  domain (numset_list_insert ls locs) = domain locs UNION set ls``,
+  domain (numset_list_insert ls locs) = domain locs UNION set ls`,
   Induct>>full_simp_tac(srw_ss())[numset_list_insert_def]>>srw_tac[][]>>
   metis_tac[INSERT_UNION_EQ,UNION_COMM]);
 
-val strong_locals_rel_get_var = prove(``
+val strong_locals_rel_get_var = Q.prove(`
   strong_locals_rel f live st.locals cst.locals ∧
   n ∈ live ∧
   get_var n st = SOME x
   ⇒
-  get_var (f n) cst = SOME x``,
+  get_var (f n) cst = SOME x`,
   full_simp_tac(srw_ss())[get_var_def,strong_locals_rel_def]);
 
-val strong_locals_rel_get_var_imm = prove(``
+val strong_locals_rel_get_var_imm = Q.prove(`
   strong_locals_rel f live st.locals cst.locals ∧
   (case n of Reg n => n ∈ live | _ => T) ∧
   get_var_imm n st = SOME x
   ⇒
-  get_var_imm (apply_colour_imm f n) cst = SOME x``,
+  get_var_imm (apply_colour_imm f n) cst = SOME x`,
   Cases_on`n`>>full_simp_tac(srw_ss())[get_var_imm_def]>>
   metis_tac[strong_locals_rel_get_var]);
 
-val strong_locals_rel_get_vars = prove(``
+val strong_locals_rel_get_vars = Q.prove(`
   ∀ls y f live st cst.
   strong_locals_rel f live st.locals cst.locals ∧
   (∀x. MEM x ls ⇒ x ∈ live) ∧
   get_vars ls st = SOME y
   ⇒
-  get_vars (MAP f ls) cst = SOME y``,
+  get_vars (MAP f ls) cst = SOME y`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>srw_tac[][]>>
   Cases_on`get_var h st`>>full_simp_tac(srw_ss())[]>>
   `h ∈ live` by full_simp_tac(srw_ss())[]>>
@@ -169,25 +169,25 @@ val strong_locals_rel_get_vars = prove(``
   >-metis_tac[]>>
   full_simp_tac(srw_ss())[]);
 
-val domain_big_union_subset = prove(``
+val domain_big_union_subset = Q.prove(`
   !ls a.
   MEM a ls ⇒
   domain (get_live_exp a) ⊆
-  domain (big_union (MAP get_live_exp ls))``,
+  domain (big_union (MAP get_live_exp ls))`,
   Induct>>rw[]>>fs[big_union_def,domain_union,SUBSET_UNION,SUBSET_DEF]>>
   metis_tac[]);
 
 val size_tac= (full_simp_tac(srw_ss())[prog_size_def]>>DECIDE_TAC);
 
-val apply_nummap_key_domain = prove(``
+val apply_nummap_key_domain = Q.prove(`
   ∀f names.
   domain (apply_nummap_key f names) =
-  IMAGE f (domain names)``,
+  IMAGE f (domain names)`,
   full_simp_tac(srw_ss())[domain_def,domain_fromAList]>>
   full_simp_tac(srw_ss())[MEM_MAP,MAP_MAP_o,EXTENSION,EXISTS_PROD]>>
   metis_tac[MEM_toAList,domain_lookup]);
 
-val cut_env_lemma = store_thm("cut_env_lemma",``
+val cut_env_lemma = Q.store_thm("cut_env_lemma",`
   ∀names sloc tloc x f.
   INJ f (domain names) UNIV ∧
   cut_env names sloc = SOME x ∧
@@ -197,7 +197,7 @@ val cut_env_lemma = store_thm("cut_env_lemma",``
       domain y = IMAGE f (domain x) ∧
       strong_locals_rel f (domain names) x y ∧
       INJ f (domain x) UNIV ∧
-      domain x = domain names``,
+      domain x = domain names`,
   rpt strip_tac>>
   full_simp_tac(srw_ss())[domain_inter,cut_env_def,apply_nummap_key_domain
     ,strong_locals_rel_def]>>
@@ -219,27 +219,27 @@ val cut_env_lemma = store_thm("cut_env_lemma",``
   >>
     full_simp_tac(srw_ss())[domain_inter,SUBSET_INTER_ABSORPTION,INTER_COMM])
 
-val LENGTH_list_rerrange = prove(``
-  LENGTH (list_rearrange mover xs) = LENGTH xs``,
+val LENGTH_list_rerrange = Q.prove(`
+  LENGTH (list_rearrange mover xs) = LENGTH xs`,
   full_simp_tac(srw_ss())[list_rearrange_def]>>
   IF_CASES_TAC>>full_simp_tac(srw_ss())[])
 
 (*For any 2 lists that are permutations of each other,
   We can give a list_rearranger that permutes one to the other*)
-val list_rearrange_perm = prove(``
+val list_rearrange_perm = Q.prove(`
   PERM xs ys
   ⇒
-  ∃perm. list_rearrange perm xs = ys``,
+  ∃perm. list_rearrange perm xs = ys`,
   srw_tac[][]>>
   imp_res_tac PERM_BIJ>>full_simp_tac(srw_ss())[list_rearrange_def]>>
   qexists_tac`f`>>
   IF_CASES_TAC>>
   full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF]>>metis_tac[])
 
-val GENLIST_MAP = prove(
-  ``!k. (!i. i < LENGTH l ==> m i < LENGTH l) /\ k <= LENGTH l ==>
+val GENLIST_MAP = Q.prove(
+  `!k. (!i. i < LENGTH l ==> m i < LENGTH l) /\ k <= LENGTH l ==>
         GENLIST (\i. EL (m i) (MAP f l)) k =
-        MAP f (GENLIST (\i. EL (m i) l) k)``,
+        MAP f (GENLIST (\i. EL (m i) l) k)`,
   Induct \\ full_simp_tac(srw_ss())[GENLIST] \\ REPEAT STRIP_TAC
   \\ `k < LENGTH l /\ k <= LENGTH l` by DECIDE_TAC
   \\ full_simp_tac(srw_ss())[EL_MAP]);
@@ -378,7 +378,7 @@ val push_env_s_val_eq = store_thm("push_env_s_val_eq",``
 
 (*TODO: Maybe move to props?
 gc doesn't touch other components*)
-val gc_frame = store_thm("gc_frame",``
+val gc_frame = Q.store_thm("gc_frame",`
   gc st = SOME st'
   ⇒
   st'.mdomain = st.mdomain ∧
@@ -390,7 +390,7 @@ val gc_frame = store_thm("gc_frame",``
   st'.be = st.be ∧
   st'.ffi = st.ffi ∧
   st'.permute = st.permute ∧
-  st'.termdep = st.termdep``,
+  st'.termdep = st.termdep`,
   full_simp_tac(srw_ss())[gc_def,LET_THM]>>EVERY_CASE_TAC>>
   full_simp_tac(srw_ss())[state_component_equality]);
 
@@ -438,11 +438,11 @@ val ALOOKUP_key_remap_2 = store_thm("ALOOKUP_key_remap_2",``
 
 val lookup_alist_insert = lookup_alist_insert |> INST_TYPE [alpha|->``:'a word_loc``]
 
-val strong_locals_rel_subset = prove(``
+val strong_locals_rel_subset = Q.prove(`
   s ⊆ s' ∧
   strong_locals_rel f s' st.locals cst.locals
   ⇒
-  strong_locals_rel f s st.locals cst.locals``,
+  strong_locals_rel f s st.locals cst.locals`,
   srw_tac[][strong_locals_rel_def]>>
   metis_tac[SUBSET_DEF]);
 
@@ -457,20 +457,20 @@ val env_to_list_keys = prove(``
   >>
     full_simp_tac(srw_ss())[mem_list_rearrange,QSORT_MEM,MEM_toAList,domain_lookup]);
 
-val list_rearrange_keys = store_thm("list_rearrange_keys",``
+val list_rearrange_keys = Q.store_thm("list_rearrange_keys",`
   list_rearrange perm ls = e ⇒
-  set(MAP FST e) = set(MAP FST ls)``,
+  set(MAP FST e) = set(MAP FST ls)`,
   full_simp_tac(srw_ss())[LET_THM,EXTENSION]>>srw_tac[][EQ_IMP_THM]>>
   metis_tac[MEM_toAList,mem_list_rearrange,MEM_MAP]);
 
-val push_env_pop_env_s_key_eq = store_thm("push_env_pop_env_s_key_eq",
-  ``∀s t x b. s_key_eq (push_env x b s).stack t.stack ⇒
+val push_env_pop_env_s_key_eq = Q.store_thm("push_env_pop_env_s_key_eq",
+  `∀s t x b. s_key_eq (push_env x b s).stack t.stack ⇒
        ∃l ls opt.
               t.stack = (StackFrame l opt)::ls ∧
               ∃y. (pop_env t = SOME y ∧
                    y.locals = fromAList l ∧
                    domain x = domain y.locals ∧
-                   s_key_eq s.stack y.stack)``,
+                   s_key_eq s.stack y.stack)`,
   srw_tac[][]>>Cases_on`b`>>TRY(PairCases_on`x'`)>>full_simp_tac(srw_ss())[push_env_def]>>
   full_simp_tac(srw_ss())[LET_THM,env_to_list_def]>>Cases_on`t.stack`>>
   full_simp_tac(srw_ss())[s_key_eq_def,pop_env_def]>>BasicProvers.EVERY_CASE_TAC>>
@@ -479,13 +479,13 @@ val push_env_pop_env_s_key_eq = store_thm("push_env_pop_env_s_key_eq",
   full_simp_tac(srw_ss())[EXTENSION,mem_list_rearrange,MEM_MAP,QSORT_MEM,MEM_toAList
     ,EXISTS_PROD,domain_lookup]);
 
-val pop_env_frame = store_thm("pop_env_frame",
-  ``s_val_eq r'.stack st' ∧
+val pop_env_frame = Q.store_thm("pop_env_frame",
+  `s_val_eq r'.stack st' ∧
     s_key_eq y'.stack y''.stack ∧
     pop_env (r' with stack:= st') = SOME y'' ∧
     pop_env r' = SOME y'
     ⇒
-    word_state_eq_rel y' y''``,
+    word_state_eq_rel y' y''`,
     full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>
     full_simp_tac(srw_ss())[s_val_eq_def,s_frame_val_eq_def,word_state_eq_rel_def
       ,state_component_equality]>>
@@ -501,13 +501,13 @@ val key_map_implies = store_thm("key_map_implies",
 
 (*Main proof of liveness theorem starts here*)
 
-val apply_colour_exp_lemma = prove(
-  ``∀st w cst f res.
+val apply_colour_exp_lemma = Q.prove(
+  `∀st w cst f res.
     word_exp st w = SOME res ∧
     word_state_eq_rel st cst ∧
     strong_locals_rel f (domain (get_live_exp w)) st.locals cst.locals
     ⇒
-    word_exp cst (apply_colour_exp f w) = SOME res``,
+    word_exp cst (apply_colour_exp f w) = SOME res`,
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,apply_colour_exp_def,strong_locals_rel_def,get_live_exp_def,word_state_eq_rel_def]
   >-
@@ -552,14 +552,14 @@ val setup_tac = Cases_on`word_exp st exp`>>full_simp_tac(srw_ss())[]>>
       imp_res_tac apply_colour_exp_lemma>>
       pop_assum(qspecl_then[`f`,`cst`]mp_tac)>>unabbrev_all_tac;
 
-val LASTN_LENGTH2 = prove(``
-  LASTN (LENGTH xs +1) (x::xs) = x::xs``,
+val LASTN_LENGTH2 = Q.prove(`
+  LASTN (LENGTH xs +1) (x::xs) = x::xs`,
   `LENGTH (x::xs) = LENGTH xs +1` by simp[]>>
   metis_tac[LASTN_LENGTH_ID]);
 
-val toAList_not_empty = prove(``
+val toAList_not_empty = Q.prove(`
   domain t ≠ {} ⇒
-  toAList t ≠ []``,
+  toAList t ≠ []`,
   CCONTR_TAC>>full_simp_tac(srw_ss())[GSYM MEMBER_NOT_EMPTY]>>
   full_simp_tac(srw_ss())[GSYM toAList_domain]);
 
@@ -1364,11 +1364,11 @@ val get_clash_sets_tl = prove(
     full_simp_tac(srw_ss())[UNCURRY])
   >- metis_tac[INJ_UNION,domain_union,INJ_SUBSET,SUBSET_UNION]);
 
-val colouring_ok_alt_thm = store_thm("colouring_ok_alt_thm",
-``∀f prog live.
+val colouring_ok_alt_thm = Q.store_thm("colouring_ok_alt_thm",
+`∀f prog live.
   colouring_ok_alt f prog live
   ⇒
-  colouring_ok f prog live``,
+  colouring_ok f prog live`,
   ho_match_mp_tac (fetch "-" "colouring_ok_ind")>>
   srw_tac[][]>>
   full_simp_tac(srw_ss())[get_clash_sets_def,colouring_ok_alt_def,colouring_ok_def,LET_THM]
@@ -1402,9 +1402,9 @@ val colouring_ok_alt_thm = store_thm("colouring_ok_alt_thm",
 
 val fs1 = full_simp_tac(srw_ss())[LET_THM,get_clash_sets_def,every_var_def,get_live_def,domain_numset_list_insert,domain_union,EVERY_MEM,get_writes_def,every_var_inst_def,get_live_inst_def,in_clash_sets_def,every_name_def,toAList_domain];
 
-val every_var_exp_get_live_exp = prove(
-``∀exp.
-  every_var_exp (λx. x ∈ domain (get_live_exp exp)) exp``,
+val every_var_exp_get_live_exp = Q.prove(
+`∀exp.
+  every_var_exp (λx. x ∈ domain (get_live_exp exp)) exp`,
   ho_match_mp_tac get_live_exp_ind>>
   srw_tac[][]>>full_simp_tac(srw_ss())[get_live_exp_def,every_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>srw_tac[][]>>res_tac>>
@@ -1612,22 +1612,22 @@ val check_col_INJ = store_thm("check_col_INJ",
     fs[domain_fromAList,EXTENSION,MEM_MAP,EXISTS_PROD,MEM_toAList]>>
     fs[domain_lookup]);
 
-val wf_insert_swap = prove(``
+val wf_insert_swap = Q.prove(`
   wf t ⇒
   insert a () (insert c () t) =
-  insert c () (insert a () t)``,
+  insert c () (insert a () t)`,
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[wf_insert,lookup_insert]>>
   rw[]);
 
 (*TODO: This is true without wf*)
-val numset_list_insert_swap = prove(``
+val numset_list_insert_swap = Q.prove(`
   ∀ls h live.
   wf live ⇒
   wf (numset_list_insert ls live) ∧
   numset_list_insert ls (insert h () live) =
-  insert h () (numset_list_insert ls live)``,
+  insert h () (numset_list_insert ls live)`,
   Induct>>fs[numset_list_insert_def]>>rw[]>>
   res_tac>>
   fs[wf_insert,wf_insert_swap]);
@@ -1683,18 +1683,18 @@ val check_partial_col_INJ = store_thm("check_partial_col_INJ",
       rw[])>>
     fs[]);
 
-val domain_insert_eq_union = prove(``
-  domain (insert num () live) = domain (union (insert num () LN) live)``,
+val domain_insert_eq_union = Q.prove(`
+  domain (insert num () live) = domain (union (insert num () LN) live)`,
   fs[domain_union,domain_insert,UNION_COMM,EXTENSION]>>
   metis_tac[]);
 
-val domain_numset_list_insert_eq_union = prove(``
-  domain (numset_list_insert ls live) = domain (union (numset_list_insert ls LN) live)``,
+val domain_numset_list_insert_eq_union = Q.prove(`
+  domain (numset_list_insert ls live) = domain (union (numset_list_insert ls LN) live)`,
   fs[domain_union,domain_numset_list_insert,UNION_COMM]);
 
-val get_reads_exp_get_live_exp = prove(``
+val get_reads_exp_get_live_exp = Q.prove(`
   ∀exp.
-  set(get_reads_exp exp) = domain (get_live_exp exp)``,
+  set(get_reads_exp exp) = domain (get_live_exp exp)`,
   ho_match_mp_tac get_reads_exp_ind>>
   fs[get_reads_exp_def,get_live_exp_def]>>
   rw[EXTENSION]>>
@@ -1712,19 +1712,19 @@ val get_reads_exp_get_live_exp = prove(``
   fs[]>>
   metis_tac[]);
 
-val lookup_numset_list_insert = prove(``
+val lookup_numset_list_insert = Q.prove(`
   ∀ls n t.
   lookup n (numset_list_insert ls t) =
-  if MEM n ls then SOME () else lookup n t``,
+  if MEM n ls then SOME () else lookup n t`,
   Induct>>fs[numset_list_insert_def,lookup_insert]>>rw[]>>
   fs[]);
 
-val numset_list_insert_eq_UNION = prove(``
+val numset_list_insert_eq_UNION = Q.prove(`
   ∀t t' ls.
   wf t ∧ wf t' ∧
   domain t' = set ls ⇒
   numset_list_insert ls t =
-  union t' t``,
+  union t' t`,
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[numset_list_insert_swap,wf_union,EXTENSION]>>rw[]>>
@@ -1739,33 +1739,33 @@ val numset_list_insert_eq_UNION = prove(``
     metis_tac[domain_lookup,option_CASES]>>
   fs[lookup_union,domain_lookup]);
 
-val wf_delete_swap = prove(``
+val wf_delete_swap = Q.prove(`
   wf t ⇒
   delete a (delete c t) =
-  delete c (delete a t)``,
+  delete c (delete a t)`,
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[wf_delete,lookup_delete]>>
   rw[]);
 
-val numset_list_delete_swap = prove(``
+val numset_list_delete_swap = Q.prove(`
   ∀ls h live.
   wf live ⇒
   wf (numset_list_delete ls live) ∧
   numset_list_delete ls (delete h live) =
-  delete h (numset_list_delete ls live)``,
+  delete h (numset_list_delete ls live)`,
   Induct>>fs[numset_list_delete_def]>>rw[]>>
   res_tac>>
   fs[wf_delete,wf_delete_swap]);
 
-val wf_numset_list_delete_eq = prove(``
+val wf_numset_list_delete_eq = Q.prove(`
   ∀ls t live.
   wf t ⇒
-  FOLDR delete t ls = numset_list_delete ls t``,
+  FOLDR delete t ls = numset_list_delete ls t`,
   Induct>>fs[numset_list_delete_def,numset_list_delete_swap])
 
-val wf_get_live_exp = prove(``
-  ∀exp. wf(get_live_exp exp)``,
+val wf_get_live_exp = Q.prove(`
+  ∀exp. wf(get_live_exp exp)`,
   ho_match_mp_tac get_live_exp_ind>>fs[get_live_exp_def,wf_insert,wf_def]>>
   rw[]>>
   fs[big_union_def]>>
@@ -2042,10 +2042,10 @@ val even_starting_locals_def = Define`
 fun rm_let tm = tm|> SIMP_RULE std_ss [LET_THM];
 
 (* Not needed
-val check_colouring_ok_alt_INJ = prove(``
+val check_colouring_ok_alt_INJ = Q.prove(`
   ∀ls.
   check_colouring_ok_alt f ls ⇒
-  EVERY (λx. INJ f (domain x) UNIV) ls``,
+  EVERY (λx. INJ f (domain x) UNIV) ls`,
   Induct>>full_simp_tac(srw_ss())[check_colouring_ok_alt_def,LET_THM]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[GSYM MAP_MAP_o]>>
   imp_res_tac INJ_ALL_DISTINCT_MAP>>
@@ -2130,43 +2130,43 @@ val word_alloc_correct = store_thm("word_alloc_correct",``
   full_simp_tac(srw_ss())[LET_THM]>>
   FULL_CASE_TAC>>full_simp_tac(srw_ss())[]);
 
-val apply_colour_exp_I = prove(``
+val apply_colour_exp_I = Q.prove(`
   ∀f exp.
   f = I ⇒
-  apply_colour_exp f exp = exp``,
+  apply_colour_exp f exp = exp`,
   ho_match_mp_tac apply_colour_exp_ind>>rw[]>>
   fs[MAP_EQ_ID]) |> SIMP_RULE std_ss[];
 
 (* Dead code removal *)
-val strong_locals_rel_I_word_exp = prove(``
+val strong_locals_rel_I_word_exp = Q.prove(`
    word_exp st exp = SOME res ∧
    strong_locals_rel I (domain (union (get_live_exp exp) live)) st.locals t ⇒
-   word_exp (st with locals := t) exp = SOME res``,
+   word_exp (st with locals := t) exp = SOME res`,
    rw[]>>drule apply_colour_exp_lemma>>
    disch_then (qspecl_then [`st with locals:= t`,`I`] mp_tac)>>
    rfs[word_state_eq_rel_def,apply_colour_exp_I]>>
    impl_tac>>fs[]>>
    fs[strong_locals_rel_def,domain_union]);
 
-val strong_locals_rel_insert_notin = prove(``
+val strong_locals_rel_insert_notin = Q.prove(`
   strong_locals_rel f live s t ∧
   n ∉ live ⇒
-  strong_locals_rel f live (insert n v s) t``,
+  strong_locals_rel f live (insert n v s) t`,
   rw[strong_locals_rel_def,lookup_insert]>>
   Cases_on`n'=n`>>fs[]);
 
-val strong_locals_rel_I_get_var = prove(``
+val strong_locals_rel_I_get_var = Q.prove(`
   get_var x st = SOME v ∧
   strong_locals_rel I (x INSERT live) st.locals t ⇒
-  get_var x (st with locals:=t) = SOME v``,
+  get_var x (st with locals:=t) = SOME v`,
   fs[strong_locals_rel_def,get_var_def]);
 
-val strong_locals_rel_I_get_vars = prove(``
+val strong_locals_rel_I_get_vars = Q.prove(`
   ∀ls live st t vs.
   (∀x. MEM x ls ⇒ x ∈ live) ∧
   strong_locals_rel I live st.locals t ∧
   get_vars ls st = SOME vs ⇒
-  get_vars ls (st with locals:=t) = SOME vs``,
+  get_vars ls (st with locals:=t) = SOME vs`,
   Induct>>rw[get_vars_def]>>
   pop_assum mp_tac>>ntac 2 TOP_CASE_TAC>>
   strip_tac>>
@@ -2178,10 +2178,10 @@ val strong_locals_rel_I_get_vars = prove(``
   strip_tac >> res_tac>>
   fs[]);
 
-val strong_locals_rel_I_cut_env = prove(``
+val strong_locals_rel_I_cut_env = Q.prove(`
   strong_locals_rel I (domain cutset) st.locals t ∧
   cut_env cutset st.locals = SOME x ⇒
-  cut_env cutset t = SOME x``,
+  cut_env cutset t = SOME x`,
   fs[cut_env_def,strong_locals_rel_def,SUBSET_DEF]>>rw[]
   >-
     metis_tac[domain_lookup]
@@ -2200,23 +2200,23 @@ val rm_tac =
       imp_res_tac strong_locals_rel_I_word_exp>>
       fs[state_component_equality,strong_locals_rel_def,lookup_insert,domain_union]>>rw[]
 
-val get_vars_eq = prove(
-  ``(set ls) SUBSET domain st.locals ==> ?z. get_vars ls st = SOME z /\
-                                             z = MAP (\x. THE (lookup x st.locals)) ls``,
+val get_vars_eq = Q.prove(
+  `(set ls) SUBSET domain st.locals ==> ?z. get_vars ls st = SOME z /\
+                                             z = MAP (\x. THE (lookup x st.locals)) ls`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[get_vars_def,get_var_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[domain_lookup]);
 
-val get_vars_exists = prove(``
+val get_vars_exists = Q.prove(`
   ∀ls.
   (∃z. get_vars ls st = SOME z) ⇔
-  set ls ⊆ domain st.locals``,
+  set ls ⊆ domain st.locals`,
   Induct>>fs[get_vars_def,get_var_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[domain_lookup]);
 
-val strong_locals_rel_I_insert_insert = prove(``
+val strong_locals_rel_I_insert_insert = Q.prove(`
   strong_locals_rel I (live DELETE p) A B ∧
   v = v' ⇒
-  strong_locals_rel I live (insert p v A) (insert p v' B)``,
+  strong_locals_rel I live (insert p v A) (insert p v' B)`,
   rw[strong_locals_rel_def,lookup_insert]>>
   IF_CASES_TAC>>fs[]);
 
@@ -2625,32 +2625,32 @@ val exists_tac = qexists_tac`cst.permute`>>
     full_simp_tac(srw_ss())[evaluate_def,LET_THM,word_state_eq_rel_def
       ,ssa_cc_trans_def];
 
-val ssa_locals_rel_get_var = prove(``
+val ssa_locals_rel_get_var = Q.prove(`
   ssa_locals_rel na ssa st.locals cst.locals ∧
   get_var n st = SOME x
   ⇒
-  get_var (option_lookup ssa n) cst = SOME x``,
+  get_var (option_lookup ssa n) cst = SOME x`,
   full_simp_tac(srw_ss())[get_var_def,ssa_locals_rel_def,strong_locals_rel_def,option_lookup_def]>>
   srw_tac[][]>>
   FULL_CASE_TAC>>full_simp_tac(srw_ss())[domain_lookup]>>
   first_x_assum(qspecl_then[`n`,`x`] assume_tac)>>rev_full_simp_tac(srw_ss())[]);
 
-val ssa_locals_rel_get_vars = prove(``
+val ssa_locals_rel_get_vars = Q.prove(`
   ∀ls y na ssa st cst.
   ssa_locals_rel na ssa st.locals cst.locals ∧
   get_vars ls st = SOME y
   ⇒
-  get_vars (MAP (option_lookup ssa) ls) cst = SOME y``,
+  get_vars (MAP (option_lookup ssa) ls) cst = SOME y`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>srw_tac[][]>>
   Cases_on`get_var h st`>>full_simp_tac(srw_ss())[]>>
   imp_res_tac ssa_locals_rel_get_var>>full_simp_tac(srw_ss())[]>>
   Cases_on`get_vars ls st`>>full_simp_tac(srw_ss())[]>>
   res_tac>>full_simp_tac(srw_ss())[]);
 
-val ssa_map_ok_extend = prove(``
+val ssa_map_ok_extend = Q.prove(`
   ssa_map_ok na ssa ∧
   ¬is_phy_var na ⇒
-  ssa_map_ok (na+4) (insert h na ssa)``,
+  ssa_map_ok (na+4) (insert h na ssa)`,
   full_simp_tac(srw_ss())[ssa_map_ok_def]>>
   srw_tac[][]>>full_simp_tac(srw_ss())[lookup_insert]>>
   Cases_on`x=h`>>full_simp_tac(srw_ss())[]>>
@@ -3188,35 +3188,35 @@ val fake_moves_correctR = prove(``
 
 (*Swapping lemma that allows us to swap in ssaL for ssaR
   after we are done fixing them*)
-val ssa_eq_rel_swap = prove(``
+val ssa_eq_rel_swap = Q.prove(`
   ssa_locals_rel na ssaR st.locals cst.locals ∧
   domain ssaL = domain ssaR ∧
   (∀x. lookup x ssaL = lookup x ssaR) ⇒
-  ssa_locals_rel na ssaL st.locals cst.locals``,
+  ssa_locals_rel na ssaL st.locals cst.locals`,
   srw_tac[][ssa_locals_rel_def]);
 
-val ssa_locals_rel_more = prove(``
+val ssa_locals_rel_more = Q.prove(`
   ssa_locals_rel na ssa stlocs cstlocs ∧ na ≤ na' ⇒
-  ssa_locals_rel na' ssa stlocs cstlocs``,
+  ssa_locals_rel na' ssa stlocs cstlocs`,
   srw_tac[][ssa_locals_rel_def]>>full_simp_tac(srw_ss())[]
   >- metis_tac[]>>
   res_tac>>full_simp_tac(srw_ss())[]>>
   DECIDE_TAC);
 
-val ssa_map_ok_more = prove(``
+val ssa_map_ok_more = Q.prove(`
   ssa_map_ok na ssa ∧ na ≤ na' ⇒
-  ssa_map_ok na' ssa``,
+  ssa_map_ok na' ssa`,
   full_simp_tac(srw_ss())[ssa_map_ok_def]>>srw_tac[][]
   >-
     metis_tac[]>>
   res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
 
-val get_var_ignore = prove(``
+val get_var_ignore = Q.prove(`
   ∀ls a.
   get_var x cst = SOME y ∧
   ¬MEM x ls ∧
   LENGTH ls = LENGTH a ⇒
-  get_var x (set_vars ls a cst) = SOME y``,
+  get_var x (set_vars ls a cst) = SOME y`,
   Induct>>full_simp_tac(srw_ss())[get_var_def,set_vars_def,alist_insert_def]>>
   srw_tac[][]>>
   Cases_on`a`>>full_simp_tac(srw_ss())[alist_insert_def,lookup_insert]);
@@ -3418,10 +3418,10 @@ val list_next_var_rename_move_preserve = prove(``
       full_simp_tac(srw_ss())[])>>
     metis_tac[convention_partitions]);
 
-val get_vars_list_insert_eq_gen= prove(
-``!ls x locs a b. (LENGTH ls = LENGTH x /\ ALL_DISTINCT ls /\
+val get_vars_list_insert_eq_gen= Q.prove(
+`!ls x locs a b. (LENGTH ls = LENGTH x /\ ALL_DISTINCT ls /\
                   LENGTH a = LENGTH b /\ !e. MEM e ls ==> ~MEM e a)
-  ==> get_vars ls (st with locals := alist_insert (a++ls) (b++x) locs) = SOME x``,
+  ==> get_vars ls (st with locals := alist_insert (a++ls) (b++x) locs) = SOME x`,
   ho_match_mp_tac alist_insert_ind>>
   srw_tac[][]>-
     (Cases_on`x`>>full_simp_tac(srw_ss())[get_vars_def])>>
@@ -3438,21 +3438,21 @@ val get_vars_list_insert_eq_gen= prove(
   `a++[ls]++ls' = a++ls::ls' /\ b++[x]++x' = b++x::x'` by full_simp_tac(srw_ss())[]>>
   ntac 2 (pop_assum SUBST_ALL_TAC)>> full_simp_tac(srw_ss())[]);
 
-val get_vars_set_vars_eq = prove(``
+val get_vars_set_vars_eq = Q.prove(`
   ∀ls x.
   ALL_DISTINCT ls ∧ LENGTH x = LENGTH ls ⇒
-  get_vars ls (set_vars ls x cst) = SOME x``,
+  get_vars ls (set_vars ls x cst) = SOME x`,
   full_simp_tac(srw_ss())[get_vars_def,set_vars_def]>>srw_tac[][]>>
   Q.ISPECL_THEN [`cst`,`ls`,`x`,`cst.locals`,`[]:num list`
     ,`[]:'a word_loc list`] mp_tac (GEN_ALL get_vars_list_insert_eq_gen)>>
   impl_tac>>full_simp_tac(srw_ss())[]);
 
-val ssa_locals_rel_ignore_set_var = prove(``
+val ssa_locals_rel_ignore_set_var = Q.prove(`
   ssa_map_ok na ssa ∧
   ssa_locals_rel na ssa st.locals cst.locals ∧
   is_phy_var v
   ⇒
-  ssa_locals_rel na ssa st.locals (set_var v a cst).locals``,
+  ssa_locals_rel na ssa st.locals (set_var v a cst).locals`,
   srw_tac[][ssa_locals_rel_def,ssa_map_ok_def,set_var_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>-
     metis_tac[]
@@ -3461,13 +3461,13 @@ val ssa_locals_rel_ignore_set_var = prove(``
   full_simp_tac(srw_ss())[domain_lookup]>>
   metis_tac[]);
 
-val ssa_locals_rel_ignore_list_insert = prove(``
+val ssa_locals_rel_ignore_list_insert = Q.prove(`
   ssa_map_ok na ssa ∧
   ssa_locals_rel na ssa st.locals cst.locals ∧
   EVERY is_phy_var ls ∧
   LENGTH ls = LENGTH x
   ⇒
-  ssa_locals_rel na ssa st.locals (alist_insert ls x cst.locals)``,
+  ssa_locals_rel na ssa st.locals (alist_insert ls x cst.locals)`,
   srw_tac[][ssa_locals_rel_def,ssa_map_ok_def]>>
   full_simp_tac(srw_ss())[domain_alist_insert,lookup_alist_insert]>-
     metis_tac[]
@@ -3480,11 +3480,11 @@ val ssa_locals_rel_ignore_list_insert = prove(``
     metis_tac[EVERY_EL])>>
   full_simp_tac(srw_ss())[]);
 
-val ssa_locals_rel_set_var = prove(``
+val ssa_locals_rel_set_var = Q.prove(`
   ssa_locals_rel na ssa st.locals cst.locals ∧
   ssa_map_ok na ssa ∧
   n < na ⇒
-  ssa_locals_rel (na+4) (insert n na ssa) (insert n w st.locals) (insert na w cst.locals)``,
+  ssa_locals_rel (na+4) (insert n na ssa) (insert n w st.locals) (insert na w cst.locals)`,
   srw_tac[][ssa_locals_rel_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>>Cases_on`x=n`>>full_simp_tac(srw_ss())[]
   >-
@@ -3506,15 +3506,15 @@ val ssa_locals_rel_set_var = prove(``
     (*Finally, this illustrates need for <na assumption on st.locals*)
     full_simp_tac(srw_ss())[ssa_map_ok_def]>>res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
 
-val is_alloc_var_add = prove(``
-  is_alloc_var na ⇒ is_alloc_var (na+4)``,
+val is_alloc_var_add = Q.prove(`
+  is_alloc_var na ⇒ is_alloc_var (na+4)`,
   full_simp_tac(srw_ss())[is_alloc_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`4`] assume_tac)>>
     rev_full_simp_tac(srw_ss())[]));
 
-val is_stack_var_add= prove(``
-  is_stack_var na ⇒ is_stack_var (na+4)``,
+val is_stack_var_add= Q.prove(`
+  is_stack_var na ⇒ is_stack_var (na+4)`,
   full_simp_tac(srw_ss())[is_stack_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`4`] assume_tac)>>
@@ -3523,15 +3523,15 @@ val is_stack_var_add= prove(``
 
 val _ = diminish_srw_ss ["MOD_ss"]
 
-val is_alloc_var_flip = prove(``
-  is_alloc_var na ⇒ is_stack_var (na+2)``,
+val is_alloc_var_flip = Q.prove(`
+  is_alloc_var na ⇒ is_stack_var (na+2)`,
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`2`] assume_tac)>>
     srw_tac[][]>>full_simp_tac(srw_ss())[]));
 
-val is_stack_var_flip = prove(``
-  is_stack_var na ⇒ is_alloc_var (na+2)``,
+val is_stack_var_flip = Q.prove(`
+  is_stack_var na ⇒ is_alloc_var (na+2)`,
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`2`] assume_tac)>>
@@ -3628,9 +3628,9 @@ val th =
     (PROVE[]``((a ⇒ b) ∧ (c ⇒ d)) ⇒ ((a ∨ c) ⇒ b ∨ d)``)
     (CONJ is_stack_var_flip is_alloc_var_flip))
 
-val flip_rw = prove(
-  ``is_stack_var(na+2) = is_alloc_var na ∧
-    is_alloc_var(na+2) = is_stack_var na``,
+val flip_rw = Q.prove(
+  `is_stack_var(na+2) = is_alloc_var na ∧
+    is_alloc_var(na+2) = is_stack_var na`,
   conj_tac >> (reverse EQ_TAC >-
     metis_tac[is_alloc_var_flip,is_stack_var_flip]) >>
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
@@ -3650,8 +3650,8 @@ val list_next_var_rename_props_2 =
   |> DISCH_ALL
   |> REWRITE_RULE[flip_rw];
 
-val ssa_map_ok_lem = prove(``
-  ssa_map_ok na ssa ⇒ ssa_map_ok (na+2) ssa``,
+val ssa_map_ok_lem = Q.prove(`
+  ssa_map_ok na ssa ⇒ ssa_map_ok (na+2) ssa`,
   metis_tac[ssa_map_ok_more, DECIDE``na:num ≤ na+2``]);
 
 val list_next_var_rename_move_props_2 = prove(``
@@ -3849,8 +3849,8 @@ val ALOOKUP_ALL_DISTINCT_REMAP = prove(``
     metis_tac[EL_MAP])>>
   metis_tac[]);
 
-val set_toAList_keys = prove(``
-  set (MAP FST (toAList t)) = domain t``,
+val set_toAList_keys = Q.prove(`
+  set (MAP FST (toAList t)) = domain t`,
   full_simp_tac(srw_ss())[toAList_domain,EXTENSION]);
 
 val is_phy_var_tac =
@@ -3859,20 +3859,20 @@ val is_phy_var_tac =
     `∀k.(2:num)*k=k*2` by DECIDE_TAC>>
     metis_tac[arithmeticTheory.MOD_EQ_0];
 
-val ssa_map_ok_inter = prove(``
+val ssa_map_ok_inter = Q.prove(`
   ssa_map_ok na ssa ⇒
-  ssa_map_ok na (inter ssa ssa')``,
+  ssa_map_ok na (inter ssa ssa')`,
   full_simp_tac(srw_ss())[ssa_map_ok_def,lookup_inter]>>srw_tac[][]>>EVERY_CASE_TAC>>
   full_simp_tac(srw_ss())[]>>
   metis_tac[]);
 
-val ssa_cc_trans_exp_correct = prove(
-``∀st w cst ssa na res.
+val ssa_cc_trans_exp_correct = Q.prove(
+`∀st w cst ssa na res.
   word_exp st w = SOME res ∧
   word_state_eq_rel st cst ∧
   ssa_locals_rel na ssa st.locals cst.locals
   ⇒
-  word_exp cst (ssa_cc_trans_exp ssa w) = SOME res``,
+  word_exp cst (ssa_cc_trans_exp ssa w) = SOME res`,
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,ssa_cc_trans_exp_def]>>
   qpat_x_assum`A=SOME res` mp_tac
@@ -5444,9 +5444,9 @@ val ssa_cc_trans_correct = store_thm("ssa_cc_trans_correct",
       srw_tac[][]>>
       Cases_on`evaluate(ret_mov,rcstt)`>>unabbrev_all_tac>>full_simp_tac(srw_ss())[state_component_equality,word_state_eq_rel_def]);
 
-val get_vars_eq = prove(
-  ``(set ls) SUBSET domain st.locals ==> ?y. get_vars ls st = SOME y /\
-                                             y = MAP (\x. THE (lookup x st.locals)) ls``,
+val get_vars_eq = Q.prove(
+  `(set ls) SUBSET domain st.locals ==> ?y. get_vars ls st = SOME y /\
+                                             y = MAP (\x. THE (lookup x st.locals)) ls`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[get_vars_def,get_var_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[domain_lookup]);
 
@@ -5523,9 +5523,9 @@ val setup_ssa_props = prove(``
     `is_phy_var x` by is_phy_var_tac>>
     metis_tac[convention_partitions]);
 
-val max_var_exp_max = prove(``
+val max_var_exp_max = Q.prove(`
   ∀exp.
-    every_var_exp (λx. x≤ max_var_exp exp) exp``,
+    every_var_exp (λx. x≤ max_var_exp exp) exp`,
   ho_match_mp_tac max_var_exp_ind>>
   srw_tac[][every_var_exp_def,max_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>srw_tac[][]>>res_tac>>
@@ -5537,18 +5537,18 @@ val max_var_exp_max = prove(``
   pop_assum(qspec_then`a` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
   DECIDE_TAC);
 
-val max_var_inst_max = prove(``
+val max_var_inst_max = Q.prove(`
   ∀inst.
-    every_var_inst (λx. x ≤ max_var_inst inst) inst``,
+    every_var_inst (λx. x ≤ max_var_inst inst) inst`,
   ho_match_mp_tac max_var_inst_ind>>
   srw_tac[][every_var_inst_def,max_var_inst_def]>>
   TRY(Cases_on`ri`)>>full_simp_tac(srw_ss())[every_var_imm_def]>>
   TRY(IF_CASES_TAC)>>full_simp_tac(srw_ss())[]>>
   DECIDE_TAC);
 
-val max_var_max = store_thm("max_var_max",``
+val max_var_max = Q.store_thm("max_var_max",`
   ∀prog.
-    every_var (λx. x ≤ max_var prog) prog``,
+    every_var (λx. x ≤ max_var prog) prog`,
   ho_match_mp_tac max_var_ind>>
   srw_tac[][every_var_def,max_var_def]>>
   TRY(Cases_on`ri`)>>full_simp_tac(srw_ss())[every_var_imm_def]>>
@@ -5598,10 +5598,10 @@ val max_var_max = store_thm("max_var_max",``
     full_simp_tac(srw_ss())[every_name_def,Abbr`ls'`,EVERY_MEM,MEM_MAP,PULL_EXISTS,FORALL_PROD,MEM_toAList,domain_lookup,MAX_DEF]>>srw_tac[][]>>
     res_tac>>DECIDE_TAC);
 
-val limit_var_props = prove(``
+val limit_var_props = Q.prove(`
   limit_var prog = lim ⇒
   is_alloc_var lim ∧
-  every_var (λx. x< lim) prog``,
+  every_var (λx. x< lim) prog`,
   reverse (srw_tac[][limit_var_def,is_alloc_var_def])
   >-
     (qspec_then `prog` assume_tac max_var_max >>
@@ -5880,9 +5880,9 @@ val setup_ssa_props_2 = prove(``
     full_simp_tac(srw_ss())[ssa_map_ok_def,lookup_def]>>
   imp_res_tac list_next_var_rename_props>>NO_TAC));
 
-val full_ssa_cc_trans_pre_alloc_conventions = store_thm("full_ssa_cc_trans_pre_alloc_conventions",
-``∀n prog.
-  pre_alloc_conventions (full_ssa_cc_trans n prog)``,
+val full_ssa_cc_trans_pre_alloc_conventions = Q.store_thm("full_ssa_cc_trans_pre_alloc_conventions",
+`∀n prog.
+  pre_alloc_conventions (full_ssa_cc_trans n prog)`,
   full_simp_tac(srw_ss())[full_ssa_cc_trans_def,pre_alloc_conventions_def,list_next_var_rename_move_def]>>LET_ELIM_TAC>>
   full_simp_tac(srw_ss())[Abbr`lim'`]>>
   imp_res_tac limit_var_props>>
@@ -5920,9 +5920,9 @@ val ssa_cc_trans_wf_cutsets = prove(``
   rpt(pairarg_tac>>fs[])>>rveq>>fs[wf_cutsets_def,wf_fromAList]>>
   metis_tac[fake_moves_wf_cutsets])
 
-val full_ssa_cc_trans_wf_cutsets = store_thm("full_ssa_cc_trans_wf_cutsets",``
+val full_ssa_cc_trans_wf_cutsets = Q.store_thm("full_ssa_cc_trans_wf_cutsets",`
   ∀n prog.
-  wf_cutsets (full_ssa_cc_trans n prog)``,
+  wf_cutsets (full_ssa_cc_trans n prog)`,
   fs[full_ssa_cc_trans_def,setup_ssa_def,list_next_var_rename_move_def]>>
   rw[]>>pairarg_tac>>fs[]>>
   pairarg_tac>>fs[]>>
@@ -5941,12 +5941,12 @@ val fake_moves_distinct_tar_reg = prove(``
   unabbrev_all_tac>>
   metis_tac[fake_move_def,every_inst_def,distinct_tar_reg_def]);
 
-val ssa_cc_trans_distinct_tar_reg = prove(``
+val ssa_cc_trans_distinct_tar_reg = Q.prove(`
   ∀prog ssa na.
   is_alloc_var na ∧
   every_var (λx. x < na) prog ∧
   ssa_map_ok na ssa ⇒
-  every_inst distinct_tar_reg (FST (ssa_cc_trans prog ssa na))``,
+  every_inst distinct_tar_reg (FST (ssa_cc_trans prog ssa na))`,
   ho_match_mp_tac ssa_cc_trans_ind>>full_simp_tac(srw_ss())[ssa_cc_trans_def]>>srw_tac[][]>>
   unabbrev_all_tac>>
   full_simp_tac(srw_ss())[every_inst_def]>>imp_res_tac ssa_cc_trans_props>>full_simp_tac(srw_ss())[]
@@ -6046,9 +6046,9 @@ val ssa_cc_trans_distinct_tar_reg = prove(``
       LET_ELIM_TAC>>full_simp_tac(srw_ss())[EQ_SYM_EQ,every_inst_def]>>
       metis_tac[fake_moves_distinct_tar_reg]);
 
-val full_ssa_cc_trans_distinct_tar_reg = store_thm("full_ssa_cc_trans_distinct_tar_reg",``
+val full_ssa_cc_trans_distinct_tar_reg = Q.store_thm("full_ssa_cc_trans_distinct_tar_reg",`
   ∀n prog.
-  every_inst distinct_tar_reg (full_ssa_cc_trans n prog)``,
+  every_inst distinct_tar_reg (full_ssa_cc_trans n prog)`,
   srw_tac[][]>>
   full_simp_tac(srw_ss())[full_ssa_cc_trans_def]>>
   LET_ELIM_TAC>>
@@ -6085,10 +6085,10 @@ val fake_moves_conventions2 = prove(``
   rveq>>fs[flat_exp_conventions_def,fake_move_def,full_inst_ok_less_def,inst_ok_less_def,every_inst_def,distinct_tar_reg_def]>>
   metis_tac[]);
 
-val ssa_cc_trans_flat_exp_conventions = prove(``
+val ssa_cc_trans_flat_exp_conventions = Q.prove(`
   ∀prog ssa na.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (FST (ssa_cc_trans prog ssa na))``,
+  flat_exp_conventions (FST (ssa_cc_trans prog ssa na))`,
   ho_match_mp_tac ssa_cc_trans_ind>>full_simp_tac(srw_ss())[ssa_cc_trans_def]>>srw_tac[][]>>
   unabbrev_all_tac>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def]
@@ -6120,21 +6120,21 @@ val ssa_cc_trans_flat_exp_conventions = prove(``
       rpt (pop_assum mp_tac)>> LET_ELIM_TAC>>full_simp_tac(srw_ss())[]>>
       metis_tac[fake_moves_conventions2,flat_exp_conventions_def]);
 
-val full_ssa_cc_trans_flat_exp_conventions = store_thm("full_ssa_cc_trans_flat_exp_conventions",``
+val full_ssa_cc_trans_flat_exp_conventions = Q.store_thm("full_ssa_cc_trans_flat_exp_conventions",`
   ∀prog n.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (full_ssa_cc_trans n prog)``,
+  flat_exp_conventions (full_ssa_cc_trans n prog)`,
   full_simp_tac(srw_ss())[full_ssa_cc_trans_def,setup_ssa_def,list_next_var_rename_move_def]>>
   LET_ELIM_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[flat_exp_conventions_def,EQ_SYM_EQ]>>
   metis_tac[ssa_cc_trans_flat_exp_conventions,FST]);
 
-val ssa_cc_trans_full_inst_ok_less = prove(``
+val ssa_cc_trans_full_inst_ok_less = Q.prove(`
   ∀prog ssa na c.
   every_var (λx. x < na) prog ∧
   is_alloc_var na ∧
   ssa_map_ok na ssa ∧
   full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (FST (ssa_cc_trans prog ssa na))``,
+  full_inst_ok_less c (FST (ssa_cc_trans prog ssa na))`,
   ho_match_mp_tac ssa_cc_trans_ind>>full_simp_tac(srw_ss())[ssa_cc_trans_def]>>srw_tac[][]>>
   unabbrev_all_tac>>
   full_simp_tac(srw_ss())[full_inst_ok_less_def]
@@ -6231,10 +6231,10 @@ val ssa_cc_trans_full_inst_ok_less = prove(``
         metis_tac[convention_partitions])
     >- metis_tac[fake_moves_conventions2,full_inst_ok_less_def]);
 
-val full_ssa_cc_trans_full_inst_ok_less = store_thm("full_ssa_cc_trans_full_inst_ok_less",``
+val full_ssa_cc_trans_full_inst_ok_less = Q.store_thm("full_ssa_cc_trans_full_inst_ok_less",`
   ∀prog n c.
   full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (full_ssa_cc_trans n prog)``,
+  full_inst_ok_less c (full_ssa_cc_trans n prog)`,
   full_simp_tac(srw_ss())[full_ssa_cc_trans_def,list_next_var_rename_move_def]>>
   LET_ELIM_TAC>>
   fs[markerTheory.Abbrev_def]>>
@@ -6292,11 +6292,11 @@ val is_phy_var_tac =
     `∀k.(2:num)*k=k*2` by DECIDE_TAC>>
     metis_tac[arithmeticTheory.MOD_EQ_0];
 
-val call_arg_convention_preservation = prove(``
+val call_arg_convention_preservation = Q.prove(`
   ∀prog f.
   every_var (λx. is_phy_var x ⇒ f x = x) prog ∧
   call_arg_convention prog ⇒
-  call_arg_convention (apply_colour f prog)``,
+  call_arg_convention (apply_colour f prog)`,
   ho_match_mp_tac call_arg_convention_ind>>
   srw_tac[][call_arg_convention_def,every_var_def]>>
   EVERY_CASE_TAC>>unabbrev_all_tac>>
@@ -6316,28 +6316,28 @@ val call_arg_convention_preservation = prove(``
   rev_full_simp_tac(srw_ss())[]);
 
 (*Composing with a function using apply_colour*)
-val every_var_inst_apply_colour_inst = store_thm("every_var_inst_apply_colour_inst",``
+val every_var_inst_apply_colour_inst = Q.store_thm("every_var_inst_apply_colour_inst",`
   ∀P inst Q f.
   every_var_inst P inst ∧
   (∀x. P x ⇒ Q (f x)) ⇒
-  every_var_inst Q (apply_colour_inst f inst)``,
+  every_var_inst Q (apply_colour_inst f inst)`,
   ho_match_mp_tac every_var_inst_ind>>srw_tac[][every_var_inst_def]>>
   TRY(Cases_on`ri`>>full_simp_tac(srw_ss())[apply_colour_imm_def])>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_imm_def]);
 
-val every_var_exp_apply_colour_exp = store_thm("every_var_exp_apply_colour_exp",``
+val every_var_exp_apply_colour_exp = Q.store_thm("every_var_exp_apply_colour_exp",`
   ∀P exp Q f.
   every_var_exp P exp ∧
   (∀x. P x ⇒ Q (f x)) ⇒
-  every_var_exp Q (apply_colour_exp f exp)``,
+  every_var_exp Q (apply_colour_exp f exp)`,
   ho_match_mp_tac every_var_exp_ind>>srw_tac[][every_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MAP,EVERY_MEM]);
 
-val every_var_apply_colour = store_thm("every_var_apply_colour",``
+val every_var_apply_colour = Q.store_thm("every_var_apply_colour",`
   ∀P prog Q f.
   every_var P prog ∧
   (∀x. P x ⇒ Q (f x)) ⇒
-  every_var Q (apply_colour f prog)``,
+  every_var Q (apply_colour f prog)`,
   ho_match_mp_tac every_var_ind>>srw_tac[][every_var_def]>>
   full_simp_tac(srw_ss())[MAP_ZIP,(GEN_ALL o SYM o SPEC_ALL) MAP_MAP_o]>>
   full_simp_tac(srw_ss())[EVERY_MAP,EVERY_MEM]
@@ -6365,11 +6365,11 @@ val every_var_apply_colour = store_thm("every_var_apply_colour",``
   >>
     metis_tac[every_var_exp_apply_colour_exp]);
 
-val every_stack_var_apply_colour = store_thm("every_stack_var_apply_colour",``
+val every_stack_var_apply_colour = Q.store_thm("every_stack_var_apply_colour",`
   ∀P prog Q f.
   every_stack_var P prog ∧
   (∀x. P x ⇒ Q (f x)) ⇒
-  every_stack_var Q (apply_colour f prog)``,
+  every_stack_var Q (apply_colour f prog)`,
   ho_match_mp_tac every_stack_var_ind>>srw_tac[][every_stack_var_def]
   >>
   (EVERY_CASE_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[every_stack_var_def,EVERY_MAP,EVERY_MEM]>>
@@ -6377,8 +6377,8 @@ val every_stack_var_apply_colour = store_thm("every_stack_var_apply_colour",``
     srw_tac[][]>>full_simp_tac(srw_ss())[domain_fromAList,MEM_MAP,ZIP_MAP]>>
     Cases_on`y'`>>full_simp_tac(srw_ss())[MEM_toAList,domain_lookup]));
 
-val every_var_exp_get_reads_exp = prove(``
-  ∀exp. every_var_exp (λx. MEM x (get_reads_exp exp)) exp``,
+val every_var_exp_get_reads_exp = Q.prove(`
+  ∀exp. every_var_exp (λx. MEM x (get_reads_exp exp)) exp`,
   assume_tac every_var_exp_get_live_exp>>
   rw[]>>pop_assum(qspec_then`exp` assume_tac)>>
   ho_match_mp_tac every_var_exp_mono>>
@@ -6389,9 +6389,9 @@ val exp_tac =
   ho_match_mp_tac every_var_exp_mono>>
   HINT_EXISTS_TAC>>fs[in_clash_tree_def];
 
-val every_var_in_get_clash_tree = prove(``
+val every_var_in_get_clash_tree = Q.prove(`
   ∀prog.
-  every_var (in_clash_tree (get_clash_tree prog)) prog``,
+  every_var (in_clash_tree (get_clash_tree prog)) prog`,
   ho_match_mp_tac get_clash_tree_ind>>rw[get_clash_tree_def]>>
   fs[every_var_def,in_clash_tree_def,EVERY_MEM,in_clash_tree_def,every_name_def,toAList_domain]>>
   TRY(exp_tac)
@@ -6410,19 +6410,19 @@ val every_var_in_get_clash_tree = prove(``
     fs[in_clash_tree_def,domain_numset_list_insert,domain_union]>>
     metis_tac[every_var_mono,in_clash_tree_def]);
 
-val every_var_T = prove(``
+val every_var_T = Q.prove(`
   ∀prog.
-  every_var (λx. T) prog``,
+  every_var (λx. T) prog`,
   rw[]>>
   mp_tac (Q.SPEC`prog` max_var_max)>>
   rw[]>>
   ho_match_mp_tac every_var_mono>>HINT_EXISTS_TAC>>
   fs[]);
 
-val oracle_colour_ok_conventions = prove(``
+val oracle_colour_ok_conventions = Q.prove(`
   pre_alloc_conventions prog ∧
   oracle_colour_ok k col_opt (get_clash_tree prog) prog = SOME x ⇒
-  post_alloc_conventions k x``,
+  post_alloc_conventions k x`,
   fs[oracle_colour_ok_def]>>EVERY_CASE_TAC>>fs[post_alloc_conventions_def,pre_alloc_conventions_def]>>
   rw[]>>fs[]>>
   match_mp_tac call_arg_convention_preservation>>fs[]>>
@@ -6433,10 +6433,10 @@ val oracle_colour_ok_conventions = prove(``
   fs[GSYM MEM_toAList]>>
   fs[EVERY_MEM,FORALL_PROD]);
 
-val pre_post_conventions_word_alloc = store_thm("pre_post_conventions_word_alloc",``
+val pre_post_conventions_word_alloc = Q.store_thm("pre_post_conventions_word_alloc",`
   ∀alg prog k col_opt.
   pre_alloc_conventions prog ⇒
-  post_alloc_conventions k (word_alloc alg k prog col_opt)``,
+  post_alloc_conventions k (word_alloc alg k prog col_opt)`,
   fs[post_alloc_conventions_def,word_alloc_def]>>
   rw[]>>
   FULL_CASE_TAC>>fs[]>>
@@ -6475,10 +6475,10 @@ val pre_post_conventions_word_alloc = store_thm("pre_post_conventions_word_alloc
   metis_tac[]);
 
 (*word_alloc preserves syntactic conventions*)
-val word_alloc_two_reg_inst_lem = prove(``
+val word_alloc_two_reg_inst_lem = Q.prove(`
   ∀f prog.
   every_inst two_reg_inst prog ⇒
-  every_inst two_reg_inst (apply_colour f prog)``,
+  every_inst two_reg_inst (apply_colour f prog)`,
   ho_match_mp_tac apply_colour_ind>>full_simp_tac(srw_ss())[every_inst_def]>>srw_tac[][]
   >-
     (Cases_on`i`>>TRY(Cases_on`a`)>>TRY(Cases_on`m`)>>
@@ -6486,37 +6486,37 @@ val word_alloc_two_reg_inst_lem = prove(``
   >>
     EVERY_CASE_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[every_inst_def]);
 
-val word_alloc_two_reg_inst = store_thm("word_alloc_two_reg_inst",``
+val word_alloc_two_reg_inst = Q.store_thm("word_alloc_two_reg_inst",`
   ∀alg k prog col_opt.
   every_inst two_reg_inst prog ⇒
-  every_inst two_reg_inst (word_alloc alg k prog col_opt)``,
+  every_inst two_reg_inst (word_alloc alg k prog col_opt)`,
   full_simp_tac(srw_ss())[word_alloc_def,oracle_colour_ok_def]>>
   srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[word_alloc_two_reg_inst_lem]);
 
-val word_alloc_flat_exp_conventions_lem = prove(``
+val word_alloc_flat_exp_conventions_lem = Q.prove(`
   ∀f prog.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (apply_colour f prog)``,
+  flat_exp_conventions (apply_colour f prog)`,
   ho_match_mp_tac apply_colour_ind>>full_simp_tac(srw_ss())[flat_exp_conventions_def]>>srw_tac[][]
   >-
     (EVERY_CASE_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[flat_exp_conventions_def])
   >>
     Cases_on`exp`>>full_simp_tac(srw_ss())[flat_exp_conventions_def]);
 
-val word_alloc_flat_exp_conventions = store_thm("word_alloc_flat_exp_conventions",``
+val word_alloc_flat_exp_conventions = Q.store_thm("word_alloc_flat_exp_conventions",`
   ∀alg k prog col_opt.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (word_alloc alg k prog col_opt)``,
+  flat_exp_conventions (word_alloc alg k prog col_opt)`,
   full_simp_tac(srw_ss())[word_alloc_def,oracle_colour_ok_def]>>
   srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[word_alloc_flat_exp_conventions_lem]);
 
 (*
-val word_alloc_full_inst_ok_less_lem = prove(``
+val word_alloc_full_inst_ok_less_lem = Q.prove(`
   ∀f prog c.
   full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (apply_colour f prog)``,
+  full_inst_ok_less c (apply_colour f prog)`,
   ho_match_mp_tac apply_colour_ind>>full_simp_tac(srw_ss())[full_inst_ok_less_def]>>srw_tac[][]
   >-
     (Cases_on`i`>>TRY(Cases_on`a`)>>TRY(Cases_on`m`)>>TRY(Cases_on`r`)>>
@@ -6525,10 +6525,10 @@ val word_alloc_full_inst_ok_less_lem = prove(``
     EVERY_CASE_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[full_inst_ok_less_def]>>
     rfs[])
 
-val word_alloc_full_inst_ok_less = store_thm("word_alloc_full_inst_ok_less",``
+val word_alloc_full_inst_ok_less = Q.store_thm("word_alloc_full_inst_ok_less",`
   ∀alg k prog col_opt c.
   full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (word_alloc alg k prog col_opt)``,
+  full_inst_ok_less c (word_alloc alg k prog col_opt)`,
   full_simp_tac(srw_ss())[word_alloc_def,oracle_colour_ok_def]>>
   srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[word_alloc_full_inst_ok_less_lem])
@@ -6563,29 +6563,29 @@ val full_ssa_cc_trans_lab_pres = store_thm ("full_ssa_cc_trans_lab_pres",``
   imp_res_tac fake_moves_no_labs>>
   fs[]);
 
-val apply_colour_lab_pres = prove(``
+val apply_colour_lab_pres = Q.prove(`
   ∀col prog.
-  extract_labels prog = extract_labels (apply_colour col prog)``,
+  extract_labels prog = extract_labels (apply_colour col prog)`,
   ho_match_mp_tac apply_colour_ind>>fs[extract_labels_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[]);
 
-val word_alloc_lab_pres = store_thm("word_alloc_lab_pres",``
-  extract_labels prog = extract_labels (word_alloc alg k prog col_opt)``,
+val word_alloc_lab_pres = Q.store_thm("word_alloc_lab_pres",`
+  extract_labels prog = extract_labels (word_alloc alg k prog col_opt)`,
   fs[word_alloc_def,oracle_colour_ok_def]>>EVERY_CASE_TAC>>fs[]>>
   TRY(pairarg_tac)>>fs[]>>metis_tac[apply_colour_lab_pres]);
 
 (* every remove_dead syntactic theorem proved together *)
 val convs = [flat_exp_conventions_def,full_inst_ok_less_def,every_inst_def,pre_alloc_conventions_def,call_arg_convention_def,every_stack_var_def,every_var_def,extract_labels_def,wf_cutsets_def];
 
-val remove_dead_conventions = store_thm("remove_dead_conventions",
-  ``∀p live c k.
+val remove_dead_conventions = Q.store_thm("remove_dead_conventions",
+  `∀p live c k.
   let comp = FST (remove_dead p live) in
   (flat_exp_conventions p ⇒ flat_exp_conventions comp) ∧
   (full_inst_ok_less c p ⇒ full_inst_ok_less c comp) ∧
   (pre_alloc_conventions p ⇒ pre_alloc_conventions comp) ∧
   (every_inst distinct_tar_reg p ⇒ every_inst distinct_tar_reg comp) ∧
   (wf_cutsets p ⇒ wf_cutsets comp) ∧
-  (extract_labels p = extract_labels comp)``,
+  (extract_labels p = extract_labels comp)`,
   ho_match_mp_tac remove_dead_ind>>rw[]>>
   fs[remove_dead_def]>>
   rpt IF_CASES_TAC>>fs convs>>
@@ -6594,25 +6594,25 @@ val remove_dead_conventions = store_thm("remove_dead_conventions",
   EVERY_CASE_TAC>>fs convs);
 
 (* MISC *)
-val list_max_IMP = prove(``
+val list_max_IMP = Q.prove(`
   ∀ls.
-  P 0 ∧ EVERY P ls ⇒ P (list_max ls)``,
+  P 0 ∧ EVERY P ls ⇒ P (list_max ls)`,
   Induct>>full_simp_tac(srw_ss())[list_max_def]>>srw_tac[][]>>
   IF_CASES_TAC>>full_simp_tac(srw_ss())[]);
 
-val max_var_exp_IMP = prove(``
+val max_var_exp_IMP = Q.prove(`
   ∀exp.
   P 0 ∧ every_var_exp P exp ⇒
-  P (max_var_exp exp)``,
+  P (max_var_exp exp)`,
   ho_match_mp_tac max_var_exp_ind>>full_simp_tac(srw_ss())[max_var_exp_def,every_var_exp_def]>>
   srw_tac[][]>>
   match_mp_tac list_max_IMP>>
   full_simp_tac(srw_ss())[EVERY_MAP,EVERY_MEM]);
 
-val max_var_IMP = store_thm("max_var_IMP",``
+val max_var_IMP = Q.store_thm("max_var_IMP",`
   ∀prog.
   P 0 ∧ every_var P prog ⇒
-  P (max_var prog)``,
+  P (max_var prog)`,
   ho_match_mp_tac max_var_ind>>
   full_simp_tac(srw_ss())[every_var_def,max_var_def,max_var_exp_IMP,MAX_DEF]>>srw_tac[][]>>
   TRY(metis_tac[max_var_exp_IMP])>>

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -244,8 +244,8 @@ val GENLIST_MAP = Q.prove(
   \\ `k < LENGTH l /\ k <= LENGTH l` by DECIDE_TAC
   \\ full_simp_tac(srw_ss())[EL_MAP]);
 
-val list_rearrange_MAP = store_thm ("list_rearrange_MAP",
-  ``!l f m. list_rearrange m (MAP f l) = MAP f (list_rearrange m l)``,
+val list_rearrange_MAP = Q.store_thm ("list_rearrange_MAP",
+  `!l f m. list_rearrange m (MAP f l) = MAP f (list_rearrange m l)`,
   SRW_TAC [] [list_rearrange_def] \\ MATCH_MP_TAC GENLIST_MAP \\
   full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF]);
 
@@ -259,7 +259,7 @@ val ALL_DISTINCT_FST = ALL_DISTINCT_MAP |> Q.ISPEC `FST`
    given by the IH)
 *)
 
-val env_to_list_perm = prove(``
+val env_to_list_perm = Q.prove(`
   ∀tperm.
   domain y = IMAGE f (domain x) ∧
   INJ f (domain x) UNIV ∧
@@ -269,7 +269,7 @@ val env_to_list_perm = prove(``
   ∃perm'.
     let(l',permute') = env_to_list x perm' in
       permute' = tperm ∧ (*Just change the first permute*)
-      MAP (λx,y.f x,y) l' = l``,
+      MAP (λx,y.f x,y) l' = l`,
   srw_tac[][]>>
   full_simp_tac(srw_ss())[env_to_list_def,LET_THM,strong_locals_rel_def]>>
   qabbrev_tac `xls = QSORT key_val_compare (toAList x)`>>
@@ -330,7 +330,7 @@ val env_to_list_perm = prove(``
   full_simp_tac(srw_ss())[FUN_EQ_THM]);
 
 (*Proves s_val_eq and some extra conditions on the resulting lists*)
-val push_env_s_val_eq = store_thm("push_env_s_val_eq",``
+val push_env_s_val_eq = Q.store_thm("push_env_s_val_eq",`
   ∀tperm.
   st.handler = cst.handler ∧
   st.stack = cst.stack ∧
@@ -350,7 +350,7 @@ val push_env_s_val_eq = store_thm("push_env_s_val_eq",``
       (∀x y. MEM x (MAP FST l') ∧ MEM y (MAP FST l')
         ∧ f x = f y ⇒ x = y) ) ∧
   s_val_eq (push_env x b (st with permute:=perm)).stack
-           (push_env y b' cst).stack``,
+           (push_env y b' cst).stack`,
   srw_tac[][]>>Cases_on`b`>>
   TRY(PairCases_on`x'`>>Cases_on`b'`>>full_simp_tac(srw_ss())[]>>PairCases_on`x'`>>full_simp_tac(srw_ss())[])>>
   (full_simp_tac(srw_ss())[push_env_def]>>
@@ -395,7 +395,7 @@ val gc_frame = Q.store_thm("gc_frame",`
   full_simp_tac(srw_ss())[state_component_equality]);
 
 (*Convenient rewrite for pop_env*)
-val s_key_eq_val_eq_pop_env = store_thm("s_key_eq_val_eq_pop_env",``
+val s_key_eq_val_eq_pop_env = Q.store_thm("s_key_eq_val_eq_pop_env",`
   pop_env s = SOME s' ∧
   s_key_eq s.stack ((StackFrame ls opt)::keys) ∧
   s_val_eq s.stack vals
@@ -406,7 +406,7 @@ val s_key_eq_val_eq_pop_env = store_thm("s_key_eq_val_eq_pop_env",``
   s_key_eq s'.stack keys ∧
   s_val_eq s'.stack rest ∧
   case opt of NONE => s'.handler = s.handler
-            | SOME (h,l1,l2) => s'.handler = h``,
+            | SOME (h,l1,l2) => s'.handler = h`,
   strip_tac>>
   full_simp_tac(srw_ss())[pop_env_def]>>
   EVERY_CASE_TAC>>
@@ -418,13 +418,13 @@ val s_key_eq_val_eq_pop_env = store_thm("s_key_eq_val_eq_pop_env",``
   metis_tac[ZIP_MAP_FST_SND_EQ]);
 
 (*Less powerful form*)
-val ALOOKUP_key_remap_2 = store_thm("ALOOKUP_key_remap_2",``
+val ALOOKUP_key_remap_2 = Q.store_thm("ALOOKUP_key_remap_2",`
   ∀ls vals f.
     (∀x y. MEM x ls ∧ MEM y ls ∧ f x = f y ⇒ x = y) ∧
     LENGTH ls = LENGTH vals ∧
     ALOOKUP (ZIP (ls,vals)) n = SOME v
     ⇒
-    ALOOKUP (ZIP (MAP f ls,vals)) (f n) = SOME v``,
+    ALOOKUP (ZIP (MAP f ls,vals)) (f n) = SOME v`,
   Induct>>srw_tac[][]>>
   Cases_on`vals`>>full_simp_tac(srw_ss())[]>>
   Cases_on`h=n`>>full_simp_tac(srw_ss())[]>>
@@ -446,9 +446,9 @@ val strong_locals_rel_subset = Q.prove(`
   srw_tac[][strong_locals_rel_def]>>
   metis_tac[SUBSET_DEF]);
 
-val env_to_list_keys = prove(``
+val env_to_list_keys = Q.prove(`
   let (l,permute) = env_to_list x perm in
-  set (MAP FST l) = domain x``,
+  set (MAP FST l) = domain x`,
   full_simp_tac(srw_ss())[LET_THM,env_to_list_def,EXTENSION,MEM_MAP,EXISTS_PROD]>>
   srw_tac[][EQ_IMP_THM]
   >-
@@ -492,9 +492,9 @@ val pop_env_frame = Q.store_thm("pop_env_frame",
     srw_tac[][]>>rev_full_simp_tac(srw_ss())[]>>
     metis_tac[s_val_and_key_eq]);
 
-val key_map_implies = store_thm("key_map_implies",
- ``MAP (λx,y.f x,y) l' = l
- ⇒ MAP f (MAP FST l') = MAP FST l``,
+val key_map_implies = Q.store_thm("key_map_implies",
+ `MAP (λx,y.f x,y) l' = l
+ ⇒ MAP f (MAP FST l') = MAP FST l`,
  srw_tac[][]>>match_mp_tac LIST_EQ>>
  srw_tac[][EL_MAP]>>
  Cases_on`EL x l'`>>full_simp_tac(srw_ss())[]);
@@ -564,8 +564,8 @@ val toAList_not_empty = Q.prove(`
   full_simp_tac(srw_ss())[GSYM toAList_domain]);
 
 (*liveness theorem*)
-val evaluate_apply_colour = store_thm("evaluate_apply_colour",
-``∀prog st cst f live.
+val evaluate_apply_colour = Q.store_thm("evaluate_apply_colour",
+`∀prog st cst f live.
   colouring_ok f prog live ∧
   word_state_eq_rel st cst ∧
   strong_locals_rel f (domain (get_live prog live)) st.locals cst.locals
@@ -579,7 +579,7 @@ val evaluate_apply_colour = store_thm("evaluate_apply_colour",
     (case res of
       NONE => strong_locals_rel f (domain live)
               rst.locals rcst.locals
-    | SOME _ => rst.locals = rcst.locals )``,
+    | SOME _ => rst.locals = rcst.locals )`,
   (*Induct on size of program*)
   completeInduct_on`prog_size (K 0) prog`>>
   rpt strip_tac>>
@@ -1309,10 +1309,10 @@ val colouring_ok_alt_def = Define`
     INJ f (domain hd) UNIV`;
 
 (*hd element is just get_live*)
-val get_clash_sets_hd = prove(
-``∀prog live hd ls.
+val get_clash_sets_hd = Q.prove(
+`∀prog live hd ls.
   get_clash_sets prog live = (hd,ls) ⇒
-  get_live prog live = hd``,
+  get_live prog live = hd`,
   Induct>>srw_tac[][get_clash_sets_def]>>full_simp_tac(srw_ss())[LET_THM]
   >-
     full_simp_tac(srw_ss())[get_live_def]
@@ -1331,11 +1331,11 @@ val get_clash_sets_hd = prove(
     full_simp_tac(srw_ss())[get_live_def,LET_THM]>>metis_tac[]);
 
 (*The liveset passed in at the back is always satisfied*)
-val get_clash_sets_tl = prove(
-``∀prog live f.
+val get_clash_sets_tl = Q.prove(
+`∀prog live f.
   let (hd,ls) = get_clash_sets prog live in
   EVERY (λs. INJ f (domain s) UNIV) ls ⇒
-  INJ f (domain live) UNIV``,
+  INJ f (domain live) UNIV`,
   completeInduct_on`prog_size (K 0) prog`>>
   full_simp_tac(srw_ss())[PULL_FORALL]>>
   rpt strip_tac>>
@@ -1413,12 +1413,12 @@ val every_var_exp_get_live_exp = Q.prove(
   metis_tac[SUBSET_DEF,domain_big_union_subset]);
 
 (*Every variable is in some clash set*)
-val every_var_in_get_clash_set = store_thm("every_var_in_get_clash_set",
-``∀prog live.
+val every_var_in_get_clash_set = Q.store_thm("every_var_in_get_clash_set",
+`∀prog live.
   let (hd,clash_sets) = get_clash_sets prog live in
   let ls = hd::clash_sets in
   (∀x. x ∈ domain live ⇒ in_clash_sets ls x) ∧
-  (every_var (in_clash_sets ls) prog)``,
+  (every_var (in_clash_sets ls) prog)`,
   completeInduct_on`prog_size (K 0) prog`>>
   ntac 2 (full_simp_tac(srw_ss())[Once PULL_FORALL])>>
   rpt strip_tac>>
@@ -1597,12 +1597,12 @@ val every_var_in_get_clash_set = store_thm("every_var_in_get_clash_set",
     qexists_tac`insert n0 () (insert n1 () s)`>>full_simp_tac(srw_ss())[]));
 
 (* Proofs for check_clash_tree *)
-val check_col_INJ = store_thm("check_col_INJ",
-  ``
+val check_col_INJ = Q.store_thm("check_col_INJ",
+  `
   check_col f numset = SOME (q,r) ⇒
   q = numset ∧
   INJ f (domain q) UNIV ∧
-  domain r = IMAGE f (domain q)``,
+  domain r = IMAGE f (domain q)`,
   rw[check_col_def,GSYM MAP_MAP_o]
   >-
     (fs[INJ_DEF,domain_lookup,FORALL_PROD,GSYM MEM_toAList]>>rw[]>>
@@ -1632,8 +1632,8 @@ val numset_list_insert_swap = Q.prove(`
   res_tac>>
   fs[wf_insert,wf_insert_swap]);
 
-val check_partial_col_INJ = store_thm("check_partial_col_INJ",
-  ``∀ls f live flive live' flive'.
+val check_partial_col_INJ = Q.store_thm("check_partial_col_INJ",
+  `∀ls f live flive live' flive'.
   wf live ∧
   domain flive = IMAGE f (domain live) ∧
   INJ f (domain live) UNIV ∧
@@ -1641,7 +1641,7 @@ val check_partial_col_INJ = store_thm("check_partial_col_INJ",
   wf live' ∧
   live' = numset_list_insert ls live ∧
   INJ f (domain live') UNIV ∧
-  domain flive' = IMAGE f (domain live')``,
+  domain flive' = IMAGE f (domain live')`,
   Induct>>fs[check_partial_col_def,numset_list_insert_def]>>
   ntac 6 strip_tac>>
   TOP_CASE_TAC>>fs[]>>strip_tac
@@ -1786,7 +1786,7 @@ val subset_tac =
   HINT_EXISTS_TAC>>fs[domain_numset_list_insert_eq_union,SUBSET_DEF]>>
   simp[domain_union];
 
-val clash_tree_colouring_ok = store_thm("clash_tree_colouring_ok",``
+val clash_tree_colouring_ok = Q.store_thm("clash_tree_colouring_ok",`
   ∀prog f live flive livein flivein.
   wf_cutsets prog ∧
   wf live ∧
@@ -1798,7 +1798,7 @@ val clash_tree_colouring_ok = store_thm("clash_tree_colouring_ok",``
   INJ f (domain livein) UNIV ∧
   colouring_ok f prog live ∧
   livein = get_live prog live ∧
-  domain flivein = IMAGE f (domain livein))``,
+  domain flivein = IMAGE f (domain livein))`,
   ho_match_mp_tac get_clash_tree_ind>>fs[get_clash_tree_def,check_clash_tree_def,colouring_ok_def,get_live_def,get_writes_def]>>rw[]
   >-
     fs[hide_def,numset_list_delete_def,check_partial_col_def]
@@ -2053,7 +2053,7 @@ val check_colouring_ok_alt_INJ = Q.prove(`
 *)
 
 (*Prove the full correctness theorem for word_alloc*)
-val word_alloc_correct = store_thm("word_alloc_correct",``
+val word_alloc_correct = Q.store_thm("word_alloc_correct",`
   ∀alg prog k col_opt st.
   even_starting_locals st.locals ∧
   wf_cutsets prog
@@ -2066,7 +2066,7 @@ val word_alloc_correct = store_thm("word_alloc_correct",``
     word_state_eq_rel rst rcst ∧
     case res of
       NONE => T
-    | SOME _ => rst.locals = rcst.locals``,
+    | SOME _ => rst.locals = rcst.locals`,
   srw_tac[][]>>
   qpat_abbrev_tac`cprog = word_alloc A B C D`>>
   full_simp_tac(srw_ss())[word_alloc_def]>>
@@ -2220,8 +2220,8 @@ val strong_locals_rel_I_insert_insert = Q.prove(`
   rw[strong_locals_rel_def,lookup_insert]>>
   IF_CASES_TAC>>fs[]);
 
-val evaluate_remove_dead = store_thm("evaluate_remove_dead",
-``∀prog live prog' livein st t res rst.
+val evaluate_remove_dead = Q.store_thm("evaluate_remove_dead",
+`∀prog live prog' livein st t res rst.
   strong_locals_rel I (domain livein) st.locals t ∧
   evaluate (prog,st) = (res,rst) ∧
   remove_dead prog live = (prog',livein) ∧
@@ -2230,7 +2230,7 @@ val evaluate_remove_dead = store_thm("evaluate_remove_dead",
     evaluate(prog',st with locals := t) = (res,rst with locals:=t') ∧
     (case res of
       NONE => strong_locals_rel I (domain live) rst.locals t'
-    | SOME _ => rst.locals = t')``,
+    | SOME _ => rst.locals = t')`,
   ho_match_mp_tac remove_dead_ind>>rw[]>>
   fs[remove_dead_def]>>
   rpt var_eq_tac>>fs[get_live_def,evaluate_def,state_component_equality,set_var_def]
@@ -2575,13 +2575,13 @@ val ssa_map_ok_def = Define`
     ¬is_phy_var y ∧ y < na ∧
     (∀z. z ≠ x ⇒ lookup z ssa ≠ SOME y))`;
 
-val list_next_var_rename_lemma_1 = prove(``
+val list_next_var_rename_lemma_1 = Q.prove(`
   ∀ls ssa na ls' ssa' na'.
   list_next_var_rename ls ssa na = (ls',ssa',na') ⇒
   let len = LENGTH ls in
   ALL_DISTINCT ls' ∧
   ls' = (MAP (λx. 4*x+na) (COUNT_LIST len)) ∧
-  na' = na + 4* len``,
+  na' = na + 4* len`,
   Induct>>
   full_simp_tac(srw_ss())[list_next_var_rename_def,LET_THM,next_var_rename_def,COUNT_LIST_def]>>
   ntac 7 strip_tac>>
@@ -2605,14 +2605,14 @@ val list_next_var_rename_lemma_1 = prove(``
   >>
     DECIDE_TAC);
 
-val list_next_var_rename_lemma_2 = prove(``
+val list_next_var_rename_lemma_2 = Q.prove(`
   ∀ls ssa na.
   ALL_DISTINCT ls ⇒
   let (ls',ssa',na') = list_next_var_rename ls ssa na in
   ls' = MAP (λx. THE(lookup x ssa')) ls ∧
   domain ssa' = domain ssa ∪ set ls ∧
   (∀x. ¬MEM x ls ⇒ lookup x ssa' = lookup x ssa) ∧
-  (∀x. MEM x ls ⇒ ∃y. lookup x ssa' = SOME y)``,
+  (∀x. MEM x ls ⇒ ∃y. lookup x ssa' = SOME y)`,
   Induct>>full_simp_tac(srw_ss())[list_next_var_rename_def,LET_THM,next_var_rename_def]>>
   srw_tac[][]>>
   first_x_assum(qspecl_then[`insert h na ssa`,`na+4`] assume_tac)>>
@@ -2662,7 +2662,7 @@ val ssa_map_ok_extend = Q.prove(`
   >>
     Cases_on`z=h`>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
 
-val merge_moves_frame = prove(``
+val merge_moves_frame = Q.prove(`
   ∀ls na ssaL ssaR.
   is_alloc_var na
   ⇒
@@ -2670,7 +2670,7 @@ val merge_moves_frame = prove(``
   is_alloc_var na' ∧
   na ≤ na' ∧
   (ssa_map_ok na ssaL ⇒ ssa_map_ok na' ssaL') ∧
-  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')``,
+  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')`,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -2691,12 +2691,12 @@ val merge_moves_frame = prove(``
   >>
   metis_tac[ssa_map_ok_extend,convention_partitions]);
 
-val merge_moves_fst = prove(``
+val merge_moves_fst = Q.prove(`
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   na ≤ na' ∧
   EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveL) ∧
-  EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveR) ``,
+  EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveR) `,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[EVERY_MAP]>>
   first_x_assum(qspecl_then[`na`,`ssaL`,`ssaR`]assume_tac)>>
@@ -2709,13 +2709,13 @@ val merge_moves_fst = prove(``
   DECIDE_TAC);
 
 (*Characterize result of merge_moves*)
-val merge_moves_frame2 = prove(``
+val merge_moves_frame2 = Q.prove(`
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   domain ssaL' = domain ssaL ∧
   domain ssaR' = domain ssaR ∧
   ∀x. MEM x ls ∧ x ∈ domain (inter ssaL ssaR) ⇒
-    lookup x ssaL' = lookup x ssaR'``,
+    lookup x ssaL' = lookup x ssaR'`,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -2740,12 +2740,12 @@ val merge_moves_frame2 = prove(``
     metis_tac[domain_lookup,lookup_insert]);
 
 (*Another frame proof about unchanged lookups*)
-val merge_moves_frame3 = prove(``
+val merge_moves_frame3 = Q.prove(`
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   ∀x. ¬MEM x ls ∨ x ∉ domain (inter ssaL ssaR) ⇒
     lookup x ssaL' = lookup x ssaL ∧
-    lookup x ssaR' = lookup x ssaR``,
+    lookup x ssaR' = lookup x ssaR`,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])>>
   rpt strip_tac>>
@@ -2766,20 +2766,20 @@ val merge_moves_frame3 = prove(``
 (*Don't know a neat way to prove this for both sides at once neatly,
 Also, the cases are basically copy pasted... *)
 
-val mov_eval_head = prove(``
+val mov_eval_head = Q.prove(`
   evaluate(Move p moves,st) = (NONE,rst) ∧
   y ∈ domain st.locals ∧
   ¬MEM y (MAP FST moves) ∧
   ¬MEM x (MAP FST moves)
   ⇒
-  evaluate(Move p ((x,y)::moves),st) = (NONE, rst with locals:=insert x (THE (lookup y st.locals)) rst.locals)``,
+  evaluate(Move p ((x,y)::moves),st) = (NONE, rst with locals:=insert x (THE (lookup y st.locals)) rst.locals)`,
   full_simp_tac(srw_ss())[evaluate_def,get_vars_def,get_var_def,domain_lookup]>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>
   strip_tac>>
   full_simp_tac(srw_ss())[set_vars_def,alist_insert_def]>>
   qpat_x_assum `A=rst` (sym_sub_tac)>>full_simp_tac(srw_ss())[]);
 
-val merge_moves_correctL = prove(``
+val merge_moves_correctL = Q.prove(`
   ∀ls na ssaL ssaR stL cstL pri.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -2793,7 +2793,7 @@ val merge_moves_correctL = prove(``
     (∀x y. (x < na ∧ lookup x cstL.locals = SOME y)
     ⇒  lookup x rcstL.locals = SOME y) ∧
     ssa_locals_rel na' ssaL' stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)``,
+    word_state_eq_rel cstL rcstL)`,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -2854,7 +2854,7 @@ val merge_moves_correctL = prove(``
   >>
       full_simp_tac(srw_ss())[word_state_eq_rel_def]);
 
-val merge_moves_correctR = prove(``
+val merge_moves_correctR = Q.prove(`
   ∀ls na ssaL ssaR stR cstR pri.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -2868,7 +2868,7 @@ val merge_moves_correctR = prove(``
     (∀x y. (x < na ∧ lookup x cstR.locals = SOME y)
     ⇒  lookup x rcstR.locals = SOME y) ∧
     ssa_locals_rel na' ssaR' stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)``,
+    word_state_eq_rel cstR rcstR)`,
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -2929,7 +2929,7 @@ val merge_moves_correctR = prove(``
   >>
       full_simp_tac(srw_ss())[word_state_eq_rel_def]);
 
-val fake_moves_frame = prove(``
+val fake_moves_frame = Q.prove(`
   ∀ls na ssaL ssaR.
   is_alloc_var na
   ⇒
@@ -2937,7 +2937,7 @@ val fake_moves_frame = prove(``
   is_alloc_var na' ∧
   na ≤ na' ∧
   (ssa_map_ok na ssaL ⇒ ssa_map_ok na' ssaL') ∧
-  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')``,
+  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -2958,12 +2958,12 @@ val fake_moves_frame = prove(``
   >>
   metis_tac[ssa_map_ok_extend,convention_partitions]);
 
-val fake_moves_frame2 = prove(``
+val fake_moves_frame2 = Q.prove(`
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = fake_moves ls ssaL ssaR na in
   domain ssaL' = domain ssaL ∪ (set ls ∩ (domain ssaR ∪ domain ssaL)) ∧
   domain ssaR' = domain ssaR ∪ (set ls ∩ (domain ssaR ∪ domain ssaL)) ∧
-  ∀x. MEM x ls ∧ x ∉ domain(inter ssaL ssaR) ⇒ lookup x ssaL' = lookup x ssaR'``,
+  ∀x. MEM x ls ∧ x ∉ domain(inter ssaL ssaR) ⇒ lookup x ssaL' = lookup x ssaR'`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -2976,12 +2976,12 @@ val fake_moves_frame2 = prove(``
   full_simp_tac(srw_ss())[EXTENSION,domain_inter]>>srw_tac[][]>>
   metis_tac[domain_lookup,lookup_insert]);
 
-val fake_moves_frame3 = prove(``
+val fake_moves_frame3 = Q.prove(`
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = fake_moves ls ssaL ssaR na in
   ∀x. ¬ MEM x ls ∨ x ∈ domain(inter ssaL ssaR) ⇒
     lookup x ssaL' = lookup x ssaL ∧
-    lookup x ssaR' = lookup x ssaR``,
+    lookup x ssaR' = lookup x ssaR`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3000,7 +3000,7 @@ val fake_moves_frame3 = prove(``
   res_tac>>
   full_simp_tac(srw_ss())[lookup_NONE_domain]);
 
-val fake_moves_correctL = prove(``
+val fake_moves_correctL = Q.prove(`
   ∀ls na ssaL ssaR stL cstL.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3014,7 +3014,7 @@ val fake_moves_correctL = prove(``
     (∀x y. (x < na ∧ lookup x cstL.locals = SOME y)
     ⇒  lookup x rcstL.locals = SOME y) ∧
     ssa_locals_rel na' ssaL' stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)``,
+    word_state_eq_rel cstL rcstL)`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>
     full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3093,7 +3093,7 @@ val fake_moves_correctL = prove(``
     >>
       full_simp_tac(srw_ss())[word_state_eq_rel_def]));
 
-val fake_moves_correctR = prove(``
+val fake_moves_correctR = Q.prove(`
   ∀ls na ssaL ssaR stR cstR.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3107,7 +3107,7 @@ val fake_moves_correctR = prove(``
     (∀x y. (x < na ∧ lookup x cstR.locals = SOME y)
     ⇒  lookup x rcstR.locals = SOME y) ∧
     ssa_locals_rel na' ssaR' stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)``,
+    word_state_eq_rel cstR rcstR)`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3221,7 +3221,7 @@ val get_var_ignore = Q.prove(`
   srw_tac[][]>>
   Cases_on`a`>>full_simp_tac(srw_ss())[alist_insert_def,lookup_insert]);
 
-val fix_inconsistencies_correctL = prove(``
+val fix_inconsistencies_correctL = Q.prove(`
   ∀na ssaL ssaR.
   is_alloc_var na ∧
   ssa_map_ok na ssaL
@@ -3232,7 +3232,7 @@ val fix_inconsistencies_correctL = prove(``
   let (resL,rcstL) = evaluate(moveL,cstL) in
     resL = NONE ∧
     ssa_locals_rel na' ssaU stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)``,
+    word_state_eq_rel cstL rcstL)`,
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   Q.SPECL_THEN [`var_union`,`na`,`ssaL`,`ssaR`,`stL`,`cstL`,`1`] mp_tac
       merge_moves_correctL>>
@@ -3253,7 +3253,7 @@ val fix_inconsistencies_correctL = prove(``
   rpt VAR_EQ_TAC>>full_simp_tac(srw_ss())[]>>
   srw_tac[][]>>full_simp_tac(srw_ss())[word_state_eq_rel_def]) |> INST_TYPE [gamma |-> beta];
 
-val fix_inconsistencies_correctR = prove(``
+val fix_inconsistencies_correctR = Q.prove(`
   ∀na ssaL ssaR.
   is_alloc_var na ∧
   ssa_map_ok na ssaR
@@ -3264,7 +3264,7 @@ val fix_inconsistencies_correctR = prove(``
   let (resR,rcstR) = evaluate(moveR,cstR) in
     resR = NONE ∧
     ssa_locals_rel na' ssaU stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)``,
+    word_state_eq_rel cstR rcstR)`,
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   Q.SPECL_THEN [`var_union`,`na`,`ssaL`,`ssaR`,`stR`,`cstR`,`1`] mp_tac
       merge_moves_correctR>>
@@ -3316,7 +3316,7 @@ fun use_ALOOKUP_ALL_DISTINCT_MEM (g as (asl,w)) =
     mp_tac(ISPECL [al,k] (Q.GENL[`v`,`k`,`al`] ALOOKUP_ALL_DISTINCT_MEM))
   end g;
 
-val list_next_var_rename_move_preserve = prove(``
+val list_next_var_rename_move_preserve = Q.prove(`
   ∀st ssa na ls cst.
   ssa_locals_rel na ssa st.locals cst.locals ∧
   set ls ⊆ domain st.locals ∧
@@ -3329,7 +3329,7 @@ val list_next_var_rename_move_preserve = prove(``
     res = NONE ∧
     ssa_locals_rel na' ssa' st.locals rcst.locals ∧
     word_state_eq_rel st rcst ∧
-    (¬is_phy_var na ⇒ ∀w. is_phy_var w ⇒ lookup w rcst.locals = lookup w cst.locals)``,
+    (¬is_phy_var na ⇒ ∀w. is_phy_var w ⇒ lookup w rcst.locals = lookup w cst.locals)`,
   full_simp_tac(srw_ss())[list_next_var_rename_move_def,ssa_locals_rel_def]>>
   srw_tac[][]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -3537,7 +3537,7 @@ val is_stack_var_flip = Q.prove(`
     pop_assum (qspecl_then [`na`,`2`] assume_tac)>>
     srw_tac[][]>>full_simp_tac(srw_ss())[]));
 
-val list_next_var_rename_props = prove(``
+val list_next_var_rename_props = Q.prove(`
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧
   ssa_map_ok na ssa ∧
@@ -3546,7 +3546,7 @@ val list_next_var_rename_props = prove(``
   na ≤ na' ∧
   (is_alloc_var na ⇒ is_alloc_var na') ∧
   (is_stack_var na ⇒ is_stack_var na') ∧
-  ssa_map_ok na' ssa'``,
+  ssa_map_ok na' ssa'`,
   Induct>>full_simp_tac(srw_ss())[list_next_var_rename_def,next_var_rename_def]>>
   LET_ELIM_TAC>>
   first_x_assum(qspecl_then[`ssa''`,`na''`,`ys`,`ssa'''`,`na'''`]
@@ -3570,7 +3570,7 @@ val list_next_var_rename_props = prove(``
   srw_tac[][]>> TRY(DECIDE_TAC)>> full_simp_tac(srw_ss())[]>>
   metis_tac[is_alloc_var_add,is_stack_var_add]);
 
-val list_next_var_rename_move_props = prove(``
+val list_next_var_rename_move_props = Q.prove(`
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧
   ssa_map_ok na ssa ∧
@@ -3579,12 +3579,12 @@ val list_next_var_rename_move_props = prove(``
   na ≤ na' ∧
   (is_alloc_var na ⇒ is_alloc_var na') ∧
   (is_stack_var na ⇒ is_stack_var na') ∧
-  ssa_map_ok na' ssa'``,
+  ssa_map_ok na' ssa'`,
   full_simp_tac(srw_ss())[list_next_var_rename_move_def]>>LET_ELIM_TAC>>
   full_simp_tac(srw_ss())[]>>
   imp_res_tac list_next_var_rename_props);
 
-val ssa_cc_trans_inst_props = prove(``
+val ssa_cc_trans_inst_props = Q.prove(`
   ∀i ssa na i' ssa' na'.
   ssa_cc_trans_inst i ssa na = (i',ssa',na') ∧
   ssa_map_ok na ssa ∧
@@ -3592,7 +3592,7 @@ val ssa_cc_trans_inst_props = prove(``
   ⇒
   na ≤ na' ∧
   is_alloc_var na' ∧
-  ssa_map_ok na' ssa'``,
+  ssa_map_ok na' ssa'`,
   Induct>>srw_tac[][]>>
   TRY(Cases_on`a`)>>
   TRY(Cases_on`r`)>>
@@ -3606,7 +3606,7 @@ val exp_tac = (LET_ELIM_TAC>>full_simp_tac(srw_ss())[next_var_rename_def]>>
     TRY(DECIDE_TAC)>>
     metis_tac[ssa_map_ok_extend,convention_partitions,is_alloc_var_add]);
 
-val fix_inconsistencies_props = prove(``
+val fix_inconsistencies_props = Q.prove(`
   ∀ssaL ssaR na a b na' ssaU.
   fix_inconsistencies ssaL ssaR na = (a,b,na',ssaU) ∧
   is_alloc_var na ∧
@@ -3615,7 +3615,7 @@ val fix_inconsistencies_props = prove(``
   ⇒
   na ≤ na' ∧
   is_alloc_var na' ∧
-  ssa_map_ok na' ssaU``,
+  ssa_map_ok na' ssaU`,
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   imp_res_tac merge_moves_frame>>
   pop_assum(qspecl_then[`ssaR`,`ssaL`,`var_union`] assume_tac)>>
@@ -3654,20 +3654,20 @@ val ssa_map_ok_lem = Q.prove(`
   ssa_map_ok na ssa ⇒ ssa_map_ok (na+2) ssa`,
   metis_tac[ssa_map_ok_more, DECIDE``na:num ≤ na+2``]);
 
-val list_next_var_rename_move_props_2 = prove(``
+val list_next_var_rename_move_props_2 = Q.prove(`
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧ ssa_map_ok na ssa ∧
   list_next_var_rename_move ssa (na+2) ls = (ls',ssa',na') ⇒
   (na+2) ≤ na' ∧
   (is_alloc_var na ⇒ is_stack_var na') ∧
   (is_stack_var na ⇒ is_alloc_var na') ∧
-  ssa_map_ok na' ssa'``,
+  ssa_map_ok na' ssa'`,
   ntac 7 strip_tac>>imp_res_tac list_next_var_rename_move_props>>
   full_simp_tac(srw_ss())[]>>
   metis_tac[is_stack_var_flip,is_alloc_var_flip,ssa_map_ok_lem]);
 
 (*Prove the properties that hold of ssa_cc_trans independent of semantics*)
-val ssa_cc_trans_props = prove(``
+val ssa_cc_trans_props = Q.prove(`
   ∀prog ssa na prog' ssa' na'.
   ssa_cc_trans prog ssa na = (prog',ssa',na') ∧
   ssa_map_ok na ssa ∧
@@ -3675,7 +3675,7 @@ val ssa_cc_trans_props = prove(``
   ⇒
   na ≤ na' ∧
   is_alloc_var na' ∧
-  ssa_map_ok na' ssa'``,
+  ssa_map_ok na' ssa'`,
   ho_match_mp_tac ssa_cc_trans_ind>>
   full_simp_tac(srw_ss())[ssa_cc_trans_def]>>
   strip_tac >-
@@ -3811,30 +3811,30 @@ val ssa_cc_trans_props = prove(``
     imp_res_tac fix_inconsistencies_props>>
     DECIDE_TAC);
 
-val PAIR_ZIP_MEM = prove(``
+val PAIR_ZIP_MEM = Q.prove(`
   LENGTH c = LENGTH d ∧
   MEM (a,b) (ZIP (c,d)) ⇒
-  MEM a c ∧ MEM b d``,
+  MEM a c ∧ MEM b d`,
   srw_tac[][]>>imp_res_tac MEM_ZIP>>
   full_simp_tac(srw_ss())[MEM_EL]>>
   metis_tac[]);
 
-val ALOOKUP_ZIP_MEM = prove(``
+val ALOOKUP_ZIP_MEM = Q.prove(`
   LENGTH a = LENGTH b ∧
   ALOOKUP (ZIP (a,b)) x = SOME y
   ⇒
-  MEM x a ∧ MEM y b``,
+  MEM x a ∧ MEM y b`,
   srw_tac[][]>>imp_res_tac ALOOKUP_MEM>>
   metis_tac[PAIR_ZIP_MEM]);
 
-val ALOOKUP_ALL_DISTINCT_REMAP = prove(``
+val ALOOKUP_ALL_DISTINCT_REMAP = Q.prove(`
   ∀ls x f y n.
   LENGTH ls = LENGTH x ∧
   ALL_DISTINCT (MAP f ls) ∧
   n < LENGTH ls ∧
   ALOOKUP (ZIP (ls,x)) (EL n ls) = SOME y
   ⇒
-  ALOOKUP (ZIP (MAP f ls,x)) (f (EL n ls)) = SOME y``,
+  ALOOKUP (ZIP (MAP f ls,x)) (f (EL n ls)) = SOME y`,
   Induct>>srw_tac[][]>>
   Cases_on`x`>>full_simp_tac(srw_ss())[]>>
   imp_res_tac ALL_DISTINCT_MAP>>
@@ -3917,8 +3917,8 @@ val setup_tac = Cases_on`word_exp st exp`>>full_simp_tac(srw_ss())[]>>
                 rev_full_simp_tac(srw_ss())[word_state_eq_rel_def]>>
                 full_simp_tac(srw_ss())[Abbr`exp`,ssa_cc_trans_exp_def,option_lookup_def,set_var_def];
 
-val ssa_cc_trans_correct = store_thm("ssa_cc_trans_correct",
-``∀prog st cst ssa na.
+val ssa_cc_trans_correct = Q.store_thm("ssa_cc_trans_correct",
+`∀prog st cst ssa na.
   word_state_eq_rel st cst ∧
   ssa_locals_rel na ssa st.locals cst.locals ∧
   (*The following 3 assumptions are from the transform properties and
@@ -3937,7 +3937,7 @@ val ssa_cc_trans_correct = store_thm("ssa_cc_trans_correct",
     (case res of
       NONE =>
         ssa_locals_rel na' ssa' rst.locals rcst.locals
-    | SOME _    => rst.locals = rcst.locals )``,
+    | SOME _    => rst.locals = rcst.locals )`,
   completeInduct_on`prog_size (K 0) prog`>>
   rpt strip_tac>>
   full_simp_tac(srw_ss())[PULL_FORALL,evaluate_def]>>
@@ -5451,7 +5451,7 @@ val get_vars_eq = Q.prove(
   full_simp_tac(srw_ss())[domain_lookup]);
 
 (*For starting up*)
-val setup_ssa_props = prove(``
+val setup_ssa_props = Q.prove(`
   is_alloc_var lim ∧
   domain st.locals = set (even_list n) ⇒
   let (mov:'a wordLang$prog,ssa,na) = setup_ssa n lim (prog:'a wordLang$prog) in
@@ -5461,7 +5461,7 @@ val setup_ssa_props = prove(``
     ssa_map_ok na ssa ∧
     ssa_locals_rel na ssa st.locals cst.locals ∧
     is_alloc_var na ∧
-    lim ≤ na``,
+    lim ≤ na`,
   srw_tac[][setup_ssa_def,list_next_var_rename_move_def]>>
   full_simp_tac(srw_ss())[word_state_eq_rel_def,evaluate_def]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -5634,8 +5634,8 @@ val limit_var_props = Q.prove(`
   full_simp_tac(srw_ss())[]);
 
 (*Full correctness theorem*)
-val full_ssa_cc_trans_correct = store_thm("full_ssa_cc_trans_correct",
-``∀prog st n.
+val full_ssa_cc_trans_correct = Q.store_thm("full_ssa_cc_trans_correct",
+`∀prog st n.
   domain st.locals = set (even_list n) ⇒
   ∃perm'.
   let (res,rst) = evaluate(prog,st with permute:=perm') in
@@ -5645,7 +5645,7 @@ val full_ssa_cc_trans_correct = store_thm("full_ssa_cc_trans_correct",
     word_state_eq_rel rst rcst ∧
     (case res of
       NONE => T
-    | SOME _    => rst.locals = rcst.locals )``,
+    | SOME _    => rst.locals = rcst.locals )`,
   srw_tac[][]>>
   qpat_abbrev_tac`sprog = full_ssa_cc_trans n prog`>>
   full_simp_tac(srw_ss())[full_ssa_cc_trans_def]>>
@@ -5671,13 +5671,13 @@ val full_ssa_cc_trans_correct = store_thm("full_ssa_cc_trans_correct",
    and preserves some syntactic conventions
 *)
 
-val fake_moves_conventions = prove(``
+val fake_moves_conventions = Q.prove(`
   ∀ls ssaL ssaR na.
   let (a,b,c,d,e) = fake_moves ls ssaL ssaR na in
   every_stack_var is_stack_var a ∧
   every_stack_var is_stack_var b ∧
   call_arg_convention a ∧
-  call_arg_convention b``,
+  call_arg_convention b`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>>
   LET_ELIM_TAC>>
   TRY(first_x_assum (assume_tac o SYM)>>
@@ -5687,14 +5687,14 @@ val fake_moves_conventions = prove(``
   full_simp_tac(srw_ss())[LET_THM,fake_move_def]>>rpt VAR_EQ_TAC>>
   full_simp_tac(srw_ss())[call_arg_convention_def,every_stack_var_def,fake_moves_def,inst_arg_convention_def]);
 
-val fix_inconsistencies_conventions = prove(``
+val fix_inconsistencies_conventions = Q.prove(`
   ∀ssaL ssaR na.
   let (a:'a wordLang$prog,b:'a wordLang$prog,c,d) =
     fix_inconsistencies ssaL ssaR na in
   every_stack_var is_stack_var a ∧
   every_stack_var is_stack_var b ∧
   call_arg_convention a ∧
-  call_arg_convention b``,
+  call_arg_convention b`,
   full_simp_tac(srw_ss())[fix_inconsistencies_def,inst_arg_convention_def,call_arg_convention_def,every_stack_var_def,UNCURRY]>>
   rpt strip_tac>>
   srw_tac[][]>>unabbrev_all_tac>>
@@ -5705,12 +5705,12 @@ val fix_inconsistencies_conventions = prove(``
 
 (*Prove that the transform sets up arbitrary programs with
   the appropriate conventions*)
-val ssa_cc_trans_pre_alloc_conventions = store_thm("ssa_cc_trans_pre_alloc_conventions",
-``∀prog ssa na.
+val ssa_cc_trans_pre_alloc_conventions = Q.store_thm("ssa_cc_trans_pre_alloc_conventions",
+`∀prog ssa na.
   is_alloc_var na ∧
   ssa_map_ok na ssa ⇒
   let (prog',ssa',na') = ssa_cc_trans prog ssa na in
-  pre_alloc_conventions prog'``,
+  pre_alloc_conventions prog'`,
   completeInduct_on`wordLang$prog_size (K 0) prog`>>
   rpt strip_tac>>
   full_simp_tac(srw_ss())[PULL_FORALL,LET_THM]>>
@@ -5864,13 +5864,13 @@ val ssa_cc_trans_pre_alloc_conventions = store_thm("ssa_cc_trans_pre_alloc_conve
   disch_then(qspecl_then [`4*x`,`na+2`] assume_tac)>>
   rev_full_simp_tac(srw_ss())[is_stack_var_def]));
 
-val setup_ssa_props_2 = prove(``
+val setup_ssa_props_2 = Q.prove(`
   is_alloc_var lim ⇒
   let (mov:'a wordLang$prog,ssa,na) = setup_ssa n lim (prog:'a wordLang$prog) in
     ssa_map_ok na ssa ∧
     is_alloc_var na ∧
     pre_alloc_conventions mov ∧
-    lim ≤ na``,
+    lim ≤ na`,
   srw_tac[][setup_ssa_def,list_next_var_rename_move_def,pre_alloc_conventions_def]>>
   full_simp_tac(srw_ss())[word_state_eq_rel_def,evaluate_def,every_stack_var_def,call_arg_convention_def]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -5892,19 +5892,19 @@ val full_ssa_cc_trans_pre_alloc_conventions = Q.store_thm("full_ssa_cc_trans_pre
   Q.ISPECL_THEN [`prog`,`ssa`,`na`] assume_tac ssa_cc_trans_pre_alloc_conventions>>
   rev_full_simp_tac(srw_ss())[pre_alloc_conventions_def,every_stack_var_def,call_arg_convention_def,LET_THM]);
 
-val fake_moves_wf_cutsets = prove(``
+val fake_moves_wf_cutsets = Q.prove(`
   ∀ls A B C L R D E G.
   fake_moves ls A B C = (L,R,D,E,G) ⇒
-  wf_cutsets L ∧ wf_cutsets R``,
+  wf_cutsets L ∧ wf_cutsets R`,
   Induct>>fs[fake_moves_def,wf_cutsets_def]>>rw[]>>
   pairarg_tac>>fs[]>>EVERY_CASE_TAC>>fs[]>>
   rveq>>fs[wf_cutsets_def,fake_move_def]>>
   metis_tac[]);
 
-val ssa_cc_trans_wf_cutsets = prove(``
+val ssa_cc_trans_wf_cutsets = Q.prove(`
   ∀prog ssa na.
   let (prog',ssa',na') = ssa_cc_trans prog ssa na in
-  wf_cutsets prog'``,
+  wf_cutsets prog'`,
   ho_match_mp_tac ssa_cc_trans_ind>>fs[wf_cutsets_def,ssa_cc_trans_def,fix_inconsistencies_def,list_next_var_rename_move_def]>>
   rw[]>>
   rpt(pairarg_tac>>fs[])>>rveq>>fs[wf_cutsets_def]>>
@@ -5931,11 +5931,11 @@ val full_ssa_cc_trans_wf_cutsets = Q.store_thm("full_ssa_cc_trans_wf_cutsets",`
   Q.ISPECL_THEN [`prog`,`ssa`,`n'`] assume_tac ssa_cc_trans_wf_cutsets>>
   rfs[]);
 
-val fake_moves_distinct_tar_reg = prove(``
+val fake_moves_distinct_tar_reg = Q.prove(`
   ∀ls ssal ssar na l r a b c conf.
   fake_moves ls ssal ssar na = (l,r,a,b,c) ⇒
   every_inst distinct_tar_reg l ∧
-  every_inst distinct_tar_reg r``,
+  every_inst distinct_tar_reg r`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>>srw_tac[][]>>full_simp_tac(srw_ss())[every_inst_def]>>
   pop_assum mp_tac>> LET_ELIM_TAC>> EVERY_CASE_TAC>> full_simp_tac(srw_ss())[LET_THM]>>
   unabbrev_all_tac>>
@@ -6070,7 +6070,7 @@ val full_ssa_cc_trans_distinct_tar_reg = Q.store_thm("full_ssa_cc_trans_distinct
     DECIDE_TAC)>>
   full_simp_tac(srw_ss())[]);
 
-val fake_moves_conventions2 = prove(``
+val fake_moves_conventions2 = Q.prove(`
   ∀ls ssal ssar na l r a b c conf.
   fake_moves ls ssal ssar na = (l,r,a,b,c) ⇒
   flat_exp_conventions l ∧
@@ -6078,7 +6078,7 @@ val fake_moves_conventions2 = prove(``
   full_inst_ok_less conf l ∧
   full_inst_ok_less conf r ∧
   every_inst distinct_tar_reg l ∧
-  every_inst distinct_tar_reg r``,
+  every_inst distinct_tar_reg r`,
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>>srw_tac[][]>>full_simp_tac(srw_ss())[flat_exp_conventions_def,full_inst_ok_less_def,every_inst_def]>>
   pop_assum mp_tac>> LET_ELIM_TAC>> EVERY_CASE_TAC>> full_simp_tac(srw_ss())[LET_THM]>>
   unabbrev_all_tac>>
@@ -6251,13 +6251,13 @@ val full_ssa_cc_trans_full_inst_ok_less = Q.store_thm("full_ssa_cc_trans_full_in
 (* word_alloc syntactic stuff *)
 
 (* No longer needed
-val colouring_satisfactory_colouring_ok_alt = prove(``
+val colouring_satisfactory_colouring_ok_alt = Q.prove(`
   ∀prog f live hd tl spg.
   get_clash_sets prog live = (hd,tl) ∧
   spg = clash_sets_to_sp_g (hd::tl) ∧
   colouring_satisfactory (f:num->num) spg
   ⇒
-  colouring_ok_alt f prog live``,
+  colouring_ok_alt f prog live`,
   rpt strip_tac>>
   full_simp_tac(srw_ss())[LET_THM,colouring_ok_alt_def,colouring_satisfactory_def]>>
   qabbrev_tac `ls = hd::tl`>>
@@ -6535,18 +6535,18 @@ val word_alloc_full_inst_ok_less = Q.store_thm("word_alloc_full_inst_ok_less",`
 *)
 
 (* label preservation theorems *)
-val fake_moves_no_labs = prove(``
+val fake_moves_no_labs = Q.prove(`
   ∀ls a b c d e f g h.
   fake_moves ls a b c = (d,e,f,g,h) ⇒
-  extract_labels d = [] ∧ extract_labels e = []``,
+  extract_labels d = [] ∧ extract_labels e = []`,
   Induct>>fs[fake_moves_def,extract_labels_def,fake_move_def]>>rw[]>>
   rpt(pairarg_tac>>fs[])>>
   EVERY_CASE_TAC>>fs[]>>rveq>>fs[extract_labels_def]>>
   metis_tac[]);
 
-val full_ssa_cc_trans_lab_pres = store_thm ("full_ssa_cc_trans_lab_pres",``
+val full_ssa_cc_trans_lab_pres = Q.store_thm ("full_ssa_cc_trans_lab_pres",`
   ∀prog n.
-  extract_labels prog = extract_labels (full_ssa_cc_trans n prog)``,
+  extract_labels prog = extract_labels (full_ssa_cc_trans n prog)`,
   rw[full_ssa_cc_trans_def,setup_ssa_def,list_next_var_rename_move_def]>>
   ntac 3 (pairarg_tac>>fs[])>>rveq>>fs[extract_labels_def]>>
   pop_assum kall_tac >> pop_assum mp_tac>>

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -5737,7 +5737,7 @@ val ssa_cc_trans_pre_alloc_conventions = store_thm("ssa_cc_trans_pre_alloc_conve
   full_simp_tac(srw_ss())[ssa_cc_trans_def]>>LET_ELIM_TAC>>
   `∀x. x ∈ domain stack_set ⇒ is_stack_var x` by
   (unabbrev_all_tac>>
-  rpt (rator_x_assum `list_next_var_rename_move` mp_tac)>>
+  rpt (qhdtm_x_assum `list_next_var_rename_move` mp_tac)>>
   full_simp_tac(srw_ss())[domain_fromAList,MAP_ZIP,list_next_var_rename_move_def]>>
   LET_ELIM_TAC>>
   `ALL_DISTINCT (MAP FST (toAList x1))` by full_simp_tac(srw_ss())[ALL_DISTINCT_MAP_FST_toAList]>>
@@ -5792,7 +5792,7 @@ val ssa_cc_trans_pre_alloc_conventions = store_thm("ssa_cc_trans_pre_alloc_conve
       rev_full_simp_tac(srw_ss())[]>>
       DECIDE_TAC)>>
     rev_full_simp_tac(srw_ss())[]>>metis_tac[convention_partitions])))>>
-  rpt (rator_x_assum `list_next_var_rename_move` mp_tac)>>
+  rpt (qhdtm_x_assum `list_next_var_rename_move` mp_tac)>>
   full_simp_tac(srw_ss())[list_next_var_rename_move_def]>>LET_ELIM_TAC>>
   full_simp_tac(srw_ss())[EQ_SYM_EQ]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[every_stack_var_def,call_arg_convention_def]>>

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -364,7 +364,7 @@ val flatten_exp_every_var_exp = Q.prove(`
 (* inst_select correctness
   Main difficulty: Dealing with multiple choice of optimizations, depending on whether we are allowed to use them w.r.t. to the asm configuration
 *)
-val inst_select_exp_thm = prove(``
+val inst_select_exp_thm = Q.prove(`
   ∀c tar temp exp s w loc.
   binary_branch_exp exp ∧
   every_var_exp (λx. x < temp) exp ∧
@@ -376,7 +376,7 @@ val inst_select_exp_thm = prove(``
   ∀x.
     if x = tar then lookup x loc' = SOME w
     else if x < temp then lookup x loc' = lookup x s.locals
-    else T``,
+    else T`,
   completeInduct_on`exp_size (K 0) exp`>>
   rpt strip_tac>>
   Cases_on`exp`>>
@@ -569,7 +569,7 @@ val locals_rm = Q.prove(`
     The inst-selected program gives same result but
     with possibly more locals used
 *)
-val inst_select_thm = store_thm("inst_select_thm",``
+val inst_select_thm = Q.store_thm("inst_select_thm",`
   ∀c temp prog st res rst loc.
   evaluate (prog,st) = (res,rst) ∧
   every_var (λx. x < temp) prog ∧
@@ -579,7 +579,7 @@ val inst_select_thm = store_thm("inst_select_thm",``
   evaluate (inst_select c temp prog,st with locals:=loc) = (res,rst with locals:=loc') ∧
   case res of
     NONE => locals_rel temp rst.locals loc'
-  | SOME _ => rst.locals = loc'``,
+  | SOME _ => rst.locals = loc'`,
   ho_match_mp_tac inst_select_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[inst_select_def,locals_rel_evaluate_thm]
   >-
@@ -836,12 +836,12 @@ val inst_select_full_inst_ok_less = Q.store_thm("inst_select_full_inst_ok_less",
 (* three_to_two_reg semantics *)
 
 (*Semantics preservation*)
-val three_to_two_reg_correct = store_thm("three_to_two_reg_correct",``
+val three_to_two_reg_correct = Q.store_thm("three_to_two_reg_correct",`
   ∀prog s res s'.
   every_inst distinct_tar_reg prog ∧
   evaluate (prog,s) = (res,s') ∧ res ≠ SOME Error
   ⇒
-  evaluate(three_to_two_reg prog,s) = (res,s')``,
+  evaluate(three_to_two_reg prog,s) = (res,s')`,
   ho_match_mp_tac three_to_two_reg_ind>>
   srw_tac[][]>>full_simp_tac(srw_ss())[three_to_two_reg_def,evaluate_def,state_component_equality]>>
   TRY
@@ -930,9 +930,9 @@ val inst_select_lab_pres = Q.store_thm("inst_select_lab_pres",`
   EVERY_CASE_TAC>>fs[extract_labels_def]>>
   TRY(metis_tac[inst_select_exp_no_lab]))
 
-val three_to_two_reg_lab_pres = store_thm ("three_to_two_reg_lab_pres",``
+val three_to_two_reg_lab_pres = Q.store_thm ("three_to_two_reg_lab_pres",`
   ∀prog.
-  extract_labels prog = extract_labels (three_to_two_reg prog)``,
+  extract_labels prog = extract_labels (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>rw[three_to_two_reg_def,extract_labels_def]>>EVERY_CASE_TAC>>fs[])
 
 val _ = export_theory ();

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -5,18 +5,18 @@ open preamble
 val _ = new_theory "word_instProof";
 
 (* TODO: Move, but some of these are specific instantiations *)
-val PERM_SWAP_SIMP = prove(``
-  PERM (A ++ (B::C)) (B::(A++C))``,
+val PERM_SWAP_SIMP = Q.prove(`
+  PERM (A ++ (B::C)) (B::(A++C))`,
   match_mp_tac APPEND_PERM_SYM>>full_simp_tac(srw_ss())[]>>
   metis_tac[PERM_APPEND])
 
-val EL_FILTER = prove(``
-  ∀ls x. x < LENGTH (FILTER P ls) ⇒ P (EL x (FILTER P ls))``,
+val EL_FILTER = Q.prove(`
+  ∀ls x. x < LENGTH (FILTER P ls) ⇒ P (EL x (FILTER P ls))`,
   Induct>>srw_tac[][]>>
   Cases_on`x`>>full_simp_tac(srw_ss())[EL])
 
-val PERM_SWAP = prove(``
-  PERM (A ++ B ++ C) (B++(A++C))``,
+val PERM_SWAP = Q.prove(`
+  PERM (A ++ B ++ C) (B++(A++C))`,
   full_simp_tac(srw_ss())[PERM_DEF]>>srw_tac[][]>>
   match_mp_tac LIST_EQ>>CONJ_ASM1_TAC
   >-
@@ -40,20 +40,20 @@ val PERM_SWAP = prove(``
 *)
 
 (* pull_exp correctness *)
-val convert_sub_ok = prove(``
+val convert_sub_ok = Q.prove(`
   ∀ls.
-  word_exp s (convert_sub ls) = word_exp s (Op Sub ls)``,
+  word_exp s (convert_sub ls) = word_exp s (Op Sub ls)`,
   ho_match_mp_tac convert_sub_ind>>srw_tac[][convert_sub_def,word_exp_def]>>unabbrev_all_tac>>
   full_simp_tac(srw_ss())[word_op_def,the_words_def]>>
   EVERY_CASE_TAC>>
   simp[])
 
 (*In general, any permutation works*)
-val word_exp_op_permute_lem = prove(``
+val word_exp_op_permute_lem = Q.prove(`
   op ≠ Sub ⇒
   ∀ls ls'.
   PERM ls ls' ⇒
-  word_exp s (Op op ls) = word_exp s (Op op ls')``,
+  word_exp s (Op op ls) = word_exp s (Op op ls')`,
   strip_tac>>
   ho_match_mp_tac PERM_STRONG_IND>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,LET_THM,the_words_def]>>
@@ -78,18 +78,18 @@ val pull_ops_simp_def = Define`
     |  (Op op' ls) => if op = op' then ls ++ (pull_ops_simp op xs) else x::(pull_ops_simp op xs)
     |  _  => x::(pull_ops_simp op xs))`
 
-val pull_ops_simp_pull_ops_perm = prove(``
+val pull_ops_simp_pull_ops_perm = Q.prove(`
   ∀ls x.
-  PERM (pull_ops op ls x) ((pull_ops_simp op ls)++x)``,
+  PERM (pull_ops op ls x) ((pull_ops_simp op ls)++x)`,
   Induct>>full_simp_tac(srw_ss())[pull_ops_def,pull_ops_simp_def]>>srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>
   TRY(qpat_abbrev_tac`A = B::x`>>
   first_x_assum(qspec_then`A` assume_tac)>>full_simp_tac(srw_ss())[Abbr`A`])>>
   TRY(first_x_assum(qspec_then`l++x` assume_tac))>>
   metis_tac[PERM_SWAP,PERM_TRANS,PERM_SWAP_SIMP,PERM_SYM])
 
-val pull_ops_simp_pull_ops_word_exp = prove(``
+val pull_ops_simp_pull_ops_word_exp = Q.prove(`
   op ≠ Sub ⇒
-  word_exp s (Op op (pull_ops op ls [])) = word_exp s (Op op (pull_ops_simp op ls))``,
+  word_exp s (Op op (pull_ops op ls [])) = word_exp s (Op op (pull_ops_simp op ls))`,
   strip_tac>> imp_res_tac word_exp_op_permute_lem>>
   pop_assum match_mp_tac>>
   assume_tac pull_ops_simp_pull_ops_perm>>
@@ -97,18 +97,18 @@ val pull_ops_simp_pull_ops_word_exp = prove(``
 
 (* TODO: Maybe move to props, if these are needed elsewhere *)
 
-val word_exp_op_mono = prove(``
+val word_exp_op_mono = Q.prove(`
   op ≠ Sub ⇒
   word_exp s (Op op ls) = word_exp s (Op op ls') ⇒
   word_exp s (Op op (x::ls)) =
-  word_exp s (Op op (x::ls'))``,
+  word_exp s (Op op (x::ls'))`,
   srw_tac[][word_exp_def,LET_THM]>>
   fs[the_words_def]>>Cases_on`word_exp s x`>>fs[]>>
   Cases_on`x'`>>fs[]>>
   rpt(qpat_x_assum`A=B` mp_tac)>>ntac 2 (TOP_CASE_TAC>>fs[])>>
   Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def])
 
-val the_words_append = prove(``
+val the_words_append = Q.prove(`
   ∀ls ls'.
   the_words (ls ++ ls') =
   case the_words ls of
@@ -116,19 +116,19 @@ val the_words_append = prove(``
   | SOME w =>
     (case the_words ls' of
       NONE => NONE
-    | SOME w' => SOME(w ++ w'))``,
+    | SOME w' => SOME(w ++ w'))`,
   Induct>>fs[the_words_def]>>rw[]>>
   TOP_CASE_TAC>>fs[]>>
   TOP_CASE_TAC>>fs[]>>
   Cases_on`the_words ls`>>fs[]>>
   Cases_on`the_words ls'`>>fs[])
 
-val word_exp_op_op = prove(``
+val word_exp_op_op = Q.prove(`
   op ≠ Sub ⇒
   ∀ls ls'.
   word_exp s (Op op ls) = word_exp s (Op op ls') ⇒
   word_exp s (Op op (l ++ ls)) =
-  word_exp s (Op op ((Op op l) :: ls'))``,
+  word_exp s (Op op ((Op op l) :: ls'))`,
   srw_tac[][word_exp_def,LET_THM]>>
   fs[the_words_append]>>
   qpat_abbrev_tac`C = MAP f l`>>
@@ -140,10 +140,10 @@ val word_exp_op_op = prove(``
   rpt(pop_assum kall_tac)>>
   Induct_on`x`>>fs[])
 
-val pull_ops_ok = prove(``
+val pull_ops_ok = Q.prove(`
   op ≠ Sub ⇒
   ∀ls. word_exp s (Op op (pull_ops op ls [])) =
-         word_exp s (Op op ls)``,
+         word_exp s (Op op ls)`,
   strip_tac>>
   full_simp_tac(srw_ss())[pull_ops_simp_pull_ops_word_exp]>>
   Induct>>srw_tac[][pull_ops_simp_def]>>Cases_on`op`>>full_simp_tac(srw_ss())[]>>
@@ -155,11 +155,11 @@ val pull_ops_ok = prove(``
 
 (* Done with pull_ops, next is optimize_consts *)
 
-val word_exp_swap_head = prove(``
+val word_exp_swap_head = Q.prove(`
   ∀B.
   op ≠ Sub ⇒
   word_exp s (Op op A) = SOME (Word w) ⇒
-  word_exp s (Op op (B++A)) = word_exp s (Op op (Const w::B))``,
+  word_exp s (Op op (B++A)) = word_exp s (Op op (Const w::B))`,
   fs[word_exp_def,the_words_append,the_words_def]>>rw[]>>
   FULL_CASE_TAC>>fs[]>>
   FULL_CASE_TAC>>fs[word_op_def]>>
@@ -167,17 +167,17 @@ val word_exp_swap_head = prove(``
   rpt(pop_assum kall_tac)>>
   Induct_on`x'`>>full_simp_tac(srw_ss())[])
 
-val EVERY_is_const_word_exp = prove(``
+val EVERY_is_const_word_exp = Q.prove(`
   ∀ls. EVERY is_const ls ⇒
-  EVERY IS_SOME (MAP (λa. word_exp s a) ls)``,
+  EVERY IS_SOME (MAP (λa. word_exp s a) ls)`,
   Induct>>srw_tac[][]>>Cases_on`h`>>full_simp_tac(srw_ss())[is_const_def,word_exp_def])
 
-val all_consts_simp = prove(``
+val all_consts_simp = Q.prove(`
   op ≠ Sub ⇒
   ∀ls.
   EVERY is_const ls ⇒
   word_exp s (Op op ls) =
-  SOME( Word(THE (word_op op (MAP rm_const ls))))``,
+  SOME( Word(THE (word_op op (MAP rm_const ls))))`,
   strip_tac>>Induct>>full_simp_tac(srw_ss())[word_exp_def,the_words_def]
   >-
     (full_simp_tac(srw_ss())[word_op_def]>>
@@ -188,10 +188,10 @@ val all_consts_simp = prove(``
   FULL_CASE_TAC>>fs[EVERY_is_const_word_exp]>>
   Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def,rm_const_def])
 
-val optimize_consts_ok = prove(``
+val optimize_consts_ok = Q.prove(`
   op ≠ Sub ⇒
   ∀ls. word_exp s (optimize_consts op ls) =
-       word_exp s (Op op ls)``,
+       word_exp s (Op op ls)`,
   strip_tac>>srw_tac[][optimize_consts_def]>>
   Cases_on`const_ls`>>full_simp_tac(srw_ss())[]
   >-
@@ -222,10 +222,10 @@ val optimize_consts_ok = prove(``
     `h:: (t ++A) = B ++A` by full_simp_tac(srw_ss())[]>>pop_assum SUBST_ALL_TAC>>
     metis_tac[PERM_APPEND])
 
-val pull_exp_ok = prove(``
+val pull_exp_ok = Q.prove(`
   ∀exp s x.
   word_exp s exp = SOME x ⇒
-  word_exp s (pull_exp exp) = SOME x``,
+  word_exp s (pull_exp exp) = SOME x`,
   ho_match_mp_tac pull_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[pull_exp_def,LET_THM]>>
   TRY(full_simp_tac(srw_ss())[op_consts_def,word_exp_def,LET_THM,word_op_def,the_words_def]>>
@@ -269,33 +269,33 @@ val pull_exp_ok = prove(``
   rfs[])
 
 (* pull_exp syntax *)
-val convert_sub_every_var_exp = prove(``
+val convert_sub_every_var_exp = Q.prove(`
   ∀ls.
   (∀x. MEM x ls ⇒ every_var_exp P x) ⇒
-  every_var_exp P (convert_sub ls)``,
+  every_var_exp P (convert_sub ls)`,
   ho_match_mp_tac convert_sub_ind>>srw_tac[][convert_sub_def]>>
   full_simp_tac(srw_ss())[every_var_exp_def,EVERY_MEM])
 
-val optimize_consts_every_var_exp = prove(``
+val optimize_consts_every_var_exp = Q.prove(`
   ∀ls.
   (∀x. MEM x ls ⇒ every_var_exp P x) ⇒
-  every_var_exp P (optimize_consts op ls)``,
+  every_var_exp P (optimize_consts op ls)`,
   srw_tac[][optimize_consts_def]>>
   `PERM ls (const_ls++nconst_ls)` by metis_tac[PERM_PARTITION]>>full_simp_tac(srw_ss())[]>>
   imp_res_tac PERM_MEM_EQ>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_exp_def,LET_THM,EVERY_MEM])
 
-val pull_ops_every_var_exp = prove(``
+val pull_ops_every_var_exp = Q.prove(`
   ∀ls acc.
   EVERY (every_var_exp P) acc ∧ EVERY (every_var_exp P) ls ⇒
-  EVERY (every_var_exp P) (pull_ops op ls acc)``,
+  EVERY (every_var_exp P) (pull_ops op ls acc)`,
   Induct>>full_simp_tac(srw_ss())[pull_ops_def]>>srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_exp_def]>>
   metis_tac[ETA_AX,EVERY_APPEND,every_var_exp_def]) |> REWRITE_RULE[EVERY_MEM]
 
-val pull_exp_every_var_exp = prove(``
+val pull_exp_every_var_exp = Q.prove(`
   ∀exp.
   every_var_exp P exp ⇒
-  every_var_exp P (pull_exp exp)``,
+  every_var_exp P (pull_exp exp)`,
   ho_match_mp_tac pull_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,pull_exp_def,every_var_exp_def,EVERY_MEM,EVERY_MAP,LET_THM]>>srw_tac[][]
   >-
     metis_tac[convert_sub_every_var_exp,MEM_MAP,PULL_EXISTS]
@@ -305,10 +305,10 @@ val pull_exp_every_var_exp = prove(``
     metis_tac[MEM_MAP])
 
 (* flatten_exp correctness *)
-val flatten_exp_ok = prove(``
+val flatten_exp_ok = Q.prove(`
   ∀exp s x.
   word_exp s exp = SOME x ⇒
-  word_exp s (flatten_exp exp) = SOME x``,
+  word_exp s (flatten_exp exp) = SOME x`,
   ho_match_mp_tac flatten_exp_ind>>srw_tac[][]>>
   fs[word_exp_def,flatten_exp_def]
   >-
@@ -350,15 +350,15 @@ val binary_branch_exp_def = tDefine "binary_branch_exp" `
    \\ TRY (DECIDE_TAC))
 
 (* flatten_exp syntax *)
-val flatten_exp_binary_branch_exp = prove(``
+val flatten_exp_binary_branch_exp = Q.prove(`
   ∀exp.
-  binary_branch_exp (flatten_exp exp)``,
+  binary_branch_exp (flatten_exp exp)`,
   ho_match_mp_tac flatten_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,flatten_exp_def,binary_branch_exp_def,EVERY_MEM,EVERY_MAP])
 
-val flatten_exp_every_var_exp = prove(``
+val flatten_exp_every_var_exp = Q.prove(`
   ∀exp.
   every_var_exp P exp ⇒
-  every_var_exp P (flatten_exp exp)``,
+  every_var_exp P (flatten_exp exp)`,
   ho_match_mp_tac flatten_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,flatten_exp_def,every_var_exp_def,EVERY_MEM,EVERY_MAP])
 
 (* inst_select correctness
@@ -561,8 +561,8 @@ val inst_select_exp_thm = prove(``
       (`num_exp n ≥ dimindex(:'a)` by DECIDE_TAC>>
       full_simp_tac(srw_ss())[word_sh_def])))
 
-val locals_rm = prove(``
-  D with locals := D.locals = D``,
+val locals_rm = Q.prove(`
+  D with locals := D.locals = D`,
   full_simp_tac(srw_ss())[state_component_equality])
 
 (*  Main semantics theorem for inst selection:
@@ -797,15 +797,15 @@ val inst_select_thm = store_thm("inst_select_thm",``
         full_simp_tac(srw_ss())[state_component_equality])
 
 (* inst_select syntax *)
-val inst_select_exp_flat_exp_conventions = prove(``
+val inst_select_exp_flat_exp_conventions = Q.prove(`
   ∀c tar temp exp.
-  flat_exp_conventions (inst_select_exp c tar temp exp)``,
+  flat_exp_conventions (inst_select_exp c tar temp exp)`,
   ho_match_mp_tac inst_select_exp_ind>>srw_tac[][]>>full_simp_tac(srw_ss())[inst_select_exp_def,flat_exp_conventions_def,LET_THM]>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_exp_def,LET_THM])
 
-val inst_select_flat_exp_conventions = store_thm("inst_select_flat_exp_conventions",``
+val inst_select_flat_exp_conventions = Q.store_thm("inst_select_flat_exp_conventions",`
   ∀c temp prog.
-  flat_exp_conventions (inst_select c temp prog)``,
+  flat_exp_conventions (inst_select c temp prog)`,
   ho_match_mp_tac inst_select_ind >>srw_tac[][]>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_def,LET_THM]>>
   EVERY_CASE_TAC>>
@@ -813,20 +813,20 @@ val inst_select_flat_exp_conventions = store_thm("inst_select_flat_exp_conventio
   metis_tac[inst_select_exp_flat_exp_conventions])
 
 (*Less restrictive version of inst_ok guaranteed by inst_select*)
-val inst_select_exp_full_inst_ok_less = prove(``
+val inst_select_exp_full_inst_ok_less = Q.prove(`
   ∀c tar temp exp.
   addr_offset_ok 0w c ⇒
-  full_inst_ok_less c (inst_select_exp c tar temp exp)``,
+  full_inst_ok_less c (inst_select_exp c tar temp exp)`,
   ho_match_mp_tac inst_select_exp_ind>>rw[]>>
   fs[inst_select_exp_def,LET_THM,inst_ok_less_def,full_inst_ok_less_def]>>
   every_case_tac>>fs[full_inst_ok_less_def,inst_ok_less_def,inst_select_exp_def,LET_THM])
 
-val inst_select_full_inst_ok_less = store_thm("inst_select_full_inst_ok_less",``
+val inst_select_full_inst_ok_less = Q.store_thm("inst_select_full_inst_ok_less",`
   ∀c temp prog.
   addr_offset_ok 0w c ∧
   every_inst (λi. F) prog
   ⇒
-  full_inst_ok_less c (inst_select c temp prog)``,
+  full_inst_ok_less c (inst_select c temp prog)`,
   ho_match_mp_tac inst_select_ind>>
   rw[inst_select_def,full_inst_ok_less_def,every_inst_def]>>
   EVERY_CASE_TAC>>
@@ -880,17 +880,17 @@ val three_to_two_reg_correct = store_thm("three_to_two_reg_correct",``
       rev_full_simp_tac(srw_ss())[])
 
 (* Syntactic three_to_two_reg *)
-val three_to_two_reg_two_reg_inst = store_thm("three_to_two_reg_two_reg_inst",``
-  ∀prog. every_inst two_reg_inst (three_to_two_reg prog)``,
+val three_to_two_reg_two_reg_inst = Q.store_thm("three_to_two_reg_two_reg_inst",`
+  ∀prog. every_inst two_reg_inst (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>full_simp_tac(srw_ss())[every_inst_def,two_reg_inst_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])
 
-val three_to_two_reg_wf_cutsets = store_thm("three_to_two_reg_wf_cutsets",
-  ``∀prog. wf_cutsets prog ⇒ wf_cutsets (three_to_two_reg prog)``,
+val three_to_two_reg_wf_cutsets = Q.store_thm("three_to_two_reg_wf_cutsets",
+  `∀prog. wf_cutsets prog ⇒ wf_cutsets (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[wf_cutsets_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])
 
-val three_to_two_reg_pre_alloc_conventions = store_thm("three_to_two_reg_pre_alloc_conventions",
-  ``∀prog. pre_alloc_conventions prog ⇒ pre_alloc_conventions (three_to_two_reg prog)``,
+val three_to_two_reg_pre_alloc_conventions = Q.store_thm("three_to_two_reg_pre_alloc_conventions",
+  `∀prog. pre_alloc_conventions prog ⇒ pre_alloc_conventions (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[pre_alloc_conventions_def,every_stack_var_def,three_to_two_reg_def,LET_THM,call_arg_convention_def,inst_arg_convention_def]>>
   FULL_CASE_TAC>>fs[]>>
@@ -898,14 +898,14 @@ val three_to_two_reg_pre_alloc_conventions = store_thm("three_to_two_reg_pre_all
   FULL_CASE_TAC>>fs[]>>
   PairCases_on`x`>>fs[])
 
-val three_to_two_reg_flat_exp_conventions = store_thm("three_to_two_reg_flat_exp_conventions",
-  ``∀prog. flat_exp_conventions prog ⇒ flat_exp_conventions (three_to_two_reg prog)``,
+val three_to_two_reg_flat_exp_conventions = Q.store_thm("three_to_two_reg_flat_exp_conventions",
+  `∀prog. flat_exp_conventions prog ⇒ flat_exp_conventions (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])
 
-val three_to_two_reg_full_inst_ok_less = store_thm("three_to_two_reg_full_inst_ok_less",
-  ``∀prog. full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (three_to_two_reg prog)``,
+val three_to_two_reg_full_inst_ok_less = Q.store_thm("three_to_two_reg_full_inst_ok_less",
+  `∀prog. full_inst_ok_less c prog ⇒
+  full_inst_ok_less c (three_to_two_reg prog)`,
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>fs[full_inst_ok_less_def]
   >-
@@ -916,15 +916,15 @@ val three_to_two_reg_full_inst_ok_less = store_thm("three_to_two_reg_full_inst_o
     metis_tac[inst_ok_less_def])
 
 (* label preservation stuff *)
-val inst_select_exp_no_lab = prove(``
+val inst_select_exp_no_lab = Q.prove(`
   ∀c temp temp' exp.
-  extract_labels (inst_select_exp c temp temp' exp) = []``,
+  extract_labels (inst_select_exp c temp temp' exp) = []`,
   ho_match_mp_tac inst_select_exp_ind>>rw[inst_select_exp_def]>>fs[extract_labels_def]>>
   rpt(TOP_CASE_TAC>>fs[extract_labels_def,inst_select_exp_def]))
 
-val inst_select_lab_pres = store_thm("inst_select_lab_pres",``
+val inst_select_lab_pres = Q.store_thm("inst_select_lab_pres",`
   ∀c temp prog.
-  extract_labels prog = extract_labels (inst_select c temp prog)``,
+  extract_labels prog = extract_labels (inst_select c temp prog)`,
   ho_match_mp_tac inst_select_ind>>rw[inst_select_def,extract_labels_def]>>
   TRY(metis_tac[inst_select_exp_no_lab])>>
   EVERY_CASE_TAC>>fs[extract_labels_def]>>

--- a/compiler/backend/proofs/word_removeProofScript.sml
+++ b/compiler/backend/proofs/word_removeProofScript.sml
@@ -16,14 +16,14 @@ val alloc_termdep_code_frame = prove(``
   FULL_CASE_TAC>>full_simp_tac(srw_ss())[has_space_def]>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])|>INST_TYPE[beta|->alpha,gamma|->beta,delta|->alpha]
 
-val get_vars_termdep_code_frame = prove(``
+val get_vars_termdep_code_frame = Q.prove(`
   ∀ls.
-  get_vars ls s = get_vars ls (s with <|termdep:=0;code:=l|>)``,
+  get_vars ls s = get_vars ls (s with <|termdep:=0;code:=l|>)`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_def])
 
-val word_exp_termdep_code_frame = prove(``
+val word_exp_termdep_code_frame = Q.prove(`
   ∀s exp.
-  word_exp s exp = word_exp (s with <|termdep:=0;code:=l|>) exp``,
+  word_exp s exp = word_exp (s with <|termdep:=0;code:=l|>) exp`,
   ho_match_mp_tac word_exp_ind>>
   full_simp_tac(srw_ss())[word_exp_def,LET_THM,mem_load_def]>>
   full_simp_tac(srw_ss())[EVERY_MAP,EVERY_MEM]>>srw_tac[][]>>
@@ -33,13 +33,13 @@ val word_exp_termdep_code_frame = prove(``
 
 val tac = (full_simp_tac(srw_ss())[GSYM word_exp_termdep_code_frame]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[state_component_equality,set_store_def,mem_store_def])
 
-val push_env_code = prove(``
-  (push_env x handler s).code = s.code``,
+val push_env_code = Q.prove(`
+  (push_env x handler s).code = s.code`,
   Cases_on`handler`>>TRY(PairCases_on`x'`)>>full_simp_tac(srw_ss())[push_env_def,LET_THM,env_to_list_def])
 
-val pop_env_termdep_code_frame = prove(``
+val pop_env_termdep_code_frame = Q.prove(`
   pop_env (r' with <|termdep:=0; code:=l|>) =
-  lift (λs. s with <|termdep:=0;code:=l|>) (pop_env r')``,
+  lift (λs. s with <|termdep:=0;code:=l|>) (pop_env r')`,
   full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])
 
 val word_remove_correct = store_thm("word_remove_correct",``
@@ -180,14 +180,14 @@ val word_remove_correct = store_thm("word_remove_correct",``
 (* syntactic preservation all in one go *)
 val convs = [flat_exp_conventions_def,full_inst_ok_less_def,every_inst_def,post_alloc_conventions_def,call_arg_convention_def,wordLangTheory.every_stack_var_def,wordLangTheory.every_var_def,extract_labels_def]
 
-val remove_must_terminate_conventions = store_thm("remove_must_terminate_conventions",``
+val remove_must_terminate_conventions = Q.store_thm("remove_must_terminate_conventions",`
   ∀p c k.
   let comp = remove_must_terminate p in
   (flat_exp_conventions p ⇒ flat_exp_conventions comp) ∧
   (full_inst_ok_less c p ⇒ full_inst_ok_less c comp) ∧
   (post_alloc_conventions k p ⇒ post_alloc_conventions k comp) ∧
   (every_inst two_reg_inst p ⇒ every_inst two_reg_inst comp) ∧
-  (extract_labels p = extract_labels comp)``,
+  (extract_labels p = extract_labels comp)`,
   ho_match_mp_tac remove_must_terminate_ind>>rw[]>>
   fs[remove_must_terminate_def]>>fs convs>>
   TRY

--- a/compiler/backend/proofs/word_removeProofScript.sml
+++ b/compiler/backend/proofs/word_removeProofScript.sml
@@ -3,9 +3,9 @@ open preamble word_removeTheory wordSemTheory wordPropsTheory;
 val _ = new_theory "word_removeProof";
 
 (* semantics *)
-val alloc_termdep_code_frame = prove(``
+val alloc_termdep_code_frame = Q.prove(`
   alloc c names (s with <|termdep:=d;code:=l|>) =
-  (FST (alloc c names s),SND(alloc c names s) with <|termdep:=d;code:=l|>)``,
+  (FST (alloc c names s),SND(alloc c names s) with <|termdep:=d;code:=l|>)`,
   full_simp_tac(srw_ss())[alloc_def]>>TOP_CASE_TAC>>
   full_simp_tac(srw_ss())[push_env_def,env_to_list_def,LET_THM,gc_def,set_store_def]>>
   ntac 3(FULL_CASE_TAC>>full_simp_tac(srw_ss())[])
@@ -42,14 +42,14 @@ val pop_env_termdep_code_frame = Q.prove(`
   lift (λs. s with <|termdep:=0;code:=l|>) (pop_env r')`,
   full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[])
 
-val word_remove_correct = store_thm("word_remove_correct",``
+val word_remove_correct = Q.store_thm("word_remove_correct",`
   ∀prog st res rst.
   (!n v p. lookup n st.code = SOME (v,p) ==>
          lookup n l = SOME (v,remove_must_terminate p)) ∧
   evaluate(prog,st) = (res,rst) ∧
   res ≠ SOME Error ⇒
   ∃clk.
-  evaluate(remove_must_terminate prog,st with <|clock:=st.clock+clk;termdep:=0;code:=l|>) = (res,rst with <|termdep:=0;code:=l|>)``,
+  evaluate(remove_must_terminate prog,st with <|clock:=st.clock+clk;termdep:=0;code:=l|>) = (res,rst with <|termdep:=0;code:=l|>)`,
   recInduct evaluate_ind>>
   full_simp_tac(srw_ss())[evaluate_def,remove_must_terminate_def,state_component_equality,call_env_def,get_var_def,set_var_def,dec_clock_def]>>srw_tac[][]
   >-

--- a/compiler/backend/proofs/word_simpProofScript.sml
+++ b/compiler/backend/proofs/word_simpProofScript.sml
@@ -6,21 +6,21 @@ val s = ``s:('a,'ffi) wordSem$state``
 
 (* verification of Seq_assoc *)
 
-val evaluate_SmartSeq = store_thm("evaluate_SmartSeq",
-  ``evaluate (SmartSeq p1 p2,s) = evaluate (Seq p1 p2,^s)``,
+val evaluate_SmartSeq = Q.store_thm("evaluate_SmartSeq",
+  `evaluate (SmartSeq p1 p2,s) = evaluate (Seq p1 p2,^s)`,
   rw [SmartSeq_def,evaluate_def]);
 
-val evaluate_Seq_Skip = store_thm("evaluate_Seq_Skip",
-  ``!p1 s. evaluate (Seq p1 Skip,s) = evaluate (p1,^s)``,
+val evaluate_Seq_Skip = Q.store_thm("evaluate_Seq_Skip",
+  `!p1 s. evaluate (Seq p1 Skip,s) = evaluate (p1,^s)`,
   Induct \\ fs [evaluate_def] \\ rw []
   \\ rpt (pairarg_tac \\ fs [] \\ rw [] \\ fs []));
 
-val evaluate_Skip_Seq = store_thm("evaluate_Skip_Seq",
-  ``evaluate (Seq Skip p,s) = evaluate (p,^s)``,
+val evaluate_Skip_Seq = Q.store_thm("evaluate_Skip_Seq",
+  `evaluate (Seq Skip p,s) = evaluate (p,^s)`,
   fs [evaluate_def]);
 
-val evaluate_Seq_assoc_lemma = store_thm("evaluate_Seq_assoc_lemma",
-  ``!p1 p2 s. evaluate (Seq_assoc p1 p2,s) = evaluate (Seq p1 p2,^s)``,
+val evaluate_Seq_assoc_lemma = Q.store_thm("evaluate_Seq_assoc_lemma",
+  `!p1 p2 s. evaluate (Seq_assoc p1 p2,s) = evaluate (Seq p1 p2,^s)`,
   HO_MATCH_MP_TAC Seq_assoc_ind \\ fs [] \\ rw []
   \\ fs [evaluate_SmartSeq,Seq_assoc_def,evaluate_Seq_Skip,evaluate_def]
   \\ (rpt (pairarg_tac \\ fs [] \\ rw [] \\ fs []))
@@ -32,8 +32,8 @@ val evaluate_Seq_assoc_lemma = store_thm("evaluate_Seq_assoc_lemma",
   \\ PairCases_on `x'` \\ fs[add_ret_loc_def]
   \\ PairCases_on `x''` \\ fs[add_ret_loc_def,push_env_def])
 
-val evaluate_Seq_assoc = store_thm("evaluate_Seq_assoc",
-  ``!p s. evaluate (Seq_assoc Skip p,s) = evaluate (p,^s)``,
+val evaluate_Seq_assoc = Q.store_thm("evaluate_Seq_assoc",
+  `!p s. evaluate (Seq_assoc Skip p,s) = evaluate (p,^s)`,
   fs [evaluate_Seq_assoc_lemma,evaluate_def]);
 
 val extract_labels_SmartSeq = Q.store_thm("extract_labels_SmartSeq",
@@ -55,31 +55,31 @@ val extract_labels_Seq_assoc = Q.store_thm("extract_labels_Seq_assoc",
 
 (* verification of simp_if *)
 
-val dest_If_Eq_Imm_thm = store_thm("dest_If_Eq_Imm_thm",
-  ``dest_If_Eq_Imm x2 = SOME (n,w,p1,p2) <=>
-    x2 = If Equal n (Imm w) p1 p2``,
+val dest_If_Eq_Imm_thm = Q.store_thm("dest_If_Eq_Imm_thm",
+  `dest_If_Eq_Imm x2 = SOME (n,w,p1,p2) <=>
+    x2 = If Equal n (Imm w) p1 p2`,
   Cases_on `x2` \\ fs [dest_If_Eq_Imm_def,dest_If_def]
   \\ every_case_tac \\ fs []);
 
-val dest_If_thm = store_thm("dest_If_thm",
-  ``dest_If x2 = SOME (g1,g2,g3,g4,g5) <=> x2 = If g1 g2 g3 g4 g5``,
+val dest_If_thm = Q.store_thm("dest_If_thm",
+  `dest_If x2 = SOME (g1,g2,g3,g4,g5) <=> x2 = If g1 g2 g3 g4 g5`,
   Cases_on `x2` \\ fs [dest_If_def]);
 
-val dest_Seq_IMP = store_thm("dest_Seq_IMP",
-  ``dest_Seq p1 = (x1,x2) ==> evaluate (p1,s) = evaluate (Seq x1 x2,^s)``,
+val dest_Seq_IMP = Q.store_thm("dest_Seq_IMP",
+  `dest_Seq p1 = (x1,x2) ==> evaluate (p1,s) = evaluate (Seq x1 x2,^s)`,
   Cases_on `p1` \\ fs [SmartSeq_def,dest_Seq_def]
   \\ rw [] \\ fs [evaluate_Skip_Seq]);
 
-val dest_Seq_Assign_Const_IMP = store_thm("dest_Seq_Assign_Const_IMP",
-  ``dest_Seq_Assign_Const v p = SOME (q,w) ==>
-    evaluate (p,s) = evaluate (Seq q (Assign v (Const w)),^s)``,
+val dest_Seq_Assign_Const_IMP = Q.store_thm("dest_Seq_Assign_Const_IMP",
+  `dest_Seq_Assign_Const v p = SOME (q,w) ==>
+    evaluate (p,s) = evaluate (Seq q (Assign v (Const w)),^s)`,
   fs [dest_Seq_Assign_Const_def] \\ pairarg_tac \\ fs []
   \\ Cases_on `p2` \\ fs [] \\ Cases_on `e` \\ fs []
   \\ rw [] \\ imp_res_tac dest_Seq_IMP \\ fs []);
 
-val evaluate_apply_if_opt = store_thm("evaluate_apply_if_opt",
-  ``apply_if_opt p1 p2 = SOME x ==>
-    evaluate (Seq p1 p2,s) = evaluate (x,^s)``,
+val evaluate_apply_if_opt = Q.store_thm("evaluate_apply_if_opt",
+  `apply_if_opt p1 p2 = SOME x ==>
+    evaluate (Seq p1 p2,s) = evaluate (x,^s)`,
   fs [apply_if_opt_def]
   \\ pairarg_tac \\ fs []
   \\ every_case_tac \\ fs []
@@ -105,8 +105,8 @@ val evaluate_apply_if_opt = store_thm("evaluate_apply_if_opt",
   \\ Cases_on `res' = NONE` \\ fs [word_exp_def] \\ rveq
   \\ fs [get_var_def,set_var_def,asmSemTheory.word_cmp_def]);
 
-val evaluate_simp_if = store_thm("evaluate_simp_if",
-  ``!p s. evaluate (simp_if p,s) = evaluate (p,^s)``,
+val evaluate_simp_if = Q.store_thm("evaluate_simp_if",
+  `!p s. evaluate (simp_if p,s) = evaluate (p,^s)`,
   HO_MATCH_MP_TAC simp_if_ind \\ fs [simp_if_def,evaluate_def] \\ rw []
   THEN1
    (CASE_TAC \\ fs [evaluate_def]
@@ -146,9 +146,9 @@ val extract_labels_simp_if = Q.store_thm("extract_labels_simp_if",
 
 (* putting it all together *)
 
-val compile_exp_thm = store_thm("compile_exp_thm",
-  ``wordSem$evaluate (prog,^s) = (res,s2) /\ res <> SOME Error ==>
-    evaluate (word_simp$compile_exp prog,s) = (res,s2)``,
+val compile_exp_thm = Q.store_thm("compile_exp_thm",
+  `wordSem$evaluate (prog,^s) = (res,s2) /\ res <> SOME Error ==>
+    evaluate (word_simp$compile_exp prog,s) = (res,s2)`,
   fs [word_simpTheory.compile_exp_def,evaluate_simp_if,evaluate_Seq_assoc]);
 
 val extract_labels_compile_exp = Q.store_thm("extract_labels_compile_exp[simp]",

--- a/compiler/backend/proofs/word_simpProofScript.sml
+++ b/compiler/backend/proofs/word_simpProofScript.sml
@@ -36,21 +36,21 @@ val evaluate_Seq_assoc = store_thm("evaluate_Seq_assoc",
   ``!p s. evaluate (Seq_assoc Skip p,s) = evaluate (p,^s)``,
   fs [evaluate_Seq_assoc_lemma,evaluate_def]);
 
-val extract_labels_SmartSeq = store_thm("extract_labels_SmartSeq",
-  ``extract_labels (SmartSeq p1 p2) = extract_labels (Seq p1 p2)``,
+val extract_labels_SmartSeq = Q.store_thm("extract_labels_SmartSeq",
+  `extract_labels (SmartSeq p1 p2) = extract_labels (Seq p1 p2)`,
   rw [SmartSeq_def,extract_labels_def]);
 
-val extract_labels_Seq_assoc_lemma = store_thm("extract_labels_Seq_assoc_lemma",
-  ``!p1 p2. extract_labels (Seq_assoc p1 p2) =
-            extract_labels p1 ++ extract_labels p2``,
+val extract_labels_Seq_assoc_lemma = Q.store_thm("extract_labels_Seq_assoc_lemma",
+  `!p1 p2. extract_labels (Seq_assoc p1 p2) =
+            extract_labels p1 ++ extract_labels p2`,
   HO_MATCH_MP_TAC Seq_assoc_ind \\ fs [] \\ rw []
   \\ fs [Seq_assoc_def,extract_labels_def,extract_labels_SmartSeq]
   \\ Cases_on `ret_prog` \\ Cases_on `handler` \\ fs []
   \\ PairCases_on `x` \\ fs []
   \\ PairCases_on `x'` \\ fs []);
 
-val extract_labels_Seq_assoc = store_thm("extract_labels_Seq_assoc",
-  ``extract_labels (Seq_assoc Skip p) = extract_labels p``,
+val extract_labels_Seq_assoc = Q.store_thm("extract_labels_Seq_assoc",
+  `extract_labels (Seq_assoc Skip p) = extract_labels p`,
   fs [extract_labels_Seq_assoc_lemma,extract_labels_def]);
 
 (* verification of simp_if *)
@@ -119,15 +119,15 @@ val evaluate_simp_if = store_thm("evaluate_simp_if",
   \\ PairCases_on `x'` \\ fs[add_ret_loc_def,push_env_def]
   \\ TRY (PairCases_on `x''`) \\ fs[add_ret_loc_def,push_env_def]);
 
-val simp_if_works = store_thm("simp_if_works",
-  ``IS_SOME (apply_if_opt
+val simp_if_works = Q.store_thm("simp_if_works",
+  `IS_SOME (apply_if_opt
      (If Less 5 (Imm 5w) (Assign 3 (Const 5w)) (Assign 3 (Const (4w:word32))))
-     (If Equal 3 (Imm (4w:word32)) (Raise 1) (Raise 2)))``,
+     (If Equal 3 (Imm (4w:word32)) (Raise 1) (Raise 2)))`,
   EVAL_TAC);
 
-val extract_labels_apply_if_opt = store_thm("extract_labels_apply_if_opt",
-  ``apply_if_opt p1 p2 = SOME p ==>
-    PERM (extract_labels p) (extract_labels p1 ++ extract_labels p2)``,
+val extract_labels_apply_if_opt = Q.store_thm("extract_labels_apply_if_opt",
+  `apply_if_opt p1 p2 = SOME p ==>
+    PERM (extract_labels p) (extract_labels p1 ++ extract_labels p2)`,
   fs [apply_if_opt_def]
   \\ every_case_tac \\ fs [] \\ pairarg_tac \\ fs []
   \\ every_case_tac \\ fs [] \\ rw []
@@ -136,8 +136,8 @@ val extract_labels_apply_if_opt = store_thm("extract_labels_apply_if_opt",
   \\ Cases_on `p1` \\ fs [dest_Seq_def] \\ rveq \\ fs [extract_labels_def]
   \\ metis_tac[PERM_APPEND,APPEND_ASSOC,PERM_APPEND_IFF])
 
-val extract_labels_simp_if = store_thm("extract_labels_simp_if",
-  ``!p. PERM (extract_labels (simp_if p)) (extract_labels p)``,
+val extract_labels_simp_if = Q.store_thm("extract_labels_simp_if",
+  `!p. PERM (extract_labels (simp_if p)) (extract_labels p)`,
   HO_MATCH_MP_TAC simp_if_ind \\ fs [simp_if_def] \\ rw []
   \\ fs [extract_labels_def]
   \\ every_case_tac \\ fs [extract_labels_def]
@@ -151,8 +151,8 @@ val compile_exp_thm = store_thm("compile_exp_thm",
     evaluate (word_simp$compile_exp prog,s) = (res,s2)``,
   fs [word_simpTheory.compile_exp_def,evaluate_simp_if,evaluate_Seq_assoc]);
 
-val extract_labels_compile_exp = store_thm("extract_labels_compile_exp[simp]",
-  ``!p. PERM (extract_labels (word_simp$compile_exp p)) (extract_labels p)``,
+val extract_labels_compile_exp = Q.store_thm("extract_labels_compile_exp[simp]",
+  `!p. PERM (extract_labels (word_simp$compile_exp p)) (extract_labels p)`,
   fs [word_simpTheory.compile_exp_def]>>
   metis_tac[extract_labels_simp_if,extract_labels_Seq_assoc,PERM_TRANS])
 

--- a/compiler/backend/proofs/word_simpProofScript.sml
+++ b/compiler/backend/proofs/word_simpProofScript.sml
@@ -156,17 +156,17 @@ val extract_labels_compile_exp = Q.store_thm("extract_labels_compile_exp[simp]",
   fs [word_simpTheory.compile_exp_def]>>
   metis_tac[extract_labels_simp_if,extract_labels_Seq_assoc,PERM_TRANS])
 
-val dest_Seq_no_inst = prove(``
+val dest_Seq_no_inst = Q.prove(`
   ∀prog.
   every_inst (inst_ok_less ac) prog ⇒
   every_inst (inst_ok_less ac) (FST (dest_Seq prog)) ∧
-  every_inst (inst_ok_less ac) (SND (dest_Seq prog))``,
+  every_inst (inst_ok_less ac) (SND (dest_Seq prog))`,
   ho_match_mp_tac dest_Seq_ind>>rw[dest_Seq_def]>>fs[every_inst_def])
 
-val simp_if_no_inst = prove(``
+val simp_if_no_inst = Q.prove(`
   ∀prog.
   every_inst (inst_ok_less ac) prog ⇒
-  every_inst (inst_ok_less ac) (simp_if prog)``,
+  every_inst (inst_ok_less ac) (simp_if prog)`,
   ho_match_mp_tac simp_if_ind>>rw[simp_if_def]>>
   EVERY_CASE_TAC>>
   fs[every_inst_def,apply_if_opt_def]>>
@@ -179,18 +179,18 @@ val simp_if_no_inst = prove(``
   EVERY_CASE_TAC>>rw[]>>rveq>>fs[every_inst_def,dest_If_Eq_Imm_thm]>>
   imp_res_tac dest_Seq_no_inst>> rfs[every_inst_def])
 
-val Seq_assoc_no_inst = prove(``
+val Seq_assoc_no_inst = Q.prove(`
   ∀p1 p2.
   every_inst (inst_ok_less ac) p1 ∧ every_inst (inst_ok_less ac) p2 ⇒
-  every_inst (inst_ok_less ac) (Seq_assoc p1 p2)``,
+  every_inst (inst_ok_less ac) (Seq_assoc p1 p2)`,
   ho_match_mp_tac Seq_assoc_ind>>fs[Seq_assoc_def,SmartSeq_def]>>rw[]>>
   fs[every_inst_def]>>
   every_case_tac>>fs[])
 
-val compile_exp_no_inst = store_thm("compile_exp_no_inst",``
+val compile_exp_no_inst = Q.store_thm("compile_exp_no_inst",`
   ∀prog.
   every_inst (inst_ok_less ac) prog ⇒
-  every_inst (inst_ok_less ac) (compile_exp prog)``,
+  every_inst (inst_ok_less ac) (compile_exp prog)`,
   fs[compile_exp_def]>>
   metis_tac[simp_if_no_inst,Seq_assoc_no_inst,every_inst_def])
 

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -23,19 +23,19 @@ val wf_LN = Q.store_thm("wf_LN[simp]",
 
 (*TODO: Simplify and move to HOL or miscLib*)
 (*This property is frequently used in other sptree proofs*)
-val splem1 = prove(``
+val splem1 = Q.prove(`
   a ≠ 0 ⇒
-  (a-1) DIV 2 < a``,
+  (a-1) DIV 2 < a`,
   `0 < (2:num)` by fs[] >>
   imp_res_tac DIV_LT_X>>rw[]>>
   DECIDE_TAC)
 
-val splem2 = prove(``
+val splem2 = Q.prove(`
   ∀a c.
   a ≠ 0 ∧
   a < c ∧
   2 ≤ c-a ⇒
-  (a -1) DIV 2 < (c-1) DIV 2``,
+  (a -1) DIV 2 < (c-1) DIV 2`,
   Induct>>Induct>>rw[]>>
   Cases_on`SUC a < c`>>fs[]>>simp[]>>
   Cases_on` 2 ≤ c - SUC a`>>fs[]
@@ -47,11 +47,11 @@ val splem2 = prove(``
     `c = a+2` by DECIDE_TAC>>
     simp[ADD_DIV_RWT])
 
-val EVEN_ODD_diff = prove(``
+val EVEN_ODD_diff = Q.prove(`
   ∀a c.
   a < c ∧
   (EVEN a ∧ EVEN c ∨ ODD a ∧ ODD c) ⇒
-  2 ≤ c-a``,
+  2 ≤ c-a`,
   Induct>>fs[]>>
   rw[]
   >-
@@ -62,20 +62,20 @@ val EVEN_ODD_diff = prove(``
     first_assum match_mp_tac>>
     fs[EVEN,EVEN_ODD,ODD])
 
-val splem3 = prove(``
+val splem3 = Q.prove(`
   (EVEN c ∧ EVEN a ∨ ODD a ∧ ODD c) ∧
   a ≠ c ∧ a ≠ 0 ∧ c ≠ 0 ⇒
-  (a-1) DIV 2 ≠ (c-1) DIV 2``,
+  (a-1) DIV 2 ≠ (c-1) DIV 2`,
   rw[]>>
   `a < c ∨ c <a` by DECIDE_TAC>>
   imp_res_tac splem2>>
   imp_res_tac EVEN_ODD_diff>>
   DECIDE_TAC)
 
-val insert_swap = store_thm("insert_swap",`` (* TODO: move *)
+val insert_swap = Q.store_thm("insert_swap",` (* TODO: move *)
   ∀t a b c d.
   a ≠ c ⇒
-  insert a b (insert c d t) = insert c d (insert a b t)``,
+  insert a b (insert c d t) = insert c d (insert a b t)`,
   completeInduct_on`a`>>
   completeInduct_on`c`>>
   Induct>>
@@ -251,17 +251,17 @@ val filter_bitmap_MEM = Q.store_thm("filter_bitmap_MEM",
   EVERY_CASE_TAC>>fs[]>>rveq>>
   fs[MEM])
 
-val get_var_set_var = store_thm("get_var_set_var[simp]",``
-  stackSem$get_var k (set_var k v st) = SOME v``,
+val get_var_set_var = Q.store_thm("get_var_set_var[simp]",`
+  stackSem$get_var k (set_var k v st) = SOME v`,
   fs[stackSemTheory.get_var_def,stackSemTheory.set_var_def]>>
   fs[FLOOKUP_UPDATE])
 
-val MEM_TAKE = prove(
-  ``!xs n x. MEM x (TAKE n xs) ==> MEM x xs``,
+val MEM_TAKE = Q.prove(
+  `!xs n x. MEM x (TAKE n xs) ==> MEM x xs`,
   Induct \\ fs [TAKE_def] \\ rw [] \\ res_tac \\ fs []);
 
-val MEM_LASTN_ALT = prove(
-  ``!xs n x. MEM x (LASTN n xs) ==> MEM x xs``,
+val MEM_LASTN_ALT = Q.prove(
+  `!xs n x. MEM x (LASTN n xs) ==> MEM x xs`,
   fs [LASTN_def] \\ rw [] \\ imp_res_tac MEM_TAKE \\ fs []);
 
 val clock_add_0 = store_thm("clock_add_0[simp]",
@@ -269,27 +269,27 @@ val clock_add_0 = store_thm("clock_add_0[simp]",
     ((t with clock := t.clock) = t:('a,'ffi) stackSem$state)``,
   fs [stackSemTheory.state_component_equality]);
 
-val DROP_DROP_EQ = store_thm("DROP_DROP_EQ",
-  ``!n m xs. DROP m (DROP n xs) = DROP (m + n) xs``,
+val DROP_DROP_EQ = Q.store_thm("DROP_DROP_EQ",
+  `!n m xs. DROP m (DROP n xs) = DROP (m + n) xs`,
   Induct \\ fs [] \\ Cases_on `xs` \\ fs []
   \\ rpt strip_tac \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac);
 
-val TAKE_TAKE_MIN = prove(
-    ``!xs m n. TAKE n (TAKE m xs) = TAKE (MIN m n) xs``,
+val TAKE_TAKE_MIN = Q.prove(
+    `!xs m n. TAKE n (TAKE m xs) = TAKE (MIN m n) xs`,
     Induct \\ Cases_on `m` \\ Cases_on `n` \\ fs [MIN_DEF]
     \\ rw [] \\ fs [] \\ Cases_on`n` \\ fs[]);
 
-val TAKE_DROP_EQ = prove(
-  ``!xs n m. TAKE m (DROP n xs) = DROP n (TAKE (m + n) xs)``,
+val TAKE_DROP_EQ = Q.prove(
+  `!xs n m. TAKE m (DROP n xs) = DROP n (TAKE (m + n) xs)`,
   Induct \\ fs [] \\ rw [] \\ fs [] \\ Cases_on`n` \\ fs[]
   \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac);
 
-val DROP_TAKE_NIL = prove(
-  ``DROP n (TAKE n xs) = []``,
+val DROP_TAKE_NIL = Q.prove(
+  `DROP n (TAKE n xs) = []`,
   fs [GSYM LENGTH_NIL,LENGTH_TAKE_EQ] >> simp[]);
 
-val TAKE_LUPDATE = store_thm("TAKE_LUPDATE[simp]",
-  ``!xs n x i. TAKE n (LUPDATE x i xs) = LUPDATE x i (TAKE n xs)``,
+val TAKE_LUPDATE = Q.store_thm("TAKE_LUPDATE[simp]",
+  `!xs n x i. TAKE n (LUPDATE x i xs) = LUPDATE x i (TAKE n xs)`,
   Induct \\ fs [LUPDATE_def] \\ Cases_on `i` \\ fs [LUPDATE_def] \\ rw [LUPDATE_def]
   >-
     (Cases_on`n`>>fs[LUPDATE_def])
@@ -297,81 +297,81 @@ val TAKE_LUPDATE = store_thm("TAKE_LUPDATE[simp]",
     Cases_on`n'`>>fs[LUPDATE_def]);
 
 local
-  val DROP_LUPDATE_lemma1 = prove(
-    ``!xs n m h. n <= m ==>
-                 DROP n (LUPDATE h m xs) = LUPDATE h (m - n) (DROP n xs)``,
+  val DROP_LUPDATE_lemma1 = Q.prove(
+    `!xs n m h. n <= m ==>
+                 DROP n (LUPDATE h m xs) = LUPDATE h (m - n) (DROP n xs)`,
     Induct \\ fs [LUPDATE_def] \\ rw []
     \\ Cases_on `m` \\ fs [LUPDATE_def]
     \\ qmatch_assum_rename_tac `n <= SUC i`
     \\ Cases_on`n`>>fs[LUPDATE_def])
-  val DROP_LUPDATE_lemma2 = prove(
-    ``!xs n m h. m < n ==> DROP n (LUPDATE h m xs) = DROP n xs``,
+  val DROP_LUPDATE_lemma2 = Q.prove(
+    `!xs n m h. m < n ==> DROP n (LUPDATE h m xs) = DROP n xs`,
     Induct \\ fs [LUPDATE_def] \\ rw []
     \\ Cases_on `m` \\ fs [LUPDATE_def])
 in
-  val DROP_LUPDATE = store_thm("DROP_LUPDATE",
-    ``!n h m xs.
+  val DROP_LUPDATE = Q.store_thm("DROP_LUPDATE",
+    `!n h m xs.
         DROP n (LUPDATE h m xs) =
-        if m < n then DROP n xs else LUPDATE h (m - n) (DROP n xs)``,
+        if m < n then DROP n xs else LUPDATE h (m - n) (DROP n xs)`,
     rw [DROP_LUPDATE_lemma2]
     \\ match_mp_tac DROP_LUPDATE_lemma1
     \\ fs [NOT_LESS])
 end
 
-val MIN_ADD = prove(
-  ``MIN m1 m2 + n = MIN (m1 + n) (m2 + n)``,
+val MIN_ADD = Q.prove(
+  `MIN m1 m2 + n = MIN (m1 + n) (m2 + n)`,
   fs [MIN_DEF] \\ decide_tac);
 
 val list_LUPDATE_def = Define `
   (list_LUPDATE [] n ys = ys) /\
   (list_LUPDATE (x::xs) n ys = list_LUPDATE xs (n+1) (LUPDATE x n ys))`
 
-val LENGTH_list_LUPDATE = store_thm("LENGTH_list_LUPDATE[simp]",
-  ``!xs n ys. LENGTH (list_LUPDATE xs n ys) = LENGTH ys``,
+val LENGTH_list_LUPDATE = Q.store_thm("LENGTH_list_LUPDATE[simp]",
+  `!xs n ys. LENGTH (list_LUPDATE xs n ys) = LENGTH ys`,
   Induct \\ fs [list_LUPDATE_def]);
 
-val TAKE_list_LUPDATE = store_thm("TAKE_list_LUPDATE[simp]",
-  ``!ys xs n i. TAKE n (list_LUPDATE ys i xs) = list_LUPDATE ys i (TAKE n xs)``,
+val TAKE_list_LUPDATE = Q.store_thm("TAKE_list_LUPDATE[simp]",
+  `!ys xs n i. TAKE n (list_LUPDATE ys i xs) = list_LUPDATE ys i (TAKE n xs)`,
   Induct \\ fs [list_LUPDATE_def]);
 
-val LLOOKUP_list_LUPDATE_IGNORE = prove(
-  ``!xs i n ys.
+val LLOOKUP_list_LUPDATE_IGNORE = Q.prove(
+  `!xs i n ys.
       i + LENGTH xs <= n ==>
-      LLOOKUP (list_LUPDATE xs i ys) n = LLOOKUP ys n``,
+      LLOOKUP (list_LUPDATE xs i ys) n = LLOOKUP ys n`,
   Induct \\ fs [list_LUPDATE_def] \\ rpt strip_tac
   \\ `(i+1) + LENGTH xs <= n` by decide_tac \\ res_tac
   \\ `i <> n` by decide_tac \\ fs [LLOOKUP_LUPDATE]);
 
-val DROP_list_LUPDATE = prove(
-  ``!ys n m xs.
+val DROP_list_LUPDATE = Q.prove(
+  `!ys n m xs.
       n <= m ==>
       DROP n (list_LUPDATE ys m xs) =
-      list_LUPDATE ys (m - n) (DROP n xs)``,
+      list_LUPDATE ys (m - n) (DROP n xs)`,
   Induct
   \\ fs [list_LUPDATE_def,LENGTH_NIL,PULL_FORALL]
   \\ rpt strip_tac \\ `n <= m + 1` by decide_tac
   \\ rw [] \\ `m + 1 - n = m - n + 1 /\ ~(m < n)` by decide_tac
   \\ fs [DROP_LUPDATE]);
 
-val DROP_list_LUPDATE_IGNORE = prove(
-  ``!xs i ys n.
+val DROP_list_LUPDATE_IGNORE = Q.prove(
+  `!xs i ys n.
       LENGTH xs + i <= n ==>
-      DROP n (list_LUPDATE xs i ys) = DROP n ys``,
+      DROP n (list_LUPDATE xs i ys) = DROP n ys`,
   Induct \\ fs [list_LUPDATE_def] \\ rpt strip_tac
   \\ `LENGTH xs + (i+1) <= n /\ i < n` by decide_tac
   \\ fs [DROP_LUPDATE]);
 
-val list_LUPDATE_NIL = store_thm("list_LUPDATE_NIL[simp]",
-  ``!xs i. list_LUPDATE xs i [] = []``,
+val list_LUPDATE_NIL = Q.store_thm("list_LUPDATE_NIL[simp]",
+  `!xs i. list_LUPDATE xs i [] = []`,
   Induct \\ fs [list_LUPDATE_def,LUPDATE_def]);
 
-val LUPDATE_TAKE_LEMMA = prove(
-  ``!xs n w. LUPDATE w n xs = TAKE n xs ++ LUPDATE w 0 (DROP n xs)``,
+val LUPDATE_TAKE_LEMMA = Q.prove(
+  `!xs n w. LUPDATE w n xs = TAKE n xs ++ LUPDATE w 0 (DROP n xs)`,
   Induct \\ Cases_on `n` \\ fs [LUPDATE_def]);
 
-val list_LUPDATE_TAKE_DROP = store_thm("list_LUPDATE_TAKE_DROP",
-  ``!xs (ys:'a list) n.
-       list_LUPDATE xs n ys = TAKE n ys ++ list_LUPDATE xs 0 (DROP n ys)``,
+val list_LUPDATE_TAKE_DROP = Q.store_thm("list_LUPDATE_TAKE_DROP",
+  `!xs (ys:'a list) n.
+       list_LUPDATE xs n ys = TAKE n ys ++ list_LUPDATE xs 0 (DROP n ys)`,
   Induct \\ simp_tac std_ss [Once list_LUPDATE_def]
   \\ once_rewrite_tac [list_LUPDATE_def] THEN1 fs []
   \\ pop_assum (fn th => once_rewrite_tac [th])
@@ -380,26 +380,26 @@ val list_LUPDATE_TAKE_DROP = store_thm("list_LUPDATE_TAKE_DROP",
   \\ `MIN (n + 1) n = n`  by (fs [MIN_DEF] \\ decide_tac) \\ fs []
   \\ AP_TERM_TAC \\ fs [TAKE_DROP_EQ,AC ADD_COMM ADD_ASSOC]);
 
-val list_LUPDATE_0_CONS = store_thm("list_LUPDATE_0_CONS[simp]",
-  ``!xs x ys y. list_LUPDATE (x::xs) 0 (y::ys) = x :: list_LUPDATE xs 0 ys``,
+val list_LUPDATE_0_CONS = Q.store_thm("list_LUPDATE_0_CONS[simp]",
+  `!xs x ys y. list_LUPDATE (x::xs) 0 (y::ys) = x :: list_LUPDATE xs 0 ys`,
   fs [list_LUPDATE_def,LUPDATE_def]
   \\ simp_tac std_ss [Once list_LUPDATE_TAKE_DROP] \\ fs []);
 
-val list_LUPDATE_APPEND = store_thm("list_LUPDATE_APPEND",
-  ``!xs ys zs.
-      LENGTH xs = LENGTH ys ==> (list_LUPDATE xs 0 (ys ++ zs) = xs ++ zs)``,
+val list_LUPDATE_APPEND = Q.store_thm("list_LUPDATE_APPEND",
+  `!xs ys zs.
+      LENGTH xs = LENGTH ys ==> (list_LUPDATE xs 0 (ys ++ zs) = xs ++ zs)`,
   Induct \\ Cases_on `ys` \\ fs [list_LUPDATE_def]);
 
 (* move to stackProps? *)
 
-val DIV_ADD_1 = prove(
-  ``0 < d ==> (m DIV d + 1 = (m + d) DIV d)``,
+val DIV_ADD_1 = Q.prove(
+  `0 < d ==> (m DIV d + 1 = (m + d) DIV d)`,
   rpt strip_tac
   \\ ASSUME_TAC (ADD_DIV_ADD_DIV |> Q.SPECL [`d`] |> UNDISCH
       |> Q.SPECL [`1`,`m`] |> ONCE_REWRITE_RULE [ADD_COMM]) \\ fs []);
 
-val LENGTH_word_list_lemma = prove(
-  ``!xs d. 0 < d ==> (LENGTH (word_list xs d) = (LENGTH xs - 1) DIV d + 1)``,
+val LENGTH_word_list_lemma = Q.prove(
+  `!xs d. 0 < d ==> (LENGTH (word_list xs d) = (LENGTH xs - 1) DIV d + 1)`,
   recInduct word_list_ind
   \\ rpt strip_tac \\ fsrw_tac[] []
   \\ once_rewrite_tac [word_list_def] \\ fsrw_tac[] [] \\ rw []
@@ -412,16 +412,16 @@ val LENGTH_word_list_lemma = prove(
   \\ imp_res_tac DIV_ADD_1 \\ fsrw_tac[] []
   \\ AP_THM_TAC \\ AP_TERM_TAC \\ decide_tac);
 
-val LENGTH_word_list = store_thm("LENGTH_word_list",
-  ``!xs d. LENGTH (word_list xs d) =
-           if d = 0 then 1 else (LENGTH xs - 1) DIV d + 1``,
+val LENGTH_word_list = Q.store_thm("LENGTH_word_list",
+  `!xs d. LENGTH (word_list xs d) =
+           if d = 0 then 1 else (LENGTH xs - 1) DIV d + 1`,
   rw [] THEN1 (once_rewrite_tac [word_list_def] \\ fs [])
   \\ match_mp_tac LENGTH_word_list_lemma \\ decide_tac);
 
 (* move to wordProps? *)
 
-val list_rearrange_I = prove(
-  ``(list_rearrange I = I)``,
+val list_rearrange_I = Q.prove(
+  `(list_rearrange I = I)`,
   fs [list_rearrange_def,FUN_EQ_THM]
   \\ fs [BIJ_DEF,INJ_DEF,SURJ_DEF,GENLIST_ID]);
 
@@ -603,38 +603,38 @@ val LENGTH_write_bitmap = prove(
 val DROP_list_LUPDATE_lemma =
   MATCH_MP DROP_list_LUPDATE (SPEC_ALL LESS_EQ_REFL) |> SIMP_RULE std_ss []
 
-val bits_to_word_bit = prove(
-  ``!bs i.
+val bits_to_word_bit = Q.prove(
+  `!bs i.
       i < dimindex (:'a) /\ i < LENGTH bs ==>
-      ((bits_to_word bs:'a word) ' i = EL i bs)``,
+      ((bits_to_word bs:'a word) ' i = EL i bs)`,
   Induct \\ fs [] \\ Cases_on `i` \\ fs []
   \\ Cases \\ fs [bits_to_word_def,word_or_def,fcpTheory.FCP_BETA,
        word_index,word_lsl_def,ADD1] \\ rpt strip_tac
   \\ first_x_assum match_mp_tac \\ fs [] \\ decide_tac);
 
-val bits_to_word_miss = prove(
-  ``!bs i.
+val bits_to_word_miss = Q.prove(
+  `!bs i.
       i < dimindex (:'a) /\ LENGTH bs <= i ==>
-      ~((bits_to_word bs:'a word) ' i)``,
+      ~((bits_to_word bs:'a word) ' i)`,
   Induct \\ fs [] THEN1 (EVAL_TAC \\ fs [word_0])
   \\ Cases_on `i` \\ fs [] \\ NTAC 2 strip_tac
   \\ `n < dimindex (:'a)` by decide_tac \\ res_tac
   \\ Cases_on `h` \\ fs [bits_to_word_def,word_or_def,fcpTheory.FCP_BETA,
        word_index,word_lsl_def,ADD1]);
 
-val bits_to_word_NOT_0 = prove(
-  ``!bs. LENGTH bs <= dimindex (:'a) /\ EXISTS I bs ==>
-         (bits_to_word bs <> 0w:'a word)``,
+val bits_to_word_NOT_0 = Q.prove(
+  `!bs. LENGTH bs <= dimindex (:'a) /\ EXISTS I bs ==>
+         (bits_to_word bs <> 0w:'a word)`,
   fs [fcpTheory.CART_EQ] \\ rpt strip_tac
   \\ fs [EXISTS_MEM,MEM_EL]
   \\ Q.EXISTS_TAC `n`   \\ fs []
   \\ `n < dimindex (:'a)` by decide_tac \\ fs [word_0]
   \\ fs [bits_to_word_bit]);
 
-val list_LUPDATE_write_bitmap_NOT_NIL = prove(
-  ``8 <= dimindex (:'a) ==>
+val list_LUPDATE_write_bitmap_NOT_NIL = Q.prove(
+  `8 <= dimindex (:'a) ==>
     (list_LUPDATE (MAP Word (write_bitmap names k f')) 0 xs <>
-     [Word (0w:'a word)])``,
+     [Word (0w:'a word)])`,
   Cases_on `xs` \\ fs [list_LUPDATE_NIL]
   \\ fs [write_bitmap_def,LET_DEF,Once word_list_def]
   \\ strip_tac \\ `~(dimindex (:'a) <= 1)` by decide_tac \\ fs []
@@ -642,30 +642,30 @@ val list_LUPDATE_write_bitmap_NOT_NIL = prove(
   \\ match_mp_tac bits_to_word_NOT_0 \\ fs [LENGTH_TAKE_EQ]
   \\ fs [MIN_LE,MIN_ADD] \\ decide_tac);
 
-val LESS_EQ_LENGTH = prove(
-  ``!xs n. n <= LENGTH xs ==> ?xs1 xs2. xs = xs1 ++ xs2 /\ n = LENGTH xs1``,
+val LESS_EQ_LENGTH = Q.prove(
+  `!xs n. n <= LENGTH xs ==> ?xs1 xs2. xs = xs1 ++ xs2 /\ n = LENGTH xs1`,
   once_rewrite_tac [EQ_SYM_EQ]
   \\ Induct_on `n` \\ fs [LENGTH_NIL] \\ rpt strip_tac
   \\ Cases_on `xs` \\ fs [] \\ res_tac \\ rw []
   \\ Q.LIST_EXISTS_TAC [`h::xs1`,`xs2`] \\ fs []);
 
-val word_or_eq_0 = prove(
-  ``((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)``,
+val word_or_eq_0 = Q.prove(
+  `((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ metis_tac [])
 
-val shift_shift_lemma = prove(
-  ``~(word_msb w) ==> (w ≪ 1 ⋙ 1 = w)``,
+val shift_shift_lemma = Q.prove(
+  `~(word_msb w) ==> (w ≪ 1 ⋙ 1 = w)`,
   srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ Cases_on `i + 1 < dimindex (:α)`
   \\ full_simp_tac (srw_ss()++wordsLib.WORD_BIT_EQ_ss) [NOT_LESS]
   \\ `i = dimindex (:'a) - 1` by decide_tac
   \\ simp [])
 
-val bit_length_bits_to_word = prove(
-  ``!qs.
+val bit_length_bits_to_word = Q.prove(
+  `!qs.
       LENGTH qs + 1 < dimindex (:'a) ==>
-      bit_length (bits_to_word (qs ++ [T]):'a word) = LENGTH qs + 1``,
+      bit_length (bits_to_word (qs ++ [T]):'a word) = LENGTH qs + 1`,
   Induct THEN1
    (fs [] \\ fs [Once bit_length_def] \\ fs [Once bit_length_def]
     \\ fs [bits_to_word_def] \\ EVAL_TAC)
@@ -687,26 +687,26 @@ val bit_length_bits_to_word = prove(
     \\ match_mp_tac bits_to_word_miss \\ fs [] \\ decide_tac)
   \\ fs [ADD1,word_or_eq_0]);
 
-val GENLIST_bits_to_word_alt = prove(
-  ``LENGTH (xs ++ ys) <= dimindex (:'a) ==>
-    GENLIST (\i. (bits_to_word (xs ++ ys):'a word) ' i) (LENGTH xs) = xs``,
+val GENLIST_bits_to_word_alt = Q.prove(
+  `LENGTH (xs ++ ys) <= dimindex (:'a) ==>
+    GENLIST (\i. (bits_to_word (xs ++ ys):'a word) ' i) (LENGTH xs) = xs`,
   fs [LIST_EQ_REWRITE] \\ rpt strip_tac
   \\ `EL x xs = EL x (xs ++ ys)` by fs [EL_APPEND1]
   \\ pop_assum (fn th => once_rewrite_tac [th])
   \\ match_mp_tac bits_to_word_bit
   \\ fs [] \\ decide_tac);
 
-val GENLIST_bits_to_word = prove(
-  ``LENGTH qs' + 1 < dimindex (:'a) ==>
-    GENLIST (\i. (bits_to_word (qs' ++ [T]):'a word) ' i) (LENGTH qs') = qs'``,
+val GENLIST_bits_to_word = Q.prove(
+  `LENGTH qs' + 1 < dimindex (:'a) ==>
+    GENLIST (\i. (bits_to_word (qs' ++ [T]):'a word) ' i) (LENGTH qs') = qs'`,
   rpt strip_tac \\ match_mp_tac GENLIST_bits_to_word_alt
   \\ fs [] \\ decide_tac);
 
-val read_bitmap_word_list = prove(
-  ``8 <= dimindex (:'a) ==>
+val read_bitmap_word_list = Q.prove(
+  `8 <= dimindex (:'a) ==>
     read_bitmap
       ((word_list (qs ++ [T]) (dimindex (:'a) - 1)) ++ (xs:'a word list)) =
-    SOME qs``,
+    SOME qs`,
   completeInduct_on `LENGTH (qs:bool list)` \\ rpt strip_tac \\ fs [PULL_FORALL]
   \\ rw [] \\ once_rewrite_tac [word_list_def]
   \\ `dimindex (:'a) - 1 <> 0` by decide_tac \\ fs []
@@ -748,9 +748,9 @@ val read_bitmap_word_list = prove(
   \\ match_mp_tac GENLIST_bits_to_word_alt \\ fs []
   \\ decide_tac);
 
-val APPEND_LEMMA = prove(
-  ``n1 + n2 + n3 <= LENGTH xs ==>
-    ?xs2 xs3. (DROP n1 xs = xs2 ++ xs3) /\ n2 = LENGTH xs2``,
+val APPEND_LEMMA = Q.prove(
+  `n1 + n2 + n3 <= LENGTH xs ==>
+    ?xs2 xs3. (DROP n1 xs = xs2 ++ xs3) /\ n2 = LENGTH xs2`,
   rpt strip_tac
   \\ `n1 <= LENGTH xs` by decide_tac
   \\ Q.PAT_X_ASSUM `n1 + n2 + n3 <= LENGTH xs` MP_TAC
@@ -833,28 +833,28 @@ val read_bitmap_write_bitmap = prove(
 
 *)
 
-val abs_stack_IMP_LENGTH = prove(
-  ``∀bs wstack sstack lens stack.
-    abs_stack bs wstack sstack lens = SOME stack ⇒ LENGTH stack = LENGTH wstack ∧ LENGTH lens = LENGTH wstack``,
+val abs_stack_IMP_LENGTH = Q.prove(
+  `∀bs wstack sstack lens stack.
+    abs_stack bs wstack sstack lens = SOME stack ⇒ LENGTH stack = LENGTH wstack ∧ LENGTH lens = LENGTH wstack`,
   recInduct (theorem "abs_stack_ind")
   \\ fs [abs_stack_def,LET_THM] \\ rpt strip_tac
   \\ EVERY_CASE_TAC \\ fs [] \\ rw [])
 
-val SORTED_FST_LESS_IMP = prove(
-  ``!xs x.
+val SORTED_FST_LESS_IMP = Q.prove(
+  `!xs x.
       SORTED (\x y. FST x > FST y:num) (x::xs) ==>
       SORTED (\x y. FST x > FST y) xs /\ ~(MEM x xs) /\
-      (!y. MEM y xs ==> FST x > FST y)``,
+      (!y. MEM y xs ==> FST x > FST y)`,
   Induct \\ fs [SORTED_DEF]
   \\ ntac 3 strip_tac \\ res_tac \\ rpt strip_tac
   \\ rw [] \\ fs [] \\ res_tac \\ decide_tac);
 
-val SORTED_IMP_EQ_LISTS = prove(
-  ``!xs ys.
+val SORTED_IMP_EQ_LISTS = Q.prove(
+  `!xs ys.
       SORTED (\x y. FST x > FST y:num) ys /\
       SORTED (\x y. FST x > FST y) xs /\
       (!x. MEM x ys <=> MEM x xs) ==>
-      (xs = ys)``,
+      (xs = ys)`,
   Induct \\ fs [] \\ Cases_on `ys` \\ fs [] THEN1 metis_tac []
   THEN1 (CCONTR_TAC THEN fs [] THEN metis_tac [])
   \\ ntac 2 strip_tac
@@ -887,8 +887,8 @@ val total_key_val_compare = Q.store_thm("total_key_val_compare",
   \\ fs [GSYM WORD_NOT_LESS]
   \\ wordsLib.WORD_DECIDE_TAC)
 
-val SORTS_QSORT_key_val_compare = prove(
-  ``SORTS QSORT key_val_compare``,
+val SORTS_QSORT_key_val_compare = Q.prove(
+  `SORTS QSORT key_val_compare`,
   match_mp_tac QSORT_SORTS >>
   MATCH_ACCEPT_TAC (CONJ transitive_key_val_compare total_key_val_compare))
 
@@ -905,17 +905,17 @@ val SORTED_weaken2 = Q.prove(`
   Induct>>rw[]>>Cases_on`ls`>>fs[SORTED_DEF]>>
   metis_tac[])
 
-val EVEN_GT = prove(``
+val EVEN_GT = Q.prove(`
   ∀a b.
   EVEN a ∧ EVEN b ∧
   a > b ⇒
-  a DIV 2 > b DIV 2``,
+  a DIV 2 > b DIV 2`,
   fs[EVEN_EXISTS]>>rw[]>>
   fsrw_tac[][MULT_DIV,MULT_COMM]>>
   DECIDE_TAC)
 
-val transitive_GT = prove(``
-  transitive ($> : (num->num->bool))``,
+val transitive_GT = Q.prove(`
+  transitive ($> : (num->num->bool))`,
   fs[transitive_def]>>DECIDE_TAC)
 
 val env_to_list_K_I_IMP = prove(
@@ -1133,14 +1133,14 @@ val evaluate_wLive = Q.prove(
   \\ simp[]
   \\ simp_tac (srw_ss()) [MULT_COMM,MULT_DIV]);
 
-val push_env_set_store = prove(
-  ``push_env env ^nn (set_store AllocSize (Word c) s) =
-    set_store AllocSize (Word c) (push_env env ^nn s)``,
+val push_env_set_store = Q.prove(
+  `push_env env ^nn (set_store AllocSize (Word c) s) =
+    set_store AllocSize (Word c) (push_env env ^nn s)`,
   fs [push_env_def,set_store_def,env_to_list_def,LET_DEF])|> INST_TYPE [beta|-> alpha, gamma|->beta];
 
-val state_rel_set_store_0 = prove(
-  ``state_rel k 0 0 s5 t5 len ==>
-    state_rel k 0 0 (set_store AllocSize w s5) (set_store AllocSize w t5) len``,
+val state_rel_set_store_0 = Q.prove(
+  `state_rel k 0 0 s5 t5 len ==>
+    state_rel k 0 0 (set_store AllocSize w s5) (set_store AllocSize w t5) len`,
   rpt strip_tac
   \\ fs [state_rel_def,set_store_def,stackSemTheory.set_store_def,LET_DEF,
          FLOOKUP_DEF] \\ REPEAT STRIP_TAC \\ rfs[]
@@ -1150,25 +1150,25 @@ val state_rel_set_store_0 = prove(
   \\ fs [FAPPLY_FUPDATE_THM,DOMSUB_FAPPLY_THM]
   \\ metis_tac[]);
 
-val MAP_SND_MAP_FST = prove(
-  ``!xs f. MAP SND (MAP_FST f xs) = MAP SND xs``,
+val MAP_SND_MAP_FST = Q.prove(
+  `!xs f. MAP SND (MAP_FST f xs) = MAP SND xs`,
   Induct \\ fs [MAP,MAP_FST_def,FORALL_PROD]);
 
-val read_bitmap_not_empty = prove(``
+val read_bitmap_not_empty = Q.prove(`
   read_bitmap stack = SOME a ⇒
-  stack ≠ []``,
+  stack ≠ []`,
   rw[]>>CCONTR_TAC>>
   fs[]>>
   fs[read_bitmap_def])
 
-val n2w_lsr_1 = prove(
-  ``n < dimword (:'a) ==> n2w n >>> 1 = (n2w (n DIV 2)):'a word``,
+val n2w_lsr_1 = Q.prove(
+  `n < dimword (:'a) ==> n2w n >>> 1 = (n2w (n DIV 2)):'a word`,
   once_rewrite_tac [GSYM w2n_11] \\ rewrite_tac [w2n_lsr] \\ fs []
   \\ fs [DIV_LT_X] \\ decide_tac);
 
-val handler_bitmap_props = prove(``
+val handler_bitmap_props = Q.prove(`
   good_dimindex(:'a) ⇒
-  read_bitmap ((4w:'a word)::stack) = SOME [F;F]``,
+  read_bitmap ((4w:'a word)::stack) = SOME [F;F]`,
   fs [read_bitmap_def,good_dimindex_def] \\ strip_tac
   \\ `~(word_msb 4w)` by fs [word_msb_def,wordsTheory.word_index] \\ fs []
   \\ `4 < dimword (:'a) /\ 2 < dimword (:'a)` by fs [dimword_def]
@@ -1176,8 +1176,8 @@ val handler_bitmap_props = prove(``
    (NTAC 4 (fs [dimword_def,Once bit_length_def,n2w_lsr_1,EVAL ``1w ⋙ 1``]))
   \\ fs [] \\ EVAL_TAC \\ rw [] \\ decide_tac)
 
-val enc_stack_lemma = prove(
-  ``∀bs (wstack:'a stack_frame list) sstack lens astack bs'.
+val enc_stack_lemma = Q.prove(
+  `∀bs (wstack:'a stack_frame list) sstack lens astack bs'.
       good_dimindex(:'a) ∧
       LENGTH bs + 1 < dimword (:'a) ∧
       abs_stack bs wstack sstack lens = SOME astack ∧
@@ -1185,7 +1185,7 @@ val enc_stack_lemma = prove(
       1 ≤ LENGTH bs ∧
       HD bs = 4w ∧
       stack_rel_aux k len wstack astack ⇒
-      enc_stack bs sstack = SOME (enc_stack wstack)``,
+      enc_stack bs sstack = SOME (enc_stack wstack)`,
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   fs[enc_stack_def]>>
   rw[]>>
@@ -1228,11 +1228,11 @@ val enc_stack_lemma = prove(
   simp[Once stackSemTheory.enc_stack_def]>>
   simp[full_read_bitmap_def,MAP_SND_MAP_FST]);
 
-val IMP_enc_stack = prove(
-  ``state_rel k 0 0 s1 t1 lens
+val IMP_enc_stack = Q.prove(
+  `state_rel k 0 0 s1 t1 lens
     ==>
     (enc_stack t1.bitmaps (DROP t1.stack_space t1.stack) =
-       SOME (enc_stack s1.stack))``,
+       SOME (enc_stack s1.stack))`,
   fs [state_rel_def,LET_DEF] \\ rpt strip_tac
   \\ fs [stack_rel_def] \\ imp_res_tac enc_stack_lemma>>
   simp[]);
@@ -1267,10 +1267,10 @@ val map_bitmap_more_simp = prove(``
   metis_tac[TAKE_DROP,map_bitmap_more])
 
 (*These two are actually implied by s_key_eq*)
-val word_stack_dec_stack_shape = prove(``
+val word_stack_dec_stack_shape = Q.prove(`
   ∀ls wstack res n.
   dec_stack ls wstack = SOME res ∧ n < LENGTH wstack ⇒
-  (is_handler_frame (EL n wstack) ⇔ is_handler_frame (EL n res))``,
+  (is_handler_frame (EL n wstack) ⇔ is_handler_frame (EL n res))`,
   ho_match_mp_tac dec_stack_ind>>fs[dec_stack_def,is_handler_frame_def]>>
   rw[]>>
   EVERY_CASE_TAC>>fs[]>>
@@ -1296,20 +1296,20 @@ val sorted_env_zip = prove(``
   rw[]>>res_tac>>
   fs[Abbr`R`,EL_MAP])
 
-val word_stack_dec_stack_sorted = prove(``
+val word_stack_dec_stack_sorted = Q.prove(`
   ∀(ls:'a word_loc list) (wstack:'a stack_frame list) res.
   dec_stack ls wstack = SOME res ∧
   EVERY sorted_env wstack ⇒
-  EVERY sorted_env res``,
+  EVERY sorted_env res`,
   ho_match_mp_tac dec_stack_ind>>fs[dec_stack_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[]>>rveq>>
   rfs[]>>
   match_mp_tac sorted_env_zip>>
   simp[])
 
-val abs_stack_empty = prove(``
+val abs_stack_empty = Q.prove(`
   ∀bs ls stack lens.
-  abs_stack bs [] ls lens = SOME stack ⇒ ls = [Word 0w] ∧ lens = []``,
+  abs_stack bs [] ls lens = SOME stack ⇒ ls = [Word 0w] ∧ lens = []`,
   rpt Cases>>fs[abs_stack_def])
 
 val abs_frame_eq_def = Define`
@@ -1318,16 +1318,16 @@ val abs_frame_eq_def = Define`
   FST (SND p) = FST (SND q) ∧
   LENGTH (SND (SND p)) = LENGTH (SND (SND q))`
 
-val LIST_REL_abs_frame_eq_handler_val = prove(``
+val LIST_REL_abs_frame_eq_handler_val = Q.prove(`
   ∀xs ys.
   LIST_REL abs_frame_eq xs ys ⇒
-  handler_val xs = handler_val ys``,
+  handler_val xs = handler_val ys`,
   ho_match_mp_tac LIST_REL_ind>>
   fs[handler_val_def,abs_frame_eq_def,FORALL_PROD]>>rw[]>>
   Cases_on`p_1`>>fs[handler_val_def])
 
 (*Prove the inductive bits first...*)
-val dec_stack_lemma1 = prove(``
+val dec_stack_lemma1 = Q.prove(`
   ∀bs (wstack:'a stack_frame list) sstack lens astack wdec ls.
   good_dimindex(:'a) ∧
   1 ≤ LENGTH bs ∧
@@ -1343,7 +1343,7 @@ val dec_stack_lemma1 = prove(``
   abs_stack bs wdec sdec lens = SOME bstack ∧
   stack_rel_aux k len wdec bstack ∧
   (*They have exactly the same shape*)
-  LIST_REL abs_frame_eq astack bstack``,
+  LIST_REL abs_frame_eq astack bstack`,
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   fsrw_tac[][dec_stack_def,enc_stack_def]>>
   srw_tac[][]>>
@@ -1445,7 +1445,7 @@ val dec_stack_lemma1 = prove(``
     fsrw_tac[][abs_frame_eq_def]>>
     simp[]))
 
-val dec_stack_lemma = prove(``
+val dec_stack_lemma = Q.prove(`
   good_dimindex(:'a) ∧
   1 ≤ LENGTH t1.bitmaps ∧
   HD t1.bitmaps = 4w ∧
@@ -1459,7 +1459,7 @@ val dec_stack_lemma = prove(``
     ?yy:'a word_loc list. dec_stack t1.bitmaps x0 (DROP t1.stack_space t1.stack) = SOME yy /\
          (t1.stack_space + LENGTH yy = LENGTH t1.stack) /\
          stack_rel k s1.handler x (SOME (t1.store ' Handler)) yy
-            (LENGTH t1.stack) t1.bitmaps lens``,
+            (LENGTH t1.stack) t1.bitmaps lens`,
   rw[]>>
   fs[stack_rel_def]>>
   drule (GEN_ALL dec_stack_lemma1)>>
@@ -1697,11 +1697,11 @@ val alloc_IMP_alloc = prove(
   \\ imp_res_tac FLOOKUP_SUBMAP \\ fsrw_tac[] [] \\ srw_tac[] [] \\ fsrw_tac[] []
   \\ fsrw_tac[] [state_rel_def]);
 
-val word_gc_empty_frame = prove(``
+val word_gc_empty_frame = Q.prove(`
   gc (s with stack:= (StackFrame [] NONE::s.stack)) = SOME x ∧
   pop_env x = SOME y ⇒
   y.locals = LN ∧
-  gc s = SOME (y with locals:=s.locals)``,
+  gc s = SOME (y with locals:=s.locals)`,
   fs[gc_def,enc_stack_def,dec_stack_def,LET_THM]>>EVERY_CASE_TAC>>
   rw[]>>fs[pop_env_def]>>
   rveq>>fs[fromAList_def]>>
@@ -1781,9 +1781,9 @@ val compile_result_def = Define`
   (compile_result Error = Error)`;
 val _ = export_rewrites["compile_result_def"];
 
-val Halt_EQ_compile_result = prove(
-  ``(Halt (Word 1w) = compile_result z <=> z = NotEnoughSpace) /\
-    (good_dimindex (:'a) ==> Halt (Word (2w:'a word)) <> compile_result z)``,
+val Halt_EQ_compile_result = Q.prove(
+  `(Halt (Word 1w) = compile_result z <=> z = NotEnoughSpace) /\
+    (good_dimindex (:'a) ==> Halt (Word (2w:'a word)) <> compile_result z)`,
   Cases_on `z` \\ fs [] \\ fs [good_dimindex_def] \\ rw [] \\ fs [dimword_def]);
 
 val stack_evaluate_add_clock_NONE =
@@ -1794,24 +1794,24 @@ val push_locals_def = Define `
   push_locals s = s with <| locals := LN;
     stack := StackFrame (FST (env_to_list s.locals (K I))) NONE :: s.stack |>`
 
-val LASTN_LENGTH_ID2 = prove(``
+val LASTN_LENGTH_ID2 = Q.prove(`
   ∀stack x.
   (x+1 = LENGTH stack) ⇒
   LASTN (x+1) stack =
-  HD stack::LASTN x stack``,
+  HD stack::LASTN x stack`,
   fs[LASTN_LENGTH_ID]>>Induct>>rw[]>>
   `x = LENGTH stack` by DECIDE_TAC>>
   fs[LASTN_CONS,LASTN_LENGTH_ID])
 
-val stack_rel_aux_LENGTH = prove(``
+val stack_rel_aux_LENGTH = Q.prove(`
   ∀k len xs ys.
   stack_rel_aux k len xs ys ⇒
-  LENGTH xs = LENGTH ys``,
+  LENGTH xs = LENGTH ys`,
   ho_match_mp_tac (theorem "stack_rel_aux_ind")>>fs[stack_rel_aux_def])
 
-val LASTN_MORE = prove(``
+val LASTN_MORE = Q.prove(`
   ∀ls n.
-  ¬(n < LENGTH ls) ⇒ LASTN n ls = ls``,
+  ¬(n < LENGTH ls) ⇒ LASTN n ls = ls`,
   fs[LASTN_def]>>Induct>>rw[]>>
   Cases_on`n < LENGTH ls`>>
   fs[TAKE_APPEND1,LENGTH_REVERSE] >>
@@ -1820,10 +1820,10 @@ val LASTN_MORE = prove(``
     IF_CASES_TAC>>fs[]>>
     DECIDE_TAC)
 
-val stack_rel_aux_LASTN = prove(``
+val stack_rel_aux_LASTN = Q.prove(`
   ∀k len xs ys n.
   stack_rel_aux k len xs ys ⇒
-  stack_rel_aux k len (LASTN n xs) (LASTN n ys)``,
+  stack_rel_aux k len (LASTN n xs) (LASTN n ys)`,
   ho_match_mp_tac (theorem "stack_rel_aux_ind")>>
   fs[stack_rel_aux_def]>>rw[]>>
   imp_res_tac stack_rel_aux_LENGTH
@@ -1834,10 +1834,10 @@ val stack_rel_aux_LASTN = prove(``
     `¬(n < SUC(LENGTH ys))` by DECIDE_TAC>>
     fs[LASTN_MORE,stack_rel_aux_def])
 
-val abs_stack_to_stack_LENGTH = prove(``
+val abs_stack_to_stack_LENGTH = Q.prove(`
   ∀bs wstack sstack lens stack.
   abs_stack bs wstack sstack lens = SOME stack ⇒
-  handler_val stack = LENGTH sstack``,
+  handler_val stack = LENGTH sstack`,
   ho_match_mp_tac (theorem "abs_stack_ind")>>rw[]>>
   fs[abs_stack_def,LET_THM]>>TRY(Cases_on`w`)>>
   fs[full_read_bitmap_def]
@@ -1854,23 +1854,23 @@ val abs_stack_to_stack_LENGTH = prove(``
     simp[handler_val_def]))
 
 (*Equality theorems available if n ≤ LENGTH ls*)
-val LASTN_LENGTH_BOUNDS = prove(``
+val LASTN_LENGTH_BOUNDS = Q.prove(`
   ∀n ls.
   let xs = LASTN n ls in
   LENGTH xs ≤ n ∧
-  LENGTH xs ≤ LENGTH ls``,
+  LENGTH xs ≤ LENGTH ls`,
   fs[LASTN_def,LET_THM]>>Induct>>fs[LENGTH_TAKE_EQ]>>rw[]>>
   decide_tac)
 
-val LASTN_CONS_ID = prove(``
+val LASTN_CONS_ID = Q.prove(`
   n = LENGTH ls ⇒
-  LASTN (SUC n) (frame::ls) = (frame::ls)``,
+  LASTN (SUC n) (frame::ls) = (frame::ls)`,
   rw[]>>EVAL_TAC>>fs[])
 
 (*Strengthened version of LASTN_DROP after change to make it total*)
-val LASTN_DROP2 = prove(``
+val LASTN_DROP2 = Q.prove(`
   ∀l n.
-  LASTN n l = DROP (LENGTH l -n) l``,
+  LASTN n l = DROP (LENGTH l -n) l`,
   Induct>>fs[LASTN_def]>>
   rw[TAKE_APPEND]>>
   Cases_on`n > LENGTH l`>>fs[ADD1]>>
@@ -1880,7 +1880,7 @@ val LASTN_DROP2 = prove(``
 (* Allow prefixes of (frames of) stacks to be directly dropped
   using handler_val
 *)
-val abs_stack_prefix_drop = prove(``
+val abs_stack_prefix_drop = Q.prove(`
   ∀bs wstack sstack lens stack h wrest k len.
   h ≤ LENGTH wstack ∧
   LASTN h wstack = wrest ∧
@@ -1890,7 +1890,7 @@ val abs_stack_prefix_drop = prove(``
   let lrest = LASTN h lens in
   let srest = LASTN (handler_val rest) sstack in
   abs_stack bs wrest srest lrest = SOME rest ∧
-  stack_rel_aux k len wrest rest``,
+  stack_rel_aux k len wrest rest`,
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   rpt strip_tac>>fs[LET_THM,abs_stack_def]
   >-
@@ -1965,10 +1965,10 @@ val abs_stack_prefix_drop = prove(``
         simp[LENGTH_TAKE])>>
       fs[Abbr`frame`,Abbr`ls`,abs_stack_def,LET_THM,full_read_bitmap_def])
 
-val abs_stack_len = prove(``
+val abs_stack_len = Q.prove(`
   ∀bs wstack sstack lens stack handler.
   abs_stack bs wstack sstack lens = SOME stack ⇒
-  handler_val (LASTN handler stack) ≤ LENGTH sstack``,
+  handler_val (LASTN handler stack) ≤ LENGTH sstack`,
   ho_match_mp_tac (theorem "abs_stack_ind")>>rw[]>>
   fs[abs_stack_def,LET_THM]
   >-
@@ -1991,16 +1991,16 @@ val abs_stack_len = prove(``
       fs[LENGTH_TAKE_EQ]>>IF_CASES_TAC>>
       DECIDE_TAC))
 
-val EL_REVERSE_REWRITE = prove(``
+val EL_REVERSE_REWRITE = Q.prove(`
   ∀l n k. n < LENGTH l ∧ k < n ⇒
-  EL (LENGTH l - n + k) l = EL (n-k -1) (REVERSE l)``,
+  EL (LENGTH l - n + k) l = EL (n-k -1) (REVERSE l)`,
   rw[]>> fs[EL_REVERSE,PRE_SUB1])
 
-val LASTN_LESS = prove(``
+val LASTN_LESS = Q.prove(`
   ∀ls n x xs.
   n+1 ≤ LENGTH ls ∧
   LASTN (n+1) ls = x::xs ⇒
-  LASTN n ls = xs``,
+  LASTN n ls = xs`,
   Induct>>rw[]>>
   Cases_on`n+1 ≤ LENGTH ls`>>fs[]
   >-
@@ -2019,32 +2019,32 @@ val ALOOKUP_IFF_MEM = prove(
     (ALOOKUP l q = SOME r <=> MEM (q,r) l)``,
   Induct_on `l` \\ fs [FORALL_PROD,MEM_MAP] \\ rw [] \\ metis_tac []);
 
-val SORTED_CONS_IMP = prove(
-  ``SORTED (\x y. FST x > (FST y):num) (h::t) ==>
+val SORTED_CONS_IMP = Q.prove(
+  `SORTED (\x y. FST x > (FST y):num) (h::t) ==>
     ~(MEM h t) /\ SORTED (\x y. FST x > FST y) t /\
-    !x. MEM x t ==> FST h > FST x``,
+    !x. MEM x t ==> FST h > FST x`,
   Induct_on `t` \\ fs [SORTED_DEF] \\ rw []
   \\ `SORTED (\x y. FST x > FST y) (h::t)` by
     (Cases_on `t` \\ fs [SORTED_DEF] \\ decide_tac)
   \\ fs [] \\ Cases_on `h` \\ Cases_on `h'` \\ fs []
   \\ disj1_tac \\ decide_tac);
 
-val SORTED_IMP_ALL_DISTINCT_LEMMA = prove(
-  ``!l. SORTED (\x y. FST x > (FST y):num) l ==> ALL_DISTINCT (MAP FST l)``,
+val SORTED_IMP_ALL_DISTINCT_LEMMA = Q.prove(
+  `!l. SORTED (\x y. FST x > (FST y):num) l ==> ALL_DISTINCT (MAP FST l)`,
   Induct \\ fs [] \\ rw [MEM_MAP]
   \\ metis_tac [DECIDE ``m>n ==> m<>n:num``,SORTED_CONS_IMP]);
 
-val MEM_toAList_fromAList = prove(
-  ``SORTED (\x y. FST x > (FST y):num) l ==>
-    MEM a (toAList (fromAList l)) = MEM a l``,
+val MEM_toAList_fromAList = Q.prove(
+  `SORTED (\x y. FST x > (FST y):num) l ==>
+    MEM a (toAList (fromAList l)) = MEM a l`,
   Cases_on `a` \\ fs [MEM_toAList,lookup_fromAList] \\ rw []
   \\ imp_res_tac SORTED_IMP_ALL_DISTINCT_LEMMA \\ fs [ALOOKUP_IFF_MEM]);
 
-val SORTED_FST_PERM_IMP_ALIST_EQ = prove(
-  ``SORTED (\x y. FST x > FST y) l /\
+val SORTED_FST_PERM_IMP_ALIST_EQ = Q.prove(
+  `SORTED (\x y. FST x > FST y) l /\
     SORTED (\x y. FST x > FST y) q /\
     PERM (toAList (fromAList l)) q ==>
-    q = l``,
+    q = l`,
   rw [] \\ drule MEM_PERM \\ fs [MEM_toAList_fromAList]
   \\ pop_assum kall_tac \\ rpt (pop_assum mp_tac)
   \\ Q.SPEC_TAC (`l`,`l`) \\ Induct_on `q` \\ fs [MEM]
@@ -2156,15 +2156,15 @@ val stack_rel_raise = prove(``
   rw[]>>
   fs[abs_stack_def,LET_THM])
 
-val EVERY_IMP_EVERY_LASTN = prove(
-  ``!xs ys P. EVERY P xs /\ LASTN n xs = ys ==> EVERY P ys``,
+val EVERY_IMP_EVERY_LASTN = Q.prove(
+  `!xs ys P. EVERY P xs /\ LASTN n xs = ys ==> EVERY P ys`,
   fs [EVERY_MEM] \\ rw [] \\ imp_res_tac MEM_LASTN_ALT \\ res_tac \\ fs []);
 
-val LASTN_HD = prove(``
+val LASTN_HD = Q.prove(`
   ∀ls x.
   x ≤ LENGTH ls ⇒
   HD (LASTN x ls) =
-  EL (LENGTH ls - x) ls``,
+  EL (LENGTH ls - x) ls`,
   fs[LASTN_def]>>
   Induct>>rw[]>>
   Cases_on`x = SUC(LENGTH ls)`
@@ -2624,20 +2624,20 @@ val evaluate_SeqStackFree = store_thm("evaluate_SeqStackFree",
   THEN1 (`F` by decide_tac)
   \\ AP_TERM_TAC \\ fs [stackSemTheory.state_component_equality]);
 
-val get_vars_eq = prove(
-  ``∀ls z.
+val get_vars_eq = Q.prove(
+  `∀ls z.
   get_vars ls st = SOME z ⇒
   let lookups = MAP (\x. lookup x st.locals) ls in
   EVERY IS_SOME lookups ∧
-  z = MAP THE lookups``,
+  z = MAP THE lookups`,
   Induct>>fs[get_vars_def,get_var_def]>>rw[]>>unabbrev_all_tac>>
   EVERY_CASE_TAC>>fs[]>>
   metis_tac[])
 
-val LAST_add_ret_loc = prove(``
+val LAST_add_ret_loc = Q.prove(`
   args' ≠ [] ⇒
   LAST (add_ret_loc ret args') =
-  LAST args'``,
+  LAST args'`,
   Cases_on`ret`>>TRY(PairCases_on`x`)>>fs[add_ret_loc_def]>>
   Cases_on`args'`>>fs[LAST_CONS])
 
@@ -2738,9 +2738,9 @@ val call_dest_lemma = prove(
     res_tac>>
     simp[]);
 
-val compile_result_NOT_2 = prove(
-  ``good_dimindex (:'a) ==>
-    compile_result x ≠ Halt (Word (2w:'a word))``,
+val compile_result_NOT_2 = Q.prove(
+  `good_dimindex (:'a) ==>
+    compile_result x ≠ Halt (Word (2w:'a word))`,
   Cases_on `x` \\ fs [compile_result_def]
   \\ rw [good_dimindex_def] \\ fs [dimword_def]);
 
@@ -2904,10 +2904,10 @@ val ALOOKUP_ID_TABULATE = Q.store_thm("ALOOKUP_ID_TABULATE",
   Induct_on`ls`\\simp[]\\rw[]\\fs[]);
 
 (*These two might be used to remove wf assumption if needed*)
-val insert_unchanged = prove(``
+val insert_unchanged = Q.prove(`
   ∀t x.
   lookup x t = SOME y ⇒
-  insert x y t = t``,
+  insert x y t = t`,
   completeInduct_on`x`>>
   Induct>>
   fs[lookup_def]>>rw[]>>
@@ -3027,8 +3027,8 @@ val alist_insert_get_vars = Q.store_thm("alist_insert_get_vars",
     \\ fs[get_var_def] )
   \\ IF_CASES_TAC \\ fs[]);
 
-val wf_fromList2 = prove(``
-  ∀ls. wf(fromList2 ls)``,
+val wf_fromList2 = Q.prove(`
+  ∀ls. wf(fromList2 ls)`,
   ho_match_mp_tac SNOC_INDUCT>>
   fs[fromList2_def,FOLDL_SNOC,wf_def]>>rw[]>>
   pairarg_tac>>fs[wf_insert])
@@ -4007,10 +4007,10 @@ val state_rel_set_store = Q.store_thm("state_rel_set_store",
   \\ metis_tac[]);
 
 (*For calls*)
-val get_vars_fromList2_eq = prove(``
+val get_vars_fromList2_eq = Q.prove(`
     get_vars (GENLIST (λx. 2*x) (LENGTH args)) s = SOME x ∧
     lookup n (fromList2 x) = SOME y ⇒
-    lookup n s.locals = SOME y``,
+    lookup n s.locals = SOME y`,
     rw[]>>imp_res_tac get_vars_eq>>
     fs[lookup_fromList2,lookup_fromList,LET_THM]>>
     fs[EVERY_MAP,EVERY_GENLIST,MAP_GENLIST]>>rfs[EL_GENLIST]>>
@@ -4024,10 +4024,10 @@ val get_vars_fromList2_eq = prove(``
     simp[])
 
 (*For returning calls*)
-val get_vars_fromList2_eq_cons = prove(``
+val get_vars_fromList2_eq_cons = Q.prove(`
     get_vars (GENLIST (λx. 2*(x+1)) (LENGTH args)) s = SOME x ∧
     lookup n (fromList2 (Loc x3 x4::x)) = SOME y ∧ n ≠ 0 ⇒
-    lookup n s.locals = SOME y``,
+    lookup n s.locals = SOME y`,
   rw[]>>imp_res_tac get_vars_eq>>
   fs[lookup_fromList2,lookup_fromList,LET_THM]>>
   Cases_on`n`>>fs[]>>
@@ -4044,36 +4044,36 @@ val get_vars_fromList2_eq_cons = prove(``
   pop_assum(qspec_then`n` assume_tac)>>
   fs[EVEN_MOD2]>>simp[])
 
-val lookup_fromList2_prefix = prove(``
+val lookup_fromList2_prefix = Q.prove(`
   ∀x z y.
   IS_PREFIX z x ∧
   lookup n (fromList2 x) = SOME y ⇒
-  lookup n (fromList2 z) = SOME y``,
+  lookup n (fromList2 z) = SOME y`,
   fs[lookup_fromList2,lookup_fromList]>>rw[]>>
   imp_res_tac IS_PREFIX_LENGTH >- DECIDE_TAC>>
   fs[IS_PREFIX_APPEND]>>
   fs[EL_APPEND1])
 
-val list_max_APPEND = store_thm("list_max_APPEND",``
+val list_max_APPEND = Q.store_thm("list_max_APPEND",`
   ∀a b.
-  list_max (a++b) = MAX (list_max a) (list_max b)``,
+  list_max (a++b) = MAX (list_max a) (list_max b)`,
   Induct>>fs[list_max_def,LET_THM,MAX_DEF]>>rw[]>>
   DECIDE_TAC)
 
-val list_max_SNOC = store_thm("list_max_SNOC",``
-  list_max (SNOC x ls) = MAX x (list_max ls)``,
+val list_max_SNOC = Q.store_thm("list_max_SNOC",`
+  list_max (SNOC x ls) = MAX x (list_max ls)`,
   fs[SNOC_APPEND,list_max_APPEND,list_max_def,LET_THM,MAX_DEF]>>
   DECIDE_TAC)
 
-val list_max_GENLIST_evens = store_thm("list_max_GENLIST_evens",``
-  ∀n. list_max (GENLIST (λx. 2*x) n) = 2*(n-1)``,
+val list_max_GENLIST_evens = Q.store_thm("list_max_GENLIST_evens",`
+  ∀n. list_max (GENLIST (λx. 2*x) n) = 2*(n-1)`,
   Induct>>
   fs[list_max_def]>>rw[]>>
   fs[GENLIST,list_max_SNOC,MAX_DEF]>>
   DECIDE_TAC)
 
-val list_max_GENLIST_evens2 = store_thm("list_max_GENLIST_evens2",``
-  ∀n. list_max (GENLIST (λx. 2*(x+1)) n) = 2*n``,
+val list_max_GENLIST_evens2 = Q.store_thm("list_max_GENLIST_evens2",`
+  ∀n. list_max (GENLIST (λx. 2*(x+1)) n) = 2*n`,
   Induct>>
   fs[list_max_def]>>rw[]>>
   fs[GENLIST,list_max_SNOC,MAX_DEF]>>
@@ -4172,9 +4172,9 @@ val evaluate_wLive_clock = prove(``
     simp[stackSemTheory.evaluate_def,FORALL_PROD,stackSemTheory.inst_def,stackSemTheory.assign_def,stackSemTheory.set_var_def,stackSemTheory.word_exp_def,empty_env_def,stackSemTheory.get_var_def]>>
     EVERY_CASE_TAC>>fs[])
 
-val state_rel_IMP_LENGTH = prove(``
+val state_rel_IMP_LENGTH = Q.prove(`
   state_rel k f f' s t lens ⇒
-  LENGTH lens = LENGTH s.stack``,
+  LENGTH lens = LENGTH s.stack`,
   fs[state_rel_def,stack_rel_def,LET_THM]>>rw[]>>
   metis_tac[abs_stack_IMP_LENGTH])
 
@@ -4254,14 +4254,14 @@ val evaluate_stack_move_clock = prove(``
   (*get_var_set_var?*)
   fs[stackSemTheory.get_var_def,stackSemTheory.set_var_def,FLOOKUP_UPDATE])|>SIMP_RULE arith_ss [LET_THM];
 
-val pop_env_ffi = prove(``
+val pop_env_ffi = Q.prove(`
   pop_env s = SOME s' ⇒
-  s.ffi = s'.ffi``,
+  s.ffi = s'.ffi`,
   fs[pop_env_def]>>EVERY_CASE_TAC>>fs[state_component_equality]);
 
-val stack_rel_DROP_NONE = prove(``
+val stack_rel_DROP_NONE = Q.prove(`
   stack_rel k whandler (StackFrame l NONE::wstack) shandler sstack len bs (f'::lens) ⇒
-  stack_rel k whandler wstack shandler (DROP (f'+1) sstack) len bs lens``,
+  stack_rel k whandler wstack shandler (DROP (f'+1) sstack) len bs lens`,
   simp[stack_rel_def]>>rw[]>>
   Cases_on`sstack`>>fs[abs_stack_def]>>qpat_x_assum`A=SOME stack` mp_tac>>
   rpt (TOP_CASE_TAC>>simp[])>>
@@ -4285,18 +4285,18 @@ val stack_rel_DROP_SOME = prove(``
   imp_res_tac abs_stack_IMP_LENGTH>>
   simp[]);
 
-val LAST_GENLIST_evens = prove(``
+val LAST_GENLIST_evens = Q.prove(`
   n ≠ 0 ⇒
   let reg = LAST (GENLIST (λx. 2 * (x+1)) n) in
-  reg ≠ 0 ∧ EVEN reg``,
+  reg ≠ 0 ∧ EVEN reg`,
   Cases_on`n`>>
   simp[LAST_EL,GENLIST_CONS]>>
   `0 < 2n` by DECIDE_TAC>>
   metis_tac[EVEN_MOD2,MULT_COMM,MOD_EQ_0]);
 
-val stack_rel_cons_LEN_NONE = prove(``
+val stack_rel_cons_LEN_NONE = Q.prove(`
   stack_rel k whandler (StackFrame l NONE::wstack) shandler sstack len bs (f'::lens) ⇒
-  f'+1 ≤ LENGTH sstack``,
+  f'+1 ≤ LENGTH sstack`,
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
   rpt TOP_CASE_TAC>>simp[])
 
@@ -4306,20 +4306,20 @@ val stack_rel_cons_LEN_SOME = prove(``
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
   rpt TOP_CASE_TAC>>simp[]);
 
-val DROP_SUB = prove(``
+val DROP_SUB = Q.prove(`
   a ≤ LENGTH ls ∧ b ≤ a ⇒
-  DROP (a-b) ls = (DROP(a-b) (TAKE a ls))++ DROP a ls``,
+  DROP (a-b) ls = (DROP(a-b) (TAKE a ls))++ DROP a ls`,
   rw[]>>
   Q.ISPECL_THEN[`a`,`ls`] mp_tac(GSYM TAKE_DROP)>>
   disch_then SUBST_ALL_TAC>>
   simp[GSYM DROP_APPEND1]);
 
-val DROP_SUB2 = prove(``
+val DROP_SUB2 = Q.prove(`
   ∀a ls b.
   b ≤ a ∧
   a = LENGTH ls ⇒
   ∃rest.
-  DROP (a-b) ls = rest ∧ LENGTH rest = b``,
+  DROP (a-b) ls = rest ∧ LENGTH rest = b`,
   Induct>>
   fs[]>>rw[]>>
   simp[]);
@@ -4420,27 +4420,27 @@ val evaluate_PopHandler_seq = prove(``
   rw[]>>EVERY_CASE_TAC>>fs[]>>
   EVERY_CASE_TAC>>fs[]);
 
-val word_cmp_Word_Word = prove(
-  ``word_cmp cmp (Word c) (Word c') = SOME (word_cmp cmp c c')``,
+val word_cmp_Word_Word = Q.prove(
+  `word_cmp cmp (Word c) (Word c') = SOME (word_cmp cmp c c')`,
   Cases_on `cmp`
   \\ rw [labSemTheory.word_cmp_def,asmSemTheory.word_cmp_def]);
 
-val ALL_DISTINCT_MEM_toAList_fromAList = prove(``
+val ALL_DISTINCT_MEM_toAList_fromAList = Q.prove(`
   ALL_DISTINCT (MAP FST ls) ⇒
   (MEM x (toAList (fromAList ls)) ⇔
-  MEM x ls)``,
+  MEM x ls)`,
   Cases_on`x`>>fs[MEM_toAList,lookup_fromAList]>>
   rw[]>>
   metis_tac[ALOOKUP_MEM,ALOOKUP_ALL_DISTINCT_MEM]);
 
-val state_rel_code_domain = prove(``
+val state_rel_code_domain = Q.prove(`
   state_rel k f f' s t lens ⇒
-  domain s.code ⊆ domain t.code``,
+  domain s.code ⊆ domain t.code`,
   strip_tac>>fs[state_rel_def,SUBSET_DEF,domain_lookup,EXISTS_PROD]>>
   metis_tac[]);
 
-val get_labels_wStackLoad = store_thm("get_labels_wStackLoad",
-  ``!xs p. get_labels (wStackLoad xs p) = get_labels p``,
+val get_labels_wStackLoad = Q.store_thm("get_labels_wStackLoad",
+  `!xs p. get_labels (wStackLoad xs p) = get_labels p`,
   Induct \\ fs [wStackLoad_def]
   \\ Cases \\ fs [wStackLoad_def,get_labels_def]);
 
@@ -6644,16 +6644,16 @@ val compile_semantics = store_thm("compile_semantics",
   \\ match_mp_tac compile_word_to_stack_IMP_ALOOKUP
   \\ metis_tac []);
 
-val stack_move_no_labs = prove(``
+val stack_move_no_labs = Q.prove(`
   ∀n a b c p.
   extract_labels p = [] ⇒
-  extract_labels (stack_move n a b c p) = []``,
+  extract_labels (stack_move n a b c p) = []`,
   Induct>>rw[stack_move_def]>>
   EVAL_TAC>>metis_tac[])
 
-val word_to_stack_lab_pres = store_thm("word_to_stack_lab_pres",``
+val word_to_stack_lab_pres = Q.store_thm("word_to_stack_lab_pres",`
   ∀p bs kf.
-  extract_labels p = extract_labels (FST (comp p bs kf))``,
+  extract_labels p = extract_labels (FST (comp p bs kf))`,
   ho_match_mp_tac comp_ind>>
   rw[comp_def,extract_labels_def,wordPropsTheory.extract_labels_def]>>
   TRY(PairCases_on`kf`)>>TRY(PairCases_on`kf'`)>>

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -264,9 +264,9 @@ val MEM_LASTN_ALT = Q.prove(
   `!xs n x. MEM x (LASTN n xs) ==> MEM x xs`,
   fs [LASTN_def] \\ rw [] \\ imp_res_tac MEM_TAKE \\ fs []);
 
-val clock_add_0 = store_thm("clock_add_0[simp]",
-  ``((t with clock := t.clock + 0) = t:('a,'ffi) stackSem$state) /\
-    ((t with clock := t.clock) = t:('a,'ffi) stackSem$state)``,
+val clock_add_0 = Q.store_thm("clock_add_0[simp]",
+  `((t with clock := t.clock + 0) = t:('a,'ffi) stackSem$state) /\
+    ((t with clock := t.clock) = t:('a,'ffi) stackSem$state)`,
   fs [stackSemTheory.state_component_equality]);
 
 val DROP_DROP_EQ = Q.store_thm("DROP_DROP_EQ",
@@ -571,10 +571,10 @@ val state_rel_def = Define `
 
 (* correctness proof *)
 
-val evaluate_SeqStackFree = prove(
-  ``t.use_stack /\ t.stack_space <= LENGTH t.stack ==>
+val evaluate_SeqStackFree = Q.prove(
+  `t.use_stack /\ t.stack_space <= LENGTH t.stack ==>
     evaluate (SeqStackFree f p,t) =
-    evaluate (Seq (StackFree f) p,t)``,
+    evaluate (Seq (StackFree f) p,t)`,
   fsrw_tac[] [SeqStackFree_def] \\ srw_tac[] [stackSemTheory.evaluate_def]
   THEN1 (`F` by decide_tac) \\ AP_TERM_TAC
   \\ fs [stackSemTheory.state_component_equality]);
@@ -591,9 +591,9 @@ val convs_def = LIST_CONJ
 val nn = ``(NONE:(num # 'a wordLang$prog # num # num) option)``
 
 (*
-val LENGTH_write_bitmap = prove(
-  ``state_rel k f f' (s:('a,'ffi) wordSem$state) t /\ 1 <= f ==>
-    (LENGTH ((write_bitmap (names:num_set) k f'):'a word list) + f' = f)``,
+val LENGTH_write_bitmap = Q.prove(
+  `state_rel k f f' (s:('a,'ffi) wordSem$state) t /\ 1 <= f ==>
+    (LENGTH ((write_bitmap (names:num_set) k f'):'a word list) + f' = f)`,
   fs [state_rel_def,write_bitmap_def,LET_DEF]
   \\ fs [LENGTH_word_list] \\ rpt strip_tac
   \\ `~(dimindex (:'a) <= 1) /\ f <> 0` by decide_tac \\ fs []
@@ -807,8 +807,8 @@ val insert_bitmap_length = Q.store_thm("insert_bitmap_length",
 
 (*
 
-val read_bitmap_write_bitmap = prove(
-  ``t.stack_space + f <= LENGTH t.stack /\ 8 <= dimindex (:'a) /\
+val read_bitmap_write_bitmap = Q.prove(
+  `t.stack_space + f <= LENGTH t.stack /\ 8 <= dimindex (:'a) /\
     (LENGTH (write_bitmap names k f': 'a word list) + f' = f) /\
     (if f' = 0 then f = 0 else f = f' + f' DIV (dimindex (:'a) - 1) + 1) /\
     (1 <= f) ==>
@@ -817,7 +817,7 @@ val read_bitmap_write_bitmap = prove(
          (DROP t.stack_space t.stack)) =
     SOME (GENLIST (\x. MEM x (MAP (\(r,y). (f'-1) - (r DIV 2 - k)) (toAList names))) f',
           MAP Word (write_bitmap names k f'): 'a word_loc list,
-          (DROP (f - f') (DROP t.stack_space t.stack)))``,
+          (DROP (f - f') (DROP t.stack_space t.stack)))`,
   fs [write_bitmap_def,LET_DEF]
   \\ Q.ABBREV_TAC `qs = GENLIST
            (\x. MEM x (MAP (\(r,y). (f'-1) - (r DIV 2 -k) ) (toAList names))) f'`
@@ -918,10 +918,10 @@ val transitive_GT = Q.prove(`
   transitive ($> : (num->num->bool))`,
   fs[transitive_def]>>DECIDE_TAC)
 
-val env_to_list_K_I_IMP = prove(
-  ``!env l oracle.
+val env_to_list_K_I_IMP = Q.prove(
+  `!env l oracle.
       env_to_list env (K I) = (l,oracle) ==>
-      SORTED (\x y. FST x > FST y) l /\ oracle = K I /\ PERM (toAList env) l``,
+      SORTED (\x y. FST x > FST y) l /\ oracle = K I /\ PERM (toAList env) l`,
   fs [env_to_list_def,LET_DEF,FUN_EQ_THM,list_rearrange_I] \\ rw []
   \\ pop_assum kall_tac
   \\ qspec_then `toAList env` mp_tac (SORTS_QSORT_key_val_compare
@@ -1237,13 +1237,13 @@ val IMP_enc_stack = Q.prove(
   \\ fs [stack_rel_def] \\ imp_res_tac enc_stack_lemma>>
   simp[]);
 
-val map_bitmap_success = prove(``
+val map_bitmap_success = Q.prove(`
   ∀bs stack a b ls.
   filter_bitmap bs stack = SOME(a,b) ∧
   LENGTH ls = LENGTH a ⇒
   ∃x z.
   map_bitmap bs ls stack = SOME(x,[],DROP (LENGTH bs) stack) ∧
-  filter_bitmap bs x = SOME(ls,[])``,
+  filter_bitmap bs x = SOME(ls,[])`,
   ho_match_mp_tac filter_bitmap_ind>>fs[filter_bitmap_def,map_bitmap_def]>>
   rw[LENGTH_NIL]
   >-
@@ -1254,16 +1254,16 @@ val map_bitmap_success = prove(``
     res_tac>>fs[filter_bitmap_def])
 
 (*Might need to extend c as well*)
-val map_bitmap_more = prove(``
+val map_bitmap_more = Q.prove(`
   ∀bs ls stack n a c ls'.
   map_bitmap bs ls stack = SOME(a,[],c) ⇒
-  map_bitmap bs (ls++ls') stack = SOME(a,ls',c)``,
+  map_bitmap bs (ls++ls') stack = SOME(a,ls',c)`,
   ho_match_mp_tac map_bitmap_ind>>fs[map_bitmap_def]>>rw[]>>
   pop_assum mp_tac>>ntac 3 TOP_CASE_TAC>>fs[])
 
-val map_bitmap_more_simp = prove(``
+val map_bitmap_more_simp = Q.prove(`
   map_bitmap bs (TAKE (LENGTH l) ls) stack = SOME (a,[],c) ⇒
-  map_bitmap bs ls stack = SOME (a,DROP (LENGTH l) ls,c)``,
+  map_bitmap bs ls stack = SOME (a,DROP (LENGTH l) ls,c)`,
   metis_tac[TAKE_DROP,map_bitmap_more])
 
 (*These two are actually implied by s_key_eq*)
@@ -1280,11 +1280,11 @@ val word_stack_dec_stack_shape = Q.prove(`
     simp[is_handler_frame_def])>>
   simp[])
 
-val sorted_env_zip = prove(``
+val sorted_env_zip = Q.prove(`
   ∀l:(num,'a word_loc) alist ls:'a word_loc list x.
   sorted_env (StackFrame l x) ∧
   LENGTH ls = LENGTH l⇒
-  sorted_env (StackFrame (ZIP (MAP FST l, ls)) x)``,
+  sorted_env (StackFrame (ZIP (MAP FST l, ls)) x)`,
   fs[sorted_env_def]>>
   Induct>>fs[LENGTH_NIL]>>rw[]>>
   Cases_on`ls`>>fs[]>>
@@ -1485,9 +1485,9 @@ val dec_stack_lemma = Q.prove(`
     metis_tac[LIST_REL_abs_frame_eq_handler_val])
   )|> INST_TYPE [beta|->``:'ffi``,gamma|->``:'ffi``];
 
-val gc_state_rel = prove(
-  ``(gc (s1:('a,'ffi) wordSem$state) = SOME s2) /\ state_rel k 0 0 s1 t1 lens /\ (s1.locals = LN) ==>
-    ?t2. gc t1 = SOME t2 /\ state_rel k 0 0 s2 t2 lens``,
+val gc_state_rel = Q.prove(
+  `(gc (s1:('a,'ffi) wordSem$state) = SOME s2) /\ state_rel k 0 0 s1 t1 lens /\ (s1.locals = LN) ==>
+    ?t2. gc t1 = SOME t2 /\ state_rel k 0 0 s2 t2 lens`,
   fs [gc_def,LET_DEF]
   \\ Cases_on `s1.gc_fun (enc_stack s1.stack,s1.memory,s1.mdomain,s1.store)` \\ fs []
   \\ PairCases_on `x` \\ fs [] \\ Cases_on `dec_stack x0 s1.stack` \\ fs []
@@ -1508,8 +1508,8 @@ val gc_state_rel = prove(
   \\ fs [DROP_APPEND,DROP_TAKE_NIL]
   \\ metis_tac[]);
 
-val alloc_alt = prove(
-  ``FST (alloc c names (s:('a,'ffi) wordSem$state)) <>
+val alloc_alt = Q.prove(
+  `FST (alloc c names (s:('a,'ffi) wordSem$state)) <>
     SOME (Error:'a wordSem$result) ==>
     (alloc c names (s:('a,'ffi) wordSem$state) =
      case cut_env names s.locals of
@@ -1530,7 +1530,7 @@ val alloc_alt = prove(
                      | SOME T => (NONE,s')
                      | SOME F =>
                          (SOME NotEnoughSpace,
-                          call_env [] s' with stack := []))``,
+                          call_env [] s' with stack := []))`,
   fs [alloc_def]
   \\ Cases_on `cut_env names s.locals` \\ fs []
   \\ fs [gc_def,set_store_def,push_env_def,LET_DEF,
@@ -1540,10 +1540,10 @@ val alloc_alt = prove(
    \\ fs [state_component_equality] \\ rw []);
 
 (*MEM to an EL characterization for index lists*)
-val MEM_index_list_LIM = prove(``
+val MEM_index_list_LIM = Q.prove(`
   ∀ls n v k.
   MEM (n,v) (index_list ls k) ⇒
-  n-k < LENGTH ls``,
+  n-k < LENGTH ls`,
   Induct>>fs[index_list_def]>>rw[]
   >-
     DECIDE_TAC
@@ -1551,10 +1551,10 @@ val MEM_index_list_LIM = prove(``
   res_tac>>
   DECIDE_TAC)
 
-val MEM_index_list_EL = prove(``
+val MEM_index_list_EL = Q.prove(`
   ∀ls n v.
   MEM (n,v) (index_list ls k) ⇒
-  EL (LENGTH ls - (n-k+1)) ls = v``,
+  EL (LENGTH ls - (n-k+1)) ls = v`,
   Induct>>fs[index_list_def,FORALL_PROD]>>rw[]>>
   simp[ADD1]>>
   res_tac>>
@@ -1565,8 +1565,8 @@ val MEM_index_list_EL = prove(``
   simp[])
 
 val _ = type_abbrev("result", ``:'a wordSem$result``)
-val alloc_IMP_alloc = prove(
-  ``(wordSem$alloc c names (s:('a,'ffi) wordSem$state) = (res:'a result option,s1)) /\
+val alloc_IMP_alloc = Q.prove(
+  `(wordSem$alloc c names (s:('a,'ffi) wordSem$state) = (res:'a result option,s1)) /\
     (∀x. x ∈ domain names ⇒ EVEN x /\ k ≤ x DIV 2) /\
     1 ≤ f /\
     state_rel k f f' s t5 lens /\
@@ -1579,7 +1579,7 @@ val alloc_IMP_alloc = prove(
         res1 = NONE /\ state_rel k f f' s1 t1 lens
       else
         res = SOME NotEnoughSpace /\ res1 = SOME (Halt (Word 1w)) /\
-        s1.clock = t1.clock /\ s1.ffi = t1.ffi``,
+        s1.clock = t1.clock /\ s1.ffi = t1.ffi`,
   Cases_on `FST (alloc c names (s:('a,'ffi) wordSem$state)) = SOME (Error:'a result)`
   THEN1 (rpt strip_tac \\ fsrw_tac[] [] \\ rfs [])
   \\ fsrw_tac[] [alloc_alt, stackSemTheory.alloc_def]
@@ -1708,7 +1708,7 @@ val word_gc_empty_frame = Q.prove(`
   rw[]>>rveq>>fs[pop_env_def]>>
   fs[state_component_equality])
 
-val alloc_IMP_alloc2 = prove(``
+val alloc_IMP_alloc2 = Q.prove(`
   (wordSem$alloc c names (s:('a,'ffi) wordSem$state) = (res:'a result option,s1)) ∧
   state_rel k 0 0 s t lens ∧
   domain names = {} ∧
@@ -1719,7 +1719,7 @@ val alloc_IMP_alloc2 = prove(``
       res1 = NONE ∧ state_rel k 0 0 s1 t1 lens
     else
       res = SOME NotEnoughSpace /\ res1 = SOME (Halt (Word 1w)) ∧
-      s1.clock = t1.clock /\ s1.ffi = t1.ffi``,
+      s1.clock = t1.clock /\ s1.ffi = t1.ffi`,
   Cases_on `FST (alloc c names (s:('a,'ffi) wordSem$state)) = SOME (Error:'a result)`
   THEN1 (rpt strip_tac \\ fs [] \\ rfs [])
   \\ fs [alloc_alt, stackSemTheory.alloc_def]
@@ -2014,9 +2014,9 @@ val LASTN_LESS = Q.prove(`
   imp_res_tac LASTN_LENGTH_ID2>>
   fs[LASTN_CONS])
 
-val ALOOKUP_IFF_MEM = prove(
-  ``ALL_DISTINCT (MAP FST l) ==>
-    (ALOOKUP l q = SOME r <=> MEM (q,r) l)``,
+val ALOOKUP_IFF_MEM = Q.prove(
+  `ALL_DISTINCT (MAP FST l) ==>
+    (ALOOKUP l q = SOME r <=> MEM (q,r) l)`,
   Induct_on `l` \\ fs [FORALL_PROD,MEM_MAP] \\ rw [] \\ metis_tac []);
 
 val SORTED_CONS_IMP = Q.prove(
@@ -2055,7 +2055,7 @@ val SORTED_FST_PERM_IMP_ALIST_EQ = Q.prove(
   \\ `!m n:num. m > n /\ n > m ==> F` by decide_tac
   \\ metis_tac []);
 
-val stack_rel_raise = prove(``
+val stack_rel_raise = Q.prove(`
     n ≤ LENGTH sstack /\
     handler+1 ≤ LENGTH wstack /\ SORTED (\x y. FST x > FST y) l /\
     LASTN (handler + 1) wstack = StackFrame l (SOME (h1,l3,l4))::rest /\
@@ -2076,7 +2076,7 @@ val stack_rel_raise = prove(``
             ((NONE,payload) :: LASTN handler stack) /\
       abs_stack bs (StackFrame (FST (env_to_list (fromAList l) (K I))) NONE::rest)
         (DROP (LENGTH sstack - handler_val (LASTN (handler+1) stack) + 3)
-           sstack) (LASTN (handler+1) lens) = SOME ((NONE,payload) :: LASTN handler stack)``,
+           sstack) (LASTN (handler+1) lens) = SOME ((NONE,payload) :: LASTN handler stack)`,
   rw[]>>
   imp_res_tac abs_stack_prefix_drop>>
   fs[LET_THM]>>
@@ -2202,16 +2202,16 @@ val comp_IMP_isPREFIX = Q.store_thm("comp_IMP_isPREFIX",
   \\ rveq
   \\ metis_tac[IS_PREFIX_TRANS,wLive_isPREFIX]);
 
-val compile_prog_isPREFIX = prove(
-  ``compile_prog x y k bs = (prog,bs1) ==> bs ≼ bs1``,
+val compile_prog_isPREFIX = Q.prove(
+  `compile_prog x y k bs = (prog,bs1) ==> bs ≼ bs1`,
   fs [compile_prog_def,LET_THM] \\ rw []
   \\ pairarg_tac \\ fs []
   \\ imp_res_tac comp_IMP_isPREFIX
   \\ imp_res_tac IS_PREFIX_TRANS \\ fs []);
 
-val compile_word_to_stack_isPREFIX = store_thm("compile_word_to_stack_isPREFIX",
-  ``!code k bs progs1 bs1.
-       compile_word_to_stack k code bs = (progs1,bs1) ==> bs ≼ bs1``,
+val compile_word_to_stack_isPREFIX = Q.store_thm("compile_word_to_stack_isPREFIX",
+  `!code k bs progs1 bs1.
+       compile_word_to_stack k code bs = (progs1,bs1) ==> bs ≼ bs1`,
   Induct \\ fs [compile_word_to_stack_def,FORALL_PROD,LET_THM] \\ rw []
   \\ pairarg_tac \\ fs []
   \\ pairarg_tac \\ fs [] \\ rw []
@@ -2617,9 +2617,9 @@ val evaluate_wMoveAux_seqsem = Q.store_thm("evaluate_wMoveAux_seqsem",
   \\ Cases_on`z` \\ fs[]
   \\ res_tac \\ fs[]);
 
-val evaluate_SeqStackFree = store_thm("evaluate_SeqStackFree",
-  ``s.use_stack /\ s.stack_space <= LENGTH s.stack ==>
-    evaluate (SeqStackFree n p,s) = evaluate (Seq (StackFree n) p,s)``,
+val evaluate_SeqStackFree = Q.store_thm("evaluate_SeqStackFree",
+  `s.use_stack /\ s.stack_space <= LENGTH s.stack ==>
+    evaluate (SeqStackFree n p,s) = evaluate (Seq (StackFree n) p,s)`,
   RW_TAC std_ss [SeqStackFree_def,stackSemTheory.evaluate_def]
   THEN1 (`F` by decide_tac)
   \\ AP_TERM_TAC \\ fs [stackSemTheory.state_component_equality]);
@@ -2641,8 +2641,8 @@ val LAST_add_ret_loc = Q.prove(`
   Cases_on`ret`>>TRY(PairCases_on`x`)>>fs[add_ret_loc_def]>>
   Cases_on`args'`>>fs[LAST_CONS])
 
-val call_dest_lemma = prove(
-  ``¬bad_dest_args dest args /\
+val call_dest_lemma = Q.prove(
+  `¬bad_dest_args dest args /\
     state_rel k f f' (s:('a,'ffi) state) t lens /\
     call_dest dest args (k,f,f') = (q0,dest') /\
     get_vars args s = SOME args' ==>
@@ -2653,7 +2653,7 @@ val call_dest_lemma = prove(
             ?bs bs2 stack_prog.
               compile_prog prog (LENGTH real_args) k bs = (stack_prog,bs2) ∧
               bs2 ≼ t4.bitmaps /\
-              find_code dest' t4.regs t4.code = SOME stack_prog``,
+              find_code dest' t4.regs t4.code = SOME stack_prog`,
   Cases_on`dest`>>fs[call_dest_def,bad_dest_args_def,LENGTH_NIL]>>rw[]
   >-
     (fs[wReg2_def,TWOxDIV2,LET_THM]>>
@@ -2916,12 +2916,12 @@ val insert_unchanged = Q.prove(`
   imp_res_tac splem1>>
   metis_tac[])
 
-val alist_insert_ALL_DISTINCT = prove(``
+val alist_insert_ALL_DISTINCT = Q.prove(`
   ∀xs ys t ls.
   ALL_DISTINCT xs ∧
   LENGTH xs = LENGTH ys ∧
   PERM (ZIP (xs,ys)) ls ⇒
-  alist_insert xs ys t = alist_insert (MAP FST ls) (MAP SND ls) t``,
+  alist_insert xs ys t = alist_insert (MAP FST ls) (MAP SND ls) t`,
   ho_match_mp_tac alist_insert_ind>>rw[]>>
   fs[LENGTH_NIL_SYM]>>rveq>>fs[ZIP]>>
   simp[alist_insert_def]>>
@@ -4079,10 +4079,10 @@ val list_max_GENLIST_evens2 = Q.store_thm("list_max_GENLIST_evens2",`
   fs[GENLIST,list_max_SNOC,MAX_DEF]>>
   DECIDE_TAC)
 
-val evaluate_wStackLoad_seq = store_thm("evaluate_wStackLoad_seq",
-  ``∀ls prog s.
+val evaluate_wStackLoad_seq = Q.store_thm("evaluate_wStackLoad_seq",
+  `∀ls prog s.
   evaluate(wStackLoad ls prog,s) =
-  evaluate (Seq (wStackLoad ls Skip) prog,s)``,
+  evaluate (Seq (wStackLoad ls Skip) prog,s)`,
   Induct>>rw[]>>fs[stackSemTheory.evaluate_def,wStackLoad_def,LET_THM]>>rw[]>>
   Cases_on`h`>>
   simp[wStackLoad_def]>>
@@ -4090,7 +4090,7 @@ val evaluate_wStackLoad_seq = store_thm("evaluate_wStackLoad_seq",
   simp[stackSemTheory.evaluate_def]>>
   EVERY_CASE_TAC>>fs[])
 
-val evaluate_wStackLoad_wReg1 = prove(``
+val evaluate_wStackLoad_wReg1 = Q.prove(`
   wReg1 r (k,f,f') = (x ,r') ∧
   EVEN r ∧
   get_var r (s:('a,'ffi)state) = SOME (Word c) ∧
@@ -4100,7 +4100,7 @@ val evaluate_wStackLoad_wReg1 = prove(``
   t.clock = t'.clock ∧
   state_rel k f f' s t' lens ∧
   r' ≠ k+1 ∧
-  get_var r' t' = SOME (Word c)``,
+  get_var r' t' = SOME (Word c)`,
   rw[wReg1_def,LET_THM,EVEN_EXISTS]>>
   fs[wStackLoad_def,stackSemTheory.evaluate_def,LET_THM,stackSemTheory.get_var_def]>>simp[]>-
     (imp_res_tac state_rel_get_var_imp>>
@@ -4116,14 +4116,14 @@ val evaluate_wStackLoad_wReg1 = prove(``
   simp[stackSemTheory.set_var_def,FLOOKUP_UPDATE]>>
   fs[TWOxDIV2])
 
-val evaluate_wStackLoad_clock = prove(``
+val evaluate_wStackLoad_clock = Q.prove(`
   ∀x t.
   evaluate(wStackLoad x Skip,t with clock:= clk) =
   (FST (evaluate(wStackLoad x Skip,t)),
-   (SND (evaluate(wStackLoad x Skip,t))) with clock:=clk)``,
+   (SND (evaluate(wStackLoad x Skip,t))) with clock:=clk)`,
   Induct>>fs[wStackLoad_def,FORALL_PROD,stackSemTheory.evaluate_def,LET_THM]>>rw[])
 
-val evaluate_wStackLoad_wRegImm2 = prove(``
+val evaluate_wStackLoad_wRegImm2 = Q.prove(`
   wRegImm2 ri (k,f,f') = (x,r') ∧
   (case ri of Reg r => EVEN r | _ => T) ∧
   get_var_imm ri (s:('a,'ffi)state) = SOME (Word c) ∧
@@ -4133,7 +4133,7 @@ val evaluate_wStackLoad_wRegImm2 = prove(``
   t.clock = t'.clock ∧
   get_var_imm r' t' = SOME(Word c) ∧
   (∀r. r ≠ k+1 ⇒ get_var r t' = get_var r t) ∧
-  state_rel k f f' s t' lens``,
+  state_rel k f f' s t' lens`,
   Cases_on`ri`>>rw[wRegImm2_def,LET_THM,wReg2_def,EVEN_EXISTS]>>
   fs[wStackLoad_def,stackSemTheory.evaluate_def,LET_THM,stackSemTheory.get_var_def,stackSemTheory.get_var_imm_def,get_var_imm_def]>>simp[]>-
     (imp_res_tac state_rel_get_var_imp>>
@@ -4149,21 +4149,21 @@ val evaluate_wStackLoad_wRegImm2 = prove(``
   simp[stackSemTheory.set_var_def,FLOOKUP_UPDATE]>>
   fs[TWOxDIV2])
 
-val evaluate_call_dest_clock = prove(``
+val evaluate_call_dest_clock = Q.prove(`
   call_dest dest args (k,f,f') = (q0,dest') ⇒
   evaluate(q0,t with clock := clk) =
   (FST(evaluate(q0,t:('a,'ffi)stackSem$state)),
-   (SND(evaluate(q0,t))) with clock := clk)``,
+   (SND(evaluate(q0,t))) with clock := clk)`,
   Cases_on`dest`>>fs[call_dest_def,LET_THM]>>rw[]>>
   simp[stackSemTheory.evaluate_def]>>
   pairarg_tac>>fs[]>>rveq>>fs[evaluate_wStackLoad_clock])
 
-val evaluate_wLive_clock = prove(``
+val evaluate_wLive_clock = Q.prove(`
   ∀x t q bs bs'.
   wLive x bs kf = (q,bs') ⇒
   evaluate(q, t with clock:= clk) =
   (FST (evaluate(q,t:('a,'ffi)stackSem$state)),
-   (SND (evaluate(q,t)) with clock:=clk))``,
+   (SND (evaluate(q,t)) with clock:=clk))`,
   PairCases_on`kf`>>fs[wLive_def,LET_THM]>>rw[]
   >-
     simp[stackSemTheory.evaluate_def]
@@ -4178,7 +4178,7 @@ val state_rel_IMP_LENGTH = Q.prove(`
   fs[state_rel_def,stack_rel_def,LET_THM]>>rw[]>>
   metis_tac[abs_stack_IMP_LENGTH])
 
-val evaluate_stack_move = prove(``
+val evaluate_stack_move = Q.prove(`
   ∀n tar t offset.
   t.use_stack ∧
   t.stack_space + tar + n + offset ≤ LENGTH t.stack ∧
@@ -4197,7 +4197,7 @@ val evaluate_stack_move = prove(``
   (*Copying the first frame*)
   let stack = DROP (t'.stack_space+tar) t'.stack in
   ∀x. x < n ⇒
-  EL x stack = EL (x+offset) stack``,
+  EL x stack = EL (x+offset) stack`,
   Induct>>fsrw_tac[][stack_move_def,stackSemTheory.evaluate_def]>-
     simp[stackSemTheory.state_component_equality]>>
   ntac 4 strip_tac>>
@@ -4225,10 +4225,10 @@ val evaluate_stack_move = prove(``
     first_x_assum(qspec_then`x-1` mp_tac)>>
     simp[EL_DROP])
 
-val evaluate_stack_move_seq = prove(``
+val evaluate_stack_move_seq = Q.prove(`
   ∀a b c d prog (t:('a,'ffi)stackSem$state).
   evaluate (stack_move a b c d prog,t) =
-  evaluate (Seq prog (stack_move a b c d Skip),t)``,
+  evaluate (Seq prog (stack_move a b c d Skip),t)`,
   Induct>>rw[]>>fs[stack_move_def,LET_THM]
   >-
     (simp[stackSemTheory.evaluate_def]>>
@@ -4242,12 +4242,12 @@ val evaluate_stack_move_seq = prove(``
     IF_CASES_TAC>>fs[]>>
     rpt IF_CASES_TAC>>fs[]);
 
-val evaluate_stack_move_clock = prove(``
+val evaluate_stack_move_clock = Q.prove(`
   ∀a b c d (t:('a,'ffi)stackSem$state).
   let prog = stack_move a b c d Skip in
   evaluate (prog,t with clock:=clk) =
   (FST (evaluate(prog,t:('a,'ffi)stackSem$state)),
-   (SND (evaluate(prog,t)) with clock:=clk))``,
+   (SND (evaluate(prog,t)) with clock:=clk))`,
   Induct>>fs[LET_THM,stack_move_def,stackSemTheory.evaluate_def]>>rw[]>>
   TRY(pairarg_tac>>fs[])>>
   simp[]>>
@@ -4273,9 +4273,9 @@ val stack_rel_DROP_NONE = Q.prove(`
   imp_res_tac abs_stack_IMP_LENGTH>>
   simp[LASTN_CONS]);
 
-val stack_rel_DROP_SOME = prove(``
+val stack_rel_DROP_SOME = Q.prove(`
   stack_rel k whandler (StackFrame l (SOME (whandler',b,c))::wstack) shandler sstack len bs (f'::lens) ⇒
-  stack_rel k whandler' wstack (SOME(EL 2 sstack)) (DROP (f'+4) sstack) len bs lens``,
+  stack_rel k whandler' wstack (SOME(EL 2 sstack)) (DROP (f'+4) sstack) len bs lens`,
   simp[stack_rel_def]>>rw[]>>
   Cases_on`sstack`>>fs[abs_stack_def]>>qpat_x_assum`A=SOME stack` mp_tac>>
   rpt (TOP_CASE_TAC>>simp[])>>
@@ -4300,9 +4300,9 @@ val stack_rel_cons_LEN_NONE = Q.prove(`
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
   rpt TOP_CASE_TAC>>simp[])
 
-val stack_rel_cons_LEN_SOME = prove(``
+val stack_rel_cons_LEN_SOME = Q.prove(`
   stack_rel k whandler (StackFrame l (SOME(a,b,c))::wstack) shandler sstack len bs (f'::lens) ⇒
-  f'+4 ≤ LENGTH sstack``,
+  f'+4 ≤ LENGTH sstack`,
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
   rpt TOP_CASE_TAC>>simp[]);
 
@@ -4324,7 +4324,7 @@ val DROP_SUB2 = Q.prove(`
   fs[]>>rw[]>>
   simp[]);
 
-val evaluate_PushHandler = prove(``
+val evaluate_PushHandler = Q.prove(`
   3 ≤ t.stack_space ∧
   state_rel k 0 0 (push_env x' NONE s with locals:=LN) t (f'::lens) ∧
   loc_check t.code (x''2,x''3) ⇒
@@ -4337,7 +4337,7 @@ val evaluate_PushHandler = prove(``
   (∀i. i ≠ k ⇒ get_var i t' = get_var i t) ∧
   t'.stack_space +3 = t.stack_space ∧
   LENGTH t'.stack = LENGTH t.stack ∧
-  state_rel k 0 0 (push_env x' (SOME (x''0,x''1,x''2,x''3)) s with locals:=LN) t' (f'::lens)``,
+  state_rel k 0 0 (push_env x' (SOME (x''0,x''1,x''2,x''3)) s with locals:=LN) t' (f'::lens)`,
   rw[]>>
   `t.use_stack ∧ t.use_store ∧ t.stack_space -3 < LENGTH t.stack ∧ ∃h. FLOOKUP t.store Handler = SOME h` by
     (fs[state_rel_def,flookup_thm]>>
@@ -4392,30 +4392,30 @@ val evaluate_PushHandler = prove(``
   rw[]>>
   simp[LASTN_CONS]);
 
-val evaluate_PushHandler_clock = prove(``
+val evaluate_PushHandler_clock = Q.prove(`
   ∀(t:('a,'ffi)stackSem$state).
   let prog = PushHandler a b (k,f:num,f':num) in
   evaluate (prog,t with clock:=clk) =
   (FST (evaluate(prog,t:('a,'ffi)stackSem$state)),
-   (SND (evaluate(prog,t)) with clock:=clk))``,
+   (SND (evaluate(prog,t)) with clock:=clk))`,
   simp[PushHandler_def,stackSemTheory.evaluate_def,stackSemTheory.inst_def,stackSemTheory.assign_def,stackSemTheory.word_exp_def,stackSemTheory.get_var_def,stackSemTheory.set_var_def,stackSemTheory.set_store_def]>>rw[]>>
   TOP_CASE_TAC>>fs[empty_env_def,FLOOKUP_UPDATE]>>
   rpt(TOP_CASE_TAC>>fs[]))|>SIMP_RULE arith_ss [LET_THM];
 
-val evaluate_PopHandler_clock = prove(``
+val evaluate_PopHandler_clock = Q.prove(`
   ∀(t:('a,'ffi)stackSem$state).
   let prog = PopHandler (k,f:num,f':num) Skip in
   evaluate (prog,t with clock:=clk) =
   (FST (evaluate(prog,t:('a,'ffi)stackSem$state)),
-   (SND (evaluate(prog,t)) with clock:=clk))``,
+   (SND (evaluate(prog,t)) with clock:=clk))`,
   simp[stackSemTheory.evaluate_def,PopHandler_def,stackSemTheory.set_var_def,stackSemTheory.get_var_def,stackSemTheory.set_store_def,empty_env_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[]>>
   EVERY_CASE_TAC>>fs[]);
 
-val evaluate_PopHandler_seq = prove(``
+val evaluate_PopHandler_seq = Q.prove(`
   ∀prog (t:('a,'ffi)stackSem$state).
   evaluate (PopHandler (k,f,f') prog,t) =
-  evaluate (Seq (PopHandler (k,f,f') Skip) prog,t)``,
+  evaluate (Seq (PopHandler (k,f,f') Skip) prog,t)`,
   simp[stackSemTheory.evaluate_def,PopHandler_def]>>
   rw[]>>EVERY_CASE_TAC>>fs[]>>
   EVERY_CASE_TAC>>fs[]);
@@ -6240,8 +6240,8 @@ val comp_correct = Q.store_thm("comp_correct",
       strip_tac>>
       fs[state_rel_def]));
 
-val evaluate_Seq_Skip = prove(
-  ``stackSem$evaluate (Seq Skip p,s) = evaluate (p,s)``,
+val evaluate_Seq_Skip = Q.prove(
+  `stackSem$evaluate (Seq Skip p,s) = evaluate (p,s)`,
   fs [stackSemTheory.evaluate_def,LET_THM]);
 
 val comp_Call_lemma = comp_correct
@@ -6254,8 +6254,8 @@ val comp_Call_lemma = comp_correct
        EVAL  ``flat_exp_conventions (Call NONE (SOME start) [0] NONE)``,
        word_allocTheory.max_var_def,LET_DEF,MAX_DEF] |> GEN_ALL
 
-val comp_Call = prove(
-  ``∀start (s:('a,'ffi) wordSem$state) k res s1 t lens.
+val comp_Call = Q.prove(
+  `∀start (s:('a,'ffi) wordSem$state) k res s1 t lens.
       evaluate (Call NONE (SOME start) [0] NONE,s) = (res,s1) /\
       res ≠ SOME Error /\ state_rel k 0 0 s t lens ⇒
       ∃ck t1 res1.
@@ -6266,7 +6266,7 @@ val comp_Call = prove(
         else
           res1 = SOME (Halt (Word 2w)) /\
           t1.ffi.io_events ≼ s1.ffi.io_events /\
-          (IS_SOME t1.ffi.final_event ⇒ t1.ffi = s1.ffi)``,
+          (IS_SOME t1.ffi.final_event ⇒ t1.ffi = s1.ffi)`,
   rw [] \\ drule comp_Call_lemma \\ fs [get_labels_def]
   \\ disch_then drule \\ disch_then(qspecl_then[`t.bitmaps`] mp_tac)
   \\ fs [] \\ strip_tac
@@ -6579,8 +6579,8 @@ val make_init_def = Define `
      ; ffi     := t.ffi
      ; termdep := 0 |> `;
 
-val init_state_ok_IMP_state_rel = prove(
-  ``lookup raise_stub_location t.code = SOME (raise_stub k) /\
+val init_state_ok_IMP_state_rel = Q.prove(
+  `lookup raise_stub_location t.code = SOME (raise_stub k) /\
     (!n word_prog arg_count.
        (lookup n code = SOME (arg_count,word_prog)) ==>
        post_alloc_conventions k word_prog /\
@@ -6590,7 +6590,7 @@ val init_state_ok_IMP_state_rel = prove(
          isPREFIX bs2 t.bitmaps /\
          (lookup n t.code = SOME stack_prog)) /\
     init_state_ok k t ==>
-    state_rel k 0 0 (make_init t code) (t:('a,'ffi)stackSem$state) []``,
+    state_rel k 0 0 (make_init t code) (t:('a,'ffi)stackSem$state) []`,
   fs [state_rel_def,make_init_def,LET_DEF,lookup_def,init_state_ok_def] \\ rw []
   \\ fs [stack_rel_def,sorted_env_def,abs_stack_def,LET_THM]
   \\ fs [handler_val_def,LASTN_def,stack_rel_aux_def]
@@ -6605,14 +6605,14 @@ val init_state_ok_semantics =
   |> (fn th => (MATCH_MP th (UNDISCH init_state_ok_IMP_state_rel)))
   |> DISCH_ALL |> SIMP_RULE std_ss [AND_IMP_INTRO,GSYM CONJ_ASSOC]
 
-val compile_word_to_stack_IMP_ALOOKUP = prove(
-  ``!code k bs progs bitmaps n arg_count word_prog x.
+val compile_word_to_stack_IMP_ALOOKUP = Q.prove(
+  `!code k bs progs bitmaps n arg_count word_prog x.
       compile_word_to_stack k code bs = (progs,bitmaps) /\
       ALOOKUP code n = SOME (arg_count,word_prog) /\
       bitmaps ≼ x ⇒
       ∃bs bs2 stack_prog.
         compile_prog word_prog arg_count k bs = (stack_prog,bs2) ∧
-        bs2 ≼ x ∧ ALOOKUP progs n = SOME stack_prog``,
+        bs2 ≼ x ∧ ALOOKUP progs n = SOME stack_prog`,
   Induct \\ fs [] \\ strip_tac \\ PairCases_on `h`
   \\ fs [compile_word_to_stack_def] \\ rw [] \\ fs [LET_THM]
   \\ pairarg_tac \\ fs []
@@ -6622,14 +6622,14 @@ val compile_word_to_stack_IMP_ALOOKUP = prove(
   \\ first_x_assum match_mp_tac
   \\ asm_exists_tac \\ fs []);
 
-val compile_semantics = store_thm("compile_semantics",
-  ``(t:(α,'ffi)stackSem$state).code = fromAList (SND (compile asm_conf code)) /\
+val compile_semantics = Q.store_thm("compile_semantics",
+  `(t:(α,'ffi)stackSem$state).code = fromAList (SND (compile asm_conf code)) /\
     init_state_ok (asm_conf.reg_count - (5 + LENGTH asm_conf.avoid_regs)) t /\ (ALOOKUP code raise_stub_location = NONE) /\
     (FST (compile asm_conf code)).bitmaps ≼ t.bitmaps /\
     EVERY (λn,m,prog. flat_exp_conventions prog /\ post_alloc_conventions (asm_conf.reg_count - (5 + LENGTH asm_conf.avoid_regs)) prog) code /\
     semantics (make_init t (fromAList code)) start <> Fail ==>
     semantics start t IN
-    extend_with_resource_limit {semantics (make_init t (fromAList code)) start}``,
+    extend_with_resource_limit {semantics (make_init t (fromAList code)) start}`,
   qabbrev_tac `k = asm_conf.reg_count - (5 + LENGTH asm_conf.avoid_regs)`
   \\ rw [compile_def] \\ match_mp_tac (GEN_ALL init_state_ok_semantics)
   \\ qexists_tac `k` \\ fs []
@@ -6697,7 +6697,7 @@ val word_to_stack_lab_pres = Q.store_thm("word_to_stack_lab_pres",`
     EVERY_CASE_TAC>>fs[]>>rveq>>fs[]>>EVAL_TAC)
   >- (EVAL_TAC>>EVERY_CASE_TAC>>EVAL_TAC))
 
-val word_to_stack_compile_lab_pres = store_thm("word_to_stack_compile_lab_pres",``
+val word_to_stack_compile_lab_pres = Q.store_thm("word_to_stack_compile_lab_pres",`
   EVERY (λn,m,p.
     let labs = extract_labels p in
     EVERY (λ(l1,l2).l1 = n ∧ l2 ≠ 0) labs ∧
@@ -6707,7 +6707,7 @@ val word_to_stack_compile_lab_pres = store_thm("word_to_stack_compile_lab_pres",
     EVERY (λn,p.
       let labs = extract_labels p in
       EVERY (λ(l1,l2).l1 = n ∧ l2 ≠ 0) labs ∧
-      ALL_DISTINCT labs) p``,
+      ALL_DISTINCT labs) p`,
   fs[compile_def]>>pairarg_tac>>rw[]>>
   pairarg_tac>>fs[]>>rveq>>fs[]>>
   EVAL_TAC>>

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -6746,19 +6746,19 @@ val word_to_stack_compile_lab_pres = Q.store_thm("word_to_stack_compile_lab_pres
   pairarg_tac>>rw[]>>EVAL_TAC>>
   metis_tac[FST,word_to_stack_lab_pres])
 
-val EVEN_DIV_2_props = prove(``
+val EVEN_DIV_2_props = Q.prove(`
   a MOD 2 = 0 ∧ b MOD 2 = 0 ⇒
-  (a ≠ b ⇒ a DIV 2 ≠ b DIV 2) ∧ (a ≠ 0 ⇒ a DIV 2 ≠ 0)``,
+  (a ≠ b ⇒ a DIV 2 ≠ b DIV 2) ∧ (a ≠ 0 ⇒ a DIV 2 ≠ 0)`,
   cheat)
 
 val wconvs = [post_alloc_conventions_def,wordPropsTheory.full_inst_ok_less_def,call_arg_convention_def,wordLangTheory.every_var_def,wordLangTheory.every_stack_var_def]
 
-val call_dest_stack_asm_name = prove(``
+val call_dest_stack_asm_name = Q.prove(`
   call_dest d a k = (q0,d') ⇒
   stack_asm_name c q0 ∧
   case d' of
     INR r => r ≤ (FST k)+1
-  | INL l => T``,
+  | INL l => T`,
   Cases_on`d`>>EVAL_TAC>>rw[]>>
   EVAL_TAC>>
   pairarg_tac>>fs[]>>
@@ -6766,24 +6766,24 @@ val call_dest_stack_asm_name = prove(``
   EVAL_TAC>>rw[]>>
   EVAL_TAC>>rw[])
 
-val wLive_stack_asm_name = prove(``
+val wLive_stack_asm_name = Q.prove(`
   (FST kf)+1 < c.reg_count - LENGTH c.avoid_regs ∧
   wLive q bs kf = (q1,bs') ⇒
-  stack_asm_name c q1``,
+  stack_asm_name c q1`,
   PairCases_on`kf`>>
   fs[wLive_def]>>
   rw[]>-EVAL_TAC>>
   rpt(pairarg_tac>>fs[])>>
   rveq>>EVAL_TAC>>fs[])
 
-val word_to_stack_stack_asm_name_lem = prove(``
+val word_to_stack_stack_asm_name_lem = Q.prove(`
   ∀p bs kf c.
   post_alloc_conventions (FST kf) p ∧
   full_inst_ok_less c p ∧
   (c.two_reg_arith ⇒ every_inst two_reg_inst p) ∧
   (FST kf)+1 < c.reg_count - LENGTH c.avoid_regs ∧
   4 < (FST kf) ⇒
-  stack_asm_name c (FST (comp p bs kf))``,
+  stack_asm_name c (FST (comp p bs kf))`,
   ho_match_mp_tac comp_ind>>rw[]>>fs[comp_def,stack_asm_name_def]
   >-
     (PairCases_on`kf`>>fs[wMove_def]>>
@@ -6858,13 +6858,13 @@ val word_to_stack_stack_asm_name_lem = prove(``
     EVAL_TAC>>rw[]>>
     EVAL_TAC>>rw[]))
 
-val call_dest_stack_asm_remove = prove(``
+val call_dest_stack_asm_remove = Q.prove(`
   (FST k)+1 < c.reg_count - LENGTH c.avoid_regs ∧
   call_dest d a k = (q0,d') ⇒
   stack_asm_remove c q0 ∧
   case d' of
     INR r => r ≤ (FST k)+1
-  | INL l => T``,
+  | INL l => T`,
   Cases_on`d`>>EVAL_TAC>>rw[]>>
   EVAL_TAC>>
   pairarg_tac>>fs[]>>
@@ -6872,20 +6872,20 @@ val call_dest_stack_asm_remove = prove(``
   EVAL_TAC>>rw[]>>
   EVAL_TAC>>rw[])
 
-val wLive_stack_asm_remove = prove(``
+val wLive_stack_asm_remove = Q.prove(`
   (FST kf)+1 < c.reg_count - LENGTH c.avoid_regs ∧
   wLive q bs kf = (q1,bs') ⇒
-  stack_asm_remove c q1``,
+  stack_asm_remove c q1`,
   PairCases_on`kf`>>
   fs[wLive_def]>>
   rw[]>-EVAL_TAC>>
   rpt(pairarg_tac>>fs[])>>
   rveq>>EVAL_TAC>>fs[])
 
-val word_to_stack_stack_asm_remove_lem = prove(``
+val word_to_stack_stack_asm_remove_lem = Q.prove(`
   ∀(p:'a prog) bs kf (c:'a asm_config).
   (FST kf)+1 < c.reg_count - LENGTH c.avoid_regs ⇒
-  stack_asm_remove c (FST (comp p bs kf))``,
+  stack_asm_remove c (FST (comp p bs kf))`,
   ho_match_mp_tac comp_ind>>rw[]>>fs[comp_def,stack_asm_remove_def]
   >-
     (PairCases_on`kf`>>fs[wMove_def]>>
@@ -6944,13 +6944,13 @@ val word_to_stack_stack_asm_remove_lem = prove(``
     EVAL_TAC>>rw[]>>
     EVAL_TAC>>rw[]))
 
-val word_to_stack_stack_asm_convs = store_thm("word_to_stack_stack_asm_convs",``
+val word_to_stack_stack_asm_convs = Q.store_thm("word_to_stack_stack_asm_convs",`
   EVERY (λ(n,m,p).
   full_inst_ok_less c p ∧
   (c.two_reg_arith ⇒ every_inst two_reg_inst p) ∧
   post_alloc_conventions (c.reg_count - (LENGTH c.avoid_regs +5)) p) progs ∧
   4 < (c.reg_count - (LENGTH c.avoid_regs +5)) ⇒
-  EVERY (λ(n,p). stack_asm_name c p ∧ stack_asm_remove c p) (SND(compile c progs))``,
+  EVERY (λ(n,p). stack_asm_name c p ∧ stack_asm_remove c p) (SND(compile c progs))`,
   fs[compile_def]>>pairarg_tac>>rw[]
   >- (EVAL_TAC>>fs[])
   >- (EVAL_TAC>>fs[])

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -1095,7 +1095,7 @@ val evaluate_wLive = Q.prove(
     fsrw_tac[][Abbr`R`]>>
     fsrw_tac[][SORTED_EL_SUC]>>srw_tac[][]>>`n < m` by DECIDE_TAC>>
     fsrw_tac[][EL_GENLIST]>>DECIDE_TAC)
-  \\ rator_x_assum`cut_env`mp_tac
+  \\ qhdtm_x_assum`cut_env`mp_tac
   \\ simp[MEM_MAP,MEM_FILTER,MEM_GENLIST,PULL_EXISTS,MEM_QSORT,
             MEM_toAList,EXISTS_PROD,FORALL_PROD,cut_env_def]
   \\ strip_tac >> rveq
@@ -2091,7 +2091,7 @@ val stack_rel_raise = prove(``
   CONJ_TAC>- fs[LASTN_LESS]>>
   imp_res_tac abs_stack_len>>
   fs[handler_val_def]>>CONJ_ASM1_TAC>-
-    (rator_x_assum `abs_stack` mp_tac>>
+    (qhdtm_x_assum `abs_stack` mp_tac>>
     Cases_on`LASTN (handler+1) lens`>>fs[]>>
     (*The DROP must have length ≥ 3*)
     Cases_on`DROP n sstack`>>simp[abs_stack_def,LASTN_def]>>
@@ -2103,7 +2103,7 @@ val stack_rel_raise = prove(``
     Q.ISPECL_THEN [`n`,`sstack`] assume_tac LENGTH_DROP >>
     `LENGTH (DROP n sstack) ≤ LENGTH sstack` by DECIDE_TAC>>
     simp[])>>
-  rator_x_assum `abs_stack` mp_tac>>
+  qhdtm_x_assum `abs_stack` mp_tac>>
   qpat_abbrev_tac`ls = LASTN A B`>>
   qpat_abbrev_tac`lens' = LASTN A lens`>>
   strip_tac>>
@@ -2112,7 +2112,7 @@ val stack_rel_raise = prove(``
   qpat_abbrev_tac`preconds = (h1 < LENGTH rest ∧ B)`>>
   `EL 1 ls = Loc l3 l4
    ∧ (preconds ⇒ EL 2 ls = w)` by
-    (rator_x_assum`abs_stack` mp_tac>>
+    (qhdtm_x_assum`abs_stack` mp_tac>>
     Cases_on`lens'`>>fs[]>>
     Cases_on`ls`>-simp[abs_stack_def]>>
     Cases_on`h'`>>simp[abs_stack_def,LET_THM]>>
@@ -2263,7 +2263,7 @@ val state_rel_get_var_imp2 = Q.store_thm("state_rel_get_var_imp2",
   \\ simp[MULT_DIV]
   \\ simp[LLOOKUP_THM]
   \\ strip_tac
-  \\ rator_x_assum`EL`mp_tac
+  \\ qhdtm_x_assum`EL`mp_tac
   \\ simp[EL_TAKE]
   \\ simp[EL_DROP]
   \\ simp[ADD_COMM]);
@@ -2564,7 +2564,7 @@ val evaluate_wMoveAux_seqsem = Q.store_thm("evaluate_wMoveAux_seqsem",
       \\ metis_tac[IS_SOME_get_vars_set_var,IS_SOME_EXISTS])
     \\ reverse conj_tac
     >- (
-      rator_x_assum`ALL_DISTINCT`mp_tac
+      qhdtm_x_assum`ALL_DISTINCT`mp_tac
       \\ IF_CASES_TAC \\ simp[] )
     \\ BasicProvers.TOP_CASE_TAC \\ simp[]
     \\ qpat_x_assum`option_CASE (find_index _ _ _) _ _`mp_tac
@@ -2858,12 +2858,12 @@ val ALOOKUP_MAP_any = Q.store_thm("ALOOKUP_MAP_any",
   \\ rw[]
   >- (
     `F` suffices_by rw[]
-    \\ rator_x_assum`INJ`mp_tac
+    \\ qhdtm_x_assum`INJ`mp_tac
     \\ simp[INJ_DEF]
     \\ PROVE_TAC[] )
   \\ first_x_assum match_mp_tac
   \\ simp[]
-  \\ rator_x_assum`INJ`mp_tac
+  \\ qhdtm_x_assum`INJ`mp_tac
   \\ REWRITE_TAC[INJ_DEF,IN_INSERT,MEM_MAP]
   \\ PROVE_TAC[FST,PAIR]);
 
@@ -2886,7 +2886,7 @@ val ALOOKUP_MAP_INJ_FST = Q.store_thm("ALOOKUP_MAP_INJ_FST",
   \\ qmatch_assum_abbrev_tac`f x = v2`
   \\ `h = x ⇔ FST v1 = FST v2`
   by (
-    rator_x_assum`INJ`mp_tac
+    qhdtm_x_assum`INJ`mp_tac
     \\ REWRITE_TAC[INJ_DEF,IN_INSERT,IN_UNIV,o_DEF]
     \\ CONV_TAC(DEPTH_CONV BETA_CONV)
     \\ metis_tac[] )
@@ -2894,7 +2894,7 @@ val ALOOKUP_MAP_INJ_FST = Q.store_thm("ALOOKUP_MAP_INJ_FST",
   \\ IF_CASES_TAC \\ fs[]
   \\ first_x_assum(qspecl_then[`f`,`x`]mp_tac)
   \\ simp[] \\ disch_then match_mp_tac
-  \\ rator_x_assum`INJ`mp_tac
+  \\ qhdtm_x_assum`INJ`mp_tac
   \\ REWRITE_TAC[INJ_DEF,IN_INSERT,IN_UNIV]
   \\ metis_tac[]);
 
@@ -4536,7 +4536,7 @@ val comp_correct = Q.store_thm("comp_correct",
       \\ simp[GSYM MAP_MAP_o]
       \\ reverse conj_asm2_tac
       >- (
-        rator_x_assum`post_alloc_conventions`mp_tac
+        qhdtm_x_assum`post_alloc_conventions`mp_tac
         \\ simp[convs_def,EVERY_MEM,reg_allocTheory.is_phy_var_def,EVEN_MOD2] )
       \\ match_mp_tac ALL_DISTINCT_MAP_INJ
       \\ rw[]
@@ -4567,7 +4567,7 @@ val comp_correct = Q.store_thm("comp_correct",
         \\ simp[MEM_MAP,PULL_EXISTS]
         \\ simp[DIV2_def,bitTheory.DIV_MULT_THM2]
         \\ rw[] \\ res_tac
-        \\ rator_x_assum`post_alloc_conventions`mp_tac
+        \\ qhdtm_x_assum`post_alloc_conventions`mp_tac
         \\ simp[convs_def,EVERY_MEM,reg_allocTheory.is_phy_var_def,EVEN_MOD2]
         \\ simp[MEM_MAP,PULL_EXISTS] )
       \\ conj_tac
@@ -4601,7 +4601,7 @@ val comp_correct = Q.store_thm("comp_correct",
     \\ last_assum(Q.ISPEC_THEN`r`mp_tac o MATCH_MP parmoveTheory.parmove_correct)
     \\ simp[parmoveTheory.eqenv_def]
     \\ strip_tac
-    \\ rator_x_assum`state_rel`mp_tac
+    \\ qhdtm_x_assum`state_rel`mp_tac
     \\ qmatch_abbrev_tac`_ _ _ _ a _ _ ⇒ _ _ _ _ b _ _`
     \\ `a = b` suffices_by rw[]
     \\ simp[Abbr`a`,Abbr`b`]
@@ -5198,7 +5198,7 @@ val comp_correct = Q.store_thm("comp_correct",
     \\ PairCases_on `x` \\ fs [LET_DEF]
     \\ pairarg_tac \\ fs []
     \\ pairarg_tac \\ fs []
-    \\ rator_x_assum`wordSem$evaluate`mp_tac
+    \\ qhdtm_x_assum`wordSem$evaluate`mp_tac
     \\ simp[wordSemTheory.evaluate_def]
     \\ BasicProvers.TOP_CASE_TAC \\ fs[]
     \\ BasicProvers.TOP_CASE_TAC \\ fs[]
@@ -6305,7 +6305,7 @@ val state_rel_IMP_semantics = Q.store_thm("state_rel_IMP_semantics",
     simp[stackSemTheory.semantics_def] >>
     IF_CASES_TAC >- (
       fs[] >> rveq >> fs[] >>
-      rator_x_assum`wordSem$evaluate`kall_tac >>
+      qhdtm_x_assum`wordSem$evaluate`kall_tac >>
       last_x_assum(qspec_then`k''`mp_tac)>>simp[] >>
       (fn g => subterm (fn tm => Cases_on`^(assert(has_pair_type)tm)`) (#2 g) g) >>
       strip_tac >>
@@ -6351,7 +6351,7 @@ val state_rel_IMP_semantics = Q.store_thm("state_rel_IMP_semantics",
           Cases_on`t''.ffi.final_event`>>fs[]>>
           `t'.ffi = t''.ffi` by (every_case_tac >> fs[]) >>
           fs[]) >>
-        rator_x_assum`stackSem$evaluate`mp_tac >>
+        qhdtm_x_assum`stackSem$evaluate`mp_tac >>
         drule(GEN_ALL stackPropsTheory.evaluate_add_clock) >>
         simp[] >>
         disch_then(qspec_then`ck+k'`mp_tac) >>
@@ -6388,7 +6388,7 @@ val state_rel_IMP_semantics = Q.store_thm("state_rel_IMP_semantics",
         fs[] ) >>
       first_x_assum(qspec_then`k''`mp_tac)>>simp[]>>
       strip_tac >> fs[]>>
-      rator_x_assum`stackSem$evaluate`mp_tac >>
+      qhdtm_x_assum`stackSem$evaluate`mp_tac >>
       drule(GEN_ALL stackPropsTheory.evaluate_add_clock) >>
       disch_then(qspec_then`k'+ck`mp_tac) >>
       simp[] >> strip_tac >>
@@ -6457,7 +6457,7 @@ val state_rel_IMP_semantics = Q.store_thm("state_rel_IMP_semantics",
     first_assum(qspec_then`k'`mp_tac) >>
     first_x_assum(qspec_then`k'+ck`mp_tac) >>
     fsrw_tac[ARITH_ss][] >>
-    rator_x_assum`stackSem$evaluate`mp_tac >>
+    qhdtm_x_assum`stackSem$evaluate`mp_tac >>
     drule(GEN_ALL stackPropsTheory.evaluate_add_clock)>>
     simp[]>>
     disch_then(qspec_then`ck`mp_tac)>>

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -6527,7 +6527,7 @@ val state_rel_IMP_semantics = Q.store_thm("state_rel_IMP_semantics",
     IF_CASES_TAC >> simp[] >> strip_tac >> fs[] >>
     first_x_assum(qspec_then`ck+k'`mp_tac)>>simp[]>>
     BasicProvers.TOP_CASE_TAC >> simp[]) >>
-  (fn g => subterm (fn tm => Cases_on`^(replace_term(#1(dest_exists(#2 g)))(``k':num``)(assert(has_pair_type)tm))`) (#2 g) g) >>
+    (fn g => subterm (fn tm => Cases_on`^(Term.subst[{redex = #1(dest_exists(#2 g)), residue = ``k':num``}] (assert(has_pair_type)tm))`) (#2 g) g) >>
   drule comp_Call >>
   simp[GSYM AND_IMP_INTRO,RIGHT_FORALL_IMP_THM] >>
   impl_tac >- (

--- a/compiler/backend/proofs/word_to_wordProofScript.sml
+++ b/compiler/backend/proofs/word_to_wordProofScript.sml
@@ -17,7 +17,7 @@ val is_phy_var_tac =
 val rmd_thms = (remove_dead_conventions |>SIMP_RULE std_ss [LET_THM,FORALL_AND_THM])|>CONJUNCTS
 
 (*Chains up compile_single theorems*)
-val compile_single_lem = store_thm("compile_single_lem",``
+val compile_single_lem = Q.store_thm("compile_single_lem",`
   ∀prog n st.
   domain st.locals = set(even_list n)
   ⇒
@@ -30,7 +30,7 @@ val compile_single_lem = store_thm("compile_single_lem",``
     word_state_eq_rel rst rcst ∧
     case res of
       SOME _ => rst.locals = rcst.locals
-    | _ => T``,
+    | _ => T`,
   full_simp_tac(srw_ss())[compile_single_def,LET_DEF]>>srw_tac[][]>>
   qpat_abbrev_tac`p1 = inst_select A B C`>>
   qpat_abbrev_tac`p2 = full_ssa_cc_trans n p1`>>
@@ -93,9 +93,9 @@ val get_vars_code_frame = Q.prove(`
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_def])
 
 (*TODO: Move to wordProps so there're no scoping problems..*)
-val word_exp_code_frame = prove(``
+val word_exp_code_frame = Q.prove(`
   ∀(s:('a,'b) wordSem$state) exp. word_exp (s with code:=l) exp =
-          word_exp s (exp:'a wordLang$exp)``,
+          word_exp s (exp:'a wordLang$exp)`,
   ho_match_mp_tac wordSemTheory.word_exp_ind>>srw_tac[][word_exp_def]
   >-
     (every_case_tac>>full_simp_tac(srw_ss())[mem_load_def])
@@ -114,14 +114,14 @@ val rm_perm = Q.prove(`
 
 val size_tac= (full_simp_tac(srw_ss())[wordLangTheory.prog_size_def]>>DECIDE_TAC);
 
-val find_code_thm = prove(``
+val find_code_thm = Q.prove(`
   (!n v. lookup n st.code = SOME v ==>
          ∃t k a c col.
          lookup n l = SOME (SND (compile_single t k a c ((n,v),col)))) ∧
   find_code o1 (add_ret_loc o' x) st.code = SOME (args,prog) ⇒
   ∃t k a c col n prog'.
   SND(compile_single t k a c ((n,LENGTH args,prog),col)) = (LENGTH args,prog') ∧
-  find_code o1 (add_ret_loc o' x) l = SOME(args,prog')``,
+  find_code o1 (add_ret_loc o' x) l = SOME(args,prog')`,
   Cases_on`o1`>>simp[find_code_def]>>srw_tac[][]
   >-
     (ntac 2 (TOP_CASE_TAC>>full_simp_tac(srw_ss())[])>>
@@ -144,7 +144,7 @@ val pop_env_termdep = Q.prove(`
   pop_env rst = SOME x ⇒ x.termdep = rst.termdep`,
   full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[state_component_equality])
 
-val compile_single_correct = prove(``
+val compile_single_correct = Q.prove(`
   ∀prog st l.
   (!n v. lookup n st.code = SOME v ==>
          ∃t k a c col.
@@ -156,7 +156,7 @@ val compile_single_correct = prove(``
         let (res1,rst1) = evaluate (prog,st with code := l) in
           res1 = res ∧
           rst.code = st.code ∧
-          rst1 = rst with code:=l``,
+          rst1 = rst with code:=l`,
   (*recInduct doesn't seem to give a nice induction thm*)
   completeInduct_on`((st:('a,'b)wordSem$state).termdep)`>>
   completeInduct_on`((st:('a,'b)wordSem$state).clock)`>>
@@ -479,8 +479,8 @@ val compile_single_correct = prove(``
   >- (tac>>
      Cases_on`call_FFI st.ffi n x'`>>simp[]));
 
-val compile_word_to_word_thm = store_thm("compile_word_to_word_thm",
-  ``(!n v. lookup n (st:('a,'ffi)wordSem$state).code = SOME v ==>
+val compile_word_to_word_thm = Q.store_thm("compile_word_to_word_thm",
+  `(!n v. lookup n (st:('a,'ffi)wordSem$state).code = SOME v ==>
            ∃t k a c col.
            lookup n l = SOME (SND (full_compile_single t k a c ((n,v),col)))) ==>
     ?perm' clk.
@@ -488,7 +488,7 @@ val compile_word_to_word_thm = store_thm("compile_word_to_word_thm",
       let (res,rst) = evaluate (prog,st with permute := perm') in
         if res = SOME Error then T else
           let (res1,rst1) = evaluate (prog,st with <|code := l;clock:=st.clock+clk;termdep:=0|>) in
-            res1 = res /\ rst1.clock = rst.clock /\ rst1.ffi = rst.ffi``,
+            res1 = res /\ rst1.clock = rst.clock /\ rst1.ffi = rst.ffi`,
   simp[LET_THM]>>
   srw_tac[][]>>
   (*namely, l' is some map over st.code that replicates l everywhere except
@@ -540,7 +540,7 @@ val rmt_thms = (remove_must_terminate_conventions|>SIMP_RULE std_ss [LET_THM,FOR
   inst_ok_less and two_reg_inst are IGNORED for now
   since we still have an exit check in lab_to_target
 *)
-val compile_conventions = store_thm("compile_to_word_conventions",``
+val compile_conventions = Q.store_thm("compile_to_word_conventions",`
   (*addr_offset_ok 0w ac ∧ EVERY (λ(n,m,prog). every_inst (λi. F) prog) p ⇒*)
   let (_,progs) = compile wc ac p in
   MAP FST progs = MAP FST p ∧
@@ -550,7 +550,7 @@ val compile_conventions = store_thm("compile_to_word_conventions",``
     flat_exp_conventions prog ∧
     post_alloc_conventions (ac.reg_count - (5+LENGTH ac.avoid_regs)) prog
     (*full_inst_ok_less ac prog ∧
-    (ac.two_reg_arith ⇒ every_inst two_reg_inst prog)*)) progs``,
+    (ac.two_reg_arith ⇒ every_inst two_reg_inst prog)*)) progs`,
   fs[compile_def]>>pairarg_tac>>fs[]>>
   pairarg_tac>>fs[]>>rveq>>rw[]>>
   `LENGTH n_oracles = LENGTH p` by

--- a/compiler/backend/proofs/word_to_wordProofScript.sml
+++ b/compiler/backend/proofs/word_to_wordProofScript.sml
@@ -86,10 +86,10 @@ val compile_single_lem = store_thm("compile_single_lem",``
     pairarg_tac>>full_simp_tac(srw_ss())[word_state_eq_rel_def,state_component_equality]>>
     FULL_CASE_TAC>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]);
 
-val get_vars_code_frame = prove(``
+val get_vars_code_frame = Q.prove(`
   ∀ls.
   get_vars ls (st with code:=l) =
-  get_vars ls st``,
+  get_vars ls st`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_def])
 
 (*TODO: Move to wordProps so there're no scoping problems..*)
@@ -109,8 +109,8 @@ val tac =
     qexists_tac`st.permute`>>full_simp_tac(srw_ss())[alloc_def,get_var_def,gc_def,LET_THM,push_env_def,set_store_def,env_to_list_def,pop_env_def,has_space_def,call_env_def,set_var_def,get_var_def,dec_clock_def,jump_exc_def,get_vars_perm,get_vars_code_frame,set_vars_def,word_exp_perm,word_exp_code_frame,mem_store_def]>>
     every_case_tac>>full_simp_tac(srw_ss())[state_component_equality]
 
-val rm_perm = prove(``
-  s with permute:= s.permute = s``,full_simp_tac(srw_ss())[state_component_equality])
+val rm_perm = Q.prove(`
+  s with permute:= s.permute = s`,full_simp_tac(srw_ss())[state_component_equality])
 
 val size_tac= (full_simp_tac(srw_ss())[wordLangTheory.prog_size_def]>>DECIDE_TAC);
 
@@ -136,12 +136,12 @@ val find_code_thm = prove(``
     Cases_on`x''`>>full_simp_tac(srw_ss())[compile_single_def,LET_THM]>>
     metis_tac[])
 
-val push_env_code_frame = prove(``
-  (push_env a b c).code = c.code``,
+val push_env_code_frame = Q.prove(`
+  (push_env a b c).code = c.code`,
   Cases_on`b`>>TRY(PairCases_on`x`)>>full_simp_tac(srw_ss())[push_env_def,LET_THM,env_to_list_def])
 
-val pop_env_termdep = prove(``
-  pop_env rst = SOME x ⇒ x.termdep = rst.termdep``,
+val pop_env_termdep = Q.prove(`
+  pop_env rst = SOME x ⇒ x.termdep = rst.termdep`,
   full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[state_component_equality])
 
 val compile_single_correct = prove(``

--- a/compiler/backend/reg_alloc/parmoveScript.sml
+++ b/compiler/backend/reg_alloc/parmoveScript.sml
@@ -258,7 +258,7 @@ val parsem_MAP_INJ = Q.store_thm("parsem_MAP_INJ",
   by (
     simp[MAP_MAP_o,o_PAIR_MAP] \\ fs[MEM_MAP]
     \\ spose_not_then strip_assume_tac
-    \\ rator_x_assum`INJ`mp_tac
+    \\ qhdtm_x_assum`INJ`mp_tac
     \\ simp[INJ_DEF]
     \\ simp[MEM_MAP]
     \\ metis_tac[] )
@@ -268,13 +268,13 @@ val parsem_MAP_INJ = Q.store_thm("parsem_MAP_INJ",
   \\ strip_tac \\ rveq \\ simp[]
   \\ `f x =  f y ⇒ x = y`
   by  (
-    rator_x_assum`INJ`mp_tac
+    qhdtm_x_assum`INJ`mp_tac
     \\ REWRITE_TAC[INJ_DEF,IN_INSERT,IN_UNION]
     \\ metis_tac[] )
   \\ rw[] \\ fs[]
   \\ first_x_assum(match_mp_tac o MP_CANON)
   \\ simp[]
-  \\ rator_x_assum`INJ`mp_tac
+  \\ qhdtm_x_assum`INJ`mp_tac
   \\ REWRITE_TAC[INJ_DEF,IN_INSERT,IN_UNION]
   \\ metis_tac[]);
 
@@ -1091,7 +1091,7 @@ val fstep_MAP_INJ = Q.store_thm("fstep_MAP_INJ",
   \\ `splitAtPki P2 k2 p0 = splitAtPki P1 k2 p0`
   by (
     match_mp_tac splitAtPki_change_predicate
-    \\ rator_x_assum`inj_on_state`mp_tac
+    \\ qhdtm_x_assum`inj_on_state`mp_tac
     \\ simp[Abbr`P1`,Abbr`P2`]
     \\ simp[inj_on_state_def]
     \\ rw[EQ_IMP_THM]
@@ -1118,7 +1118,7 @@ val fstep_MAP_INJ = Q.store_thm("fstep_MAP_INJ",
   \\ REWRITE_TAC[GSYM MAP]
   \\ simp[LAST_MAP]
   \\ simp[MAP_FRONT]
-  \\ rator_x_assum`inj_on_state`mp_tac
+  \\ qhdtm_x_assum`inj_on_state`mp_tac
   \\ simp[inj_on_state_def]
   \\ rw[EQ_IMP_THM]
   \\ first_x_assum match_mp_tac

--- a/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
+++ b/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
@@ -234,12 +234,12 @@ val id_colour_lemma = Q.prove(`
   Induct>>full_simp_tac(srw_ss())[id_colour_def,LET_THM,lookup_insert]>>srw_tac[][])
 
 (*alloc_colouring_aux never overwrites an old colouring*)
-val alloc_colouring_aux_never_overwrites_col = prove(``
+val alloc_colouring_aux_never_overwrites_col = Q.prove(`
   ∀xs spill col spill' col'.
   lookup x col = SOME y ∧
   alloc_colouring_aux G k prefs xs col spill = (col',spill')
   ⇒
-  lookup x col' = SOME y``,
+  lookup x col' = SOME y`,
   Induct>>full_simp_tac(srw_ss())[alloc_colouring_aux_def,assign_colour_def]>>srw_tac[][]>>full_simp_tac(srw_ss())[LET_THM]>>
   Cases_on`x = h`>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]
   >-
@@ -248,12 +248,12 @@ val alloc_colouring_aux_never_overwrites_col = prove(``
   every_case_tac>>full_simp_tac(srw_ss())[]>>TRY(metis_tac[])>>
   res_tac>>full_simp_tac(srw_ss())[lookup_insert])
 
-val alloc_colouring_aux_never_overwrites_spill = prove(``
+val alloc_colouring_aux_never_overwrites_spill = Q.prove(`
   ∀xs spill col spill' col'.
   MEM x spill ∧
   alloc_colouring_aux G k prefs xs col spill = (col',spill')
   ⇒
-  MEM x spill'``,
+  MEM x spill'`,
   Induct>>full_simp_tac(srw_ss())[alloc_colouring_aux_def,assign_colour_def]>>srw_tac[][]>>full_simp_tac(srw_ss())[LET_THM]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
   TRY(`MEM x (h::spill')` by (full_simp_tac(srw_ss())[]>>NO_TAC))>>
@@ -338,14 +338,14 @@ val partial_colouring_satisfactory_extend = Q.prove(`
 
 (*Coloring produced after each alloc_colouring_aux_step is
   partial_colouring_satisfactory*)
-val alloc_colouring_aux_satisfactory = prove(``
+val alloc_colouring_aux_satisfactory = Q.prove(`
   ∀G k prefs ls col spill.
   undir_graph G ∧
   satisfactory_pref prefs ∧
   partial_colouring_satisfactory col G
   ⇒
   let (col',spill') = alloc_colouring_aux G k prefs ls col spill in
-    partial_colouring_satisfactory col' G``,
+    partial_colouring_satisfactory col' G`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[alloc_colouring_aux_def,assign_colour_def,LET_THM]>>srw_tac[][]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
   TRY
@@ -373,12 +373,12 @@ val alloc_colouring_aux_satisfactory = prove(``
   metis_tac[])
 
 (*Domains of the colouring and spills are disjoint*)
-val alloc_colouring_aux_domain_1 = prove(``
+val alloc_colouring_aux_domain_1 = Q.prove(`
   ∀G k prefs ls col spill col' spill'.
   domain col ∩ set spill = {} ∧
   alloc_colouring_aux G k prefs ls col spill = (col',spill')
   ⇒
-  domain col' ∩ set spill' = {}``,
+  domain col' ∩ set spill' = {}`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[alloc_colouring_aux_def,LET_THM,assign_colour_def]>>srw_tac[][]
   >-(every_case_tac>>full_simp_tac(srw_ss())[]>>metis_tac[])
   >>
@@ -405,12 +405,12 @@ val alloc_colouring_aux_domain_1 = prove(``
     metis_tac[domain_lookup])
 
 (*Coloring and spills contain everything in the list*)
-val alloc_colouring_aux_domain_2 = prove(``
+val alloc_colouring_aux_domain_2 = Q.prove(`
   ∀G k prefs ls col spill col' spill'.
   alloc_colouring_aux G k prefs ls col spill = (col',spill')
   ⇒
   ∀x. MEM x ls ∧ x ∈ domain G ⇒
-    x ∈ domain col' ∨ MEM x spill'``,
+    x ∈ domain col' ∨ MEM x spill'`,
   Induct_on`ls`>>reverse (srw_tac[][alloc_colouring_aux_def,UNCURRY,LET_THM])>>full_simp_tac(srw_ss())[]
   >- metis_tac[]
   >>
@@ -420,7 +420,7 @@ val alloc_colouring_aux_domain_2 = prove(``
   full_simp_tac(srw_ss())[domain_lookup]>>
   metis_tac[lookup_insert])
 
-val assign_colour_props = prove(``
+val assign_colour_props = Q.prove(`
   h ∉ domain col ∧
   ¬MEM h spill' ∧
   h ∈ domain G ∧
@@ -435,7 +435,7 @@ val assign_colour_props = prove(``
         ∃y. col' = insert h y col ∧ is_phy_var y
       else col = col' ∧ MEM h spill''
     else col = col' ∧ MEM h spill'') ∧
-    domain col' ∩ set spill'' = {}``,
+    domain col' ∩ set spill'' = {}`,
   rpt strip_tac>>
   full_simp_tac(srw_ss())[assign_colour_def]>>
   `lookup h col = NONE` by
@@ -451,7 +451,7 @@ val assign_colour_props = prove(``
   full_simp_tac(srw_ss())[EXTENSION,INTER_DEF]>>metis_tac[]))
 
 (*Conventions over the extension domain*)
-val alloc_colouring_aux_domain_3 = prove(``
+val alloc_colouring_aux_domain_3 = Q.prove(`
   ∀G:sp_graph k prefs ls col spill col' spill'.
   (∀x. MEM x k ⇒ is_phy_var x) ∧
   (domain col ∩ set spill = {}) ∧
@@ -463,7 +463,7 @@ val alloc_colouring_aux_domain_3 = prove(``
       if x ∈ domain col' then
         ∃y. lookup x col' = SOME y ∧ is_phy_var y
       else MEM x spill'
-    else MEM x spill')``,
+    else MEM x spill')`,
   Induct_on`ls`>>srw_tac[][alloc_colouring_aux_def,LET_THM]
   >-
     (imp_res_tac assign_colour_props>>full_simp_tac(srw_ss())[LET_THM]>>
@@ -537,37 +537,37 @@ val list_mem = Q.prove(`
   srw_tac[][]>>full_simp_tac(srw_ss())[])
 
 (*If not the assigned colour then it must have come from before*)
-val assign_colour_reverse = prove(``
+val assign_colour_reverse = Q.prove(`
   ∀G:sp_graph k prefs h col spill col' spill'.
   assign_colour G k prefs h col spill = (col',spill')
   ⇒
   (∀x. x ≠ h ⇒
   (x ∈ domain col' ⇒ x ∈ domain col) ∧
-  (MEM x spill' ⇒ MEM x spill))``,
+  (MEM x spill' ⇒ MEM x spill))`,
   srw_tac[][assign_colour_def]>>every_case_tac>>full_simp_tac(srw_ss())[LET_THM]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
   qpat_x_assum `A = col'` (SUBST_ALL_TAC o SYM)>>
   full_simp_tac(srw_ss())[domain_insert]>>metis_tac[list_mem])
 
 (*Not in the final state means it must have come from before*)
-val alloc_colouring_aux_domain_4 = prove(``
+val alloc_colouring_aux_domain_4 = Q.prove(`
   ∀G:sp_graph k prefs ls col spill col' spill'.
   alloc_colouring_aux G k prefs ls col spill = (col',spill')
   ⇒
   ∀x. ¬MEM x ls ⇒
   (x ∈ domain col' ⇒ x ∈ domain col) ∧
-  (MEM x spill' ⇒ MEM x spill)``,
+  (MEM x spill' ⇒ MEM x spill)`,
   Induct_on`ls`>>srw_tac[][alloc_colouring_aux_def,LET_THM]>>
   Cases_on`assign_colour G k prefs h col spill'`>>full_simp_tac(srw_ss())[]>>
   metis_tac[assign_colour_reverse])
 
 (*Everything appearing in the spills was already in G*)
-val alloc_colouring_aux_domain_5 = prove(``
+val alloc_colouring_aux_domain_5 = Q.prove(`
   ∀G:sp_graph k prefs ls col spill col' spill'.
   alloc_colouring_aux G k prefs ls col spill = (col',spill')
   ⇒
   ∀x. MEM x spill' ⇒
-  x ∈ domain G ∨ MEM x spill``,
+  x ∈ domain G ∨ MEM x spill`,
   Induct_on`ls`>>srw_tac[][alloc_colouring_aux_def,LET_THM]>>
   Cases_on`assign_colour G k prefs h col spill'`>>
   full_simp_tac(srw_ss())[]>>
@@ -604,7 +604,7 @@ val id_colour_always_sat = Q.prove(`
   Stack vars are all in spills
   Alloc vars are either spilled (exclusive)OR in the colouring
 *)
-val alloc_colouring_success = prove(``
+val alloc_colouring_success = Q.prove(`
   undir_graph G ∧ satisfactory_pref prefs ⇒
   let (col,spills) = alloc_colouring G k prefs ls in
   partial_colouring_satisfactory col G ∧
@@ -615,7 +615,7 @@ val alloc_colouring_success = prove(``
     else (*is_alloc_var x*)
       if x ∈ domain col then
         ∃y. lookup x col = SOME y ∧ is_phy_var y
-      else MEM x spills``,
+      else MEM x spills`,
   full_simp_tac(srw_ss())[alloc_colouring_def]>>srw_tac[][]
   >-
     (imp_res_tac alloc_colouring_aux_satisfactory>>
@@ -710,9 +710,9 @@ val alloc_colouring_success = prove(``
           ,`col''`,`spills'`] assume_tac alloc_colouring_aux_domain_3>>
         full_simp_tac(srw_ss())[]>>metis_tac[])
 
-val alloc_colouring_success_2 = prove(``
+val alloc_colouring_success_2 = Q.prove(`
   let (col,spills) = alloc_colouring G k prefs ls in
-  ∀x. MEM x spills ⇒ x ∈ domain G``,
+  ∀x. MEM x spills ⇒ x ∈ domain G`,
   full_simp_tac(srw_ss())[alloc_colouring_def]>>srw_tac[][]>>
   imp_res_tac alloc_colouring_aux_domain_5>>full_simp_tac(srw_ss())[])
 
@@ -1066,7 +1066,7 @@ val is_subgraph_edges_trans = Q.prove(`
   is_subgraph_edges A C`,
   full_simp_tac(srw_ss())[is_subgraph_edges_def]>>srw_tac[][SUBSET_DEF])
 
-val full_coalesce_aux_extends = prove(``
+val full_coalesce_aux_extends = Q.prove(`
   ∀(G:sp_graph) (ls:(num,num#num) alist) spills col.
   partial_colouring_satisfactory col G ∧
   (∀x. MEM x spills ⇒ x ∈ domain G ∧  x ∉ domain col) ∧
@@ -1074,7 +1074,7 @@ val full_coalesce_aux_extends = prove(``
   let (G',ls') = full_coalesce_aux G spills ls in
   is_subgraph_edges G G' ∧
   undir_graph G' ∧
-  partial_colouring_satisfactory col G'``,
+  partial_colouring_satisfactory col G'`,
   Induct_on`ls`>-full_simp_tac(srw_ss())[full_coalesce_aux_def,LET_THM,is_subgraph_edges_def]>>
   ntac 4 strip_tac>>
   PairCases_on`h`>>
@@ -1113,7 +1113,7 @@ val full_coalesce_aux_extends = prove(``
     full_simp_tac(srw_ss())[EXTENSION,list_g_insert_domain])>>
   metis_tac[is_subgraph_edges_trans])
 
-val full_coalesce_lemma = prove(``
+val full_coalesce_lemma = Q.prove(`
   undir_graph G ∧
   partial_colouring_satisfactory col G ∧
   (∀x. MEM x ls ⇒ x ∉ domain col ∧ x ∈ domain G) ∧
@@ -1121,7 +1121,7 @@ val full_coalesce_lemma = prove(``
   ⇒
   is_subgraph_edges G G' ∧
   undir_graph G' ∧
-  partial_colouring_satisfactory col G'``,
+  partial_colouring_satisfactory col G'`,
   full_simp_tac(srw_ss())[full_coalesce_def,LET_THM]>>
   qpat_abbrev_tac `lss = QSORT g (FILTER f moves)`>>
   Cases_on`full_coalesce_aux G ls lss`>>
@@ -1135,23 +1135,23 @@ val full_coalesce_lemma = prove(``
 
 fun fsm ls = fs (ls@[BIND_DEF,UNIT_DEF,IGNORE_BIND_DEF,FOREACH_def]);
 
-val foreach_graph = prove(``
+val foreach_graph = Q.prove(`
   ∀ls s.
     ∃s'.
     FOREACH (ls,dec_one) s = ((),s') ∧
     s'.graph = s.graph ∧
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
     Induct>>srw_tac[][]>>fsm[dec_one_def,get_deg_def,set_deg_def]>>
     every_case_tac>>fsm[]>>
     first_x_assum(qspec_then`s with degs := insert h (x-1) s.degs` assume_tac)>>
     srw_tac[][]>>metis_tac[])
 
-val foreach_graph2 = prove(``
+val foreach_graph2 = Q.prove(`
   ∀ls s.
     ∃s'.
     FOREACH (ls,revive_moves) s = ((),s') ∧
     s'.graph = s.graph ∧
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
     Induct>>srw_tac[][]>>
     fsm[revive_moves_def,get_graph_def,LET_THM,get_unavail_moves_def,
         set_unavail_moves_def,add_avail_moves_def,add_avail_moves_pri_def]>>
@@ -1185,11 +1185,11 @@ val rest_tac =
   srw_tac[][Abbr`sopt`]>>full_simp_tac(srw_ss())[ra_state_nchotomy]
 
 (*Simplify neverchanges the graph*)
-val simplify_graph = prove(``
+val simplify_graph = Q.prove(`
   ∀s G s' opt.
     simplify s = (opt,s') ⇒
     s'.graph = s.graph ∧
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
   srw_tac[][]>>
   fsm[simplify_def,get_simp_worklist_def]>>
   Cases_on`s.simp_worklist`>>fsm[set_simp_worklist_def]>>
@@ -1201,11 +1201,11 @@ val simplify_graph = prove(``
   qpat_abbrev_tac`sopt = s with simp_worklist := A`>>
   rest_tac)
 
-val freeze_graph = prove(``
+val freeze_graph = Q.prove(`
 ∀s G s' opt.
     freeze s = (opt,s') ⇒
     s'.graph = s.graph ∧
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
   srw_tac[][]>>
   fsm[freeze_def,get_coalesced_def,get_freeze_worklist_def,freeze_node_def,get_unavail_moves_def,get_graph_def,get_degs_def,set_move_rel_def,set_unavail_moves_def,LET_THM]>>
   pop_assum mp_tac>>
@@ -1221,11 +1221,11 @@ val freeze_graph = prove(``
   TRY(qpat_abbrev_tac`sopt = s with <|freeze_worklist:=A;move_related:=B;unavail_moves:=C|>`)>>
   rest_tac)
 
-val spill_graph = prove(``
+val spill_graph = Q.prove(`
 ∀s G s' opt.
     spill s = (opt,s') ⇒
     s'.graph = s.graph ∧
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
   srw_tac[][]>>
   fsm[spill_def,get_coalesced_def,get_spill_worklist_def]>>
   Cases_on`s.spill_worklist`>>fsm[set_spill_worklist_def]>>
@@ -1254,7 +1254,7 @@ val rest_tac2 =
     srw_tac[][]>>full_simp_tac(srw_ss())[EXTENSION]>>
     metis_tac[lookup_dir_g_insert_correct]
 
-val foreach_graph_extend = prove(``
+val foreach_graph_extend = Q.prove(`
   ∀ls s.
   undir_graph s.graph ∧
   x ∈ domain s.graph ∧
@@ -1270,7 +1270,7 @@ val foreach_graph_extend = prove(``
             else
               dec_one v)) s = ((),s') ∧
    is_subgraph_edges s.graph s'.graph ∧
-   undir_graph s'.graph``,
+   undir_graph s'.graph`,
   Induct>>srw_tac[][]>>fsm[is_subgraph_edges_def]>>
   IF_CASES_TAC>>fsm[force_add_def,inc_one_def,get_deg_def]>>
   every_case_tac>>
@@ -1287,7 +1287,7 @@ val foreach_graph_extend = prove(``
     first_x_assum(qspec_then`sopt`mp_tac)>>
     unabbrev_all_tac>>full_simp_tac(srw_ss())[]))
 
-val foreach_graph_extend_2 = prove(``
+val foreach_graph_extend_2 = Q.prove(`
   ∀ls s s'.
   FOREACH (ls,
           (λv.
@@ -1298,18 +1298,18 @@ val foreach_graph_extend_2 = prove(``
               od
             else
               dec_one v)) s = ((),s') ⇒
-   s'.clock = s.clock``,
+   s'.clock = s.clock`,
   Induct>>srw_tac[][]>>fsm[is_subgraph_edges_def]>>
   fsm[force_add_def,inc_one_def,get_deg_def]>>
   every_case_tac>>fsm[set_deg_def,dec_one_def,get_deg_def]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
   res_tac>>full_simp_tac(srw_ss())[])
 
-val split_avail_filter = prove(``
+val split_avail_filter = Q.prove(`
   ∀ls acc B C.
   split_avail (is_valid_move G A) Q ls acc = (SOME (p,x,y),B,C)
   ⇒
-  ¬ lookup_g x y G``,
+  ¬ lookup_g x y G`,
   Induct>>
   srw_tac[][split_avail_def,LET_THM]
   >-
@@ -1325,13 +1325,13 @@ val unspill_lem = GEN_ALL (prove(``
   qpat_abbrev_tac`sopt = s`>>
   rest_tac))
 
-val do_coalesce_lem = prove(``
+val do_coalesce_lem = Q.prove(`
   undir_graph s.graph ∧
   is_subgraph_edges G s.graph ∧
   ¬lookup_g q r s.graph ∧
   do_coalesce (q,r) s = ((),s') ⇒
   undir_graph s'.graph ∧
-  is_subgraph_edges G s'.graph``,
+  is_subgraph_edges G s'.graph`,
   fsm[do_coalesce_def,add_coalesce_def,get_edges_def,get_degs_def
      ,get_colours_def,LET_THM]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
@@ -1375,9 +1375,9 @@ val do_coalesce_clock_lem=prove(``
   Q.ISPECL_THEN [`x`,`q`,`ls`,`sopt`,`s'`] assume_tac (GEN_ALL foreach_graph_extend_2)>>
   fsm[]>>rev_full_simp_tac(srw_ss())[Abbr`sopt`])
 
-val respill_lem = prove(``
+val respill_lem = Q.prove(`
   ∀s v r. respill v s = ((),r) ⇒
-  r.graph = s.graph ∧ r.clock = s.clock``,
+  r.graph = s.graph ∧ r.clock = s.clock`,
   srw_tac[][respill_def]>>
   fsm[get_colours_def,get_deg_def,get_freeze_worklist_def
      ,add_spill_worklist_def,set_freeze_worklist_def]>>
@@ -1386,13 +1386,13 @@ val respill_lem = prove(``
   qpat_x_assum`A=r` (SUBST_ALL_TAC o SYM)>>
   full_simp_tac(srw_ss())[])
 
-val coalesce_graph = prove(``
+val coalesce_graph = Q.prove(`
 ∀s G s' opt.
     undir_graph s.graph ∧
     is_subgraph_edges G s.graph ∧
     coalesce s = (opt,s') ⇒
     undir_graph s'.graph ∧
-    is_subgraph_edges G s'.graph``,
+    is_subgraph_edges G s'.graph`,
   ntac 5 strip_tac>>
   fsm[coalesce_def,get_avail_moves_pri_def,get_avail_moves_def,get_graph_def,get_colours_def,get_degs_def,get_move_rel_def]>>
   every_case_tac>>
@@ -1421,10 +1421,10 @@ val coalesce_graph = prove(``
   unabbrev_all_tac>>full_simp_tac(srw_ss())[]>>
   rev_full_simp_tac(srw_ss())[])
 
-val coalesce_graph_2 = prove(``
+val coalesce_graph_2 = Q.prove(`
 ∀s G s' opt.
     coalesce s = (opt,s') ⇒
-    s'.clock = s.clock``,
+    s'.clock = s.clock`,
   ntac 5 strip_tac>>
   fsm[coalesce_def,get_avail_moves_pri_def,get_avail_moves_def,get_graph_def,get_colours_def,get_degs_def,get_move_rel_def]>>
   every_case_tac>>
@@ -1448,14 +1448,14 @@ val coalesce_graph_2 = prove(``
   imp_res_tac unspill_lem>>
   unabbrev_all_tac>>full_simp_tac(srw_ss())[])
 
-val do_step_graph_lemma = store_thm("do_step_graph_lemma",``
+val do_step_graph_lemma = Q.store_thm("do_step_graph_lemma",`
   ∀s G s'.
     undir_graph s.graph ∧
     is_subgraph_edges G s.graph ∧
     s.clock ≠ 0 ∧
     do_step s = ((),s') ⇒
     undir_graph s'.graph ∧
-    is_subgraph_edges G s'.graph``,
+    is_subgraph_edges G s'.graph`,
     srw_tac[][]>>
     fsm[do_step_def,dec_clock_def]>>
     qabbrev_tac`sopt = (s with clock:=s.clock-1)`>>
@@ -1469,11 +1469,11 @@ val do_step_graph_lemma = store_thm("do_step_graph_lemma",``
     TRY(qpat_x_assum`A=s'` (SUBST_ALL_TAC o SYM))>>full_simp_tac(srw_ss())[]>>
     metis_tac[spill_graph,coalesce_graph,freeze_graph,simplify_graph,coalesce_graph_2])
 
-val do_step_clock_lemma = store_thm("do_step_clock_lemma",``
+val do_step_clock_lemma = Q.store_thm("do_step_clock_lemma",`
   ∀s G s'.
     s.clock ≠ 0 ∧
     do_step s = ((),s') ⇒
-    s'.clock < s.clock``,
+    s'.clock < s.clock`,
     srw_tac[][]>>
     fsm[do_step_def,dec_clock_def]>>
     qabbrev_tac`sopt = (s with clock:=s.clock-1)`>>
@@ -1487,13 +1487,13 @@ val do_step_clock_lemma = store_thm("do_step_clock_lemma",``
     TRY(qpat_x_assum`A=s'` (SUBST_ALL_TAC o SYM))>>full_simp_tac(srw_ss())[]>>
     metis_tac[spill_graph,coalesce_graph,freeze_graph,simplify_graph,coalesce_graph_2])
 
-val rpt_do_step_graph_lemma = store_thm("rpt_do_step_graph_lemma",``
+val rpt_do_step_graph_lemma = Q.store_thm("rpt_do_step_graph_lemma",`
   ∀s.
     undir_graph s.graph
     ⇒
     let ((),s') = rpt_do_step s in
     undir_graph s'.graph ∧
-    is_subgraph_edges s.graph s'.graph``,
+    is_subgraph_edges s.graph s'.graph`,
   full_simp_tac(srw_ss())[rpt_do_step_def]>>
   completeInduct_on`s.clock`>>
   srw_tac[][]>>
@@ -1517,11 +1517,11 @@ val rpt_do_step_graph_lemma = store_thm("rpt_do_step_graph_lemma",``
   pop_assum(qspec_then`r` mp_tac)>>rev_full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[is_subgraph_edges_trans])
 
-val do_step2_clock_lemma = store_thm("do_step2_clock_lemma",``
+val do_step2_clock_lemma = Q.store_thm("do_step2_clock_lemma",`
   ∀s G s'.
     s.clock ≠ 0 ∧
     do_step2 s = ((),s') ⇒
-    s'.clock < s.clock``,
+    s'.clock < s.clock`,
   srw_tac[][]>>fsm[do_step2_def,dec_clock_def,full_simplify_def,get_simp_worklist_def,get_degs_def]>>full_case_tac>>
   fsm[dec_deg_def,set_simp_worklist_def,get_graph_def,push_stack_def]>>
   TRY(full_case_tac)>>full_simp_tac(srw_ss())[]>>
@@ -1534,18 +1534,18 @@ val do_step2_clock_lemma = store_thm("do_step2_clock_lemma",``
   fsm[]>>
   DECIDE_TAC)
 
-val do_briggs_step_clock_lemma = store_thm("do_briggs_step_clock_lemma",``
+val do_briggs_step_clock_lemma = Q.store_thm("do_briggs_step_clock_lemma",`
   ∀s G s'.
     s.clock ≠ 0 ∧
     do_briggs_step s = ((),s') ⇒
-    s'.clock < s.clock``,
+    s'.clock < s.clock`,
   rw[]>>fsm[do_briggs_step_def,dec_clock_def,UNCURRY]>>
   Cases_on`coalesce (s with clock:=s.clock-1)`>>Cases_on`q`>>full_simp_tac(srw_ss())[push_stack_def]>>
   imp_res_tac coalesce_graph_2>>
   rpt var_eq_tac>>fs[])
 
 (*Note:Briggs clock is not pulled out since it isn't used (yet)*)
-val do_briggs_step_graph_lemma = prove(``
+val do_briggs_step_graph_lemma = Q.prove(`
   ∀s G s'.
     undir_graph s.graph ∧
     is_subgraph_edges G s.graph ∧
@@ -1553,7 +1553,7 @@ val do_briggs_step_graph_lemma = prove(``
     do_briggs_step s = ((),s') ⇒
     undir_graph s'.graph ∧
     is_subgraph_edges G s'.graph ∧
-    s'.clock < s.clock``,
+    s'.clock < s.clock`,
   srw_tac[][]>>
   fsm[do_briggs_step_def,dec_clock_def]>>
   qabbrev_tac`sopt = (s with clock:=s.clock-1)`>>
@@ -1564,13 +1564,13 @@ val do_briggs_step_graph_lemma = prove(``
   TRY(qpat_x_assum`A=s'` (SUBST_ALL_TAC o SYM))>>full_simp_tac(srw_ss())[]>>
   metis_tac[coalesce_graph,coalesce_graph_2])
 
-val briggs_coalesce_lemma = prove(``
+val briggs_coalesce_lemma = Q.prove(`
   ∀s.
     undir_graph s.graph
     ⇒
     let ((),s') = briggs_coalesce s in
     undir_graph s'.graph ∧
-    is_subgraph_edges s.graph s'.graph``,
+    is_subgraph_edges s.graph s'.graph`,
   full_simp_tac(srw_ss())[briggs_coalesce_def]>>
   completeInduct_on`s.clock`>>
   srw_tac[][]>>
@@ -1591,12 +1591,12 @@ val briggs_coalesce_lemma = prove(``
   pop_assum(qspec_then`r` mp_tac)>>rev_full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[is_subgraph_edges_trans])
 
-val reg_alloc_satisfactory = store_thm ("reg_alloc_satisfactory",``
+val reg_alloc_satisfactory = Q.store_thm ("reg_alloc_satisfactory",`
   ∀G k moves alg.
   undir_graph G ⇒
   let col = reg_alloc alg G k moves in
   (domain G ⊆ domain col ∧
-  partial_colouring_satisfactory col G)``,
+  partial_colouring_satisfactory col G)`,
   rpt strip_tac>>full_simp_tac(srw_ss())[reg_alloc_def]>>LET_ELIM_TAC>>
   `satisfactory_pref pref` by
     (every_case_tac>>full_simp_tac(srw_ss())[Abbr`pref`,aux_pref_satisfactory,move_pref_satisfactory,aux_move_pref_satisfactory])>>
@@ -1640,11 +1640,11 @@ val reg_alloc_satisfactory = store_thm ("reg_alloc_satisfactory",``
     Q.EXISTS_TAC`G'`>>full_simp_tac(srw_ss())[]>>
     metis_tac[spill_colouring_satisfactory])
 
-val reg_alloc_total_satisfactory = store_thm ("reg_alloc_total_satisfactory",``
+val reg_alloc_total_satisfactory = Q.store_thm ("reg_alloc_total_satisfactory",`
   ∀alg G k moves.
   undir_graph G ⇒
   let col = reg_alloc alg G k moves in
-  colouring_satisfactory (total_colour col) G``,
+  colouring_satisfactory (total_colour col) G`,
   srw_tac[][]>>imp_res_tac reg_alloc_satisfactory>>
   pop_assum(qspecl_then[`moves`,`k`]assume_tac)>>rev_full_simp_tac(srw_ss())[LET_THM]>>
   full_simp_tac(srw_ss())[colouring_satisfactory_def,partial_colouring_satisfactory_def
@@ -1827,7 +1827,7 @@ val clique_g_insert_subgraph = Q.prove(`
   fs[is_subgraph_def,clique_g_insert_domain])
 
 (* The result is undirected, contains a clique and is a subgraph *)
-val extend_clique_props = prove(``
+val extend_clique_props = Q.prove(`
   ∀l live G G' live'.
   sp_g_is_clique live G ∧
   undir_graph G ∧
@@ -1837,7 +1837,7 @@ val extend_clique_props = prove(``
   undir_graph G' ∧
   sp_g_is_clique live' G' ∧
   is_subgraph G G' ∧
-  set live' = set (live++l)``,
+  set live' = set (live++l)`,
   Induct>>fs[extend_clique_def,is_subgraph_refl]>>
   ntac 5 strip_tac>> IF_CASES_TAC>>strip_tac
   >-
@@ -1868,7 +1868,7 @@ val INJ_less = Q.prove(`
   metis_tac[INJ_DEF,SUBSET_DEF])
 
 (*Form up the entire clique, then check*)
-val check_partial_col_success = prove(``
+val check_partial_col_success = Q.prove(`
   ∀ls live flive col.
   domain flive = IMAGE col (domain live) ∧
   INJ col (set ls ∪ domain live) UNIV
@@ -1876,7 +1876,7 @@ val check_partial_col_success = prove(``
   ∃livein flivein.
   check_partial_col col ls live flive = SOME (livein,flivein) ∧
   domain livein = set ls ∪ domain live ∧
-  domain flivein = IMAGE col (domain livein)``,
+  domain flivein = IMAGE col (domain livein)`,
   Induct>>fs[check_partial_col_def]>>rw[]>>
   TOP_CASE_TAC>>fs[]
   >-
@@ -1955,7 +1955,7 @@ val domain_numset_list_delete = Q.store_thm("domain_numset_list_delete",`
   fs[EXTENSION]>>
   metis_tac[])
 
-val clash_tree_to_spg_props = store_thm("clash_tree_to_spg_props",``
+val clash_tree_to_spg_props = Q.store_thm("clash_tree_to_spg_props",`
   ∀ct live G G' live'.
   undir_graph G ∧
   ALL_DISTINCT live ∧
@@ -1964,7 +1964,7 @@ val clash_tree_to_spg_props = store_thm("clash_tree_to_spg_props",``
   is_subgraph G G' ∧
   ALL_DISTINCT live' ∧
   undir_graph G' ∧
-  sp_g_is_clique live' G'``,
+  sp_g_is_clique live' G'`,
   Induct>>fs[clash_tree_to_spg_def]
   >-
     (ntac 7 strip_tac>>
@@ -2015,7 +2015,7 @@ val sp_g_is_clique_swap = Q.prove(`
   sp_g_is_clique ls' G`,
   fs[sp_g_is_clique_def,SUBSET_DEF])
 
-val colouring_satisfactory_check_clash_tree = store_thm("colouring_satisfactory_check_clash_tree",``
+val colouring_satisfactory_check_clash_tree = Q.store_thm("colouring_satisfactory_check_clash_tree",`
   ∀ct G livelist live flive col G' live'.
   domain live = set livelist ∧
   ALL_DISTINCT livelist ∧
@@ -2029,7 +2029,7 @@ val colouring_satisfactory_check_clash_tree = store_thm("colouring_satisfactory_
   check_clash_tree col ct live flive = SOME (livein,flivein) ∧
   domain livein = set live' ∧
   (*can be separated out into props*)
-  domain flivein = IMAGE col (domain livein)``,
+  domain flivein = IMAGE col (domain livein)`,
   Induct>>rw[clash_tree_to_spg_def,check_clash_tree_def]
   >-
     (pairarg_tac>>fs[]>>
@@ -2156,7 +2156,7 @@ val in_clash_tree_def = Define`
   (in_clash_tree (Seq t t') x ⇔ in_clash_tree t x ∨ in_clash_tree t' x)`
 
 (*Not all the assumptions are needed...*)
-val clash_tree_to_spg_domain = store_thm("clash_tree_to_spg_domain",``
+val clash_tree_to_spg_domain = Q.store_thm("clash_tree_to_spg_domain",`
   ∀ct live G G' live'.
   undir_graph G ∧
   ALL_DISTINCT live ∧
@@ -2165,7 +2165,7 @@ val clash_tree_to_spg_domain = store_thm("clash_tree_to_spg_domain",``
   clash_tree_to_spg ct live G = (G',live') ⇒
   ∀x.
   in_clash_tree ct x ⇒
-  x ∈ domain G'``,
+  x ∈ domain G'`,
   Induct>>fs[in_clash_tree_def,clash_tree_to_spg_def]
   >-
     (rw[]>>pairarg_tac>>fs[]>>pairarg_tac>>fs[]>>

--- a/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
+++ b/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
@@ -7,10 +7,10 @@ val _ = ParseExtras.temp_tight_equality ();
 
 val _ = new_theory "reg_allocProof";
 
-val convention_partitions = store_thm("convention_partitions",``
+val convention_partitions = Q.store_thm("convention_partitions",`
   ∀n. (is_stack_var n ⇔ (¬is_phy_var n) ∧ ¬(is_alloc_var n)) ∧
       (is_phy_var n ⇔ (¬is_stack_var n) ∧ ¬(is_alloc_var n)) ∧
-      (is_alloc_var n ⇔ (¬is_phy_var n) ∧ ¬(is_stack_var n))``,
+      (is_alloc_var n ⇔ (¬is_phy_var n) ∧ ¬(is_stack_var n))`,
   srw_tac[][is_stack_var_def,is_phy_var_def,is_alloc_var_def,EQ_IMP_THM]
   \\ `n MOD 2 = (n MOD 4) MOD 2` by
    (ONCE_REWRITE_TAC [GSYM (EVAL ``2*2:num``)]
@@ -29,13 +29,13 @@ val in_clash_sets_def = Define`
   colouring_satisfactory guarantees that cliques have all distinct colours
 *)
 
-val lookup_dir_g_insert_correct = prove(``
+val lookup_dir_g_insert_correct = Q.prove(`
   ∀x y g.
   let g' = dir_g_insert x y g in
   lookup_g x y g' = T ∧
   ∀x' y'.
     x' ≠ x ∨ y' ≠ y ⇒
-    lookup_g x' y' g' = lookup_g x' y' g``,
+    lookup_g x' y' g' = lookup_g x' y' g`,
   full_simp_tac(srw_ss())[dir_g_insert_def,LET_THM,lookup_g_def]>>
   ntac 3 strip_tac>>CONJ_ASM1_TAC
   >-
@@ -46,37 +46,37 @@ val lookup_dir_g_insert_correct = prove(``
     full_case_tac>>
     full_simp_tac(srw_ss())[domain_insert,lookup_insert,lookup_def])
 
-val undir_g_insert_domain = prove(``
+val undir_g_insert_domain = Q.prove(`
   domain (undir_g_insert x y G) =
-  {x;y} ∪ domain G``,
+  {x;y} ∪ domain G`,
   srw_tac[][undir_g_insert_def,dir_g_insert_def]>>
   full_simp_tac(srw_ss())[domain_insert,EXTENSION]>>
   metis_tac[])
 
-val list_g_insert_domain = prove(``
+val list_g_insert_domain = Q.prove(`
   ∀ls.
   domain(list_g_insert q ls G) =
-  domain G ∪ set ls ∪ {q}``,
+  domain G ∪ set ls ∪ {q}`,
   Induct>>full_simp_tac(srw_ss())[list_g_insert_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[EXTENSION,undir_g_insert_domain]>>
   every_case_tac>>full_simp_tac(srw_ss())[domain_insert,domain_lookup,lookup_insert]>>
   metis_tac[])
 
-val clique_g_insert_domain = prove(``
+val clique_g_insert_domain = Q.prove(`
   ∀ls.
   domain (clique_g_insert ls G) =
-  domain G ∪ set ls``,
+  domain G ∪ set ls`,
   Induct>>full_simp_tac(srw_ss())[clique_g_insert_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[list_g_insert_domain]>>
   srw_tac[][EXTENSION]>>metis_tac[])
 
-val list_g_insert_correct = prove(``
+val list_g_insert_correct = Q.prove(`
   ∀ls x g.
   let g' = list_g_insert x ls g in
     ∀u v.
       lookup_g u v g' = ((u = x ∧ MEM v ls)
                       ∨ (v = x ∧ MEM u ls)
-                      ∨ lookup_g u v g)``,
+                      ∨ lookup_g u v g)`,
   Induct>>srw_tac[][list_g_insert_def,undir_g_insert_def]>>
   unabbrev_all_tac>>full_simp_tac(srw_ss())[]>-
     (full_simp_tac(srw_ss())[lookup_g_def]>>every_case_tac>>full_simp_tac(srw_ss())[lookup_insert]>>
@@ -84,13 +84,13 @@ val list_g_insert_correct = prove(``
     full_simp_tac(srw_ss())[lookup_def])>>
   metis_tac[lookup_dir_g_insert_correct])
 
-val clique_g_insert_correct = prove(``
+val clique_g_insert_correct = Q.prove(`
   !ls x g.
   ALL_DISTINCT ls ⇒
   let g' = clique_g_insert ls g in
     ∀u v.
       lookup_g u v g' = ((MEM u ls ∧ MEM v ls ∧ u ≠ v)
-                      ∨ lookup_g u v g)``,
+                      ∨ lookup_g u v g)`,
   Induct>>srw_tac[][clique_g_insert_def]>>
   unabbrev_all_tac>>metis_tac[list_g_insert_correct])
 
@@ -109,9 +109,9 @@ val colouring_satisfactory_def = Define `
     case edges of NONE => F
                 | SOME edges => ∀e. e ∈ domain edges ⇒ col e ≠ col v)`
 
-val clique_g_insert_is_clique = prove(``
+val clique_g_insert_is_clique = Q.prove(`
   !ls g.
-  sp_g_is_clique ls (clique_g_insert ls g)``,
+  sp_g_is_clique ls (clique_g_insert ls g)`,
   Induct>>
   srw_tac[][clique_g_insert_def,sp_g_is_clique_def]>>
   fs[list_g_insert_domain,clique_g_insert_domain,SUBSET_DEF]>>
@@ -120,31 +120,31 @@ val clique_g_insert_is_clique = prove(``
     full_simp_tac(srw_ss())[sp_g_is_clique_def]>>
     metis_tac[list_g_insert_correct])
 
-val clique_g_insert_preserves_clique = prove(``
+val clique_g_insert_preserves_clique = Q.prove(`
   !ls g ls'.
   ALL_DISTINCT ls' ∧
   sp_g_is_clique ls g ⇒
-  sp_g_is_clique ls (clique_g_insert ls' g)``,
+  sp_g_is_clique ls (clique_g_insert ls' g)`,
   Induct>>
   srw_tac[][clique_g_insert_def,sp_g_is_clique_def]>>
   fs[clique_g_insert_domain,SUBSET_DEF]>>
   metis_tac[clique_g_insert_correct])
 
-val clash_sets_clique = store_thm("clash_sets_clique",``
+val clash_sets_clique = Q.store_thm("clash_sets_clique",`
   ∀ls x.
   MEM x ls ⇒
-  sp_g_is_clique (MAP FST (toAList x)) (clash_sets_to_sp_g ls)``,
+  sp_g_is_clique (MAP FST (toAList x)) (clash_sets_to_sp_g ls)`,
   Induct>>full_simp_tac(srw_ss())[clash_sets_to_sp_g_def]>>srw_tac[][]>>
   unabbrev_all_tac>>
   metis_tac[clique_g_insert_is_clique
            ,clique_g_insert_preserves_clique,ALL_DISTINCT_MAP_FST_toAList])
 
-val colouring_satisfactory_cliques = store_thm("colouring_satisfactory_cliques",``
+val colouring_satisfactory_cliques = Q.store_thm("colouring_satisfactory_cliques",`
   ∀ls g (f:num->num).
   ALL_DISTINCT ls ∧
   colouring_satisfactory f g ∧ sp_g_is_clique ls g
   ⇒
-  ALL_DISTINCT (MAP f ls)``,
+  ALL_DISTINCT (MAP f ls)`,
   Induct>>
   full_simp_tac(srw_ss())[sp_g_is_clique_def,colouring_satisfactory_def]>>
   srw_tac[][]
@@ -195,42 +195,42 @@ val satisfactory_pref_def = Define`
   2) The total colouring generated is conventional
 *)
 
-val aux_pref_satisfactory = prove(``
+val aux_pref_satisfactory = Q.prove(`
   ∀prefs.
-  satisfactory_pref (aux_pref prefs)``,
+  satisfactory_pref (aux_pref prefs)`,
   full_simp_tac(srw_ss())[satisfactory_pref_def,aux_pref_def,LET_THM]>>srw_tac[][]>>
   every_case_tac>>
   Cases_on`ls`>>full_simp_tac(srw_ss())[]>>
   metis_tac[])
 
-val first_match_col_mem = prove(``
+val first_match_col_mem = Q.prove(`
   ∀ls.
   first_match_col cand col ls = SOME x
-  ⇒ MEM x cand``,
+  ⇒ MEM x cand`,
   Induct>>srw_tac[][first_match_col_def]>>
   Cases_on`h`>>full_simp_tac(srw_ss())[first_match_col_def,LET_THM]>>
   every_case_tac>>rev_full_simp_tac(srw_ss())[])
 
-val move_pref_satisfactory = prove(``
+val move_pref_satisfactory = Q.prove(`
   ∀moves.
-  satisfactory_pref (move_pref moves)``,
+  satisfactory_pref (move_pref moves)`,
   full_simp_tac(srw_ss())[satisfactory_pref_def,move_pref_def,LET_THM]>>srw_tac[][]>>
   every_case_tac>>Cases_on`ls`>>full_simp_tac(srw_ss())[]>>
   imp_res_tac first_match_col_mem>>
   full_simp_tac(srw_ss())[])
 
-val aux_move_pref_satisfactory = prove(``
+val aux_move_pref_satisfactory = Q.prove(`
   ∀prefs moves.
-  satisfactory_pref (aux_move_pref prefs moves)``,
+  satisfactory_pref (aux_move_pref prefs moves)`,
   full_simp_tac(srw_ss())[satisfactory_pref_def,aux_move_pref_def,LET_THM]>>srw_tac[][]>>
   every_case_tac>>
   metis_tac[aux_pref_satisfactory,move_pref_satisfactory,satisfactory_pref_def])
 
-val id_colour_lemma = prove(``
+val id_colour_lemma = Q.prove(`
   ∀ls.
   let t = id_colour ls in
   domain t = set ls ∧
-  ∀x. (MEM x ls ⇒ lookup x t = SOME x)``,
+  ∀x. (MEM x ls ⇒ lookup x t = SOME x)`,
   Induct>>full_simp_tac(srw_ss())[id_colour_def,LET_THM,lookup_insert]>>srw_tac[][])
 
 (*alloc_colouring_aux never overwrites an old colouring*)
@@ -271,13 +271,13 @@ val partial_colouring_satisfactory_def = Define`
     let edges = THE (lookup v G) in
     ∀v'. v' ∈ domain edges ∧ v' ∈ domain col ⇒ lookup v col ≠ lookup v' col`
 
-val remove_colours_removes = prove(``
+val remove_colours_removes = Q.prove(`
   ∀ls col k ls'.
   remove_colours col ls k = ls'
   ⇒
   ∀x. MEM x ls' ⇒
   MEM x k ∧
-  (∀y c. MEM y ls ∧ lookup y col = SOME c ⇒ c ≠ x)``,
+  (∀y c. MEM y ls ∧ lookup y col = SOME c ⇒ c ≠ x)`,
   Induct>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>
   Cases_on`k`>>
   full_simp_tac(srw_ss())[remove_colours_def,LET_THM]
@@ -295,7 +295,7 @@ val remove_colours_removes = prove(``
     first_x_assum(qspec_then`y` assume_tac)>>
     Cases_on`y=h`>>full_simp_tac(srw_ss())[MEM_FILTER]>>metis_tac[])
 
-val partial_colouring_satisfactory_extend = prove(``
+val partial_colouring_satisfactory_extend = Q.prove(`
   partial_colouring_satisfactory col G ∧
   undir_graph G ∧
   h ∉ domain col ∧
@@ -304,7 +304,7 @@ val partial_colouring_satisfactory_extend = prove(``
        y ∈ domain col ⇒
        THE (lookup y col) ≠ (v:num))
   ⇒
-  partial_colouring_satisfactory (insert h v col) G``,
+  partial_colouring_satisfactory (insert h v col) G`,
   full_simp_tac(srw_ss())[partial_colouring_satisfactory_def]>>rpt strip_tac
   >-
     full_simp_tac(srw_ss())[domain_lookup]
@@ -529,11 +529,11 @@ val alloc_colouring_aux_domain_3 = prove(``
     >>
     res_tac)
 
-val list_mem = prove(``
+val list_mem = Q.prove(`
   ∀ls ls'.
     MEM x ls ∧ (h::ls') = ls ∧ x ≠ h
     ⇒
-    MEM x ls'``,
+    MEM x ls'`,
   srw_tac[][]>>full_simp_tac(srw_ss())[])
 
 (*If not the assigned colour then it must have come from before*)
@@ -578,11 +578,11 @@ val alloc_colouring_aux_domain_5 = prove(``
   qpat_x_assum`A=r` (SUBST_ALL_TAC o SYM)>>
   full_simp_tac(srw_ss())[domain_lookup])
 
-val id_colour_always_sat = prove(``
+val id_colour_always_sat = Q.prove(`
   undir_graph G ∧
   (∀x. MEM x ls ⇒ x ∈ domain G)
   ⇒
-  partial_colouring_satisfactory (id_colour ls) G``,
+  partial_colouring_satisfactory (id_colour ls) G`,
   Q.ISPEC_THEN `ls` assume_tac id_colour_lemma>>
   srw_tac[][undir_graph_def,partial_colouring_satisfactory_def]>>
   full_simp_tac(srw_ss())[LET_THM]>-
@@ -716,12 +716,12 @@ val alloc_colouring_success_2 = prove(``
   full_simp_tac(srw_ss())[alloc_colouring_def]>>srw_tac[][]>>
   imp_res_tac alloc_colouring_aux_domain_5>>full_simp_tac(srw_ss())[])
 
-val spill_colouring_never_overwrites = prove(``
+val spill_colouring_never_overwrites = Q.prove(`
   ∀ls col col'.
   lookup x col = SOME y ∧
   spill_colouring G k prefs ls col = col'
   ⇒
-  lookup x col' = SOME y``,
+  lookup x col' = SOME y`,
   Induct>>full_simp_tac(srw_ss())[spill_colouring_def,assign_colour2_def]>>srw_tac[][]>>
   Cases_on`x=h`>>full_simp_tac(srw_ss())[]>>rev_full_simp_tac(srw_ss())[]
   >-
@@ -730,20 +730,20 @@ val spill_colouring_never_overwrites = prove(``
   every_case_tac>>full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[lookup_insert])
 
-val spill_colouring_domain_subset = prove(``
+val spill_colouring_domain_subset = Q.prove(`
   ∀ls col col'.
-  domain col ⊆ domain (spill_colouring G k prefs ls col)``,
+  domain col ⊆ domain (spill_colouring G k prefs ls col)`,
   srw_tac[][SUBSET_DEF]>>full_simp_tac(srw_ss())[domain_lookup]>>
   metis_tac[domain_lookup,spill_colouring_never_overwrites])
 
-val SORTED_TAIL = prove(``
-  SORTED R (x::xs) ⇒ SORTED R xs``,
+val SORTED_TAIL = Q.prove(`
+  SORTED R (x::xs) ⇒ SORTED R xs`,
   Cases_on`xs`>>full_simp_tac(srw_ss())[SORTED_DEF])
 
-val SORTED_HEAD_LT = prove(``
+val SORTED_HEAD_LT = Q.prove(`
   ∀ls.
   (col:num) < h ∧ SORTED (λx y. x≤y) (h::ls) ⇒
-  ¬MEM col ls``,
+  ¬MEM col ls`,
   Induct>>srw_tac[][SORTED_DEF]
   >-
     DECIDE_TAC
@@ -752,14 +752,14 @@ val SORTED_HEAD_LT = prove(``
     Cases_on`ls`>>full_simp_tac(srw_ss())[SORTED_DEF]>>DECIDE_TAC)
 
 (*prove multiple properties in one go*)
-val unbound_colours_props = prove(``
+val unbound_colours_props = Q.prove(`
   ∀col ls col'.
     is_phy_var col ∧
     SORTED (λx y.x≤y) ls ∧
     unbound_colours col ls = col'
     ⇒
     is_phy_var col' ∧ col' ≥ col ∧
-    ¬MEM col' ls``,
+    ¬MEM col' ls`,
   Induct_on`ls`>>srw_tac[][unbound_colours_def]>>
   imp_res_tac SORTED_TAIL>>
   `is_phy_var (col+2)` by
@@ -785,14 +785,14 @@ val is_phy_var_tac =
     `(2:num)*k=k*2` by DECIDE_TAC>>
     metis_tac[arithmeticTheory.MOD_EQ_0]);
 
-val option_filter_eq = prove(``
-  ∀ls. option_filter ls = MAP THE (FILTER IS_SOME ls)``,
+val option_filter_eq = Q.prove(`
+  ∀ls. option_filter ls = MAP THE (FILTER IS_SOME ls)`,
   Induct>>srw_tac[][option_filter_def]>>every_case_tac>>full_simp_tac(srw_ss())[])
 
-val assign_colour2_satisfactory = prove(``
+val assign_colour2_satisfactory = Q.prove(`
   undir_graph G ∧
   partial_colouring_satisfactory col G ⇒
-  partial_colouring_satisfactory (assign_colour2 G k prefs h col) G``,
+  partial_colouring_satisfactory (assign_colour2 G k prefs h col) G`,
   srw_tac[][assign_colour2_def]>>
   full_simp_tac(srw_ss())[LET_THM]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
@@ -817,12 +817,12 @@ val assign_colour2_satisfactory = prove(``
     ,PULL_EXISTS,MEM_toAList]>>
   HINT_EXISTS_TAC>>full_simp_tac(srw_ss())[])
 
-val assign_colour2_conventional = prove(``
+val assign_colour2_conventional = Q.prove(`
   v ∈ domain G ∧
   v ∉ domain col ∧
   assign_colour2 G k prefs v col  = col'
   ⇒
-  ∃y. lookup v col' = SOME y ∧ y≥2*k ∧ is_phy_var y``,
+  ∃y. lookup v col' = SOME y ∧ y≥2*k ∧ is_phy_var y`,
   srw_tac[][assign_colour2_def]>>
   full_simp_tac(srw_ss())[LET_THM,domain_lookup]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
@@ -833,23 +833,23 @@ val assign_colour2_conventional = prove(``
 
 (*Coloring produced after each spill_colouring step is
   partial_colouring_satisfactory*)
-val spill_colouring_satisfactory = prove(``
+val spill_colouring_satisfactory = Q.prove(`
   ∀G k prefs ls col.
   undir_graph G ∧
   partial_colouring_satisfactory col G
   ⇒
   let col' = spill_colouring G k prefs ls col in
-    partial_colouring_satisfactory col' G``,
+    partial_colouring_satisfactory col' G`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[spill_colouring_def,LET_THM]>>srw_tac[][]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>
   metis_tac[assign_colour2_satisfactory])
 
 (*Domain is extended*)
-val spill_colouring_domain_1 = prove(``
+val spill_colouring_domain_1 = Q.prove(`
   ∀G k prefs ls col.
   let col' = spill_colouring G k prefs ls col in
   ∀x. MEM x ls ∧ x ∈ domain G ⇒
-      x ∈ domain col'``,
+      x ∈ domain col'`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[spill_colouring_def,LET_THM]>>srw_tac[][]
   >-
     (full_simp_tac(srw_ss())[assign_colour2_def,domain_lookup,LET_THM]>>
@@ -872,11 +872,11 @@ val spill_colouring_domain_1 = prove(``
     metis_tac[])
 
 (*Coloring is extended on the list according to conventions*)
-val spill_colouring_domain_2 = prove(``
+val spill_colouring_domain_2 = Q.prove(`
   ∀G k prefs ls col.
   let col' = spill_colouring G k prefs ls col in
   ∀x. MEM x ls ∧ x ∈ domain G ∧ x ∉ domain col ⇒
-      ∃y. lookup x col' = SOME y ∧ y ≥ 2*k ∧ is_phy_var y``,
+      ∃y. lookup x col' = SOME y ∧ y ≥ 2*k ∧ is_phy_var y`,
   Induct_on`ls`>>full_simp_tac(srw_ss())[spill_colouring_def,LET_THM]>>srw_tac[][]
   >-
     (imp_res_tac assign_colour2_conventional>>full_simp_tac(srw_ss())[]>>
@@ -891,20 +891,20 @@ val spill_colouring_domain_2 = prove(``
       full_simp_tac(srw_ss())[LET_THM]>>
       metis_tac[])
 
-val assign_colour2_reverse = prove(``
+val assign_colour2_reverse = Q.prove(`
   ∀G:sp_graph k prefs h col col'.
   assign_colour2 G k prefs h col = col'
   ⇒
   ∀x. x ≠ h ⇒
-  (x ∈ domain col' ⇒ x ∈ domain col)``,
+  (x ∈ domain col' ⇒ x ∈ domain col)`,
   srw_tac[][assign_colour2_def]>>every_case_tac>>full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[])
 
-val spill_colouring_domain_3 = prove(``
+val spill_colouring_domain_3 = Q.prove(`
   ∀G k prefs ls col.
   let col' = spill_colouring G k prefs ls col in
   ∀x. ¬MEM x ls ⇒
-  (x ∈ domain col' ⇒ x ∈ domain col)``,
+  (x ∈ domain col' ⇒ x ∈ domain col)`,
   Induct_on`ls`>>srw_tac[][spill_colouring_def,LET_THM]>>
   Cases_on`assign_colour2 G k prefs h col`>>full_simp_tac(srw_ss())[]>>
   metis_tac[assign_colour2_reverse])
@@ -914,13 +914,13 @@ val is_subgraph_edges_def = Define`
     domain G = domain H  ∧  (*We never change the vertex set*)
    (∀x y. lookup_g x y G ⇒ lookup_g x y H)`
 
-val partial_colouring_satisfactory_subgraph_edges = prove(``
+val partial_colouring_satisfactory_subgraph_edges = Q.prove(`
   ∀G H col.
   (*Every edge in G is in H*)
   undir_graph G ∧
   is_subgraph_edges G H ∧
   (partial_colouring_satisfactory col H) ⇒
-  partial_colouring_satisfactory col G``,
+  partial_colouring_satisfactory col G`,
   full_simp_tac(srw_ss())[partial_colouring_satisfactory_def,lookup_g_def,is_subgraph_edges_def]>>
   srw_tac[][]>>
   `v ∈ domain G` by full_simp_tac(srw_ss())[]>>
@@ -938,10 +938,10 @@ val partial_colouring_satisfactory_subgraph_edges = prove(``
   pop_assum(qspec_then`v'` assume_tac)>>
   rev_full_simp_tac(srw_ss())[])
 
-val undir_g_preserve = prove(``
+val undir_g_preserve = Q.prove(`
   undir_graph G ∧
   x ≠ y ⇒
-  undir_graph (undir_g_insert x y G)``,
+  undir_graph (undir_g_insert x y G)`,
   full_simp_tac(srw_ss())[undir_graph_def,undir_g_insert_def,dir_g_insert_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[lookup_insert]>>
   IF_CASES_TAC >-
@@ -968,12 +968,12 @@ val finish_tac =
   last_x_assum(qspec_then `v'` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
   pop_assum(qspec_then`v` assume_tac)>>rev_full_simp_tac(srw_ss())[];
 
-val partial_colouring_satisfactory_extend_2 = prove(``
+val partial_colouring_satisfactory_extend_2 = Q.prove(`
   undir_graph G ∧
   partial_colouring_satisfactory col G ∧
   (x ∉ domain col ∨ y ∉ domain col ∧
   x ∈ domain G ∧ y ∈ domain G) ⇒
-  partial_colouring_satisfactory col (undir_g_insert x y G)``,
+  partial_colouring_satisfactory col (undir_g_insert x y G)`,
   full_simp_tac(srw_ss())[undir_g_insert_def,dir_g_insert_def
     ,partial_colouring_satisfactory_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[domain_lookup,LET_THM]>>
@@ -998,12 +998,12 @@ val partial_colouring_satisfactory_extend_2 = prove(``
   Cases_on`v'=y`>>full_simp_tac(srw_ss())[lookup_def]>>
   finish_tac)
 
-val list_g_insert_undir = prove(``
+val list_g_insert_undir = Q.prove(`
   ∀ls G col.
   undir_graph G ∧
   ¬MEM q ls ⇒
   let G' = list_g_insert q ls G in
-  undir_graph G'``,
+  undir_graph G'`,
   Induct>>srw_tac[][list_g_insert_def]>>
   full_simp_tac(srw_ss())[Abbr`G'`]
   >-
@@ -1016,7 +1016,7 @@ val list_g_insert_undir = prove(``
   >>
     metis_tac[undir_g_preserve])
 
-val list_g_insert_lemma = prove(``
+val list_g_insert_lemma = Q.prove(`
   ∀ls G col.
   undir_graph G ∧
   ¬ MEM q ls ∧
@@ -1027,7 +1027,7 @@ val list_g_insert_lemma = prove(``
   let G' = list_g_insert q ls G in
   is_subgraph_edges G G' ∧
   undir_graph G' ∧
-  partial_colouring_satisfactory col G'``,
+  partial_colouring_satisfactory col G'`,
   Induct
   >-
     (srw_tac[][list_g_insert_def,is_subgraph_edges_def]>>
@@ -1060,10 +1060,10 @@ val list_g_insert_lemma = prove(``
     match_mp_tac partial_colouring_satisfactory_extend_2>>
     rev_full_simp_tac(srw_ss())[list_g_insert_domain])
 
-val is_subgraph_edges_trans = prove(``
+val is_subgraph_edges_trans = Q.prove(`
   is_subgraph_edges A B ∧
   is_subgraph_edges B C ⇒
-  is_subgraph_edges A C``,
+  is_subgraph_edges A C`,
   full_simp_tac(srw_ss())[is_subgraph_edges_def]>>srw_tac[][SUBSET_DEF])
 
 val full_coalesce_aux_extends = prove(``
@@ -1659,11 +1659,11 @@ val reg_alloc_total_satisfactory = store_thm ("reg_alloc_total_satisfactory",``
   first_x_assum(qspec_then`v'''` assume_tac)>>rev_full_simp_tac(srw_ss())[LET_THM]>>
   metis_tac[])
 
-val reg_alloc_conventional = store_thm("reg_alloc_conventional" ,``
+val reg_alloc_conventional = Q.store_thm("reg_alloc_conventional" ,`
   ∀alg G k moves.
   undir_graph G ⇒
   let col = reg_alloc alg G k moves in
-  colouring_conventional G k (total_colour col)``,
+  colouring_conventional G k (total_colour col)`,
   srw_tac[][]>>imp_res_tac reg_alloc_satisfactory>>
   pop_assum(qspecl_then[`moves`,`k`,`alg`] assume_tac)>>rev_full_simp_tac(srw_ss())[LET_THM]>>
   srw_tac[][total_colour_def,reg_alloc_def,colouring_conventional_def]>>
@@ -1737,11 +1737,11 @@ val reg_alloc_conventional = store_thm("reg_alloc_conventional" ,``
       metis_tac[spill_colouring_domain_3,optionTheory.option_CLAUSES])
 
 (*strengthen case of the above*)
-val reg_alloc_conventional_phy_var = store_thm("reg_alloc_conventional_phy_var",``
+val reg_alloc_conventional_phy_var = Q.store_thm("reg_alloc_conventional_phy_var",`
   ∀alg G k moves.
   undir_graph G ⇒
   let col = reg_alloc alg G k moves in
-  ∀x. is_phy_var x ⇒ (total_colour col) x = x``,
+  ∀x. is_phy_var x ⇒ (total_colour col) x = x`,
   srw_tac[][]>>Cases_on`x ∈ domain col`
   >-
   (imp_res_tac reg_alloc_satisfactory >>
@@ -1761,28 +1761,28 @@ val reg_alloc_conventional_phy_var = store_thm("reg_alloc_conventional_phy_var",
   - clash_sets_to_sp_g produces undirected graphs
 *)
 
-val clique_g_insert_undir = prove(``
+val clique_g_insert_undir = Q.prove(`
   ∀ls G.
   undir_graph G ∧
   ALL_DISTINCT ls
   ⇒
-  undir_graph (clique_g_insert ls G)``,
+  undir_graph (clique_g_insert ls G)`,
   Induct>>full_simp_tac(srw_ss())[clique_g_insert_def]>>srw_tac[][]>>
   metis_tac[list_g_insert_undir])
 
-val clash_sets_to_sp_g_undir = store_thm("clash_sets_to_sp_g_undir",``
+val clash_sets_to_sp_g_undir = Q.store_thm("clash_sets_to_sp_g_undir",`
 ∀ls.
-  undir_graph (clash_sets_to_sp_g ls)``,
+  undir_graph (clash_sets_to_sp_g ls)`,
   Induct>-srw_tac[][clash_sets_to_sp_g_def,undir_graph_def,lookup_def]>>
   srw_tac[][clash_sets_to_sp_g_def]>>
   match_mp_tac clique_g_insert_undir>>
   unabbrev_all_tac>>
   full_simp_tac(srw_ss())[ALL_DISTINCT_MAP_FST_toAList])
 
-val clash_sets_to_sp_g_domain = store_thm("clash_sets_to_sp_g_domain",``
+val clash_sets_to_sp_g_domain = Q.store_thm("clash_sets_to_sp_g_domain",`
 ∀ls x.
   in_clash_sets ls x ⇒
-  x ∈ domain (clash_sets_to_sp_g ls)``,
+  x ∈ domain (clash_sets_to_sp_g ls)`,
   Induct>>full_simp_tac(srw_ss())[in_clash_sets_def,clash_sets_to_sp_g_def,LET_THM]>>srw_tac[][]>>res_tac>>
   full_simp_tac(srw_ss())[clique_g_insert_domain]>>
   full_simp_tac(srw_ss())[domain_lookup,MEM_MAP,MEM_toAList,EXISTS_PROD])
@@ -1795,15 +1795,15 @@ val is_subgraph_def = Define`
   domain G ⊆ domain H ∧
   ∀x y. lookup_g x y G ⇒ lookup_g x y H`
 
-val is_subgraph_refl = prove(``is_subgraph G G``, fs[is_subgraph_def])
+val is_subgraph_refl = Q.prove(`is_subgraph G G`, fs[is_subgraph_def])
 
-val is_subgraph_trans = prove(``
+val is_subgraph_trans = Q.prove(`
   is_subgraph A B ∧ is_subgraph B C ⇒
-  is_subgraph A C``,
+  is_subgraph A C`,
   fs[is_subgraph_def]>>
   metis_tac[SUBSET_TRANS])
 
-val list_g_insert_props = prove(``
+val list_g_insert_props = Q.prove(`
   ∀live h G.
   sp_g_is_clique live G ∧
   undir_graph G ∧
@@ -1811,17 +1811,17 @@ val list_g_insert_props = prove(``
   let G' = list_g_insert h live G in
   is_subgraph G G' ∧
   undir_graph G' ∧
-  sp_g_is_clique (h::live) G'``,
+  sp_g_is_clique (h::live) G'`,
   ntac 4 strip_tac>>
   Q.ISPECL_THEN [`live`,`h`,`G`] assume_tac list_g_insert_correct>>
   Q.ISPECL_THEN [`h`,`live`,`G`] assume_tac (GEN_ALL list_g_insert_undir)>>
   fs[is_subgraph_def,sp_g_is_clique_def,list_g_insert_domain]>>
   metis_tac[SUBSET_UNION,UNION_COMM,UNION_ASSOC])
 
-val clique_g_insert_subgraph = prove(``
+val clique_g_insert_subgraph = Q.prove(`
   ∀live G.
   ALL_DISTINCT live ⇒
-  is_subgraph G (clique_g_insert live G)``,
+  is_subgraph G (clique_g_insert live G)`,
   rw[]>>
   imp_res_tac clique_g_insert_correct>>
   fs[is_subgraph_def,clique_g_insert_domain])
@@ -1850,10 +1850,10 @@ val extend_clique_props = prove(``
     rfs[is_subgraph_def]>>
     fs[EXTENSION]>>metis_tac[SUBSET_TRANS]))
 
-val colouring_satisfactory_subgraph = prove(``
+val colouring_satisfactory_subgraph = Q.prove(`
   is_subgraph G H ∧
   colouring_satisfactory col H ⇒
-  colouring_satisfactory col G``,
+  colouring_satisfactory col G`,
   fs[colouring_satisfactory_def,is_subgraph_def]>>rw[]>>
   fs[domain_lookup,lookup_g_def]>>rw[]>>
   first_x_assum(qspecl_then[`v`,`e`] assume_tac)>>rfs[]>>
@@ -1861,10 +1861,10 @@ val colouring_satisfactory_subgraph = prove(``
   first_x_assum(qspec_then`v`assume_tac)>>rfs[])
 
 (*TODO: this is in word_allocProof*)
-val INJ_less = prove(``
+val INJ_less = Q.prove(`
   INJ f s' UNIV ∧ s ⊆ s'
   ⇒
-  INJ f s UNIV``,
+  INJ f s UNIV`,
   metis_tac[INJ_DEF,SUBSET_DEF])
 
 (*Form up the entire clique, then check*)
@@ -1911,46 +1911,46 @@ val check_partial_col_success = prove(``
   rw[]>>fs[EXTENSION]>>
   fs[domain_lookup]>>metis_tac[])
 
-val ALL_DISTINCT_set_INJ = prove(``
+val ALL_DISTINCT_set_INJ = Q.prove(`
   ∀ls col.
   ALL_DISTINCT (MAP col ls) ⇒
-  INJ col (set ls) UNIV``,
+  INJ col (set ls) UNIV`,
   Induct>>fs[INJ_DEF]>>rw[]>>
   fs[MEM_MAP]>>
   metis_tac[])
 
-val ALL_DISTINCT_IMP_INJ = prove(``
+val ALL_DISTINCT_IMP_INJ = Q.prove(`
   ALL_DISTINCT (MAP col live') ∧
   set live' = set livelist ∪ set l ⇒
-  INJ col (set l ∪ set livelist) UNIV``,
+  INJ col (set l ∪ set livelist) UNIV`,
   rw[]>>
   imp_res_tac ALL_DISTINCT_set_INJ>>
   metis_tac[UNION_COMM])
 
-val sp_g_is_clique_subgraph = prove(``
+val sp_g_is_clique_subgraph = Q.prove(`
   ∀ls.
   sp_g_is_clique ls G ∧
   is_subgraph G G' ⇒
-  sp_g_is_clique ls G'``,
+  sp_g_is_clique ls G'`,
   Induct>>fs[sp_g_is_clique_def,SUBSET_DEF]>>
   ntac 5 strip_tac>>fs[is_subgraph_def,SUBSET_DEF]>>
   metis_tac[])
 
 (*More generally, any LIST SUBSET satisfies this*)
-val sp_g_is_clique_FILTER = prove(``
+val sp_g_is_clique_FILTER = Q.prove(`
   ∀ls.
   sp_g_is_clique ls G ⇒
-  sp_g_is_clique (FILTER P ls) G``,
+  sp_g_is_clique (FILTER P ls) G`,
   Induct>>fs[sp_g_is_clique_def]>>
   strip_tac>>
   cases_on`P h`>>
   fs[MEM_FILTER]>>
   metis_tac[])
 
-val domain_numset_list_delete = store_thm("domain_numset_list_delete",``
+val domain_numset_list_delete = Q.store_thm("domain_numset_list_delete",`
   ∀l live.
   domain (numset_list_delete l live) =
-  domain live DIFF set l``,
+  domain live DIFF set l`,
   Induct>>fs[numset_list_delete_def]>>rw[]>>
   fs[EXTENSION]>>
   metis_tac[])
@@ -2008,11 +2008,11 @@ val clash_tree_to_spg_props = store_thm("clash_tree_to_spg_props",``
     rfs[]>>
     metis_tac[is_subgraph_trans])
 
-val sp_g_is_clique_swap = prove(``
+val sp_g_is_clique_swap = Q.prove(`
   ∀ls'.
   sp_g_is_clique ls G ∧
   (∀x. MEM x ls ⇔ MEM x ls') ⇒
-  sp_g_is_clique ls' G``,
+  sp_g_is_clique ls' G`,
   fs[sp_g_is_clique_def,SUBSET_DEF])
 
 val colouring_satisfactory_check_clash_tree = store_thm("colouring_satisfactory_check_clash_tree",``

--- a/compiler/backend/reg_alloc/reg_allocScript.sml
+++ b/compiler/backend/reg_alloc/reg_allocScript.sml
@@ -17,10 +17,10 @@ val is_phy_var_def = Define`
 val is_alloc_var_def = Define`
   is_alloc_var (n:num) = (n MOD 4 = 1)`
 
-val convention_partitions = store_thm("convention_partitions",``
+val convention_partitions = Q.store_thm("convention_partitions",`
   ∀n. (is_stack_var n ⇔ (¬is_phy_var n) ∧ ¬(is_alloc_var n)) ∧
       (is_phy_var n ⇔ (¬is_stack_var n) ∧ ¬(is_alloc_var n)) ∧
-      (is_alloc_var n ⇔ (¬is_phy_var n) ∧ ¬(is_stack_var n))``,
+      (is_alloc_var n ⇔ (¬is_phy_var n) ∧ ¬(is_stack_var n))`,
   rw[is_stack_var_def,is_phy_var_def,is_alloc_var_def,EQ_IMP_THM]
   \\ `n MOD 2 = (n MOD 4) MOD 2` by
    (ONCE_REWRITE_TAC [GSYM (EVAL ``2*2:num``)]

--- a/compiler/backend/semantics/bviPropsScript.sml
+++ b/compiler/backend/semantics/bviPropsScript.sml
@@ -16,8 +16,8 @@ val initial_state_with_simp = Q.store_thm("initial_state_with_simp[simp]",
    initial_state f c k with code := c1 = initial_state f c1 k`,
   EVAL_TAC);
 
-val bvl_to_bvi_id = store_thm("bvl_to_bvi_id",
-  ``bvl_to_bvi (bvi_to_bvl s) s = s``,
+val bvl_to_bvi_id = Q.store_thm("bvl_to_bvi_id",
+  `bvl_to_bvi (bvi_to_bvl s) s = s`,
   EVAL_TAC \\ full_simp_tac(srw_ss())[bviSemTheory.state_component_equality]);
 
 val bvl_to_bvi_with_refs = Q.store_thm("bvl_to_bvi_with_refs",
@@ -138,12 +138,12 @@ val evaluate_APPEND = store_thm("evaluate_APPEND",
 val inc_clock_def = Define `
   inc_clock n (s:'ffi bviSem$state) = s with clock := s.clock + n`;
 
-val inc_clock_ZERO = store_thm("inc_clock_ZERO",
-  ``!s. inc_clock 0 s = s``,
+val inc_clock_ZERO = Q.store_thm("inc_clock_ZERO",
+  `!s. inc_clock 0 s = s`,
   full_simp_tac(srw_ss())[inc_clock_def,state_component_equality]);
 
-val inc_clock_ADD = store_thm("inc_clock_ADD",
-  ``inc_clock n (inc_clock m s) = inc_clock (n+m) s``,
+val inc_clock_ADD = Q.store_thm("inc_clock_ADD",
+  `inc_clock n (inc_clock m s) = inc_clock (n+m) s`,
   full_simp_tac(srw_ss())[inc_clock_def,state_component_equality,AC ADD_ASSOC ADD_COMM]);
 
 val inc_clock_refs = Q.store_thm("inc_clock_refs[simp]",
@@ -184,14 +184,14 @@ val dec_clock_code = Q.store_thm("dec_clock_code[simp]",
   `(dec_clock n s).code = s.code`,
   srw_tac[][dec_clock_def])
 
-val dec_clock_inv_clock = store_thm("dec_clock_inv_clock",
-  ``¬(t1.clock < ticks + 1) ==>
-    (dec_clock (ticks + 1) (inc_clock c t1) = inc_clock c (dec_clock (ticks + 1) t1))``,
+val dec_clock_inv_clock = Q.store_thm("dec_clock_inv_clock",
+  `¬(t1.clock < ticks + 1) ==>
+    (dec_clock (ticks + 1) (inc_clock c t1) = inc_clock c (dec_clock (ticks + 1) t1))`,
   full_simp_tac(srw_ss())[dec_clock_def,inc_clock_def,state_component_equality] \\ DECIDE_TAC);
 
-val dec_clock_inv_clock1 = store_thm("dec_clock_inv_clock1",
-  ``t1.clock <> 0 ==>
-    (dec_clock 1 (inc_clock c t1) = inc_clock c (dec_clock 1 t1))``,
+val dec_clock_inv_clock1 = Q.store_thm("dec_clock_inv_clock1",
+  `t1.clock <> 0 ==>
+    (dec_clock 1 (inc_clock c t1) = inc_clock c (dec_clock 1 t1))`,
   full_simp_tac(srw_ss())[dec_clock_def,inc_clock_def,state_component_equality] \\ DECIDE_TAC);
 
 val dec_clock0 = Q.store_thm ("dec_clock0[simp]",

--- a/compiler/backend/semantics/bviPropsScript.sml
+++ b/compiler/backend/semantics/bviPropsScript.sml
@@ -60,11 +60,11 @@ val domain_bvi_to_bvl_code = Q.store_thm("domain_bvi_to_bvl_code[simp]",
   `domain (bvi_to_bvl s).code = domain s.code`,
   srw_tac[][bvi_to_bvl_def,domain_map])
 
-val evaluate_LENGTH = prove(
-  ``!xs s env. (\(xs,s,env).
+val evaluate_LENGTH = Q.prove(
+  `!xs s env. (\(xs,s,env).
       (case evaluate (xs,s,env) of (Rval res,s1) => (LENGTH xs = LENGTH res)
             | _ => T))
-      (xs,s,env)``,
+      (xs,s,env)`,
   HO_MATCH_MP_TAC evaluate_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [evaluate_def]
   \\ SRW_TAC [] [] \\ SRW_TAC [] []
@@ -74,24 +74,24 @@ val evaluate_LENGTH = prove(
 
 val _ = save_thm("evaluate_LENGTH", evaluate_LENGTH);
 
-val evaluate_IMP_LENGTH = store_thm("evaluate_IMP_LENGTH",
-  ``(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)``,
+val evaluate_IMP_LENGTH = Q.store_thm("evaluate_IMP_LENGTH",
+  `(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL evaluate_LENGTH) \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_SING_IMP = store_thm("evaluate_SING_IMP",
-  ``(evaluate ([x],env,s1) = (Rval vs,s2)) ==> ?w. vs = [w]``,
+val evaluate_SING_IMP = Q.store_thm("evaluate_SING_IMP",
+  `(evaluate ([x],env,s1) = (Rval vs,s2)) ==> ?w. vs = [w]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC evaluate_IMP_LENGTH
   \\ Cases_on `vs` \\ FULL_SIMP_TAC (srw_ss()) []
   \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val evaluate_CONS = store_thm("evaluate_CONS",
-  ``evaluate (x::xs,env,s) =
+val evaluate_CONS = Q.store_thm("evaluate_CONS",
+  `evaluate (x::xs,env,s) =
       case evaluate ([x],env,s) of
       | (Rval v,s2) =>
          (case evaluate (xs,env,s2) of
           | (Rval vs,s1) => (Rval (HD v::vs),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Cases_on `xs` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `evaluate ([x],env,s)` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `q` \\ full_simp_tac(srw_ss())[evaluate_def]
@@ -99,15 +99,15 @@ val evaluate_CONS = store_thm("evaluate_CONS",
   \\ Cases_on `a` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `t` \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_SNOC = store_thm("evaluate_SNOC",
-  ``!xs env s x.
+val evaluate_SNOC = Q.store_thm("evaluate_SNOC",
+  `!xs env s x.
       evaluate (SNOC x xs,env,s) =
       case evaluate (xs,env,s) of
       | (Rval vs,s2) =>
          (case evaluate ([x],env,s2) of
           | (Rval v,s1) => (Rval (vs ++ v),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Induct THEN1
    (full_simp_tac(srw_ss())[SNOC_APPEND,evaluate_def] \\ REPEAT STRIP_TAC
     \\ Cases_on `evaluate ([x],env,s)` \\ Cases_on `q` \\ full_simp_tac(srw_ss())[])
@@ -121,15 +121,15 @@ val evaluate_SNOC = store_thm("evaluate_SNOC",
   \\ Cases_on `a''` \\ full_simp_tac(srw_ss())[LENGTH]
   \\ REV_FULL_SIMP_TAC std_ss [LENGTH_NIL] \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_APPEND = store_thm("evaluate_APPEND",
-  ``!xs env s ys.
+val evaluate_APPEND = Q.store_thm("evaluate_APPEND",
+  `!xs env s ys.
       evaluate (xs ++ ys,env,s) =
       case evaluate (xs,env,s) of
         (Rval vs,s2) =>
           (case evaluate (ys,env,s2) of
              (Rval ws,s1) => (Rval (vs ++ ws),s1)
            | res => res)
-      | res => res``,
+      | res => res`,
   Induct \\ full_simp_tac(srw_ss())[APPEND,evaluate_def] \\ REPEAT STRIP_TAC
   THEN1 REPEAT BasicProvers.CASE_TAC
   \\ ONCE_REWRITE_TAC [evaluate_CONS]
@@ -198,19 +198,19 @@ val dec_clock0 = Q.store_thm ("dec_clock0[simp]",
   `!n (s:'ffi bviSem$state). dec_clock 0 s = s`,
   simp [dec_clock_def, state_component_equality]);
 
-val do_app_inv_clock = prove(
-  ``case do_app op (REVERSE a) s of
+val do_app_inv_clock = Q.prove(
+  `case do_app op (REVERSE a) s of
     | Rerr e => (do_app op (REVERSE a) (inc_clock n s) = Rerr e)
-    | Rval (v,s1) => (do_app op (REVERSE a) (inc_clock n s) = Rval (v,inc_clock n s1))``,
+    | Rval (v,s1) => (do_app op (REVERSE a) (inc_clock n s) = Rval (v,inc_clock n s1))`,
   full_simp_tac(srw_ss())[bviSemTheory.do_app_def] \\ Cases_on `op` \\ full_simp_tac(srw_ss())[do_app_aux_def,bvlSemTheory.do_app_def]
   \\ BasicProvers.EVERY_CASE_TAC
   \\ full_simp_tac(srw_ss())[bvi_to_bvl_def,closSemTheory.get_global_def,inc_clock_def,bvl_to_bvi_def,LET_DEF]
   \\ SRW_TAC [] [] \\ REV_FULL_SIMP_TAC std_ss []);
 
-val evaluate_inv_clock = store_thm("evaluate_inv_clock",
-  ``!xs env t1 res t2 n.
+val evaluate_inv_clock = Q.store_thm("evaluate_inv_clock",
+  `!xs env t1 res t2 n.
       (evaluate (xs,env,t1) = (res,t2)) /\ res <> Rerr(Rabort Rtimeout_error) ==>
-      (evaluate (xs,env,inc_clock n t1) = (res,inc_clock n t2))``,
+      (evaluate (xs,env,inc_clock n t1) = (res,inc_clock n t2))`,
   SIMP_TAC std_ss [] \\ recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[evaluate_def]
   THEN1 (`?res5 s5. evaluate ([x],env,s) = (res5,s5)` by METIS_TAC [PAIR]
@@ -251,8 +251,8 @@ val evaluate_inv_clock = store_thm("evaluate_inv_clock",
     \\ RES_TAC \\ TRY (full_simp_tac(srw_ss())[inc_clock_def] \\ decide_tac)
     \\ Cases_on `handler` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]));
 
-val evaluate_code_const_lemma = prove(
-  ``!xs env s. (SND (evaluate (xs,env,s))).code = s.code``,
+val evaluate_code_const_lemma = Q.prove(
+  `!xs env s. (SND (evaluate (xs,env,s))).code = s.code`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ REV_FULL_SIMP_TAC std_ss [] \\ full_simp_tac(srw_ss())[dec_clock_def]
@@ -263,8 +263,8 @@ val evaluate_code_const_lemma = prove(
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[bvl_to_bvi_def] \\ full_simp_tac(srw_ss())[do_app_aux_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]);
 
-val evaluate_code_const = store_thm("evaluate_code_const",
-  ``!xs env s res t. (evaluate (xs,env,s) = (res,t)) ==> (t.code = s.code)``,
+val evaluate_code_const = Q.store_thm("evaluate_code_const",
+  `!xs env s res t. (evaluate (xs,env,s) = (res,t)) ==> (t.code = s.code)`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL evaluate_code_const_lemma) \\ full_simp_tac(srw_ss())[]);
 
 val evaluate_global_mono_lemma = Q.prove(
@@ -281,8 +281,8 @@ val evaluate_global_mono = Q.store_thm("evaluate_global_mono",
   `∀xs env s res t. (evaluate (xs,env,s) = (res,t)) ⇒ IS_SOME s.global ⇒ IS_SOME t.global`,
   METIS_TAC[SND,evaluate_global_mono_lemma]);
 
-val do_app_code = store_thm("do_app_code",
-  ``!op s1 s2. (do_app op a s1 = Rval (x0,s2)) ==> (s2.code = s1.code)``,
+val do_app_code = Q.store_thm("do_app_code",
+  `!op s1 s2. (do_app op a s1 = Rval (x0,s2)) ==> (s2.code = s1.code)`,
   SIMP_TAC std_ss [do_app_def] \\ REPEAT STRIP_TAC
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `do_app_aux op a s1` \\ full_simp_tac(srw_ss())[]

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -16,8 +16,8 @@ val _ = Datatype `
 val dec_clock_def = Define `
   dec_clock x s = s with clock := s.clock - x`;
 
-val LESS_EQ_dec_clock = prove(
-  ``r.clock <= (dec_clock x s).clock ==> r.clock <= s.clock``,
+val LESS_EQ_dec_clock = Q.prove(
+  `r.clock <= (dec_clock x s).clock ==> r.clock <= s.clock`,
   SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
 
 val bvi_to_bvl_def = Define `
@@ -87,18 +87,18 @@ val check_clock_def = Define `
   check_clock (s1:'ffi bviSem$state) (s2:'ffi bviSem$state) =
     if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
 
-val check_clock_thm = prove(
-  ``(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_thm = Q.prove(
+  `(check_clock s1 s2).clock <= s2.clock /\
+    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def])
 
-val check_clock_lemma = prove(
-  ``b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)``,
+val check_clock_lemma = Q.prove(
+  `b ==> ((check_clock s1 s).clock < s.clock \/
+          ((check_clock s1 s).clock = s.clock) /\ b)`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val check_clock_IMP = prove(
-  ``n <= (check_clock r s).clock ==> n <= s.clock``,
+val check_clock_IMP = Q.prove(
+  `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 (* The semantics of expression evaluation is defined next. For

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -166,9 +166,9 @@ val evaluate_ind = theorem"evaluate_ind";
 
 (* We prove that the clock never increases. *)
 
-val do_app_const = store_thm("do_app_const",
-  ``(bviSem$do_app op args s1 = Rval (res,s2)) ==>
-    (s2.clock = s1.clock) /\ (s2.code = s1.code)``,
+val do_app_const = Q.store_thm("do_app_const",
+  `(bviSem$do_app op args s1 = Rval (res,s2)) ==>
+    (s2.clock = s1.clock) /\ (s2.code = s1.code)`,
   SIMP_TAC std_ss [do_app_def]
   \\ Cases_on `do_app_aux op args s1` \\ fs []
   \\ Cases_on `x` \\ fs [] THEN1
@@ -182,9 +182,9 @@ val do_app_const = store_thm("do_app_const",
   \\ BasicProvers.EVERY_CASE_TAC
   \\ fs [LET_DEF] \\ SRW_TAC [] [] \\ fs []);
 
-val evaluate_clock = store_thm("evaluate_clock",
-  ``!xs env s1 vs s2.
-      (bviSem$evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock``,
+val evaluate_clock = Q.store_thm("evaluate_clock",
+  `!xs env s1 vs s2.
+      (bviSem$evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss [] \\ BasicProvers.EVERY_CASE_TAC
@@ -209,9 +209,9 @@ val evaluate_clock = store_thm("evaluate_clock",
   \\ FULL_SIMP_TAC std_ss []
   \\ RES_TAC \\ DECIDE_TAC)
 
-val evaluate_check_clock = prove(
-  ``!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)``,
+val evaluate_check_clock = Q.prove(
+  `!xs env s1 vs s2.
+      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
   METIS_TAC [evaluate_clock,check_clock_thm]);
 
 (* Finally, we remove check_clock from the induction and definition theorems. *)

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -83,23 +83,12 @@ val do_app_def = Define `
 (* The evaluation is defined as a clocked functional version of
    a conventional big-step operational semantics. *)
 
-val check_clock_def = Define `
-  check_clock (s1:'ffi bviSem$state) (s2:'ffi bviSem$state) =
-    if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
+val fix_clock_def = Define `
+  fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)`
 
-val check_clock_thm = Q.prove(
-  `(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
-  SRW_TAC [] [check_clock_def])
-
-val check_clock_lemma = Q.prove(
-  `b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
-
-val check_clock_IMP = Q.prove(
-  `n <= (check_clock r s).clock ==> n <= s.clock`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 (* The semantics of expression evaluation is defined next. For
    convenience of subsequent proofs, the evaluation function is
@@ -108,24 +97,24 @@ val check_clock_IMP = Q.prove(
 val evaluate_def = tDefine "evaluate" `
   (evaluate ([],env,s) = (Rval [],s)) /\
   (evaluate (x::y::xs,env,s) =
-     case evaluate ([x],env,s) of
+     case fix_clock s (evaluate ([x],env,s)) of
      | (Rval v1,s1) =>
-         (case evaluate (y::xs,env,check_clock s1 s) of
+         (case evaluate (y::xs,env,s1) of
           | (Rval vs,s2) => (Rval (HD v1::vs),s2)
           | res => res)
      | res => res) /\
   (evaluate ([Var n],env,s) =
      if n < LENGTH env then (Rval [EL n env],s) else (Rerr(Rabort Rtype_error),s)) /\
   (evaluate ([If x1 x2 x3],env,s) =
-     case evaluate ([x1],env,s) of
+     case fix_clock s (evaluate ([x1],env,s)) of
      | (Rval vs,s1) =>
-          if Boolv T = HD vs then evaluate([x2],env,check_clock s1 s) else
-          if Boolv F = HD vs then evaluate([x3],env,check_clock s1 s) else
+          if Boolv T = HD vs then evaluate([x2],env,s1) else
+          if Boolv F = HD vs then evaluate([x3],env,s1) else
             (Rerr(Rabort Rtype_error),s1)
      | res => res) /\
   (evaluate ([Let xs x2],env,s) =
-     case evaluate (xs,env,s) of
-     | (Rval vs,s1) => evaluate ([x2],vs++env,check_clock s1 s)
+     case fix_clock s (evaluate (xs,env,s)) of
+     | (Rval vs,s1) => evaluate ([x2],vs++env,s1)
      | res => res) /\
   (evaluate ([Raise x1],env,s) =
      case evaluate ([x1],env,s) of
@@ -141,26 +130,26 @@ val evaluate_def = tDefine "evaluate" `
      if s.clock = 0 then (Rerr(Rabort Rtimeout_error),s) else evaluate ([x],env,dec_clock 1 s)) /\
   (evaluate ([Call ticks dest xs handler],env,s1) =
      if IS_NONE dest /\ IS_SOME handler then (Rerr(Rabort Rtype_error),s1) else
-     case evaluate (xs,env,s1) of
+     case fix_clock s1 (evaluate (xs,env,s1)) of
      | (Rval vs,s) =>
          (case find_code dest vs s.code of
           | NONE => (Rerr(Rabort Rtype_error),s)
           | SOME (args,exp) =>
-              if (s.clock < ticks + 1) \/ (s1.clock < ticks + 1) then (Rerr(Rabort Rtimeout_error),s with clock := 0) else
-                case evaluate ([exp],args,dec_clock (ticks+1) (check_clock s s1)) of
+              if (s.clock < ticks + 1) then (Rerr(Rabort Rtimeout_error),s with clock := 0) else
+                case fix_clock (dec_clock (ticks+1) s) (evaluate ([exp],args,dec_clock (ticks+1) s)) of
                 | (Rerr(Rraise v),s) =>
                      (case handler of
-                      | SOME x => evaluate ([x],v::env,check_clock s s1)
+                      | SOME x => evaluate ([x],v::env,s)
                       | NONE => (Rerr(Rraise v),s))
                 | res => res)
      | res => res)`
   (WF_REL_TAC `(inv_image (measure I LEX measure exp2_size)
-                             (\(xs,env,s). (s.clock,xs)))`
-   \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-   \\ TRY (MATCH_MP_TAC check_clock_lemma \\ DECIDE_TAC)
-   \\ EVAL_TAC \\ Cases_on `s.clock <= s1.clock`
-   \\ FULL_SIMP_TAC (srw_ss()) []
-   \\ DECIDE_TAC);
+                          (\(xs,env,s). (s.clock,xs)))`
+  >> rpt strip_tac
+  >> simp[dec_clock_def]
+  >> imp_res_tac fix_clock_IMP
+  >> imp_res_tac LESS_EQ_dec_clock
+  >> rw[]);
 
 val evaluate_ind = theorem"evaluate_ind";
 
@@ -184,89 +173,26 @@ val do_app_const = Q.store_thm("do_app_const",
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
   `!xs env s1 vs s2.
-      (bviSem$evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
-  recInduct evaluate_ind \\ REPEAT STRIP_TAC
-  \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
-  \\ FULL_SIMP_TAC std_ss [] \\ BasicProvers.EVERY_CASE_TAC
-  \\ REPEAT STRIP_TAC \\ SRW_TAC [] [check_clock_def]
-  \\ RES_TAC \\ IMP_RES_TAC check_clock_IMP
-  \\ FULL_SIMP_TAC std_ss [PULL_FORALL] \\ RES_TAC
-  \\ IMP_RES_TAC check_clock_IMP
-  \\ IMP_RES_TAC do_app_const
-  \\ FULL_SIMP_TAC (srw_ss()) [dec_clock_def] \\ TRY DECIDE_TAC
-  \\ REV_FULL_SIMP_TAC std_ss []
-  \\ TRY (`check_clock r s1 = r` by SRW_TAC [] [check_clock_def]
-          \\ fs [] \\ RES_TAC \\ DECIDE_TAC)
-  \\ `check_clock r s1 = r` by SRW_TAC [] [check_clock_def]
-  \\ fs [] \\ POP_ASSUM (K ALL_TAC)
-  \\ SRW_TAC [] [] \\ RES_TAC
-  \\ Q.PAT_X_ASSUM `!x.bbb` MP_TAC
-  \\ `r''.clock <= s1.clock` by DECIDE_TAC
-  \\ POP_ASSUM (fn th => SIMP_TAC std_ss [th])
-  \\ REPEAT STRIP_TAC
-  \\ `r''.clock <= s1.clock` by DECIDE_TAC
-  \\ `check_clock r'' s1 = r''` by SRW_TAC [] [check_clock_def]
-  \\ FULL_SIMP_TAC std_ss []
-  \\ RES_TAC \\ DECIDE_TAC)
+  (bviSem$evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
+  recInduct evaluate_ind >> rw[evaluate_def] >>
+  every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >>
+  imp_res_tac do_app_const >> fs[]);
 
-val evaluate_check_clock = Q.prove(
-  `!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
-  METIS_TAC [evaluate_clock,check_clock_thm]);
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate (xs,env,s)) = evaluate (xs,env,s)`,
+  Cases_on `evaluate(xs,env,s)` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-(* Finally, we remove check_clock from the induction and definition theorems. *)
 
-val clean_term = term_rewrite
-                   [``check_clock s1 s2 = s1:'ffi bviSem$state``,
-                    ``(s.clock < k \/ b2) <=> (s:'ffi bviSem$state).clock < k:num``]
+(* Finally, we remove fix_clock from the induction and definition theorems. *)
 
-val evaluate_ind = save_thm("evaluate_ind",let
-  val raw_ind = evaluate_ind |> INST_TYPE[alpha|->``:'ffi``]
-  val goal = raw_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val ind = prove(goal,
-    STRIP_TAC \\ STRIP_TAC \\ MATCH_MP_TAC raw_ind
-    \\ reverse (REPEAT STRIP_TAC) \\ ASM_REWRITE_TAC []
-    THEN1 (first_x_assum match_mp_tac
-           \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC \\ fs []
-           \\ SRW_TAC [] [] \\ IMP_RES_TAC evaluate_clock
-           \\ IMP_RES_TAC evaluate_check_clock \\ fs []
-           \\ fs [check_clock_def, dec_clock_def]
-           \\ rfs []
-           \\ TRY (`s'.clock ≤ s1.clock` by decide_tac)
-           \\ fs []
-           \\ first_x_assum match_mp_tac
-           \\ decide_tac)
-    \\ FIRST_X_ASSUM (MATCH_MP_TAC)
-    \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC \\ RES_TAC
-    \\ REPEAT (Q.PAT_X_ASSUM `!x.bbb` (K ALL_TAC))
-    \\ IMP_RES_TAC evaluate_clock
-    \\ FULL_SIMP_TAC std_ss [check_clock_thm])
-  in ind end);
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = save_thm("evaluate_def",let
-  val goal = evaluate_def |> INST_TYPE[alpha|->``:'ffi``] |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val def = prove(goal,
-    REPEAT STRIP_TAC
-    \\ SIMP_TAC (srw_ss()) []
-    \\ BasicProvers.EVERY_CASE_TAC
-    \\ fs [evaluate_def] \\ rfs []
-    \\ IMP_RES_TAC evaluate_check_clock
-    \\ IMP_RES_TAC evaluate_clock
-    \\ IMP_RES_TAC LESS_EQ_TRANS
-    \\ IMP_RES_TAC LESS_EQ_dec_clock
-    \\ REPEAT (Q.PAT_X_ASSUM `!x. bbb` (K ALL_TAC))
-    \\ IMP_RES_TAC do_app_const
-    \\ SRW_TAC [] []
-    \\ fs [check_clock_thm]
-    \\ rfs [check_clock_thm]
-    \\ fs [check_clock_thm, dec_clock_def]
-    \\ IMP_RES_TAC LESS_EQ_TRANS
-    \\ REPEAT (Q.PAT_X_ASSUM `!x. bbb` (K ALL_TAC))
-    \\ fs [check_clock_thm]
-    \\ imp_res_tac LESS_EQ_LESS_TRANS)
-  in def end);
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 (* observational semantics *)
 

--- a/compiler/backend/semantics/bvlPropsScript.sml
+++ b/compiler/backend/semantics/bvlPropsScript.sml
@@ -50,9 +50,9 @@ val bool_to_tag_11 = Q.store_thm("bool_to_tag_11[simp]",
 
 val _ = Q.store_thm("Boolv_11[simp]",`bvlSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
 
-val find_code_EVERY_IMP = store_thm("find_code_EVERY_IMP",
-  ``(find_code dest a (r:'ffi bvlSem$state).code = SOME (q,t)) ==>
-    EVERY P a ==> EVERY P q``,
+val find_code_EVERY_IMP = Q.store_thm("find_code_EVERY_IMP",
+  `(find_code dest a (r:'ffi bvlSem$state).code = SOME (q,t)) ==>
+    EVERY P a ==> EVERY P q`,
   Cases_on `dest` \\ full_simp_tac(srw_ss())[find_code_def] \\ REPEAT STRIP_TAC
   \\ BasicProvers.EVERY_CASE_TAC \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
   \\ BasicProvers.EVERY_CASE_TAC \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
@@ -67,11 +67,11 @@ val do_app_err = Q.store_thm("do_app_err",
   `do_app op vs s = Rerr e ⇒ (e = Rabort Rtype_error)`,
   srw_tac[][do_app_def] >> every_case_tac >> full_simp_tac(srw_ss())[LET_THM] >> srw_tac[][]);
 
-val evaluate_LENGTH = prove(
-  ``!xs s env. (\(xs,s,env).
+val evaluate_LENGTH = Q.prove(
+  `!xs s env. (\(xs,s,env).
       (case evaluate (xs,s,env) of (Rval res,s1) => (LENGTH xs = LENGTH res)
             | _ => T))
-      (xs,s,env)``,
+      (xs,s,env)`,
   HO_MATCH_MP_TAC evaluate_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [evaluate_def]
   \\ SRW_TAC [] [] \\ SRW_TAC [] []
@@ -81,18 +81,18 @@ val evaluate_LENGTH = prove(
 
 val _ = save_thm("evaluate_LENGTH", evaluate_LENGTH);
 
-val evaluate_IMP_LENGTH = store_thm("evaluate_IMP_LENGTH",
-  ``(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)``,
+val evaluate_IMP_LENGTH = Q.store_thm("evaluate_IMP_LENGTH",
+  `(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL evaluate_LENGTH) \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_CONS = store_thm("evaluate_CONS",
-  ``evaluate (x::xs,env,s) =
+val evaluate_CONS = Q.store_thm("evaluate_CONS",
+  `evaluate (x::xs,env,s) =
       case evaluate ([x],env,s) of
       | (Rval v,s2) =>
          (case evaluate (xs,env,s2) of
           | (Rval vs,s1) => (Rval (HD v::vs),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Cases_on `xs` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `evaluate ([x],env,s)` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `q` \\ full_simp_tac(srw_ss())[evaluate_def]
@@ -100,15 +100,15 @@ val evaluate_CONS = store_thm("evaluate_CONS",
   \\ Cases_on `a` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `t` \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_SNOC = store_thm("evaluate_SNOC",
-  ``!xs env s x.
+val evaluate_SNOC = Q.store_thm("evaluate_SNOC",
+  `!xs env s x.
       evaluate (SNOC x xs,env,s) =
       case evaluate (xs,env,s) of
       | (Rval vs,s2) =>
          (case evaluate ([x],env,s2) of
           | (Rval v,s1) => (Rval (vs ++ v),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Induct THEN1
    (full_simp_tac(srw_ss())[SNOC_APPEND,evaluate_def] \\ REPEAT STRIP_TAC
     \\ Cases_on `evaluate ([x],env,s)` \\ Cases_on `q` \\ full_simp_tac(srw_ss())[])
@@ -122,15 +122,15 @@ val evaluate_SNOC = store_thm("evaluate_SNOC",
   \\ Cases_on `a''` \\ full_simp_tac(srw_ss())[LENGTH]
   \\ REV_FULL_SIMP_TAC std_ss [LENGTH_NIL] \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_APPEND = store_thm("evaluate_APPEND",
-  ``!xs env s ys.
+val evaluate_APPEND = Q.store_thm("evaluate_APPEND",
+  `!xs env s ys.
       evaluate (xs ++ ys,env,s) =
       case evaluate (xs,env,s) of
         (Rval vs,s2) =>
           (case evaluate (ys,env,s2) of
              (Rval ws,s1) => (Rval (vs ++ ws),s1)
            | res => res)
-      | res => res``,
+      | res => res`,
   Induct \\ full_simp_tac(srw_ss())[APPEND,evaluate_def] \\ REPEAT STRIP_TAC
   THEN1 REPEAT BasicProvers.CASE_TAC
   \\ ONCE_REWRITE_TAC [evaluate_CONS]
@@ -141,9 +141,9 @@ val evaluate_SING = Q.store_thm("evaluate_SING",
   REPEAT STRIP_TAC \\ IMP_RES_TAC evaluate_IMP_LENGTH
   \\ Cases_on `a` \\ full_simp_tac(srw_ss())[LENGTH_NIL]);
 
-val evaluate_code = store_thm("evaluate_code",
-  ``!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> s2.code = s1.code``,
+val evaluate_code = Q.store_thm("evaluate_code",
+  `!xs env s1 vs s2.
+      (evaluate (xs,env,s1) = (vs,s2)) ==> s2.code = s1.code`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss []
@@ -178,10 +178,10 @@ val evaluate_mk_tick = Q.store_thm ("evaluate_mk_tick",
   >- (`s.clock = n` by decide_tac >>
       full_simp_tac(srw_ss())[]));
 
-val evaluate_MAP_Const = store_thm("evaluate_MAP_Const",
-  ``!exps.
+val evaluate_MAP_Const = Q.store_thm("evaluate_MAP_Const",
+  `!exps.
       evaluate (MAP (K (Op (Const i) [])) (exps:'a list),env,t1) =
-        (Rval (MAP (K (Number i)) exps),t1)``,
+        (Rval (MAP (K (Number i)) exps),t1)`,
   Induct \\ full_simp_tac(srw_ss())[evaluate_def,evaluate_CONS,do_app_def]);
 
 val evaluate_Bool = Q.store_thm("evaluate_Bool[simp]",
@@ -478,15 +478,15 @@ val evaluate_isConst = Q.store_thm("evaluate_isConst",
   \\ Cases_on `o'` \\ full_simp_tac(srw_ss())[isConst_def]
   \\ Cases_on `l` \\ full_simp_tac(srw_ss())[isConst_def,evaluate_def,do_app_def,getConst_def]);
 
-val do_app_refs_SUBSET = store_thm("do_app_refs_SUBSET",
-  ``(do_app op a r = Rval (q,t)) ==> FDOM r.refs SUBSET FDOM t.refs``,
+val do_app_refs_SUBSET = Q.store_thm("do_app_refs_SUBSET",
+  `(do_app op a r = Rval (q,t)) ==> FDOM r.refs SUBSET FDOM t.refs`,
   full_simp_tac(srw_ss())[do_app_def]
   \\ NTAC 5 (full_simp_tac(srw_ss())[SUBSET_DEF,IN_INSERT] \\ SRW_TAC [] []
   \\ BasicProvers.EVERY_CASE_TAC
   \\ full_simp_tac(srw_ss())[LET_DEF,dec_clock_def]));
 
-val evaluate_refs_SUBSET_lemma = prove(
-  ``!xs env s. FDOM s.refs SUBSET FDOM (SND (evaluate (xs,env,s))).refs``,
+val evaluate_refs_SUBSET_lemma = Q.prove(
+  `!xs env s. FDOM s.refs SUBSET FDOM (SND (evaluate (xs,env,s))).refs`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ REV_FULL_SIMP_TAC std_ss []
@@ -494,8 +494,8 @@ val evaluate_refs_SUBSET_lemma = prove(
   \\ full_simp_tac(srw_ss())[dec_clock_def] \\ full_simp_tac(srw_ss())[]
   \\ IMP_RES_TAC do_app_refs_SUBSET \\ full_simp_tac(srw_ss())[SUBSET_DEF]);
 
-val evaluate_refs_SUBSET = store_thm("evaluate_refs_SUBSET",
-  ``(evaluate (xs,env,s) = (res,t)) ==> FDOM s.refs SUBSET FDOM t.refs``,
+val evaluate_refs_SUBSET = Q.store_thm("evaluate_refs_SUBSET",
+  `(evaluate (xs,env,s) = (res,t)) ==> FDOM s.refs SUBSET FDOM t.refs`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL evaluate_refs_SUBSET_lemma) \\ full_simp_tac(srw_ss())[]);
 
 val get_vars_def = Define `

--- a/compiler/backend/semantics/bvlPropsScript.sml
+++ b/compiler/backend/semantics/bvlPropsScript.sml
@@ -44,8 +44,8 @@ val initial_state_with_simp = Q.store_thm("initial_state_with_simp[simp]",
    initial_state f c k with code := c1 = initial_state f c1 k`,
   EVAL_TAC);
 
-val bool_to_tag_11 = store_thm("bool_to_tag_11[simp]",
-  ``bool_to_tag b1 = bool_to_tag b2 ⇔ (b1 = b2)``,
+val bool_to_tag_11 = Q.store_thm("bool_to_tag_11[simp]",
+  `bool_to_tag b1 = bool_to_tag b2 ⇔ (b1 = b2)`,
   srw_tac[][bool_to_tag_def] >> EVAL_TAC >> simp[])
 
 val _ = Q.store_thm("Boolv_11[simp]",`bvlSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
@@ -345,7 +345,7 @@ val evaluate_io_events_mono = Q.store_thm("evaluate_io_events_mono",
   srw_tac[][] >> rev_full_simp_tac(srw_ss())[] >>
   metis_tac[IS_PREFIX_TRANS,do_app_io_events_mono])
 
-val Boolv_11 = store_thm("Boolv_11[simp]",``bvlSem$Boolv b1 = Boolv b2 ⇔ b1 = b2``,EVAL_TAC>>srw_tac[][]);
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",`bvlSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
 
 val do_app_inc_clock = Q.prove(
   `do_app op vs (inc_clock x y) =

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -214,22 +214,15 @@ val find_code_def = Define `
 
 (* Proving termination of the evaluator directly is tricky. We make
    our life simpler by forcing the clock to stay good using
-   check_clock. At the bottom of this file, we remove all occurrences
-   of check_clock. *)
+   fix_clock. At the bottom of this file, we remove all occurrences
+   of fix_clock. *)
 
-val check_clock_def = Define `
-  check_clock (s1:'ffi bvlSem$state) (s2:'ffi bvlSem$state) =
-    if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
+val fix_clock_def = Define `
+  fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)`
 
-val check_clock_thm = Q.prove(
-  `(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
-  SRW_TAC [] [check_clock_def])
-
-val check_clock_lemma = Q.prove(
-  `b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 (* The semantics of expression evaluation is defined next. For
    convenience of subsequent proofs, the evaluation function is
@@ -238,32 +231,32 @@ val check_clock_lemma = Q.prove(
 val evaluate_def = tDefine "evaluate" `
   (evaluate ([],env,s:'ffi bvlSem$state) = (Rval [],s)) /\
   (evaluate (x::y::xs,env,s) =
-     case evaluate ([x],env,s) of
+     case fix_clock s (evaluate ([x],env,s)) of
      | (Rval v1,s1) =>
-         (case evaluate (y::xs,env,check_clock s1 s) of
+         (case evaluate (y::xs,env,s1) of
           | (Rval vs,s2) => (Rval (HD v1::vs),s2)
           | res => res)
      | res => res) /\
   (evaluate ([Var n],env,s) =
      if n < LENGTH env then (Rval [EL n env],s) else (Rerr(Rabort Rtype_error),s)) /\
   (evaluate ([If x1 x2 x3],env,s) =
-     case evaluate ([x1],env,s) of
+     case fix_clock s (evaluate ([x1],env,s)) of
      | (Rval vs,s1) =>
-          if Boolv T = HD vs then evaluate([x2],env,check_clock s1 s) else
-          if Boolv F = HD vs then evaluate([x3],env,check_clock s1 s) else
+          if Boolv T = HD vs then evaluate([x2],env,s1) else
+          if Boolv F = HD vs then evaluate([x3],env,s1) else
             (Rerr(Rabort Rtype_error),s1)
      | res => res) /\
   (evaluate ([Let xs x2],env,s) =
-     case evaluate (xs,env,s) of
-     | (Rval vs,s1) => evaluate ([x2],vs++env,check_clock s1 s)
+     case fix_clock s (evaluate (xs,env,s)) of
+     | (Rval vs,s1) => evaluate ([x2],vs++env,s1)
      | res => res) /\
   (evaluate ([Raise x1],env,s) =
      case evaluate ([x1],env,s) of
      | (Rval vs,s) => (Rerr(Rraise (HD vs)),s)
      | res => res) /\
   (evaluate ([Handle x1 x2],env,s1) =
-     case evaluate ([x1],env,s1) of
-     | (Rerr(Rraise v),s) => evaluate ([x2],v::env,check_clock s s1)
+     case fix_clock s1 (evaluate ([x1],env,s1)) of
+     | (Rerr(Rraise v),s) => evaluate ([x2],v::env,s)
      | res => res) /\
   (evaluate ([Op op xs],env,s) =
      case evaluate (xs,env,s) of
@@ -274,26 +267,25 @@ val evaluate_def = tDefine "evaluate" `
   (evaluate ([Tick x],env,s) =
      if s.clock = 0 then (Rerr(Rabort Rtimeout_error),s) else evaluate ([x],env,dec_clock 1 s)) /\
   (evaluate ([Call ticks dest xs],env,s1) =
-     case evaluate (xs,env,s1) of
+     case fix_clock s1 (evaluate (xs,env,s1)) of
      | (Rval vs,s) =>
          (case find_code dest vs s.code of
           | NONE => (Rerr(Rabort Rtype_error),s)
           | SOME (args,exp) =>
-              if (s.clock < ticks + 1) \/ (s1.clock < ticks + 1) then (Rerr(Rabort Rtimeout_error),s with clock := 0) else
-                  evaluate ([exp],args,dec_clock (ticks + 1) (check_clock s s1)))
+              if s.clock < ticks + 1 then (Rerr(Rabort Rtimeout_error),s with clock := 0) else
+                  evaluate ([exp],args,dec_clock (ticks + 1) s))
      | res => res)`
  (WF_REL_TAC `(inv_image (measure I LEX measure exp1_size)
-                            (\(xs,env,s). (s.clock,xs)))`
-  \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-  \\ TRY (MATCH_MP_TAC check_clock_lemma \\ DECIDE_TAC)
-  \\ EVAL_TAC \\ Cases_on `s.clock <= s1.clock`
-  \\ FULL_SIMP_TAC (srw_ss()) [] \\ DECIDE_TAC);
+                         (\(xs,env,s). (s.clock,xs)))`
+  \\ rpt strip_tac
+  \\ simp[dec_clock_def]
+  \\ imp_res_tac fix_clock_IMP
+  \\ FULL_SIMP_TAC (srw_ss()) []
+  \\ decide_tac);
+
+val evaluate_ind = theorem"evaluate_ind";		
 
 (* We prove that the clock never increases. *)
-
-val check_clock_IMP = Q.prove(
-  `n <= (check_clock r s).clock ==> n <= s.clock`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 val do_app_const = Q.store_thm("do_app_const",
   `(do_app op args s1 = Rval (res,s2)) ==>
@@ -304,74 +296,26 @@ val do_app_const = Q.store_thm("do_app_const",
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
   `!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
-  recInduct (fetch "-" "evaluate_ind") \\ REPEAT STRIP_TAC
-  \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
-  \\ FULL_SIMP_TAC std_ss [] \\ BasicProvers.EVERY_CASE_TAC
-  \\ REPEAT STRIP_TAC \\ SRW_TAC [] [check_clock_def]
-  \\ RES_TAC \\ IMP_RES_TAC check_clock_IMP
-  \\ FULL_SIMP_TAC std_ss [PULL_FORALL] \\ RES_TAC
-  \\ IMP_RES_TAC check_clock_IMP
-  \\ IMP_RES_TAC do_app_const
-  \\ FULL_SIMP_TAC (srw_ss()) [dec_clock_def] \\ TRY DECIDE_TAC
-  \\ POP_ASSUM MP_TAC \\ REPEAT (POP_ASSUM (K ALL_TAC))
-  \\ SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
+				(evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
+  recInduct evaluate_ind >> rw[evaluate_def] >>
+  every_case_tac >>
+  full_simp_tac(srw_ss())[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[] >>
+  imp_res_tac do_app_const >> fs[]);
 
-val evaluate_check_clock = Q.prove(
-  `!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
-  METIS_TAC [evaluate_clock,check_clock_thm]);
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate (xs,env,s)) = evaluate (xs,env,s)`,
+  Cases_on `evaluate (xs,env,s)` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-(* Finally, we remove check_clock from the induction and definition theorems. *)
+(* Finally, we remove fix_clock from the induction and definition theorems. *)
 
-val clean_term = term_rewrite
-                   [``check_clock s1 s2 = s1:'ffi bvlSem$state``,
-                    ``(s.clock < k \/ b2) <=> (s:'ffi bvlSem$state).clock < k:num``]
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_ind = save_thm("evaluate_ind",let
-  val raw_ind = fetch "-" "evaluate_ind"
-  val goal = raw_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val ind = prove(goal,
-    STRIP_TAC \\ STRIP_TAC \\ MATCH_MP_TAC raw_ind
-    \\ reverse (REPEAT STRIP_TAC) \\ ASM_REWRITE_TAC []
-    THEN1 (Q.PAT_X_ASSUM `!ticks dest xs env s1. bb ==> bbb` MATCH_MP_TAC
-           \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC
-           \\ IMP_RES_TAC evaluate_clock
-           \\ `¬(s1.clock < ticks + 1)` by DECIDE_TAC
-           \\ SRW_TAC [] []
-           \\ FULL_SIMP_TAC (srw_ss()) []
-           \\ IMP_RES_TAC evaluate_check_clock
-           \\ FULL_SIMP_TAC std_ss [])
-    \\ FIRST_X_ASSUM (MATCH_MP_TAC)
-    \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC \\ RES_TAC
-    \\ REPEAT (Q.PAT_X_ASSUM `!x.bbb` (K ALL_TAC))
-    \\ IMP_RES_TAC evaluate_clock
-    \\ FULL_SIMP_TAC std_ss [check_clock_thm])
-  in ind end);
-
-val evaluate_def = save_thm("evaluate_def",let
-  val goal = evaluate_def |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val def = prove(goal,
-    REPEAT STRIP_TAC
-    \\ SIMP_TAC (srw_ss()) []
-    \\ BasicProvers.EVERY_CASE_TAC
-    \\ fs [evaluate_def] \\ rfs []
-    \\ IMP_RES_TAC evaluate_check_clock
-    \\ IMP_RES_TAC evaluate_clock
-    \\ IMP_RES_TAC LESS_EQ_TRANS
-    \\ REPEAT (Q.PAT_X_ASSUM `!x. bbb` (K ALL_TAC))
-    \\ IMP_RES_TAC do_app_const
-    \\ SRW_TAC [] []
-    \\ fs [check_clock_thm]
-    \\ rfs [check_clock_thm]
-    \\ fs [check_clock_thm, dec_clock_def]
-    \\ IMP_RES_TAC LESS_EQ_TRANS
-    \\ REPEAT (Q.PAT_X_ASSUM `!x. bbb` (K ALL_TAC))
-    \\ fs [check_clock_thm]
-    \\ imp_res_tac LESS_EQ_LESS_TRANS)
-  in def end);
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 (* observational semantics *)
 

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -221,14 +221,14 @@ val check_clock_def = Define `
   check_clock (s1:'ffi bvlSem$state) (s2:'ffi bvlSem$state) =
     if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
 
-val check_clock_thm = prove(
-  ``(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_thm = Q.prove(
+  `(check_clock s1 s2).clock <= s2.clock /\
+    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def])
 
-val check_clock_lemma = prove(
-  ``b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)``,
+val check_clock_lemma = Q.prove(
+  `b ==> ((check_clock s1 s).clock < s.clock \/
+          ((check_clock s1 s).clock = s.clock) /\ b)`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 (* The semantics of expression evaluation is defined next. For
@@ -291,8 +291,8 @@ val evaluate_def = tDefine "evaluate" `
 
 (* We prove that the clock never increases. *)
 
-val check_clock_IMP = prove(
-  ``n <= (check_clock r s).clock ==> n <= s.clock``,
+val check_clock_IMP = Q.prove(
+  `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 val do_app_const = store_thm("do_app_const",

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -295,16 +295,16 @@ val check_clock_IMP = Q.prove(
   `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val do_app_const = store_thm("do_app_const",
-  ``(do_app op args s1 = Rval (res,s2)) ==>
-    (s2.clock = s1.clock) /\ (s2.code = s1.code)``,
+val do_app_const = Q.store_thm("do_app_const",
+  `(do_app op args s1 = Rval (res,s2)) ==>
+    (s2.clock = s1.clock) /\ (s2.code = s1.code)`,
   SIMP_TAC std_ss [do_app_def]
   \\ BasicProvers.EVERY_CASE_TAC
   \\ fs [LET_DEF] \\ SRW_TAC [] [] \\ fs []);
 
-val evaluate_clock = store_thm("evaluate_clock",
-  ``!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock``,
+val evaluate_clock = Q.store_thm("evaluate_clock",
+  `!xs env s1 vs s2.
+      (evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
   recInduct (fetch "-" "evaluate_ind") \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss [] \\ BasicProvers.EVERY_CASE_TAC
@@ -317,9 +317,9 @@ val evaluate_clock = store_thm("evaluate_clock",
   \\ POP_ASSUM MP_TAC \\ REPEAT (POP_ASSUM (K ALL_TAC))
   \\ SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val evaluate_check_clock = prove(
-  ``!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)``,
+val evaluate_check_clock = Q.prove(
+  `!xs env s1 vs s2.
+      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
   METIS_TAC [evaluate_clock,check_clock_thm]);
 
 (* Finally, we remove check_clock from the induction and definition theorems. *)

--- a/compiler/backend/semantics/closPropsScript.sml
+++ b/compiler/backend/semantics/closPropsScript.sml
@@ -74,18 +74,18 @@ val code_locs_def = tDefine "code_locs" `
    full_simp_tac(srw_ss())[exp_size_def] >>
    decide_tac);
 
-val code_locs_cons = store_thm("code_locs_cons",
-  ``∀x xs. code_locs (x::xs) = code_locs [x] ++ code_locs xs``,
+val code_locs_cons = Q.store_thm("code_locs_cons",
+  `∀x xs. code_locs (x::xs) = code_locs [x] ++ code_locs xs`,
   gen_tac >> Cases >> simp[code_locs_def]);
 
-val code_locs_append = store_thm("code_locs_append",
-  ``!l1 l2. code_locs (l1 ++ l2) = code_locs l1 ++ code_locs l2``,
+val code_locs_append = Q.store_thm("code_locs_append",
+  `!l1 l2. code_locs (l1 ++ l2) = code_locs l1 ++ code_locs l2`,
   Induct >> simp[code_locs_def] >>
   simp[Once code_locs_cons] >>
   simp[Once code_locs_cons,SimpRHS]);
 
-val code_locs_map = store_thm("code_locs_map",
-  ``!xs f. code_locs (MAP f xs) = FLAT (MAP (\x. code_locs [f x]) xs)``,
+val code_locs_map = Q.store_thm("code_locs_map",
+  `!xs f. code_locs (MAP f xs) = FLAT (MAP (\x. code_locs [f x]) xs)`,
   Induct \\ full_simp_tac(srw_ss())[code_locs_def]
   \\ ONCE_REWRITE_TAC [code_locs_cons] \\ full_simp_tac(srw_ss())[code_locs_def]);
 
@@ -130,8 +130,8 @@ val contains_App_SOME_def = tDefine "contains_App_SOME" `
    full_simp_tac(srw_ss())[exp_size_def] >>
    decide_tac);
 
-val contains_App_SOME_EXISTS = store_thm("contains_App_SOME_EXISTS",
-  ``∀ls max_app. contains_App_SOME max_app ls ⇔ EXISTS (λx. contains_App_SOME max_app [x]) ls``,
+val contains_App_SOME_EXISTS = Q.store_thm("contains_App_SOME_EXISTS",
+  `∀ls max_app. contains_App_SOME max_app ls ⇔ EXISTS (λx. contains_App_SOME max_app [x]) ls`,
   Induct >> simp[contains_App_SOME_def] >>
   Cases_on`ls`>>full_simp_tac(srw_ss())[contains_App_SOME_def])
 
@@ -178,8 +178,8 @@ val every_Fn_SOME_def = tDefine "every_Fn_SOME" `
    decide_tac);
 val _ = export_rewrites["every_Fn_SOME_def"];
 
-val every_Fn_SOME_EVERY = store_thm("every_Fn_SOME_EVERY",
-  ``∀ls. every_Fn_SOME ls ⇔ EVERY (λx. every_Fn_SOME [x]) ls``,
+val every_Fn_SOME_EVERY = Q.store_thm("every_Fn_SOME_EVERY",
+  `∀ls. every_Fn_SOME ls ⇔ EVERY (λx. every_Fn_SOME [x]) ls`,
   Induct >> simp[every_Fn_SOME_def] >>
   Cases_on`ls`>>full_simp_tac(srw_ss())[every_Fn_SOME_def])
 
@@ -226,8 +226,8 @@ val every_Fn_vs_NONE_def = tDefine "every_Fn_vs_NONE" `
    decide_tac);
 val _ = export_rewrites["every_Fn_vs_NONE_def"];
 
-val every_Fn_vs_NONE_EVERY = store_thm("every_Fn_vs_NONE_EVERY",
-  ``∀ls. every_Fn_vs_NONE ls ⇔ EVERY (λx. every_Fn_vs_NONE [x]) ls``,
+val every_Fn_vs_NONE_EVERY = Q.store_thm("every_Fn_vs_NONE_EVERY",
+  `∀ls. every_Fn_vs_NONE ls ⇔ EVERY (λx. every_Fn_vs_NONE [x]) ls`,
   Induct >> simp[every_Fn_vs_NONE_def] >>
   Cases_on`ls`>>full_simp_tac(srw_ss())[every_Fn_vs_NONE_def])
 
@@ -274,8 +274,8 @@ val every_Fn_vs_SOME_def = tDefine "every_Fn_vs_SOME" `
    decide_tac);
 val _ = export_rewrites["every_Fn_vs_SOME_def"];
 
-val every_Fn_vs_SOME_EVERY = store_thm("every_Fn_vs_SOME_EVERY",
-  ``∀ls. every_Fn_vs_SOME ls ⇔ EVERY (λx. every_Fn_vs_SOME [x]) ls``,
+val every_Fn_vs_SOME_EVERY = Q.store_thm("every_Fn_vs_SOME_EVERY",
+  `∀ls. every_Fn_vs_SOME ls ⇔ EVERY (λx. every_Fn_vs_SOME [x]) ls`,
   Induct >> simp[every_Fn_vs_SOME_def] >>
   Cases_on`ls`>>full_simp_tac(srw_ss())[every_Fn_vs_SOME_def])
 
@@ -369,7 +369,7 @@ val do_app_err = Q.store_thm("do_app_err",
   srw_tac[][do_app_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[LET_THM] >> srw_tac[][])
 
-val Boolv_11 = store_thm("Boolv_11[simp]",``closSem$Boolv b1 = Boolv b2 ⇔ b1 = b2``,EVAL_TAC>>srw_tac[][]);
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",`closSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
 
 val do_eq_list_rel = store_thm("do_eq_list_rel",
   ``∀l1 l2 l3 l4.
@@ -509,8 +509,8 @@ val evaluate_REPLICATE_Op_AllocGlobal = store_thm("evaluate_REPLICATE_Op_AllocGl
   simp[Once evaluate_CONS,evaluate_def,do_app_def,GENLIST_CONS] >>
   simp[state_component_equality])
 
-val lookup_vars_NONE = store_thm("lookup_vars_NONE",
-  ``!vs. (lookup_vars vs env = NONE) <=> ?v. MEM v vs /\ LENGTH env <= v``,
+val lookup_vars_NONE = Q.store_thm("lookup_vars_NONE",
+  `!vs. (lookup_vars vs env = NONE) <=> ?v. MEM v vs /\ LENGTH env <= v`,
   Induct \\ full_simp_tac(srw_ss())[lookup_vars_def]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `h < LENGTH env` \\ full_simp_tac(srw_ss())[NOT_LESS]
@@ -518,18 +518,18 @@ val lookup_vars_NONE = store_thm("lookup_vars_NONE",
   THEN1 METIS_TAC []
   \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[] \\ METIS_TAC [NOT_LESS]);
 
-val lookup_vars_SOME = store_thm("lookup_vars_SOME",
-  ``!vs env xs.
+val lookup_vars_SOME = Q.store_thm("lookup_vars_SOME",
+  `!vs env xs.
       (lookup_vars vs env = SOME xs) ==>
-      (LENGTH vs = LENGTH xs)``,
+      (LENGTH vs = LENGTH xs)`,
   Induct \\ full_simp_tac(srw_ss())[lookup_vars_def] \\ REPEAT STRIP_TAC
   \\ Cases_on `lookup_vars vs env` \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ RES_TAC);
 
-val lookup_vars_MEM = prove(
-  ``!ys n x (env2:closSem$v list).
+val lookup_vars_MEM = Q.prove(
+  `!ys n x (env2:closSem$v list).
       (lookup_vars ys env2 = SOME x) /\ n < LENGTH ys ==>
       (EL n ys) < LENGTH env2 /\
-      (EL n x = EL (EL n ys) env2)``,
+      (EL n x = EL (EL n ys) env2)`,
   Induct \\ full_simp_tac(srw_ss())[lookup_vars_def] \\ NTAC 5 STRIP_TAC
   \\ Cases_on `lookup_vars ys env2` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `n` \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]) |> SPEC_ALL

--- a/compiler/backend/semantics/closPropsScript.sml
+++ b/compiler/backend/semantics/closPropsScript.sml
@@ -371,11 +371,11 @@ val do_app_err = Q.store_thm("do_app_err",
 
 val Boolv_11 = Q.store_thm("Boolv_11[simp]",`closSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
 
-val do_eq_list_rel = store_thm("do_eq_list_rel",
-  ``∀l1 l2 l3 l4.
+val do_eq_list_rel = Q.store_thm("do_eq_list_rel",
+  `∀l1 l2 l3 l4.
      LENGTH l1 = LENGTH l2 ∧ LENGTH l3 = LENGTH l4 ∧
      LIST_REL (λp1 p2. UNCURRY do_eq p1 = UNCURRY do_eq p2) (ZIP(l1,l2)) (ZIP(l3,l4)) ⇒
-     closSem$do_eq_list l1 l2 = do_eq_list l3 l4``,
+     closSem$do_eq_list l1 l2 = do_eq_list l3 l4`,
    Induct >> simp[LENGTH_NIL_SYM] >- (
      simp[GSYM AND_IMP_INTRO, ZIP_EQ_NIL] ) >>
    gen_tac >> Cases >> simp[PULL_EXISTS] >>
@@ -401,31 +401,31 @@ val evaluate_LENGTH = prove(evaluate_LENGTH_ind |> concl |> rand,
 
 val _ = save_thm("evaluate_LENGTH", evaluate_LENGTH);
 
-val evaluate_IMP_LENGTH = store_thm("evaluate_IMP_LENGTH",
-  ``(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)``,
+val evaluate_IMP_LENGTH = Q.store_thm("evaluate_IMP_LENGTH",
+  `(evaluate (xs,s,env) = (Rval res,s1)) ==> (LENGTH xs = LENGTH res)`,
   REPEAT STRIP_TAC
   \\ (evaluate_LENGTH |> CONJUNCT1 |> Q.ISPECL_THEN [`xs`,`s`,`env`] MP_TAC)
   \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_app_IMP_LENGTH = store_thm("evaluate_app_IMP_LENGTH",
-  ``(evaluate_app x1 x2 x3 x4 = (Rval res,s1)) ==> (LENGTH res = 1)``,
+val evaluate_app_IMP_LENGTH = Q.store_thm("evaluate_app_IMP_LENGTH",
+  `(evaluate_app x1 x2 x3 x4 = (Rval res,s1)) ==> (LENGTH res = 1)`,
   REPEAT STRIP_TAC
   \\ (evaluate_LENGTH |> CONJUNCT2 |> Q.ISPECL_THEN [`x1`,`x2`,`x3`,`x4`] MP_TAC)
   \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_SING = store_thm("evaluate_SING",
-  ``(evaluate ([x],s,env) = (Rval r,s2)) ==> ?r1. r = [r1]``,
+val evaluate_SING = Q.store_thm("evaluate_SING",
+  `(evaluate ([x],s,env) = (Rval r,s2)) ==> ?r1. r = [r1]`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC evaluate_IMP_LENGTH
   \\ Cases_on `r` \\ full_simp_tac(srw_ss())[] \\ Cases_on `t` \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_CONS = store_thm("evaluate_CONS",
-  ``evaluate (x::xs,env,s) =
+val evaluate_CONS = Q.store_thm("evaluate_CONS",
+  `evaluate (x::xs,env,s) =
       case evaluate ([x],env,s) of
       | (Rval v,s2) =>
          (case evaluate (xs,env,s2) of
           | (Rval vs,s1) => (Rval (HD v::vs),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Cases_on `xs` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `evaluate ([x],env,s)` \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ Cases_on `q` \\ full_simp_tac(srw_ss())[evaluate_def]
@@ -433,15 +433,15 @@ val evaluate_CONS = store_thm("evaluate_CONS",
   \\ Cases_on `a` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `t` \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_SNOC = store_thm("evaluate_SNOC",
-  ``!xs env s x.
+val evaluate_SNOC = Q.store_thm("evaluate_SNOC",
+  `!xs env s x.
       evaluate (SNOC x xs,env,s) =
       case evaluate (xs,env,s) of
       | (Rval vs,s2) =>
          (case evaluate ([x],env,s2) of
           | (Rval v,s1) => (Rval (vs ++ v),s1)
           | t => t)
-      | t => t``,
+      | t => t`,
   Induct THEN1
    (full_simp_tac(srw_ss())[SNOC_APPEND,evaluate_def] \\ REPEAT STRIP_TAC
     \\ Cases_on `evaluate ([x],env,s)` \\ Cases_on `q` \\ full_simp_tac(srw_ss())[])
@@ -476,34 +476,34 @@ val evaluate_const_lemma = prove(
   \\ IMP_RES_TAC do_app_const \\ full_simp_tac(srw_ss())[dec_clock_def])
   |> SIMP_RULE std_ss [FORALL_PROD]
 
-val evaluate_const = store_thm("evaluate_const",
-  ``(evaluate (xs,env,s) = (res,s1)) ==>
+val evaluate_const = Q.store_thm("evaluate_const",
+  `(evaluate (xs,env,s) = (res,s1)) ==>
       (s1.code = s.code) ∧
-      (s1.max_app = s.max_app)``,
+      (s1.max_app = s.max_app)`,
   REPEAT STRIP_TAC
   \\ (evaluate_const_lemma |> CONJUNCT1 |> Q.ISPECL_THEN [`xs`,`env`,`s`] mp_tac)
   \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_app_const = store_thm("evaluate_app_const",
-  ``(evaluate_app x1 x2 x3 x4 = (res,s1)) ==>
+val evaluate_app_const = Q.store_thm("evaluate_app_const",
+  `(evaluate_app x1 x2 x3 x4 = (res,s1)) ==>
       (s1.code = x4.code) ∧
-      (s1.max_app = x4.max_app)``,
+      (s1.max_app = x4.max_app)`,
   REPEAT STRIP_TAC
   \\ (evaluate_const_lemma |> CONJUNCT2 |> Q.ISPECL_THEN [`x1`,`x2`,`x3`,`x4`] mp_tac)
   \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_MAP_Op_Const = store_thm("evaluate_MAP_Op_Const",
-  ``∀f env s ls.
+val evaluate_MAP_Op_Const = Q.store_thm("evaluate_MAP_Op_Const",
+  `∀f env s ls.
       evaluate (MAP (λx. Op (Const (f x)) []) ls,env,s) =
-      (Rval (MAP (Number o f) ls),s)``,
+      (Rval (MAP (Number o f) ls),s)`,
   ntac 3 gen_tac >> Induct >>
   simp[evaluate_def] >>
   simp[Once evaluate_CONS] >>
   simp[evaluate_def,do_app_def])
 
-val evaluate_REPLICATE_Op_AllocGlobal = store_thm("evaluate_REPLICATE_Op_AllocGlobal",
-  ``∀n env s. evaluate (REPLICATE n (Op AllocGlobal []),env,s) =
-              (Rval (GENLIST (K Unit) n),s with globals := s.globals ++ GENLIST (K NONE) n)``,
+val evaluate_REPLICATE_Op_AllocGlobal = Q.store_thm("evaluate_REPLICATE_Op_AllocGlobal",
+  `∀n env s. evaluate (REPLICATE n (Op AllocGlobal []),env,s) =
+              (Rval (GENLIST (K Unit) n),s with globals := s.globals ++ GENLIST (K NONE) n)`,
   Induct >> simp[evaluate_def,REPLICATE] >- (
     simp[state_component_equality] ) >>
   simp[Once evaluate_CONS,evaluate_def,do_app_def,GENLIST_CONS] >>

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -458,22 +458,22 @@ val check_clock_IMP = Q.prove(
   `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val do_app_const = store_thm("do_app_const",
-  ``(do_app op args s1 = Rval (res,s2)) ==>
+val do_app_const = Q.store_thm("do_app_const",
+  `(do_app op args s1 = Rval (res,s2)) ==>
     (s2.clock = s1.clock) /\
     (s2.max_app = s1.max_app) /\
-    (s2.code = s1.code)``,
+    (s2.code = s1.code)`,
   SIMP_TAC std_ss [do_app_def]
   \\ BasicProvers.EVERY_CASE_TAC
   \\ fs [LET_DEF] \\ SRW_TAC [] [] \\ fs []);
 
 val evaluate_ind = theorem"evaluate_ind"
 
-val evaluate_clock_help = prove (
-  ``(!tup vs (s2:'ffi closSem$state).
+val evaluate_clock_help = Q.prove (
+  `(!tup vs (s2:'ffi closSem$state).
       (evaluate tup = (vs,s2)) ==> s2.clock <= (SND (SND tup)).clock) ∧
     (!loc_opt f args (s1:'ffi closSem$state) vs s2.
-      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)``,
+      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)`,
   ho_match_mp_tac evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss [LET_THM] \\ BasicProvers.EVERY_CASE_TAC
@@ -488,16 +488,16 @@ val evaluate_clock_help = prove (
           \\ SRW_TAC [] [check_clock_def] \\ DECIDE_TAC)
   \\ rfs [] \\ fs [] \\ rfs [check_clock_def]);
 
-val evaluate_clock = store_thm("evaluate_clock",
-``(!xs env s1 vs s2.
+val evaluate_clock = Q.store_thm("evaluate_clock",
+`(!xs env s1 vs s2.
       (evaluate (xs,env,s1) = (vs,s2)) ==> s2.clock <= s1.clock) ∧
     (!loc_opt f args s1 vs s2.
-      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)``,
+      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)`,
  metis_tac [evaluate_clock_help, SND]);
 
-val evaluate_check_clock = prove(
-  ``!xs env s1 vs s2.
-      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)``,
+val evaluate_check_clock = Q.prove(
+  `!xs env s1 vs s2.
+      (evaluate (xs,env,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
   METIS_TAC [evaluate_clock,check_clock_thm]);
 
 (* Finally, we remove check_clock from the induction and definition theorems. *)

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -250,14 +250,14 @@ val check_clock_def = Define `
   check_clock (s1:'ffi closSem$state) (s2:'ffi closSem$state) =
     if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
 
-val check_clock_thm = prove(
-  ``(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_thm = Q.prove(
+  `(check_clock s1 s2).clock <= s2.clock /\
+    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def])
 
-val check_clock_lemma = prove(
-  ``b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)``,
+val check_clock_lemma = Q.prove(
+  `b ==> ((check_clock s1 s).clock < s.clock \/
+          ((check_clock s1 s).clock = s.clock) /\ b)`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 (* The semantics of expression evaluation is defined next. For
@@ -454,8 +454,8 @@ val evaluate_app_NIL = save_thm(
 
 (* We prove that the clock never increases. *)
 
-val check_clock_IMP = prove(
-  ``n <= (check_clock r s).clock ==> n <= s.clock``,
+val check_clock_IMP = Q.prove(
+  `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 val do_app_const = store_thm("do_app_const",

--- a/compiler/backend/semantics/clos_relationPropsScript.sml
+++ b/compiler/backend/semantics/clos_relationPropsScript.sml
@@ -9,14 +9,14 @@ val state_rel_ffi_mono = Q.store_thm(
     state_rel k w (s1 with ffi := (ffi:'ffi ffi_state)) (s2 with ffi := ffi)`,
   ONCE_REWRITE_TAC [val_rel_def] >> simp[]);
 
-val exp_rel_evaluate = store_thm(
+val exp_rel_evaluate = Q.store_thm(
   "exp_rel_evaluate",
-  ``∀e1 e2.
+  `∀e1 e2.
       exp_rel (:'ffi) w e1 e2 ==>
       ∀(s1: 'ffi closSem$state) s2 k.
          state_rel k w s1 s2 ⇒
          res_rel w (evaluate (e1,[], s1 with clock := k))
-                   (evaluate (e2,[], s2 with clock := k))``,
+                   (evaluate (e2,[], s2 with clock := k))`,
   simp[exp_rel_def, exec_rel_rw, evaluate_ev_def] >>
   qx_genl_tac [`e1`, `e2`] >> strip_tac >>
   qx_genl_tac [`s1`, `s2`, `k`] >>
@@ -50,8 +50,8 @@ val appkindeq =
     prove_case_eq_thm { case_def = TypeBase.case_def_of ``:app_kind``,
                         nchotomy = TypeBase.nchotomy_of ``:app_kind``}
 
-val paireq = prove(
-  ``pair_CASE p f = v ⇔ ∃a b. p = (a,b) ∧ v = f a b``,
+val paireq = Q.prove(
+  `pair_CASE p f = v ⇔ ∃a b. p = (a,b) ∧ v = f a b`,
   Cases_on `p` >> simp[] >> metis_tac[]);
 
 val ioeventeq =
@@ -67,9 +67,9 @@ val optioneq = Q.prove(
   Cases_on `opt` >> simp[] >> metis_tac[]);
 
 (*
-val do_app_preserves_ioNONE = store_thm(
+val do_app_preserves_ioNONE = Q.store_thm(
   "do_app_preserves_ioNONE",
-  ``do_app op args s = Rval (v, s') ∧ s.io = NONE ⇒ s'.io = NONE``,
+  `do_app op args s = Rval (v, s') ∧ s.io = NONE ⇒ s'.io = NONE`,
   Cases_on `op` >> Cases_on `args` >>
   simp[do_app_def, optioneq, listeq, veq, booleq, refeq, eqresulteq, paireq] >>
   srw_tac[][] >> srw_tac[][] >> full_simp_tac(srw_ss())[ffiTheory.call_FFI_def]);
@@ -81,13 +81,13 @@ val dec_clock_ffi = Q.store_thm(
   simp[dec_clock_def]);
 
 (*
-val ioNONE_preserved = store_thm(
+val ioNONE_preserved = Q.store_thm(
   "ioNONE_preserved",
-  ``(∀esenvs es env s s' rv.
+  `(∀esenvs es env s s' rv.
        evaluate esenvs = (rv, s') ∧ esenvs = (es,env,s) ∧ s.io = NONE ⇒
        s'.io = NONE) ∧
     (∀l f vs s s' rv.
-       evaluate_app l f vs s = (rv, s') ∧ s.io = NONE ⇒ s'.io = NONE)``,
+       evaluate_app l f vs s = (rv, s') ∧ s.io = NONE ⇒ s'.io = NONE)`,
   ho_match_mp_tac evaluate_ind >> rpt conj_tac >>
   simp[Once evaluate_def, paireq, resulteq, booleq, errorresulteq,
        optioneq, appkindeq, listeq] >>
@@ -180,18 +180,18 @@ val doapp_extendio_type_error = Q.store_thm(
   Cases_on `opt` >> Cases_on `args` >>
   dsimp[do_app_def, optioneq, listeq, veq, booleq, refeq, eqresulteq, paireq])
 
-val doapp_extendio_nonffi = store_thm(
+val doapp_extendio_nonffi = Q.store_thm(
   "doapp_extendio_nonffi",
-  ``do_app opt args s0 = Rval (rv, s) ∧ (∀n. opt ≠ FFI n) ⇒
-    do_app opt args (extendio s0 io) = Rval (rv, extendio s io)``,
+  `do_app opt args s0 = Rval (rv, s) ∧ (∀n. opt ≠ FFI n) ⇒
+    do_app opt args (extendio s0 io) = Rval (rv, extendio s io)`,
   Cases_on `opt` >> Cases_on `args` >>
   dsimp[do_app_def, optioneq, listeq, veq, booleq, refeq, eqresulteq, paireq] >>
   metis_tac[])
 
-val doapp_extendio_SOMEioresult = store_thm(
+val doapp_extendio_SOMEioresult = Q.store_thm(
   "doapp_extendio_SOMEioresult",
-  ``do_app opt args s0 = Rval (rv, s) ∧ s.io ≠ NONE ⇒
-    do_app opt args (extendio s0 io) = Rval (rv, extendio s io)``,
+  `do_app opt args s0 = Rval (rv, s) ∧ s.io ≠ NONE ⇒
+    do_app opt args (extendio s0 io) = Rval (rv, extendio s io)`,
   Cases_on `∀n. opt ≠ FFI n` >> simp[] >- metis_tac[doapp_extendio_nonffi] >>
   full_simp_tac(srw_ss())[] >> Cases_on `args` >>
   dsimp[do_app_def, optioneq, listeq, veq, booleq, refeq, eqresulteq, paireq] >>
@@ -203,10 +203,10 @@ val doapp_extendio_SOMEioresult = store_thm(
 
 fun first_r_assum ttac = first_x_assum (fn th => ttac th >> assume_tac th)
 
-val res_rel_ffi = store_thm(
+val res_rel_ffi = Q.store_thm(
   "res_rel_ffi",
-  ``res_rel w (r1,s1) (r2,s2) ∧ r1 ≠ Rerr (Rabort Rtype_error) ⇒
-    s2.ffi = s1.ffi``,
+  `res_rel w (r1,s1) (r2,s2) ∧ r1 ≠ Rerr (Rabort Rtype_error) ⇒
+    s2.ffi = s1.ffi`,
   Cases_on `r1` >> simp[]
   >- (simp[res_rel_rw] >> strip_tac >> full_simp_tac(srw_ss())[Once state_rel_rw]) >>
   rename1 `Rerr e` >> Cases_on `e` >> simp[]

--- a/compiler/backend/semantics/clos_relationPropsScript.sml
+++ b/compiler/backend/semantics/clos_relationPropsScript.sml
@@ -3,10 +3,10 @@ open clos_relationTheory closSemTheory closPropsTheory;
 
 val _ = new_theory "clos_relationProps";
 
-val state_rel_ffi_mono = store_thm(
+val state_rel_ffi_mono = Q.store_thm(
   "state_rel_ffi_mono[simp]",
-  ``state_rel k w (s1:'ffi closSem$state) s2 ⇒
-    state_rel k w (s1 with ffi := (ffi:'ffi ffi_state)) (s2 with ffi := ffi)``,
+  `state_rel k w (s1:'ffi closSem$state) s2 ⇒
+    state_rel k w (s1 with ffi := (ffi:'ffi ffi_state)) (s2 with ffi := ffi)`,
   ONCE_REWRITE_TAC [val_rel_def] >> simp[]);
 
 val exp_rel_evaluate = store_thm(
@@ -58,12 +58,12 @@ val ioeventeq =
     prove_case_eq_thm { case_def = TypeBase.case_def_of ``:io_event``,
                         nchotomy = TypeBase.nchotomy_of ``:io_event``}
 
-val booleq = prove(
-  ``(if p then x else y) = z ⇔ p ∧ x = z ∨ ¬p ∧ y = z``,
+val booleq = Q.prove(
+  `(if p then x else y) = z ⇔ p ∧ x = z ∨ ¬p ∧ y = z`,
   srw_tac[][]);
 
-val optioneq = prove(
-  ``option_CASE opt n s = x ⇔ opt = NONE ∧ n = x ∨ ∃y. opt = SOME y ∧ x = s y``,
+val optioneq = Q.prove(
+  `option_CASE opt n s = x ⇔ opt = NONE ∧ n = x ∨ ∃y. opt = SOME y ∧ x = s y`,
   Cases_on `opt` >> simp[] >> metis_tac[]);
 
 (*
@@ -75,9 +75,9 @@ val do_app_preserves_ioNONE = store_thm(
   srw_tac[][] >> srw_tac[][] >> full_simp_tac(srw_ss())[ffiTheory.call_FFI_def]);
 *)
 
-val dec_clock_ffi = store_thm(
+val dec_clock_ffi = Q.store_thm(
   "dec_clock_ffi[simp]",
-  ``(dec_clock n s).ffi = s.ffi``,
+  `(dec_clock n s).ffi = s.ffi`,
   simp[dec_clock_def]);
 
 (*
@@ -96,9 +96,9 @@ val ioNONE_preserved = store_thm(
   >- metis_tac[]);
 *)
 
-val exp3_size_EQ0 = store_thm(
+val exp3_size_EQ0 = Q.store_thm(
   "exp3_size_EQ0[simp]",
-  ``closLang$exp3_size l = 0 ⇔ l = []``,
+  `closLang$exp3_size l = 0 ⇔ l = []`,
   Cases_on `l` >> simp[closLangTheory.exp_size_def]);
 
 val evaluate_ind' = save_thm(
@@ -123,15 +123,15 @@ val kill_asm_guard =
     disch_then (fn th => SUBGOAL_THEN (lhand (concl th))
                                       (MP_TAC o MATCH_MP th)) >- simp[]
 
-val merge1 = prove(
-  ``(∀s:'ffi closSem$state x. s.clock < N ⇒ P s x) ∧
+val merge1 = Q.prove(
+  `(∀s:'ffi closSem$state x. s.clock < N ⇒ P s x) ∧
     (∀s x. s.clock = N ∧ Q s x ⇒ P s x) ⇒
-    (∀s x. s.clock ≤ N ∧ Q s x ⇒ P s x)``,
+    (∀s x. s.clock ≤ N ∧ Q s x ⇒ P s x)`,
   dsimp[DECIDE ``x:num ≤ y ⇔ x < y ∨ x = y``]);
 
-val merge2 = prove(
-  ``(∀s:'ffi closSem$state x. s.clock < N ⇒ P s x) ∧ (∀s x. s.clock = N ⇒ P s x) ⇒
-    ∀s x. s.clock ≤ N ⇒ P s x``,
+val merge2 = Q.prove(
+  `(∀s:'ffi closSem$state x. s.clock < N ⇒ P s x) ∧ (∀s x. s.clock = N ⇒ P s x) ⇒
+    ∀s x. s.clock ≤ N ⇒ P s x`,
   dsimp[DECIDE ``x:num ≤ y ⇔ x < y ∨ x = y``]);
 
 val merge_tac =
@@ -162,21 +162,21 @@ val extendio_def = Define`
 
 val extendio_accessors = save_thm(
   "extendio_accessors[simp]",
-  map (fn acc => prove(``^acc (extendio s io) = ^acc s``,
+  map (fn acc => Q.prove(`^acc (extendio s io) = ^acc s`,
                        simp[extendio_def] >> Cases_on `s.io` >> simp[]))
       (filter (not o aconv ``state_io``) acc_ts) |> LIST_CONJ)
 
 val extendio_updates = save_thm(
   "extendio_updates[simp]",
   map
-    (fn upd => prove(``^upd (extendio s io) = extendio (^upd s) io``,
+    (fn upd => Q.prove(`^upd (extendio s io) = extendio (^upd s) io`,
                      simp[extendio_def]>> Cases_on `s.io` >> simp[]))
     (filter (not o aconv ``state_io_fupd`` o rator) upd_ts) |> LIST_CONJ)
 
-val doapp_extendio_type_error = store_thm(
+val doapp_extendio_type_error = Q.store_thm(
   "doapp_extendio_type_error",
-  ``do_app opt args s0 = Rerr (Rabort Rtype_error) ⇒
-    do_app opt args (extendio s0 io) = Rerr (Rabort Rtype_error)``,
+  `do_app opt args s0 = Rerr (Rabort Rtype_error) ⇒
+    do_app opt args (extendio s0 io) = Rerr (Rabort Rtype_error)`,
   Cases_on `opt` >> Cases_on `args` >>
   dsimp[do_app_def, optioneq, listeq, veq, booleq, refeq, eqresulteq, paireq])
 
@@ -222,12 +222,12 @@ val _ = temp_overload_on("terminates",``λe s res.
      | SOME e => outcome = FFI_outcome e) ∧
     res = Terminate outcome s'.ffi.io_events``)
 
-val exp_rel_semantics = store_thm(
+val exp_rel_semantics = Q.store_thm(
   "exp_rel_semantics",
-  ``∀e1 e2 (s1:'ffi closSem$state) s2.
+  `∀e1 e2 (s1:'ffi closSem$state) s2.
       exp_rel (:'ffi) w e1 e2 ∧ (∀i. state_rel i w s1 s2) ∧
       semantics [] s1 e1 ≠ Fail ⇒
-      semantics [] s1 e1 = semantics [] s2 e2``,
+      semantics [] s1 e1 = semantics [] s2 e2`,
   qx_genl_tac [`e1`, `e2`, `s1`, `s2`] >> strip_tac >>
   simp[semantics_def] >>
   `fails e1 s1 ⇔ fails e2 s2` by (

--- a/compiler/backend/semantics/conPropsScript.sml
+++ b/compiler/backend/semantics/conPropsScript.sml
@@ -99,8 +99,8 @@ val pat_bindings_accum = Q.store_thm ("pat_bindings_accum",
   >- srw_tac[][pat_bindings_def]
   >- metis_tac [APPEND_ASSOC, pat_bindings_def]);
 
-val Boolv_11 = store_thm("Boolv_11[simp]",
-  ``Boolv b1 = Boolv b2 ⇔ (b1 = b2)``, EVAL_TAC >> srw_tac[][])
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",
+  `Boolv b1 = Boolv b2 ⇔ (b1 = b2)`, EVAL_TAC >> srw_tac[][])
 
 val evaluate_length = Q.store_thm("evaluate_length",
   `(∀env (s:'ffi conSem$state) ls s' vs.
@@ -329,11 +329,11 @@ val pats_bindings_MAP_Pvar = Q.store_thm("pats_bindings_MAP_Pvar",
   `∀ws ls. pats_bindings (MAP Pvar ws) ls = (REVERSE ws) ++ ls`,
   Induct >> simp[pat_bindings_def]);
 
-val pmatch_any_match = store_thm("pmatch_any_match",
-  ``(∀(exh:exh_ctors_env) s p v env env'. pmatch exh s p v env = Match env' ⇒
+val pmatch_any_match = Q.store_thm("pmatch_any_match",
+  `(∀(exh:exh_ctors_env) s p v env env'. pmatch exh s p v env = Match env' ⇒
        ∀env. ∃env'. pmatch exh s p v env = Match env') ∧
     (∀(exh:exh_ctors_env) s ps vs env env'. pmatch_list exh s ps vs env = Match env' ⇒
-       ∀env. ∃env'. pmatch_list exh s ps vs env = Match env')``,
+       ∀env. ∃env'. pmatch_list exh s ps vs env = Match env')`,
   ho_match_mp_tac pmatch_ind >>
   srw_tac[][pmatch_def] >>
   pop_assum mp_tac >>
@@ -343,11 +343,11 @@ val pmatch_any_match = store_thm("pmatch_any_match",
   TRY BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> rev_full_simp_tac(srw_ss())[] >> full_simp_tac(srw_ss())[] >>
   metis_tac[semanticPrimitivesTheory.match_result_distinct])
 
-val pmatch_any_no_match = store_thm("pmatch_any_no_match",
-  ``(∀(exh:exh_ctors_env) s p v env. pmatch exh s p v env = No_match ⇒
+val pmatch_any_no_match = Q.store_thm("pmatch_any_no_match",
+  `(∀(exh:exh_ctors_env) s p v env. pmatch exh s p v env = No_match ⇒
        ∀env. pmatch exh s p v env = No_match) ∧
     (∀(exh:exh_ctors_env) s ps vs env. pmatch_list exh s ps vs env = No_match ⇒
-       ∀env. pmatch_list exh s ps vs env = No_match)``,
+       ∀env. pmatch_list exh s ps vs env = No_match)`,
   ho_match_mp_tac pmatch_ind >>
   srw_tac[][pmatch_def] >>
   pop_assum mp_tac >>

--- a/compiler/backend/semantics/conPropsScript.sml
+++ b/compiler/backend/semantics/conPropsScript.sml
@@ -261,7 +261,7 @@ val evaluate_decs_add_to_clock_io_events_mono = Q.store_thm("evaluate_decs_add_t
   simp[] >> strip_tac >>
   imp_res_tac evaluate_dec_add_to_clock >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_decs_io_events_mono >> full_simp_tac(srw_ss())[] >>
-  rveq >|[rator_x_assum`evaluate_decs`mp_tac,ALL_TAC,ALL_TAC]>>
+  rveq >|[qhdtm_x_assum`evaluate_decs`mp_tac,ALL_TAC,ALL_TAC]>>
   qmatch_assum_abbrev_tac`evaluate_decs ee sss prog = _` >>
   last_x_assum(qspecl_then[`ee`,`sss`,`extra`]mp_tac)>>simp[Abbr`sss`]>>
   fsrw_tac[ARITH_ss][] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >>
@@ -312,7 +312,7 @@ val evaluate_prog_add_to_clock_io_events_mono = Q.store_thm("evaluate_prog_add_t
   simp[] >> srw_tac[][] >>
   imp_res_tac evaluate_prompt_add_to_clock >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_prog_io_events_mono >> full_simp_tac(srw_ss())[] >>
-  rveq >|[rator_x_assum`evaluate_prog`mp_tac,ALL_TAC,ALL_TAC]>>
+  rveq >|[qhdtm_x_assum`evaluate_prog`mp_tac,ALL_TAC,ALL_TAC]>>
   qmatch_assum_abbrev_tac`evaluate_prog ee sss prog = _` >>
   last_x_assum(qspecl_then[`ee`,`sss`,`extra`]mp_tac)>>simp[Abbr`sss`]>>
   fsrw_tac[ARITH_ss][] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >>

--- a/compiler/backend/semantics/conSemScript.sml
+++ b/compiler/backend/semantics/conSemScript.sml
@@ -452,7 +452,7 @@ val evaluate_def = tDefine "evaluate"`
    | res => res) ∧
   (evaluate env s [Handle e pes] =
    case fix_clock s (evaluate env s [e]) of
-   | (s', Rerr (Rraise v)) => evaluate_match env s v pes v
+   | (s, Rerr (Rraise v)) => evaluate_match env s v pes v
    | res => res) ∧
   (evaluate env s [Con tag es] =
    case evaluate env s (REVERSE es) of
@@ -491,7 +491,7 @@ val evaluate_def = tDefine "evaluate"`
    | res => res) ∧
   (evaluate env s [Let n e1 e2] =
    case fix_clock s (evaluate env s [e1]) of
-   | (s', Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) s [e2]
+   | (s, Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    if ALL_DISTINCT (MAP FST funs)

--- a/compiler/backend/semantics/conSemScript.sml
+++ b/compiler/backend/semantics/conSemScript.sml
@@ -426,23 +426,22 @@ val pat_bindings_def = Define`
   (pats_bindings (p::ps) already_bound =
    pats_bindings ps (pat_bindings p already_bound))`;
 
-val check_clock_def = Define`
-  check_clock s' s =
-    s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
-
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ conSem$check_clock s' s = s'`,
-  EVAL_TAC >> rw[theorem"state_component_equality"])
-
 val dec_clock_def = Define`
-  dec_clock s = s with clock := s.clock -1`;
+dec_clock s = s with clock := s.clock -1`;
 
-val evaluate_def = tDefine"evaluate"`
+val fix_clock_def = Define `
+  fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
+
+val fix_clock_IMP = prove(
+  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+
+val evaluate_def = tDefine "evaluate"`
   (evaluate (env:conSem$environment) (s:'ffi conSem$state) ([]:conLang$exp list) = (s,Rval [])) ∧
   (evaluate env s (e1::e2::es) =
-    case evaluate env s [e1] of
-    | (s', Rval v) =>
-        (case evaluate env (check_clock s' s) (e2::es) of
+    case fix_clock s (evaluate env s [e1]) of
+    | (s, Rval v) =>
+        (case evaluate env s (e2::es) of
          | (s, Rval vs) => (s, Rval (HD v::vs))
          | res => res)
     | res => res) ∧
@@ -452,8 +451,8 @@ val evaluate_def = tDefine"evaluate"`
    | (s, Rval v) => (s, Rerr (Rraise (HD v)))
    | res => res) ∧
   (evaluate env s [Handle e pes] =
-   case evaluate env s [e] of
-   | (s', Rerr (Rraise v)) => evaluate_match env (check_clock s' s) v pes v
+   case fix_clock s (evaluate env s [e]) of
+   | (s', Rerr (Rraise v)) => evaluate_match env s v pes v
    | res => res) ∧
   (evaluate env s [Con tag es] =
    case evaluate env s (REVERSE es) of
@@ -469,30 +468,30 @@ val evaluate_def = tDefine"evaluate"`
    else Rerr (Rabort Rtype_error))) ∧
   (evaluate env s [Fun n e] = (s, Rval [Closure env.v n e])) ∧
   (evaluate env s [App op es] =
-   case evaluate env s (REVERSE es) of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s (REVERSE es)) of
+   | (s, Rval vs) =>
        if op = Op Opapp then
          (case do_opapp (REVERSE vs) of
           | SOME (env', e) =>
-            if s'.clock = 0 ∨ s.clock = 0 then
-              (s', Rerr (Rabort Rtimeout_error))
+            if s.clock = 0 then
+              (s, Rerr (Rabort Rtimeout_error))
             else
-              evaluate (env with v := env') (dec_clock (check_clock s' s)) [e]
-          | NONE => (s', Rerr (Rabort Rtype_error)))
+              evaluate (env with v := env') (dec_clock s) [e]
+          | NONE => (s, Rerr (Rabort Rtype_error)))
        else
-       (case (do_app (s'.refs,s'.ffi) op (REVERSE vs)) of
-        | NONE => (s', Rerr (Rabort Rtype_error))
-        | SOME ((refs',ffi'),r) => (s' with <|refs:=refs';ffi:=ffi'|>, list_result r))
+       (case (do_app (s.refs,s.ffi) op (REVERSE vs)) of
+        | NONE => (s, Rerr (Rabort Rtype_error))
+        | SOME ((refs',ffi'),r) => (s with <|refs:=refs';ffi:=ffi'|>, list_result r))
    | res => res) ∧
   (evaluate env s [Mat e pes] =
-   case evaluate env s [e] of
-   | (s', Rval v) =>
-       evaluate_match env (check_clock s' s) (HD v) pes
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rval v) =>
+       evaluate_match env s (HD v) pes
          (Conv (SOME (bind_tag, (TypeExn (Short "Bind")))) [])
    | res => res) ∧
   (evaluate env s [Let n e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s', Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    if ALL_DISTINCT (MAP FST funs)
@@ -509,55 +508,32 @@ val evaluate_def = tDefine"evaluate"`
    else (s, Rerr(Rabort Rtype_error)))`
   (wf_rel_tac`inv_image ($< LEX $<)
                 (λx. case x of (INL(_,s,es)) => (s.clock,exp6_size es)
-                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))` >>
-   simp[check_clock_def,dec_clock_def] >>
-   rw[] >> simp[])
+                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))`
+  >> rpt strip_tac
+  >> simp[dec_clock_def]
+  >> imp_res_tac fix_clock_IMP
+  >> rw[]);
 
-val evaluate_ind = theorem"evaluate_ind"
-
-val s = ``s1:'ffi conSem$state``
+val evaluate_ind = theorem"evaluate_ind";
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
-  `(∀env ^s e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
-   (∀env ^s v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
+  `(∀env (s1:'a state) e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
+   (∀env (s1:'a state) v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
-  every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[] >>
-  fs[do_app_def] >>
-  every_case_tac >> fs[] >> rw[])
+  every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[]);
 
-val s' = ``s':'ffi conSem$state``
-val clean_term =
-  term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``]
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate env s e) = evaluate env s e`,
+  Cases_on `evaluate env s e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-val evaluate_ind = let
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end
-|> curry save_thm "evaluate_ind"
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = let
-  val goal = evaluate_def |> concl |> clean_term |> replace_term s' s
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
-|> curry save_thm "evaluate_def"
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 val evaluate_dec_def = Define`
   (evaluate_dec env s (Dlet n e) =

--- a/compiler/backend/semantics/conSemScript.sml
+++ b/compiler/backend/semantics/conSemScript.sml
@@ -432,8 +432,8 @@ dec_clock s = s with clock := s.clock -1`;
 val fix_clock_def = Define `
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine "evaluate"`

--- a/compiler/backend/semantics/dataPropsScript.sml
+++ b/compiler/backend/semantics/dataPropsScript.sml
@@ -107,10 +107,10 @@ val do_app_const = Q.store_thm("do_app_const",
   imp_res_tac bviPropsTheory.do_app_aux_const >> full_simp_tac(srw_ss())[] >>
   full_simp_tac(srw_ss())[consume_space_def] >> TRY var_eq_tac >> simp[])
 
-val do_app_locals = store_thm("do_app_locals",
-  ``(do_app op x s = Rval (q,r)) ==>
+val do_app_locals = Q.store_thm("do_app_locals",
+  `(do_app op x s = Rval (q,r)) ==>
     (do_app op x (s with locals := extra) =
-       Rval (q,r with locals := extra))``,
+       Rval (q,r with locals := extra))`,
   full_simp_tac(srw_ss())[do_app_def,do_space_def,consume_space_def,data_to_bvi_def]
   \\ every_case_tac >> full_simp_tac(srw_ss())[] \\ SRW_TAC [] []
   \\ full_simp_tac(srw_ss())[bvi_to_data_def,state_component_equality]);
@@ -122,8 +122,8 @@ val do_space_alt = Q.store_thm("do_space_alt",
   full_simp_tac(srw_ss())[do_space_def] \\ SRW_TAC [] [consume_space_def]
   \\ full_simp_tac(srw_ss())[state_component_equality] \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC);
 
-val Seq_Skip = store_thm("Seq_Skip",
-  ``evaluate (Seq c Skip,s) = evaluate (c,s)``,
+val Seq_Skip = Q.store_thm("Seq_Skip",
+  `evaluate (Seq c Skip,s) = evaluate (c,s)`,
   full_simp_tac(srw_ss())[evaluate_def] \\ Cases_on `evaluate (c,s)` \\ full_simp_tac(srw_ss())[LET_DEF] \\ SRW_TAC [] []);
 
 val evaluate_stack_swap = Q.store_thm("evaluate_stack_swap",
@@ -367,54 +367,54 @@ val evaluate_stack_swap = Q.store_thm("evaluate_stack_swap",
       \\ POP_ASSUM (fn th => full_simp_tac(srw_ss())[GSYM th])
       \\ REPEAT AP_TERM_TAC \\ full_simp_tac(srw_ss())[dataSemTheory.state_component_equality])))
 
-val evaluate_stack = store_thm("evaluate_stack",
-  ``!c s.
+val evaluate_stack = Q.store_thm("evaluate_stack",
+  `!c s.
       case evaluate (c,s) of
       | (SOME (Rerr(Rabort Rtype_error)),s1) => T
       | (SOME (Rerr(Rabort _)),s1) => (s1.stack = [])
       | (SOME (Rerr _),s1) =>
             (?s2. (jump_exc s = SOME s2) /\ (s2.locals = s1.locals) /\
                   (s2.stack = s1.stack) /\ (s2.handler = s1.handler))
-      | (_,s1) => (s1.stack = s.stack) /\ (s1.handler = s.handler)``,
+      | (_,s1) => (s1.stack = s.stack) /\ (s1.handler = s.handler)`,
   REPEAT STRIP_TAC \\ ASSUME_TAC (SPEC_ALL evaluate_stack_swap)
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
 
-val evaluate_NONE_jump_exc = store_thm("evaluate_NONE_jump_exc",
-  ``(evaluate (c,s) = (NONE,u1)) /\ (jump_exc u1 = SOME x) ==>
+val evaluate_NONE_jump_exc = Q.store_thm("evaluate_NONE_jump_exc",
+  `(evaluate (c,s) = (NONE,u1)) /\ (jump_exc u1 = SOME x) ==>
     (jump_exc s = SOME (s with <| stack := x.stack ;
                                   handler := x.handler ;
-                                  locals := x.locals |>))``,
+                                  locals := x.locals |>))`,
   REPEAT STRIP_TAC \\ MP_TAC (Q.SPECL [`c`,`s`] evaluate_stack) \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[jump_exc_def] \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] []);
 
-val evaluate_NONE_jump_exc_ALT = store_thm("evaluate_NONE_jump_exc_ALT",
-  ``(evaluate (c,s) = (NONE,u1)) /\ (jump_exc s = SOME x) ==>
+val evaluate_NONE_jump_exc_ALT = Q.store_thm("evaluate_NONE_jump_exc_ALT",
+  `(evaluate (c,s) = (NONE,u1)) /\ (jump_exc s = SOME x) ==>
     (jump_exc u1 = SOME (u1 with <| stack := x.stack ;
                                   handler := x.handler ;
-                                  locals := x.locals |>))``,
+                                  locals := x.locals |>))`,
   REPEAT STRIP_TAC \\ MP_TAC (Q.SPECL [`c`,`s`] evaluate_stack) \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[jump_exc_def] \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] []);
 
-val evaluate_locals_LN_lemma = prove(
-  ``!c s.
+val evaluate_locals_LN_lemma = Q.prove(
+  `!c s.
       FST (evaluate (c,s)) <> NONE /\
       FST (evaluate (c,s)) <> SOME (Rerr(Rabort Rtype_error)) ==>
       ((SND (evaluate (c,s))).locals = LN) \/
-      ?t. FST (evaluate (c,s)) = SOME (Rerr(Rraise t))``,
+      ?t. FST (evaluate (c,s)) = SOME (Rerr(Rraise t))`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[call_env_def,fromList_def]
   \\ imp_res_tac do_app_err >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[LET_DEF] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
   \\ Cases_on`a`>>full_simp_tac(srw_ss())[]);
 
-val evaluate_locals_LN = store_thm("evaluate_locals_LN",
-  ``!c s res t.
+val evaluate_locals_LN = Q.store_thm("evaluate_locals_LN",
+  `!c s res t.
       (evaluate (c,s) = (res,t)) /\ res <> NONE /\ res <> SOME (Rerr(Rabort Rtype_error)) ==>
-      (t.locals = LN) \/ ?t. res = SOME (Rerr(Rraise t))``,
+      (t.locals = LN) \/ ?t. res = SOME (Rerr(Rraise t))`,
   REPEAT STRIP_TAC \\ MP_TAC (SPEC_ALL evaluate_locals_LN_lemma) \\ full_simp_tac(srw_ss())[]);
 
 val locals_ok_def = Define `
@@ -490,14 +490,14 @@ val bvi_to_data_space_locals = Q.store_thm("bvi_to_data_space_locals",
    ((bvi_to_data s t).space = t.space)`,
   EVAL_TAC);
 
-val evaluate_locals = store_thm("evaluate_locals",
-  ``!c s res s2 vars l.
+val evaluate_locals = Q.store_thm("evaluate_locals",
+  `!c s res s2 vars l.
       res <> SOME (Rerr(Rabort Rtype_error)) /\ (evaluate (c,s) = (res,s2)) /\
       locals_ok s.locals l ==>
       ?w. (evaluate (c, s with locals := l) =
              (res,if res = NONE then s2 with locals := w
                                 else s2)) /\
-          locals_ok s2.locals w``,
+          locals_ok s2.locals w`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   THEN1 (* Skip *) (METIS_TAC [])
   THEN1 (* Move *)

--- a/compiler/backend/semantics/dataPropsScript.sml
+++ b/compiler/backend/semantics/dataPropsScript.sml
@@ -21,41 +21,41 @@ val initial_state_with_simp = Q.store_thm("initial_state_with_simp[simp]",
    (initial_state f c k with locals := LN = initial_state f c k)`,
   srw_tac[][initial_state_def]);
 
-val with_same_locals = store_thm("with_same_locals",
-  ``(s with locals := s.locals) = s``,
+val with_same_locals = Q.store_thm("with_same_locals",
+  `(s with locals := s.locals) = s`,
   full_simp_tac(srw_ss())[state_component_equality]);
 
 val var_corr_def = Define `
   var_corr env corr t <=>
     EVERY2 (\v x. get_var v t = SOME x) corr env`;
 
-val get_vars_thm = store_thm("get_vars_thm",
-  ``!vs a t2. var_corr a vs t2 ==> (get_vars vs t2 = SOME a)``,
+val get_vars_thm = Q.store_thm("get_vars_thm",
+  `!vs a t2. var_corr a vs t2 ==> (get_vars vs t2 = SOME a)`,
   Induct \\ Cases_on `a` \\ FULL_SIMP_TAC std_ss [get_vars_def]
   \\ FULL_SIMP_TAC (srw_ss()) [var_corr_def] \\ REPEAT STRIP_TAC
   \\ RES_TAC \\ FULL_SIMP_TAC std_ss []);
 
-val get_vars_append = store_thm("get_vars_append",
-  ``∀l1 l2 s. get_vars (l1 ++ l2) s = OPTION_BIND (get_vars l1 s)(λy1. OPTION_BIND (get_vars l2 s)(λy2. SOME(y1 ++ y2)))``,
+val get_vars_append = Q.store_thm("get_vars_append",
+  `∀l1 l2 s. get_vars (l1 ++ l2) s = OPTION_BIND (get_vars l1 s)(λy1. OPTION_BIND (get_vars l2 s)(λy2. SOME(y1 ++ y2)))`,
   Induct >> simp[get_vars_def,OPTION_BIND_SOME,ETA_AX] >> srw_tac[][] >>
   BasicProvers.EVERY_CASE_TAC >> full_simp_tac(srw_ss())[]);
 
-val get_vars_reverse = store_thm("get_vars_reverse",
-  ``∀ls s ys. get_vars ls s = SOME ys ⇒ get_vars (REVERSE ls) s = SOME (REVERSE ys)``,
+val get_vars_reverse = Q.store_thm("get_vars_reverse",
+  `∀ls s ys. get_vars ls s = SOME ys ⇒ get_vars (REVERSE ls) s = SOME (REVERSE ys)`,
   Induct >> simp[get_vars_def] >> srw_tac[][get_vars_append] >>
   BasicProvers.EVERY_CASE_TAC >> full_simp_tac(srw_ss())[] >>
   srw_tac[][get_vars_def]);
 
-val EVERY_get_vars = store_thm("EVERY_get_vars",
-  ``!args s1 s2.
+val EVERY_get_vars = Q.store_thm("EVERY_get_vars",
+  `!args s1 s2.
       EVERY (\a. lookup a s1 = lookup a s2) args ==>
-      (get_vars args s1 = get_vars args s2)``,
+      (get_vars args s1 = get_vars args s2)`,
   Induct \\ full_simp_tac(srw_ss())[get_vars_def,get_var_def] \\ REPEAT STRIP_TAC
   \\ RES_TAC \\ FULL_SIMP_TAC std_ss []);
 
-val get_vars_IMP_domain = store_thm("get_vars_IMP_domain",
-  ``!args x s vs. MEM x args /\ (get_vars args s = SOME vs) ==>
-                  x IN domain s``,
+val get_vars_IMP_domain = Q.store_thm("get_vars_IMP_domain",
+  `!args x s vs. MEM x args /\ (get_vars args s = SOME vs) ==>
+                  x IN domain s`,
   Induct \\ full_simp_tac(srw_ss())[get_vars_def,get_var_def] \\ REPEAT STRIP_TAC
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] []
   \\ full_simp_tac(srw_ss())[domain_lookup]);
@@ -65,9 +65,9 @@ val cut_state_opt_with_const = Q.store_thm("cut_state_opt_with_const",
    (cut_state_opt x (y with clock := k) = OPTION_MAP (λs. s with clock := k) (cut_state_opt x y))`,
   EVAL_TAC >> every_case_tac >> simp[]);
 
-val consume_space_add_space = store_thm("consume_space_add_space",
-  ``consume_space k (add_space t k with locals := env1) =
-    SOME (t with <| locals := env1 ; space := 0  |>)``,
+val consume_space_add_space = Q.store_thm("consume_space_add_space",
+  `consume_space k (add_space t k with locals := env1) =
+    SOME (t with <| locals := env1 ; space := 0  |>)`,
   full_simp_tac(srw_ss())[consume_space_def,add_space_def,state_component_equality] \\ DECIDE_TAC);
 
 val consume_space_with_stack = Q.prove(
@@ -115,10 +115,10 @@ val do_app_locals = store_thm("do_app_locals",
   \\ every_case_tac >> full_simp_tac(srw_ss())[] \\ SRW_TAC [] []
   \\ full_simp_tac(srw_ss())[bvi_to_data_def,state_component_equality]);
 
-val do_space_alt = store_thm("do_space_alt",
-  ``do_space op l s =
+val do_space_alt = Q.store_thm("do_space_alt",
+  `do_space op l s =
       if op_space_reset op then SOME (s with space := 0)
-      else consume_space (op_space_req op l) s``,
+      else consume_space (op_space_req op l) s`,
   full_simp_tac(srw_ss())[do_space_def] \\ SRW_TAC [] [consume_space_def]
   \\ full_simp_tac(srw_ss())[state_component_equality] \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC);
 
@@ -421,35 +421,35 @@ val locals_ok_def = Define `
   locals_ok l1 l2 =
     !v x. (sptree$lookup v l1 = SOME x) ==> (sptree$lookup v l2 = SOME x)`;
 
-val locals_ok_IMP = store_thm("locals_ok_IMP",
-  ``locals_ok l1 l2 ==> domain l1 SUBSET domain l2``,
+val locals_ok_IMP = Q.store_thm("locals_ok_IMP",
+  `locals_ok l1 l2 ==> domain l1 SUBSET domain l2`,
   full_simp_tac(srw_ss())[locals_ok_def,SUBSET_DEF,domain_lookup] \\ METIS_TAC []);
 
-val locals_ok_refl = store_thm("locals_ok_refl",
-  ``!l. locals_ok l l``,
+val locals_ok_refl = Q.store_thm("locals_ok_refl",
+  `!l. locals_ok l l`,
   full_simp_tac(srw_ss())[locals_ok_def]);
 
-val locals_ok_cut_env = store_thm("locals_ok_cut_env",
-  ``locals_ok l1 l2 /\
+val locals_ok_cut_env = Q.store_thm("locals_ok_cut_env",
+  `locals_ok l1 l2 /\
     (cut_env names l1 = SOME x) ==>
-    (cut_env names l2 = SOME x)``,
+    (cut_env names l2 = SOME x)`,
   full_simp_tac(srw_ss())[cut_env_def] \\ SRW_TAC [] []
   THEN1 (IMP_RES_TAC locals_ok_IMP \\ IMP_RES_TAC SUBSET_TRANS)
   \\ full_simp_tac(srw_ss())[lookup_inter_alt] \\ SRW_TAC [] []
   \\ full_simp_tac(srw_ss())[locals_ok_def,domain_lookup,SUBSET_DEF,PULL_EXISTS]
   \\ full_simp_tac(srw_ss())[oneTheory.one] \\ RES_TAC \\ RES_TAC \\ full_simp_tac(srw_ss())[]);
 
-val locals_ok_get_var = store_thm("locals_ok_get_var",
-  ``locals_ok s l /\
+val locals_ok_get_var = Q.store_thm("locals_ok_get_var",
+  `locals_ok s l /\
     (get_var x s = SOME w) ==>
-    (get_var x l = SOME w)``,
+    (get_var x l = SOME w)`,
   full_simp_tac(srw_ss())[locals_ok_def,get_var_def]);
 
-val locals_ok_get_vars = store_thm("locals_ok_get_vars",
-  ``!x w.
+val locals_ok_get_vars = Q.store_thm("locals_ok_get_vars",
+  `!x w.
       locals_ok s l /\
       (get_vars x s = SOME w) ==>
-      (get_vars x l = SOME w)``,
+      (get_vars x l = SOME w)`,
   Induct \\ full_simp_tac(srw_ss())[get_vars_def] \\ REPEAT STRIP_TAC
   \\ Cases_on `get_var h s` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `get_vars x s` \\ full_simp_tac(srw_ss())[]
@@ -614,34 +614,34 @@ val evaluate_mk_ticks = Q.store_thm ("evaluate_mk_ticks",
   full_simp_tac(srw_ss())[ADD1, LESS_OR_EQ] >>
   full_simp_tac (srw_ss()++ARITH_ss) []);
 
-val FUNPOW_dec_clock_code = store_thm("FUNPOW_dec_clock_code[simp]",
-  ``((FUNPOW dec_clock n t).code = t.code) /\
+val FUNPOW_dec_clock_code = Q.store_thm("FUNPOW_dec_clock_code[simp]",
+  `((FUNPOW dec_clock n t).code = t.code) /\
     ((FUNPOW dec_clock n t).stack = t.stack) /\
     ((FUNPOW dec_clock n t).handler = t.handler) /\
     ((FUNPOW dec_clock n t).refs = t.refs) /\
     ((FUNPOW dec_clock n t).ffi = t.ffi) /\
     ((FUNPOW dec_clock n t).global = t.global) /\
     ((FUNPOW dec_clock n t).locals = t.locals) /\
-    ((FUNPOW dec_clock n t).clock = t.clock - n)``,
+    ((FUNPOW dec_clock n t).clock = t.clock - n)`,
   Induct_on `n` \\ full_simp_tac(srw_ss())[FUNPOW_SUC,dec_clock_def] \\ DECIDE_TAC);
 
-val jump_exc_NONE = store_thm("jump_exc_NONE",
-  ``(jump_exc (t with locals := x) = NONE <=> jump_exc t = NONE) /\
-    (jump_exc (t with clock := c) = NONE <=> jump_exc t = NONE)``,
+val jump_exc_NONE = Q.store_thm("jump_exc_NONE",
+  `(jump_exc (t with locals := x) = NONE <=> jump_exc t = NONE) /\
+    (jump_exc (t with clock := c) = NONE <=> jump_exc t = NONE)`,
   FULL_SIMP_TAC (srw_ss()) [jump_exc_def] \\ REPEAT STRIP_TAC
   \\ every_case_tac \\ FULL_SIMP_TAC std_ss []);
 
-val jump_exc_IMP = store_thm("jump_exc_IMP",
-  ``(jump_exc s = SOME t) ==>
+val jump_exc_IMP = Q.store_thm("jump_exc_IMP",
+  `(jump_exc s = SOME t) ==>
     s.handler < LENGTH s.stack /\
     ?n e xs. (LASTN (s.handler + 1) s.stack = Exc e n::xs) /\
-             (t = s with <|handler := n; locals := e; stack := xs|>)``,
+             (t = s with <|handler := n; locals := e; stack := xs|>)`,
   SIMP_TAC std_ss [jump_exc_def]
   \\ Cases_on `LASTN (s.handler + 1) s.stack` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `h` \\ full_simp_tac(srw_ss())[]);
 
-val do_app_Rerr = store_thm("do_app_Rerr",
-  ``dataSem$do_app op x' s1 = Rerr e ==> e = Rabort Rtype_error``,
+val do_app_Rerr = Q.store_thm("do_app_Rerr",
+  `dataSem$do_app op x' s1 = Rerr e ==> e = Rabort Rtype_error`,
   full_simp_tac(srw_ss())[dataSemTheory.do_app_def,bviSemTheory.do_app_def] \\ every_case_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[bvlSemTheory.do_app_def] \\ every_case_tac \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[LET_DEF]);
@@ -866,9 +866,9 @@ val semantics_Term_IMP_PREFIX = Q.store_thm("semantics_Term_IMP_PREFIX",
   \\ imp_res_tac evaluate_io_events_mono \\ fs[]);
 
 val Resource_limit_hit_implements_semantics =
-  store_thm("Resource_limit_hit_implements_semantics",
-  ``implements {Terminate Resource_limit_hit ffi.io_events}
-       {semantics ffi (fromAList prog) start}``,
+  Q.store_thm("Resource_limit_hit_implements_semantics",
+  `implements {Terminate Resource_limit_hit ffi.io_events}
+       {semantics ffi (fromAList prog) start}`,
   fs [implements_def,extend_with_resource_limit_def]
   \\ Cases_on `semantics ffi (fromAList prog) start` \\ fs []
   \\ imp_res_tac semantics_Div_IMP_LPREFIX \\ fs []

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -245,15 +245,15 @@ val evaluate_ind = theorem"evaluate_ind";
 
 (* We prove that the clock never increases. *)
 
-val do_app_clock = store_thm("do_app_clock",
-  ``(dataSem$do_app op args s1 = Rval (res,s2)) ==> s2.clock <= s1.clock``,
+val do_app_clock = Q.store_thm("do_app_clock",
+  `(dataSem$do_app op args s1 = Rval (res,s2)) ==> s2.clock <= s1.clock`,
   SIMP_TAC std_ss [do_app_def,do_space_def,consume_space_def]
   \\ SRW_TAC [] [] \\ REPEAT (BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[])
   \\ IMP_RES_TAC bviSemTheory.do_app_const \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[data_to_bvi_def,bvi_to_data_def] \\ SRW_TAC [] []);
 
-val evaluate_clock = store_thm("evaluate_clock",
-  ``!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock``,
+val evaluate_clock = Q.store_thm("evaluate_clock",
+  `!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ simp[]
@@ -269,8 +269,8 @@ val evaluate_clock = store_thm("evaluate_clock",
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
   \\ imp_res_tac check_clock_IMP >> full_simp_tac(srw_ss())[] >> simp[]);
 
-val evaluate_check_clock = prove(
-  ``!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)``,
+val evaluate_check_clock = Q.prove(
+  `!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
   METIS_TAC [evaluate_clock,check_clock_thm]);
 
 (* Finally, we remove check_clock from the induction and definition theorems. *)

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -266,9 +266,9 @@ val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
   \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
 val fix_clock_evaluate_call = Q.store_thm("fix_clock_evaluate_call",
-  `fix_clock s (evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s)))) =
-   (evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s))))`,
-  Cases_on `(evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s))))`
+  `fix_clock s (evaluate (prog,call_env args1 (push_env env h (dec_clock s)))) =
+   (evaluate (prog,call_env args1 (push_env env h (dec_clock s))))`,
+  Cases_on `(evaluate (prog,call_env args1 (push_env env h (dec_clock s))))`
   >> fs [fix_clock_def]
   >> imp_res_tac evaluate_clock
   >> fs[MIN_DEF,theorem "state_component_equality",call_env_def,dec_clock_def,push_env_clock]

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -19,13 +19,6 @@ val _ = Datatype `
      ; ffi     : 'ffi ffi_state
      ; space   : num |> `
 
-val dec_clock_def = Define `
-  dec_clock (s:'ffi dataSem$state) = s with clock := s.clock - 1`;
-
-val LESS_EQ_dec_clock = Q.prove(
-  `r.clock <= (dec_clock s).clock ==> r.clock <= s.clock`,
-  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
-
 val data_to_bvi_def = Define `
   (data_to_bvi:'ffi dataSem$state->'ffi bviSem$state) s =
     <| refs := s.refs
@@ -75,25 +68,25 @@ val get_vars_def = Define `
                   | SOME xs => SOME (x::xs)))`;
 
 val set_var_def = Define `
-  set_var v x s = (s with locals := (insert v x s.locals))`;
+set_var v x s = (s with locals := (insert v x s.locals))`;
 
-val check_clock_def = Define `
-  check_clock (s1:'ffi dataSem$state) (s2:'ffi dataSem$state) =
-    if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
+val dec_clock_def = Define`
+dec_clock s = s with clock := s.clock -1`;
 
-val check_clock_thm = Q.prove(
-  `(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
-  SRW_TAC [] [check_clock_def])
+val fix_clock_def = Define `
+  fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)`
 
-val check_clock_lemma = Q.prove(
-  `b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
-val check_clock_IMP = Q.prove(
-  `n <= (check_clock r s).clock ==> n <= s.clock`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
+val fix_clock_IMP_SYM = Q.prove(
+  `(res,s1) = fix_clock s x  ==> s1.clock <= s.clock`,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+
+val LESS_EQ_dec_clock = Q.prove(
+  `r.clock <= (dec_clock s).clock ==> r.clock <= s.clock`,
+  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
 
 val call_env_def = Define `
   call_env args s =
@@ -186,8 +179,8 @@ val evaluate_def = tDefine "evaluate" `
      | NONE => (SOME (Rerr(Rabort Rtype_error)),s)
      | SOME x => (SOME (Rval x),call_env [] s)) /\
   (evaluate (Seq c1 c2,s) =
-     let (res,s1) = evaluate (c1,s) in
-       if res = NONE then evaluate (c2,check_clock s1 s) else (res,s1)) /\
+     let (res,s1) = fix_clock s (evaluate (c1,s)) in
+       if res = NONE then evaluate (c2,s1) else (res,s1)) /\
   (evaluate (If n c1 c2,s) =
      case get_var n s.locals of
      | NONE => (SOME (Rerr(Rabort Rtype_error)),s)
@@ -220,8 +213,8 @@ val evaluate_def = tDefine "evaluate" `
                then (SOME (Rerr(Rabort Rtimeout_error)),
                      call_env [] s with stack := [])
                else
-                 (case evaluate (prog, call_env args1
-                        (push_env env (IS_SOME handler) (dec_clock s))) of
+                 (case fix_clock s (evaluate (prog, call_env args1
+                        (push_env env (IS_SOME handler) (dec_clock s)))) of
                   | (SOME (Rval x),s2) =>
                      (case pop_env s2 of
                       | NONE => (SOME (Rerr(Rabort Rtype_error)),s2)
@@ -229,17 +222,17 @@ val evaluate_def = tDefine "evaluate" `
                   | (SOME (Rerr(Rraise x)),s2) =>
                      (case handler of (* if handler is present, then handle exc *)
                       | NONE => (SOME (Rerr(Rraise x)),s2)
-                      | SOME (n,h) => evaluate (h, set_var n x (check_clock s2 s)))
+                      | SOME (n,h) => evaluate (h, set_var n x s2))
                   | (NONE,s) => (SOME (Rerr(Rabort Rtype_error)),s)
                   | res => res)))))`
   (WF_REL_TAC `(inv_image (measure I LEX measure prog_size)
-                             (\(xs,s). (s.clock,xs)))`
-   \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-   \\ TRY (MATCH_MP_TAC check_clock_lemma \\ DECIDE_TAC)
-   \\ EVAL_TAC \\ Cases_on `s.clock <= s1.clock`
-   \\ FULL_SIMP_TAC (srw_ss()) [push_env_clock]
-   \\ IMP_RES_TAC pop_env_clock \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] []
-   \\ Cases_on `s2.clock < s.clock` \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC)
+                          (\(xs,s). (s.clock,xs)))`
+  \\ rpt strip_tac
+  \\ simp[dec_clock_def]
+  \\ imp_res_tac fix_clock_IMP
+  \\ imp_res_tac (GSYM fix_clock_IMP)
+  \\ FULL_SIMP_TAC (srw_ss()) [set_var_def,push_env_clock, call_env_def]
+  \\ decide_tac);
 
 val evaluate_ind = theorem"evaluate_ind";
 
@@ -253,78 +246,41 @@ val do_app_clock = Q.store_thm("do_app_clock",
   \\ full_simp_tac(srw_ss())[data_to_bvi_def,bvi_to_data_def] \\ SRW_TAC [] []);
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
-  `!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
-  recInduct evaluate_ind \\ REPEAT STRIP_TAC
-  \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
-  \\ simp[]
-  \\ every_case_tac >> simp[] >> srw_tac[][]
-  \\ full_simp_tac(srw_ss())[set_var_def,cut_state_opt_def,cut_state_def,call_env_def,dec_clock_def,
-        add_space_def,jump_exc_def,push_env_clock]
-  \\ every_case_tac >> simp[] >> srw_tac[][] >> simp[]
-  \\ imp_res_tac pop_env_clock
-  \\ imp_res_tac do_app_clock >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]
-  \\ imp_res_tac check_clock_IMP >> full_simp_tac(srw_ss())[] >> simp[]
-  \\ imp_res_tac check_clock_IMP >> full_simp_tac(srw_ss())[] >> simp[]
-  \\ first_assum(split_uncurry_arg_tac o lhs o concl) >> full_simp_tac(srw_ss())[]
+`!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
+  recInduct evaluate_ind >> rw[evaluate_def] >>
+  every_case_tac >>
+  full_simp_tac(srw_ss())[set_var_def,cut_state_opt_def,cut_state_def,call_env_def,dec_clock_def,add_space_def,jump_exc_def,push_env_clock] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[] >>
+  imp_res_tac pop_env_clock >>
+  imp_res_tac do_app_clock >>
+  imp_res_tac do_app_clock >> fs[] >>
+  every_case_tac >> rw[] >> simp[] >> rfs[] >>
+  first_assum(split_uncurry_arg_tac o lhs o concl) >> full_simp_tac(srw_ss())[]
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
-  \\ imp_res_tac check_clock_IMP >> full_simp_tac(srw_ss())[] >> simp[]);
+  \\ imp_res_tac fix_clock_IMP >> full_simp_tac(srw_ss())[] >> simp[] >> rfs[]);
 
-val evaluate_check_clock = Q.prove(
-  `!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> (check_clock s2 s1 = s2)`,
-  METIS_TAC [evaluate_clock,check_clock_thm]);
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate (xs,s)) = evaluate (xs,s)`,
+  Cases_on `evaluate (xs,s)` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-(* Finally, we remove check_clock from the induction and definition theorems. *)
+val fix_clock_evaluate_call = Q.store_thm("fix_clock_evaluate_call",
+  `fix_clock s (evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s)))) =
+   (evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s))))`,
+  Cases_on `(evaluate (prog,call_env args1 (push_env env (IS_SOME handler) (dec_clock s))))`
+  >> fs [fix_clock_def]
+  >> imp_res_tac evaluate_clock
+  >> fs[MIN_DEF,theorem "state_component_equality",call_env_def,dec_clock_def,push_env_clock]
+  >> imp_res_tac push_env_clock);
 
-val clean_term = term_rewrite
-                   [``check_clock s1 s2 = s1:'ffi dataSem$state``,
-                    ``(s.clock < k \/ b2) <=> (s:'ffi dataSem$state).clock < k:num``]
+(* Finally, we remove fix_clock from the induction and definition theorems. *)
 
-val set_var_check_clock = Q.prove(
-  `set_var v x (check_clock s1 s2) = check_clock (set_var v x s1) s2`,
-  SIMP_TAC std_ss [set_var_def,check_clock_def] \\ SRW_TAC [] []);
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate,fix_clock_evaluate_call] evaluate_def);
 
-val evaluate_ind = save_thm("evaluate_ind",let
-  val raw_ind = evaluate_ind
-  val goal = raw_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val ind = prove(goal,
-    STRIP_TAC \\ STRIP_TAC \\ MATCH_MP_TAC raw_ind
-    \\ reverse (REPEAT STRIP_TAC) \\ ASM_REWRITE_TAC []
-    THEN1 (FIRST_X_ASSUM MATCH_MP_TAC
-           \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC
-           \\ IMP_RES_TAC evaluate_clock \\ SRW_TAC [] []
-           \\ `s2.clock <= s.clock` by
-            (full_simp_tac(srw_ss())[call_env_def,push_env_def,dec_clock_def]
-             \\ IMP_RES_TAC pop_env_clock \\ DECIDE_TAC)
-           \\ `s2 = check_clock s2 s` by full_simp_tac(srw_ss())[check_clock_def]
-           \\ POP_ASSUM (fn th => ONCE_REWRITE_TAC [th])
-           \\ FIRST_X_ASSUM MATCH_MP_TAC \\ full_simp_tac(srw_ss())[])
-    \\ FIRST_X_ASSUM (MATCH_MP_TAC)
-    \\ ASM_REWRITE_TAC [] \\ REPEAT STRIP_TAC \\ RES_TAC
-    \\ REPEAT (Q.PAT_X_ASSUM `!x.bbb` (K ALL_TAC))
-    \\ IMP_RES_TAC evaluate_clock
-    \\ IMP_RES_TAC (GSYM evaluate_clock)
-    \\ FULL_SIMP_TAC (srw_ss()) [check_clock_thm,GSYM set_var_check_clock])
-  in ind |> SIMP_RULE std_ss [bvlPropsTheory.Boolv_11] end);
-
-val evaluate_def = save_thm("evaluate_def",let
-  val goal = evaluate_def |> concl |> clean_term
-  (* set_goal([],goal) *)
-  val def = prove(goal,
-    REPEAT STRIP_TAC
-    \\ SIMP_TAC (srw_ss()) []
-    \\ BasicProvers.EVERY_CASE_TAC
-    \\ full_simp_tac(srw_ss())[evaluate_def] \\ rev_full_simp_tac(srw_ss())[]
-    \\ SRW_TAC [] [] \\ SRW_TAC [] []
-    \\ IMP_RES_TAC evaluate_check_clock
-    \\ IMP_RES_TAC evaluate_clock
-    \\ full_simp_tac(srw_ss())[check_clock_thm]
-    \\ rev_full_simp_tac(srw_ss())[check_clock_thm]
-    \\ full_simp_tac(srw_ss())[check_clock_thm]
-    \\ full_simp_tac(srw_ss())[call_env_def,push_env_def]
-    \\ IMP_RES_TAC LESS_EQ_dec_clock
-    \\ full_simp_tac(srw_ss())[check_clock_thm])
-  in def end);
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate,fix_clock_evaluate_call] evaluate_ind);
 
 (* observational semantics *)
 

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -22,8 +22,8 @@ val _ = Datatype `
 val dec_clock_def = Define `
   dec_clock (s:'ffi dataSem$state) = s with clock := s.clock - 1`;
 
-val LESS_EQ_dec_clock = prove(
-  ``r.clock <= (dec_clock s).clock ==> r.clock <= s.clock``,
+val LESS_EQ_dec_clock = Q.prove(
+  `r.clock <= (dec_clock s).clock ==> r.clock <= s.clock`,
   SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
 
 val data_to_bvi_def = Define `
@@ -81,18 +81,18 @@ val check_clock_def = Define `
   check_clock (s1:'ffi dataSem$state) (s2:'ffi dataSem$state) =
     if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
 
-val check_clock_thm = prove(
-  ``(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_thm = Q.prove(
+  `(check_clock s1 s2).clock <= s2.clock /\
+    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def])
 
-val check_clock_lemma = prove(
-  ``b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)``,
+val check_clock_lemma = Q.prove(
+  `b ==> ((check_clock s1 s).clock < s.clock \/
+          ((check_clock s1 s).clock = s.clock) /\ b)`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val check_clock_IMP = prove(
-  ``n <= (check_clock r s).clock ==> n <= s.clock``,
+val check_clock_IMP = Q.prove(
+  `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 val call_env_def = Define `
@@ -138,14 +138,14 @@ val cut_state_opt_def = Define `
     | NONE => SOME s
     | SOME names => cut_state names s`;
 
-val pop_env_clock = prove(
-  ``(pop_env s = SOME s1) ==> (s1.clock = s.clock)``,
+val pop_env_clock = Q.prove(
+  `(pop_env s = SOME s1) ==> (s1.clock = s.clock)`,
   full_simp_tac(srw_ss())[pop_env_def]
   \\ REPEAT BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
 
-val push_env_clock = prove(
-  ``(push_env env b s).clock = s.clock``,
+val push_env_clock = Q.prove(
+  `(push_env env b s).clock = s.clock`,
   Cases_on `b` \\ full_simp_tac(srw_ss())[push_env_def]
   \\ REPEAT BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
@@ -279,8 +279,8 @@ val clean_term = term_rewrite
                    [``check_clock s1 s2 = s1:'ffi dataSem$state``,
                     ``(s.clock < k \/ b2) <=> (s:'ffi dataSem$state).clock < k:num``]
 
-val set_var_check_clock = prove(
-  ``set_var v x (check_clock s1 s2) = check_clock (set_var v x s1) s2``,
+val set_var_check_clock = Q.prove(
+  `set_var v x (check_clock s1 s2) = check_clock (set_var v x s1) s2`,
   SIMP_TAC std_ss [set_var_def,check_clock_def] \\ SRW_TAC [] []);
 
 val evaluate_ind = save_thm("evaluate_ind",let

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -80,10 +80,6 @@ val fix_clock_IMP = Q.prove(
   `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
-val fix_clock_IMP_SYM = Q.prove(
-  `(res,s1) = fix_clock s x  ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
-
 val LESS_EQ_dec_clock = Q.prove(
   `r.clock <= (dec_clock s).clock ==> r.clock <= s.clock`,
   SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);

--- a/compiler/backend/semantics/decPropsScript.sml
+++ b/compiler/backend/semantics/decPropsScript.sml
@@ -16,9 +16,9 @@ val map_state_clock = Q.store_thm("map_state_clock[simp]",
 val state_every_def = Define`
   state_every P s ⇔ EVERY (sv_every P) s.refs ∧ EVERY (OPTION_EVERY P) s.globals`
 
-val do_app_genv_weakening = prove(
-  ``decSem$do_app x op vs = SOME (x',c) ⇒
-    do_app (x with globals := x.globals ++ y) op vs = SOME (x' with globals := x'.globals ++ y,c)``,
+val do_app_genv_weakening = Q.prove(
+  `decSem$do_app x op vs = SOME (x',c) ⇒
+    do_app (x with globals := x.globals ++ y) op vs = SOME (x' with globals := x'.globals ++ y,c)`,
   srw_tac[][do_app_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
   fsrw_tac[ARITH_ss][EL_APPEND1,LUPDATE_APPEND1,state_component_equality])

--- a/compiler/backend/semantics/decSemScript.sml
+++ b/compiler/backend/semantics/decSemScript.sml
@@ -39,23 +39,22 @@ val _ = Datatype`
     exh : exh_ctors_env
   |>`;
 
-val check_clock_def = Define`
-  check_clock s' s =
-    s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
-
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ decSem$check_clock s' s = s'`,
-  EVAL_TAC >> rw[theorem"state_component_equality"])
-
 val dec_clock_def = Define`
-  dec_clock s = s with clock := s.clock -1`;
+dec_clock s = s with clock := s.clock -1`;
+
+val fix_clock_def = Define `
+  fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
+
+val fix_clock_IMP = prove(
+  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`
   (evaluate (env:decSem$environment) (s:'ffi decSem$state) ([]:conLang$exp list) = (s,Rval [])) ∧
   (evaluate env s (e1::e2::es) =
-    case evaluate env s [e1] of
-    | (s', Rval v) =>
-        (case evaluate env (check_clock s' s) (e2::es) of
+    case fix_clock s (evaluate env s [e1]) of
+    | (s, Rval v) =>
+        (case evaluate env s (e2::es) of
          | (s, Rval vs) => (s, Rval (HD v::vs))
          | res => res)
     | res => res) ∧
@@ -65,8 +64,8 @@ val evaluate_def = tDefine"evaluate"`
    | (s, Rval v) => (s, Rerr (Rraise (HD v)))
    | res => res) ∧
   (evaluate env s [Handle e pes] =
-   case evaluate env s [e] of
-   | (s', Rerr (Rraise v)) => evaluate_match env (check_clock s' s) v pes v
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rerr (Rraise v)) => evaluate_match env s v pes v
    | res => res) ∧
   (evaluate env s [Con tag es] =
    case evaluate env s (REVERSE es) of
@@ -82,30 +81,30 @@ val evaluate_def = tDefine"evaluate"`
    else Rerr (Rabort Rtype_error))) ∧
   (evaluate env s [Fun n e] = (s, Rval [Closure env.v n e])) ∧
   (evaluate env s [App op es] =
-   case evaluate env s (REVERSE es) of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s (REVERSE es)) of
+   | (s, Rval vs) =>
        if op = Op Opapp then
          (case do_opapp (REVERSE vs) of
           | SOME (env', e) =>
-            if s'.clock = 0 ∨ s.clock = 0 then
-              (s', Rerr (Rabort Rtimeout_error))
+            if s.clock = 0 then
+              (s, Rerr (Rabort Rtimeout_error))
             else
-              evaluate (env with v := env') (dec_clock (check_clock s' s)) [e]
-          | NONE => (s', Rerr (Rabort Rtype_error)))
+              evaluate (env with v := env') (dec_clock s) [e]
+          | NONE => (s, Rerr (Rabort Rtype_error)))
        else
-       (case (do_app s' op (REVERSE vs)) of
-        | NONE => (s', Rerr (Rabort Rtype_error))
+       (case (do_app s op (REVERSE vs)) of
+        | NONE => (s, Rerr (Rabort Rtype_error))
         | SOME (s,r) => (s, list_result r))
    | res => res) ∧
   (evaluate env s [Mat e pes] =
-   case evaluate env s [e] of
-   | (s', Rval v) =>
-       evaluate_match env (check_clock s' s) (HD v) pes
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rval v) =>
+       evaluate_match env s (HD v) pes
          (Conv (SOME (bind_tag, (TypeExn (Short "Bind")))) [])
    | res => res) ∧
   (evaluate env s [Let n e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    if ALL_DISTINCT (MAP FST funs)
@@ -123,55 +122,35 @@ val evaluate_def = tDefine"evaluate"`
    else (s, Rerr(Rabort Rtype_error)))`
   (wf_rel_tac`inv_image ($< LEX $<)
                 (λx. case x of (INL(_,s,es)) => (s.clock,exp6_size es)
-                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))` >>
-   simp[check_clock_def,dec_clock_def] >>
-   rw[] >> simp[])
+                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))`
+  >> rpt strip_tac
+  >> simp[dec_clock_def]
+  >> imp_res_tac fix_clock_IMP
+  >> rw[]);
 
 val evaluate_ind = theorem"evaluate_ind"
 
 val s = ``s1:'ffi decSem$state``
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
-  `(∀env ^s e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
-   (∀env ^s v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
+  `(∀env (s1:'a state) e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
+   (∀env (s1:'a state) v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
-  every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[] >>
-  fs[do_app_def] >>
+  every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[do_app_def] >>
   every_case_tac >> fs[] >> rw[])
 
-val s' = ``s':'ffi decSem$state``
-val clean_term =
-  term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``]
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate env s e) = evaluate env s e`,
+  Cases_on `evaluate env s e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-val evaluate_ind = let
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end
-|> curry save_thm "evaluate_ind"
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = let
-  val goal = evaluate_def |> concl |> clean_term |> replace_term s' s
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
-|> curry save_thm "evaluate_def"
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 val semantics_def = Define`
   semantics env st es =

--- a/compiler/backend/semantics/decSemScript.sml
+++ b/compiler/backend/semantics/decSemScript.sml
@@ -45,8 +45,8 @@ dec_clock s = s with clock := s.clock -1`;
 val fix_clock_def = Define `
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`

--- a/compiler/backend/semantics/exhPropsScript.sml
+++ b/compiler/backend/semantics/exhPropsScript.sml
@@ -13,11 +13,11 @@ val build_rec_env_merge = store_thm("build_rec_env_merge",
 
 val Boolv_disjoint = save_thm("Boolv_disjoint",EVAL``exhSem$Boolv T = Boolv F``);
 
-val pmatch_any_match = store_thm("pmatch_any_match",
-  ``(∀s p v env env'. pmatch s p v env = Match env' ⇒
+val pmatch_any_match = Q.store_thm("pmatch_any_match",
+  `(∀s p v env env'. pmatch s p v env = Match env' ⇒
        ∀env. ∃env'. pmatch s p v env = Match env') ∧
     (∀s ps vs env env'. pmatch_list s ps vs env = Match env' ⇒
-       ∀env. ∃env'. pmatch_list s ps vs env = Match env')``,
+       ∀env. ∃env'. pmatch_list s ps vs env = Match env')`,
   ho_match_mp_tac pmatch_ind >>
   srw_tac[][pmatch_def] >>
   pop_assum mp_tac >>
@@ -26,11 +26,11 @@ val pmatch_any_match = store_thm("pmatch_any_match",
   BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
   metis_tac[semanticPrimitivesTheory.match_result_distinct])
 
-val pmatch_any_no_match = store_thm("pmatch_any_no_match",
-  ``(∀s p v env. pmatch s p v env = No_match ⇒
+val pmatch_any_no_match = Q.store_thm("pmatch_any_no_match",
+  `(∀s p v env. pmatch s p v env = No_match ⇒
        ∀env. pmatch s p v env = No_match) ∧
     (∀s ps vs env. pmatch_list s ps vs env = No_match ⇒
-       ∀env. pmatch_list s ps vs env = No_match)``,
+       ∀env. pmatch_list s ps vs env = No_match)`,
   ho_match_mp_tac pmatch_ind >>
   srw_tac[][pmatch_def] >>
   pop_assum mp_tac >>
@@ -40,44 +40,44 @@ val pmatch_any_no_match = store_thm("pmatch_any_no_match",
   imp_res_tac pmatch_any_match >>
   metis_tac[semanticPrimitivesTheory.match_result_distinct])
 
-val pmatch_any_match_error = store_thm("pmatch_any_match_error",
-  ``(∀s p v env. pmatch s p v env = Match_type_error ⇒
+val pmatch_any_match_error = Q.store_thm("pmatch_any_match_error",
+  `(∀s p v env. pmatch s p v env = Match_type_error ⇒
        ∀env. pmatch s p v env = Match_type_error) ∧
     (∀s ps vs env. pmatch_list s ps vs env = Match_type_error ⇒
-       ∀env. pmatch_list s ps vs env = Match_type_error)``,
+       ∀env. pmatch_list s ps vs env = Match_type_error)`,
   srw_tac[][] >> qmatch_abbrev_tac`X = Y` >> Cases_on`X` >> full_simp_tac(srw_ss())[markerTheory.Abbrev_def] >>
   metis_tac[semanticPrimitivesTheory.match_result_distinct
            ,pmatch_any_no_match,pmatch_any_match]);
 
-val pmatch_list_pairwise = store_thm("pmatch_list_pairwise",
-  ``∀ps vs s env env'. pmatch_list s ps vs env = Match env' ⇒
-      EVERY2 (λp v. ∀env. ∃env'. pmatch s p v env = Match env') ps vs``,
+val pmatch_list_pairwise = Q.store_thm("pmatch_list_pairwise",
+  `∀ps vs s env env'. pmatch_list s ps vs env = Match env' ⇒
+      EVERY2 (λp v. ∀env. ∃env'. pmatch s p v env = Match env') ps vs`,
   Induct >> Cases_on`vs` >> simp[pmatch_def] >>
   rpt gen_tac >> BasicProvers.CASE_TAC >> strip_tac >>
   res_tac >> simp[] >> metis_tac[pmatch_any_match])
 
-val _ = store_thm("pmatch_list_snoc_nil[simp]",
-  ``∀p ps v vs s env.
+val _ = Q.store_thm("pmatch_list_snoc_nil[simp]",
+  `∀p ps v vs s env.
       (pmatch_list s [] (SNOC v vs) env = Match_type_error) ∧
-      (pmatch_list s (SNOC p ps) [] env = Match_type_error)``,
+      (pmatch_list s (SNOC p ps) [] env = Match_type_error)`,
   Cases_on`ps`>>Cases_on`vs`>>simp[pmatch_def]);
 
-val pmatch_list_snoc = store_thm("pmatch_list_snoc",
-  ``∀ps vs p v s env. LENGTH ps = LENGTH vs ⇒
+val pmatch_list_snoc = Q.store_thm("pmatch_list_snoc",
+  `∀ps vs p v s env. LENGTH ps = LENGTH vs ⇒
       pmatch_list s (SNOC p ps) (SNOC v vs) env =
       case pmatch_list s ps vs env of
       | Match env' => pmatch s p v env'
-      | res => res``,
+      | res => res`,
   Induct >> Cases_on`vs` >> simp[pmatch_def] >> srw_tac[][] >>
   BasicProvers.CASE_TAC)
 
-val pmatch_append = store_thm("pmatch_append",
-  ``(∀s p v env n.
+val pmatch_append = Q.store_thm("pmatch_append",
+  `(∀s p v env n.
       (pmatch s p v env =
        map_match (combin$C APPEND (DROP n env)) (pmatch s p v (TAKE n env)))) ∧
     (∀s ps vs env n.
       (pmatch_list s ps vs env =
-       map_match (combin$C APPEND (DROP n env)) (pmatch_list s ps vs (TAKE n env))))``,
+       map_match (combin$C APPEND (DROP n env)) (pmatch_list s ps vs (TAKE n env))))`,
   ho_match_mp_tac pmatch_ind >>
   srw_tac[][pmatch_def]
   >- ( BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>

--- a/compiler/backend/semantics/exhPropsScript.sml
+++ b/compiler/backend/semantics/exhPropsScript.sml
@@ -2,8 +2,8 @@ open preamble exhSemTheory;
 
 val _ = new_theory"exhProps";
 
-val build_rec_env_merge = store_thm("build_rec_env_merge",
-  ``build_rec_env funs cle env = MAP (λ(f,cdr). (f, (Recclosure cle funs f))) funs ++ env``,
+val build_rec_env_merge = Q.store_thm("build_rec_env_merge",
+  `build_rec_env funs cle env = MAP (λ(f,cdr). (f, (Recclosure cle funs f))) funs ++ env`,
   srw_tac[][build_rec_env_def] >>
   qho_match_abbrev_tac `FOLDR (f funs) env funs = MAP (g funs) funs ++ env` >>
   qsuff_tac `∀funs env funs0. FOLDR (f funs0) env funs = MAP (g funs0) funs ++ env` >- srw_tac[][]  >>

--- a/compiler/backend/semantics/exhSemScript.sml
+++ b/compiler/backend/semantics/exhSemScript.sml
@@ -420,23 +420,22 @@ val pat_bindings_def = Define`
   (pats_bindings (p::ps) already_bound =
    pats_bindings ps (pat_bindings p already_bound))`;
 
-val check_clock_def = Define`
-  check_clock s' s =
-    s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
-
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ exhSem$check_clock s' s = s'`,
-  EVAL_TAC >> rw[theorem"state_component_equality"])
-
 val dec_clock_def = Define`
-  dec_clock s = s with clock := s.clock -1`;
+dec_clock s = s with clock := s.clock -1`;
+
+val fix_clock_def = Define `
+  fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
+
+val fix_clock_IMP = prove(
+  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`
   (evaluate (env:(string,exhSem$v) alist) (s:'ffi exhSem$state) ([]:exhLang$exp list) = (s,Rval [])) ∧
   (evaluate env s (e1::e2::es) =
-    case evaluate env s [e1] of
-    | (s', Rval v) =>
-        (case evaluate env (check_clock s' s) (e2::es) of
+    case fix_clock s (evaluate env s [e1]) of
+    | (s, Rval v) =>
+        (case evaluate env s (e2::es) of
          | (s, Rval vs) => (s, Rval (HD v::vs))
          | res => res)
     | res => res) ∧
@@ -446,8 +445,8 @@ val evaluate_def = tDefine"evaluate"`
    | (s, Rval v) => (s, Rerr (Rraise (HD v)))
    | res => res) ∧
   (evaluate env s [Handle e pes] =
-   case evaluate env s [e] of
-   | (s', Rerr (Rraise v)) => evaluate_match env (check_clock s' s) v pes
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rerr (Rraise v)) => evaluate_match env s v pes
    | res => res) ∧
   (evaluate env s [Con tag es] =
    case evaluate env s (REVERSE es) of
@@ -463,28 +462,28 @@ val evaluate_def = tDefine"evaluate"`
    else Rerr (Rabort Rtype_error))) ∧
   (evaluate env s [Fun n e] = (s, Rval [Closure env n e])) ∧
   (evaluate env s [App op es] =
-   case evaluate env s (REVERSE es) of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s (REVERSE es)) of
+   | (s, Rval vs) =>
        if op = Op Opapp then
          (case do_opapp (REVERSE vs) of
           | SOME (env, e) =>
-            if s'.clock = 0 ∨ s.clock = 0 then
-              (s', Rerr (Rabort Rtimeout_error))
+            if s.clock = 0 then
+              (s, Rerr (Rabort Rtimeout_error))
             else
-              evaluate env (dec_clock (check_clock s' s)) [e]
-          | NONE => (s', Rerr (Rabort Rtype_error)))
+              evaluate env (dec_clock s) [e]
+          | NONE => (s, Rerr (Rabort Rtype_error)))
        else
-       (case (do_app s' op (REVERSE vs)) of
-        | NONE => (s', Rerr (Rabort Rtype_error))
+       (case (do_app s op (REVERSE vs)) of
+        | NONE => (s, Rerr (Rabort Rtype_error))
         | SOME (s,r) => (s, list_result r))
    | res => res) ∧
   (evaluate env s [Mat e pes] =
-   case evaluate env s [e] of
-   | (s', Rval v) => evaluate_match env (check_clock s' s) (HD v) pes
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rval v) => evaluate_match env s (HD v) pes
    | res => res) ∧
   (evaluate env s [Let n e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate (opt_bind n (HD vs) env) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) => evaluate (opt_bind n (HD vs) env) s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    if ALL_DISTINCT (MAP FST funs)
@@ -502,59 +501,39 @@ val evaluate_def = tDefine"evaluate"`
    else (s, Rerr(Rabort Rtype_error)))`
   (wf_rel_tac`inv_image ($< LEX $<)
                 (λx. case x of (INL(_,s,es)) => (s.clock,exp6_size es)
-                             | (INR(_,s,_,pes)) => (s.clock,exp3_size pes))` >>
-   simp[check_clock_def,dec_clock_def] >>
-   rw[] >> simp[])
+                             | (INR(_,s,_,pes)) => (s.clock,exp3_size pes))`
+  >> rpt strip_tac
+  >> simp[dec_clock_def]
+  >> imp_res_tac fix_clock_IMP
+  >> rw[]);
 
 val evaluate_ind = theorem"evaluate_ind"
 
-val s = ``s1:'ffi exhSem$state``
+val do_app_clock = Q.store_thm("do_app_clock",
+  `exhSem$do_app s op vs = SOME(s',r) ==> s.clock = s'.clock`,
+  rpt strip_tac
+  THEN imp_res_tac do_app_cases
+  THEN (fs [do_app_def] >> every_case_tac >> fs[LET_THM,semanticPrimitivesTheory.store_alloc_def,semanticPrimitivesTheory.store_assign_def] >> rw[]))
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
-  `(∀env ^s e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
-   (∀env ^s v pes r s2. evaluate_match env s1 v pes = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
+  `(∀env (s1:'a state) e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
+   (∀env (s1:'a state) v pes r s2. evaluate_match env s1 v pes = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
-  every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[] >>
-  imp_res_tac do_app_cases >>
-  fs[do_app_def] >>
-  every_case_tac >>
-  fs[LET_THM,semanticPrimitivesTheory.store_alloc_def,semanticPrimitivesTheory.store_assign_def] >>
-  rw[] >> every_case_tac >> fs[] >> rw[] )
+  every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[] >>
+  imp_res_tac do_app_clock >> fs[]);
 
-val s = ``s:'ffi exhSem$state``
-val s' = ``s':'ffi exhSem$state``
-val clean_term =
-  term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``]
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate env s e) = evaluate env s e`,
+  Cases_on `evaluate env s e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-val evaluate_ind = let
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end
-|> curry save_thm "evaluate_ind"
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = let
-  val goal = evaluate_def |> concl |> clean_term |> replace_term s' s
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
-|> curry save_thm "evaluate_def"
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 val semantics_def = Define`
   semantics env st es =

--- a/compiler/backend/semantics/exhSemScript.sml
+++ b/compiler/backend/semantics/exhSemScript.sml
@@ -426,8 +426,8 @@ dec_clock s = s with clock := s.clock -1`;
 val fix_clock_def = Define `
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -222,7 +222,7 @@ val evaluate_io_events_mono = Q.store_thm("evaluate_io_events_mono",
   `∀s1 r s2. evaluate s1 = (r,s2) ⇒ s1.ffi.io_events ≼ s2.ffi.io_events`,
   ho_match_mp_tac evaluate_ind >> rw[] >>
   Cases_on`s1.clock=0`>-fs[Once evaluate_def]>>fs[]>>
-  rator_x_assum`evaluate`mp_tac >>
+  qhdtm_x_assum`evaluate`mp_tac >>
   simp[Once evaluate_def] >>
   Cases_on`asm_fetch s1`>>fs[] >>
   Cases_on`x`>>fs[] >- (
@@ -242,7 +242,7 @@ val evaluate_ADD_clock = store_thm("evaluate_ADD_clock",
       evaluate s = (res,r) /\ res <> TimeOut ==>
       evaluate (s with clock := s.clock + k) = (res,r with clock := r.clock + k)``,
   ho_match_mp_tac evaluate_ind >> rw[] >>
-  rator_x_assum`evaluate`mp_tac >>
+  qhdtm_x_assum`evaluate`mp_tac >>
   simp[Once evaluate_def] >>
   IF_CASES_TAC >> fs[] >> strip_tac >>
   simp[Once evaluate_def] >>

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -35,8 +35,8 @@ val inc_pc_dec_clock = Q.store_thm("inc_pc_dec_clock",
   `inc_pc (dec_clock x) = dec_clock (inc_pc x)`,
   EVAL_TAC);
 
-val update_simps = store_thm("update_simps[simp]",
-  ``((labSem$upd_pc x s).ffi = s.ffi) /\
+val update_simps = Q.store_thm("update_simps[simp]",
+  `((labSem$upd_pc x s).ffi = s.ffi) /\
     ((labSem$dec_clock s).ffi = s.ffi) /\
     ((labSem$upd_pc x s).pc = x) /\
     ((labSem$dec_clock s).pc = s.pc) /\
@@ -68,7 +68,7 @@ val update_simps = store_thm("update_simps[simp]",
     ((labSem$inc_pc s).io_regs = s.io_regs) ∧
     ((labSem$inc_pc s).mem = s.mem) ∧
     ((labSem$inc_pc s).pc = s.pc + 1) ∧
-    ((labSem$inc_pc s).ffi = s.ffi)``,
+    ((labSem$inc_pc s).ffi = s.ffi)`,
   EVAL_TAC);
 
 val binop_upd_consts = Q.store_thm("binop_upd_consts[simp]",
@@ -110,9 +110,9 @@ val LENGTH_line_bytes = Q.store_thm("LENGTH_line_bytes[simp]",
 val good_dimindex_def = Define `
   good_dimindex (:'a) <=> dimindex (:'a) = 32 \/ dimindex (:'a) = 64`;
 
-val get_byte_set_byte = store_thm("get_byte_set_byte",
-  ``good_dimindex (:'a) ==>
-    (get_byte a (set_byte (a:'a word) b w be) be = b)``,
+val get_byte_set_byte = Q.store_thm("get_byte_set_byte",
+  `good_dimindex (:'a) ==>
+    (get_byte a (set_byte (a:'a word) b w be) be = b)`,
   fs [get_byte_def,set_byte_def,LET_DEF]
   \\ fs [fcpTheory.CART_EQ,w2w,good_dimindex_def] \\ rpt strip_tac
   \\ `i < dimindex (:'a)` by decide_tac
@@ -128,13 +128,13 @@ val get_byte_set_byte = store_thm("get_byte_set_byte",
   \\ `~(byte_index a be + 8 <= i + byte_index a be)` by decide_tac
   \\ fs [])
 
-val byte_index_LESS_IMP = prove(
-  ``(dimindex (:'a) = 32 \/ dimindex (:'a) = 64) /\
+val byte_index_LESS_IMP = Q.prove(
+  `(dimindex (:'a) = 32 \/ dimindex (:'a) = 64) /\
     byte_index (a:'a word) be < byte_index (a':'a word) be /\ i < 8 ==>
     byte_index a be + i < byte_index a' be /\
     byte_index a be <= i + byte_index a' be /\
     byte_index a be + 8 <= i + byte_index a' be /\
-    i + byte_index a' be < byte_index a be + dimindex (:α)``,
+    i + byte_index a' be < byte_index a be + dimindex (:α)`,
   fs [byte_index_def,LET_DEF] \\ Cases_on `be` \\ fs []
   \\ rpt strip_tac \\ rfs [] \\ fs []
   \\ `w2n a MOD 4 < 4` by (match_mp_tac MOD_LESS \\ decide_tac)
@@ -143,24 +143,24 @@ val byte_index_LESS_IMP = prove(
   \\ `w2n a' MOD 8 < 8` by (match_mp_tac MOD_LESS \\ decide_tac)
   \\ decide_tac);
 
-val NOT_w2w_bit = prove(
-  ``8 <= i /\ i < dimindex (:'b) ==> ~((w2w:word8->'b word) w ' i)``,
+val NOT_w2w_bit = Q.prove(
+  `8 <= i /\ i < dimindex (:'b) ==> ~((w2w:word8->'b word) w ' i)`,
   rpt strip_tac \\ rfs [w2w] \\ decide_tac);
 
 val LESS4 = DECIDE ``n < 4 <=> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num)``
 val LESS8 = DECIDE ``n < 8 <=> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num) \/
                                (n = 4) \/ (n = 5) \/ (n = 6) \/ (n = 7)``
 
-val DIV_EQ_DIV_IMP = prove(
-  ``0 < d /\ n <> n' /\ (n DIV d * d = n' DIV d * d) ==> n MOD d <> n' MOD d``,
+val DIV_EQ_DIV_IMP = Q.prove(
+  `0 < d /\ n <> n' /\ (n DIV d * d = n' DIV d * d) ==> n MOD d <> n' MOD d`,
   rpt strip_tac \\ Q.PAT_X_ASSUM `n <> n'` mp_tac \\ fs []
   \\ MP_TAC (Q.SPEC `d` DIVISION) \\ fs []
   \\ rpt strip_tac \\ pop_assum (fn th => once_rewrite_tac [th])
   \\ fs []);
 
-val get_byte_set_byte_diff = store_thm("get_byte_set_byte_diff",
-  ``good_dimindex (:'a) /\ a <> a' /\ (byte_align a = byte_align a') ==>
-    (get_byte a (set_byte (a':'a word) b w be) be = get_byte a w be)``,
+val get_byte_set_byte_diff = Q.store_thm("get_byte_set_byte_diff",
+  `good_dimindex (:'a) /\ a <> a' /\ (byte_align a = byte_align a') ==>
+    (get_byte a (set_byte (a':'a word) b w be) be = get_byte a w be)`,
   fs [get_byte_def,set_byte_def,LET_DEF] \\ rpt strip_tac
   \\ `byte_index a be <> byte_index a' be` by
    (fs [good_dimindex_def]

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -205,9 +205,9 @@ val get_byte_set_byte_diff = Q.store_thm("get_byte_set_byte_diff",
   \\ fs [w2w] \\ TRY (match_mp_tac NOT_w2w_bit)
   \\ fs [] \\ decide_tac)
 
-val evaluate_pres_final_event = store_thm("evaluate_pres_final_event",
-  ``!s1.
-      (evaluate s1 = (res,s2)) /\ s1.ffi.final_event ≠ NONE ==> s2.ffi = s1.ffi``,
+val evaluate_pres_final_event = Q.store_thm("evaluate_pres_final_event",
+  `!s1.
+      (evaluate s1 = (res,s2)) /\ s1.ffi.final_event ≠ NONE ==> s2.ffi = s1.ffi`,
   completeInduct_on `s1.clock`
   \\ rpt strip_tac \\ fs [PULL_FORALL] \\ rw []
   \\ ntac 2 (POP_ASSUM MP_TAC) \\ simp_tac std_ss [Once evaluate_def,LET_DEF]
@@ -237,10 +237,10 @@ val evaluate_io_events_mono = Q.store_thm("evaluate_io_events_mono",
   rpt var_eq_tac >> fs[] >>
   fs[IS_PREFIX_APPEND]);
 
-val evaluate_ADD_clock = store_thm("evaluate_ADD_clock",
-  ``!s res r k.
+val evaluate_ADD_clock = Q.store_thm("evaluate_ADD_clock",
+  `!s res r k.
       evaluate s = (res,r) /\ res <> TimeOut ==>
-      evaluate (s with clock := s.clock + k) = (res,r with clock := r.clock + k)``,
+      evaluate (s with clock := s.clock + k) = (res,r with clock := r.clock + k)`,
   ho_match_mp_tac evaluate_ind >> rw[] >>
   qhdtm_x_assum`evaluate`mp_tac >>
   simp[Once evaluate_def] >>

--- a/compiler/backend/semantics/labSemScript.sml
+++ b/compiler/backend/semantics/labSemScript.sml
@@ -181,9 +181,9 @@ val asm_code_length_def = Define `
   (asm_code_length ((Section k (y::ys))::xs) =
      asm_code_length ((Section k ys)::xs) + if is_Label y then 0 else 1:num)`
 
-val asm_fetch_IMP = prove(
-  ``(asm_fetch s = SOME x) ==>
-    s.pc < asm_code_length s.code``,
+val asm_fetch_IMP = Q.prove(
+  `(asm_fetch s = SOME x) ==>
+    s.pc < asm_code_length s.code`,
   fs [asm_fetch_def,asm_code_length_def]
   \\ Q.SPEC_TAC (`s.pc`,`pc`)
   \\ Q.SPEC_TAC (`s.code`,`xs`)
@@ -210,14 +210,14 @@ val loc_to_pc_def = Define `
              | NONE => NONE
              | SOME pos => SOME (pos + 1))`;
 
-val asm_inst_consts = store_thm("asm_inst_consts",
-  ``((asm_inst i s).pc = s.pc) /\
+val asm_inst_consts = Q.store_thm("asm_inst_consts",
+  `((asm_inst i s).pc = s.pc) /\
     ((asm_inst i s).code = s.code) /\
     ((asm_inst i s).clock = s.clock) /\
     ((asm_inst i s).ffi = s.ffi) ∧
     ((asm_inst i s).ptr_reg = s.ptr_reg) ∧
     ((asm_inst i s).len_reg = s.len_reg) ∧
-    ((asm_inst i s).link_reg = s.link_reg)``,
+    ((asm_inst i s).link_reg = s.link_reg)`,
   Cases_on `i` \\ fs [asm_inst_def,upd_reg_def,arith_upd_def]
   \\ TRY (Cases_on `a`)
   \\ fs [asm_inst_def,upd_reg_def,arith_upd_def]

--- a/compiler/backend/semantics/modPropsScript.sml
+++ b/compiler/backend/semantics/modPropsScript.sml
@@ -124,7 +124,7 @@ val evaluate_decs_add_to_clock = Q.prove(
   BasicProvers.TOP_CASE_TAC >> full_simp_tac(srw_ss())[] >>
   BasicProvers.TOP_CASE_TAC >> full_simp_tac(srw_ss())[] >>
   BasicProvers.TOP_CASE_TAC >> full_simp_tac(srw_ss())[] >>
-  rator_x_assum`evaluate_decs`mp_tac >>
+  qhdtm_x_assum`evaluate_decs`mp_tac >>
   qmatch_assum_abbrev_tac`evaluate_decs envv ss decs = (sr,rr)` >>
   first_x_assum(qspecl_then[`envv`,`ss`,`sr`,`rr`]mp_tac) >>
   unabbrev_all_tac >> simp[]);
@@ -275,7 +275,7 @@ val evaluate_decs_add_to_clock_io_events_mono = Q.store_thm("evaluate_decs_add_t
   simp[] >> strip_tac >>
   imp_res_tac evaluate_dec_add_to_clock >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_decs_io_events_mono >> full_simp_tac(srw_ss())[] >>
-  rveq >|[rator_x_assum`evaluate_decs`mp_tac,ALL_TAC,ALL_TAC]>>
+  rveq >|[qhdtm_x_assum`evaluate_decs`mp_tac,ALL_TAC,ALL_TAC]>>
   qmatch_assum_abbrev_tac`evaluate_decs eee sss prog = _` >>
   last_x_assum(qspecl_then[`eee`,`sss`,`extra`]mp_tac)>>simp[Abbr`sss`]>>
   fsrw_tac[ARITH_ss][] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >>
@@ -328,7 +328,7 @@ val evaluate_prompts_add_to_clock_io_events_mono = Q.store_thm("evaluate_prompts
   simp[] >> srw_tac[][] >>
   imp_res_tac evaluate_prompt_add_to_clock >> full_simp_tac(srw_ss())[] >>
   imp_res_tac evaluate_prompts_io_events_mono >> full_simp_tac(srw_ss())[] >>
-  rveq >|[rator_x_assum`evaluate_prompts`mp_tac,ALL_TAC,ALL_TAC]>>
+  rveq >|[qhdtm_x_assum`evaluate_prompts`mp_tac,ALL_TAC,ALL_TAC]>>
   qmatch_assum_abbrev_tac`evaluate_prompts eee sss prog = _` >>
   last_x_assum(qspecl_then[`eee`,`sss`,`extra`]mp_tac)>>simp[Abbr`sss`]>>
   fsrw_tac[ARITH_ss][] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >>

--- a/compiler/backend/semantics/modPropsScript.sml
+++ b/compiler/backend/semantics/modPropsScript.sml
@@ -41,7 +41,7 @@ val build_rec_env_merge = Q.store_thm ("build_rec_env_merge",
     MAP (λ(fn,n,e). (fn, Recclosure env funs fn)) funs ++ env'`,
   srw_tac[][build_rec_env_def, build_rec_env_help_lem]);
 
-val Boolv_11 = store_thm("Boolv_11[simp]",``Boolv b1 = Boolv b2 ⇔ (b1 = b2)``,srw_tac[][Boolv_def]);
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",`Boolv b1 = Boolv b2 ⇔ (b1 = b2)`,srw_tac[][Boolv_def]);
 
 val evaluate_length = Q.store_thm("evaluate_length",
   `(∀env (s:'ffi modSem$state) ls s' vs.
@@ -515,17 +515,17 @@ val evaluate_decs_state_const = Q.store_thm("evaluate_decs_state_const",
   `∀x f.(x with globals updated_by f).defined_mods = x.defined_mods` by simp[] >>
   metis_tac[FST]);
 
-val evaluate_dec_tids_acc = store_thm("evaluate_dec_tids_acc",
-  ``∀env st d res. evaluate_dec env st d = res ⇒
-      st.defined_types ⊆ (FST res).defined_types``,
+val evaluate_dec_tids_acc = Q.store_thm("evaluate_dec_tids_acc",
+  `∀env st d res. evaluate_dec env st d = res ⇒
+      st.defined_types ⊆ (FST res).defined_types`,
   Cases_on`d`>>srw_tac[][evaluate_dec_def] >> srw_tac[][] >>
   BasicProvers.CASE_TAC >>
   imp_res_tac evaluate_state_const >>
   every_case_tac >> srw_tac[][]);
 
-val evaluate_decs_tids_acc = store_thm("evaluate_decs_tids_acc",
-  ``∀env st ds res. evaluate_decs env st ds = res ⇒
-      st.defined_types ⊆ (FST res).defined_types``,
+val evaluate_decs_tids_acc = Q.store_thm("evaluate_decs_tids_acc",
+  `∀env st ds res. evaluate_decs env st ds = res ⇒
+      st.defined_types ⊆ (FST res).defined_types`,
   Induct_on`ds`>>srw_tac[][evaluate_decs_def]>>srw_tac[][]>>
   every_case_tac >> full_simp_tac(srw_ss())[]>>
   imp_res_tac evaluate_dec_tids_acc >> full_simp_tac(srw_ss())[] >>
@@ -562,16 +562,16 @@ val evaluate_decs_tids_disjoint = Q.store_thm("evaluate_decs_tids_disjoint",
 val tids_of_prompt_def = Define`
   tids_of_prompt (Prompt _ ds) = tids_of_decs ds`;
 
-val evaluate_prompt_tids_disjoint = prove(
-  ``∀env s p res. evaluate_prompt env s p = res ⇒
+val evaluate_prompt_tids_disjoint = Q.prove(
+  `∀env s p res. evaluate_prompt env s p = res ⇒
       SND(SND(SND res)) = NONE ⇒
-      DISJOINT (IMAGE TypeId (tids_of_prompt p)) s.defined_types``,
+      DISJOINT (IMAGE TypeId (tids_of_prompt p)) s.defined_types`,
   Cases_on`p`>>srw_tac[][evaluate_prompt_def]>>full_simp_tac(srw_ss())[tids_of_prompt_def]>>
   full_simp_tac(srw_ss())[LET_THM,UNCURRY] >> metis_tac[evaluate_decs_tids_disjoint]);
 
-val evaluate_prompt_tids_acc = prove(
-  ``∀env s p res. evaluate_prompt env s p = res ⇒
-      s.defined_types ⊆ (FST res).defined_types``,
+val evaluate_prompt_tids_acc = Q.prove(
+  `∀env s p res. evaluate_prompt env s p = res ⇒
+      s.defined_types ⊆ (FST res).defined_types`,
   Cases_on`p`>>srw_tac[][evaluate_prompt_def]>>full_simp_tac(srw_ss())[]>>
   metis_tac[evaluate_decs_tids_acc,FST]);
 

--- a/compiler/backend/semantics/modSemScript.sml
+++ b/compiler/backend/semantics/modSemScript.sml
@@ -397,8 +397,8 @@ dec_clock s = s with clock := s.clock -1`;
 val fix_clock_def = Define `
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`

--- a/compiler/backend/semantics/modSemScript.sml
+++ b/compiler/backend/semantics/modSemScript.sml
@@ -494,8 +494,8 @@ val evaluate_def = tDefine"evaluate"`
 val evaluate_ind = theorem"evaluate_ind"
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
-  `(∀env ^s e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
-   (∀env ^s v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
+  `(∀env (s1:'a state) e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
+   (∀env (s1:'a state) v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
   every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
   imp_res_tac fix_clock_IMP >> fs[])

--- a/compiler/backend/semantics/modSemScript.sml
+++ b/compiler/backend/semantics/modSemScript.sml
@@ -330,7 +330,14 @@ val do_if_def = Define `
   else if v = Boolv F then
     SOME e2
   else
-    NONE)`;
+      NONE)`;
+
+val do_if_either_or = Q.store_thm("do_if_is_ether_or",
+  `do_if v e1 e2 = SOME e ⇒ e = e1 ∨ e = e2`,
+  simp [do_if_def]
+  THEN1 (Cases_on `v = Boolv T`
+  THENL [simp [],
+    Cases_on `v = Boolv F` THEN simp []]))
 
 val pmatch_def = tDefine"pmatch"`
 (pmatch envC s (Pvar x) v' env = (Match ((x,v') :: env)))
@@ -384,23 +391,22 @@ val pmatch_def = tDefine"pmatch"`
                                         | INR (a,x,ps,y,z) => pats_size ps)` >>
   srw_tac [ARITH_ss] [terminationTheory.size_abbrevs, astTheory.pat_size_def]);
 
-val check_clock_def = Define`
-  check_clock s' s =
-    s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
-
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ modSem$check_clock s' s = s'`,
-  EVAL_TAC >> rw[theorem"state_component_equality"])
-
 val dec_clock_def = Define`
-  dec_clock s = s with clock := s.clock -1`;
+dec_clock s = s with clock := s.clock -1`;
+
+val fix_clock_def = Define `
+  fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
+
+val fix_clock_IMP = prove(
+  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine"evaluate"`
   (evaluate (env:modSem$environment) (s:'ffi modSem$state) ([]:modLang$exp list) = (s,Rval [])) ∧
   (evaluate env s (e1::e2::es) =
-    case evaluate env s [e1] of
-    | (s', Rval v) =>
-        (case evaluate env (check_clock s' s) (e2::es) of
+    case fix_clock s (evaluate env s [e1]) of
+    | (s, Rval v) =>
+        (case evaluate env s (e2::es) of
          | (s, Rval vs) => (s, Rval (HD v::vs))
          | res => res)
     | res => res) ∧
@@ -410,8 +416,8 @@ val evaluate_def = tDefine"evaluate"`
    | (s, Rval v) => (s, Rerr (Rraise (HD v)))
    | res => res) ∧
   (evaluate env s [Handle e pes] =
-   case evaluate env s [e] of
-   | (s', Rerr (Rraise v)) => evaluate_match env (check_clock s' s) v pes v
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rerr (Rraise v)) => evaluate_match env s v pes v
    | res => res) ∧
   (evaluate env s [Con cn es] =
    if do_con_check env.c cn (LENGTH es) then
@@ -432,37 +438,37 @@ val evaluate_def = tDefine"evaluate"`
    else Rerr (Rabort Rtype_error))) ∧
   (evaluate env s [Fun n e] = (s, Rval [Closure (env.c,env.v) n e])) ∧
   (evaluate env s [App op es] =
-   case evaluate env s (REVERSE es) of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s (REVERSE es)) of
+   | (s, Rval vs) =>
        if op = Opapp then
          (case do_opapp (REVERSE vs) of
           | SOME (env', e) =>
-            if s'.clock = 0 ∨ s.clock = 0 then
-              (s', Rerr (Rabort Rtimeout_error))
+            if s.clock = 0 then
+              (s, Rerr (Rabort Rtimeout_error))
             else
-              evaluate env' (dec_clock (check_clock s' s)) [e]
-          | NONE => (s', Rerr (Rabort Rtype_error)))
+              evaluate env' (dec_clock s) [e]
+          | NONE => (s, Rerr (Rabort Rtype_error)))
        else
-       (case (do_app (s'.refs,s'.ffi) op (REVERSE vs)) of
-        | NONE => (s', Rerr (Rabort Rtype_error))
-        | SOME ((refs',ffi'),r) => (s' with <|refs:=refs';ffi:=ffi'|>, list_result r))
+       (case (do_app (s.refs,s.ffi) op (REVERSE vs)) of
+        | NONE => (s, Rerr (Rabort Rtype_error))
+        | SOME ((refs',ffi'),r) => (s with <|refs:=refs';ffi:=ffi'|>, list_result r))
    | res => res) ∧
   (evaluate env s [If e1 e2 e3] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) =>
      (case do_if (HD vs) e2 e3 of
-      | SOME e => evaluate env (check_clock s' s) [e]
-      | NONE => (s', Rerr (Rabort Rtype_error)))
+      | SOME e => evaluate env s [e]
+      | NONE => (s, Rerr (Rabort Rtype_error)))
    | res => res) ∧
   (evaluate env s [Mat e pes] =
-   case evaluate env s [e] of
-   | (s', Rval v) =>
-       evaluate_match env (check_clock s' s) (HD v) pes
+   case fix_clock s (evaluate env s [e]) of
+   | (s, Rval v) =>
+       evaluate_match env s (HD v) pes
          (Conv (SOME ("Bind", (TypeExn (Short "Bind")))) [])
    | res => res) ∧
   (evaluate env s [Let n e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) => evaluate (env with v updated_by opt_bind n (HD vs)) s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    if ALL_DISTINCT (MAP FST funs)
@@ -478,55 +484,33 @@ val evaluate_def = tDefine"evaluate"`
    else (s, Rerr(Rabort Rtype_error)))`
   (wf_rel_tac`inv_image ($< LEX $<)
                 (λx. case x of (INL(_,s,es)) => (s.clock,exp6_size es)
-                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))` >>
-   simp[check_clock_def,dec_clock_def,do_if_def] >>
-   rw[] >> simp[]);
+                             | (INR(_,s,_,pes,_)) => (s.clock,exp3_size pes))`
+  >> rpt strip_tac
+  >> simp[dec_clock_def]
+  >> imp_res_tac fix_clock_IMP
+  >> imp_res_tac do_if_either_or
+  >> rw[]);
 
 val evaluate_ind = theorem"evaluate_ind"
-
-val s = ``s1:'ffi modSem$state``
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
   `(∀env ^s e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock) ∧
    (∀env ^s v pes v_err r s2. evaluate_match env s1 v pes v_err = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
-  every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[] >>
-  fs[do_app_def] >>
-  every_case_tac >> fs[] >> rw[])
+  every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >>
+  imp_res_tac fix_clock_IMP >> fs[])
 
-val s' = ``s':'ffi modSem$state``
-val clean_term =
-  term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``]
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate env s e) = evaluate env s e`,
+  Cases_on `evaluate env s e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-val evaluate_ind = let
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end
-|> curry save_thm "evaluate_ind"
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = let
-  val goal = evaluate_def |> concl |> clean_term |> replace_term s' s
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
-|> curry save_thm "evaluate_def"
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 val evaluate_dec_def = Define`
   (evaluate_dec env s (Dlet n e) =

--- a/compiler/backend/semantics/patPropsScript.sml
+++ b/compiler/backend/semantics/patPropsScript.sml
@@ -5,7 +5,7 @@ val _ = new_theory"patProps"
 val evaluate_lit = save_thm("evaluate_lit[simp]",
       EVAL``patSem$evaluate env s [Lit l]``)
 
-val Boolv_11 = store_thm("Boolv_11[simp]",``patSem$Boolv b1 = Boolv b2 ⇔ b1 = b2``,EVAL_TAC>>srw_tac[][]);
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",`patSem$Boolv b1 = Boolv b2 ⇔ b1 = b2`,EVAL_TAC>>srw_tac[][]);
 
 val Boolv_disjoint = save_thm("Boolv_disjoint",EVAL``patSem$Boolv T = Boolv F``);
 
@@ -25,8 +25,8 @@ val no_closures_def = tDefine"no_closures"`
  simp[v_size_def]>>srw_tac[][]>>res_tac>>simp[])
 val _ = export_rewrites["no_closures_def"];
 
-val no_closures_Boolv = store_thm("no_closures_Boolv[simp]",
-  ``no_closures (Boolv b)``,
+val no_closures_Boolv = Q.store_thm("no_closures_Boolv[simp]",
+  `no_closures (Boolv b)`,
   EVAL_TAC);
 
 val evaluate_raise_rval = store_thm("evaluate_raise_rval",

--- a/compiler/backend/semantics/patPropsScript.sml
+++ b/compiler/backend/semantics/patPropsScript.sml
@@ -29,14 +29,14 @@ val no_closures_Boolv = Q.store_thm("no_closures_Boolv[simp]",
   `no_closures (Boolv b)`,
   EVAL_TAC);
 
-val evaluate_raise_rval = store_thm("evaluate_raise_rval",
-  ``∀env s e s' v. patSem$evaluate env s [Raise e] ≠ (s', Rval v)``,
+val evaluate_raise_rval = Q.store_thm("evaluate_raise_rval",
+  `∀env s e s' v. patSem$evaluate env s [Raise e] ≠ (s', Rval v)`,
   EVAL_TAC >> srw_tac[][] >> every_case_tac >> simp[])
 val _ = export_rewrites["evaluate_raise_rval"]
 
-val evaluate_length = store_thm("evaluate_length",
-  ``∀env s ls s' vs.
-      evaluate env s ls = (s',Rval vs) ⇒ LENGTH vs = LENGTH ls``,
+val evaluate_length = Q.store_thm("evaluate_length",
+  `∀env s ls s' vs.
+      evaluate env s ls = (s',Rval vs) ⇒ LENGTH vs = LENGTH ls`,
   ho_match_mp_tac evaluate_ind >>
   srw_tac[][evaluate_def] >> srw_tac[][] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
@@ -66,23 +66,23 @@ val evaluate_sing = Q.store_thm("evaluate_sing",
   `evaluate env s [e] = (s',Rval vs) ⇒ ∃y. vs = [y]`,
   srw_tac[][] >> imp_res_tac evaluate_length >> full_simp_tac(srw_ss())[] >> metis_tac[SING_HD])
 
-val evaluate_append_Rval = store_thm("evaluate_append_Rval",
-  ``∀l1 env s l2 s' vs.
+val evaluate_append_Rval = Q.store_thm("evaluate_append_Rval",
+  `∀l1 env s l2 s' vs.
     evaluate env s (l1 ++ l2) = (s',Rval vs) ⇒
     ∃s1 v1 v2. evaluate env s l1 = (s1,Rval v1) ∧
                evaluate env s1 l2 = (s',Rval v2) ∧
-               vs = v1++v2``,
+               vs = v1++v2`,
   Induct >> simp[evaluate_def,Once evaluate_cons] >>
   srw_tac[][] >> simp[Once evaluate_cons] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> res_tac >>
   srw_tac[][] >> full_simp_tac(srw_ss())[] >> srw_tac[][]);
 
-val evaluate_append_Rval_iff = store_thm("evaluate_append_Rval_iff",
-  ``∀l1 env s l2 s' vs.
+val evaluate_append_Rval_iff = Q.store_thm("evaluate_append_Rval_iff",
+  `∀l1 env s l2 s' vs.
     evaluate env s (l1 ++ l2) = (s',Rval vs) ⇔
     ∃s1 v1 v2. evaluate env s l1 = (s1,Rval v1) ∧
                evaluate env s1 l2 = (s',Rval v2) ∧
-               vs = v1++v2``,
+               vs = v1++v2`,
   srw_tac[][] >> EQ_TAC >- MATCH_ACCEPT_TAC evaluate_append_Rval >>
   map_every qid_spec_tac[`vs`,`s`] >>
   Induct_on`l1`>>srw_tac[][evaluate_def,Once evaluate_cons] >> srw_tac[][] >>
@@ -91,13 +91,13 @@ val evaluate_append_Rval_iff = store_thm("evaluate_append_Rval_iff",
   full_simp_tac(srw_ss())[PULL_EXISTS] >>
   res_tac >> full_simp_tac(srw_ss())[]);
 
-val evaluate_append_Rerr = store_thm("evaluate_append_Rerr",
-  ``∀l1 env s l2 s' e.
+val evaluate_append_Rerr = Q.store_thm("evaluate_append_Rerr",
+  `∀l1 env s l2 s' e.
     evaluate env s (l1 ++ l2) = (s',Rerr e) ⇔
     (evaluate env s l1 = (s', Rerr e) ∨
        ∃s1 v1.
          evaluate env s l1 = (s1, Rval v1) ∧
-         evaluate env s1 l2 = (s', Rerr e))``,
+         evaluate env s1 l2 = (s', Rerr e))`,
   Induct >> srw_tac[][evaluate_def] >>
   srw_tac[][Once evaluate_cons] >> MATCH_MP_TAC EQ_SYM >>
   srw_tac[][Once evaluate_cons] >> MATCH_MP_TAC EQ_SYM >>
@@ -199,13 +199,13 @@ val evaluate_add_to_clock_io_events_mono = Q.store_thm("evaluate_add_to_clock_io
   metis_tac[evaluate_io_events_mono,with_clock_ffi,FST,IS_PREFIX_TRANS,lemma])
 
 (*
-val not_evaluate_list_append = store_thm("not_evaluate_list_append",
-  ``∀l1 ck env s l2 res.
+val not_evaluate_list_append = Q.store_thm("not_evaluate_list_append",
+  `∀l1 ck env s l2 res.
     (∀res. ¬evaluate_list ck env s (l1 ++ l2) res) ⇔
     ((∀res. ¬evaluate_list ck env s l1 res) ∨
        ∃s1 v1.
          evaluate_list ck env s l1 (s1, Rval v1) ∧
-         (∀res. ¬evaluate_list ck env s1 l2 res))``,
+         (∀res. ¬evaluate_list ck env s1 l2 res))`,
   Induct >- (
     srw_tac[][EQ_IMP_THM] >- (
       full_simp_tac(srw_ss())[Once(CONJUNCT2(evaluate_cases))] >>

--- a/compiler/backend/semantics/patSemScript.sml
+++ b/compiler/backend/semantics/patSemScript.sml
@@ -373,15 +373,6 @@ val do_if_either_or = Q.store_thm("do_if_is_ether_or",
   THENL [simp [],
     Cases_on `v = Boolv F` THEN simp []]))
 
-
-val check_clock_def = Define`
-  check_clock s' s =
-    s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
-
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ patSem$check_clock s' s = s'`,
-  EVAL_TAC >> rw[theorem"state_component_equality"])
-
 val dec_clock_def = Define`
 dec_clock s = s with clock := s.clock -1`;
 
@@ -391,8 +382,6 @@ val fix_clock_def = Define `
 val fix_clock_IMP = prove(
   ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
-
-val STOP_def = Define `STOP x = x`;
 
 val evaluate_def = tDefine "evaluate"`
   (evaluate (env:patSem$v list) (s:'ffi patSem$state) ([]:patLang$exp list) = (s,Rval [])) ∧
@@ -465,7 +454,7 @@ val evaluate_def = tDefine "evaluate"`
   THEN rpt strip_tac
   THEN imp_res_tac fix_clock_IMP
   THEN imp_res_tac do_if_either_or
-  THEN fs [dec_clock_def,check_clock_def])
+  THEN fs [dec_clock_def])
 
 val evaluate_ind = theorem"evaluate_ind"
 

--- a/compiler/backend/semantics/patSemScript.sml
+++ b/compiler/backend/semantics/patSemScript.sml
@@ -379,8 +379,8 @@ dec_clock s = s with clock := s.clock -1`;
 val fix_clock_def = Define `
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val evaluate_def = tDefine "evaluate"`

--- a/compiler/backend/semantics/patSemScript.sml
+++ b/compiler/backend/semantics/patSemScript.sml
@@ -366,6 +366,14 @@ val do_if_def = Define `
     if v = Boolv T then SOME e1 else
     if v = Boolv F then SOME e2 else NONE`;
 
+val do_if_either_or = Q.store_thm("do_if_is_ether_or",
+  `do_if v e1 e2 = SOME e ⇒ e = e1 ∨ e = e2`,
+  simp [do_if_def]
+  THEN1 (Cases_on `v = Boolv T`
+  THENL [simp [],
+    Cases_on `v = Boolv F` THEN simp []]))
+
+
 val check_clock_def = Define`
   check_clock s' s =
     s' with clock := if s'.clock ≤ s.clock then s'.clock else s.clock`;
@@ -375,14 +383,23 @@ val check_clock_id = Q.store_thm("check_clock_id",
   EVAL_TAC >> rw[theorem"state_component_equality"])
 
 val dec_clock_def = Define`
-  dec_clock s = s with clock := s.clock -1`;
+dec_clock s = s with clock := s.clock -1`;
 
-val evaluate_def = tDefine"evaluate"`
+val fix_clock_def = Define `
+  fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)`
+
+val fix_clock_IMP = prove(
+  ``fix_clock s x = (s1,res) ==> s1.clock <= s.clock``,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+
+val STOP_def = Define `STOP x = x`;
+
+val evaluate_def = tDefine "evaluate"`
   (evaluate (env:patSem$v list) (s:'ffi patSem$state) ([]:patLang$exp list) = (s,Rval [])) ∧
   (evaluate env s (e1::e2::es) =
-    case evaluate env s [e1] of
-    | (s', Rval v) =>
-        (case evaluate env (check_clock s' s) (e2::es) of
+    case fix_clock s (evaluate env s [e1]) of
+    | (s, Rval v) =>
+        (case evaluate env s (e2::es) of
          | (s, Rval vs) => (s, Rval (HD v::vs))
          | res => res)
     | res => res) ∧
@@ -392,8 +409,8 @@ val evaluate_def = tDefine"evaluate"`
    | (s, Rval v) => (s, Rerr (Rraise (HD v)))
    | res => res) ∧
   (evaluate env s [Handle e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rerr (Rraise v)) => evaluate (v::env) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rerr (Rraise v)) => evaluate (v::env) s [e2]
    | res => res) ∧
   (evaluate env s [Con tag es] =
    case evaluate env s (REVERSE es) of
@@ -409,91 +426,70 @@ val evaluate_def = tDefine"evaluate"`
       else Rerr (Rabort Rtype_error))) ∧
   (evaluate env s [Fun e] = (s, Rval [Closure env e])) ∧
   (evaluate env s [App op es] =
-   case evaluate env s (REVERSE es) of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s (REVERSE es)) of
+   | (s, Rval vs) =>
        if op = Op (Op Opapp) then
          (case do_opapp (REVERSE vs) of
           | SOME (env, e) =>
-            if s'.clock = 0 ∨ s.clock = 0 then
-              (s', Rerr (Rabort Rtimeout_error))
+            if s.clock = 0 then
+              (s, Rerr (Rabort Rtimeout_error))
             else
-              evaluate env (dec_clock (check_clock s' s)) [e]
-          | NONE => (s', Rerr (Rabort Rtype_error)))
+              evaluate env (dec_clock s) [e]
+          | NONE => (s, Rerr (Rabort Rtype_error)))
        else
-       (case (do_app s' op (REVERSE vs)) of
-        | NONE => (s', Rerr (Rabort Rtype_error))
+       (case (do_app s op (REVERSE vs)) of
+        | NONE => (s, Rerr (Rabort Rtype_error))
         | SOME (s,r) => (s, list_result r))
    | res => res) ∧
   (evaluate env s [If e1 e2 e3] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) =>
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) =>
        (case do_if (HD vs) e2 e3 of
-        | SOME e => evaluate env (check_clock s' s) [e]
-        | NONE => (s', Rerr (Rabort Rtype_error)))
+        | SOME e => evaluate env s [e]
+        | NONE => (s, Rerr (Rabort Rtype_error)))
    | res => res) ∧
   (evaluate env s [Let e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate (HD vs::env) (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) => evaluate (HD vs::env) s [e2]
    | res => res) ∧
   (evaluate env s [Seq e1 e2] =
-   case evaluate env s [e1] of
-   | (s', Rval vs) => evaluate env (check_clock s' s) [e2]
+   case fix_clock s (evaluate env s [e1]) of
+   | (s, Rval vs) => evaluate env s [e2]
    | res => res) ∧
   (evaluate env s [Letrec funs e] =
    evaluate ((build_rec_env funs env)++env) s [e]) ∧
   (evaluate env s [Extend_global n] =
    (s with globals := s.globals++GENLIST(K NONE) n, Rval [Conv tuple_tag []]))`
   (wf_rel_tac`inv_image ($< LEX $<)
-                (λx. case x of (_,s,es) => (s.clock,exp1_size es))` >>
-   simp[check_clock_def,dec_clock_def] >>
-   rw[do_if_def] >> simp[])
+  (λx. case x of (_,s,es) => (s.clock,exp1_size es))`
+  THEN rpt strip_tac
+  THEN imp_res_tac fix_clock_IMP
+  THEN imp_res_tac do_if_either_or
+  THEN fs [dec_clock_def,check_clock_def])
 
 val evaluate_ind = theorem"evaluate_ind"
 
+val do_app_clock = Q.store_thm("do_app_clock",
+  `patSem$do_app s op vs = SOME(s',r) ==> s.clock = s'.clock`,
+  rpt strip_tac
+  THEN imp_res_tac do_app_cases
+  THEN (fs [do_app_def] >> every_case_tac >> fs[LET_THM,semanticPrimitivesTheory.store_alloc_def,semanticPrimitivesTheory.store_assign_def] >> rw[]))
+
 val evaluate_clock = Q.store_thm("evaluate_clock",
   `(∀env s1 e r s2. evaluate env s1 e = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
-  ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
-  every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[] >>
-  imp_res_tac do_app_cases >>
-  fs[do_app_def] >>
-  every_case_tac >>
-  fs[LET_THM,semanticPrimitivesTheory.store_alloc_def,semanticPrimitivesTheory.store_assign_def] >>
-  rw[] >> every_case_tac >> fs[] >> rw[] )
+  ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >> every_case_tac >> fs[dec_clock_def] >> rw[] >> rfs[] >> imp_res_tac fix_clock_IMP >> imp_res_tac do_app_clock >> fs[])
 
-val s = ``s:'ffi patSem$state``
-val s' = ``s':'ffi patSem$state``
-val clean_term =
-  term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``]
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate env s e) = evaluate env s e`,
+  Cases_on `evaluate env s e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,theorem "state_component_equality"]);
 
-val evaluate_ind = let
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end
-|> curry save_thm "evaluate_ind"
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def);
 
-val evaluate_def = let
-  val goal = evaluate_def |> concl |> clean_term |> replace_term s' s
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
-|> curry save_thm "evaluate_def"
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind);
 
 val semantics_def = Define`
   semantics env st es =

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -141,8 +141,8 @@ val dec_clock_const = Q.store_thm("dec_clock_const[simp]",
    (dec_clock z).bitmaps = z.bitmaps`,
   EVAL_TAC);
 
-val evaluate_consts = store_thm("evaluate_consts",
-  ``!c s r s1.
+val evaluate_consts = Q.store_thm("evaluate_consts",
+  `!c s r s1.
       evaluate (c,s) = (r,s1) ==>
       s1.use_alloc = s.use_alloc /\
       s1.use_store = s.use_store /\
@@ -151,7 +151,7 @@ val evaluate_consts = store_thm("evaluate_consts",
       s1.be = s.be /\
       s1.gc_fun = s.gc_fun /\
       s1.mdomain = s.mdomain /\
-      s1.bitmaps = s.bitmaps``,
+      s1.bitmaps = s.bitmaps`,
   recInduct evaluate_ind >>
   rpt conj_tac >>
   simp[evaluate_def] >>
@@ -335,10 +335,10 @@ val inst_clock_neutral_ffi = Q.prove(
   \\ full_simp_tac(srw_ss())[mem_load_def,get_var_def,mem_store_def]
   \\ srw_tac[][state_component_equality]));
 
-val evaluate_clock_neutral = store_thm("evaluate_clock_neutral",
-  ``!prog s res t.
+val evaluate_clock_neutral = Q.store_thm("evaluate_clock_neutral",
+  `!prog s res t.
       evaluate (prog,s) = (res,t) /\ clock_neutral prog ==>
-      evaluate (prog,s with clock := c) = (res,t with clock := c)``,
+      evaluate (prog,s with clock := c) = (res,t with clock := c)`,
   recInduct evaluate_ind \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[evaluate_def,get_var_def,clock_neutral_def]
   THEN1 (every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[])
@@ -348,10 +348,10 @@ val evaluate_clock_neutral = store_thm("evaluate_clock_neutral",
          (Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def,get_var_def])
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[set_var_def]);
 
-val evaluate_ffi_neutral = store_thm("evaluate_ffi_neutral",
-  ``!prog s res t.
+val evaluate_ffi_neutral = Q.store_thm("evaluate_ffi_neutral",
+  `!prog s res t.
       evaluate (prog,s) = (res,t) /\ clock_neutral prog ==>
-      evaluate (prog,s with ffi := c) = (res,t with ffi := c)``,
+      evaluate (prog,s with ffi := c) = (res,t with ffi := c)`,
   recInduct evaluate_ind \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[evaluate_def,get_var_def,clock_neutral_def]
   THEN1 (every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[empty_env_def])
@@ -388,11 +388,11 @@ val semantics_Diverge_IMP_LPREFIX = Q.store_thm("semantics_Diverge_IMP_LPREFIX",
             EVAL``(s with clock := k).clock``,
             EVAL``((s with clock := k) with clock := k2) = (s with clock := k2)``]);
 
-val map_bitmap_length = store_thm("map_bitmap_length",``
+val map_bitmap_length = Q.store_thm("map_bitmap_length",`
   ∀a b c x y z.
   map_bitmap a b c = SOME(x,y,z) ⇒
   LENGTH c = LENGTH x + LENGTH z ∧
-  LENGTH x = LENGTH a``,
+  LENGTH x = LENGTH a`,
   Induct>>rw[]>>
   Cases_on`b`>>TRY(Cases_on`h`)>>Cases_on`c`>>
   fs[map_bitmap_def]>>

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -310,9 +310,9 @@ val clock_neutral_def = Define `
   (clock_neutral (If _ _ _ p1 p2) <=> clock_neutral p1 /\ clock_neutral p2) /\
   (clock_neutral r <=> F)`
 
-val inst_clock_neutral = prove(
-  ``(inst i s = SOME t ==> inst i (s with clock := k) = SOME (t with clock := k)) /\
-    (inst i s = NONE ==> inst i (s with clock := k) = NONE)``,
+val inst_clock_neutral = Q.prove(
+  `(inst i s = SOME t ==> inst i (s with clock := k) = SOME (t with clock := k)) /\
+    (inst i s = NONE ==> inst i (s with clock := k) = NONE)`,
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,word_exp_def,set_var_def,LET_DEF]
   \\ srw_tac[][state_component_equality]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_exp_def]
@@ -320,9 +320,9 @@ val inst_clock_neutral = prove(
   \\ full_simp_tac(srw_ss())[mem_load_def,get_var_def,mem_store_def]
   \\ srw_tac[][state_component_equality]);
 
-val inst_clock_neutral_ffi = prove(
-  ``(inst i s = SOME t ==> inst i (s with ffi := k) = SOME (t with ffi := k)) /\
-    (inst i s = NONE ==> inst i (s with ffi := k) = NONE)``,
+val inst_clock_neutral_ffi = Q.prove(
+  `(inst i s = SOME t ==> inst i (s with ffi := k) = SOME (t with ffi := k)) /\
+    (inst i s = NONE ==> inst i (s with ffi := k) = NONE)`,
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,word_exp_def,set_var_def,LET_DEF,state_component_equality]>>
   reverse full_case_tac>>fs[]>>
   TRY
@@ -361,8 +361,8 @@ val evaluate_ffi_neutral = store_thm("evaluate_ffi_neutral",
          (Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def,get_var_def])
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[set_var_def]);
 
-val semantics_Terminate_IMP_PREFIX = store_thm("semantics_Terminate_IMP_PREFIX",
-  ``semantics start s1 = Terminate x l ==> isPREFIX s1.ffi.io_events l``,
+val semantics_Terminate_IMP_PREFIX = Q.store_thm("semantics_Terminate_IMP_PREFIX",
+  `semantics start s1 = Terminate x l ==> isPREFIX s1.ffi.io_events l`,
   full_simp_tac(srw_ss())[semantics_def,LET_DEF] \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
   \\ DEEP_INTRO_TAC some_intro \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac evaluate_io_events_mono \\ full_simp_tac(srw_ss())[]);
@@ -402,10 +402,10 @@ val map_bitmap_length = store_thm("map_bitmap_length",``
   pop_assum mp_tac>>every_case_tac>>rw[]>>res_tac>>
   fs[]>>DECIDE_TAC);
 
-val dec_stack_length = store_thm("dec_stack_length",``
+val dec_stack_length = Q.store_thm("dec_stack_length",`
   ∀bs enc orig_stack new_stack.
   dec_stack bs enc orig_stack = SOME new_stack ⇒
-  LENGTH orig_stack = LENGTH new_stack``,
+  LENGTH orig_stack = LENGTH new_stack`,
   ho_match_mp_tac stackSemTheory.dec_stack_ind>>
   fs[stackSemTheory.dec_stack_def,LENGTH_NIL]>>rw[]>>
   pop_assum mp_tac>>
@@ -433,9 +433,9 @@ val extract_labels_def = Define`
     (extract_labels e2 ++ extract_labels e3)) ∧
   (extract_labels _ = [])`
 
-val find_code_IMP_get_labels = store_thm("find_code_IMP_get_labels",
-  ``find_code d r code = SOME e ==>
-    get_labels e SUBSET loc_check code``,
+val find_code_IMP_get_labels = Q.store_thm("find_code_IMP_get_labels",
+  `find_code d r code = SOME e ==>
+    get_labels e SUBSET loc_check code`,
   Cases_on `d`
   \\ fs [stackSemTheory.find_code_def,SUBSET_DEF,IN_DEF,
          loc_check_def,FORALL_PROD]

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -143,28 +143,6 @@ val set_var_def = Define `
 val set_store_def = Define `
   set_store v x (s:('a,'ffi) stackSem$state) = (s with store := s.store |+ (v,x))`;
 
-val check_clock_def = Define `
-  check_clock (s1:('a,'ffi) stackSem$state) (s2:('a,'ffi) stackSem$state) =
-    if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
-
-val check_clock_thm = Q.prove(
-  `(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
-  SRW_TAC [] [check_clock_def])
-
-val check_clock_alt = Q.prove(
-  `(s1.clock <= (dec_clock s2).clock ==> (check_clock s1 s2 = s1))`,
-  SRW_TAC [] [check_clock_def,dec_clock_def] \\ `F` by DECIDE_TAC)
-
-val check_clock_lemma = Q.prove(
-  `b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
-
-val check_clock_IMP = Q.prove(
-  `n <= (check_clock r s).clock ==> n <= s.clock`,
-  SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
-
 val empty_env_def = Define `
   empty_env (s:('a,'ffi) stackSem$state) = s with <| regs := FEMPTY ; stack := [] |>`;
 
@@ -585,7 +563,7 @@ val evaluate_clock = Q.store_thm("evaluate_clock",
   \\ FULL_SIMP_TAC std_ss [cut_state_opt_def,STOP_def]
   \\ TRY BasicProvers.TOP_CASE_TAC \\ fs []
   \\ rpt (every_case_tac \\ fs []
-    \\ REPEAT STRIP_TAC \\ SRW_TAC [] [check_clock_def,empty_env_def]
+    \\ REPEAT STRIP_TAC \\ SRW_TAC [] [empty_env_def]
     \\ IMP_RES_TAC inst_clock
     \\ IMP_RES_TAC alloc_clock
     \\ fs [set_var_def,set_store_def,dec_clock_def,LET_THM]

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -33,18 +33,18 @@ val map_bitmap_def = Define `
      | SOME (xs,ys,zs) => SOME (t::xs,ys,zs)) /\
   (map_bitmap _ _ _ = NONE)`
 
-val filter_bitmap_LENGTH = store_thm("filter_bitmap_LENGTH",
-  ``!bs xs x y. (filter_bitmap bs xs = SOME (x,y)) ==> LENGTH y <= LENGTH xs``,
+val filter_bitmap_LENGTH = Q.store_thm("filter_bitmap_LENGTH",
+  `!bs xs x y. (filter_bitmap bs xs = SOME (x,y)) ==> LENGTH y <= LENGTH xs`,
   Induct \\ fs [filter_bitmap_def] \\ Cases_on `xs` \\ TRY (Cases_on `h`)
   \\ fs [filter_bitmap_def] \\ Cases \\ fs [filter_bitmap_def]
   \\ REPEAT STRIP_TAC \\ RES_TAC \\ res_tac
   \\ BasicProvers.EVERY_CASE_TAC \\ fs [] \\ SRW_TAC [] []
   \\ res_tac \\ decide_tac);
 
-val map_bitmap_LENGTH = store_thm("map_bitmap_LENGTH",
-  ``!t1 t2 t3 x y z. (map_bitmap t1 t2 t3 = SOME (x,y,z)) ==>
+val map_bitmap_LENGTH = Q.store_thm("map_bitmap_LENGTH",
+  `!t1 t2 t3 x y z. (map_bitmap t1 t2 t3 = SOME (x,y,z)) ==>
                    LENGTH y ≤ LENGTH t2 ∧
-                   LENGTH z <= LENGTH t3``,
+                   LENGTH z <= LENGTH t3`,
   Induct \\ fs [map_bitmap_def] \\ Cases_on `t2` \\ Cases_on `t3`
   \\ TRY (Cases_on `h`)
   \\ fs [map_bitmap_def] \\ Cases \\ fs [map_bitmap_def]
@@ -346,8 +346,8 @@ val find_code_def = Define `
 val fix_clock_def = Define `
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)`
 
-val fix_clock_IMP = prove(
-  ``fix_clock s x = (res,s1) ==> s1.clock <= s.clock``,
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
   Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val STOP_def = Define `STOP x = x`;
@@ -561,8 +561,8 @@ val gc_clock = Q.store_thm("gc_clock",
   \\ every_case_tac >> fs[]
   \\ SRW_TAC [] [] \\ fs []);
 
-val alloc_clock = store_thm("alloc_clock",
-  ``!xs s1 vs s2. (alloc x s1 = (vs,s2)) ==> s2.clock <= s1.clock``,
+val alloc_clock = Q.store_thm("alloc_clock",
+  `!xs s1 vs s2. (alloc x s1 = (vs,s2)) ==> s2.clock <= s1.clock`,
   SIMP_TAC std_ss [alloc_def] \\ REPEAT STRIP_TAC
   \\ every_case_tac \\ SRW_TAC [] [] \\ fs []
   \\ Q.ABBREV_TAC `s3 = set_store AllocSize (Word x) s1`
@@ -578,8 +578,8 @@ val inst_clock = Q.prove(
   \\ SRW_TAC [] [set_var_def] \\ fs []
   \\ fs [mem_store_def] \\ SRW_TAC [] []);
 
-val evaluate_clock = store_thm("evaluate_clock",
-  ``!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock``,
+val evaluate_clock = Q.store_thm("evaluate_clock",
+  `!xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s2.clock <= s1.clock`,
   recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss [cut_state_opt_def,STOP_def]
@@ -595,8 +595,8 @@ val evaluate_clock = store_thm("evaluate_clock",
     \\ imp_res_tac LESS_EQ_TRANS \\ fs [] \\ rfs []
     \\ TRY decide_tac));
 
-val fix_clock_evaluate = store_thm("fix_clock_evaluate",
-  ``fix_clock s (evaluate (xs,s)) = evaluate (xs,s)``,
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s (evaluate (xs,s)) = evaluate (xs,s)`,
   Cases_on `evaluate (xs,s)` \\ fs [fix_clock_def]
   \\ imp_res_tac evaluate_clock
   \\ fs [MIN_DEF,GSYM NOT_LESS,theorem "state_component_equality"]);

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -147,22 +147,22 @@ val check_clock_def = Define `
   check_clock (s1:('a,'ffi) stackSem$state) (s2:('a,'ffi) stackSem$state) =
     if s1.clock <= s2.clock then s1 else s1 with clock := s2.clock`;
 
-val check_clock_thm = prove(
-  ``(check_clock s1 s2).clock <= s2.clock /\
-    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_thm = Q.prove(
+  `(check_clock s1 s2).clock <= s2.clock /\
+    (s1.clock <= s2.clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def])
 
-val check_clock_alt = prove(
-  ``(s1.clock <= (dec_clock s2).clock ==> (check_clock s1 s2 = s1))``,
+val check_clock_alt = Q.prove(
+  `(s1.clock <= (dec_clock s2).clock ==> (check_clock s1 s2 = s1))`,
   SRW_TAC [] [check_clock_def,dec_clock_def] \\ `F` by DECIDE_TAC)
 
-val check_clock_lemma = prove(
-  ``b ==> ((check_clock s1 s).clock < s.clock \/
-          ((check_clock s1 s).clock = s.clock) /\ b)``,
+val check_clock_lemma = Q.prove(
+  `b ==> ((check_clock s1 s).clock < s.clock \/
+          ((check_clock s1 s).clock = s.clock) /\ b)`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
-val check_clock_IMP = prove(
-  ``n <= (check_clock r s).clock ==> n <= s.clock``,
+val check_clock_IMP = Q.prove(
+  `n <= (check_clock r s).clock ==> n <= s.clock`,
   SRW_TAC [] [check_clock_def] \\ DECIDE_TAC);
 
 val empty_env_def = Define `
@@ -555,8 +555,8 @@ val evaluate_ind = theorem"evaluate_ind";
 
 (* We prove that the clock never increases. *)
 
-val gc_clock = store_thm("gc_clock",
-  ``!s1 s2. (gc s1 = SOME s2) ==> s2.clock <= s1.clock``,
+val gc_clock = Q.store_thm("gc_clock",
+  `!s1 s2. (gc s1 = SOME s2) ==> s2.clock <= s1.clock`,
   fs [gc_def,LET_DEF] \\ SRW_TAC [] []
   \\ every_case_tac >> fs[]
   \\ SRW_TAC [] [] \\ fs []);
@@ -572,8 +572,8 @@ val alloc_clock = store_thm("alloc_clock",
   \\ Cases_on `x'` \\ fs [] \\ SRW_TAC [] []
   \\ EVAL_TAC \\ decide_tac);
 
-val inst_clock = prove(
-  ``inst i s = SOME s2 ==> s2.clock <= s.clock``,
+val inst_clock = Q.prove(
+  `inst i s = SOME s2 ==> s2.clock <= s.clock`,
   Cases_on `i` \\ fs [inst_def,assign_def] \\ every_case_tac
   \\ SRW_TAC [] [set_var_def] \\ fs []
   \\ fs [mem_store_def] \\ SRW_TAC [] []);

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -503,9 +503,9 @@ val pop_env_code_clock = Q.store_thm("pop_env_code_clock",`
   r.clock = x.clock`,
   fs[pop_env_def]>>EVERY_CASE_TAC>>fs[state_component_equality])
 
-val alloc_code_const = store_thm("alloc_code_const",``
+val alloc_code_const = Q.store_thm("alloc_code_const",`
   alloc x names s = (res,t) ⇒
-  t.code = s.code``,
+  t.code = s.code`,
   fs[alloc_def,gc_def,LET_THM]>>EVERY_CASE_TAC>>
   fs[call_env_def,push_env_def,LET_THM,env_to_list_def,set_store_def,state_component_equality]>>
   imp_res_tac pop_env_code_clock>>fs[])
@@ -514,8 +514,8 @@ val inst_code_const = Q.prove(`
   inst i s = SOME t ⇒ s.code = t.code`,
   Cases_on`i`>>fs[inst_def,assign_def]>>EVERY_CASE_TAC>>fs[set_var_def,state_component_equality,mem_store_def])
 
-val evaluate_code_const = store_thm("evaluate_code_const",``
-  ∀xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s1.code = s2.code``,
+val evaluate_code_const = Q.store_thm("evaluate_code_const",`
+  ∀xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==> s1.code = s2.code`,
   recInduct evaluate_ind>>fs[evaluate_def,LET_THM]>>reverse (rw[])
   >-
     (rename1 `bad_dest_args _ _`>>
@@ -725,8 +725,8 @@ val gc_s_val_eq_word_state = Q.store_thm("gc_s_val_eq_word_state",
   full_simp_tac(srw_ss())[state_component_equality]>>rev_full_simp_tac(srw_ss())[])
 
 (*Most generalised gc_s_val_eq*)
-val gc_s_val_eq_gen = store_thm ("gc_s_val_eq_gen",
-``
+val gc_s_val_eq_gen = Q.store_thm ("gc_s_val_eq_gen",
+`
   !s t s'.
   s.gc_fun = t.gc_fun ∧
   s.memory = t.memory ∧
@@ -739,7 +739,7 @@ val gc_s_val_eq_gen = store_thm ("gc_s_val_eq_gen",
   s_val_eq s'.stack t'.stack ∧
   s_key_eq t.stack t'.stack ∧
   t'.memory = s'.memory ∧
-  t'.store = s'.store`` ,
+  t'.store = s'.store` ,
   srw_tac[][]>>
   full_simp_tac(srw_ss())[gc_def,LET_THM]>>
   IMP_RES_TAC s_val_eq_enc_stack>>
@@ -891,7 +891,7 @@ val word_exp_stack_swap = Q.prove(
   every_case_tac>>full_simp_tac(srw_ss())[])
 
 (*Stack swap theorem for evaluate*)
-val evaluate_stack_swap = store_thm("evaluate_stack_swap",``
+val evaluate_stack_swap = Q.store_thm("evaluate_stack_swap",`
   !c s.
       case evaluate (c,s) of
       | (SOME Error,s1) => T
@@ -933,7 +933,7 @@ val evaluate_stack_swap = store_thm("evaluate_stack_swap",``
                           ?st. evaluate (c,s with stack := xs) =
                                 (res, s1 with stack := st)  /\
                                 s_val_eq s1.stack st /\
-                                s_key_eq xs st)``,
+                                s_key_eq xs st)`,
   ho_match_mp_tac (evaluate_ind |> Q.SPEC`UNCURRY P` |> SIMP_RULE (srw_ss())[] |> Q.GEN`P`) >> srw_tac[][]
   >-(*Skip*)
     (full_simp_tac(srw_ss())[evaluate_def,s_key_eq_refl]>>srw_tac[][]>>HINT_EXISTS_TAC>>full_simp_tac(srw_ss())[s_key_eq_refl])
@@ -1563,23 +1563,23 @@ val mem_store_perm = Q.prove(`
   full_simp_tac(srw_ss())[mem_store_def]>>every_case_tac>>
   full_simp_tac(srw_ss())[state_component_equality])
 
-val jump_exc_perm = prove(``
+val jump_exc_perm = Q.prove(`
   jump_exc (st with permute:=perm) =
   case jump_exc st of
     NONE => NONE
-  | SOME (x,l1,l2) => SOME (x with permute:=perm,l1,l2)``,
+  | SOME (x,l1,l2) => SOME (x with permute:=perm,l1,l2)`,
   full_simp_tac(srw_ss())[jump_exc_def]>>
   every_case_tac>>
   full_simp_tac(srw_ss())[state_component_equality]);
 
 (*For any target result permute, we can find an initial permute such that the resulting permutation is the same*)
-val permute_swap_lemma = store_thm("permute_swap_lemma",``
+val permute_swap_lemma = Q.store_thm("permute_swap_lemma",`
   ∀prog st perm.
   let (res,rst) = evaluate(prog,st) in
     res ≠ SOME Error  (*Provable without this assum*)
     ⇒
     ∃perm'. evaluate(prog,st with permute := perm') =
-    (res,rst with permute:=perm)``,
+    (res,rst with permute:=perm)`,
   ho_match_mp_tac (evaluate_ind |> Q.SPEC`UNCURRY P` |> SIMP_RULE (srw_ss())[] |> Q.GEN`P`) >> srw_tac[][]>>full_simp_tac(srw_ss())[evaluate_def]
   >-
     metis_tac[ignore_perm]
@@ -1940,7 +1940,7 @@ val locals_rel_cut_env = Q.prove(`
 
 val srestac = qpat_x_assum`A=res`sym_sub_tac>>full_simp_tac(srw_ss())[]
 
-val locals_rel_evaluate_thm = store_thm("locals_rel_evaluate_thm",``
+val locals_rel_evaluate_thm = Q.store_thm("locals_rel_evaluate_thm",`
   ∀prog st res rst loc temp.
   evaluate (prog,st) = (res,rst) ∧
   res ≠ SOME Error ∧
@@ -1950,7 +1950,7 @@ val locals_rel_evaluate_thm = store_thm("locals_rel_evaluate_thm",``
   evaluate (prog,st with locals:=loc) = (res,rst with locals:=loc') ∧
   case res of
     NONE => locals_rel temp rst.locals loc'
-  |  SOME _ => rst.locals = loc'``,
+  |  SOME _ => rst.locals = loc'`,
   completeInduct_on`prog_size (K 0) prog`>>
   rpt strip_tac>>
   Cases_on`prog`>>

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -497,10 +497,10 @@ val evaluate_add_clock_io_events_mono = Q.store_thm("evaluate_add_clock_io_event
   metis_tac[evaluate_io_events_mono,IS_PREFIX_TRANS,SND,PAIR]);
 
 (*code is unchanged across eval*)
-val pop_env_code_clock = store_thm("pop_env_code_clock",``
+val pop_env_code_clock = Q.store_thm("pop_env_code_clock",`
   pop_env r = SOME x ⇒
   r.code = x.code ∧
-  r.clock = x.clock``,
+  r.clock = x.clock`,
   fs[pop_env_def]>>EVERY_CASE_TAC>>fs[state_component_equality])
 
 val alloc_code_const = store_thm("alloc_code_const",``
@@ -510,8 +510,8 @@ val alloc_code_const = store_thm("alloc_code_const",``
   fs[call_env_def,push_env_def,LET_THM,env_to_list_def,set_store_def,state_component_equality]>>
   imp_res_tac pop_env_code_clock>>fs[])
 
-val inst_code_const = prove(``
-  inst i s = SOME t ⇒ s.code = t.code``,
+val inst_code_const = Q.prove(`
+  inst i s = SOME t ⇒ s.code = t.code`,
   Cases_on`i`>>fs[inst_def,assign_def]>>EVERY_CASE_TAC>>fs[set_var_def,state_component_equality,mem_store_def])
 
 val evaluate_code_const = store_thm("evaluate_code_const",``
@@ -538,9 +538,9 @@ val evaluate_code_const = store_thm("evaluate_code_const",``
 
 (* -- *)
 
-val get_vars_length_lemma = store_thm("get_vars_length_lemma",
-  ``!ls s y. get_vars ls s = SOME y ==>
-           LENGTH y = LENGTH ls``,
+val get_vars_length_lemma = Q.store_thm("get_vars_length_lemma",
+  `!ls s y. get_vars ls s = SOME y ==>
+           LENGTH y = LENGTH ls`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>
   Cases_on`get_var h s`>>full_simp_tac(srw_ss())[]>>
   Cases_on`get_vars ls s`>>full_simp_tac(srw_ss())[]>>
@@ -577,78 +577,78 @@ val s_key_eq_def = Define`
   (s_key_eq _ _ = F)`
 
 (*Reflexive*)
-val s_key_eq_refl = store_thm( "s_key_eq_refl",
-  ``!ls .s_key_eq ls ls = T``,
+val s_key_eq_refl = Q.store_thm( "s_key_eq_refl",
+  `!ls .s_key_eq ls ls = T`,
    Induct >> srw_tac[][s_key_eq_def]>>
    Cases_on`h`>> Cases_on`o'`>>srw_tac[][s_frame_key_eq_def])
 
-val s_val_eq_refl = store_thm( "s_val_eq_refl",
-  ``!ls.s_val_eq ls ls = T``,
+val s_val_eq_refl = Q.store_thm( "s_val_eq_refl",
+  `!ls.s_val_eq ls ls = T`,
   Induct >> srw_tac[][s_val_eq_def]>>
   Cases_on`h`>> Cases_on`o'`>>srw_tac[][s_frame_val_eq_def])
 
 (*transitive*)
-val s_frame_key_eq_trans = prove(
-  ``!a b c. s_frame_key_eq a b /\ s_frame_key_eq b c ==>
-            s_frame_key_eq a c``,
+val s_frame_key_eq_trans = Q.prove(
+  `!a b c. s_frame_key_eq a b /\ s_frame_key_eq b c ==>
+            s_frame_key_eq a c`,
   Cases_on`a`>>Cases_on`b`>>Cases_on`c`>>
   Cases_on`o'`>>Cases_on`o''`>>Cases_on`o'''`>>
   full_simp_tac(srw_ss())[s_frame_key_eq_def])
 
-val s_key_eq_trans = store_thm("s_key_eq_trans",
-  ``!a b c. s_key_eq a b /\ s_key_eq b c ==>
-            s_key_eq a c``,
+val s_key_eq_trans = Q.store_thm("s_key_eq_trans",
+  `!a b c. s_key_eq a b /\ s_key_eq b c ==>
+            s_key_eq a c`,
   Induct>>
   Cases_on`b`>>Cases_on`c`>>full_simp_tac(srw_ss())[s_key_eq_def]>>
   srw_tac[][]>>metis_tac[s_frame_key_eq_trans])
 
-val s_frame_val_eq_trans = prove(
-  ``!a b c. s_frame_val_eq a b /\ s_frame_val_eq b c ==>
-            s_frame_val_eq a c``,
+val s_frame_val_eq_trans = Q.prove(
+  `!a b c. s_frame_val_eq a b /\ s_frame_val_eq b c ==>
+            s_frame_val_eq a c`,
   Cases_on`a`>>Cases_on`b`>>Cases_on`c`>>
   Cases_on`o'`>>Cases_on`o''`>>Cases_on`o'''`>>
   full_simp_tac(srw_ss())[s_frame_val_eq_def])
 
-val s_val_eq_trans = prove(
-  ``!a b c. s_val_eq a b /\ s_val_eq b c ==>
-            s_val_eq a c``,
+val s_val_eq_trans = Q.prove(
+  `!a b c. s_val_eq a b /\ s_val_eq b c ==>
+            s_val_eq a c`,
   Induct>>
   Cases_on`b`>>Cases_on`c`>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   srw_tac[][]>>metis_tac[s_frame_val_eq_trans])
 
 (*Symmetric*)
-val s_frame_key_eq_sym = prove(
-  ``!a b. s_frame_key_eq a b <=> s_frame_key_eq b a``,
+val s_frame_key_eq_sym = Q.prove(
+  `!a b. s_frame_key_eq a b <=> s_frame_key_eq b a`,
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>full_simp_tac(srw_ss())[s_frame_key_eq_def,EQ_SYM_EQ])
 
-val s_key_eq_sym = store_thm("s_key_eq_sym",
-  ``!a b. s_key_eq a b <=> s_key_eq b a``,
+val s_key_eq_sym = Q.store_thm("s_key_eq_sym",
+  `!a b. s_key_eq a b <=> s_key_eq b a`,
   Induct>> Cases_on`b`>>full_simp_tac(srw_ss())[s_key_eq_def]>>
   strip_tac>>metis_tac[s_frame_key_eq_sym])
 
-val s_frame_val_eq_sym = prove(
-   ``!a b. s_frame_val_eq a b <=> s_frame_val_eq b a``,
+val s_frame_val_eq_sym = Q.prove(
+   `!a b. s_frame_val_eq a b <=> s_frame_val_eq b a`,
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>full_simp_tac(srw_ss())[s_frame_val_eq_def,EQ_SYM_EQ])
 
-val s_val_eq_sym = store_thm("s_val_eq_sym",
-  ``!a b. s_val_eq a b <=> s_val_eq b a``,
+val s_val_eq_sym = Q.store_thm("s_val_eq_sym",
+  `!a b. s_val_eq a b <=> s_val_eq b a`,
   Induct>> Cases_on`b`>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   strip_tac>>metis_tac[s_frame_val_eq_sym])
 
-val s_frame_val_and_key_eq = prove(
-  ``!s t. s_frame_val_eq s t /\ s_frame_key_eq s t ==> s = t``,
+val s_frame_val_and_key_eq = Q.prove(
+  `!s t. s_frame_val_eq s t /\ s_frame_key_eq s t ==> s = t`,
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>
   full_simp_tac(srw_ss())[s_frame_val_eq_def,s_frame_key_eq_def,LIST_EQ_MAP_PAIR])
 
-val s_val_and_key_eq = store_thm("s_val_and_key_eq",
-  ``!s t. s_val_eq s t /\ s_key_eq s t ==> s =t``,
+val s_val_and_key_eq = Q.store_thm("s_val_and_key_eq",
+  `!s t. s_val_eq s t /\ s_key_eq s t ==> s =t`,
   Induct>-
     (Cases>>full_simp_tac(srw_ss())[s_val_eq_def])>>
   srw_tac[][]>>
   Cases_on`t`>>full_simp_tac(srw_ss())[s_val_eq_def,s_key_eq_def,s_frame_val_and_key_eq])
 
-val dec_stack_stack_key_eq = prove(
-  ``!wl st st'. dec_stack wl st = SOME st' ==> s_key_eq st st'``,
+val dec_stack_stack_key_eq = Q.prove(
+  `!wl st st'. dec_stack wl st = SOME st' ==> s_key_eq st st'`,
   ho_match_mp_tac dec_stack_ind>>srw_tac[][dec_stack_def]>>
   full_simp_tac(srw_ss())[s_key_eq_def]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>full_simp_tac(srw_ss())[dec_stack_def]>>srw_tac[][]>>
@@ -656,21 +656,21 @@ val dec_stack_stack_key_eq = prove(
   full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def,MAP_ZIP,NOT_LESS])
 
 (*gc preserves the stack_key relation*)
-val gc_s_key_eq = store_thm("gc_s_key_eq",
-  ``!s x. gc s = SOME x ==> s_key_eq s.stack x.stack``,
+val gc_s_key_eq = Q.store_thm("gc_s_key_eq",
+  `!s x. gc s = SOME x ==> s_key_eq s.stack x.stack`,
   srw_tac[][gc_def] >>full_simp_tac(srw_ss())[LET_THM]>>every_case_tac>>full_simp_tac(srw_ss())[]>>
   IMP_RES_TAC dec_stack_stack_key_eq>>
   full_simp_tac(srw_ss())[state_component_equality]>>rev_full_simp_tac(srw_ss())[])
 
-val s_val_eq_enc_stack = prove(
-  ``!st st'. s_val_eq st st' ==> enc_stack st = enc_stack st'``,
+val s_val_eq_enc_stack = Q.prove(
+  `!st st'. s_val_eq st st' ==> enc_stack st = enc_stack st'`,
   Induct>>Cases_on`st'`>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   Cases_on`h`>>Cases_on`h'`>>Cases_on`o''`>>Cases_on`o'`>>
   full_simp_tac(srw_ss())[s_frame_val_eq_def,enc_stack_def])
 
-val s_val_eq_dec_stack = prove(
-  ``!q st st' x. s_val_eq st st' /\ dec_stack q st = SOME x ==>
-    ?y. dec_stack q st' = SOME y /\ s_val_eq x y``,
+val s_val_eq_dec_stack = Q.prove(
+  `!q st st' x. s_val_eq st st' /\ dec_stack q st = SOME x ==>
+    ?y. dec_stack q st' = SOME y /\ s_val_eq x y`,
    ho_match_mp_tac dec_stack_ind >> srw_tac[][] >>
    Cases_on`st'`>>full_simp_tac(srw_ss())[s_val_eq_def,s_val_eq_refl]>>
    Cases_on`h`>>full_simp_tac(srw_ss())[dec_stack_def]>>
@@ -686,11 +686,11 @@ val s_val_eq_dec_stack = prove(
 
 (*gc succeeds on all stacks related by stack_val and there are relations
   in the result*)
-val gc_s_val_eq = store_thm("gc_s_val_eq",
-  ``!s x st y. s_val_eq s.stack st /\
+val gc_s_val_eq = Q.store_thm("gc_s_val_eq",
+  `!s x st y. s_val_eq s.stack st /\
              gc s = SOME y ==>
       ?z. gc (s with stack := st) = SOME (y with stack := z) /\
-          s_val_eq y.stack z /\ s_key_eq z st``,
+          s_val_eq y.stack z /\ s_key_eq z st`,
   srw_tac[][gc_def]>>full_simp_tac(srw_ss())[LET_THM]>>
   SIMP_TAC std_ss [markerTheory.Abbrev_def]>>
   IMP_RES_TAC s_val_eq_enc_stack>>full_simp_tac(srw_ss())[]>>
@@ -703,14 +703,14 @@ val gc_s_val_eq = store_thm("gc_s_val_eq",
   Q.EXISTS_TAC`y'`>>full_simp_tac(srw_ss())[state_component_equality]>>rev_full_simp_tac(srw_ss())[])
 
 (*Slightly more general theorem allows the unused locals to be differnt*)
-val gc_s_val_eq_word_state = store_thm("gc_s_val_eq_word_state",
-  ``!s tlocs tstack y.
+val gc_s_val_eq_word_state = Q.store_thm("gc_s_val_eq_word_state",
+  `!s tlocs tstack y.
           s_val_eq s.stack tstack /\
           gc s = SOME y ==>
     ?zlocs zstack.
           gc (s with <|stack:=tstack;locals:=tlocs|>) =
           SOME (y with <|stack:=zstack;locals:=zlocs|>) /\
-          s_val_eq y.stack zstack /\ s_key_eq zstack tstack``,
+          s_val_eq y.stack zstack /\ s_key_eq zstack tstack`,
   srw_tac[][gc_def]>>full_simp_tac(srw_ss())[LET_THM]>>
   SIMP_TAC std_ss [markerTheory.Abbrev_def]>>
   IMP_RES_TAC s_val_eq_enc_stack>>full_simp_tac(srw_ss())[]>>
@@ -750,55 +750,55 @@ val gc_s_val_eq_gen = store_thm ("gc_s_val_eq_gen",
   metis_tac[s_val_eq_sym])
 
 (*pushing and popping maintain the stack_key relation*)
-val push_env_pop_env_s_key_eq = store_thm("push_env_pop_env_s_key_eq",
-  ``!s t x opt. s_key_eq (push_env x opt s).stack t.stack ==>
+val push_env_pop_env_s_key_eq = Q.store_thm("push_env_pop_env_s_key_eq",
+  `!s t x opt. s_key_eq (push_env x opt s).stack t.stack ==>
               ?y. (pop_env t = SOME y /\
-                   s_key_eq s.stack y.stack)``,
+                   s_key_eq s.stack y.stack)`,
   srw_tac[][]>>Cases_on`opt`>>TRY(PairCases_on`x'`)>>
   full_simp_tac(srw_ss())[push_env_def]>>full_simp_tac(srw_ss())[LET_THM,env_to_list_def]>>Cases_on`t.stack`>>
   full_simp_tac(srw_ss())[s_key_eq_def,pop_env_def]>>every_case_tac>>
   full_simp_tac(srw_ss())[])
 
-val get_vars_stack_swap = prove(
-  ``!l s t. s.locals = t.locals ==>
-    get_vars l s = get_vars l t``,
+val get_vars_stack_swap = Q.prove(
+  `!l s t. s.locals = t.locals ==>
+    get_vars l s = get_vars l t`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_def]>>
   srw_tac[][]>> every_case_tac>>
   metis_tac[NOT_NONE_SOME,SOME_11])
 
-val get_vars_stack_swap_simp = prove(
-  ``!args. get_vars args (s with stack := xs) = get_vars args s``,
+val get_vars_stack_swap_simp = Q.prove(
+  `!args. get_vars args (s with stack := xs) = get_vars args s`,
   `(s with stack:=xs).locals = s.locals` by full_simp_tac(srw_ss())[]>>
   metis_tac[get_vars_stack_swap])
 
-val s_val_eq_length = store_thm("s_val_eq_length",
-  ``!s t. s_val_eq s t ==> LENGTH s = LENGTH t``,
+val s_val_eq_length = Q.store_thm("s_val_eq_length",
+  `!s t. s_val_eq s t ==> LENGTH s = LENGTH t`,
   Induct>>Cases>>full_simp_tac(srw_ss())[s_val_eq_def,LENGTH]>>
   Cases>>full_simp_tac(srw_ss())[s_val_eq_def])
 
-val s_key_eq_length = store_thm("s_key_eq_length",
-  ``!s t. s_key_eq s t ==> LENGTH s = LENGTH t``,
+val s_key_eq_length = Q.store_thm("s_key_eq_length",
+  `!s t. s_key_eq s t ==> LENGTH s = LENGTH t`,
   Induct>>Cases>>full_simp_tac(srw_ss())[s_key_eq_def,LENGTH]>>
   Cases>>full_simp_tac(srw_ss())[s_key_eq_def])
 
-val s_val_eq_APPEND = prove(
-  ``!s t x y. (s_val_eq s t /\ s_val_eq x y)==> s_val_eq (s++x) (t++y)``,
+val s_val_eq_APPEND = Q.prove(
+  `!s t x y. (s_val_eq s t /\ s_val_eq x y)==> s_val_eq (s++x) (t++y)`,
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
   srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def])
 
-val s_val_eq_REVERSE = prove(
-  ``!s t. s_val_eq s t ==> s_val_eq (REVERSE s) (REVERSE t)``,
+val s_val_eq_REVERSE = Q.prove(
+  `!s t. s_val_eq s t ==> s_val_eq (REVERSE s) (REVERSE t)`,
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
   srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def,s_val_eq_APPEND])
 
-val s_val_eq_TAKE = prove(
-  ``!s t n. s_val_eq s t ==> s_val_eq (TAKE n s) (TAKE n t)``,
+val s_val_eq_TAKE = Q.prove(
+  `!s t n. s_val_eq s t ==> s_val_eq (TAKE n s) (TAKE n t)`,
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>rw[]>>
   Cases_on`n`>>fs[s_val_eq_def])
 
-val s_val_eq_LASTN = prove(
-  ``!s t n. s_val_eq s t
-    ==> s_val_eq (LASTN n s) (LASTN n t)``,
+val s_val_eq_LASTN = Q.prove(
+  `!s t n. s_val_eq s t
+    ==> s_val_eq (LASTN n s) (LASTN n t)`,
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
   srw_tac[][LASTN_def]>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   `s_val_eq [x] [y]` by full_simp_tac(srw_ss())[s_val_eq_def]>>
@@ -807,24 +807,24 @@ val s_val_eq_LASTN = prove(
   IMP_RES_TAC s_val_eq_TAKE>>
   metis_tac[s_val_eq_REVERSE])
 
-val s_key_eq_APPEND = prove(
-  ``!s t x y. (s_key_eq s t /\ s_key_eq x y)==> s_key_eq (s++x) (t++y)``,
+val s_key_eq_APPEND = Q.prove(
+  `!s t x y. (s_key_eq s t /\ s_key_eq x y)==> s_key_eq (s++x) (t++y)`,
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
   srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def])
 
-val s_key_eq_REVERSE = prove(
-  ``!s t. s_key_eq s t ==> s_key_eq (REVERSE s) (REVERSE t)``,
+val s_key_eq_REVERSE = Q.prove(
+  `!s t. s_key_eq s t ==> s_key_eq (REVERSE s) (REVERSE t)`,
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
   srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def,s_key_eq_APPEND])
 
-val s_key_eq_TAKE = prove(
-  ``!s t n. s_key_eq s t ==> s_key_eq (TAKE n s) (TAKE n t)``,
+val s_key_eq_TAKE = Q.prove(
+  `!s t n. s_key_eq s t ==> s_key_eq (TAKE n s) (TAKE n t)`,
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
   rw[]>>Cases_on`n`>>fs[s_key_eq_def])
 
-val s_key_eq_LASTN = prove(
-  ``!s t n. s_key_eq s t
-    ==> s_key_eq (LASTN n s) (LASTN n t)``,
+val s_key_eq_LASTN = Q.prove(
+  `!s t n. s_key_eq s t
+    ==> s_key_eq (LASTN n s) (LASTN n t)`,
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
   srw_tac[][LASTN_def]>>full_simp_tac(srw_ss())[s_key_eq_def]>>
   `s_key_eq [x] [y]` by full_simp_tac(srw_ss())[s_key_eq_def]>>
@@ -833,20 +833,20 @@ val s_key_eq_LASTN = prove(
   IMP_RES_TAC s_key_eq_TAKE>>
   metis_tac[s_key_eq_REVERSE])
 
-val s_key_eq_tail = store_thm("s_key_eq_tail",
- ``!a b c d. s_key_eq (a::b) (c::d) ==> s_key_eq b d``,
+val s_key_eq_tail = Q.store_thm("s_key_eq_tail",
+ `!a b c d. s_key_eq (a::b) (c::d) ==> s_key_eq b d`,
   full_simp_tac(srw_ss())[s_key_eq_def])
 
-val s_val_eq_tail = prove(
- ``!a b c d. s_val_eq (a::b) (c::d) ==> s_val_eq b d``,
+val s_val_eq_tail = Q.prove(
+ `!a b c d. s_val_eq (a::b) (c::d) ==> s_val_eq b d`,
   full_simp_tac(srw_ss())[s_val_eq_def])
 
-val s_key_eq_LASTN_exists = prove(
-  ``!s t n e y xs. s_key_eq s t /\
+val s_key_eq_LASTN_exists = Q.prove(
+  `!s t n e y xs. s_key_eq s t /\
     LASTN n s = StackFrame e (SOME y)::xs
     ==> ?e' ls. LASTN n t = StackFrame e' (SOME y)::ls
         /\ MAP FST e' = MAP FST e
-        /\ s_key_eq xs ls``,
+        /\ s_key_eq xs ls`,
    rpt strip_tac>>
    IMP_RES_TAC s_key_eq_LASTN>>
    first_x_assum (qspec_then `n` assume_tac)>> rev_full_simp_tac(srw_ss())[]>>
@@ -854,12 +854,12 @@ val s_key_eq_LASTN_exists = prove(
    full_simp_tac(srw_ss())[s_key_eq_def]>>
    Cases_on`h`>>Cases_on`o'`>>full_simp_tac(srw_ss())[s_frame_key_eq_def])
 
-val s_val_eq_LASTN_exists = store_thm("s_val_eq_LASTN_exists",
-  ``!s t n e y xs. s_val_eq s t /\
+val s_val_eq_LASTN_exists = Q.store_thm("s_val_eq_LASTN_exists",
+  `!s t n e y xs. s_val_eq s t /\
    LASTN n s = StackFrame e (SOME y)::xs
     ==> ?e' ls. LASTN n t = StackFrame e' (SOME y)::ls
        /\ MAP SND e' = MAP SND e
-       /\ s_val_eq xs ls``,
+       /\ s_val_eq xs ls`,
   rpt strip_tac>>
   IMP_RES_TAC s_val_eq_LASTN>>
   first_x_assum (qspec_then `n` assume_tac)>> rev_full_simp_tac(srw_ss())[]>>
@@ -867,16 +867,16 @@ val s_val_eq_LASTN_exists = store_thm("s_val_eq_LASTN_exists",
   full_simp_tac(srw_ss())[s_val_eq_def]>>
   Cases_on`h`>>Cases_on`o'`>>full_simp_tac(srw_ss())[s_frame_val_eq_def])
 
-val LASTN_LENGTH_cond = store_thm("LASTN_LENGTH_cond",
-  ``!n xs. n = LENGTH xs ==> LASTN n xs =xs``,
+val LASTN_LENGTH_cond = Q.store_thm("LASTN_LENGTH_cond",
+  `!n xs. n = LENGTH xs ==> LASTN n xs =xs`,
   metis_tac[LASTN_LENGTH_ID] )
 
-val handler_eq = prove(
-  ``x with handler := x.handler = x``, full_simp_tac(srw_ss())[state_component_equality])
+val handler_eq = Q.prove(
+  `x with handler := x.handler = x`, full_simp_tac(srw_ss())[state_component_equality])
 
 (*Stack is irrelevant to word_exp*)
-val word_exp_stack_swap = prove(
-  ``!s e st. word_exp s e = word_exp (s with stack:=st) e``,
+val word_exp_stack_swap = Q.prove(
+  `!s e st. word_exp s e = word_exp (s with stack:=st) e`,
   ho_match_mp_tac word_exp_ind>>
   srw_tac[][word_exp_def]
   >-
@@ -1480,60 +1480,60 @@ val evaluate_stack_swap = store_thm("evaluate_stack_swap",``
 
 (*--Permute Swap Lemma--*)
 
-val ignore_inc = prove(``
+val ignore_inc = Q.prove(`
   ∀perm:num->num->num.
-  (λn. perm(n+0)) = perm``,srw_tac[][FUN_EQ_THM])
+  (λn. perm(n+0)) = perm`,srw_tac[][FUN_EQ_THM])
 
-val ignore_perm = prove(``
-  ∀st. st with permute := st.permute = st`` ,
+val ignore_perm = Q.prove(`
+  ∀st. st with permute := st.permute = st` ,
   srw_tac[][]>>full_simp_tac(srw_ss())[state_component_equality])
 
-val get_vars_perm = store_thm("get_vars_perm",``
-  ∀args.get_vars args (st with permute:=perm) = get_vars args st``,
+val get_vars_perm = Q.store_thm("get_vars_perm",`
+  ∀args.get_vars args (st with permute:=perm) = get_vars args st`,
   Induct>>srw_tac[][get_vars_def,get_var_def])
 
-val pop_env_perm = store_thm("pop_env_perm",``
+val pop_env_perm = Q.store_thm("pop_env_perm",`
   pop_env (rst with permute:=perm) =
   (case pop_env rst of
     NONE => NONE
-  | SOME rst' => SOME (rst' with permute:=perm))``,
+  | SOME rst' => SOME (rst' with permute:=perm))`,
   full_simp_tac(srw_ss())[pop_env_def]>>every_case_tac>>
   full_simp_tac(srw_ss())[state_component_equality])
 
-val gc_perm = prove(``
+val gc_perm = Q.prove(`
   gc st = SOME x ⇒
-  gc (st with permute:=perm) = SOME (x with permute := perm)``,
+  gc (st with permute:=perm) = SOME (x with permute := perm)`,
   full_simp_tac(srw_ss())[gc_def,LET_THM]>>every_case_tac>>
   full_simp_tac(srw_ss())[state_component_equality])
 
-val get_var_perm = store_thm("get_var_perm",``
+val get_var_perm = Q.store_thm("get_var_perm",`
   get_var n (st with permute:=perm) =
-  (get_var n st)``,full_simp_tac(srw_ss())[get_var_def])
+  (get_var n st)`,full_simp_tac(srw_ss())[get_var_def])
 
-val get_var_imm_perm = store_thm("get_var_imm_perm",``
+val get_var_imm_perm = Q.store_thm("get_var_imm_perm",`
   get_var_imm n (st with permute:=perm) =
-  (get_var_imm n st)``,
+  (get_var_imm n st)`,
   Cases_on`n`>>
   full_simp_tac(srw_ss())[get_var_imm_def,get_var_perm])
 
-val set_var_perm = store_thm("set_var_perm",``
+val set_var_perm = Q.store_thm("set_var_perm",`
   set_var v x (s with permute:=perm) =
-  (set_var v x s) with permute:=perm``,
+  (set_var v x s) with permute:=perm`,
   full_simp_tac(srw_ss())[set_var_def])
 
-val get_vars_perm = prove(``
+val get_vars_perm = Q.prove(`
   ∀ls. get_vars ls (st with permute:=perm) =
-  (get_vars ls st)``,
+  (get_vars ls st)`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_perm])
 
-val set_vars_perm = prove(``
+val set_vars_perm = Q.prove(`
   ∀ls. set_vars ls x (st with permute := perm) =
-       (set_vars ls x st) with permute:=perm``,
+       (set_vars ls x st) with permute:=perm`,
   full_simp_tac(srw_ss())[set_vars_def])
 
-val word_state_rewrites = prove(``
+val word_state_rewrites = Q.prove(`
   (st with clock:=A) with permute:=B =
-  (st with <|clock:=A ;permute:=B|>)``,
+  (st with <|clock:=A ;permute:=B|>)`,
   full_simp_tac(srw_ss())[])
 
 val perm_assum_tac = (first_x_assum(qspec_then`perm`assume_tac)>>
@@ -1543,9 +1543,9 @@ val perm_assum_tac = (first_x_assum(qspec_then`perm`assume_tac)>>
           `(λn. perm' n) = perm'` by full_simp_tac(srw_ss())[FUN_EQ_THM]>>
           simp[]);
 
-val word_exp_perm = store_thm("word_exp_perm",``
+val word_exp_perm = Q.store_thm("word_exp_perm",`
   ∀s exp. word_exp (s with permute:=perm) exp =
-          word_exp s exp``,
+          word_exp s exp`,
   ho_match_mp_tac word_exp_ind>>srw_tac[][word_exp_def]
   >-
     (every_case_tac>>full_simp_tac(srw_ss())[mem_load_def])
@@ -1555,11 +1555,11 @@ val word_exp_perm = store_thm("word_exp_perm",``
     `ls = ls'` by
       (unabbrev_all_tac>>fs[MAP_EQ_f])>> fs[])
 
-val mem_store_perm = prove(``
+val mem_store_perm = Q.prove(`
   mem_store a (w:'a word_loc) (s with permute:=perm) =
   case mem_store a w s of
     NONE => NONE
-  | SOME x => SOME(x with permute:=perm)``,
+  | SOME x => SOME(x with permute:=perm)`,
   full_simp_tac(srw_ss())[mem_store_def]>>every_case_tac>>
   full_simp_tac(srw_ss())[state_component_equality])
 
@@ -1735,37 +1735,37 @@ val permute_swap_lemma = store_thm("permute_swap_lemma",``
         qpat_x_assum`A=res` (SUBST1_TAC o SYM)>>full_simp_tac(srw_ss())[]));
 
 (*Monotonicity*)
-val every_var_inst_mono = store_thm("every_var_inst_mono",``
+val every_var_inst_mono = Q.store_thm("every_var_inst_mono",`
   ∀P inst Q.
   (∀x. P x ⇒ Q x) ∧
   every_var_inst P inst
   ⇒
-  every_var_inst Q inst``,
+  every_var_inst Q inst`,
   ho_match_mp_tac every_var_inst_ind>>srw_tac[][every_var_inst_def]>>
   Cases_on`ri`>>full_simp_tac(srw_ss())[every_var_imm_def])
 
-val every_var_exp_mono = store_thm("every_var_exp_mono",``
+val every_var_exp_mono = Q.store_thm("every_var_exp_mono",`
   ∀P exp Q.
   (∀x. P x ⇒ Q x) ∧
   every_var_exp P exp
   ⇒
-  every_var_exp Q exp``,
+  every_var_exp Q exp`,
   ho_match_mp_tac every_var_exp_ind>>srw_tac[][every_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM])
 
-val every_name_mono = store_thm("every_name_mono",``
+val every_name_mono = Q.store_thm("every_name_mono",`
   ∀P names Q.
   (∀x. P x ⇒ Q x) ∧
-  every_name P names ⇒ every_name Q names``,
+  every_name P names ⇒ every_name Q names`,
   srw_tac[][every_name_def]>>
   metis_tac[EVERY_MONOTONIC])
 
-val every_var_mono = store_thm("every_var_mono",``
+val every_var_mono = Q.store_thm("every_var_mono",`
   ∀P prog Q.
   (∀x. P x ⇒ Q x) ∧
   every_var P prog
   ⇒
-  every_var Q prog``,
+  every_var Q prog`,
   ho_match_mp_tac every_var_ind>>srw_tac[][every_var_def]>>
   TRY(Cases_on`ret`>>full_simp_tac(srw_ss())[]>>PairCases_on`x`>>Cases_on`h`>>full_simp_tac(srw_ss())[]>>TRY(Cases_on`x`)>>full_simp_tac(srw_ss())[])>>
   TRY(Cases_on`r`>>full_simp_tac(srw_ss())[])>>
@@ -1773,33 +1773,33 @@ val every_var_mono = store_thm("every_var_mono",``
   metis_tac[EVERY_MONOTONIC,every_var_inst_mono,every_var_exp_mono,every_name_mono])
 
 (*Conjunct*)
-val every_var_inst_conj = store_thm("every_var_inst_conj",``
+val every_var_inst_conj = Q.store_thm("every_var_inst_conj",`
   ∀P inst Q.
   every_var_inst P inst ∧ every_var_inst Q inst ⇔
-  every_var_inst (λx. P x ∧ Q x) inst``,
+  every_var_inst (λx. P x ∧ Q x) inst`,
   ho_match_mp_tac every_var_inst_ind>>srw_tac[][every_var_inst_def]>>
   TRY(Cases_on`ri`>>full_simp_tac(srw_ss())[every_var_imm_def])>>
   metis_tac[])
 
-val every_var_exp_conj = store_thm("every_var_exp_conj",``
+val every_var_exp_conj = Q.store_thm("every_var_exp_conj",`
   ∀P exp Q.
   every_var_exp P exp ∧ every_var_exp Q exp ⇔
-  every_var_exp (λx. P x ∧ Q x) exp``,
+  every_var_exp (λx. P x ∧ Q x) exp`,
   ho_match_mp_tac every_var_exp_ind>>srw_tac[][every_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>
   metis_tac[])
 
-val every_name_conj = store_thm("every_name_conj",``
+val every_name_conj = Q.store_thm("every_name_conj",`
   ∀P names Q.
   every_name P names ∧ every_name Q names ⇔
-  every_name (λx. P x ∧ Q x) names``,
+  every_name (λx. P x ∧ Q x) names`,
   srw_tac[][every_name_def]>>
   metis_tac[EVERY_CONJ])
 
-val every_var_conj = store_thm("every_var_conj",``
+val every_var_conj = Q.store_thm("every_var_conj",`
   ∀P prog Q.
   every_var P prog  ∧ every_var Q prog ⇔
-  every_var (λx. P x ∧ Q x) prog``,
+  every_var (λx. P x ∧ Q x) prog`,
   ho_match_mp_tac every_var_ind>>srw_tac[][every_var_def]>>
   TRY(Cases_on`ret`>>full_simp_tac(srw_ss())[])>>
   TRY(PairCases_on`x`>>Cases_on`h`>>full_simp_tac(srw_ss())[])>>
@@ -1809,9 +1809,9 @@ val every_var_conj = store_thm("every_var_conj",``
   TRY(metis_tac[EVERY_CONJ,every_var_inst_conj,every_var_exp_conj,every_name_conj]))
 
 (*Similar lemmas about every_stack_var*)
-val every_var_imp_every_stack_var = store_thm("every_var_imp_every_stack_var",``
+val every_var_imp_every_stack_var = Q.store_thm("every_var_imp_every_stack_var",`
   ∀P prog.
-  every_var P prog ⇒ every_stack_var P prog``,
+  every_var P prog ⇒ every_stack_var P prog`,
   ho_match_mp_tac every_stack_var_ind>>
   srw_tac[][every_stack_var_def,every_var_def]>>
   Cases_on`ret`>>
@@ -1819,20 +1819,20 @@ val every_var_imp_every_stack_var = store_thm("every_var_imp_every_stack_var",``
   PairCases_on`x`>>full_simp_tac(srw_ss())[]>>
   Cases_on`x'`>>Cases_on`r`>>full_simp_tac(srw_ss())[])
 
-val every_stack_var_mono = store_thm("every_stack_var_mono",``
+val every_stack_var_mono = Q.store_thm("every_stack_var_mono",`
   ∀P prog Q.
   (∀x. P x ⇒ Q x) ∧
   every_stack_var P prog
   ⇒
-  every_stack_var Q prog``,
+  every_stack_var Q prog`,
   ho_match_mp_tac every_stack_var_ind>>srw_tac[][every_stack_var_def]>>
   TRY(Cases_on`ret`>>full_simp_tac(srw_ss())[]>>PairCases_on`x`>>Cases_on`h`>>full_simp_tac(srw_ss())[]>>TRY(Cases_on`x`>>Cases_on`r`>>full_simp_tac(srw_ss())[]))>>
   metis_tac[every_name_mono])
 
-val every_stack_var_conj = store_thm("every_stack_var_conj",``
+val every_stack_var_conj = Q.store_thm("every_stack_var_conj",`
   ∀P prog Q.
   every_stack_var P prog  ∧ every_stack_var Q prog ⇔
-  every_stack_var (λx. P x ∧ Q x) prog``,
+  every_stack_var (λx. P x ∧ Q x) prog`,
   ho_match_mp_tac every_stack_var_ind>>srw_tac[][every_stack_var_def]>>
   TRY(Cases_on`ret`>>full_simp_tac(srw_ss())[])>>
   TRY(PairCases_on`x`>>Cases_on`h`>>full_simp_tac(srw_ss())[])>>
@@ -1843,20 +1843,20 @@ val every_stack_var_conj = store_thm("every_stack_var_conj",``
 val locals_rel_def = Define`
   locals_rel temp (s:'a word_loc num_map) t ⇔ (∀x. x < temp ⇒ lookup x s = lookup x t)`
 
-val the_words_EVERY_IS_SOME = store_thm("the_words_EVERY_IS_SOME",
-  ``∀ls x.
+val the_words_EVERY_IS_SOME = Q.store_thm("the_words_EVERY_IS_SOME",
+  `∀ls x.
   the_words ls = SOME x ⇒
-  EVERY IS_SOME ls``,
+  EVERY IS_SOME ls`,
   Induct>>fs[]>>Cases>>fs[the_words_def]>>
   TOP_CASE_TAC>>fs[]>>
   TOP_CASE_TAC>>fs[])
 
-val locals_rel_word_exp = store_thm("locals_rel_word_exp",``
+val locals_rel_word_exp = Q.store_thm("locals_rel_word_exp",`
   ∀s exp w.
   every_var_exp (λx. x < temp) exp ∧
   word_exp s exp = SOME w ∧
   locals_rel temp s.locals loc ⇒
-  word_exp (s with locals:=loc) exp = SOME w``,
+  word_exp (s with locals:=loc) exp = SOME w`,
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,every_var_exp_def,locals_rel_def]
   >-
@@ -1879,54 +1879,54 @@ val locals_rel_word_exp = store_thm("locals_rel_word_exp",``
   >>
     every_case_tac>>res_tac>>full_simp_tac(srw_ss())[])
 
-val locals_rel_get_vars  = store_thm("locals_rel_get_vars",``
+val locals_rel_get_vars  = Q.store_thm("locals_rel_get_vars",`
   ∀ls vs.
   get_vars ls st = SOME vs ∧
   EVERY (λx. x < temp) ls ∧
   locals_rel temp st.locals loc ⇒
-  get_vars ls (st with locals:= loc) = SOME vs``,
+  get_vars ls (st with locals:= loc) = SOME vs`,
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>srw_tac[][]>>
   qpat_x_assum`A=SOME vs` mp_tac>>ntac 2 full_case_tac>>srw_tac[][]>>
   res_tac>>full_simp_tac(srw_ss())[get_var_def,locals_rel_def]>>
   res_tac>>
   full_simp_tac(srw_ss())[])
 
-val locals_rel_alist_insert = store_thm("locals_rel_alist_insert",``
+val locals_rel_alist_insert = Q.store_thm("locals_rel_alist_insert",`
   ∀ls vs s t.
   locals_rel temp s t ∧
   EVERY (λx. x < temp) ls ⇒
-  locals_rel temp (alist_insert ls vs s) (alist_insert ls vs t)``,
+  locals_rel temp (alist_insert ls vs s) (alist_insert ls vs t)`,
   ho_match_mp_tac alist_insert_ind>>full_simp_tac(srw_ss())[alist_insert_def,locals_rel_def]>>
   srw_tac[][]>>
   Cases_on`x'=ls`>>full_simp_tac(srw_ss())[lookup_insert])
 
-val locals_rel_get_var = store_thm("locals_rel_get_var",``
+val locals_rel_get_var = Q.store_thm("locals_rel_get_var",`
   r < temp ∧
   get_var r st = SOME x ∧
   locals_rel temp st.locals loc ⇒
-  get_var r (st with locals:=loc) = SOME x``,
+  get_var r (st with locals:=loc) = SOME x`,
   full_simp_tac(srw_ss())[get_var_def,locals_rel_def]>>
   metis_tac[])
 
-val locals_rel_get_var_imm = store_thm("locals_rel_get_var_imm",``
+val locals_rel_get_var_imm = Q.store_thm("locals_rel_get_var_imm",`
   every_var_imm (λx.x<temp) r ∧
   get_var_imm r st = SOME x ∧
   locals_rel temp st.locals loc ⇒
-  get_var_imm r (st with locals:=loc) = SOME x``,
+  get_var_imm r (st with locals:=loc) = SOME x`,
   Cases_on`r`>>full_simp_tac(srw_ss())[get_var_imm_def,every_var_imm_def]>>
   metis_tac[locals_rel_get_var])
 
-val locals_rel_set_var = prove(``
+val locals_rel_set_var = Q.prove(`
   ∀n s t.
   locals_rel temp s t ⇒
-  locals_rel temp (insert n v s) (insert n v t)``,
+  locals_rel temp (insert n v s) (insert n v t)`,
   srw_tac[][]>>full_simp_tac(srw_ss())[locals_rel_def,lookup_insert])
 
-val locals_rel_cut_env = prove(``
+val locals_rel_cut_env = Q.prove(`
   locals_rel temp loc loc' ∧
   every_name (λx. x < temp) names ∧
   cut_env names loc = SOME x ⇒
-  cut_env names loc' = SOME x``,
+  cut_env names loc' = SOME x`,
   srw_tac[][locals_rel_def,cut_env_def,SUBSET_DEF,every_name_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM,toAList_domain]
   >- metis_tac[domain_lookup]
@@ -2129,8 +2129,8 @@ val locals_rel_evaluate_thm = store_thm("locals_rel_evaluate_thm",``
     full_case_tac>>full_simp_tac(srw_ss())[state_component_equality,locals_rel_def]>>
     Cases_on`res`>>full_simp_tac(srw_ss())[]))
 
-val mem_list_rearrange = store_thm("mem_list_rearrange",``
-  ∀ls x f. MEM x (list_rearrange f ls) ⇔ MEM x ls``,
+val mem_list_rearrange = Q.store_thm("mem_list_rearrange",`
+  ∀ls x f. MEM x (list_rearrange f ls) ⇔ MEM x ls`,
   full_simp_tac(srw_ss())[MEM_EL]>>srw_tac[][wordSemTheory.list_rearrange_def]>>
   imp_res_tac BIJ_IFF_INV>>
   full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF,SURJ_DEF]>>

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -457,8 +457,8 @@ val termdep_rw = Q.prove(
     ((set_var n v s).termdep = s.termdep)`,
   EVAL_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val fix_clock_IMP_LESS_EQ = prove(
-  ``!x. fix_clock s x = (res,s1) ==> s1.clock <= s.clock /\ s1.termdep = s.termdep``,
+val fix_clock_IMP_LESS_EQ = Q.prove(
+  `!x. fix_clock s x = (res,s1) ==> s1.clock <= s.clock /\ s1.termdep = s.termdep`,
   full_simp_tac(srw_ss())[fix_clock_def,FORALL_PROD] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ decide_tac);
 
 val evaluate_def = tDefine "evaluate" `
@@ -613,9 +613,9 @@ val gc_clock = Q.store_thm("gc_clock",
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
 
-val alloc_clock = store_thm("alloc_clock",
-  ``!xs s1 vs s2. (alloc x names s1 = (vs,s2)) ==>
-                  s2.clock <= s1.clock /\ s2.termdep = s1.termdep``,
+val alloc_clock = Q.store_thm("alloc_clock",
+  `!xs s1 vs s2. (alloc x names s1 = (vs,s2)) ==>
+                  s2.clock <= s1.clock /\ s2.termdep = s1.termdep`,
   SIMP_TAC std_ss [alloc_def] \\ rpt gen_tac
   \\ rpt (BasicProvers.TOP_CASE_TAC \\ full_simp_tac(srw_ss())[])
   \\ imp_res_tac gc_clock
@@ -662,8 +662,8 @@ val evaluate_clock = Q.store_thm("evaluate_clock",
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ decide_tac);
 
-val fix_clock_evaluate = prove(
-  ``fix_clock s (evaluate (c1,s)) = evaluate (c1,s)``,
+val fix_clock_evaluate = Q.prove(
+  `fix_clock s (evaluate (c1,s)) = evaluate (c1,s)`,
   Cases_on `evaluate (c1,s)` \\ full_simp_tac(srw_ss())[fix_clock_def]
   \\ imp_res_tac evaluate_clock \\ full_simp_tac(srw_ss())[GSYM NOT_LESS]
   \\ full_simp_tac(srw_ss())[state_component_equality]);

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -451,10 +451,10 @@ val add_ret_loc_def = Define `
 val bad_dest_args_def = Define`
   bad_dest_args dest args ⇔ dest = NONE ∧ args = []`
 
-val termdep_rw = prove(
-  ``((call_env p_1 s).termdep = s.termdep) /\
+val termdep_rw = Q.prove(
+  `((call_env p_1 s).termdep = s.termdep) /\
     ((dec_clock s).termdep = s.termdep) /\
-    ((set_var n v s).termdep = s.termdep)``,
+    ((set_var n v s).termdep = s.termdep)`,
   EVAL_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
 val fix_clock_IMP_LESS_EQ = prove(
@@ -607,8 +607,8 @@ val evaluate_ind = theorem"evaluate_ind";
 
 (* We prove that the clock never increases and that termdep is constant. *)
 
-val gc_clock = store_thm("gc_clock",
-  ``!s1 s2. (gc s1 = SOME s2) ==> s2.clock <= s1.clock /\ s2.termdep = s1.termdep``,
+val gc_clock = Q.store_thm("gc_clock",
+  `!s1 s2. (gc s1 = SOME s2) ==> s2.clock <= s1.clock /\ s2.termdep = s1.termdep`,
   full_simp_tac(srw_ss())[gc_def,LET_DEF] \\ SRW_TAC [] []
   \\ every_case_tac >> full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
@@ -626,8 +626,8 @@ val alloc_clock = store_thm("alloc_clock",
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]);
 
-val inst_clock = prove(
-  ``inst i s = SOME s2 ==> s2.clock <= s.clock /\ s2.termdep = s.termdep``,
+val inst_clock = Q.prove(
+  `inst i s = SOME s2 ==> s2.clock <= s.clock /\ s2.termdep = s.termdep`,
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,get_vars_def,LET_THM]
   \\ every_case_tac
   \\ SRW_TAC [] [set_var_def] \\ full_simp_tac(srw_ss())[]

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -23,8 +23,8 @@ val _ = Datatype `
       | Op binop (exp list)
       | Shift shift exp ('a num_exp)`
 
-val MEM_IMP_exp_size = store_thm("MEM_IMP_exp_size",
-  ``!xs a. MEM a xs ==> (exp_size l a < exp1_size l xs)``,
+val MEM_IMP_exp_size = Q.store_thm("MEM_IMP_exp_size",
+  `!xs a. MEM a xs ==> (exp_size l a < exp1_size l xs)`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) []
   \\ REPEAT STRIP_TAC \\ SRW_TAC [] [definition"exp_size_def"]
   \\ RES_TAC \\ DECIDE_TAC);

--- a/compiler/bootstrap/io/catScript.sml
+++ b/compiler/bootstrap/io/catScript.sml
@@ -118,33 +118,33 @@ fun prove_array_spec op_name =
   xsimpl \\ fs [INT_def, NUM_def, WORD_def, w2w_def, UNIT_TYPE_def] \\
   TRY (simp_tac (arith_ss ++ intSimps.INT_ARITH_ss) [])
 
-val w8array_alloc_spec = store_thm ("w8array_alloc_spec",
-  ``!n nv w wv.
+val w8array_alloc_spec = Q.store_thm ("w8array_alloc_spec",
+  `!n nv w wv.
      NUM n nv /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.array" (basis_st())) [nv; wv]
-       emp (POSTv v. W8ARRAY v (REPLICATE n w))``,
+       emp (POSTv v. W8ARRAY v (REPLICATE n w))`,
   prove_array_spec "Word8Array.array");
 
-val w8array_sub_spec = store_thm ("w8array_sub_spec",
-  ``!a av n nv.
+val w8array_sub_spec = Q.store_thm ("w8array_sub_spec",
+  `!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.sub" (basis_st())) [av; nv]
-       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.sub");
 
-val w8array_length_spec = store_thm ("w8array_length_spec",
-  ``!a av.
+val w8array_length_spec = Q.store_thm ("w8array_length_spec",
+  `!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.length" (basis_st())) [av]
-       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.length");
 
-val w8array_update_spec = store_thm ("w8array_update_spec",
-  ``!a av n nv w wv.
+val w8array_update_spec = Q.store_thm ("w8array_update_spec",
+  `!a av n nv w wv.
      NUM n nv /\ n < LENGTH a /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.update" (basis_st()))
        [av; nv; wv]
        (W8ARRAY av a)
-       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
+       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))`,
   prove_array_spec "Word8Array.update");
 
 (* Char module -- translated *)
@@ -479,15 +479,15 @@ val FILENAME_def = Define `
      strlen s < 256)
 `;
 
-val write_spec = store_thm ("write_spec",
-  ``!c cv.
+val write_spec = Q.store_thm ("write_spec",
+  `!c cv.
      CHAR (c:char) cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.write" (basis_st()))
        [cv]
        (CHAR_IO * CATFS fs)
        (POSTv uv.
          cond (UNIT_TYPE () uv) * CHAR_IO *
-         CATFS (fs with stdout := fs.stdout ++ [c]))``,
+         CATFS (fs with stdout := fs.stdout ++ [c]))`,
   xcf "CharIO.write" (basis_st()) >>
   xlet `POSTv civ. &NUM (ORD c) civ * CHAR_IO * CATFS fs`
   >- (xapp >> xsimpl >> instantiate) >>

--- a/compiler/bootstrap/io/catfileSystemScript.sml
+++ b/compiler/bootstrap/io/catfileSystemScript.sml
@@ -292,9 +292,9 @@ val decode_files_def = Define`
   decode_files f = decode_list (decode_pair (lift implode o destStr) destStr) f
 `
 
-val decode_encode_files = store_thm(
+val decode_encode_files = Q.store_thm(
   "decode_encode_files",
-  ``∀l. decode_files (encode_files l) = return l``,
+  `∀l. decode_files (encode_files l) = return l`,
   simp[encode_files_def, decode_files_def] >>
   simp[decode_encode_list, decode_encode_pair, implode_explode]);
 

--- a/compiler/bootstrap/io/helloProgScript.sml
+++ b/compiler/bootstrap/io/helloProgScript.sml
@@ -82,33 +82,33 @@ fun prove_array_spec op_name =
   xsimpl \\ fs [INT_def, NUM_def, WORD_def, w2w_def, UNIT_TYPE_def] \\
   TRY (simp_tac (arith_ss ++ intSimps.INT_ARITH_ss) [])
 
-val w8array_alloc_spec = store_thm ("w8array_alloc_spec",
-  ``!n nv w wv.
+val w8array_alloc_spec = Q.store_thm ("w8array_alloc_spec",
+  `!n nv w wv.
      NUM n nv /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.array" (basis_st())) [nv; wv]
-       emp (POSTv v. W8ARRAY v (REPLICATE n w))``,
+       emp (POSTv v. W8ARRAY v (REPLICATE n w))`,
   prove_array_spec "Word8Array.array");
 
-val w8array_sub_spec = store_thm ("w8array_sub_spec",
-  ``!a av n nv.
+val w8array_sub_spec = Q.store_thm ("w8array_sub_spec",
+  `!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.sub" (basis_st())) [av; nv]
-       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.sub");
 
-val w8array_length_spec = store_thm ("w8array_length_spec",
-  ``!a av.
+val w8array_length_spec = Q.store_thm ("w8array_length_spec",
+  `!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.length" (basis_st())) [av]
-       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.length");
 
-val w8array_update_spec = store_thm ("w8array_update_spec",
-  ``!a av n nv w wv.
+val w8array_update_spec = Q.store_thm ("w8array_update_spec",
+  `!a av n nv w wv.
      NUM n nv /\ n < LENGTH a /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.update" (basis_st()))
        [av; nv; wv]
        (W8ARRAY av a)
-       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
+       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))`,
   prove_array_spec "Word8Array.update");
 
 
@@ -165,13 +165,13 @@ val STDOUT_def = Define `
 val CHAR_IO_def = Define `
   CHAR_IO = SEP_EXISTS w. W8ARRAY write_loc [w]`;
 
-val write_spec = store_thm ("write_spec",
-  ``!a av n nv v.
+val write_spec = Q.store_thm ("write_spec",
+  `!a av n nv v.
      WORD (c:word8) cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.write" (basis_st()))
        [cv]
        (CHAR_IO * STDOUT output)
-       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [CHR (w2n c)]))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [CHR (w2n c)]))`,
   xcf "CharIO.write" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
   \\ xlet `POSTv zv. STDOUT output * W8ARRAY write_loc [c] *
@@ -194,12 +194,12 @@ val e =
 
 val _ = ml_prog_update (add_Dlet_Fun ``"main"`` ``"c"`` e "main_v")
 
-val main_spec = store_thm ("main",
-  ``!cv input output.
+val main_spec = Q.store_thm ("main",
+  `!cv input output.
       app (p:'ffi ffi_proj) ^(fetch_v "main" (basis_st()))
         [cv]
         (CHAR_IO * STDOUT "")
-        (POSTv uv. CHAR_IO * STDOUT "Hi")``,
+        (POSTv uv. CHAR_IO * STDOUT "Hi")`,
   xcf "main" (basis_st())
   \\ xlet `POSTv v. CHAR_IO * STDOUT "H"` THEN1
    (xapp \\ qexists_tac `emp` \\ qexists_tac `""` \\ qexists_tac `n2w (ORD #"H")`

--- a/compiler/bootstrap/io/ioProgLib.sml
+++ b/compiler/bootstrap/io/ioProgLib.sml
@@ -20,12 +20,12 @@ fun append_main_call compile_str compile_tm = let
 
   fun basis_st () = get_ml_prog_state ()
 
-  val main_spec = prove(
-    ``!cv input output.
+  val main_spec = Q.prove(
+    `!cv input output.
         app (p:'ffi ffi_proj) ^(fetch_v "main" (basis_st()))
           [cv]
           (CHAR_IO * STDIN input * STDOUT [])
-          (POSTv uv. CHAR_IO * STDIN "" * STDOUT (^compile input))``,
+          (POSTv uv. CHAR_IO * STDIN "" * STDOUT (^compile input))`,
     xcf "main" (basis_st())
     \\ xlet `POSTv v. CHAR_IO * STDIN input * STDOUT [] * &(LIST_TYPE CHAR "" v)`
     THEN1 (xcon \\ fs [] \\ xsimpl \\ EVAL_TAC)
@@ -165,11 +165,11 @@ fun append_main_call compile_str compile_tm = let
              |> REWRITE_RULE []
     in th end
 
-  val semantics_prog_entire_program = store_thm("semantics_prog_entire_program",
-    ``?io_list.
+  val semantics_prog_entire_program = Q.store_thm("semantics_prog_entire_program",
+    `?io_list.
         semantics_prog (init_state (io_ffi input)) init_env entire_program
           (Terminate Success io_list) /\
-        extract_output io_list = SOME (^compile input)``,
+        extract_output io_list = SOME (^compile input)`,
     fs[semanticsTheory.semantics_prog_def,PULL_EXISTS]
     \\ strip_assume_tac evaluate_prog
     \\ fs[semanticsTheory.evaluate_prog_with_clock_def]

--- a/compiler/bootstrap/io/ioProgScript.sml
+++ b/compiler/bootstrap/io/ioProgScript.sml
@@ -137,8 +137,8 @@ val _ = ml_prog_update (close_module NONE);
 val _ = trans "byte_is_nonzero" `\(w:word8). w <> 0w`
 val _ = trans "char_of_byte" `\(w:word8). CHR (w2n w)`
 
-val char_of_byte_side = store_thm("char_of_byte_side",
-  ``char_of_byte_side w``,
+val char_of_byte_side = Q.store_thm("char_of_byte_side",
+  `char_of_byte_side w`,
   metis_tac [fetch"-" "char_of_byte_side_def",w2n_lt,EVAL ``dimword(:8)``]);
 
 (* CharIO -- CF verified *)
@@ -426,14 +426,14 @@ val extract_output_def = Define `
          if LENGTH bytes <> 1 then NONE else
            SOME ((SND (HD bytes)) :: rest))`
 
-val extract_output_APPEND = store_thm("extract_output_APPEND",
-  ``!xs ys.
+val extract_output_APPEND = Q.store_thm("extract_output_APPEND",
+  `!xs ys.
       extract_output (xs ++ ys) =
       case extract_output ys of
       | NONE => NONE
       | SOME rest => case extract_output xs of
                      | NONE => NONE
-                     | SOME front => SOME (front ++ rest)``,
+                     | SOME front => SOME (front ++ rest)`,
   Induct \\ fs [APPEND,extract_output_def] \\ rw []
   THEN1 (every_case_tac \\ fs [])
   \\ Cases_on `h` \\ fs [extract_output_def]
@@ -452,12 +452,12 @@ val evaluate_prog_RTC_call_FFI_rel = store_thm("evaluate_prog_RTC_call_FFI_rel",
   \\ imp_res_tac determTheory.prog_determ
   \\ fs[] \\ rw[]);
 
-val RTC_call_FFI_rel_IMP_io_events = store_thm("RTC_call_FFI_rel_IMP_io_events",
-  ``!st st'.
+val RTC_call_FFI_rel_IMP_io_events = Q.store_thm("RTC_call_FFI_rel_IMP_io_events",
+  `!st st'.
       call_FFI_rel^* st st' ==>
       st.oracle = io_ffi_oracle /\
       extract_output st.io_events = SOME (SND (st.ffi_state)) ==>
-      extract_output st'.io_events = SOME (SND (st'.ffi_state))``,
+      extract_output st'.io_events = SOME (SND (st'.ffi_state))`,
   HO_MATCH_MP_TAC RTC_INDUCT \\ rw [] \\ fs []
   \\ fs [evaluatePropsTheory.call_FFI_rel_def]
   \\ fs [ffiTheory.call_FFI_def]
@@ -486,9 +486,9 @@ val w2n_lt_256 =
   w2n_lt |> INST_TYPE [``:'a``|->``:8``]
          |> SIMP_RULE std_ss [EVAL ``dimword (:8)``]
 
-val MAP_CHR_w2n_11 = store_thm("MAP_CHR_w2n_11",
-  ``!ws1 ws2:word8 list.
-      MAP (CHR ∘ w2n) ws1 = MAP (CHR ∘ w2n) ws2 <=> ws1 = ws2``,
+val MAP_CHR_w2n_11 = Q.store_thm("MAP_CHR_w2n_11",
+  `!ws1 ws2:word8 list.
+      MAP (CHR ∘ w2n) ws1 = MAP (CHR ∘ w2n) ws2 <=> ws1 = ws2`,
   Induct \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []
   \\ Cases_on `ws2` \\ fs [] \\ metis_tac [CHR_11,w2n_lt_256,w2n_11]);
 

--- a/compiler/bootstrap/io/ioProgScript.sml
+++ b/compiler/bootstrap/io/ioProgScript.sml
@@ -94,33 +94,33 @@ fun prove_array_spec op_name =
   xsimpl \\ fs [INT_def, NUM_def, WORD_def, w2w_def, UNIT_TYPE_def] \\
   TRY (simp_tac (arith_ss ++ intSimps.INT_ARITH_ss) [])
 
-val w8array_alloc_spec = store_thm ("w8array_alloc_spec",
-  ``!n nv w wv.
+val w8array_alloc_spec = Q.store_thm ("w8array_alloc_spec",
+  `!n nv w wv.
      NUM n nv /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.array" (basis_st())) [nv; wv]
-       emp (POSTv v. W8ARRAY v (REPLICATE n w))``,
+       emp (POSTv v. W8ARRAY v (REPLICATE n w))`,
   prove_array_spec "Word8Array.array");
 
-val w8array_sub_spec = store_thm ("w8array_sub_spec",
-  ``!a av n nv.
+val w8array_sub_spec = Q.store_thm ("w8array_sub_spec",
+  `!a av n nv.
      NUM n nv /\ n < LENGTH a ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.sub" (basis_st())) [av; nv]
-       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.sub");
 
-val w8array_length_spec = store_thm ("w8array_length_spec",
-  ``!a av.
+val w8array_length_spec = Q.store_thm ("w8array_length_spec",
+  `!a av.
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.length" (basis_st())) [av]
-       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)``,
+       (W8ARRAY av a) (POSTv v. cond (NUM (LENGTH a) v) * W8ARRAY av a)`,
   prove_array_spec "Word8Array.length");
 
-val w8array_update_spec = store_thm ("w8array_update_spec",
-  ``!a av n nv w wv.
+val w8array_update_spec = Q.store_thm ("w8array_update_spec",
+  `!a av n nv w wv.
      NUM n nv /\ n < LENGTH a /\ WORD w wv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "Word8Array.update" (basis_st()))
        [av; nv; wv]
        (W8ARRAY av a)
-       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))``,
+       (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))`,
   prove_array_spec "Word8Array.update");
 
 
@@ -233,13 +233,13 @@ val STDOUT_def = Define `
 val CHAR_IO_def = Define `
   CHAR_IO = SEP_EXISTS w. W8ARRAY write_loc [w]`;
 
-val can_read_spec = store_thm ("can_read_spec",
-  ``!a av n nv v.
+val can_read_spec = Q.store_thm ("can_read_spec",
+  `!a av n nv v.
      UNIT_TYPE c cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.can_read" (basis_st()))
        [cv]
        (CHAR_IO * STDIN input)
-       (POSTv uv. cond (BOOL (input <> "") uv) * CHAR_IO * STDIN input)``,
+       (POSTv uv. cond (BOOL (input <> "") uv) * CHAR_IO * STDIN input)`,
   xcf "CharIO.can_read" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
   \\ xlet `POSTv wv. W8ARRAY write_loc [if input = "" then 0w else 1w] * STDIN input`
@@ -255,13 +255,13 @@ val can_read_spec = store_thm ("can_read_spec",
   \\ xapp \\ xsimpl
   \\ instantiate \\ rw []);
 
-val read_spec = store_thm ("read_spec",
-  ``!a av n nv v.
+val read_spec = Q.store_thm ("read_spec",
+  `!a av n nv v.
      UNIT_TYPE c cv /\ input <> "" ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.read" (basis_st()))
        [cv]
        (CHAR_IO * STDIN input)
-       (POSTv uv. cond (CHAR (HD input) uv) * CHAR_IO * STDIN (TL input))``,
+       (POSTv uv. cond (CHAR (HD input) uv) * CHAR_IO * STDIN (TL input))`,
   xcf "CharIO.read" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
   \\ xlet `POSTv wv. W8ARRAY write_loc [n2w (ORD (HD input))] * STDIN (TL input)`
@@ -278,13 +278,13 @@ val read_spec = store_thm ("read_spec",
   \\ instantiate \\ rw []
   \\ fs [ORD_BOUND,CHR_ORD]);
 
-val write_spec = store_thm ("write_spec",
-  ``!a av n nv v.
+val write_spec = Q.store_thm ("write_spec",
+  `!a av n nv v.
      WORD c cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "CharIO.write" (basis_st()))
        [cv]
        (CHAR_IO * STDOUT output)
-       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))``,
+       (POSTv uv. cond (UNIT_TYPE () uv) * CHAR_IO * STDOUT (output ++ [c]))`,
   xcf "CharIO.write" (basis_st())
   \\ fs [CHAR_IO_def] \\ xpull
   \\ xlet `POSTv zv. STDOUT output * W8ARRAY write_loc [c] *
@@ -319,13 +319,13 @@ val read_all = parse_topdecs
 
 val _ = ml_prog_update (ml_progLib.add_prog read_all pick_name);
 
-val write_list_spec = store_thm ("write_list_spec",
-  ``!xs cv output.
+val write_list_spec = Q.store_thm ("write_list_spec",
+  `!xs cv output.
      LIST_TYPE WORD xs cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "write_list" (basis_st()))
        [cv]
        (CHAR_IO * STDOUT output)
-       (POSTv uv. CHAR_IO * STDOUT (output ++ xs))``,
+       (POSTv uv. CHAR_IO * STDOUT (output ++ xs))`,
   Induct
   THEN1
    (xcf "write_list" (basis_st()) \\ fs [LIST_TYPE_def]
@@ -347,13 +347,13 @@ val char_reverse_v_thm = save_thm("char_reverse_v_thm",
   std_preludeTheory.reverse_v_thm
   |> GEN_ALL |> ISPEC ``CHAR``);
 
-val read_all_spec = store_thm ("read_all_spec",
-  ``!xs cv input.
+val read_all_spec = Q.store_thm ("read_all_spec",
+  `!xs cv input.
      LIST_TYPE CHAR xs cv ==>
      app (p:'ffi ffi_proj) ^(fetch_v "read_all" (basis_st()))
        [cv]
        (CHAR_IO * STDIN input)
-       (POSTv uv. CHAR_IO * STDIN "" * &(LIST_TYPE CHAR (REVERSE xs ++ input) uv))``,
+       (POSTv uv. CHAR_IO * STDIN "" * &(LIST_TYPE CHAR (REVERSE xs ++ input) uv))`,
   Induct_on `input`
   THEN1
    (xcf "read_all" (basis_st()) \\ fs [LIST_TYPE_def]
@@ -441,9 +441,9 @@ val extract_output_APPEND = Q.store_thm("extract_output_APPEND",
   \\ Cases_on `h` \\ fs [extract_output_def]
   \\ rpt (CASE_TAC \\ fs []));
 
-val evaluate_prog_RTC_call_FFI_rel = store_thm("evaluate_prog_RTC_call_FFI_rel",
-  ``evaluate_prog F env st prog (st',tds,res) ==>
-    RTC call_FFI_rel st.ffi st'.ffi``,
+val evaluate_prog_RTC_call_FFI_rel = Q.store_thm("evaluate_prog_RTC_call_FFI_rel",
+  `evaluate_prog F env st prog (st',tds,res) ==>
+    RTC call_FFI_rel st.ffi st'.ffi`,
   rw[bigClockTheory.prog_clocked_unclocked_equiv]
   \\ (funBigStepEquivTheory.functional_evaluate_tops
       |> CONV_RULE(LAND_CONV SYM_CONV) |> LET_INTRO
@@ -494,11 +494,11 @@ val MAP_CHR_w2n_11 = Q.store_thm("MAP_CHR_w2n_11",
   Induct \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []
   \\ Cases_on `ws2` \\ fs [] \\ metis_tac [CHR_11,w2n_lt_256,w2n_11]);
 
-val evaluate_prog_rel_IMP_evaluate_prog_fun = store_thm(
+val evaluate_prog_rel_IMP_evaluate_prog_fun = Q.store_thm(
    "evaluate_prog_rel_IMP_evaluate_prog_fun",
-  ``bigStep$evaluate_whole_prog F env st prog (st',new_tds,Rval r) ==>
+  `bigStep$evaluate_whole_prog F env st prog (st',new_tds,Rval r) ==>
     ?k. evaluate$evaluate_prog (st with clock := k) env prog =
-          (st',new_tds,Rval r)``,
+          (st',new_tds,Rval r)`,
   rw[bigClockTheory.prog_clocked_unclocked_equiv,bigStepTheory.evaluate_whole_prog_def]
   \\ qexists_tac`c + st.clock`
   \\ (funBigStepEquivTheory.functional_evaluate_prog
@@ -514,8 +514,8 @@ val evaluate_prog_rel_IMP_evaluate_prog_fun = store_thm(
   \\ TRY (disch_then drule \\ rw[])
   \\ fs[semanticPrimitivesTheory.state_component_equality]);
 
-val parts_ok_io_ffi = store_thm("parts_ok_io_ffi",
-  ``parts_ok (io_ffi input) (io_proj1,io_proj2)``,
+val parts_ok_io_ffi = Q.store_thm("parts_ok_io_ffi",
+  `parts_ok (io_ffi input) (io_proj1,io_proj2)`,
   fs [cfStoreTheory.parts_ok_def]
   \\ rw [] \\ TRY (EVAL_TAC \\ NO_TAC)
   THEN1

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -26,8 +26,8 @@ val _ = register_type ``:lexer_fun$symbol``;
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = store_thm("NOT_NIL_AND_LEMMA",
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.store_thm("NOT_NIL_AND_LEMMA",
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -53,16 +53,16 @@ val _ = (find_def_for_const := def_of_const);
 
 (* type inference: t_walkstar and t_unify *)
 
-val PRECONDITION_INTRO = prove(
-  ``(b ==> (x = y)) ==> (x = if PRECONDITION b then y else x)``,
+val PRECONDITION_INTRO = Q.prove(
+  `(b ==> (x = y)) ==> (x = if PRECONDITION b then y else x)`,
   Cases_on `b` THEN SIMP_TAC std_ss [PRECONDITION_def]);
 
-val t_vwalk_ind = store_thm("t_vwalk_ind",
-  ``!P.
+val t_vwalk_ind = Q.store_thm("t_vwalk_ind",
+  `!P.
       (!s v.
         (!v1 u. FLOOKUP s v = SOME v1 /\ v1 = Infer_Tuvar u ==> P s u) ==>
         P s v) ==>
-      (!s v. t_wfs s ==> P s v)``,
+      (!s v. t_wfs s ==> P s v)`,
   NTAC 3 STRIP_TAC
   THEN Cases_on `t_wfs s` THEN FULL_SIMP_TAC std_ss []
   THEN HO_MATCH_MP_TAC (unifyTheory.t_vwalk_ind |> Q.SPEC `P (s:num |-> infer_t)`
@@ -74,8 +74,8 @@ val _ = translate
     |> SIMP_RULE std_ss [PULL_FORALL] |> SPEC_ALL
     |> MATCH_MP PRECONDITION_INTRO);
 
-val t_vwalk_side_def = store_thm("t_vwalk_side_def",
-  ``!s v. t_vwalk_side s v <=> t_wfs s``,
+val t_vwalk_side_def = Q.store_thm("t_vwalk_side_def",
+  `!s v. t_vwalk_side s v <=> t_wfs s`,
   STRIP_TAC THEN reverse (Cases_on `t_wfs s`) THEN FULL_SIMP_TAC std_ss []
   THEN1 (ONCE_REWRITE_TAC [fetch "-" "t_vwalk_side_def"]
          THEN FULL_SIMP_TAC std_ss [])
@@ -89,16 +89,16 @@ val t_vwalk_side_def = store_thm("t_vwalk_side_def",
 
 val _ = translate unifyTheory.t_walk_eqn;
 
-val t_walkstar_ind = store_thm("t_walkstar_ind",
-  ``!P.
+val t_walkstar_ind = Q.store_thm("t_walkstar_ind",
+  `!P.
       (!s t.
          (!ts tc0 a. t_walk s t = Infer_Tapp ts tc0 /\ MEM a ts ==> P s a) ==>
          P s t) ==>
-      !s t. t_wfs s ==> P s t``,
+      !s t. t_wfs s ==> P s t`,
   METIS_TAC [unifyTheory.t_walkstar_ind]);
 
-val expand_lemma = prove(
-  ``t_walkstar s = \x. t_walkstar s x``,
+val expand_lemma = Q.prove(
+  `t_walkstar s = \x. t_walkstar s x`,
   SIMP_TAC std_ss [FUN_EQ_THM]);
 
 val _ = translate
@@ -106,8 +106,8 @@ val _ = translate
     |> RW1 [expand_lemma] |> SIMP_RULE std_ss [PULL_FORALL]
     |> SPEC_ALL |> MATCH_MP PRECONDITION_INTRO)
 
-val t_walkstar_side_def = store_thm("t_walkstar_side_def",
-  ``!s v. t_walkstar_side s v <=> t_wfs s``,
+val t_walkstar_side_def = Q.store_thm("t_walkstar_side_def",
+  `!s v. t_walkstar_side s v <=> t_wfs s`,
   STRIP_TAC THEN reverse (Cases_on `t_wfs s`) THEN FULL_SIMP_TAC std_ss []
   THEN1 (ONCE_REWRITE_TAC [fetch "-" "t_walkstar_side_def"]
          THEN FULL_SIMP_TAC std_ss [])
@@ -119,18 +119,18 @@ val t_walkstar_side_def = store_thm("t_walkstar_side_def",
   THEN METIS_TAC [])
   |> update_precondition;
 
-val t_oc_ind = store_thm("t_oc_ind",
-  ``!P.
+val t_oc_ind = Q.store_thm("t_oc_ind",
+  `!P.
       (!s t v.
         (!ts tt a. t_walk s t = Infer_Tapp ts tt /\ MEM a ts ==> P s a v) ==>
         P s t v) ==>
-      (!s t v. t_wfs s ==> P (s:num |-> infer_t) (t:infer_t) (v:num))``,
+      (!s t v. t_wfs s ==> P (s:num |-> infer_t) (t:infer_t) (v:num))`,
   REPEAT STRIP_TAC THEN Q.SPEC_TAC (`t`,`t`)
   THEN IMP_RES_TAC unifyTheory.t_walkstar_ind
   THEN POP_ASSUM HO_MATCH_MP_TAC THEN METIS_TAC []);
 
-val EXISTS_LEMMA = prove(
-  ``!xs P. EXISTS P xs = EXISTS I (MAP P xs)``,
+val EXISTS_LEMMA = Q.prove(
+  `!xs P. EXISTS P xs = EXISTS I (MAP P xs)`,
   Induct THEN SRW_TAC [] []);
 
 val _ = translate
@@ -138,8 +138,8 @@ val _ = translate
     |> SIMP_RULE std_ss [PULL_FORALL] |> SPEC_ALL
     |> RW1 [EXISTS_LEMMA] |> MATCH_MP PRECONDITION_INTRO)
 
-val t_oc_side_lemma = prove(
-  ``!s t v. t_wfs s ==> t_wfs s ==> t_oc_side s t v``,
+val t_oc_side_lemma = Q.prove(
+  `!s t v. t_wfs s ==> t_wfs s ==> t_oc_side s t v`,
   HO_MATCH_MP_TAC t_oc_ind THEN REPEAT STRIP_TAC
   THEN FULL_SIMP_TAC std_ss [AND_IMP_INTRO]
   THEN ONCE_REWRITE_TAC [fetch "-" "t_oc_side_def"]
@@ -147,8 +147,8 @@ val t_oc_side_lemma = prove(
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss()) [])
   |> SIMP_RULE std_ss [];
 
-val t_oc_side_def = store_thm("t_oc_side_def",
-  ``!s t v. t_oc_side s t v <=> t_wfs s``,
+val t_oc_side_def = Q.store_thm("t_oc_side_def",
+  `!s t v. t_oc_side s t v <=> t_wfs s`,
   STRIP_TAC THEN Cases_on `t_wfs s`
   THEN FULL_SIMP_TAC std_ss [t_oc_side_lemma]
   THEN ONCE_REWRITE_TAC [fetch "-" "t_oc_side_def"]
@@ -195,9 +195,9 @@ val _ = translate t_unify_lemma
 
 val t_unify_side_rw = fetch "-" "t_unify_side_def"
 
-val t_unify_side_lemma = prove(
-  ``(!s t v. t_wfs s ==> t_wfs s ==> t_unify_side s t v) /\
-    (!s ts v. t_wfs s ==> t_wfs s ==> ts_unify_side s ts v)``,
+val t_unify_side_lemma = Q.prove(
+  `(!s t v. t_wfs s ==> t_wfs s ==> t_unify_side s t v) /\
+    (!s ts v. t_wfs s ==> t_wfs s ==> ts_unify_side s ts v)`,
   HO_MATCH_MP_TAC unifyTheory.t_unify_ind THEN REPEAT STRIP_TAC
   THEN FULL_SIMP_TAC std_ss [AND_IMP_INTRO]
   THEN ONCE_REWRITE_TAC [fetch "-" "t_unify_side_def"]
@@ -206,16 +206,16 @@ val t_unify_side_lemma = prove(
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss()) []
   THEN METIS_TAC [unifyTheory.t_unify_unifier]) |> SIMP_RULE std_ss [];
 
-val t_unify_side_def = store_thm("t_unify_side_def",
-  ``!s t v. t_unify_side s t v <=> t_wfs s``,
+val t_unify_side_def = Q.store_thm("t_unify_side_def",
+  `!s t v. t_unify_side s t v <=> t_wfs s`,
   STRIP_TAC THEN Cases_on `t_wfs s`
   THEN FULL_SIMP_TAC std_ss [t_unify_side_lemma]
   THEN ONCE_REWRITE_TAC [t_unify_side_rw]
   THEN FULL_SIMP_TAC std_ss [])
   |> update_precondition;
 
-val ts_unify_side_def = store_thm("ts_unify_side_def",
-  ``!s t v. ts_unify_side s t v <=> t_wfs s``,
+val ts_unify_side_def = Q.store_thm("ts_unify_side_def",
+  `!s t v. ts_unify_side s t v <=> t_wfs s`,
   STRIP_TAC THEN Cases_on `t_wfs s`
   THEN FULL_SIMP_TAC std_ss [t_unify_side_lemma]
   THEN ONCE_REWRITE_TAC [t_unify_side_rw]
@@ -276,20 +276,20 @@ fun fix_infer_induction_thm def = let
   val _ = save_thm(ind_name,ind)
   in () end handle HOL_ERR _ => ();
 
-val if_apply = prove(
-  ``!b. (if b then x1 else x2) x = if b then x1 x else x2 x``,
+val if_apply = Q.prove(
+  `!b. (if b then x1 else x2) x = if b then x1 x else x2 x`,
   Cases THEN SRW_TAC [] []);
 
-val option_case_apply = prove(
-  ``!oo. option_CASE oo x1 x2 x = option_CASE oo (x1 x) (\y. x2 y x)``,
+val option_case_apply = Q.prove(
+  `!oo. option_CASE oo x1 x2 x = option_CASE oo (x1 x) (\y. x2 y x)`,
   Cases THEN SRW_TAC [] []);
 
 val pr_CASE = prove(
   ``pair_CASE (x,y) f = f x y``,
   SRW_TAC [] []);
 
-val op_apply = prove(
-  ``!op. (ast$op_CASE op x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29) y =
+val op_apply = Q.prove(
+  `!op. (ast$op_CASE op x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29) y =
          (ast$op_CASE op
             (\z. x1 z y)
             (\z. x2 z y)
@@ -300,12 +300,12 @@ val op_apply = prove(
             (x16 y) (x17 y)
             (\z. x18 z y)
             (x19 y) (x20 y) (x21 y) (x22 y) (x23 y) (x24 y) (x25 y) (x26 y) (x27 y) (x28 y)
-            (\z. x29 z y))``,
+            (\z. x29 z y))`,
   Cases THEN SRW_TAC [] []);
 
-val list_apply = prove(
-  ``!op. (list_CASE op x1 x2) y =
-         (list_CASE op (x1 y) (\z1 z2. x2 z1 z2 y))``,
+val list_apply = Q.prove(
+  `!op. (list_CASE op x1 x2) y =
+         (list_CASE op (x1 y) (\z1 z2. x2 z1 z2 y))`,
   Cases THEN SRW_TAC [] []);
 
 fun full_infer_def aggressive const = let
@@ -363,9 +363,9 @@ val _ = translate (typeSystemTheory.build_ctor_tenv_def
 
 val type_name_subst_side_def = theorem"type_name_subst_side_def";
 
-val type_name_subst_side_thm = store_thm("type_name_subst_side_thm",
-  ``∀a b. check_type_names a b
-    ⇒ type_name_subst_side a b``,
+val type_name_subst_side_thm = Q.store_thm("type_name_subst_side_thm",
+  `∀a b. check_type_names a b
+    ⇒ type_name_subst_side a b`,
   ho_match_mp_tac terminationTheory.type_name_subst_ind >>
   rw[Once type_name_subst_side_def] >>
   rw[Once type_name_subst_side_def] >>
@@ -373,8 +373,8 @@ val type_name_subst_side_thm = store_thm("type_name_subst_side_thm",
 
 val build_ctor_tenv_side_def = definition"build_ctor_tenv_side_def";
 
-val build_ctor_tenv_side_thm = store_thm("build_ctor_tenv_side_thm",
-  ``∀x y z. check_ctor_tenv x y z ⇒ build_ctor_tenv_side x y z``,
+val build_ctor_tenv_side_thm = Q.store_thm("build_ctor_tenv_side_thm",
+  `∀x y z. check_ctor_tenv x y z ⇒ build_ctor_tenv_side x y z`,
   rw[build_ctor_tenv_side_def] >>
   fs[typeSystemTheory.check_ctor_tenv_def] >>
   fs[EVERY_MEM,MEM_MAP,PULL_EXISTS] >>
@@ -384,12 +384,12 @@ val build_ctor_tenv_side_thm = store_thm("build_ctor_tenv_side_thm",
   match_mp_tac type_name_subst_side_thm >>
   pop_assum ACCEPT_TAC);
 
-val EVERY_INTRO = prove(
-  ``(!x::set s. P x) = EVERY P s``,
+val EVERY_INTRO = Q.prove(
+  `(!x::set s. P x) = EVERY P s`,
   SIMP_TAC std_ss [res_quanTheory.RES_FORALL,EVERY_MEM]);
 
-val EVERY_EQ_EVERY = prove(
-  ``!xs. EVERY P xs = EVERY I (MAP P xs)``,
+val EVERY_EQ_EVERY = Q.prove(
+  `!xs. EVERY P xs = EVERY I (MAP P xs)`,
   Induct THEN SRW_TAC [] []);
 
 val _ = translate (infer_def ``check_freevars``
@@ -453,8 +453,8 @@ val EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR = find_equality_type_thm
 val EqualityType_AST_TCTOR_TYPE = find_equality_type_thm``AST_TCTOR_TYPE``
   |> SIMP_RULE std_ss [EqualityType_AST_ID_TYPE_LIST_TYPE_CHAR]
 
-val AST_T_TYPE_no_closures = prove(
-  ``∀a b. AST_T_TYPE a b ⇒ no_closures b``,
+val AST_T_TYPE_no_closures = Q.prove(
+  `∀a b. AST_T_TYPE a b ⇒ no_closures b`,
   ho_match_mp_tac AST_T_TYPE_ind >>
   simp[AST_T_TYPE_def,PULL_EXISTS,no_closures_def] >> rw[] >- (
     pop_assum kall_tac >>
@@ -465,8 +465,8 @@ val AST_T_TYPE_no_closures = prove(
     rw[] >> METIS_TAC[] ) >>
   METIS_TAC[EqualityType_AST_TCTOR_TYPE,EqualityType_def,EqualityType_NUM,EqualityType_LIST_TYPE_CHAR])
 
-val AST_T_TYPE_types_match = prove(
-  ``∀a b c d. AST_T_TYPE a b ∧ AST_T_TYPE c d ⇒ types_match b d``,
+val AST_T_TYPE_types_match = Q.prove(
+  `∀a b c d. AST_T_TYPE a b ∧ AST_T_TYPE c d ⇒ types_match b d`,
   ho_match_mp_tac AST_T_TYPE_ind >>
   simp[AST_T_TYPE_def,PULL_EXISTS,types_match_def,ctor_same_type_def] >> rw[] >- (
     Cases_on`c`>>fs[AST_T_TYPE_def,types_match_def,ctor_same_type_def] >>
@@ -486,8 +486,8 @@ val AST_T_TYPE_types_match = prove(
     Cases_on`c`>>fs[AST_T_TYPE_def,types_match_def,ctor_same_type_def] >>
     METIS_TAC[EqualityType_LIST_TYPE_CHAR,EqualityType_def] ))
 
-val AST_T_TYPE_11 = prove(
-  ``∀a b c d. AST_T_TYPE a b ∧ AST_T_TYPE c d ⇒ (a = c ⇔ b = d)``,
+val AST_T_TYPE_11 = Q.prove(
+  `∀a b c d. AST_T_TYPE a b ∧ AST_T_TYPE c d ⇒ (a = c ⇔ b = d)`,
   ho_match_mp_tac AST_T_TYPE_ind >>
   simp[AST_T_TYPE_def,PULL_EXISTS] >> rw[] >- (
     Cases_on`c`>>fs[AST_T_TYPE_def] >>
@@ -507,14 +507,14 @@ val AST_T_TYPE_11 = prove(
     Cases_on`c`>>fs[AST_T_TYPE_def] >>
     METIS_TAC[EqualityType_LIST_TYPE_CHAR,EqualityType_def] ))
 
-val EqualityType_AST_T_TYPE = prove(
-  ``EqualityType AST_T_TYPE``,
+val EqualityType_AST_T_TYPE = Q.prove(
+  `EqualityType AST_T_TYPE`,
   simp[EqualityType_def] >>
   METIS_TAC[AST_T_TYPE_no_closures,AST_T_TYPE_types_match,AST_T_TYPE_11])
   |> store_eq_thm
 
-val AST_PAT_TYPE_no_closures = prove(
-  ``∀a b. AST_PAT_TYPE a b ⇒ no_closures b``,
+val AST_PAT_TYPE_no_closures = Q.prove(
+  `∀a b. AST_PAT_TYPE a b ⇒ no_closures b`,
   ho_match_mp_tac AST_PAT_TYPE_ind >>
   simp[AST_PAT_TYPE_def,PULL_EXISTS,no_closures_def] >>
   rw[] >>
@@ -531,8 +531,8 @@ val AST_PAT_TYPE_no_closures = prove(
             EqualityType_AST_T_TYPE,
             EqualityType_LIST_TYPE_CHAR])
 
-val AST_PAT_TYPE_types_match = prove(
-  ``∀a b c d. AST_PAT_TYPE a b ∧ AST_PAT_TYPE c d ⇒ types_match b d``,
+val AST_PAT_TYPE_types_match = Q.prove(
+  `∀a b c d. AST_PAT_TYPE a b ∧ AST_PAT_TYPE c d ⇒ types_match b d`,
   ho_match_mp_tac AST_PAT_TYPE_ind >>
   simp[AST_PAT_TYPE_def,PULL_EXISTS,types_match_def,ctor_same_type_def] >> rw[] >>
   Cases_on`c`>>fs[AST_PAT_TYPE_def,types_match_def,ctor_same_type_def] >> rw[] >>
@@ -547,8 +547,8 @@ val AST_PAT_TYPE_types_match = prove(
   METIS_TAC[EqualityType_def,EqualityType_LIST_TYPE_CHAR,EqualityType_AST_LIT_TYPE,
             EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR,EqualityType_AST_T_TYPE])
 
-val AST_PAT_TYPE_11 = prove(
-  ``∀a b c d. AST_PAT_TYPE a b ∧ AST_PAT_TYPE c d ⇒ (a = c ⇔ b = d)``,
+val AST_PAT_TYPE_11 = Q.prove(
+  `∀a b c d. AST_PAT_TYPE a b ∧ AST_PAT_TYPE c d ⇒ (a = c ⇔ b = d)`,
   ho_match_mp_tac AST_PAT_TYPE_ind >>
   simp[AST_PAT_TYPE_def,PULL_EXISTS] >> rw[] >>
   Cases_on`c`>>fs[AST_PAT_TYPE_def] >> rw[] >-
@@ -566,8 +566,8 @@ val AST_PAT_TYPE_11 = prove(
   METIS_TAC[EqualityType_def,EqualityType_LIST_TYPE_CHAR,EqualityType_AST_LIT_TYPE,
             EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR])
 
-val EqualityType_AST_PAT_TYPE = prove(
-  ``EqualityType AST_PAT_TYPE``,
+val EqualityType_AST_PAT_TYPE = Q.prove(
+  `EqualityType AST_PAT_TYPE`,
   METIS_TAC[EqualityType_def,AST_PAT_TYPE_no_closures,AST_PAT_TYPE_types_match,AST_PAT_TYPE_11])
   |> store_eq_thm
 
@@ -588,8 +588,8 @@ val EqualityType_AST_LOP_TYPE = find_equality_type_thm``AST_LOP_TYPE``
 val EqualityType_OPTION_TYPE_LIST_TYPE_CHAR = find_equality_type_thm``OPTION_TYPE a``
   |> Q.GEN`a` |> Q.ISPEC`LIST_TYPE CHAR` |> SIMP_RULE std_ss [EqualityType_LIST_TYPE_CHAR]
 
-val AST_EXP_TYPE_no_closures = prove(
-  ``∀a b. AST_EXP_TYPE a b ⇒ no_closures b``,
+val AST_EXP_TYPE_no_closures = Q.prove(
+  `∀a b. AST_EXP_TYPE a b ⇒ no_closures b`,
   ho_match_mp_tac AST_EXP_TYPE_ind >>
   simp[AST_EXP_TYPE_def,PULL_EXISTS,no_closures_def] >> rw[] >>
   TRY (
@@ -610,8 +610,8 @@ val AST_EXP_TYPE_no_closures = prove(
             EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR,
             EqualityType_AST_LIT_TYPE,EqualityType_AST_T_TYPE])
 
-val AST_EXP_TYPE_types_match = prove(
-  ``∀a b c d. AST_EXP_TYPE a b ∧ AST_EXP_TYPE c d ⇒ types_match b d``,
+val AST_EXP_TYPE_types_match = Q.prove(
+  `∀a b c d. AST_EXP_TYPE a b ∧ AST_EXP_TYPE c d ⇒ types_match b d`,
   ho_match_mp_tac AST_EXP_TYPE_ind >>
   simp[AST_EXP_TYPE_def,PULL_EXISTS] >> rw[] >>
   Cases_on`c`>>fs[AST_EXP_TYPE_def,types_match_def,ctor_same_type_def] >> rw[] >>
@@ -638,8 +638,8 @@ val AST_EXP_TYPE_types_match = prove(
             EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR,
             EqualityType_AST_LIT_TYPE,EqualityType_AST_T_TYPE])
 
-val AST_EXP_TYPE_11 = with_flag (metisTools.limit,{infs=SOME 1,time=NONE}) prove(
-  ``∀a b c d. AST_EXP_TYPE a b ∧ AST_EXP_TYPE c d ⇒ (a = c ⇔ b = d)``,
+val AST_EXP_TYPE_11 = with_flag (metisTools.limit,{infs=SOME 1,time=NONE}) Q.prove(
+  `∀a b c d. AST_EXP_TYPE a b ∧ AST_EXP_TYPE c d ⇒ (a = c ⇔ b = d)`,
   ho_match_mp_tac AST_EXP_TYPE_ind >>
   simp[AST_EXP_TYPE_def,PULL_EXISTS] >> rw[] >>
   Cases_on`c`>>fs[AST_EXP_TYPE_def] >> rw[] >>
@@ -680,8 +680,8 @@ val AST_EXP_TYPE_11 = with_flag (metisTools.limit,{infs=SOME 1,time=NONE}) prove
             EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR,
             EqualityType_AST_LIT_TYPE,EqualityType_AST_T_TYPE])
 
-val EqualityType_AST_EXP_TYPE = prove(
-  ``EqualityType AST_EXP_TYPE``,
+val EqualityType_AST_EXP_TYPE = Q.prove(
+  `EqualityType AST_EXP_TYPE`,
   METIS_TAC[EqualityType_def,AST_EXP_TYPE_no_closures,AST_EXP_TYPE_types_match,AST_EXP_TYPE_11])
   |> store_eq_thm
 

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -157,8 +157,8 @@ val t_oc_side_def = Q.store_thm("t_oc_side_def",
 
 val _ = translate unifyTheory.t_ext_s_check_eqn;
 
-val t_unify_lemma = prove(
-  ``t_wfs s ==>
+val t_unify_lemma = Q.prove(
+  `t_wfs s ==>
     (t_unify s t1 t2 =
        case (t_walk s t1,t_walk s t2) of
        | (Infer_Tvar_db n1,Infer_Tvar_db n2) =>
@@ -183,7 +183,7 @@ val t_unify_lemma = prove(
        | (t1::ts1,t2::ts2) => (case t_unify s t1 t2 of
                                | NONE => NONE
                                | SOME s' => ts_unify s' ts1 ts2)
-       | _ => NONE)``,
+       | _ => NONE)`,
   REPEAT STRIP_TAC
   THEN1 ASM_SIMP_TAC std_ss [unifyTheory.t_unify_eqn]
   THEN Cases_on `ts1` THEN Cases_on `ts2`
@@ -242,9 +242,9 @@ val _ = translate (def_of_const ``infer_type_subst``)
 val _ = translate rich_listTheory.COUNT_LIST_AUX_def
 val _ = translate rich_listTheory.COUNT_LIST_compute
 
-val pair_abs_hack = prove(
-  ``(\(v2:string,v1:infer_t). (v2,0,v1)) =
-    (\v3. case v3 of (v2,v1) => (v2,0:num,v1))``,
+val pair_abs_hack = Q.prove(
+  `(\(v2:string,v1:infer_t). (v2,0,v1)) =
+    (\v3. case v3 of (v2,v1) => (v2,0:num,v1))`,
   SIMP_TAC (srw_ss()) [FUN_EQ_THM,FORALL_PROD]);
 
 fun fix_infer_induction_thm def = let
@@ -284,8 +284,8 @@ val option_case_apply = Q.prove(
   `!oo. option_CASE oo x1 x2 x = option_CASE oo (x1 x) (\y. x2 y x)`,
   Cases THEN SRW_TAC [] []);
 
-val pr_CASE = prove(
-  ``pair_CASE (x,y) f = f x y``,
+val pr_CASE = Q.prove(
+  `pair_CASE (x,y) f = f x y`,
   SRW_TAC [] []);
 
 val op_apply = Q.prove(
@@ -846,7 +846,7 @@ val _ = translate (infer_def ``check_signature``)
 
 val _ = translate (infer_def ``infer_top``)
 
-val infer_prog_def = prove(``
+val infer_prog_def = Q.prove(`
   (∀idecls ienv x.
       infer_prog idecls ienv [] x =
       (Success (empty_inf_decls,(FEMPTY,FEMPTY),FEMPTY,([],[]),[]),x)) ∧
@@ -873,7 +873,7 @@ val infer_prog_def = prove(``
                   SND (SND (SND (SND y'))) ++ SND (SND (SND (SND y)))),
                s)
           | (Failure e,s) => (Failure e,s))
-     | (Failure e,s) => (Failure e,s)``,
+     | (Failure e,s) => (Failure e,s)`,
      rw[infer_prog_def]>>EVAL_TAC>>
      BasicProvers.EVERY_CASE_TAC>>PairCases_on`a`>>
      fs[]>>

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -472,7 +472,7 @@ val AST_T_TYPE_types_match = Q.prove(
     Cases_on`c`>>fs[AST_T_TYPE_def,types_match_def,ctor_same_type_def] >>
     reverse conj_tac >- METIS_TAC[EqualityType_AST_TCTOR_TYPE,EqualityType_def] >> rw[] >>
     pop_assum kall_tac >>
-    rator_x_assum`AST_TCTOR_TYPE`kall_tac >>
+    qhdtm_x_assum`AST_TCTOR_TYPE`kall_tac >>
     rpt (pop_assum mp_tac) >>
     map_every qid_spec_tac[`v3_1'`,`v3_1`,`l`,`x_4`] >>
     Induct >> simp[LIST_TYPE_def,PULL_EXISTS] >- (
@@ -492,7 +492,7 @@ val AST_T_TYPE_11 = Q.prove(
   simp[AST_T_TYPE_def,PULL_EXISTS] >> rw[] >- (
     Cases_on`c`>>fs[AST_T_TYPE_def] >>
     `x_3 = t ⇔ v3_2 = v3_2'` by METIS_TAC[EqualityType_AST_TCTOR_TYPE,EqualityType_def] >> rw[] >>
-    rpt(rator_x_assum`AST_TCTOR_TYPE`kall_tac) >>
+    rpt(qhdtm_x_assum`AST_TCTOR_TYPE`kall_tac) >>
     pop_assum kall_tac >>
     rpt (pop_assum mp_tac) >>
     map_every qid_spec_tac[`v3_1'`,`v3_1`,`l`,`x_4`] >>
@@ -537,7 +537,7 @@ val AST_PAT_TYPE_types_match = Q.prove(
   simp[AST_PAT_TYPE_def,PULL_EXISTS,types_match_def,ctor_same_type_def] >> rw[] >>
   Cases_on`c`>>fs[AST_PAT_TYPE_def,types_match_def,ctor_same_type_def] >> rw[] >>
   TRY (
-    rpt(rator_x_assum`LIST_TYPE`mp_tac) >>
+    rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
     ntac 2 (pop_assum kall_tac) >> pop_assum mp_tac >>
     map_every qid_spec_tac[`v3_2`,`v3_2'`,`l`,`x_3`] >>
     Induct >> simp[LIST_TYPE_def] >- (
@@ -554,7 +554,7 @@ val AST_PAT_TYPE_11 = Q.prove(
   Cases_on`c`>>fs[AST_PAT_TYPE_def] >> rw[] >-
   ( METIS_TAC[EqualityType_def,EqualityType_AST_T_TYPE] )
   >- (
-    rpt(rator_x_assum`LIST_TYPE`mp_tac) >>
+    rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
     `x_4 = o' ⇔ v3_1 = v3_1'` by METIS_TAC[EqualityType_def,EqualityType_OPTION_TYPE_AST_ID_TYPE_LIST_TYPE_CHAR] >>
     simp[] >>
     ntac 3 (pop_assum kall_tac) >> pop_assum mp_tac >>
@@ -594,7 +594,7 @@ val AST_EXP_TYPE_no_closures = Q.prove(
   simp[AST_EXP_TYPE_def,PULL_EXISTS,no_closures_def] >> rw[] >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     TRY(SIMP_RULE std_ss [EqualityType_def] EqualityType_LIST_TYPE_CHAR |> CONJUNCT1 |> MATCH_ACCEPT_TAC)>>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
@@ -617,9 +617,9 @@ val AST_EXP_TYPE_types_match = Q.prove(
   Cases_on`c`>>fs[AST_EXP_TYPE_def,types_match_def,ctor_same_type_def] >> rw[] >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y1`,`x1`,`y2`,`x2`] >>
@@ -645,9 +645,9 @@ val AST_EXP_TYPE_11 = with_flag (metisTools.limit,{infs=SOME 1,time=NONE}) Q.pro
   Cases_on`c`>>fs[AST_EXP_TYPE_def] >> rw[] >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     REWRITE_TAC[AND_IMP_INTRO] >>
     last_x_assum mp_tac >>
     MATCH_MP_TAC SWAP_IMP >>

--- a/compiler/bootstrap/translation/lexerProgScript.sml
+++ b/compiler/bootstrap/translation/lexerProgScript.sml
@@ -21,8 +21,8 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = store_thm("NOT_NIL_AND_LEMMA",
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.store_thm("NOT_NIL_AND_LEMMA",
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -52,13 +52,13 @@ val _ = translate (next_token_def |> SIMP_RULE std_ss [next_sym_eq])
 
 val _ = translate lexer_fun_def
 
-val l2n_side = prove(``
-  ∀b a. a ≠ 0 ⇒ l2n_side a b``,
+val l2n_side = Q.prove(`
+  ∀b a. a ≠ 0 ⇒ l2n_side a b`,
   Induct>>
   rw[Once (fetch"-""l2n_side_def")])
 
-val num_from_dec_string_alt_side = prove(``
-  ∀x. num_from_dec_string_alt_side x ⇔ T``,
+val num_from_dec_string_alt_side = Q.prove(`
+  ∀x. num_from_dec_string_alt_side x ⇔ T`,
   simp[Once (fetch"-""num_from_dec_string_alt_side_def")]>>
   strip_tac>>CONJ_TAC
   >-
@@ -74,21 +74,21 @@ val num_from_dec_string_alt_side = prove(``
        DECIDE_TAC>>
     fs[]);
 
-val read_string_side = prove(``
+val read_string_side = Q.prove(`
   ∀x y.
-  read_string_side x y ⇔ T``,
+  read_string_side x y ⇔ T`,
   ho_match_mp_tac read_string_ind>>
   rw[]>>
   simp[Once (fetch"-""read_string_side_def")]);
 
-val next_sym_alt_side = prove(``
-  ∀x. next_sym_alt_side x ⇔ T``,
+val next_sym_alt_side = Q.prove(`
+  ∀x. next_sym_alt_side x ⇔ T`,
   ho_match_mp_tac next_sym_alt_ind>>rw[]>>
   simp[Once (fetch"-""next_sym_alt_side_def"),num_from_dec_string_alt_side,read_string_side]>>
   rw[]>>metis_tac[]);
 
-val lexer_fun_side = prove(``
-  ∀x. lexer_fun_side x ⇔ T``,
+val lexer_fun_side = Q.prove(`
+  ∀x. lexer_fun_side x ⇔ T`,
   ho_match_mp_tac lexer_fun_ind>>rw[]>>
   simp[Once (fetch"-""lexer_fun_side_def"),
        Once (fetch"-""next_token_side_def"),next_sym_alt_side]) |> update_precondition

--- a/compiler/bootstrap/translation/mipsProgScript.sml
+++ b/compiler/bootstrap/translation/mipsProgScript.sml
@@ -14,8 +14,8 @@ val RW = REWRITE_RULE
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -91,8 +91,8 @@ val spec_word_bit = word_bit |> ISPEC``foo:word16`` |> SPEC``15n``|> SIMP_RULE s
 
 val _ = translate (mips_enc_def |> CONV_RULE (wordsLib.WORD_CONV) |> we_simp |> SIMP_RULE std_ss[SHIFT_ZERO] |> SIMP_RULE std_ss[spec_word_bit,word_mul_def]|> econv)
 
-val mips_enc_side = prove(``
-  ∀x. mips_enc_side x ⇔ T``,
+val mips_enc_side = Q.prove(`
+  ∀x. mips_enc_side x ⇔ T`,
   simp[fetch "-" "mips_enc_side_def"]>>rw[]>>
   EVAL_TAC) |> update_precondition
 

--- a/compiler/bootstrap/translation/parserProgScript.sml
+++ b/compiler/bootstrap/translation/parserProgScript.sml
@@ -117,7 +117,7 @@ val GRAMMAR_PARSETREE_TYPE_types_match = Q.prove(
   rw[] >- (
     Cases_on`e`>>fs[GRAMMAR_PARSETREE_TYPE_def,types_match_def,ctor_same_type_def] >>
     conj_tac >- METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def] >>
-    rw[] >> rpt(rator_x_assum`LIST_TYPE`mp_tac) >>
+    rw[] >> rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
     last_x_assum mp_tac >>
     map_every qid_spec_tac[`v2_2`,`v2_2'`,`x_2`,`l`] >>
     Induct >> simp[LIST_TYPE_def,PULL_EXISTS] >> rw[] >>
@@ -135,7 +135,7 @@ val GRAMMAR_PARSETREE_TYPE_11 = Q.prove(
   rw[] >- (
     Cases_on`e`>>fs[GRAMMAR_PARSETREE_TYPE_def] >>
     `x_3 = s ⇔ v2_1 = v2_1'` by METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def] >>
-    rw[] >> rpt(rator_x_assum`LIST_TYPE`mp_tac) >>
+    rw[] >> rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
     last_x_assum mp_tac >>
     map_every qid_spec_tac[`v2_2`,`v2_2'`,`x_2`,`l`] >>
     Induct >> simp[LIST_TYPE_def,PULL_EXISTS] >> rw[] >>

--- a/compiler/bootstrap/translation/parserProgScript.sml
+++ b/compiler/bootstrap/translation/parserProgScript.sml
@@ -24,8 +24,8 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = store_thm("NOT_NIL_AND_LEMMA",
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.store_thm("NOT_NIL_AND_LEMMA",
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -78,8 +78,8 @@ val EqualityType_GRAM_MMLNONT_TYPE = find_equality_type_thm``GRAM_MMLNONT_TYPE``
 
 val GRAMMAR_SYMBOL_TYPE_def = theorem"GRAMMAR_SYMBOL_TYPE_def";
 
-val EqualityType_GRAMMAR_SYMBOL_TYPE = prove(
-  ``∀a b. EqualityType a ∧ EqualityType b ⇒ EqualityType (GRAMMAR_SYMBOL_TYPE a b)``,
+val EqualityType_GRAMMAR_SYMBOL_TYPE = Q.prove(
+  `∀a b. EqualityType a ∧ EqualityType b ⇒ EqualityType (GRAMMAR_SYMBOL_TYPE a b)`,
   rw[EqualityType_def] >- (
     Cases_on`x1`>>fs[GRAMMAR_SYMBOL_TYPE_def]>>rw[]>>
     rw[no_closures_def] >- METIS_TAC[] >>
@@ -96,8 +96,8 @@ val EqualityType_GRAMMAR_SYMBOL_TYPE = prove(
 val GRAMMAR_PARSETREE_TYPE_def = theorem"GRAMMAR_PARSETREE_TYPE_def";
 val GRAMMAR_PARSETREE_TYPE_ind = theorem"GRAMMAR_PARSETREE_TYPE_ind";
 
-val GRAMMAR_PARSETREE_TYPE_no_closures = prove(
-  ``∀a b c d. EqualityType a ∧ EqualityType b ∧ GRAMMAR_PARSETREE_TYPE a b c d ⇒ no_closures d``,
+val GRAMMAR_PARSETREE_TYPE_no_closures = Q.prove(
+  `∀a b c d. EqualityType a ∧ EqualityType b ∧ GRAMMAR_PARSETREE_TYPE a b c d ⇒ no_closures d`,
   ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
   simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS,no_closures_def] >>
   rw[] >- METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def]
@@ -108,10 +108,10 @@ val GRAMMAR_PARSETREE_TYPE_no_closures = prove(
     rw[] >> METIS_TAC[]) >>
   METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def])
 
-val GRAMMAR_PARSETREE_TYPE_types_match = prove(
-  ``∀a b c d e f.
+val GRAMMAR_PARSETREE_TYPE_types_match = Q.prove(
+  `∀a b c d e f.
       EqualityType a ∧ EqualityType b ∧ GRAMMAR_PARSETREE_TYPE a b c d ∧
-      GRAMMAR_PARSETREE_TYPE a b e f ⇒ types_match d f``,
+      GRAMMAR_PARSETREE_TYPE a b e f ⇒ types_match d f`,
   ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
   simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS,types_match_def] >>
   rw[] >- (
@@ -126,10 +126,10 @@ val GRAMMAR_PARSETREE_TYPE_types_match = prove(
   Cases_on`e`>>fs[GRAMMAR_PARSETREE_TYPE_def,types_match_def,ctor_same_type_def] >>
   METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def])
 
-val GRAMMAR_PARSETREE_TYPE_11 = prove(
-  ``∀a b c d e f.
+val GRAMMAR_PARSETREE_TYPE_11 = Q.prove(
+  `∀a b c d e f.
       EqualityType a ∧ EqualityType b ∧ GRAMMAR_PARSETREE_TYPE a b c d ∧
-      GRAMMAR_PARSETREE_TYPE a b e f ⇒ (c = e ⇔ d = f)``,
+      GRAMMAR_PARSETREE_TYPE a b e f ⇒ (c = e ⇔ d = f)`,
   ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
   simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS] >>
   rw[] >- (
@@ -144,8 +144,8 @@ val GRAMMAR_PARSETREE_TYPE_11 = prove(
   Cases_on`e`>>fs[GRAMMAR_PARSETREE_TYPE_def] >>
   METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def])
 
-val EqualityType_GRAMMAR_PARSETREE_TYPE_TOKENS_TOKEN_TYPE_GRAM_MMLNONT_TYPE = prove(
-  ``EqualityType (GRAMMAR_PARSETREE_TYPE TOKENS_TOKEN_TYPE GRAM_MMLNONT_TYPE)``,
+val EqualityType_GRAMMAR_PARSETREE_TYPE_TOKENS_TOKEN_TYPE_GRAM_MMLNONT_TYPE = Q.prove(
+  `EqualityType (GRAMMAR_PARSETREE_TYPE TOKENS_TOKEN_TYPE GRAM_MMLNONT_TYPE)`,
   simp[EqualityType_def] >>
   assume_tac EqualityType_TOKENS_TOKEN_TYPE >>
   assume_tac EqualityType_GRAM_MMLNONT_TYPE >>
@@ -155,13 +155,13 @@ val EqualityType_GRAMMAR_PARSETREE_TYPE_TOKENS_TOKEN_TYPE_GRAM_MMLNONT_TYPE = pr
 
 val _ = translate (def_of_const ``cmlPEG``);
 
-val INTRO_FLOOKUP = store_thm("INTRO_FLOOKUP",
-  ``(if n IN FDOM G.rules
+val INTRO_FLOOKUP = Q.store_thm("INTRO_FLOOKUP",
+  `(if n IN FDOM G.rules
      then EV (G.rules ' n) i r y fk
      else Result NONE) =
     (case FLOOKUP G.rules n of
        NONE => Result NONE
-     | SOME x => EV x i r y fk)``,
+     | SOME x => EV x i r y fk)`,
   SRW_TAC [] [finite_mapTheory.FLOOKUP_DEF]);
 
 val _ = translate (def_of_const ``coreloop`` |> RW [INTRO_FLOOKUP]
@@ -171,16 +171,16 @@ val _ = translate (def_of_const ``peg_exec``);
 
 (* parsing: cmlvalid *)
 
-val monad_unitbind_assert = prove(
-  ``!b x. monad_unitbind (assert b) x = if b then x else NONE``,
+val monad_unitbind_assert = Q.prove(
+  `!b x. monad_unitbind (assert b) x = if b then x else NONE`,
   Cases THEN EVAL_TAC THEN SIMP_TAC std_ss []);
 
 val _ = translate grammarTheory.ptree_head_def
 
 (* parsing: ptree converstion *)
 
-val OPTION_BIND_THM = store_thm("OPTION_BIND_THM",
-  ``!x y. OPTION_BIND x y = case x of NONE => NONE | SOME i => y i``,
+val OPTION_BIND_THM = Q.store_thm("OPTION_BIND_THM",
+  `!x y. OPTION_BIND x y = case x of NONE => NONE | SOME i => y i`,
   Cases THEN SRW_TAC [] []);
 
 val _ = (extra_preprocessing :=
@@ -196,8 +196,8 @@ val _ = translate (RW [monad_unitbind_assert] parse_prog_def);
 
 val _ = ParseExtras.temp_tight_equality()
 
-val parse_prog_side_lemma = store_thm("parse_prog_side_lemma",
-  ``!x. parse_prog_side x = T``,
+val parse_prog_side_lemma = Q.store_thm("parse_prog_side_lemma",
+  `!x. parse_prog_side x = T`,
   SIMP_TAC std_ss [fetch "-" "parse_prog_side_def",
     fetch "-" "peg_exec_side_def", fetch "-" "coreloop_side_def"]
   THEN REPEAT STRIP_TAC

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -39,8 +39,8 @@ val _ = (find_def_for_const := def_of_const);
 fun fsm ls = fs (ls@[BIND_DEF,UNIT_DEF,IGNORE_BIND_DEF,FOREACH_def]);
 
 (*Use WHILE which is already translated in the prelude*)
-val rpt_do_step_alt = prove(``
-  rpt_do_step = \s. ((),WHILE (FST o has_work) (SND o do_step) s)``,
+val rpt_do_step_alt = Q.prove(`
+  rpt_do_step = \s. ((),WHILE (FST o has_work) (SND o do_step) s)`,
   fs[FUN_EQ_THM,rpt_do_step_def]>>
   completeInduct_on`s.clock`>>
   rw[]>>
@@ -61,8 +61,8 @@ val rpt_do_step_alt = prove(``
 
 val _ = translate rpt_do_step_alt
 
-val rpt_do_step2_alt = prove(``
-  rpt_do_step2 = \s. ((),WHILE (FST o has_work) (SND o do_step2) s)``,
+val rpt_do_step2_alt = Q.prove(`
+  rpt_do_step2 = \s. ((),WHILE (FST o has_work) (SND o do_step2) s)`,
   fs[FUN_EQ_THM,rpt_do_step2_def]>>
   completeInduct_on`s.clock`>>
   rw[]>>
@@ -82,10 +82,10 @@ val rpt_do_step2_alt = prove(``
 
 val _ = translate rpt_do_step2_alt
 
-val briggs_coalesce_alt_lem = prove(
-``∀s.
+val briggs_coalesce_alt_lem = Q.prove(
+`∀s.
   MWHILE briggs_has_work do_briggs_step s =
-  ((),WHILE (FST o briggs_has_work) (SND o do_briggs_step) s)``,
+  ((),WHILE (FST o briggs_has_work) (SND o do_briggs_step) s)`,
   completeInduct_on`s.clock`>>rw[]>>
   fs[Once whileTheory.WHILE]>>
   Q.ISPECL_THEN [`briggs_has_work`,`do_briggs_step`] assume_tac MWHILE_DEF>>
@@ -98,8 +98,8 @@ val briggs_coalesce_alt_lem = prove(
   strip_tac>>
   simp[Once whileTheory.WHILE,SimpRHS])
 
-val briggs_coalesce_alt = prove(``
-  briggs_coalesce = \s. ((),SND (set_unavail_moves [] (SND (set_move_rel LN (WHILE (FST o briggs_has_work) (SND o do_briggs_step) s)))))``,
+val briggs_coalesce_alt = Q.prove(`
+  briggs_coalesce = \s. ((),SND (set_unavail_moves [] (SND (set_move_rel LN (WHILE (FST o briggs_has_work) (SND o do_briggs_step) s)))))`,
   fs[FUN_EQ_THM,briggs_coalesce_def,IGNORE_BIND_DEF,BIND_DEF,UNCURRY,set_unavail_moves_def,set_move_rel_def]>>
   fs[briggs_coalesce_alt_lem])
 

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -10,8 +10,8 @@ val _ = translation_extends "inferProg";
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -106,8 +106,8 @@ val briggs_coalesce_alt = prove(``
 val _ = translate briggs_coalesce_alt
 
 (*Use the clock trick*)
-val rpt_do_step_side = prove(``
-  ∀s. rpt_do_step_side s ⇔ T``,
+val rpt_do_step_side = Q.prove(`
+  ∀s. rpt_do_step_side s ⇔ T`,
   fsm[fetch "-" "rpt_do_step_side_def"]>>
   completeInduct_on`s.clock`>>
   rw[]>>
@@ -131,8 +131,8 @@ val rpt_do_step_side = prove(``
   IF_CASES_TAC>>fs[]>>metis_tac[])|>update_precondition
 
 (*Use the clock trick*)
-val rpt_do_step2_side = prove(``
-  ∀s. rpt_do_step2_side s ⇔ T``,
+val rpt_do_step2_side = Q.prove(`
+  ∀s. rpt_do_step2_side s ⇔ T`,
   fsm[fetch "-" "rpt_do_step2_side_def"]>>
   completeInduct_on`s.clock`>>
   rw[]>>
@@ -155,8 +155,8 @@ val rpt_do_step2_side = prove(``
     fs[FUNPOW]>>
   IF_CASES_TAC>>fs[]>>metis_tac[])|>update_precondition
 
-val briggs_coalesce_side = prove(``
-  ∀s. briggs_coalesce_side s ⇔ T``,
+val briggs_coalesce_side = Q.prove(`
+  ∀s. briggs_coalesce_side s ⇔ T`,
   fsm[fetch "-" "briggs_coalesce_side_def"]>>
   completeInduct_on`s.clock`>>
   rw[]>>
@@ -182,16 +182,16 @@ val briggs_coalesce_side = prove(``
 
 val _ = translate init_ra_state_def
 
-val init_ra_state_side_def = prove(``
-  ∀a b c. init_ra_state_side a b c ⇔ T``,
+val init_ra_state_side_def = Q.prove(`
+  ∀a b c. init_ra_state_side a b c ⇔ T`,
   fs[fetch "-" "init_ra_state_side_def"]>>rw[]>>
   fs[MEM_FILTER,MEM_MAP]>>Cases_on`y`>>
   fs[MEM_toAList]) |> update_precondition
 
 val _ = translate (sec_ra_state_def |> REWRITE_RULE[MEMBER_INTRO])
 
-val sec_ra_state_side_def = prove(``
-  ∀a b c d. sec_ra_state_side a b c d ⇔ T``,
+val sec_ra_state_side_def = Q.prove(`
+  ∀a b c d. sec_ra_state_side a b c d ⇔ T`,
   fs[fetch "-" "sec_ra_state_side_def"]>>rw[]>>
   fs[MEM_FILTER,MEM_MAP,quantHeuristicsTheory.IS_SOME_EQ_NOT_NONE])
   |>update_precondition

--- a/compiler/bootstrap/translation/to_dataProgScript.sml
+++ b/compiler/bootstrap/translation/to_dataProgScript.sml
@@ -109,7 +109,7 @@ val PATLANG_EXP_TYPE_no_closures = Q.prove(
   rw[PATLANG_EXP_TYPE_def] \\ rw[no_closures_def] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y1`,`x1`] >>
@@ -132,9 +132,9 @@ val PATLANG_EXP_TYPE_types_match = Q.prove(
   Cases_on`c` \\ fs[PATLANG_EXP_TYPE_def,types_match_def,ctor_same_type_def] \\ rw[] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`x2`,`y1`,`x1`] >>
@@ -156,9 +156,9 @@ val PATLANG_EXP_TYPE_11 = Q.prove(
   Cases_on`c` \\ fs[PATLANG_EXP_TYPE_def] \\ rw[EQ_IMP_THM] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`y1`,`x`] >>
@@ -167,9 +167,9 @@ val PATLANG_EXP_TYPE_11 = Q.prove(
     metis_tac[]) >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y`,`x1`,`x2`] >>
@@ -345,7 +345,7 @@ val BVL_EXP_TYPE_no_closures = Q.prove(
   rw[BVL_EXP_TYPE_def] \\ rw[no_closures_def] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y1`,`x1`] >>
@@ -366,9 +366,9 @@ val BVL_EXP_TYPE_types_match = Q.prove(
   Cases_on`c` \\ fs[BVL_EXP_TYPE_def,types_match_def,ctor_same_type_def] \\ rw[] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`x2`,`y1`,`x1`] >>
@@ -390,9 +390,9 @@ val BVL_EXP_TYPE_11 = Q.prove(
   Cases_on`c` \\ fs[BVL_EXP_TYPE_def] \\ rw[EQ_IMP_THM] \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`y1`,`x`] >>
@@ -401,9 +401,9 @@ val BVL_EXP_TYPE_11 = Q.prove(
     metis_tac[]) >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     last_x_assum mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y`,`x1`,`x2`] >>
@@ -576,7 +576,7 @@ val BVI_EXP_TYPE_no_closures = Q.prove(
     rw[no_closures_def] \\ NO_TAC) \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qpat_x_assum`∀a b. MEM a x1 ⇒ _` mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y1`,`x1`] >>
@@ -597,16 +597,16 @@ val BVI_EXP_TYPE_types_match = Q.prove(
   Cases_on`c` \\ fs[BVI_EXP_TYPE_def,types_match_def,ctor_same_type_def] \\ rw[] \\
   TRY (
     qmatch_assum_rename_tac`OPTION_TYPE _ x1 y1` \\
-    rator_x_assum`OPTION_TYPE`mp_tac \\
+    qhdtm_x_assum`OPTION_TYPE`mp_tac \\
     qmatch_assum_rename_tac`OPTION_TYPE BVI_EXP_TYPE x2 y2` \\
     Cases_on`x1` \\ Cases_on`x2` \\ fs[OPTION_TYPE_def] \\
     rw[] \\ rw[types_match_def,ctor_same_type_def] \\
     metis_tac[]) \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qpat_x_assum`∀a b. MEM a x2 ⇒ _` mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`x2`,`y1`,`x1`] >>
@@ -628,21 +628,21 @@ val BVI_EXP_TYPE_11 = Q.prove(
   Cases_on`c` \\ fs[BVI_EXP_TYPE_def] \\ rw[EQ_IMP_THM] \\
   TRY (
     qmatch_assum_rename_tac`OPTION_TYPE BVI_EXP_TYPE x y1` \\
-    rator_x_assum`OPTION_TYPE`mp_tac \\
+    qhdtm_x_assum`OPTION_TYPE`mp_tac \\
     qmatch_assum_rename_tac`OPTION_TYPE BVI_EXP_TYPE x y2` \\
     Cases_on`x` \\ fs[OPTION_TYPE_def] \\ rw[] \\
     metis_tac[]) \\
   TRY (
     qmatch_assum_rename_tac`OPTION_TYPE BVI_EXP_TYPE x1 y` \\
-    rator_x_assum`OPTION_TYPE`mp_tac \\
+    qhdtm_x_assum`OPTION_TYPE`mp_tac \\
     qmatch_assum_rename_tac`OPTION_TYPE BVI_EXP_TYPE x2 y` \\
     Cases_on`x1` \\ Cases_on`x2` \\ fs[OPTION_TYPE_def] \\ rw[] \\
     metis_tac[]) \\
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x y1` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x y2` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qpat_x_assum`∀a b. MEM a x ⇒ _` mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y2`,`y1`,`x`] >>
@@ -651,9 +651,9 @@ val BVI_EXP_TYPE_11 = Q.prove(
     metis_tac[]) >>
   TRY (
     qmatch_assum_rename_tac`LIST_TYPE _ x1 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qmatch_assum_rename_tac`LIST_TYPE _ x2 y` >>
-    rator_x_assum`LIST_TYPE`mp_tac >>
+    qhdtm_x_assum`LIST_TYPE`mp_tac >>
     qpat_x_assum`∀a b. MEM a x2 ⇒ _` mp_tac >>
     rpt(pop_assum kall_tac) >>
     map_every qid_spec_tac[`y`,`x1`,`x2`] >>

--- a/compiler/bootstrap/translation/to_dataProgScript.sml
+++ b/compiler/bootstrap/translation/to_dataProgScript.sml
@@ -23,8 +23,8 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -189,8 +189,8 @@ val EqualityType_PATLANG_EXP_TYPE = Q.prove(
 
 val _ = translate (pat_to_closTheory.compile_def);
 
-val pat_to_clos_compile_side = prove(``
-  ∀x. pat_to_clos_compile_side x ⇔ T``,
+val pat_to_clos_compile_side = Q.prove(`
+  ∀x. pat_to_clos_compile_side x ⇔ T`,
   recInduct pat_to_closTheory.compile_ind>>
   rw[]>>
   simp[Once (fetch "-" "pat_to_clos_compile_side_def")]>>
@@ -198,8 +198,8 @@ val pat_to_clos_compile_side = prove(``
 
 val _ = translate(clos_mtiTheory.intro_multi_def)
 
-val clos_mti_intro_multi_side = prove(``
-  ∀max_app a. clos_mti_intro_multi_side max_app a ⇔ T``,
+val clos_mti_intro_multi_side = Q.prove(`
+  ∀max_app a. clos_mti_intro_multi_side max_app a ⇔ T`,
   ho_match_mp_tac clos_mtiTheory.intro_multi_ind>>
   `∀max_app z. intro_multi max_app [z] ≠ []` by
     (rw[] >> CCONTR_TAC>>fs[]>>
@@ -213,9 +213,9 @@ TODO: make this not have to be explicitly translated, probably by renaming it to
 *)
 val _ = translate (clos_numberTheory.renumber_code_locs_def)
 
-val clos_number_renumber_code_locs_list_side = prove(``
+val clos_number_renumber_code_locs_list_side = Q.prove(`
   (∀a b. clos_number_renumber_code_locs_list_side a b ⇔ T) ∧
-  (∀a b. clos_number_renumber_code_locs_side a b ⇔ T)``,
+  (∀a b. clos_number_renumber_code_locs_side a b ⇔ T)`,
   ho_match_mp_tac clos_numberTheory.renumber_code_locs_ind>>rw[]>>
   simp[Once (fetch"-" "clos_number_renumber_code_locs_list_side_def")]>>
   metis_tac[clos_numberTheory.renumber_code_locs_length,LENGTH_MAP,SND]) |> update_precondition
@@ -223,8 +223,8 @@ val clos_number_renumber_code_locs_list_side = prove(``
 (* known *)
 val _ = translate clos_knownTheory.merge_alt
 
-val num_abs_intro = prove(``
-  ∀x. Num x = if 0 ≤ x then Num (ABS x) else Num x``,
+val num_abs_intro = Q.prove(`
+  ∀x. Num x = if 0 ≤ x then Num (ABS x) else Num x`,
   rw[]>>intLib.COOPER_TAC);
 
 val _ = translate (clos_knownTheory.known_op_def |> ONCE_REWRITE_RULE [num_abs_intro] |> SIMP_RULE std_ss []);
@@ -233,21 +233,21 @@ val _ = translate (clos_knownTheory.known_def)
 
 val clos_known_merge_tup_side_def = theorem"clos_known_merge_tup_side_def";
 
-val clos_known_merge_side = prove(``
-  ∀a b. clos_known_merge_side a b ⇔ T``,
+val clos_known_merge_side = Q.prove(`
+  ∀a b. clos_known_merge_side a b ⇔ T`,
   EVAL_TAC \\
   recInduct clos_knownTheory.merge_tup_ind \\
   rw[] \\
   rw[Once clos_known_merge_tup_side_def]);
 
-val clos_known_known_op_side = prove(``
-  ∀a b c. clos_known_known_op_side a b c ⇔ T``,
+val clos_known_known_op_side = Q.prove(`
+  ∀a b c. clos_known_known_op_side a b c ⇔ T`,
   simp[Once (fetch"-" "clos_known_known_op_side_def")]>>
   rw[clos_known_merge_side]>>
   intLib.COOPER_TAC)
 
-val clos_known_known_side = prove(``
-  ∀a b c. clos_known_known_side a b c ⇔ T``,
+val clos_known_known_side = Q.prove(`
+  ∀a b c. clos_known_known_side a b c ⇔ T`,
   ho_match_mp_tac clos_knownTheory.known_ind>>
   `∀z a b c. known [z] a b ≠ ([],c)` by
     (CCONTR_TAC>>fs[]>>
@@ -261,16 +261,16 @@ val clos_known_known_side = prove(``
 
 val _ = translate (clos_callTheory.calls_def)
 
-val clos_free_free_side = prove(``
-  ∀a. clos_free_free_side a ⇔ T``,
+val clos_free_free_side = Q.prove(`
+  ∀a. clos_free_free_side a ⇔ T`,
   ho_match_mp_tac clos_freeTheory.free_ind>>rw[]>>
   simp[Once (fetch "-" "clos_free_free_side_def")]>>rw[]>>
   CCONTR_TAC>>fs[]>>
   imp_res_tac clos_freeTheory.free_SING>>fs[]>>
   metis_tac[]) |> update_precondition
 
-val clos_call_calls_side = prove(``
-  ∀a b. clos_call_calls_side a b ⇔ T``,
+val clos_call_calls_side = Q.prove(`
+  ∀a b. clos_call_calls_side a b ⇔ T`,
   ho_match_mp_tac clos_callTheory.calls_ind>>
   (*Move from calls proof*)
   `∀a b c. calls [a] b ≠ ([],c)` by
@@ -292,8 +292,8 @@ val _ = save_thm ("remove_ind",clos_removeTheory.remove_alt_ind)
 
 val _ = translate (clos_removeTheory.remove_alt)
 
-val clos_remove_remove_side = prove(``
-  ∀x. clos_remove_remove_side x ⇔ T``,
+val clos_remove_remove_side = Q.prove(`
+  ∀x. clos_remove_remove_side x ⇔ T`,
   recInduct clos_removeTheory.remove_alt_ind>>
   rw[]>>
   simp[Once (fetch "-" "clos_remove_remove_side_def")]>>
@@ -306,8 +306,8 @@ val clos_remove_remove_side = prove(``
 (* shift *)
 val _ = translate (clos_annotateTheory.shift_def)
 
-val clos_annotate_shift_side = prove(``
-  ∀a b c d. clos_annotate_shift_side a b c d ⇔ T``,
+val clos_annotate_shift_side = Q.prove(`
+  ∀a b c d. clos_annotate_shift_side a b c d ⇔ T`,
   ho_match_mp_tac clos_annotateTheory.shift_ind>>
   `∀a b c d. shift [a] b c d ≠ []` by
     (CCONTR_TAC>>fs[]>>
@@ -421,8 +421,8 @@ val EqualityType_BVL_EXP_TYPE = Q.prove(
   metis_tac[EqualityType_def,BVL_EXP_TYPE_no_closures,BVL_EXP_TYPE_types_match,BVL_EXP_TYPE_11])
   |> store_eq_thm;
 
-val bvl_jump_jumplist_side = prove(``
-  ∀a b. bvl_jump_jumplist_side a b ⇔ T``,
+val bvl_jump_jumplist_side = Q.prove(`
+  ∀a b. bvl_jump_jumplist_side a b ⇔ T`,
   completeInduct_on`LENGTH (b:bvl$exp list)`>>
   rw[Once (fetch "-" "bvl_jump_jumplist_side_def")]
   >-
@@ -438,17 +438,17 @@ val bvl_jump_jumplist_side = prove(``
       fs[]>>
     simp[]);
 
-val clos_to_bvl_recc_lets_side = prove(``
+val clos_to_bvl_recc_lets_side = Q.prove(`
   ∀a b c d.
   c = LENGTH b ⇒
-  clos_to_bvl_recc_lets_side a b c d``,
+  clos_to_bvl_recc_lets_side a b c d`,
   ho_match_mp_tac clos_to_bvlTheory.recc_Lets_ind>>
   rw[]>>
   simp[Once (fetch"-" "clos_to_bvl_recc_lets_side_def")]>>
   Cases_on`b`>>fs[])
 
-val clos_to_bvl_compile_exps_side = prove(``
-  ∀max_app a b. clos_to_bvl_compile_exps_side max_app a b``,
+val clos_to_bvl_compile_exps_side = Q.prove(`
+  ∀max_app a b. clos_to_bvl_compile_exps_side max_app a b`,
   ho_match_mp_tac clos_to_bvlTheory.compile_exps_ind>>
   `∀max_app a b c. compile_exps max_app [a] b ≠ ([],c)` by
     (CCONTR_TAC>>fs[]>>
@@ -466,13 +466,13 @@ val clos_to_bvl_compile_exps_side = prove(``
   first_x_assum(qspecl_then[`max_app`,`x1`,`x43`,`x41`] assume_tac)>>
   CCONTR_TAC>>fs[])
 
-val clos_to_bvl_compile_prog_side = prove(``
-  ∀max_app x. clos_to_bvl_compile_prog_side max_app x ⇔ T``,
+val clos_to_bvl_compile_prog_side = Q.prove(`
+  ∀max_app x. clos_to_bvl_compile_prog_side max_app x ⇔ T`,
   ho_match_mp_tac clos_to_bvlTheory.compile_prog_ind>>rw[]>>
   simp[Once (fetch "-" "clos_to_bvl_compile_prog_side_def"),clos_to_bvl_compile_exps_side])
 
-val clos_to_bvl_compile_side = prove(``
-  ∀x y. clos_to_bvl_compile_side x y ⇔ T``,
+val clos_to_bvl_compile_side = Q.prove(`
+  ∀x y. clos_to_bvl_compile_side x y ⇔ T`,
   rw[Once (fetch "-" "clos_to_bvl_compile_side_def"),
   Once (fetch "-" "clos_call_compile_side_def"),
   Once (fetch "-" "clos_to_bvl_compile_prog_side_def"),
@@ -516,8 +516,8 @@ val _ = translate (bvl_handleTheory.LetLet_def |> SIMP_RULE std_ss [MAPi_enumera
 
 val _ = translate(bvl_handleTheory.compile_def)
 
-val bvl_handle_compile_side = prove(``
-  ∀x y z. bvl_handle_compile_side x y z ⇔ T``,
+val bvl_handle_compile_side = Q.prove(`
+  ∀x y z. bvl_handle_compile_side x y z ⇔ T`,
   ho_match_mp_tac bvl_handleTheory.compile_ind>>
   `∀a b c d e. bvl_handle$compile a b [c] ≠ ([],d,e)` by
   (CCONTR_TAC>>fs[]>>
@@ -531,8 +531,8 @@ val bvl_handle_compile_side = prove(``
 
 val _ = translate (bvl_inlineTheory.inline_def)
 
-val bvl_inline_inline_side = prove(``
-  ∀x y. bvl_inline_inline_side x y ⇔ T``,
+val bvl_inline_inline_side = Q.prove(`
+  ∀x y. bvl_inline_inline_side x y ⇔ T`,
   ho_match_mp_tac bvl_inlineTheory.inline_ind>>
   `∀a b. bvl_inline$inline a [b] ≠ []` by
     (CCONTR_TAC>>fs[]>>
@@ -543,8 +543,8 @@ val bvl_inline_inline_side = prove(``
 
 val _ = translate (bvl_constTheory.compile_def)
 
-val bvl_const_compile_side = prove(``
-  ∀x y. bvl_const_compile_side x y ⇔ T``,
+val bvl_const_compile_side = Q.prove(`
+  ∀x y. bvl_const_compile_side x y ⇔ T`,
   ho_match_mp_tac bvl_constTheory.compile_ind>>
   `∀a b. bvl_const$compile a [b] ≠ []` by
     (CCONTR_TAC>>fs[]>>
@@ -555,8 +555,8 @@ val bvl_const_compile_side = prove(``
 
 val _ = translate(bvl_to_bviTheory.compile_int_def)
 
-val bvl_to_bvi_compile_int_side = prove(``
-  ∀x. bvl_to_bvi_compile_int_side x ⇔ T``,
+val bvl_to_bvi_compile_int_side = Q.prove(`
+  ∀x. bvl_to_bvi_compile_int_side x ⇔ T`,
   completeInduct_on`Num(ABS x)`>>
   simp[Once (fetch "-" "bvl_to_bvi_compile_int_side_def")]>>
   rw[]>>fs[PULL_FORALL]>>
@@ -673,8 +673,8 @@ val EqualityType_BVI_EXP_TYPE = Q.prove(
 
 val _ = translate(bvi_letTheory.compile_def)
 
-val bvi_let_compile_side = prove(``
-  ∀x y z. bvi_let_compile_side x y z ⇔ T``,
+val bvi_let_compile_side = Q.prove(`
+  ∀x y z. bvi_let_compile_side x y z ⇔ T`,
   ho_match_mp_tac bvi_letTheory.compile_ind>>rw[]>>
   `∀a b c . bvi_let$compile a b [c] ≠ []` by
     (CCONTR_TAC>>fs[]>>
@@ -690,8 +690,8 @@ val _ = translate(bvl_to_bviTheory.compile_aux_def);
 
 val _ = translate(bvl_to_bviTheory.compile_exps_def);
 
-val bvl_to_bvi_compile_exps_side = prove(``
-  ∀x y. bvl_to_bvi_compile_exps_side x y ⇔ T``,
+val bvl_to_bvi_compile_exps_side = Q.prove(`
+  ∀x y. bvl_to_bvi_compile_exps_side x y ⇔ T`,
   ho_match_mp_tac bvl_to_bviTheory.compile_exps_ind>>
   `∀a b c d. bvl_to_bvi$compile_exps a [b] ≠ ([],c,d)` by
     (CCONTR_TAC>>fs[]>>
@@ -702,8 +702,8 @@ val bvl_to_bvi_compile_exps_side = prove(``
 
 val _ = translate(bvl_to_bviTheory.compile_single_def);
 
-val bvl_to_bvi_compile_single_side = prove(``
-  ∀x y. bvl_to_bvi_compile_single_side x y ⇔ T``,
+val bvl_to_bvi_compile_single_side = Q.prove(`
+  ∀x y. bvl_to_bvi_compile_single_side x y ⇔ T`,
   EVAL_TAC \\ rw[]
   \\ imp_res_tac bvl_to_bviTheory.compile_exps_LENGTH
   \\ CCONTR_TAC \\ fs[]) |> update_precondition
@@ -714,8 +714,8 @@ val _ = translate(bvl_to_bviTheory.compile_prog_def);
 
 val _ = translate(bvl_inlineTheory.inline_all_def);
 
-val bvl_inline_inline_all_side = prove(``
-  ∀a b c d. bvl_inline_inline_all_side a b c d ⇔ T``,
+val bvl_inline_inline_all_side = Q.prove(`
+  ∀a b c d. bvl_inline_inline_all_side a b c d ⇔ T`,
   ho_match_mp_tac bvl_inlineTheory.inline_all_ind>>
   rw[]>>simp[Once (fetch "-" "bvl_inline_inline_all_side_def")]>>
   CCONTR_TAC>>fs[]>>
@@ -726,8 +726,8 @@ val _ = translate(bvl_inlineTheory.compile_prog_def);
 
 val _ = translate(bvl_handleTheory.compile_exp_def);
 
-val bvl_handle_compile_exp_side = prove(``
-  ∀x y z. bvl_handle_compile_exp_side x y z ⇔ T``,
+val bvl_handle_compile_exp_side = Q.prove(`
+  ∀x y z. bvl_handle_compile_exp_side x y z ⇔ T`,
   EVAL_TAC \\ rpt strip_tac
   \\ pop_assum(mp_tac o Q.AP_TERM`LENGTH`)
   \\ rw[]) |> update_precondition;
@@ -742,8 +742,8 @@ val _ = translate (list_to_num_set_def)
 
 val _ = translate (bvi_to_dataTheory.compile_def)
 
-val bvi_to_data_compile_side = prove(``
-  ∀a b c d e. bvi_to_data_compile_side a b c d e ⇔ T``,
+val bvi_to_data_compile_side = Q.prove(`
+  ∀a b c d e. bvi_to_data_compile_side a b c d e ⇔ T`,
   ho_match_mp_tac bvi_to_dataTheory.compile_ind>>
   `∀a b c d e f g. bvi_to_data$compile a b c d [e] ≠ (f,[],g)` by
     (CCONTR_TAC>>fs[]>>

--- a/compiler/bootstrap/translation/to_target64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_target64ProgScript.sml
@@ -11,8 +11,8 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -212,16 +212,16 @@ val _ = translate PAIR_MAP
 
 val _ = translate parmoveTheory.fstep_def
 
-val parmove_fstep_side = prove(``
-  ∀x. parmove_fstep_side x ⇔ T``,
+val parmove_fstep_side = Q.prove(`
+  ∀x. parmove_fstep_side x ⇔ T`,
   EVAL_TAC>>rw[]>>Cases_on`v18`>>fs[]) |> update_precondition
 
 val _ = translate (spec64 word_to_stackTheory.wMove_def)
 
 val _ = translate (spec64 call_dest_def)
 
-val word_to_stack_call_dest_side = prove(``
-  ∀a b c. word_to_stack_call_dest_side a b c ⇔ T``,
+val word_to_stack_call_dest_side = Q.prove(`
+  ∀a b c. word_to_stack_call_dest_side a b c ⇔ T`,
   EVAL_TAC>>Cases_on`b`>>fs[]) |> update_precondition
 
 val _ = translate (spec64 comp_def)

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -11,8 +11,8 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -425,9 +425,9 @@ val _ = translate (GiveUp_def |> wcomp_simp |> conv64)
 
 val _ = matches:= [``foo:'a wordLang$prog``,``foo:'a wordLang$exp``]
 
-val assign_rw = prove(``
+val assign_rw = Q.prove(`
   (i < 0 ⇒ n2w (Num (4 * (0 -i))) = n2w (Num (ABS (4*(0-i))))) ∧
-  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))``,
+  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))`,
   rw[]
   >-
     (`0 ≤ 4* -i` by intLib.COOPER_TAC>>
@@ -443,8 +443,8 @@ val assign_rw = prove(``
 val _ = translate (assign_def |> SIMP_RULE std_ss [assign_rw] |> inline_simp |> conv64 |> we_simp |> SIMP_RULE std_ss[SHIFT_ZERO,shift_left_rwt] |> SIMP_RULE std_ss [word_mul_def,LET_THM]|>gconv)
 
 (*
-val data_to_word_assign_side = prove(``
-  ∀a b c d e f g. data_to_word_assign_side a b c d e f g ⇔ T``,
+val data_to_word_assign_side = Q.prove(`
+  ∀a b c d e f g. data_to_word_assign_side a b c d e f g ⇔ T`,
   rw[]>>
   simp[fetch "-" "data_to_word_assign_side_def",NULL]>>
   Cases_on`e`>>rw[]>>
@@ -472,11 +472,11 @@ val _ = translate (inst_select_exp_def |> conv64 |> SIMP_RULE std_ss [word_mul_d
 
 val _ = translate (op_consts_def|>conv64|>econv)
 
-val rws = prove(``
+val rws = Q.prove(`
   ($+ = λx y. x + y) ∧
   ($&& = λx y. x && y) ∧
   ($|| = λx y. x || y) ∧
-  ($?? = λx y. x ?? y)``,
+  ($?? = λx y. x ?? y)`,
   fs[FUN_EQ_THM])
 
 val _ = translate (wordLangTheory.word_op_def |> ONCE_REWRITE_RULE [rws]|> conv64 |> SIMP_RULE std_ss [word_mul_def,word_2comp_def] |> conv64)
@@ -485,8 +485,8 @@ val _ = translate (convert_sub_def |> conv64 |> SIMP_RULE std_ss [word_2comp_def
 
 val _ = translate (spec64 pull_exp_def)
 
-val word_inst_pull_exp_side = prove(``
-  ∀x. word_inst_pull_exp_side x ⇔ T``,
+val word_inst_pull_exp_side = Q.prove(`
+  ∀x. word_inst_pull_exp_side x ⇔ T`,
   ho_match_mp_tac pull_exp_ind>>rw[]>>
   simp[Once (fetch "-" "word_inst_pull_exp_side_def"),
       fetch "-" "word_inst_optimize_consts_side_def",
@@ -497,8 +497,8 @@ val _ = translate (spec64 inst_select_def)
 
 val _ = translate (spec64 list_next_var_rename_move_def)
 
-val word_alloc_list_next_var_rename_move_side = prove(``
-  ∀x y z. word_alloc_list_next_var_rename_move_side x y z ⇔ T``,
+val word_alloc_list_next_var_rename_move_side = Q.prove(`
+  ∀x y z. word_alloc_list_next_var_rename_move_side x y z ⇔ T`,
   simp[fetch "-" "word_alloc_list_next_var_rename_move_side_def"]>>
   Induct_on`z`>>fs[list_next_var_rename_def]>>rw[]>>
   rpt(pairarg_tac>>fs[])>>
@@ -506,8 +506,8 @@ val word_alloc_list_next_var_rename_move_side = prove(``
 
 val _ = translate (spec64 full_ssa_cc_trans_def)
 
-val word_alloc_full_ssa_cc_trans_side = prove(``
-  ∀x y. word_alloc_full_ssa_cc_trans_side x y``,
+val word_alloc_full_ssa_cc_trans_side = Q.prove(`
+  ∀x y. word_alloc_full_ssa_cc_trans_side x y`,
   simp[fetch "-" "word_alloc_full_ssa_cc_trans_side_def"]>>
   rw[]>>pop_assum kall_tac>>
   map_every qid_spec_tac [`v6`,`v7`,`y`]>>
@@ -523,13 +523,13 @@ val _ = translate (spec64 remove_dead_def)
 
 val _ = translate (spec64 word_alloc_def)
 
-val word_alloc_apply_colour_side = prove(``
-  ∀x y. word_alloc_apply_colour_side x y ⇔ T``,
+val word_alloc_apply_colour_side = Q.prove(`
+  ∀x y. word_alloc_apply_colour_side x y ⇔ T`,
   ho_match_mp_tac apply_colour_ind>>rw[]>>
   simp[Once(fetch"-""word_alloc_apply_colour_side_def")])
 
-val word_alloc_word_alloc_side = prove(``
-  ∀w x y z. word_alloc_word_alloc_side w x y z ⇔ T``,
+val word_alloc_word_alloc_side = Q.prove(`
+  ∀w x y z. word_alloc_word_alloc_side w x y z ⇔ T`,
   simp[Once(fetch"-""word_alloc_word_alloc_side_def"),
   Once(fetch"-""word_alloc_oracle_colour_ok_side_def"),
   word_alloc_apply_colour_side]) |> update_precondition
@@ -540,8 +540,8 @@ val _ = translate (spec64 word_removeTheory.remove_must_terminate_def)
 
 val _ = translate (spec64 word_to_wordTheory.compile_def)
 
-val word_to_word_compile_side = prove(``
-  ∀x y z. word_to_word_compile_side x y z ⇔ T``,
+val word_to_word_compile_side = Q.prove(`
+  ∀x y z. word_to_word_compile_side x y z ⇔ T`,
   simp[fetch"-""word_to_word_compile_side_def"]>>
   Induct_on`z`>>fs[word_to_wordTheory.next_n_oracle_def]) |> update_precondition
 

--- a/compiler/bootstrap/translation/x64ProgScript.sml
+++ b/compiler/bootstrap/translation/x64ProgScript.sml
@@ -13,8 +13,8 @@ val RW = REWRITE_RULE
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = prove(
-  ``(b <> [] /\ x) = if b = [] then F else x``,
+val NOT_NIL_AND_LEMMA = Q.prove(
+  `(b <> [] /\ x) = if b = [] then F else x`,
   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
@@ -95,8 +95,8 @@ val _ = translate (encode_def|>SIMP_RULE std_ss [word_bit_thm] |> wc_simp |> we_
 
 val _ = translate (x64_enc0_def |> we_simp |> gconv)
 
-val total_num2zreg_side = prove(``
-  ∀x. total_num2zreg_side x ⇔ T``,
+val total_num2zreg_side = Q.prove(`
+  ∀x. total_num2zreg_side x ⇔ T`,
   simp[fetch "-" "total_num2zreg_side_def"]>>
   FULL_SIMP_TAC std_ss [fetch "-" "num2zreg_side_def"]>>
   ntac 2 strip_tac>>
@@ -106,8 +106,8 @@ val total_num2zreg_side = prove(``
   Cases_on`n'`>>FULL_SIMP_TAC std_ss [ADD1])>>
   Cases_on`n`>>fs[])
 
-val x64_enc0_side = prove(``
-  ∀x. x64_enc0_side x ⇔ T``,
+val x64_enc0_side = Q.prove(`
+  ∀x. x64_enc0_side x ⇔ T`,
   simp[fetch "-" "x64_enc0_side_def",total_num2zreg_side]) |> update_precondition
 
 val _ = translate x64_enc_def

--- a/compiler/eval/targets/proofs/configProofScript.sml
+++ b/compiler/eval/targets/proofs/configProofScript.sml
@@ -120,8 +120,8 @@ val names_tac =
 val x64_machine_config_def = Define`
   x64_machine_config = <|target:= x64_target; len_reg:=6 ; ptr_reg := 7 ; callee_saved_regs := [12;13;14]|>`
 
-val x64_conf_ok = prove(``
-  conf_ok x64_compiler_config x64_machine_config``,
+val x64_conf_ok = Q.prove(`
+  conf_ok x64_compiler_config x64_machine_config`,
   simp[conf_ok_def]>>rw[]>>TRY(EVAL_TAC>>NO_TAC)
   >- fs[x64_machine_config_def,x64_backend_correct]
   >- names_tac
@@ -131,8 +131,8 @@ val x64_conf_ok = prove(``
 val arm6_machine_config_def = Define`
   arm6_machine_config = <|target:= arm6_target ; len_reg:=1  ; ptr_reg := 0 ; callee_saved_regs := [8;10;11]|>`
 
-val arm6_conf_ok = prove(``
-  conf_ok arm_compiler_config arm6_machine_config``,
+val arm6_conf_ok = Q.prove(`
+  conf_ok arm_compiler_config arm6_machine_config`,
   simp[conf_ok_def]>>rw[]>>TRY(EVAL_TAC>>NO_TAC)
   >- fs[arm6_machine_config_def,arm6_backend_correct]
   >- names_tac
@@ -143,8 +143,8 @@ val arm6_conf_ok = prove(``
 val arm8_machine_config_def = Define`
   arm8_machine_config = <|target:= arm8_target ; len_reg:=1  ; ptr_reg := 0 ; callee_saved_regs := [27;28;29]|>`
 
-val arm8_conf_ok = prove(``
-  conf_ok arm8_compiler_config arm8_machine_config``,
+val arm8_conf_ok = Q.prove(`
+  conf_ok arm8_compiler_config arm8_machine_config`,
   simp[conf_ok_def]>>rw[]>>TRY(EVAL_TAC>>NO_TAC)
   >- fs[arm8_machine_config_def,arm8_backend_correct]
   >- names_tac
@@ -156,8 +156,8 @@ val arm8_conf_ok = prove(``
 val riscv_machine_config_def = Define`
   riscv_machine_config = <|target:= riscv_target; len_reg:= 11 ; ptr_reg :=10 ; callee_saved_regs := [25;26;27]|>`
 
-val riscv_conf_ok = prove(``
-  conf_ok riscv_compiler_config riscv_machine_config``,
+val riscv_conf_ok = Q.prove(`
+  conf_ok riscv_compiler_config riscv_machine_config`,
   simp[conf_ok_def]>>rw[]>> TRY(EVAL_TAC>>NO_TAC)
   >- fs[riscv_machine_config_def,riscv_backend_correct]
   >- names_tac
@@ -169,8 +169,8 @@ val riscv_conf_ok = prove(``
 val mips_machine_config_def = Define`
   mips_machine_config = <|target:= mips_target; len_reg:=5  ; ptr_reg := 4 ; callee_saved_regs := [21;22;23]|>`
 
-val mips_conf_ok = prove(``
-  conf_ok mips_compiler_config mips_machine_config``,
+val mips_conf_ok = Q.prove(`
+  conf_ok mips_compiler_config mips_machine_config`,
   simp[conf_ok_def]>>rw[]>> TRY(EVAL_TAC>>NO_TAC)
   >- fs[mips_machine_config_def,mips_backend_correct]
   >- names_tac

--- a/compiler/inference/proofs/inferCompleteScript.sml
+++ b/compiler/inference/proofs/inferCompleteScript.sml
@@ -600,7 +600,7 @@ val infer_d_complete = Q.store_thm ("infer_d_complete",
     ntac 2 (pop_assum mp_tac) >>
     simp[MAP2_MAP,LENGTH_COUNT_LIST,MEM_MAP,PULL_EXISTS,EXISTS_PROD,tenv_add_tvs_def] >>
     qunabbrev_tac`funs_ls1` >>
-    rator_x_assum`Abbrev`mp_tac >>
+    qhdtm_x_assum`Abbrev`mp_tac >>
     simp[markerTheory.Abbrev_def] >>
     simp[MAP2_MAP,LENGTH_COUNT_LIST,MEM_MAP,PULL_EXISTS,EXISTS_PROD] >>
     simp[Once LIST_EQ_REWRITE] >>

--- a/compiler/inference/proofs/inferCompleteScript.sml
+++ b/compiler/inference/proofs/inferCompleteScript.sml
@@ -71,9 +71,9 @@ val generalise_no_uvars = Q.prove (
 
 (* this might be totally wrong
 
-val generalise_uvars = prove(
-  ``(∀t m n s u d. FINITE u ∧ check_t d u t ⇒ FST(generalise m n s t) ≤ n + CARD (u DIFF (FDOM s))) ∧
-    (∀ts m n s u d. FINITE u ∧ EVERY (check_t d u) ts ⇒ FST(generalise_list m n s ts) ≤ CARD (u DIFF (FDOM s)))``,
+val generalise_uvars = Q.prove(
+  `(∀t m n s u d. FINITE u ∧ check_t d u t ⇒ FST(generalise m n s t) ≤ n + CARD (u DIFF (FDOM s))) ∧
+    (∀ts m n s u d. FINITE u ∧ EVERY (check_t d u) ts ⇒ FST(generalise_list m n s ts) ≤ CARD (u DIFF (FDOM s)))`,
   ho_match_mp_tac infer_tTheory.infer_t_induction >>
   rw[generalise_def,check_t_def] >> rw[] >>
   TRY BasicProvers.CASE_TAC >> simp[] >>
@@ -1135,28 +1135,28 @@ val check_specs_complete = store_thm("check_specs_complete",
   simp[EXTENSION]>>
   metis_tac[FUPDATE_EQ_FUNION,FUNION_ASSOC])
 
-val check_flat_weakT_complete = store_thm("check_flat_weakT_complete",
-  ``∀mn tenvT1 tenvT2.
+val check_flat_weakT_complete = Q.store_thm("check_flat_weakT_complete",
+  `∀mn tenvT1 tenvT2.
     flat_weakT mn tenvT1 tenvT2 ⇒
-    check_flat_weakT mn tenvT1 tenvT2``,
+    check_flat_weakT mn tenvT1 tenvT2`,
   simp[flat_weakT_def,check_flat_weakT_def,FEVERY_ALL_FLOOKUP,FORALL_PROD] >>
   rw[] >> first_x_assum(qspec_then`k`strip_assume_tac) >> rfs[])
 
-val check_flat_weakC_complete = store_thm("check_flat_weakC_complete",
-  ``∀tenvC1 tenvC2.
+val check_flat_weakC_complete = Q.store_thm("check_flat_weakC_complete",
+  `∀tenvC1 tenvC2.
     flat_weakC tenvC1 tenvC2 ⇒
-    check_flat_weakC tenvC1 (anub tenvC2 [])``,
+    check_flat_weakC tenvC1 (anub tenvC2 [])`,
   simp[flat_weakC_def,check_flat_weakC_def] >> rw[] >>
   match_mp_tac EVERY_anub_suff >> rw[] >>
   first_x_assum(qspec_then`x`mp_tac) >> rw[] >>
   BasicProvers.EVERY_CASE_TAC  >> fs[])
 
-val weakE_anub_rev = store_thm("weakE_anub_rev",
-  ``∀env1 env2. weakE env1 env2 ⇒ weakE env1 (anub env2 [])``,
+val weakE_anub_rev = Q.store_thm("weakE_anub_rev",
+  `∀env1 env2. weakE env1 env2 ⇒ weakE env1 (anub env2 [])`,
   rw[weakE_def] >>
   fs[Once ALOOKUP_anub])
 
-val deBruijn_subst_unconvert = prove(``
+val deBruijn_subst_unconvert = Q.prove(`
   (∀t.
   check_freevars n [] t ⇒
   unconvert_t (deBruijn_subst 0 subst t) =
@@ -1165,7 +1165,7 @@ val deBruijn_subst_unconvert = prove(``
   EVERY (check_freevars n []) ts ⇒
   MAP (unconvert_t o (deBruijn_subst 0 subst)) ts
   =
-  MAP ((infer_deBruijn_subst (MAP unconvert_t subst)) o unconvert_t) ts)``,
+  MAP ((infer_deBruijn_subst (MAP unconvert_t subst)) o unconvert_t) ts)`,
   Induct>>fs[check_freevars_def]>>rw[]>>
   fs[deBruijn_subst_def,unconvert_t_def,infer_deBruijn_subst_def]
   >-
@@ -1174,7 +1174,7 @@ val deBruijn_subst_unconvert = prove(``
     fs[MAP_MAP_o,EVERY_MEM,MAP_EQ_f])
 
 (*This might have been proven elsewhere...*)
-val infer_deBruijn_subst_twice = prove(``
+val infer_deBruijn_subst_twice = Q.prove(`
   (∀t.
   check_t (LENGTH subst2) {} t ⇒
   (infer_deBruijn_subst subst1 (infer_deBruijn_subst subst2 t) =
@@ -1182,13 +1182,13 @@ val infer_deBruijn_subst_twice = prove(``
   (∀ts.
   EVERY (check_t (LENGTH subst2) {}) ts ⇒
   MAP ((infer_deBruijn_subst subst1) o (infer_deBruijn_subst subst2)) ts =
-  MAP (infer_deBruijn_subst(MAP(infer_deBruijn_subst subst1) subst2)) ts)``,
+  MAP (infer_deBruijn_subst(MAP(infer_deBruijn_subst subst1) subst2)) ts)`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,infer_deBruijn_subst_def]>>
   simp[EL_MAP]>>
   fs[MAP_MAP_o,EVERY_MEM,MAP_EQ_f])
 
-val t_walkstar_infer_deBruijn_subst = prove(``
+val t_walkstar_infer_deBruijn_subst = Q.prove(`
  t_wfs s ∧
  LENGTH ls = tvs ∧
  EVERY (check_t y {}) ls ∧
@@ -1203,7 +1203,7 @@ val t_walkstar_infer_deBruijn_subst = prove(``
   EVERY (check_t tvs {}) ts
   ⇒
   MAP ((t_walkstar s) o (infer_deBruijn_subst ls)) ts =
-  MAP ((t_walkstar s) o (infer_deBruijn_subst (GENLIST Infer_Tuvar tvs))) ts))``,
+  MAP ((t_walkstar s) o (infer_deBruijn_subst (GENLIST Infer_Tuvar tvs))) ts))`,
   strip_tac>>ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,infer_deBruijn_subst_def]>>
   fs[EVERY_MEM,MEM_EL]
@@ -1213,7 +1213,7 @@ val t_walkstar_infer_deBruijn_subst = prove(``
     fs[t_walkstar_eqn1,MAP_MAP_o,MAP_EQ_f])
 
 (*Definitely proved before somewhere*)
-val infer_deBruijn_subst_check_t = prove(``
+val infer_deBruijn_subst_check_t = Q.prove(`
   EVERY (check_t tvs {}) ls
   ⇒
   (∀t.
@@ -1223,7 +1223,7 @@ val infer_deBruijn_subst_check_t = prove(``
   (∀ts.
   EVERY (check_t (LENGTH ls) {}) ts
   ⇒
-  EVERY (check_t tvs {}) (MAP (infer_deBruijn_subst ls) ts))``,
+  EVERY (check_t tvs {}) (MAP (infer_deBruijn_subst ls) ts))`,
   strip_tac>>ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,infer_deBruijn_subst_def]>>
   fs[EVERY_MEM,MEM_EL]>>
@@ -1314,10 +1314,10 @@ val check_weakE_complete = store_thm("check_weakE_complete",
    strip_tac>>
    metis_tac[IS_SOME_EXISTS,SUBMAP_t_compat,t_compat_eqs_t_unify])
 
-val check_weak_decls_complete = store_thm("check_weak_decls_complete",
-  ``decls1.inf_defined_mods = decls2.inf_defined_mods ∧
+val check_weak_decls_complete = Q.store_thm("check_weak_decls_complete",
+  `decls1.inf_defined_mods = decls2.inf_defined_mods ∧
     weak_decls (convert_decls decls1) (convert_decls decls2) ⇒
-    check_weak_decls decls1 decls2``,
+    check_weak_decls decls1 decls2`,
   rw[weak_decls_def,convert_decls_def,check_weak_decls_def,list_subset_def] >>
   fs[EXTENSION,SUBSET_DEF,EVERY_MEM]);
 

--- a/compiler/inference/proofs/inferCompleteScript.sml
+++ b/compiler/inference/proofs/inferCompleteScript.sml
@@ -98,7 +98,7 @@ val generalise_uvars = Q.prove(
   metis_tac[FST,arithmeticTheory.ADD_ASSOC,arithmeticTheory.ADD_COMM]
 *)
 
-val tenv_inv_letrec_merge2 = prove(``
+val tenv_inv_letrec_merge2 = Q.prove(`
   ∀funs:(tvarN,tvarN #exp)alist tenv' env tenv s tenv'' tenv'''.
     tenv''' = (MAP2 (λ(f,x,e) uvar. (f,0,uvar)) funs
           (MAP (λn. Infer_Tuvar n)
@@ -111,7 +111,7 @@ val tenv_inv_letrec_merge2 = prove(``
                      (t_walkstar s (Infer_Tuvar n)))
                 (COUNT_LIST (LENGTH funs)))) tenv) ∧
      t_wfs s ∧ tenv_inv s env tenv ⇒
-     tenv_inv s tenv''' tenv''``,
+     tenv_inv s tenv''' tenv''`,
     rw[]>>
     imp_res_tac (INST_TYPE [alpha|->``:tvarN``,beta|->``:exp``,delta|->``:num|->infer_t``] tenv_inv_letrec_merge)>>
     pop_assum(qspecl_then [`<|subst:=FEMPTY;next_uvar:=0|>`,`funs`] assume_tac)>>
@@ -808,7 +808,7 @@ val infer_d_complete = Q.store_thm ("infer_d_complete",
  >- metis_tac []
  >- fs[tenv_alpha_empty]);
 
-val infer_ds_complete = prove(``
+val infer_ds_complete = Q.prove(`
 !ds mn decls decls' tenvT' cenv' tenv tenv' st ienv idecls.
   type_ds T mn decls tenv ds decls' (tenvT',cenv',tenv') ∧
   env_rel tenv ienv ∧
@@ -822,7 +822,7 @@ val infer_ds_complete = prove(``
     tenv_alpha itenv' (bind_var_list2 tenv' Empty) ∧
     MAP FST itenv' = MAP FST tenv' ∧
     (*maybe implied as well*)
-    check_env ∅ itenv'``,
+    check_env ∅ itenv'`,
   fs[env_rel_def,GSYM check_cenv_tenvC_ok,tenv_bvl_def]>>rfs[]>>
   Induct>-
   (rw [Once type_ds_cases, infer_ds_def, success_eqns, LAMBDA_PROD, EXISTS_PROD, init_state_def,empty_decls_def,check_env_def,convert_decls_def,empty_inf_decls_def]>>
@@ -884,8 +884,8 @@ val t_ind = t_induction
   |> SIMP_RULE (srw_ss()) []
   |> Q.GEN`P`
 
-val rename_lemma = store_thm("rename_lemma",
-  ``∀t fvs fvs'.
+val rename_lemma = Q.store_thm("rename_lemma",
+  `∀t fvs fvs'.
     check_freevars 0 fvs' t ∧
     set fvs' ⊆ set fvs ∧
     ALL_DISTINCT fvs'
@@ -894,7 +894,7 @@ val rename_lemma = store_thm("rename_lemma",
       (type_subst (alist_to_fmap (ZIP (fvs, MAP Tvar_db (GENLIST I (LENGTH fvs))))) t) =
     convert_t
       (infer_type_subst
-        (ZIP (fvs', MAP Infer_Tvar_db (GENLIST I (LENGTH fvs')))) t)``,
+        (ZIP (fvs', MAP Infer_Tvar_db (GENLIST I (LENGTH fvs')))) t)`,
   ho_match_mp_tac t_ind >>
   conj_tac >- (
     simp[check_freevars_def,infer_type_subst_def,type_subst_def] >>
@@ -923,8 +923,8 @@ val rename_lemma = store_thm("rename_lemma",
   simp[MAP_EQ_f] >>
   fs[EVERY_MEM,check_freevars_def])
 
-val rename_lemma2 = store_thm("rename_lemma2",
-  ``∀t fvs fvs'.
+val rename_lemma2 = Q.store_thm("rename_lemma2",
+  `∀t fvs fvs'.
     check_freevars 0 fvs' t ∧
     set fvs' ⊆ set fvs ∧
     ALL_DISTINCT fvs'
@@ -933,7 +933,7 @@ val rename_lemma2 = store_thm("rename_lemma2",
       (infer_type_subst (ZIP (fvs', MAP Infer_Tvar_db (GENLIST I (LENGTH fvs')))) t) =
     unconvert_t
       (type_subst
-        (alist_to_fmap (ZIP (fvs, MAP Tvar_db (GENLIST I (LENGTH fvs))))) t)``,
+        (alist_to_fmap (ZIP (fvs, MAP Tvar_db (GENLIST I (LENGTH fvs))))) t)`,
   ho_match_mp_tac t_ind >>
   conj_tac >- (
     simp[check_freevars_def,infer_type_subst_def,type_subst_def] >>
@@ -967,8 +967,8 @@ val rename_lemma2 = store_thm("rename_lemma2",
   simp[MAP_EQ_f] >>
   fs[EVERY_MEM,check_freevars_def])
 
-val check_specs_complete = store_thm("check_specs_complete",
-  ``∀mn tenvT specs decls new_tenv.
+val check_specs_complete = Q.store_thm("check_specs_complete",
+  `∀mn tenvT specs decls new_tenv.
     type_specs mn tenvT specs decls new_tenv ⇒
     tenv_tabbrev_ok tenvT ⇒
     ∀tenv cenv venv.
@@ -979,7 +979,7 @@ val check_specs_complete = store_thm("check_specs_complete",
       (Success (idecls',tenv ⊌ itenvT,cenv ++ icenv,env'++env),st') ∧
     tenv_alpha env' (bind_var_list2 venv Empty) ∧
     set(MAP FST env') = set(MAP FST venv) ∧
-    convert_decls idecls' = union_decls decls (convert_decls idecls)``,
+    convert_decls idecls' = union_decls decls (convert_decls idecls)`,
   ho_match_mp_tac type_specs_strongind >>
   conj_tac >- (
     simp[check_specs_def,success_eqns,tenv_alpha_empty,empty_decls_def,union_decls_def,convert_decls_def] ) >>
@@ -1229,8 +1229,8 @@ val infer_deBruijn_subst_check_t = Q.prove(`
   fs[EVERY_MEM,MEM_EL]>>
   metis_tac[])
 
-val check_weakE_complete = store_thm("check_weakE_complete",
-  ``∀itenv1 itenv2 st tenv1 tenv2.
+val check_weakE_complete = Q.store_thm("check_weakE_complete",
+  `∀itenv1 itenv2 st tenv1 tenv2.
     weakE tenv1 tenv2 ∧
     check_env {} itenv1 ∧
     check_env {} itenv2 ∧
@@ -1238,7 +1238,7 @@ val check_weakE_complete = store_thm("check_weakE_complete",
     tenv_alpha itenv2 (bind_var_list2 tenv2 Empty)
   ⇒
     ∃st'.
-    check_weakE itenv1 (anub itenv2 []) st = (Success(),st')``,
+    check_weakE itenv1 (anub itenv2 []) st = (Success(),st')`,
   rw[check_weakE_EVERY]>>
   imp_res_tac weakE_anub_rev>>
   last_x_assum kall_tac>>

--- a/compiler/inference/proofs/inferPropsScript.sml
+++ b/compiler/inference/proofs/inferPropsScript.sml
@@ -2482,21 +2482,21 @@ val check_freevars_more = Q.store_thm("check_freevars_more",
     fs[SUBSET_DEF] >>
   fs[EVERY_MEM])
 
-val check_freevars_t_to_freevars = store_thm("check_freevars_t_to_freevars",
-  ``(∀t fvs (st:'a). check_freevars 0 fvs t ⇒
+val check_freevars_t_to_freevars = Q.store_thm("check_freevars_t_to_freevars",
+  `(∀t fvs (st:'a). check_freevars 0 fvs t ⇒
       ∃fvs' st'. t_to_freevars t st = (Success fvs', st') ∧ set fvs' ⊆ set fvs) ∧
     (∀ts fvs (st:'a). EVERY (check_freevars 0 fvs) ts ⇒
-      ∃fvs' st'. ts_to_freevars ts st = (Success fvs', st') ∧ set fvs' ⊆ set fvs)``,
+      ∃fvs' st'. ts_to_freevars ts st = (Success fvs', st') ∧ set fvs' ⊆ set fvs)`,
   Induct >> simp[check_freevars_def,t_to_freevars_def,PULL_EXISTS,success_eqns] >>
   simp_tac(srw_ss()++boolSimps.ETA_ss)[] >> simp[] >> metis_tac[])
 
-val check_t_infer_type_subst_dbs = store_thm("check_t_infer_type_subst_dbs",
-  ``∀m w t n u ls.
+val check_t_infer_type_subst_dbs = Q.store_thm("check_t_infer_type_subst_dbs",
+  `∀m w t n u ls.
     check_freevars m w t ∧
     m + LENGTH ls ≤ n ∧
     (ls = [] ⇒ 0 < m)
     ⇒
-    check_t n u (infer_type_subst (ZIP(ls,MAP Infer_Tvar_db (COUNT_LIST (LENGTH ls)))) t)``,
+    check_t n u (infer_type_subst (ZIP(ls,MAP Infer_Tvar_db (COUNT_LIST (LENGTH ls)))) t)`,
   ho_match_mp_tac check_freevars_ind >>
   conj_tac >- (
     simp[check_freevars_def] >>
@@ -3210,7 +3210,7 @@ val menv_alpha_def = Define`
 
 val sym_sub_tac = SUBST_ALL_TAC o SYM;
 
-val generalise_subst_exist = store_thm("generalise_subst_exist",``
+val generalise_subst_exist = Q.store_thm("generalise_subst_exist",`
   (t_wfs s ∧
   (∀uv. uv ∈ FDOM s ⇒ check_t tvs {} (t_walkstar s (Infer_Tuvar uv))))
   ⇒
@@ -3237,7 +3237,7 @@ val generalise_subst_exist = store_thm("generalise_subst_exist",``
   ∃subst'.
     LENGTH subst' = a ∧
     (∀x. MEM x subst' ⇒ check_t tvs {} x) ∧
-    (∀x. x ∈ FDOM b ⇒  EL (b ' x) (subst++subst') = t_walkstar s (Infer_Tuvar x)))``,
+    (∀x. x ∈ FDOM b ⇒  EL (b ' x) (subst++subst') = t_walkstar s (Infer_Tuvar x)))`,
   strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   srw_tac[][]>>
@@ -3396,15 +3396,15 @@ val tenv_alpha_bind_var_list2 = Q.store_thm("tenv_alpha_bind_var_list2",`
   fs[tenv_alpha_def]>>
   metis_tac[tenv_inv_bind_var_list2,tenv_invC_bind_var_list2])
 
-val check_weakE_EVERY = store_thm("check_weakE_EVERY",
-  ``∀env_impl env_spec st.
+val check_weakE_EVERY = Q.store_thm("check_weakE_EVERY",
+  `∀env_impl env_spec st.
       (∃st'. check_weakE env_impl env_spec st = (Success (),st')) ⇔
       EVERY (λ(n,tvs_spec,t_spec).
            case ALOOKUP env_impl n of
            | NONE => F
            | SOME (tvs_impl,t_impl) =>
                let t = infer_deBruijn_subst (GENLIST Infer_Tuvar tvs_impl) t_impl in
-               IS_SOME (t_unify FEMPTY t_spec t)) env_spec``,
+               IS_SOME (t_unify FEMPTY t_spec t)) env_spec`,
   ho_match_mp_tac check_weakE_ind >>
   conj_tac >- rw[check_weakE_def,success_eqns] >>
   rw[check_weakE_def] >>

--- a/compiler/inference/proofs/inferPropsScript.sml
+++ b/compiler/inference/proofs/inferPropsScript.sml
@@ -1249,13 +1249,13 @@ rw [check_freevars_def, check_t_def, infer_type_subst_def] >|
  metis_tac [EVERY_MAP]]);
 
 (* moved this one arround a bit *)
-val infer_type_subst_empty_check = store_thm("infer_type_subst_empty_check",``
+val infer_type_subst_empty_check = Q.store_thm("infer_type_subst_empty_check",`
 (∀t.
   check_freevars 0 [] t ⇒
   check_t 0 {} (infer_type_subst [] t)) ∧
 ∀ts.
 EVERY (check_freevars 0 []) ts ⇒
-EVERY (check_t 0 {}) (MAP (infer_type_subst []) ts)``,
+EVERY (check_t 0 {}) (MAP (infer_type_subst []) ts)`,
                                              Induct>>fs[check_freevars_def,infer_type_subst_def,check_t_def]>>
                                                    metis_tac[])
 
@@ -2475,8 +2475,8 @@ rw [t_to_freevars_def, success_eqns, check_freevars_def] >>
 rw [] >>
 metis_tac [check_freevars_more_append]);
 
-val check_freevars_more = store_thm("check_freevars_more",
-  ``∀a b c. check_freevars a b c ⇒ ∀b'. set b ⊆ set b' ⇒ check_freevars a b' c``,
+val check_freevars_more = Q.store_thm("check_freevars_more",
+  `∀a b c. check_freevars a b c ⇒ ∀b'. set b ⊆ set b' ⇒ check_freevars a b' c`,
   ho_match_mp_tac check_freevars_ind >>
   rw[check_freevars_def] >-
     fs[SUBSET_DEF] >>
@@ -2521,8 +2521,8 @@ val check_t_infer_type_subst_dbs = store_thm("check_t_infer_type_subst_dbs",
   rw[check_freevars_def,check_t_def,infer_type_subst_def] >>
   DECIDE_TAC)
 
-val nub_eq_nil = store_thm("nub_eq_nil",
-  ``∀ls. nub ls = [] ⇔ ls = []``,
+val nub_eq_nil = Q.store_thm("nub_eq_nil",
+  `∀ls. nub ls = [] ⇔ ls = []`,
   Induct >> simp[nub_def] >> rw[] >>
   Cases_on`ls`>>fs[])
 
@@ -3092,22 +3092,22 @@ val unconvert_t_Tword = Q.store_thm("unconvert_t_Tword[simp]",
   `unconvert_t (Tword wz) = Infer_Tapp [] (TC_word wz)`,
   EVAL_TAC);
 
-val check_freevars_empty_convert_unconvert_id = store_thm("check_freevars_empty_convert_unconvert_id",
-``!t. check_freevars n [] t ⇒ convert_t (unconvert_t t) = t``,
+val check_freevars_empty_convert_unconvert_id = Q.store_thm("check_freevars_empty_convert_unconvert_id",
+`!t. check_freevars n [] t ⇒ convert_t (unconvert_t t) = t`,
   ho_match_mp_tac unconvert_t_ind>>
   rw[]>>fs[unconvert_t_def,convert_t_def,check_freevars_def]>>
   fs[MAP_MAP_o,MAP_EQ_ID,EVERY_MEM])
 
-val check_t_empty_unconvert_convert_id = store_thm("check_t_empty_unconvert_convert_id",
-``!t. check_t n {} t ⇒
-  unconvert_t (convert_t t) = t``,
+val check_t_empty_unconvert_convert_id = Q.store_thm("check_t_empty_unconvert_convert_id",
+`!t. check_t n {} t ⇒
+  unconvert_t (convert_t t) = t`,
   ho_match_mp_tac (fetch "-" "convert_t_ind") >>
   rw[]>>
   fs[unconvert_t_def,convert_t_def,check_t_def]>>
   fs[MAP_MAP_o,MAP_EQ_ID,EVERY_MEM])
 
-val check_freevars_to_check_t = store_thm("check_freevars_to_check_t",
-``!t z. check_freevars n [] t ⇒ check_t n {} (unconvert_t t)``,
+val check_freevars_to_check_t = Q.store_thm("check_freevars_to_check_t",
+`!t z. check_freevars n [] t ⇒ check_t n {} (unconvert_t t)`,
   ho_match_mp_tac unconvert_t_ind>>rw[]>>
   fs[unconvert_t_def,check_freevars_def,check_t_def]>>
   fs[EVERY_MAP,EVERY_MEM])
@@ -3139,13 +3139,13 @@ val tenv_alpha_def = Define`
     (tenv_inv FEMPTY tenv tenvE ∧
     tenv_invC FEMPTY tenv tenvE)`
 
-val infer_deBruijn_subst_id2 = store_thm("infer_deBruijn_subst_id2",
-  ``(∀t.
+val infer_deBruijn_subst_id2 = Q.store_thm("infer_deBruijn_subst_id2",
+  `(∀t.
   check_t tvs {} t ⇒
   infer_deBruijn_subst (GENLIST (Infer_Tvar_db) tvs) t = t) ∧
   (∀ts.
   EVERY (check_t tvs {}) ts ⇒
-  MAP (infer_deBruijn_subst (GENLIST (Infer_Tvar_db) tvs)) ts = ts)``,
+  MAP (infer_deBruijn_subst (GENLIST (Infer_Tvar_db) tvs)) ts = ts)`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[]>>fs[check_t_def]
   >-
@@ -3183,24 +3183,24 @@ val tenv_invC_convert_env2 = Q.store_thm ("tenv_invC_convert_env2",
   >>
   fs[tenv_invC_def,convert_env2_def])
 
-val infer_deBruijn_subst_id = store_thm("infer_deBruijn_subst_id",
-``(!t. infer_deBruijn_subst [] t = t) ∧
-  (!ts. MAP (infer_deBruijn_subst []) ts = ts)``,
+val infer_deBruijn_subst_id = Q.store_thm("infer_deBruijn_subst_id",
+`(!t. infer_deBruijn_subst [] t = t) ∧
+  (!ts. MAP (infer_deBruijn_subst []) ts = ts)`,
   Induct>>rw[]>>fs[infer_deBruijn_subst_def,MAP_EQ_ID])
 
-val deBruijn_subst_nothing = store_thm("deBruijn_subst_nothing",
-  ``(∀t.
+val deBruijn_subst_nothing = Q.store_thm("deBruijn_subst_nothing",
+  `(∀t.
   deBruijn_subst 0 [] t = t )∧
   ∀ts.
-  MAP (deBruijn_subst 0 []) ts = ts``,
+  MAP (deBruijn_subst 0 []) ts = ts`,
   ho_match_mp_tac astTheory.t_induction>>
   fs[deBruijn_subst_def]>>rw[]>>
   fs[LIST_EQ_REWRITE]>>rw[]>>
   fs[MEM_EL,EL_MAP])
 
-val infer_type_subst_nil = store_thm("infer_type_subst_nil",
-  ``(∀t. check_freevars n [] t ⇒ infer_type_subst [] t = unconvert_t t) ∧
-    (∀ts. EVERY (check_freevars n []) ts ⇒ MAP (infer_type_subst []) ts = MAP unconvert_t ts)``,
+val infer_type_subst_nil = Q.store_thm("infer_type_subst_nil",
+  `(∀t. check_freevars n [] t ⇒ infer_type_subst [] t = unconvert_t t) ∧
+    (∀ts. EVERY (check_freevars n []) ts ⇒ MAP (infer_type_subst []) ts = MAP unconvert_t ts)`,
   ho_match_mp_tac(TypeBase.induction_of(``:t``)) >>
   rw[infer_type_subst_def,convert_t_def,unconvert_t_def,check_freevars_def] >>
   fsrw_tac[boolSimps.ETA_ss][])
@@ -3294,7 +3294,7 @@ val generalise_subst_exist = store_thm("generalise_subst_exist",``
     qexists_tac`subst'++subst''`>>fs[]>>
     metis_tac[])
 
-val infer_deBruijn_subst_infer_subst_walkstar = store_thm("infer_deBruijn_subst_infer_subst_walkstar",``
+val infer_deBruijn_subst_infer_subst_walkstar = Q.store_thm("infer_deBruijn_subst_infer_subst_walkstar",`
   ∀b subst n m.
   FRANGE b ⊆ count (LENGTH subst) ∧
   t_wfs s
@@ -3312,7 +3312,7 @@ val infer_deBruijn_subst_infer_subst_walkstar = store_thm("infer_deBruijn_subst_
   EVERY (λt.t_vars t ⊆ FDOM b) ts
   ⇒
   MAP ((infer_deBruijn_subst subst) o (infer_subst b)) ts =
-  MAP (t_walkstar s) ts))``,
+  MAP (t_walkstar s) ts))`,
   ntac 5 strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>rw[]>>
   fs[infer_subst_def,t_walkstar_eqn1,check_t_def,infer_deBruijn_subst_def]
@@ -3330,29 +3330,29 @@ val infer_deBruijn_subst_infer_subst_walkstar = store_thm("infer_deBruijn_subst_
   >- (fs[SUBSET_DEF,IN_FRANGE,PULL_EXISTS]>>metis_tac[])
   >> REFL_TAC))
 
-val tenv_alpha_empty = store_thm("tenv_alpha_empty",``
-  tenv_alpha [] (bind_var_list2 [] Empty)``,
+val tenv_alpha_empty = Q.store_thm("tenv_alpha_empty",`
+  tenv_alpha [] (bind_var_list2 [] Empty)`,
   fs[tenv_alpha_def,bind_var_list2_def,tenv_inv_def,tenv_invC_def,lookup_tenv_val_def])
 
-val tenv_alpha_convert = store_thm("tenv_alpha_convert",
-  ``check_env ∅ tenv ⇒
-    tenv_alpha tenv (bind_var_list2 (convert_env2 tenv) Empty) ``,
+val tenv_alpha_convert = Q.store_thm("tenv_alpha_convert",
+  `check_env ∅ tenv ⇒
+    tenv_alpha tenv (bind_var_list2 (convert_env2 tenv) Empty) `,
   rw[tenv_alpha_def,tenv_inv_convert_env2,tenv_invC_convert_env2])
 
-val menv_alpha_convert = store_thm("menv_alpha_convert",
-  ``check_menv menv ⇒ menv_alpha menv (convert_menv menv)``,
+val menv_alpha_convert = Q.store_thm("menv_alpha_convert",
+  `check_menv menv ⇒ menv_alpha menv (convert_menv menv)`,
   rw[menv_alpha_def,convert_menv_def,fmap_rel_OPTREL_FLOOKUP,optionTheory.OPTREL_def,FLOOKUP_o_f] >>
   CASE_TAC >>
   fs[check_menv_def,FEVERY_ALL_FLOOKUP] >>
   res_tac >> fs[GSYM check_env_def] >>
   rw[GSYM convert_env2_def, tenv_alpha_convert])
 
-val tenv_inv_bind_var_list2 = prove(``
+val tenv_inv_bind_var_list2 = Q.prove(`
   tenv_inv FEMPTY itenv (bind_var_list2 tenv Empty) ∧
   tenv_inv FEMPTY itenv' (bind_var_list2 tenv' Empty) ∧
   set (MAP FST itenv) = set (MAP FST tenv)
   ⇒
-  tenv_inv FEMPTY (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)``,
+  tenv_inv FEMPTY (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)`,
   rw[tenv_inv_def]>>
   fs[GSYM bvl2_lookup]>>
   fs[ALOOKUP_APPEND]>>
@@ -3365,12 +3365,12 @@ val tenv_inv_bind_var_list2 = prove(``
     res_tac>>
     fs[])
 
-val tenv_invC_bind_var_list2 = prove(``
+val tenv_invC_bind_var_list2 = Q.prove(`
   tenv_invC FEMPTY itenv (bind_var_list2 tenv Empty) ∧
   tenv_invC FEMPTY itenv' (bind_var_list2 tenv' Empty) ∧
   set (MAP FST itenv) = set (MAP FST tenv)
   ⇒
-  tenv_invC FEMPTY (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)``,
+  tenv_invC FEMPTY (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)`,
   rw[tenv_invC_def]>>
   fs[GSYM bvl2_lookup]>>
   fs[ALOOKUP_APPEND]>>
@@ -3387,12 +3387,12 @@ val tenv_invC_bind_var_list2 = prove(``
     res_tac>>
     fs[])
 
-val tenv_alpha_bind_var_list2 = store_thm("tenv_alpha_bind_var_list2",``
+val tenv_alpha_bind_var_list2 = Q.store_thm("tenv_alpha_bind_var_list2",`
   tenv_alpha itenv (bind_var_list2 tenv Empty) ∧
   set (MAP FST itenv) = set (MAP FST tenv) ∧
   tenv_alpha itenv' (bind_var_list2 tenv' Empty)
   ⇒
-  tenv_alpha (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)``,
+  tenv_alpha (itenv++itenv') (bind_var_list2 (tenv++tenv') Empty)`,
   fs[tenv_alpha_def]>>
   metis_tac[tenv_inv_bind_var_list2,tenv_invC_bind_var_list2])
 
@@ -3419,8 +3419,8 @@ val check_weakE_EVERY = store_thm("check_weakE_EVERY",
     metis_tac[] ) >>
   simp[markerTheory.Abbrev_def,IS_SOME_EXISTS] )
 
-val convert_env2_anub = store_thm("convert_env2_anub",
-  ``∀ls ac. convert_env2 (anub ls ac) = anub (convert_env2 ls) ac``,
+val convert_env2_anub = Q.store_thm("convert_env2_anub",
+  `∀ls ac. convert_env2 (anub ls ac) = anub (convert_env2 ls) ac`,
   Induct >> fs[anub_def,convert_env2_def] >>
   fs[UNCURRY] >>
   Cases >> fs[anub_def,UNCURRY] >> rw[] >>

--- a/compiler/inference/proofs/inferSoundScript.sml
+++ b/compiler/inference/proofs/inferSoundScript.sml
@@ -18,10 +18,10 @@ val _ = new_theory "inferSound";
 
 val sym_sub_tac = SUBST_ALL_TAC o SYM
 
-val lookup_tenv_NONE = prove(``
+val lookup_tenv_NONE = Q.prove(`
   ∀ls n.
   (lookup_tenv_val x n ls = NONE ⇒
-  ∀m. lookup_tenv_val x m ls = NONE)``,
+  ∀m. lookup_tenv_val x m ls = NONE)`,
   Induct>>fs[lookup_tenv_val_def]>>rw[]>>
   metis_tac[])
 
@@ -109,7 +109,7 @@ val check_s_more5 = Q.prove (
  rw [check_s_def] >>
  metis_tac [check_t_more5]);
 
-val deBruijn_subst_convert = prove(``
+val deBruijn_subst_convert = Q.prove(`
   (∀t.
   check_t n {} t ⇒
   deBruijn_subst 0 (MAP convert_t subst) (convert_t t) =
@@ -118,7 +118,7 @@ val deBruijn_subst_convert = prove(``
   EVERY (check_t n {}) ts ⇒
   MAP ((deBruijn_subst 0 (MAP convert_t subst)) o convert_t) ts
   =
-  MAP (convert_t o (infer_deBruijn_subst subst)) ts)``,
+  MAP (convert_t o (infer_deBruijn_subst subst)) ts)`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def]>>
   fs[convert_t_def,deBruijn_subst_def,infer_deBruijn_subst_def]
@@ -804,13 +804,13 @@ rw [convert_t_def, deBruijn_subst_def, EL_MAP, t_walkstar_eqn1,
     infer_deBruijn_subst_def, MAP_MAP_o, combinTheory.o_DEF, check_t_def,
     LENGTH_COUNT_LIST]);
 
-val weakE_anub = store_thm("weakE_anub",
-  ``∀env1 env2. weakE env1 (anub env2 []) ⇒ weakE env1 env2``,
+val weakE_anub = Q.store_thm("weakE_anub",
+  `∀env1 env2. weakE env1 (anub env2 []) ⇒ weakE env1 env2`,
   rw[weakE_def] >>
   fs[Once ALOOKUP_anub])
 
-val flat_weakC_anub = store_thm("flat_weakC_anub",
-  ``flat_weakC x (anub y []) ⇒ flat_weakC x y``,
+val flat_weakC_anub = Q.store_thm("flat_weakC_anub",
+  `flat_weakC x (anub y []) ⇒ flat_weakC x y`,
   rw[flat_weakC_def] >>
   fs[Once ALOOKUP_anub])
 

--- a/compiler/inference/proofs/inferSoundScript.sml
+++ b/compiler/inference/proofs/inferSoundScript.sml
@@ -591,7 +591,7 @@ val infer_d_sound = Q.store_thm ("infer_d_sound",
           impl_tac>-
             (fs[]>>metis_tac[pure_add_constraints_wfs])
           >>
-          rator_x_assum `generalise_list` mp_tac>>
+          qhdtm_x_assum `generalise_list` mp_tac>>
           qpat_abbrev_tac `ts:infer_t list = MAP A B`>>
           qpat_abbrev_tac `ts':infer_t list = MAP A B`>>
           rw[]>>
@@ -652,7 +652,7 @@ val infer_d_sound = Q.store_thm ("infer_d_sound",
          `r = EL n (MAP SND bindings')` by (
            qpat_x_assum`MEM X bindings'`mp_tac >>
            qpat_x_assum`X = EL n Y`mp_tac >>
-           rator_x_assum`ALL_DISTINCT`mp_tac >>
+           qhdtm_x_assum`ALL_DISTINCT`mp_tac >>
            imp_res_tac type_funs_MAP_FST >>
            pop_assum kall_tac >> pop_assum mp_tac >>
            `n < LENGTH l` by metis_tac[] >> pop_assum mp_tac >>
@@ -830,7 +830,7 @@ val check_weakE_sound = Q.prove (
   REV_FULL_SIMP_TAC(srw_ss())[] >>
   Cases_on`ALOOKUP tenv1 n` >> fsrw_tac[][] >>
   `?tvs_impl t_impl. x = (tvs_impl,t_impl)` by metis_tac[PAIR] >> fsrw_tac[][] >>
-  rator_x_assum`EVERY`(mp_tac o CONV_RULE(REWR_CONV(GSYM check_weakE_EVERY))) >>
+  qhdtm_x_assum`EVERY`(mp_tac o CONV_RULE(REWR_CONV(GSYM check_weakE_EVERY))) >>
   strip_tac >>
   imp_res_tac anub_tl_anub >>
   fs[] >>

--- a/compiler/inference/proofs/inferSoundScript.sml
+++ b/compiler/inference/proofs/inferSoundScript.sml
@@ -25,10 +25,10 @@ val lookup_tenv_NONE = Q.prove(`
   Induct>>fs[lookup_tenv_val_def]>>rw[]>>
   metis_tac[])
 
-val lookup_tenv_SOME = prove(``
+val lookup_tenv_SOME = Q.prove(`
   ∀ls n tvs t.
   (lookup_tenv_val x n ls = SOME(tvs,t) ⇒
-  ∀m. ∃tvs' t'. lookup_tenv_val x m ls = SOME(tvs',t'))``,
+  ∀m. ∃tvs' t'. lookup_tenv_val x m ls = SOME(tvs',t'))`,
   Induct>>fs[lookup_tenv_val_def]>>rw[]>>
   metis_tac[])
 

--- a/compiler/inference/proofs/infer_eCompleteScript.sml
+++ b/compiler/inference/proofs/infer_eCompleteScript.sml
@@ -7,8 +7,8 @@ open inferPropsTheory;
 val _ = new_theory "infer_eComplete";
 
 (*Useful lemmas about pure add constraints, some of these imply the others*)
-val pure_add_constraints_success = store_thm("pure_add_constraints_success",
-``
+val pure_add_constraints_success = Q.store_thm("pure_add_constraints_success",
+`
 !s constraints s'.
 t_wfs s ∧
 pure_add_constraints s constraints s'
@@ -16,7 +16,7 @@ pure_add_constraints s constraints s'
 s SUBMAP s' ∧
 FDOM s ⊆ FDOM s' ∧
 t_compat s s' ∧
-t_wfs s'``,
+t_wfs s'`,
   ho_match_mp_tac pure_add_constraints_ind>>
   fs[pure_add_constraints_def,t_compat_refl]>>
   ntac 7 strip_tac>>
@@ -57,11 +57,11 @@ val t_compat_pure_add_constraints_2 = store_thm("t_compat_pure_add_constraints_2
     metis_tac[t_unify_wfs])
 
 (*behaves like a function if the first 2 arguments are equal*)
-val pure_add_constraints_functional = store_thm("pure_add_constraints_functional",
-`` !constraints s s' s''.
+val pure_add_constraints_functional = Q.store_thm("pure_add_constraints_functional",
+` !constraints s s' s''.
    t_wfs s ∧
    pure_add_constraints s constraints s' ∧
-   pure_add_constraints s constraints s'' ⇒ s' = s''``,
+   pure_add_constraints s constraints s'' ⇒ s' = s''`,
    Induct>>
    rw[]>>
    fs[pure_add_constraints_def]>>
@@ -72,12 +72,12 @@ val pure_add_constraints_functional = store_thm("pure_add_constraints_functional
    metis_tac[])
 
 (*1 direction is sufficient to imply the other*)
-val pure_add_constraints_swap_lemma = prove(
-``t_wfs s ∧
+val pure_add_constraints_swap_lemma = Q.prove(
+`t_wfs s ∧
   pure_add_constraints s (a++b) sx
   ⇒
   ?si. pure_add_constraints s (b++a) si ∧
-       t_compat si sx ``,
+       t_compat si sx `,
   rw[]>>
   imp_res_tac t_compat_pure_add_constraints_2>>
   fs[pure_add_constraints_append]>>
@@ -92,13 +92,13 @@ val pure_add_constraints_swap_lemma = prove(
   rfs[]>>
   HINT_EXISTS_TAC>>fs[])
 
-val pure_add_constraints_swap = store_thm("pure_add_constraints_swap",
-``t_wfs s ∧
+val pure_add_constraints_swap = Q.store_thm("pure_add_constraints_swap",
+`t_wfs s ∧
   pure_add_constraints s (a++b) sx
   ⇒
   ?si. pure_add_constraints s (b++a) si ∧
        t_compat si sx ∧
-       t_compat sx si``,
+       t_compat sx si`,
   rw[]>>
   assume_tac pure_add_constraints_swap_lemma>>rfs[]>>
   HINT_EXISTS_TAC>>fs[]>>
@@ -123,9 +123,9 @@ val extend_t_vR_WF = prove
   imp_res_tac check_t_t_vars>>
   fs[FLOOKUP_DEF])
 
-val not_t_oc = prove(
-``(!t s v lim. t_wfs s ∧ check_t lim {} t ⇒ ¬ t_oc s t v) ∧
-  (!ts s t v lim. t_wfs s ∧ EVERY (check_t lim {}) ts ⇒ ~ EXISTS (\t. t_oc s t v) ts)``,
+val not_t_oc = Q.prove(
+`(!t s v lim. t_wfs s ∧ check_t lim {} t ⇒ ¬ t_oc s t v) ∧
+  (!ts s t v lim. t_wfs s ∧ EVERY (check_t lim {}) ts ⇒ ~ EXISTS (\t. t_oc s t v) ts)`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def]>>
   TRY (res_tac>>metis_tac[])>>
@@ -209,14 +209,14 @@ val check_t_t_walkstar = prove
     metis_tac[MEM_MAP])
 
 (*Ignore increment on deBrujin vars*)
-val t_walkstar_ignore_inc = prove(
-``t_wfs s ⇒
+val t_walkstar_ignore_inc = Q.prove(
+`t_wfs s ⇒
 (!t.(!uv. uv ∈ FDOM s ⇒ check_t 0 {} (t_walkstar s (Infer_Tuvar uv)))
 ⇒
 t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ∧
 (!ts. (!t.(!uv. uv ∈ FDOM s ⇒ check_t 0 {} (t_walkstar s (Infer_Tuvar uv)))
 ⇒
-EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))``,
+EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))`,
   strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[]>>
@@ -240,10 +240,10 @@ EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))``,
   fs[infer_deBruijn_inc_def])
 
 (*Adding a list of keys that did not already exist is safe*)
-val SUBMAP_FUPDATE_LIST_NON_EXIST = prove(
-``set (MAP FST ls) ∩ (FDOM s) = {}
+val SUBMAP_FUPDATE_LIST_NON_EXIST = Q.prove(
+`set (MAP FST ls) ∩ (FDOM s) = {}
   ⇒
-  s SUBMAP (s|++ls)``,
+  s SUBMAP (s|++ls)`,
   Induct_on`ls`>>fs[FUPDATE_LIST_THM]>>
   rw[]>>
   Cases_on`h`>>
@@ -260,9 +260,9 @@ val SUBMAP_FUPDATE_LIST_NON_EXIST = prove(
       fs[FDOM_FUPDATE_LIST])>>
   metis_tac[SUBMAP_TRANS])
 
-val t_vwalk_o_f_id = prove(
-``t_wfs s ⇒
-  !t. t_vwalk (infer_deBruijn_inc 0 o_f s) t = t_vwalk s t``,
+val t_vwalk_o_f_id = Q.prove(
+`t_wfs s ⇒
+  !t. t_vwalk (infer_deBruijn_inc 0 o_f s) t = t_vwalk s t`,
   strip_tac>>
   ho_match_mp_tac (Q.INST[`s`|->`s`]t_vwalk_ind)>>
   rw[]>>
@@ -274,9 +274,9 @@ val t_vwalk_o_f_id = prove(
   fs[FLOOKUP_o_f,infer_deBruijn_inc0]>>
   metis_tac[])
 
-val t_walkstar_o_f_id = prove(
-``t_wfs s ⇒
-  !t. t_walkstar ((infer_deBruijn_inc 0) o_f s) t  = t_walkstar s t``,
+val t_walkstar_o_f_id = Q.prove(
+`t_wfs s ⇒
+  !t. t_walkstar ((infer_deBruijn_inc 0) o_f s) t  = t_walkstar s t`,
   rw[]>>
   imp_res_tac t_walkstar_ind>>
   Q.SPEC_TAC (`t`, `t`) >>
@@ -291,16 +291,16 @@ val t_walkstar_o_f_id = prove(
   fs[MAP_EQ_f]>>rw[]>>res_tac>>
   fs[t_walkstar_eqn])
 
-val deBruijn_subst_id = prove(
-``(!t. deBruijn_subst 0 [] t = t) ∧
-  (!ts. MAP (deBruijn_subst 0 []) ts = ts)``,
+val deBruijn_subst_id = Q.prove(
+`(!t. deBruijn_subst 0 [] t = t) ∧
+  (!ts. MAP (deBruijn_subst 0 []) ts = ts)`,
   Induct>>rw[]>>fs[deBruijn_subst_def,MAP_EQ_ID])
 
-val tenv_invC_t_compat = prove(
-``t_compat s s' ∧
+val tenv_invC_t_compat = Q.prove(
+`t_compat s s' ∧
   t_wfs s' ∧
   tenv_invC s tenv tenvE ⇒
-  tenv_invC s' tenv tenvE``,
+  tenv_invC s' tenv tenvE`,
   rw[tenv_invC_def]
   >-
     metis_tac[]
@@ -310,16 +310,16 @@ val tenv_invC_t_compat = prove(
   IF_CASES_TAC>>fs[]>>
   metis_tac[check_freevars_to_check_t,t_walkstar_no_vars])
 
-val NOT_SOME_NONE = prove(
-``(!x. A ≠ SOME x) ⇒ A = NONE``,
+val NOT_SOME_NONE = Q.prove(
+`(!x. A ≠ SOME x) ⇒ A = NONE`,
 metis_tac[optionTheory.option_nchotomy])
 
-val t_walk_submap_walkstar = prove(
-``
+val t_walk_submap_walkstar = Q.prove(
+`
 !s s'. s SUBMAP s' ∧ t_wfs s ∧ t_wfs s'
 ⇒
 (!h. t_walk s (t_walkstar s' h) = t_walkstar s' h) ∧
-(!hs. MAP ((t_walk s) o t_walkstar s') hs = MAP (t_walkstar s') hs)``,
+(!hs. MAP ((t_walk s) o t_walkstar s') hs = MAP (t_walkstar s') hs)`,
   ntac 3 strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>rw[]>>
   fs[t_walkstar_eqn,t_walk_eqn,MAP_MAP_o]>>
@@ -351,12 +351,12 @@ val add_constraint_success = prove(
   rw[add_constraint_success,pure_add_constraints_def,EQ_IMP_THM]>>
   rw[infer_st_rewrs,infer_st_component_equality])
 
-val pure_add_constraints_combine = prove(
-``
+val pure_add_constraints_combine = Q.prove(
+`
 (?st'. (pure_add_constraints st.subst ls st'.subst ∧ st'.next_uvar = x) ∧
 (pure_add_constraints st'.subst ls' st''.subst ∧ y = st'.next_uvar))
 ⇔
-pure_add_constraints st.subst (ls++ls') st''.subst ∧ y = x``,
+pure_add_constraints st.subst (ls++ls') st''.subst ∧ y = x`,
 
 fs[pure_add_constraints_def,EQ_IMP_THM]>>rw[]
 >-
@@ -365,15 +365,15 @@ fs[pure_add_constraints_def,EQ_IMP_THM]>>rw[]
   fs[pure_add_constraints_append]>>
   Q.EXISTS_TAC `<| subst:= s2 ; next_uvar := x|>`>>fs[])
 
-val t_unify_ignore = prove(
-``(!s t t'.
+val t_unify_ignore = Q.prove(
+`(!s t t'.
   t_wfs s ⇒
   t_walkstar s t = t_walkstar s t' ⇒
   t_unify s t t' = SOME s) ∧
   (!s ts ts'.
   t_wfs s ⇒
   MAP (t_walkstar s) ts = MAP (t_walkstar s) ts' ⇒
-  ts_unify s ts ts' = SOME s)``,
+  ts_unify s ts ts' = SOME s)`,
   ho_match_mp_tac t_unify_strongind>>rw[]>>
   fs[t_unify_eqn]>-
   (full_case_tac>>
@@ -395,25 +395,25 @@ val pure_add_constraints_ignore = store_thm("pure_add_constraints_ignore",
   metis_tac[])
 
 (*t_compat preserves all grounded (no unification variable after walk) terms*)
-val t_compat_ground = prove(
-``t_compat a b
+val t_compat_ground = Q.prove(
+`t_compat a b
   ⇒
   ∀uv. uv ∈ FDOM a ∧
        check_t tvs {} (t_walkstar a (Infer_Tuvar uv))
        ⇒ uv ∈ FDOM b ∧
-         check_t tvs {} (t_walkstar b (Infer_Tuvar uv))``,
+         check_t tvs {} (t_walkstar b (Infer_Tuvar uv))`,
   rw[t_compat_def]>>
   first_x_assum (qspec_then `Infer_Tuvar uv` assume_tac)>>
   imp_res_tac t_walkstar_no_vars>>
   fs[check_t_def]>>
   metis_tac[t_walkstar_tuvar_props])
 
-val t_walkstar_tuvar_props2 = prove(
-``t_wfs s ∧ t_walkstar s x = Infer_Tuvar uv
+val t_walkstar_tuvar_props2 = Q.prove(
+`t_wfs s ∧ t_walkstar s x = Infer_Tuvar uv
   ⇒
   ?k. x = Infer_Tuvar k ∧
       (k = uv ⇒ k ∉ FDOM s) ∧
-      (k ≠ uv ⇒ k ∈ FDOM s)``,
+      (k ≠ uv ⇒ k ∈ FDOM s)`,
   rw[]>>
   Cases_on`x`>>
   TRY
@@ -427,8 +427,8 @@ val t_walkstar_tuvar_props2 = prove(
   fs[])
 
 (*Remove every uvar in the FDOM if we walkstar using a completed map*)
-val check_t_less = store_thm("check_t_less",
-``
+val check_t_less = Q.store_thm("check_t_less",
+`
   (!t.
   t_wfs s ∧
   (!uv. uv ∈ FDOM s ⇒ check_t n {} (t_walkstar s (Infer_Tuvar uv))) ∧
@@ -440,7 +440,7 @@ val check_t_less = store_thm("check_t_less",
   (!uv. uv ∈ FDOM s ⇒ check_t n {} (t_walkstar s (Infer_Tuvar uv))) ∧
   EVERY (check_t 0 uvars) ts
   ⇒
-  EVERY (check_t n (uvars ∩ (COMPL (FDOM s)))) (MAP (t_walkstar s) ts))``,
+  EVERY (check_t n (uvars ∩ (COMPL (FDOM s)))) (MAP (t_walkstar s) ts))`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[]
   >- fs[t_walkstar_eqn,t_walk_eqn,check_t_def]
@@ -455,15 +455,15 @@ val check_t_less = store_thm("check_t_less",
     fs[check_t_def])
 
 (*Double sided t_compat thm*)
-val t_compat_bi_ground = store_thm("t_compat_bi_ground",
-``(!uv. uv ∈ FDOM a ⇒ check_t n {} (t_walkstar a (Infer_Tuvar uv))) ∧
+val t_compat_bi_ground = Q.store_thm("t_compat_bi_ground",
+`(!uv. uv ∈ FDOM a ⇒ check_t n {} (t_walkstar a (Infer_Tuvar uv))) ∧
   t_compat a b ∧
   t_compat b a
   ⇒
   (!uv. uv ∈ FDOM b ⇒ check_t n {} (t_walkstar b (Infer_Tuvar uv))) ∧
   FDOM a = FDOM b ∧
   ((!t. t_walkstar a t= t_walkstar b t) ∧
-  (!ts. MAP (t_walkstar a) ts = MAP (t_walkstar b) ts))``,
+  (!ts. MAP (t_walkstar a) ts = MAP (t_walkstar b) ts))`,
   strip_tac>>
   CONJ_ASM1_TAC
   >-
@@ -577,12 +577,12 @@ val ALOOKUP_lemma = GEN_ALL (prove(
   fs[MEM_ZIP,LENGTH_COUNT_LIST]>>HINT_EXISTS_TAC>>
   fs[EL_MAP,LENGTH_COUNT_LIST,EL_COUNT_LIST]))
 
-val submap_t_walkstar_replace = prove(
-``t_wfs s' ∧
+val submap_t_walkstar_replace = Q.prove(
+`t_wfs s' ∧
   s SUBMAP s' ∧
   check_t n {} (t_walkstar s h)
   ⇒
-  t_walkstar s h = t_walkstar s' h``,
+  t_walkstar s h = t_walkstar s' h`,
   rw[]>>
   imp_res_tac t_walkstar_SUBMAP>>
   metis_tac[t_walkstar_no_vars])
@@ -981,35 +981,35 @@ val simp_tenv_invC_def = Define`
   !n t'. ALOOKUP tenv n = SOME t' ⇒
   ?t. ALOOKUP tenvE n = SOME t`
 
-val simp_tenv_invC_empty = prove(
-``simp_tenv_invC s n [] []``,
+val simp_tenv_invC_empty = Q.prove(
+`simp_tenv_invC s n [] []`,
   rw[simp_tenv_invC_def])
 
-val simp_tenv_invC_more = prove(
-``simp_tenv_invC s tvs tenv tenvE ∧
+val simp_tenv_invC_more = Q.prove(
+`simp_tenv_invC s tvs tenv tenvE ∧
   t_compat s s' ⇒
-  simp_tenv_invC s' tvs tenv tenvE``,
+  simp_tenv_invC s' tvs tenv tenvE`,
   rw[simp_tenv_invC_def]>>
   res_tac>>
   fs[t_compat_def]>>
   metis_tac[check_freevars_to_check_t,t_walkstar_no_vars])
 
-val simp_tenv_invC_append = prove(
-``simp_tenv_invC s'' tvs tenv tenvE ∧
+val simp_tenv_invC_append = Q.prove(
+`simp_tenv_invC s'' tvs tenv tenvE ∧
   simp_tenv_invC s'' tvs tenv' tenvE'
   ⇒
-  simp_tenv_invC s'' tvs (tenv'++tenv) (tenvE' ++ tenvE)``,
+  simp_tenv_invC s'' tvs (tenv'++tenv) (tenvE' ++ tenvE)`,
   rw[simp_tenv_invC_def]>>
   fs[ALOOKUP_APPEND]>>
   every_case_tac>>res_tac>>fs[]>>metis_tac[])
 
 (*convert on both sides of eqn*)
-val convert_bi_remove = store_thm("convert_bi_remove",
-``convert_t A = convert_t B ∧
+val convert_bi_remove = Q.store_thm("convert_bi_remove",
+`convert_t A = convert_t B ∧
   check_t n {} A ∧
   check_t m {} B
   ⇒
-  A = B``,
+  A = B`,
   rw[]>>
   last_x_assum (assume_tac o (Q.AP_TERM `unconvert_t`))>>
   metis_tac[check_t_empty_unconvert_convert_id])
@@ -1300,14 +1300,14 @@ val infer_p_complete = store_thm("infer_p_complete",
        metis_tac[t_walkstar_no_vars]));
 
 (*Specialize check_t_less a bit since we use this form a lot*)
-val sub_completion_completes = store_thm("sub_completion_completes",
-``t_wfs s ∧
+val sub_completion_completes = Q.store_thm("sub_completion_completes",
+`t_wfs s ∧
   check_t 0 (count n) t ∧
   FDOM s = count n ∧
   (!uv. uv < n ⇒
     check_t (num_tvs tenvE) {} (t_walkstar s (Infer_Tuvar uv)))
   ⇒
-  check_t (num_tvs tenvE) {} (t_walkstar s t)``,
+  check_t (num_tvs tenvE) {} (t_walkstar s t)`,
   assume_tac (GEN_ALL (fst(CONJ_PAIR check_t_less)))>>
   rw[]>>
   first_x_assum(qspecl_then[`count n`,`s`,`num_tvs tenvE`,`t`] mp_tac)>>
@@ -1509,13 +1509,13 @@ val infer_pes_complete = prove(``
     ntac 2 HINT_EXISTS_TAC>> fs[]>>
     metis_tac[t_compat_trans]));
 
-val deBrujin_subst_excess = prove(``
+val deBrujin_subst_excess = Q.prove(`
   (∀n targs t t'.
   check_freevars (LENGTH targs) [] t ∧
   deBruijn_subst n targs t = t'
   ⇒
   ∀ls.
-  deBruijn_subst n (targs++ls) t = t')``,
+  deBruijn_subst n (targs++ls) t = t')`,
   ho_match_mp_tac deBruijn_subst_ind>>
   fs[deBruijn_subst_def]>>rw[]
   >-
@@ -1528,11 +1528,11 @@ val deBrujin_subst_excess = prove(``
   >>
   fs[MAP_EQ_f,check_freevars_def,EVERY_MEM])
 
-val convert_infer_deBruijn_subst = prove(``
+val convert_infer_deBruijn_subst = Q.prove(`
   ∀subst t.
   check_t (LENGTH subst) {} t ⇒
   convert_t (infer_deBruijn_subst subst t) =
-  deBruijn_subst 0 (MAP convert_t subst) (convert_t t)``,
+  deBruijn_subst 0 (MAP convert_t subst) (convert_t t)`,
   ho_match_mp_tac infer_deBruijn_subst_ind>>
   rw[]>>
   EVAL_TAC>>simp[EL_MAP]>>rw[]>>fs[check_t_def]>>

--- a/compiler/inference/proofs/infer_eCompleteScript.sml
+++ b/compiler/inference/proofs/infer_eCompleteScript.sml
@@ -25,11 +25,11 @@ t_wfs s'`,
   metis_tac[SUBMAP_DEF,SUBSET_DEF,SUBMAP_t_compat,SUBMAP_TRANS])
 
 (*t_compat is preserved over certain types of pure_add_constraints*)
-val t_compat_pure_add_constraints_1 = store_thm("t_compat_pure_add_constraints_1",
-``!ls s sx.
+val t_compat_pure_add_constraints_1 = Q.store_thm("t_compat_pure_add_constraints_1",
+`!ls s sx.
   t_compat s sx ∧ EVERY (\x,y. t_walkstar sx x = t_walkstar sx y) ls
   ⇒
-  ?si. pure_add_constraints s ls si ∧ t_compat si sx``,
+  ?si. pure_add_constraints s ls si ∧ t_compat si sx`,
   Induct>>fs[pure_add_constraints_def]>>rw[]>>
   Cases_on`h`>>fs[]>>
   simp[pure_add_constraints_def]>>
@@ -37,12 +37,12 @@ val t_compat_pure_add_constraints_1 = store_thm("t_compat_pure_add_constraints_1
   fs[])
 
 (*If pure add constraints succeeds then the constraints all unify*)
-val t_compat_pure_add_constraints_2 = store_thm("t_compat_pure_add_constraints_2",
-``!ls s sx.
+val t_compat_pure_add_constraints_2 = Q.store_thm("t_compat_pure_add_constraints_2",
+`!ls s sx.
   t_wfs s ∧
   pure_add_constraints s ls sx
   ⇒
-  EVERY (\x,y. t_walkstar sx x = t_walkstar sx y) ls``,
+  EVERY (\x,y. t_walkstar sx x = t_walkstar sx y) ls`,
   Induct>>rw[]>>
   Cases_on`h`>>fs[pure_add_constraints_def]
   >-
@@ -136,17 +136,17 @@ val not_t_oc = Q.prove(
   fs[EVERY_MEM,EXISTS_MEM]>>
   res_tac)
 
-val FDOM_extend = prove (
-`` FDOM s = count next_uvar ⇒
-   FDOM (s |+ (next_uvar, n)) = count (SUC next_uvar)``,
+val FDOM_extend = Q.prove (
+` FDOM s = count next_uvar ⇒
+   FDOM (s |+ (next_uvar, n)) = count (SUC next_uvar)`,
    fs[FDOM_FUPDATE,count_def,INSERT_DEF,SET_EQ_SUBSET,SUBSET_DEF]>>
    rw[]>- DECIDE_TAC>-
    (res_tac>>DECIDE_TAC)>>
    Cases_on`x=next_uvar`>>fs[]>>
    `x<next_uvar` by DECIDE_TAC>>fs[])
 
-val pure_add_constraints_exists = store_thm ("pure_add_constraints_exists",
-``!s ts next_uvar lim.
+val pure_add_constraints_exists = Q.store_thm ("pure_add_constraints_exists",
+`!s ts next_uvar lim.
   t_wfs s ∧
   FDOM s = count next_uvar ∧
   EVERY (check_freevars lim []) ts
@@ -155,7 +155,7 @@ val pure_add_constraints_exists = store_thm ("pure_add_constraints_exists",
   let targs = MAP unconvert_t ts in
   let constraints = ZIP ((MAP Infer_Tuvar tys),targs) in
   let extension = ZIP (tys,targs) in
-  pure_add_constraints s constraints (s|++extension)``,
+  pure_add_constraints s constraints (s|++extension)`,
   induct_on`ts`>>
   srw_tac[][] >>unabbrev_all_tac>>
   srw_tac[] [COUNT_LIST_def, pure_add_constraints_def]>-rw[FUPDATE_LIST]>>
@@ -331,23 +331,23 @@ val t_walk_submap_walkstar = Q.prove(
   imp_res_tac flookup_thm>>
   fs[])
 
-val t_unify_to_pure_add_constraints = prove(
-``
+val t_unify_to_pure_add_constraints = Q.prove(
+`
 !s s' h t constraints s''.
 pure_add_constraints s (constraints ++ [h,t]) s'' ⇒
 (?s'. pure_add_constraints s constraints s' ∧
-t_unify s' h t = SOME s'')``,
+t_unify s' h t = SOME s'')`,
   rw[pure_add_constraints_append]>>
   Q.EXISTS_TAC`s2`>>fs[]>>
   fs[pure_add_constraints_def])
 
-val add_constraint_success = prove(
-``
+val add_constraint_success = Q.prove(
+`
   !t1 t2 st st' x.
   add_constraint t1 t2 st = (Success x, st') ⇔
   x = () ∧
   pure_add_constraints st.subst [t1,t2] st'.subst ∧
-  st'.next_uvar = st.next_uvar``,
+  st'.next_uvar = st.next_uvar`,
   rw[add_constraint_success,pure_add_constraints_def,EQ_IMP_THM]>>
   rw[infer_st_rewrs,infer_st_component_equality])
 
@@ -384,9 +384,9 @@ val t_unify_ignore = Q.prove(
   Cases_on`ts`>>Cases_on`ts'`>>
   fs[ts_unify_def])
 
-val pure_add_constraints_ignore = store_thm("pure_add_constraints_ignore",
-``!s ls. t_wfs s ∧ EVERY (λx,y. t_walkstar s x = t_walkstar s y) ls
-  ⇒ pure_add_constraints s ls s``,
+val pure_add_constraints_ignore = Q.store_thm("pure_add_constraints_ignore",
+`!s ls. t_wfs s ∧ EVERY (λx,y. t_walkstar s x = t_walkstar s y) ls
+  ⇒ pure_add_constraints s ls s`,
   strip_tac>>Induct>>
   fs[pure_add_constraints_def]>>
   rw[]>>
@@ -501,8 +501,8 @@ val t_compat_bi_ground = Q.store_thm("t_compat_bi_ground",
       metis_tac[t_walkstar_tuvar_props])
 
 (*Free properties when extending the completed map with uvar->ground var*)
-val extend_one_props = prove(
-``
+val extend_one_props = Q.prove(
+`
   t_wfs st.subst ∧
   t_wfs s ∧
   pure_add_constraints st.subst constraints s ∧
@@ -518,7 +518,7 @@ val extend_one_props = prove(
     (constraints ++ [(Infer_Tuvar st.next_uvar,unconvert_t t)]) s' ∧
   FDOM s' = count (st.next_uvar +1) ∧
   t_walkstar s' (Infer_Tuvar st.next_uvar) = unconvert_t t ∧
-  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))``,
+  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))`,
   strip_tac>>
   fs[LET_THM]>>
   imp_res_tac check_freevars_to_check_t>>
@@ -590,8 +590,8 @@ val submap_t_walkstar_replace = Q.prove(
 (*Generalize extend_one_props
   ts is a list of types given by the type system
 *)
-val extend_multi_props = store_thm("extend_multi_props",
-``!st constraints s ts n.
+val extend_multi_props = Q.store_thm("extend_multi_props",
+`!st constraints s ts n.
   t_wfs st.subst ∧
   t_wfs s ∧
   pure_add_constraints st.subst constraints s ∧
@@ -611,7 +611,7 @@ val extend_multi_props = store_thm("extend_multi_props",
   FDOM s' = count (st.next_uvar +LENGTH ts) ∧
   (∀n. n<LENGTH ts ⇒
   t_walkstar s' (Infer_Tuvar (st.next_uvar+n)) = EL n targs) ∧
-  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))``,
+  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))`,
   rpt strip_tac>>
   fsrw_tac[][LET_THM]>>CONJ_ASM1_TAC>-
     (imp_res_tac pure_add_constraints_exists>>
@@ -773,8 +773,8 @@ val rest_uvar_tac =
 
 val extend_uvar_tac = Q_TAC extend_uvar_tac
 
-val constrain_op_complete = prove(
-``
+val constrain_op_complete = Q.prove(
+`
 !n.
 type_op op ts t ∧
 sub_completion n st.next_uvar st.subst constraints s ∧
@@ -790,7 +790,7 @@ sub_completion n st'.next_uvar st'.subst constraints' s' ∧
 t_compat s s' ∧
 FDOM st'.subst ⊆ count st'.next_uvar ∧
 FDOM s' = count st'.next_uvar ∧
-t = convert_t (t_walkstar s' t')``,
+t = convert_t (t_walkstar s' t')`,
   strip_tac>>
   fs[sub_completion_def]>>
   rw[]>>
@@ -1015,8 +1015,8 @@ val convert_bi_remove = Q.store_thm("convert_bi_remove",
   metis_tac[check_t_empty_unconvert_convert_id])
 
 (*Substituting every tvs away with something that has no tvs leaves none left*)
-val infer_type_subst_check_t_less = prove(
-``
+val infer_type_subst_check_t_less = Q.prove(
+`
   LENGTH ls = LENGTH tvs ∧
   EVERY (check_t n {}) ls ⇒
   (!t.
@@ -1026,7 +1026,7 @@ val infer_type_subst_check_t_less = prove(
   (!ts.
   EVERY (check_freevars n tvs) ts
   ⇒
-  EVERY (check_t n {}) (MAP (infer_type_subst (ZIP(tvs,ls))) ts))``,
+  EVERY (check_t n {}) (MAP (infer_type_subst (ZIP(tvs,ls))) ts))`,
   strip_tac>>
   Induct>>rw[]
   >-
@@ -1043,8 +1043,8 @@ val infer_type_subst_check_t_less = prove(
     fs[infer_type_subst_def,check_t_def,check_freevars_def]>>
     fs[EVERY_MAP]>>metis_tac[]);
 
-val infer_p_complete = store_thm("infer_p_complete",
-``
+val infer_p_complete = Q.store_thm("infer_p_complete",
+`
   (!tvs tenv p t tenvE.
   type_p tvs tenv p t tenvE
   ⇒
@@ -1086,7 +1086,7 @@ val infer_p_complete = store_thm("infer_p_complete",
     FDOM s' = count st'.next_uvar ∧
     t_compat s s' ∧
     simp_tenv_invC s' tvs new_bindings tenvE ∧
-    ts = MAP (convert_t o t_walkstar s') ts')``,
+    ts = MAP (convert_t o t_walkstar s') ts')`,
   ho_match_mp_tac type_p_strongind>>
   rw[UNCURRY,success_eqns,infer_p_def]
   >-
@@ -1313,17 +1313,17 @@ val sub_completion_completes = Q.store_thm("sub_completion_completes",
   first_x_assum(qspecl_then[`count n`,`s`,`num_tvs tenvE`,`t`] mp_tac)>>
   impl_tac>>fs[]);
 
-val lookup_tenv_bind_var_list = prove(
-``!tenv.
+val lookup_tenv_bind_var_list = Q.prove(
+`!tenv.
   lookup_tenv_val x 0 (bind_var_list 0 tenv tenvE) =
   case ALOOKUP tenv x of
     SOME t => SOME (0,t)
-  | NONE => lookup_tenv_val x 0 tenvE``,
+  | NONE => lookup_tenv_val x 0 tenvE`,
   Induct>>rw[bind_var_list_def]>>
   Cases_on`h`>>rw[bind_var_list_def,lookup_tenv_val_def,deBruijn_inc0])
 
 (*This should be general enough to prove both Mat and Handle cases*)
-val infer_pes_complete = prove(``
+val infer_pes_complete = Q.prove(`
   ∀pes st' constraints' s'.
   pes ≠ [] ∧
   tenv_ctor_ok tenv.c ∧
@@ -1373,7 +1373,7 @@ val infer_pes_complete = prove(``
   sub_completion (num_tvs tenv.v) st''.next_uvar st''.subst constraints'' s'' ∧
   FDOM st''.subst ⊆ count st''.next_uvar ∧
   FDOM s'' = count st''.next_uvar ∧
-  t_compat s' s''``,
+  t_compat s' s''`,
   Induct>- rw[]>>
   rpt GEN_TAC>>
   strip_tac>>

--- a/compiler/inference/proofs/type_eDetermScript.sml
+++ b/compiler/inference/proofs/type_eDetermScript.sml
@@ -188,7 +188,7 @@ val generalise_complete_lem = Q.prove (
  mp_tac (Q.SPECL [`n`, `s`, `[t]`] generalise_complete) >>
  rw [generalise_def, LET_THM]);
 
-val t_vars_check_t = prove(``
+val t_vars_check_t = Q.prove(`
   (∀t.
   ¬check_t 0 {} t ∧
   check_t 0 s t ⇒
@@ -197,7 +197,7 @@ val t_vars_check_t = prove(``
   ∀x.MEM x ts ⇒
     ¬check_t 0 {} x ∧
     check_t 0 s x ⇒
-    ∃n'. n' ∈ s ∧ n' ∈ t_vars x)``,
+    ∃n'. n' ∈ s ∧ n' ∈ t_vars x)`,
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,t_vars_eqn]>>
   fs[EXISTS_MEM,EVERY_MEM]>>res_tac>>
@@ -205,14 +205,14 @@ val t_vars_check_t = prove(``
   fs[MEM_MAP]>>
   metis_tac[]);
 
-val t_walkstar_diff = prove(``
+val t_walkstar_diff = Q.prove(`
   t_wfs s1 ∧ t_wfs s2 ∧
   (t_walkstar s1 (Infer_Tuvar n) ≠ t_walkstar s2 (Infer_Tuvar n))
   ⇒
   (∀t.(n ∈ t_vars t) ⇒ t_walkstar s1 t ≠ t_walkstar s2 t) ∧
   (∀ts.
   ∀x. MEM x ts ⇒
-    n ∈ t_vars x ⇒ t_walkstar s1 x ≠ t_walkstar s2 x)``,
+    n ∈ t_vars x ⇒ t_walkstar s1 x ≠ t_walkstar s2 x)`,
   strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[t_vars_eqn]>>fs[]>>

--- a/compiler/inference/unifyLib.sml
+++ b/compiler/inference/unifyLib.sml
@@ -2,12 +2,12 @@ structure unifyLib = struct
 local
   open HolKernel boolLib bossLib lcsymtacs
 
-  val t_unify_wfs = prove(
-   ``t_wfs s ∧ (t_unify s t1 t2 = SOME sx) ==> t_wfs sx``,
+  val t_unify_wfs = Q.prove(
+   `t_wfs s ∧ (t_unify s t1 t2 = SOME sx) ==> t_wfs sx`,
    metis_tac[unifyTheory.t_unify_unifier])
 
-  val t_wfs_FEMPTY = prove(
-    ``t_wfs FEMPTY``,
+  val t_wfs_FEMPTY = Q.prove(
+    `t_wfs FEMPTY`,
     rw[unifyTheory.t_wfs_def])
 
   val funs =

--- a/compiler/inference/unifyScript.sml
+++ b/compiler/inference/unifyScript.sml
@@ -3,12 +3,12 @@ open unifPropsTheory unifDefTheory walkTheory walkstarTheory collapseTheory;
 open substTheory;
 open infer_tTheory;
 
-val option_map_case = prove (
-  ``!f opt.
+val option_map_case = Q.prove (
+  `!f opt.
     OPTION_MAP f opt =
     case opt of
          NONE => NONE
-       | SOME a => SOME (f a)``,
+       | SOME a => SOME (f a)`,
   simp[FUN_EQ_THM] >>
   gen_tac >> Cases >>
   rw[OPTION_MAP_DEF])
@@ -1037,9 +1037,9 @@ metis_tac [no_vars_lem, MAP_MAP_o, combinTheory.o_DEF]);
 
 (*Theorems about unification for completeness proof*)
 
-val t_walk_vwalk_id = store_thm ("t_walk_vwalk_id",
-``t_wfs s ⇒
-  !n. t_walk s (t_vwalk s n) = t_vwalk s n``,
+val t_walk_vwalk_id = Q.store_thm ("t_walk_vwalk_id",
+`t_wfs s ⇒
+  !n. t_walk s (t_vwalk s n) = t_vwalk s n`,
   strip_tac>>
   ho_match_mp_tac (Q.INST[`s`|->`s`]t_vwalk_ind)>>
   rw[]>>
@@ -1077,12 +1077,12 @@ val encode_walkstar_reverse = encode_walkstar |>
 			      SPEC_ALL|>UNDISCH|>SYM |>
 			      DISCH_ALL |> GEN_ALL;
 
-val t_unify_mgu = store_thm ("t_unify_mgu",
-``!s t1 t2 sx s2.
+val t_unify_mgu = Q.store_thm ("t_unify_mgu",
+`!s t1 t2 sx s2.
   t_wfs s ∧ (t_unify s t1 t2 = SOME sx) ∧ t_wfs s2 ∧
   (t_walkstar s2 (t_walkstar s t1)) = t_walkstar s2 (t_walkstar s t2)
   ⇒
-  ∀t. t_walkstar s2 (t_walkstar sx t) = t_walkstar s2 (t_walkstar s t)``,
+  ∀t. t_walkstar s2 (t_walkstar sx t) = t_walkstar s2 (t_walkstar s t)`,
   rw[]>>
   `t_wfs sx` by metis_tac[t_unify_wfs]>>
   rfs[t_walkstar_def,encode_walkstar_reverse]>>

--- a/compiler/inference/unifyScript.sml
+++ b/compiler/inference/unifyScript.sml
@@ -233,9 +233,9 @@ val ts_unify_def = Define `
    | SOME s' => ts_unify s' ts1 ts2) ∧
 (ts_unify s _ _ = NONE)`;
 
-val encode_walk = prove(
-  ``∀s. t_wfs s ⇒
-      ∀t. walk (encode_infer_t o_f s) (encode_infer_t t) = encode_infer_t (t_walk s t)``,
+val encode_walk = Q.prove(
+  `∀s. t_wfs s ⇒
+      ∀t. walk (encode_infer_t o_f s) (encode_infer_t t) = encode_infer_t (t_walk s t)`,
   rw[walk_def] >>
   imp_res_tac encode_vwalk >>
   fs[] >>
@@ -243,11 +243,11 @@ val encode_walk = prove(
   rw[t_walk_def,decode_left_inverse] >>
   metis_tac[decode_left_inverse])
 
-val encode_pair_cases = prove(
-  ``(∀t t1 t2.
+val encode_pair_cases = Q.prove(
+  `(∀t t1 t2.
     (encode_infer_t t = Pair t1 t2) ⇒
       ((t1 = Const Tapp_tag) ∧
-       (∃tc ts. t2 = Pair (Const (TC_tag tc)) (encode_infer_ts ts))))``,
+       (∃tc ts. t2 = Pair (Const (TC_tag tc)) (encode_infer_ts ts))))`,
   Cases >> rw[encode_infer_t_def] >>
   PROVE_TAC[])
 
@@ -546,8 +546,8 @@ val encode_infer_t_inj_rwt = Q.prove(
  (∀t1s t2s. (encode_infer_ts t1s = encode_infer_ts t2s) ⇔ (t1s = t2s))`,
  metis_tac[encode_infer_t_inj])
 
-val t_unify_ind = store_thm("t_unify_ind",
-  ``!P0 P1.
+val t_unify_ind = Q.store_thm("t_unify_ind",
+  `!P0 P1.
       (!s t1 t2.
          (!ts1 ts2 tc2.
             t_walk s t1 = Infer_Tapp ts1 tc2 /\
@@ -563,7 +563,7 @@ val t_unify_ind = store_thm("t_unify_ind",
             ts1 = t1::ts1' /\ ts2 = t2::ts2' ==> P0 s t1 t2) ==>
          P1 s ts1 ts2) ==>
       (!s t1 t2. t_wfs s ==> P0 s t1 t2) /\
-      (!s ts1 ts2. t_wfs s ==> P1 s ts1 ts2)``,
+      (!s ts1 ts2. t_wfs s ==> P1 s ts1 ts2)`,
   rpt gen_tac >> strip_tac >>
   Q.ISPEC_THEN`λs t1 t2.
     (∀us u1 u2. wfs s ∧ (s = encode_infer_t o_f us) ∧ (t1 = encode_infer_t u1) ∧ (t2 = encode_infer_t u2) ⇒ P0 us u1 u2) ∧
@@ -729,8 +729,8 @@ val t_collapse_eqn = Q.store_thm ("t_collapse_eqn",
 rw [collapse_def, t_collapse_def, t_walkstar_def, encode_infer_t_def, walkstar_def] >>
 rw [GSYM fmap_EQ_THM, FUN_FMAP_DEF]);
 
-val t_unify_unifier = store_thm("t_unify_unifier",
-  ``t_wfs s ∧ (t_unify s t1 t2 = SOME sx) ⇒ t_wfs sx ∧ s ⊑ sx ∧ (t_walkstar sx t1 = t_walkstar sx t2)``,
+val t_unify_unifier = Q.store_thm("t_unify_unifier",
+  `t_wfs s ∧ (t_unify s t1 t2 = SOME sx) ⇒ t_wfs sx ∧ s ⊑ sx ∧ (t_walkstar sx t1 = t_walkstar sx t2)`,
   simp[t_unify_def] >> strip_tac >>
   qmatch_assum_abbrev_tac`unify us ut1 ut2 = SOME uz` >>
   qspecl_then[`us`,`ut1`,`ut2`,`s`,`t1`,`t2`]mp_tac encode_unify >>
@@ -1054,17 +1054,17 @@ val t_walk_vwalk_id = store_thm ("t_walk_vwalk_id",
   >>
     fs[])
 
-val t_walk_walk_id = store_thm("t_walk_walk_id",
-``t_wfs s ⇒
-  t_walk s (t_walk s h) = t_walk s h``,
+val t_walk_walk_id = Q.store_thm("t_walk_walk_id",
+`t_wfs s ⇒
+  t_walk s (t_walk s h) = t_walk s h`,
   Cases_on`h`>>
   fs[t_walk_eqn,t_walk_vwalk_id])
 
-val eqs_t_unify = store_thm( "eqs_t_unify",
-``t_wfs s ∧ t_wfs s2 ∧
+val eqs_t_unify = Q.store_thm( "eqs_t_unify",
+`t_wfs s ∧ t_wfs s2 ∧
   t_walkstar s2 (t_walkstar s t1) = t_walkstar s2 (t_walkstar s t2)
   ⇒
-  ?sx. t_unify s t1 t2 = SOME sx``,
+  ?sx. t_unify s t1 t2 = SOME sx`,
   rw[t_unify_def] >>
   match_mp_tac (GEN_ALL eqs_unify) >>
   qexists_tac`encode_infer_t o_f s2` >>
@@ -1100,10 +1100,10 @@ val t_unify_mgu = store_thm ("t_unify_mgu",
   qpat_x_assum `decode_infer_t A = B` mp_tac>>
   fs[encode_walkstar,decode_left_inverse])
 
-val t_walkstar_tuvar_props = store_thm("t_walkstar_tuvar_props",
-``t_wfs s
+val t_walkstar_tuvar_props = Q.store_thm("t_walkstar_tuvar_props",
+`t_wfs s
   ⇒
-  (uv ∉ FDOM s ⇔  t_walkstar s (Infer_Tuvar uv) = Infer_Tuvar uv)``,
+  (uv ∉ FDOM s ⇔  t_walkstar s (Infer_Tuvar uv) = Infer_Tuvar uv)`,
   rw[EQ_IMP_THM]
   >-
     (fs[t_walkstar_eqn,t_walk_eqn,Once t_vwalk_eqn]>>
@@ -1119,16 +1119,16 @@ val t_compat_def = Define`
   t_wfs s ∧ t_wfs s' ∧
   !t. t_walkstar s' (t_walkstar s t) = t_walkstar s' t`
 
-val t_compat_refl = store_thm("t_compat_refl",
-``t_wfs s ⇒ t_compat s s``,
+val t_compat_refl = Q.store_thm("t_compat_refl",
+`t_wfs s ⇒ t_compat s s`,
   rw[t_compat_def]>>fs[t_walkstar_SUBMAP])
 
-val t_compat_trans = store_thm("t_compat_trans",
-``t_compat a b ∧ t_compat b c ⇒ t_compat a c``,
+val t_compat_trans = Q.store_thm("t_compat_trans",
+`t_compat a b ∧ t_compat b c ⇒ t_compat a c`,
   rw[t_compat_def]>>metis_tac[])
 
-val SUBMAP_t_compat = store_thm("SUBMAP_t_compat",
-``t_wfs s' ∧ s SUBMAP s' ⇒ t_compat s s'``,
+val SUBMAP_t_compat = Q.store_thm("SUBMAP_t_compat",
+`t_wfs s' ∧ s SUBMAP s' ⇒ t_compat s s'`,
   rw[t_compat_def]
   >-
     metis_tac[t_wfs_SUBMAP]>>
@@ -1136,11 +1136,11 @@ val SUBMAP_t_compat = store_thm("SUBMAP_t_compat",
 
 (*t_compat is preserved under certain types of unification
   Proof basically from HOL*)
-val t_compat_eqs_t_unify = store_thm("t_compat_eqs_t_unify",
-``!s t1 t2 sx.
+val t_compat_eqs_t_unify = Q.store_thm("t_compat_eqs_t_unify",
+`!s t1 t2 sx.
     t_compat s sx ∧ (t_walkstar sx t1 = t_walkstar sx t2)
     ⇒
-    ?si. (t_unify s t1 t2 = SOME si) ∧ t_compat si sx``,
+    ?si. (t_unify s t1 t2 = SOME si) ∧ t_compat si sx`,
   rw[t_compat_def]>>
   Q.ISPECL_THEN [`t2`,`t1`,`sx`,`s`] assume_tac (GEN_ALL eqs_t_unify)>>
   rfs[]>>

--- a/compiler/parsing/cmlPEGScript.sml
+++ b/compiler/parsing/cmlPEGScript.sml
@@ -510,8 +510,8 @@ val _ = computeLib.add_persistent_funs ["cmlPEG_exec_thm"]
 
 val test1 = time EVAL ``peg_exec cmlPEG (pnt nErel) [IntT 3; StarT; IntT 4; SymbolT "/"; IntT (-2); SymbolT ">"; AlphaT "x"] [] done failed``
 
-val frange_image = prove(
-  ``FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)``,
+val frange_image = Q.prove(
+  `FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)`,
   simp[finite_mapTheory.FRANGE_DEF, pred_setTheory.EXTENSION] >> metis_tac[]);
 
 val peg_range =
@@ -569,7 +569,7 @@ val pegnt_case_ths = peg0_cases
 
 fun pegnt(t,acc) = let
   val th =
-      prove(``¬peg0 cmlPEG (pnt ^t)``,
+      Q.prove(`¬peg0 cmlPEG (pnt ^t)`,
             simp(pegnt_case_ths @ cmlpeg_rules_applied @
                  [FDOM_cmlPEG, peg_V_def, peg_UQConstructorName_def,
                   peg_StructName_def,
@@ -657,7 +657,7 @@ val peg0_tokeq = Store_thm(
 
 fun wfnt(t,acc) = let
   val th =
-    prove(``wfpeg cmlPEG (pnt ^t)``,
+    Q.prove(`wfpeg cmlPEG (pnt ^t)`,
           SIMP_TAC (srw_ss())
                    (cmlpeg_rules_applied @
                     [wfpeg_pnt, FDOM_cmlPEG, try_def, peg_longV_def,
@@ -702,8 +702,8 @@ set_diff (TypeBase.constructors_of ``:MMLnonT``)
                       ``nDtypeCons``])
 *)
 
-val subexprs_pnt = prove(
-  ``subexprs (pnt n) = {pnt n}``,
+val subexprs_pnt = Q.prove(
+  `subexprs (pnt n) = {pnt n}`,
   simp[subexprs_def, pnt_def]);
 
 val PEG_exprs = save_thm(
@@ -718,9 +718,9 @@ val PEG_exprs = save_thm(
           pred_setTheory.INSERT_UNION_EQ
          ])
 
-val PEG_wellformed = store_thm(
+val PEG_wellformed = Q.store_thm(
   "PEG_wellformed",
-  ``wfG cmlPEG``,
+  `wfG cmlPEG`,
   simp[wfG_def, Gexprs_def, subexprs_def,
        subexprs_pnt, peg_start, peg_range, DISJ_IMP_THM, FORALL_AND_THM,
        choicel_def, seql_def, pegf_def, tokeq_def, try_def,
@@ -754,7 +754,7 @@ local
   val nts = recurse [] r
 in
 val FDOM_cmlPEG_nts = let
-  fun p t = prove(``^t ∈ FDOM cmlPEG.rules``, simp[FDOM_cmlPEG])
+  fun p t = Q.prove(`^t ∈ FDOM cmlPEG.rules`, simp[FDOM_cmlPEG])
 in
   save_thm("FDOM_cmlPEG_nts", LIST_CONJ (map p nts)) before
   export_rewrites ["FDOM_cmlPEG_nts"]

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -50,10 +50,10 @@ val strip_sxcons_11 = Q.store_thm("strip_sxcons_11",
   \\ simp[Once simpleSexpTheory.strip_sxcons_def]
   \\ CASE_TAC \\ fs[] \\ strip_tac \\ rveq \\ fs[]);
 
-val dstrip_sexp_size = store_thm(
+val dstrip_sexp_size = Q.store_thm(
   "dstrip_sexp_size",
-  ``∀s sym args. dstrip_sexp s = SOME (sym, args) ⇒
-                 ∀e. MEM e args ⇒ sexp_size e < sexp_size s``,
+  `∀s sym args. dstrip_sexp s = SOME (sym, args) ⇒
+                 ∀e. MEM e args ⇒ sexp_size e < sexp_size s`,
   Induct >> simp[dstrip_sexp_def, sexp_size_def] >>
   rename1 `sexp_CASE sxp` >> Cases_on `sxp` >> simp[] >> rpt strip_tac >>
   rename1 `MEM sxp0 sxpargs` >> rename1 `strip_sxcons sxp'` >>

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -159,12 +159,12 @@ val decode_encode_control = Q.store_thm("decode_encode_control[simp]",
   \\ first_x_assum(CHANGED_TAC o SUBST1_TAC o SYM)
   \\ simp[stringTheory.CHR_ORD])
 
-val isHexDigit_alt = prove(
-  ``isHexDigit c ⇔ c ∈ set "0123456789abcdefABCDEF"``,
+val isHexDigit_alt = Q.prove(
+  `isHexDigit c ⇔ c ∈ set "0123456789abcdefABCDEF"`,
   rw[stringTheory.isHexDigit_def, EQ_IMP_THM] >> CONV_TAC EVAL >> simp[]);
 
-val UNHEX_lt16 = prove(
-  ``isHexDigit c ⇒ UNHEX c < 16``,
+val UNHEX_lt16 = Q.prove(
+  `isHexDigit c ⇒ UNHEX c < 16`,
   dsimp[isHexDigit_alt, ASCIInumbersTheory.UNHEX_def]);
 
 val isAlpha_isUpper_isLower = Q.store_thm(
@@ -308,41 +308,41 @@ val sexppair_def = Define`
     | _ => fail
 `;
 
-val sexppair_CONG = store_thm(
+val sexppair_CONG = Q.store_thm(
   "sexppair_CONG[defncong]",
-  ``∀s1 s2 p1 p1' p2 p2'.
+  `∀s1 s2 p1 p1' p2 p2'.
        s1 = s2 ∧
        (∀s. (∃s'. s2 = SX_CONS s s') ⇒ p1 s = p1' s) ∧
        (∀s. (∃s'. s2 = SX_CONS s' s) ⇒ p2 s = p2' s)
       ⇒
-       sexppair p1 p2 s1 = sexppair p1' p2' s2``,
+       sexppair p1 p2 s1 = sexppair p1' p2' s2`,
   simp[] >> Cases >> simp[sexppair_def])
 
 
-val strip_sxcons_FAIL_sexplist_FAIL = store_thm(
+val strip_sxcons_FAIL_sexplist_FAIL = Q.store_thm(
   "strip_sxcons_FAIL_sexplist_FAIL",
-  ``∀s. (strip_sxcons s = NONE) ⇒ (sexplist p s = NONE)``,
+  `∀s. (strip_sxcons s = NONE) ⇒ (sexplist p s = NONE)`,
   Induct >> simp[Once strip_sxcons_def, Once sexplist_def] >>
   metis_tac[TypeBase.nchotomy_of ``:α option``]);
 
-val monad_bind_FAIL = store_thm(
+val monad_bind_FAIL = Q.store_thm(
   "monad_bind_FAIL",
-  ``monad_bind m1 (λx. fail) = fail``,
+  `monad_bind m1 (λx. fail) = fail`,
   Cases_on `m1` >> simp[]);
 
-val monad_unitbind_CONG = store_thm(
+val monad_unitbind_CONG = Q.store_thm(
   "monad_unitbind_CONG[defncong]",
-  ``∀m11 m21 m12 m22.
+  `∀m11 m21 m12 m22.
       m11 = m12 ∧ (m12 = SOME () ⇒ m21 = m22) ⇒
-      monad_unitbind m11 m21 = monad_unitbind m12 m22``,
+      monad_unitbind m11 m21 = monad_unitbind m12 m22`,
   simp[] >> rpt gen_tac >> rename1 `m12 = SOME ()` >>
   Cases_on `m12` >> simp[]);
 
-val sexplist_CONG = store_thm(
+val sexplist_CONG = Q.store_thm(
   "sexplist_CONG[defncong]",
-  ``∀s1 s2 p1 p2.
+  `∀s1 s2 p1 p2.
       (s1 = s2) ∧ (∀e. sxMEM e s2 ⇒ p1 e = p2 e) ⇒
-      (sexplist p1 s1 = sexplist p2 s2)``,
+      (sexplist p1 s1 = sexplist p2 s2)`,
   simp[sxMEM_def] >> Induct >> dsimp[Once strip_sxcons_def]
   >- (ONCE_REWRITE_TAC [sexplist_def] >> simp[] >>
       rename1 `strip_sxcons t` >> Cases_on `strip_sxcons t` >>

--- a/compiler/parsing/lexer_implScript.sml
+++ b/compiler/parsing/lexer_implScript.sml
@@ -213,22 +213,22 @@ val next_sym_alt_def = tDefine "next_sym_alt"`
    THEN IMP_RES_TAC skip_comment_thm THEN Cases_on `str`
    THEN FULL_SIMP_TAC (srw_ss()) [LENGTH] THEN DECIDE_TAC)
 
-val EVERY_isDigit_imp = prove(``
+val EVERY_isDigit_imp = Q.prove(`
   EVERY isDigit x ⇒
-  MAP UNHEX x = MAP unhex_alt x``,
+  MAP UNHEX x = MAP unhex_alt x`,
   rw[]>>match_mp_tac LIST_EQ>>fs[EL_MAP,EVERY_EL,unhex_alt_def])
 
-val toNum_rw = prove(``
+val toNum_rw = Q.prove(`
   ∀x. EVERY isDigit x ⇒
-  toNum x = num_from_dec_string_alt x``,
+  toNum x = num_from_dec_string_alt x`,
   rw[ASCIInumbersTheory.s2n_def,ASCIInumbersTheory.num_from_dec_string_def,num_from_dec_string_alt_def]>>
   AP_TERM_TAC>>
   match_mp_tac EVERY_isDigit_imp>>
   metis_tac[rich_listTheory.EVERY_REVERSE])
 
-val EVERY_IMPLODE = prove(``
+val EVERY_IMPLODE = Q.prove(`
   ∀ls P.
-  EVERY P (IMPLODE ls) ⇔ EVERY P ls``,
+  EVERY P (IMPLODE ls) ⇔ EVERY P ls`,
   Induct>>fs[])
 
 val read_while_P_lem = prove(``
@@ -248,8 +248,8 @@ val read_while_P = prove(``
   rw[]>>ho_match_mp_tac read_while_P_lem>>
   MAP_EVERY qexists_tac [`ls`,`""`,`y`]>>fs[])
 
-val next_sym_eq = store_thm("next_sym_eq",
-  ``∀x. next_sym x = next_sym_alt x``,
+val next_sym_eq = Q.store_thm("next_sym_eq",
+  `∀x. next_sym x = next_sym_alt x`,
   ho_match_mp_tac next_sym_ind>>fs[next_sym_def,next_sym_alt_def]>>rw[]>>
   TRY(BasicProvers.TOP_CASE_TAC>>fs[]>>NO_TAC)>>
   TRY(rpt(pop_assum mp_tac)>> EVAL_TAC>> simp[]>>NO_TAC)>>
@@ -361,14 +361,14 @@ val lex_until_top_semicolon_alt_LESS = store_thm(
   THEN REPEAT STRIP_TAC THEN IMP_RES_TAC lex_aux_alt_LESS
   THEN FULL_SIMP_TAC std_ss []);
 
-val token_of_sym_EQ_LEMMA = prove(
-  ``((token_of_sym q = LetT) = (q = OtherS "let")) /\
+val token_of_sym_EQ_LEMMA = Q.prove(
+  `((token_of_sym q = LetT) = (q = OtherS "let")) /\
     ((token_of_sym q = EndT) = (q = OtherS "end")) /\
     ((token_of_sym q = SigT) = (q = OtherS "sig")) /\
     ((token_of_sym q = StructT) = (q = OtherS "struct")) /\
     ((token_of_sym q = SemicolonT) = (q = OtherS ";")) /\
     ((token_of_sym q = RparT) = (q = OtherS ")")) /\
-    ((token_of_sym q = LparT) = (q = OtherS "("))``,
+    ((token_of_sym q = LparT) = (q = OtherS "("))`,
   REPEAT STRIP_TAC
   THEN SIMP_TAC std_ss [token_of_sym_def,get_token_def,processIdent_def,LET_DEF]
   THEN BasicProvers.FULL_CASE_TAC THEN SRW_TAC [] []
@@ -479,9 +479,9 @@ val lex_aux_tokens_thm = prove(
   >> SRW_TAC [] [] >> SRW_TAC [] []
   >> ASM_SIMP_TAC std_ss [GSYM lexer_fun_def]) |> SIMP_RULE std_ss [];
 
-val lex_impl_all_tokens_thm = prove(
-  ``!input. lex_impl_all input =
-            lex_impl_all_tokens (lexer_fun input)``,
+val lex_impl_all_tokens_thm = Q.prove(
+  `!input. lex_impl_all input =
+            lex_impl_all_tokens (lexer_fun input)`,
   HO_MATCH_MP_TAC (fetch "-" "lex_impl_all_ind") >> REPEAT STRIP_TAC
   >> SIMP_TAC std_ss [Once lex_impl_all_def,Once lex_impl_all_tokens_def]
   >> FULL_SIMP_TAC std_ss [lex_until_toplevel_semicolon_tokens_def]
@@ -517,8 +517,8 @@ val lex_aux_tokens_thm = prove(
   >> FULL_SIMP_TAC (srw_ss()) [LENGTH,arithmeticTheory.ADD1])
   |> Q.SPECL [`input`,`0`,`[]`] |> Q.GEN `res` |> SIMP_RULE std_ss [LENGTH];
 
-val split_top_level_semi_thm = prove(
-  ``!input. split_top_level_semi input = lex_impl_all_tokens input``,
+val split_top_level_semi_thm = Q.prove(
+  `!input. split_top_level_semi input = lex_impl_all_tokens input`,
   HO_MATCH_MP_TAC split_top_level_semi_ind >> REPEAT STRIP_TAC
   >> SIMP_TAC std_ss [Once split_top_level_semi_def,Once lex_impl_all_tokens_def,
       Once lex_until_toplevel_semicolon_tokens_def]
@@ -529,8 +529,8 @@ val split_top_level_semi_thm = prove(
   >> STRIP_TAC >> RES_TAC >> POP_ASSUM MP_TAC
   >> FULL_SIMP_TAC std_ss [TAKE_LENGTH_APPEND,DROP_LENGTH_APPEND]);
 
-val lexer_correct = store_thm("lexer_correct",
-  ``!input. split_top_level_semi (lexer_fun input) = lex_impl_all input``,
+val lexer_correct = Q.store_thm("lexer_correct",
+  `!input. split_top_level_semi (lexer_fun input) = lex_impl_all input`,
   SIMP_TAC std_ss [lex_impl_all_tokens_thm,split_top_level_semi_thm]);
 
 val _ = export_theory();

--- a/compiler/parsing/lexer_implScript.sml
+++ b/compiler/parsing/lexer_implScript.sml
@@ -231,20 +231,20 @@ val EVERY_IMPLODE = Q.prove(`
   EVERY P (IMPLODE ls) ⇔ EVERY P ls`,
   Induct>>fs[])
 
-val read_while_P_lem = prove(``
+val read_while_P_lem = Q.prove(`
   ∀ls rest P x y.
   EVERY P rest ∧
   read_while P ls rest = (x,y) ⇒
-  EVERY P x``,
+  EVERY P x`,
   Induct>>fs[read_while_def]>>rw[]>>
   fs[EVERY_IMPLODE,rich_listTheory.EVERY_REVERSE]>>
   first_assum match_mp_tac>>fs[]>>
   qexists_tac`STRING h rest`>>fs[])
 
-val read_while_P = prove(``
+val read_while_P = Q.prove(`
   ∀ls P x y.
   read_while P ls "" = (x,y) ⇒
-  EVERY P x``,
+  EVERY P x`,
   rw[]>>ho_match_mp_tac read_while_P_lem>>
   MAP_EVERY qexists_tac [`ls`,`""`,`y`]>>fs[])
 
@@ -284,11 +284,11 @@ val lex_aux_def = tDefine "lex_aux" `
 val lex_until_toplevel_semicolon_def = Define `
   lex_until_toplevel_semicolon input = lex_aux [] 0 input`;
 
-val lex_aux_LESS = prove(
-  ``!acc d input.
+val lex_aux_LESS = Q.prove(
+  `!acc d input.
       (lex_aux acc d input = SOME (ts, rest)) ==>
       if acc = [] then LENGTH rest < LENGTH input
-                  else LENGTH rest <= LENGTH input``,
+                  else LENGTH rest <= LENGTH input`,
   HO_MATCH_MP_TAC (fetch "-" "lex_aux_ind")
   THEN REPEAT STRIP_TAC THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [lex_aux_def]
@@ -302,10 +302,10 @@ val lex_aux_LESS = prove(
   THEN IMP_RES_TAC (DECIDE ``n < m ==> n <= m:num``)
   THEN DECIDE_TAC);
 
-val lex_until_toplevel_semicolon_LESS = store_thm(
+val lex_until_toplevel_semicolon_LESS = Q.store_thm(
   "lex_until_toplevel_semicolon_LESS",
-  ``(lex_until_toplevel_semicolon input = SOME (ts,rest)) ==>
-    LENGTH rest < LENGTH input``,
+  `(lex_until_toplevel_semicolon input = SOME (ts,rest)) ==>
+    LENGTH rest < LENGTH input`,
   SIMP_TAC std_ss [lex_until_toplevel_semicolon_def]
   THEN REPEAT STRIP_TAC THEN IMP_RES_TAC lex_aux_LESS
   THEN FULL_SIMP_TAC std_ss []);
@@ -335,11 +335,11 @@ val lex_aux_alt_def = tDefine "lex_aux_alt" `
 val lex_until_top_semicolon_alt_def = Define `
   lex_until_top_semicolon_alt input = lex_aux_alt [] 0 input`
 
-val lex_aux_alt_LESS = prove(
-  ``!acc d input.
+val lex_aux_alt_LESS = Q.prove(
+  `!acc d input.
       (lex_aux_alt acc d input = SOME (ts, rest)) ==>
       if acc = [] then LENGTH rest < LENGTH input
-                  else LENGTH rest <= LENGTH input``,
+                  else LENGTH rest <= LENGTH input`,
   HO_MATCH_MP_TAC (fetch "-" "lex_aux_alt_ind")
   THEN REPEAT STRIP_TAC THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [lex_aux_alt_def]
@@ -353,10 +353,10 @@ val lex_aux_alt_LESS = prove(
   THEN IMP_RES_TAC (DECIDE ``n < m ==> n <= m:num``)
   THEN DECIDE_TAC);
 
-val lex_until_top_semicolon_alt_LESS = store_thm(
+val lex_until_top_semicolon_alt_LESS = Q.store_thm(
   "lex_until_top_semicolon_alt_LESS",
-  ``(lex_until_top_semicolon_alt input = SOME (ts,rest)) ==>
-    LENGTH rest < LENGTH input``,
+  `(lex_until_top_semicolon_alt input = SOME (ts,rest)) ==>
+    LENGTH rest < LENGTH input`,
   SIMP_TAC std_ss [lex_until_top_semicolon_alt_def]
   THEN REPEAT STRIP_TAC THEN IMP_RES_TAC lex_aux_alt_LESS
   THEN FULL_SIMP_TAC std_ss []);
@@ -376,12 +376,12 @@ val token_of_sym_EQ_LEMMA = Q.prove(
   THEN BasicProvers.FULL_CASE_TAC THEN SRW_TAC [] []
   THEN CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV) THEN SRW_TAC [] []);
 
-val lex_aux_alt_thm = prove(
-  ``!acc d input.
+val lex_aux_alt_thm = Q.prove(
+  `!acc d input.
       case lex_aux_alt acc d input of
       | NONE => (lex_aux (MAP token_of_sym acc) d input = NONE)
       | SOME (ts,rest) => (lex_aux (MAP token_of_sym acc) d input =
-                           SOME (MAP token_of_sym ts,rest))``,
+                           SOME (MAP token_of_sym ts,rest))`,
   HO_MATCH_MP_TAC (fetch "-" "lex_aux_alt_ind") THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [lex_aux_alt_def,lex_aux_def]
   THEN SIMP_TAC std_ss [next_token_def]
@@ -392,12 +392,12 @@ val lex_aux_alt_thm = prove(
   THEN FULL_SIMP_TAC (srw_ss()) [token_of_sym_def,get_token_def])
   |> Q.SPECL [`[]`,`0`] |> SIMP_RULE std_ss [MAP];
 
-val lex_until_top_semicolon_alt_thm = store_thm(
+val lex_until_top_semicolon_alt_thm = Q.store_thm(
   "lex_until_top_semicolon_alt_thm",
-  ``case lex_until_top_semicolon_alt input of
+  `case lex_until_top_semicolon_alt input of
     | NONE => (lex_until_toplevel_semicolon input = NONE)
     | SOME (ts,rest) =>
-        (lex_until_toplevel_semicolon input = SOME (MAP token_of_sym ts,rest))``,
+        (lex_until_toplevel_semicolon input = SOME (MAP token_of_sym ts,rest))`,
   SIMP_TAC std_ss [lex_until_top_semicolon_alt_def,
     lex_until_toplevel_semicolon_def,lex_aux_alt_thm]);
 
@@ -438,11 +438,11 @@ val lex_aux_tokens_def = Define `
 val lex_until_toplevel_semicolon_tokens_def = Define `
   lex_until_toplevel_semicolon_tokens input = lex_aux_tokens [] 0 input`;
 
-val lex_aux_tokens_LESS = prove(
-  ``!acc d input.
+val lex_aux_tokens_LESS = Q.prove(
+  `!acc d input.
       (lex_aux_tokens acc d input = SOME (t,rest)) ==>
       (if acc = [] then LENGTH rest < LENGTH input
-                   else LENGTH rest <= LENGTH input)``,
+                   else LENGTH rest <= LENGTH input)`,
   Induct_on `input`
   THEN1 (EVAL_TAC >> SRW_TAC [] [LENGTH] >> SRW_TAC [] [LENGTH])
   >> SIMP_TAC (srw_ss()) [Once lex_aux_tokens_def,LET_DEF]
@@ -462,12 +462,12 @@ val lex_impl_all_tokens_def = tDefine "lex_impl_all_tokens" `
    >> SIMP_TAC std_ss [lex_until_toplevel_semicolon_tokens_def]
    >> METIS_TAC [lex_aux_tokens_LESS])
 
-val lex_aux_tokens_thm = prove(
-  ``!input acc d res1 res2.
+val lex_aux_tokens_thm = Q.prove(
+  `!input acc d res1 res2.
       (lex_aux_tokens acc d (lexer_fun input) = res1) /\
       (lex_aux acc d input = res2) ==>
       (case res2 of NONE => (res1 = NONE)
-                  | SOME (ts,rest) => (res1 = SOME (ts,lexer_fun rest)))``,
+                  | SOME (ts,rest) => (res1 = SOME (ts,lexer_fun rest)))`,
   HO_MATCH_MP_TAC lexer_fun_ind >> SIMP_TAC std_ss []
   >> REPEAT STRIP_TAC >> SIMP_TAC std_ss [Once lex_aux_def]
   >> ONCE_REWRITE_TAC [lexer_fun_def]
@@ -491,14 +491,14 @@ val lex_impl_all_tokens_thm = Q.prove(
   >> Cases_on `x` >> FULL_SIMP_TAC (srw_ss()) []
   >> REPEAT STRIP_TAC >> RES_TAC);
 
-val lex_aux_tokens_thm = prove(
-  ``!input d acc.
+val lex_aux_tokens_thm = Q.prove(
+  `!input d acc.
       (res = lex_aux_tokens acc d input) ==>
       case res of
         NONE => (toplevel_semi_dex (LENGTH acc) d input = NONE)
       | SOME (toks,rest) =>
           (toplevel_semi_dex (LENGTH acc) d input = SOME (LENGTH toks)) /\
-          (REVERSE acc ++ input = toks ++ rest)``,
+          (REVERSE acc ++ input = toks ++ rest)`,
   Induct
   >> SIMP_TAC (srw_ss()) [Once lex_aux_tokens_def]
   >> ONCE_REWRITE_TAC [toplevel_semi_dex_def]

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -12,8 +12,8 @@ val _ = new_theory "pegComplete"
 val _ = set_trace "Goalstack.print_goal_at_top" 0
 
 
-val MAP_EQ_CONS = prove(
-  ``MAP f l = h::t <=> ∃h0 t0. l = h0::t0 ∧ f h0 = h ∧ MAP f t0 = t``,
+val MAP_EQ_CONS = Q.prove(
+  `MAP f l = h::t <=> ∃h0 t0. l = h0::t0 ∧ f h0 = h ∧ MAP f t0 = t`,
   metis_tac[MAP_EQ_CONS])
 
 fun FIXEQ_CONV t = let
@@ -95,10 +95,10 @@ val peg_eval_choice_NONE =
   ``peg_eval G (i, choice s1 s2 f) NONE``
     |> SIMP_CONV (srw_ss()) [Once peg_eval_cases]
 
-val disjImpI = prove(``~p \/ q ⇔ p ⇒ q``, DECIDE_TAC)
+val disjImpI = Q.prove(`~p \/ q ⇔ p ⇒ q`, DECIDE_TAC)
 
-val ptree_head_eq_tok0 = prove(
-  ``(ptree_head pt = TOK tk) ⇔ (pt = Lf (TOK tk))``,
+val ptree_head_eq_tok0 = Q.prove(
+  `(ptree_head pt = TOK tk) ⇔ (pt = Lf (TOK tk))`,
   Cases_on `pt` >> simp[]);
 val ptree_head_eq_tok = save_thm(
   "ptree_head_eq_tok",
@@ -107,22 +107,22 @@ val ptree_head_eq_tok = save_thm(
 val _ = export_rewrites ["ptree_head_eq_tok"]
 
 open NTpropertiesTheory
-val firstSet_nUQTyOp = store_thm(
+val firstSet_nUQTyOp = Q.store_thm(
   "firstSet_nUQTyOp[simp]",
-  ``firstSet cmlG (NN nUQTyOp::rest) = {AlphaT s | T} ∪ {SymbolT s | T}``,
+  `firstSet cmlG (NN nUQTyOp::rest) = {AlphaT s | T} ∪ {SymbolT s | T}`,
   simp[Once firstSet_NT, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nTyOp = store_thm(
+val firstSet_nTyOp = Q.store_thm(
   "firstSet_nTyOp[simp]",
-  ``firstSet cmlG (NN nTyOp :: rest) =
-      {AlphaT s | T} ∪ {SymbolT s | T} ∪ {LongidT s1 s2 | T}``,
+  `firstSet cmlG (NN nTyOp :: rest) =
+      {AlphaT s | T} ∪ {SymbolT s | T} ∪ {LongidT s1 s2 | T}`,
   simp[Once firstSet_NT, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nTyVarList = store_thm(
+val firstSet_nTyVarList = Q.store_thm(
   "firstSet_nTyVarList[simp]",
-  ``firstSet cmlG [NT (mkNT nTyVarList)] = { TyvarT s | T }``,
+  `firstSet cmlG [NT (mkNT nTyVarList)] = { TyvarT s | T }`,
   simp[firstSetML_eqn] >> simp[firstSetML_def] >>
   simp[cmlG_applied, cmlG_FDOM] >> simp[firstSetML_def] >>
   simp[cmlG_applied, cmlG_FDOM] >>
@@ -132,119 +132,119 @@ val _ =
     firstSetML_def |> CONJUNCTS |> (fn l => List.take(l,2)) |> rewrites
                    |> (fn ss => augment_srw_ss [ss])
 
-val firstSet_nLetDec = store_thm(
+val firstSet_nLetDec = Q.store_thm(
   "firstSet_nLetDec[simp]",
-  ``firstSet cmlG [NT (mkNT nLetDec)] = {ValT; FunT}``,
+  `firstSet cmlG [NT (mkNT nLetDec)] = {ValT; FunT}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_FDOM,
        cmlG_applied, INSERT_UNION_EQ]);
 
-val firstSet_nLetDecs = store_thm(
+val firstSet_nLetDecs = Q.store_thm(
   "firstSet_nLetDecs[simp]",
-  ``firstSet cmlG [NT (mkNT nLetDecs)] = {ValT; FunT; SemicolonT}``,
+  `firstSet cmlG [NT (mkNT nLetDecs)] = {ValT; FunT; SemicolonT}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_FDOM,
        cmlG_applied] >>
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied, INSERT_UNION_EQ]);
 
-val firstSet_nTypeDec = store_thm(
+val firstSet_nTypeDec = Q.store_thm(
   "firstSet_nTypeDec[simp]",
-  ``firstSet cmlG [NT (mkNT nTypeDec)] = {DatatypeT}``,
+  `firstSet cmlG [NT (mkNT nTypeDec)] = {DatatypeT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied]);
 
-val firstSet_nTypeAbbrevDec = store_thm(
+val firstSet_nTypeAbbrevDec = Q.store_thm(
   "firstSet_nTypeAbbrevDec[simp]",
-  ``firstSet cmlG [NT (mkNT nTypeAbbrevDec)] = {TypeT}``,
+  `firstSet cmlG [NT (mkNT nTypeAbbrevDec)] = {TypeT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied])
 
-val firstSet_nDecl = store_thm(
+val firstSet_nDecl = Q.store_thm(
   "firstSet_nDecl[simp]",
-  ``firstSet cmlG [NT (mkNT nDecl)] =
-      {ValT; FunT; DatatypeT;ExceptionT;TypeT}``,
+  `firstSet cmlG [NT (mkNT nDecl)] =
+      {ValT; FunT; DatatypeT;ExceptionT;TypeT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied,
        INSERT_UNION_EQ]);
 
-val firstSet_nDecls = store_thm(
+val firstSet_nDecls = Q.store_thm(
   "firstSet_nDecls[simp]",
-  ``firstSet cmlG [NN nDecls] =
-      {ValT; DatatypeT; FunT; SemicolonT; ExceptionT; TypeT}``,
+  `firstSet cmlG [NN nDecls] =
+      {ValT; DatatypeT; FunT; SemicolonT; ExceptionT; TypeT}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   ONCE_REWRITE_TAC [firstSetML_def] >>
   simp[cmlG_applied, cmlG_FDOM, INSERT_UNION_EQ, INSERT_COMM]);
 
-val firstSet_nMultOps = store_thm(
+val firstSet_nMultOps = Q.store_thm(
   "firstSet_nMultOps[simp]",
-  ``firstSet cmlG (NT (mkNT nMultOps)::rest) =
-      {AlphaT "div"; AlphaT"mod"; StarT; SymbolT "/"}``,
+  `firstSet cmlG (NT (mkNT nMultOps)::rest) =
+      {AlphaT "div"; AlphaT"mod"; StarT; SymbolT "/"}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_FDOM, cmlG_applied,
        INSERT_UNION_EQ]);
 
-val firstSet_nRelOps = store_thm(
+val firstSet_nRelOps = Q.store_thm(
   "firstSet_nRelOps[simp]",
-  ``firstSet cmlG (NT (mkNT nRelOps)::rest) =
+  `firstSet cmlG (NT (mkNT nRelOps)::rest) =
       {SymbolT "<"; SymbolT ">"; SymbolT "<="; SymbolT ">="; SymbolT "<>";
-       EqualsT}``,
+       EqualsT}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nAddOps = store_thm(
+val firstSet_nAddOps = Q.store_thm(
   "firstSet_nAddOps[simp]",
-  ``firstSet cmlG (NT (mkNT nAddOps)::rest) = {SymbolT "+"; SymbolT "-"}``,
+  `firstSet cmlG (NT (mkNT nAddOps)::rest) = {SymbolT "+"; SymbolT "-"}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_applied, cmlG_FDOM,
        INSERT_UNION_EQ]);
 
-val firstSet_nCompOps = store_thm(
+val firstSet_nCompOps = Q.store_thm(
   "firstSet_nCompOps[simp]",
-  ``firstSet cmlG (NT (mkNT nCompOps)::rest) = {AlphaT "o"; SymbolT ":="}``,
+  `firstSet cmlG (NT (mkNT nCompOps)::rest) = {AlphaT "o"; SymbolT ":="}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_FDOM, cmlG_applied,
        INSERT_UNION_EQ])
 
-val firstSet_nListOps = store_thm(
+val firstSet_nListOps = Q.store_thm(
   "firstSet_nListOps[simp]",
-  ``firstSet cmlG (NT (mkNT nListOps)::rest) = {SymbolT "::"; SymbolT "@"}``,
+  `firstSet cmlG (NT (mkNT nListOps)::rest) = {SymbolT "::"; SymbolT "@"}`,
   simp[firstSetML_eqn, Once firstSetML_def, cmlG_FDOM, cmlG_applied,
        INSERT_UNION_EQ, INSERT_COMM])
 
-val firstSet_nUQTyOp = store_thm(
+val firstSet_nUQTyOp = Q.store_thm(
   "firstSet_nUQTyOp",
-  ``firstSet cmlG [NT (mkNT nUQTyOp)] = { AlphaT l | T } ∪ { SymbolT l | T }``,
+  `firstSet cmlG [NT (mkNT nUQTyOp)] = { AlphaT l | T } ∪ { SymbolT l | T }`,
   dsimp[EXTENSION, EQ_IMP_THM, firstSet_def] >> rpt conj_tac >>
   simp[Once relationTheory.RTC_CASES1, cmlG_applied, cmlG_FDOM] >>
   dsimp[]);
 
-val firstSet_nStructure = store_thm(
+val firstSet_nStructure = Q.store_thm(
   "firstSet_nStructure[simp]",
-  ``firstSet cmlG [NT (mkNT nStructure)] = {StructureT}``,
+  `firstSet cmlG [NT (mkNT nStructure)] = {StructureT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied]);
 
 
-val firstSet_nTopLevelDec = store_thm(
+val firstSet_nTopLevelDec = Q.store_thm(
   "firstSet_nTopLevelDec[simp]",
-  ``firstSet cmlG [NT (mkNT nTopLevelDec)] =
-    {ValT; FunT; DatatypeT; StructureT; ExceptionT; TypeT}``,
+  `firstSet cmlG [NT (mkNT nTopLevelDec)] =
+    {ValT; FunT; DatatypeT; StructureT; ExceptionT; TypeT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied, INSERT_UNION_EQ, INSERT_COMM]);
 
-val firstSet_nSpecLine = store_thm(
+val firstSet_nSpecLine = Q.store_thm(
   "firstSet_nSpecLine[simp]",
-  ``firstSet cmlG [NT (mkNT nSpecLine)] = {ValT; DatatypeT; TypeT; ExceptionT}``,
+  `firstSet cmlG [NT (mkNT nSpecLine)] = {ValT; DatatypeT; TypeT; ExceptionT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied, INSERT_UNION_EQ, INSERT_COMM]);
 
-val firstSet_nSpecLineList = store_thm(
+val firstSet_nSpecLineList = Q.store_thm(
   "firstSet_nSpecLineList[simp]",
-  ``firstSet cmlG [NT (mkNT nSpecLineList)] =
-      {ValT; DatatypeT; TypeT; SemicolonT; ExceptionT}``,
+  `firstSet cmlG [NT (mkNT nSpecLineList)] =
+      {ValT; DatatypeT; TypeT; SemicolonT; ExceptionT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied,
        INSERT_UNION_EQ, INSERT_COMM]);
 
-val firstSet_nV = store_thm(
+val firstSet_nV = Q.store_thm(
   "firstSet_nV",
-  ``firstSet cmlG (NN nV:: rest) =
+  `firstSet cmlG (NN nV:: rest) =
       { AlphaT s | s ≠ "" ∧ ¬isUpper (HD s) ∧ s ≠ "before" ∧ s ≠ "div" ∧
                    s ≠ "mod" ∧ s ≠ "o" ∧ s ≠ "true" ∧ s ≠ "false" ∧ s ≠ "ref" ∧
                    s ≠ "nil"} ∪
       { SymbolT s | s ≠ "+" ∧ s ≠ "*" ∧ s ≠ "-" ∧ s ≠ "/" ∧ s ≠ "<" ∧ s ≠ ">" ∧
                     s ≠ "<=" ∧ s ≠ ">=" ∧ s ≠ "<>" ∧ s ≠ ":=" ∧ s ≠ "::" ∧
-                    s ≠ "@"}``,
+                    s ≠ "@"}`,
   simp[Once firstSet_NT, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
@@ -267,264 +267,264 @@ val firstSet_nConstructorName = store_thm(
   ntac 2 (simp [Once firstSet_NT, cmlG_applied, cmlG_FDOM]) >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSetML_nConstructorName = store_thm(
+val firstSetML_nConstructorName = Q.store_thm(
   "firstSetML_nConstructorName[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ⇒
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ⇒
     (firstSetML cmlG sn (NN nConstructorName::rest) =
-     firstSet cmlG [NN nConstructorName])``,
+     firstSet cmlG [NN nConstructorName])`,
   simp[firstSetML_eqn] >>
   ntac 2 (simp[firstSetML_def] >> simp[cmlG_applied, cmlG_FDOM]) >>
   strip_tac >> simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[firstSetML_def]);
 
-val firstSetML_nV = store_thm(
+val firstSetML_nV = Q.store_thm(
   "firstSetML_nV[simp]",
-  ``mkNT nV ∉ sn ⇒
-    (firstSetML cmlG sn (NN nV::rest) = firstSet cmlG [NN nV])``,
+  `mkNT nV ∉ sn ⇒
+    (firstSetML cmlG sn (NN nV::rest) = firstSet cmlG [NN nV])`,
   simp[firstSetML_eqn] >> simp[firstSetML_def] >>
   simp[cmlG_FDOM, cmlG_applied] >> strip_tac >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSetML_nFQV = store_thm(
+val firstSetML_nFQV = Q.store_thm(
   "firstSetML_nFQV[simp]",
-  ``mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ⇒
-    (firstSetML cmlG sn (NN nFQV::rest) = firstSet cmlG [NN nFQV])``,
+  `mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ⇒
+    (firstSetML cmlG sn (NN nFQV::rest) = firstSet cmlG [NN nFQV])`,
   simp[firstSetML_eqn] >>
   ntac 2 (simp[firstSetML_def] >> simp[cmlG_FDOM, cmlG_applied]) >>
   strip_tac >> simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nEtuple = store_thm(
+val firstSet_nEtuple = Q.store_thm(
   "firstSet_nEtuple[simp]",
-  ``firstSet cmlG [NT (mkNT nEtuple)] = {LparT}``,
+  `firstSet cmlG [NT (mkNT nEtuple)] = {LparT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied]);
 
-val firstSet_nEbase = store_thm(
+val firstSet_nEbase = Q.store_thm(
   "firstSet_nEbase[simp]",
-  ``firstSet cmlG [NT (mkNT nEbase)] =
+  `firstSet cmlG [NT (mkNT nEbase)] =
       {LetT; LparT; LbrackT; OpT} ∪ firstSet cmlG [NT (mkNT nFQV)] ∪
       {IntT i | T} ∪ {StringT s | T} ∪ {CharT c | T} ∪
-      firstSet cmlG [NT (mkNT nConstructorName)]``,
+      firstSet cmlG [NT (mkNT nConstructorName)]`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   dsimp[Once EXTENSION] >> gen_tac >> eq_tac >> rw[] >> simp[]);
 
-val firstSetML_nEbase = store_thm(
+val firstSetML_nEbase = Q.store_thm(
   "firstSetML_nEbase[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nEbase)::rest) =
-    firstSet cmlG [NT (mkNT nEbase)]``,
+    firstSet cmlG [NT (mkNT nEbase)]`,
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM] >> strip_tac >>
   Cases_on `mkNT nEtuple ∈ sn` >>
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied] >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nEapp = store_thm(
+val firstSet_nEapp = Q.store_thm(
   "firstSet_nEapp[simp]",
-  ``firstSet cmlG [NT (mkNT nEapp)] = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG [NT (mkNT nEapp)] = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[Once firstSetML_eqn, SimpLHS] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSetML_nEapp = store_thm(
+val firstSetML_nEapp = Q.store_thm(
   "firstSetML_nEapp[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nEapp) :: rest) =
-    firstSet cmlG [NT(mkNT nEbase)]``,
+    firstSet cmlG [NT(mkNT nEbase)]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nEmult = store_thm(
+val firstSet_nEmult = Q.store_thm(
   "firstSet_nEmult[simp]",
-  ``firstSet cmlG [NT (mkNT nEmult)] = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG [NT (mkNT nEmult)] = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEmult = store_thm(
+val firstSetML_nEmult = Q.store_thm(
   "firstSetML_nEmult[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nEmult) :: rest) =
-    firstSet cmlG [NT (mkNT nEbase)]``,
+    firstSet cmlG [NT (mkNT nEbase)]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nEadd = store_thm(
+val firstSet_nEadd = Q.store_thm(
   "firstSet_nEadd[simp]",
-  ``firstSet cmlG [NT (mkNT nEadd)] = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG [NT (mkNT nEadd)] = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEadd = store_thm(
+val firstSetML_nEadd = Q.store_thm(
   "firstSetML_nEadd[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nEadd) :: rest) =
-    firstSet cmlG [NT(mkNT nEbase)]``,
+    firstSet cmlG [NT(mkNT nEbase)]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nElistop = store_thm(
+val firstSet_nElistop = Q.store_thm(
   "firstSet_nElistop[simp]",
-  ``firstSet cmlG (NT (mkNT nElistop)::rest) =
-       firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT (mkNT nElistop)::rest) =
+       firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nElistop = store_thm(
+val firstSetML_nElistop = Q.store_thm(
   "firstSetML_nElistop[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nElistop ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nElistop) :: rest) =
-    firstSet cmlG [NT(mkNT nEbase)]``,
+    firstSet cmlG [NT(mkNT nEbase)]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nErel = store_thm(
+val firstSet_nErel = Q.store_thm(
   "firstSet_nErel[simp]",
-  ``firstSet cmlG (NT(mkNT nErel)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nErel)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nErel = store_thm(
+val firstSetML_nErel = Q.store_thm(
   "firstSetML_nErel[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nErel) :: rest) = firstSet cmlG [NN nEbase]``,
+    firstSetML cmlG sn (NT (mkNT nErel) :: rest) = firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nEcomp = store_thm(
+val firstSet_nEcomp = Q.store_thm(
   "firstSet_nEcomp[simp]",
-  ``firstSet cmlG (NT(mkNT nEcomp)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nEcomp)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEcomp = store_thm(
+val firstSetML_nEcomp = Q.store_thm(
   "firstSetML_nEcomp[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nEcomp) :: rest) = firstSet cmlG [NN nEbase]``,
+    firstSetML cmlG sn (NT (mkNT nEcomp) :: rest) = firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nEbefore = store_thm(
+val firstSet_nEbefore = Q.store_thm(
   "firstSet_nEbefore[simp]",
-  ``firstSet cmlG (NT(mkNT nEbefore)::rest) =
-      firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nEbefore)::rest) =
+      firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEbefore = store_thm(
+val firstSetML_nEbefore = Q.store_thm(
   "firstSetML_nEbefore[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nEbefore)::rest) = firstSet cmlG [NN nEbase]``,
+    firstSetML cmlG sn (NT (mkNT nEbefore)::rest) = firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nEtyped = store_thm(
+val firstSet_nEtyped = Q.store_thm(
   "firstSet_nEtyped[simp]",
-  ``firstSet cmlG (NT(mkNT nEtyped)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nEtyped)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEtyped = store_thm(
+val firstSetML_nEtyped = Q.store_thm(
   "firstSetML_nEtyped[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nEtyped)::rest) = firstSet cmlG [NN nEbase]``,
+    firstSetML cmlG sn (NT (mkNT nEtyped)::rest) = firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nElogicAND = store_thm(
+val firstSet_nElogicAND = Q.store_thm(
   "firstSet_nElogicAND[simp]",
-  ``firstSet cmlG (NT(mkNT nElogicAND)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nElogicAND)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nElogicAND = store_thm(
+val firstSetML_nElogicAND = Q.store_thm(
   "firstSetML_nElogicAND[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElogicAND ∉ sn ∧
     mkNT nElistop ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nElogicAND)::rest) =
-      firstSet cmlG [NN nEbase]``,
+      firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nElogicOR = store_thm(
+val firstSet_nElogicOR = Q.store_thm(
   "firstSet_nElogicOR[simp]",
-  ``firstSet cmlG (NT(mkNT nElogicOR)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nElogicOR)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nElogicOR = store_thm(
+val firstSetML_nElogicOR = Q.store_thm(
   "firstSetML_nElogicOR[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElogicAND ∉ sn ∧
     mkNT nElogicOR ∉ sn ∧ mkNT nElistop ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nElogicOR)::rest) =
-      firstSet cmlG [NN nEbase]``,
+      firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nEhandle = store_thm(
+val firstSet_nEhandle = Q.store_thm(
   "firstSet_nEhandle[simp]",
-  ``firstSet cmlG (NT(mkNT nEhandle)::rest) = firstSet cmlG [NT (mkNT nEbase)]``,
+  `firstSet cmlG (NT(mkNT nEhandle)::rest) = firstSet cmlG [NT (mkNT nEbase)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSetML_nEhandle = store_thm(
+val firstSetML_nEhandle = Q.store_thm(
   "firstSetML_nEhandle[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElogicAND ∉ sn ∧
     mkNT nElogicOR ∉ sn ∧ mkNT nEhandle ∉ sn ∧ mkNT nElistop ∉ sn ⇒
     firstSetML cmlG sn (NT (mkNT nEhandle)::rest) =
-      firstSet cmlG [NN nEbase]``,
+      firstSet cmlG [NN nEbase]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]));
 
-val firstSet_nE = store_thm(
+val firstSet_nE = Q.store_thm(
   "firstSet_nE",
-  ``firstSet cmlG (NT(mkNT nE)::rest) =
-      firstSet cmlG [NT (mkNT nEbase)] ∪ {IfT; CaseT; FnT; RaiseT}``,
+  `firstSet cmlG (NT(mkNT nE)::rest) =
+      firstSet cmlG [NT (mkNT nEbase)] ∪ {IfT; CaseT; FnT; RaiseT}`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nTopLevelDecs = store_thm(
+val firstSet_nTopLevelDecs = Q.store_thm(
   "firstSet_nTopLevelDecs[simp]",
-  ``firstSet cmlG [NN nTopLevelDecs] =
+  `firstSet cmlG [NN nTopLevelDecs] =
       {ValT; FunT; SemicolonT; DatatypeT; StructureT; ExceptionT; TypeT} ∪
-      firstSet cmlG [NT (mkNT nE)]``,
+      firstSet cmlG [NT (mkNT nE)]`,
   simp[Once firstSet_NT, cmlG_applied, cmlG_FDOM] >>
   ONCE_REWRITE_TAC [firstSet_NT] >> simp[cmlG_applied, cmlG_FDOM] >>
   simp[INSERT_UNION_EQ, INSERT_COMM] >>
   simp[EXTENSION, EQ_IMP_THM] >> rpt strip_tac >> rveq >> simp[]);
 
-val firstSet_nNonETopLevelDecs = store_thm(
+val firstSet_nNonETopLevelDecs = Q.store_thm(
   "firstSet_nNonETopLevelDecs[simp]",
-  ``firstSet cmlG [NN nNonETopLevelDecs] =
-      {ValT; FunT; SemicolonT; DatatypeT; StructureT; ExceptionT; TypeT}``,
+  `firstSet cmlG [NN nNonETopLevelDecs] =
+      {ValT; FunT; SemicolonT; DatatypeT; StructureT; ExceptionT; TypeT}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   simp[INSERT_COMM, INSERT_UNION_EQ]);
 
-val firstSet_nEseq = store_thm(
+val firstSet_nEseq = Q.store_thm(
   "firstSet_nEseq[simp]",
-  ``firstSet cmlG (NN nEseq :: rest) = firstSet cmlG [NN nE]``,
+  `firstSet cmlG (NN nEseq :: rest) = firstSet cmlG [NN nE]`,
   simp[SimpLHS, Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   simp[firstSet_nE]);
 
-val NOTIN_firstSet_nE = store_thm(
+val NOTIN_firstSet_nE = Q.store_thm(
   "NOTIN_firstSet_nE[simp]",
-  ``ValT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
+  `ValT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
     StructureT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
     FunT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
     DatatypeT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
@@ -532,124 +532,124 @@ val NOTIN_firstSet_nE = store_thm(
     SemicolonT ∉ firstSet cmlG (NT (mkNT nE) :: rest) ∧
     RparT ∉ firstSet cmlG (NN nE :: rest) ∧
     RbrackT ∉ firstSet cmlG (NN nE :: rest) ∧
-    TypeT ∉ firstSet cmlG (NN nE :: rest)``,
+    TypeT ∉ firstSet cmlG (NN nE :: rest)`,
   simp[firstSet_nE, firstSet_nFQV] >>
   rpt (dsimp[Once firstSet_NT, cmlG_FDOM, cmlG_applied, disjImpI]))
 
-val firstSetML_nE = store_thm(
+val firstSetML_nE = Q.store_thm(
   "firstSetML_nE[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElogicAND ∉ sn ∧
     mkNT nElogicOR ∉ sn ∧ mkNT nEhandle ∉ sn ∧ mkNT nE ∉ sn ∧
     mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nE)::rest) = firstSet cmlG [NN nE]``,
+    firstSetML cmlG sn (NT (mkNT nE)::rest) = firstSet cmlG [NN nE]`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM, firstSet_nE]) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nE' = store_thm(
+val firstSet_nE' = Q.store_thm(
   "firstSet_nE'",
-  ``firstSet cmlG (NT(mkNT nE')::rest) =
-      firstSet cmlG [NT (mkNT nEbase)] ∪ {IfT; RaiseT}``,
+  `firstSet cmlG (NT(mkNT nE')::rest) =
+      firstSet cmlG [NT (mkNT nEbase)] ∪ {IfT; RaiseT}`,
   simp[SimpLHS, firstSetML_eqn] >>
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSetML_nE' = store_thm(
+val firstSetML_nE' = Q.store_thm(
   "firstSetML_nE'[simp]",
-  ``mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
+  `mkNT nConstructorName ∉ sn ∧ mkNT nUQConstructorName ∉ sn ∧
     mkNT nEbase ∉ sn ∧ mkNT nFQV ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nEapp ∉ sn ∧
     mkNT nEmult ∉ sn ∧ mkNT nEadd ∉ sn ∧ mkNT nErel ∉ sn ∧ mkNT nEcomp ∉ sn ∧
     mkNT nEbefore ∉ sn ∧ mkNT nEtyped ∉ sn ∧ mkNT nElogicAND ∉ sn ∧
     mkNT nElogicOR ∉ sn ∧ mkNT nE' ∉ sn ∧ mkNT nElistop ∉ sn ⇒
-    firstSetML cmlG sn (NT (mkNT nE')::rest) = firstSet cmlG [NN nE']``,
+    firstSetML cmlG sn (NT (mkNT nE')::rest) = firstSet cmlG [NN nE']`,
   ntac 2 (simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM, firstSet_nE']) >>
   simp[Once EXTENSION, EQ_IMP_THM] >> dsimp[]);
 
-val firstSet_nElist1 = store_thm(
+val firstSet_nElist1 = Q.store_thm(
   "firstSet_nElist1[simp]",
-  ``firstSet cmlG (NT (mkNT nElist1)::rest) = firstSet cmlG [NT (mkNT nE)]``,
+  `firstSet cmlG (NT (mkNT nElist1)::rest) = firstSet cmlG [NT (mkNT nE)]`,
   simp[SimpLHS, firstSetML_eqn] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM]);
 
-val firstSetML_nPtuple = store_thm(
+val firstSetML_nPtuple = Q.store_thm(
   "firstSetML_nPtuple[simp]",
-  ``mkNT nPtuple ∉ sn ⇒ (firstSetML cmlG sn (NN nPtuple :: rest) = {LparT})``,
+  `mkNT nPtuple ∉ sn ⇒ (firstSetML cmlG sn (NN nPtuple :: rest) = {LparT})`,
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied]);
 
-val firstSet_nPtuple = store_thm(
+val firstSet_nPtuple = Q.store_thm(
   "firstSet_nPtuple[simp]",
-  ``firstSet cmlG (NN nPtuple :: rest) = {LparT}``,
+  `firstSet cmlG (NN nPtuple :: rest) = {LparT}`,
   simp[firstSetML_eqn, firstSetML_nPtuple]);
 
-val firstSet_nPbase = store_thm(
+val firstSet_nPbase = Q.store_thm(
   "firstSet_nPbase[simp]",
-  ``firstSet cmlG (NN nPbase :: rest) =
+  `firstSet cmlG (NN nPbase :: rest) =
       {LparT; UnderbarT; LbrackT} ∪ {IntT i | T } ∪ {StringT s | T } ∪
       {CharT c | T } ∪
-      firstSet cmlG [NN nConstructorName] ∪ firstSet cmlG [NN nV]``,
+      firstSet cmlG [NN nConstructorName] ∪ firstSet cmlG [NN nV]`,
   simp[SimpLHS, firstSetML_eqn] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSetML_nPbase = store_thm(
+val firstSetML_nPbase = Q.store_thm(
   "firstSetML_nPbase[simp]",
-  ``mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
+  `mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
     mkNT nUQConstructorName ∉ sn ∧ mkNT nPtuple ∉ sn ⇒
-    firstSetML cmlG sn (NN nPbase :: rest) = firstSet cmlG [NN nPbase]``,
+    firstSetML cmlG sn (NN nPbase :: rest) = firstSet cmlG [NN nPbase]`,
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nPapp = store_thm(
+val firstSet_nPapp = Q.store_thm(
   "firstSet_nPapp[simp]",
-  ``firstSet cmlG (NN nPapp :: rest) = firstSet cmlG [NN nPbase]``,
+  `firstSet cmlG (NN nPapp :: rest) = firstSet cmlG [NN nPbase]`,
   simp[SimpLHS, firstSetML_eqn] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSetML_nPapp = store_thm(
+val firstSetML_nPapp = Q.store_thm(
   "firstSetML_nPapp[simp]",
-  ``mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
+  `mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
     mkNT nUQConstructorName ∉ sn ∧ mkNT nPtuple ∉ sn ∧ mkNT nPapp ∉ sn ⇒
-    firstSetML cmlG sn (NN nPapp :: rest) = firstSet cmlG [NN nPbase]``,
+    firstSetML cmlG sn (NN nPapp :: rest) = firstSet cmlG [NN nPbase]`,
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nPcons = store_thm(
+val firstSet_nPcons = Q.store_thm(
   "firstSet_nPcons[simp]",
-  ``firstSet cmlG (NN nPcons :: rest) = firstSet cmlG [NN nPbase]``,
+  `firstSet cmlG (NN nPcons :: rest) = firstSet cmlG [NN nPbase]`,
   simp[SimpLHS, firstSetML_eqn] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM])
 
-val firstSetML_nPcons = store_thm(
+val firstSetML_nPcons = Q.store_thm(
   "firstSetML_nPcons[simp]",
-  ``mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
+  `mkNT nPbase ∉ sn ∧ mkNT nV ∉ sn ∧ mkNT nConstructorName ∉ sn ∧
     mkNT nUQConstructorName ∉ sn ∧ mkNT nPtuple ∉ sn ∧ mkNT nPapp ∉ sn ∧
     mkNT nPcons ∉ sn ⇒
-    firstSetML cmlG sn (NN nPcons :: rest) = firstSet cmlG [NN nPbase]``,
+    firstSetML cmlG sn (NN nPcons :: rest) = firstSet cmlG [NN nPbase]`,
   simp[Once firstSetML_def, cmlG_FDOM, cmlG_applied]);
 
-val firstSet_nPattern = store_thm(
+val firstSet_nPattern = Q.store_thm(
   "firstSet_nPattern[simp]",
-  ``firstSet cmlG (NN nPattern :: rest) = firstSet cmlG [NN nPbase]``,
+  `firstSet cmlG (NN nPattern :: rest) = firstSet cmlG [NN nPbase]`,
   simp[SimpLHS, firstSetML_eqn] >>
   simp[Once firstSetML_def, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nPatternList = store_thm(
+val firstSet_nPatternList = Q.store_thm(
   "firstSet_nPatternList[simp]",
-  ``firstSet cmlG (NN nPatternList :: rest) = firstSet cmlG [NN nPattern]``,
+  `firstSet cmlG (NN nPatternList :: rest) = firstSet cmlG [NN nPattern]`,
   simp[SimpLHS, Once firstSet_NT, cmlG_FDOM, cmlG_applied] >> simp[]);
 
-val firstSet_nPbaseList1 = store_thm(
+val firstSet_nPbaseList1 = Q.store_thm(
   "firstSet_nPbaseList1[simp]",
-  ``firstSet cmlG (NN nPbaseList1 :: rest) = firstSet cmlG [NN nPbase]``,
+  `firstSet cmlG (NN nPbaseList1 :: rest) = firstSet cmlG [NN nPbase]`,
   simp[SimpLHS, Once firstSet_NT, cmlG_FDOM, cmlG_applied] >> simp[]);
 
-val NOTIN_firstSet_nV = store_thm(
+val NOTIN_firstSet_nV = Q.store_thm(
   "NOTIN_firstSet_nV[simp]",
-  ``CommaT ∉ firstSet cmlG [NN nV] ∧ LparT ∉ firstSet cmlG [NN nV] ∧
+  `CommaT ∉ firstSet cmlG [NN nV] ∧ LparT ∉ firstSet cmlG [NN nV] ∧
     RparT ∉ firstSet cmlG [NN nV] ∧ UnderbarT ∉ firstSet cmlG [NN nV] ∧
     BarT ∉ firstSet cmlG [NN nV] ∧ OpT ∉ firstSet cmlG [NN nV] ∧
     FnT ∉ firstSet cmlG [NN nV] ∧ IfT ∉ firstSet cmlG [NN nV] ∧
@@ -674,12 +674,12 @@ val NOTIN_firstSet_nV = store_thm(
     DatatypeT ∉ firstSet cmlG [NN nV] ∧
     TypeT ∉ firstSet cmlG [NN nV] ∧
     SemicolonT ∉ firstSet cmlG [NN nV] ∧ ColonT ∉ firstSet cmlG [NN nV] ∧
-    StructureT ∉ firstSet cmlG [NN nV]``,
+    StructureT ∉ firstSet cmlG [NN nV]`,
   simp[firstSet_nV]);
 
-val NOTIN_firstSet_nFQV = store_thm(
+val NOTIN_firstSet_nFQV = Q.store_thm(
   "NOTIN_firstSet_nFQV[simp]",
-  ``AndT ∉ firstSet cmlG [NN nFQV] ∧
+  `AndT ∉ firstSet cmlG [NN nFQV] ∧
     BarT ∉ firstSet cmlG [NN nFQV] ∧
     CaseT ∉ firstSet cmlG [NN nFQV] ∧
     CharT c ∉ firstSet cmlG [NN nFQV] ∧
@@ -710,12 +710,12 @@ val NOTIN_firstSet_nFQV = store_thm(
     ThenT ∉ firstSet cmlG [NN nFQV] ∧
     TypeT ∉ firstSet cmlG [NN nFQV] ∧
     UnderbarT ∉ firstSet cmlG [NN nFQV] ∧
-    ValT ∉ firstSet cmlG [NN nFQV]``,
+    ValT ∉ firstSet cmlG [NN nFQV]`,
   simp[firstSet_nFQV]);
 
-val NOTIN_firstSet_nConstructorName = store_thm(
+val NOTIN_firstSet_nConstructorName = Q.store_thm(
   "NOTIN_firstSet_nConstructorName[simp]",
-  ``AndT ∉ firstSet cmlG [NN nConstructorName] ∧
+  `AndT ∉ firstSet cmlG [NN nConstructorName] ∧
     BarT ∉ firstSet cmlG [NN nConstructorName] ∧
     ColonT ∉ firstSet cmlG [NN nConstructorName] ∧
     CaseT ∉ firstSet cmlG [NN nConstructorName] ∧
@@ -746,7 +746,7 @@ val NOTIN_firstSet_nConstructorName = store_thm(
     ThenT ∉ firstSet cmlG [NN nConstructorName] ∧
     TypeT ∉ firstSet cmlG [NN nConstructorName] ∧
     UnderbarT ∉ firstSet cmlG [NN nConstructorName] ∧
-    ValT ∉ firstSet cmlG [NN nConstructorName]``,
+    ValT ∉ firstSet cmlG [NN nConstructorName]`,
   simp[firstSet_nConstructorName]);
 
 val cmlPEG_total =
@@ -794,9 +794,9 @@ val not_peg0_peg_eval_NIL_NONE = store_thm(
   Cases_on `r` >> simp[] >> Cases_on `x` >>
   erule mp_tac not_peg0_LENGTH_decreases >> simp[]);
 
-val list_case_lemma = prove(
-  ``([x] = case a of [] => [] | h::t => f h t) ⇔
-    (a ≠ [] ∧ [x] = f (HD a) (TL a))``,
+val list_case_lemma = Q.prove(
+  `([x] = case a of [] => [] | h::t => f h t) ⇔
+    (a ≠ [] ∧ [x] = f (HD a) (TL a))`,
   Cases_on `a` >> simp[]);
 
 val left_insert1_def = Define`
@@ -808,15 +808,15 @@ val left_insert1_def = Define`
        | _ => Nd n subs)
 `;
 
-val left_insert1_FOLDL = store_thm(
+val left_insert1_FOLDL = Q.store_thm(
   "left_insert1_FOLDL",
-  ``left_insert1 pt (FOLDL (λa b. Nd (mkNT P) [a; b]) acc arg) =
-    FOLDL (λa b. Nd (mkNT P) [a; b]) (left_insert1 pt acc) arg``,
+  `left_insert1 pt (FOLDL (λa b. Nd (mkNT P) [a; b]) acc arg) =
+    FOLDL (λa b. Nd (mkNT P) [a; b]) (left_insert1 pt acc) arg`,
   qid_spec_tac `acc` >> Induct_on `arg` >> simp[left_insert1_def]);
 
-val eapp_reassociated = store_thm(
+val eapp_reassociated = Q.store_thm(
   "eapp_reassociated",
-  ``∀pt bpt pf bf.
+  `∀pt bpt pf bf.
       valid_ptree cmlG pt ∧ ptree_head pt = NN nEapp ∧
       ptree_fringe pt = MAP TK pf ∧
       valid_ptree cmlG bpt ∧ ptree_head bpt = NN nEbase ∧
@@ -825,7 +825,7 @@ val eapp_reassociated = store_thm(
         valid_ptree cmlG pt' ∧ valid_ptree cmlG bpt' ∧
         ptree_head pt' = NN nEapp ∧ ptree_head bpt' = NN nEbase ∧
         ptree_fringe bpt' ++ ptree_fringe pt' = MAP TK (pf ++ bf) ∧
-        Nd (mkNT nEapp) [pt; bpt] = left_insert1 bpt' pt'``,
+        Nd (mkNT nEapp) [pt; bpt] = left_insert1 bpt' pt'`,
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >>
   qx_gen_tac `subs` >> strip_tac >>
@@ -865,16 +865,16 @@ val left_insert2_def = Define`
        | _ => Nd n subs)
 `;
 
-val left_insert2_FOLDL = store_thm(
+val left_insert2_FOLDL = Q.store_thm(
   "left_insert2_FOLDL",
-  ``left_insert2 pt (FOLDL (λa b. Nd (mkNT P) [a; b]) acc arg) =
-    FOLDL (λa b. Nd (mkNT P) [a; b]) (left_insert2 pt acc) arg``,
+  `left_insert2 pt (FOLDL (λa b. Nd (mkNT P) [a; b]) acc arg) =
+    FOLDL (λa b. Nd (mkNT P) [a; b]) (left_insert2 pt acc) arg`,
   qid_spec_tac `acc` >> Induct_on `arg` >> simp[left_insert2_def]);
 
 
-val dtype_reassociated = store_thm(
+val dtype_reassociated = Q.store_thm(
   "dtype_reassociated",
-  ``∀pt bpt pf bf.
+  `∀pt bpt pf bf.
       valid_ptree cmlG pt ∧ ptree_head pt = NN nDType ∧
       ptree_fringe pt = MAP TK pf ∧
       valid_ptree cmlG bpt ∧ ptree_head bpt = NN nTyOp ∧
@@ -884,7 +884,7 @@ val dtype_reassociated = store_thm(
         valid_ptree cmlG (leftmost pt') ∧ ptree_head (leftmost pt') = NN nTyOp ∧
         ptree_head pt' = NN nDType ∧ ptree_head bpt' = NN nTbase ∧
         ptree_fringe bpt' ++ ptree_fringe pt' = MAP TK (pf ++ bf) ∧
-        Nd (mkNT nDType) [pt; bpt] = left_insert2 bpt' pt'``,
+        Nd (mkNT nDType) [pt; bpt] = left_insert2 bpt' pt'`,
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >>
   qx_gen_tac `subs` >> strip_tac >>
@@ -915,9 +915,9 @@ val left_insert_def = Define`
          | _ => Nd p subs)
 `;
 
-val lassoc_reassociated = store_thm(
+val lassoc_reassociated = Q.store_thm(
   "lassoc_reassociated",
-  ``∀G P SEP C ppt spt cpt pf sf cf.
+  `∀G P SEP C ppt spt cpt pf sf cf.
       G.rules ' P = {[NT P; SEP; C]; [C]} ⇒
       valid_ptree G ppt ∧ ptree_head ppt = NT P ∧
       ptree_fringe ppt = MAP TOK pf ∧
@@ -929,7 +929,7 @@ val lassoc_reassociated = store_thm(
         valid_ptree G cpt' ∧ ptree_head cpt' = C ∧
         ptree_fringe cpt' ++ ptree_fringe spt' ++ ptree_fringe ppt' =
         MAP TOK (pf ++ sf ++ cf) ∧
-        Nd P [ppt; spt; cpt] = left_insert ppt' P spt' cpt'``,
+        Nd P [ppt; spt; cpt] = left_insert ppt' P spt' cpt'`,
   rpt gen_tac >> strip_tac >>
   map_every qid_spec_tac [`cf`, `sf`, `pf`, `cpt`, `spt`, `ppt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >> simp[MAP_EQ_SING] >>
@@ -956,10 +956,10 @@ val lassoc_reassociated = store_thm(
   map_every qexists_tac [`cpt'`, `spt'`, `Nd P [ppt'; spt; cpt]`] >>
   simp[DISJ_IMP_THM, FORALL_AND_THM, left_insert_def])
 
-val left_insert_mk_linfix = store_thm(
+val left_insert_mk_linfix = Q.store_thm(
   "left_insert_mk_linfix",
-  ``left_insert (mk_linfix N acc arg) N s c =
-    mk_linfix N (left_insert acc N s c) arg``,
+  `left_insert (mk_linfix N acc arg) N s c =
+    mk_linfix N (left_insert acc N s c) arg`,
   qid_spec_tac `acc` >> completeInduct_on `LENGTH arg` >> rw[] >>
   full_simp_tac (srw_ss() ++ DNF_ss)[] >>
   `arg = [] ∨ ∃h1 t. arg = h1::t` by (Cases_on `arg` >> simp[])
@@ -968,14 +968,14 @@ val left_insert_mk_linfix = store_thm(
   >- simp[mk_linfix_def] >>
   rw[] >> simp[mk_linfix_def, left_insert_def]);
 
-val firstSets_nV_nConstructorName = store_thm(
+val firstSets_nV_nConstructorName = Q.store_thm(
   "firstSets_nV_nConstructorName",
-  ``¬(t ∈ firstSet cmlG [NN nConstructorName] ∧ t ∈ firstSet cmlG [NN nV])``,
+  `¬(t ∈ firstSet cmlG [NN nConstructorName] ∧ t ∈ firstSet cmlG [NN nV])`,
   Cases_on `t ∈ firstSet cmlG [NN nV]` >> simp[] >>
   fs[firstSet_nV, firstSet_nConstructorName]);
 
-val elim_disjineq = prove( ``p \/ x ≠ y ⇔ (x = y ⇒ p)``, DECIDE_TAC)
-val elim_det = prove(``(!x. P x ⇔ (x = y)) ==> P y``, METIS_TAC[])
+val elim_disjineq = Q.prove( `p \/ x ≠ y ⇔ (x = y ⇒ p)`, DECIDE_TAC)
+val elim_det = Q.prove(`(!x. P x ⇔ (x = y)) ==> P y`, METIS_TAC[])
 
 val peg_det = CONJUNCT1 peg_deterministic
 
@@ -1350,10 +1350,10 @@ val eapp_complete = store_thm(
                  REVERSE_11, listTheory.LENGTH_REVERSE] >>
   rveq >> simp[]);
 
-val leftmost_FOLDL = store_thm(
+val leftmost_FOLDL = Q.store_thm(
   "leftmost_FOLDL",
-  ``leftmost (FOLDL (λa b. Nd (mkNT nDType) [a;b]) acc args) =
-    leftmost acc``,
+  `leftmost (FOLDL (λa b. Nd (mkNT nDType) [a;b]) acc args) =
+    leftmost acc`,
   qid_spec_tac `acc` >> Induct_on `args` >> simp[leftmost_def]);
 
 val dtype_complete = store_thm(

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -248,22 +248,22 @@ val firstSet_nV = Q.store_thm(
   simp[Once firstSet_NT, cmlG_applied, cmlG_FDOM] >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
-val firstSet_nFQV = store_thm(
+val firstSet_nFQV = Q.store_thm(
   "firstSet_nFQV",
-  ``firstSet cmlG [NT (mkNT nFQV)] =
+  `firstSet cmlG [NT (mkNT nFQV)] =
       firstSet cmlG [NT (mkNT nV)] ∪
       { LongidT m i | (m,i) | i ≠ "" ∧ (isAlpha (HD i) ⇒ ¬isUpper (HD i)) ∧
-                              i ∉ {"true"; "false"; "ref"; "nil"}}``,
+                              i ∉ {"true"; "false"; "ref"; "nil"}}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   dsimp[Once EXTENSION]);
 
-val firstSet_nConstructorName = store_thm(
+val firstSet_nConstructorName = Q.store_thm(
   "firstSet_nConstructorName",
-  ``firstSet cmlG (NN nConstructorName :: rest) =
+  `firstSet cmlG (NN nConstructorName :: rest) =
       { LongidT str s | (str,s) | s ≠ "" ∧ isAlpha (HD s) ∧ isUpper (HD s) ∨
                                   s ∈ {"true"; "false"; "ref"; "nil"}} ∪
       { AlphaT s | s ≠ "" ∧ isUpper (HD s) } ∪
-      { AlphaT s | s ∈ {"true"; "false"; "ref"; "nil"}}``,
+      { AlphaT s | s ∈ {"true"; "false"; "ref"; "nil"}}`,
   ntac 2 (simp [Once firstSet_NT, cmlG_applied, cmlG_FDOM]) >>
   dsimp[Once EXTENSION, EQ_IMP_THM]);
 
@@ -753,12 +753,12 @@ val cmlPEG_total =
     peg_eval_total |> Q.GEN `G` |> Q.ISPEC `cmlPEG`
                              |> C MATCH_MP PEG_wellformed
 
-val peg_respects_firstSets = store_thm(
+val peg_respects_firstSets = Q.store_thm(
   "peg_respects_firstSets",
-  ``∀N i0 t.
+  `∀N i0 t.
       t ∉ firstSet cmlG [NT N] ∧ ¬peg0 cmlPEG (nt N I) ∧
       nt N I ∈ Gexprs cmlPEG ⇒
-      peg_eval cmlPEG (t::i0, nt N I) NONE``,
+      peg_eval cmlPEG (t::i0, nt N I) NONE`,
   rpt gen_tac >> CONV_TAC CONTRAPOS_CONV >> simp[] >>
   Cases_on `nt N I ∈ Gexprs cmlPEG` >> simp[] >>
   IMP_RES_THEN (qspec_then `t::i0` (qxchl [`r`] assume_tac)) cmlPEG_total >>
@@ -784,10 +784,10 @@ val sym2peg_def = Define`
   sym2peg (NT N) = nt N I
 `;
 
-val not_peg0_peg_eval_NIL_NONE = store_thm(
+val not_peg0_peg_eval_NIL_NONE = Q.store_thm(
   "not_peg0_peg_eval_NIL_NONE",
-  ``¬peg0 G sym ∧ sym ∈ Gexprs G ∧ wfG G ⇒
-    peg_eval G ([], sym) NONE``,
+  `¬peg0 G sym ∧ sym ∈ Gexprs G ∧ wfG G ⇒
+    peg_eval G ([], sym) NONE`,
   strip_tac >>
   `∃r. peg_eval G ([], sym) r`
     by metis_tac [peg_eval_total] >>
@@ -979,32 +979,32 @@ val elim_det = Q.prove(`(!x. P x ⇔ (x = y)) ==> P y`, METIS_TAC[])
 
 val peg_det = CONJUNCT1 peg_deterministic
 
-val peg_seql_NONE_det = store_thm(
+val peg_seql_NONE_det = Q.store_thm(
   "peg_seql_NONE_det",
-  ``peg_eval G (i0, seql syms f) NONE ⇒
-    ∀f' r. peg_eval G (i0, seql syms f') r ⇔ r = NONE``,
+  `peg_eval G (i0, seql syms f) NONE ⇒
+    ∀f' r. peg_eval G (i0, seql syms f') r ⇔ r = NONE`,
   Induct_on `syms` >> simp[] >> rpt strip_tac >>
   rpt (first_x_assum (assume_tac o MATCH_MP peg_det)) >> simp[]);
 
-val peg_seql_NONE_append = store_thm(
+val peg_seql_NONE_append = Q.store_thm(
   "peg_seql_NONE_append",
-  ``∀i0 f. peg_eval G (i0, seql (l1 ++ l2) f) NONE ⇔
+  `∀i0 f. peg_eval G (i0, seql (l1 ++ l2) f) NONE ⇔
            peg_eval G (i0, seql l1 I) NONE ∨
            ∃i' r. peg_eval G (i0, seql l1 I) (SOME(i',r)) ∧
-                  peg_eval G (i', seql l2 I) NONE``,
+                  peg_eval G (i', seql l2 I) NONE`,
   Induct_on `l1` >> simp[] >- metis_tac [peg_seql_NONE_det] >>
   map_every qx_gen_tac [`h`, `i0`] >>
   Cases_on `peg_eval G (i0,h) NONE` >> simp[] >>
   dsimp[] >> metis_tac[]);
 
-val peg_seql_SOME_append = store_thm(
+val peg_seql_SOME_append = Q.store_thm(
   "peg_seql_SOME_append",
-  ``∀i0 l2 f i r.
+  `∀i0 l2 f i r.
       peg_eval G (i0, seql (l1 ++ l2) f) (SOME(i,r)) ⇔
       ∃i' r1 r2.
           peg_eval G (i0, seql l1 I) (SOME(i',r1)) ∧
           peg_eval G (i', seql l2 I) (SOME(i,r2)) ∧
-          (r = f (r1 ++ r2))``,
+          (r = f (r1 ++ r2))`,
   Induct_on `l1` >> simp[]
   >- (Induct_on `l2` >- simp[] >>
       ONCE_REWRITE_TAC [peg_eval_seql_CONS] >>
@@ -1013,12 +1013,12 @@ val peg_seql_SOME_append = store_thm(
 
 fun has_const c = assert (Lib.can (find_term (same_const c)) o concl)
 
-val eOR_wrongtok = store_thm(
+val eOR_wrongtok = Q.store_thm(
   "eOR_wrongtok",
-  ``¬peg_eval cmlPEG (RaiseT::i0, nt (mkNT nElogicOR) I) (SOME(i,r)) ∧
+  `¬peg_eval cmlPEG (RaiseT::i0, nt (mkNT nElogicOR) I) (SOME(i,r)) ∧
     ¬peg_eval cmlPEG (FnT::i0, nt (mkNT nElogicOR) I) (SOME(i,r)) ∧
     ¬peg_eval cmlPEG (CaseT::i0, nt (mkNT nElogicOR) I) (SOME(i,r)) ∧
-    ¬peg_eval cmlPEG (IfT::i0, nt (mkNT nElogicOR) I) (SOME(i,r))``,
+    ¬peg_eval cmlPEG (IfT::i0, nt (mkNT nElogicOR) I) (SOME(i,r))`,
   rpt conj_tac >>
   qmatch_abbrev_tac `¬peg_eval cmlPEG (ttk::i0, nt (mkNT nElogicOR) I) (SOME(i,r))` >>
   strip_tac >>
@@ -1026,12 +1026,12 @@ val eOR_wrongtok = store_thm(
     suffices_by (first_assum (assume_tac o MATCH_MP peg_det) >> simp[]) >>
   simp[Abbr`ttk`, peg_respects_firstSets]);
 
-val nE'_nE = store_thm(
+val nE'_nE = Q.store_thm(
   "nE'_nE",
-  ``∀i0 i r.
+  `∀i0 i r.
       peg_eval cmlPEG (i0, nt (mkNT nE') I) (SOME(i,r)) ∧
       (i ≠ [] ⇒ HD i ≠ HandleT) ⇒
-      ∃r'. peg_eval cmlPEG (i0, nt (mkNT nE) I) (SOME(i,r'))``,
+      ∃r'. peg_eval cmlPEG (i0, nt (mkNT nE) I) (SOME(i,r'))`,
   gen_tac >> completeInduct_on `LENGTH i0` >> gen_tac >> strip_tac >>
   full_simp_tac (srw_ss() ++ DNF_ss) [AND_IMP_INTRO] >>
   simp[peg_eval_NT_SOME] >> simp[cmlpeg_rules_applied] >>
@@ -1053,13 +1053,13 @@ val nE'_nE = store_thm(
   fs[eOR_wrongtok]);
 
 
-val nE'_bar_nE = store_thm(
+val nE'_bar_nE = Q.store_thm(
   "nE'_bar_nE",
-  ``∀i0 i i' r r'.
+  `∀i0 i i' r r'.
         peg_eval cmlPEG (i0, nt (mkNT nE) I) (SOME(i,r)) ∧
         (i ≠ [] ⇒ HD i ≠ BarT ∧ HD i ≠ HandleT) ∧ i' ≠ [] ∧
         peg_eval cmlPEG (i0, nt (mkNT nE') I) (SOME(i',r')) ⇒
-        HD i' ≠ BarT``,
+        HD i' ≠ BarT`,
   gen_tac >> completeInduct_on `LENGTH i0` >> rpt strip_tac >>
   full_simp_tac (srw_ss() ++ DNF_ss) [AND_IMP_INTRO] >> rw[] >>
   rpt (qpat_x_assum `peg_eval X Y Z` mp_tac) >>
@@ -1274,9 +1274,9 @@ in
 end g
 val normlist = REWRITE_TAC [GSYM APPEND_ASSOC, listTheory.APPEND]
 
-val eapp_complete = store_thm(
+val eapp_complete = Q.store_thm(
   "eapp_complete",
-  ``(∀pt' pfx' sfx' N.
+  `(∀pt' pfx' sfx' N.
        LENGTH pfx' < LENGTH master ∧ valid_ptree cmlG pt' ∧
        mkNT N ∈ FDOM cmlPEG.rules ∧
        ptree_head pt' = NN N ∧ ptree_fringe pt' = MAP TK pfx' ∧
@@ -1292,7 +1292,7 @@ val eapp_complete = store_thm(
        IS_SUFFIX master pfx ∧ valid_ptree cmlG apt ∧
        ptree_head apt = NN nEapp ∧ ptree_fringe apt = MAP TK pfx ∧
        (sfx ≠ [] ⇒ HD sfx ∈ stoppers nEapp) ⇒
-       peg_eval cmlPEG (pfx ++ sfx, nt (mkNT nEapp) I) (SOME(sfx, [apt]))``,
+       peg_eval cmlPEG (pfx ++ sfx, nt (mkNT nEapp) I) (SOME(sfx, [apt]))`,
   strip_tac >>
   simp[Once peg_eval_NT_SOME, cmlpeg_rules_applied, (*list_case_lemma, *)
        peg_eval_rpt, GSYM LEFT_EXISTS_AND_THM, GSYM RIGHT_EXISTS_AND_THM] >>
@@ -1356,9 +1356,9 @@ val leftmost_FOLDL = Q.store_thm(
     leftmost acc`,
   qid_spec_tac `acc` >> Induct_on `args` >> simp[leftmost_def]);
 
-val dtype_complete = store_thm(
+val dtype_complete = Q.store_thm(
   "dtype_complete",
-  ``(∀pt' pfx' sfx' N.
+  `(∀pt' pfx' sfx' N.
        LENGTH pfx' < LENGTH master ∧ valid_ptree cmlG pt' ∧
        mkNT N ∈ FDOM cmlPEG.rules ∧
        ptree_head pt' = NN N ∧ ptree_fringe pt' = MAP TK pfx' ∧
@@ -1374,7 +1374,7 @@ val dtype_complete = store_thm(
        IS_SUFFIX master pfx ∧ valid_ptree cmlG apt ∧
        ptree_head apt = NN nDType ∧ ptree_fringe apt = MAP TK pfx ∧
        (sfx ≠ [] ⇒ HD sfx ∈ stoppers nDType) ⇒
-       peg_eval cmlPEG (pfx ++ sfx, nt (mkNT nDType) I) (SOME(sfx, [apt]))``,
+       peg_eval cmlPEG (pfx ++ sfx, nt (mkNT nDType) I) (SOME(sfx, [apt]))`,
   strip_tac >>
   simp[Once peg_eval_NT_SOME, cmlpeg_rules_applied, (*list_case_lemma, *)
        peg_eval_rpt, GSYM LEFT_EXISTS_AND_THM, GSYM RIGHT_EXISTS_AND_THM] >>
@@ -1458,9 +1458,9 @@ val dtype_complete = store_thm(
      (sfx ≠ [] ∧ nullable cmlG [SEP] ⇒ HD sfx ∉ firstSet cmlG [C])
    and I can't be bothered with that right now. *)
 
-val peg_linfix_complete = store_thm(
+val peg_linfix_complete = Q.store_thm(
   "peg_linfix_complete",
-  ``(∀n. SEP = NT n ⇒
+  `(∀n. SEP = NT n ⇒
          ∃nn. n = mkNT nn ∧ nt (mkNT nn) I ∈ Gexprs cmlPEG ∧
               stoppers nn = UNIV) ∧
     (∀n. C = NT n ⇒ ∃nn. n = mkNT nn) ∧
@@ -1492,7 +1492,7 @@ val peg_linfix_complete = store_thm(
   ⇒
       peg_eval cmlPEG (pfx ++ sfx,
                        peg_linfix (mkNT P) (sym2peg C) (sym2peg SEP))
-                      (SOME(sfx,[pt]))``,
+                      (SOME(sfx,[pt]))`,
   strip_tac >>
   simp[peg_linfix_def, list_case_lemma, peg_eval_rpt] >> dsimp[] >>
   gen_tac >>
@@ -1599,14 +1599,14 @@ val stdstart =
 
 fun note_tac s g = (print (s ^ "\n"); ALL_TAC g)
 
-val completeness = store_thm(
+val completeness = Q.store_thm(
   "completeness",
-  ``∀pt N pfx sfx.
+  `∀pt N pfx sfx.
       valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT N) ∧
       mkNT N ∈ FDOM cmlPEG.rules ∧
       (sfx ≠ [] ⇒ HD sfx ∈ stoppers N) ∧ ptree_fringe pt = MAP TOK pfx ⇒
       peg_eval cmlPEG (pfx ++ sfx, nt (mkNT N) I)
-                      (SOME(sfx, [pt]))``,
+                      (SOME(sfx, [pt]))`,
   ho_match_mp_tac parsing_ind >> qx_gen_tac `pt` >>
   disch_then (strip_assume_tac o SIMP_RULE (srw_ss() ++ DNF_ss) []) >>
   RULE_ASSUM_TAC (SIMP_RULE (srw_ss() ++ CONJ_ss) [AND_IMP_INTRO]) >>
@@ -2594,14 +2594,14 @@ val completeness = store_thm(
 
 (* two valid parse-trees with the same head, and the same fringes, which
    are all tokens, must be identical. *)
-val cmlG_unambiguous = store_thm(
+val cmlG_unambiguous = Q.store_thm(
   "cmlG_unambiguous",
-  ``valid_ptree cmlG pt1 ∧ ptree_head pt1 = NT (mkNT N) ∧
+  `valid_ptree cmlG pt1 ∧ ptree_head pt1 = NT (mkNT N) ∧
     valid_ptree cmlG pt2 ∧ ptree_head pt2 = NT (mkNT N) ∧
     mkNT N ∈ FDOM cmlPEG.rules ∧ (* e.g., nTopLevelDecs *)
     ptree_fringe pt2 = ptree_fringe pt1 ∧
     (∀s. s ∈ set (ptree_fringe pt1) ⇒ ∃t. s = TOK t) ⇒
-    pt1 = pt2``,
+    pt1 = pt2`,
   rpt strip_tac >>
   `∃ts. ptree_fringe pt1 = MAP TK ts`
     by (Q.UNDISCH_THEN `ptree_fringe pt2 = ptree_fringe pt1` kall_tac >>

--- a/compiler/parsing/proofs/pegSoundScript.sml
+++ b/compiler/parsing/proofs/pegSoundScript.sml
@@ -208,9 +208,9 @@ val length_no_greater = store_thm(
   metis_tac[peg_eval_suffix',
             DECIDE ``x ≤ y:num ⇔ x < y ∨ x = y``]);
 
-val MAP_TK_11 = store_thm(
+val MAP_TK_11 = Q.store_thm(
   "MAP_TK_11[simp]",
-  ``MAP TK x = MAP TK y ⇔ x = y``,
+  `MAP TK x = MAP TK y ⇔ x = y`,
   eq_tac >> simp[] >> strip_tac >>
   match_mp_tac
     (INST_TYPE [beta |-> ``:(token,MMLnonT) grammar$symbol``]

--- a/compiler/parsing/proofs/pegSoundScript.sml
+++ b/compiler/parsing/proofs/pegSoundScript.sml
@@ -9,41 +9,41 @@ in
 end
 val i = TypeBase.one_one_of ``:(α,β,γ)pegsym``
 
-val peg_eval_choicel_NIL = store_thm(
+val peg_eval_choicel_NIL = Q.store_thm(
   "peg_eval_choicel_NIL[simp]",
-  ``peg_eval G (i0, choicel []) x = (x = NONE)``,
+  `peg_eval G (i0, choicel []) x = (x = NONE)`,
   simp[choicel_def, Once peg_eval_cases]);
 
-val peg_eval_choicel_CONS = store_thm(
+val peg_eval_choicel_CONS = Q.store_thm(
   "peg_eval_choicel_CONS",
-  ``∀x. peg_eval G (i0, choicel (h::t)) x ⇔
+  `∀x. peg_eval G (i0, choicel (h::t)) x ⇔
           peg_eval G (i0, h) x ∧ x <> NONE ∨
-          peg_eval G (i0,h) NONE ∧ peg_eval G (i0, choicel t) x``,
+          peg_eval G (i0,h) NONE ∧ peg_eval G (i0, choicel t) x`,
   simp[choicel_def, SimpLHS, Once peg_eval_cases] >>
   simp[sumID_def, pairTheory.FORALL_PROD, optionTheory.FORALL_OPTION]);
 
-val peg_eval_seql_NIL = store_thm(
+val peg_eval_seql_NIL = Q.store_thm(
   "peg_eval_seql_NIL[simp]",
-  ``peg_eval G (i0, seql [] f) x ⇔ (x = SOME(i0,f []))``,
+  `peg_eval G (i0, seql [] f) x ⇔ (x = SOME(i0,f []))`,
   simp[seql_def, pegf_def] >> simp[Once peg_eval_cases]);
 
-val peg_eval_try = store_thm(
+val peg_eval_try = Q.store_thm(
   "peg_eval_try",
-  ``∀x. peg_eval G (i0, try s) x ⇔
+  `∀x. peg_eval G (i0, try s) x ⇔
          peg_eval G (i0, s) NONE ∧ x = SOME(i0,[]) ∨
-         ∃i r. peg_eval G (i0, s) (SOME(i,r)) ∧ x = SOME(i,r)``,
+         ∃i r. peg_eval G (i0, s) (SOME(i,r)) ∧ x = SOME(i,r)`,
   simp[Once peg_eval_cases, try_def, SimpLHS, choicel_def,
        peg_eval_choice] >> simp[sumID_def] >> metis_tac[]);
 
-val peg_eval_seql_CONS = store_thm(
+val peg_eval_seql_CONS = Q.store_thm(
   "peg_eval_seql_CONS",
-  ``∀x. peg_eval G (i0, seql (h::t) f) x ⇔
+  `∀x. peg_eval G (i0, seql (h::t) f) x ⇔
           peg_eval G (i0, h) NONE ∧ x = NONE ∨
           (∃rh i1. peg_eval G (i0,h) (SOME(i1,rh)) ∧
                    peg_eval G (i1, seql t I) NONE ∧ x = NONE) ∨
           (∃rh i1 i rt. peg_eval G (i0, h) (SOME(i1,rh)) ∧
                         peg_eval G (i1, seql t I) (SOME(i,rt)) ∧
-                        x = SOME(i,f(rh ++ rt)))``,
+                        x = SOME(i,f(rh ++ rt)))`,
   simp[seql_def, pegf_def] >>
   simp[SimpLHS, Once peg_eval_cases] >>
   simp[optionTheory.FORALL_OPTION, pairTheory.FORALL_PROD] >>
@@ -59,9 +59,9 @@ val peg_eval_choicel_SING = save_thm(
     (``peg_eval G (i0, choicel [sym]) NONE``
        |> SIMP_CONV (srw_ss()) [peg_eval_choicel_CONS, peg_eval_choicel_NIL]));
 
-val not_peg0_LENGTH_decreases = store_thm(
+val not_peg0_LENGTH_decreases = Q.store_thm(
   "not_peg0_LENGTH_decreases",
-  ``¬peg0 G s ⇒ peg_eval G (i0, s) (SOME(i,r)) ⇒ LENGTH i < LENGTH i0``,
+  `¬peg0 G s ⇒ peg_eval G (i0, s) (SOME(i,r)) ⇒ LENGTH i < LENGTH i0`,
   metis_tac[peg_eval_suffix', lemma4_1a])
 
 
@@ -70,61 +70,61 @@ val _ = augment_srw_ss [rewrites [
   peg_eval_choicel_CONS, pegf_def, peg_eval_seq_SOME, pnt_def, peg_eval_try,
   try_def]]
 
-val peg_eval_TypeDec_wrongtok = store_thm(
+val peg_eval_TypeDec_wrongtok = Q.store_thm(
   "peg_eval_TypeDec_wrongtok",
-  ``tk ≠ DatatypeT ⇒ ¬peg_eval cmlPEG (tk::i, nt (mkNT nTypeDec) f) (SOME x)``,
+  `tk ≠ DatatypeT ⇒ ¬peg_eval cmlPEG (tk::i, nt (mkNT nTypeDec) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, FDOM_cmlPEG,
        peg_TypeDec_def, peg_eval_seq_SOME, tokeq_def, peg_eval_tok_SOME]);
 
-val peg_eval_TypeAbbrevDec_wrongtok = store_thm(
+val peg_eval_TypeAbbrevDec_wrongtok = Q.store_thm(
   "peg_eval_TypeAbbrevDec_wrongtok",
-  ``tk ≠ TypeT ⇒ ¬peg_eval cmlPEG (tk::i, nt (mkNT nTypeAbbrevDec) f) (SOME x)``,
+  `tk ≠ TypeT ⇒ ¬peg_eval cmlPEG (tk::i, nt (mkNT nTypeAbbrevDec) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, FDOM_cmlPEG,
        peg_eval_seq_SOME, tokeq_def, peg_eval_tok_SOME]);
 
-val peg_eval_LetDec_wrongtok = store_thm(
+val peg_eval_LetDec_wrongtok = Q.store_thm(
   "peg_eval_LetDec_wrongtok",
-  ``¬peg_eval cmlPEG (SemicolonT::i, nt (mkNT nLetDec) f) (SOME x)``,
+  `¬peg_eval cmlPEG (SemicolonT::i, nt (mkNT nLetDec) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, FDOM_cmlPEG,
        peg_TypeDec_def, peg_eval_seq_SOME, tokeq_def, peg_eval_tok_SOME,
        peg_eval_choicel_CONS, peg_eval_seql_CONS]);
 
-val peg_eval_nUQConstructor_wrongtok = store_thm(
+val peg_eval_nUQConstructor_wrongtok = Q.store_thm(
   "peg_eval_nUQConstructor_wrongtok",
-  ``(∀s. t ≠ AlphaT s) ⇒
-    ¬peg_eval cmlPEG (t::i, nt (mkNT nUQConstructorName) f) (SOME x)``,
+  `(∀s. t ≠ AlphaT s) ⇒
+    ¬peg_eval cmlPEG (t::i, nt (mkNT nUQConstructorName) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied,
        peg_eval_tok_SOME,
        peg_UQConstructorName_def] >> Cases_on `t` >> simp[]);
 
-val peg_eval_nConstructor_wrongtok = store_thm(
+val peg_eval_nConstructor_wrongtok = Q.store_thm(
   "peg_eval_nConstructor_wrongtok",
-  ``(∀s. t ≠ AlphaT s) ∧ (∀s1 s2. t ≠ LongidT s1 s2) ⇒
-    ¬peg_eval cmlPEG (t::i, nt (mkNT nConstructorName) f) (SOME x)``,
+  `(∀s. t ≠ AlphaT s) ∧ (∀s1 s2. t ≠ LongidT s1 s2) ⇒
+    ¬peg_eval cmlPEG (t::i, nt (mkNT nConstructorName) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, peg_eval_tok_SOME,
        peg_eval_choicel_CONS, peg_eval_seq_NONE, pegf_def, pnt_def,
        peg_eval_nUQConstructor_wrongtok, peg_eval_seq_SOME] >>
   Cases_on `t` >> simp[]);
 
-val peg_eval_nV_wrongtok = store_thm(
+val peg_eval_nV_wrongtok = Q.store_thm(
   "peg_eval_nV_wrongtok",
-  ``(∀s. t ≠ AlphaT s) ∧ (∀s. t ≠ SymbolT s) ⇒
-    ¬peg_eval cmlPEG (t::i, nt (mkNT nV) f) (SOME x)``,
+  `(∀s. t ≠ AlphaT s) ∧ (∀s. t ≠ SymbolT s) ⇒
+    ¬peg_eval cmlPEG (t::i, nt (mkNT nV) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, peg_V_def,
        peg_eval_seq_NONE, peg_eval_choice] >>
   Cases_on `t` >> simp[]);
 
-val peg_eval_nFQV_wrongtok = store_thm(
+val peg_eval_nFQV_wrongtok = Q.store_thm(
   "peg_eval_nFQV_wrongtok",
-  ``(∀s. t ≠ AlphaT s) ∧ (∀s. t ≠ SymbolT s) ∧ (∀s1 s2. t ≠ LongidT s1 s2) ⇒
-    ¬peg_eval cmlPEG (t::i, nt (mkNT nFQV) f) (SOME x)``,
+  `(∀s. t ≠ AlphaT s) ∧ (∀s. t ≠ SymbolT s) ∧ (∀s1 s2. t ≠ LongidT s1 s2) ⇒
+    ¬peg_eval cmlPEG (t::i, nt (mkNT nFQV) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied,
        peg_eval_seq_NONE, peg_eval_choice, peg_eval_nV_wrongtok] >>
   Cases_on `t` >> simp[peg_longV_def]);
 
-val peg_eval_rpt_never_NONE = store_thm(
+val peg_eval_rpt_never_NONE = Q.store_thm(
   "peg_eval_rpt_never_NONE",
-  ``¬peg_eval G (i, rpt sym f) NONE``,
+  `¬peg_eval G (i, rpt sym f) NONE`,
   simp[Once peg_eval_cases]);
 val _ = export_rewrites ["peg_eval_rpt_never_NONE"]
 
@@ -134,9 +134,9 @@ val pegsym_to_sym_def = Define`
   pegsym_to_sym _ = {}
 `
 
-val peg_linfix_correct_lemma = store_thm(
+val peg_linfix_correct_lemma = Q.store_thm(
   "peg_linfix_correct_lemma",
-  ``∀UpperN sym sepsym i0 i pts.
+  `∀UpperN sym sepsym i0 i pts.
       peg_eval cmlPEG (i0, peg_linfix UpperN sym sepsym) (SOME(i,pts)) ⇒
       (∀i0' i pts s.
          s ∈ {sym;sepsym} ⇒
@@ -156,7 +156,7 @@ val peg_linfix_correct_lemma = store_thm(
           gsep ∈ pegsym_to_sym sepsym ∧ gsym ∈ pegsym_to_sym sym } ⊆
         cmlG.rules ' UpperN ⇒
       ∃pt. pts = [pt] ∧ ptree_head pt = NT UpperN ∧ valid_ptree cmlG pt ∧
-           MAP TK i0 = ptree_fringe pt ++ MAP TK i``,
+           MAP TK i0 = ptree_fringe pt ++ MAP TK i`,
   rpt strip_tac >> qpat_x_assum `peg_eval X Y Z` mp_tac >>
   simp[peg_linfix_def, peg_eval_rpt, peg_eval_seq_SOME] >>
   rpt strip_tac >> rveq >>
@@ -202,9 +202,9 @@ val peg_linfix_correct_lemma = store_thm(
     by fs[SUBSET_DEF] >>
   simp[]);
 
-val length_no_greater = store_thm(
+val length_no_greater = Q.store_thm(
   "length_no_greater",
-  ``peg_eval G (i0, sym) (SOME(i,r)) ⇒ LENGTH i ≤ LENGTH i0``,
+  `peg_eval G (i0, sym) (SOME(i,r)) ⇒ LENGTH i ≤ LENGTH i0`,
   metis_tac[peg_eval_suffix',
             DECIDE ``x ≤ y:num ⇔ x < y ∨ x = y``]);
 
@@ -218,9 +218,9 @@ val MAP_TK_11 = Q.store_thm(
   qexists_tac `TK` >>
   simp[INJ_DEF]);
 
-val peg_eval_nTyOp_wrongtok = store_thm(
+val peg_eval_nTyOp_wrongtok = Q.store_thm(
   "peg_eval_nTyOp_wrongtok",
-  ``¬peg_eval cmlPEG (LparT::i, nt (mkNT nTyOp) f) (SOME x)``,
+  `¬peg_eval cmlPEG (LparT::i, nt (mkNT nTyOp) f) (SOME x)`,
   simp[Once peg_eval_cases, cmlpeg_rules_applied, FDOM_cmlPEG] >>
   simp[Once peg_eval_cases, cmlpeg_rules_applied, FDOM_cmlPEG]);
 
@@ -240,9 +240,9 @@ in
                    assert P o concl))
 end
 
-val peg_EbaseParen_sound = store_thm(
+val peg_EbaseParen_sound = Q.store_thm(
   "peg_EbaseParen_sound",
-  ``∀i0 i pts.
+  `∀i0 i pts.
       peg_eval cmlPEG (i0, peg_EbaseParen) (SOME(i,pts)) ⇒
       (∀i0' N i pts.
         LENGTH i0' < LENGTH i0 ∧
@@ -252,7 +252,7 @@ val peg_EbaseParen_sound = store_thm(
           valid_ptree cmlG pt ∧ MAP TOK i0' = ptree_fringe pt ++ MAP TOK i) ⇒
       ∃pt.
         pts = [pt] ∧ ptree_head pt = NT (mkNT nEbase) ∧
-        valid_ptree cmlG pt ∧ MAP TOK i0 = ptree_fringe pt ++ MAP TOK i``,
+        valid_ptree cmlG pt ∧ MAP TOK i0 = ptree_fringe pt ++ MAP TOK i`,
   rw[peg_EbaseParen_def]
   >- (rlresolve X (K true) mp_tac >> simp[] >> strip_tac >> rveq >>
       simp[peg_EbaseParenFn_def, cmlG_FDOM, cmlG_applied, DISJ_IMP_THM])
@@ -273,13 +273,13 @@ val peg_EbaseParen_sound = store_thm(
   simp[peg_EbaseParenFn_def, cmlG_applied, cmlG_FDOM,
        DISJ_IMP_THM, FORALL_AND_THM])
 
-val peg_sound = store_thm(
+val peg_sound = Q.store_thm(
   "peg_sound",
-  ``∀N i0 i pts.
+  `∀N i0 i pts.
        peg_eval cmlPEG (i0,nt N I) (SOME(i,pts)) ⇒
        ∃pt. pts = [pt] ∧ ptree_head pt = NT N ∧
             valid_ptree cmlG pt ∧
-            MAP TOK i0 = ptree_fringe pt ++ MAP TOK i``,
+            MAP TOK i0 = ptree_fringe pt ++ MAP TOK i`,
   ntac 2 gen_tac >> `?iN. iN = (i0,N)` by simp[] >> pop_assum mp_tac >>
   map_every qid_spec_tac [`i0`, `N`, `iN`] >>
   qispl_then [`measure (LENGTH:token list->num) LEX measure NT_rank`]

--- a/compiler/proofs/compilerProofScript.sml
+++ b/compiler/proofs/compilerProofScript.sml
@@ -124,7 +124,7 @@ val compile_correct_gen = Q.store_thm("compile_correct_gen",
   \\ drule (GEN_ALL infertype_prog_correct)
   \\ simp[]
   \\ disch_then(qspec_then`prelude++x`mp_tac)
-  \\ rator_assum`type_sound_invariant`(strip_assume_tac o SIMP_RULE std_ss [typeSoundTheory.type_sound_invariant_def])
+  \\ qhdtm_assum`type_sound_invariant`(strip_assume_tac o SIMP_RULE std_ss [typeSoundTheory.type_sound_invariant_def])
   \\ rfs[]
   \\ strip_tac \\ simp[]
   \\ IF_CASES_TAC \\ fs[]

--- a/compiler/targets/asm/asmPropsScript.sml
+++ b/compiler/targets/asm/asmPropsScript.sml
@@ -137,30 +137,30 @@ val upd_pc_simps = Q.store_thm("upd_pc_simps[simp]",
    ((asmSem$upd_pc x s).pc = x)`,
   EVAL_TAC);
 
-val asm_failed_ignore_new_pc = store_thm("asm_failed_ignore_new_pc",
-  ``!i v w s. (asm i w s).failed <=> (asm i v s).failed``,
+val asm_failed_ignore_new_pc = Q.store_thm("asm_failed_ignore_new_pc",
+  `!i v w s. (asm i w s).failed <=> (asm i v s).failed`,
   Cases \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,jump_to_offset_def,upd_reg_def]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val asm_mem_ignore_new_pc = store_thm("asm_mem_ignore_new_pc",
-  ``!i v w s. (asm i w s).mem = (asm i v s).mem``,
+val asm_mem_ignore_new_pc = Q.store_thm("asm_mem_ignore_new_pc",
+  `!i v w s. (asm i w s).mem = (asm i v s).mem`,
   Cases \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,jump_to_offset_def,upd_reg_def]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
 
-val SND_read_mem_word_consts = prove(
-  ``!n a s. ((SND (read_mem_word a n s)).be = s.be) /\
+val SND_read_mem_word_consts = Q.prove(
+  `!n a s. ((SND (read_mem_word a n s)).be = s.be) /\
             ((SND (read_mem_word a n s)).lr = s.lr) /\
             ((SND (read_mem_word a n s)).align = s.align) /\
-            ((SND (read_mem_word a n s)).mem_domain = s.mem_domain)``,
+            ((SND (read_mem_word a n s)).mem_domain = s.mem_domain)`,
   Induct \\ full_simp_tac(srw_ss())[read_mem_word_def,LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
   \\ full_simp_tac(srw_ss())[assert_def])
 
-val write_mem_word_consts = prove(
-  ``!n a w s. ((write_mem_word a n w s).be = s.be) /\
+val write_mem_word_consts = Q.prove(
+  `!n a w s. ((write_mem_word a n w s).be = s.be) /\
               ((write_mem_word a n w s).lr = s.lr) /\
               ((write_mem_word a n w s).align = s.align) /\
-              ((write_mem_word a n w s).mem_domain = s.mem_domain)``,
+              ((write_mem_word a n w s).mem_domain = s.mem_domain)`,
   Induct \\ full_simp_tac(srw_ss())[write_mem_word_def,LET_DEF,assert_def,upd_mem_def])
 
 val binop_upd_consts = Q.store_thm("binop_upd_consts[simp]",
@@ -180,11 +180,11 @@ val arith_upd_consts = Q.store_thm("arith_upd_consts[simp]",
    ((arith_upd a x).be = x.be)`,
   Cases_on`a` >> EVAL_TAC >> srw_tac[][]);
 
-val asm_consts = store_thm("asm_consts[simp]",
-  ``!i w s. ((asm i w s).be = s.be) /\
+val asm_consts = Q.store_thm("asm_consts[simp]",
+  `!i w s. ((asm i w s).be = s.be) /\
             ((asm i w s).lr = s.lr) /\
             ((asm i w s).align = s.align) /\
-            ((asm i w s).mem_domain = s.mem_domain)``,
+            ((asm i w s).mem_domain = s.mem_domain)`,
   Cases \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,jump_to_offset_def,upd_reg_def]
   \\ TRY (Cases_on `i'`) \\ full_simp_tac(srw_ss())[inst_def]
   \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,jump_to_offset_def,upd_reg_def]

--- a/compiler/targets/targetPropsScript.sml
+++ b/compiler/targets/targetPropsScript.sml
@@ -6,10 +6,10 @@ open preamble
 val _ = ParseExtras.temp_tight_equality();
 val _ = new_theory"targetProps";
 
-val asserts_restrict = prove(
-  ``!n next1 next2 s P Q.
+val asserts_restrict = Q.prove(
+  `!n next1 next2 s P Q.
       (!k. k <= n ==> (next1 k = next2 k)) ==>
-      (asserts n next1 s P Q ==> asserts n next2 s P Q)``,
+      (asserts n next1 s P Q ==> asserts n next2 s P Q)`,
   Induct \\ full_simp_tac(srw_ss())[asserts_def,LET_DEF]
   \\ REPEAT STRIP_TAC \\ POP_ASSUM MP_TAC
   \\ FIRST_X_ASSUM MATCH_MP_TAC
@@ -21,13 +21,13 @@ val shift_interfer_def = Define `
   shift_interfer k s =
     s with next_interfer := shift_seq k s.next_interfer`
 
-val shift_interfer_intro = prove(
-  ``shift_interfer k1 (shift_interfer k2 c) =
-    shift_interfer (k1+k2) c``,
+val shift_interfer_intro = Q.prove(
+  `shift_interfer k1 (shift_interfer k2 c) =
+    shift_interfer (k1+k2) c`,
   full_simp_tac(srw_ss())[shift_interfer_def,shift_seq_def,ADD_ASSOC]);
 
-val evaluate_EQ_evaluate_lemma = prove(
-  ``!n ms1 c.
+val evaluate_EQ_evaluate_lemma = Q.prove(
+  `!n ms1 c.
       c.target.get_pc ms1 IN c.prog_addresses /\ c.target.state_ok ms1 /\
       interference_ok c.next_interfer (c.target.proj dm) /\
       (!s ms. target_state_rel c.target s ms ==> c.target.state_ok ms) /\
@@ -41,7 +41,7 @@ val evaluate_EQ_evaluate_lemma = prove(
       ?ms2.
         !k. (evaluate c io (k + (n + 1)) ms1 =
              evaluate (shift_interfer (n+1) c) io k ms2) /\
-            target_state_rel c.target s2 ms2``,
+            target_state_rel c.target s2 ms2`,
   Induct THEN1
    (full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
     \\ full_simp_tac(srw_ss())[asserts_def,LET_DEF]
@@ -77,25 +77,25 @@ val evaluate_EQ_evaluate_lemma = prove(
   \\ POP_ASSUM (ASSUME_TAC o Q.SPEC `k`)
   \\ full_simp_tac(srw_ss())[GSYM shift_interfer_def,shift_interfer_intro] \\ full_simp_tac(srw_ss())[GSYM ADD1]);
 
-val enc_ok_not_empty = prove(
-  ``enc_ok c /\ asm_ok w c ==> (c.encode w <> [])``,
+val enc_ok_not_empty = Q.prove(
+  `enc_ok c /\ asm_ok w c ==> (c.encode w <> [])`,
   METIS_TAC [listTheory.LENGTH_NIL,enc_ok_def]);
 
-val asserts_WEAKEN = prove(
-  ``!n next s P Q.
+val asserts_WEAKEN = Q.prove(
+  `!n next s P Q.
       (!x. P x ==> P' x) /\ (!k. k <= n ==> (next k = next' k)) ==>
       asserts n next s P Q ==>
-      asserts n next' s P' Q``,
+      asserts n next' s P' Q`,
   Induct \\ full_simp_tac(srw_ss())[asserts_def,LET_DEF] \\ REPEAT STRIP_TAC \\ RES_TAC
   \\ `!k. k <= n ==> (next k = next' k)` by ALL_TAC \\ RES_TAC
   \\ REPEAT STRIP_TAC \\ FIRST_X_ASSUM MATCH_MP_TAC \\ decide_tac);
 
-val bytes_in_memory_IMP_SUBSET = prove(
-  ``!xs pc. bytes_in_memory pc xs m d ==> all_pcs (LENGTH xs) pc SUBSET d``,
+val bytes_in_memory_IMP_SUBSET = Q.prove(
+  `!xs pc. bytes_in_memory pc xs m d ==> all_pcs (LENGTH xs) pc SUBSET d`,
   Induct \\ full_simp_tac(srw_ss())[all_pcs_def,bytes_in_memory_def]);
 
-val asm_step_IMP_evaluate_step = store_thm("asm_step_IMP_evaluate_step",
-  ``!c s1 ms1 io i s2.
+val asm_step_IMP_evaluate_step = Q.store_thm("asm_step_IMP_evaluate_step",
+  `!c s1 ms1 io i s2.
       backend_correct c.target /\
       (c.prog_addresses = s1.mem_domain) /\
       interference_ok c.next_interfer (c.target.proj s1.mem_domain) /\
@@ -104,7 +104,7 @@ val asm_step_IMP_evaluate_step = store_thm("asm_step_IMP_evaluate_step",
       target_state_rel c.target (s1:'a asm_state) (ms1:'state) ==>
       ?l ms2. !k. (evaluate c io (k + l) ms1 =
                    evaluate (shift_interfer l c) io k ms2) /\
-                  target_state_rel c.target s2 ms2 /\ l <> 0``,
+                  target_state_rel c.target s2 ms2 /\ l <> 0`,
   full_simp_tac(srw_ss()) [backend_correct_def, target_ok_def, LET_DEF]
   \\ REPEAT STRIP_TAC \\ RES_TAC
   \\ full_simp_tac(srw_ss())[]

--- a/compiler/targets/targetPropsScript.sml
+++ b/compiler/targets/targetPropsScript.sml
@@ -142,7 +142,7 @@ val evaluate_add_clock = store_thm("evaluate_add_clock",
     evaluate mc_conf ffi k ms = (r,ms1,st1) /\ r <> TimeOut ==>
     evaluate mc_conf ffi (k + k1) ms = (r,ms1,st1)``,
   ho_match_mp_tac evaluate_ind >> srw_tac[][] >>
-  rator_x_assum`evaluate` mp_tac >>
+  qhdtm_x_assum`evaluate` mp_tac >>
   simp[Once evaluate_def] >>
   IF_CASES_TAC >> full_simp_tac(srw_ss())[] >>
   simp[Once evaluate_def,SimpR``$==>``] >>

--- a/compiler/targets/targetPropsScript.sml
+++ b/compiler/targets/targetPropsScript.sml
@@ -137,10 +137,10 @@ val asm_step_IMP_evaluate_step = Q.store_thm("asm_step_IMP_evaluate_step",
 
 (* basic properties *)
 
-val evaluate_add_clock = store_thm("evaluate_add_clock",
-  ``∀mc_conf ffi k ms k1 r ms1 st1.
+val evaluate_add_clock = Q.store_thm("evaluate_add_clock",
+  `∀mc_conf ffi k ms k1 r ms1 st1.
     evaluate mc_conf ffi k ms = (r,ms1,st1) /\ r <> TimeOut ==>
-    evaluate mc_conf ffi (k + k1) ms = (r,ms1,st1)``,
+    evaluate mc_conf ffi (k + k1) ms = (r,ms1,st1)`,
   ho_match_mp_tac evaluate_ind >> srw_tac[][] >>
   qhdtm_x_assum`evaluate` mp_tac >>
   simp[Once evaluate_def] >>

--- a/flame/set-theory/setModelScript.sml
+++ b/flame/set-theory/setModelScript.sml
@@ -113,8 +113,8 @@ val FINITE_SET_THEORY_IMAGE = TAC_PROOF(([],
   first_assum (mp_tac o REFORM_RULE o SPECL[``(INR x):'a+num``,``(INR y):'a+num``,``(INR y'):'a+num``]) >>
   simp[])
 
-val l_model_exists = store_thm("l_model_exists",
-  ``∃(P : α+num -> bool) (mem : α+num -> α+num -> bool). is_set_theory_pred P mem``,
+val l_model_exists = Q.store_thm("l_model_exists",
+  `∃(P : α+num -> bool) (mem : α+num -> α+num -> bool). is_set_theory_pred P mem`,
   qexists_tac`ISR` >>
   REWRITE_TAC[is_set_theory_pred_def] >>
   qexists_tac`λl1 l2. BIT (OUTR l1) (OUTR l2)` >>
@@ -343,8 +343,8 @@ val V_mem_rep_def =
 val V_mem_def = Define`V_mem x y = V_mem_rep (dest_V x) (dest_V y)`
 
 
-val is_set_theory_V = store_thm("is_set_theory_V",
-  ``is_set_theory V_mem``,
+val is_set_theory_V = Q.store_thm("is_set_theory_V",
+  `is_set_theory V_mem`,
   simp[is_set_theory_def] >>
   conj_tac >- (
     simp[extensional_def] >>
@@ -407,8 +407,8 @@ val is_set_theory_V = store_thm("is_set_theory_V",
   disch_then (strip_assume_tac o REWRITE_RULE[V_bij] o Q.SPEC`dest_V d`) >>
   metis_tac[V_bij] )
 
-val V_choice_exists = prove(
-  ``∃ch. is_choice V_mem ch``,
+val V_choice_exists = Q.prove(
+  `∃ch. is_choice V_mem ch`,
   simp[is_choice_def,GSYM SKOLEM_THM] >>
   rw[] >> simp[V_mem_def] >>
   qspecl_then[`dest_V x`]mp_tac

--- a/flame/set-theory/setModelScript.sml
+++ b/flame/set-theory/setModelScript.sml
@@ -423,9 +423,9 @@ val V_indset_def =
   new_specification("V_indset_def",["V_indset"],
     METIS_PROVE[]``∃i:α V. (∃x:α V. is_inductive V_mem x) ⇒ is_inductive V_mem i``)
 
-val is_model_V = store_thm("is_model_V",
-  ``(∃I:α V. is_inductive V_mem I) ⇒
-    is_model (V_mem,V_indset:α V,V_choice)``,
+val is_model_V = Q.store_thm("is_model_V",
+  `(∃I:α V. is_inductive V_mem I) ⇒
+    is_model (V_mem,V_indset:α V,V_choice)`,
   simp[is_model_def,is_set_theory_V,V_choice_def,V_indset_def])
 
 val _ = print_theory_to_file "-" "setModel";

--- a/flame/set-theory/setSpecScript.sml
+++ b/flame/set-theory/setSpecScript.sml
@@ -62,24 +62,24 @@ val is_set_theory_def = Define`
     regular mem ∧
     replacement mem`
 
-val separation_unique = store_thm("separation_unique",
-  ``extensional ^mem ⇒
-    ∀sub1 sub2. is_separation mem sub1 ∧ is_separation mem sub2 ⇒ sub1 = sub2``,
+val separation_unique = Q.store_thm("separation_unique",
+  `extensional ^mem ⇒
+    ∀sub1 sub2. is_separation mem sub1 ∧ is_separation mem sub2 ⇒ sub1 = sub2`,
   rw[is_separation_def,extensional_def,FUN_EQ_THM])
 
-val power_unique = store_thm("power_unique",
-  ``extensional ^mem ⇒
-    ∀power1 power2. is_power mem power1 ∧ is_power mem power2 ⇒ power1 = power2``,
+val power_unique = Q.store_thm("power_unique",
+  `extensional ^mem ⇒
+    ∀power1 power2. is_power mem power1 ∧ is_power mem power2 ⇒ power1 = power2`,
   rw[is_power_def,extensional_def,FUN_EQ_THM])
 
-val union_unique = store_thm("union_unique",
-  ``extensional ^mem ⇒
-    ∀union1 union2. is_union mem union1 ∧ is_union mem union2 ⇒ union1 = union2``,
+val union_unique = Q.store_thm("union_unique",
+  `extensional ^mem ⇒
+    ∀union1 union2. is_union mem union1 ∧ is_union mem union2 ⇒ union1 = union2`,
   rw[is_union_def,extensional_def,FUN_EQ_THM])
 
-val upair_unique = store_thm("upair_unique",
-  ``extensional ^mem ⇒
-    ∀upair1 upair2. is_upair mem upair1 ∧ is_upair mem upair2 ⇒ upair1 = upair2``,
+val upair_unique = Q.store_thm("upair_unique",
+  `extensional ^mem ⇒
+    ∀upair1 upair2. is_upair mem upair1 ∧ is_upair mem upair2 ⇒ upair1 = upair2`,
   rw[is_upair_def,extensional_def,FUN_EQ_THM])
 
 val sub_def = Define`
@@ -94,28 +94,28 @@ val union_def = Define`
 val upair_def = Define`
   upair ^mem = @upair. is_upair mem upair`
 
-val is_extensional = store_thm("is_extensional",
-  ``is_set_theory ^mem ⇒ extensional mem``,
+val is_extensional = Q.store_thm("is_extensional",
+  `is_set_theory ^mem ⇒ extensional mem`,
   rw[is_set_theory_def])
 
-val is_separation_sub = store_thm("is_separation_sub",
-  ``is_set_theory ^mem ⇒ is_separation mem (sub mem)``,
+val is_separation_sub = Q.store_thm("is_separation_sub",
+  `is_set_theory ^mem ⇒ is_separation mem (sub mem)`,
   rw[sub_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_power_power = store_thm("is_power_power",
-  ``is_set_theory ^mem ⇒ is_power mem (power mem)``,
+val is_power_power = Q.store_thm("is_power_power",
+  `is_set_theory ^mem ⇒ is_power mem (power mem)`,
   rw[power_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_union_union = store_thm("is_union_union",
-  ``is_set_theory ^mem ⇒ is_union mem (union mem)``,
+val is_union_union = Q.store_thm("is_union_union",
+  `is_set_theory ^mem ⇒ is_union mem (union mem)`,
   rw[union_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_upair_upair = store_thm("is_upair_upair",
-  ``is_set_theory ^mem ⇒ is_upair mem (upair mem)``,
+val is_upair_upair = Q.store_thm("is_upair_upair",
+  `is_set_theory ^mem ⇒ is_upair mem (upair mem)`,
   rw[upair_def] >> SELECT_ELIM_TAC >> fsrw_tac[SATISFY_ss][is_set_theory_def])
 
-val is_regular = store_thm("is_regular",
-  ``is_set_theory ^mem ⇒ regular mem``,
+val is_regular = Q.store_thm("is_regular",
+  `is_set_theory ^mem ⇒ regular mem`,
   rw[is_set_theory_def])
 
 val _ = Parse.add_infix("suchthat",9,Parse.LEFT)
@@ -124,22 +124,22 @@ val _ = Parse.overload_on("Pow",``power ^mem``)
 val _ = Parse.overload_on("+",``upair ^mem``)
 val _ = Parse.overload_on("⋃",``union ^mem``)
 
-val mem_sub = store_thm("mem_sub",
-  ``is_set_theory ^mem ⇒ ∀x s P. x <: (s suchthat P) ⇔ x <: s ∧ P x``,
+val mem_sub = Q.store_thm("mem_sub",
+  `is_set_theory ^mem ⇒ ∀x s P. x <: (s suchthat P) ⇔ x <: s ∧ P x`,
   strip_tac >> imp_res_tac is_separation_sub >> fs[is_separation_def])
 
-val mem_power = store_thm("mem_power",
-  ``is_set_theory ^mem ⇒
-    ∀x y. x <: (Pow y) ⇔ (∀b. b <: x ⇒ b <: y)``,
+val mem_power = Q.store_thm("mem_power",
+  `is_set_theory ^mem ⇒
+    ∀x y. x <: (Pow y) ⇔ (∀b. b <: x ⇒ b <: y)`,
   strip_tac >> imp_res_tac is_power_power >> fs[is_power_def])
 
-val mem_union = store_thm("mem_union",
-  ``is_set_theory ^mem ⇒
-    ∀x s. x <: ⋃ s ⇔ ∃a. x <: a ∧ a <: s``,
+val mem_union = Q.store_thm("mem_union",
+  `is_set_theory ^mem ⇒
+    ∀x s. x <: ⋃ s ⇔ ∃a. x <: a ∧ a <: s`,
   strip_tac >> imp_res_tac is_union_union >> fs[is_union_def])
 
-val mem_upair = store_thm("mem_upair",
-  ``is_set_theory ^mem ⇒ ∀a x y. a <: (x + y) ⇔ a = x ∨ a = y``,
+val mem_upair = Q.store_thm("mem_upair",
+  `is_set_theory ^mem ⇒ ∀a x y. a <: (x + y) ⇔ a = x ∨ a = y`,
   strip_tac >> imp_res_tac is_upair_upair >> fs[is_upair_def])
 
 val empty_def = Define`
@@ -147,18 +147,18 @@ val empty_def = Define`
 
 val _ = Parse.overload_on("∅",``empty ^mem``)
 
-val mem_empty = store_thm("mem_empty",
-  ``is_set_theory ^mem ⇒ ∀x. ¬(x <: ∅)``,
+val mem_empty = Q.store_thm("mem_empty",
+  `is_set_theory ^mem ⇒ ∀x. ¬(x <: ∅)`,
   strip_tac >> imp_res_tac is_separation_sub >>
   fs[empty_def,is_separation_def])
 
-val not_empty = store_thm("not_empty",
-  ``is_set_theory ^mem ⇒ ∀x. ¬(x = ∅) ⇔ ∃y. y <: x``,
+val not_empty = Q.store_thm("not_empty",
+  `is_set_theory ^mem ⇒ ∀x. ¬(x = ∅) ⇔ ∃y. y <: x`,
   strip_tac >> imp_res_tac is_extensional >>
   fs[empty_def,extensional_def,mem_sub])
 
-val eq_empty = store_thm("eq_empty",
-  ``is_set_theory ^mem ⇒ ∀x. (x = ∅) ⇔ ∀y. ~(y <: x)``,
+val eq_empty = Q.store_thm("eq_empty",
+  `is_set_theory ^mem ⇒ ∀x. (x = ∅) ⇔ ∀y. ~(y <: x)`,
   strip_tac >> imp_res_tac is_extensional >>
   fs[empty_def,extensional_def,mem_sub])
 
@@ -167,15 +167,15 @@ val unit_def = Define`
 
 val _ = Parse.overload_on("Unit",``unit ^mem``)
 
-val mem_unit = store_thm("mem_unit",
-  ``is_set_theory ^mem ⇒
-    ∀x y. x <: (Unit y) ⇔ x = y``,
+val mem_unit = Q.store_thm("mem_unit",
+  `is_set_theory ^mem ⇒
+    ∀x y. x <: (Unit y) ⇔ x = y`,
   strip_tac >> imp_res_tac is_upair_upair >>
   fs[is_upair_def,unit_def])
 
-val unit_inj = store_thm("unit_inj",
-  ``is_set_theory ^mem ⇒
-    ∀x y. Unit x = Unit y ⇔ x = y``,
+val unit_inj = Q.store_thm("unit_inj",
+  `is_set_theory ^mem ⇒
+    ∀x y. Unit x = Unit y ⇔ x = y`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_unit] >>
@@ -186,9 +186,9 @@ val one_def = Define`
 
 val _ = Parse.overload_on("One",``one ^mem``)
 
-val mem_one = store_thm("mem_one",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: One ⇔ x = ∅``,
+val mem_one = Q.store_thm("mem_one",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: One ⇔ x = ∅`,
   strip_tac >> simp[mem_unit,one_def])
 
 val two_def = Define`
@@ -196,9 +196,9 @@ val two_def = Define`
 
 val _ = Parse.overload_on("Two",``two ^mem``)
 
-val mem_two = store_thm("mem_two",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: Two ⇔ x = ∅ ∨ x = One``,
+val mem_two = Q.store_thm("mem_two",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: Two ⇔ x = ∅ ∨ x = One`,
   strip_tac >> simp[mem_upair,mem_one,two_def])
 
 val binary_inter_def = Define`
@@ -206,9 +206,9 @@ val binary_inter_def = Define`
 
 val _ = Parse.overload_on("INTER",``binary_inter ^mem``)
 
-val mem_binary_inter = store_thm("mem_binary_inter",
-  ``is_set_theory ^mem ⇒
-    ∀x y z. x <: y ∩ z ⇔ x <: y ∧ x <: z``,
+val mem_binary_inter = Q.store_thm("mem_binary_inter",
+  `is_set_theory ^mem ⇒
+    ∀x y z. x <: y ∩ z ⇔ x <: y ∧ x <: z`,
   strip_tac >> simp[binary_inter_def,mem_sub])
 
 val subset_def = Define`
@@ -216,14 +216,14 @@ val subset_def = Define`
 
 val _ = Parse.overload_on("SUBSET",``subset ^mem``)
 
-val subset_refl = store_thm("subset_refl",
-  ``is_set_theory ^mem ⇒
-    ∀x. x ⊆ x``,
+val subset_refl = Q.store_thm("subset_refl",
+  `is_set_theory ^mem ⇒
+    ∀x. x ⊆ x`,
   strip_tac >> simp[subset_def])
 
-val subset_mem = store_thm("subset_mem",
-  ``is_set_theory ^mem ⇒
-    ∀x y z. x <: y ∧ y ⊆ z ⇒ x <: z``,
+val subset_mem = Q.store_thm("subset_mem",
+  `is_set_theory ^mem ⇒
+    ∀x y z. x <: y ∧ y ⊆ z ⇒ x <: z`,
   strip_tac >> simp[subset_def])
 
 val psubset_def = Define`
@@ -242,17 +242,17 @@ val mem_pair = store_thm("mem_pair",
   strip_tac >>
   simp[pair_def,mem_upair])
 
-val upair_inj = store_thm("upair_inj",
-  ``is_set_theory ^mem ⇒
-    ∀a b c d. a + b = c + d ⇔ a = c ∧ b = d ∨ a = d ∧ b = c``,
+val upair_inj = Q.store_thm("upair_inj",
+  `is_set_theory ^mem ⇒
+    ∀a b c d. a + b = c + d ⇔ a = c ∧ b = d ∨ a = d ∧ b = c`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_upair] >>
   metis_tac[])
 
-val unit_eq_upair = store_thm("unit_eq_upair",
-  ``is_set_theory ^mem ⇒
-    ∀x y z. Unit x = y + z ⇔ x = y ∧ y = z``,
+val unit_eq_upair = Q.store_thm("unit_eq_upair",
+  `is_set_theory ^mem ⇒
+    ∀x y z. Unit x = y + z ⇔ x = y ∧ y = z`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_unit,mem_upair] >>
@@ -270,9 +270,9 @@ val binary_union_def = Define`
 
 val _ = Parse.overload_on("UNION",``binary_union ^mem``)
 
-val mem_binary_union = store_thm("mem_binary_union",
-  ``is_set_theory ^mem ⇒
-    ∀a x y. a <: (x ∪ y) ⇔ a <: x ∨ a <: y``,
+val mem_binary_union = Q.store_thm("mem_binary_union",
+  `is_set_theory ^mem ⇒
+    ∀a x y. a <: (x ∪ y) ⇔ a <: x ∨ a <: y`,
   strip_tac >> fs[binary_union_def,mem_union,mem_upair] >>
   metis_tac[])
 
@@ -297,10 +297,10 @@ val relspace_def = Define`
 
 val _ = Parse.overload_on("Relspace",``relspace ^mem``)
 
-val mem_relspace = store_thm("mem_relspace",
-  ``is_set_theory ^mem ⇒
+val mem_relspace = Q.store_thm("mem_relspace",
+  `is_set_theory ^mem ⇒
     ∀d r f. f <: Relspace d r ⇔
-            f <: Pow (d × r)``,
+            f <: Pow (d × r)`,
   rw[relspace_def])
 
 val relspace_pairs = store_thm("relspace_pairs",
@@ -358,10 +358,10 @@ val mem_id = store_thm("mem_id",
   strip_tac >>
   asm_rewrite_tac[])
 
-val replacement = store_thm("replacement",
-  ``is_set_theory ^mem ⇒
+val replacement = Q.store_thm("replacement",
+  `is_set_theory ^mem ⇒
      ∀R. is_functional R ⇒
-          ∀d. ∃r. ∀y. y <: r ⇔ ∃x. x <: d ∧ R x y``,
+          ∀d. ∃r. ∀y. y <: r ⇔ ∃x. x <: d ∧ R x y`,
   DISCH_TAC >> IMP_RES_TAC is_set_theory_def >>
   IMP_RES_THEN MP_TAC replacement_def >>
   rw[])
@@ -373,9 +373,9 @@ val _ = Parse.hide "''"
 val _ = Parse.add_infix("''",2000,Parse.LEFT)
 val _ = Parse.overload_on("''",``image ^mem``)
 
-val mem_image = store_thm("mem_image",
-  ``is_set_theory ^mem ⇒
-    ∀f d y. y <: f '' d ⇔ ∃x. x <: d ∧ f x = y``,
+val mem_image = Q.store_thm("mem_image",
+  `is_set_theory ^mem ⇒
+    ∀f d y. y <: f '' d ⇔ ∃x. x <: d ∧ f x = y`,
   REPEAT STRIP_TAC >>
   IMP_RES_TAC replacement >>
   `is_functional (λx y. f x = y)` by simp[is_functional_def] >>
@@ -421,9 +421,9 @@ val inverse_pairs = store_thm("inverse_pairs",
 
 (* Unless f is 1-1 and onto, Inverse f is not a function. *)
 
-val funspace_inverse = store_thm("funspace_inverse",
-  ``is_set_theory ^mem ⇒
-    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ Inverse f <: Funspace r d``,
+val funspace_inverse = Q.store_thm("funspace_inverse",
+  `is_set_theory ^mem ⇒
+    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ Inverse f <: Funspace r d`,
   strip_tac >>
   simp[is_one_one_def,is_onto_def,mem_funspace,mem_relspace,mem_power,mem_product,EXISTS_UNIQUE_THM] >>
   REPEAT gen_tac >> strip_tac >>
@@ -435,9 +435,9 @@ val funspace_inverse = store_thm("funspace_inverse",
       metis_tac[pair_inj]
     ])
 
-val inverse_is_11_onto = store_thm("inverse_is_11_onto",
-  ``is_set_theory ^mem ⇒
-    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ is_11 (Inverse f) r ∧ is_Onto (Inverse f) d``,
+val inverse_is_11_onto = Q.store_thm("inverse_is_11_onto",
+  `is_set_theory ^mem ⇒
+    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ is_11 (Inverse f) r ∧ is_Onto (Inverse f) d`,
   strip_tac >>
   simp[is_one_one_def,is_onto_def,mem_funspace,mem_relspace,mem_power,mem_product,EXISTS_UNIQUE_THM] >>
   REPEAT gen_tac >> strip_tac >>
@@ -456,9 +456,9 @@ val mem_funspace_pairs = store_thm("mem_funspace_pairs",
 
 val pop_tac = pop_assum (fn th => all_tac)
 
-val inverse_inverse_eq_id = store_thm("inverse_inverse_eq_id",
-  ``is_set_theory ^mem ⇒
-    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ Inverse (Inverse f) = f``,
+val inverse_inverse_eq_id = Q.store_thm("inverse_inverse_eq_id",
+  `is_set_theory ^mem ⇒
+    ∀f d r. f <: Funspace d r ∧ is_11 f d ∧ is_Onto f r ⇒ Inverse (Inverse f) = f`,
   rw[] >>
   `is_11 (Inverse f) r ∧ is_Onto (Inverse f) d` by metis_tac[inverse_is_11_onto] >>
   `Inverse f <: Funspace r d` by simp[funspace_inverse] >>
@@ -480,17 +480,17 @@ val false_def = Define`
 val _ = Parse.overload_on("True",``true ^mem``)
 val _ = Parse.overload_on("False",``false ^mem``)
 
-val true_neq_false = store_thm("true_neq_false",
-  ``is_set_theory ^mem ⇒ True ≠ False``,
+val true_neq_false = Q.store_thm("true_neq_false",
+  `is_set_theory ^mem ⇒ True ≠ False`,
   strip_tac >>
   imp_res_tac mem_one >>
   imp_res_tac mem_empty >>
   fs[true_def,false_def,is_set_theory_def,extensional_def,one_def] >>
   metis_tac[])
 
-val mem_boolset = store_thm("mem_boolset",
-  ``is_set_theory ^mem ⇒
-    ∀x. x <: boolset ⇔ ((x = True) ∨ (x = False))``,
+val mem_boolset = Q.store_thm("mem_boolset",
+  `is_set_theory ^mem ⇒
+    ∀x. x <: boolset ⇔ ((x = True) ∨ (x = False))`,
   strip_tac >> fs[mem_two,true_def,false_def])
 
 val boolean_def = Define`
@@ -498,14 +498,14 @@ val boolean_def = Define`
 
 val _ = Parse.overload_on("Boolean",``boolean ^mem``)
 
-val boolean_in_boolset = store_thm("boolean_in_boolset",
-  ``is_set_theory ^mem ⇒
-    ∀b. Boolean b <: boolset``,
+val boolean_in_boolset = Q.store_thm("boolean_in_boolset",
+  `is_set_theory ^mem ⇒
+    ∀b. Boolean b <: boolset`,
   strip_tac >> imp_res_tac mem_boolset >>
   Cases >> simp[boolean_def])
 
-val boolean_eq_true = store_thm("boolean_eq_true",
-  ``is_set_theory ^mem ⇒ ∀b. Boolean b = True ⇔ b``,
+val boolean_eq_true = Q.store_thm("boolean_eq_true",
+  `is_set_theory ^mem ⇒ ∀b. Boolean b = True ⇔ b`,
   strip_tac >> rw[boolean_def,true_neq_false])
 
 val holds_def = Define`
@@ -518,23 +518,23 @@ val suc_def = Define`
 
 val _ = Parse.overload_on("Suc",``suc ^mem``)
 
-val mem_suc = store_thm("mem_suc",
-  ``is_set_theory ^mem ⇒
-    ∀x y. x <: (Suc y) ⇔ x = y ∨ x <: y``,
+val mem_suc = Q.store_thm("mem_suc",
+  `is_set_theory ^mem ⇒
+    ∀x y. x <: (Suc y) ⇔ x = y ∨ x <: y`,
   strip_tac >> rw[suc_def,mem_binary_union,mem_unit] >> METIS_TAC[])
 
-val suc_not_empty = store_thm("suc_not_empty",
-  ``is_set_theory ^mem ⇒
-    ∀x. ~(∅ = Suc x)``,
+val suc_not_empty = Q.store_thm("suc_not_empty",
+  `is_set_theory ^mem ⇒
+    ∀x. ~(∅ = Suc x)`,
   strip_tac >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_empty] >>
   simp[suc_def,mem_binary_union,mem_unit] >>
   metis_tac[])
 
-val not_mem_ident = store_thm("not_mem_ident",
-  ``is_set_theory ^mem ⇒
-    ∀x. ~(x <: x)``,
+val not_mem_ident = Q.store_thm("not_mem_ident",
+  `is_set_theory ^mem ⇒
+    ∀x. ~(x <: x)`,
   strip_tac >>
   imp_res_tac is_regular >>
   gen_tac >>
@@ -543,9 +543,9 @@ val not_mem_ident = store_thm("not_mem_ident",
   first_assum (mp_tac o Q.SPEC`Unit x`) >>
   simp[mem_unit])
 
-val not_mem_cycle = store_thm("not_mem_cycle",
-  ``is_set_theory ^mem ⇒
-    ∀x y. ~(x <: y ∧ y <: x)``,
+val not_mem_cycle = Q.store_thm("not_mem_cycle",
+  `is_set_theory ^mem ⇒
+    ∀x y. ~(x <: y ∧ y <: x)`,
   strip_tac >>
   imp_res_tac is_regular >>
   REPEAT gen_tac >>
@@ -554,9 +554,9 @@ val not_mem_cycle = store_thm("not_mem_cycle",
   first_assum (mp_tac o Q.SPEC`x + y`) >>
   metis_tac[mem_upair])
 
-val suc_11 = store_thm("suc_11",
-  ``is_set_theory ^mem ⇒
-    ∀x y. (Suc x = Suc y) ⇔ (x = y)``,
+val suc_11 = Q.store_thm("suc_11",
+  `is_set_theory ^mem ⇒
+    ∀x y. (Suc x = Suc y) ⇔ (x = y)`,
   metis_tac[mem_suc,not_mem_cycle])
 
 
@@ -565,39 +565,39 @@ val abstract_def = Define`
 
 val _ = Parse.overload_on("Abstract",``abstract ^mem``)
 
-val apply_abstract = store_thm("apply_abstract",
-  ``is_set_theory ^mem ⇒
-    ∀f x s t. x <: s ∧ f x <: t ⇒ (Abstract s t f) ' x = f x``,
+val apply_abstract = Q.store_thm("apply_abstract",
+  `is_set_theory ^mem ⇒
+    ∀f x s t. x <: s ∧ f x <: t ⇒ (Abstract s t f) ' x = f x`,
   strip_tac >>
   rw[apply_def,abstract_def] >>
   SELECT_ELIM_TAC >>
   simp[mem_sub,mem_product,pair_inj])
 
-val apply_abstract_matchable = store_thm("apply_abstract_matchable",
-  ``∀f x s t u. x <: s ∧ f x <: t ∧ is_set_theory ^mem ∧ f x = u ⇒ Abstract s t f ' x = u``,
+val apply_abstract_matchable = Q.store_thm("apply_abstract_matchable",
+  `∀f x s t u. x <: s ∧ f x <: t ∧ is_set_theory ^mem ∧ f x = u ⇒ Abstract s t f ' x = u`,
   metis_tac[apply_abstract])
 
-val apply_in_rng = store_thm("apply_in_rng",
-  ``is_set_theory ^mem ⇒
+val apply_in_rng = Q.store_thm("apply_in_rng",
+  `is_set_theory ^mem ⇒
     ∀f x s t. x <: s ∧ f <: Funspace s t ⇒
-    f ' x <: t``,
+    f ' x <: t`,
   strip_tac >>
   simp[funspace_def,mem_sub,relspace_def,
        mem_power,apply_def,mem_product,EXISTS_UNIQUE_THM] >>
   rw[] >> res_tac >> SELECT_ELIM_TAC >> res_tac >> rfs[pair_inj] >> metis_tac[])
 
-val abstract_in_funspace = store_thm("abstract_in_funspace",
-  ``is_set_theory ^mem ⇒
-    ∀f s t. (∀x. x <: s ⇒ f x <: t) ⇒ Abstract s t f <: Funspace s t``,
+val abstract_in_funspace = Q.store_thm("abstract_in_funspace",
+  `is_set_theory ^mem ⇒
+    ∀f s t. (∀x. x <: s ⇒ f x <: t) ⇒ Abstract s t f <: Funspace s t`,
   strip_tac >>
   simp[funspace_def,relspace_def,abstract_def,mem_power,mem_product,mem_sub] >>
   simp[EXISTS_UNIQUE_THM,pair_inj])
 
-val abstract_eq = store_thm("abstract_eq",
-  ``is_set_theory ^mem ⇒
+val abstract_eq = Q.store_thm("abstract_eq",
+  `is_set_theory ^mem ⇒
     ∀s t1 t2 f g.
     (∀x. x <: s ⇒ f x <: t1 ∧ g x <: t2 ∧ f x = g x)
-    ⇒ Abstract s t1 f = Abstract s t2 g``,
+    ⇒ Abstract s t1 f = Abstract s t2 g`,
   rw[] >>
   imp_res_tac is_extensional >>
   pop_assum mp_tac >>
@@ -606,10 +606,10 @@ val abstract_eq = store_thm("abstract_eq",
   simp[abstract_def,mem_sub,mem_product] >>
   metis_tac[pair_inj])
 
-val in_funspace_abstract = store_thm("in_funspace_abstract",
-  ``is_set_theory ^mem ⇒
+val in_funspace_abstract = Q.store_thm("in_funspace_abstract",
+  `is_set_theory ^mem ⇒
     ∀z s t. z <: Funspace s t ⇒
-    ∃f. z = Abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)``,
+    ∃f. z = Abstract s t f ∧ (∀x. x <: s ⇒ f x <: t)`,
   rw[funspace_def,mem_sub,relspace_def,mem_power] >>
   qexists_tac`λx. @y. (x,y) <: z` >>
   conj_tac >- (
@@ -634,15 +634,15 @@ val apply_eq_mem = store_thm("apply_eq_mem",
   conj_tac >- simp[] >>
   metis_tac[])
 
-val id_funspace = store_thm("id_funspace",
-  ``is_set_theory ^mem ⇒
-    ∀d. Id d <: Funspace d d``,
+val id_funspace = Q.store_thm("id_funspace",
+  `is_set_theory ^mem ⇒
+    ∀d. Id d <: Funspace d d`,
   strip_tac >>
   simp[id_def,funspace_def,mem_sub,mem_relspace,mem_power,mem_product,pair_inj,EXISTS_UNIQUE_THM])
 
-val apply_id = store_thm("apply_id",
-  ``is_set_theory ^mem ⇒
-    ∀d x. x <: d ⇒ Id d ' x = x``,
+val apply_id = Q.store_thm("apply_id",
+  `is_set_theory ^mem ⇒
+    ∀d x. x <: d ⇒ Id d ' x = x`,
   rw[] >>
   imp_res_tac id_funspace >>
   pop_assum (assume_tac o SPEC_ALL) >>
@@ -650,9 +650,9 @@ val apply_id = store_thm("apply_id",
   asm_rewrite_tac[] >>
   simp[mem_id])
 
-val apply_extensional = store_thm("apply_extensional",
-  ``is_set_theory ^mem ⇒
-    ∀d r f g. f <: Funspace d r ∧ g <: Funspace d r ⇒ ((f = g) ⇔ ∀x. x <: d ⇒ f ' x = g ' x)``,
+val apply_extensional = Q.store_thm("apply_extensional",
+  `is_set_theory ^mem ⇒
+    ∀d r f g. f <: Funspace d r ∧ g <: Funspace d r ⇒ ((f = g) ⇔ ∀x. x <: d ⇒ f ' x = g ' x)`,
   rw[] >>
   EQ_TAC >|
     [ strip_tac >>
@@ -744,17 +744,17 @@ val is_model_def = Define`
     is_inductive mem indset ∧
     is_choice mem ch`
 
-val is_model_is_set_theory = store_thm("is_model_is_set_theory",
-  ``is_model M ⇒ is_set_theory ^mem``,
+val is_model_is_set_theory = Q.store_thm("is_model_is_set_theory",
+  `is_model M ⇒ is_set_theory ^mem`,
   rw[is_model_def])
 
-val indset_inhabited = store_thm("indset_inhabited",
-  ``is_infinite ^mem indset ⇒ ∃i. i <: indset``,
+val indset_inhabited = Q.store_thm("indset_inhabited",
+  `is_infinite ^mem indset ⇒ ∃i. i <: indset`,
   rw[is_infinite_def] >> imp_res_tac INFINITE_INHAB >>
   fs[] >> metis_tac[])
 
-val inductive_set_inhabited = store_thm("inductive_set_inhabited",
-  ``is_inductive ^mem indset ⇒ ∃i. i <: indset``,
+val inductive_set_inhabited = Q.store_thm("inductive_set_inhabited",
+  `is_inductive ^mem indset ⇒ ∃i. i <: indset`,
   metis_tac[is_inductive_def])
 
 val num2indset_def = Define`
@@ -763,48 +763,48 @@ val num2indset_def = Define`
 
 val _ = Parse.overload_on("Num2indset",``num2indset ^mem``)
 
-val num2indset_in_indset = store_thm("num2indset_in_indset",
-  ``is_inductive ^mem indset ⇒ ∀n. Num2indset n <: indset``,
+val num2indset_in_indset = Q.store_thm("num2indset_in_indset",
+  `is_inductive ^mem indset ⇒ ∀n. Num2indset n <: indset`,
   simp[is_inductive_def] >>
   strip_tac >>
   Induct >>
   simp[num2indset_def])
 
-val empty_num2indset = store_thm("empty_num2indset",
-  ``is_set_theory ^mem ⇒
-    ∀n. ∅ = Num2indset n ∨ ∅ <: Num2indset n``,
+val empty_num2indset = Q.store_thm("empty_num2indset",
+  `is_set_theory ^mem ⇒
+    ∀n. ∅ = Num2indset n ∨ ∅ <: Num2indset n`,
   strip_tac >>
   Induct >>
   simp[num2indset_def,mem_suc])
 
-val full_mem_num2indset = store_thm("full_mem_num2indset",
-  ``is_set_theory ^mem ⇒
-    ∀n m. m < n ⇒ Num2indset m <: Num2indset n``,
+val full_mem_num2indset = Q.store_thm("full_mem_num2indset",
+  `is_set_theory ^mem ⇒
+    ∀n m. m < n ⇒ Num2indset m <: Num2indset n`,
   strip_tac >>
   Induct >>
   simp[prim_recTheory.NOT_LESS_0,prim_recTheory.LESS_THM,num2indset_def,mem_suc] >>
   metis_tac[])
 
-val mem_num2indset_is_num2indset = store_thm("mem_num2indset_is_num2indset",
-  ``is_set_theory ^mem ⇒
-    ∀n a. a <: Num2indset n ⇒ ∃m. a = Num2indset m ∧ m < n``,
+val mem_num2indset_is_num2indset = Q.store_thm("mem_num2indset_is_num2indset",
+  `is_set_theory ^mem ⇒
+    ∀n a. a <: Num2indset n ⇒ ∃m. a = Num2indset m ∧ m < n`,
   strip_tac >>
   Induct >>
   simp[prim_recTheory.NOT_LESS_0,prim_recTheory.LESS_THM,num2indset_def,mem_empty,mem_suc] >>
   metis_tac[])
 
-val mem_num2indset_is_num2indset_eq = store_thm("mem_num2indset_is_num2indset_eq",
-  ``is_set_theory ^mem ⇒
-    ∀n a. (a <: Num2indset n) = ∃m. a = Num2indset m ∧ m < n``,
+val mem_num2indset_is_num2indset_eq = Q.store_thm("mem_num2indset_is_num2indset_eq",
+  `is_set_theory ^mem ⇒
+    ∀n a. (a <: Num2indset n) = ∃m. a = Num2indset m ∧ m < n`,
   metis_tac[mem_num2indset_is_num2indset,full_mem_num2indset] )
 
 val MAX_SUC = TAC_PROOF(([],
   ``∀a b. MAX (SUC a) (SUC b) = SUC (MAX a b)``),
   simp[arithmeticTheory.MAX_DEF])
 
-val num2indset_11 = store_thm("num2indset_11",
-  ``is_set_theory ^mem ⇒
-    ∀n m. (Num2indset n = Num2indset m) ⇔ (n = m)``,
+val num2indset_11 = Q.store_thm("num2indset_11",
+  `is_set_theory ^mem ⇒
+    ∀n m. (Num2indset n = Num2indset m) ⇔ (n = m)`,
   strip_tac >>
   completeInduct_on `MAX n m` >>
   Cases >> Cases >>
@@ -817,15 +817,15 @@ val num2indset_11 = store_thm("num2indset_11",
   strip_tac >>
   simp[suc_11])
 
-val num2indset_mem_less = store_thm("num2indset_mem_less",
-  ``is_set_theory ^mem ⇒
-    ∀n m. (Num2indset m <: Num2indset n) ⇔ (m < n)``,
+val num2indset_mem_less = Q.store_thm("num2indset_mem_less",
+  `is_set_theory ^mem ⇒
+    ∀n m. (Num2indset m <: Num2indset n) ⇔ (m < n)`,
   strip_tac >>
   simp[mem_num2indset_is_num2indset_eq] >>
   simp[num2indset_11])
 
-val inductive_set_infinite = store_thm("inductive_set_infinite",
-  ``is_set_theory ^mem ∧ is_inductive ^mem indset ⇒ is_infinite mem indset``,
+val inductive_set_infinite = Q.store_thm("inductive_set_infinite",
+  `is_set_theory ^mem ∧ is_inductive ^mem indset ⇒ is_infinite mem indset`,
   rw[is_infinite_def] >>
   match_mp_tac (REFORM_RULE INFINITE_SUBSET) >>
   qexists_tac`pred_set$IMAGE Num2indset UNIV` >>
@@ -838,8 +838,8 @@ val inductive_set_infinite = store_thm("inductive_set_infinite",
       rw[] >>
       simp[num2indset_in_indset] ])
 
-val funspace_inhabited = store_thm("funspace_inhabited",
-  ``is_set_theory ^mem ⇒ ∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ⇒ ∃f. f <: Funspace s t``,
+val funspace_inhabited = Q.store_thm("funspace_inhabited",
+  `is_set_theory ^mem ⇒ ∀s t. (∃x. x <: s) ∧ (∃x. x <: t) ⇒ ∃f. f <: Funspace s t`,
   rw[] >> qexists_tac`Abstract s t (λx. @x. x <: t)` >>
   match_mp_tac (MP_CANON abstract_in_funspace) >>
   metis_tac[])
@@ -858,14 +858,14 @@ val pair_not_empty = store_thm("pair_not_empty",
   simp[pair_def,mem_upair] >>
   metis_tac[])
 
-val tuple_empty = store_thm("tuple_empty",
-  ``is_set_theory ^mem ⇒ ∀ls. tuple ls = ∅ ⇔ ls = []``,
+val tuple_empty = Q.store_thm("tuple_empty",
+  `is_set_theory ^mem ⇒ ∀ls. tuple ls = ∅ ⇔ ls = []`,
   strip_tac >> Cases >> simp[tuple_def] >>
   simp[pair_not_empty] )
 
-val tuple_inj = store_thm("tuple_inj",
-  ``is_set_theory ^mem ⇒
-    ∀l1 l2. tuple l1 = tuple l2 ⇔ l1 = l2``,
+val tuple_inj = Q.store_thm("tuple_inj",
+  `is_set_theory ^mem ⇒
+    ∀l1 l2. tuple l1 = tuple l2 ⇔ l1 = l2`,
   strip_tac >>
   Induct >> simp[tuple_def] >- metis_tac[tuple_empty] >>
   gen_tac >> Cases >> simp[tuple_def,pair_not_empty] >>
@@ -876,9 +876,9 @@ val bigcross_def = Define`
   (bigcross0 ^mem (a::as) = a × (bigcross0 ^mem as))`
 val _ = Parse.overload_on("bigcross",``bigcross0 ^mem``)
 
-val mem_bigcross = store_thm("mem_bigcross",
-  ``is_set_theory ^mem ⇒
-    ∀ls x. (mem x (bigcross ls) ⇔ ∃xs. x = tuple xs ∧ LIST_REL mem xs ls)``,
+val mem_bigcross = Q.store_thm("mem_bigcross",
+  `is_set_theory ^mem ⇒
+    ∀ls x. (mem x (bigcross ls) ⇔ ∃xs. x = tuple xs ∧ LIST_REL mem xs ls)`,
   strip_tac >> Induct >>
   simp[bigcross_def,tuple_def,mem_one] >>
   simp[mem_product,PULL_EXISTS,tuple_def])

--- a/flame/set-theory/setSpecScript.sml
+++ b/flame/set-theory/setSpecScript.sml
@@ -236,9 +236,9 @@ val pair_def = Define`
 
 val _ = Parse.overload_on(",",``pair ^mem``)
 
-val mem_pair = store_thm("mem_pair",
-  ``is_set_theory ^mem ⇒
-    ∀a x y. a <: (x,y) ⇔ a = Unit x ∨ a = (x + y)``,
+val mem_pair = Q.store_thm("mem_pair",
+  `is_set_theory ^mem ⇒
+    ∀a x y. a <: (x,y) ⇔ a = Unit x ∨ a = (x + y)`,
   strip_tac >>
   simp[pair_def,mem_upair])
 
@@ -258,9 +258,9 @@ val unit_eq_upair = Q.store_thm("unit_eq_upair",
   fs[extensional_def,mem_unit,mem_upair] >>
   metis_tac[])
 
-val pair_inj = store_thm("pair_inj",
-  ``is_set_theory ^mem ⇒
-    ∀a b c d. (a,b) = (c,d) ⇔ a = c ∧ b = d``,
+val pair_inj = Q.store_thm("pair_inj",
+  `is_set_theory ^mem ⇒
+    ∀a b c d. (a,b) = (c,d) ⇔ a = c ∧ b = d`,
   strip_tac >> fs[pair_def] >> rw[] >>
   simp[upair_inj,unit_inj,unit_eq_upair] >>
   metis_tac[])
@@ -283,9 +283,9 @@ val product_def = Define`
 
 val _ = Parse.overload_on("CROSS",``product ^mem``)
 
-val mem_product = store_thm("mem_product",
-  ``is_set_theory ^mem ⇒
-    ∀a x y. a <: (x × y) ⇔ ∃b c. a = (b,c) ∧ b <: x ∧ c <: y``,
+val mem_product = Q.store_thm("mem_product",
+  `is_set_theory ^mem ⇒
+    ∀a x y. a <: (x × y) ⇔ ∃b c. a = (b,c) ∧ b <: x ∧ c <: y`,
   strip_tac >> fs[product_def] >>
   simp[mem_sub,mem_power,mem_binary_union] >>
   rw[EQ_IMP_THM] >> TRY(metis_tac[]) >>
@@ -303,17 +303,17 @@ val mem_relspace = Q.store_thm("mem_relspace",
             f <: Pow (d × r)`,
   rw[relspace_def])
 
-val relspace_pairs = store_thm("relspace_pairs",
-  ``is_set_theory ^mem ⇒
-    ∀d r f a. f <: Relspace d r ∧ a <: f ⇒ ∃x y. x <: d ∧ y <: r ∧ a = (x,y)``,
+val relspace_pairs = Q.store_thm("relspace_pairs",
+  `is_set_theory ^mem ⇒
+    ∀d r f a. f <: Relspace d r ∧ a <: f ⇒ ∃x y. x <: d ∧ y <: r ∧ a = (x,y)`,
   strip_tac >>
   simp[relspace_def,mem_sub,mem_power,mem_product] >>
   metis_tac[])
 
-val mem_rel = store_thm("mem_rel",
-  ``is_set_theory ^mem ⇒
+val mem_rel = Q.store_thm("mem_rel",
+  `is_set_theory ^mem ⇒
     ∀d r f. f <: Relspace d r ⇒
-            ∀x y. (x,y) <: f ⇒ x <: d ∧ y <: r``,
+            ∀x y. (x,y) <: f ⇒ x <: d ∧ y <: r`,
   strip_tac >>
   simp[relspace_def,mem_power,mem_product] >>
   metis_tac[pair_inj])
@@ -325,15 +325,15 @@ val funspace_def = Define`
 
 val _ = Parse.overload_on("Funspace",``funspace ^mem``)
 
-val mem_funspace = store_thm("mem_funspace",
-  ``is_set_theory ^mem ⇒
+val mem_funspace = Q.store_thm("mem_funspace",
+  `is_set_theory ^mem ⇒
     ∀d r f. f <: Funspace d r ⇔
-            f <: Relspace d r ∧ ∀x. x <: d ⇒ ∃!y. (x,y) <: f``,
+            f <: Relspace d r ∧ ∀x. x <: d ⇒ ∃!y. (x,y) <: f`,
   rw[funspace_def,mem_sub])
 
-val funspace_pairs = store_thm("funspace_pairs",
-  ``is_set_theory ^mem ⇒
-    ∀d r f a. f <: Funspace d r ∧ a <: f ⇒ ∃x y. x <: d ∧ y <: r ∧ a = (x,y)``,
+val funspace_pairs = Q.store_thm("funspace_pairs",
+  `is_set_theory ^mem ⇒
+    ∀d r f a. f <: Funspace d r ∧ a <: f ⇒ ∃x y. x <: d ∧ y <: r ∧ a = (x,y)`,
   strip_tac >>
   simp[funspace_def,mem_sub] >>
   metis_tac[relspace_pairs])
@@ -348,9 +348,9 @@ val id_def = Define`
 
 val _ = Parse.overload_on("Id",``id ^mem``)
 
-val mem_id = store_thm("mem_id",
-  ``is_set_theory ^mem ⇒
-        ∀d x y. (x,y) <: Id d ⇔ (y <: d ∧ x = y)``,
+val mem_id = Q.store_thm("mem_id",
+  `is_set_theory ^mem ⇒
+        ∀d x y. (x,y) <: Id d ⇔ (y <: d ∧ x = y)`,
   strip_tac >>
   simp[id_def,mem_sub,mem_product,pair_inj] >>
   rw[] >>
@@ -396,9 +396,9 @@ val inverse_def = Define`
 
 val _ = Parse.overload_on("Inverse",``inverse ^mem``)
 
-val mem_inverse = store_thm("mem_inverse",
-  ``is_set_theory ^mem ⇒
-    ∀f x y. (x,y) <: Inverse f ⇔ (y,x) <: f``,
+val mem_inverse = Q.store_thm("mem_inverse",
+  `is_set_theory ^mem ⇒
+    ∀f x y. (x,y) <: Inverse f ⇔ (y,x) <: f`,
   strip_tac >> simp[inverse_def] >> rw[] >>
   SELECT_ELIM_TAC >>
   conj_tac >- (
@@ -407,9 +407,9 @@ val mem_inverse = store_thm("mem_inverse",
     metis_tac[mem_pair,mem_unit,mem_upair,pair_inj] ) >>
   metis_tac[pair_inj])
 
-val inverse_pairs = store_thm("inverse_pairs",
-  ``is_set_theory ^mem ⇒
-    ∀f a. a <: Inverse f ⇒ ∃y x. a = (y,x)``,
+val inverse_pairs = Q.store_thm("inverse_pairs",
+  `is_set_theory ^mem ⇒
+    ∀f a. a <: Inverse f ⇒ ∃y x. a = (y,x)`,
   strip_tac >> simp[inverse_def] >>
   REPEAT gen_tac >>
   SELECT_ELIM_TAC >>
@@ -447,9 +447,9 @@ val inverse_is_11_onto = Q.store_thm("inverse_is_11_onto",
       simp[mem_inverse]
     ])
 
-val mem_funspace_pairs = store_thm("mem_funspace_pairs",
-  ``is_set_theory ^mem ⇒
-    ∀f d r. f <: Funspace d r ⇒ ∀a. a <: f ⇒ ∃x y. a = (x,y)``,
+val mem_funspace_pairs = Q.store_thm("mem_funspace_pairs",
+  `is_set_theory ^mem ⇒
+    ∀f d r. f <: Funspace d r ⇒ ∀a. a <: f ⇒ ∃x y. a = (x,y)`,
   strip_tac >>
   simp[is_one_one_def,is_onto_def,mem_funspace,mem_relspace,mem_power,mem_product,EXISTS_UNIQUE_THM] >>
   metis_tac[])
@@ -625,10 +625,10 @@ val in_funspace_abstract = Q.store_thm("in_funspace_abstract",
   rfs[EXISTS_UNIQUE_THM,mem_product] >>
   metis_tac[pair_inj])
 
-val apply_eq_mem = store_thm("apply_eq_mem",
-  ``is_set_theory ^mem ⇒
+val apply_eq_mem = Q.store_thm("apply_eq_mem",
+  `is_set_theory ^mem ⇒
     ∀f d r. f <: Funspace d r ⇒
-            ∀x. x <: d ⇒ ∀y. f ' x = y ⇔ (x,y) <: f``,
+            ∀x. x <: d ⇒ ∀y. f ' x = y ⇔ (x,y) <: f`,
   strip_tac >> simp[apply_def,mem_funspace,EXISTS_UNIQUE_THM] >> rw[] >>
   SELECT_ELIM_TAC >>
   conj_tac >- simp[] >>
@@ -678,11 +678,11 @@ val dep_funspace_def = Define`
 
 val _ = Parse.overload_on("Dep_funspace",``dep_funspace ^mem``)
 
-val mem_dep_funspace = store_thm("mem_dep_funspace",
-  ``is_set_theory ^mem ⇒
+val mem_dep_funspace = Q.store_thm("mem_dep_funspace",
+  `is_set_theory ^mem ⇒
     ∀f d g. g <: Dep_funspace d f ⇔
             g <: Relspace d (⋃ (f '' d)) ∧
-            ∀x. x <: d ⇒ (∃!y. (x,y) <: g) ∧ g ' x <: f x``,
+            ∀x. x <: d ⇒ (∃!y. (x,y) <: g) ∧ g ' x <: f x`,
   rw[dep_funspace_def,mem_sub,mem_funspace] >>
   METIS_TAC[])
 
@@ -693,11 +693,11 @@ val dep_prodspace_def = Define`
 
 val _ = Parse.overload_on("Dep_prodspace",``dep_prodspace ^mem``)
 
-val mem_dep_prodspace = store_thm("mem_dep_prodspace",
-  ``is_set_theory ^mem ⇒
+val mem_dep_prodspace = Q.store_thm("mem_dep_prodspace",
+  `is_set_theory ^mem ⇒
     ∀f d r. r <: Dep_prodspace d f ⇔
             r <: d × ⋃ (f '' d) ∧
-            ∀x y. (x,y) <: r ⇒ x <: d ∧ y <: f x``,
+            ∀x y. (x,y) <: r ⇒ x <: d ∧ y <: f x`,
   rw[dep_prodspace_def,mem_sub])
 
 val axiom_of_choice = save_thm("axiom_of_choice",UNDISCH(prove(
@@ -849,8 +849,8 @@ val tuple_def = Define`
   (tuple0 ^mem (a::as) = (a, tuple0 ^mem as))`
 val _ = Parse.overload_on("tuple",``tuple0 ^mem``)
 
-val pair_not_empty = store_thm("pair_not_empty",
-  ``is_set_theory ^mem ⇒ (x,y) ≠ ∅``,
+val pair_not_empty = Q.store_thm("pair_not_empty",
+  `is_set_theory ^mem ⇒ (x,y) ≠ ∅`,
   rw[] >>
   imp_res_tac is_extensional >>
   fs[extensional_def,mem_empty] >>

--- a/miscScript.sml
+++ b/miscScript.sml
@@ -17,8 +17,8 @@ val _ = numLib.prefer_num();
 
 val IMP_IMP = save_thm("IMP_IMP",METIS_PROVE[]``(P /\ (Q ==> R)) ==> ((P ==> Q) ==> R)``);
 
-val SUBSET_IMP = store_thm("SUBSET_IMP",
-  ``s SUBSET t ==> (x IN s ==> x IN t)``,
+val SUBSET_IMP = Q.store_thm("SUBSET_IMP",
+  `s SUBSET t ==> (x IN s ==> x IN t)`,
   fs[pred_setTheory.SUBSET_DEF]);
 
 val fmap_eq_flookup = save_thm("fmap_eq_flookup",FLOOKUP_EXT |> REWRITE_RULE[FUN_EQ_THM]);
@@ -76,21 +76,21 @@ val read_bytearray_def = Define `
                  | NONE => NONE
                  | SOME bs => SOME (b::bs))`
 
-val read_bytearray_LENGTH = store_thm("read_bytearray_LENGTH",
-  ``!n a f x.
-      (read_bytearray a n f = SOME x) ==> (LENGTH x = n)``,
+val read_bytearray_LENGTH = Q.store_thm("read_bytearray_LENGTH",
+  `!n a f x.
+      (read_bytearray a n f = SOME x) ==> (LENGTH x = n)`,
   Induct \\ fs [read_bytearray_def] \\ REPEAT STRIP_TAC
   \\ BasicProvers.EVERY_CASE_TAC \\ fs [] \\ rw [] \\ res_tac);
 
 val shift_seq_def = Define `
   shift_seq k s = \i. s (i + k:num)`;
 
-val SUM_SET_IN_LT = store_thm("SUM_SET_IN_LT",
-  ``!s x y. FINITE s /\ x IN s /\ y < x ==> y < SUM_SET s``,
+val SUM_SET_IN_LT = Q.store_thm("SUM_SET_IN_LT",
+  `!s x y. FINITE s /\ x IN s /\ y < x ==> y < SUM_SET s`,
   metis_tac[SUM_SET_IN_LE,LESS_LESS_EQ_TRANS]);
 
-val BIJ_IMP_11 = store_thm("BIJ_IMP_11",
-  ``BIJ f UNIV UNIV ==> !x y. (f x = f y) = (x = y)``,
+val BIJ_IMP_11 = Q.store_thm("BIJ_IMP_11",
+  `BIJ f UNIV UNIV ==> !x y. (f x = f y) = (x = y)`,
   full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF] \\ metis_tac []);
 
 val ALOOKUP_MAP_gen = Q.store_thm("ALOOKUP_MAP_gen",
@@ -114,36 +114,36 @@ val LLOOKUP_def = Define `
   (LLOOKUP [] n = NONE) /\
   (LLOOKUP (x::xs) n = if n = 0 then SOME x else LLOOKUP xs (n-1:num))`;
 
-val LLOOKUP_EQ_EL = store_thm("LLOOKUP_EQ_EL",
-  ``!xs n y. LLOOKUP xs n = SOME y <=> n < LENGTH xs /\ (y = EL n xs)``,
+val LLOOKUP_EQ_EL = Q.store_thm("LLOOKUP_EQ_EL",
+  `!xs n y. LLOOKUP xs n = SOME y <=> n < LENGTH xs /\ (y = EL n xs)`,
   Induct \\ fs [LLOOKUP_def] \\ rw [] THEN1 metis_tac []
   \\ Cases_on `n` \\ fs [ADD1] \\ eq_tac \\ rw []);
 
-val LLOOKUP_THM = store_thm("LLOOKUP_THM",
-  ``!xs n. LLOOKUP xs n = if n < LENGTH xs then SOME (EL n xs) else NONE``,
+val LLOOKUP_THM = Q.store_thm("LLOOKUP_THM",
+  `!xs n. LLOOKUP xs n = if n < LENGTH xs then SOME (EL n xs) else NONE`,
   Induct \\ full_simp_tac(srw_ss())[LLOOKUP_def] \\ srw_tac[][] THEN1 decide_tac
   \\ Cases_on `xs` \\ full_simp_tac(srw_ss())[] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[] \\ decide_tac);
 
-val LLOOKUP_DROP = store_thm("LLOOKUP_DROP",
-  ``(LLOOKUP (DROP f xs) n = LLOOKUP xs (f + n))``,
+val LLOOKUP_DROP = Q.store_thm("LLOOKUP_DROP",
+  `(LLOOKUP (DROP f xs) n = LLOOKUP xs (f + n))`,
   Cases_on `DROP f xs = []` \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[DROP_NIL]
   \\ full_simp_tac(srw_ss())[LLOOKUP_THM] THEN1 decide_tac
   \\ `f + n < LENGTH xs <=> n < LENGTH xs - f` by decide_tac \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ ONCE_REWRITE_TAC [ADD_COMM]
   \\ match_mp_tac (GSYM EL_DROP) \\ decide_tac);
 
-val LLOOKUP_TAKE_IMP = store_thm("LLOOKUP_TAKE_IMP",
-  ``(LLOOKUP (TAKE f xs) n = SOME x) ==>
-    (LLOOKUP xs n = SOME x)``,
+val LLOOKUP_TAKE_IMP = Q.store_thm("LLOOKUP_TAKE_IMP",
+  `(LLOOKUP (TAKE f xs) n = SOME x) ==>
+    (LLOOKUP xs n = SOME x)`,
   simp[LLOOKUP_THM,LENGTH_TAKE_EQ] >>
   srw_tac[ARITH_ss][]
   \\ match_mp_tac (GSYM EL_TAKE)
   \\ fsrw_tac[ARITH_ss][]);
 
-val LLOOKUP_LUPDATE = store_thm("LLOOKUP_LUPDATE",
-  ``!xs i n x. LLOOKUP (LUPDATE x i xs) n =
+val LLOOKUP_LUPDATE = Q.store_thm("LLOOKUP_LUPDATE",
+  `!xs i n x. LLOOKUP (LUPDATE x i xs) n =
                if i <> n then LLOOKUP xs n else
-               if i < LENGTH xs then SOME x else NONE``,
+               if i < LENGTH xs then SOME x else NONE`,
   Induct \\ full_simp_tac(srw_ss())[LLOOKUP_def,LUPDATE_def]
   \\ Cases_on `i` \\ full_simp_tac(srw_ss())[LLOOKUP_def,LUPDATE_def]
   \\ rpt strip_tac \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ `F` by decide_tac);
@@ -159,14 +159,14 @@ val append_aux_def = Define `
 val append_def = Define `
   append l = append_aux l []`;
 
-val append_aux_thm = store_thm("append_aux_thm",
-  ``!l xs. append_aux l xs = append_aux l [] ++ xs``,
+val append_aux_thm = Q.store_thm("append_aux_thm",
+  `!l xs. append_aux l xs = append_aux l [] ++ xs`,
   Induct \\ metis_tac [APPEND,APPEND_ASSOC,append_aux_def]);
 
-val append_thm = store_thm("append_thm[simp]",
-  ``append (Append l1 l2) = append l1 ++ append l2 /\
+val append_thm = Q.store_thm("append_thm[simp]",
+  `append (Append l1 l2) = append l1 ++ append l2 /\
     append (List xs) = xs /\
-    append Nil = []``,
+    append Nil = []`,
   fs [append_def,append_aux_def]
   \\ once_rewrite_tac [append_aux_thm] \\ fs []);
 
@@ -193,8 +193,8 @@ val GENLIST_eq_MAP = Q.store_thm("GENLIST_eq_MAP",
    LENGTH ls = n ∧ ∀m. m < n ⇒ f m = g (EL m ls)`,
   srw_tac[][LIST_EQ_REWRITE,EQ_IMP_THM,EL_MAP])
 
-val GENLIST_ID = store_thm("GENLIST_ID",
-  ``!x. GENLIST (\i. EL i x) (LENGTH x) = x``,
+val GENLIST_ID = Q.store_thm("GENLIST_ID",
+  `!x. GENLIST (\i. EL i x) (LENGTH x) = x`,
   HO_MATCH_MP_TAC SNOC_INDUCT
   \\ full_simp_tac(srw_ss())[] \\ simp_tac std_ss [GENLIST,GSYM ADD1]
   \\ full_simp_tac(srw_ss())[SNOC_APPEND,rich_listTheory.EL_LENGTH_APPEND]
@@ -241,8 +241,8 @@ val EL_MAP3 = Q.store_thm("EL_MAP3",
   ho_match_mp_tac MAP3_ind \\ rw[]
   \\ Cases_on`n` \\ fs[]);
 
-val LENGTH_TAKE_EQ_MIN = store_thm("LENGTH_TAKE_EQ_MIN",
-  ``!n xs. LENGTH (TAKE n xs) = MIN n (LENGTH xs)``,
+val LENGTH_TAKE_EQ_MIN = Q.store_thm("LENGTH_TAKE_EQ_MIN",
+  `!n xs. LENGTH (TAKE n xs) = MIN n (LENGTH xs)`,
   simp[LENGTH_TAKE_EQ] \\ full_simp_tac(srw_ss())[MIN_DEF] \\ decide_tac);
 
 val hd_drop = Q.store_thm ("hd_drop",
@@ -256,19 +256,19 @@ val hd_drop = Q.store_thm ("hd_drop",
   `n - 1 = PRE n` by decide_tac >>
   srw_tac[][]);
 
-val INJ_EXTEND = store_thm("INJ_EXTEND",
-  ``INJ b s t /\ ~(x IN s) /\ ~(y IN t) ==>
-    INJ ((x =+ y) b) (x INSERT s) (y INSERT t)``,
+val INJ_EXTEND = Q.store_thm("INJ_EXTEND",
+  `INJ b s t /\ ~(x IN s) /\ ~(y IN t) ==>
+    INJ ((x =+ y) b) (x INSERT s) (y INSERT t)`,
   full_simp_tac(srw_ss())[INJ_DEF,combinTheory.APPLY_UPDATE_THM] \\ METIS_TAC []);
 
-val MEM_LIST_REL = store_thm("MEM_LIST_REL",
-  ``!xs ys P x. LIST_REL P xs ys /\ MEM x xs ==> ?y. MEM y ys /\ P x y``,
+val MEM_LIST_REL = Q.store_thm("MEM_LIST_REL",
+  `!xs ys P x. LIST_REL P xs ys /\ MEM x xs ==> ?y. MEM y ys /\ P x y`,
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ RES_TAC \\ METIS_TAC []);
 
-val LIST_REL_MEM = store_thm("LIST_REL_MEM",
-  ``!xs ys P. LIST_REL P xs ys <=>
-              LIST_REL (\x y. MEM x xs /\ MEM y ys ==> P x y) xs ys``,
+val LIST_REL_MEM = Q.store_thm("LIST_REL_MEM",
+  `!xs ys P. LIST_REL P xs ys <=>
+              LIST_REL (\x y. MEM x xs /\ MEM y ys ==> P x y) xs ys`,
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN] \\ METIS_TAC [MEM_EL]);
 
 val LIST_REL_REVERSE_EQ =
@@ -278,9 +278,9 @@ val LIST_REL_REVERSE_EQ =
                     |> SIMP_RULE std_ss [REVERSE_REVERSE])
   |> SYM |> curry save_thm"LIST_REL_REVERSE_EQ";
 
-val LIST_REL_GENLIST_I = store_thm("LIST_REL_GENLIST_I",
-  ``!xs. LIST_REL P (GENLIST I (LENGTH xs)) xs =
-         !n. n < LENGTH xs ==> P n (EL n xs)``,
+val LIST_REL_GENLIST_I = Q.store_thm("LIST_REL_GENLIST_I",
+  `!xs. LIST_REL P (GENLIST I (LENGTH xs)) xs =
+         !n. n < LENGTH xs ==> P n (EL n xs)`,
   HO_MATCH_MP_TAC SNOC_INDUCT
   \\ FULL_SIMP_TAC (srw_ss()) [LENGTH,GENLIST,SNOC_APPEND]
   \\ FULL_SIMP_TAC std_ss [LIST_REL_APPEND_SING]
@@ -295,23 +295,23 @@ val LIST_REL_GENLIST_I = store_thm("LIST_REL_GENLIST_I",
   \\ POP_ASSUM (MP_TAC o Q.SPEC `LENGTH xs`)
   \\ FULL_SIMP_TAC std_ss [rich_listTheory.EL_APPEND2,EL,HD]);
 
-val LIST_REL_lookup_fromList = store_thm("LIST_REL_lookup_fromList",
-  ``LIST_REL (\v x. lookup v (fromList args) = SOME x)
-     (GENLIST I (LENGTH args)) args``,
+val LIST_REL_lookup_fromList = Q.store_thm("LIST_REL_lookup_fromList",
+  `LIST_REL (\v x. lookup v (fromList args) = SOME x)
+     (GENLIST I (LENGTH args)) args`,
   SIMP_TAC std_ss [lookup_fromList,LIST_REL_GENLIST_I]);
 
-val lookup_fromList_outside = store_thm("lookup_fromList_outside",
-  ``!k. LENGTH args <= k ==> (lookup k (fromList args) = NONE)``,
+val lookup_fromList_outside = Q.store_thm("lookup_fromList_outside",
+  `!k. LENGTH args <= k ==> (lookup k (fromList args) = NONE)`,
   SIMP_TAC std_ss [lookup_fromList] \\ DECIDE_TAC);
 
-val lemmas = prove(
-  ``(2 + 2 * n - 1 = 2 * n + 1:num) /\
+val lemmas = Q.prove(
+  `(2 + 2 * n - 1 = 2 * n + 1:num) /\
     (2 + 2 * n' = 2 * n'' + 2 <=> n' = n'':num) /\
     (2 * m = 2 * n <=> (m = n)) /\
     ((2 * n'' + 1) DIV 2 = n'') /\
     ((2 * n) DIV 2 = n) /\
     (2 + 2 * n' <> 2 * n'' + 1) /\
-    (2 * m + 1 <> 2 * n' + 2)``,
+    (2 * m + 1 <> 2 * n' + 2)`,
   REPEAT STRIP_TAC \\ SIMP_TAC std_ss []
   THEN1 DECIDE_TAC
   THEN1 DECIDE_TAC
@@ -323,8 +323,8 @@ val lemmas = prove(
   \\ ONCE_REWRITE_TAC [MATCH_MP (GSYM MOD_PLUS) (DECIDE ``0 < 2:num``)]
   \\ EVAL_TAC \\ full_simp_tac(srw_ss())[MOD_EQ_0,ONCE_REWRITE_RULE [MULT_COMM] MOD_EQ_0]);
 
-val IN_domain = store_thm("IN_domain",
-  ``!n x t1 t2.
+val IN_domain = Q.store_thm("IN_domain",
+  `!n x t1 t2.
       (n IN domain LN <=> F) /\
       (n IN domain (LS x) <=> (n = 0)) /\
       (n IN domain (BN t1 t2) <=>
@@ -332,7 +332,7 @@ val IN_domain = store_thm("IN_domain",
                               else ((n-1) DIV 2) IN domain t2)) /\
       (n IN domain (BS t1 x t2) <=>
          n = 0 \/ (if EVEN n then ((n-1) DIV 2) IN domain t1
-                             else ((n-1) DIV 2) IN domain t2))``,
+                             else ((n-1) DIV 2) IN domain t2))`,
   full_simp_tac(srw_ss())[domain_def] \\ REPEAT STRIP_TAC
   \\ Cases_on `n = 0` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `EVEN n` \\ full_simp_tac(srw_ss())[]
@@ -343,12 +343,12 @@ val IN_domain = store_thm("IN_domain",
   \\ REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[lemmas])
 
-val map_map_K = store_thm("map_map_K",
-  ``!t. map (K a) (map (K a) t) = map (K a) t``,
+val map_map_K = Q.store_thm("map_map_K",
+  `!t. map (K a) (map (K a) t) = map (K a) t`,
   Induct \\ full_simp_tac(srw_ss())[map_def]);
 
-val lookup_map_K = store_thm("lookup_map_K",
-  ``!t n. lookup n (map (K x) t) = if n IN domain t then SOME x else NONE``,
+val lookup_map_K = Q.store_thm("lookup_map_K",
+  `!t n. lookup n (map (K x) t) = if n IN domain t then SOME x else NONE`,
   Induct \\ full_simp_tac(srw_ss())[IN_domain,map_def,lookup_def]
   \\ REPEAT STRIP_TAC \\ Cases_on `n = 0` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `EVEN n` \\ full_simp_tac(srw_ss())[]);
@@ -376,9 +376,9 @@ val lookup_alist_insert = store_thm("lookup_alist_insert",
       srw_tac[][lookup_def,alist_insert_def]>>
     full_simp_tac(srw_ss())[lookup_insert])
 
-val domain_alist_insert = store_thm("domain_alist_insert",
-  ``!a b locs. LENGTH a = LENGTH b ==>
-    domain (alist_insert a b locs) = domain locs UNION set a``,
+val domain_alist_insert = Q.store_thm("domain_alist_insert",
+  `!a b locs. LENGTH a = LENGTH b ==>
+    domain (alist_insert a b locs) = domain locs UNION set a`,
   Induct_on`a`>>Cases_on`b`>>full_simp_tac(srw_ss())[alist_insert_def]>>srw_tac[][]>>
   metis_tac[INSERT_UNION_EQ,UNION_COMM])
 
@@ -395,8 +395,8 @@ val EVEN_fromList2_lemma = prove(
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[EVEN_EXISTS]
   \\ Q.EXISTS_TAC `SUC m` \\ DECIDE_TAC);
 
-val EVEN_fromList2 = store_thm("EVEN_fromList2",
-  ``!l n. n IN domain (fromList2 l) ==> EVEN n``,
+val EVEN_fromList2 = Q.store_thm("EVEN_fromList2",
+  `!l n. n IN domain (fromList2 l) ==> EVEN n`,
   ASSUME_TAC (EVEN_fromList2_lemma
     |> Q.SPECL [`l`,`0`,`LN`]
     |> SIMP_RULE (srw_ss()) [GSYM fromList2_def]
@@ -413,8 +413,8 @@ val SUBMAP_FRANGE_SUBSET = Q.store_thm("SUBMAP_FRANGE_SUBSET",
 val FDIFF_def = Define `
   FDIFF f1 s = DRESTRICT f1 (COMPL s)`;
 
-val FDOM_FDIFF = store_thm("FDOM_FDIFF",
-  ``x IN FDOM (FDIFF refs f2) <=> x IN FDOM refs /\ ~(x IN f2)``,
+val FDOM_FDIFF = Q.store_thm("FDOM_FDIFF",
+  `x IN FDOM (FDIFF refs f2) <=> x IN FDOM refs /\ ~(x IN f2)`,
   full_simp_tac(srw_ss())[FDIFF_def,DRESTRICT_DEF]);
 
 val INJ_FAPPLY_FUPDATE = Q.store_thm("INJ_FAPPLY_FUPDATE",
@@ -434,12 +434,12 @@ val NUM_NOT_IN_FDOM =
   |> SIMP_RULE std_ss [IN_UNIV]
   |> curry save_thm "NUM_NOT_IN_FDOM";
 
-val EXISTS_NOT_IN_FDOM_LEMMA = prove(
-  ``?x. ~(x IN FDOM (refs:num|->'a))``,
+val EXISTS_NOT_IN_FDOM_LEMMA = Q.prove(
+  `?x. ~(x IN FDOM (refs:num|->'a))`,
   METIS_TAC [NUM_NOT_IN_FDOM]);
 
-val LEAST_NOTIN_FDOM = store_thm("LEAST_NOTIN_FDOM",
-  ``(LEAST ptr. ptr NOTIN FDOM (refs:num|->'a)) NOTIN FDOM refs``,
+val LEAST_NOTIN_FDOM = Q.store_thm("LEAST_NOTIN_FDOM",
+  `(LEAST ptr. ptr NOTIN FDOM (refs:num|->'a)) NOTIN FDOM refs`,
   ASSUME_TAC (EXISTS_NOT_IN_FDOM_LEMMA |>
            SIMP_RULE std_ss [whileTheory.LEAST_EXISTS]) \\ full_simp_tac(srw_ss())[]);
 
@@ -451,38 +451,38 @@ val list_insert_def = Define `
   (list_insert [] t = t) /\
   (list_insert (n::ns) t = list_insert ns (insert n () t))`;
 
-val domain_list_to_num_set = store_thm("domain_list_to_num_set",
-  ``!xs. x IN domain (list_to_num_set xs) <=> MEM x xs``,
+val domain_list_to_num_set = Q.store_thm("domain_list_to_num_set",
+  `!xs. x IN domain (list_to_num_set xs) <=> MEM x xs`,
   Induct \\ full_simp_tac(srw_ss())[list_to_num_set_def]);
 
-val domain_list_insert = store_thm("domain_list_insert",
-  ``!xs x t.
-      x IN domain (list_insert xs t) <=> MEM x xs \/ x IN domain t``,
+val domain_list_insert = Q.store_thm("domain_list_insert",
+  `!xs x t.
+      x IN domain (list_insert xs t) <=> MEM x xs \/ x IN domain t`,
   Induct \\ full_simp_tac(srw_ss())[list_insert_def] \\ METIS_TAC []);
 
-val domain_FOLDR_delete = store_thm("domain_FOLDR_delete",
-  ``∀ls live. domain (FOLDR delete live ls) =
-  (domain live) DIFF (set ls)``,
+val domain_FOLDR_delete = Q.store_thm("domain_FOLDR_delete",
+  `∀ls live. domain (FOLDR delete live ls) =
+  (domain live) DIFF (set ls)`,
   Induct>>
   full_simp_tac(srw_ss())[DIFF_INSERT,EXTENSION]>>
   metis_tac[])
 
-val lookup_list_to_num_set = store_thm("lookup_list_to_num_set",
-  ``!xs. lookup x (list_to_num_set xs) = if MEM x xs then SOME () else NONE``,
+val lookup_list_to_num_set = Q.store_thm("lookup_list_to_num_set",
+  `!xs. lookup x (list_to_num_set xs) = if MEM x xs then SOME () else NONE`,
   Induct \\ srw_tac [] [list_to_num_set_def,lookup_def,lookup_insert] \\ full_simp_tac(srw_ss())[]);
 
-val OPTION_BIND_SOME = store_thm("OPTION_BIND_SOME",
-  ``∀f. OPTION_BIND f SOME = f``,
+val OPTION_BIND_SOME = Q.store_thm("OPTION_BIND_SOME",
+  `∀f. OPTION_BIND f SOME = f`,
   Cases >> simp[])
 
 val take1 = Q.store_thm ("take1",
   `!l. l ≠ [] ⇒ TAKE 1 l = [EL 0 l]`,
   Induct_on `l` >> srw_tac[][]);
 
-val SPLIT_LIST = store_thm("SPLIT_LIST",
-  ``!xs.
+val SPLIT_LIST = Q.store_thm("SPLIT_LIST",
+  `!xs.
       ?ys zs. (xs = ys ++ zs) /\
-              (LENGTH xs DIV 2 = LENGTH ys)``,
+              (LENGTH xs DIV 2 = LENGTH ys)`,
   REPEAT STRIP_TAC
   \\ Q.LIST_EXISTS_TAC [`TAKE (LENGTH xs DIV 2) xs`,`DROP (LENGTH xs DIV 2) xs`]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[TAKE_DROP]
@@ -525,15 +525,15 @@ val list_max_def = Define `
 val list_inter_def = Define `
   list_inter xs ys = FILTER (\y. MEM y xs) ys`;
 
-val SING_HD = store_thm("SING_HD",
-  ``(([HD xs] = xs) <=> (LENGTH xs = 1)) /\
-    ((xs = [HD xs]) <=> (LENGTH xs = 1))``,
+val SING_HD = Q.store_thm("SING_HD",
+  `(([HD xs] = xs) <=> (LENGTH xs = 1)) /\
+    ((xs = [HD xs]) <=> (LENGTH xs = 1))`,
   Cases_on `xs` \\ full_simp_tac(srw_ss())[LENGTH_NIL] \\ METIS_TAC []);
 
-val ALOOKUP_SNOC = store_thm("ALOOKUP_SNOC",
-  ``∀ls p k. ALOOKUP (SNOC p ls) k =
+val ALOOKUP_SNOC = Q.store_thm("ALOOKUP_SNOC",
+  `∀ls p k. ALOOKUP (SNOC p ls) k =
       case ALOOKUP ls k of SOME v => SOME v |
-        NONE => if k = FST p then SOME (SND p) else NONE``,
+        NONE => if k = FST p then SOME (SND p) else NONE`,
   Induct >> simp[] >>
   Cases >> simp[] >> srw_tac[][])
 
@@ -565,10 +565,10 @@ val EVERY_anub_imp = store_thm("EVERY_anub_imp",
   ho_match_mp_tac anub_ind >> srw_tac[][anub_def] >>
   full_simp_tac(srw_ss())[MEM_MAP,PULL_EXISTS,FORALL_PROD,EXISTS_PROD])
 
-val ALOOKUP_anub = store_thm("ALOOKUP_anub",
-  ``ALOOKUP (anub ls acc) k =
+val ALOOKUP_anub = Q.store_thm("ALOOKUP_anub",
+  `ALOOKUP (anub ls acc) k =
     if MEM k acc then ALOOKUP (anub ls acc) k
-    else ALOOKUP ls k``,
+    else ALOOKUP ls k`,
   qid_spec_tac`acc` >>
   Induct_on`ls` >>
   srw_tac[][anub_def] >>
@@ -578,8 +578,8 @@ val ALOOKUP_anub = store_thm("ALOOKUP_anub",
   first_x_assum(qspec_then`q::acc`mp_tac) >>
   srw_tac[][])
 
-val anub_eq_nil = store_thm("anub_eq_nil",
-  ``anub x y = [] ⇔ EVERY (combin$C MEM y) (MAP FST x)``,
+val anub_eq_nil = Q.store_thm("anub_eq_nil",
+  `anub x y = [] ⇔ EVERY (combin$C MEM y) (MAP FST x)`,
   qid_spec_tac`y` >>
   Induct_on`x`>>srw_tac[][anub_def]>>
   Cases_on`h`>>srw_tac[][anub_def])
@@ -600,14 +600,14 @@ val EVERY_anub_suff = store_thm("EVERY_anub_suff",
   srw_tac[][] >> res_tac >> full_simp_tac(srw_ss())[] >>
   `q ≠ x` by full_simp_tac(srw_ss())[] >> full_simp_tac(srw_ss())[])
 
-val anub_notin_acc = store_thm("anub_notin_acc",
-  ``∀ls acc. MEM x acc ⇒ ¬MEM x (MAP FST (anub ls acc))``,
+val anub_notin_acc = Q.store_thm("anub_notin_acc",
+  `∀ls acc. MEM x acc ⇒ ¬MEM x (MAP FST (anub ls acc))`,
   Induct >> simp[anub_def] >>
   Cases >> simp[anub_def] >> srw_tac[][] >>
   metis_tac[])
 
-val anub_tl_anub = store_thm("anub_tl_anub",
-  ``∀x y h t. anub x y = h::t ⇒ ∃a b. t = anub a b ∧ set a ⊆ set x ∧ set b ⊆ set ((FST h)::y)``,
+val anub_tl_anub = Q.store_thm("anub_tl_anub",
+  `∀x y h t. anub x y = h::t ⇒ ∃a b. t = anub a b ∧ set a ⊆ set x ∧ set b ⊆ set ((FST h)::y)`,
   Induct >> srw_tac[][anub_def] >>
   Cases_on`h`>>full_simp_tac(srw_ss())[anub_def] >>
   pop_assum mp_tac  >> srw_tac[][] >>
@@ -615,10 +615,10 @@ val anub_tl_anub = store_thm("anub_tl_anub",
   full_simp_tac(srw_ss())[SUBSET_DEF] >>
   metis_tac[MEM] )
 
-val anub_all_distinct_keys = store_thm("anub_all_distinct_keys",
-  ``∀ls acc.
+val anub_all_distinct_keys = Q.store_thm("anub_all_distinct_keys",
+  `∀ls acc.
     ALL_DISTINCT acc ⇒
-    ALL_DISTINCT ((MAP FST (anub ls acc)) ++ acc)``,
+    ALL_DISTINCT ((MAP FST (anub ls acc)) ++ acc)`,
   Induct>>srw_tac[][anub_def]>>PairCases_on`h`>>full_simp_tac(srw_ss())[anub_def]>>
   srw_tac[][]>>
   `ALL_DISTINCT (h0::acc)` by full_simp_tac(srw_ss())[ALL_DISTINCT]>>res_tac>>
@@ -634,42 +634,42 @@ val MEM_anub_ALOOKUP = store_thm("MEM_anub_ALOOKUP",
   full_simp_tac(srw_ss())[]>>
   metis_tac[ALOOKUP_ALL_DISTINCT_MEM])
 
-val FEMPTY_FUPDATE_EQ = store_thm("FEMPTY_FUPDATE_EQ",
-  ``∀x y. (FEMPTY |+ x = FEMPTY |+ y) ⇔ (x = y)``,
+val FEMPTY_FUPDATE_EQ = Q.store_thm("FEMPTY_FUPDATE_EQ",
+  `∀x y. (FEMPTY |+ x = FEMPTY |+ y) ⇔ (x = y)`,
   Cases >> Cases >> srw_tac[][fmap_eq_flookup,FDOM_FUPDATE,FLOOKUP_UPDATE] >>
   Cases_on`q=q'`>>srw_tac[][] >- (
     srw_tac[][EQ_IMP_THM] >>
     pop_assum(qspec_then`q`mp_tac) >> srw_tac[][] ) >>
   qexists_tac`q`>>srw_tac[][])
 
-val FUPDATE_LIST_EQ_FEMPTY = store_thm("FUPDATE_LIST_EQ_FEMPTY",
-  ``∀fm ls. fm |++ ls = FEMPTY ⇔ fm = FEMPTY ∧ ls = []``,
+val FUPDATE_LIST_EQ_FEMPTY = Q.store_thm("FUPDATE_LIST_EQ_FEMPTY",
+  `∀fm ls. fm |++ ls = FEMPTY ⇔ fm = FEMPTY ∧ ls = []`,
   srw_tac[][EQ_IMP_THM,FUPDATE_LIST_THM] >>
   full_simp_tac(srw_ss())[GSYM fmap_EQ_THM,FDOM_FUPDATE_LIST])
 
-val IS_SOME_EXISTS = store_thm("IS_SOME_EXISTS",
-  ``∀opt. IS_SOME opt ⇔ ∃x. opt = SOME x``,
+val IS_SOME_EXISTS = Q.store_thm("IS_SOME_EXISTS",
+  `∀opt. IS_SOME opt ⇔ ∃x. opt = SOME x`,
   Cases >> simp[])
 
 val _ = type_abbrev("num_set",``:unit spt``);
 val _ = type_abbrev("num_map",``:'a spt``);
 
-val toAList_domain = store_thm("toAList_domain",``
-  ∀x. MEM x (MAP FST (toAList t)) ⇔ x ∈ domain t``,
+val toAList_domain = Q.store_thm("toAList_domain",`
+  ∀x. MEM x (MAP FST (toAList t)) ⇔ x ∈ domain t`,
   full_simp_tac(srw_ss())[EXISTS_PROD,MEM_MAP,MEM_toAList,domain_lookup])
 
-val domain_nat_set_from_list = store_thm("domain_nat_set_from_list",
-  ``∀ls ns. domain (FOLDL (λs n. insert n () s) ns ls) = domain ns ∪ set ls``,
+val domain_nat_set_from_list = Q.store_thm("domain_nat_set_from_list",
+  `∀ls ns. domain (FOLDL (λs n. insert n () s) ns ls) = domain ns ∪ set ls`,
   Induct >> simp[sptreeTheory.domain_insert] >>
   srw_tac[][EXTENSION] >> metis_tac[])
 val _ = export_rewrites["domain_nat_set_from_list"]
 
-val wf_nat_set_from_list = store_thm("wf_nat_set_from_list",
-  ``∀ls ns. wf ns ⇒ wf (FOLDL (λs n. insert n z s) ns ls)``,
+val wf_nat_set_from_list = Q.store_thm("wf_nat_set_from_list",
+  `∀ls ns. wf ns ⇒ wf (FOLDL (λs n. insert n z s) ns ls)`,
   Induct >> simp[] >> srw_tac[][sptreeTheory.wf_insert])
 
-val BIT_11 = store_thm("BIT_11",
-  ``∀n m. (BIT n = BIT m) ⇔ (n = m)``,
+val BIT_11 = Q.store_thm("BIT_11",
+  `∀n m. (BIT n = BIT m) ⇔ (n = m)`,
   simp[EQ_IMP_THM] >>
   Induct >> simp[BIT0_ODD,FUN_EQ_THM] >- (
     Cases >> simp[] >>
@@ -686,8 +686,8 @@ val BIT_11 = store_thm("BIT_11",
   first_x_assum(qspec_then`x*2`mp_tac) >>
   simp[arithmeticTheory.MULT_DIV])
 
-val BIT_11_2 = store_thm("BIT_11_2",
-  ``∀n m. (∀z. (z < 2 ** (MAX n m)) ⇒ (BIT n z ⇔ BIT m z)) ⇔ (n = m)``,
+val BIT_11_2 = Q.store_thm("BIT_11_2",
+  `∀n m. (∀z. (z < 2 ** (MAX n m)) ⇒ (BIT n z ⇔ BIT m z)) ⇔ (n = m)`,
   simp[Once EQ_IMP_THM] >>
   Induct >- (
     simp[] >>
@@ -707,8 +707,8 @@ val BIT_11_2 = store_thm("BIT_11_2",
   srw_tac[][] >> full_simp_tac(srw_ss())[] >>
   simp[arithmeticTheory.EXP])
 
-val binary_induct = store_thm("binary_induct",
-  ``∀P. P (0:num) ∧ (∀n. P n ⇒ P (2*n) ∧ P (2*n+1)) ⇒ ∀n. P n``,
+val binary_induct = Q.store_thm("binary_induct",
+  `∀P. P (0:num) ∧ (∀n. P n ⇒ P (2*n) ∧ P (2*n+1)) ⇒ ∀n. P n`,
   gen_tac >> strip_tac >>
   completeInduct_on`n` >>
   Cases_on`n=0`>>simp[]>>
@@ -720,8 +720,8 @@ val binary_induct = store_thm("binary_induct",
     simp[] ) >>
   metis_tac[])
 
-val BIT_TIMES2 = store_thm("BIT_TIMES2",
-  ``BIT z (2 * n) ⇔ 0 < z ∧ BIT (PRE z) n``,
+val BIT_TIMES2 = Q.store_thm("BIT_TIMES2",
+  `BIT z (2 * n) ⇔ 0 < z ∧ BIT (PRE z) n`,
   Cases_on`z`>>simp[]>-(
     simp[BIT0_ODD] >>
     simp[arithmeticTheory.ODD_EVEN] >>
@@ -730,8 +730,8 @@ val BIT_TIMES2 = store_thm("BIT_TIMES2",
   qspecl_then[`z`,`n`,`1`]mp_tac BIT_SHIFT_THM >>
   simp[arithmeticTheory.ADD1])
 
-val BIT_TIMES2_1 = store_thm("BIT_TIMES2_1",
-  ``∀n z. BIT z (2 * n + 1) ⇔ (z=0) ∨ BIT z (2 * n)``,
+val BIT_TIMES2_1 = Q.store_thm("BIT_TIMES2_1",
+  `∀n z. BIT z (2 * n + 1) ⇔ (z=0) ∨ BIT z (2 * n)`,
   Induct >> simp[] >- (
     simp[BIT_ZERO] >>
     Cases_on`z`>>simp[BIT0_ODD] >>
@@ -747,14 +747,14 @@ val BIT_TIMES2_1 = store_thm("BIT_TIMES2_1",
   simp[arithmeticTheory.MOD_EQ_0_DIVISOR] >>
   metis_tac[] )
 
-val LOG2_TIMES2 = store_thm("LOG2_TIMES2",
-  ``0 < n ⇒ (LOG2 (2 * n) = SUC (LOG2 n))``,
+val LOG2_TIMES2 = Q.store_thm("LOG2_TIMES2",
+  `0 < n ⇒ (LOG2 (2 * n) = SUC (LOG2 n))`,
   srw_tac[][LOG2_def] >>
   qspecl_then[`1`,`2`,`n`]mp_tac logrootTheory.LOG_EXP >>
   simp[arithmeticTheory.ADD1])
 
-val LOG2_TIMES2_1 = store_thm("LOG2_TIMES2_1",
-  ``∀n. 0 < n ⇒ (LOG2 (2 * n + 1) = LOG2 (2 * n))``,
+val LOG2_TIMES2_1 = Q.store_thm("LOG2_TIMES2_1",
+  `∀n. 0 < n ⇒ (LOG2 (2 * n + 1) = LOG2 (2 * n))`,
   srw_tac[][LOG2_def] >>
   MATCH_MP_TAC logrootTheory.LOG_UNIQUE >>
   simp[GSYM LOG2_def,LOG2_TIMES2] >>
@@ -794,8 +794,8 @@ val LOG2_TIMES2_1 = store_thm("LOG2_TIMES2_1",
   simp[Abbr`Y`,arithmeticTheory.ODD_EXISTS] >>
   metis_tac[])
 
-val C_BIT_11 = store_thm("C_BIT_11",
-  ``∀n m. (∀z. (z ≤ LOG2 (MAX n m)) ⇒ (BIT z n ⇔ BIT z m)) ⇔ (n = m)``,
+val C_BIT_11 = Q.store_thm("C_BIT_11",
+  `∀n m. (∀z. (z ≤ LOG2 (MAX n m)) ⇒ (BIT z n ⇔ BIT z m)) ⇔ (n = m)`,
   simp[Once EQ_IMP_THM] >>
   ho_match_mp_tac binary_induct >>
   simp[] >>
@@ -847,8 +847,8 @@ val C_BIT_11 = store_thm("C_BIT_11",
     srw_tac[][] >> full_simp_tac(srw_ss())[] >> simp[LOG2_TIMES2_1,LOG2_TIMES2] ) >>
   simp[BIT_TIMES2_1,BIT_TIMES2])
 
-val BIT_num_from_bin_list_leading = store_thm("BIT_num_from_bin_list_leading",
-  ``∀l x. EVERY ($> 2) l ∧ LENGTH l ≤ x ⇒ ¬BIT x (num_from_bin_list l)``,
+val BIT_num_from_bin_list_leading = Q.store_thm("BIT_num_from_bin_list_leading",
+  `∀l x. EVERY ($> 2) l ∧ LENGTH l ≤ x ⇒ ¬BIT x (num_from_bin_list l)`,
   simp[numposrepTheory.num_from_bin_list_def] >>
   srw_tac[][] >>
   MATCH_MP_TAC NOT_BIT_GT_TWOEXP >>
@@ -859,12 +859,12 @@ val BIT_num_from_bin_list_leading = store_thm("BIT_num_from_bin_list_leading",
 val least_from_def = Define`
   least_from P n = if (∃x. P x ∧ n ≤ x) then $LEAST (λx. P x ∧ n ≤ x) else $LEAST P`
 
-val LEAST_thm = store_thm("LEAST_thm",
-  ``$LEAST P = least_from P 0``,
+val LEAST_thm = Q.store_thm("LEAST_thm",
+  `$LEAST P = least_from P 0`,
   srw_tac[][least_from_def,ETA_AX])
 
-val least_from_thm = store_thm("least_from_thm",
-  ``least_from P n = if P n then n else least_from P (n+1)``,
+val least_from_thm = Q.store_thm("least_from_thm",
+  `least_from P n = if P n then n else least_from P (n+1)`,
   srw_tac[][least_from_def] >>
   numLib.LEAST_ELIM_TAC >> srw_tac[][] >> full_simp_tac(srw_ss())[] >> res_tac >>
   TRY(metis_tac[arithmeticTheory.LESS_OR_EQ]) >- (
@@ -886,18 +886,18 @@ val least_from_thm = store_thm("least_from_thm",
     `x = n` by DECIDE_TAC >>
     full_simp_tac(srw_ss())[] ))
 
-val FILTER_F = store_thm("FILTER_F",
-  ``∀ls. FILTER (λx. F) ls = []``,
+val FILTER_F = Q.store_thm("FILTER_F",
+  `∀ls. FILTER (λx. F) ls = []`,
   Induct >> simp[])
 val _ = export_rewrites["FILTER_F"]
 
-val OPTREL_SOME = store_thm("OPTREL_SOME",
-  ``(!R x y. OPTREL R (SOME x) y <=> (?z. y = SOME z /\ R x z)) /\
-    (!R x y. OPTREL R x (SOME y) <=> (?z. x = SOME z /\ R z y))``,
+val OPTREL_SOME = Q.store_thm("OPTREL_SOME",
+  `(!R x y. OPTREL R (SOME x) y <=> (?z. y = SOME z /\ R x z)) /\
+    (!R x y. OPTREL R x (SOME y) <=> (?z. x = SOME z /\ R z y))`,
     srw_tac[][optionTheory.OPTREL_def])
 
-val LIST_REL_O = store_thm("LIST_REL_O",
-  ``∀R1 R2 l1 l2. LIST_REL (R1 O R2) l1 l2 ⇔ ∃l3. LIST_REL R2 l1 l3 ∧ LIST_REL R1 l3 l2``,
+val LIST_REL_O = Q.store_thm("LIST_REL_O",
+  `∀R1 R2 l1 l2. LIST_REL (R1 O R2) l1 l2 ⇔ ∃l3. LIST_REL R2 l1 l3 ∧ LIST_REL R1 l3 l2`,
   rpt gen_tac >>
   simp[EVERY2_EVERY,EVERY_MEM,EQ_IMP_THM,GSYM AND_IMP_INTRO,MEM_ZIP,PULL_EXISTS,O_DEF] >>
   srw_tac[][] >- (
@@ -906,25 +906,25 @@ val LIST_REL_O = store_thm("LIST_REL_O",
     simp[MEM_ZIP,PULL_EXISTS] ) >>
   metis_tac[])
 
-val OPTREL_O_lemma = prove(
-  ``∀R1 R2 l1 l2. OPTREL (R1 O R2) l1 l2 ⇔ ∃l3. OPTREL R2 l1 l3 ∧ OPTREL R1 l3 l2``,
+val OPTREL_O_lemma = Q.prove(
+  `∀R1 R2 l1 l2. OPTREL (R1 O R2) l1 l2 ⇔ ∃l3. OPTREL R2 l1 l3 ∧ OPTREL R1 l3 l2`,
   srw_tac[][optionTheory.OPTREL_def,EQ_IMP_THM,O_DEF,PULL_EXISTS] >> metis_tac[])
 
-val OPTREL_O = store_thm("OPTREL_O",
-  ``∀R1 R2. OPTREL (R1 O R2) = OPTREL R1 O OPTREL R2``,
+val OPTREL_O = Q.store_thm("OPTREL_O",
+  `∀R1 R2. OPTREL (R1 O R2) = OPTREL R1 O OPTREL R2`,
   srw_tac[][FUN_EQ_THM,OPTREL_O_lemma,O_DEF])
 
-val FUNPOW_mono = store_thm("FUNPOW_mono",
-  ``(∀x y. R1 x y ⇒ R2 x y) ∧
+val FUNPOW_mono = Q.store_thm("FUNPOW_mono",
+  `(∀x y. R1 x y ⇒ R2 x y) ∧
     (∀R1 R2. (∀x y. R1 x y ⇒ R2 x y) ⇒ ∀x y. f R1 x y ⇒ f R2 x y) ⇒
-    ∀n x y. FUNPOW f n R1 x y ⇒ FUNPOW f n R2 x y``,
+    ∀n x y. FUNPOW f n R1 x y ⇒ FUNPOW f n R2 x y`,
   strip_tac >> Induct >> simp[] >>
   simp[arithmeticTheory.FUNPOW_SUC] >>
   first_x_assum match_mp_tac >> srw_tac[][])
 
-val OPTREL_trans = store_thm("OPTREL_trans",
-  ``∀R x y z. (∀a b c. (x = SOME a) ∧ (y = SOME b) ∧ (z = SOME c) ∧ R a b ∧ R b c ⇒ R a c)
-    ∧ OPTREL R x y ∧ OPTREL R y z ⇒ OPTREL R x z``,
+val OPTREL_trans = Q.store_thm("OPTREL_trans",
+  `∀R x y z. (∀a b c. (x = SOME a) ∧ (y = SOME b) ∧ (z = SOME c) ∧ R a b ∧ R b c ⇒ R a c)
+    ∧ OPTREL R x y ∧ OPTREL R y z ⇒ OPTREL R x z`,
   srw_tac[][optionTheory.OPTREL_def])
 
 val UPDATE_LIST_def = Define`
@@ -932,23 +932,23 @@ val UPDATE_LIST_def = Define`
 val _ = Parse.add_infix("=++",500,Parse.LEFT)
 val _ = Parse.overload_on("=++",``UPDATE_LIST``)
 
-val UPDATE_LIST_THM = store_thm("UPDATE_LIST_THM",
-  ``∀f. (f =++ [] = f) ∧ ∀h t. (f =++ (h::t) = (FST h =+ SND h) f =++ t)``,
+val UPDATE_LIST_THM = Q.store_thm("UPDATE_LIST_THM",
+  `∀f. (f =++ [] = f) ∧ ∀h t. (f =++ (h::t) = (FST h =+ SND h) f =++ t)`,
   srw_tac[][UPDATE_LIST_def,pairTheory.UNCURRY])
 
-val APPLY_UPDATE_LIST_ALOOKUP = store_thm("APPLY_UPDATE_LIST_ALOOKUP",
-  ``∀ls f x. (f =++ ls) x = case ALOOKUP (REVERSE ls) x of NONE => f x | SOME y => y``,
+val APPLY_UPDATE_LIST_ALOOKUP = Q.store_thm("APPLY_UPDATE_LIST_ALOOKUP",
+  `∀ls f x. (f =++ ls) x = case ALOOKUP (REVERSE ls) x of NONE => f x | SOME y => y`,
   Induct >> simp[UPDATE_LIST_THM,ALOOKUP_APPEND] >>
   Cases >> simp[combinTheory.APPLY_UPDATE_THM] >>
   srw_tac[][] >> BasicProvers.CASE_TAC)
 
-val IS_SUFFIX_CONS = store_thm("IS_SUFFIX_CONS",
-  ``∀l1 l2 a. IS_SUFFIX l1 l2 ⇒ IS_SUFFIX (a::l1) l2``,
+val IS_SUFFIX_CONS = Q.store_thm("IS_SUFFIX_CONS",
+  `∀l1 l2 a. IS_SUFFIX l1 l2 ⇒ IS_SUFFIX (a::l1) l2`,
   srw_tac[][rich_listTheory.IS_SUFFIX_APPEND] >>
   qexists_tac`a::l` >>srw_tac[][])
 
-val INFINITE_INJ_NOT_SURJ = store_thm("INFINITE_INJ_NOT_SURJ",
-  ``∀s. INFINITE s ⇔ (s ≠ ∅) ∧ (∃f. INJ f s s ∧ ¬SURJ f s s)``,
+val INFINITE_INJ_NOT_SURJ = Q.store_thm("INFINITE_INJ_NOT_SURJ",
+  `∀s. INFINITE s ⇔ (s ≠ ∅) ∧ (∃f. INJ f s s ∧ ¬SURJ f s s)`,
   srw_tac[][EQ_IMP_THM] >- (
     PROVE_TAC[INFINITE_INHAB,MEMBER_NOT_EMPTY] )
   >- (
@@ -988,19 +988,19 @@ val find_index_def = Define`
   (find_index _ [] _ = NONE) ∧
   (find_index y (x::xs) n = if x = y then SOME n else find_index y xs (n+1))`
 
-val find_index_NOT_MEM = store_thm("find_index_NOT_MEM",
-  ``∀ls x n. ¬MEM x ls = (find_index x ls n = NONE)``,
+val find_index_NOT_MEM = Q.store_thm("find_index_NOT_MEM",
+  `∀ls x n. ¬MEM x ls = (find_index x ls n = NONE)`,
   Induct >> srw_tac[][find_index_def])
 
-val find_index_MEM = store_thm("find_index_MEM",
-  ``!ls x n. MEM x ls ==> ?i. (find_index x ls n = SOME (n+i)) /\ i < LENGTH ls /\ (EL i ls = x)``,
+val find_index_MEM = Q.store_thm("find_index_MEM",
+  `!ls x n. MEM x ls ==> ?i. (find_index x ls n = SOME (n+i)) /\ i < LENGTH ls /\ (EL i ls = x)`,
   Induct >> srw_tac[][find_index_def] >- (
     qexists_tac`0`>>srw_tac[][] ) >>
   first_x_assum(qspecl_then[`x`,`n+1`]mp_tac) >>
   srw_tac[][]>>qexists_tac`SUC i`>>srw_tac[ARITH_ss][ADD1])
 
-val find_index_LEAST_EL = store_thm("find_index_LEAST_EL",
-  ``∀ls x n. find_index x ls n = if MEM x ls then SOME (n + (LEAST n. x = EL n ls)) else NONE``,
+val find_index_LEAST_EL = Q.store_thm("find_index_LEAST_EL",
+  `∀ls x n. find_index x ls n = if MEM x ls then SOME (n + (LEAST n. x = EL n ls)) else NONE`,
   Induct >- srw_tac[][find_index_def] >>
   simp[find_index_def] >>
   rpt gen_tac >>
@@ -1024,45 +1024,45 @@ val find_index_LEAST_EL = store_thm("find_index_LEAST_EL",
     res_tac >> full_simp_tac(srw_ss())[GSYM ADD1] ) >>
   DECIDE_TAC )
 
-val find_index_LESS_LENGTH = store_thm(
+val find_index_LESS_LENGTH = Q.store_thm(
 "find_index_LESS_LENGTH",
-``∀ls n m i. (find_index n ls m = SOME i) ⇒ (m <= i) ∧ (i < m + LENGTH ls)``,
+`∀ls n m i. (find_index n ls m = SOME i) ⇒ (m <= i) ∧ (i < m + LENGTH ls)`,
 Induct >> srw_tac[][find_index_def] >>
 res_tac >>
 srw_tac[ARITH_ss][arithmeticTheory.ADD1])
 
-val ALOOKUP_find_index_NONE = store_thm("ALOOKUP_find_index_NONE",
-  ``(ALOOKUP env k = NONE) ⇒ (find_index k (MAP FST env) m = NONE)``,
+val ALOOKUP_find_index_NONE = Q.store_thm("ALOOKUP_find_index_NONE",
+  `(ALOOKUP env k = NONE) ⇒ (find_index k (MAP FST env) m = NONE)`,
   srw_tac[][ALOOKUP_FAILS] >> srw_tac[][GSYM find_index_NOT_MEM,MEM_MAP,EXISTS_PROD])
 
-val ALOOKUP_find_index_SOME = prove(
-  ``∀env. (ALOOKUP env k = SOME v) ⇒
+val ALOOKUP_find_index_SOME = Q.prove(
+  `∀env. (ALOOKUP env k = SOME v) ⇒
       ∀m. ∃i. (find_index k (MAP FST env) m = SOME (m+i)) ∧
-          (v = EL i (MAP SND env))``,
+          (v = EL i (MAP SND env))`,
   Induct >> simp[] >> Cases >> srw_tac[][find_index_def] >-
     (qexists_tac`0`>>simp[]) >> full_simp_tac(srw_ss())[] >>
   first_x_assum(qspec_then`m+1`mp_tac)>>srw_tac[][]>>srw_tac[][]>>
   qexists_tac`SUC i`>>simp[])
 |> SPEC_ALL |> UNDISCH_ALL |> Q.SPEC`0` |> DISCH_ALL |> SIMP_RULE (srw_ss())[]
-val ALOOKUP_find_index_SOME = store_thm("ALOOKUP_find_index_SOME",
-  ``(ALOOKUP env k = SOME v) ⇒
+val ALOOKUP_find_index_SOME = Q.store_thm("ALOOKUP_find_index_SOME",
+  `(ALOOKUP env k = SOME v) ⇒
     ∃i. (find_index k (MAP FST env) 0 = SOME i) ∧
-        i < LENGTH env ∧ (v = SND (EL i env))``,
+        i < LENGTH env ∧ (v = SND (EL i env))`,
   srw_tac[][] >> imp_res_tac ALOOKUP_find_index_SOME >>
   imp_res_tac find_index_LESS_LENGTH >> full_simp_tac(srw_ss())[EL_MAP])
 
-val find_index_ALL_DISTINCT_EL = store_thm(
+val find_index_ALL_DISTINCT_EL = Q.store_thm(
 "find_index_ALL_DISTINCT_EL",
-``∀ls n m. ALL_DISTINCT ls ∧ n < LENGTH ls ⇒ (find_index (EL n ls) ls m = SOME (m + n))``,
+`∀ls n m. ALL_DISTINCT ls ∧ n < LENGTH ls ⇒ (find_index (EL n ls) ls m = SOME (m + n))`,
 Induct >- srw_tac[][] >>
 gen_tac >> Cases >>
 srw_tac[ARITH_ss][find_index_def] >>
 metis_tac[MEM_EL])
 val _ = export_rewrites["find_index_ALL_DISTINCT_EL"]
 
-val find_index_ALL_DISTINCT_EL_eq = store_thm("find_index_ALL_DISTINCT_EL_eq",
-  ``∀ls. ALL_DISTINCT ls ⇒ ∀x m i. (find_index x ls m = SOME i) =
-      ∃j. (i = m + j) ∧ j < LENGTH ls ∧ (x = EL j ls)``,
+val find_index_ALL_DISTINCT_EL_eq = Q.store_thm("find_index_ALL_DISTINCT_EL_eq",
+  `∀ls. ALL_DISTINCT ls ⇒ ∀x m i. (find_index x ls m = SOME i) =
+      ∃j. (i = m + j) ∧ j < LENGTH ls ∧ (x = EL j ls)`,
   srw_tac[][EQ_IMP_THM] >- (
     imp_res_tac find_index_LESS_LENGTH >>
     full_simp_tac(srw_ss())[find_index_LEAST_EL] >> srw_tac[ARITH_ss][] >>
@@ -1071,12 +1071,12 @@ val find_index_ALL_DISTINCT_EL_eq = store_thm("find_index_ALL_DISTINCT_EL_eq",
     full_simp_tac(srw_ss())[EL_ALL_DISTINCT_EL_EQ] ) >>
   PROVE_TAC[find_index_ALL_DISTINCT_EL])
 
-val find_index_APPEND_same = store_thm("find_index_APPEND_same",
-  ``!l1 n m i l2. (find_index n l1 m = SOME i) ==> (find_index n (l1 ++ l2) m = SOME i)``,
+val find_index_APPEND_same = Q.store_thm("find_index_APPEND_same",
+  `!l1 n m i l2. (find_index n l1 m = SOME i) ==> (find_index n (l1 ++ l2) m = SOME i)`,
   Induct >> srw_tac[][find_index_def])
 
-val find_index_ALL_DISTINCT_REVERSE = store_thm("find_index_ALL_DISTINCT_REVERSE",
-  ``∀ls x m j. ALL_DISTINCT ls ∧ (find_index x ls m = SOME j) ⇒ (find_index x (REVERSE ls) m = SOME (m + LENGTH ls + m - j - 1))``,
+val find_index_ALL_DISTINCT_REVERSE = Q.store_thm("find_index_ALL_DISTINCT_REVERSE",
+  `∀ls x m j. ALL_DISTINCT ls ∧ (find_index x ls m = SOME j) ⇒ (find_index x (REVERSE ls) m = SOME (m + LENGTH ls + m - j - 1))`,
   srw_tac[][] >> imp_res_tac find_index_ALL_DISTINCT_EL_eq >>
   `ALL_DISTINCT (REVERSE ls)` by srw_tac[][ALL_DISTINCT_REVERSE] >>
   simp[find_index_ALL_DISTINCT_EL_eq] >>
@@ -1085,16 +1085,16 @@ val find_index_ALL_DISTINCT_REVERSE = store_thm("find_index_ALL_DISTINCT_REVERSE
   qexists_tac`LENGTH ls - z - 1` >>
   lrw[EL_REVERSE,PRE_SUB1])
 
-val THE_find_index_suff = store_thm("THE_find_index_suff",
-  ``∀P x ls n. (∀m. m < LENGTH ls ⇒ P (m + n)) ∧ MEM x ls ⇒
-    P (THE (find_index x ls n))``,
+val THE_find_index_suff = Q.store_thm("THE_find_index_suff",
+  `∀P x ls n. (∀m. m < LENGTH ls ⇒ P (m + n)) ∧ MEM x ls ⇒
+    P (THE (find_index x ls n))`,
   srw_tac[][] >>
   imp_res_tac find_index_MEM >>
   pop_assum(qspec_then`n`mp_tac) >>
   srw_tac[DNF_ss,ARITH_ss][])
 
-val find_index_APPEND1 = store_thm("find_index_APPEND1",
-  ``∀l1 n l2 m i. (find_index n (l1 ++ l2) m = SOME i) ∧ (i < m+LENGTH l1) ⇒ (find_index n l1 m = SOME i)``,
+val find_index_APPEND1 = Q.store_thm("find_index_APPEND1",
+  `∀l1 n l2 m i. (find_index n (l1 ++ l2) m = SOME i) ∧ (i < m+LENGTH l1) ⇒ (find_index n l1 m = SOME i)`,
   Induct >> simp[find_index_def] >- (
     spose_not_then strip_assume_tac >>
     imp_res_tac find_index_LESS_LENGTH >>
@@ -1103,24 +1103,24 @@ val find_index_APPEND1 = store_thm("find_index_APPEND1",
   first_x_assum match_mp_tac >>
   simp[])
 
-val find_index_APPEND2 = store_thm("find_index_APPEND2",
-  ``∀l1 n l2 m i. (find_index n (l1 ++ l2) m = SOME i) ∧ (m + LENGTH l1 ≤ i) ⇒ (find_index n l2 (m+LENGTH l1) = SOME i)``,
+val find_index_APPEND2 = Q.store_thm("find_index_APPEND2",
+  `∀l1 n l2 m i. (find_index n (l1 ++ l2) m = SOME i) ∧ (m + LENGTH l1 ≤ i) ⇒ (find_index n l2 (m+LENGTH l1) = SOME i)`,
   Induct >> simp[find_index_def] >>
   srw_tac[][] >> fsrw_tac[ARITH_ss][] >>
   res_tac >> fsrw_tac[ARITH_ss][ADD1])
 
-val find_index_is_MEM = store_thm("find_index_is_MEM",
-  ``∀x ls n j. (find_index x ls n = SOME j) ⇒ MEM x ls``,
+val find_index_is_MEM = Q.store_thm("find_index_is_MEM",
+  `∀x ls n j. (find_index x ls n = SOME j) ⇒ MEM x ls`,
   metis_tac[find_index_NOT_MEM,optionTheory.NOT_SOME_NONE])
 
-val find_index_MAP_inj = store_thm("find_index_MAP_inj",
-  ``∀ls x n f. (∀y. MEM y ls ⇒ (f x = f y) ⇒ x = y) ⇒ (find_index (f x) (MAP f ls) n = find_index x ls n)``,
+val find_index_MAP_inj = Q.store_thm("find_index_MAP_inj",
+  `∀ls x n f. (∀y. MEM y ls ⇒ (f x = f y) ⇒ x = y) ⇒ (find_index (f x) (MAP f ls) n = find_index x ls n)`,
   Induct >- simp[find_index_def] >>
   srw_tac[][] >> srw_tac[][find_index_def] >>
   metis_tac[])
 
-val find_index_shift_0 = store_thm("find_index_shift_0",
-  ``∀ls x k. find_index x ls k = OPTION_MAP (λx. x + k) (find_index x ls 0)``,
+val find_index_shift_0 = Q.store_thm("find_index_shift_0",
+  `∀ls x k. find_index x ls k = OPTION_MAP (λx. x + k) (find_index x ls 0)`,
   Induct >> simp_tac(srw_ss())[find_index_def] >>
   rpt gen_tac >>
   Cases_on`h=x` >- (
@@ -1135,15 +1135,15 @@ val find_index_shift_0 = store_thm("find_index_shift_0",
   Cases_on`find_index x ls 0`>>srw_tac[][] >>
   simp[])
 
-val find_index_shift = store_thm("find_index_shift",
-  ``∀ls x k j. (find_index x ls k = SOME j) ⇒ j ≥ k ∧ ∀n. find_index x ls n = SOME (j-k+n)``,
+val find_index_shift = Q.store_thm("find_index_shift",
+  `∀ls x k j. (find_index x ls k = SOME j) ⇒ j ≥ k ∧ ∀n. find_index x ls n = SOME (j-k+n)`,
   Induct >> simp[find_index_def] >> srw_tac[][] >> res_tac >> fsrw_tac[ARITH_ss][])
 
-val find_index_APPEND = store_thm("find_index_APPEND",
-  ``∀l1 l2 x n. find_index x (l1 ++ l2) n =
+val find_index_APPEND = Q.store_thm("find_index_APPEND",
+  `∀l1 l2 x n. find_index x (l1 ++ l2) n =
     case find_index x l1 n of
     | NONE => find_index x l2 (n + LENGTH l1)
-    | SOME x => SOME x``,
+    | SOME x => SOME x`,
   Induct >> simp[find_index_def] >> srw_tac[][] >>
   BasicProvers.CASE_TAC >>
   simp[arithmeticTheory.ADD1])
@@ -1261,8 +1261,8 @@ val PERM_ZIP = store_thm("PERM_ZIP",
   simp[] >> strip_tac >>
   metis_tac[PERM_TRANS])
 
-val PERM_BIJ = store_thm("PERM_BIJ",
-  ``∀l1 l2. PERM l1 l2 ⇒ ∃f. (BIJ f (count(LENGTH l1)) (count(LENGTH l1)) ∧ (l2 = GENLIST (λi. EL (f i) l1) (LENGTH l1)))``,
+val PERM_BIJ = Q.store_thm("PERM_BIJ",
+  `∀l1 l2. PERM l1 l2 ⇒ ∃f. (BIJ f (count(LENGTH l1)) (count(LENGTH l1)) ∧ (l2 = GENLIST (λi. EL (f i) l1) (LENGTH l1)))`,
   ho_match_mp_tac PERM_IND >> simp[BIJ_EMPTY] >>
   conj_tac >- (
     simp[GENLIST_CONS] >>
@@ -1297,21 +1297,21 @@ val PERM_BIJ = store_thm("PERM_BIJ",
   qexists_tac`g' o g` >>
   simp[combinTheory.o_DEF] )
 
-val PERM_EVERY = store_thm("PERM_EVERY",
-``∀ls ls'.
+val PERM_EVERY = Q.store_thm("PERM_EVERY",
+`∀ls ls'.
   PERM ls ls' ⇒
-  (EVERY P ls ⇔ EVERY P ls')``,
+  (EVERY P ls ⇔ EVERY P ls')`,
   ho_match_mp_tac PERM_STRONG_IND>>srw_tac[][]>>metis_tac[])
 
-val RTC_RINTER = store_thm("RTC_RINTER",
-  ``!R1 R2 x y. RTC (R1 RINTER R2) x y ⇒ ((RTC R1) RINTER (RTC R2)) x y``,
+val RTC_RINTER = Q.store_thm("RTC_RINTER",
+  `!R1 R2 x y. RTC (R1 RINTER R2) x y ⇒ ((RTC R1) RINTER (RTC R2)) x y`,
   ntac 2 gen_tac >>
   match_mp_tac RTC_INDUCT >>
   simp[RINTER] >>
   metis_tac[RTC_CASES1] )
 
-val RTC_invariant = store_thm("RTC_invariant",
-  ``!R P. (!x y. P x /\ R x y ==> P y) ==> !x y. RTC R x y ==> P x ==> RTC (R RINTER (\x y. P x /\ P y)) x y``,
+val RTC_invariant = Q.store_thm("RTC_invariant",
+  `!R P. (!x y. P x /\ R x y ==> P y) ==> !x y. RTC R x y ==> P x ==> RTC (R RINTER (\x y. P x /\ P y)) x y`,
   rpt gen_tac >> strip_tac >>
   ho_match_mp_tac RTC_INDUCT >>
   srw_tac[][] >> res_tac >> full_simp_tac(srw_ss())[] >>
@@ -1320,8 +1320,8 @@ val RTC_invariant = store_thm("RTC_invariant",
   HINT_EXISTS_TAC >>
   simp[RINTER])
 
-val RTC_RSUBSET = store_thm("RTC_RSUBSET",
-  ``!R1 R2. R1 RSUBSET R2 ==> (RTC R1) RSUBSET (RTC R2)``,
+val RTC_RSUBSET = Q.store_thm("RTC_RSUBSET",
+  `!R1 R2. R1 RSUBSET R2 ==> (RTC R1) RSUBSET (RTC R2)`,
   simp[RSUBSET] >> rpt gen_tac >> strip_tac >>
   ho_match_mp_tac RTC_INDUCT >>
   simp[] >>
@@ -1350,8 +1350,8 @@ val PERM_PARTITION = store_thm("PERM_PARTITION",
   ``∀P L A B. ((A,B) = PARTITION P L) ==> PERM L (A ++ B)``,
   METIS_TAC[PERM_PART,PARTITION_DEF,APPEND_NIL])
 
-val transitive_LESS = store_thm("transitive_LESS",
-  ``transitive ($< : (num->num->bool))``,
+val transitive_LESS = Q.store_thm("transitive_LESS",
+  `transitive ($< : (num->num->bool))`,
   srw_tac[][relationTheory.transitive_def] >> PROVE_TAC[LESS_TRANS])
 val _ = export_rewrites["transitive_LESS"]
 
@@ -1359,22 +1359,22 @@ val OPTION_EVERY_def = Define`
   (OPTION_EVERY P NONE = T) /\
   (OPTION_EVERY P (SOME v) = P v)`
 val _ = export_rewrites["OPTION_EVERY_def"]
-val OPTION_EVERY_cong = store_thm("OPTION_EVERY_cong",
-  ``!o1 o2 P1 P2. (o1 = o2) /\ (!x. (o2 = SOME x) ==> (P1 x = P2 x)) ==>
-                  (OPTION_EVERY P1 o1 = OPTION_EVERY P2 o2)``,
+val OPTION_EVERY_cong = Q.store_thm("OPTION_EVERY_cong",
+  `!o1 o2 P1 P2. (o1 = o2) /\ (!x. (o2 = SOME x) ==> (P1 x = P2 x)) ==>
+                  (OPTION_EVERY P1 o1 = OPTION_EVERY P2 o2)`,
   Cases THEN SRW_TAC[][] THEN SRW_TAC[][])
 val _ = DefnBase.export_cong"OPTION_EVERY_cong"
-val OPTION_EVERY_mono = store_thm("OPTION_EVERY_mono",
-  ``(!x. P x ==> Q x) ==> OPTION_EVERY P op ==> OPTION_EVERY Q op``,
+val OPTION_EVERY_mono = Q.store_thm("OPTION_EVERY_mono",
+  `(!x. P x ==> Q x) ==> OPTION_EVERY P op ==> OPTION_EVERY Q op`,
   Cases_on `op` THEN SRW_TAC[][])
 val _ = IndDefLib.export_mono"OPTION_EVERY_mono"
 
-val option_case_NONE_F = store_thm("option_case_NONE_F",
-  ``(case X of NONE => F | SOME x => P x) = (∃x. (X = SOME x) ∧ P x)``,
+val option_case_NONE_F = Q.store_thm("option_case_NONE_F",
+  `(case X of NONE => F | SOME x => P x) = (∃x. (X = SOME x) ∧ P x)`,
   Cases_on`X`>>srw_tac[][])
 
-val IS_PREFIX_THM = store_thm("IS_PREFIX_THM",
- ``!l2 l1. IS_PREFIX l1 l2 <=> (LENGTH l2 <= LENGTH l1) /\ !n. n < LENGTH l2 ==> (EL n l2 = EL n l1)``,
+val IS_PREFIX_THM = Q.store_thm("IS_PREFIX_THM",
+ `!l2 l1. IS_PREFIX l1 l2 <=> (LENGTH l2 <= LENGTH l1) /\ !n. n < LENGTH l2 ==> (EL n l2 = EL n l1)`,
  Induct THEN SRW_TAC[][IS_PREFIX] THEN
  Cases_on`l1`THEN SRW_TAC[][EQ_IMP_THM] THEN1 (
    Cases_on`n`THEN SRW_TAC[][EL_CONS] THEN
@@ -1384,18 +1384,18 @@ val IS_PREFIX_THM = store_thm("IS_PREFIX_THM",
  THEN1 (
    FIRST_X_ASSUM(Q.SPEC_THEN`SUC n`MP_TAC)THEN SRW_TAC[][] ))
 
-val EVERY2_RC_same = store_thm("EVERY2_RC_same",
-  ``EVERY2 (RC R) l l``,
+val EVERY2_RC_same = Q.store_thm("EVERY2_RC_same",
+  `EVERY2 (RC R) l l`,
   srw_tac[DNF_ss][EVERY2_EVERY,EVERY_MEM,MEM_ZIP,relationTheory.RC_DEF])
 val _ = export_rewrites["EVERY2_RC_same"]
 
-val FOLDL_invariant = store_thm("FOLDL_invariant",
-  ``!P f ls a. (P a) /\ (!x y . MEM y ls /\ P x ==> P (f x y)) ==> P (FOLDL f a ls)``,
+val FOLDL_invariant = Q.store_thm("FOLDL_invariant",
+  `!P f ls a. (P a) /\ (!x y . MEM y ls /\ P x ==> P (f x y)) ==> P (FOLDL f a ls)`,
   NTAC 2 GEN_TAC THEN
   Induct THEN SRW_TAC[][])
 
-val FOLDL_invariant_rest = store_thm("FOLDL_invariant_rest",
-  ``∀P f ls a. P ls a ∧ (∀x n. n < LENGTH ls ∧ P (DROP n ls) x ⇒ P (DROP (SUC n) ls) (f x (EL n ls))) ⇒ P [] (FOLDL f a ls)``,
+val FOLDL_invariant_rest = Q.store_thm("FOLDL_invariant_rest",
+  `∀P f ls a. P ls a ∧ (∀x n. n < LENGTH ls ∧ P (DROP n ls) x ⇒ P (DROP (SUC n) ls) (f x (EL n ls))) ⇒ P [] (FOLDL f a ls)`,
   ntac 2 gen_tac >>
   Induct >> srw_tac[][] >>
   first_x_assum match_mp_tac >>
@@ -1406,8 +1406,8 @@ val FOLDL_invariant_rest = store_thm("FOLDL_invariant_rest",
 val between_def = Define`
   between x y z ⇔ x:num ≤ z ∧ z < y`
 
-val SUC_LEAST = store_thm("SUC_LEAST",
-  ``!x. P x ==> (SUC ($LEAST P) = LEAST x. 0 < x /\ P (PRE x))``,
+val SUC_LEAST = Q.store_thm("SUC_LEAST",
+  `!x. P x ==> (SUC ($LEAST P) = LEAST x. 0 < x /\ P (PRE x))`,
   GEN_TAC THEN STRIP_TAC THEN
   numLib.LEAST_ELIM_TAC THEN
   STRIP_TAC THEN1 PROVE_TAC[] THEN
@@ -1431,53 +1431,53 @@ val SUC_LEAST = store_thm("SUC_LEAST",
 val fmap_linv_def = Define`
   fmap_linv f1 f2 ⇔ (FDOM f2 = FRANGE f1) /\ (!x. x IN FDOM f1 ==> (FLOOKUP f2 (FAPPLY f1 x) = SOME x))`
 
-val fmap_linv_unique = store_thm("fmap_linv_unique",
-  ``!f f1 f2. fmap_linv f f1 /\ fmap_linv f f2 ==> (f1 = f2)``,
+val fmap_linv_unique = Q.store_thm("fmap_linv_unique",
+  `!f f1 f2. fmap_linv f f1 /\ fmap_linv f f2 ==> (f1 = f2)`,
   SRW_TAC[][fmap_linv_def,GSYM fmap_EQ_THM] THEN
   FULL_SIMP_TAC(srw_ss())[FRANGE_DEF,FLOOKUP_DEF] THEN
   PROVE_TAC[])
 
-val INJ_has_fmap_linv = store_thm("INJ_has_fmap_linv",
-  ``INJ (FAPPLY f) (FDOM f) (FRANGE f) ==> ?g. fmap_linv f g``,
+val INJ_has_fmap_linv = Q.store_thm("INJ_has_fmap_linv",
+  `INJ (FAPPLY f) (FDOM f) (FRANGE f) ==> ?g. fmap_linv f g`,
   STRIP_TAC THEN
   Q.EXISTS_TAC `FUN_FMAP (\x. @y. FLOOKUP f y = SOME x) (FRANGE f)` THEN
   SRW_TAC[][fmap_linv_def,FLOOKUP_FUN_FMAP,FRANGE_DEF] THEN1 PROVE_TAC[] THEN
   SELECT_ELIM_TAC THEN
   FULL_SIMP_TAC (srw_ss()) [INJ_DEF,FRANGE_DEF,FLOOKUP_DEF])
 
-val has_fmap_linv_inj = store_thm("has_fmap_linv_inj",
-  ``(?g. fmap_linv f g) = (INJ (FAPPLY f) (FDOM f) (FRANGE f))``,
+val has_fmap_linv_inj = Q.store_thm("has_fmap_linv_inj",
+  `(?g. fmap_linv f g) = (INJ (FAPPLY f) (FDOM f) (FRANGE f))`,
   Tactical.REVERSE EQ_TAC THEN1 PROVE_TAC[INJ_has_fmap_linv] THEN
   SRW_TAC[][fmap_linv_def,INJ_DEF,EQ_IMP_THM]
   THEN1 ( SRW_TAC[][FRANGE_DEF] THEN PROVE_TAC[] )
   THEN1 ( FULL_SIMP_TAC(srw_ss())[FLOOKUP_DEF] THEN PROVE_TAC[] ))
 
-val fmap_linv_FAPPLY = store_thm("fmap_linv_FAPPLY",
-  ``fmap_linv f g /\ x IN FDOM f ==> (g ' (f ' x) = x)``,
+val fmap_linv_FAPPLY = Q.store_thm("fmap_linv_FAPPLY",
+  `fmap_linv f g /\ x IN FDOM f ==> (g ' (f ' x) = x)`,
   SRW_TAC[][fmap_linv_def,FLOOKUP_DEF])
 
-val o_f_cong = store_thm("o_f_cong",
-  ``!f fm f' fm'.
+val o_f_cong = Q.store_thm("o_f_cong",
+  `!f fm f' fm'.
     (fm = fm') /\
     (!v. v IN FRANGE fm ==> (f v = f' v))
-    ==> (f o_f fm = f' o_f fm')``,
+    ==> (f o_f fm = f' o_f fm')`,
   SRW_TAC[DNF_ss][GSYM fmap_EQ_THM,FRANGE_DEF])
 val _ = DefnBase.export_cong"o_f_cong"
 
-val plus_compose = store_thm("plus_compose",
-  ``!n:num m. $+ n o $+ m = $+ (n + m)``,
+val plus_compose = Q.store_thm("plus_compose",
+  `!n:num m. $+ n o $+ m = $+ (n + m)`,
   SRW_TAC[ARITH_ss][FUN_EQ_THM])
 
 (* TODO: move elsewhere? export as rewrite? *)
-val IN_option_rwt = store_thm(
+val IN_option_rwt = Q.store_thm(
 "IN_option_rwt",
-``(x ∈ case opt of NONE => {} | SOME y => Q y) ⇔
-  (∃y. (opt = SOME y) ∧ x ∈ Q y)``,
+`(x ∈ case opt of NONE => {} | SOME y => Q y) ⇔
+  (∃y. (opt = SOME y) ∧ x ∈ Q y)`,
 Cases_on `opt` >> srw_tac[][EQ_IMP_THM])
 
-val IN_option_rwt2 = store_thm(
+val IN_option_rwt2 = Q.store_thm(
 "IN_option_rwt2",
-``x ∈ option_CASE opt {} s ⇔ ∃y. (opt = SOME y) ∧ x ∈ s y``,
+`x ∈ option_CASE opt {} s ⇔ ∃y. (opt = SOME y) ∧ x ∈ s y`,
 Cases_on `opt` >> srw_tac[][])
 
 (* Re-expressing folds *)
@@ -1500,9 +1500,9 @@ Q.X_GEN_TAC `p` THEN
 PairCases_on `p` THEN
 SRW_TAC[][])
 
-val FOLDR_transitive_property = store_thm(
+val FOLDR_transitive_property = Q.store_thm(
 "FOLDR_transitive_property",
-``!P ls f a. P [] a /\ (!n a. n < LENGTH ls /\ P (DROP (SUC n) ls) a ==> P (DROP n ls) (f (EL n ls) a)) ==> P ls (FOLDR f a ls)``,
+`!P ls f a. P [] a /\ (!n a. n < LENGTH ls /\ P (DROP (SUC n) ls) a ==> P (DROP n ls) (f (EL n ls) a)) ==> P ls (FOLDR f a ls)`,
 GEN_TAC THEN Induct THEN SRW_TAC[][] THEN
 `P ls (FOLDR f a ls)` by (
   FIRST_X_ASSUM MATCH_MP_TAC THEN
@@ -1560,22 +1560,22 @@ MAP_ZIP
 
 (* Specialisations to identity function *)
 
-val INJ_I = store_thm(
+val INJ_I = Q.store_thm(
 "INJ_I",
-``∀s t. INJ I s t ⇔ s ⊆ t``,
+`∀s t. INJ I s t ⇔ s ⊆ t`,
 SRW_TAC[][INJ_DEF,SUBSET_DEF])
 
 
-val MAP_EQ_ID = store_thm(
+val MAP_EQ_ID = Q.store_thm(
 "MAP_EQ_ID",
-``!f ls. (MAP f ls = ls) = (!x. MEM x ls ==> (f x = x))``,
+`!f ls. (MAP f ls = ls) = (!x. MEM x ls ==> (f x = x))`,
 PROVE_TAC[MAP_EQ_f,MAP_ID,combinTheory.I_THM])
 
 (* Specialisations to FEMPTY *)
 
-val FUN_FMAP_FAPPLY_FEMPTY_FAPPLY = store_thm(
+val FUN_FMAP_FAPPLY_FEMPTY_FAPPLY = Q.store_thm(
 "FUN_FMAP_FAPPLY_FEMPTY_FAPPLY",
-``FINITE s ==> (FUN_FMAP ($FAPPLY FEMPTY) s ' x = FEMPTY ' x)``,
+`FINITE s ==> (FUN_FMAP ($FAPPLY FEMPTY) s ' x = FEMPTY ' x)`,
 Cases_on `x IN s` >>
 srw_tac[][FUN_FMAP_DEF,NOT_FDOM_FAPPLY_FEMPTY])
 val _ = export_rewrites["FUN_FMAP_FAPPLY_FEMPTY_FAPPLY"]
@@ -1584,9 +1584,9 @@ val _ = export_rewrites["FUN_FMAP_FAPPLY_FEMPTY_FAPPLY"]
 
 (* Misc. *)
 
-val LESS_1 = store_thm(
+val LESS_1 = Q.store_thm(
 "LESS_1",
-``x < 1 ⇔ (x = 0:num)``,
+`x < 1 ⇔ (x = 0:num)`,
 DECIDE_TAC)
 val _ = export_rewrites["LESS_1"]
 
@@ -1617,9 +1617,9 @@ val _ = augment_srw_ss [rewrites [map_some_eq,map_some_eq_append]];
 
 (* list misc *)
 
-val LASTN_LEMMA = store_thm("LASTN_LEMMA",
-  ``(LASTN (LENGTH xs + 1 + 1) (x::y::xs) = x::y::xs) /\
-    (LASTN (LENGTH xs + 1) (x::xs) = x::xs)``,
+val LASTN_LEMMA = Q.store_thm("LASTN_LEMMA",
+  `(LASTN (LENGTH xs + 1 + 1) (x::y::xs) = x::y::xs) /\
+    (LASTN (LENGTH xs + 1) (x::xs) = x::xs)`,
   MP_TAC (Q.SPEC `x::y::xs` LASTN_LENGTH_ID)
   \\ MP_TAC (Q.SPEC `x::xs` LASTN_LENGTH_ID) \\ full_simp_tac(srw_ss())[ADD1]);
 
@@ -1628,30 +1628,30 @@ val LASTN_TL = save_thm("LASTN_TL",
   |> C MP (DECIDE``n < LENGTH xs ⇒ n + 1 ≤ LENGTH xs`` |> UNDISCH)
   |> SPEC_ALL |> DISCH_ALL);
 
-val LASTN_LENGTH_LESS_EQ = store_thm("LASTN_LENGTH_LESS_EQ",
-  ``!xs n. LENGTH xs <= n ==> LASTN n xs = xs``,
+val LASTN_LENGTH_LESS_EQ = Q.store_thm("LASTN_LENGTH_LESS_EQ",
+  `!xs n. LENGTH xs <= n ==> LASTN n xs = xs`,
   full_simp_tac(srw_ss())[LASTN_def] \\ ONCE_REWRITE_TAC [GSYM LENGTH_REVERSE]
   \\ SIMP_TAC std_ss [listTheory.TAKE_LENGTH_TOO_LONG] \\ full_simp_tac(srw_ss())[]);
 
-val LASTN_ALT = store_thm("LASTN_ALT",
-  ``(LASTN n [] = []) /\
-    (LASTN n (x::xs) = if LENGTH (x::xs) <= n then x::xs else LASTN n xs)``,
+val LASTN_ALT = Q.store_thm("LASTN_ALT",
+  `(LASTN n [] = []) /\
+    (LASTN n (x::xs) = if LENGTH (x::xs) <= n then x::xs else LASTN n xs)`,
   srw_tac[][] THEN1 (full_simp_tac(srw_ss())[LASTN_def])
   THEN1 (match_mp_tac LASTN_LENGTH_LESS_EQ \\ full_simp_tac(srw_ss())[])
   \\ full_simp_tac(srw_ss())[LASTN_def] \\ REPEAT STRIP_TAC
   \\ `n <= LENGTH (REVERSE xs)` by (full_simp_tac(srw_ss())[] \\ DECIDE_TAC)
   \\ imp_res_tac TAKE_APPEND1 \\ full_simp_tac(srw_ss())[]);
 
-val LENGTH_LASTN_LESS = store_thm("LENGTH_LASTN_LESS",
-  ``!xs n. LENGTH (LASTN n xs) <= LENGTH xs``,
+val LENGTH_LASTN_LESS = Q.store_thm("LENGTH_LASTN_LESS",
+  `!xs n. LENGTH (LASTN n xs) <= LENGTH xs`,
   Induct \\ full_simp_tac(srw_ss())[LASTN_ALT] \\ srw_tac[][]
   \\ first_x_assum (qspec_then `n` assume_tac)
   \\ decide_tac);
 
-val MAP_EQ_MAP_IMP = store_thm("MAP_EQ_MAP_IMP",
-  ``!xs ys f.
+val MAP_EQ_MAP_IMP = Q.store_thm("MAP_EQ_MAP_IMP",
+  `!xs ys f.
       (!x y. MEM x xs /\ MEM y ys /\ (f x = f y) ==> (x = y)) ==>
-      (MAP f xs = MAP f ys) ==> (xs = ys)``,
+      (MAP f xs = MAP f ys) ==> (xs = ys)`,
   Induct \\ Cases_on `ys` \\ FULL_SIMP_TAC (srw_ss()) [MAP] \\ METIS_TAC []);
 (*
 NB: this is weaker:
@@ -1659,9 +1659,9 @@ val MAP_EQ_MAP_IMP = save_thm("MAP_EQ_MAP_IMP",
   INJ_MAP_EQ |> SIMP_RULE (srw_ss()) [INJ_DEF]);
 *)
 
-val LENGTH_EQ_FILTER_FILTER = store_thm("LENGTH_EQ_FILTER_FILTER",
-  ``!xs. EVERY (\x. (P x \/ Q x) /\ ~(P x /\ Q x)) xs ==>
-         (LENGTH xs = LENGTH (FILTER P xs) + LENGTH (FILTER Q xs))``,
+val LENGTH_EQ_FILTER_FILTER = Q.store_thm("LENGTH_EQ_FILTER_FILTER",
+  `!xs. EVERY (\x. (P x \/ Q x) /\ ~(P x /\ Q x)) xs ==>
+         (LENGTH xs = LENGTH (FILTER P xs) + LENGTH (FILTER Q xs))`,
   Induct \\ SIMP_TAC std_ss [LENGTH,FILTER,EVERY_DEF] \\ STRIP_TAC
   \\ Cases_on `P h` \\ FULL_SIMP_TAC std_ss [LENGTH,ADD_CLAUSES]);
 
@@ -1801,16 +1801,16 @@ val num_from_hex_string_num_to_hex_string = Q.store_thm("num_from_hex_string_num
   |> SIMP_RULE std_ss [combinTheory.o_DEF,FUN_EQ_THM]
   |> MATCH_ACCEPT_TAC)
 
-val MAPi_ID = store_thm("MAPi_ID[simp]",
-  ``MAPi (\x y. y) = I``,
+val MAPi_ID = Q.store_thm("MAPi_ID[simp]",
+  `MAPi (\x y. y) = I`,
   fs [FUN_EQ_THM] \\ Induct \\ fs [o_DEF]);
 
 val enumerate_def = Define`
   (enumerate n [] = []) ∧
   (enumerate n (x::xs) = (n,x)::enumerate (n+1n) xs)`
 
-val LENGTH_enumerate = store_thm("LENGTH_enumerate",``
-  ∀xs k. LENGTH (enumerate k xs) = LENGTH xs``,
+val LENGTH_enumerate = Q.store_thm("LENGTH_enumerate",`
+  ∀xs k. LENGTH (enumerate k xs) = LENGTH xs`,
   Induct>>fs[enumerate_def])
 
 val EL_enumerate = store_thm("EL_enumerate",``
@@ -1844,16 +1844,16 @@ val MEM_enumerate_IMP = store_thm("MEM_enumerate_IMP",``
   fs[MEM_EL,LENGTH_enumerate]>>rw[]>>imp_res_tac EL_enumerate>>
   qexists_tac`n`>>fs[])
 
-val SNOC_REPLICATE = store_thm("SNOC_REPLICATE",
-  ``!n x. SNOC x (REPLICATE n x) = REPLICATE (SUC n) x``,
+val SNOC_REPLICATE = Q.store_thm("SNOC_REPLICATE",
+  `!n x. SNOC x (REPLICATE n x) = REPLICATE (SUC n) x`,
   Induct \\ fs [REPLICATE]);
 
-val REVERSE_REPLICATE = store_thm("REVERSE_REPLICATE",
-  ``!n x. REVERSE (REPLICATE n x) = REPLICATE n x``,
+val REVERSE_REPLICATE = Q.store_thm("REVERSE_REPLICATE",
+  `!n x. REVERSE (REPLICATE n x) = REPLICATE n x`,
   Induct \\ fs [REPLICATE] \\ fs [GSYM REPLICATE,GSYM SNOC_REPLICATE]);
 
-val SUM_REPLICATE = store_thm("SUM_REPLICATE",
-  ``!n k. SUM (REPLICATE n k) = n * k``,
+val SUM_REPLICATE = Q.store_thm("SUM_REPLICATE",
+  `!n k. SUM (REPLICATE n k) = n * k`,
   Induct \\ full_simp_tac(srw_ss())[REPLICATE,MULT_CLAUSES,AC ADD_COMM ADD_ASSOC]);
 
 val LENGTH_FLAT_REPLICATE = Q.store_thm("LENGTH_FLAT_REPLICATE",
@@ -1864,8 +1864,8 @@ val SUM_MAP_LENGTH_REPLICATE = Q.store_thm("SUM_MAP_LENGTH_REPLICATE",
   `∀n ls. SUM (MAP LENGTH (REPLICATE n ls)) = n * LENGTH ls`,
   Induct >> simp[REPLICATE,MULT]);
 
-val FLAT_REPLICATE_NIL = store_thm("FLAT_REPLICATE_NIL",
-  ``!n. FLAT (REPLICATE n []) = []``,
+val FLAT_REPLICATE_NIL = Q.store_thm("FLAT_REPLICATE_NIL",
+  `!n. FLAT (REPLICATE n []) = []`,
   Induct \\ fs [REPLICATE]);
 
 (* n.b. used in hol-reflection *)
@@ -1882,8 +1882,8 @@ val FLAT_MAP_NIL = Q.store_thm("FLAT_MAP_NIL",
   `FLAT (MAP (λx. []) ls) = []`,
   rw[FLAT_EQ_NIL,EVERY_MAP]);
 
-val UPDATE_LIST_NOT_MEM = store_thm("UPDATE_LIST_NOT_MEM",
-  ``∀ls f x. ¬MEM x(MAP FST ls) ⇒ (f =++ ls) x = f x``,
+val UPDATE_LIST_NOT_MEM = Q.store_thm("UPDATE_LIST_NOT_MEM",
+  `∀ls f x. ¬MEM x(MAP FST ls) ⇒ (f =++ ls) x = f x`,
   Induct >> simp[UPDATE_LIST_THM,combinTheory.APPLY_UPDATE_THM])
 
 val MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same = store_thm("MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same",
@@ -1892,8 +1892,8 @@ val MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same = store_thm("MAP_ZIP_UPDATE_LIST_ALL_D
   gen_tac >> Cases >> simp[UPDATE_LIST_THM] >>
   simp[UPDATE_LIST_NOT_MEM,MAP_ZIP,combinTheory.APPLY_UPDATE_THM])
 
-val MULT_LE_EXP = store_thm("MULT_LE_EXP",
-  ``∀a:num b. a ≠ 1 ⇒ a * b ≤ a ** b``,
+val MULT_LE_EXP = Q.store_thm("MULT_LE_EXP",
+  `∀a:num b. a ≠ 1 ⇒ a * b ≤ a ** b`,
   Induct_on`b` >> simp[arithmeticTheory.MULT,arithmeticTheory.EXP] >>
   Cases >> simp[] >> strip_tac >>
   first_x_assum(qspec_then`SUC n`mp_tac) >>
@@ -1905,22 +1905,22 @@ val MULT_LE_EXP = store_thm("MULT_LE_EXP",
   Cases_on`b * n` >> simp[] >>
   fs[arithmeticTheory.MULT_EQ_0] >> fs[])
 
-val domain_rrestrict_subset = store_thm("domain_rrestrict_subset",
-  ``domain (rrestrict r s) ⊆ domain r ∩ s``,
+val domain_rrestrict_subset = Q.store_thm("domain_rrestrict_subset",
+  `domain (rrestrict r s) ⊆ domain r ∩ s`,
   rw[set_relationTheory.domain_def,
      set_relationTheory.rrestrict_def,
      SUBSET_DEF] >> metis_tac[])
 
-val range_rrestrict_subset = store_thm("range_rrestrict_subset",
-  ``range (rrestrict r s) ⊆ range r ∩ s``,
+val range_rrestrict_subset = Q.store_thm("range_rrestrict_subset",
+  `range (rrestrict r s) ⊆ range r ∩ s`,
   rw[set_relationTheory.range_def,
      set_relationTheory.rrestrict_def,
      SUBSET_DEF] >> metis_tac[])
 
-val PERM_MAP_BIJ = store_thm("PERM_MAP_BIJ",
-  ``∀f l1 l2.
+val PERM_MAP_BIJ = Q.store_thm("PERM_MAP_BIJ",
+  `∀f l1 l2.
     BIJ f UNIV UNIV ⇒
-    (PERM l1 l2 ⇔ PERM (MAP f l1) (MAP f l2))``,
+    (PERM l1 l2 ⇔ PERM (MAP f l1) (MAP f l2))`,
   rw[BIJ_IFF_INV] >>
   EQ_TAC >- rw[sortingTheory.PERM_MAP] >>
   `∀l. MEM l [l1;l2] ⇒ l = MAP g (MAP f l)` by (
@@ -1928,10 +1928,10 @@ val PERM_MAP_BIJ = store_thm("PERM_MAP_BIJ",
   fs[] >>
   metis_tac[sortingTheory.PERM_MAP])
 
-val INJ_MAP_EQ_IFF = store_thm("INJ_MAP_EQ_IFF",
-  ``∀f l1 l2.
+val INJ_MAP_EQ_IFF = Q.store_thm("INJ_MAP_EQ_IFF",
+  `∀f l1 l2.
     INJ f (set l1 ∪ set l2) UNIV ⇒
-    (MAP f l1 = MAP f l2 ⇔ l1 = l2)``,
+    (MAP f l1 = MAP f l2 ⇔ l1 = l2)`,
   rw[] >> EQ_TAC >- metis_tac[INJ_MAP_EQ] >> rw[])
 
 val bool_case_eq = Q.store_thm("bool_case_eq",
@@ -1943,9 +1943,9 @@ val pair_case_eq = Q.store_thm("pair_case_eq",
  Cases_on `x` >>
  srw_tac[][]);
 
-val lookup_fromList2 = store_thm("lookup_fromList2",
-  ``!l n. lookup n (fromList2 l) =
-          if EVEN n then lookup (n DIV 2) (fromList l) else NONE``,
+val lookup_fromList2 = Q.store_thm("lookup_fromList2",
+  `!l n. lookup n (fromList2 l) =
+          if EVEN n then lookup (n DIV 2) (fromList l) else NONE`,
   recInduct SNOC_INDUCT \\ srw_tac[][]
   THEN1 (EVAL_TAC \\ full_simp_tac(srw_ss())[lookup_def])
   THEN1 (EVAL_TAC \\ full_simp_tac(srw_ss())[lookup_def])
@@ -2004,9 +2004,9 @@ val ALL_DISTINCT_FLAT = Q.store_thm(
   Induct >> dsimp[ALL_DISTINCT_APPEND, LT_SUC, MEM_FLAT] >>
   metis_tac[MEM_EL]);
 
-val TAKE_EQ_NIL = store_thm(
+val TAKE_EQ_NIL = Q.store_thm(
   "TAKE_EQ_NIL[simp]",
-  ``TAKE n l = [] <=> n = 0 ∨ l = []``,
+  `TAKE n l = [] <=> n = 0 ∨ l = []`,
   Q.ID_SPEC_TAC `l` THEN Induct_on `n` THEN ASM_SIMP_TAC (srw_ss()) [] THEN
   Cases THEN ASM_SIMP_TAC (srw_ss()) []);
 

--- a/miscScript.sml
+++ b/miscScript.sml
@@ -100,8 +100,8 @@ val ALOOKUP_MAP_gen = Q.store_thm("ALOOKUP_MAP_gen",
   gen_tac >> Induct >> simp[] >>
   Cases >> simp[] >> srw_tac[][]);
 
-val FST_EQ_EQUIV = store_thm("FST_EQ_EQUIV",
-  ``(FST x = y) <=> ?z. x = (y,z)``,
+val FST_EQ_EQUIV = Q.store_thm("FST_EQ_EQUIV",
+  `(FST x = y) <=> ?z. x = (y,z)`,
   Cases_on `x` \\ full_simp_tac(srw_ss())[]);
 
 val map_fromAList = Q.store_thm("map_fromAList",
@@ -364,10 +364,10 @@ val alist_insert_def = Define `
   (alist_insert vs [] t = t) /\
   (alist_insert (v::vs) (x::xs) t = insert v x (alist_insert vs xs t))`
 
-val lookup_alist_insert = store_thm("lookup_alist_insert",
-  ``!x y t z. LENGTH x = LENGTH y ==>
+val lookup_alist_insert = Q.store_thm("lookup_alist_insert",
+  `!x y t z. LENGTH x = LENGTH y ==>
     (lookup z (alist_insert x y t) =
-    case ALOOKUP (ZIP(x,y)) z of SOME a => SOME a | NONE => lookup z t)``,
+    case ALOOKUP (ZIP(x,y)) z of SOME a => SOME a | NONE => lookup z t)`,
     ho_match_mp_tac (fetch "-" "alist_insert_ind")>>
     srw_tac[][]>-
       (Cases_on`y`>>
@@ -385,10 +385,10 @@ val domain_alist_insert = Q.store_thm("domain_alist_insert",
 val fromList2_def = Define `
   fromList2 l = SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (0,LN) l)`
 
-val EVEN_fromList2_lemma = prove(
-  ``!l n t.
+val EVEN_fromList2_lemma = Q.prove(
+  `!l n t.
       EVEN n /\ (!x. x IN domain t ==> EVEN x) ==>
-      !x. x IN domain (SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (n,t) l)) ==> EVEN x``,
+      !x. x IN domain (SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (n,t) l)) ==> EVEN x`,
   Induct \\ full_simp_tac(srw_ss())[FOLDL] \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[PULL_FORALL]
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`n+2`,`insert n h t`,`x`])
   \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ POP_ASSUM MATCH_MP_TAC
@@ -505,8 +505,8 @@ val EVERY_ZIP = Q.store_thm ("EVERY_ZIP",
   full_simp_tac(srw_ss())[] >>
   metis_tac []);
 
-val ZIP_MAP_FST_SND_EQ = store_thm("ZIP_MAP_FST_SND_EQ",
-  ``∀ls. ZIP (MAP FST ls,MAP SND ls) = ls``,
+val ZIP_MAP_FST_SND_EQ = Q.store_thm("ZIP_MAP_FST_SND_EQ",
+  `∀ls. ZIP (MAP FST ls,MAP SND ls) = ls`,
   Induct>>full_simp_tac(srw_ss())[])
 
 val tlookup_def = Define `
@@ -537,15 +537,15 @@ val ALOOKUP_SNOC = Q.store_thm("ALOOKUP_SNOC",
   Induct >> simp[] >>
   Cases >> simp[] >> srw_tac[][])
 
-val ALOOKUP_GENLIST = store_thm("ALOOKUP_GENLIST",
-  ``∀f n k. ALOOKUP (GENLIST (λi. (i,f i)) n) k = if k < n then SOME (f k) else NONE``,
+val ALOOKUP_GENLIST = Q.store_thm("ALOOKUP_GENLIST",
+  `∀f n k. ALOOKUP (GENLIST (λi. (i,f i)) n) k = if k < n then SOME (f k) else NONE`,
   gen_tac >> Induct >> simp[GENLIST] >> srw_tac[][] >> full_simp_tac(srw_ss())[ALOOKUP_SNOC] >>
   srw_tac[][] >> fsrw_tac[ARITH_ss][])
 
-val ALOOKUP_ZIP_FAIL = store_thm("ALOOKUP_ZIP_FAIL",
-  ``∀A B x.
+val ALOOKUP_ZIP_FAIL = Q.store_thm("ALOOKUP_ZIP_FAIL",
+  `∀A B x.
   LENGTH A = LENGTH B ⇒
-  (ALOOKUP (ZIP (A,B)) x = NONE ⇔ ¬MEM x A)``,
+  (ALOOKUP (ZIP (A,B)) x = NONE ⇔ ¬MEM x A)`,
   srw_tac[][]>>Q.ISPECL_THEN [`ZIP(A,B)`,`x`] assume_tac ALOOKUP_NONE >>
   full_simp_tac(srw_ss())[MAP_ZIP])
 
@@ -557,11 +557,11 @@ val anub_def = Define`
 
 val anub_ind = theorem"anub_ind"
 
-val EVERY_anub_imp = store_thm("EVERY_anub_imp",
-  ``∀ls acc x y.
+val EVERY_anub_imp = Q.store_thm("EVERY_anub_imp",
+  `∀ls acc x y.
       EVERY P (anub ((x,y)::ls) acc) ∧ x ∉ set acc
       ⇒
-      P (x,y) ∧ EVERY P (anub ls (x::acc))``,
+      P (x,y) ∧ EVERY P (anub ls (x::acc))`,
   ho_match_mp_tac anub_ind >> srw_tac[][anub_def] >>
   full_simp_tac(srw_ss())[MEM_MAP,PULL_EXISTS,FORALL_PROD,EXISTS_PROD])
 
@@ -584,10 +584,10 @@ val anub_eq_nil = Q.store_thm("anub_eq_nil",
   Induct_on`x`>>srw_tac[][anub_def]>>
   Cases_on`h`>>srw_tac[][anub_def])
 
-val EVERY_anub_suff = store_thm("EVERY_anub_suff",
-  ``∀ls acc.
+val EVERY_anub_suff = Q.store_thm("EVERY_anub_suff",
+  `∀ls acc.
     (∀x. ¬MEM x acc ⇒ case ALOOKUP ls x of SOME v => P (x,v) | NONE => T)
-    ⇒ EVERY P (anub ls acc)``,
+    ⇒ EVERY P (anub ls acc)`,
   Induct >> simp[anub_def] >>
   Cases >> simp[anub_def] >> srw_tac[][] >- (
     first_x_assum(match_mp_tac) >>
@@ -625,9 +625,9 @@ val anub_all_distinct_keys = Q.store_thm("anub_all_distinct_keys",
   full_simp_tac(srw_ss())[ALL_DISTINCT_APPEND]>>
   metis_tac[])
 
-val MEM_anub_ALOOKUP = store_thm("MEM_anub_ALOOKUP",
-  ``MEM (k,v) (anub ls []) ⇒
-    ALOOKUP ls k = SOME v``,
+val MEM_anub_ALOOKUP = Q.store_thm("MEM_anub_ALOOKUP",
+  `MEM (k,v) (anub ls []) ⇒
+    ALOOKUP ls k = SOME v`,
   srw_tac[][]>>
   Q.ISPECL_THEN[`ls`,`[]`] assume_tac anub_all_distinct_keys>>
   Q.ISPECL_THEN [`ls`,`k`,`[]`] assume_tac (GEN_ALL ALOOKUP_anub)>>
@@ -1148,8 +1148,8 @@ val find_index_APPEND = Q.store_thm("find_index_APPEND",
   BasicProvers.CASE_TAC >>
   simp[arithmeticTheory.ADD1])
 
-val find_index_in_FILTER_ZIP_EQ = store_thm("find_index_in_FILTER_ZIP_EQ",
-  ``∀P l1 l2 x n1 n2 v1 j1 j2.
+val find_index_in_FILTER_ZIP_EQ = Q.store_thm("find_index_in_FILTER_ZIP_EQ",
+  `∀P l1 l2 x n1 n2 v1 j1 j2.
       (LENGTH l1 = LENGTH v1) ∧
       (FILTER (P o FST) (ZIP(l1,v1)) = l2) ∧
       (find_index x l1 n1 = SOME (n1+j1)) ∧
@@ -1157,7 +1157,7 @@ val find_index_in_FILTER_ZIP_EQ = store_thm("find_index_in_FILTER_ZIP_EQ",
       P x
       ⇒
       j1 < LENGTH l1 ∧ j2 < LENGTH l2 ∧
-      (EL j1 (ZIP(l1,v1)) = EL j2 l2)``,
+      (EL j1 (ZIP(l1,v1)) = EL j2 l2)`,
   gen_tac >> Induct >> simp[find_index_def] >>
   rpt gen_tac >>
   BasicProvers.CASE_TAC >- (
@@ -1188,9 +1188,9 @@ val find_index_in_FILTER_ZIP_EQ = store_thm("find_index_in_FILTER_ZIP_EQ",
   disch_then(qspec_then`PRE j1`mp_tac) >>
   simp[rich_listTheory.EL_CONS] )
 
-val ALL_DISTINCT_PERM_ALOOKUP_ZIP = store_thm("ALL_DISTINCT_PERM_ALOOKUP_ZIP",
-  ``∀l1 l2 l3. ALL_DISTINCT (MAP FST l1) ∧ PERM (MAP FST l1) l2
-    ⇒ (set l1 = set (ZIP (l2, MAP (THE o ALOOKUP (l1 ++ l3)) l2)))``,
+val ALL_DISTINCT_PERM_ALOOKUP_ZIP = Q.store_thm("ALL_DISTINCT_PERM_ALOOKUP_ZIP",
+  `∀l1 l2 l3. ALL_DISTINCT (MAP FST l1) ∧ PERM (MAP FST l1) l2
+    ⇒ (set l1 = set (ZIP (l2, MAP (THE o ALOOKUP (l1 ++ l3)) l2)))`,
   srw_tac[][EXTENSION,FORALL_PROD,EQ_IMP_THM] >- (
     qmatch_assum_rename_tac`MEM (x,y) l1` >>
     imp_res_tac PERM_LENGTH >> full_simp_tac(srw_ss())[] >>
@@ -1220,9 +1220,9 @@ val ALL_DISTINCT_PERM_ALOOKUP_ZIP = store_thm("ALL_DISTINCT_PERM_ALOOKUP_ZIP",
     metis_tac[MEM_EL] ) >>
   metis_tac[MEM_EL,ALOOKUP_ALL_DISTINCT_MEM,optionTheory.THE_DEF])
 
-val PERM_ZIP = store_thm("PERM_ZIP",
-  ``∀l1 l2. PERM l1 l2 ⇒ ∀a b c d. (l1 = ZIP(a,b)) ∧ (l2 = ZIP(c,d)) ∧ (LENGTH a = LENGTH b) ∧ (LENGTH c = LENGTH d) ⇒
-    PERM a c ∧ PERM b d``,
+val PERM_ZIP = Q.store_thm("PERM_ZIP",
+  `∀l1 l2. PERM l1 l2 ⇒ ∀a b c d. (l1 = ZIP(a,b)) ∧ (l2 = ZIP(c,d)) ∧ (LENGTH a = LENGTH b) ∧ (LENGTH c = LENGTH d) ⇒
+    PERM a c ∧ PERM b d`,
   ho_match_mp_tac PERM_IND >>
   conj_tac >- (
     Cases >> simp[LENGTH_NIL_SYM] >>
@@ -1327,8 +1327,8 @@ val RTC_RSUBSET = Q.store_thm("RTC_RSUBSET",
   simp[] >>
   metis_tac[RTC_CASES1])
 
-val PERM_PART = store_thm("PERM_PART",
-  ``∀P L l1 l2 p q. ((p,q) = PART P L l1 l2) ⇒ PERM (L ++ (l1 ++ l2)) (p++q)``,
+val PERM_PART = Q.store_thm("PERM_PART",
+  `∀P L l1 l2 p q. ((p,q) = PART P L l1 l2) ⇒ PERM (L ++ (l1 ++ l2)) (p++q)`,
   GEN_TAC THEN Induct >>
   simp[PART_DEF] >> srw_tac[][] >- (
     first_x_assum(qspecl_then[`h::l1`,`l2`,`p`,`q`]mp_tac) >>
@@ -1346,8 +1346,8 @@ val PERM_PART = store_thm("PERM_PART",
   full_simp_tac std_ss [APPEND_ASSOC] >>
   metis_tac[PERM_REWR,PERM_APPEND,APPEND_ASSOC] )
 
-val PERM_PARTITION = store_thm("PERM_PARTITION",
-  ``∀P L A B. ((A,B) = PARTITION P L) ==> PERM L (A ++ B)``,
+val PERM_PARTITION = Q.store_thm("PERM_PARTITION",
+  `∀P L A B. ((A,B) = PARTITION P L) ==> PERM L (A ++ B)`,
   METIS_TAC[PERM_PART,PARTITION_DEF,APPEND_NIL])
 
 val transitive_LESS = Q.store_thm("transitive_LESS",
@@ -1482,18 +1482,18 @@ Cases_on `opt` >> srw_tac[][])
 
 (* Re-expressing folds *)
 
-val FOLDR_CONS_triple = store_thm(
+val FOLDR_CONS_triple = Q.store_thm(
 "FOLDR_CONS_triple",
-``!f ls a. FOLDR (\(x,y,z) w. f x y z :: w) a ls = (MAP (\(x,y,z). f x y z) ls)++a``,
+`!f ls a. FOLDR (\(x,y,z) w. f x y z :: w) a ls = (MAP (\(x,y,z). f x y z) ls)++a`,
 GEN_TAC THEN
 Induct THEN1 SRW_TAC[][] THEN
 Q.X_GEN_TAC `p` THEN
 PairCases_on `p` THEN
 SRW_TAC[][])
 
-val FOLDR_CONS_5tup = store_thm(
+val FOLDR_CONS_5tup = Q.store_thm(
 "FOLDR_CONS_5tup",
-``!f ls a. FOLDR (\(c,d,x,y,z) w. f c d x y z :: w) a ls = (MAP (\(c,d,x,y,z). f c d x y z) ls)++a``,
+`!f ls a. FOLDR (\(c,d,x,y,z) w. f c d x y z :: w) a ls = (MAP (\(c,d,x,y,z). f c d x y z) ls)++a`,
 GEN_TAC THEN
 Induct THEN1 SRW_TAC[][] THEN
 Q.X_GEN_TAC `p` THEN
@@ -1515,39 +1515,39 @@ SRW_TAC[][])
 
 (* Re-expressing curried lambdas *)
 
-val FST_triple = store_thm(
+val FST_triple = Q.store_thm(
 "FST_triple",
-``(λ(n,ns,b). n) = FST``,
+`(λ(n,ns,b). n) = FST`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val FST_5tup = store_thm(
+val FST_5tup = Q.store_thm(
 "FST_5tup",
-``(λ(n,ns,b,x,y). n) = FST``,
+`(λ(n,ns,b,x,y). n) = FST`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val SND_triple = store_thm(
+val SND_triple = Q.store_thm(
 "SND_triple",
-``(λ(n,ns,b). f ns b) = UNCURRY f o SND``,
+`(λ(n,ns,b). f ns b) = UNCURRY f o SND`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val FST_pair = store_thm(
+val FST_pair = Q.store_thm(
 "FST_pair",
-``(λ(n,v). n) = FST``,
+`(λ(n,v). n) = FST`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val SND_pair = store_thm(
+val SND_pair = Q.store_thm(
 "SND_pair",
-``(λ(n,v). v) = SND``,
+`(λ(n,v). v) = SND`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val SND_FST_pair = store_thm(
+val SND_FST_pair = Q.store_thm(
 "SND_FST_pair",
-``(λ((n,m),c).m) = SND o FST``,
+`(λ((n,m),c).m) = SND o FST`,
 srw_tac[][FUN_EQ_THM,pairTheory.UNCURRY])
 
-val MAP_ZIP_SND_triple = store_thm(
+val MAP_ZIP_SND_triple = Q.store_thm(
 "MAP_ZIP_SND_triple",
-``(LENGTH l1 = LENGTH l2) ⇒ (MAP (λ(x,y,z). f y z) (ZIP(l1,l2)) = MAP (UNCURRY f) l2)``,
+`(LENGTH l1 = LENGTH l2) ⇒ (MAP (λ(x,y,z). f y z) (ZIP(l1,l2)) = MAP (UNCURRY f) l2)`,
 strip_tac >> (
 MAP_ZIP
 |> Q.GEN`g`
@@ -1665,12 +1665,12 @@ val LENGTH_EQ_FILTER_FILTER = Q.store_thm("LENGTH_EQ_FILTER_FILTER",
   Induct \\ SIMP_TAC std_ss [LENGTH,FILTER,EVERY_DEF] \\ STRIP_TAC
   \\ Cases_on `P h` \\ FULL_SIMP_TAC std_ss [LENGTH,ADD_CLAUSES]);
 
-val LIST_REL_MAP_FILTER_NEQ = store_thm("LIST_REL_MAP_FILTER_NEQ",
-  ``∀P f1 f2 z1 z2 l1 l2.
+val LIST_REL_MAP_FILTER_NEQ = Q.store_thm("LIST_REL_MAP_FILTER_NEQ",
+  `∀P f1 f2 z1 z2 l1 l2.
       LIST_REL P (MAP f1 l1) (MAP f2 l2) ∧
       (∀y1 y2. MEM (y1,y2) (ZIP(l1,l2)) ⇒ (SND y1 ≠ z1 ⇔ SND y2 ≠ z2) ∧ (P (f1 y1) (f2 y2)))
       ⇒
-      LIST_REL P (MAP f1 (FILTER (λ(x,y). y ≠ z1) l1)) (MAP f2 (FILTER (λ(x,y). y ≠ z2) l2))``,
+      LIST_REL P (MAP f1 (FILTER (λ(x,y). y ≠ z1) l1)) (MAP f2 (FILTER (λ(x,y). y ≠ z2) l2))`,
   ntac 5 gen_tac >>
   Induct >> simp[] >>
   Cases >> simp[] >>
@@ -1813,34 +1813,34 @@ val LENGTH_enumerate = Q.store_thm("LENGTH_enumerate",`
   ∀xs k. LENGTH (enumerate k xs) = LENGTH xs`,
   Induct>>fs[enumerate_def])
 
-val EL_enumerate = store_thm("EL_enumerate",``
+val EL_enumerate = Q.store_thm("EL_enumerate",`
   ∀xs n k.
   n < LENGTH xs ⇒
-  EL n (enumerate k xs) = (n+k,EL n xs)``,
+  EL n (enumerate k xs) = (n+k,EL n xs)`,
   Induct>>fs[enumerate_def]>>rw[]>>
   Cases_on`n`>>fs[])
 
-val MAP_enumerate_MAPi = store_thm("MAP_enumerate_MAPi",``
+val MAP_enumerate_MAPi = Q.store_thm("MAP_enumerate_MAPi",`
   ∀f xs.
-  MAP f (enumerate 0 xs) = MAPi (λn e. f (n,e)) xs``,
+  MAP f (enumerate 0 xs) = MAPi (λn e. f (n,e)) xs`,
   rw[]>>match_mp_tac LIST_EQ>>fs[LENGTH_MAP,EL_MAP,EL_MAPi,LENGTH_enumerate,EL_enumerate])
 
-val MAPi_enumerate_MAP = store_thm("MAPi_enumerate_MAP",``
+val MAPi_enumerate_MAP = Q.store_thm("MAPi_enumerate_MAP",`
   ∀f xs.
-  MAPi f xs = MAP (λi,e. f i e) (enumerate 0 xs)``,
+  MAPi f xs = MAP (λi,e. f i e) (enumerate 0 xs)`,
   rw[]>>match_mp_tac LIST_EQ>>fs[LENGTH_MAP,EL_MAP,EL_MAPi,LENGTH_enumerate,EL_enumerate])
 
-val MEM_enumerate = store_thm("MEM_enumerate",``
+val MEM_enumerate = Q.store_thm("MEM_enumerate",`
   ∀xs i e.
   i < LENGTH xs ⇒
-  (MEM (i,e) (enumerate 0 xs) ⇔ EL i xs = e)``,
+  (MEM (i,e) (enumerate 0 xs) ⇔ EL i xs = e)`,
   fs[MEM_EL]>>rw[]>>eq_tac>>rw[LENGTH_enumerate]>>
   imp_res_tac EL_enumerate>>fs[]>>
   qexists_tac`i`>>fs[])
 
-val MEM_enumerate_IMP = store_thm("MEM_enumerate_IMP",``
+val MEM_enumerate_IMP = Q.store_thm("MEM_enumerate_IMP",`
   ∀xs i e.
-  MEM (i,e) (enumerate 0 xs) ⇒ MEM e xs``,
+  MEM (i,e) (enumerate 0 xs) ⇒ MEM e xs`,
   fs[MEM_EL,LENGTH_enumerate]>>rw[]>>imp_res_tac EL_enumerate>>
   qexists_tac`n`>>fs[])
 
@@ -1886,8 +1886,8 @@ val UPDATE_LIST_NOT_MEM = Q.store_thm("UPDATE_LIST_NOT_MEM",
   `∀ls f x. ¬MEM x(MAP FST ls) ⇒ (f =++ ls) x = f x`,
   Induct >> simp[UPDATE_LIST_THM,combinTheory.APPLY_UPDATE_THM])
 
-val MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same = store_thm("MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same",
-  ``∀ks vs f. LENGTH ks = LENGTH vs ∧ ALL_DISTINCT ks ⇒ (MAP (f =++ ZIP (ks,vs)) ks = vs)``,
+val MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same = Q.store_thm("MAP_ZIP_UPDATE_LIST_ALL_DISTINCT_same",
+  `∀ks vs f. LENGTH ks = LENGTH vs ∧ ALL_DISTINCT ks ⇒ (MAP (f =++ ZIP (ks,vs)) ks = vs)`,
   Induct >> simp[LENGTH_NIL_SYM] >>
   gen_tac >> Cases >> simp[UPDATE_LIST_THM] >>
   simp[UPDATE_LIST_NOT_MEM,MAP_ZIP,combinTheory.APPLY_UPDATE_THM])

--- a/mlstringScript.sml
+++ b/mlstringScript.sml
@@ -3,12 +3,12 @@ val _ = ParseExtras.temp_tight_equality()
 val _ = new_theory"mlstring"
 
 (* TODO: move *)
-val irreflexive_inv_image = store_thm("irreflexive_inv_image",
-  ``!R f. irreflexive R ==> irreflexive (inv_image R f)``,
+val irreflexive_inv_image = Q.store_thm("irreflexive_inv_image",
+  `!R f. irreflexive R ==> irreflexive (inv_image R f)`,
   SIMP_TAC std_ss [irreflexive_def,inv_image_def])
 
-val trichotomous_inv_image = store_thm("trichotomous_inv_image",
-  ``!R f. trichotomous R /\ (INJ f UNIV UNIV) ==> trichotomous (inv_image R f)``,
+val trichotomous_inv_image = Q.store_thm("trichotomous_inv_image",
+  `!R f. trichotomous R /\ (INJ f UNIV UNIV) ==> trichotomous (inv_image R f)`,
   SIMP_TAC std_ss [trichotomous,inv_image_def,INJ_DEF,IN_UNIV] THEN
   METIS_TAC[])
 
@@ -24,27 +24,27 @@ val explode_def = Define`
   explode (strlit ls) = ls`
 val _ = export_rewrites["explode_def"]
 
-val explode_implode = store_thm("explode_implode",
-  ``∀x. explode (implode x) = x``,
+val explode_implode = Q.store_thm("explode_implode",
+  `∀x. explode (implode x) = x`,
   rw[implode_def])
 
-val implode_explode = store_thm("implode_explode",
-  ``∀x. implode (explode x) = x``,
+val implode_explode = Q.store_thm("implode_explode",
+  `∀x. implode (explode x) = x`,
   Cases >> rw[implode_def])
 
-val explode_11 = store_thm("explode_11",
-  ``∀s1 s2. explode s1 = explode s2 ⇔ s1 = s2``,
+val explode_11 = Q.store_thm("explode_11",
+  `∀s1 s2. explode s1 = explode s2 ⇔ s1 = s2`,
   Cases >> Cases >> simp[])
 
-val implode_BIJ = store_thm("implode_BIJ",
-  ``BIJ implode UNIV UNIV``,
+val implode_BIJ = Q.store_thm("implode_BIJ",
+  `BIJ implode UNIV UNIV`,
   rw[BIJ_IFF_INV] >>
   qexists_tac`explode` >>
   rw[implode_explode,
      explode_implode])
 
-val explode_BIJ = store_thm("explode_BIJ",
-  ``BIJ explode UNIV UNIV``,
+val explode_BIJ = Q.store_thm("explode_BIJ",
+  `BIJ explode UNIV UNIV`,
   rw[BIJ_IFF_INV] >>
   qexists_tac`implode` >>
   rw[implode_explode,
@@ -63,53 +63,53 @@ val mlstring_lt_def = Define`
   mlstring_lt (strlit s1) (strlit s2) ⇔
     string_lt s1 s2`
 
-val mlstring_lt_inv_image = store_thm("mlstring_lt_inv_image",
-  ``mlstring_lt = inv_image string_lt explode``,
+val mlstring_lt_inv_image = Q.store_thm("mlstring_lt_inv_image",
+  `mlstring_lt = inv_image string_lt explode`,
   simp[inv_image_def,FUN_EQ_THM] >>
   Cases >> Cases >> simp[mlstring_lt_def])
 
-val transitive_mlstring_lt = prove(
-  ``transitive mlstring_lt``,
+val transitive_mlstring_lt = Q.prove(
+  `transitive mlstring_lt`,
   simp[mlstring_lt_inv_image] >>
   match_mp_tac transitive_inv_image >>
   metis_tac[transitive_def,string_lt_trans])
 
-val irreflexive_mlstring_lt = prove(
-  ``irreflexive mlstring_lt``,
+val irreflexive_mlstring_lt = Q.prove(
+  `irreflexive mlstring_lt`,
   simp[mlstring_lt_inv_image] >>
   match_mp_tac irreflexive_inv_image >>
   simp[irreflexive_def,string_lt_nonrefl])
 
-val trichotomous_mlstring_lt = prove(
-  ``trichotomous mlstring_lt``,
+val trichotomous_mlstring_lt = Q.prove(
+  `trichotomous mlstring_lt`,
   simp[mlstring_lt_inv_image] >>
   match_mp_tac trichotomous_inv_image >>
   reverse conj_tac >- metis_tac[explode_BIJ,BIJ_DEF] >>
   metis_tac[trichotomous,string_lt_cases])
 
-val StrongLinearOrder_mlstring_lt = store_thm("StrongLinearOrder_mlstring_lt",
-  ``StrongLinearOrder mlstring_lt``,
+val StrongLinearOrder_mlstring_lt = Q.store_thm("StrongLinearOrder_mlstring_lt",
+  `StrongLinearOrder mlstring_lt`,
   rw[StrongLinearOrder,trichotomous_mlstring_lt,
      StrongOrder,irreflexive_mlstring_lt,transitive_mlstring_lt])
 
 val mlstring_cmp_def = Define`
   mlstring_cmp = TO_of_LinearOrder mlstring_lt`
 
-val TotOrd_mlstring_cmp = store_thm("TotOrd_mlstring_cmp",
-  ``TotOrd mlstring_cmp``,
+val TotOrd_mlstring_cmp = Q.store_thm("TotOrd_mlstring_cmp",
+  `TotOrd mlstring_cmp`,
   simp[mlstring_cmp_def] >>
   match_mp_tac TotOrd_TO_of_Strong >>
   simp[StrongLinearOrder_mlstring_lt])
 
-val ALL_DISTINCT_MAP_implode = store_thm("ALL_DISTINCT_MAP_implode",
-  ``ALL_DISTINCT ls ⇒ ALL_DISTINCT (MAP implode ls)``,
+val ALL_DISTINCT_MAP_implode = Q.store_thm("ALL_DISTINCT_MAP_implode",
+  `ALL_DISTINCT ls ⇒ ALL_DISTINCT (MAP implode ls)`,
   strip_tac >>
   match_mp_tac ALL_DISTINCT_MAP_INJ >>
   rw[implode_def])
 val _ = export_rewrites["ALL_DISTINCT_MAP_implode"]
 
-val ALL_DISTINCT_MAP_explode = store_thm("ALL_DISTINCT_MAP_explode",
-  ``∀ls. ALL_DISTINCT (MAP explode ls) ⇔ ALL_DISTINCT ls``,
+val ALL_DISTINCT_MAP_explode = Q.store_thm("ALL_DISTINCT_MAP_explode",
+  `∀ls. ALL_DISTINCT (MAP explode ls) ⇔ ALL_DISTINCT ls`,
   gen_tac >> EQ_TAC >- MATCH_ACCEPT_TAC ALL_DISTINCT_MAP >>
   STRIP_TAC >> MATCH_MP_TAC ALL_DISTINCT_MAP_INJ >>
   simp[explode_11])

--- a/preamble.sml
+++ b/preamble.sml
@@ -33,19 +33,6 @@ fun term_rewrite eq_tms tm =
   tm |> QCONV (PURE_REWRITE_CONV (map (curry mk_thm []) eq_tms))
      |> concl |> rhs
 
-(* replace (syntactically equal) subterms of one term by another *)
-fun replace_term from to =
-  let
-    fun f tm =
-      if tm = from then to else
-        case dest_term tm of
-          COMB(t1,t2) => mk_comb(f t1, f t2)
-        | LAMB(t1,t2) => mk_abs(f t1, f t2)
-        | _ => tm
-  in
-    f
-  end
-
 (* TODO: replace these with qhdtm_assum etc. *)
 local
   fun find t asl =

--- a/preamble.sml
+++ b/preamble.sml
@@ -34,7 +34,6 @@ fun term_rewrite eq_tms tm =
      |> concl |> rhs
 
 (* replace (syntactically equal) subterms of one term by another *)
-(* TODO: can Term.subst be used instead always? If so, delete. *)
 fun replace_term from to =
   let
     fun f tm =

--- a/preamble.sml
+++ b/preamble.sml
@@ -33,20 +33,6 @@ fun term_rewrite eq_tms tm =
   tm |> QCONV (PURE_REWRITE_CONV (map (curry mk_thm []) eq_tms))
      |> concl |> rhs
 
-(* TODO: replace these with qhdtm_assum etc. *)
-local
-  fun find t asl =
-    case total (first (can (match_term t) o fst o strip_comb)) asl of SOME x => x
-    | NONE => first (can (match_term t o fst o strip_comb o lhs)) asl
-in
-  fun RATOR_X_ASSUM t ttac (g as (asl,w)) = UNDISCH_THEN (find t asl) ttac g
-  fun rator_x_assum q ttac = Q_TAC (C RATOR_X_ASSUM ttac) q
-
-  fun RATOR_ASSUM t ttac (g as (asl,w)) = ttac (ASSUME (find t asl)) g
-  fun rator_assum q ttac = Q_TAC (C RATOR_ASSUM ttac) q
-end
-(* -- *)
-
 (* TODO: move to Lib (or Portable)? *)
 fun itlist3 f L1 L2 L3 base_value =
   let

--- a/preamble.sml
+++ b/preamble.sml
@@ -212,8 +212,7 @@ fun any_match_mp impth th =
 
 val SWAP_IMP = PROVE[]``(P ==> Q ==> R) ==> (Q ==> P ==> R)``
 
-(* TODO: this doesn't prove the hyps if there's more than one *)
-fun prove_hyps_by tac th = PROVE_HYP (prove(list_mk_conj (hyp th),tac)) th
+fun prove_hyps_by tac th = foldr (uncurry PROVE_HYP) th (map (fn h => prove(h,tac)) (hyp th));
 
 (* if the first conjunct under the goal's existential prefix matches the term
    except for some places where it has structure and the term just has variables,

--- a/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
+++ b/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
@@ -614,9 +614,9 @@ val step_e_not_timeout = Q.prove (
   imp_res_tac do_app_not_timeout >>
   srw_tac[][]);
 
-val small_eval_list_not_timeout = prove(
-  ``∀env s es res. small_eval_list env s es res ⇒
-    SND res ≠ Rerr (Rabort Rtimeout_error)``,
+val small_eval_list_not_timeout = Q.prove(
+  `∀env s es res. small_eval_list env s es res ⇒
+    SND res ≠ Rerr (Rabort Rtimeout_error)`,
   ho_match_mp_tac small_eval_list_ind >> srw_tac[][] >>
   metis_tac [step_e_not_timeout]);
 
@@ -669,8 +669,8 @@ val small_eval_list_app_error = prove(
   srw_tac[][Once RTC_CASES1,e_step_reln_def,e_step_def,continue_def,Abbr`ctx`])
 
 
-val do_opapp_NONE_tail = prove(
-  ``do_opapp (h::t) = NONE ∧ LENGTH t ≠ 2 ⇒ do_opapp t = NONE``,
+val do_opapp_NONE_tail = Q.prove(
+  `do_opapp (h::t) = NONE ∧ LENGTH t ≠ 2 ⇒ do_opapp t = NONE`,
   srw_tac[][do_opapp_def] >> every_case_tac >> full_simp_tac(srw_ss())[])
 
 val e_step_exp_err_any_ctxt = prove(

--- a/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
+++ b/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
@@ -550,13 +550,13 @@ val result_cases = Q.prove (
  cases_on `e` >>
  full_simp_tac(srw_ss())[]);
 
-val small_eval_opapp_err = prove(
-  ``∀env s es res. small_eval_list env s es res ⇒
+val small_eval_opapp_err = Q.prove(
+  `∀env s es res. small_eval_list env s es res ⇒
     ∀s' vs. res = (s',Rval vs) ⇒
       ∀env0 v1 v0. LENGTH es + LENGTH v0 ≠ 1 ⇒
         ∃env' e' c'.
         e_step_reln^* (env0,s,Val v1,[Capp Opapp v0 () es,env]) (env',s',e',c') ∧
-        e_step (env',s',e',c') = Eabort Rtype_error``,
+        e_step (env',s',e',c') = Eabort Rtype_error`,
   ho_match_mp_tac small_eval_list_ind >> simp[] >> srw_tac[][] >>
   srw_tac[boolSimps.DNF_ss][Once RTC_CASES1,e_step_reln_def] >- (
     srw_tac[][Once e_step_def,continue_def,application_thm] >>
@@ -571,13 +571,13 @@ val small_eval_opapp_err = prove(
   impl_tac >- simp[] >>
   metis_tac[transitive_RTC,transitive_def] );
 
-val small_eval_app_err = prove(
-  ``∀env s es res. small_eval_list env s es res ⇒
+val small_eval_app_err = Q.prove(
+  `∀env s es res. small_eval_list env s es res ⇒
     ∀s' vs. res = (s',Rval vs) ⇒
       ∀op env0 v1 v0. LENGTH es + LENGTH v0 > 2 ∧ op ≠ Opapp ⇒
         ∃env' e' c'.
         e_step_reln^* (env0,s,Val v1,[Capp op v0 () es,env]) (env',s',e',c') ∧
-        e_step (env',s',e',c') = Eabort Rtype_error``,
+        e_step (env',s',e',c') = Eabort Rtype_error`,
   ho_match_mp_tac small_eval_list_ind >> simp[] >> srw_tac[][] >>
   srw_tac[boolSimps.DNF_ss][Once RTC_CASES1,e_step_reln_def] >- (
     srw_tac[][Once e_step_def,continue_def,application_thm] >>
@@ -620,13 +620,13 @@ val small_eval_list_not_timeout = Q.prove(
   ho_match_mp_tac small_eval_list_ind >> srw_tac[][] >>
   metis_tac [step_e_not_timeout]);
 
-val small_eval_list_app_type_error = prove(
-  ``∀env s es res. small_eval_list env s es res ⇒
+val small_eval_list_app_type_error = Q.prove(
+  `∀env s es res. small_eval_list env s es res ⇒
       ∀s' err. res = (s',Rerr (Rabort a)) ⇒
         ∀op env0 v1 v0.
           ∃env' e' c'.
             e_step_reln^* (env0,s,Val v1,[Capp op v0 () es,env]) (env',s',e',c') ∧
-            e_step (env',s',e',c') = Eabort a``,
+            e_step (env',s',e',c') = Eabort a`,
   ho_match_mp_tac (theorem"small_eval_list_strongind") >> simp[] >> srw_tac[][] >- (
     srw_tac[][Once RTC_CASES1,e_step_reln_def,Once e_step_def,continue_def,push_def] >>
     srw_tac[boolSimps.DNF_ss][] >> disj2_tac >>
@@ -645,12 +645,12 @@ val small_eval_list_app_type_error = prove(
   first_assum(match_exists_tac o concl) >> srw_tac[][] >>
   srw_tac[][Once RTC_CASES1,e_step_reln_def,e_step_def,continue_def,Abbr`ctx`])
 
-val small_eval_list_app_error = prove(
-  ``∀env s es res. small_eval_list env s es res ⇒
+val small_eval_list_app_error = Q.prove(
+  `∀env s es res. small_eval_list env s es res ⇒
       ∀s' v. res = (s',Rerr (Rraise v)) ⇒
         ∀op env0 v1 v0.
           ∃env' env''.
-            e_step_reln^* (env0,s,Val v1,[Capp op v0 () es,env]) (env',s',Val v,[(Craise (),env'')])``,
+            e_step_reln^* (env0,s,Val v1,[Capp op v0 () es,env]) (env',s',Val v,[(Craise (),env'')])`,
   ho_match_mp_tac (theorem"small_eval_list_strongind") >> simp[] >> srw_tac[][] >- (
     srw_tac[][Once RTC_CASES1,e_step_reln_def,Once e_step_def,continue_def,push_def] >>
     imp_res_tac e_step_add_ctxt >>
@@ -673,8 +673,8 @@ val do_opapp_NONE_tail = Q.prove(
   `do_opapp (h::t) = NONE ∧ LENGTH t ≠ 2 ⇒ do_opapp t = NONE`,
   srw_tac[][do_opapp_def] >> every_case_tac >> full_simp_tac(srw_ss())[])
 
-val e_step_exp_err_any_ctxt = prove(
-  ``e_step (x,y,Exp z,c1) = Eabort a ⇒ e_step (x,y,Exp z,c2) = Eabort a``,
+val e_step_exp_err_any_ctxt = Q.prove(
+  `e_step (x,y,Exp z,c1) = Eabort a ⇒ e_step (x,y,Exp z,c2) = Eabort a`,
   srw_tac[][e_step_def] >> every_case_tac >>
   full_simp_tac(srw_ss())[push_def,return_def,continue_def,application_thm] >>
   every_case_tac >> full_simp_tac(srw_ss())[] )
@@ -690,8 +690,8 @@ val do_opapp_too_many = Q.prove (
  every_case_tac >>
  full_simp_tac(srw_ss())[]);
 
-val do_app_type_error = prove(
-  ``do_app s op es = SOME (x,Rerr (Rabort a)) ⇒ x = s``,
+val do_app_type_error = Q.prove(
+  `do_app s op es = SOME (x,Rerr (Rabort a)) ⇒ x = s`,
   PairCases_on `s` >>
   srw_tac[][do_app_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[LET_THM,UNCURRY] >>

--- a/semantics/alt_semantics/proofs/bigStepPropsScript.sml
+++ b/semantics/alt_semantics/proofs/bigStepPropsScript.sml
@@ -5,12 +5,12 @@ open bigStepTheory;
 val _ = new_theory "bigStepProps";
 
 (* TODO see if this is actually needed
-val evaluate_decs_evaluate_prog_MAP_Tdec = store_thm("evaluate_decs_evaluate_prog_MAP_Tdec",
-  ``∀ck env cs tids ds res.
+val evaluate_decs_evaluate_prog_MAP_Tdec = Q.store_thm("evaluate_decs_evaluate_prog_MAP_Tdec",
+  `∀ck env cs tids ds res.
       evaluate_decs ck NONE env (cs,tids) ds res
       ⇔
       case res of ((s,tids'),envC,r) =>
-      evaluate_prog ck env (cs,tids,{}) (MAP Tdec ds) ((s,tids',{}),([],envC),map_result(λenvE. ([],envE))(I)r)``,
+      evaluate_prog ck env (cs,tids,{}) (MAP Tdec ds) ((s,tids',{}),([],envC),map_result(λenvE. ([],envE))(I)r)`,
   Induct_on`ds`>>simp[Once evaluate_decs_cases,Once evaluate_prog_cases] >- (
     rpt gen_tac >> BasicProvers.EVERY_CASE_TAC >> simp[] >>
     Cases_on`r'`>>simp[] ) >>
@@ -128,8 +128,8 @@ val eval_ds_no_new_mods = Q.store_thm ("eval_ds_no_new_mods",
 (* REPL bootstrap lemmas *)
 
 (* TODO
-val evaluate_decs_last3 = prove(
-  ``∀ck mn env s decs a b c k i j s1 x y decs0 decs1 v p q r.
+val evaluate_decs_last3 = Q.prove(
+  `∀ck mn env s decs a b c k i j s1 x y decs0 decs1 v p q r.
       evaluate_decs ck mn env s decs (((k,s1),a),b,Rval c) ∧
       decs = decs0 ++ [Dlet (Pvar x) (App Opref [Con i []]);Dlet(Pvar y)(App Opref [Con j []]);Dlet (Pvar p) (Fun q r)]
       ⇒
@@ -140,7 +140,7 @@ val evaluate_decs_last3 = prove(
       build_conv (merge_alist_mod_env([],b)(FST(SND env))) i [] = SOME iv ∧
       build_conv (merge_alist_mod_env([],b)(FST(SND env))) j [] = SOME jv ∧
       (EL n s1 = Refv iv) ∧
-      (EL (n+1) s1 = Refv jv)``,
+      (EL (n+1) s1 = Refv jv)`,
   Induct_on`decs0` >>
   srw_tac[][Once bigStepTheory.evaluate_decs_cases] >- (
     full_simp_tac(srw_ss())[Once bigStepTheory.evaluate_decs_cases]>>
@@ -173,8 +173,8 @@ val evaluate_decs_last3 = prove(
   PairCases_on`cenv` >>
   full_simp_tac(srw_ss())[semanticPrimitivesTheory.merge_alist_mod_env_def, FUNION_ASSOC])
 
-val evaluate_Tmod_last3 = store_thm("evaluate_Tmod_last3",
-  ``evaluate_top ck env0 st (Tmod mn NONE decs) ((cs,u),envC,Rval ([(mn,env)],v)) ⇒
+val evaluate_Tmod_last3 = Q.store_thm("evaluate_Tmod_last3",
+  `evaluate_top ck env0 st (Tmod mn NONE decs) ((cs,u),envC,Rval ([(mn,env)],v)) ⇒
     decs = decs0 ++[Dlet (Pvar x) (App Opref [Con i []]);Dlet (Pvar y) (App Opref [Con j []]);Dlet (Pvar p) (Fun q z)]
   ⇒
     ∃n ls1 ls iv jv.
@@ -184,18 +184,18 @@ val evaluate_Tmod_last3 = store_thm("evaluate_Tmod_last3",
     build_conv (merge_alist_mod_env ([],THE (ALOOKUP (FST envC) mn)) (FST(SND env0))) i [] = SOME iv ∧
     build_conv (merge_alist_mod_env ([],THE (ALOOKUP (FST envC) mn)) (FST(SND env0))) j [] = SOME jv ∧
     (EL n (SND cs) = Refv iv) ∧
-    (EL (n+1) (SND cs) = Refv jv)``,
+    (EL (n+1) (SND cs) = Refv jv)`,
   Cases_on`cs`>>srw_tac[][bigStepTheory.evaluate_top_cases]>>
   imp_res_tac evaluate_decs_last3 >> full_simp_tac(srw_ss())[]) |> GEN_ALL
 
-val evaluate_decs_tys = prove(
-  ``∀decs0 decs1 decs ck mn env s s' tys c tds tvs tn cts cn as.
+val evaluate_decs_tys = Q.prove(
+  `∀decs0 decs1 decs ck mn env s s' tys c tds tvs tn cts cn as.
     evaluate_decs ck (SOME mn) env s decs (s',tys,Rval c) ∧
     decs = decs0 ++ [Dtype tds] ++ decs1 ∧
     MEM (tvs,tn,cts) tds ∧ MEM (cn,as) cts ∧
     ¬MEM cn (FLAT (MAP ctors_of_dec decs1))
     ⇒
-    (ALOOKUP tys cn = SOME (LENGTH as, TypeId (Long mn tn)))``,
+    (ALOOKUP tys cn = SOME (LENGTH as, TypeId (Long mn tn)))`,
   Induct >> srw_tac[][Once evaluate_decs_cases] >- (
     full_simp_tac(srw_ss())[Once evaluate_dec_cases] >> srw_tac[][] >>
     simp[ALOOKUP_APPEND] >>
@@ -227,13 +227,13 @@ val evaluate_decs_tys = prove(
   disch_then(fn th => first_x_assum(mp_tac o MATCH_MP (ONCE_REWRITE_RULE[GSYM AND_IMP_INTRO] th))) >>
   simp[])
 
-val evaluate_Tmod_tys = store_thm("evaluate_Tmod_tys",
-  ``evaluate_top F env s (Tmod mn NONE decs) (s',([(m,tys)],e),Rval r) ⇒
+val evaluate_Tmod_tys = Q.store_thm("evaluate_Tmod_tys",
+  `evaluate_top F env s (Tmod mn NONE decs) (s',([(m,tys)],e),Rval r) ⇒
     decs = decs0 ++ [Dtype tds] ++ decs1 ⇒
     MEM (tvs,tn,cts) tds ∧ MEM (cn,as) cts ∧
     ¬MEM cn (FLAT (MAP ctors_of_dec decs1))
     ⇒
-    (ALOOKUP tys cn = SOME (LENGTH as, TypeId (Long mn tn)))``,
+    (ALOOKUP tys cn = SOME (LENGTH as, TypeId (Long mn tn)))`,
   srw_tac[][evaluate_top_cases,miscTheory.FEMPTY_FUPDATE_EQ] >>
   METIS_TAC[evaluate_decs_tys]) |> GEN_ALL
   *)

--- a/semantics/alt_semantics/proofs/bigStepPropsScript.sml
+++ b/semantics/alt_semantics/proofs/bigStepPropsScript.sml
@@ -52,11 +52,11 @@ val evaluate_decs_evaluate_prog_MAP_Tdec = store_thm("evaluate_decs_evaluate_pro
     Cases_on`a`>>full_simp_tac(srw_ss())[]))
   *)
 
-val evaluate_decs_ctors_in = store_thm("evaluate_decs_ctors_in",
-  ``∀ck mn env s decs res. evaluate_decs ck mn env s decs res ⇒
+val evaluate_decs_ctors_in = Q.store_thm("evaluate_decs_ctors_in",
+  `∀ck mn env s decs res. evaluate_decs ck mn env s decs res ⇒
       ∀cn.
         IS_SOME (ALOOKUP (FST(SND res)) cn) ⇒
-        MEM cn (FLAT (MAP ctors_of_dec decs))``,
+        MEM cn (FLAT (MAP ctors_of_dec decs))`,
   HO_MATCH_MP_TAC evaluate_decs_ind >>
   simp[] >>
   srw_tac[][Once evaluate_dec_cases] >> simp[] >>

--- a/semantics/alt_semantics/proofs/bigStepPropsScript.sml
+++ b/semantics/alt_semantics/proofs/bigStepPropsScript.sml
@@ -156,7 +156,7 @@ val evaluate_decs_last3 = prove(
     full_simp_tac(srw_ss())[Once bigStepTheory.evaluate_decs_cases]>>
     full_simp_tac(srw_ss())[semanticPrimitivesTheory.combine_dec_result_def] >>
     full_simp_tac(srw_ss())[Once bigStepTheory.evaluate_dec_cases] >>
-    rator_x_assum`evaluate`mp_tac >>
+    qhdtm_x_assum`evaluate`mp_tac >>
     simp[Once bigStepTheory.evaluate_cases] >> srw_tac[][] >>
     full_simp_tac(srw_ss())[Once bigStepTheory.evaluate_decs_cases]>>
     srw_tac[][] >>

--- a/semantics/astScript.sml
+++ b/semantics/astScript.sml
@@ -8,6 +8,7 @@ val _ = numLib.prefer_num();
 
 val _ = new_theory "ast"
 val _ = set_grammar_ancestry ["integer", "words", "string"];
+val _ = set_grammar_ancestry ["integer", "words", "string"];
 
 (*open import Pervasives*)
 (*open import Lib*)

--- a/semantics/astScript.sml
+++ b/semantics/astScript.sml
@@ -8,9 +8,6 @@ val _ = numLib.prefer_num();
 
 val _ = new_theory "ast"
 val _ = set_grammar_ancestry ["integer", "words", "string"];
-val _ = set_grammar_ancestry ["integer", "words", "string"];
-val _ = set_grammar_ancestry ["integer", "words", "string"];
-val _ = set_grammar_ancestry ["integer", "words", "string"];
 
 (*open import Pervasives*)
 (*open import Lib*)

--- a/semantics/astScript.sml
+++ b/semantics/astScript.sml
@@ -10,6 +10,7 @@ val _ = new_theory "ast"
 val _ = set_grammar_ancestry ["integer", "words", "string"];
 val _ = set_grammar_ancestry ["integer", "words", "string"];
 val _ = set_grammar_ancestry ["integer", "words", "string"];
+val _ = set_grammar_ancestry ["integer", "words", "string"];
 
 (*open import Pervasives*)
 (*open import Lib*)

--- a/semantics/astScript.sml
+++ b/semantics/astScript.sml
@@ -9,6 +9,7 @@ val _ = numLib.prefer_num();
 val _ = new_theory "ast"
 val _ = set_grammar_ancestry ["integer", "words", "string"];
 val _ = set_grammar_ancestry ["integer", "words", "string"];
+val _ = set_grammar_ancestry ["integer", "words", "string"];
 
 (*open import Pervasives*)
 (*open import Lib*)

--- a/semantics/evaluate.lem
+++ b/semantics/evaluate.lem
@@ -4,13 +4,13 @@ open import Ast
 open import SemanticPrimitives
 open import Ffi
 
-(* The semantics is defined here using check_clock so that HOL4 generates
+(* The semantics is defined here using fix_clock so that HOL4 generates
  * provable termination conditions. However, after termination is proved, we
- * clean up the definition (in HOL4) to remove occurrences of check_clock. *)
+ * clean up the definition (in HOL4) to remove occurrences of fix_clock. *)
 
-let check_clock s' s =
-  <| s' with clock = if s'.clock <= s.clock
-                     then s'.clock else s.clock |>
+let fix_clock s (s',res) =
+  (<| s' with clock = if s'.clock <= s.clock
+                     then s'.clock else s.clock |>,res)
 
 let dec_clock s = <| s with clock = s.clock - 1 |>
 
@@ -27,9 +27,9 @@ let rec
 evaluate st env [] = (st, Rval [])
 and
 evaluate st env (e1::e2::es) =
-  match evaluate st env [e1] with
+  match fix_clock st (evaluate st env [e1]) with
   | (st', Rval v1) ->
-      match evaluate (check_clock st' st) env (e2::es) with
+      match evaluate st' env (e2::es) with
       | (st'', Rval vs) -> (st'', Rval (head v1::vs))
       | res -> res
       end
@@ -45,8 +45,8 @@ evaluate st env [Raise e] =
   end
 and
 evaluate st env [Handle e pes] =
-  match evaluate st env [e] with
-  | (st', Rerr (Rraise v)) -> evaluate_match (check_clock st' st) env v pes v
+  match fix_clock st (evaluate st env [e]) with
+  | (st', Rerr (Rraise v)) -> evaluate_match st' env v pes v
   | res -> res
   end
 and
@@ -71,15 +71,15 @@ and
 evaluate st env [Fun x e] = (st, Rval [Closure env x e])
 and
 evaluate st env [App op es] =
-  match evaluate st env (reverse es) with
+  match fix_clock st (evaluate st env (reverse es)) with
   | (st', Rval vs) ->
       if op = Opapp then
         match do_opapp (reverse vs) with
         | Just (env',e) ->
-            if st'.clock = 0 || st.clock = 0 then
+            if st'.clock = 0 then
               (st', Rerr (Rabort Rtimeout_error))
             else
-              evaluate (dec_clock (check_clock st' st)) env' [e]
+              evaluate (dec_clock st') env' [e]
         | Nothing -> (st', Rerr (Rabort Rtype_error))
         end
       else
@@ -91,10 +91,10 @@ evaluate st env [App op es] =
   end
 and
 evaluate st env [Log lop e1 e2] =
-  match evaluate st env [e1] with
+  match fix_clock st (evaluate st env [e1]) with
   | (st', Rval v1) ->
       match do_log lop (head v1) e2 with
-      | Just (Exp e) -> evaluate (check_clock st' st) env [e]
+      | Just (Exp e) -> evaluate st' env [e]
       | Just (Val v) -> (st', Rval [v])
       | Nothing -> (st', Rerr (Rabort Rtype_error))
       end
@@ -102,25 +102,25 @@ evaluate st env [Log lop e1 e2] =
   end
 and
 evaluate st env [If e1 e2 e3] =
-  match evaluate st env [e1] with
+  match fix_clock st (evaluate st env [e1]) with
   | (st', Rval v) ->
       match do_if (head v) e2 e3 with
-      | Just e -> evaluate (check_clock st' st) env [e]
+      | Just e -> evaluate st' env [e]
       | Nothing -> (st', Rerr (Rabort Rtype_error))
       end
   | res -> res
   end
 and
 evaluate st env [Mat e pes] =
-  match evaluate st env [e] with
+  match fix_clock st (evaluate st env [e]) with
   | (st', Rval v) ->
-      evaluate_match (check_clock st' st) env (head v) pes Bindv
+      evaluate_match st' env (head v) pes Bindv
   | res -> res
   end
 and
 evaluate st env [Let xo e1 e2] =
-  match evaluate st env [e1] with
-  | (st', Rval v) -> evaluate (check_clock st' st) <| env with v = opt_bind xo (head v) env.v |> [e2]
+  match fix_clock st (evaluate st env [e1]) with
+  | (st', Rval v) -> evaluate st' <| env with v = opt_bind xo (head v) env.v |> [e2]
   | res -> res
   end
 and

--- a/semantics/lexer_funScript.sml
+++ b/semantics/lexer_funScript.sml
@@ -33,9 +33,9 @@ val read_while_def = Define `
      if P c then read_while P cs (c :: s)
             else (IMPLODE (REVERSE s),STRING c cs))`;
 
-val read_while_thm = store_thm("read_while_thm",
-  ``!cs s cs' s'.
-       (read_while P cs s = (s',cs')) ==> STRLEN cs' <= STRLEN cs``,
+val read_while_thm = Q.store_thm("read_while_thm",
+  `!cs s cs' s'.
+       (read_while P cs s = (s',cs')) ==> STRLEN cs' <= STRLEN cs`,
   Induct THEN SRW_TAC [][read_while_def] THEN SRW_TAC [][] THEN
   RES_TAC THEN FULL_SIMP_TAC std_ss [LENGTH,LENGTH_APPEND] THEN DECIDE_TAC);
 
@@ -60,9 +60,9 @@ val read_string_def = tDefine "read_string" `
   (WF_REL_TAC `measure (LENGTH o FST)` THEN REPEAT STRIP_TAC
    THEN Cases_on `str` THEN FULL_SIMP_TAC (srw_ss()) [] THEN DECIDE_TAC)
 
-val read_string_thm = store_thm("read_string_thm",
-  ``!s t x1 x2. (read_string s t = (x1,x2)) ==>
-                (LENGTH x2 <= LENGTH s + LENGTH t)``,
+val read_string_thm = Q.store_thm("read_string_thm",
+  `!s t x1 x2. (read_string s t = (x1,x2)) ==>
+                (LENGTH x2 <= LENGTH s + LENGTH t)`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ]
   THEN HO_MATCH_MP_TAC (fetch "-" "read_string_ind")
   THEN REPEAT STRIP_TAC THEN POP_ASSUM MP_TAC
@@ -169,8 +169,8 @@ val lem2 = Q.prove (
   Cases_on `z a` THEN
   FULL_SIMP_TAC std_ss []);
 
-val next_sym_LESS = store_thm("next_sym_LESS",
-  ``!input. (next_sym input = SOME (s,rest)) ==> LENGTH rest < LENGTH input``,
+val next_sym_LESS = Q.store_thm("next_sym_LESS",
+  `!input. (next_sym input = SOME (s,rest)) ==> LENGTH rest < LENGTH input`,
   HO_MATCH_MP_TAC (fetch "-" "next_sym_ind") THEN REPEAT STRIP_TAC
   THEN POP_ASSUM MP_TAC THEN ONCE_REWRITE_TAC [next_sym_def]
   THEN SIMP_TAC (srw_ss()) [METIS_PROVE [] ``(b ==> c) <=> ~b \/ c``]
@@ -299,9 +299,9 @@ val next_token_def = Define `
     | NONE => NONE
     | SOME (sym, rest_of_input) => SOME (token_of_sym sym, rest_of_input)`;
 
-val next_token_LESS = store_thm("next_token_LESS",
-  ``!s rest input. (next_token input = SOME (s,rest)) ==>
-                   LENGTH rest < LENGTH input``,
+val next_token_LESS = Q.store_thm("next_token_LESS",
+  `!s rest input. (next_token input = SOME (s,rest)) ==>
+                   LENGTH rest < LENGTH input`,
   NTAC 3 STRIP_TAC THEN Cases_on `next_sym input`
   THEN ASM_SIMP_TAC (srw_ss()) [next_token_def]
   THEN Cases_on `x` THEN ASM_SIMP_TAC (srw_ss()) []

--- a/semantics/lexer_funScript.sml
+++ b/semantics/lexer_funScript.sml
@@ -85,8 +85,8 @@ val skip_comment_def = Define `
      if [x;y] = "*)" then (if d = 0 then SOME xs else skip_comment xs (d-1))
      else skip_comment (y::xs) d)`
 
-val skip_comment_thm = store_thm("skip_comment_thm",
-  ``!xs d str. (skip_comment xs d = SOME str) ==> LENGTH str <= LENGTH xs``,
+val skip_comment_thm = Q.store_thm("skip_comment_thm",
+  `!xs d str. (skip_comment xs d = SOME str) ==> LENGTH str <= LENGTH xs`,
   ONCE_REWRITE_TAC [EQ_SYM_EQ]
   THEN HO_MATCH_MP_TAC (fetch "-" "skip_comment_ind") THEN REPEAT STRIP_TAC
   THEN POP_ASSUM MP_TAC THEN ONCE_REWRITE_TAC [skip_comment_def]

--- a/semantics/proofs/cmlPtreeConversionPropsScript.sml
+++ b/semantics/proofs/cmlPtreeConversionPropsScript.sml
@@ -8,10 +8,10 @@ val _ = new_theory "cmlPtreeConversionProps";
 
 val _ = export_rewrites ["option.OPTION_IGNORE_BIND_def"]
 
-val ptree_head_TOK = store_thm(
+val ptree_head_TOK = Q.store_thm(
   "ptree_head_TOK",
-  ``(ptree_head pt = TOK sym ⇔ pt = Lf (TOK sym)) ∧
-    (TOK sym = ptree_head pt ⇔ pt = Lf (TOK sym))``,
+  `(ptree_head pt = TOK sym ⇔ pt = Lf (TOK sym)) ∧
+    (TOK sym = ptree_head pt ⇔ pt = Lf (TOK sym))`,
   Cases_on `pt` >> simp[] >> metis_tac[]);
 val _ = export_rewrites ["ptree_head_TOK"]
 
@@ -21,18 +21,18 @@ val start =
   strip_tac >> rveq >> fs[cmlG_FDOM, cmlG_applied, MAP_EQ_CONS] >>
   rveq >> fs[MAP_EQ_CONS] >> rveq
 
-val UQTyOp_OK = store_thm(
+val UQTyOp_OK = Q.store_thm(
   "UQTyOp_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nUQTyOp) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nUQTyOp) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃utyop. ptree_UQTyop pt = SOME utyop``,
+    ∃utyop. ptree_UQTyop pt = SOME utyop`,
   start >> simp[ptree_UQTyop_def]);
 
-val TyOp_OK = store_thm(
+val TyOp_OK = Q.store_thm(
   "TyOp_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyOp) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyOp) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃tyop. ptree_Tyop pt = SOME tyop``,
+    ∃tyop. ptree_Tyop pt = SOME tyop`,
   start >> simp[ptree_Tyop_def] >>
   asm_match `valid_ptree cmlG pt'` >>
   `destLf pt' = NONE`
@@ -40,18 +40,18 @@ val TyOp_OK = store_thm(
         rveq >> fs[]) >>
   simp[] >> metis_tac [UQTyOp_OK]);
 
-val TyvarN_OK = store_thm(
+val TyvarN_OK = Q.store_thm(
   "TyvarN_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyvarN) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyvarN) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃tyvn. ptree_TyvarN pt = SOME tyvn``,
+    ∃tyvn. ptree_TyvarN pt = SOME tyvn`,
   start >> simp[ptree_TyvarN_def]);
 
-val TyVarList_OK = store_thm(
+val TyVarList_OK = Q.store_thm(
   "TyVarList_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyVarList) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTyVarList) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃tyvnms. ptree_linfix nTyVarList CommaT ptree_TyvarN pt = SOME tyvnms``,
+    ∃tyvnms. ptree_linfix nTyVarList CommaT ptree_TyvarN pt = SOME tyvnms`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >> rpt strip_tac >> rveq >>
@@ -62,11 +62,11 @@ val TyVarList_OK = store_thm(
   fs[MAP_EQ_APPEND, MAP_EQ_CONS] >> rveq >>
   metis_tac [TyvarN_OK]);
 
-val TypeName_OK = store_thm(
+val TypeName_OK = Q.store_thm(
   "TypeName_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTypeName) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nTypeName) ∧
     MAP TOK toks = ptree_fringe pt ⇒
-    ∃tn. ptree_TypeName pt = SOME tn``,
+    ∃tn. ptree_TypeName pt = SOME tn`,
   start >> simp[ptree_TypeName_def] >| [
     metis_tac[UQTyOp_OK],
     full_simp_tac (srw_ss() ++ DNF_ss) [MAP_EQ_CONS, MAP_EQ_APPEND] >>
@@ -74,17 +74,17 @@ val TypeName_OK = store_thm(
     metis_tac[UQTyOp_OK]
   ]);
 
-val tuplify_OK = store_thm(
+val tuplify_OK = Q.store_thm(
   "tuplify_OK",
-  ``tl <> [] ⇒ ∃t. tuplify tl = SOME t``,
+  `tl <> [] ⇒ ∃t. tuplify tl = SOME t`,
   strip_tac >>
   `∃h tl0. tl = h::tl0` by (Cases_on `tl` >> fs[]) >>
   Cases_on `tl0` >> simp[tuplify_def]);
 
 
-val Type_OK0 = store_thm(
+val Type_OK0 = Q.store_thm(
   "Type_OK0",
-  ``valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
+  `valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
     (N ∈ {nType; nDType; nTbase} ∧
      ptree_head pt = NT (mkNT N)
        ⇒
@@ -94,7 +94,7 @@ val Type_OK0 = store_thm(
     (ptree_head pt = NT (mkNT nTypeList1) ⇒
      ∃tl. ptree_TypeList1 pt = SOME tl) ∧
     (ptree_head pt = NT (mkNT nTypeList2) ⇒
-     ∃tl. ptree_Typelist2 pt = SOME tl)``,
+     ∃tl. ptree_Typelist2 pt = SOME tl)`,
   map_every qid_spec_tac [`N`, `toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >>
@@ -124,64 +124,64 @@ fun okify c q th =
 
 val Type_OK = save_thm("Type_OK", okify CONJUNCT1 `nType` Type_OK0);
 
-val V_OK = store_thm(
+val V_OK = Q.store_thm(
   "V_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nV) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nV) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃i. ptree_V pt = SOME i``,
+    ∃i. ptree_V pt = SOME i`,
   start >> simp[ptree_V_def]);
 
-val FQV_OK = store_thm(
+val FQV_OK = Q.store_thm(
   "FQV_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nFQV) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nFQV) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃i. ptree_FQV pt = SOME i``,
+    ∃i. ptree_FQV pt = SOME i`,
   start >> simp[ptree_FQV_def]
   >- metis_tac[V_OK, optionTheory.OPTION_MAP_DEF,
                optionTheory.OPTION_CHOICE_def] >>
   simp[ptree_V_def]);
 
-val UQConstructorName_OK = store_thm(
+val UQConstructorName_OK = Q.store_thm(
   "UQConstructorName_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nUQConstructorName) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nUQConstructorName) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃i. ptree_UQConstructorName pt = SOME i``,
+    ∃i. ptree_UQConstructorName pt = SOME i`,
   start >> simp[ptree_UQConstructorName_def]);
 
 val n = SIMP_RULE bool_ss [GSYM AND_IMP_INTRO]
-val ConstructorName_OK = store_thm(
+val ConstructorName_OK = Q.store_thm(
   "ConstructorName_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nConstructorName) ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NT (mkNT nConstructorName) ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃i. ptree_ConstructorName pt = SOME i``,
+    ∃i. ptree_ConstructorName pt = SOME i`,
   start >> simp[ptree_ConstructorName_def]
   >- (erule strip_assume_tac (n UQConstructorName_OK) >>
       simp[]) >>
   simp[ptree_UQConstructorName_def]);
 
-val Ops_OK0 = store_thm(
+val Ops_OK0 = Q.store_thm(
   "Ops_OK0",
-  ``N ∈ {nMultOps; nAddOps; nListOps; nRelOps; nCompOps} ∧ valid_ptree cmlG pt ∧
+  `N ∈ {nMultOps; nAddOps; nListOps; nRelOps; nCompOps} ∧ valid_ptree cmlG pt ∧
     MAP TK toks = ptree_fringe pt ∧ ptree_head pt = NT (mkNT N) ⇒
-    ∃opv. ptree_Op pt = SOME opv``,
+    ∃opv. ptree_Op pt = SOME opv`,
   start >> simp[ptree_Op_def]);
 
-val MAP_TK11 = prove(
-  ``∀l1 l2. MAP TK l1 = MAP TK l2 ⇔ l1 = l2``,
+val MAP_TK11 = Q.prove(
+  `∀l1 l2. MAP TK l1 = MAP TK l2 ⇔ l1 = l2`,
   Induct_on `l1` >> simp[] >- metis_tac[] >> rpt gen_tac >>
   Cases_on `l2` >> simp[]);
 val _ = augment_srw_ss [rewrites [MAP_TK11]]
 
 val std = rpt (first_x_assum (erule strip_assume_tac o n)) >>
           simp[]
-val Pattern_OK0 = store_thm(
+val Pattern_OK0 = Q.store_thm(
   "Pattern_OK0",
-  ``valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
+  `valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
     (N ∈ {nPattern; nPtuple; nPapp; nPbase; nPcons} ∧
     ptree_head pt = NT (mkNT N) ⇒
      ∃p. ptree_Pattern N pt = SOME p) ∧
     (ptree_head pt = NN nPatternList ⇒
-     ∃pl. ptree_Plist pt = SOME pl ∧ pl <> [])``,
+     ∃pl. ptree_Plist pt = SOME pl ∧ pl <> [])`,
   map_every qid_spec_tac [`N`, `toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >>
@@ -212,17 +212,17 @@ val Pattern_OK0 = store_thm(
 
 val Pattern_OK = save_thm("Pattern_OK", okify CONJUNCT1 `nPattern` Pattern_OK0);
 
-val Eseq_encode_OK = store_thm(
+val Eseq_encode_OK = Q.store_thm(
   "Eseq_encode_OK",
-  ``∀l. l <> [] ⇒ ∃e. Eseq_encode l = SOME e``,
+  `∀l. l <> [] ⇒ ∃e. Eseq_encode l = SOME e`,
   Induct >> simp[] >>
   Cases_on `l` >> simp[Eseq_encode_def]);
 
-val OpID_OK = store_thm(
+val OpID_OK = Q.store_thm(
   "OpID_OK",
-  ``ptree_head pt = NN nOpID ∧ MAP TK toks = ptree_fringe pt ∧
+  `ptree_head pt = NN nOpID ∧ MAP TK toks = ptree_fringe pt ∧
     valid_ptree cmlG pt ⇒
-    ∃astv. ptree_OpID pt = SOME astv``,
+    ∃astv. ptree_OpID pt = SOME astv`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >>
@@ -231,11 +231,11 @@ val OpID_OK = store_thm(
   simp[ptree_OpID_def, isConstructor_def, isSymbolicConstructor_def, ifM_def] >>
   rw[] >> Cases_on `s` >> fs[oHD_def] >> rw[]);
 
-val PbaseList1_OK = store_thm(
+val PbaseList1_OK = Q.store_thm(
   "PbaseList1_OK",
-  ``valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ∧
+  `valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ∧
     ptree_head pt = NT (mkNT nPbaseList1) ⇒
-    ∃pl. ptree_PbaseList1 pt = SOME pl ∧ 0 < LENGTH pl``,
+    ∃pl. ptree_PbaseList1 pt = SOME pl ∧ 0 < LENGTH pl`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >>
@@ -253,9 +253,9 @@ val PbaseList1_OK = store_thm(
       simp[] >> fs[]))
 
 val _ = print "The E_OK proof takes a while\n"
-val E_OK0 = store_thm(
+val E_OK0 = Q.store_thm(
   "E_OK0",
-  ``valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
+  `valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
     (N ∈ {nE; nE'; nEhandle; nElogicOR; nElogicAND; nEtuple; nEmult;
           nEadd; nElistop; nErel; nEcomp; nEbefore; nEtyped; nEapp;
           nEbase} ∧
@@ -275,7 +275,7 @@ val E_OK0 = store_thm(
     (ptree_head pt = NT (mkNT nLetDec) ⇒ ∃ld. ptree_LetDec pt = SOME ld) ∧
     (ptree_head pt = NT (mkNT nAndFDecls) ⇒
      ∃fds. ptree_AndFDecls pt = SOME fds) ∧
-    (ptree_head pt = NT (mkNT nFDecl) ⇒ ∃fd. ptree_FDecl pt = SOME fd)``,
+    (ptree_head pt = NT (mkNT nFDecl) ⇒ ∃fd. ptree_FDecl pt = SOME fd)`,
   map_every qid_spec_tac [`N`, `toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >>
@@ -328,11 +328,11 @@ val AndFDecls_OK = save_thm(
   "AndFDecls_OK",
   okify (last o #1 o front_last o CONJUNCTS) `v` E_OK0)
 
-val Dconstructor_OK = store_thm(
+val Dconstructor_OK = Q.store_thm(
   "Dconstructor_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDconstructor ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDconstructor ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃dc. ptree_Dconstructor pt = SOME dc``,
+    ∃dc. ptree_Dconstructor pt = SOME dc`,
   start >> fs[MAP_EQ_APPEND, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_Dconstructor_def]
   >- (map_every (erule strip_assume_tac o n)
@@ -340,11 +340,11 @@ val Dconstructor_OK = store_thm(
       simp[]) >>
   erule strip_assume_tac (n UQConstructorName_OK) >> simp[])
 
-val DtypeCons_OK = store_thm(
+val DtypeCons_OK = Q.store_thm(
   "DtypeCons_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeCons ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeCons ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃dtc. ptree_linfix nDtypeCons BarT ptree_Dconstructor pt = SOME dtc``,
+    ∃dtc. ptree_linfix nDtypeCons BarT ptree_Dconstructor pt = SOME dtc`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >> rpt strip_tac >> rveq >>
@@ -352,21 +352,21 @@ val DtypeCons_OK = store_thm(
   simp[Once ptree_linfix_def] >>
   erule strip_assume_tac (n Dconstructor_OK) >> simp[]);
 
-val DtypeDecl_OK = store_thm(
+val DtypeDecl_OK = Q.store_thm(
   "DtypeDecl_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeDecl ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeDecl ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃dtd. ptree_DtypeDecl pt = SOME dtd``,
+    ∃dtd. ptree_DtypeDecl pt = SOME dtd`,
   start >> fs[MAP_EQ_APPEND, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_DtypeDecl_def] >>
   map_every (erule strip_assume_tac o n) [DtypeCons_OK, TypeName_OK] >>
   simp[]);
 
-val DtypeDecls_OK = store_thm(
+val DtypeDecls_OK = Q.store_thm(
   "DtypeDecls_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeDecls ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDtypeDecls ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃td. ptree_linfix nDtypeDecls AndT ptree_DtypeDecl pt = SOME td``,
+    ∃td. ptree_linfix nDtypeDecls AndT ptree_DtypeDecl pt = SOME td`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >> rpt strip_tac >> rveq >>
@@ -374,21 +374,21 @@ val DtypeDecls_OK = store_thm(
   simp[Once ptree_linfix_def] >>
   erule strip_assume_tac (n DtypeDecl_OK) >> simp[]);
 
-val TypeDec_OK = store_thm(
+val TypeDec_OK = Q.store_thm(
   "TypeDec_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nTypeDec ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nTypeDec ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃td. ptree_TypeDec pt = SOME td``,
+    ∃td. ptree_TypeDec pt = SOME td`,
   start >> fs[MAP_EQ_APPEND, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> fs[MAP_EQ_CONS] >>
   simp[ptree_TypeDec_def] >>
   erule strip_assume_tac (n DtypeDecls_OK) >> simp[]);
 
-val TypeAbbrevDec_OK = store_thm(
+val TypeAbbrevDec_OK = Q.store_thm(
   "TypeAbbrevDec_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nTypeAbbrevDec ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nTypeAbbrevDec ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃td. ptree_TypeAbbrevDec pt = SOME td``,
+    ∃td. ptree_TypeAbbrevDec pt = SOME td`,
   start >> fs[MAP_EQ_APPEND, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> fs[MAP_EQ_CONS] >> rveq >>
   simp[ptree_TypeAbbrevDec_def, pairTheory.EXISTS_PROD,
@@ -396,11 +396,11 @@ val TypeAbbrevDec_OK = store_thm(
   metis_tac[SIMP_RULE (srw_ss()) [pairTheory.EXISTS_PROD] TypeName_OK,
             Type_OK]);
 
-val Decl_OK = store_thm(
+val Decl_OK = Q.store_thm(
   "Decl_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDecl ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDecl ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃d. ptree_Decl pt = SOME d``,
+    ∃d. ptree_Decl pt = SOME d`,
   start >> fs[MAP_EQ_APPEND, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> fs[MAP_EQ_CONS] >>
   simp[ptree_Decl_def]
@@ -415,11 +415,11 @@ val Decl_OK = store_thm(
       qmatch_abbrev_tac `∃d. foo ++ SOME x = SOME d` >>
       Cases_on `foo` >> simp[]));
 
-val Decls_OK = store_thm(
+val Decls_OK = Q.store_thm(
   "Decls_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nDecls ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nDecls ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃ds. ptree_Decls pt = SOME ds``,
+    ∃ds. ptree_Decls pt = SOME ds`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >> rpt strip_tac >> rveq >>
@@ -432,29 +432,29 @@ val Decls_OK = store_thm(
       erule strip_assume_tac (n Decl_OK) >> simp[]) >>
   metis_tac[]);
 
-val OptTypEqn_OK = store_thm(
+val OptTypEqn_OK = Q.store_thm(
   "OptTypEqn_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nOptTypEqn ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nOptTypEqn ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃typopt. ptree_OptTypEqn pt = SOME typopt``,
+    ∃typopt. ptree_OptTypEqn pt = SOME typopt`,
   start >> fs[DISJ_IMP_THM, FORALL_AND_THM] >>
   simp[ptree_OptTypEqn_def] >> metis_tac[Type_OK]);
 
-val SpecLine_OK = store_thm(
+val SpecLine_OK = Q.store_thm(
   "SpecLine_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nSpecLine ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nSpecLine ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃sl. ptree_SpecLine pt = SOME sl``,
+    ∃sl. ptree_SpecLine pt = SOME sl`,
   start >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_SpecLine_def, pairTheory.EXISTS_PROD, PULL_EXISTS] >>
   metis_tac[V_OK, Type_OK, TypeName_OK, TypeDec_OK, Dconstructor_OK,
             pairTheory.pair_CASES, OptTypEqn_OK]);
 
-val SpecLineList_OK = store_thm(
+val SpecLineList_OK = Q.store_thm(
   "SpecLineList_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nSpecLineList ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nSpecLineList ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃sl. ptree_SpeclineList pt = SOME sl``,
+    ∃sl. ptree_SpeclineList pt = SOME sl`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   simp[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >> rpt strip_tac >> rveq >>
@@ -466,28 +466,28 @@ val SpecLineList_OK = store_thm(
       Cases_on `pt'` >> fs[MAP_EQ_CONS]) >>
   metis_tac[]);
 
-val StructName_OK = store_thm(
+val StructName_OK = Q.store_thm(
   "StructName_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nStructName ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nStructName ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃sl. ptree_StructName pt = SOME sl``,
+    ∃sl. ptree_StructName pt = SOME sl`,
   start >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_StructName_def]);
 
-val SignatureValue_OK = store_thm(
+val SignatureValue_OK = Q.store_thm(
   "SignatureValue_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nSignatureValue ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nSignatureValue ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃sv. ptree_SignatureValue pt = SOME sv``,
+    ∃sv. ptree_SignatureValue pt = SOME sv`,
   start >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_SignatureValue_def] >>
   metis_tac[SpecLineList_OK]);
 
-val Structure_OK = store_thm(
+val Structure_OK = Q.store_thm(
   "Structure_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nStructure ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nStructure ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃s. ptree_Structure pt = SOME s``,
+    ∃s. ptree_Structure pt = SOME s`,
   start >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, FORALL_AND_THM, DISJ_IMP_THM] >>
   rveq >> simp[ptree_Structure_def] >>
   rpt (Q.PAT_X_ASSUM `X = ptree_head Y` (assume_tac o SYM)) >>
@@ -498,23 +498,23 @@ val Structure_OK = store_thm(
   fs[DISJ_IMP_THM, FORALL_AND_THM, MAP_EQ_CONS] >>
   metis_tac[SignatureValue_OK]);
 
-val TopLevelDec_OK = store_thm(
+val TopLevelDec_OK = Q.store_thm(
   "TopLevelDec_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nTopLevelDec ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nTopLevelDec ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃t. ptree_TopLevelDec pt = SOME t``,
+    ∃t. ptree_TopLevelDec pt = SOME t`,
   start
   >- (erule strip_assume_tac (n Structure_OK) >> simp[ptree_TopLevelDec_def]) >>
   erule strip_assume_tac (n Decl_OK) >> simp[ptree_TopLevelDec_def] >>
   rename1 `ptree_Structure pt` >>
   Cases_on `ptree_Structure pt` >> simp[]);
 
-val TopLevelDecs_OK = store_thm(
+val TopLevelDecs_OK = Q.store_thm(
   "TopLevelDecs_OK",
-  ``valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
+  `valid_ptree cmlG pt ∧ MAP TK toks = ptree_fringe pt ⇒
     (ptree_head pt = NN nTopLevelDecs ⇒ ∃ts. ptree_TopLevelDecs pt = SOME ts) ∧
     (ptree_head pt = NN nNonETopLevelDecs ⇒
-     ∃ts. ptree_NonETopLevelDecs pt = SOME ts)``,
+     ∃ts. ptree_NonETopLevelDecs pt = SOME ts)`,
   map_every qid_spec_tac [`toks`, `pt`] >>
   ho_match_mp_tac grammarTheory.ptree_ind >>
   dsimp[] >> rpt strip_tac >> fs[MAP_EQ_CONS, cmlG_applied, cmlG_FDOM] >>
@@ -527,11 +527,11 @@ val TopLevelDecs_OK = store_thm(
   >- (rw[] >> fs[] >> metis_tac[TopLevelDec_OK]))
 
 (*
-val REPLTop_OK = store_thm(
+val REPLTop_OK = Q.store_thm(
   "REPLTop_OK",
-  ``valid_ptree cmlG pt ∧ ptree_head pt = NN nREPLTop ∧
+  `valid_ptree cmlG pt ∧ ptree_head pt = NN nREPLTop ∧
     MAP TK toks = ptree_fringe pt ⇒
-    ∃r. ptree_REPLTop pt = SOME r``,
+    ∃r. ptree_REPLTop pt = SOME r`,
   start >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, DISJ_IMP_THM, FORALL_AND_THM] >>
   simp[ptree_REPLTop_def]
   >- (erule strip_assume_tac (n TopLevelDec_OK) >> simp[]) >>

--- a/semantics/proofs/gramPropsScript.sml
+++ b/semantics/proofs/gramPropsScript.sml
@@ -133,12 +133,12 @@ end
 val cmlG_FDOM = save_thm("cmlG_FDOM",
   SIMP_CONV (srw_ss()) [cmlG_def] ``FDOM cmlG.rules``)
 
-val paireq = prove(
-  ``(x,y) = z ⇔ x = FST z ∧ y = SND z``, Cases_on `z` >> simp[])
+val paireq = Q.prove(
+  `(x,y) = z ⇔ x = FST z ∧ y = SND z`, Cases_on `z` >> simp[])
 
-val GSPEC_INTER = prove(
-  ``GSPEC f ∩ Q =
-    GSPEC (S ($, o FST o f) (S ($/\ o SND o f) (Q o FST o f)))``,
+val GSPEC_INTER = Q.prove(
+  `GSPEC f ∩ Q =
+    GSPEC (S ($, o FST o f) (S ($/\ o SND o f) (Q o FST o f)))`,
   simp[GSPECIFICATION, EXTENSION, SPECIFICATION] >> qx_gen_tac `e` >>
   simp[paireq] >> metis_tac[])
 

--- a/semantics/proofs/gramPropsScript.sml
+++ b/semantics/proofs/gramPropsScript.sml
@@ -142,12 +142,12 @@ val GSPEC_INTER = prove(
   simp[GSPECIFICATION, EXTENSION, SPECIFICATION] >> qx_gen_tac `e` >>
   simp[paireq] >> metis_tac[])
 
-val RIGHT_INTER_OVER_UNION = prove(
-  ``(a ∪ b) ∩ c = (a ∩ c) ∪ (b ∩ c)``,
+val RIGHT_INTER_OVER_UNION = Q.prove(
+  `(a ∪ b) ∩ c = (a ∩ c) ∪ (b ∩ c)`,
   simp[EXTENSION] >> metis_tac[]);
 
-val GSPEC_applied = prove(
-  ``GSPEC f x ⇔ x IN GSPEC f``,
+val GSPEC_applied = Q.prove(
+  `GSPEC f x ⇔ x IN GSPEC f`,
   simp[SPECIFICATION])
 
 val c1 = Cong (DECIDE ``(p = p') ==> ((p /\ q) = (p' /\ q))``)
@@ -169,14 +169,14 @@ val safenml = LIST_CONJ (List.take(CONJUNCTS nullableML_def, 2))
 
 val nullML_t = prim_mk_const {Thy = "NTproperties", Name = "nullableML"}
 
-val nullloop_th = prove(
-  ``nullableML G (N INSERT sn) (NT N :: rest) = F``,
+val nullloop_th = Q.prove(
+  `nullableML G (N INSERT sn) (NT N :: rest) = F`,
   simp[Once nullableML_def]);
 
-val null2 = prove(
-  ``nullableML G sn (x :: y :: z) <=>
+val null2 = Q.prove(
+  `nullableML G sn (x :: y :: z) <=>
       nullableML G sn [x] ∧ nullableML G sn [y] ∧
-      nullableML G sn z``,
+      nullableML G sn z`,
   simp[Once nullableML_by_singletons, SimpLHS] >>
   dsimp[] >> simp[GSYM nullableML_by_singletons]);
 
@@ -276,10 +276,10 @@ val fringe_lengths_def = Define`
 `
 
 val RTC_R_I = relationTheory.RTC_RULES |> SPEC_ALL |> CONJUNCT2 |> GEN_ALL
-val fringe_length_ptree = store_thm(
+val fringe_length_ptree = Q.store_thm(
   "fringe_length_ptree",
-  ``∀G i pt. ptree_fringe pt = MAP TOK i ∧ valid_ptree G pt ⇒
-           LENGTH i ∈ fringe_lengths G [ptree_head pt]``,
+  `∀G i pt. ptree_fringe pt = MAP TOK i ∧ valid_ptree G pt ⇒
+           LENGTH i ∈ fringe_lengths G [ptree_head pt]`,
   ntac 2 gen_tac >>
   HO_MATCH_MP_TAC grammarTheory.ptree_ind >> dsimp[MAP_EQ_SING] >>
   conj_tac
@@ -292,27 +292,27 @@ val fringe_length_ptree = store_thm(
   `MAP TOK i = ptree_fringe pt` by simp[Abbr`pt`] >> simp[] >>
   match_mp_tac grammarTheory.valid_ptree_derive >> simp[Abbr`pt`]);
 
-val fringe_length_not_nullable = store_thm(
+val fringe_length_not_nullable = Q.store_thm(
   "fringe_length_not_nullable",
-  ``∀G s. ¬nullable G [s] ⇒
+  `∀G s. ¬nullable G [s] ⇒
           ∀pt. ptree_head pt = s ⇒ valid_ptree G pt ⇒
-               0 < LENGTH (ptree_fringe pt)``,
+               0 < LENGTH (ptree_fringe pt)`,
   spose_not_then strip_assume_tac >>
   `LENGTH (ptree_fringe pt) = 0` by decide_tac >>
   fs[listTheory.LENGTH_NIL] >>
   erule mp_tac grammarTheory.valid_ptree_derive >>
   fs[NTpropertiesTheory.nullable_def]);
 
-val derives_singleTOK = store_thm(
+val derives_singleTOK = Q.store_thm(
   "derives_singleTOK",
-  ``derives G [TOK t] l ⇔ (l = [TOK t])``,
+  `derives G [TOK t] l ⇔ (l = [TOK t])`,
   simp[Once relationTheory.RTC_CASES1, grammarTheory.derive_def] >>
   metis_tac[]);
 val _ = export_rewrites ["derives_singleTOK"]
 
-val fringe_lengths_V = store_thm(
+val fringe_lengths_V = Q.store_thm(
   "fringe_lengths_V",
-  ``fringe_lengths cmlG [NT (mkNT nV)] = {1}``,
+  `fringe_lengths cmlG [NT (mkNT nV)] = {1}`,
   simp[fringe_lengths_def] >>
   simp[Once relationTheory.RTC_CASES1, MAP_EQ_SING, cmlG_FDOM] >>
   dsimp[MAP_EQ_SING,cmlG_applied] >>

--- a/semantics/proofs/semanticPrimitivesPropsScript.sml
+++ b/semantics/proofs/semanticPrimitivesPropsScript.sml
@@ -337,8 +337,8 @@ val do_app_cases = Q.store_thm ("do_app_cases",
  metis_tac []);
  *)
 
-val do_opapp_cases = store_thm("do_opapp_cases",
-  ``∀env' vs v.
+val do_opapp_cases = Q.store_thm("do_opapp_cases",
+  `∀env' vs v.
     (do_opapp vs = SOME (env',v))
     =
   ((∃v2 env'' n e.
@@ -348,7 +348,7 @@ val do_opapp_cases = store_thm("do_opapp_cases",
     (vs = [Recclosure env'' funs n'; v2]) ∧
     (find_recfun n' funs = SOME (n'',e)) ∧
     (ALL_DISTINCT (MAP (\(f,x,e). f) funs)) ∧
-    (env' = env'' with <| v := (n'',v2)::build_rec_env funs env'' env''.v |> ∧ (v = e))))``,
+    (env' = env'' with <| v := (n'',v2)::build_rec_env funs env'' env''.v |> ∧ (v = e))))`,
   srw_tac[][do_opapp_def] >>
   cases_on `vs` >> srw_tac[][] >>
   every_case_tac >> metis_tac []);
@@ -759,13 +759,13 @@ val _ = export_rewrites["FV_def"]
 
 val _ = Parse.overload_on("SFV",``λe. {x | Short x ∈ FV e}``)
 
-val FV_pes_MAP = store_thm("FV_pes_MAP",
-  ``FV_pes pes = BIGUNION (IMAGE (λ(p,e). FV e DIFF (IMAGE Short (set (pat_bindings p [])))) (set pes))``,
+val FV_pes_MAP = Q.store_thm("FV_pes_MAP",
+  `FV_pes pes = BIGUNION (IMAGE (λ(p,e). FV e DIFF (IMAGE Short (set (pat_bindings p [])))) (set pes))`,
   Induct_on`pes`>>simp[]>>
   qx_gen_tac`p`>>PairCases_on`p`>>srw_tac[][])
 
-val FV_defs_MAP = store_thm("FV_defs_MAP",
-  ``∀ls. FV_defs ls = BIGUNION (IMAGE (λ(f,x,e). FV e DIFF {Short x}) (set ls))``,
+val FV_defs_MAP = Q.store_thm("FV_defs_MAP",
+  `∀ls. FV_defs ls = BIGUNION (IMAGE (λ(f,x,e). FV e DIFF {Short x}) (set ls))`,
   Induct_on`ls`>>simp[FORALL_PROD])
 
 val FV_dec_def = Define`

--- a/semantics/proofs/semanticPrimitivesPropsScript.sml
+++ b/semantics/proofs/semanticPrimitivesPropsScript.sml
@@ -20,7 +20,7 @@ val mk_id_11 = Q.store_thm("mk_id_11[simp]",
   `mk_id a b = mk_id c d ⇔ (a = c) ∧ (b = d)`,
   map_every Cases_on[`a`,`c`] >> EVAL_TAC)
 
-val Boolv_11 = store_thm("Boolv_11[simp]",``Boolv b1 = Boolv b2 ⇔ (b1 = b2)``,srw_tac[][Boolv_def]);
+val Boolv_11 = Q.store_thm("Boolv_11[simp]",`Boolv b1 = Boolv b2 ⇔ (b1 = b2)`,srw_tac[][Boolv_def]);
 
 val Tword_simp = Q.store_thm("Tword_simp[simp]",
   `(∀z1 z2. (Tword z1 = Tword z2) ⇔ (z1 = z2)) ∧
@@ -85,13 +85,13 @@ val do_word_from_int_def = Define`
   (do_word_from_int W64 i = Word64 (i2w i))`;
 val _ = export_rewrites["do_word_from_int_def"];
 
-val lit_same_type_refl = store_thm("lit_same_type_refl",
-  ``∀l. lit_same_type l l``,
+val lit_same_type_refl = Q.store_thm("lit_same_type_refl",
+  `∀l. lit_same_type l l`,
   Cases >> simp[semanticPrimitivesTheory.lit_same_type_def])
 val _ = export_rewrites["lit_same_type_refl"]
 
-val lit_same_type_sym = store_thm("lit_same_type_sym",
-  ``∀l1 l2. lit_same_type l1 l2 ⇒ lit_same_type l2 l1``,
+val lit_same_type_sym = Q.store_thm("lit_same_type_sym",
+  `∀l1 l2. lit_same_type l1 l2 ⇒ lit_same_type l2 l1`,
   Cases >> Cases >> simp[semanticPrimitivesTheory.lit_same_type_def])
 
 val pat_bindings_accum = Q.store_thm ("pat_bindings_accum",
@@ -411,8 +411,8 @@ val same_ctor_and_same_tid = Q.store_thm ("same_ctor_and_same_tid",
  cases_on `tn2` >>
  full_simp_tac(srw_ss())[same_tid_def, same_ctor_def]);
 
-val same_tid_refl = store_thm("same_tid_refl[simp]",
-  ``same_tid t t``,
+val same_tid_refl = Q.store_thm("same_tid_refl[simp]",
+  `same_tid t t`,
   Cases_on`t`>>EVAL_TAC);
 
 val same_tid_sym = Q.store_thm ("same_tid_sym",
@@ -444,9 +444,9 @@ val build_tdefs_cons = Q.store_thm ("build_tdefs_cons",
  (!mn. build_tdefs mn [] = [])`,
  srw_tac[][build_tdefs_def]);
 
-val MAP_FST_build_tdefs = store_thm("MAP_FST_build_tdefs",
-  ``set (MAP FST (build_tdefs mn ls)) =
-    set (MAP FST (FLAT (MAP (SND o SND) ls)))``,
+val MAP_FST_build_tdefs = Q.store_thm("MAP_FST_build_tdefs",
+  `set (MAP FST (build_tdefs mn ls)) =
+    set (MAP FST (FLAT (MAP (SND o SND) ls)))`,
   Induct_on`ls`>>simp[build_tdefs_cons] >>
   qx_gen_tac`p`>>PairCases_on`p`>>simp[build_tdefs_cons,MAP_REVERSE] >>
   simp[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX] >>
@@ -473,8 +473,8 @@ val map_error_result_def = Define`
   (map_error_result f (Rabort a) = Rabort a)`
 val _ = export_rewrites["map_error_result_def"]
 
-val map_error_result_Rtype_error = store_thm("map_error_result_Rtype_error",
-  ``map_error_result f e = (Rabort a) ⇔ e = Rabort a``,
+val map_error_result_Rtype_error = Q.store_thm("map_error_result_Rtype_error",
+  `map_error_result f e = (Rabort a) ⇔ e = Rabort a`,
   Cases_on`e`>>simp[])
 val _ = export_rewrites["map_error_result_Rtype_error"]
 
@@ -491,8 +491,8 @@ val map_result_Rval = Q.store_thm("map_result_Rval[simp]",
   `map_result f1 f2 e = Rval x ⇔ ∃y. e = Rval y ∧ x = f1 y`,
   Cases_on`e`>>simp[EQ_IMP_THM])
 
-val map_result_Rerr = store_thm("map_result_Rerr",
-  ``map_result f1 f2 e = Rerr e' ⇔ ∃a. e = Rerr a ∧ map_error_result f2 a = e'``,
+val map_result_Rerr = Q.store_thm("map_result_Rerr",
+  `map_result f1 f2 e = Rerr e' ⇔ ∃a. e = Rerr a ∧ map_error_result f2 a = e'`,
   Cases_on`e`>>simp[EQ_IMP_THM])
 val _ = export_rewrites["map_result_Rerr"]
 
@@ -502,29 +502,29 @@ val exc_rel_def = Define`
   (exc_rel _ _ _ = F)`
 val _ = export_rewrites["exc_rel_def"]
 
-val exc_rel_raise1 = store_thm("exc_rel_raise1",
-  ``exc_rel R (Rraise v) e = ∃v'. (e = Rraise v') ∧ R v v'``,
+val exc_rel_raise1 = Q.store_thm("exc_rel_raise1",
+  `exc_rel R (Rraise v) e = ∃v'. (e = Rraise v') ∧ R v v'`,
   Cases_on`e`>>srw_tac[][])
-val exc_rel_raise2 = store_thm("exc_rel_raise2",
-  ``exc_rel R e (Rraise v) = ∃v'. (e = Rraise v') ∧ R v' v``,
+val exc_rel_raise2 = Q.store_thm("exc_rel_raise2",
+  `exc_rel R e (Rraise v) = ∃v'. (e = Rraise v') ∧ R v' v`,
   Cases_on`e`>>srw_tac[][])
-val exc_rel_type_error1 = store_thm("exc_rel_type_error1",
-  ``(exc_rel R (Rabort a) e = (e = Rabort a))``,
+val exc_rel_type_error1 = Q.store_thm("exc_rel_type_error1",
+  `(exc_rel R (Rabort a) e = (e = Rabort a))`,
   Cases_on`e`>>srw_tac[][]>>metis_tac [])
-val exc_rel_type_error2 = store_thm("exc_rel_type_error2",
-  ``(exc_rel R e (Rabort a) = (e = Rabort a))``,
+val exc_rel_type_error2 = Q.store_thm("exc_rel_type_error2",
+  `(exc_rel R e (Rabort a) = (e = Rabort a))`,
   Cases_on`e`>>srw_tac[][]>>metis_tac [])
 val _ = export_rewrites["exc_rel_raise1","exc_rel_raise2","exc_rel_type_error1","exc_rel_type_error2"]
 
-val exc_rel_refl = store_thm(
+val exc_rel_refl = Q.store_thm(
 "exc_rel_refl",
-  ``(∀x. R x x) ⇒ ∀x. exc_rel R x x``,
+  `(∀x. R x x) ⇒ ∀x. exc_rel R x x`,
 strip_tac >> Cases >> srw_tac[][])
 val _ = export_rewrites["exc_rel_refl"];
 
-val exc_rel_trans = store_thm(
+val exc_rel_trans = Q.store_thm(
 "exc_rel_trans",
-``(∀x y z. R x y ∧ R y z ⇒ R x z) ⇒ (∀x y z. exc_rel R x y ∧ exc_rel R y z ⇒ exc_rel R x z)``,
+`(∀x y z. R x y ∧ R y z ⇒ R x z) ⇒ (∀x y z. exc_rel R x y ∧ exc_rel R y z ⇒ exc_rel R x z)`,
 srw_tac[][] >>
 Cases_on `x` >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >> PROVE_TAC[])
 
@@ -534,29 +534,29 @@ val result_rel_def = Define`
 (result_rel _ _ _ _ = F)`
 val _ = export_rewrites["result_rel_def"]
 
-val result_rel_Rval = store_thm(
+val result_rel_Rval = Q.store_thm(
 "result_rel_Rval",
-``result_rel R1 R2 (Rval v) r = ∃v'. (r = Rval v') ∧ R1 v v'``,
+`result_rel R1 R2 (Rval v) r = ∃v'. (r = Rval v') ∧ R1 v v'`,
 Cases_on `r` >> srw_tac[][])
-val result_rel_Rerr1 = store_thm(
+val result_rel_Rerr1 = Q.store_thm(
 "result_rel_Rerr1",
-``result_rel R1 R2 (Rerr e) r = ∃e'. (r = Rerr e') ∧ exc_rel R2 e e'``,
+`result_rel R1 R2 (Rerr e) r = ∃e'. (r = Rerr e') ∧ exc_rel R2 e e'`,
 Cases_on `r` >> srw_tac[][EQ_IMP_THM])
-val result_rel_Rerr2 = store_thm(
+val result_rel_Rerr2 = Q.store_thm(
 "result_rel_Rerr2",
-``result_rel R1 R2 r (Rerr e) = ∃e'. (r = Rerr e') ∧ exc_rel R2 e' e``,
+`result_rel R1 R2 r (Rerr e) = ∃e'. (r = Rerr e') ∧ exc_rel R2 e' e`,
 Cases_on `r` >> srw_tac[][EQ_IMP_THM])
 val _ = export_rewrites["result_rel_Rval","result_rel_Rerr1","result_rel_Rerr2"]
 
-val result_rel_refl = store_thm(
+val result_rel_refl = Q.store_thm(
 "result_rel_refl",
-``(∀x. R1 x x) ∧ (∀x. R2 x x) ⇒ ∀x. result_rel R1 R2 x x``,
+`(∀x. R1 x x) ∧ (∀x. R2 x x) ⇒ ∀x. result_rel R1 R2 x x`,
 strip_tac >> Cases >> srw_tac[][])
 val _ = export_rewrites["result_rel_refl"]
 
-val result_rel_trans = store_thm(
+val result_rel_trans = Q.store_thm(
 "result_rel_trans",
-``(∀x y z. R1 x y ∧ R1 y z ⇒ R1 x z) ∧ (∀x y z. R2 x y ∧ R2 y z ⇒ R2 x z) ⇒ (∀x y z. result_rel R1 R2 x y ∧ result_rel R1 R2 y z ⇒ result_rel R1 R2 x z)``,
+`(∀x y z. R1 x y ∧ R1 y z ⇒ R1 x z) ∧ (∀x y z. R2 x y ∧ R2 y z ⇒ R2 x z) ⇒ (∀x y z. result_rel R1 R2 x y ∧ result_rel R1 R2 y z ⇒ result_rel R1 R2 x z)`,
 srw_tac[][] >>
 Cases_on `x` >> full_simp_tac(srw_ss())[] >> srw_tac[][] >> full_simp_tac(srw_ss())[] >> PROVE_TAC[exc_rel_trans])
 
@@ -596,32 +596,32 @@ val sv_rel_def = Define`
   sv_rel R _ _ = F`
 val _ = export_rewrites["sv_rel_def"]
 
-val sv_rel_refl = store_thm("sv_rel_refl",
-  ``∀R x. (∀x. R x x) ⇒ sv_rel R x x``,
+val sv_rel_refl = Q.store_thm("sv_rel_refl",
+  `∀R x. (∀x. R x x) ⇒ sv_rel R x x`,
   gen_tac >> Cases >> srw_tac[][sv_rel_def] >>
   induct_on `l` >>
   srw_tac[][])
 val _ = export_rewrites["sv_rel_refl"]
 
-val sv_rel_trans = store_thm("sv_rel_trans",
-  ``∀R. (∀x y z. R x y ∧ R y z ⇒ R x z) ⇒ ∀x y z. sv_rel R x y ∧ sv_rel R y z ⇒ sv_rel R x z``,
+val sv_rel_trans = Q.store_thm("sv_rel_trans",
+  `∀R. (∀x y z. R x y ∧ R y z ⇒ R x z) ⇒ ∀x y z. sv_rel R x y ∧ sv_rel R y z ⇒ sv_rel R x z`,
   gen_tac >> strip_tac >> Cases >> Cases >> Cases >> srw_tac[][] >> full_simp_tac(srw_ss())[sv_rel_def] >> metis_tac[LIST_REL_trans]);
 
-val sv_rel_cases = store_thm("sv_rel_cases",
-  ``∀x y.
+val sv_rel_cases = Q.store_thm("sv_rel_cases",
+  `∀x y.
     sv_rel R x y ⇔
     (∃v1 v2. x = Refv v1 ∧ y = Refv v2 ∧ R v1 v2) ∨
     (∃w. x = W8array w ∧ y = W8array w) ∨
-    (?vs1 vs2. x = Varray vs1 ∧ y = Varray vs2 ∧ LIST_REL R vs1 vs2)``,
+    (?vs1 vs2. x = Varray vs1 ∧ y = Varray vs2 ∧ LIST_REL R vs1 vs2)`,
   Cases >> Cases >> simp[sv_rel_def,EQ_IMP_THM])
 
-val sv_rel_O = store_thm("sv_rel_O",
-  ``∀R1 R2. sv_rel (R1 O R2) = sv_rel R1 O sv_rel R2``,
+val sv_rel_O = Q.store_thm("sv_rel_O",
+  `∀R1 R2. sv_rel (R1 O R2) = sv_rel R1 O sv_rel R2`,
   srw_tac[][FUN_EQ_THM,sv_rel_cases,O_DEF,EQ_IMP_THM] >>
   metis_tac[miscTheory.LIST_REL_O])
 
-val sv_rel_mono = store_thm("sv_rel_mono",
-  ``(∀x y. P x y ⇒ Q x y) ⇒ sv_rel P x y ⇒ sv_rel Q x y``,
+val sv_rel_mono = Q.store_thm("sv_rel_mono",
+  `(∀x y. P x y ⇒ Q x y) ⇒ sv_rel P x y ⇒ sv_rel Q x y`,
   srw_tac[][sv_rel_cases] >> metis_tac [LIST_REL_mono])
 
 val store_v_vs_def = Define`
@@ -633,35 +633,35 @@ val _ = export_rewrites["store_v_vs_def"]
 val store_vs_def = Define`
   store_vs s = FLAT (MAP store_v_vs s)`
 
-val EVERY_sv_every_MAP_map_sv = store_thm("EVERY_sv_every_MAP_map_sv",
-  ``∀P f ls. EVERY P (MAP f (store_vs ls)) ⇒ EVERY (sv_every P) (MAP (map_sv f) ls)``,
+val EVERY_sv_every_MAP_map_sv = Q.store_thm("EVERY_sv_every_MAP_map_sv",
+  `∀P f ls. EVERY P (MAP f (store_vs ls)) ⇒ EVERY (sv_every P) (MAP (map_sv f) ls)`,
   rpt gen_tac >>
   simp[EVERY_MAP,EVERY_MEM,store_vs_def,MEM_MAP,PULL_EXISTS,MEM_FILTER,MEM_FLAT] >>
   strip_tac >> Cases >> simp[] >> srw_tac[][] >> res_tac >> full_simp_tac(srw_ss())[EVERY_MEM,MEM_MAP,PULL_EXISTS])
 
-val LIST_REL_store_vs_intro = store_thm("LIST_REL_store_vs_intro",
-  ``∀P l1 l2. LIST_REL (sv_rel P) l1 l2 ⇒ LIST_REL P (store_vs l1) (store_vs l2)``,
+val LIST_REL_store_vs_intro = Q.store_thm("LIST_REL_store_vs_intro",
+  `∀P l1 l2. LIST_REL (sv_rel P) l1 l2 ⇒ LIST_REL P (store_vs l1) (store_vs l2)`,
   gen_tac >>
   Induct >- simp[store_vs_def] >>
   Cases >> simp[PULL_EXISTS,sv_rel_cases] >>
   full_simp_tac(srw_ss())[store_vs_def] >> srw_tac[][] >>
   match_mp_tac rich_listTheory.EVERY2_APPEND_suff >> simp[])
 
-val EVERY_sv_every_EVERY_store_vs = store_thm("EVERY_sv_every_EVERY_store_vs",
-  ``∀P ls. EVERY (sv_every P ) ls ⇔ EVERY P (store_vs ls)``,
+val EVERY_sv_every_EVERY_store_vs = Q.store_thm("EVERY_sv_every_EVERY_store_vs",
+  `∀P ls. EVERY (sv_every P ) ls ⇔ EVERY P (store_vs ls)`,
   srw_tac[][EVERY_MEM,EQ_IMP_THM,store_vs_def,MEM_MAP,PULL_EXISTS,MEM_FILTER,MEM_FLAT] >>
   res_tac >> TRY(Cases_on`e`) >> TRY(Cases_on`y`) >> full_simp_tac(srw_ss())[] >>
   full_simp_tac(srw_ss())[EVERY_MEM])
 
-val EVERY_store_vs_intro = store_thm("EVERY_store_vs_intro",
-  ``∀P ls. EVERY (sv_every P) ls ⇒ EVERY P (store_vs ls)``,
+val EVERY_store_vs_intro = Q.store_thm("EVERY_store_vs_intro",
+  `∀P ls. EVERY (sv_every P) ls ⇒ EVERY P (store_vs ls)`,
   srw_tac[][EVERY_MEM,store_vs_def,MEM_MAP,MEM_FILTER,MEM_FLAT] >>
   res_tac >>
   qmatch_assum_rename_tac`sv_every P x` >>
   Cases_on`x`>>full_simp_tac(srw_ss())[EVERY_MEM])
 
-val map_sv_compose = store_thm("map_sv_compose",
-  ``map_sv f (map_sv g x) = map_sv (f o g) x``,
+val map_sv_compose = Q.store_thm("map_sv_compose",
+  `map_sv f (map_sv g x) = map_sv (f o g) x`,
   Cases_on`x`>>simp[MAP_MAP_o])
 
 val map_match_def = Define`
@@ -669,9 +669,9 @@ val map_match_def = Define`
   (map_match f x = x)`
 val _ = export_rewrites["map_match_def"]
 
-val find_recfun_ALOOKUP = store_thm(
+val find_recfun_ALOOKUP = Q.store_thm(
 "find_recfun_ALOOKUP",
-``∀funs n. find_recfun n funs = ALOOKUP funs n``,
+`∀funs n. find_recfun n funs = ALOOKUP funs n`,
 Induct >- srw_tac[][semanticPrimitivesTheory.find_recfun_def] >>
 qx_gen_tac `d` >>
 PairCases_on `d` >>

--- a/semantics/proofs/semanticsPropsScript.sml
+++ b/semantics/proofs/semanticsPropsScript.sml
@@ -114,28 +114,28 @@ val implements_def = Define `
   implements x y <=>
     (~(Fail IN y) ==> x SUBSET extend_with_resource_limit y)`;
 
-val implements_intro = store_thm("implements_intro",
-  ``(b /\ x <> Fail ==> y = x) ==> b ==> implements {y} {x}``,
+val implements_intro = Q.store_thm("implements_intro",
+  `(b /\ x <> Fail ==> y = x) ==> b ==> implements {y} {x}`,
   full_simp_tac(srw_ss())[implements_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]);
 
-val implements_trivial_intro = store_thm("implements_trivial_intro",
-  ``(y = x) ==> implements {y} {x}``,
+val implements_trivial_intro = Q.store_thm("implements_trivial_intro",
+  `(y = x) ==> implements {y} {x}`,
   full_simp_tac(srw_ss())[implements_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]);
 
-val implements_intro_ext = store_thm("implements_intro_ext",
-  ``(b /\ x <> Fail ==> y IN extend_with_resource_limit {x}) ==>
-    b ==> implements {y} {x}``,
+val implements_intro_ext = Q.store_thm("implements_intro_ext",
+  `(b /\ x <> Fail ==> y IN extend_with_resource_limit {x}) ==>
+    b ==> implements {y} {x}`,
   full_simp_tac(srw_ss())[implements_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]);
 
-val isPREFIX_IMP_LPREFIX = prove(
-  ``!xs ys. isPREFIX xs ys ==> LPREFIX (fromList xs) (fromList ys)``,
+val isPREFIX_IMP_LPREFIX = Q.prove(
+  `!xs ys. isPREFIX xs ys ==> LPREFIX (fromList xs) (fromList ys)`,
   full_simp_tac(srw_ss())[LPREFIX_def,llistTheory.from_toList]);
 
-val implements_trans = store_thm("implements_trans",
-  ``implements y z ==> implements x y ==> implements x z``,
+val implements_trans = Q.store_thm("implements_trans",
+  `implements y z ==> implements x y ==> implements x z`,
   full_simp_tac(srw_ss())[implements_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]
   \\ Cases_on `Fail IN y` \\ full_simp_tac(srw_ss())[]

--- a/semantics/proofs/typeSysPropsScript.sml
+++ b/semantics/proofs/typeSysPropsScript.sml
@@ -32,9 +32,9 @@ val intro_alist_to_fmap = Q.store_thm ("intro_alist_to_fmap",
 `∀ls fm. fm |++ ls = alist_to_fmap (REVERSE ls) ⊌ fm`,
  metis_tac [FUNION_alist_to_fmap, REVERSE_REVERSE]);
 
-val type_env_list_rel = store_thm("type_env_list_rel",
-  ``!ctMap tenvS env tenv.
-   type_env ctMap tenvS env (bind_var_list2 tenv Empty) ⇔ LIST_REL (λ(x,v1) (y,n,v2). x = y ∧ type_v n ctMap tenvS v1 v2) env tenv``,
+val type_env_list_rel = Q.store_thm("type_env_list_rel",
+  `!ctMap tenvS env tenv.
+   type_env ctMap tenvS env (bind_var_list2 tenv Empty) ⇔ LIST_REL (λ(x,v1) (y,n,v2). x = y ∧ type_v n ctMap tenvS v1 v2) env tenv`,
   induct_on `env` >>
   srw_tac[][] >>
   cases_on `tenv` >>
@@ -47,10 +47,10 @@ val type_env_list_rel = store_thm("type_env_list_rel",
   full_simp_tac(srw_ss())[bind_var_list2_def] >>
   metis_tac []);
 
-val type_env_list_rel_append = store_thm("type_env_list_rel_append",
-  ``!ctMap tenvS env tenv rest rst.
+val type_env_list_rel_append = Q.store_thm("type_env_list_rel_append",
+  `!ctMap tenvS env tenv rest rst.
    type_env ctMap tenvS (env ++ rest) (bind_var_list2 tenv rst) ∧ LENGTH env = LENGTH tenv
-     ⇒ LIST_REL (λ(x,v1) (y,n,v2). x = y ∧ type_v n ctMap tenvS v1 v2) env tenv``,
+     ⇒ LIST_REL (λ(x,v1) (y,n,v2). x = y ∧ type_v n ctMap tenvS v1 v2) env tenv`,
   induct_on `env` >>
   srw_tac[][LENGTH_NIL_SYM] >>
   cases_on `tenv` >> full_simp_tac(srw_ss())[] >>
@@ -878,11 +878,11 @@ val bvl2_lookup = Q.store_thm ("bvl2_lookup",
  PairCases_on `h` >>
  srw_tac[][bind_var_list2_def, lookup_tenv_val_def, deBruijn_inc0]);
 
-val lookup_bvl2 = store_thm("lookup_bvl2",
- ``∀n tenv tenv2. lookup_tenv_val n m (bind_var_list2 tenv tenv2) =
+val lookup_bvl2 = Q.store_thm("lookup_bvl2",
+ `∀n tenv tenv2. lookup_tenv_val n m (bind_var_list2 tenv tenv2) =
                   case ALOOKUP tenv n of
                   | SOME (x,y) => SOME (x,deBruijn_inc x m y)
-                  | NONE => lookup_tenv_val n m tenv2``,
+                  | NONE => lookup_tenv_val n m tenv2`,
   induct_on`tenv` >>
   srw_tac[][bind_var_list2_def, lookup_tenv_val_def] >>
   PairCases_on`h` >>
@@ -2958,15 +2958,15 @@ val type_prog_sing = Q.store_thm ("type_prog_sing[simp]",
    >> PairCases_on `r`
    >> rw []));
 
-val type_top_tenv_val_ok = store_thm("type_top_tenv_val_ok",
-  ``∀ch decls tenv top decls' env.
+val type_top_tenv_val_ok = Q.store_thm("type_top_tenv_val_ok",
+  `∀ch decls tenv top decls' env.
     type_top ch decls tenv top decls' env ⇒
     ∀tenvT' menv' cenv' tenv'.
     env = (tenvT',menv',cenv',tenv') ⇒
       num_tvs tenv.v = 0 ⇒
       tenv_tabbrev_ok tenv.t ⇒
       tenv_val_ok (bind_var_list2 tenv' Empty) ∧
-      FEVERY (λ(mn,tenv). tenv_val_ok (bind_var_list2 tenv Empty)) menv'``,
+      FEVERY (λ(mn,tenv). tenv_val_ok (bind_var_list2 tenv Empty)) menv'`,
   ho_match_mp_tac type_top_ind >>
   srw_tac[][FEVERY_FEMPTY,FEVERY_FUPDATE,bind_var_list2_def,
      typeSoundInvariantsTheory.tenv_val_ok_def] >>

--- a/semantics/proofs/typeSysPropsScript.sml
+++ b/semantics/proofs/typeSysPropsScript.sml
@@ -62,16 +62,16 @@ val type_env_list_rel_append = store_thm("type_env_list_rel_append",
   srw_tac[][] >>
   metis_tac[])
 
-val bind_var_list2_append = store_thm("bind_var_list2_append",
-  ``∀l1 l2 g. bind_var_list2 (l1 ++ l2) g = bind_var_list2 l1 (bind_var_list2 l2 g)``,
+val bind_var_list2_append = Q.store_thm("bind_var_list2_append",
+  `∀l1 l2 g. bind_var_list2 (l1 ++ l2) g = bind_var_list2 l1 (bind_var_list2 l2 g)`,
   Induct >> simp[bind_var_list2_def] >>
   qx_gen_tac`p`>>PairCases_on`p`>>simp[bind_var_list2_def])
 
-val type_env_length = store_thm("type_env_length",
-  ``∀d a b c e f g h.
+val type_env_length = Q.store_thm("type_env_length",
+  `∀d a b c e f g h.
     type_env a b (c ++ d) (bind_var_list2 e f) ∧
     type_env g h d f ⇒
-    LENGTH c = LENGTH e``,
+    LENGTH c = LENGTH e`,
   Induct >> simp[] >- (
     srw_tac[][] >>
     pop_assum mp_tac >>
@@ -1523,10 +1523,10 @@ full_simp_tac(srw_ss())[] >>
 srw_tac[][] >>
 metis_tac []);
 
-val type_funs_MAP_FST = store_thm("type_funs_MAP_FST",
-``!funs tenv env.
+val type_funs_MAP_FST = Q.store_thm("type_funs_MAP_FST",
+`!funs tenv env.
   type_funs tenv funs env ⇒
-  MAP FST funs = MAP FST env``,
+  MAP FST funs = MAP FST env`,
   Induct>>srw_tac[][]>>
   pop_assum (ASSUME_TAC o SIMP_RULE (srw_ss()) [Once type_e_cases]) >>
   full_simp_tac(srw_ss())[]>>metis_tac[])
@@ -3152,28 +3152,28 @@ val tenv_names_def = Define`
   (tenv_names (Bind_name n _ _ e) = n INSERT tenv_names e)`
 val _ = export_rewrites["tenv_names_def"]
 
-val lookup_tenv_names = store_thm("lookup_tenv_names",
-  ``∀tenv n inc x. lookup_tenv_val n inc tenv = SOME x ⇒ n ∈ tenv_names tenv``,
+val lookup_tenv_names = Q.store_thm("lookup_tenv_names",
+  `∀tenv n inc x. lookup_tenv_val n inc tenv = SOME x ⇒ n ∈ tenv_names tenv`,
   Induct >> simp[lookup_tenv_val_def] >> metis_tac[])
 
-val tenv_names_bind_var_list = store_thm("tenv_names_bind_var_list",
-  ``∀n l1 l2. tenv_names (bind_var_list n l1 l2) = set (MAP FST l1) ∪ tenv_names l2``,
+val tenv_names_bind_var_list = Q.store_thm("tenv_names_bind_var_list",
+  `∀n l1 l2. tenv_names (bind_var_list n l1 l2) = set (MAP FST l1) ∪ tenv_names l2`,
   ho_match_mp_tac bind_var_list_ind >>
   simp[bind_var_list_def,EXTENSION] >>
   metis_tac[])
 
-val tenv_names_bind_var_list2 = store_thm("tenv_names_bind_var_list2",
-  ``∀l1 tenv. tenv_names (bind_var_list2 l1 tenv) = set (MAP FST l1) ∪ tenv_names tenv``,
+val tenv_names_bind_var_list2 = Q.store_thm("tenv_names_bind_var_list2",
+  `∀l1 tenv. tenv_names (bind_var_list2 l1 tenv) = set (MAP FST l1) ∪ tenv_names tenv`,
   Induct >> TRY(qx_gen_tac`p`>>PairCases_on`p`) >> simp[bind_var_list2_def] >>
   simp[EXTENSION] >> metis_tac[])
 
-val type_p_closed = prove(
-  ``(∀tvs tcenv p t tenv.
+val type_p_closed = Q.prove(
+  `(∀tvs tcenv p t tenv.
        type_p tvs tcenv p t tenv ⇒
        pat_bindings p [] = MAP FST tenv) ∧
     (∀tvs cenv ps ts tenv.
       type_ps tvs cenv ps ts tenv ⇒
-      pats_bindings ps [] = MAP FST tenv)``,
+      pats_bindings ps [] = MAP FST tenv)`,
   ho_match_mp_tac type_p_ind >>
   simp[astTheory.pat_bindings_def] >>
   srw_tac[][] >> full_simp_tac(srw_ss())[SUBSET_DEF] >>
@@ -3189,8 +3189,8 @@ val type_funs_dom = Q.prove (
    srw_tac[][] >>
    metis_tac []);
 
-val type_e_closed = prove(
-  ``(∀tenv e t.
+val type_e_closed = Q.prove(
+  `(∀tenv e t.
       type_e tenv e t
       ⇒
       FV e ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)) ∧
@@ -3200,7 +3200,7 @@ val type_e_closed = prove(
       FV_list es ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)) ∧
     (∀tenv funs ts.
       type_funs tenv funs ts ⇒
-      FV_defs funs ⊆ (IMAGE Short (tenv_names tenv.v)) ∪ tmenv_dom tenv.m)``,
+      FV_defs funs ⊆ (IMAGE Short (tenv_names tenv.v)) ∪ tmenv_dom tenv.m)`,
   ho_match_mp_tac type_e_strongind >>
   strip_tac >- simp[] >>
   strip_tac >- simp[] >>
@@ -3302,10 +3302,10 @@ val type_e_closed = prove(
   srw_tac[][] >>
   metis_tac []);
 
-val type_d_closed = prove(
-  ``∀uniq mno decls tenv d w x.
+val type_d_closed = Q.prove(
+  `∀uniq mno decls tenv d w x.
       type_d uniq mno decls tenv d w x ⇒
-        FV_dec d ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)``,
+        FV_dec d ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)`,
   ho_match_mp_tac type_d_ind >>
   strip_tac >- (
     simp[bind_tvar_def] >>
@@ -3349,10 +3349,10 @@ val type_d_new_dec_vs = Q.prove (
    *)
 
    (*
-val type_ds_closed = prove(
-  ``∀uniq mn decls tenv ds w x. type_ds uniq mn decls tenv ds w x ⇒
+val type_ds_closed = Q.prove(
+  `∀uniq mn decls tenv ds w x. type_ds uniq mn decls tenv ds w x ⇒
      !mn'. mn = SOME mn' ⇒
-      FV_decs ds ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)``,
+      FV_decs ds ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)`,
   ho_match_mp_tac type_ds_ind >>
   srw_tac[][FV_decs_def] >>
   imp_res_tac type_d_closed >>
@@ -3367,11 +3367,11 @@ val type_ds_closed = prove(
   *)
 
   (*
-val type_top_closed = store_thm("type_top_closed",
-  ``∀uniq decls tenv top decls' new_tenv.
+val type_top_closed = Q.store_thm("type_top_closed",
+  `∀uniq decls tenv top decls' new_tenv.
       type_top uniq decls tenv top decls' new_tenv
       ⇒
-      FV_top top ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)``,
+      FV_top top ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)`,
   ho_match_mp_tac type_top_ind >>
   strip_tac >- (
     simp[] >>

--- a/semantics/proofs/typeSysPropsScript.sml
+++ b/semantics/proofs/typeSysPropsScript.sml
@@ -57,7 +57,7 @@ val type_env_list_rel_append = store_thm("type_env_list_rel_append",
   PairCases_on`h'` >>
   full_simp_tac(srw_ss())[bind_var_list2_def] >>
   PairCases_on`h`>>simp[] >>
-  rator_x_assum`type_env`mp_tac >>
+  qhdtm_x_assum`type_env`mp_tac >>
   simp[Once type_v_cases] >>
   srw_tac[][] >>
   metis_tac[])

--- a/semantics/terminationScript.sml
+++ b/semantics/terminationScript.sml
@@ -211,13 +211,13 @@ val check_dup_ctors_thm = Q.store_thm ("check_dup_ctors_thm",
     ALL_DISTINCT (FLAT (MAP (\(tvs,tn,condefs). (MAP (λ(n,ts). n)) condefs) tds))`,
 metis_tac [check_dup_ctors_def,check_ctor_foldr_flat_map]);
 
-val do_log_thm = store_thm("do_log_thm",
-  ``do_log l v e =
+val do_log_thm = Q.store_thm("do_log_thm",
+  `do_log l v e =
     if l = And ∧ v = Conv(SOME("true",TypeId(Short"bool")))[] then SOME (Exp e) else
     if l = Or ∧ v = Conv(SOME("false",TypeId(Short"bool")))[] then SOME (Exp e) else
     if v = Conv(SOME("true",TypeId(Short"bool")))[] then SOME (Val v) else
     if v = Conv(SOME("false",TypeId(Short"bool")))[] then SOME (Val v) else
-    NONE``,
+    NONE`,
   rw[semanticPrimitivesTheory.do_log_def] >>
   every_case_tac >> rw[])
 

--- a/semantics/terminationScript.sml
+++ b/semantics/terminationScript.sml
@@ -219,7 +219,11 @@ val do_log_thm = Q.store_thm("do_log_thm",
     if v = Conv(SOME("false",TypeId(Short"bool")))[] then SOME (Val v) else
     NONE`,
   rw[semanticPrimitivesTheory.do_log_def] >>
-  every_case_tac >> rw[])
+    every_case_tac >> rw[])
+
+val fix_clock_IMP = Q.prove(
+  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
 
 val (evaluate_def,evaluate_ind) =
   tprove_no_defn ((evaluate_def,evaluate_ind),
@@ -228,8 +232,9 @@ val (evaluate_def,evaluate_ind) =
          | INL(s,_,es) => (s.clock,exps_size es)
          | INR(s,_,_,pes,_) => (s.clock,pes_size pes))` >>
   rw[size_abbrevs,exp_size_def,
-  check_clock_def,dec_clock_def,LESS_OR_EQ,
+  dec_clock_def,LESS_OR_EQ,
   do_if_def,do_log_thm] >>
+  imp_res_tac fix_clock_IMP >>
   simp[SIMP_RULE(srw_ss())[]exps_size_thm,MAP_REVERSE,SUM_REVERSE]);
 
 val evaluate_clock = Q.store_thm("evaluate_clock",
@@ -237,44 +242,20 @@ val evaluate_clock = Q.store_thm("evaluate_clock",
    (∀(s1:'ffi state) env v p v' r s2. evaluate_match s1 env v p v' = (s2,r) ⇒ s2.clock ≤ s1.clock)`,
   ho_match_mp_tac evaluate_ind >> rw[evaluate_def] >>
   every_case_tac >> fs[] >> rw[] >> rfs[] >>
-  fs[check_clock_def,dec_clock_def] >> simp[]);
+  fs[dec_clock_def,fix_clock_def] >> simp[] >>
+  imp_res_tac fix_clock_IMP >> fs[]);
 
-val check_clock_id = Q.store_thm("check_clock_id",
-  `s'.clock ≤ s.clock ⇒ check_clock s' s = s'`,
-  EVAL_TAC >> rw[state_component_equality]);
+val fix_clock_evaluate = Q.store_thm("fix_clock_evaluate",
+  `fix_clock s1 (evaluate s1 env e) = evaluate s1 env e`,
+  Cases_on `evaluate s1 env e` \\ fs [fix_clock_def]
+  \\ imp_res_tac evaluate_clock
+  \\ fs [MIN_DEF,state_component_equality]);
 
-val s = ``s:'ffi state``;
-val s' = ``s':'ffi state``;
-val clean_term = term_rewrite
-  [``check_clock ^s' ^s = s'``,
-   ``^s'.clock = 0 ∨ ^s.clock = 0 ⇔ s'.clock = 0``];
+val evaluate_def = save_thm("evaluate_def",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_def |> INST_TYPE[alpha|->``:'ffi``] (* TODO: this is only broken because Lem sucks *));
 
-val evaluate_ind = let
-  val evaluate_ind = evaluate_ind |> INST_TYPE[alpha|->``:'ffi``] (* TODO: this is only broken because Lem sucks *)
-  val goal = evaluate_ind |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac evaluate_ind >>
-  rw[] >> first_x_assum match_mp_tac >>
-  rw[] >> fs[] >>
-  res_tac >>
-  imp_res_tac evaluate_clock >>
-  fsrw_tac[ARITH_ss][check_clock_id])
-end;
-
-val evaluate_def = let
-  val evaluate_def = evaluate_def |> INST_TYPE[alpha |-> ``:'ffi``] (* TODO: same as above *)
-  val goal = evaluate_def |> concl |> clean_term
-  (* set_goal([],goal) *)
-in prove(goal,
-  rpt strip_tac >>
-  rw[Once evaluate_def] >>
-  every_case_tac >>
-  imp_res_tac evaluate_clock >>
-  fs[check_clock_id] >>
-  `F` suffices_by rw[] >> decide_tac)
-end
+val evaluate_ind = save_thm("evaluate_ind",
+  REWRITE_RULE [fix_clock_evaluate] evaluate_ind |> INST_TYPE[alpha|->``:'ffi``] (* TODO: this is only broken because Lem sucks *));
 
 val _ = register "evaluate" evaluate_def evaluate_ind
 

--- a/semantics/terminationScript.sml
+++ b/semantics/terminationScript.sml
@@ -34,55 +34,55 @@ val vs_size_thm = size_thm "vs_size_thm" ``vs_size`` ``v_size``;
 val envE_size_thm = size_thm "envE_size_thm" ``envE_size`` ``v3_size``;
 val envM_size_thm = size_thm "envM_size_thm" ``envM_size`` ``v5_size``;
 
-val SUM_MAP_exp2_size_thm = store_thm(
+val SUM_MAP_exp2_size_thm = Q.store_thm(
 "SUM_MAP_exp2_size_thm",
-``∀defs. SUM (MAP exp2_size defs) = SUM (MAP (list_size char_size) (MAP FST defs)) +
+`∀defs. SUM (MAP exp2_size defs) = SUM (MAP (list_size char_size) (MAP FST defs)) +
                                           SUM (MAP exp4_size (MAP SND defs)) +
-                                          LENGTH defs``,
+                                          LENGTH defs`,
 Induct >- rw[exp_size_def] >>
 qx_gen_tac `p` >>
 PairCases_on `p` >>
 srw_tac[ARITH_ss][exp_size_def])
 
-val SUM_MAP_exp4_size_thm = store_thm(
+val SUM_MAP_exp4_size_thm = Q.store_thm(
 "SUM_MAP_exp4_size_thm",
-``∀ls. SUM (MAP exp4_size ls) = SUM (MAP (list_size char_size) (MAP FST ls)) +
+`∀ls. SUM (MAP exp4_size ls) = SUM (MAP (list_size char_size) (MAP FST ls)) +
                                       SUM (MAP exp_size (MAP SND ls)) +
-                                      LENGTH ls``,
+                                      LENGTH ls`,
 Induct >- rw[exp_size_def] >>
 Cases >> srw_tac[ARITH_ss][exp_size_def])
 
-val SUM_MAP_exp5_size_thm = store_thm(
+val SUM_MAP_exp5_size_thm = Q.store_thm(
 "SUM_MAP_exp5_size_thm",
-``∀ls. SUM (MAP exp5_size ls) = SUM (MAP pat_size (MAP FST ls)) +
+`∀ls. SUM (MAP exp5_size ls) = SUM (MAP pat_size (MAP FST ls)) +
                                 SUM (MAP exp_size (MAP SND ls)) +
-                                LENGTH ls``,
+                                LENGTH ls`,
 Induct >- rw[exp_size_def] >>
 Cases >> srw_tac[ARITH_ss][exp_size_def])
 
 (*
-val SUM_MAP_v2_size_thm = store_thm(
+val SUM_MAP_v2_size_thm = Q.store_thm(
 "SUM_MAP_v2_size_thm",
-``∀env. SUM (MAP v2_size env) = SUM (MAP (list_size char_size) (MAP FST env)) +
+`∀env. SUM (MAP v2_size env) = SUM (MAP (list_size char_size) (MAP FST env)) +
                                 SUM (MAP v_size (MAP SND env)) +
-                                LENGTH env``,
+                                LENGTH env`,
 Induct >- rw[v_size_def] >>
 Cases >> srw_tac[ARITH_ss][v_size_def])
 *)
 
 (*
-val SUM_MAP_v3_size_thm = store_thm(
+val SUM_MAP_v3_size_thm = Q.store_thm(
 "SUM_MAP_v3_size_thm",
-``∀env f. SUM (MAP (v3_size f) env) = SUM (MAP (v_size f) (MAP FST env)) +
+`∀env f. SUM (MAP (v3_size f) env) = SUM (MAP (v_size f) (MAP FST env)) +
                                       SUM (MAP (option_size (pair_size (λx. x) f)) (MAP SND env)) +
-                                      LENGTH env``,
+                                      LENGTH env`,
 Induct >- rw[v_size_def] >>
 Cases >> srw_tac[ARITH_ss][v_size_def])
 *)
 
-val exp_size_positive = store_thm(
+val exp_size_positive = Q.store_thm(
 "exp_size_positive",
-``∀e. 0 < exp_size e``,
+`∀e. 0 < exp_size e`,
 Induct >> srw_tac[ARITH_ss][exp_size_def])
 val _ = export_rewrites["exp_size_positive"];
 

--- a/semantics/tokenUtilsScript.sml
+++ b/semantics/tokenUtilsScript.sml
@@ -85,9 +85,9 @@ val destAlphaT_def = Define`
 `;
 val _ = export_rewrites ["destAlphaT_def"]
 
-val destAlphaT_EQ_SOME = store_thm(
+val destAlphaT_EQ_SOME = Q.store_thm(
   "destAlphaT_EQ_SOME[simp]",
-  ``destAlphaT t = SOME s ⇔ t = AlphaT s``,
+  `destAlphaT t = SOME s ⇔ t = AlphaT s`,
   Cases_on `t` >> simp[]);
 
 val destSymbolT_def = Define`
@@ -96,9 +96,9 @@ val destSymbolT_def = Define`
 `;
 val _ = export_rewrites ["destSymbolT_def"]
 
-val destSymbolT_EQ_SOME = store_thm(
+val destSymbolT_EQ_SOME = Q.store_thm(
   "destSymbolT_EQ_SOME[simp]",
-  ``destSymbolT t = SOME s ⇔ t = SymbolT s``,
+  `destSymbolT t = SOME s ⇔ t = SymbolT s`,
   Cases_on `t` >> simp[]);
 
 val destIntT_def = Define`

--- a/semantics/tokenUtilsScript.sml
+++ b/semantics/tokenUtilsScript.sml
@@ -63,9 +63,9 @@ val destLongidT_def = Define`
 `
 val _ = export_rewrites ["destLongidT_def"]
 
-val destLongidT_EQ_SOME = store_thm(
+val destLongidT_EQ_SOME = Q.store_thm(
   "destLongidT_EQ_SOME[simp]",
-  ``destLongidT t = SOME strs ⇔ ∃str s. t = LongidT str s ∧ strs = (str, s)``,
+  `destLongidT t = SOME strs ⇔ ∃str s. t = LongidT str s ∧ strs = (str, s)`,
   Cases_on `t` >> simp[] >> metis_tac[]);
 
 val destTyvarPT_def = Define`

--- a/translator/mini_preludeLib.sml
+++ b/translator/mini_preludeLib.sml
@@ -17,13 +17,13 @@ val _ = save_thm("append_v_thm",append_v_thm);
 val res = translate REV_DEF;
 val res = translate REVERSE_REV;
 
-val hd_side_def = prove(
-  ``!xs. hd_side xs = ~(xs = [])``,
+val hd_side_def = Q.prove(
+  `!xs. hd_side xs = ~(xs = [])`,
   Cases THEN FULL_SIMP_TAC (srw_ss()) [fetch "-" "hd_side_def"])
   |> update_precondition;
 
-val tl_side_def = prove(
-  ``!xs. tl_side xs = ~(xs = [])``,
+val tl_side_def = Q.prove(
+  `!xs. tl_side xs = ~(xs = [])`,
   Cases THEN FULL_SIMP_TAC (srw_ss()) [fetch "-" "tl_side_def"])
   |> update_precondition;
 

--- a/translator/ml_optimiseScript.sml
+++ b/translator/ml_optimiseScript.sml
@@ -29,8 +29,8 @@ val MEM_exp_size1 = Q.prove(
   Induct THEN FULL_SIMP_TAC (srw_ss()) [exp_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC);
 
-val MEM_exp_size2 = prove(
-  ``!ys p x. MEM (p,x) ys ==> exp_size x < exp3_size ys``,
+val MEM_exp_size2 = Q.prove(
+  `!ys p x. MEM (p,x) ys ==> exp_size x < exp3_size ys`,
   Induct THEN FULL_SIMP_TAC (srw_ss()) [exp_size_def] THEN Cases
   THEN FULL_SIMP_TAC std_ss [exp_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC);
@@ -74,11 +74,11 @@ val do_log_IMP_3 = Q.prove(
 
 val s = ``s:'ffi semanticPrimitives$state``
 
-val BOTTOM_UP_OPT_LEMMA = prove(
-  ``(!ck env ^s exp res. evaluate F env s exp res ==> isRval (SND res) ==> evaluate F env s (f exp) res) ==>
+val BOTTOM_UP_OPT_LEMMA = Q.prove(
+  `(!ck env ^s exp res. evaluate F env s exp res ==> isRval (SND res) ==> evaluate F env s (f exp) res) ==>
     (!ck x1 ^s x2 x3. evaluate ck x1 s x2 x3 ==> isRval (SND x3) ∧ (ck = F) ==> evaluate ck x1 s (BOTTOM_UP_OPT f x2) x3) /\
     (!ck x1 ^s x2 x3. evaluate_list ck x1 s x2 x3 ==> isRval (SND x3) ∧ (ck = F) ==> evaluate_list ck x1 s (MAP (BOTTOM_UP_OPT f) x2) x3) /\
-    (!ck x1 ^s x2 x3 x4 x5. evaluate_match ck x1 s x2 x3 x4 x5 ==> isRval (SND x5) ∧ (ck = F) ==> evaluate_match ck x1 s x2 (MAP (\(p,x). (p,BOTTOM_UP_OPT f x)) x3) x4 x5)``,
+    (!ck x1 ^s x2 x3 x4 x5. evaluate_match ck x1 s x2 x3 x4 x5 ==> isRval (SND x5) ∧ (ck = F) ==> evaluate_match ck x1 s x2 (MAP (\(p,x). (p,BOTTOM_UP_OPT f x)) x3) x4 x5)`,
   STRIP_TAC \\ ONCE_REWRITE_TAC [two_assums]
   \\ HO_MATCH_MP_TAC bigStepTheory.evaluate_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [BOTTOM_UP_OPT_def,isRval_def,AND_IMP_INTRO, rich_listTheory.MAP_REVERSE]
@@ -139,14 +139,14 @@ val BOTTOM_UP_OPT_LEMMA = prove(
     \\ METIS_TAC [Boolv_11])
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases,isRval_def] \\ METIS_TAC []);
 
-val BOTTOM_UP_OPT_THM = prove(
-  ``!f.
+val BOTTOM_UP_OPT_THM = Q.prove(
+  `!f.
       (!env ^s exp t res.
          evaluate F env s exp (t,Rval res) ==>
          evaluate F env s (f exp) (t,Rval res)) ==>
       (!env ^s exp t res.
          evaluate F env s exp (t,Rval res) ==>
-         evaluate F env s (BOTTOM_UP_OPT f exp) (t,Rval res))``,
+         evaluate F env s (BOTTOM_UP_OPT f exp) (t,Rval res))`,
   STRIP_TAC \\ STRIP_TAC \\ (BOTTOM_UP_OPT_LEMMA
     |> UNDISCH |> CONJUNCT1
     |> Q.SPECL [`F`, `env`,`s`,`exp`,`(t,Rval res)`] |> GEN_ALL
@@ -163,9 +163,9 @@ val abs2let_def = Define `
      case x of App Opapp [Fun v exp; y] => Let (SOME v) y exp
              | rest => rest`;
 
-val abs2let_thm = prove(
-  ``!env s exp t res. evaluate F env s exp (t,Rval res) ==>
-                      evaluate F env s (abs2let exp) (t,Rval res)``,
+val abs2let_thm = Q.prove(
+  `!env s exp t res. evaluate F env s exp (t,Rval res) ==>
+                      evaluate F env s (abs2let exp) (t,Rval res)`,
   SIMP_TAC std_ss [abs2let_def] \\ REPEAT STRIP_TAC
   \\ BasicProvers.EVERY_CASE_TAC
   \\ ASM_SIMP_TAC std_ss [] \\ POP_ASSUM MP_TAC
@@ -189,9 +189,9 @@ val let_id_def = Define `
      if (y = Var (Short v)) then x else Let (SOME v) x y) /\
   (let_id rest = rest)`;
 
-val let_id_thm = prove(
-  ``!env s exp t res. evaluate F env s exp (t,Rval res) ==>
-                      evaluate F env s (let_id exp) (t,Rval res)``,
+val let_id_thm = Q.prove(
+  `!env s exp t res. evaluate F env s exp (t,Rval res) ==>
+                      evaluate F env s (let_id exp) (t,Rval res)`,
   STRIP_TAC \\ STRIP_TAC \\ HO_MATCH_MP_TAC (fetch "-" "let_id_ind")
   \\ FULL_SIMP_TAC std_ss [let_id_def] \\ SRW_TAC [] [] \\ POP_ASSUM MP_TAC
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
@@ -220,34 +220,34 @@ val opt_sub_add_def = Define `
             else x
          | _ => x`;
 
-val dest_binop_thm = prove(
-  ``!x. (dest_binop x = SOME (x1,x2,x3)) ==> (x = App (Opn x1) [x2; x3])``,
+val dest_binop_thm = Q.prove(
+  `!x. (dest_binop x = SOME (x1,x2,x3)) ==> (x = App (Opn x1) [x2; x3])`,
   HO_MATCH_MP_TAC (fetch "-" "dest_binop_ind")
   \\ FULL_SIMP_TAC (srw_ss()) [dest_binop_def]);
 
-val do_app_IMP = prove(
-  ``(do_app s (Opn opn) [v1; v2] = SOME (s1,e3)) ==>
-    ?i1 i2. (v1 = Litv (IntLit i1)) /\ (v2 = Litv (IntLit i2))``,
+val do_app_IMP = Q.prove(
+  `(do_app s (Opn opn) [v1; v2] = SOME (s1,e3)) ==>
+    ?i1 i2. (v1 = Litv (IntLit i1)) /\ (v2 = Litv (IntLit i2))`,
   Cases_on`s` >> FULL_SIMP_TAC (srw_ss()) [do_app_cases]
   \\ SRW_TAC [] []);
 
-val evaluate_11_Rval = prove(
-  ``evaluate ck env s exp (t,Rval res1) ==>
-    evaluate ck env s exp (t,Rval res2) ==> (res1 = res2)``,
+val evaluate_11_Rval = Q.prove(
+  `evaluate ck env s exp (t,Rval res1) ==>
+    evaluate ck env s exp (t,Rval res2) ==> (res1 = res2)`,
   REPEAT STRIP_TAC \\ IMP_RES_TAC big_exp_determ
   \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val evaluate_Lit = prove(
-  ``evaluate ck env s (Lit l) (s1,Rval (res)) <=> (res = Litv l) /\ (s = s1)``,
+val evaluate_Lit = Q.prove(
+  `evaluate ck env s (Lit l) (s1,Rval (res)) <=> (res = Litv l) /\ (s = s1)`,
   FULL_SIMP_TAC (srw_ss()) [Once evaluate_cases] \\ METIS_TAC []);
 
 val with_same_refs_io = Q.prove(
   `x with <| refs := x.refs; ffi := x.ffi |> = x`,
   rw[state_component_equality])
 
-val opt_sub_add_thm = prove(
-  ``!env s exp t res. evaluate F env s exp (t,Rval res) ==>
-                      evaluate F env s (opt_sub_add exp) (t,Rval res)``,
+val opt_sub_add_thm = Q.prove(
+  `!env s exp t res. evaluate F env s exp (t,Rval res) ==>
+                      evaluate F env s (opt_sub_add exp) (t,Rval res)`,
   STRIP_TAC \\ STRIP_TAC \\ STRIP_TAC \\ SIMP_TAC std_ss [opt_sub_add_def]
   \\ Cases_on `dest_binop exp` \\ FULL_SIMP_TAC std_ss []
   \\ `?x1 x2 x3. x = (x1,x2,x3)` by METIS_TAC [PAIR] \\ fs []

--- a/translator/ml_optimiseScript.sml
+++ b/translator/ml_optimiseScript.sml
@@ -24,8 +24,8 @@ val _ = new_theory "ml_optimise";
 
 (* first an optimisation combinator: BOTTOM_UP_OPT *)
 
-val MEM_exp_size1 = prove(
-  ``!xs a. MEM a xs ==> exp_size a <= exp6_size xs``,
+val MEM_exp_size1 = Q.prove(
+  `!xs a. MEM a xs ==> exp_size a <= exp6_size xs`,
   Induct THEN FULL_SIMP_TAC (srw_ss()) [exp_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC);
 
@@ -58,18 +58,18 @@ val two_assums = METIS_PROVE [] ``(b ==> c) = (b ==> c /\ b)``;
 
 val isRval_def = Define `(isRval (Rval _) = T) /\ (isRval _ = F)`;
 
-val do_log_IMP = prove(
-  ``(do_log op v e2 = SOME (Exp x2)) ==> (x2 = e2)``,
+val do_log_IMP = Q.prove(
+  `(do_log op v e2 = SOME (Exp x2)) ==> (x2 = e2)`,
   fs [do_log_def] \\ BasicProvers.EVERY_CASE_TAC \\ fs []);
 
-val do_log_IMP_2 = prove(
-  ``(do_log op v e2 = SOME (Exp e2)) ==>
-    !e3. (do_log op v e3 = SOME (Exp e3))``,
+val do_log_IMP_2 = Q.prove(
+  `(do_log op v e2 = SOME (Exp e2)) ==>
+    !e3. (do_log op v e3 = SOME (Exp e3))`,
   fs [do_log_def] \\ BasicProvers.EVERY_CASE_TAC \\ fs []);
 
-val do_log_IMP_3 = prove(
-  ``(do_log op v e2 = SOME (Val x)) ==>
-    !e3. (do_log op v e3 = SOME (Val x))``,
+val do_log_IMP_3 = Q.prove(
+  `(do_log op v e2 = SOME (Val x)) ==>
+    !e3. (do_log op v e3 = SOME (Val x))`,
   fs [do_log_def] \\ BasicProvers.EVERY_CASE_TAC \\ fs []);
 
 val s = ``s:'ffi semanticPrimitives$state``
@@ -287,8 +287,8 @@ val OPTIMISE_def = Define `
   OPTIMISE =
     BOTTOM_UP_OPT (opt_sub_add o let_id) o BOTTOM_UP_OPT abs2let`;
 
-val Eval_OPTIMISE = store_thm("Eval_OPTIMISE",
-  ``Eval env exp P ==> Eval env (OPTIMISE exp) P``,
+val Eval_OPTIMISE = Q.store_thm("Eval_OPTIMISE",
+  `Eval env exp P ==> Eval env (OPTIMISE exp) P`,
   SIMP_TAC std_ss [Eval_def] \\ REPEAT STRIP_TAC
   \\ Q.EXISTS_TAC `res` \\ FULL_SIMP_TAC std_ss [OPTIMISE_def]
   \\ MATCH_MP_TAC BOTTOM_UP_OPT_THM

--- a/translator/ml_pmatchScript.sml
+++ b/translator/ml_pmatchScript.sml
@@ -122,8 +122,11 @@ val pmatch_imp_Pmatch = Q.prove(
 
 val Pmatch_imp_pmatch = Q.store_thm("Pmatch_imp_pmatch",
   `∀env s ps vs env'.
-      (Pmatch env s ps vs = SOME env' ⇒
+    (Pmatch env s ps vs = SOME env' ⇒
        pmatch_list env.c s ps vs env.v =
+         Match env'.v) ∧
+      (Pmatch env s ps vs = NONE ⇒
+       ∀env2.
        pmatch_list env.c s ps vs env.v ≠
          Match env2)`,
   ho_match_mp_tac Pmatch_ind >>

--- a/translator/ml_pmatchScript.sml
+++ b/translator/ml_pmatchScript.sml
@@ -51,26 +51,26 @@ val EvalPatBind_def = Define`
       (Pmatch env [p] [av] = SOME env2) ∧
       (pat vars = x)`
 
-val Pmatch_cons = store_thm("Pmatch_cons",
-  ``∀ps vs.
+val Pmatch_cons = Q.store_thm("Pmatch_cons",
+  `∀ps vs.
       Pmatch env (p::ps) (v::vs) =
       case Pmatch env [p] [v] of | NONE => NONE
-      | SOME env' => Pmatch env' ps vs``,
+      | SOME env' => Pmatch env' ps vs`,
   Induct >> Cases_on`vs` >> simp[Pmatch_def] >>
   BasicProvers.CASE_TAC >>
   Cases_on`ps`>>simp[Pmatch_def])
 
-val Pmatch_SOME_const = store_thm("Pmatch_SOME_const",
-  ``∀env ps vs env'.
+val Pmatch_SOME_const = Q.store_thm("Pmatch_SOME_const",
+  `∀env ps vs env'.
       Pmatch env ps vs = SOME env' ⇒
       env'.m = env.m ∧
-      env'.c = env.c``,
+      env'.c = env.c`,
   ho_match_mp_tac Pmatch_ind >> simp[Pmatch_def] >>
   rw[] >> BasicProvers.EVERY_CASE_TAC >> fs[] >>
   fs[write_def])
 
-val pmatch_imp_Pmatch = prove(
-  ``(∀envC s p v env aenv.
+val pmatch_imp_Pmatch = Q.prove(
+  `(∀envC s p v env aenv.
       s = empty_store ⇒
       envC = aenv.c ∧ env = aenv.v ⇒
       case pmatch envC s p v aenv.v of
@@ -83,7 +83,7 @@ val pmatch_imp_Pmatch = prove(
       case pmatch_list envC s ps vs aenv.v of
       | Match env' =>
         Pmatch aenv ps vs = SOME (aenv with v := env')
-      | _ => Pmatch aenv ps vs = NONE)``,
+      | _ => Pmatch aenv ps vs = NONE)`,
   ho_match_mp_tac pmatch_ind >>
   rw[pmatch_def,Pmatch_def,write_def]
   >> TRY (rw[environment_component_equality]>>NO_TAC)
@@ -112,15 +112,15 @@ val pmatch_imp_Pmatch = prove(
   |> SIMP_RULE std_ss []
   |> curry save_thm "pmatch_imp_Pmatch"
 
-val Pmatch_imp_pmatch = store_thm("Pmatch_imp_pmatch",
-  ``∀env ps vs env'.
+val Pmatch_imp_pmatch = Q.store_thm("Pmatch_imp_pmatch",
+  `∀env ps vs env'.
       (Pmatch env ps vs = SOME env' ⇒
        pmatch_list env.c empty_store ps vs env.v =
          Match env'.v) ∧
       (Pmatch env ps vs = NONE ⇒
        ∀env2.
        pmatch_list env.c empty_store ps vs env.v ≠
-         Match env2)``,
+         Match env2)`,
   ho_match_mp_tac Pmatch_ind >>
   simp[Pmatch_def,pmatch_def] >> rw[] >>
   fs[write_def] >>
@@ -132,11 +132,11 @@ val Pmatch_imp_pmatch = store_thm("Pmatch_imp_pmatch",
   Cases_on`v20`>>fs[pmatch_def] >>
   BasicProvers.EVERY_CASE_TAC >> fs[store_lookup_def,empty_store_def])
 
-val pmatch_PMATCH_ROW_COND_No_match = store_thm("pmatch_PMATCH_ROW_COND_No_match",
-  ``EvalPatRel env a p pat ∧
+val pmatch_PMATCH_ROW_COND_No_match = Q.store_thm("pmatch_PMATCH_ROW_COND_No_match",
+  `EvalPatRel env a p pat ∧
     (∀vars. ¬PMATCH_ROW_COND pat (K T) xv vars) ∧
     a xv res ⇒
-    Pmatch env [p] [res] = NONE``,
+    Pmatch env [p] [res] = NONE`,
   fs [PMATCH_ROW_COND_def] >>
   rw[EvalPatRel_def] >>
   first_x_assum(fn th => first_x_assum(strip_assume_tac o MATCH_MP th)) >>
@@ -148,11 +148,11 @@ val pmatch_PMATCH_ROW_COND_No_match = store_thm("pmatch_PMATCH_ROW_COND_No_match
   \\ REPEAT (POP_ASSUM MP_TAC)
   \\ NTAC 4 (fs[Once evaluate_cases,PMATCH_ROW_COND_def,empty_state_def]));
 
-val pmatch_PMATCH_ROW_COND_Match = store_thm("pmatch_PMATCH_ROW_COND_Match",
-  ``EvalPatRel env a p pat ∧
+val pmatch_PMATCH_ROW_COND_Match = Q.store_thm("pmatch_PMATCH_ROW_COND_Match",
+  `EvalPatRel env a p pat ∧
     PMATCH_ROW_COND pat (K T) xv vars ∧
     a xv res
-    ⇒ ∃env2. Pmatch env [p] [res] = SOME env2``,
+    ⇒ ∃env2. Pmatch env [p] [res] = SOME env2`,
   rw[EvalPatRel_def,PMATCH_ROW_COND_def] >>
   first_x_assum(fn th => first_x_assum(strip_assume_tac o MATCH_MP th)) >>
   qspecl_then[`p`,`res`,`env`]strip_assume_tac(CONJUNCT1 pmatch_imp_Pmatch) >>
@@ -162,11 +162,11 @@ val pmatch_PMATCH_ROW_COND_Match = store_thm("pmatch_PMATCH_ROW_COND_Match",
   fs[empty_state_def] >>
   PROVE_TAC[]);
 
-val Eval_PMATCH_NIL = store_thm("Eval_PMATCH_NIL",
-  ``!b x xv a.
+val Eval_PMATCH_NIL = Q.store_thm("Eval_PMATCH_NIL",
+  `!b x xv a.
       Eval env x (a xv) ==>
       CONTAINER F ==>
-      Eval env (Mat x []) (b (PMATCH xv []))``,
+      Eval env (Mat x []) (b (PMATCH xv []))`,
   rw[CONTAINER_def]);
 
 val empty_state_refs = EVAL``empty_state.refs = empty_store`` |> EQT_ELIM

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -254,7 +254,7 @@ val Decls_CONS = Q.store_thm("Decls_CONS",
   \\ ONCE_REWRITE_TAC[CONJ_COMM]
   \\ first_assum(match_exists_tac o concl) \\ simp[]
   THEN1
-   (ntac 2 (rator_x_assum`evaluate_decs`mp_tac)
+   (ntac 2 (qhdtm_x_assum`evaluate_decs`mp_tac)
     \\ rw[Once evaluate_decs_cases] >> fs[]
     \\ fs [merge_env_def] \\ rfs []
     \\ fs [empty_env_def,merge_env_def,extend_dec_env_def,merge_alist_mod_env_def]

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -41,18 +41,18 @@ val SND_ALOOKUP_def = Define `
   (SND_ALOOKUP (x,[]) q = NONE) /\
   (SND_ALOOKUP (x,(y,z)::xs) q = if q = y then SOME z else SND_ALOOKUP (x,xs) q)`;
 
-val write_simp = store_thm("write_simp[compute]",
-  ``(write n v env).c = env.c /\
+val write_simp = Q.store_thm("write_simp[compute]",
+  `(write n v env).c = env.c /\
     (write n v env).m = env.m /\
     ALOOKUP (write n v env).v q =
-      if n = q then SOME v else ALOOKUP env.v q``,
+      if n = q then SOME v else ALOOKUP env.v q`,
   fs [write_def]);
 
-val write_cons_simp = store_thm("write_cons_simp[compute]",
-  ``(write_cons n v env).v = env.v /\
+val write_cons_simp = Q.store_thm("write_cons_simp[compute]",
+  `(write_cons n v env).v = env.v /\
     (write_cons n v env).m = env.m /\
     SND_ALOOKUP (write_cons n v env).c q =
-      if n = q then SOME v else SND_ALOOKUP env.c q``,
+      if n = q then SOME v else SND_ALOOKUP env.c q`,
   Cases_on `env.c`
   \\ rw [write_cons_def,merge_alist_mod_env_def,SND_ALOOKUP_def]);
 
@@ -60,34 +60,34 @@ val SND_ALOOKUP_EQ_ALOOKUP = store_thm("SND_ALOOKUP_EQ_ALOOKUP",
   ``!xs ys q. SND_ALOOKUP (xs,ys) q = ALOOKUP ys q``,
   Induct_on `ys` \\ fs [ALOOKUP_def,SND_ALOOKUP_def,FORALL_PROD] \\ rw []);
 
-val write_mod_simp = store_thm("write_mod_simp[compute]",
-  ``(write_mod n v env).v = env.v /\
+val write_mod_simp = Q.store_thm("write_mod_simp[compute]",
+  `(write_mod n v env).v = env.v /\
     SND_ALOOKUP (write_mod n v env).c k = SND_ALOOKUP env.c k /\
     ALOOKUP (write_mod n v env).m q =
-      if n = q then SOME v.v else ALOOKUP env.m q``,
+      if n = q then SOME v.v else ALOOKUP env.m q`,
   Cases_on `env.c`
   \\ rw [write_mod_def,merge_alist_mod_env_def,SND_ALOOKUP_EQ_ALOOKUP]);
 
-val empty_simp = store_thm("empty_simp[compute]",
-  ``ALOOKUP empty_env.v q = NONE /\
+val empty_simp = Q.store_thm("empty_simp[compute]",
+  `ALOOKUP empty_env.v q = NONE /\
     ALOOKUP empty_env.m q = NONE /\
-    SND_ALOOKUP empty_env.c q = NONE``,
+    SND_ALOOKUP empty_env.c q = NONE`,
   fs [empty_env_def,SND_ALOOKUP_def] );
 
-val merge_env_simp = store_thm("merge_env_simp[compute]",
-  ``(ALOOKUP (merge_env e1 e2).v k =
+val merge_env_simp = Q.store_thm("merge_env_simp[compute]",
+  `(ALOOKUP (merge_env e1 e2).v k =
       case ALOOKUP e1.v k of SOME x => SOME x | NONE => ALOOKUP e2.v k) /\
     (ALOOKUP (merge_env e1 e2).m k =
       case ALOOKUP e1.m k of SOME x => SOME x | NONE => ALOOKUP e2.m k) /\
     (SND_ALOOKUP (merge_env e1 e2).c k =
-      case SND_ALOOKUP e1.c k of SOME x => SOME x | NONE => SND_ALOOKUP e2.c k)``,
+      case SND_ALOOKUP e1.c k of SOME x => SOME x | NONE => SND_ALOOKUP e2.c k)`,
   fs [merge_env_def,ALOOKUP_APPEND]
   \\ Cases_on `e1.c` \\ pop_assum kall_tac \\ fs []
   \\ Cases_on `e2.c` \\ pop_assum kall_tac \\ fs []
   \\ fs [SND_ALOOKUP_EQ_ALOOKUP,ALOOKUP_APPEND]);
 
-val SND_ALOOKUP_INTRO = store_thm("SND_ALOOKUP_INTRO[compute]",
-  ``lookup_alist_mod_env (Short v) x = SND_ALOOKUP x v``,
+val SND_ALOOKUP_INTRO = Q.store_thm("SND_ALOOKUP_INTRO[compute]",
+  `lookup_alist_mod_env (Short v) x = SND_ALOOKUP x v`,
   Cases_on `x` \\ fs [lookup_alist_mod_env_def,SND_ALOOKUP_EQ_ALOOKUP]);
 
 
@@ -105,9 +105,9 @@ val write_exn_def = Define `
   write_exn mn n l env =
     write_cons n (LENGTH l,TypeExn (mk_id mn n)) env`;
 
-val write_rec_thm = store_thm("write_rec_thm",
-  ``write_rec funs env1 env =
-    env with v := build_rec_env funs env1 env.v``,
+val write_rec_thm = Q.store_thm("write_rec_thm",
+  `write_rec funs env1 env =
+    env with v := build_rec_env funs env1 env.v`,
   fs [write_rec_def,build_rec_env_def]
   \\ qspec_tac (`Recclosure env1 funs`,`hh`)
   \\ qspec_tac (`env`,`env`)
@@ -164,12 +164,12 @@ val Decls_Dtype = store_thm("Decls_Dtype",
   \\ rw[write_tds_thm,environment_component_equality,empty_env_def]
   \\ rw [] \\ eq_tac \\ rw [] \\ fs [] \\ fs [merge_alist_mod_env_def]);
 
-val Decls_Dexn = store_thm("Decls_Dexn",
-  ``!mn env s n l env2 s2.
+val Decls_Dexn = Q.store_thm("Decls_Dexn",
+  `!mn env s n l env2 s2.
       Decls mn env s [Dexn n l] env2 s2 <=>
       TypeExn (mk_id mn n) NOTIN s.defined_types /\
       s2 = s with defined_types := {TypeExn (mk_id mn n)} UNION s.defined_types /\
-      env2 = write_exn mn n l empty_env``,
+      env2 = write_exn mn n l empty_env`,
   SIMP_TAC std_ss [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -178,10 +178,10 @@ val Decls_Dexn = store_thm("Decls_Dexn",
   \\ fs[PULL_EXISTS,write_exn_thm,write_tds_thm,environment_component_equality]
   \\ rw [] \\ eq_tac \\ rw [] \\ fs [empty_env_def,merge_alist_mod_env_def]);
 
-val Decls_Dtabbrev = store_thm("Decls_Dtabbrev",
-  ``!mn env s n l env2 s2.
+val Decls_Dtabbrev = Q.store_thm("Decls_Dtabbrev",
+  `!mn env s n l env2 s2.
       Decls mn env s [Dtabbrev x y z] env2 s2 <=>
-      s2 = s ∧ env2 = empty_env``,
+      s2 = s ∧ env2 = empty_env`,
   fs [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -229,10 +229,10 @@ val Decls_Dletrec = store_thm("Decls_Dletrec",
   \\ fs [environment_component_equality]
   \\ simp[] \\ rw [] \\ eq_tac \\ rw []);
 
-val Decls_NIL = store_thm("Decls_NIL",
-  ``!mn env s n l env2 s2.
+val Decls_NIL = Q.store_thm("Decls_NIL",
+  `!mn env s n l env2 s2.
       Decls mn env s [] env2 s2 <=>
-      s2 = s ∧ env2 = empty_env``,
+      s2 = s ∧ env2 = empty_env`,
   fs [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -240,13 +240,13 @@ val Decls_NIL = store_thm("Decls_NIL",
   \\ rw [environment_component_equality] \\ eq_tac
   \\ fs [empty_env_def]);
 
-val Decls_CONS = store_thm("Decls_CONS",
-  ``!s1 s3 mn env1 d ds1 ds2 env3.
+val Decls_CONS = Q.store_thm("Decls_CONS",
+  `!s1 s3 mn env1 d ds1 ds2 env3.
       Decls mn env1 s1 (d::ds2) env3 s3 =
       ?envA envB s2.
          Decls mn env1 s1 [d] envA s2 /\
          Decls mn (merge_env envA env1) s2 ds2 envB s3 /\
-         env3 = merge_env envB envA``,
+         env3 = merge_env envB envA`,
   rw[Decls_def,PULL_EXISTS]
   \\ rw[Once evaluate_decs_cases,PULL_EXISTS]
   \\ rw[Once evaluate_decs_cases,SimpRHS,PULL_EXISTS]
@@ -269,33 +269,33 @@ val Decls_CONS = store_thm("Decls_CONS",
   \\ fs [] \\ rw [environment_component_equality]
   \\ Cases_on `env1.c` \\ fs [merge_alist_mod_env_def]);
 
-val merge_env_empty_env = store_thm("merge_env_empty_env",
-  ``merge_env env empty_env = env /\
-    merge_env empty_env env = env``,
+val merge_env_empty_env = Q.store_thm("merge_env_empty_env",
+  `merge_env env empty_env = env /\
+    merge_env empty_env env = env`,
   rw [environment_component_equality,merge_env_def,empty_env_def]);
 
-val merge_env_assoc = store_thm("merge_env_assoc",
-  ``merge_env env1 (merge_env env2 env3) = merge_env (merge_env env1 env2) env3``,
+val merge_env_assoc = Q.store_thm("merge_env_assoc",
+  `merge_env env1 (merge_env env2 env3) = merge_env (merge_env env1 env2) env3`,
   fs [merge_env_def]);
 
-val Decls_APPEND = store_thm("Decls_APPEND",
-  ``!s1 s3 mn env1 ds1 ds2 env3.
+val Decls_APPEND = Q.store_thm("Decls_APPEND",
+  `!s1 s3 mn env1 ds1 ds2 env3.
       Decls mn env1 s1 (ds1 ++ ds2) env3 s3 =
       ?envA envB s2.
          Decls mn env1 s1 ds1 envA s2 /\
          Decls mn (merge_env envA env1) s2 ds2 envB s3 /\
-         env3 = merge_env envB envA``,
+         env3 = merge_env envB envA`,
   Induct_on `ds1` \\ fs [APPEND,Decls_NIL,merge_env_empty_env]
   \\ once_rewrite_tac [Decls_CONS]
   \\ fs [PULL_EXISTS,merge_env_assoc] \\ metis_tac []);
 
-val Decls_SNOC = store_thm("Decls_SNOC",
-  ``!s1 s3 mn env1 ds1 d env3.
+val Decls_SNOC = Q.store_thm("Decls_SNOC",
+  `!s1 s3 mn env1 ds1 d env3.
       Decls mn env1 s1 (SNOC d ds1) env3 s3 =
       ?envA envB s2.
          Decls mn env1 s1 ds1 envA s2 /\
          Decls mn (merge_env envA env1) s2 [d] envB s3 /\
-         env3 = merge_env envB envA``,
+         env3 = merge_env envB envA`,
   METIS_TAC [SNOC_APPEND, Decls_APPEND]);
 
 
@@ -306,19 +306,19 @@ val Prog_def = Define `
     evaluate_prog F env1 s1 prog
       (s2,env2.c,Rval (env2.m,env2.v))`
 
-val Prog_NIL = store_thm("Prog_NIL",
-  ``!s1 s3 env1 ds1 ds2 env3.
-      Prog env1 s1 [] env3 s3 <=> (env3 = empty_env) /\ (s3 = s1)``,
+val Prog_NIL = Q.store_thm("Prog_NIL",
+  `!s1 s3 env1 ds1 ds2 env3.
+      Prog env1 s1 [] env3 s3 <=> (env3 = empty_env) /\ (s3 = s1)`,
   fs [Prog_def,Once evaluate_prog_cases] \\ EVAL_TAC \\ rw [empty_env_def]
   \\ fs [environment_component_equality] \\ eq_tac \\ rw []);
 
-val Prog_CONS = store_thm("Prog_CONS",
-  ``!s1 s3 env1 d ds2 env3.
+val Prog_CONS = Q.store_thm("Prog_CONS",
+  `!s1 s3 env1 d ds2 env3.
       Prog env1 s1 (d::ds2) env3 s3 =
       ?envA envB s2.
          Prog env1 s1 [d] envA s2 /\
          Prog (merge_env envA env1) s2 ds2 envB s3 /\
-         env3 = merge_env envB envA``,
+         env3 = merge_env envB envA`,
   fs [Prog_def]
   \\ simp [Once evaluate_prog_cases]
   \\ once_rewrite_tac [EQ_SYM_EQ]
@@ -349,19 +349,19 @@ val Prog_CONS = store_thm("Prog_CONS",
   \\ fs [] \\ Cases_on `new_tds'`
   \\ rw [environment_component_equality,merge_alist_mod_env_def]);
 
-val Prog_APPEND = store_thm("Prog_APPEND",
-  ``!s1 s3 env1 ds1 ds2 env3.
+val Prog_APPEND = Q.store_thm("Prog_APPEND",
+  `!s1 s3 env1 ds1 ds2 env3.
       Prog env1 s1 (ds1 ++ ds2) env3 s3 =
       ?envA envB s2.
          Prog env1 s1 ds1 envA s2 /\
          Prog (merge_env envA env1) s2 ds2 envB s3 /\
-         env3 = merge_env envB envA``,
+         env3 = merge_env envB envA`,
   Induct_on `ds1` \\ fs [Prog_NIL] \\ once_rewrite_tac [Prog_CONS]
   \\ fs [] \\ metis_tac [merge_env_assoc,merge_env_empty_env]);
 
-val Prog_Tdec = store_thm("Prog_Tdec",
-  ``Prog env1 s1 [Tdec d] env2 s2 <=>
-    Decls NONE env1 s1 [d] env2 s2``,
+val Prog_Tdec = Q.store_thm("Prog_Tdec",
+  `Prog env1 s1 [Tdec d] env2 s2 <=>
+    Decls NONE env1 s1 [d] env2 s2`,
   fs [Prog_def,Decls_def,Once evaluate_prog_cases]
   \\ fs [Prog_def,Decls_def,Once evaluate_prog_cases]
   \\ fs [combine_mod_result_def,Once evaluate_top_cases,PULL_EXISTS]
@@ -370,13 +370,13 @@ val Prog_Tdec = store_thm("Prog_Tdec",
          extend_top_env_def,environment_component_equality]
   \\ rw [] \\ eq_tac \\ rw [] \\ asm_exists_tac \\ fs []);
 
-val Prog_Tmod = store_thm("Prog_Tmod",
-  ``Prog env1 s1 [Tmod mn specs ds] env2 s2 <=>
+val Prog_Tmod = Q.store_thm("Prog_Tmod",
+  `Prog env1 s1 [Tmod mn specs ds] env2 s2 <=>
     mn ∉ s1.defined_mods /\ no_dup_types ds /\
     ?s env.
       Decls (SOME mn) env1 s1 ds env s /\
       s2 = s with defined_mods := {mn} ∪ s.defined_mods /\
-      env2 = write_mod mn env empty_env``,
+      env2 = write_mod mn env empty_env`,
   fs [Prog_def,Decls_def,Once evaluate_prog_cases,PULL_EXISTS,
       combine_mod_result_def,Once evaluate_top_cases]
   \\ fs [Prog_def,Decls_def,Once evaluate_prog_cases,PULL_EXISTS,
@@ -419,8 +419,8 @@ in
     init_state ffi = ^init_state_tm`;
 end
 
-val ML_code_NIL = store_thm("ML_code_NIL",
-  ``ML_code init_env (init_state ffi) [] NONE empty_env (init_state ffi)``,
+val ML_code_NIL = Q.store_thm("ML_code_NIL",
+  `ML_code init_env (init_state ffi) [] NONE empty_env (init_state ffi)`,
   fs [ML_code_def,Prog_NIL]);
 
 (* opening and closing of modules *)
@@ -480,13 +480,13 @@ val ML_code_SOME_Dtype = store_thm("ML_code_SOME_Dtype",
 
 (* appending a Dexn *)
 
-val ML_code_NONE_Dexn = store_thm("ML_code_NONE_Dexn",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dexn = Q.store_thm("ML_code_NONE_Dexn",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !n l.
       TypeExn (mk_id NONE n) ∉ s2.defined_types ==>
       ML_code env1 s1 (SNOC (Tdec (Dexn n l)) prog) NONE
         (write_exn NONE n l env2)
-        (s2 with defined_types := {TypeExn (mk_id NONE n)} ∪ s2.defined_types)``,
+        (s2 with defined_types := {TypeExn (mk_id NONE n)} ∪ s2.defined_types)`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dexn]
   \\ rw [] \\ asm_exists_tac \\ fs [] \\ Cases_on `env2.c`
   \\ fs [write_exn_thm,merge_env_def,merge_alist_mod_env_def,empty_env_def]
@@ -509,10 +509,10 @@ val ML_code_SOME_Dexn = store_thm("ML_code_SOME_Dexn",
 
 (* appending a Dtabbrev *)
 
-val ML_code_NONE_Dtabbrev = store_thm("ML_code_NONE_Dtabbrev",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dtabbrev = Q.store_thm("ML_code_NONE_Dtabbrev",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !x y z.
-      ML_code env1 s1 (SNOC (Tdec (Dtabbrev x y z)) prog) NONE env2 s2``,
+      ML_code env1 s1 (SNOC (Tdec (Dtabbrev x y z)) prog) NONE env2 s2`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dtabbrev,
       merge_env_empty_env]);
 
@@ -526,9 +526,9 @@ val ML_code_SOME_Dtabbrev = store_thm("ML_code_SOME_Dtabbrev",
 
 (* appending a Letrec *)
 
-val build_rec_env_APPEND = prove(
-  ``build_rec_env funs cl_env [] ++ add_to_env =
-    build_rec_env funs cl_env add_to_env``,
+val build_rec_env_APPEND = Q.prove(
+  `build_rec_env funs cl_env [] ++ add_to_env =
+    build_rec_env funs cl_env add_to_env`,
   fs [build_rec_env_def] \\ qspec_tac (`Recclosure cl_env funs`,`xxx`)
   \\ qspec_tac (`add_to_env`,`xs`)
   \\ Induct_on `funs` \\ fs [FORALL_PROD]);
@@ -589,11 +589,11 @@ val ML_code_SOME_Dlet_var = store_thm("ML_code_SOME_Dlet_var",
   \\ fs [write_def,merge_env_def,empty_env_def]
   \\ fs [extend_top_env_def,environment_component_equality]);
 
-val ML_code_NONE_Dlet_Fun = store_thm("ML_code_NONE_Dlet_Fun",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dlet_Fun = Q.store_thm("ML_code_NONE_Dlet_Fun",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !n v e.
       ML_code env1 s1 (SNOC (Tdec (Dlet (Pvar n) (Fun v e))) prog)
-        NONE (write n (Closure (merge_env env2 env1) v e) env2) s2``,
+        NONE (write n (Closure (merge_env env2 env1) v e) env2) s2`,
   rw [] \\ match_mp_tac (ML_code_NONE_Dlet_var |> MP_CANON) \\ fs []
   \\ fs [Once evaluate_cases]);
 
@@ -607,9 +607,9 @@ val ML_code_SOME_Dlet_Fun = store_thm("ML_code_SOME_Dlet_Fun",
 
 (* misc used by automation *)
 
-val DISJOINT_set_simp = store_thm("DISJOINT_set_simp",
-  ``DISJOINT (set []) s /\
-    (DISJOINT (set (x::xs)) s <=> ~(x IN s) /\ DISJOINT (set xs) s)``,
+val DISJOINT_set_simp = Q.store_thm("DISJOINT_set_simp",
+  `DISJOINT (set []) s /\
+    (DISJOINT (set (x::xs)) s <=> ~(x IN s) /\ DISJOINT (set xs) s)`,
   fs [DISJOINT_DEF,EXTENSION] \\ metis_tac []);
 
 val _ = export_theory();

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -56,8 +56,8 @@ val write_cons_simp = Q.store_thm("write_cons_simp[compute]",
   Cases_on `env.c`
   \\ rw [write_cons_def,merge_alist_mod_env_def,SND_ALOOKUP_def]);
 
-val SND_ALOOKUP_EQ_ALOOKUP = store_thm("SND_ALOOKUP_EQ_ALOOKUP",
-  ``!xs ys q. SND_ALOOKUP (xs,ys) q = ALOOKUP ys q``,
+val SND_ALOOKUP_EQ_ALOOKUP = Q.store_thm("SND_ALOOKUP_EQ_ALOOKUP",
+  `!xs ys q. SND_ALOOKUP (xs,ys) q = ALOOKUP ys q`,
   Induct_on `ys` \\ fs [ALOOKUP_def,SND_ALOOKUP_def,FORALL_PROD] \\ rw []);
 
 val write_mod_simp = Q.store_thm("write_mod_simp[compute]",
@@ -114,9 +114,9 @@ val write_rec_thm = Q.store_thm("write_rec_thm",
   \\ Induct_on `funs` \\ fs [FORALL_PROD]
   \\ fs [environment_component_equality,write_def]);
 
-val write_tds_thm = store_thm("write_tds_thm",
-  ``write_tds mn tds env =
-    env with c := merge_alist_mod_env ([],build_tdefs mn tds) env.c``,
+val write_tds_thm = Q.store_thm("write_tds_thm",
+  `write_tds mn tds env =
+    env with c := merge_alist_mod_env ([],build_tdefs mn tds) env.c`,
   Cases_on `env.c`
   \\ fs [write_tds_def,merge_alist_mod_env_def]
   \\ pop_assum mp_tac
@@ -130,10 +130,10 @@ val write_tds_thm = store_thm("write_tds_thm",
   \\ simp [environment_component_equality,FORALL_PROD,write_cons_def,
            merge_alist_mod_env_def]);
 
-val write_exn_thm = store_thm("write_exn_thm",
-  ``write_exn mn n l env =
+val write_exn_thm = Q.store_thm("write_exn_thm",
+  `write_exn mn n l env =
     env with c := merge_alist_mod_env
-                    ([],[(n,LENGTH l,TypeExn (mk_id mn n))]) env.c``,
+                    ([],[(n,LENGTH l,TypeExn (mk_id mn n))]) env.c`,
   fs [write_exn_def,write_cons_def]);
 
 
@@ -147,14 +147,14 @@ val Decls_def = Define `
       env2.c = ([],new_tds) ∧
       env2.v = res_env`;
 
-val Decls_Dtype = store_thm("Decls_Dtype",
-  ``!mn env s tds env2 s2.
+val Decls_Dtype = Q.store_thm("Decls_Dtype",
+  `!mn env s tds env2 s2.
       Decls mn env s [Dtype tds] env2 s2 <=>
       check_dup_ctors tds /\
       DISJOINT (type_defs_to_new_tdecs mn tds) s.defined_types /\
       ALL_DISTINCT (MAP (\(tvs,tn,ctors). tn) tds) /\
       s2 = s with defined_types := type_defs_to_new_tdecs mn tds UNION s.defined_types /\
-      env2 = write_tds mn tds empty_env``,
+      env2 = write_tds mn tds empty_env`,
   SIMP_TAC std_ss [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -188,11 +188,11 @@ val Decls_Dtabbrev = Q.store_thm("Decls_Dtabbrev",
   \\ SIMP_TAC (srw_ss()) [evaluate_dec_cases, combine_dec_result_def]
   \\ rw [environment_component_equality] \\ eq_tac \\ fs [empty_env_def]);
 
-val Decls_Dlet = store_thm("Decls_Dlet",
-  ``!mn env s1 v e s2 env2.
+val Decls_Dlet = Q.store_thm("Decls_Dlet",
+  `!mn env s1 v e s2 env2.
       Decls mn env s1 [Dlet (Pvar v) e] env2 s2 <=>
       ?x. evaluate F env s1 e (s2,Rval x) /\
-          (env2 = write v x empty_env)``,
+          (env2 = write v x empty_env)`,
   SIMP_TAC std_ss [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -206,17 +206,17 @@ val Decls_Dlet = store_thm("Decls_Dlet",
   \\ simp[] \\ rw [] \\ eq_tac \\ rw []
   \\ METIS_TAC [big_unclocked, pair_CASES, evaluate_no_new_types_mods,FST]);
 
-val FOLDR_LEMMA = prove(
-  ``!xs ys. FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) [] xs ++ ys =
-            FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) ys xs``,
+val FOLDR_LEMMA = Q.prove(
+  `!xs ys. FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) [] xs ++ ys =
+            FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) ys xs`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [FORALL_PROD]);
 
-val Decls_Dletrec = store_thm("Decls_Dletrec",
-  ``!mn env s1 funs s2 env2.
+val Decls_Dletrec = Q.store_thm("Decls_Dletrec",
+  `!mn env s1 funs s2 env2.
       Decls mn env s1 [Dletrec funs] env2 s2 <=>
       (s2 = s1) /\
       ALL_DISTINCT (MAP (\(x,y,z). x) funs) /\
-      (env2 = write_rec funs env empty_env)``,
+      (env2 = write_rec funs env empty_env)`,
   SIMP_TAC std_ss [Decls_def]
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
   \\ ONCE_REWRITE_TAC [evaluate_decs_cases] \\ SIMP_TAC (srw_ss()) []
@@ -425,18 +425,18 @@ val ML_code_NIL = Q.store_thm("ML_code_NIL",
 
 (* opening and closing of modules *)
 
-val ML_code_new_module = store_thm("ML_code_new_module",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_new_module = Q.store_thm("ML_code_new_module",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !mn. mn ∉ s2.defined_mods ==>
-         ML_code env1 s1 prog (SOME (mn,[],env2)) empty_env s2``,
+         ML_code env1 s1 prog (SOME (mn,[],env2)) empty_env s2`,
   fs [ML_code_def] \\ rw [Decls_NIL] \\ EVAL_TAC);
 
-val ML_code_close_module = store_thm("ML_code_close_module",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_close_module = Q.store_thm("ML_code_close_module",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !sigs.
       ML_code env1 s1 (SNOC (Tmod mn sigs ds) prog) NONE
         (write_mod mn env2 env)
-        (s2 with defined_mods := mn INSERT s2.defined_mods)``,
+        (s2 with defined_mods := mn INSERT s2.defined_mods)`,
   fs [ML_code_def] \\ rw [] \\ fs [SNOC_APPEND,Prog_APPEND]
   \\ asm_exists_tac \\ fs [Prog_Tmod,PULL_EXISTS]
   \\ asm_exists_tac \\ fs []
@@ -447,8 +447,8 @@ val ML_code_close_module = store_thm("ML_code_close_module",
 
 (* appending a Dtype *)
 
-val ML_code_NONE_Dtype = store_thm("ML_code_NONE_Dtype",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dtype = Q.store_thm("ML_code_NONE_Dtype",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !tds.
       check_dup_ctors tds ∧
       DISJOINT (type_defs_to_new_tdecs NONE tds) s2.defined_types ∧
@@ -456,14 +456,14 @@ val ML_code_NONE_Dtype = store_thm("ML_code_NONE_Dtype",
       ML_code env1 s1 (SNOC (Tdec (Dtype tds)) prog) NONE
         (write_tds NONE tds env2)
         (s2 with defined_types :=
-                   type_defs_to_new_tdecs NONE tds ∪ s2.defined_types)``,
+                   type_defs_to_new_tdecs NONE tds ∪ s2.defined_types)`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dtype]
   \\ rw [] \\ asm_exists_tac \\ fs [] \\ Cases_on `env2.c`
   \\ fs [write_tds_thm,merge_env_def,merge_alist_mod_env_def,empty_env_def]
   \\ fs [extend_top_env_def,environment_component_equality]);
 
-val ML_code_SOME_Dtype = store_thm("ML_code_SOME_Dtype",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dtype = Q.store_thm("ML_code_SOME_Dtype",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !tds.
       check_dup_ctors tds ∧ no_dup_types (SNOC (Dtype tds) ds) /\
       DISJOINT (type_defs_to_new_tdecs (SOME mn) tds) s2.defined_types ∧
@@ -471,7 +471,7 @@ val ML_code_SOME_Dtype = store_thm("ML_code_SOME_Dtype",
       ML_code env1 s1 prog (SOME (mn,SNOC (Dtype tds) ds,env))
         (write_tds (SOME mn) tds env2)
         (s2 with defined_types :=
-                   type_defs_to_new_tdecs (SOME mn) tds ∪ s2.defined_types)``,
+                   type_defs_to_new_tdecs (SOME mn) tds ∪ s2.defined_types)`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dtype,Decls_SNOC]
   \\ rw [] \\ asm_exists_tac \\ fs [] \\ rw [] \\ asm_exists_tac
   \\ fs [] \\ Cases_on `env2.c`
@@ -492,14 +492,14 @@ val ML_code_NONE_Dexn = Q.store_thm("ML_code_NONE_Dexn",
   \\ fs [write_exn_thm,merge_env_def,merge_alist_mod_env_def,empty_env_def]
   \\ fs [extend_top_env_def,environment_component_equality]);
 
-val ML_code_SOME_Dexn = store_thm("ML_code_SOME_Dexn",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dexn = Q.store_thm("ML_code_SOME_Dexn",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !n l.
       TypeExn (mk_id (SOME mn) n) ∉ s2.defined_types ==>
       ML_code env1 s1 prog (SOME (mn,SNOC (Dexn n l) ds,env))
         (write_exn (SOME mn) n l env2)
         (s2 with defined_types :=
-                   {TypeExn (mk_id (SOME mn) n)} ∪ s2.defined_types)``,
+                   {TypeExn (mk_id (SOME mn) n)} ∪ s2.defined_types)`,
   fs [ML_code_def,SNOC_APPEND,Decls_APPEND,Prog_Tdec,Decls_Dexn]
   \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [no_dup_types_def,  decs_to_types_def]
@@ -516,10 +516,10 @@ val ML_code_NONE_Dtabbrev = Q.store_thm("ML_code_NONE_Dtabbrev",
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dtabbrev,
       merge_env_empty_env]);
 
-val ML_code_SOME_Dtabbrev = store_thm("ML_code_SOME_Dtabbrev",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dtabbrev = Q.store_thm("ML_code_SOME_Dtabbrev",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !x y z.
-      ML_code env1 s1 prog (SOME (mn,SNOC (Dtabbrev x y z) ds,env)) env2 s2``,
+      ML_code env1 s1 prog (SOME (mn,SNOC (Dtabbrev x y z) ds,env)) env2 s2`,
   fs [ML_code_def,SNOC_APPEND,Decls_APPEND,Prog_Tdec,Decls_Dtabbrev]
   \\ rw [] \\ asm_exists_tac \\ fs [no_dup_types_def,  decs_to_types_def]
   \\ asm_exists_tac \\ fs [merge_env_empty_env]);
@@ -533,24 +533,24 @@ val build_rec_env_APPEND = Q.prove(
   \\ qspec_tac (`add_to_env`,`xs`)
   \\ Induct_on `funs` \\ fs [FORALL_PROD]);
 
-val ML_code_NONE_Dletrec = store_thm("ML_code_NONE_Dletrec",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dletrec = Q.store_thm("ML_code_NONE_Dletrec",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !fns.
       ALL_DISTINCT (MAP (λ(x,y,z). x) fns) ==>
       ML_code env1 s1 (SNOC (Tdec (Dletrec fns)) prog) NONE
-        (write_rec fns (merge_env env2 env1) env2) s2``,
+        (write_rec fns (merge_env env2 env1) env2) s2`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dletrec]
   \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [merge_env_def,write_rec_thm,empty_env_def]
   \\ fs [extend_top_env_def,environment_component_equality]
   \\ fs [build_rec_env_APPEND]);
 
-val ML_code_SOME_Dletrec = store_thm("ML_code_SOME_Dletrec",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dletrec = Q.store_thm("ML_code_SOME_Dletrec",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !fns.
       ALL_DISTINCT (MAP (λ(x,y,z). x) fns) ==>
       ML_code env1 s1 prog (SOME (mn,SNOC (Dletrec fns) ds,env))
-        (write_rec fns (merge_env env2 (merge_env env env1)) env2) s2``,
+        (write_rec fns (merge_env env2 (merge_env env env1)) env2) s2`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dletrec,Decls_SNOC]
   \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [no_dup_types_def,  decs_to_types_def]
@@ -561,26 +561,26 @@ val ML_code_SOME_Dletrec = store_thm("ML_code_SOME_Dletrec",
 
 (* appending a Let *)
 
-val ML_code_NONE_Dlet_var = store_thm("ML_code_NONE_Dlet_var",
-  ``ML_code env1 s1 prog NONE env2 s2 ==>
+val ML_code_NONE_Dlet_var = Q.store_thm("ML_code_NONE_Dlet_var",
+  `ML_code env1 s1 prog NONE env2 s2 ==>
     !e x s3.
       evaluate F (merge_env env2 env1) s2 e (s3,Rval x) ==>
       !n.
         ML_code env1 s1 (SNOC (Tdec (Dlet (Pvar n) e)) prog)
-          NONE (write n x env2) s3``,
+          NONE (write n x env2) s3`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dlet]
   \\ rw [] \\ asm_exists_tac \\ fs [PULL_EXISTS]
   \\ rw [] \\ asm_exists_tac \\ fs []
   \\ fs [write_def,merge_env_def,empty_env_def]
   \\ fs [extend_top_env_def,environment_component_equality]);
 
-val ML_code_SOME_Dlet_var = store_thm("ML_code_SOME_Dlet_var",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dlet_var = Q.store_thm("ML_code_SOME_Dlet_var",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !e x s3.
       evaluate F (merge_env env2 (merge_env env env1)) s2 e (s3,Rval x) ==>
       !n.
         ML_code env1 s1 prog (SOME (mn,SNOC (Dlet (Pvar n) e) ds,env))
-          (write n x env2) s3``,
+          (write n x env2) s3`,
   fs [ML_code_def,SNOC_APPEND,Prog_APPEND,Prog_Tdec,Decls_Dlet,Decls_SNOC]
   \\ rw [] \\ asm_exists_tac \\ fs [PULL_EXISTS]
   \\ fs [no_dup_types_def,  decs_to_types_def]
@@ -597,11 +597,11 @@ val ML_code_NONE_Dlet_Fun = Q.store_thm("ML_code_NONE_Dlet_Fun",
   rw [] \\ match_mp_tac (ML_code_NONE_Dlet_var |> MP_CANON) \\ fs []
   \\ fs [Once evaluate_cases]);
 
-val ML_code_SOME_Dlet_Fun = store_thm("ML_code_SOME_Dlet_Fun",
-  ``ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
+val ML_code_SOME_Dlet_Fun = Q.store_thm("ML_code_SOME_Dlet_Fun",
+  `ML_code env1 s1 prog (SOME (mn,ds,env)) env2 s2 ==>
     !n v e.
       ML_code env1 s1 prog (SOME (mn,SNOC (Dlet (Pvar n) (Fun v e)) ds,env))
-        (write n (Closure (merge_env env2 (merge_env env env1)) v e) env2) s2``,
+        (write n (Closure (merge_env env2 (merge_env env env1)) v e) env2) s2`,
   rw [] \\ match_mp_tac (ML_code_SOME_Dlet_var |> MP_CANON) \\ fs []
   \\ fs [Once evaluate_cases]);
 

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -95,10 +95,10 @@ val evaluate_11_Rval = store_thm("evaluate_11_Rval",
   REPEAT STRIP_TAC \\ IMP_RES_TAC big_exp_determ
   \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val Eval_Arrow = store_thm("Eval_Arrow",
-  ``Eval env x1 ((a --> b) f) ==>
+val Eval_Arrow = Q.store_thm("Eval_Arrow",
+  `Eval env x1 ((a --> b) f) ==>
     Eval env x2 (a x) ==>
-    Eval env (App Opapp [x1;x2]) (b (f x))``,
+    Eval env (App Opapp [x1;x2]) (b (f x))`,
   SIMP_TAC std_ss [Eval_def,Arrow_def] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
   \\ FULL_SIMP_TAC std_ss [AppReturns_def] \\ RES_TAC
@@ -110,44 +110,44 @@ val Eval_Arrow = store_thm("Eval_Arrow",
   \\ ntac 3 (rw [Once (hd (tl (CONJUNCTS evaluate_cases)))])
   \\ METIS_TAC []);
 
-val Eval_Fun = store_thm("Eval_Fun",
-  ``(!v x. a x v ==> Eval (write name v env) body (b ((f:'a->'b) x))) ==>
-    Eval env (Fun name body) ((a --> b) f)``,
+val Eval_Fun = Q.store_thm("Eval_Fun",
+  `(!v x. a x v ==> Eval (write name v env) body (b ((f:'a->'b) x))) ==>
+    Eval env (Fun name body) ((a --> b) f)`,
   SIMP_TAC std_ss [Eval_def,Arrow_def] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
   \\ FULL_SIMP_TAC (srw_ss()) [AppReturns_def,Eval_def,do_opapp_def,
        evaluate_closure_def,write_def]);
 
-val Eval_Fun_Eq = store_thm("Eval_Fun_Eq",
-  ``(!v. a x v ==> Eval (write name v env) body (b (f x))) ==>
-    Eval env (Fun name body) ((Eq a x --> b) f)``,
+val Eval_Fun_Eq = Q.store_thm("Eval_Fun_Eq",
+  `(!v. a x v ==> Eval (write name v env) body (b (f x))) ==>
+    Eval env (Fun name body) ((Eq a x --> b) f)`,
   SIMP_TAC std_ss [Eval_def,Arrow_def] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
   \\ FULL_SIMP_TAC (srw_ss()) [AppReturns_def,Eval_def,do_opapp_def,
        evaluate_closure_def,write_def,Eq_def]);
 
-val And_IMP_Eq = store_thm("And_IMP_Eq",
-  ``Eval env exp ((And a P --> b) f) ==>
-    (P x ==> Eval env exp ((Eq a x --> b) f))``,
+val And_IMP_Eq = Q.store_thm("And_IMP_Eq",
+  `Eval env exp ((And a P --> b) f) ==>
+    (P x ==> Eval env exp ((Eq a x --> b) f))`,
   FULL_SIMP_TAC std_ss [Eval_def,Arrow_def,AppReturns_def,And_def,Eq_def]
   \\ METIS_TAC []);
 
-val Eq_IMP_And = store_thm("Eq_IMP_And",
-  ``(!x. P x ==> Eval env (Fun name exp) ((Eq a x --> b) f)) ==>
-    Eval env (Fun name exp) ((And a P --> b) f)``,
+val Eq_IMP_And = Q.store_thm("Eq_IMP_And",
+  `(!x. P x ==> Eval env (Fun name exp) ((Eq a x --> b) f)) ==>
+    Eval env (Fun name exp) ((And a P --> b) f)`,
   FULL_SIMP_TAC std_ss [Eval_def,Arrow_def,AppReturns_def,And_def,Eq_def]
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []);
 
-val Eval_Fun_And = store_thm("Eval_Fun_And",
-  ``(!v x. P x ==> a x v ==> Eval (write name v env) body (b (f x))) ==>
-    Eval env (Fun name body) ((And a P --> b) f)``,
+val Eval_Fun_And = Q.store_thm("Eval_Fun_And",
+  `(!v x. P x ==> a x v ==> Eval (write name v env) body (b (f x))) ==>
+    Eval env (Fun name body) ((And a P --> b) f)`,
   FULL_SIMP_TAC std_ss [GSYM And_def,AND_IMP_INTRO]
   \\ REPEAT STRIP_TAC \\ MATCH_MP_TAC Eval_Fun \\ ASM_SIMP_TAC std_ss []);
 
-val Eval_Let = store_thm("Eval_Let",
-  ``Eval env exp (a res) /\
+val Eval_Let = Q.store_thm("Eval_Let",
+  `Eval env exp (a res) /\
     (!v. a res v ==> Eval (write name v env) body (b (f res))) ==>
-    Eval env (Let (SOME name) exp body) (b (LET f res))``,
+    Eval env (Let (SOME name) exp body) (b (LET f res))`,
   SIMP_TAC std_ss [Eval_def,Arrow_def] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
   \\ RES_TAC \\ Q.EXISTS_TAC `res''` \\ FULL_SIMP_TAC std_ss [LET_DEF,opt_bind_def]
@@ -164,58 +164,58 @@ val lookup_cons_def = Define `
 val lookup_mod_def = Define `
   lookup_mod name env = ALOOKUP env.m name`;
 
-val lookup_cons_thm = store_thm("lookup_cons_thm",
-  ``lookup_cons name (env:v environment) =
-      lookup_alist_mod_env (Short name) env.c``,
+val lookup_cons_thm = Q.store_thm("lookup_cons_thm",
+  `lookup_cons name (env:v environment) =
+      lookup_alist_mod_env (Short name) env.c`,
   Cases_on `env.c`
   \\ fs [lookup_cons_def,lookup_alist_mod_env_def,SND_ALOOKUP_EQ_ALOOKUP]);
 
-val lookup_var_id_thm = store_thm("lookup_var_id_thm",
-  ``(lookup_var_id (Short v) env = lookup_var v env) /\
+val lookup_var_id_thm = Q.store_thm("lookup_var_id_thm",
+  `(lookup_var_id (Short v) env = lookup_var v env) /\
     (lookup_var_id (Long mn v) env =
        case lookup_mod mn env of
        | NONE => NONE
-       | SOME env1 => ALOOKUP env1 v)``,
+       | SOME env1 => ALOOKUP env1 v)`,
   fs [lookup_var_id_def,lookup_mod_def,lookup_var_def] \\ CASE_TAC \\ fs []);
 
-val lookup_var_write = store_thm("lookup_var_write",
-  ``(lookup_var v (write w x env) = if v = w then SOME x else lookup_var v env) /\
+val lookup_var_write = Q.store_thm("lookup_var_write",
+  `(lookup_var v (write w x env) = if v = w then SOME x else lookup_var v env) /\
     (lookup_var_id (Short v) (write w x env) =
         if v = w then SOME x else lookup_var_id (Short v) env) /\
     (lookup_var_id (Long mn v) (write w x env) =
         lookup_var_id (Long mn v) env) /\
-    (lookup_cons name (write w x env) = lookup_cons name env)``,
+    (lookup_cons name (write w x env) = lookup_cons name env)`,
   fs [lookup_var_id_def,lookup_var_def,write_def,lookup_cons_thm] \\ rw []);
 
-val lookup_var_write_mod = store_thm("lookup_var_write_mod",
-  ``(lookup_var v (write_mod mn e1 env) = lookup_var v env) /\
+val lookup_var_write_mod = Q.store_thm("lookup_var_write_mod",
+  `(lookup_var v (write_mod mn e1 env) = lookup_var v env) /\
     (lookup_mod m (write_mod mn e1 env) =
      if m = mn then SOME e1.v else lookup_mod m env) /\
-    (lookup_cons name (write_mod mn e1 env) = lookup_cons name env)``,
+    (lookup_cons name (write_mod mn e1 env) = lookup_cons name env)`,
   fs [lookup_var_id_def,lookup_var_def,write_mod_def,
       lookup_cons_thm,lookup_mod_def] \\ rw []
   \\ Cases_on `env.c` \\ fs [] \\ fs [lookup_alist_mod_env_def]);
 
-val lookup_var_write_cons = store_thm("lookup_var_write_mod",
-  ``(lookup_var v (write_cons n d env) = lookup_var v env) /\
+val lookup_var_write_cons = Q.store_thm("lookup_var_write_mod",
+  `(lookup_var v (write_cons n d env) = lookup_var v env) /\
     (lookup_mod m (write_cons n d env) = lookup_mod m env) /\
     (lookup_cons name (write_cons n d env) =
-     if name = n then SOME d else lookup_cons name env)``,
+     if name = n then SOME d else lookup_cons name env)`,
   fs [lookup_var_id_def,lookup_var_def,write_cons_def,
       lookup_cons_thm,lookup_mod_def] \\ rw []
   \\ Cases_on `env.c` \\ fs []
   \\ fs [lookup_alist_mod_env_def,merge_alist_mod_env_def]);
 
-val lookup_var_empty_env = store_thm("lookup_var_empty_env",
-  ``(lookup_var v empty_env = NONE) /\
+val lookup_var_empty_env = Q.store_thm("lookup_var_empty_env",
+  `(lookup_var v empty_env = NONE) /\
     (lookup_var_id (Short v) empty_env = NONE) /\
     (lookup_var_id (Long m v) empty_env = NONE) /\
-    (lookup_cons name empty_env = NONE)``,
+    (lookup_cons name empty_env = NONE)`,
   fs [lookup_var_id_def,lookup_var_def,empty_env_def,lookup_cons_thm] \\ rw []
   \\ fs [lookup_alist_mod_env_def]);
 
-val lookup_var_merge_env = store_thm("lookup_var_merge_env",
-  ``(lookup_var v1 (merge_env e1 e2) =
+val lookup_var_merge_env = Q.store_thm("lookup_var_merge_env",
+  `(lookup_var v1 (merge_env e1 e2) =
        case lookup_var v1 e1 of
        | NONE => lookup_var v1 e2
        | res => res) /\
@@ -226,28 +226,28 @@ val lookup_var_merge_env = store_thm("lookup_var_merge_env",
     (lookup_mod v1 (merge_env e1 e2) =
        case lookup_mod v1 e1 of
        | NONE => lookup_mod v1 e2
-       | res => res)``,
+       | res => res)`,
   fs [lookup_var_def,lookup_cons_thm,merge_env_def,ALOOKUP_APPEND,lookup_mod_def]
   \\ Cases_on `e1.c` \\ Cases_on `e2.c`
   \\ fs [lookup_alist_mod_env_def,ALOOKUP_APPEND]);
 
-val Eval_Var_Short = store_thm("Eval_Var_Short",
-  ``P v ==> !name env.
+val Eval_Var_Short = Q.store_thm("Eval_Var_Short",
+  `P v ==> !name env.
                (lookup_var_id (Short name) env = SOME v) ==>
-               Eval env (Var (Short name)) P``,
+               Eval env (Var (Short name)) P`,
   fs [Eval_def,Once evaluate_cases]);
 
-val Eval_Var_Long = store_thm("Eval_Var_Long",
-  ``P v ==> !m name env.
+val Eval_Var_Long = Q.store_thm("Eval_Var_Long",
+  `P v ==> !m name env.
                (lookup_var_id (Long m name) env = SOME v) ==>
-               Eval env (Var (Long m name)) P``,
+               Eval env (Var (Long m name)) P`,
   fs [Eval_def,Once evaluate_cases]);
 
-val Eval_Var_SWAP_ENV = store_thm("Eval_Var_SWAP_ENV",
-  ``!env1.
+val Eval_Var_SWAP_ENV = Q.store_thm("Eval_Var_SWAP_ENV",
+  `!env1.
       Eval env1 (Var (Short name)) P /\
       (lookup_var name env = lookup_var name env1) ==>
-      Eval env (Var (Short name)) P``,
+      Eval env (Var (Short name)) P`,
   FULL_SIMP_TAC std_ss [FORALL_PROD,lookup_var_def]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases,Eval_def, lookup_var_id_def]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases,Eval_def, lookup_var_id_def]);
@@ -255,60 +255,60 @@ val Eval_Var_SWAP_ENV = store_thm("Eval_Var_SWAP_ENV",
 val LOOKUP_VAR_def = Define `
   LOOKUP_VAR name env x = (lookup_var name env = SOME x)`;
 
-val LOOKUP_VAR_THM = store_thm("LOOKUP_VAR_THM",
-  ``LOOKUP_VAR name env x ==> Eval env (Var (Short name)) ($= x)``,
+val LOOKUP_VAR_THM = Q.store_thm("LOOKUP_VAR_THM",
+  `LOOKUP_VAR name env x ==> Eval env (Var (Short name)) ($= x)`,
   FULL_SIMP_TAC std_ss [FORALL_PROD,lookup_var_def]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases,Eval_def,LOOKUP_VAR_def,
        lookup_var_id_def,lookup_var_def]);
 
-val LOOKUP_VAR_SIMP = store_thm("LOOKUP_VAR_SIMP",
-  ``LOOKUP_VAR name (write x v  env) y =
-    if x = name then (v = y) else LOOKUP_VAR name env y``,
+val LOOKUP_VAR_SIMP = Q.store_thm("LOOKUP_VAR_SIMP",
+  `LOOKUP_VAR name (write x v  env) y =
+    if x = name then (v = y) else LOOKUP_VAR name env y`,
   ASM_SIMP_TAC std_ss [LOOKUP_VAR_def,lookup_var_id_def,write_def,
        lookup_var_def] \\ SRW_TAC [] []);
 
-val Eval_Val_INT = store_thm("Eval_Val_INT",
-  ``!n. Eval env (Lit (IntLit n)) (INT n)``,
+val Eval_Val_INT = Q.store_thm("Eval_Val_INT",
+  `!n. Eval env (Lit (IntLit n)) (INT n)`,
   SIMP_TAC (srw_ss()) [Once evaluate_cases,NUM_def,INT_def,Eval_def]);
 
-val Eval_Val_NUM = store_thm("Eval_Val_NUM",
-  ``!n. Eval env (Lit (IntLit (&n))) (NUM n)``,
+val Eval_Val_NUM = Q.store_thm("Eval_Val_NUM",
+  `!n. Eval env (Lit (IntLit (&n))) (NUM n)`,
   SIMP_TAC (srw_ss()) [Once evaluate_cases,NUM_def,INT_def,Eval_def]);
 
-val Eval_Val_UNIT = store_thm("Eval_Val_UNIT",
-  ``Eval env (Con NONE []) (UNIT_TYPE ())``,
+val Eval_Val_UNIT = Q.store_thm("Eval_Val_UNIT",
+  `Eval env (Con NONE []) (UNIT_TYPE ())`,
   SIMP_TAC (srw_ss()) [Once evaluate_cases,UNIT_TYPE_def,Eval_def,
      build_conv_def,do_con_check_def] \\ fs [Once evaluate_cases]);
 
-val Eval_Val_BOOL_T = store_thm("Eval_Val_BOOL_T",
-  ``Eval env (App (Opb Leq) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL T)``,
+val Eval_Val_BOOL_T = Q.store_thm("Eval_Val_BOOL_T",
+  `Eval env (App (Opb Leq) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL T)`,
   NTAC 5 (SIMP_TAC (srw_ss()) [Once evaluate_cases,BOOL_def,Eval_def,
     do_con_check_def,build_conv_def]) \\ fs [PULL_EXISTS]
   \\ fs [do_app_def] \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ EVAL_TAC);
 
-val Eval_Val_BOOL_F = store_thm("Eval_Val_BOOL_F",
-  ``Eval env (App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL F)``,
+val Eval_Val_BOOL_F = Q.store_thm("Eval_Val_BOOL_F",
+  `Eval env (App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL F)`,
   NTAC 5 (SIMP_TAC (srw_ss()) [Once evaluate_cases,BOOL_def,Eval_def,
     do_con_check_def,build_conv_def]) \\ fs [PULL_EXISTS]
   \\ fs [do_app_def] \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ EVAL_TAC);
 
-val Eval_Val_CHAR = store_thm("Eval_Val_CHAR",
-  ``!c. Eval env (Lit (Char c)) (CHAR c)``,
+val Eval_Val_CHAR = Q.store_thm("Eval_Val_CHAR",
+  `!c. Eval env (Lit (Char c)) (CHAR c)`,
   SIMP_TAC (srw_ss()) [CHAR_def,Eval_def,Once evaluate_cases])
 
-val Eval_Val_STRING = store_thm("Eval_Val_STRING",
-  ``!s. Eval env (Lit (StrLit s)) (STRING_TYPE (strlit s))``,
+val Eval_Val_STRING = Q.store_thm("Eval_Val_STRING",
+  `!s. Eval env (Lit (StrLit s)) (STRING_TYPE (strlit s))`,
   SIMP_TAC (srw_ss()) [STRING_TYPE_def,Eval_def,Once evaluate_cases])
 
-val Eval_Val_WORD = store_thm("Eval_Val_WORD",
-  ``!w:'a word.
+val Eval_Val_WORD = Q.store_thm("Eval_Val_WORD",
+  `!w:'a word.
     dimindex(:'a) ≤ 64 ⇒
     Eval env (Lit (if dimindex(:'a) ≤ 8
                    then Word8 (w2w w << (8-dimindex(:'a)))
                    else Word64 (w2w w << (64-dimindex(:'a)))))
-             (WORD w)``,
+             (WORD w)`,
   SIMP_TAC (srw_ss()) [WORD_def,Eval_def,Once evaluate_cases])
 
 (* Equality *)
@@ -343,18 +343,18 @@ val EqualityType_def = Define `
     (!x1 v1 x2 v2. abs x1 v1 /\ abs x2 v2 ==> ((v1 = v2) = (x1 = x2))) /\
     (!x1 v1 x2 v2. abs x1 v1 /\ abs x2 v2 ==> types_match v1 v2)`;
 
-val Eq_lemma = prove(
-  ``n < dimword (:'a) /\ dimindex (:α) <= k ==>
-    (n * 2n ** (k − dimindex (:α))) < 2 ** k``,
+val Eq_lemma = Q.prove(
+  `n < dimword (:'a) /\ dimindex (:α) <= k ==>
+    (n * 2n ** (k − dimindex (:α))) < 2 ** k`,
   fs [dimword_def] \\ rw []
   \\ fs [LESS_EQ_EXISTS] \\ rw [] \\ fs [EXP_ADD]
   \\ simp_tac std_ss [Once MULT_COMM] \\ fs []);
 
-val EqualityType_NUM_BOOL = store_thm("EqualityType_NUM_BOOL",
-  ``EqualityType NUM /\ EqualityType INT /\
+val EqualityType_NUM_BOOL = Q.store_thm("EqualityType_NUM_BOOL",
+  `EqualityType NUM /\ EqualityType INT /\
     EqualityType BOOL /\ EqualityType WORD /\
     EqualityType CHAR /\ EqualityType STRING_TYPE /\
-    EqualityType UNIT_TYPE``,
+    EqualityType UNIT_TYPE`,
   EVAL_TAC \\ fs [no_closures_def,
     types_match_def, lit_same_type_def,
     stringTheory.ORD_11,mlstringTheory.explode_11]
@@ -364,24 +364,24 @@ val EqualityType_NUM_BOOL = store_thm("EqualityType_NUM_BOOL",
   \\ imp_res_tac Eq_lemma \\ fs []
   \\ fs [MULT_EXP_MONO |> Q.SPECL [`p`,`1`] |> SIMP_RULE bool_ss [EVAL ``SUC 1``]]);
 
-val types_match_list_length = store_thm("types_match_list_length",
-  ``!vs1 vs2. types_match_list vs1 vs2 ==> LENGTH vs1 = LENGTH vs2``,
+val types_match_list_length = Q.store_thm("types_match_list_length",
+  `!vs1 vs2. types_match_list vs1 vs2 ==> LENGTH vs1 = LENGTH vs2`,
   Induct \\ Cases_on`vs2` \\ rw[types_match_def])
 
-val type_match_implies_do_eq_succeeds = store_thm(
+val type_match_implies_do_eq_succeeds = Q.store_thm(
   "type_match_implies_do_eq_succeeds",
-  ``(!v1 v2. types_match v1 v2 ==> (do_eq v1 v2 = Eq_val (v1 = v2))) /\
+  `(!v1 v2. types_match v1 v2 ==> (do_eq v1 v2 = Eq_val (v1 = v2))) /\
     (!vs1 vs2.
-       types_match_list vs1 vs2 ==> (do_eq_list vs1 vs2 = Eq_val (vs1 = vs2)))``,
+       types_match_list vs1 vs2 ==> (do_eq_list vs1 vs2 = Eq_val (vs1 = vs2)))`,
   ho_match_mp_tac do_eq_ind
   \\ rw [do_eq_def, types_match_def]
   \\ imp_res_tac types_match_list_length
   \\ fs[] \\ Cases_on`cn1=cn2`\\fs[]
   \\ imp_res_tac types_match_list_length);
 
-val do_eq_succeeds = prove(``
+val do_eq_succeeds = Q.prove(`
   (!a x1 v1 x2 v2. EqualityType a /\ a x1 v1 /\ a x2 v2 ==>
-                   (do_eq v1 v2 = Eq_val (x1 = x2)))``,
+                   (do_eq v1 v2 = Eq_val (x1 = x2)))`,
  rw [EqualityType_def]
  \\ res_tac
  \\ imp_res_tac type_match_implies_do_eq_succeeds
@@ -399,10 +399,10 @@ val record_simp_failure_tac =
   \\ `X = Y` by simp[Abbr`X`,Abbr`Y`,state_component_equality]
   \\ fs[]
 
-val Eval_Equality = store_thm("Eval_Equality",
-  ``Eval env x1 (a y1) /\ Eval env x2 (a y2) ==>
+val Eval_Equality = Q.store_thm("Eval_Equality",
+  `Eval env x1 (a y1) /\ Eval env x2 (a y2) ==>
     EqualityType a ==>
-    Eval env (App Equality [x1;x2]) (BOOL (y1 = y2))``,
+    Eval env (App Equality [x1;x2]) (BOOL (y1 = y2))`,
   SIMP_TAC std_ss [Eval_def,BOOL_def] \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -418,10 +418,10 @@ val Eval_Equality = store_thm("Eval_Equality",
 
 (* booleans *)
 
-val Eval_Or = store_thm("Eval_Or",
-  ``Eval env x1 (BOOL b1) ==>
+val Eval_Or = Q.store_thm("Eval_Or",
+  `Eval env x1 (BOOL b1) ==>
     Eval env x2 (BOOL b2) ==>
-    Eval env (Log Or x1 x2) (BOOL (b1 \/ b2))``,
+    Eval env (Log Or x1 x2) (BOOL (b1 \/ b2))`,
   SIMP_TAC std_ss [Eval_def,NUM_def,BOOL_def] \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -432,10 +432,10 @@ val Eval_Or = store_thm("Eval_Or",
   \\ fs [EVAL ``do_log Or (Boolv F) x``]
   \\ metis_tac[]);
 
-val Eval_And = store_thm("Eval_And",
-  ``Eval env x1 (BOOL b1) ==>
+val Eval_And = Q.store_thm("Eval_And",
+  `Eval env x1 (BOOL b1) ==>
     Eval env x2 (BOOL b2) ==>
-    Eval env (Log And x1 x2) (BOOL (b1 /\ b2))``,
+    Eval env (Log And x1 x2) (BOOL (b1 /\ b2))`,
   SIMP_TAC std_ss [Eval_def,NUM_def,BOOL_def] \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -447,12 +447,12 @@ val Eval_And = store_thm("Eval_And",
   \\ DISJ2_TAC \\ Q.EXISTS_TAC `Boolv F`
   \\ fs [EVAL ``do_log And (Boolv F) x``] \\ EVAL_TAC)
 
-val Eval_If = store_thm("Eval_If",
-  ``(a1 ==> Eval env x1 (BOOL b1)) /\
+val Eval_If = Q.store_thm("Eval_If",
+  `(a1 ==> Eval env x1 (BOOL b1)) /\
     (a2 ==> Eval env x2 (a b2)) /\
     (a3 ==> Eval env x3 (a b3)) ==>
     (a1 /\ (CONTAINER b1 ==> a2) /\ (~CONTAINER b1 ==> a3) ==>
-     Eval env (If x1 x2 x3) (a (if b1 then b2 else b3)))``,
+     Eval env (If x1 x2 x3) (a (if b1 then b2 else b3)))`,
   SIMP_TAC std_ss [Eval_def,NUM_def,BOOL_def] \\ SIMP_TAC std_ss [CONTAINER_def]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -464,10 +464,10 @@ val Eval_If = store_thm("Eval_If",
     \\ Q.EXISTS_TAC `Boolv F` \\ fs [do_if_def,EVAL ``Boolv F = Boolv T``]
     \\ Q.EXISTS_TAC `empty_state` \\ FULL_SIMP_TAC std_ss []));
 
-val Eval_Bool_Not = store_thm("Eval_Bool_Not",
-  ``Eval env x1 (BOOL b1) ==>
+val Eval_Bool_Not = Q.store_thm("Eval_Bool_Not",
+  `Eval env x1 (BOOL b1) ==>
     Eval env (App Equality
-      [x1; App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]]) (BOOL (~b1))``,
+      [x1; App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]]) (BOOL (~b1))`,
   SIMP_TAC std_ss [Eval_def,NUM_def,BOOL_def] \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SIMP_TAC (srw_ss()) []
@@ -492,11 +492,11 @@ val Eval_Bool_Not = store_thm("Eval_Bool_Not",
   \\ SRW_TAC[quantHeuristicsLib.QUANT_INST_ss[record_default_qp]][EXISTS_PROD,state_component_equality]
   \\ FULL_SIMP_TAC (srw_ss()) [do_app_cases,opb_lookup_def]);
 
-val Eval_Implies = store_thm("Eval_Implies",
-  ``Eval env x1 (BOOL b1) ==>
+val Eval_Implies = Q.store_thm("Eval_Implies",
+  `Eval env x1 (BOOL b1) ==>
     Eval env x2 (BOOL b2) ==>
     Eval env (If x1 x2 (App (Opb Leq) [Lit (IntLit 0); Lit (IntLit 0)]))
-      (BOOL (b1 ==> b2))``,
+      (BOOL (b1 ==> b2))`,
   REPEAT STRIP_TAC
   \\ PURE_REWRITE_TAC [METIS_PROVE [] ``(b1 ==> b2) <=> (if b1 then b2 else T)``]
   \\ MATCH_MP_TAC (MP_CANON Eval_If |> GEN_ALL)
@@ -504,16 +504,16 @@ val Eval_Implies = store_thm("Eval_Implies",
 
 (* misc *)
 
-val Eval_Var_SIMP = store_thm("Eval_Var_SIMP",
-  ``Eval (write x v env) (Var (Short y)) p =
-      if x = y then p v else Eval env (Var (Short y)) p``,
+val Eval_Var_SIMP = Q.store_thm("Eval_Var_SIMP",
+  `Eval (write x v env) (Var (Short y)) p =
+      if x = y then p v else Eval env (Var (Short y)) p`,
   ASM_SIMP_TAC (srw_ss()) [LOOKUP_VAR_def,lookup_var_id_def,write_def,
        lookup_var_def,Eval_def,Once evaluate_cases,lookup_var_id_def]
   \\ SRW_TAC [] [] \\ SIMP_TAC (srw_ss()) [Eval_def,Once evaluate_cases,
        lookup_var_id_def]);
 
-val Eval_Eq = store_thm("Eval_Eq",
-  ``Eval env exp (a x) ==> Eval env exp ((Eq a x) x)``,
+val Eval_Eq = Q.store_thm("Eval_Eq",
+  `Eval env exp (a x) ==> Eval env exp ((Eq a x) x)`,
   SIMP_TAC std_ss [Eval_def,Eq_def]);
 
 val FUN_FORALL = new_binder_definition("FUN_FORALL",
@@ -522,13 +522,13 @@ val FUN_FORALL = new_binder_definition("FUN_FORALL",
 val FUN_EXISTS = new_binder_definition("FUN_EXISTS",
   ``($FUN_EXISTS) = \(abs:'a->'b->v->bool) a v. ?y. abs y a v``);
 
-val FUN_FORALL_INTRO = store_thm("FUN_FORALL_INTRO",
-  ``(!x. p x f v) ==> (FUN_FORALL x. p x) f v``,
+val FUN_FORALL_INTRO = Q.store_thm("FUN_FORALL_INTRO",
+  `(!x. p x f v) ==> (FUN_FORALL x. p x) f v`,
   fs [FUN_FORALL]);
 
-val Eval_FUN_FORALL = store_thm("Eval_FUN_FORALL",
-  ``(!x. Eval env exp ((p x) f)) ==>
-    Eval env exp ((FUN_FORALL x. p x) f)``,
+val Eval_FUN_FORALL = Q.store_thm("Eval_FUN_FORALL",
+  `(!x. Eval env exp ((p x) f)) ==>
+    Eval env exp ((FUN_FORALL x. p x) f)`,
   SIMP_TAC std_ss [Eval_def,Arrow_def,Eq_def] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [AppReturns_def,FUN_FORALL]
   \\ `?res. evaluate F env empty_state exp (empty_state,Rval res)` by METIS_TAC []
@@ -536,14 +536,14 @@ val Eval_FUN_FORALL = store_thm("Eval_FUN_FORALL",
   \\ REPEAT STRIP_TAC \\ Q.PAT_X_ASSUM `!x.bbb` (STRIP_ASSUME_TAC o Q.SPEC `y`)
   \\ IMP_RES_TAC evaluate_11_Rval \\ FULL_SIMP_TAC (srw_ss()) []);
 
-val Eval_FUN_FORALL_EQ = store_thm("Eval_FUN_FORALL_EQ",
-  ``(!x. Eval env exp ((p x) f)) =
-    Eval env exp ((FUN_FORALL x. p x) f)``,
+val Eval_FUN_FORALL_EQ = Q.store_thm("Eval_FUN_FORALL_EQ",
+  `(!x. Eval env exp ((p x) f)) =
+    Eval env exp ((FUN_FORALL x. p x) f)`,
   REPEAT STRIP_TAC \\ EQ_TAC \\ FULL_SIMP_TAC std_ss [Eval_FUN_FORALL]
   \\ EVAL_TAC \\ FULL_SIMP_TAC std_ss [FUN_FORALL] \\ METIS_TAC []);
 
-val FUN_FORALL_PUSH1 = prove(
-  ``(FUN_FORALL x. a --> (b x)) = (a --> FUN_FORALL x. b x)``,
+val FUN_FORALL_PUSH1 = Q.prove(
+  `(FUN_FORALL x. a --> (b x)) = (a --> FUN_FORALL x. b x)`,
   FULL_SIMP_TAC std_ss [Arrow_def,FUN_EQ_THM,AppReturns_def,FUN_FORALL,
     Eval_def,evaluate_closure_def] \\ REPEAT STRIP_TAC \\ reverse EQ_TAC
   THEN1 METIS_TAC [evaluate_11_Rval]
@@ -557,13 +557,13 @@ val FUN_FORALL_PUSH1 = prove(
   \\ FULL_SIMP_TAC std_ss []
   \\ METIS_TAC [evaluate_11_Rval,PAIR_EQ]) |> GEN_ALL;
 
-val FUN_FORALL_PUSH2 = prove(
-  ``(FUN_FORALL x. (a x) --> b) = ((FUN_EXISTS x. a x) --> b)``,
+val FUN_FORALL_PUSH2 = Q.prove(
+  `(FUN_FORALL x. (a x) --> b) = ((FUN_EXISTS x. a x) --> b)`,
   FULL_SIMP_TAC std_ss [Arrow_def,FUN_EQ_THM,AppReturns_def,FUN_FORALL,FUN_EXISTS,
     Eval_def] \\ METIS_TAC []) |> GEN_ALL;
 
-val FUN_EXISTS_Eq = prove(
-  ``(FUN_EXISTS x. Eq a x) = a``,
+val FUN_EXISTS_Eq = Q.prove(
+  `(FUN_EXISTS x. Eq a x) = a`,
   SIMP_TAC std_ss [FUN_EQ_THM,FUN_EXISTS,Eq_def]) |> GEN_ALL;
 
 val FUN_QUANT_SIMP = save_thm("FUN_QUANT_SIMP",
@@ -612,10 +612,10 @@ val Eval_Recclosure = store_thm("Eval_Recclosure",
 
 val SafeVar_def = Define `SafeVar = Var`;
 
-val Eval_Eq_Recclosure = store_thm("Eval_Eq_Recclosure",
-  ``LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
+val Eval_Eq_Recclosure = Q.store_thm("Eval_Eq_Recclosure",
+  `LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
     (P f (Recclosure x1 x2 x3) =
-     Eval env (Var (Short name)) (P f))``,
+     Eval env (Var (Short name)) (P f))`,
   ASM_SIMP_TAC std_ss [Eval_Var_SIMP,Eval_def,LOOKUP_VAR_def,lookup_var_def]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
@@ -623,34 +623,34 @@ val Eval_Eq_Recclosure = store_thm("Eval_Eq_Recclosure",
   \\ FULL_SIMP_TAC (srw_ss()) []
   \\ METIS_TAC []);
 
-val Eval_Eq_Fun = store_thm("Eval_Eq_Fun",
-  ``Eval env (Fun v x) p ==>
+val Eval_Eq_Fun = Q.store_thm("Eval_Eq_Fun",
+  `Eval env (Fun v x) p ==>
     !env2. Eval env2 (Var name) ($= (Closure env v x)) ==>
-           Eval env2 (Var name) p``,
+           Eval env2 (Var name) p`,
   SIMP_TAC std_ss [Eval_Var_SIMP,Eval_def]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC []);
 
-val Eval_WEAKEN = store_thm("Eval_WEAKEN",
-  ``Eval env exp P ==> (!v. P v ==> Q v) ==> Eval env exp Q``,
+val Eval_WEAKEN = Q.store_thm("Eval_WEAKEN",
+  `Eval env exp P ==> (!v. P v ==> Q v) ==> Eval env exp Q`,
   SIMP_TAC std_ss [Eval_def] \\ METIS_TAC []);
 
-val Eval_CONST = store_thm("Eval_CONST",
-  ``(!v. P v = (v = x)) ==>
-    Eval env (Var name) ($= x) ==> Eval env (Var name) P``,
+val Eval_CONST = Q.store_thm("Eval_CONST",
+  `(!v. P v = (v = x)) ==>
+    Eval env (Var name) ($= x) ==> Eval env (Var name) P`,
   SIMP_TAC std_ss [Eval_def])
 
 
 (* arithmetic for integers *)
 
-val Eval_Opn = prove(
-  ``!f n1 n2.
+val Eval_Opn = Q.prove(
+  `!f n1 n2.
         Eval env x1 (INT n1) ==>
         Eval env x2 (INT n2) ==>
         PRECONDITION (((f = Divide) \/ (f = Modulo)) ==> ~(n2 = 0)) ==>
-        Eval env (App (Opn f) [x1;x2]) (INT (opn_lookup f n1 n2))``,
+        Eval env (App (Opn f) [x1;x2]) (INT (opn_lookup f n1 n2))`,
   SIMP_TAC std_ss [Eval_def,INT_def] \\ SIMP_TAC std_ss [PRECONDITION_def]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ empty_state_tac
@@ -676,11 +676,11 @@ in
   val Eval_INT_MOD  = f "INT_MOD" `Modulo`
 end
 
-val Eval_Opb = prove(
-  ``!f n1 n2.
+val Eval_Opb = Q.prove(
+  `!f n1 n2.
         Eval env x1 (INT n1) ==>
         Eval env x2 (INT n2) ==>
-        Eval env (App (Opb f) [x1;x2]) (BOOL (opb_lookup f n1 n2))``,
+        Eval env (App (Opb f) [x1;x2]) (BOOL (opb_lookup f n1 n2))`,
   SIMP_TAC std_ss [Eval_def,INT_def,BOOL_def] \\ SIMP_TAC std_ss []
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ empty_state_tac
@@ -724,9 +724,9 @@ val code =
 
 in
 
-val Eval_Num_ABS = store_thm("Eval_Num_ABS",
-  ``Eval env x1 (INT i) ==>
-    Eval env ^code (NUM (Num (ABS i)))``,
+val Eval_Num_ABS = Q.store_thm("Eval_Num_ABS",
+  `Eval env x1 (INT i) ==>
+    Eval env ^code (NUM (Num (ABS i)))`,
   SIMP_TAC std_ss [NUM_def]
   \\ `&(Num (ABS i)) = let k = i in if k < 0 then 0 - k else k` by
     (FULL_SIMP_TAC std_ss [LET_DEF] THEN intLib.COOPER_TAC)
@@ -738,25 +738,25 @@ val Eval_Num_ABS = store_thm("Eval_Num_ABS",
 
 end;
 
-val Eval_int_of_num = store_thm("Eval_int_of_num",
-  ``Eval env x1 (NUM n) ==>
-    Eval env x1 (INT (int_of_num n))``,
+val Eval_int_of_num = Q.store_thm("Eval_int_of_num",
+  `Eval env x1 (NUM n) ==>
+    Eval env x1 (INT (int_of_num n))`,
   SIMP_TAC std_ss [NUM_def]);
 
-val Eval_int_of_num_o = store_thm("Eval_int_of_num_o",
-  ``Eval env x1 ((A --> NUM) f) ==>
-    Eval env x1 ((A --> INT) (int_of_num o f))``,
+val Eval_int_of_num_o = Q.store_thm("Eval_int_of_num_o",
+  `Eval env x1 ((A --> NUM) f) ==>
+    Eval env x1 ((A --> INT) (int_of_num o f))`,
   SIMP_TAC std_ss [NUM_def,Arrow_def]);
 
-val Eval_o_int_of_num = store_thm("Eval_o_int_of_num",
-  ``Eval env x1 ((INT --> A) f) ==>
-    Eval env x1 ((NUM --> A) (f o int_of_num))``,
+val Eval_o_int_of_num = Q.store_thm("Eval_o_int_of_num",
+  `Eval env x1 ((INT --> A) f) ==>
+    Eval env x1 ((NUM --> A) (f o int_of_num))`,
   SIMP_TAC std_ss [NUM_def,Arrow_def,Eval_def]
   \\ METIS_TAC[]);
 
-val Eval_int_negate = store_thm("Eval_int_negate",
-  ``Eval env x1 (INT i) ==>
-    Eval env (App (Opn Minus) [Lit (IntLit 0); x1]) (INT (-i))``,
+val Eval_int_negate = Q.store_thm("Eval_int_negate",
+  `Eval env x1 (INT i) ==>
+    Eval env (App (Opn Minus) [Lit (IntLit 0); x1]) (INT (-i))`,
   rw[Eval_def] >> rw[Once evaluate_cases] >>
   empty_state_tac >>
   simp[state_component_equality] >>
@@ -816,10 +816,10 @@ val code =
 
 in
 
-val Eval_NUM_SUB = store_thm("Eval_NUM_SUB",
-  ``Eval env x1 (NUM m) ==>
+val Eval_NUM_SUB = Q.store_thm("Eval_NUM_SUB",
+  `Eval env x1 (NUM m) ==>
     Eval env x2 (NUM n) ==>
-    Eval env ^code (NUM (m - n))``,
+    Eval env ^code (NUM (m - n))`,
   SIMP_TAC std_ss [NUM_def]
   \\ `&(m - n:num) = let k = &m - &n in if k < 0 then 0 else k:int` by
    (FULL_SIMP_TAC std_ss [LET_DEF,INT_LT_SUB_RADD,INT_ADD,INT_LT]
@@ -852,9 +852,9 @@ val Eval_NUM_GREATER_EQ = save_thm("Eval_NUM_GREATER_EQ",
   |> REWRITE_RULE [GSYM NUM_def,INT_LT,INT_LE,int_ge,int_gt]
   |> REWRITE_RULE [GSYM GREATER_DEF, GSYM GREATER_EQ]);
 
-val Eval_NUM_EQ_0 = store_thm("Eval_NUM_EQ_0",
-  ``!n. Eval env x (NUM n) ==>
-        Eval env (App (Opb Leq) [x; Lit (IntLit 0)]) (BOOL (n = 0))``,
+val Eval_NUM_EQ_0 = Q.store_thm("Eval_NUM_EQ_0",
+  `!n. Eval env x (NUM n) ==>
+        Eval env (App (Opb Leq) [x; Lit (IntLit 0)]) (BOOL (n = 0))`,
   REPEAT STRIP_TAC \\ ASSUME_TAC (Q.SPEC `0` Eval_Val_NUM)
   \\ FULL_SIMP_TAC std_ss [NUM_def]
   \\ `(n = 0) = (&n <= 0)` by intLib.COOPER_TAC
@@ -863,11 +863,11 @@ val Eval_NUM_EQ_0 = store_thm("Eval_NUM_EQ_0",
 
 (* word operations *)
 
-val Eval_word_and = store_thm("Eval_word_and",
-  ``Eval env x1 (WORD (w1:'a word)) /\
+val Eval_word_and = Q.store_thm("Eval_word_and",
+  `Eval env x1 (WORD (w1:'a word)) /\
     Eval env x2 (WORD (w2:'a word)) ==>
     Eval env (App (Opw (if dimindex (:'a) <= 8 then W8 else W64) Andw) [x1;x2])
-      (WORD (word_and w1 w2))``,
+      (WORD (word_and w1 w2))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -879,11 +879,11 @@ val Eval_word_and = store_thm("Eval_word_and",
   \\ fs [do_app_def,opw8_lookup_def,opw64_lookup_def]
   \\ fs [GSYM WORD_w2w_OVER_BITWISE]);
 
-val Eval_word_or = store_thm("Eval_word_or",
-  ``Eval env x1 (WORD (w1:'a word)) /\
+val Eval_word_or = Q.store_thm("Eval_word_or",
+  `Eval env x1 (WORD (w1:'a word)) /\
     Eval env x2 (WORD (w2:'a word)) ==>
     Eval env (App (Opw (if dimindex (:'a) <= 8 then W8 else W64) Orw) [x1;x2])
-      (WORD (word_or w1 w2))``,
+      (WORD (word_or w1 w2))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -895,11 +895,11 @@ val Eval_word_or = store_thm("Eval_word_or",
   \\ fs [do_app_def,opw8_lookup_def,opw64_lookup_def]
   \\ fs [GSYM WORD_w2w_OVER_BITWISE]);
 
-val Eval_word_xor = store_thm("Eval_word_xor",
-  ``Eval env x1 (WORD (w1:'a word)) /\
+val Eval_word_xor = Q.store_thm("Eval_word_xor",
+  `Eval env x1 (WORD (w1:'a word)) /\
     Eval env x2 (WORD (w2:'a word)) ==>
     Eval env (App (Opw (if dimindex (:'a) <= 8 then W8 else W64) Xor) [x1;x2])
-      (WORD (word_xor w1 w2))``,
+      (WORD (word_xor w1 w2))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -911,37 +911,37 @@ val Eval_word_xor = store_thm("Eval_word_xor",
   \\ fs [do_app_def,opw8_lookup_def,opw64_lookup_def]
   \\ fs [GSYM WORD_w2w_OVER_BITWISE]);
 
-val DISTRIB_ANY = prove(
-  ``(p * m + p * n = p * (m + n)) /\
+val DISTRIB_ANY = Q.prove(
+  `(p * m + p * n = p * (m + n)) /\
     (p * m + n * p = p * (m + n)) /\
     (m * p + p * n = p * (m + n)) /\
     (m * p + n * p = p * (m + n:num)) /\
     (p * m - p * n = p * (m - n)) /\
     (p * m - n * p = p * (m - n)) /\
     (m * p - p * n = p * (m - n)) /\
-    (m * p - n * p = p * (m - n:num))``,
+    (m * p - n * p = p * (m - n:num))`,
   fs [LEFT_ADD_DISTRIB]);
 
-val MOD_COMMON_FACTOR_ANY = prove(
-  ``!n p q. 0 < n ∧ 0 < q ==>
+val MOD_COMMON_FACTOR_ANY = Q.prove(
+  `!n p q. 0 < n ∧ 0 < q ==>
             ((n * p) MOD (n * q) = n * p MOD q) /\
             ((p * n) MOD (n * q) = n * p MOD q) /\
             ((n * p) MOD (q * n) = n * p MOD q) /\
-            ((p * n) MOD (q * n) = n * p MOD q)``,
+            ((p * n) MOD (q * n) = n * p MOD q)`,
   fs [GSYM MOD_COMMON_FACTOR]);
 
-val Eval_word_add_lemma = prove(
-  ``dimindex (:'a) <= k ==>
+val Eval_word_add_lemma = Q.prove(
+  `dimindex (:'a) <= k ==>
     (2 ** (k − dimindex (:α)) * q MOD dimword (:α)) MOD 2 ** k =
-    (2 ** (k − dimindex (:α)) * q) MOD 2 ** k``,
+    (2 ** (k − dimindex (:α)) * q) MOD 2 ** k`,
   rw [] \\ fs [LESS_EQ_EXISTS]
   \\ rw [EXP_ADD,dimword_def,MOD_COMMON_FACTOR_ANY]);
 
-val Eval_word_add = store_thm("Eval_word_add",
-  ``Eval env x1 (WORD (w1:'a word)) /\
+val Eval_word_add = Q.store_thm("Eval_word_add",
+  `Eval env x1 (WORD (w1:'a word)) /\
     Eval env x2 (WORD (w2:'a word)) ==>
     Eval env (App (Opw (if dimindex (:'a) <= 8 then W8 else W64) Add) [x1;x2])
-      (WORD (word_add w1 w2))``,
+      (WORD (word_add w1 w2))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -955,11 +955,11 @@ val Eval_word_add = store_thm("Eval_word_add",
   \\ fs [word_add_n2w,w2w_def,WORD_MUL_LSL,word_mul_n2w,GSYM RIGHT_ADD_DISTRIB]
   \\ imp_res_tac Eval_word_add_lemma \\ fs []);
 
-val Eval_word_sub_lemma = prove(
-  ``dimindex (:'a) <= k /\ n' < dimword (:α) ==>
+val Eval_word_sub_lemma = Q.prove(
+  `dimindex (:'a) <= k /\ n' < dimword (:α) ==>
     (n * 2 ** (k − dimindex (:α)) +
       (2 ** k − (n' * 2 ** (k − dimindex (:α))) MOD 2 ** k) MOD 2 ** k) MOD 2 ** k =
-    ((n + dimword (:α) − n') * 2 ** (k − dimindex (:α))) MOD 2 ** k``,
+    ((n + dimword (:α) − n') * 2 ** (k − dimindex (:α))) MOD 2 ** k`,
   fs [LESS_EQ_EXISTS,dimword_def] \\ rw []
   \\ fs [RIGHT_ADD_DISTRIB,RIGHT_SUB_DISTRIB,EXP_ADD]
   \\ full_simp_tac std_ss [DISTRIB_ANY,MOD_COMMON_FACTOR_ANY] \\ AP_TERM_TAC
@@ -968,11 +968,11 @@ val Eval_word_sub_lemma = prove(
   \\ pop_assum (fn th => once_rewrite_tac [th])
   \\ fs [Once (GSYM MOD_PLUS)]);
 
-val Eval_word_sub = store_thm("Eval_word_sub",
-  ``Eval env x1 (WORD (w1:'a word)) /\
+val Eval_word_sub = Q.store_thm("Eval_word_sub",
+  `Eval env x1 (WORD (w1:'a word)) /\
     Eval env x2 (WORD (w2:'a word)) ==>
     Eval env (App (Opw (if dimindex (:'a) <= 8 then W8 else W64) Sub) [x1;x2])
-      (WORD (word_sub w1 w2))``,
+      (WORD (word_sub w1 w2))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -991,28 +991,28 @@ val Eval_word_sub = store_thm("Eval_word_sub",
   \\ fs [word_2comp_n2w,word_add_n2w]
   \\ imp_res_tac Eval_word_sub_lemma \\ fs []);
 
-val w2n_w2w_8 = prove(
-  ``dimindex (:α) < 8 ==>
+val w2n_w2w_8 = Q.prove(
+  `dimindex (:α) < 8 ==>
     w2n ((w2w:'a word ->word8) w << (8 − dimindex (:α)) >>>
-            (8 − dimindex (:α))) = w2n w``,
+            (8 − dimindex (:α))) = w2n w`,
   Cases_on `w` \\ fs [w2n_lsr,w2w_def,WORD_MUL_LSL,word_mul_n2w,dimword_def]
   \\ rw []  \\ drule (DECIDE ``n<m ==> n <= m:num``)
   \\ fs [LESS_EQ_EXISTS] \\ fs [] \\ rw []
   \\ fs [] \\ full_simp_tac bool_ss [GSYM (EVAL ``2n ** 8``),EXP_ADD]
   \\ fs [MOD_COMMON_FACTOR_ANY,MULT_DIV]);
 
-val w2n_w2w_64 = prove(
-  ``dimindex (:α) < 64 ==>
+val w2n_w2w_64 = Q.prove(
+  `dimindex (:α) < 64 ==>
     w2n ((w2w:'a word ->word64) w << (64 − dimindex (:α)) >>>
-            (64 − dimindex (:α))) = w2n w``,
+            (64 − dimindex (:α))) = w2n w`,
   Cases_on `w` \\ fs [w2n_lsr,w2w_def,WORD_MUL_LSL,word_mul_n2w,dimword_def]
   \\ rw []  \\ drule (DECIDE ``n<m ==> n <= m:num``)
   \\ fs [LESS_EQ_EXISTS] \\ fs [] \\ rw []
   \\ fs [] \\ full_simp_tac bool_ss [GSYM (EVAL ``2n ** 64``),EXP_ADD]
   \\ fs [MOD_COMMON_FACTOR_ANY,MULT_DIV]);
 
-val Eval_w2n = store_thm("Eval_w2n",
-  ``Eval env x1 (WORD (w:'a word)) ==>
+val Eval_w2n = Q.store_thm("Eval_w2n",
+  `Eval env x1 (WORD (w:'a word)) ==>
     Eval env
       (if dimindex (:'a) = 8 then
          App (WordToInt W8) [x1]
@@ -1022,7 +1022,7 @@ val Eval_w2n = store_thm("Eval_w2n",
          App (WordToInt W8) [App (Shift W8 Lsr (8 - dimindex (:'a))) [x1]]
        else
          App (WordToInt W64) [App (Shift W64 Lsr (64 - dimindex (:'a))) [x1]])
-      (NUM (w2n w))``,
+      (NUM (w2n w))`,
   rw[Eval_def,WORD_def] \\ fs []
   \\ TRY (* takes care of = 8 and = 64 cases *)
    (rw[Once evaluate_cases,PULL_EXISTS]
@@ -1044,8 +1044,8 @@ val Eval_w2n = store_thm("Eval_w2n",
   \\ fs [empty_state_def,state_component_equality,do_app_def]
   \\ EVAL_TAC \\ fs [w2n_w2w_64,w2n_w2w_8]);
 
-val Eval_n2w = store_thm("Eval_n2w",
-  ``dimindex (:'a) <= 64 ==>
+val Eval_n2w = Q.store_thm("Eval_n2w",
+  `dimindex (:'a) <= 64 ==>
     Eval env x1 (NUM n) ==>
     Eval env
       (if dimindex (:'a) = 8 then
@@ -1056,7 +1056,7 @@ val Eval_n2w = store_thm("Eval_n2w",
          App (Shift W8 Lsl (8 - dimindex (:'a))) [App (WordFromInt W8) [x1]]
        else
          App (Shift W64 Lsl (64 - dimindex (:'a))) [App (WordFromInt W64) [x1]])
-      (WORD ((n2w n):'a word))``,
+      (WORD ((n2w n):'a word))`,
   rw[Eval_def,WORD_def] \\ fs [] \\ rfs []
   \\ TRY (* takes care of = 8 and = 64 cases *)
    (rw[Once evaluate_cases,PULL_EXISTS]
@@ -1084,11 +1084,11 @@ val Eval_n2w = store_thm("Eval_n2w",
        [GSYM (EVAL ``2n ** 8``),GSYM (EVAL ``2n ** 64``),EXP_ADD]
   \\ fs [MOD_COMMON_FACTOR_ANY,MULT_DIV]);
 
-val Eval_word_lsl = store_thm("Eval_word_lsl",
-  ``!n.
+val Eval_word_lsl = Q.store_thm("Eval_word_lsl",
+  `!n.
       Eval env x1 (WORD (w1:'a word)) ==>
       Eval env (App (Shift (if dimindex (:'a) <= 8 then W8 else W64) Lsl n) [x1])
-        (WORD (word_lsl w1 n))``,
+        (WORD (word_lsl w1 n))`,
   rw[Eval_def,WORD_def]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
   \\ rw[Once evaluate_cases,PULL_EXISTS]
@@ -1102,8 +1102,8 @@ val Eval_word_lsl = store_thm("Eval_word_lsl",
   \\ fs [fcpTheory.CART_EQ,word_lsl_def,fcpTheory.FCP_BETA,w2w] \\ rw []
   \\ Cases_on `w1 ' (i − (n + p))` \\ fs []);
 
-val Eval_word_lsr = store_thm("Eval_word_lsr",
-  ``!n.
+val Eval_word_lsr = Q.store_thm("Eval_word_lsr",
+  `!n.
       Eval env x1 (WORD (w1:'a word)) ==>
       Eval env (let w = (if dimindex (:'a) <= 8 then W8 else W64) in
                 let k = (if dimindex (:'a) <= 8 then 8 else 64) - dimindex(:'a) in
@@ -1111,7 +1111,7 @@ val Eval_word_lsr = store_thm("Eval_word_lsr",
                     App (Shift w Lsr n) [x1]
                   else
                     App (Shift w Lsl k) [App (Shift w Lsr (n+k)) [x1]])
-        (WORD (word_lsr w1 n))``,
+        (WORD (word_lsr w1 n))`,
   rw[Eval_def,WORD_def]
   \\ TRY (* takes care of = 8 and = 64 cases *)
    (rw[Once evaluate_cases,PULL_EXISTS]
@@ -1143,8 +1143,8 @@ val Eval_word_lsr = store_thm("Eval_word_lsr",
   \\ TRY (`i − p + (n + p) < 8` by decide_tac \\ fs [fcpTheory.FCP_BETA,w2w])
   \\ TRY (`i − p + (n + p) < 64` by decide_tac \\ fs [fcpTheory.FCP_BETA,w2w]));
 
-val Eval_word_asr = store_thm("Eval_word_asr",
-  ``!n.
+val Eval_word_asr = Q.store_thm("Eval_word_asr",
+  `!n.
       Eval env x1 (WORD (w1:'a word)) ==>
       Eval env (let w = (if dimindex (:'a) <= 8 then W8 else W64) in
                 let k = (if dimindex (:'a) <= 8 then 8 else 64) - dimindex(:'a) in
@@ -1152,7 +1152,7 @@ val Eval_word_asr = store_thm("Eval_word_asr",
                     App (Shift w Asr n) [x1]
                   else
                     App (Shift w Lsl k) [App (Shift w Asr (n+k)) [x1]])
-        (WORD (word_asr w1 n))``,
+        (WORD (word_asr w1 n))`,
   rw[Eval_def,WORD_def]
   \\ TRY (* takes care of = 8 and = 64 cases *)
    (rw[Once evaluate_cases,PULL_EXISTS]
@@ -1195,10 +1195,10 @@ val LIST_TYPE_def = Define `
      LIST_TYPE a [] v <=>
      v = Conv (SOME ("nil",TypeId (Short "list"))) []`
 
-val LIST_TYPE_SIMP = prove(
-  ``!xs b. CONTAINER LIST_TYPE
+val LIST_TYPE_SIMP = Q.prove(
+  `!xs b. CONTAINER LIST_TYPE
               (\x v. if b x \/ MEM x xs then p x v else ARB) xs =
-           LIST_TYPE (p:('a -> v -> bool)) xs``,
+           LIST_TYPE (p:('a -> v -> bool)) xs`,
   Induct THEN FULL_SIMP_TAC std_ss [FUN_EQ_THM,LIST_TYPE_def,MEM,
     DISJ_ASSOC,CONTAINER_def])
   |> Q.SPECL [`xs`,`\x.F`] |> SIMP_RULE std_ss [] |> GSYM
@@ -1211,10 +1211,10 @@ val PAIR_TYPE_def = Define `
     PAIR_TYPE b c (x_2:'b,x_1:'c) v <=>
     ?v1_1 v1_2. v = Conv NONE [v1_1; v1_2] /\ b x_2 v1_1 /\ c x_1 v1_2`;
 
-val PAIR_TYPE_SIMP = prove(
-  ``!x. CONTAINER PAIR_TYPE (\y v. if y = FST x then a y v else ARB)
+val PAIR_TYPE_SIMP = Q.prove(
+  `!x. CONTAINER PAIR_TYPE (\y v. if y = FST x then a y v else ARB)
                             (\y v. if y = SND x then b y v else ARB) x =
-        PAIR_TYPE (a:('a -> v -> bool)) (b:('b -> v -> bool)) x``,
+        PAIR_TYPE (a:('a -> v -> bool)) (b:('b -> v -> bool)) x`,
   Cases \\ SIMP_TAC std_ss [PAIR_TYPE_def,CONTAINER_def,FUN_EQ_THM])
   |> GSYM |> SPEC_ALL |> curry save_thm "PAIR_TYPE_SIMP";
 
@@ -1230,19 +1230,19 @@ val OPTION_TYPE_def = Define `
      OPTION_TYPE a NONE v <=>
      v = Conv (SOME ("NONE",TypeId (Short "option"))) []`
 
-val OPTION_TYPE_SIMP = prove(
-  ``!x. CONTAINER OPTION_TYPE
+val OPTION_TYPE_SIMP = Q.prove(
+  `!x. CONTAINER OPTION_TYPE
               (\y v. if x = SOME y then p y v else ARB) x =
-           OPTION_TYPE (p:('a -> v -> bool)) x``,
+           OPTION_TYPE (p:('a -> v -> bool)) x`,
   Cases>>FULL_SIMP_TAC std_ss [FUN_EQ_THM,OPTION_TYPE_def,DISJ_ASSOC,CONTAINER_def])
   |> Q.SPECL [`x`] |> SIMP_RULE std_ss [] |> GSYM
   |> curry save_thm "OPTION_TYPE_SIMP";
 
 (* characters *)
 
-val Eval_Ord = store_thm("Eval_Ord",
-  ``Eval env x (CHAR c) ==>
-    Eval env (App Ord [x]) (NUM (ORD c))``,
+val Eval_Ord = Q.store_thm("Eval_Ord",
+  `Eval env x (CHAR c) ==>
+    Eval env (App Ord [x]) (NUM (ORD c))`,
   rw[Eval_def] >>
   rw[Once evaluate_cases] >>
   empty_state_tac >>
@@ -1255,10 +1255,10 @@ val Eval_Ord = store_thm("Eval_Ord",
   rw[do_app_cases,PULL_EXISTS] >>
   fs[CHAR_def,NUM_def,INT_def])
 
-val Eval_Chr = store_thm("Eval_Chr",
-  ``Eval env x (NUM n) ==>
+val Eval_Chr = Q.store_thm("Eval_Chr",
+  `Eval env x (NUM n) ==>
     n < 256 ==>
-    Eval env (App Chr [x]) (CHAR (CHR n))``,
+    Eval env (App Chr [x]) (CHAR (CHR n))`,
   rw[Eval_def] >>
   rw[Once evaluate_cases] >>
   empty_state_tac >>
@@ -1273,8 +1273,8 @@ val Eval_Chr = store_thm("Eval_Chr",
   conj_tac >- intLib.COOPER_TAC >>
   simp[integerTheory.INT_ABS_NUM])
 
-val Boolv_11 = store_thm("Boolv_11",
-  ``(Boolv b1 = Boolv b2) <=> (b1 = b2)``,
+val Boolv_11 = Q.store_thm("Boolv_11",
+  `(Boolv b1 = Boolv b2) <=> (b1 = b2)`,
   Cases_on `b1` \\ Cases_on `b2` \\ EVAL_TAC);
 
 val tac =
@@ -1290,43 +1290,43 @@ val tac =
   conj_tac >- record_simp_failure_tac >>
   rw[BOOL_def,opb_lookup_def,Boolv_11]
 
-val Eval_char_lt = store_thm("Eval_char_lt",
-  ``!c1 c2.
+val Eval_char_lt = Q.store_thm("Eval_char_lt",
+  `!c1 c2.
         Eval env x1 (CHAR c1) ==>
         Eval env x2 (CHAR c2) ==>
-        Eval env (App (Chopb Lt) [x1;x2]) (BOOL (c1 < c2))``,
+        Eval env (App (Chopb Lt) [x1;x2]) (BOOL (c1 < c2))`,
   tac >> rw[stringTheory.char_lt_def])
 
-val Eval_char_le = store_thm("Eval_char_le",
-  ``!c1 c2.
+val Eval_char_le = Q.store_thm("Eval_char_le",
+  `!c1 c2.
         Eval env x1 (CHAR c1) ==>
         Eval env x2 (CHAR c2) ==>
-        Eval env (App (Chopb Leq) [x1;x2]) (BOOL (c1 ≤ c2))``,
+        Eval env (App (Chopb Leq) [x1;x2]) (BOOL (c1 ≤ c2))`,
   tac >> rw[stringTheory.char_le_def])
 
-val Eval_char_gt = store_thm("Eval_char_gt",
-  ``!c1 c2.
+val Eval_char_gt = Q.store_thm("Eval_char_gt",
+  `!c1 c2.
         Eval env x1 (CHAR c1) ==>
         Eval env x2 (CHAR c2) ==>
-        Eval env (App (Chopb Gt) [x1;x2]) (BOOL (c1 > c2))``,
+        Eval env (App (Chopb Gt) [x1;x2]) (BOOL (c1 > c2))`,
   tac >> rw[stringTheory.char_gt_def] >> intLib.COOPER_TAC)
 
-val Eval_char_ge = store_thm("Eval_char_ge",
-  ``!c1 c2.
+val Eval_char_ge = Q.store_thm("Eval_char_ge",
+  `!c1 c2.
         Eval env x1 (CHAR c1) ==>
         Eval env x2 (CHAR c2) ==>
-        Eval env (App (Chopb Geq) [x1;x2]) (BOOL (c1 ≥ c2))``,
+        Eval env (App (Chopb Geq) [x1;x2]) (BOOL (c1 ≥ c2))`,
   tac >> rw[stringTheory.char_ge_def] >> intLib.COOPER_TAC)
 
 (* strings *)
 
-val LIST_TYPE_CHAR_v_to_char_list = store_thm("LIST_TYPE_CHAR_v_to_char_list",
-  ``∀l v. LIST_TYPE CHAR l v ⇒ v_to_char_list v = SOME l``,
+val LIST_TYPE_CHAR_v_to_char_list = Q.store_thm("LIST_TYPE_CHAR_v_to_char_list",
+  `∀l v. LIST_TYPE CHAR l v ⇒ v_to_char_list v = SOME l`,
   Induct >>
   simp[LIST_TYPE_def,v_to_char_list_def,PULL_EXISTS,CHAR_def])
 
-val LIST_TYPE_CHAR_char_list_to_v = store_thm("LIST_TYPE_CHAR_char_list_to_v",
-  ``∀l. LIST_TYPE CHAR l (char_list_to_v l)``,
+val LIST_TYPE_CHAR_char_list_to_v = Q.store_thm("LIST_TYPE_CHAR_char_list_to_v",
+  `∀l. LIST_TYPE CHAR l (char_list_to_v l)`,
   Induct >> simp[char_list_to_v_def,LIST_TYPE_def,CHAR_def])
 
 val tac =
@@ -1341,27 +1341,27 @@ val tac =
   rw[do_app_cases,PULL_EXISTS] >>
   rw[state_component_equality]
 
-val Eval_implode = store_thm("Eval_implode",
-  ``!env x1 l.
+val Eval_implode = Q.store_thm("Eval_implode",
+  `!env x1 l.
       Eval env x1 (LIST_TYPE CHAR l) ==>
-      Eval env (App Implode [x1]) (STRING_TYPE (implode l))``,
+      Eval env (App Implode [x1]) (STRING_TYPE (implode l))`,
   tac >>
   rw[STRING_TYPE_def] >>
   imp_res_tac LIST_TYPE_CHAR_v_to_char_list >>
   simp[stringTheory.IMPLODE_EXPLODE_I,mlstringTheory.explode_implode])
 
-val Eval_explode = store_thm("Eval_explode",
-  ``!env x1 s.
+val Eval_explode = Q.store_thm("Eval_explode",
+  `!env x1 s.
       Eval env x1 (STRING_TYPE s) ==>
-      Eval env (App Explode [x1]) (LIST_TYPE CHAR (explode s))``,
+      Eval env (App Explode [x1]) (LIST_TYPE CHAR (explode s))`,
   tac >>
   fs[STRING_TYPE_def,stringTheory.IMPLODE_EXPLODE_I,
      LIST_TYPE_CHAR_char_list_to_v])
 
-val Eval_strlen = store_thm("Eval_strlen",
-  ``!env x1 s.
+val Eval_strlen = Q.store_thm("Eval_strlen",
+  `!env x1 s.
       Eval env x1 (STRING_TYPE s) ==>
-      Eval env (App Strlen [x1]) (NUM (strlen s))``,
+      Eval env (App Strlen [x1]) (NUM (strlen s))`,
   tac >>
   fs[STRING_TYPE_def,NUM_def,INT_def,mlstringTheory.strlen_def])
 
@@ -1383,12 +1383,12 @@ val VECTOR_TYPE_def = Define `
   VECTOR_TYPE a (Vector l) v <=>
     ?l'. v = Vectorv l' /\ LENGTH l = LENGTH l' /\ LIST_REL a l l'`;
 
-val Eval_sub = store_thm("Eval_sub",
- ``!env x1 x2 a n v.
+val Eval_sub = Q.store_thm("Eval_sub",
+ `!env x1 x2 a n v.
      Eval env x1 (VECTOR_TYPE a v) ==>
      Eval env x2 (NUM n) ==>
      n < length v ==>
-     Eval env (App Vsub [x1; x2]) (a (sub v n))``,
+     Eval env (App Vsub [x1; x2]) (a (sub v n))`,
   rw [Eval_def] >>
   rw [Once evaluate_cases] >>
   empty_state_tac >>
@@ -1406,10 +1406,10 @@ val Eval_sub = store_thm("Eval_sub",
   fs [LIST_REL_EL_EQN] >> res_tac >> fs [INT_ABS_NUM,GSYM NOT_LESS] >>
   record_simp_failure_tac);
 
-val Eval_vector = store_thm("Eval_vector",
- ``!env x1 a l.
+val Eval_vector = Q.store_thm("Eval_vector",
+ `!env x1 a l.
      Eval env x1 (LIST_TYPE a l) ==>
-     Eval env (App VfromList [x1]) (VECTOR_TYPE a (Vector l))``,
+     Eval env (App VfromList [x1]) (VECTOR_TYPE a (Vector l))`,
   rw [Eval_def] >>
   rw [Once evaluate_cases] >>
   empty_state_tac >>
@@ -1432,10 +1432,10 @@ val Eval_vector = store_thm("Eval_vector",
   fs [] >>
   metis_tac [optionTheory.NOT_SOME_NONE, optionTheory.SOME_11]);
 
-val Eval_length = store_thm("Eval_length",
-  ``!env x1 x2 a n v.
+val Eval_length = Q.store_thm("Eval_length",
+  `!env x1 x2 a n v.
       Eval env x1 (VECTOR_TYPE a v) ==>
-      Eval env (App Vlength [x1]) (NUM (length v))``,
+      Eval env (App Vlength [x1]) (NUM (length v))`,
   rw [Eval_def] >>
   rw [Once evaluate_cases] >>
   empty_state_tac >>
@@ -1457,13 +1457,13 @@ val _ = temp_overload_on("has_emp",``\x. (FST x).refs = empty_store``)
 
 val s = ``s:'ffi state``
 
-val evaluate_empty_store_lemma = prove(
- ``(!ck env s e r1.
+val evaluate_empty_store_lemma = Q.prove(
+ `(!ck env s e r1.
       evaluate ck env ^s e r1 ==> has_emp r1 ==> (s.refs = empty_store)) /\
    (!ck env s es r1.
       evaluate_list ck env ^s es r1 ==> has_emp r1 ==> (s.refs = empty_store)) /\
    (!ck env s v pes errv r1.
-      evaluate_match ck env ^s v pes errv r1 ==> has_emp r1 ==> (s.refs = empty_store))``,
+      evaluate_match ck env ^s v pes errv r1 ==> has_emp r1 ==> (s.refs = empty_store))`,
   HO_MATCH_MP_TAC evaluate_ind \\ rw [] \\ POP_ASSUM MP_TAC
   \\ TRY (Cases_on `op`)
   \\ FULL_SIMP_TAC (srw_ss()) [do_app_cases,LET_DEF,store_alloc_def]
@@ -1488,13 +1488,13 @@ val _ = temp_overload_on("has_emp_no_fail",
   ``\x. ((FST x).refs = empty_store) /\
         ~(SND x = (Rerr (Rabort Rtype_error)):('b,'c) result)``)
 
-val evaluate_no_clock = prove(
- ``(!ck env ^s e r1.
+val evaluate_no_clock = Q.prove(
+ `(!ck env ^s e r1.
       evaluate ck env s e r1 ==> ~ck ==> (s.clock = (FST r1).clock)) /\
    (!ck env ^s es r1.
       evaluate_list ck env s es r1 ==> ~ck ==> (s.clock = (FST r1).clock))  /\
    (!ck env ^s v pes errv r1.
-      evaluate_match ck env s v pes errv r1 ==>  ~ck ==> (s.clock = (FST r1).clock))``,
+      evaluate_match ck env s v pes errv r1 ==>  ~ck ==> (s.clock = (FST r1).clock))`,
   HO_MATCH_MP_TAC evaluate_ind \\ rw [])
   |> SIMP_RULE std_ss [PULL_EXISTS,AND_IMP_INTRO];
 
@@ -1548,13 +1548,13 @@ val do_app_lemma_gen = prove(
                                store_alloc_def]
   \\ rw []);
 
-val pmatch_empty_store = store_thm("pmatch_empty_store",
-  ``(!cenv (s:v store) (p:pat) v env x.
+val pmatch_empty_store = Q.store_thm("pmatch_empty_store",
+  `(!cenv (s:v store) (p:pat) v env x.
       (pmatch cenv empty_store p v env = x) /\ x <> Match_type_error ==>
       !s. (pmatch cenv s p v env = x)) /\
     (!cenv (s:v store) (p:pat list) vs env x.
       (pmatch_list cenv empty_store p vs env = x) /\ x <> Match_type_error ==>
-      !s. (pmatch_list cenv s p vs env = x))``,
+      !s. (pmatch_list cenv s p vs env = x))`,
   HO_MATCH_MP_TAC pmatch_ind \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [pmatch_def]
   \\ FULL_SIMP_TAC std_ss [store_lookup_def,empty_store_def,LENGTH]
@@ -1699,8 +1699,8 @@ val evaluate_empty_state_IMP = prove(
 
 (* a few misc. lemmas that help the automation *)
 
-val IMP_PreImp = store_thm("IMP_PreImp",
-  ``!b1 b2 b3. (b1 /\ b2 ==> b3) ==> b1 ==> PreImp b2 b3``,
+val IMP_PreImp = Q.store_thm("IMP_PreImp",
+  `!b1 b2 b3. (b1 /\ b2 ==> b3) ==> b1 ==> PreImp b2 b3`,
   REPEAT Cases \\ EVAL_TAC);
 
 val evaluate_list_SIMP = store_thm("evaluate_list_SIMP",
@@ -1719,8 +1719,8 @@ val UNCURRY1 = prove(
   STRIP_TAC \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,pair_case_def]
   \\ Cases \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,pair_case_def]);
 
-val UNCURRY2 = prove(
-  ``!x y f. pair_CASE x f y  = pair_CASE x (\z1 z2. f z1 z2 y)``,
+val UNCURRY2 = Q.prove(
+  `!x y f. pair_CASE x f y  = pair_CASE x (\z1 z2. f z1 z2 y)`,
   Cases \\ EVAL_TAC \\ SIMP_TAC std_ss []);
 
 val UNCURRY3 = prove(
@@ -1730,8 +1730,8 @@ val UNCURRY3 = prove(
 val UNCURRY_SIMP = save_thm("UNCURRY_SIMP",
   LIST_CONJ [UNCURRY1,UNCURRY2,UNCURRY3]);
 
-val num_case_thm = store_thm("num_case_thm",
-  ``num_CASE = \n b f. if n = 0 then b else f (n-1)``,
+val num_case_thm = Q.store_thm("num_case_thm",
+  `num_CASE = \n b f. if n = 0 then b else f (n-1)`,
   SIMP_TAC std_ss [FUN_EQ_THM,num_case_def] \\ Cases_on `n`
   \\ EVAL_TAC \\ SIMP_TAC std_ss []);
 
@@ -1741,24 +1741,24 @@ val PUSH_FORALL_INTO_IMP = save_thm("PUSH_FORALL_INTO_IMP",
 val FALSE_def = Define `FALSE = F`;
 val TRUE_def = Define `TRUE = T`;
 
-val Eval_Val_BOOL_FALSE = store_thm("Eval_Val_BOOL_FALSE",
-  ``Eval env (App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL FALSE)``,
+val Eval_Val_BOOL_FALSE = Q.store_thm("Eval_Val_BOOL_FALSE",
+  `Eval env (App (Opb Lt) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL FALSE)`,
   SIMP_TAC (srw_ss()) [Eval_Val_BOOL_F,FALSE_def]);
 
-val Eval_Val_BOOL_TRUE = store_thm("Eval_Val_BOOL_TRUE",
-  ``Eval env (App (Opb Leq) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL TRUE)``,
+val Eval_Val_BOOL_TRUE = Q.store_thm("Eval_Val_BOOL_TRUE",
+  `Eval env (App (Opb Leq) [Lit (IntLit 0); Lit (IntLit 0)]) (BOOL TRUE)`,
   SIMP_TAC (srw_ss()) [Eval_Val_BOOL_T,TRUE_def]);
 
 val MEMBER_def = Define `
   (MEMBER (x:'a) [] <=> F) /\
   (MEMBER x (y::ys) <=> (x = y) \/ MEMBER x ys)`;
 
-val MEM_EQ_MEMBER = prove(
-  ``!ys x. MEM x ys = MEMBER x ys``,
+val MEM_EQ_MEMBER = Q.prove(
+  `!ys x. MEM x ys = MEMBER x ys`,
   Induct \\ FULL_SIMP_TAC (srw_ss()) [MEMBER_def]);
 
-val MEMBER_INTRO = store_thm("MEMBER_INTRO",
-  ``(MEM = MEMBER) /\ (MEM x = MEMBER x) /\ (MEM x ys = MEMBER x ys)``,
+val MEMBER_INTRO = Q.store_thm("MEMBER_INTRO",
+  `(MEM = MEMBER) /\ (MEM x = MEMBER x) /\ (MEM x ys = MEMBER x ys)`,
   FULL_SIMP_TAC std_ss [FUN_EQ_THM,MEM_EQ_MEMBER]);
 
 (* always_evaluates *)
@@ -1767,16 +1767,16 @@ val always_evaluates_def = Define `
   always_evaluates env exp =
     !(s1:unit state). ?s2 res. evaluate F env s1 exp (s2,Rval res)`;
 
-val Eval_IMP_always_evaluates = store_thm("Eval_IMP_always_evaluates",
-  ``!env exp P. Eval env exp P ==> always_evaluates env exp``,
+val Eval_IMP_always_evaluates = Q.store_thm("Eval_IMP_always_evaluates",
+  `!env exp P. Eval env exp P ==> always_evaluates env exp`,
   FULL_SIMP_TAC std_ss [Eval_def,always_evaluates_def] \\ REPEAT STRIP_TAC
   \\ Q.LIST_EXISTS_TAC [`s1`,`res`] \\ FULL_SIMP_TAC std_ss []
   \\ imp_res_tac evaluate_empty_state_IMP
   \\ FULL_SIMP_TAC std_ss []);
 
-val always_evaluates_ref = store_thm("always_evaluates_ref",
-  ``!env exp. always_evaluates env exp ==>
-              always_evaluates env (App Opref [exp])``,
+val always_evaluates_ref = Q.store_thm("always_evaluates_ref",
+  `!env exp. always_evaluates env exp ==>
+              always_evaluates env (App Opref [exp])`,
   FULL_SIMP_TAC std_ss [always_evaluates_def]
   \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ FIRST_X_ASSUM (STRIP_ASSUME_TAC o Q.SPEC `s1`)
@@ -1788,30 +1788,30 @@ val always_evaluates_ref = store_thm("always_evaluates_ref",
   \\ SRW_TAC [] []
   \\ METIS_TAC []);
 
-val always_evaluates_fn = store_thm("always_evaluates_fn",
-  ``!n exp env. always_evaluates env (Fun n exp)``,
+val always_evaluates_fn = Q.store_thm("always_evaluates_fn",
+  `!n exp env. always_evaluates env (Fun n exp)`,
   FULL_SIMP_TAC std_ss [always_evaluates_def]
   \\ ONCE_REWRITE_TAC [evaluate_cases] \\ SRW_TAC [] []);
 
 (* lookup cons *)
 
-val lookup_cons_write = store_thm("lookup_cons_write",
-  ``!funs n x env name env1.
+val lookup_cons_write = Q.store_thm("lookup_cons_write",
+  `!funs n x env name env1.
       (lookup_cons name (write n x env) = lookup_cons name env) /\
-      (lookup_cons name (write_rec funs env1 env) = lookup_cons name env)``,
+      (lookup_cons name (write_rec funs env1 env) = lookup_cons name env)`,
   Induct \\ REPEAT STRIP_TAC
   \\ fs [write_rec_thm,write_def,lookup_cons_thm]);
 
-val lookup_var_id_write = store_thm("lookup_var_id_write",
-  ``(lookup_var_id (Short name) (write n v env) =
+val lookup_var_id_write = Q.store_thm("lookup_var_id_write",
+  `(lookup_var_id (Short name) (write n v env) =
        if n = name then SOME v else lookup_var_id (Short name) env) /\
     (lookup_var_id (Long mn name) (write n v env) =
-       lookup_var_id (Long mn name) env)``,
+       lookup_var_id (Long mn name) env)`,
   fs [write_def] \\ EVAL_TAC \\ rw [] \\ fs [lookup_var_id_def]);
 
-val DISJOINT_set_SIMP = store_thm("DISJOINT_set_SIMP",
-  ``(DISJOINT (set []) s <=> T) /\
-    (DISJOINT (set (x::xs)) s <=> ~(x IN s) /\ DISJOINT (set xs) s)``,
+val DISJOINT_set_SIMP = Q.store_thm("DISJOINT_set_SIMP",
+  `(DISJOINT (set []) s <=> T) /\
+    (DISJOINT (set (x::xs)) s <=> ~(x IN s) /\ DISJOINT (set xs) s)`,
   REPEAT STRIP_TAC THEN1 (SRW_TAC [] []) \\ Cases_on `x IN s` \\ fs []);
 
 (* removing shadowed elements from an alist *)
@@ -1826,18 +1826,18 @@ val ASHADOW_def = tDefine "ASHADOW" `
   \\ MATCH_MP_TAC LESS_EQ_LESS_TRANS
   \\ Q.EXISTS_TAC `LENGTH xs` \\ fs [rich_listTheory.LENGTH_FILTER_LEQ])
 
-val ASHADOW_PREFIX = prove(
-  ``!xs ys.
+val ASHADOW_PREFIX = Q.prove(
+  `!xs ys.
       ALL_DISTINCT (MAP FST xs) /\
       EVERY (\y. ~(MEM y (MAP FST ys))) (MAP FST xs) ==>
-      (ASHADOW (xs ++ ys) = xs ++ ASHADOW ys)``,
+      (ASHADOW (xs ++ ys) = xs ++ ASHADOW ys)`,
   Induct \\ fs [FORALL_PROD,ASHADOW_def]
   \\ REPEAT STRIP_TAC \\ SRW_TAC [] []
   \\ fs [EVERY_MEM,FORALL_PROD,EXISTS_MEM,MEM_MAP,EXISTS_PROD,PULL_EXISTS]
   \\ Cases_on `y` \\ fs [] \\ RES_TAC);
 
-val MEM_MAP_ASHADOW = prove(
-  ``!xs y. MEM y (MAP FST (ASHADOW xs)) = MEM y (MAP FST xs)``,
+val MEM_MAP_ASHADOW = Q.prove(
+  `!xs y. MEM y (MAP FST (ASHADOW xs)) = MEM y (MAP FST xs)`,
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs[] THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
@@ -1857,15 +1857,15 @@ val EVERY_ALOOKUP_LEMMA = prove(
   \\ res_tac \\ Cases_on `h0 = p_1`
   \\ fs [MEM_MAP,FORALL_PROD] \\ metis_tac []);
 
-val ALOOKUP_FILTER = prove(
-  ``!t a q. q <> a ==> (ALOOKUP (FILTER (\y. q <> FST y) t) a = ALOOKUP t a)``,
+val ALOOKUP_FILTER = Q.prove(
+  `!t a q. q <> a ==> (ALOOKUP (FILTER (\y. q <> FST y) t) a = ALOOKUP t a)`,
   Induct THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
   \\ fs [alistTheory.ALOOKUP_def,FORALL_PROD]
   \\ REPEAT STRIP_TAC \\ Cases_on `p_1 = a` \\ fs []
   \\ SRW_TAC [] []);
 
-val ALOOKUP_ASHADOW = prove(
-  ``!xs a. ALOOKUP (ASHADOW xs) a = ALOOKUP xs a``,
+val ALOOKUP_ASHADOW = Q.prove(
+  `!xs a. ALOOKUP (ASHADOW xs) a = ALOOKUP xs a`,
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs [] THEN1 EVAL_TAC
@@ -1877,8 +1877,8 @@ val ALOOKUP_ASHADOW = prove(
   \\ Q.EXISTS_TAC `LENGTH t`
   \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]);
 
-val ALL_DISTINCT_MAP_FST_ASHADOW = prove(
-  ``!xs. ALL_DISTINCT (MAP FST (ASHADOW xs))``,
+val ALL_DISTINCT_MAP_FST_ASHADOW = Q.prove(
+  `!xs. ALL_DISTINCT (MAP FST (ASHADOW xs))`,
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs [] THEN1 EVAL_TAC
@@ -1892,8 +1892,8 @@ val ALL_DISTINCT_MAP_FST_ASHADOW = prove(
 
 (* size lemmas *)
 
-val v6_size = prove(
-  ``!vs v. (MEM v vs ==> v_size v < v6_size vs)``,
+val v6_size = Q.prove(
+  `!vs v. (MEM v vs ==> v_size v < v6_size vs)`,
   Induct \\ SRW_TAC [] [semanticPrimitivesTheory.v_size_def]
   \\ RES_TAC \\ DECIDE_TAC);
 
@@ -1903,8 +1903,8 @@ val v4_size = prove(
   \\ SRW_TAC [] [semanticPrimitivesTheory.v_size_def]
   \\ RES_TAC \\ DECIDE_TAC);
 
-val v2_size = prove(
-  ``!xs a. MEM a xs ==> v3_size a < v2_size xs``,
+val v2_size = Q.prove(
+  `!xs a. MEM a xs ==> v3_size a < v2_size xs`,
   Induct \\ SRW_TAC [] [semanticPrimitivesTheory.v_size_def]
   \\ SRW_TAC [] [semanticPrimitivesTheory.v_size_def]
   \\ RES_TAC \\ DECIDE_TAC);
@@ -1941,13 +1941,13 @@ val type_names_eq = prove(
   Induct \\ fs [type_names_def] \\ Cases_on `h`
   \\ fs [type_names_def] \\ fs [FORALL_PROD,listTheory.MAP_EQ_f]);
 
-val no_dup_types_eval = prove(
-  ``!ds. no_dup_types ds = ALL_DISTINCT (type_names ds [])``,
+val no_dup_types_eval = Q.prove(
+  `!ds. no_dup_types ds = ALL_DISTINCT (type_names ds [])`,
   fs [no_dup_types_def,type_names_eq,decs_to_types_def,ALL_DISTINCT_FLAT_REVERSE]);
 
-val lookup_APPEND = prove(
-  ``!xs ys n. ~(MEM n (MAP FST ys)) ==>
-              (ALOOKUP (xs ++ ys) n = ALOOKUP xs n)``,
+val lookup_APPEND = Q.prove(
+  `!xs ys n. ~(MEM n (MAP FST ys)) ==>
+              (ALOOKUP (xs ++ ys) n = ALOOKUP xs n)`,
   Induct THEN1
    (FULL_SIMP_TAC std_ss [APPEND] \\ Induct
     \\ FULL_SIMP_TAC std_ss [MAP,MEM,FORALL_PROD] >>
@@ -1965,8 +1965,8 @@ val FEVERY_DRESTRICT_FUPDATE = store_thm("FEVERY_DRESTRICT_FUPDATE",
   \\ `COMPL s = COMPL (x INSERT s)` by
      (fs [Once pred_setTheory.EXTENSION] \\ METIS_TAC []) \\ fs [])
 
-val PULL_EXISTS_EXTRA = store_thm("PULL_EXISTS_EXTRA",
-  ``(Q ==> ?x. P x) <=> ?x. Q ==> P x``,
+val PULL_EXISTS_EXTRA = Q.store_thm("PULL_EXISTS_EXTRA",
+  `(Q ==> ?x. P x) <=> ?x. Q ==> P x`,
   metis_tac []);
 
 val evaluate_Fun = store_thm("evaluate_Fun",
@@ -1978,8 +1978,8 @@ val evaluate_Var = store_thm("evaluate_Var",
     ?v. lookup_var n env = SOME r``,
   fs [Once evaluate_cases] \\ EVAL_TAC);
 
-val lookup_var_eq_lookup_var_id = store_thm("lookup_var_eq_lookup_var_id",
-  ``lookup_var n = lookup_var_id (Short n)``,
+val lookup_var_eq_lookup_var_id = Q.store_thm("lookup_var_eq_lookup_var_id",
+  `lookup_var n = lookup_var_id (Short n)`,
   fs [FUN_EQ_THM] \\ EVAL_TAC \\ fs []);
 
 val PRECONDITION_T = save_thm("PRECONDITION_T",EVAL ``PRECONDITION T``);
@@ -1990,89 +1990,89 @@ val Eval_evaluate_IMP = store_thm("Eval_evaluate_IMP",
     P v``,
   fs [Eval_def] \\ rw [] \\ imp_res_tac evaluate_11_Rval \\ fs []);
 
-val pair_CASE_UNCURRY = store_thm("pair_CASE_UNCURRY",
-  ``!x y. pair_CASE x y = UNCURRY y x``,
+val pair_CASE_UNCURRY = Q.store_thm("pair_CASE_UNCURRY",
+  `!x y. pair_CASE x y = UNCURRY y x`,
   Cases \\ EVAL_TAC \\ fs []);
 
-val IF_T = store_thm("IF_T",``(if T then x else y) = x:'a``,SIMP_TAC std_ss []);
-val IF_F = store_thm("IF_F",``(if F then x else y) = y:'a``,SIMP_TAC std_ss []);
+val IF_T = Q.store_thm("IF_T",`(if T then x else y) = x:'a`,SIMP_TAC std_ss []);
+val IF_F = Q.store_thm("IF_F",`(if F then x else y) = y:'a`,SIMP_TAC std_ss []);
 
-val sat_hyp_lemma = store_thm("sat_hyp_lemma",
-  ``(b1 ==> (x1 = x2)) /\ (x1 ==> y) ==> b1 /\ x2 ==> y``,
+val sat_hyp_lemma = Q.store_thm("sat_hyp_lemma",
+  `(b1 ==> (x1 = x2)) /\ (x1 ==> y) ==> b1 /\ x2 ==> y`,
   Cases_on `b1` \\ Cases_on `x1` \\ Cases_on `x2` \\ Cases_on `y` \\ EVAL_TAC);
 
-val IMP_EQ_F = store_thm("IMP_EQ_F",``~b ==> (b = F)``,REWRITE_TAC [])
-val IMP_EQ_T = store_thm("IMP_EQ_T",``b ==> (b = T)``,REWRITE_TAC [])
+val IMP_EQ_F = Q.store_thm("IMP_EQ_F",`~b ==> (b = F)`,REWRITE_TAC [])
+val IMP_EQ_T = Q.store_thm("IMP_EQ_T",`b ==> (b = T)`,REWRITE_TAC [])
 
-val IF_TAKEN = store_thm("IF_TAKEN",
-  ``!b x y. b ==> ((if b then x else y) = x:'unlikely)``,
+val IF_TAKEN = Q.store_thm("IF_TAKEN",
+  `!b x y. b ==> ((if b then x else y) = x:'unlikely)`,
   SIMP_TAC std_ss []);
 
-val LIST_TYPE_And = store_thm("LIST_TYPE_And",
-  ``LIST_TYPE (And a P) = And (LIST_TYPE a) (EVERY (P:'a->bool))``,
+val LIST_TYPE_And = Q.store_thm("LIST_TYPE_And",
+  `LIST_TYPE (And a P) = And (LIST_TYPE a) (EVERY (P:'a->bool))`,
   SIMP_TAC std_ss [FUN_EQ_THM,And_def] \\ Induct
   \\ FULL_SIMP_TAC std_ss [MEM,LIST_TYPE_def]
   \\ REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC (srw_ss()) [And_def])
 
-val EVERY_MEM_CONTAINER = store_thm("EVERY_MEM_CONTAINER",
-  ``!P l. EVERY P l <=> !e. CONTAINER (MEM e l) ==> P (e:'a)``,
+val EVERY_MEM_CONTAINER = Q.store_thm("EVERY_MEM_CONTAINER",
+  `!P l. EVERY P l <=> !e. CONTAINER (MEM e l) ==> P (e:'a)`,
   SIMP_TAC std_ss [EVERY_MEM,CONTAINER_def]);
 
-val PRECONDITION_EQ_CONTAINER = store_thm("PRECONDITION_EQ_CONTAINER",
-  ``(PRECONDITION p = CONTAINER p) /\
-    (CONTAINER ~p = ~CONTAINER p) /\ CONTAINER T``,
+val PRECONDITION_EQ_CONTAINER = Q.store_thm("PRECONDITION_EQ_CONTAINER",
+  `(PRECONDITION p = CONTAINER p) /\
+    (CONTAINER ~p = ~CONTAINER p) /\ CONTAINER T`,
   EVAL_TAC);
 
-val CONTAINER_NOT_ZERO = store_thm("CONTAINER_NOT_ZERO",
-  ``!P. (~(CONTAINER (b = 0)) ==> P b) =
-        !n. (CONTAINER (b = SUC n)) ==> P (SUC n:num)``,
+val CONTAINER_NOT_ZERO = Q.store_thm("CONTAINER_NOT_ZERO",
+  `!P. (~(CONTAINER (b = 0)) ==> P b) =
+        !n. (CONTAINER (b = SUC n)) ==> P (SUC n:num)`,
   REPEAT STRIP_TAC THEN Cases_on `b`
   THEN EVAL_TAC THEN SRW_TAC [] [ADD1]);
 
-val IMP_PreImp_LEMMA = store_thm("IMP_PreImp_LEMMA",
-  ``!b1 b2 b3. (b1 ==> b3 ==> b2) ==> b3 ==> PreImp b1 b2``,
+val IMP_PreImp_LEMMA = Q.store_thm("IMP_PreImp_LEMMA",
+  `!b1 b2 b3. (b1 ==> b3 ==> b2) ==> b3 ==> PreImp b1 b2`,
   REPEAT Cases THEN REWRITE_TAC [PreImp_def,PRECONDITION_def]);
 
-val PRE_IMP = store_thm("PRE_IMP",
-  ``T /\ PRECONDITION b ==> PRECONDITION b``,
+val PRE_IMP = Q.store_thm("PRE_IMP",
+  `T /\ PRECONDITION b ==> PRECONDITION b`,
   EVAL_TAC)
 
-val PreImp_IMP_T = store_thm("PreImp_IMP_T",
-  ``PreImp b1 b2 /\ T ==> PreImp b1 b2``,
+val PreImp_IMP_T = Q.store_thm("PreImp_IMP_T",
+  `PreImp b1 b2 /\ T ==> PreImp b1 b2`,
   EVAL_TAC)
 
-val CONJ_IMP = store_thm("CONJ_IMP",
-  ``!b1 b2 b12 b3 b4 b34.
+val CONJ_IMP = Q.store_thm("CONJ_IMP",
+  `!b1 b2 b12 b3 b4 b34.
       (b1 /\ b2 ==> b12) /\ (b3 /\ b4 ==> b34) ==>
-      ((b1 /\ b3) /\ (b2 /\ b4) ==> b12 /\ b34)``,
+      ((b1 /\ b3) /\ (b2 /\ b4) ==> b12 /\ b34)`,
   REPEAT Cases THEN EVAL_TAC) |> SPEC_ALL;
 
-val IMP_SPLIT = store_thm("IMP_SPLIT",
-  ``!b12 b3 b4 b34.
+val IMP_SPLIT = Q.store_thm("IMP_SPLIT",
+  `!b12 b3 b4 b34.
       (b12 = b12) /\ (b3 /\ b4 ==> b34) ==>
-      ((b12 ==> b3) /\ (b12 ==> b4) ==> (b12 ==> b34))``,
+      ((b12 ==> b3) /\ (b12 ==> b4) ==> (b12 ==> b34))`,
   REPEAT Cases THEN EVAL_TAC) |> SPEC_ALL;
 
-val FORALL_SPLIT = store_thm("FORALL_SPLIT",
-  ``(!x. P1 x /\ P2 x ==> P (x:'a)) ==>
-    ($! P1 ) /\ ($! P2 ) ==> $! P ``,
+val FORALL_SPLIT = Q.store_thm("FORALL_SPLIT",
+  `(!x. P1 x /\ P2 x ==> P (x:'a)) ==>
+    ($! P1 ) /\ ($! P2 ) ==> $! P `,
   FULL_SIMP_TAC std_ss [FORALL_THM]);
 
-val DEFAULT_IMP = store_thm("DEFAULT_IMP",
-  ``!b1. b1 /\ b1 ==> b1``,
+val DEFAULT_IMP = Q.store_thm("DEFAULT_IMP",
+  `!b1. b1 /\ b1 ==> b1`,
   SIMP_TAC std_ss []);
 
-val combine_lemma = store_thm("combine_lemma",
-  ``!b1 b2 b3 b4. (b1 /\ b2 ==> b3) /\ (b3 ==> b4) ==> b2 ==> b1 ==> b4``,
+val combine_lemma = Q.store_thm("combine_lemma",
+  `!b1 b2 b3 b4. (b1 /\ b2 ==> b3) /\ (b3 ==> b4) ==> b2 ==> b1 ==> b4`,
   REPEAT Cases THEN SIMP_TAC std_ss [])
 
-val IMP_PreImp_THM = store_thm("IMP_PreImp_THM",
-  ``(b ==> PreImp x y) ==> ((x ==> b) ==> PreImp x y)``,
+val IMP_PreImp_THM = Q.store_thm("IMP_PreImp_THM",
+  `(b ==> PreImp x y) ==> ((x ==> b) ==> PreImp x y)`,
   Cases_on `b` \\ FULL_SIMP_TAC std_ss [PreImp_def,PRECONDITION_def]);
 
-val PreImp_IMP = store_thm("PreImp_IMP",
-  ``(PRECONDITION x ==> PreImp x y) ==> PreImp x y``,
+val PreImp_IMP = Q.store_thm("PreImp_IMP",
+  `(PRECONDITION x ==> PreImp x y) ==> PreImp x y`,
   SIMP_TAC std_ss [PreImp_def]);
 
 val evaluate_Mat = save_thm("evaluate_Mat",

--- a/translator/ml_translator_demoScript.sml
+++ b/translator/ml_translator_demoScript.sml
@@ -38,8 +38,8 @@ val lookup_qsort = save_thm("lookup_qsort",
 
 (* --- a more concrete example, not much use --- *)
 
-val Eval_Var_lemma = prove(
-  ``(lookup_var name env = SOME x) /\ P x ==> Eval env (Var (Short name)) P``,
+val Eval_Var_lemma = Q.prove(
+  `(lookup_var name env = SOME x) /\ P x ==> Eval env (Var (Short name)) P`,
   fs [Eval_def,lookup_var_id_def,lookup_var_def,
       Once bigStepTheory.evaluate_cases]);
 

--- a/translator/okasaki-examples/BankersQueueScript.sml
+++ b/translator/okasaki-examples/BankersQueueScript.sml
@@ -35,30 +35,30 @@ val queue_inv_def = Define `
     (q = f ++ REVERSE r) /\ (lenr = LENGTH r) /\
     (lenf = LENGTH f) /\ lenr <= lenf`;
 
-val empty_thm = prove(
-  ``!xs. queue_inv xs empty = (xs = [])``,
+val empty_thm = Q.prove(
+  `!xs. queue_inv xs empty = (xs = [])`,
   EVAL_TAC THEN SIMP_TAC std_ss []);
 
-val is_empty_thm = prove(
-  ``!q xs. queue_inv xs q ==> (is_empty q = (xs = []))``,
+val is_empty_thm = Q.prove(
+  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,LENGTH_NIL,REV_DEF]);
 
-val snoc_thm = prove(
-  ``!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)``,
+val snoc_thm = Q.prove(
+  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
   Cases THEN Cases_on `l` THEN1
    (EVAL_TAC THEN SRW_TAC [] []
     THEN FULL_SIMP_TAC std_ss [LENGTH_NIL,REV_DEF,APPEND,LENGTH] THEN EVAL_TAC)
   THEN FULL_SIMP_TAC std_ss [queue_inv_def,snoc_def,checkf_def]
   THEN SRW_TAC [] [queue_inv_def] THEN DECIDE_TAC);
 
-val head_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> (head q = x)``,
+val head_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL,REV_DEF]);
 
-val tail_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)``,
+val tail_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
   Cases THEN Cases_on `l` THEN1
    (FULL_SIMP_TAC std_ss [queue_inv_def,APPEND,tail_def]
     THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) []

--- a/translator/okasaki-examples/BatchedQueueScript.sml
+++ b/translator/okasaki-examples/BatchedQueueScript.sml
@@ -35,27 +35,27 @@ val queue_inv_def = Define `
   queue_inv q (QUEUE xs ys) <=>
     (q = xs ++ REVERSE ys) /\ ((xs = []) ==> (ys = []))`;
 
-val empty_thm = prove(
-  ``!xs. queue_inv xs empty = (xs = [])``,
+val empty_thm = Q.prove(
+  `!xs. queue_inv xs empty = (xs = [])`,
   EVAL_TAC THEN SIMP_TAC std_ss []);
 
-val is_empty_thm = prove(
-  ``!q xs. queue_inv xs q ==> (is_empty q = (xs = []))``,
+val is_empty_thm = Q.prove(
+  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] [REV_DEF]);
 
-val snoc_thm = prove(
-  ``!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)``,
+val snoc_thm = Q.prove(
+  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [queue_inv_def,snoc_def,REVERSE_DEF,checkf_def,APPEND]);
 
-val head_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> (head q = x)``,
+val head_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [queue_inv_def,head_def,REVERSE_DEF,checkf_def,APPEND]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss()) []);
 
-val tail_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)``,
+val tail_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN TRY (Cases_on `t`) THEN EVAL_TAC
   THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,REV_DEF]);

--- a/translator/okasaki-examples/ImplicitQueueScript.sml
+++ b/translator/okasaki-examples/ImplicitQueueScript.sml
@@ -81,74 +81,74 @@ val queue_ok_def = Define `
 val queue_inv_def = Define `
   queue_inv q t <=> queue_ok 0 t /\ (q = flatten t)`;
 
-val empty_thm = prove(
-  ``queue_inv [] empty``,
+val empty_thm = Q.prove(
+  `queue_inv [] empty`,
   EVAL_TAC);
 
-val exps_NOT_NIL = prove(
-  ``!e. ~(exps e = [])``,
+val exps_NOT_NIL = Q.prove(
+  `!e. ~(exps e = [])`,
   Induct THEN EVAL_TAC THEN FULL_SIMP_TAC std_ss [APPEND_eq_NIL]);
 
-val is_empty_thm = prove(
-  ``!xs q. queue_inv xs q ==> (is_empty q = (xs = []))``,
+val is_empty_thm = Q.prove(
+  `!xs q. queue_inv xs q ==> (is_empty q = (xs = []))`,
   Cases THEN Cases THEN EVAL_TAC
   THEN1 (Cases_on `d` THEN EVAL_TAC THEN SIMP_TAC std_ss [exps_NOT_NIL])
   THEN1 (Cases_on `d0` THEN EVAL_TAC THEN ONCE_REWRITE_TAC [EQ_SYM_EQ]
          THEN SIMP_TAC std_ss [exps_NOT_NIL,APPEND_eq_NIL])
   THEN Cases_on `d` THEN EVAL_TAC);
 
-val flatten_snoc = prove(
-  ``!x y n. queue_ok n x ==> (flatten (snoc x y) = flatten x ++ exps y)``,
+val flatten_snoc = Q.prove(
+  `!x y n. queue_ok n x ==> (flatten (snoc x y) = flatten x ++ exps y)`,
   Induct THEN Cases_on `d`
   THEN FULL_SIMP_TAC (srw_ss()) [snoc_def,flatten_def,digits_def,
       empty_def,queue_ok_def,two_def] THEN REPEAT STRIP_TAC
   THEN RES_TAC THEN FULL_SIMP_TAC std_ss [exps_def,APPEND_ASSOC]);
 
-val queue_ok_snoc = prove(
-  ``!q y n. queue_ok n q /\ depth n y ==> queue_ok n (snoc q y)``,
+val queue_ok_snoc = Q.prove(
+  `!q y n. queue_ok n q /\ depth n y ==> queue_ok n (snoc q y)`,
   Induct THEN Cases_on `d`
   THEN FULL_SIMP_TAC (srw_ss()) [snoc_def,queue_ok_def,ddepth_def,two_def,
     only_digits_def,EVERY_DEF,empty_def] THEN REPEAT STRIP_TAC
   THEN Q.PAT_X_ASSUM `!x.bbb` MATCH_MP_TAC
   THEN FULL_SIMP_TAC (srw_ss()) [depth_def]);
 
-val snoc_thm = prove(
-  ``!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q (Once x))``,
+val snoc_thm = Q.prove(
+  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q (Once x))`,
   STRIP_TAC THEN SIMP_TAC std_ss [queue_inv_def] THEN REPEAT STRIP_TAC
   THEN IMP_RES_TAC flatten_snoc THEN FULL_SIMP_TAC std_ss [exps_def]
   THEN MATCH_MP_TAC queue_ok_snoc THEN FULL_SIMP_TAC std_ss [] THEN EVAL_TAC);
 
-val depth_0 = prove(
-  ``!e. depth 0 e ==> ?x. e = Once x``,
+val depth_0 = Q.prove(
+  `!e. depth 0 e ==> ?x. e = Once x`,
   Cases THEN SIMP_TAC (srw_ss()) [depth_def]);
 
-val head_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> (head q = Once x)``,
+val head_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> (head q = Once x)`,
   Cases THEN TRY (Cases_on `d`) THEN TRY (Cases_on `d0`)
   THEN EVAL_TAC THEN SIMP_TAC (srw_ss()) []
   THEN REPEAT STRIP_TAC THEN IMP_RES_TAC depth_0
   THEN FULL_SIMP_TAC (srw_ss()) [exps_def])
 
-val depth_IMP = prove(
-  ``!t n. depth n t ==> (LENGTH (exps t) = 2**n)``,
+val depth_IMP = Q.prove(
+  `!t n. depth n t ==> (LENGTH (exps t) = 2**n)`,
   Induct THEN1 (EVAL_TAC THEN FULL_SIMP_TAC std_ss [])
   THEN Cases THEN FULL_SIMP_TAC std_ss [depth_def,ADD1]
   THEN REPEAT STRIP_TAC THEN RES_TAC
   THEN FULL_SIMP_TAC (srw_ss()) [exps_def,GSYM ADD1,EXP] THEN DECIDE_TAC);
 
-val LENGTH_EQ_APPEND_EQ = prove(
-  ``!xs xs2 ys ys2.
-      (LENGTH xs = LENGTH ys) /\ (xs ++ xs2 = ys ++ ys2) ==> (xs2 = ys2)``,
+val LENGTH_EQ_APPEND_EQ = Q.prove(
+  `!xs xs2 ys ys2.
+      (LENGTH xs = LENGTH ys) /\ (xs ++ xs2 = ys ++ ys2) ==> (xs2 = ys2)`,
   Induct THEN Cases_on `ys` THEN FULL_SIMP_TAC (srw_ss()) [ADD1]);
 
-val is_empty_EQ = prove(
-  ``!q. is_empty q = (q = Shallow Zero)``,
+val is_empty_EQ = Q.prove(
+  `!q. is_empty q = (q = Shallow Zero)`,
   Cases THEN Cases_on `d` THEN EVAL_TAC);
 
-val tail_lemma = prove(
-  ``!q n x xs.
+val tail_lemma = Q.prove(
+  `!q n x xs.
       queue_ok n q /\ (exps x ++ xs = flatten q) /\ depth n x ==>
-      queue_ok n (tail q) /\ (xs = flatten (tail q))``,
+      queue_ok n (tail q) /\ (xs = flatten (tail q))`,
   Induct THEN1 (Cases_on `d`
     THEN FULL_SIMP_TAC (srw_ss()) [flatten_def,digits_def,exps_NOT_NIL,tail_def,
            queue_ok_def,empty_def,ddepth_def,EVERY_DEF,two_def,only_digits_def]
@@ -204,8 +204,8 @@ val tail_lemma = prove(
   THEN MATCH_MP_TAC (METIS_PROVE [] ``b /\ (b1 ==> b2) ==> (b ==> b1) ==> b2``)
   THEN FULL_SIMP_TAC std_ss [exps_def,depth_def]);
 
-val tail_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)``,
+val tail_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
   FULL_SIMP_TAC std_ss [queue_inv_def] THEN NTAC 4 STRIP_TAC
   THEN MATCH_MP_TAC tail_lemma THEN Q.EXISTS_TAC `Once x`
   THEN FULL_SIMP_TAC std_ss [exps_def,APPEND,depth_def]);

--- a/translator/okasaki-examples/LazyPairingHeapScript.sml
+++ b/translator/okasaki-examples/LazyPairingHeapScript.sml
@@ -114,7 +114,7 @@ val merge_ind =
   SIMP_RULE (srw_ss()) [merge_size_lem, LET_THM] (fetch "-" "merge_ind");
 val _ = save_thm ("merge_ind",merge_ind);
 
-val merge_thm = prove(``
+val merge_thm = Q.prove(`
   merge get_key leq a b =
     case (a,b) of
     | (a,Empty) => a
@@ -131,7 +131,7 @@ val merge_thm = prove(``
           | Empty => Tree y (Tree x h1 h2) h2'
           | _ =>
             Tree y Empty (merge get_key leq
-                         (merge get_key leq (Tree x h1 h2) h1') h2')``,
+                         (merge get_key leq (Tree x h1 h2) h1') h2')`,
   Cases_on `a` THEN Cases_on `b` THEN SIMP_TAC (srw_ss()) [merge_def]);
 
 val _ = translate merge_thm;

--- a/translator/okasaki-examples/PhysicistsQueueScript.sml
+++ b/translator/okasaki-examples/PhysicistsQueueScript.sml
@@ -42,25 +42,25 @@ val queue_inv_def = Define `
     (q = f ++ REVERSE r) /\ (lenr = LENGTH r) /\ (lenf = LENGTH f) /\
     lenr <= lenf /\ ((w = []) ==> (q = [])) /\ isPREFIX w f`;
 
-val empty_thm = prove(
-  ``!xs. queue_inv xs empty = (xs = [])``,
+val empty_thm = Q.prove(
+  `!xs. queue_inv xs empty = (xs = [])`,
   EVAL_TAC THEN SIMP_TAC std_ss []);
 
-val is_empty_thm = prove(
-  ``!q xs. queue_inv xs q ==> (is_empty q = (xs = []))``,
+val is_empty_thm = Q.prove(
+  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [APPEND_eq_NIL,LENGTH_NIL]);
 
-val isPREFIX_APPEND = prove(
-  ``!xs ys. isPREFIX xs (xs ++ ys)``,
+val isPREFIX_APPEND = Q.prove(
+  `!xs ys. isPREFIX xs (xs ++ ys)`,
   Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]);
 
-val isPREFIX_REFL = prove(
-  ``!xs ys. isPREFIX xs xs``,
+val isPREFIX_REFL = Q.prove(
+  `!xs ys. isPREFIX xs xs`,
   Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]);
 
-val snoc_thm = prove(
-  ``!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)``,
+val snoc_thm = Q.prove(
+  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
   Cases THEN Cases_on `l`
   THEN FULL_SIMP_TAC (srw_ss()) [queue_inv_def,snoc_def,check_def,checkw_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss())
@@ -70,13 +70,13 @@ val snoc_thm = prove(
   THEN FULL_SIMP_TAC std_ss [isPREFIX_APPEND,GSYM APPEND_ASSOC]
   THEN DECIDE_TAC);
 
-val head_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> (head q = x)``,
+val head_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL]);
 
-val tail_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)``,
+val tail_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
   Cases THEN Cases_on `l`
   THEN FULL_SIMP_TAC (srw_ss()) [queue_inv_def,tail_def,check_def,checkw_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss())

--- a/translator/okasaki-examples/RealTimeQueueScript.sml
+++ b/translator/okasaki-examples/RealTimeQueueScript.sml
@@ -42,19 +42,19 @@ val prop_def = Define `
 val queue_inv_def = Define `
   queue_inv q (QUEUE f r s) <=> prop 0 q (QUEUE f r s)`
 
-val empty_thm = prove(
-  ``!xs. queue_inv xs empty = (xs = [])``,
+val empty_thm = Q.prove(
+  `!xs. queue_inv xs empty = (xs = [])`,
   EVAL_TAC THEN SIMP_TAC std_ss []);
 
-val is_empty_thm = prove(
-  ``!q xs. queue_inv xs q ==> (is_empty q = (xs = []))``,
+val is_empty_thm = Q.prove(
+  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
   Cases THEN Cases_on `l`
   THEN SRW_TAC [] [LENGTH_NIL,queue_inv_def,is_empty_def,prop_def,LENGTH]);
 
-val rotate_thm = prove(
-  ``!f r s.
+val rotate_thm = Q.prove(
+  `!f r s.
       (LENGTH r = LENGTH f + 1) ==>
-      (rotate (QUEUE f r s) = f ++ REVERSE r ++ s)``,
+      (rotate (QUEUE f r s) = f ++ REVERSE r ++ s)`,
   Induct
   THEN Cases_on `r` THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,rotate_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,rotate_def]
@@ -62,28 +62,28 @@ val rotate_thm = prove(
   THEN `LENGTH (h'::t') = LENGTH f + 1` by (EVAL_TAC THEN DECIDE_TAC)
   THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,GSYM APPEND_ASSOC,APPEND]);
 
-val exec_thm = prove(
-  ``prop 1 xs (QUEUE f r s) ==>
-    queue_inv xs (exec (QUEUE f r s))``,
+val exec_thm = Q.prove(
+  `prop 1 xs (QUEUE f r s) ==>
+    queue_inv xs (exec (QUEUE f r s))`,
   Cases_on `s` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,exec_def,LET_DEF,prop_def,queue_inv_def]
   THEN REPEAT STRIP_TAC THEN DECIDE_TAC);
 
-val snoc_thm = prove(
-  ``!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)``,
+val snoc_thm = Q.prove(
+  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
   Cases THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,snoc_def]
   THEN REPEAT STRIP_TAC THEN MATCH_MP_TAC exec_thm
   THEN FULL_SIMP_TAC (srw_ss()) [prop_def] THEN DECIDE_TAC);
 
-val head_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> (head q = x)``,
+val head_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,head_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,REVERSE_DEF]);
 
-val tail_thm = prove(
-  ``!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)``,
+val tail_thm = Q.prove(
+  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,tail_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,REVERSE_DEF]

--- a/translator/other-examples/example_aesScriptTodo.sml
+++ b/translator/other-examples/example_aesScriptTodo.sml
@@ -25,13 +25,13 @@ val AES_CORRECT = save_thm("AES_CORRECT",AES_CORRECT);
 val res = translate (find_def ``Sbox``);
 val res = translate (find_def ``InvSbox``);
 
-val Sbox_side = prove(
-  ``!x. sbox_side x = T``,
+val Sbox_side = Q.prove(
+  `!x. sbox_side x = T`,
   EVAL_TAC THEN MP_TAC (INST_TYPE [alpha|->``:8``] w2n_lt) THEN SRW_TAC [] [])
   |> update_precondition;
 
-val InvSbox_side = prove(
-  ``!x. invsbox_side x = T``,
+val InvSbox_side = Q.prove(
+  `!x. invsbox_side x = T`,
   EVAL_TAC THEN MP_TAC (INST_TYPE [alpha|->``:8``] w2n_lt) THEN SRW_TAC [] [])
   |> update_precondition;
 

--- a/translator/other-examples/example_copying_gcScript.sml
+++ b/translator/other-examples/example_copying_gcScript.sml
@@ -8,15 +8,15 @@ val res = translate rel_move_def;
 val res = translate rel_move_list_def;
 val res = translate rel_gc_step_def;
 
-val rel_gc_loop_thm = prove(
-  ``rel_gc_loop z y =
+val rel_gc_loop_thm = Q.prove(
+  `rel_gc_loop z y =
      case y of (i,j,m,b,e,b2,e2) =>
        if i = j then (i,m)
        else if ¬(i < j ∧ j ≤ e) then (i,m)
        else
          let (i,j,m) = rel_gc_step z (i,j,m,b,e,b2,e2) in
          let (i,m) = rel_gc_loop z (i,j,m,b,e,b2,e2) in
-           (i,m)``,
+           (i,m)`,
   PairCases_on `y` \\ fs [Once rel_gc_loop_def]);
 
 val res = translate rel_gc_loop_thm;

--- a/translator/other-examples/example_primality_testScript.sml
+++ b/translator/other-examples/example_primality_testScript.sml
@@ -23,8 +23,8 @@ val _ = translation_extends "mini_prelude";
 
 val res = translate EVEN_MOD2;
 
-val UNIT_thm = prove(
-  ``UNIT x s = (x,s)``,
+val UNIT_thm = Q.prove(
+  `UNIT x s = (x,s)`,
   FULL_SIMP_TAC std_ss [state_transformerTheory.UNIT_DEF]);
 
 val _ = translate UNIT_thm;

--- a/translator/other-examples/example_primality_testScript.sml
+++ b/translator/other-examples/example_primality_testScript.sml
@@ -32,8 +32,8 @@ val _ = translate UNIT_thm;
 val def = find_def ``BIND``;
 val _ = translate (SIMP_RULE std_ss [FUN_EQ_THM] def);
 
-val lemma = prove(
-  ``prob_while_cut c b n = \x. prob_while_cut c b n x``,
+val lemma = Q.prove(
+  `prob_while_cut c b n = \x. prob_while_cut c b n x`,
   SIMP_TAC std_ss [FUN_EQ_THM]);
 
 val def = find_def ``prob_while_cut``

--- a/translator/other-examples/word_preludeScriptOld.sml
+++ b/translator/other-examples/word_preludeScriptOld.sml
@@ -24,44 +24,44 @@ val _ = add_type_inv (inst [alpha|->``:32``] ``WORD``) ``:num``
 val _ = add_type_inv (inst [alpha|->``:16``] ``WORD``) ``:num``
 val _ = add_type_inv (inst [alpha|->``:8``] ``WORD``) ``:num``
 
-val EqualityType_WORD = prove(
-  ``EqualityType WORD``,
+val EqualityType_WORD = Q.prove(
+  `EqualityType WORD`,
   EVAL_TAC THEN SRW_TAC [] [] THEN EVAL_TAC)
   |> store_eq_thm;
 
-val Eval_w2n_word32 = prove(
-  ``!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word32->num)) v``,
+val Eval_w2n_word32 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word32->num)) v`,
   SIMP_TAC std_ss [Arrow_def,AppReturns_def,WORD_def])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x:num``))
   |> store_eval_thm;
 
-val Eval_w2n_word16 = prove(
-  ``!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word16->num)) v``,
+val Eval_w2n_word16 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word16->num)) v`,
   SIMP_TAC std_ss [Arrow_def,AppReturns_def,WORD_def])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x:num``))
   |> store_eval_thm;
 
-val Eval_w2n_word8 = prove(
-  ``!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word8->num)) v``,
+val Eval_w2n_word8 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x)) v ==> ((WORD --> NUM) (w2n:word8->num)) v`,
   SIMP_TAC std_ss [Arrow_def,AppReturns_def,WORD_def])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x:num``))
   |> store_eval_thm;
 
-val Eval_n2w_word32 = prove(
-  ``!v. ((NUM --> NUM) (\x.x MOD 4294967296)) v ==> ((NUM --> WORD) (n2w:num->word32)) v``,
+val Eval_n2w_word32 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x MOD 4294967296)) v ==> ((NUM --> WORD) (n2w:num->word32)) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,WORD_def,w2n_n2w])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x MOD 4294967296``))
   |> store_eval_thm;
 
-val Eval_n2w_word16 = prove(
-  ``!v. ((NUM --> NUM) (\x.x MOD 65536)) v ==> ((NUM --> WORD)
-  (n2w:num->word16)) v``,
+val Eval_n2w_word16 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x MOD 65536)) v ==> ((NUM --> WORD)
+  (n2w:num->word16)) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,WORD_def,w2n_n2w])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x MOD 65536``))
   |> store_eval_thm;
 
-val Eval_n2w_word8 = prove(
-  ``!v. ((NUM --> NUM) (\x.x MOD 256)) v ==> ((NUM --> WORD) (n2w:num->word8)) v``,
+val Eval_n2w_word8 = Q.prove(
+  `!v. ((NUM --> NUM) (\x.x MOD 256)) v ==> ((NUM --> WORD) (n2w:num->word8)) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,WORD_def,w2n_n2w])
   |> MATCH_MP (MATCH_MP Eval_WEAKEN (hol2deep ``\x.x MOD 256``))
   |> store_eval_thm;
@@ -74,30 +74,30 @@ val res = translate (word_add_def |> INST_TYPE [alpha|->``:8``]);
 val res = translate (word_mul_def |> INST_TYPE [alpha|->``:8``]);
 val res = translate (bitTheory.BITWISE_def)
 
-val word_xor_lemma = prove(
-  ``!w v:word32. (w ?? v) = n2w (BITWISE 32 (\x y. x <> y) (w2n w) (w2n v))``,
+val word_xor_lemma = Q.prove(
+  `!w v:word32. (w ?? v) = n2w (BITWISE 32 (\x y. x <> y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_xor_n2w]);
 
-val word_xor_lemma8 = prove(
-  ``!w v:word8. (w ?? v) = n2w (BITWISE 8 (\x y. x <> y) (w2n w) (w2n v))``,
+val word_xor_lemma8 = Q.prove(
+  `!w v:word8. (w ?? v) = n2w (BITWISE 8 (\x y. x <> y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_xor_n2w]);
 
-val word_xor_lemma16 = prove(
-  ``!w v:word16. (w ?? v) = n2w (BITWISE 16 (\x y. x <> y) (w2n w) (w2n v))``,
+val word_xor_lemma16 = Q.prove(
+  `!w v:word16. (w ?? v) = n2w (BITWISE 16 (\x y. x <> y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_xor_n2w]);
 
 val res = translate word_xor_lemma
 val res = translate word_xor_lemma8
 val res = translate word_xor_lemma16
 
-val word_or_lemma = prove(
-  ``!w v:word32. (w !! v) = n2w (BITWISE 32 (\x y. x \/ y) (w2n w) (w2n v))``,
+val word_or_lemma = Q.prove(
+  `!w v:word32. (w !! v) = n2w (BITWISE 32 (\x y. x \/ y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_or_n2w]
   THEN `(\x y. x \/ y) = $\/` by FULL_SIMP_TAC std_ss [FUN_EQ_THM]
   THEN FULL_SIMP_TAC std_ss []);
 
-val word_or_lemma16 = prove(
-  ``!w v:word16. (w !! v) = n2w (BITWISE 16 (\x y. x \/ y) (w2n w) (w2n v))``,
+val word_or_lemma16 = Q.prove(
+  `!w v:word16. (w !! v) = n2w (BITWISE 16 (\x y. x \/ y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_or_n2w]
   THEN `(\x y. x \/ y) = $\/` by FULL_SIMP_TAC std_ss [FUN_EQ_THM]
   THEN FULL_SIMP_TAC std_ss []);
@@ -105,8 +105,8 @@ val word_or_lemma16 = prove(
 val res = translate word_or_lemma
 val res = translate word_or_lemma16
 
-val word_and_lemma = prove(
-  ``!w v:word32. (w && v) = n2w (BITWISE 32 (\x y. x /\ y) (w2n w) (w2n v))``,
+val word_and_lemma = Q.prove(
+  `!w v:word32. (w && v) = n2w (BITWISE 32 (\x y. x /\ y) (w2n w) (w2n v))`,
   REPEAT Cases THEN FULL_SIMP_TAC (srw_ss()) [word_and_n2w]
   THEN `(\x y. x /\ y) = (/\)` by FULL_SIMP_TAC std_ss [FUN_EQ_THM]
   THEN FULL_SIMP_TAC std_ss []);
@@ -117,8 +117,8 @@ val res = translate (WORD_MUL_LSL |> INST_TYPE [alpha|->``:32``])
 val res = translate (WORD_MUL_LSL |> INST_TYPE [alpha|->``:16``])
 val res = translate (WORD_MUL_LSL |> INST_TYPE [alpha|->``:8``])
 
-val WORD_LSR_LEMMA = prove(
-  ``!w n. (w >>> n) = n2w (w2n w DIV 2**n)``,
+val WORD_LSR_LEMMA = Q.prove(
+  `!w n. (w >>> n) = n2w (w2n w DIV 2**n)`,
   Cases THEN SIMP_TAC std_ss [GSYM w2n_11,w2n_lsr,w2n_n2w,n2w_w2n]
   THEN REPEAT STRIP_TAC
   THEN `n MOD dimword (:'a) DIV 2 ** n' < dimword (:'a)` by ALL_TAC
@@ -130,12 +130,12 @@ val res = translate (WORD_LSR_LEMMA |> INST_TYPE [alpha|->``:32``])
 val res = translate (WORD_LSR_LEMMA |> INST_TYPE [alpha|->``:16``])
 val res = translate (WORD_LSR_LEMMA |> INST_TYPE [alpha|->``:8``])
 
-val word_msb_thm = prove(
-  ``!w. word_msb (w:'a word) = BIT (dimindex (:'a) - 1) (w2n w)``,
+val word_msb_thm = Q.prove(
+  `!w. word_msb (w:'a word) = BIT (dimindex (:'a) - 1) (w2n w)`,
   Cases THEN FULL_SIMP_TAC std_ss [word_msb_n2w,w2n_n2w]);
 
-val word_lsb_thm = prove(
-  ``!w. word_lsb (w:'a word) = ~(w2n w MOD 2 = 0)``,
+val word_lsb_thm = Q.prove(
+  `!w. word_lsb (w:'a word) = ~(w2n w MOD 2 = 0)`,
   Cases THEN FULL_SIMP_TAC std_ss [word_lsb_n2w,w2n_n2w,ODD_EVEN,EVEN_MOD2]);
 
 val sub_lemma = SIMP_RULE std_ss [word_2comp_def] word_sub_def
@@ -170,8 +170,8 @@ val res = translate (ff32 sub_lemma);
 val res = translate (ff16 sub_lemma);
 val res = translate (ff8 sub_lemma);
 
-val lemma = prove(
-  ``(h--l) (w:word32 ) = n2w (BITS (MIN h 31) l (w2n w))``,
+val lemma = Q.prove(
+  `(h--l) (w:word32 ) = n2w (BITS (MIN h 31) l (w2n w))`,
   `(h--l) w = (h--l) (n2w (w2n w))` by METIS_TAC [n2w_w2n]
   THEN SRW_TAC [] [word_bits_n2w, dimindex_32]);
 

--- a/translator/std_preludeLib.sml
+++ b/translator/std_preludeLib.sml
@@ -40,14 +40,14 @@ val res = translate IS_SOME_DEF;
 val res = translate OPTION_MAP_DEF;
 val res = translate OPTION_MAP2_DEF;
 
-val the_side_def = prove(
-  ``the_side = IS_SOME``,
+val the_side_def = Q.prove(
+  `the_side = IS_SOME`,
   FULL_SIMP_TAC std_ss [FUN_EQ_THM] THEN Cases
   THEN FULL_SIMP_TAC (srw_ss()) [fetch "-" "the_side_def"])
   |> update_precondition;
 
-val option_map2_side_def = prove(
-  ``!f x y. option_map2_side f x y = T``,
+val option_map2_side_def = Q.prove(
+  `!f x y. option_map2_side f x y = T`,
   FULL_SIMP_TAC (srw_ss()) [fetch "-" "option_map2_side_def",the_side_def])
   |> update_precondition;
 
@@ -59,14 +59,14 @@ val res = translate OUTL;
 val res = translate OUTR;
 val res = translate SUM_MAP_def;
 
-val outl_side_def = prove(
-  ``outl_side = ISL``,
+val outl_side_def = Q.prove(
+  `outl_side = ISL`,
   FULL_SIMP_TAC std_ss [FUN_EQ_THM] THEN Cases
   THEN FULL_SIMP_TAC (srw_ss()) [fetch "-" "outl_side_def"])
   |> update_precondition;
 
-val outr_side_def = prove(
-  ``outr_side = ISR``,
+val outr_side_def = Q.prove(
+  `outr_side = ISR`,
   FULL_SIMP_TAC std_ss [FUN_EQ_THM] THEN Cases
   THEN FULL_SIMP_TAC (srw_ss()) [fetch "-" "outr_side_def"])
   |> update_precondition;
@@ -77,12 +77,12 @@ val LENGTH_AUX_def = Define `
   (LENGTH_AUX [] n = (n:num)) /\
   (LENGTH_AUX (x::xs) n = LENGTH_AUX xs (n+1))`;
 
-val LENGTH_AUX_THM = prove(
-  ``!xs n. LENGTH_AUX xs n = LENGTH xs + n``,
+val LENGTH_AUX_THM = Q.prove(
+  `!xs n. LENGTH_AUX xs n = LENGTH xs + n`,
   Induct THEN ASM_SIMP_TAC std_ss [LENGTH_AUX_def,LENGTH,ADD1,AC ADD_COMM ADD_ASSOC])
   |> Q.SPECL [`xs`,`0`] |> GSYM |> SIMP_RULE std_ss [];
 
-val SUC_LEMMA = prove(``SUC = \x. x+1``,SIMP_TAC std_ss [FUN_EQ_THM,ADD1]);
+val SUC_LEMMA = Q.prove(`SUC = \x. x+1`,SIMP_TAC std_ss [FUN_EQ_THM,ADD1]);
 
 val res = translate LENGTH_AUX_def;
 val res = translate LENGTH_AUX_THM;
@@ -110,27 +110,27 @@ val res = translate EL;
 val res = translate LAST_DEF;
 val res = translate (splitAtPki_def |> REWRITE_RULE [SUC_LEMMA])
 
-val front_side_def = prove(
-  ``!xs. front_side xs = ~(xs = [])``,
+val front_side_def = Q.prove(
+  `!xs. front_side xs = ~(xs = [])`,
   Induct THEN ONCE_REWRITE_TAC [fetch "-" "front_side_def"]
   THEN FULL_SIMP_TAC (srw_ss()) [CONTAINER_def])
   |> update_precondition;
 
-val zip_side_def = prove(
-  ``!x. zip_side x = (LENGTH (FST x) = LENGTH (SND x))``,
+val zip_side_def = Q.prove(
+  `!x. zip_side x = (LENGTH (FST x) = LENGTH (SND x))`,
   Cases THEN Q.SPEC_TAC (`r`,`r`) THEN Induct_on `q` THEN Cases_on `r`
   THEN ONCE_REWRITE_TAC [fetch "-" "zip_side_def"]
   THEN FULL_SIMP_TAC (srw_ss()) [])
   |> update_precondition;
 
-val el_side_def = prove(
-  ``!n xs. el_side n xs = (n < LENGTH xs)``,
+val el_side_def = Q.prove(
+  `!n xs. el_side n xs = (n < LENGTH xs)`,
   Induct THEN Cases_on `xs` THEN ONCE_REWRITE_TAC [fetch "-" "el_side_def"]
   THEN FULL_SIMP_TAC (srw_ss()) [CONTAINER_def])
   |> update_precondition;
 
-val last_side_def = prove(
-  ``!xs. last_side xs = ~(xs = [])``,
+val last_side_def = Q.prove(
+  `!xs. last_side xs = ~(xs = [])`,
   Induct THEN ONCE_REWRITE_TAC [fetch "-" "last_side_def"]
   THEN FULL_SIMP_TAC (srw_ss()) [CONTAINER_def])
   |> update_precondition;
@@ -146,8 +146,8 @@ val res = translate sortingTheory.QSORT_DEF;
 val EXP_AUX_def = Define `
   EXP_AUX m n k = if n = 0 then k else EXP_AUX m (n-1:num) (m * k:num)`;
 
-val EXP_AUX_THM = prove(
-  ``!n k. EXP_AUX m n (m**k) = m**(k+n)``,
+val EXP_AUX_THM = Q.prove(
+  `!n k. EXP_AUX m n (m**k) = m**(k+n)`,
   Induct THEN SIMP_TAC std_ss [EXP,Once EXP_AUX_def,ADD1]
   THEN ASM_SIMP_TAC std_ss [GSYM EXP]
   THEN FULL_SIMP_TAC std_ss [ADD1,AC ADD_COMM ADD_ASSOC])
@@ -179,8 +179,8 @@ val num_to_dec_def = Define `
 
 val _ = translate num_to_dec_def;
 
-val num_to_dec_side_def = prove(
-  ``!n. num_to_dec_side n = T``,
+val num_to_dec_side_def = Q.prove(
+  `!n. num_to_dec_side n = T`,
   HO_MATCH_MP_TAC (fetch "-" "num_to_dec_ind") THEN REPEAT STRIP_TAC
   THEN SIMP_TAC std_ss []
   THEN ONCE_REWRITE_TAC [fetch "-" "num_to_dec_side_def"]
@@ -189,8 +189,8 @@ val num_to_dec_side_def = prove(
   THEN DECIDE_TAC) |> SPEC_ALL
   |> update_precondition;
 
-val toString_thm = prove(
-  ``toString n = REVERSE (num_to_dec n)``,
+val toString_thm = Q.prove(
+  `toString n = REVERSE (num_to_dec n)`,
   SIMP_TAC std_ss [ASCIInumbersTheory.num_to_dec_string_def,
     ASCIInumbersTheory.n2s_def]
   THEN AP_TERM_TAC THEN Q.SPEC_TAC (`n`,`n`)
@@ -222,10 +222,10 @@ val _ = add_type_inv ``FMAP_TYPE (a:'a -> v -> bool) (b:'b -> v -> bool)``
 
 val ALOOKUP_eval = translate ALOOKUP_def;
 
-val Eval_FLOOKUP = prove(
-  ``!v. ((LIST_TYPE (PAIR_TYPE (b:'b -> v -> bool) (a:'a -> v -> bool)) -->
+val Eval_FLOOKUP = Q.prove(
+  `!v. ((LIST_TYPE (PAIR_TYPE (b:'b -> v -> bool) (a:'a -> v -> bool)) -->
           b --> OPTION_TYPE a) ALOOKUP) v ==>
-        ((FMAP_TYPE b a --> b --> OPTION_TYPE a) FLOOKUP) v``,
+        ((FMAP_TYPE b a --> b --> OPTION_TYPE a) FLOOKUP) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS,FMAP_EQ_ALIST_def] THEN METIS_TAC [])
   |> (fn th => MATCH_MP th ALOOKUP_eval)
@@ -240,11 +240,11 @@ val FMAP_EQ_ALIST_UPDATE = prove(
     finite_mapTheory.FLOOKUP_DEF,finite_mapTheory.FAPPLY_FUPDATE_THM]
   THEN METIS_TAC []);
 
-val Eval_FUPDATE = prove(
-  ``!v. ((LIST_TYPE (PAIR_TYPE a b) -->
+val Eval_FUPDATE = Q.prove(
+  `!v. ((LIST_TYPE (PAIR_TYPE a b) -->
           PAIR_TYPE (a:'a -> v -> bool) (b:'b -> v -> bool) -->
           LIST_TYPE (PAIR_TYPE a b)) AUPDATE) v ==>
-        ((FMAP_TYPE a b --> PAIR_TYPE a b --> FMAP_TYPE a b) FUPDATE) v``,
+        ((FMAP_TYPE a b --> PAIR_TYPE a b --> FMAP_TYPE a b) FUPDATE) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS] THEN REPEAT STRIP_TAC THEN RES_TAC
   THEN Q.EXISTS_TAC `u` THEN FULL_SIMP_TAC std_ss []
@@ -256,9 +256,9 @@ val Eval_FUPDATE = prove(
 
 val NIL_eval = hol2deep ``[]:('a # 'b) list``
 
-val Eval_FEMPTY = prove(
-  ``!v. (LIST_TYPE (PAIR_TYPE (a:'a -> v -> bool) (b:'b -> v -> bool)) []) v ==>
-        ((FMAP_TYPE a b) FEMPTY) v``,
+val Eval_FEMPTY = Q.prove(
+  `!v. (LIST_TYPE (PAIR_TYPE (a:'a -> v -> bool) (b:'b -> v -> bool)) []) v ==>
+        ((FMAP_TYPE a b) FEMPTY) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS,FMAP_EQ_ALIST_def] THEN REPEAT STRIP_TAC THEN Q.EXISTS_TAC `[]`
   THEN FULL_SIMP_TAC (srw_ss()) [ALOOKUP_def,FUN_EQ_THM,
@@ -287,16 +287,16 @@ val AEVERY_THM = prove(
   ``AEVERY P l <=> !x y. (ALOOKUP l x = SOME y) ==> P (x,y)``,
   SIMP_TAC (srw_ss()) [AEVERY_def,AEVERY_AUX_THM]);
 
-val AEVERY_EQ_FEVERY = prove(
-  ``FMAP_EQ_ALIST f l ==> (AEVERY P l <=> FEVERY P f)``,
+val AEVERY_EQ_FEVERY = Q.prove(
+  `FMAP_EQ_ALIST f l ==> (AEVERY P l <=> FEVERY P f)`,
   FULL_SIMP_TAC std_ss [FMAP_EQ_ALIST_def,FEVERY_DEF,AEVERY_THM]
   THEN FULL_SIMP_TAC std_ss [FLOOKUP_DEF]);
 
-val Eval_FEVERY = prove(
-  ``!v. (((PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool) --> BOOL) -->
+val Eval_FEVERY = Q.prove(
+  `!v. (((PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool) --> BOOL) -->
          LIST_TYPE (PAIR_TYPE a b) --> BOOL) AEVERY) v ==>
         (((PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool) --> BOOL) -->
-         FMAP_TYPE a b --> BOOL) FEVERY) v``,
+         FMAP_TYPE a b --> BOOL) FEVERY) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS] THEN REPEAT STRIP_TAC
   THEN RES_TAC THEN Q.EXISTS_TAC `u` THEN FULL_SIMP_TAC std_ss []
@@ -312,21 +312,21 @@ val AMAP_def = Define `
   (AMAP f ((x:'a,y:'b)::xs) = (x,(f y):'c) :: AMAP f xs)`;
 val AMAP_eval = translate AMAP_def;
 
-val ALOOKUP_AMAP = prove(
-  ``!l. ALOOKUP (AMAP f l) a =
-        case ALOOKUP l a of NONE => NONE | SOME x => SOME (f x)``,
+val ALOOKUP_AMAP = Q.prove(
+  `!l. ALOOKUP (AMAP f l) a =
+        case ALOOKUP l a of NONE => NONE | SOME x => SOME (f x)`,
   Induct THEN SIMP_TAC std_ss [AMAP_def,ALOOKUP_def,FORALL_PROD]
   THEN SRW_TAC [] []);
 
-val FMAP_EQ_ALIST_o_f = prove(
-  ``FMAP_EQ_ALIST m l ==> FMAP_EQ_ALIST (x o_f m) (AMAP x l)``,
+val FMAP_EQ_ALIST_o_f = Q.prove(
+  `FMAP_EQ_ALIST m l ==> FMAP_EQ_ALIST (x o_f m) (AMAP x l)`,
   SIMP_TAC std_ss [FMAP_EQ_ALIST_def,FUN_EQ_THM,FLOOKUP_DEF,
     o_f_DEF,ALOOKUP_AMAP] THEN REPEAT STRIP_TAC THEN SRW_TAC [] []);
 
-val Eval_o_f = prove(
-  ``!v. (((b --> c) --> LIST_TYPE (PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool)) -->
+val Eval_o_f = Q.prove(
+  `!v. (((b --> c) --> LIST_TYPE (PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool)) -->
           LIST_TYPE (PAIR_TYPE a (c:'c->v->bool))) AMAP) v ==>
-        (((b --> c) --> FMAP_TYPE a b --> FMAP_TYPE a c) $o_f) v``,
+        (((b --> c) --> FMAP_TYPE a b --> FMAP_TYPE a c) $o_f) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS] THEN REPEAT STRIP_TAC
   THEN RES_TAC THEN Q.EXISTS_TAC `u` THEN FULL_SIMP_TAC std_ss []
@@ -337,11 +337,11 @@ val Eval_o_f = prove(
   |> (fn th => MATCH_MP th AMAP_eval)
   |> add_user_proved_v_thm;
 
-val ALOOKUP_APPEND = prove(
-  ``!l1 l2 x.
+val ALOOKUP_APPEND = Q.prove(
+  `!l1 l2 x.
       ALOOKUP (l1 ++ l2) x =
       case ALOOKUP l1 x of NONE => ALOOKUP l2 x
-                         | SOME y => SOME y``,
+                         | SOME y => SOME y`,
   Induct THEN FULL_SIMP_TAC std_ss [APPEND,ALOOKUP_def,FORALL_PROD]
   THEN SRW_TAC [] []);
 
@@ -354,10 +354,10 @@ val append_eval = let
   val th = INST ii (INST_TYPE ss th)
   in th end
 
-val Eval_FUNION = prove(
-  ``!v. (LIST_TYPE (PAIR_TYPE a b) --> LIST_TYPE (PAIR_TYPE a b) -->
+val Eval_FUNION = Q.prove(
+  `!v. (LIST_TYPE (PAIR_TYPE a b) --> LIST_TYPE (PAIR_TYPE a b) -->
          LIST_TYPE (PAIR_TYPE a b)) APPEND v ==>
-        (FMAP_TYPE a b --> FMAP_TYPE a b --> FMAP_TYPE a b) $FUNION v``,
+        (FMAP_TYPE a b --> FMAP_TYPE a b --> FMAP_TYPE a b) $FUNION v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS,FMAP_EQ_ALIST_def]
   THEN REPEAT STRIP_TAC
@@ -380,22 +380,22 @@ val ADEL_def = Define `
   (ADEL ((x:'a,y:'b)::xs) z = if x = z then ADEL xs z else (x,y)::ADEL xs z)`
 val ADEL_eval = translate ADEL_def;
 
-val ALOOKUP_ADEL = prove(
-  ``!l a x. ALOOKUP (ADEL l a) x = if x = a then NONE else ALOOKUP l x``,
+val ALOOKUP_ADEL = Q.prove(
+  `!l a x. ALOOKUP (ADEL l a) x = if x = a then NONE else ALOOKUP l x`,
   Induct THEN SRW_TAC [] [ALOOKUP_def,ADEL_def] THEN Cases_on `h`
   THEN SRW_TAC [] [ALOOKUP_def,ADEL_def]);
 
-val FMAP_EQ_ALIST_ADEL = prove(
-  ``!x l. FMAP_EQ_ALIST x l ==>
-          FMAP_EQ_ALIST (x \\ a) (ADEL l a)``,
+val FMAP_EQ_ALIST_ADEL = Q.prove(
+  `!x l. FMAP_EQ_ALIST x l ==>
+          FMAP_EQ_ALIST (x \\ a) (ADEL l a)`,
   FULL_SIMP_TAC std_ss [FMAP_EQ_ALIST_def,ALOOKUP_def,fmap_domsub,FUN_EQ_THM]
   THEN REPEAT STRIP_TAC THEN SRW_TAC [] [ALOOKUP_ADEL,FLOOKUP_DEF,DRESTRICT_DEF]
   THEN FULL_SIMP_TAC std_ss []);
 
-val Eval_fmap_domsub = prove(
-  ``!v. ((LIST_TYPE (PAIR_TYPE a b) --> a -->
+val Eval_fmap_domsub = Q.prove(
+  `!v. ((LIST_TYPE (PAIR_TYPE a b) --> a -->
           LIST_TYPE (PAIR_TYPE a b)) ADEL) v ==>
-        ((FMAP_TYPE a b --> a --> FMAP_TYPE a b) $\\) v``,
+        ((FMAP_TYPE a b --> a --> FMAP_TYPE a b) $\\) v`,
   SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,FMAP_TYPE_def,
     PULL_EXISTS] THEN REPEAT STRIP_TAC THEN RES_TAC
   THEN Q.EXISTS_TAC `u` THEN FULL_SIMP_TAC std_ss []
@@ -410,9 +410,9 @@ val Eval_fmap_domsub = prove(
 
 val _ = add_preferred_thy "-";
 
-val IS_SOME_OWHILE_THM = prove(
-  ``!g f x. (IS_SOME (OWHILE g f x)) =
-            ?n. ~ g (FUNPOW f n x) /\ !m. m < n ==> g (FUNPOW f m x)``,
+val IS_SOME_OWHILE_THM = Q.prove(
+  `!g f x. (IS_SOME (OWHILE g f x)) =
+            ?n. ~ g (FUNPOW f n x) /\ !m. m < n ==> g (FUNPOW f m x)`,
   REPEAT STRIP_TAC THEN Cases_on `OWHILE g f x`
   THEN FULL_SIMP_TAC (srw_ss()) [OWHILE_EQ_NONE]
   THEN FULL_SIMP_TAC std_ss [OWHILE_def]
@@ -422,9 +422,9 @@ val IS_SOME_OWHILE_THM = prove(
   THEN ASM_SIMP_TAC std_ss [] THEN REPEAT STRIP_TAC
   THEN IMP_RES_TAC LESS_LEAST THEN FULL_SIMP_TAC std_ss []);
 
-val WHILE_ind = store_thm("WHILE_ind",
-  ``!P. (!p g x. (p x ==> P p g (g x)) ==> P p g x) ==>
-        !p g x. IS_SOME (OWHILE p g x) ==> P p g x``,
+val WHILE_ind = Q.store_thm("WHILE_ind",
+  `!P. (!p g x. (p x ==> P p g (g x)) ==> P p g x) ==>
+        !p g x. IS_SOME (OWHILE p g x) ==> P p g x`,
   SIMP_TAC std_ss [IS_SOME_OWHILE_THM,PULL_EXISTS,PULL_FORALL]
   THEN Induct_on `n` THEN SRW_TAC [] []
   THEN FIRST_ASSUM MATCH_MP_TAC
@@ -439,18 +439,18 @@ val OWHILE_ind = save_thm("OWHILE_ind",WHILE_ind);
 val _ = translate WHILE;
 val _ = translate OWHILE_THM;
 
-val LEAST_LEMMA = prove(
-  ``$LEAST P = WHILE (\x. ~(P x)) (\x. x + 1) 0``,
+val LEAST_LEMMA = Q.prove(
+  `$LEAST P = WHILE (\x. ~(P x)) (\x. x + 1) 0`,
   SIMP_TAC std_ss [LEAST_DEF,o_DEF,SUC_LEMMA]);
 
 val res = translate LEAST_LEMMA;
 
-val FUNPOW_LEMMA = prove(
-  ``!n m. FUNPOW (\x. x + 1) n m = n + m``,
+val FUNPOW_LEMMA = Q.prove(
+  `!n m. FUNPOW (\x. x + 1) n m = n + m`,
   Induct THEN FULL_SIMP_TAC std_ss [FUNPOW,ADD1,AC ADD_COMM ADD_ASSOC]);
 
-val least_side_thm = prove(
-  ``!s. least_side s = ~(s = {})``,
+val least_side_thm = Q.prove(
+  `!s. least_side s = ~(s = {})`,
   SIMP_TAC std_ss [fetch "-" "least_side_def"]
   THEN FULL_SIMP_TAC std_ss [OWHILE_def,FUNPOW_LEMMA,FUN_EQ_THM,EMPTY_DEF]
   THEN METIS_TAC [IS_SOME_DEF])


### PR DESCRIPTION
Miscellaneous cleanup work.

For example:
- Goals are stated as quotations rather than terms, as per the convention
- Semantics of all languages updated to use fix_clock rather than check_clock style
- replace_term -- a curious substitution function that does not respect alpha-equivalence and may cause variable capture -- removed