### PR TITLE
Stop using [match_goal] in the implementation of CF tactics

### DIFF
--- a/characteristic/cfSyntax.sig
+++ b/characteristic/cfSyntax.sig
@@ -1,19 +1,41 @@
 signature cfSyntax = sig
   include Abbrev
 
+  (* cf_lit lit env H Q *)
   val cf_lit_tm   : term
   val mk_cf_lit   : term * term * term * term -> term
   val dest_cf_lit : term -> term * term * term * term
   val is_cf_lit   : term -> bool
 
+  (* cf_con cname args env H Q *)
   val cf_con_tm   : term
   val mk_cf_con   : term * term * term * term * term -> term
   val dest_cf_con : term -> term * term * term * term * term
   val is_cf_con   : term -> bool
 
+  (* cf_var name env H Q *)
   val cf_var_tm   : term
   val mk_cf_var   : term * term * term * term -> term
   val dest_cf_var : term -> term * term * term * term
   val is_cf_var   : term -> bool
 
+  (* cf_fun p f ns F1 F2 env H Q *)
+  val cf_fun_tm   : term
+  val mk_cf_fun   : term * term * term * term * term * term * term * term ->
+                    term
+  val dest_cf_fun : term ->
+                    term * term * term * term * term * term * term * term
+  val is_cf_fun   : term -> bool
+
+  (* cf_fun_rec p fs_FS F2 env H Q *)
+  val cf_fun_rec_tm   : term
+  val mk_cf_fun_rec   : term * term * term * term * term * term -> term
+  val dest_cf_fun_rec : term -> term * term * term * term * term * term
+  val is_cf_fun_rec   : term -> bool
+
+  (* cf_app p f args env H Q *)
+  val cf_app_tm   : term
+  val mk_cf_app   : term * term * term * term * term * term -> term
+  val dest_cf_app : term -> term * term * term * term * term * term
+  val is_cf_app   : term -> bool
 end

--- a/characteristic/cfSyntax.sml
+++ b/characteristic/cfSyntax.sml
@@ -13,13 +13,36 @@ local
         if same_const t c then (t1, t2, t3, t4, t5) else raise e
       | _ => raise e
 
+  fun make6 tm (a,b,c,d,e,f) =
+    list_mk_icomb (tm, [a, b, c, d, e, f])
+
+  fun dest6 c e tm =
+    case with_exn strip_comb tm e of
+        (t, [t1, t2, t3, t4, t5, t6]) =>
+        if same_const t c then (t1, t2, t3, t4, t5, t6) else raise e
+      | _ => raise e
+
+  fun make8 tm (a,b,c,d,e,f,g,h) =
+    list_mk_icomb (tm, [a, b, c, d, e, f, g, h])
+
+  fun dest8 c e tm =
+    case with_exn strip_comb tm e of
+        (t, [t1, t2, t3, t4, t5, t6, t7, t8]) =>
+        if same_const t c then (t1, t2, t3, t4, t5, t6, t7, t8) else raise e
+      | _ => raise e
+
   val s4 = HolKernel.syntax_fns4 "cf"
   val s5 = HolKernel.syntax_fns {n = 5, make = make5, dest = dest5} "cf"
+  val s6 = HolKernel.syntax_fns {n = 6, make = make6, dest = dest6} "cf"
+  val s8 = HolKernel.syntax_fns {n = 8, make = make8, dest = dest8} "cf"
 in
 
 val (cf_lit_tm, mk_cf_lit, dest_cf_lit, is_cf_lit) = s4 "cf_lit"
 val (cf_con_tm, mk_cf_con, dest_cf_con, is_cf_con) = s5 "cf_con"
 val (cf_var_tm, mk_cf_var, dest_cf_var, is_cf_var) = s4 "cf_var"
+val (cf_fun_tm, mk_cf_fun, dest_cf_fun, is_cf_fun) = s8 "cf_fun"
+val (cf_fun_rec_tm, mk_cf_fun_rec, dest_cf_fun_rec, is_cf_fun_rec) = s6 "cf_fun_rec"
+val (cf_app_tm, mk_cf_app, dest_cf_app, is_cf_app) = s6 "cf_app"
 
 end
 


### PR DESCRIPTION
Use helpers from cfSyntax and cfAppSyntax instead.
This should make the tactics a little more robust wrt parsing-related changes as they don't use quotations anymore.