### PR TITLE
Add support for resuming monadic translations

### DIFF
--- a/translator/monadic/ml_monad_translatorLib.sig
+++ b/translator/monadic/ml_monad_translatorLib.sig
@@ -1,4 +1,4 @@
-signature ml_monad_translatorLib = 
+signature ml_monad_translatorLib =
 sig
     include ml_translatorLib
 
@@ -30,4 +30,13 @@ sig
     (* Translation functions *)
     val m_translate : thm -> thm
     val m_translate_run : thm -> thm
+    val m2deep : term -> thm
+
+    (* Resume prior monadic translation.
+
+       Loads the state specific to the monadic translation from the specified
+       theory, followed by a call to translation_extends from the 'standard'
+       translator (i.e. fetching the rest of the translator state). *)
+    val m_translation_extends : string -> unit
+
 end


### PR DESCRIPTION
Adds functionality to export and import translations performed with the
monadic translator. State is automatically exported at calls to
`export_theory ()` just as with the standard translator, and can be
resumed by calling `m_translation_extends "..."`, which restores the
monadcic state and recursively calls on `translation_extends` from the
standard translator.