### PR TITLE
Issue200

### DIFF
--- a/compiler/bootstrap/io/Holmakefile
+++ b/compiler/bootstrap/io/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = ../../.. ../../../semantics/alt_semantics/proofs ../../../translator ../../../characteristic
+INCLUDES = ../../.. ../../../semantics ../../../semantics/alt_semantics/proofs ../../../translator ../../../characteristic
 OPTIONS = QUIT_ON_FAILURE
 
 ifdef POLY
@@ -14,7 +14,8 @@ all: $(TARGETS) $(HOLHEAP)
 BARE_THYS = ../../../translator/ml_translatorLib \
 	../../../translator/std_preludeLib \
 	../../../characteristic/cfTheory \
-	../../../semantics/alt_semantics/proofs/funBigStepEquivTheory
+	../../../semantics/alt_semantics/proofs/funBigStepEquivTheory \
+	../../../semantics/semanticsLib
 
 DEPS = $(patsubst %,%.uo,$(BARE_THYS)) $(PARENT_HOLHEAP)
 

--- a/compiler/bootstrap/io/ioProgLib.sml
+++ b/compiler/bootstrap/io/ioProgLib.sml
@@ -2,112 +2,11 @@ structure ioProgLib =
 struct
 
 local
+
 open preamble;
 open ioProgTheory ml_translatorLib ml_progLib;
 open cfHeapsTheory cfTheory cfTacticsBaseLib cfTacticsLib;
