### PR TITLE
Make bignum machinery allow non-tail-recursive functions

### DIFF
--- a/compiler/backend/proofs/data_to_word_bignumProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_bignumProofScript.sml
@@ -1427,9 +1427,7 @@ val AnyArith_thm = Q.store_thm("AnyArith_thm",
     \\ rewrite_tac [word_bignumProofTheory.state_rel_def]
     \\ simp_tac (srw_ss()) [FLOOKUP_UPDATE,TempOut_def]
     \\ qunabbrev_tac `s0` \\ full_simp_tac (srw_ss()) []
-    \\ rpt strip_tac THEN1
-     (qpat_x_assum `code_rel c s.code t.code` mp_tac
-      \\ asm_rewrite_tac [])
+    \\ rpt strip_tac
     \\ rewrite_tac [GSYM (EVAL ``Smallnum 0``)]
     \\ match_mp_tac IMP_memory_rel_Number
     \\ imp_res_tac small_int_0

--- a/compiler/backend/proofs/data_to_word_gcProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_gcProofScript.sml
@@ -145,23 +145,6 @@ val IS_SOME_IF = Q.store_thm("IS_SOME_IF",
   `IS_SOME (if b then x else y) = if b then IS_SOME x else IS_SOME y`,
   Cases_on `b` \\ full_simp_tac(srw_ss())[]);
 
-val PERM_ALL_DISTINCT_MAP = Q.store_thm("PERM_ALL_DISTINCT_MAP",
-  `!xs ys. PERM xs ys ==>
-            ALL_DISTINCT (MAP f xs) ==>
-            ALL_DISTINCT (MAP f ys) /\ !x. MEM x ys <=> MEM x xs`,
-  full_simp_tac(srw_ss())[MEM_PERM] \\ srw_tac[][]
-  \\ `PERM (MAP f xs) (MAP f ys)` by full_simp_tac(srw_ss())[PERM_MAP]
-  \\ metis_tac [ALL_DISTINCT_PERM])
-
-val ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME = Q.store_thm(
-   "ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME",
-  `!xs x y. ALL_DISTINCT (MAP FST xs) /\ MEM (x,y) xs ==> ALOOKUP xs x = SOME y`,
-  Induct \\ full_simp_tac(srw_ss())[]
-  \\ Cases \\ full_simp_tac(srw_ss())[ALOOKUP_def] \\ srw_tac[][]
-  \\ res_tac \\ full_simp_tac(srw_ss())[MEM_MAP,FORALL_PROD]
-  \\ rev_full_simp_tac(srw_ss())[]) |> SPEC_ALL
-  |> curry save_thm "ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME";
-
 val IS_SOME_ALOOKUP_EQ = Q.store_thm("IS_SOME_ALOOKUP_EQ",
   `!l x. IS_SOME (ALOOKUP l x) = MEM x (MAP FST l)`,
   Induct \\ full_simp_tac(srw_ss())[]
@@ -4818,33 +4801,6 @@ val find_code_thm = Q.store_thm("find_code_thm",
         full_simp_tac(srw_ss())[wordSemTheory.get_vars_def]
   \\ imp_res_tac state_rel_call_env \\ full_simp_tac(srw_ss())[]) |> SPEC_ALL;
 val _ = save_thm("find_code_thm",find_code_thm);
-
-val env_to_list_lookup_equiv = Q.store_thm("env_to_list_lookup_equiv",
-  `env_to_list y f = (q,r) ==>
-    (!n. ALOOKUP q n = lookup n y) /\
-    (!x1 x2. MEM (x1,x2) q ==> lookup x1 y = SOME x2)`,
-  full_simp_tac(srw_ss())[wordSemTheory.env_to_list_def,LET_DEF] \\ srw_tac[][]
-  \\ `ALL_DISTINCT (MAP FST (toAList y))` by full_simp_tac(srw_ss())[ALL_DISTINCT_MAP_FST_toAList]
-  \\ imp_res_tac (MATCH_MP PERM_ALL_DISTINCT_MAP
-        (QSORT_PERM |> Q.ISPEC `key_val_compare` |> SPEC_ALL))
-  \\ `ALL_DISTINCT (QSORT key_val_compare (toAList y))`
-        by imp_res_tac ALL_DISTINCT_MAP
-  \\ pop_assum (assume_tac o Q.SPEC `f (0:num)` o MATCH_MP PERM_list_rearrange)
-  \\ imp_res_tac PERM_ALL_DISTINCT_MAP
-  \\ rpt (qpat_x_assum `!x. pp ==> qq` (K all_tac))
-  \\ rpt (qpat_x_assum `!x y. pp ==> qq` (K all_tac)) \\ rev_full_simp_tac(srw_ss())[]
-  \\ rpt (pop_assum (mp_tac o Q.GEN `x` o SPEC_ALL))
-  \\ rpt (pop_assum (mp_tac o SPEC ``f:num->num->num``))
-  \\ Q.ABBREV_TAC `xs =
-       (list_rearrange (f 0) (QSORT key_val_compare (toAList y)))`
-  \\ rpt strip_tac \\ rev_full_simp_tac(srw_ss())[MEM_toAList]
-  \\ Cases_on `?i. MEM (n,i) xs` \\ full_simp_tac(srw_ss())[] THEN1
-     (imp_res_tac ALL_DISTINCT_MEM_IMP_ALOOKUP_SOME \\ full_simp_tac(srw_ss())[]
-      \\ UNABBREV_ALL_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[MEM_toAList])
-  \\ `~MEM n (MAP FST xs)` by rev_full_simp_tac(srw_ss())[MEM_MAP,FORALL_PROD]
-  \\ full_simp_tac(srw_ss())[GSYM ALOOKUP_NONE]
-  \\ UNABBREV_ALL_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[MEM_toAList]
-  \\ Cases_on `lookup n y` \\ full_simp_tac(srw_ss())[]);
 
 val cut_env_adjust_set_lookup_0 = Q.store_thm("cut_env_adjust_set_lookup_0",
   `wordSem$cut_env (adjust_set r) x = SOME y ==> lookup 0 y = lookup 0 x`,

--- a/compiler/backend/proofs/word_bignumProofScript.sml
+++ b/compiler/backend/proofs/word_bignumProofScript.sml
@@ -152,6 +152,16 @@ val eval_cases =
      ``Eval rec s1 (Loop r vs p) s2``,
      ``Eval rec s1 (LoopBody p) s2``] |> LIST_CONJ;
 
+val Eval_NONE_IMP = store_thm("Eval_NONE_IMP",
+  ``!s1 c s2 p. Eval NONE s1 c s2 ==> Eval (SOME p) s1 c s2``,
+  qsuff_tac
+    `!r s1 c s2. Eval r s1 c s2 ==>
+                 Eval r s1 c s2 /\
+                !p. r = NONE ==> Eval (SOME p) s1 c s2`
+  THEN1 metis_tac []
+  \\ ho_match_mp_tac eval_ind \\ rw []
+  \\ once_rewrite_tac [eval_cases] \\ fs [] \\ metis_tac []);
+
 
 (* verification of compiler to wordLang *)
 
@@ -1990,6 +2000,30 @@ val const_def = time (first (not o time (can derive_corr_thm)))
                 handle HOL_ERR _ => TRUTH;
 
 val _ = (concl const_def = T) orelse failwith "derive_corr_thm failed";
+
+(*
+
+val mc_fac_init_corr = snd (derive_corr_thm mc_fac_init_code_def);
+val mc_fac_final_corr = snd (derive_corr_thm mc_fac_final_code_def);
+
+val mc_fac_corr = store_thm("mc_fac_corr",
+  ``Corr mc_fac_code s
+     (INR
+        (let (l,r1) = mc_fac (s.clock-1,s.regs ' 1) in
+           delete_vars [3;0;2] (clock_write l (reg_write 1 (SOME r1) s))))
+     (1 ∈ FDOM s.regs ∧ mc_fac_pre (s.clock-1,s.regs ' 1) ∧ s.clock <> 0)``,
+  cheat);
+
+val th = let
+  val raw_th = mc_fac_corr |> SIMP_RULE std_ss [LET_THM]
+  val th = raw_th |> CONV_RULE (DEPTH_CONV PairRules.PBETA_CONV THENC
+                                sort_writes_conv)
+  val _ = (all_corrs := th::(!all_corrs))
+  in th end
+
+val mc_use_fac_corr = snd (derive_corr_thm mc_use_fac_code_def);
+
+*)
 
 (* connecting all the theormes *)
 


### PR DESCRIPTION
This is needed for a MSc project, which aims to implement 
Karatsuba multiplication for CakeML's bignum library.