### PR TITLE
FFI syntax

### DIFF
--- a/compiler/parsing/cmlPEGScript.sml
+++ b/compiler/parsing/cmlPEGScript.sml
@@ -235,7 +235,8 @@ val cmlPEG_def = zDefine`
                choicel [tok isInt (bindNT nEliteral o mktokLf);
                         tok isString (bindNT nEliteral o mktokLf);
                         tok isCharT (bindNT nEliteral o mktokLf);
-                        tok isWordT (bindNT nEliteral o mktokLf)]);
+                        tok isWordT (bindNT nEliteral o mktokLf);
+                        tok (IS_SOME o destFFIT) (bindNT nEliteral o mktokLf)]);
               (mkNT nEbase,
                choicel [pegf (pnt nEliteral) (bindNT nEbase);
                         seql [tokeq LparT; tokeq RparT] (bindNT nEbase);

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -307,7 +307,8 @@ val firstSet_nEtuple = Q.store_thm(
 val firstSet_nEliteral = Q.store_thm(
   "firstSet_nEliteral[simp]",
   `firstSet cmlG [NT (mkNT nEliteral)] =
-     {IntT i | T} ∪ {StringT s | T} ∪ {CharT c | T} ∪ {WordT w | T}`,
+     {IntT i | T} ∪ {StringT s | T} ∪ {CharT c | T} ∪ {WordT w | T} ∪
+     {FFIT s | T}`,
   simp[Once firstSet_NT, cmlG_FDOM, cmlG_applied] >>
   dsimp[Once EXTENSION] >> gen_tac >> eq_tac >> rw[]);
 