-open stringLib Boolconv ListConv1 pred_setLib;
-
-val [ALL_DISTINCT_NIL,ALL_DISTINCT_CONS] = ALL_DISTINCT |> CONJUNCTS
-val [MEM_NIL,MEM_CONS] = MEM |> CONJUNCTS
-val [FLAT_NIL,FLAT_CONS] = FLAT |> CONJUNCTS
-val [MAP_NIL,MAP_CONS] = MAP |> CONJUNCTS
-val [APPEND_NIL_LEFT,APPEND_CONS] = APPEND |> CONJUNCTS
-val APPEND_NIL_RIGHT = APPEND_NIL |> CONJUNCTS |> hd
-val decs_to_types_def = fetch "semanticPrimitives" "decs_to_types_def"
-val prog_to_top_types_def = fetch "semanticPrimitives" "prog_to_top_types_def"
-val no_dup_types_def = fetch "semanticPrimitives" "no_dup_types_def"
-val prog_to_mods_def = fetch "semanticPrimitives" "prog_to_mods_def"
-val no_dup_mods_def = fetch "semanticPrimitives" "no_dup_mods_def"
-val no_dup_top_types_def = fetch "semanticPrimitives" "no_dup_top_types_def"
-val dec_case_def = fetch "ast" "dec_case_def" |> CONJUNCTS
-val top_case_def = fetch "ast" "top_case_def" |> CONJUNCTS
-val [set_nil,set_cons] = LIST_TO_SET |> CONJUNCTS
-val state_accessors = fetch "semanticPrimitives" "state_accessors"
-
-fun mem_conv eq_conv tm =
-  tm |> (
-    REWR_CONV MEM_NIL
-    ORELSEC
-   (REWR_CONV MEM_CONS
-     THENC RATOR_CONV(RAND_CONV(eq_conv))
-     THENC OR_CONV
-     THENC (fn tm => if tm = ``T`` then ALL_CONV tm else mem_conv eq_conv tm))
-   )
-    
-fun all_distinct_conv eq_conv tm =
-  tm |> (
-     REWR_CONV ALL_DISTINCT_NIL
-     ORELSEC
-     (REWR_CONV ALL_DISTINCT_CONS
-      THENC RATOR_CONV(RAND_CONV(RAND_CONV(mem_conv eq_conv)))
-      THENC RATOR_CONV(RAND_CONV(NOT_CONV))
-      THENC AND_CONV
-      THENC (fn tm => if tm = ``F`` then ALL_CONV tm else all_distinct_conv eq_conv tm)
-     )
-  )
-
-val all_distinct_string_conv = all_distinct_conv string_EQ_CONV
-       
-val decs_to_types_conv =
-  REWR_CONV decs_to_types_def
-  THENC RAND_CONV (MAP_CONV EVAL) THENC FLAT_CONV
-
-fun set_conv tm =
-  tm |>
-  (
-    REWR_CONV set_nil
-    ORELSEC
-    (REWR_CONV set_cons THENC RAND_CONV set_conv)
-  )
-
-val prog_to_top_types_conv =
-  REWR_CONV prog_to_top_types_def
-            THENC RAND_CONV (MAP_CONV (BETA_CONV
-                                       THENC FIRST_CONV (map REWR_CONV top_case_def)
-                                       THENC LIST_BETA_CONV
-                                       THENC TRY_CONV decs_to_types_conv
-                                      )
-                            ) THENC FLAT_CONV
-
-val prog_to_mods_conv =
-  REWR_CONV prog_to_mods_def
-            THENC RAND_CONV (MAP_CONV (BETA_CONV
-                                       THENC FIRST_CONV (map REWR_CONV top_case_def)
-                                       THENC LIST_BETA_CONV
-                                      )
-                            ) THENC FLAT_CONV
-
-val no_dup_types_conv =
-  REWR_CONV no_dup_types_def
-  THENC RAND_CONV decs_to_types_conv THENC all_distinct_string_conv
-
-fun no_dup_top_types_conv tm =
-  let
-    val tops = rand(rator tm)
-    val thm1 = prog_to_top_types_conv(mk_comb(``prog_to_top_types``,tops))
-  in
-    REWR_CONV no_dup_top_types_def
-    THENC RATOR_CONV(RAND_CONV(RAND_CONV (REWR_CONV thm1) THENC all_distinct_string_conv))
-    THENC AND_CONV
-    THENC RATOR_CONV(RAND_CONV(RAND_CONV(RAND_CONV(REWR_CONV thm1) THENC MAP_CONV BETA_CONV)))
-    THENC REWRITE_CONV [ml_progTheory.DISJOINT_set_simp]
-    THENC EVERY_CONJ_CONV (RAND_CONV(IN_CONV EVAL) THENC NOT_CONV)
-    THENC REPEATC AND_CONV
-  end tm
-
-fun no_dup_mods_conv tm =
-  let
-    val tops = rand(rator tm)
-    val thm1 = prog_to_mods_conv(mk_comb(``prog_to_mods``,tops))
-  in
-    REWR_CONV no_dup_mods_def
-    THENC RATOR_CONV(RAND_CONV(RAND_CONV (REWR_CONV thm1) THENC all_distinct_string_conv))
-    THENC AND_CONV
-    THENC RATOR_CONV(RAND_CONV(RAND_CONV(REWR_CONV thm1)))
-    THENC REWRITE_CONV [ml_progTheory.DISJOINT_set_simp]
-    THENC EVERY_CONJ_CONV (RAND_CONV(IN_CONV EVAL) THENC NOT_CONV)
-    THENC REPEATC AND_CONV
-  end tm
+open stringLib Boolconv ListConv1 pred_setLib semanticsLib;
 
 in
 

--- a/compiler/bootstrap/io/ioProgLib.sml
+++ b/compiler/bootstrap/io/ioProgLib.sml
@@ -6,7 +6,9 @@ local
 open preamble;
 open ioProgTheory ml_translatorLib ml_progLib;
 open cfHeapsTheory cfTheory cfTacticsBaseLib cfTacticsLib;
-open stringLib Boolconv ListConv1 pred_setLib semanticsLib;
+open semanticsLib;
+
+val state_accessors = fetch "semanticPrimitives" "state_accessors"
 
 in
 

