### PR TITLE
Start traces of with SourceLoc

### DIFF
--- a/compiler/backend/backend_commonScript.sml
+++ b/compiler/backend/backend_commonScript.sml
@@ -29,7 +29,7 @@ val _ = Define`clos_tag_shift tag = if tag < 30 then tag:num else tag+2`
 (* Trace of an expression through the compiler, for exploring transformations *)
 val _ = Datatype`
   tra =
-    | Empty
+    | SourceLoc num (* start-row *) num (* start-col *) num (* end-row *) num (* end-col *)
     | None (* Dead trace, do not make traces at all *)
     | Cons tra num
     | Union tra tra`
@@ -46,7 +46,7 @@ val _ = overload_on ("▷", Term `backend_common$Cons`);
 * It's structure guarantees it will not conflict with any trace originating from
 * source, since the always start with four Cons, indicating source position. *)
 val orphan_trace_def = Define`
-  orphan_trace = Union Empty Empty`;
+  orphan_trace = SourceLoc 2 2 1 1`;
 
 (* Create new Cons trace, unless original trace is `None`, indicating traces are
 * turned off. *)

--- a/compiler/backend/backend_commonScript.sml
+++ b/compiler/backend/backend_commonScript.sml
@@ -30,9 +30,9 @@ val _ = Define`clos_tag_shift tag = if tag < 30 then tag:num else tag+2`
 val _ = Datatype`
   tra =
     | SourceLoc num (* start-row *) num (* start-col *) num (* end-row *) num (* end-col *)
-    | None (* Dead trace, do not make traces at all *)
     | Cons tra num
-    | Union tra tra`
+    | Union tra tra
+    | None (* Dead trace, do not make traces at all *)`
 
 (* The code below replaces "Cons" in hol output with the chosen symbol *)
 val _ = set_fixity "▷" (Infixl 480);

--- a/compiler/backend/clos_callScript.sml
+++ b/compiler/backend/clos_callScript.sml
@@ -136,10 +136,10 @@ val calls_sing = Q.store_thm("calls_sing",
 
 val selftest = let
   (* example code *)
-  val f = ``Fn Empty (SOME 800) NONE 1 (Op Empty Add [Var Empty 0; Op Empty (Const 1) []])``
-  val g = ``Fn Empty (SOME 900) NONE 1 (App Empty (SOME 800) (Var Empty 1) [Var Empty 0])``
-  val f_g_5 = ``App Empty (SOME 800) (Var Empty 1) [App Empty (SOME 900) (Var Empty 0) [Op Empty (Const 5) []]]``
-  val let_let = ``Let Empty [^f] (Let Empty [^g] ^f_g_5)``
+  val f = ``Fn None (SOME 800) NONE 1 (Op None Add [Var None 0; Op None (Const 1) []])``
+  val g = ``Fn None (SOME 900) NONE 1 (App None (SOME 800) (Var None 1) [Var None 0])``
+  val f_g_5 = ``App None (SOME 800) (Var None 1) [App None (SOME 900) (Var None 0) [Op None (Const 5) []]]``
+  val let_let = ``Let None [^f] (Let None [^g] ^f_g_5)``
   (* compiler evaluation *)
   val tm = EVAL ``compile T ^let_let`` |> concl
   val n = tm |> find_terms (aconv ``closLang$Call``) |> length

--- a/compiler/backend/displayLangScript.sml
+++ b/compiler/backend/displayLangScript.sml
@@ -29,7 +29,9 @@ val trace_to_json_def = Define`
   (trace_to_json (Union tra1 tra2) =
       Object [("name", String "Union"); ("trace1", trace_to_json tra1); ("trace2", trace_to_json tra2)])
   /\
-  (trace_to_json Empty = Object [("name", String "Empty")])
+  (trace_to_json (SourceLoc sr sc er ec) =
+    let arr = MAP Int (MAP (&)  [ sr; sc; er; ec ]) in
+      Object [("name", String "SourcePos"); ("pos", Array arr)])
   /\
   (* TODO: cancel entire trace when None, or verify that None will always be at
   * the top level of a trace. *)

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -154,7 +154,7 @@ val compile_exp_def = tDefine"compile_exp"`
   ∧
   (* When encountering a Lannot, we update the trace we are passing *)
   (compile_exp t env (Lannot e (Locs st en)) =
-    let t' = if t = None then t else (Cons (Cons (Cons (Cons Empty st.row) st.col) en.row) en.col) in
+    let t' = if t = None then t else SourceLoc st.row st.col en.row en.col in
       compile_exp t' env e)
   ∧
   (compile_exps t env [] = [])


### PR DESCRIPTION
Rather than using the hack of creating a list of `Cons`, we use a dedicated SourceLoc constructor. We have gotten feedback consistently from many people we have shown traces to that starting of with a list of Cons  is confusing, and that an approach like this one would be preferable.