### PR TITLE
Fix contexts in bvi_tailrec

### DIFF
--- a/compiler/backend/backendComputeLib.sml
+++ b/compiler/backend/backendComputeLib.sml
@@ -379,6 +379,7 @@ val add_backend_compset = computeLib.extend_compset
     ,bvi_tailrecTheory.assoc_swap_def
     ,bvi_tailrecTheory.rewrite_op_def
     ,bvi_tailrecTheory.decide_ty_def
+    ,bvi_tailrecTheory.LAST1_def
     ,bvi_tailrecTheory.scan_expr_def
     ,bvi_tailrecTheory.push_call_def
     ,bvi_tailrecTheory.mk_tailcall_def

--- a/compiler/backend/bvi_tailrecScript.sml
+++ b/compiler/backend/bvi_tailrecScript.sml
@@ -171,11 +171,9 @@ val decide_ty_def = Define `
   (decide_ty _   _   = Any)`;
 
 val LAST1_def = Define `
-  LAST1 xs = case xs of
-               []    => NONE
-             | [x]   => SOME x
-             | x::xs => LAST1 xs
-  `;
+  LAST1 []      = NONE   /\
+  LAST1 [x]     = SOME x /\
+  LAST1 (x::xs) = LAST1 xs`;
 
 (* Gather information about expressions:
 
@@ -206,7 +204,6 @@ val scan_expr_def = tDefine "scan_expr" `
   (scan_expr ts loc [Let xs x] =
     let ys = scan_expr ts loc xs in
     let tt = MAP (FST o SND) ys in
-    (*let tr = FST (LAST ys) in*)
     let tr = (case LAST1 ys of SOME c => FST c | NONE => ts) in
     let (tu, ty, _, op) = HD (scan_expr (tt ++ tr) loc [x]) in
       [(DROP (LENGTH ys) tu, ty, F, op)]) ∧
@@ -265,7 +262,6 @@ val rewrite_def = Define `
   (rewrite (loc, next, op, acc, ts) (Let xs x) =
     let ys = scan_expr ts loc xs in
     let tt = MAP (FST o SND) ys in
-    (*let tr = FST (LAST ys) in*)
     let tr = (case LAST1 ys of SOME c => FST c | NONE => ts) in
     let (r, y) = rewrite (loc, next, op, acc + LENGTH xs, tt ++ tr) x in
       (r, Let xs y)) ∧

--- a/compiler/backend/proofs/bvi_tailrecProofScript.sml
+++ b/compiler/backend/proofs/bvi_tailrecProofScript.sml
@@ -759,7 +759,6 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
                  evaluate ([x], env2, s with code := c) =
                  evaluate ([apply_op op (HD xs) (Var acc)],
                    env2, s with code := c))`,
-
   ho_match_mp_tac evaluate_complete_ind
   \\ ntac 2 (rpt gen_tac \\ strip_tac)
   \\ Cases_on `xs` \\ fs []
@@ -834,10 +833,8 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
     \\ rpt (PURE_FULL_CASE_TAC \\ fs [])
     \\ rw [] \\ fs [])
   \\ Cases_on `∃xs x1. h = Let xs x1` \\ fs [] \\ rveq
-
   >-