--- a/compiler/bootstrap/io/ioProgLib.sml
+++ b/compiler/bootstrap/io/ioProgLib.sml
@@ -291,8 +291,7 @@ val compile_tm = ``compile``
     by (
       simp[bigStepTheory.evaluate_whole_prog_def,Abbr`res`]
       \\ simp[Abbr`inp`,Abbr`prog`,init_state_eq,state_accessors]
-      \\ CONV_TAC(REDEPTH_CONV(REWR_CONV (definition "entire_program_def")))
-      \\ PURE_REWRITE_TAC [SNOC]
+      \\ PURE_REWRITE_TAC [definition "entire_program_def",SNOC]
       \\ CONV_TAC(FORK_CONV(no_dup_mods_conv,no_dup_top_types_conv))
       \\ EVAL_TAC )
     \\ unabbrev_all_tac

--- a/semantics/semanticsLib.sig
+++ b/semantics/semanticsLib.sig
@@ -1,0 +1,10 @@
+signature semanticsLib =
+sig
+
+    val decs_to_types_conv : Abbrev.conv
+    val prog_to_top_types_conv : Abbrev.conv
+    val prog_to_mods_conv : Abbrev.conv
+    val no_dup_top_types_conv : Abbrev.conv
+    val no_dup_mods_conv : Abbrev.conv
+
+end

