### PR TITLE
fixed wrong dependence name in Holmakefile

### DIFF
--- a/compiler/bootstrap/evaluation/Holmakefile
+++ b/compiler/bootstrap/evaluation/Holmakefile
@@ -26,5 +26,5 @@ ifndef CC
 CC=gcc
 endif
 
-cake: cake.S ../../../basis_ffi.o
+cake: cake.S ../../../basis/basis_ffi.o
 	$(CC) $< ../../../basis/basis_ffi.o -o $@


### PR DESCRIPTION
just a minor fix, now "Holmake cake" correctly build "cake" execution