@@ -701,6 +702,7 @@ val NOTIN_firstSet_nV = Q.store_thm(
     ExceptionT ∉ firstSet cmlG [NN nV] ∧
     EndT ∉ firstSet cmlG [NN nV] ∧
     AndT ∉ firstSet cmlG [NN nV] ∧
+    FFIT s ∉ firstSet cmlG [NN nV] ∧
     FunT ∉ firstSet cmlG [NN nV] ∧
     LbrackT ∉ firstSet cmlG [NN nV] ∧
     RbrackT ∉ firstSet cmlG [NN nV] ∧
@@ -734,6 +736,7 @@ val NOTIN_firstSet_nFQV = Q.store_thm(
     EndT ∉ firstSet cmlG [NN nFQV] ∧
     EqualsT ∉ firstSet cmlG [NN nFQV] ∧
     ExceptionT ∉ firstSet cmlG [NN nFQV] ∧
+    FFIT s ∉ firstSet cmlG [NN nFQV] ∧
     FnT ∉ firstSet cmlG [NN nFQV] ∧
     FunT ∉ firstSet cmlG [NN nFQV] ∧
     IfT ∉ firstSet cmlG [NN nFQV] ∧
@@ -771,6 +774,7 @@ val NOTIN_firstSet_nConstructorName = Q.store_thm(
     EndT ∉ firstSet cmlG [NN nConstructorName] ∧
     EqualsT ∉ firstSet cmlG [NN nConstructorName] ∧
     ExceptionT ∉ firstSet cmlG [NN nConstructorName] ∧
+    FFIT s ∉ firstSet cmlG [NN nConstructorName] ∧
     FnT ∉ firstSet cmlG [NN nConstructorName] ∧
     FunT ∉ firstSet cmlG [NN nConstructorName] ∧
     IfT ∉ firstSet cmlG [NN nConstructorName] ∧

--- a/compiler/parsing/tests/cmlTestsScript.sml
+++ b/compiler/parsing/tests/cmlTestsScript.sml
@@ -115,6 +115,9 @@ val elab_decls = ``OPTION_MAP (elab_decs NONE [] []) o ptree_Decls``
 val _ = parsetest0 ``nTopLevelDec`` ``ptree_TopLevelDec`` "val w = 0wx3"
           (SOME ``Tdec (Dlet (Pvar "w") (Lit (Word64 3w)))``)
 
+val _ = parsetest0 ``nE`` ``ptree_Expr nE`` "#(read) byte_array"
+          (SOME ``App (FFI "read") [Var (Short "byte_array")]``)
+
 val _ = parsetest0 ``nTopLevelDec`` ``ptree_TopLevelDec`` "val w = 0wxf"
           (SOME ``Tdec (Dlet (Pvar "w") (Lit (Word64 15w)))``)
 

--- a/semantics/gramScript.sml
+++ b/semantics/gramScript.sml
@@ -110,7 +110,7 @@ val cmlG_def = mk_grammar_def ginfo
        |  ^(``{SymbolT s | s ≠ ""}``)
        |  "*" | "=" ;
 
- Eliteral ::= <IntT> |  <CharT> | <StringT> | <WordT> ;
+ Eliteral ::= <IntT> |  <CharT> | <StringT> | <WordT> | <FFIT> ;
 
  Ebase ::= "(" Eseq ")" | Etuple | "(" ")" | FQV | ConstructorName | Eliteral
         | "let" LetDecs "in" Eseq "end" | "[" "]"

--- a/semantics/lexer_funScript.sml
+++ b/semantics/lexer_funScript.sml
@@ -18,6 +18,7 @@ val _ = Datatype `symbol = StringS string
                          | NumberS int
                          | WordS num
                          | LongS string (* identifiers with a . in them *)
+                         | FFIS string
                          | OtherS string
                          | ErrorS `;
 
@@ -51,7 +52,7 @@ val read_string_def = tDefine "read_string" `
     if str = "" then (ErrorS, loc, "") else
     if HD str = #"\"" then (StringS s, loc with col := loc.col, TL str) else
     if HD str = #"\n" then (ErrorS, loc with <|row := loc.row + 1; col := 0|>, TL str) else
-    if HD str <> #"\\" then 
+    if HD str <> #"\\" then
       read_string (TL str) (s ++ [HD str]) (loc with col := loc.col + 1)
     else
       case TL str of
@@ -90,12 +91,12 @@ val skip_comment_def = Define `
   (skip_comment "" d _ = NONE) /\
   (skip_comment [x] d _ = NONE) /\
   (skip_comment (x::y::xs) d loc =
-    if [x;y] = "(*" then 
+    if [x;y] = "(*" then
       skip_comment xs (d+1) (loc with col := loc.col + 2)
-    else if [x;y] = "*)" then 
-      (if d = 0 then SOME (xs, loc with col := loc.col + 2) 
+    else if [x;y] = "*)" then
+      (if d = 0 then SOME (xs, loc with col := loc.col + 2)
        else skip_comment xs (d-1) (loc with col := loc.col +2))
-    else if ORD x = 10 then 
+    else if ORD x = 10 then
       skip_comment (y::xs) d (loc_row (loc.row+1))
     else skip_comment (y::xs) d (loc with col := loc.col + 1))`
 
@@ -107,6 +108,23 @@ val skip_comment_thm = Q.store_thm("skip_comment_thm",
   THEN SRW_TAC [] [] THEN RES_TAC THEN TRY DECIDE_TAC
   THEN FULL_SIMP_TAC std_ss [] THEN SRW_TAC [] [] THEN RES_TAC
   THEN DECIDE_TAC);
+
+val read_FFIcall_def = Define‘
+  (read_FFIcall "" acc loc = (ErrorS, loc, "")) ∧
+  (read_FFIcall (c::s0) acc loc =
+      if c = #")" then
+        (FFIS (REVERSE acc), loc with col updated_by (+) 2, s0)
+      else if c = #"\n" then (ErrorS, loc, s0)
+      else if isSpace c then read_FFIcall s0 acc (loc with col updated_by SUC)
+      else read_FFIcall s0 (c::acc) (loc with col updated_by SUC))
+’
+
+val read_FFIcall_reduces_input = Q.store_thm(
+  "read_FFIcall_reduces_input",
+  ‘∀s0 a l0 t l s.
+     read_FFIcall s0 a l0 = (t, l, s) ⇒ LENGTH s < LENGTH s0 + 1’,
+  Induct >> dsimp[read_FFIcall_def, bool_case_eq] >> rw[] >>
+  qpat_x_assum `_ = _` (assume_tac o SYM) >> res_tac >> simp[]);
 
 val isAlphaNumPrime_def = Define`
   isAlphaNumPrime c <=> isAlphaNum c \/ (c = #"'") \/ (c = #"_")`
@@ -126,8 +144,8 @@ val next_sym_def = tDefine "next_sym" `
          if TL str = "" then SOME (ErrorS, (loc, loc), "")
          else if isDigit (HD (TL str)) then
            let (n,rest) = read_while isDigit (TL str) [] in
-             SOME (WordS (num_from_dec_string n), 
-                   (loc, loc with col := loc.col + LENGTH n + 1), 
+             SOME (WordS (num_from_dec_string n),
+                   (loc, loc with col := loc.col + LENGTH n + 1),
                    rest)
          else if HD(TL str) = #"x" then
            let (n,rest) = read_while isHexDigit (TL (TL str)) [] in
@@ -137,12 +155,12 @@ val next_sym_def = tDefine "next_sym" `
          else SOME (ErrorS, (loc, loc), TL str)
        else
          let (n,rest) = read_while isDigit str [] in
-           SOME (NumberS (&(num_from_dec_string (c::n))), 
+           SOME (NumberS (&(num_from_dec_string (c::n))),
                  (loc, loc with col := loc.col + LENGTH n),
                  rest)
      else if c = #"~" /\ str <> "" /\ isDigit (HD str) then (* read negative number *)
        let (n,rest) = read_while isDigit str [] in
-         SOME (NumberS (0- &(num_from_dec_string n)), 
+         SOME (NumberS (0- &(num_from_dec_string n)),
                (loc, loc with col := loc.col + LENGTH n),
                rest)
      else if c = #"'" then (* read type variable *)
@@ -156,6 +174,10 @@ val next_sym_def = tDefine "next_sym" `
      else if isPREFIX "#\"" (c::str) then
        let (t, loc', rest) = read_string (TL str) "" (loc with col := loc.col + 2) in
          SOME (mkCharS t, (loc, loc'), rest)
+     else if isPREFIX "#(" (c::str) then
+       let (t, loc', rest) = read_FFIcall (TL str) "" (loc with col := loc.col + 2) in
+
+         SOME (t, (loc, loc'), rest)
      else if isPREFIX "(*" (c::str) then
        case skip_comment (TL str) 0 (loc with col := loc.col + 2) of
        | NONE => SOME (ErrorS, (loc, loc with col := loc.col + 2), "")
@@ -173,19 +195,19 @@ val next_sym_def = tDefine "next_sym" `
                       c'::rest' =>
                         if isAlpha c' then
                           let (n', rest'') = read_while isAlphaNumPrime rest' [c'] in
-                            SOME (LongS (n ++ "." ++ n'), 
+                            SOME (LongS (n ++ "." ++ n'),
                                   (loc, loc with col := loc.col + LENGTH n + LENGTH n'),
                                   rest'')
                         else if isSymbol c' then
                           let (n', rest'') = read_while isSymbol rest' [c'] in
-                            SOME (LongS (n ++ "." ++ n'), 
-                                  (loc, loc with col := loc.col + LENGTH n + LENGTH n'), 
+                            SOME (LongS (n ++ "." ++ n'),
+                                  (loc, loc with col := loc.col + LENGTH n + LENGTH n'),
                                   rest'')
                         else
-                          SOME (ErrorS, 
-                                (loc, loc with col := loc.col + LENGTH n), 
+                          SOME (ErrorS,
+                                (loc, loc with col := loc.col + LENGTH n),
                                 rest')
-                    | "" => SOME (ErrorS, 
+                    | "" => SOME (ErrorS,
                                   (loc, loc with col := loc.col + LENGTH n),
                                   []))
             | _ => SOME (OtherS n, (loc, loc with col := loc.col + LENGTH n - 1), rest)
@@ -227,7 +249,7 @@ val optioneq = prove_case_eq_thm { nchotomy = option_nchotomy,
 
 
 val next_sym_LESS = Q.store_thm("next_sym_LESS",
-  `!input l. (next_sym input l = SOME (s, l', rest)) 
+  `!input l. (next_sym input l = SOME (s, l', rest))
     ==> LENGTH rest < LENGTH input`,
   ho_match_mp_tac (fetch "-" "next_sym_ind") >>
   simp[next_sym_def, bool_case_eq, listeq, optioneq] >> rw[] >> fs[] >>
@@ -239,7 +261,9 @@ val next_sym_LESS = Q.store_thm("next_sym_LESS",
        res_tac >> imp_res_tac skip_comment_thm >> simp[] >> NO_TAC) >>
   TRY (rename1 `UNCURRY` >>
        rpt (pairarg_tac>> fs[]) >> rveq >>
-       imp_res_tac read_while_thm >> simp[] >> NO_TAC)
+       imp_res_tac read_while_thm >> simp[] >> NO_TAC) >>
+  TRY (rename1 `read_FFIcall` >>
+       imp_res_tac read_FFIcall_reduces_input >> simp[] >> NO_TAC)
   (* TODO simpler? *)
   >> `STRLEN rest < STRLEN input` by fs[]
   >> fs[]);
@@ -333,13 +357,14 @@ val token_of_sym_def = Define `
     | WordS n => WordT n
     | LongS s => let (s1,s2) = SPLITP (\x. x = #".") s in
                    LongidT s1 (case s2 of "" => "" | (c::cs) => cs)
+    | FFIS s => FFIT s
     | OtherS s  => get_token s `;
 
 val next_token_def = Define `
   next_token input loc =
     case next_sym input loc of
     | NONE => NONE
-    | SOME (sym, locs, rest_of_input) => 
+    | SOME (sym, locs, rest_of_input) =>
         SOME (token_of_sym sym, locs, rest_of_input)`;
 
 val next_token_LESS = Q.store_thm("next_token_LESS",
@@ -347,7 +372,7 @@ val next_token_LESS = Q.store_thm("next_token_LESS",
                    LENGTH rest < LENGTH input`,
   NTAC 5 STRIP_TAC THEN Cases_on `next_sym input l`
   THEN ASM_SIMP_TAC (srw_ss()) [next_token_def]
-  THEN every_case_tac 
+  THEN every_case_tac
   THEN ASM_SIMP_TAC (srw_ss()) []
   THEN IMP_RES_TAC next_sym_LESS THEN REPEAT STRIP_TAC
   THEN FULL_SIMP_TAC std_ss []);
@@ -358,8 +383,8 @@ val lexer_fun_aux_def = tDefine "lexer_fun_aux" `
   lexer_fun_aux input loc =
     case next_token input loc of
     | NONE => []
-    | SOME (token, (loc', loc''), rest_of_input) => 
-        (token, (loc', loc'')) :: 
+    | SOME (token, (loc', loc''), rest_of_input) =>
+        (token, (loc', loc'')) ::
             lexer_fun_aux rest_of_input (loc'' with col := loc''.col +1)`
     (WF_REL_TAC `measure (LENGTH o FST)` >> rw[] >> imp_res_tac next_token_LESS);
 

--- a/semantics/tokenUtilsScript.sml
+++ b/semantics/tokenUtilsScript.sml
@@ -133,4 +133,10 @@ val destWordT_def = Define`
 `;
 val _ = export_rewrites ["destWordT_def"]
 
+val destFFIT_def = Define`
+  (destFFIT (FFIT s) = SOME s) ∧
+  (destFFIT _ = NONE)
+`;
+val _ = export_rewrites ["destFFIT_def"]
+
 val _ = export_theory()

--- a/semantics/tokens.lem
+++ b/semantics/tokens.lem
@@ -19,3 +19,4 @@ type token =
 | AlphaT of string
 | SymbolT of string
 | LongidT of string * string
+| FFIT of string

--- a/semantics/tokensScript.sml
+++ b/semantics/tokensScript.sml
@@ -30,7 +30,7 @@ val _ = Hol_datatype `
 | TyvarT of string
 | AlphaT of string
 | SymbolT of string
-| LongidT of string => string`;
+| LongidT of string => string
+| FFIT of string`;
 
 val _ = export_theory()
-


### PR DESCRIPTION
As per issue #161, this implements `#(ffiname)` as syntax for a reference to a FFI call.  You have to then apply this as if it were a function, *e.g.*: `#(read) byte_array`.