--- a/semantics/semanticsLib.sml
+++ b/semantics/semanticsLib.sml
@@ -1,0 +1,112 @@
+structure semanticsLib :> semanticsLib =
+struct
+
+open preamble;
+open semanticPrimitivesTheory;
+open stringLib Boolconv ListConv1 pred_setLib;
+
+val [ALL_DISTINCT_NIL,ALL_DISTINCT_CONS] = ALL_DISTINCT |> CONJUNCTS
+val [MEM_NIL,MEM_CONS] = MEM |> CONJUNCTS
+val [FLAT_NIL,FLAT_CONS] = FLAT |> CONJUNCTS
+val [MAP_NIL,MAP_CONS] = MAP |> CONJUNCTS
+val [APPEND_NIL_LEFT,APPEND_CONS] = APPEND |> CONJUNCTS
+val APPEND_NIL_RIGHT = APPEND_NIL |> CONJUNCTS |> hd
+val decs_to_types_def = fetch "semanticPrimitives" "decs_to_types_def"
+val prog_to_top_types_def = fetch "semanticPrimitives" "prog_to_top_types_def"
+val no_dup_types_def = fetch "semanticPrimitives" "no_dup_types_def"
+val prog_to_mods_def = fetch "semanticPrimitives" "prog_to_mods_def"
+val no_dup_mods_def = fetch "semanticPrimitives" "no_dup_mods_def"
+val no_dup_top_types_def = fetch "semanticPrimitives" "no_dup_top_types_def"
+val dec_case_def = fetch "ast" "dec_case_def" |> CONJUNCTS
+val top_case_def = fetch "ast" "top_case_def" |> CONJUNCTS
+val [set_nil,set_cons] = LIST_TO_SET |> CONJUNCTS
+val state_accessors = fetch "semanticPrimitives" "state_accessors"
+
+(* TODO: move to listLib, consolidate with IS_EL_CONV *)
+fun mem_conv eq_conv tm =
+  tm |> (
+    REWR_CONV MEM_NIL
+    ORELSEC
+   (REWR_CONV MEM_CONS
+     THENC RATOR_CONV(RAND_CONV(eq_conv))
+     THENC OR_CONV
+     THENC (fn tm => if tm = ``T`` then ALL_CONV tm else mem_conv eq_conv tm))
+   )
+
+(* TODO: move to listLib, cf. Z3ProofReplay.ALL_DISTINCT_CONV *)
+fun all_distinct_conv eq_conv tm =
+  tm |> (
+     REWR_CONV ALL_DISTINCT_NIL
+     ORELSEC
+     (REWR_CONV ALL_DISTINCT_CONS
+      THENC RATOR_CONV(RAND_CONV(RAND_CONV(mem_conv eq_conv)))
+      THENC RATOR_CONV(RAND_CONV(NOT_CONV))
+      THENC AND_CONV
+      THENC (fn tm => if tm = ``F`` then ALL_CONV tm else all_distinct_conv eq_conv tm)
+     )
+  )
+
+val all_distinct_string_conv = all_distinct_conv string_EQ_CONV
+       
+val decs_to_types_conv =
+  REWR_CONV decs_to_types_def
+  THENC RAND_CONV (MAP_CONV EVAL) THENC FLAT_CONV
+
+fun set_conv tm =
+  tm |>
+  (
+    REWR_CONV set_nil
+    ORELSEC
+    (REWR_CONV set_cons THENC RAND_CONV set_conv)
+  )
+
+val prog_to_top_types_conv =
+  REWR_CONV prog_to_top_types_def
+            THENC RAND_CONV (MAP_CONV (BETA_CONV
+                                       THENC FIRST_CONV (map REWR_CONV top_case_def)
+                                       THENC LIST_BETA_CONV
+                                       THENC TRY_CONV decs_to_types_conv
+                                      )
+                            ) THENC FLAT_CONV
+
+val prog_to_mods_conv =
+  REWR_CONV prog_to_mods_def
+            THENC RAND_CONV (MAP_CONV (BETA_CONV
+                                       THENC FIRST_CONV (map REWR_CONV top_case_def)
+                                       THENC LIST_BETA_CONV
+                                      )
+                            ) THENC FLAT_CONV
+
+val no_dup_types_conv =
+  REWR_CONV no_dup_types_def
+  THENC RAND_CONV decs_to_types_conv THENC all_distinct_string_conv
+
+fun no_dup_top_types_conv tm =
+  let
+    val tops = rand(rator tm)
+    val thm1 = prog_to_top_types_conv(mk_comb(``prog_to_top_types``,tops))
+  in
+    REWR_CONV no_dup_top_types_def
+    THENC RATOR_CONV(RAND_CONV(RAND_CONV (REWR_CONV thm1) THENC all_distinct_string_conv))
+    THENC AND_CONV
+    THENC RATOR_CONV(RAND_CONV(RAND_CONV(RAND_CONV(REWR_CONV thm1) THENC MAP_CONV BETA_CONV)))
+    THENC REWRITE_CONV [ml_progTheory.DISJOINT_set_simp]
+    THENC EVERY_CONJ_CONV (RAND_CONV(IN_CONV EVAL) THENC NOT_CONV)
+    THENC REPEATC AND_CONV
+  end tm
+
+fun no_dup_mods_conv tm =
+  let
+    val tops = rand(rator tm)
+    val thm1 = prog_to_mods_conv(mk_comb(``prog_to_mods``,tops))
+  in
+    REWR_CONV no_dup_mods_def
+    THENC RATOR_CONV(RAND_CONV(RAND_CONV (REWR_CONV thm1) THENC all_distinct_string_conv))
+    THENC AND_CONV
+    THENC RATOR_CONV(RAND_CONV(RAND_CONV(REWR_CONV thm1)))
+    THENC REWRITE_CONV [ml_progTheory.DISJOINT_set_simp]
+    THENC EVERY_CONJ_CONV (RAND_CONV(IN_CONV EVAL) THENC NOT_CONV)
+    THENC REPEATC AND_CONV
+  end tm
+
+end

--- a/semantics/semanticsLib.sml
+++ b/semantics/semanticsLib.sml
@@ -20,7 +20,6 @@ val no_dup_top_types_def = fetch "semanticPrimitives" "no_dup_top_types_def"
 val dec_case_def = fetch "ast" "dec_case_def" |> CONJUNCTS
 val top_case_def = fetch "ast" "top_case_def" |> CONJUNCTS
 val [set_nil,set_cons] = LIST_TO_SET |> CONJUNCTS
-val state_accessors = fetch "semanticPrimitives" "state_accessors"
 
 (* TODO: move to listLib, consolidate with IS_EL_CONV *)
 fun mem_conv eq_conv tm =


### PR DESCRIPTION
Custom conversions for no_dup_{top_types,mods} (see issue #200).

About 15x faster than EVAL_TAC. There is plenty of room for further improvement if needed. For an example, all_distinct_conv is O(n^2) wrt. the length of the list, but could be made O(n lg n) with some effort.