-   (
-    simp [evaluate_def]
+   (simp [evaluate_def]
     \\ `env_rel F acc env1 env2` by fs [env_rel_def]
     \\ PURE_TOP_CASE_TAC \\ fs []
     \\ reverse PURE_TOP_CASE_TAC \\ fs []
@@ -863,47 +860,24 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
     \\ imp_res_tac evaluate_code_const
     \\ rename1 `evaluate (xs,env,s) = (Rval a, s2)`
     \\ qabbrev_tac `ttt = scan_expr ts loc xs`
-    \\ sg `ty_rel (a ++ env) (MAP (FST o SND) ttt ++ FST (LAST ttt))`
+    \\ sg `ty_rel (a ++ env) (MAP (FST o SND) ttt ++ (case LAST1 ttt of SOME z => FST z | NONE => ts))`
     >-
-     (
-      drule scan_expr_ty_rel
+     (match_mp_tac ty_rel_APPEND
+      \\ drule scan_expr_ty_rel
       \\ disch_then (qspecl_then [`loc`,`xs`,`ttt`,`s`] mp_tac)
-      \\ qunabbrev_tac `ttt` \\ rw []
-      \\ sg `ty_rel env (FST (LAST (scan_expr ts loc xs)))`
-      >-
-       (
-        fs [ty_rel_def]
-        \\ fs [EVERY_MEM]
-        \\ sg `?z zs. scan_expr ts loc xs = z::zs`
-        >-
-         (
-          `LENGTH (scan_expr ts loc xs) = LENGTH xs` by fs []
-          \\
-         )
-        \\ fs [MEM_LAST]
-       )
-      \\
-      \\ match_mp_tac EVERY2_APPEND
-      \\ metis_tac [ty_rel_def, EVERY2_APPEND]
-      )
-    \\ sg `ty_rel env (FST (LAST (scan_expr ts loc xs)))`
-    >-
-     (
-      drule scan_expr_ty_rel
+      \\ qunabbrev_tac `ttt`
       \\ simp []
-      \\ disch_then (qspecl_then [`loc`,`xs`,`s`] mp_tac)
-      \\ simp []
-     )
-    scan_expr_ty_rel
-    scan_expr_def
-
-
-    \\ sg `ty_rel (a++env) (MAP (FST o SND) (scan_expr ts loc xs) ++ ts)`
-    >-
-     (drule scan_expr_ty_rel
-      \\ disch_then (qspecl_then [`loc`,`xs`,`scan_expr ts loc xs`,`s`] mp_tac)
-      \\ simp [] \\ rw []
-      \\ metis_tac [ty_rel_def, EVERY2_APPEND])
+      \\ strip_tac
+      \\ fs [ty_rel_def]
+      \\ fs [Once LAST1_def]
+      \\ CASE_TAC \\ fs [] \\ rveq
+      \\ CASE_TAC \\ fs [] \\ rveq
+      \\ CASE_TAC \\ fs [] \\ rveq
+      \\ imp_res_tac EVERY_LAST1
+      \\ pop_assum mp_tac
+      \\ simp_tac std_ss [EVERY_DEF]
+      \\ fs [EVERY_MEM])
+    \\ qunabbrev_tac `ttt`
     \\ first_assum (qspecl_then [`[x1]`,`s2`] mp_tac)
     \\ impl_tac
     >- simp [bviTheory.exp_size_def]

--- a/compiler/backend/proofs/bvi_tailrecProofScript.sml
+++ b/compiler/backend/proofs/bvi_tailrecProofScript.sml
@@ -13,21 +13,11 @@ val _ = new_theory "bvi_tailrecProof";
 
 val find_code_def = bvlSemTheory.find_code_def;
 
-val case_SOME = Q.store_thm ("case_SOME",
-  `(case x of
-    | NONE => NONE
-    | SOME y => SOME (f y)) = SOME res
-    ⇔
-    ∃y. x = SOME y ∧ res = f y`,
-  Cases_on `x` \\ fs [EQ_SYM_EQ]);
-
-val _ = bossLib.augment_srw_ss [rewrites [case_SOME]];
-
 val get_bin_args_SOME = Q.store_thm ("get_bin_args_SOME[simp]",
   `∀exp q. get_bin_args exp = SOME q
     ⇔
     ∃e1 e2 op. q = (e1, e2) ∧ exp = Op op [e1; e2]`,
-  Cases \\ rw[get_bin_args_def]
+  Cases \\ rw [get_bin_args_def]
   \\ rw[bvlPropsTheory.case_eq_thms]
   \\ rw[EQ_IMP_THM]);
 
@@ -167,58 +157,28 @@ val evaluate_rewrite_op = Q.store_thm ("evaluate_rewrite_op",
      evaluate ([exp], env, s) = (r, t) ∧
      r ≠ Rerr (Rabort Rtype_error) ∧
      ty_rel env ts ∧
-     rewrite_op ts op loc exp = (p, exp2) ∧
-     evaluate ([exp], env, s) = (r, t) ⇒
+     rewrite_op ts op loc exp = (p, exp2) ==>
        if ¬p then exp2 = exp else
          evaluate ([exp2], env, s) = (r, t)`,
-  ho_match_mp_tac rewrite_op_ind \\ rw []
-  \\ IF_CASES_TAC \\ rw []
+  ho_match_mp_tac rewrite_op_ind \\ rw [] \\ rw []
   \\ pop_assum mp_tac
   \\ once_rewrite_tac [rewrite_op_def]
-  \\ rpt (PURE_CASE_TAC \\ fs [])
-  \\ rpt (pairarg_tac \\ fs [])
-  >- rpt (PURE_FULL_CASE_TAC \\ fs [])
-  \\ rpt (IF_CASES_TAC \\ fs [])
-  \\ rw []
-  \\ qpat_x_assum `_ = (r, t)` mp_tac
+  \\ rw [bool_case_eq, case_eq_thms, pair_case_eq]
+  \\ rpt (pairarg_tac \\ fs []) \\ rfs []
+  \\ fs [evaluate_def, assoc_swap_def, apply_op_def] \\ rveq
+  \\ fs [bool_case_eq, case_eq_thms, case_elim_thms, pair_case_eq] \\ rveq
+  \\ imp_res_tac evaluate_SING_IMP \\ fs [] \\ rveq
   \\ Cases_on `r1` \\ Cases_on `r2` \\ fs []
-  \\ simp [evaluate_def]
-  \\ TRY
-   (PURE_CASE_TAC \\ fs [] \\ first_x_assum drule \\ strip_tac
-    \\ PURE_CASE_TAC \\ fs [] \\ first_x_assum drule \\ strip_tac
-    \\ rename1 `_ ([e1],_,_) = (r1,_)`
-    \\ rename1 `_ ([e2],_,_) = (r2,_)`
-    \\ Cases_on `r1 = Rerr (Rabort Rtype_error)` \\ rfs []
-    \\ Cases_on `r2 = Rerr (Rabort Rtype_error)` \\ fs []
-    >-
-     (PURE_CASE_TAC \\ fs [] \\ rw []
-      \\ simp [assoc_swap_def, apply_op_def]
-      \\ IF_CASES_TAC
-      \\ simp [evaluate_def]
-      \\ rpt (PURE_CASE_TAC \\ fs [])
-      \\ rw [evaluate_def]
-      \\ fs [op_eq_to_op] \\ rveq
-      \\ qpat_x_assum `_ = (Rerr e, _)` mp_tac
-      \\ simp [evaluate_def]
-      \\ rpt (PURE_FULL_CASE_TAC \\ fs [])
-      \\ imp_res_tac evaluate_SING_IMP \\ rw [] \\ fs []
-      \\ imp_res_tac do_app_err \\ fs []
-      \\ imp_res_tac no_err_correct \\ fs [])
-    \\ drule (GEN_ALL no_err_correct)
-    \\ rpt (disch_then drule)
-    \\ strip_tac \\ fs [] \\ rveq
-    \\ simp [assoc_swap_def, apply_op_def]
-    \\ IF_CASES_TAC \\ simp [evaluate_def]
-    \\ rpt (PURE_FULL_CASE_TAC \\ fs [])
-    \\ rw [evaluate_def]
-    \\ fs [evaluate_def]
-    \\ rpt (PURE_FULL_CASE_TAC \\ fs []) \\ rw []
-    \\ imp_res_tac evaluate_SING_IMP \\ rw [] \\ fs []
-    \\ Cases_on `op` \\ fs [to_op_def]
-    \\ fs [do_app_def, do_app_aux_def, bvlSemTheory.do_app_def, bvl_to_bvi_id]
-    \\ rpt (PURE_FULL_CASE_TAC \\ fs [])
-    \\ fs [bvl_to_bvi_id] \\ rw []
-    \\ intLib.COOPER_TAC));
+  \\ rpt (first_x_assum drule \\ fs []) \\ rw []
+  \\ fs [evaluate_def, case_eq_thms, case_elim_thms, pair_case_eq] \\ rw []
+  \\ imp_res_tac no_err_correct \\ fs [] \\ rveq
+  \\ Cases_on `op` \\ fs [to_op_def]
+  \\ fs [do_app_def, do_app_aux_def, bvlSemTheory.do_app_def]
+  \\ fs [case_eq_thms, case_elim_thms, pair_case_eq]
+  \\ rveq \\ fs [bvl_to_bvi_id]
+  \\ rveq \\ fs [bvl_to_bvi_id]
+  \\ TRY intLib.COOPER_TAC
+  \\ fs [is_rec_or_rec_binop_def, no_err_def, is_rec_def, get_bin_args_def]);
 
 (* TODO for append, parametrise on op *)
 val env_rel_def = Define `
@@ -294,52 +254,6 @@ val code_rel_domain = Q.store_thm ("code_rel_domain",
   \\ CASE_TAC \\ fs [] \\ rw []
   \\ pairarg_tac \\ fs []);
 
-val take_drop_lem = Q.prove (
-  `!skip env.
-    skip < LENGTH env ∧
-    skip + SUC n ≤ LENGTH env ∧
-    DROP skip env ≠ [] ⇒
-    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)`,
-  Induct_on `n` >>
-  srw_tac[][take1, hd_drop] >>
-  `skip + SUC n ≤ LENGTH env` by decide_tac >>
-  res_tac >>
-  `LENGTH (DROP skip env) = LENGTH env - skip` by srw_tac[][LENGTH_DROP] >>
-  `SUC n < LENGTH (DROP skip env)` by decide_tac >>
-  `LENGTH (DROP (1 + skip) env) = LENGTH env - (1 + skip)` by srw_tac[][LENGTH_DROP] >>
-  `n < LENGTH (DROP (1 + skip) env)` by decide_tac >>
-  srw_tac[][TAKE_EL_SNOC, ADD1] >>
-  `n + (1 + skip) < LENGTH env` by decide_tac >>
-  `(n+1) + skip < LENGTH env` by decide_tac >>
-  srw_tac[][EL_DROP] >>
-  srw_tac [ARITH_ss] []);
-
-val evaluate_genlist_vars = Q.store_thm ("evaluate_genlist_vars",
-  `!skip env n (st:'ffi bviSem$state).
-    n + skip ≤ LENGTH env ⇒
-    evaluate (GENLIST (λarg. Var (arg + skip)) n, env, st)
-    =
-    (Rval (TAKE n (DROP skip env)), st)`,
-  Induct_on `n` >>
-  srw_tac[][evaluate_def, DROP_LENGTH_NIL, GSYM ADD1] >>
-  srw_tac[][Once GENLIST_CONS] >>
-  srw_tac[][Once evaluate_CONS, evaluate_def] >>
-  full_simp_tac (srw_ss()++ARITH_ss) [] >>
-  first_x_assum (qspecl_then [`skip + 1`, `env`] mp_tac) >>
-  srw_tac[][] >>
-  `n + (skip + 1) ≤ LENGTH env` by decide_tac >>
-  full_simp_tac(srw_ss())[] >>
-  srw_tac[][combinTheory.o_DEF, ADD1, GSYM ADD_ASSOC] >>
-  `skip + 1 = 1 + skip ` by decide_tac >>
-  full_simp_tac(srw_ss())[] >>
-  `LENGTH (DROP skip env) = LENGTH env - skip` by srw_tac[][LENGTH_DROP] >>
-  `n < LENGTH env - skip` by decide_tac >>
-  `DROP skip env ≠ []`
-        by (Cases_on `DROP skip env` >>
-            full_simp_tac(srw_ss())[] >>
-            decide_tac) >>
-  metis_tac [take_drop_lem]);
-
 val evaluate_let_wrap = Q.store_thm ("evaluate_let_wrap",
   `∀x op vs (s:'ffi bviSem$state) r t.
      op ≠ Noop ⇒
@@ -389,13 +303,12 @@ val rewrite_op_exp_size = Q.store_thm ("rewrite_op_exp_size",
   \\ rw []
   \\ pop_assum mp_tac
   \\ once_rewrite_tac [rewrite_op_def]
-  \\ rpt (PURE_CASE_TAC \\ fs [])
+  \\ fs [case_eq_thms, pair_case_eq, case_elim_thms, bool_case_eq] \\ rw []
   \\ rpt (pairarg_tac \\ fs [])
-  \\ rpt (PURE_CASE_TAC \\ fs [])
-  \\ rw [assoc_swap_def]
-  \\ fs [apply_op_def, bviTheory.exp_size_def]
-  \\ PURE_CASE_TAC \\ fs [op_eq_to_op, bviTheory.exp_size_def]
-  \\ rw [] \\ fs []);
+  \\ rfs [] \\ rveq
+  \\ fs [bool_case_eq, assoc_swap_def, apply_op_def, case_eq_thms]
+  \\ fs [to_op_def, op_eq_to_op] \\ rveq
+  \\ fs [bviTheory.exp_size_def]);
 
 val no_err_extra = Q.prove (
   `∀ts exp extra.
@@ -482,7 +395,8 @@ val is_rec_rewrite_op_thm = Q.store_thm ("is_rec_rewrite_op_thm",
   \\ simp [op_eq_def, get_bin_args_def]);
 
 val is_rec_or_rec_binop_Op = Q.store_thm("is_rec_or_rec_binop_Op",
-  `is_rec_or_rec_binop ts loc op (Op (to_op op) [e1;e2]) ⇔ op ≠ Noop ∧ is_rec loc e1 ∧ no_err ts e2`,
+  `is_rec_or_rec_binop ts loc op (Op (to_op op) [e1;e2]) ⇔
+   op ≠ Noop ∧ is_rec loc e1 ∧ no_err ts e2`,
   rw[is_rec_or_rec_binop_def,is_rec_def,case_elim_thms,PULL_EXISTS]);
 
 val assoc_swap_is_apply_op = Q.store_thm("assoc_swap_is_apply_op",
@@ -600,6 +514,21 @@ val scan_expr_EVERY_SING = Q.store_thm ("scan_expr_EVERY_SING[simp]",
   `LENGTH (scan_expr ts loc [x]) = 1` by fs []
   \\ Cases_on `scan_expr ts loc [x]` \\ fs []);
 
+(* TODO: What? *)
+val EVERY_LAST1 = Q.store_thm("EVERY_LAST1",
+  `!xs y. EVERY P xs /\ LAST1 xs = SOME y ==> P y`,
+  ho_match_mp_tac LAST1_ind
+  \\ rw [Once LAST1_def]
+  \\ fs [case_eq_thms, case_elim_thms]
+  \\ pop_assum mp_tac
+  \\ simp [Once LAST1_def, case_eq_thms, case_elim_thms, PULL_EXISTS]
+  \\ rw [] \\ fs []
+  \\ pop_assum mp_tac
+  \\ srw_tac [DNF_ss] []
+  \\ Cases_on `v5` \\ fs []
+  >- fs [Once LAST1_def]
+  \\ rfs [Once LAST1_def]);
+
 val scan_expr_LENGTH = Q.store_thm ("scan_expr_LENGTH",
   `∀ts loc xs ys.
      scan_expr ts loc xs = ys ⇒
@@ -607,8 +536,12 @@ val scan_expr_LENGTH = Q.store_thm ("scan_expr_LENGTH",
   ho_match_mp_tac scan_expr_ind
   \\ rw [scan_expr_def] \\ fs []
   \\ rpt (pairarg_tac \\ fs [])
-  \\ TRY (PURE_TOP_CASE_TAC \\ fs [])
-  \\ rw [LENGTH_MAP2_MIN, try_update_LENGTH]);
+  \\ TRY (PURE_CASE_TAC \\ fs [case_eq_thms, case_elim_thms, pair_case_eq])
+  \\ rw [LENGTH_MAP2_MIN, try_update_LENGTH]
+  \\ fs [Once LAST1_def, case_eq_thms] \\ rw [] \\ fs []
+  \\ imp_res_tac EVERY_LAST1
+  \\ pop_assum mp_tac
+  \\ simp [EVERY_DEF]);
 
 val ty_rel_decide_ty = Q.store_thm ("ty_rel_decide_ty",
   `∀ts tt env.
@@ -659,65 +592,34 @@ val scan_expr_ty_rel = Q.store_thm ("scan_expr_ty_rel",
   \\ rpt gen_tac
   \\ simp [evaluate_def]
   >- (* Cons *)
-   (strip_tac
-    \\ rpt gen_tac
-    \\ rpt (PURE_TOP_CASE_TAC \\ fs [])
-    \\ strip_tac \\ rveq
-    \\ res_tac \\ fs [] \\ rw []
-    \\ imp_res_tac evaluate_SING_IMP \\ fs [] \\ rveq
-    \\ PairCases_on `x0` \\ rfs [])
+   (fs [case_eq_thms, pair_case_eq, case_elim_thms, PULL_EXISTS] \\ rw []
+    \\ rpt (pairarg_tac \\ fs [])
+    \\ res_tac \\ fs [] \\ rw [])
   >- (* Var *)
-   (rw []
-    \\ fs [ty_rel_def, LIST_REL_EL_EQN])
+   (rw [] \\ fs [ty_rel_def, LIST_REL_EL_EQN])
   \\ strip_tac
   \\ rpt gen_tac
   \\ rpt (pairarg_tac \\ fs [])
-  >- (* If *)
-   (rpt (PURE_TOP_CASE_TAC \\ fs [])
-    \\ strip_tac \\ rveq
-    \\ res_tac \\ fs [] \\ rveq
+  \\ TRY (* All but Let, Op *)
+   (fs [case_eq_thms, pair_case_eq, case_elim_thms, bool_case_eq, PULL_EXISTS]
+    \\ rw []
+    \\ res_tac \\ fs [] \\ rw []
+    \\ imp_res_tac evaluate_SING_IMP \\ fs []
     \\ imp_res_tac scan_expr_LENGTH \\ fs []
     \\ metis_tac [ty_rel_decide_ty])
   >- (* Let *)
-   (rpt (PURE_TOP_CASE_TAC \\ fs [])
-    \\ strip_tac \\ rveq
-    \\ sg `ty_rel (a++env) (MAP (FST o SND) (scan_expr ts loc xs) ++ ts)`
-    >- metis_tac [ty_rel_def, EVERY2_APPEND]
-    \\ last_x_assum drule
-    \\ disch_then drule \\ rw []
-    \\ sg `LENGTH xs + LENGTH ts = LENGTH tu`
-    >- (imp_res_tac scan_expr_LENGTH \\ rfs [])
-    \\ simp [ty_rel_def, LIST_REL_EL_EQN, EL_DROP]
-    \\ conj_tac
-    >- fs [ty_rel_def, LIST_REL_EL_EQN]
-    \\ rw []
-    \\ `n + LENGTH xs < LENGTH tu` by fs [ty_rel_def, LIST_REL_EL_EQN]
-    \\ fs [EL_DROP]
-    \\ fs [ty_rel_def, LIST_REL_EL_EQN]
-    \\ `n + LENGTH xs < LENGTH a + LENGTH env` by fs []
-    \\ first_x_assum drule \\ rw []
-    \\ `LENGTH a = LENGTH xs` by fs []
-    \\ fs [EL_APPEND2])
-  >- (* Raise *)
-   (rpt (PURE_FULL_CASE_TAC
-    \\ fs []))
-  >- (* Tick *)
-   (IF_CASES_TAC \\ fs []
-    \\ strip_tac \\ rveq
-    \\ metis_tac [])
-  >- (* Call *)
-   (rpt (PURE_FULL_CASE_TAC \\ fs []) \\ rw []
-    \\ imp_res_tac evaluate_SING_IMP \\ fs [])
-     (* Op *)
-  \\ pop_assum mp_tac
-  \\ ntac 4 (PURE_TOP_CASE_TAC \\ fs [])
-  \\ strip_tac \\ rveq
+   (
+    cheat (* TODO *)
+   )
+  \\ fs [case_eq_thms, case_elim_thms, pair_case_eq, bool_case_eq, PULL_EXISTS]
+  \\ rveq \\ fs []
   \\ reverse conj_tac \\ fs []
   >-
-   (pop_assum mp_tac
-    \\ Cases_on `op` \\ fs [is_arith_op_def, is_const_def]
-    \\ fs [do_app_def, do_app_aux_def, bvlSemTheory.do_app_def]
-    \\ rpt (PURE_CASE_TAC \\ fs []) \\ rw [])
+   (Cases_on `op`
+    \\ fs [do_app_def, do_app_aux_def, bvlSemTheory.do_app_def,
+           is_arith_op_def, is_const_def]
+    \\ fs [case_eq_thms, case_elim_thms, bool_case_eq, pair_case_eq]
+    \\ fs [small_enough_int_def, small_int_def] \\ rw [])
   \\ IF_CASES_TAC >- fs []
   \\ `¬is_arith_op op ⇒ is_num_rel op` by fs []
   \\ qpat_x_assum `¬(_)` kall_tac
@@ -728,18 +630,13 @@ val scan_expr_ty_rel = Q.store_thm ("scan_expr_ty_rel",
     >-
      (sg `∃k. EL n env = Number k ∧ ∃j. EL m env = Number j`
       >-
-       (qpat_x_assum `evaluate _ = _` mp_tac
-        \\ simp [evaluate_def]
-        \\ IF_CASES_TAC \\ fs []
-        \\ IF_CASES_TAC \\ fs []
-        \\ rw []
-        \\ qpat_x_assum `do_app _ _ _ = _` mp_tac
+       (fs [evaluate_def, do_app_def, do_app_aux_def, bvlSemTheory.do_app_def]
         \\ Cases_on `op` \\ fs [is_arith_op_def, is_num_rel_def]
-        \\ simp [do_app_def, do_app_aux_def, bvlSemTheory.do_app_def]
-        \\ rpt (PURE_CASE_TAC \\ fs []) \\ rw [])
-      \\ fs [ty_rel_def, LIST_REL_EL_EQN, LENGTH_MAP2_MIN, index_of_def,
-             try_update_LENGTH, EL_MAP2]
-      \\ rw []
+        \\ fs [case_eq_thms, case_elim_thms, pair_case_eq, bool_case_eq, PULL_EXISTS]
+        \\ fs [bvl_to_bvi_id]
+        \\ rw [] \\ fs [])
+      \\ fs [ty_rel_def, LIST_REL_EL_EQN, LENGTH_MAP2_MIN, index_of_def]
+      \\ fs [try_update_LENGTH, EL_MAP2] \\ rw []
       \\ pop_assum mp_tac
       \\ simp [try_update_def]
       \\ TRY (IF_CASES_TAC \\ fs [])
@@ -811,10 +708,10 @@ val from_op_thm = save_thm("from_op_thm[simp]",
 (* -- *)
 
 val rewrite_scan_expr = Q.store_thm ("rewrite_scan_expr",
-  `∀loc next op acc ts exp tt ty p exp2 tt' ty' r opr.
-   rewrite (loc,next,op,acc,ts) exp = (tt,ty,p,exp2) ∧
+  `∀loc next op acc ts exp tt ty p exp2 r opr.
+   rewrite (loc,next,op,acc,ts) exp = (p,exp2) ∧
    op ≠ Noop ∧
-   scan_expr ts loc [exp] = [(tt', ty', r, opr)] ⇒
+   scan_expr ts loc [exp] = [(tt, ty, r, opr)] ⇒
      case opr of
        SOME op' => op = op' ⇒ p
      | NONE     => ¬p`,
@@ -858,10 +755,11 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
            (∃op' tt ty r.
              scan_expr ts loc [HD xs] = [(tt, ty, r, SOME op')] ∧
              op' ≠ Noop ∧ ty = Int) ⇒
-               let (tu, tz, lr, x) = rewrite (loc, n, op, acc, ts) (HD xs) in
+               let (lr, x) = rewrite (loc, n, op, acc, ts) (HD xs) in
                  evaluate ([x], env2, s with code := c) =
                  evaluate ([apply_op op (HD xs) (Var acc)],
                    env2, s with code := c))`,
+
   ho_match_mp_tac evaluate_complete_ind
   \\ ntac 2 (rpt gen_tac \\ strip_tac)
   \\ Cases_on `xs` \\ fs []
@@ -936,8 +834,10 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
     \\ rpt (PURE_FULL_CASE_TAC \\ fs [])
     \\ rw [] \\ fs [])
   \\ Cases_on `∃xs x1. h = Let xs x1` \\ fs [] \\ rveq
+
   >-
-   (simp [evaluate_def]
+   (
+    simp [evaluate_def]
     \\ `env_rel F acc env1 env2` by fs [env_rel_def]
     \\ PURE_TOP_CASE_TAC \\ fs []
     \\ reverse PURE_TOP_CASE_TAC \\ fs []
@@ -962,6 +862,42 @@ val evaluate_rewrite_tail = Q.store_thm ("evaluate_rewrite_tail",
     \\ imp_res_tac evaluate_clock
     \\ imp_res_tac evaluate_code_const
     \\ rename1 `evaluate (xs,env,s) = (Rval a, s2)`
+    \\ qabbrev_tac `ttt = scan_expr ts loc xs`
+    \\ sg `ty_rel (a ++ env) (MAP (FST o SND) ttt ++ FST (LAST ttt))`
+    >-
+     (
+      drule scan_expr_ty_rel
+      \\ disch_then (qspecl_then [`loc`,`xs`,`ttt`,`s`] mp_tac)
+      \\ qunabbrev_tac `ttt` \\ rw []
+      \\ sg `ty_rel env (FST (LAST (scan_expr ts loc xs)))`
+      >-
+       (
+        fs [ty_rel_def]
+        \\ fs [EVERY_MEM]
+        \\ sg `?z zs. scan_expr ts loc xs = z::zs`
+        >-
+         (
+          `LENGTH (scan_expr ts loc xs) = LENGTH xs` by fs []
+          \\
+         )
+        \\ fs [MEM_LAST]
+       )
+      \\
+      \\ match_mp_tac EVERY2_APPEND
+      \\ metis_tac [ty_rel_def, EVERY2_APPEND]
+      )
+    \\ sg `ty_rel env (FST (LAST (scan_expr ts loc xs)))`
+    >-
+     (
+      drule scan_expr_ty_rel
+      \\ simp []
+      \\ disch_then (qspecl_then [`loc`,`xs`,`s`] mp_tac)
+      \\ simp []
+     )
+    scan_expr_ty_rel
+    scan_expr_def
+
+
     \\ sg `ty_rel (a++env) (MAP (FST o SND) (scan_expr ts loc xs) ++ ts)`
     >-
      (drule scan_expr_ty_rel

--- a/compiler/backend/semantics/bviPropsScript.sml
+++ b/compiler/backend/semantics/bviPropsScript.sml
@@ -528,4 +528,50 @@ val evaluate_add_to_clock_io_events_mono = Q.store_thm("evaluate_add_to_clock_io
   metis_tac[evaluate_io_events_mono,SND,IS_PREFIX_TRANS,PAIR,
             inc_clock_ffi,dec_clock_ffi]);
 
+val take_drop_lem = Q.prove (
+  `!skip env.
+    skip < LENGTH env ∧
+    skip + SUC n ≤ LENGTH env ∧
+    DROP skip env ≠ [] ⇒
+    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)`,
+  Induct_on `n` >>
+  srw_tac[][take1, hd_drop] >>
+  `skip + SUC n ≤ LENGTH env` by decide_tac >>
+  res_tac >>
+  `LENGTH (DROP skip env) = LENGTH env - skip` by srw_tac[][LENGTH_DROP] >>
+  `SUC n < LENGTH (DROP skip env)` by decide_tac >>
+  `LENGTH (DROP (1 + skip) env) = LENGTH env - (1 + skip)` by srw_tac[][LENGTH_DROP] >>
+  `n < LENGTH (DROP (1 + skip) env)` by decide_tac >>
+  srw_tac[][TAKE_EL_SNOC, ADD1] >>
+  `n + (1 + skip) < LENGTH env` by decide_tac >>
+  `(n+1) + skip < LENGTH env` by decide_tac >>
+  srw_tac[][EL_DROP] >>
+  srw_tac [ARITH_ss] []);
+
+val evaluate_genlist_vars = Q.store_thm ("evaluate_genlist_vars",
+  `!skip env n (st:'ffi bviSem$state).
+    n + skip ≤ LENGTH env ⇒
+    evaluate (GENLIST (λarg. Var (arg + skip)) n, env, st)
+    =
+    (Rval (TAKE n (DROP skip env)), st)`,
+  Induct_on `n` >>
+  srw_tac[][evaluate_def, DROP_LENGTH_NIL, GSYM ADD1] >>
+  srw_tac[][Once GENLIST_CONS] >>
+  srw_tac[][Once evaluate_CONS, evaluate_def] >>
+  full_simp_tac (srw_ss()++ARITH_ss) [] >>
+  first_x_assum (qspecl_then [`skip + 1`, `env`] mp_tac) >>
+  srw_tac[][] >>
+  `n + (skip + 1) ≤ LENGTH env` by decide_tac >>
+  full_simp_tac(srw_ss())[] >>
+  srw_tac[][combinTheory.o_DEF, ADD1, GSYM ADD_ASSOC] >>
+  `skip + 1 = 1 + skip ` by decide_tac >>
+  full_simp_tac(srw_ss())[] >>
+  `LENGTH (DROP skip env) = LENGTH env - skip` by srw_tac[][LENGTH_DROP] >>
+  `n < LENGTH env - skip` by decide_tac >>
+  `DROP skip env ≠ []`
+        by (Cases_on `DROP skip env` >>
+            full_simp_tac(srw_ss())[] >>
+            decide_tac) >>
+  metis_tac [take_drop_lem]);
+
 val _ = export_theory();


### PR DESCRIPTION
This fixes an issue with the analysis pass in `bvi_tailrec` losing track of variable types when traversing `Let`-expressions, causing the optimization to not be applied in all cases that it should. 

In addition, two theorems from `bvi_tailrecProof` that I originally copied from `bvlProps` are moved to `bviProps`.