### PR TITLE
Monad trans

### DIFF
--- a/candle/standard/ml_kernel/ml_hol_initScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_initScript.sml
@@ -1,8 +1,7 @@
 open preamble
-open ml_translatorLib ml_hol_kernelProgTheory holKernelProofTheory ml_monad_translatorTheory
-open bigStepTheory
-open terminationTheory
-open cfStoreTheory
+open ml_hol_kernelProgTheory holKernelProofTheory
+open ml_monad_translatorBaseTheory ml_translatorLib
+open bigStepTheory terminationTheory cfStoreTheory
 
 val _ = new_theory"ml_hol_init"
 

--- a/translator/monadic/cfMonadScript.sml
+++ b/translator/monadic/cfMonadScript.sml
@@ -1,4 +1,4 @@
-open ml_monad_translatorTheory cfHeapsBaseTheory set_sepTheory pred_setTheory cfStoreTheory Satisfy
+open ml_monad_translatorBaseTheory ml_monad_translatorTheory cfHeapsBaseTheory set_sepTheory pred_setTheory cfStoreTheory Satisfy
 open semanticPrimitivesTheory cfTacticsLib 
 
 val _ = new_theory"cfMonad"
@@ -113,134 +113,54 @@ rw[]
 val st2heap_clock_inv = Q.prove(`st2heap p (st with clock := c) = st2heap p st`,
 Cases_on `p` \\ fs[st2heap_def]);
 
-val ArrowP_MONAD_to_app_basic_unit_thm =  Q.store_thm("ArrowP_MONAD_to_app_basic_unit_thm",
-`ArrowP H (PURE A) (MONAD B C) f fv ==>
-!refs x xv. A x xv ==>
-app_basic (p : unit ffi_proj) fv xv (H refs)
-(POST
-     (\rv. SEP_EXISTS refs' r. H refs' * &(f x refs = (Success r, refs')) * &(B r rv))
-     (\ev. SEP_EXISTS refs' e. H refs' * &(f x refs = (Failure e, refs')) * &(C e ev)))`,
-rw[]
-\\ rw[app_basic_def]
-\\ fs[ArrowP_def]
-\\ fs[PURE_def]
-\\ last_x_assum (qspec_then `x` ASSUME_TAC)
-\\ POP_ASSUM IMP_RES_TAC
-\\ fs[]
-\\ IMP_RES_TAC REFS_PRED_lemma
-\\ qpat_x_assum `!s1. P` IMP_RES_TAC
-\\ fs[state_with_refs_eq]
-\\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[]
-\\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[MONAD_def]
-\\ fs[with_same_refs]
-\\ fs[REFS_PRED_FRAME_def]
-\\ fs[evaluate_ck_def]
-\\ `(H refs * (\s. s = h_k)) (st2heap p st)` by (rw[STAR_def] \\ SATISFY_TAC)
-\\ qpat_assum `!F. P` IMP_RES_TAC
-\\ IMP_RES_TAC HPROP_SPLIT3
-\\ fs[] \\ rw[]
-\\ Cases_on `res3` \\ Cases_on `f x refs` \\ fs[] \\ Cases_on `q` \\ fs[]
-THENL[qexists_tac `Val a` \\ IMP_RES_TAC evaluate_Rval_bigStep_to_evaluate,
-      Cases_on `e` \\ fs[] \\ qexists_tac `Exn a` \\ IMP_RES_TAC evaluate_Rerr_bigStep_to_evaluate]
-\\ qexists_tac `h1`
-\\ qexists_tac `h3`
-\\ qexists_tac `st with <|clock := 0; refs := refs'|>`
-\\ qexists_tac `c`
-\\ fs[st2heap_clock_inv]
-\\ fs[SEP_EXISTS_THM]
-\\ fs[GSYM STAR_ASSOC]
-\\ CONV_TAC ((STRIP_QUANT_CONV o RATOR_CONV) PURE_FACTS_FIRST_CONV)
-\\ fs[GSYM STAR_ASSOC, HCOND_EXTRACT]);
+(*
+ * REFS_PRED_Mem_Only: a property we need to be satisfied by the heap to
+ * prove the following theorems.
+ *)
 
-(* val ArrowP_PURE_to_app_basic_unit_thm =  Q.store_thm("ArrowP_PURE_to_app_basic_unit_thm",
-`ArrowP H (PURE A) (PURE B) f fv ==>
-!refs x xv. A x xv ==>
-app_basic (p : unit ffi_proj) fv xv (H refs)
-(POSTv rv. SEP_EXISTS r. H refs * &(B (f x) rv))`,
-rw[]
-\\ rw[app_basic_def]
-\\ fs[ArrowP_def]
-\\ fs[PURE_def]
-\\ last_x_assum (qspec_then `x` ASSUME_TAC)
-\\ POP_ASSUM IMP_RES_TAC
-\\ fs[]
-\\ IMP_RES_TAC REFS_PRED_lemma
-\\ qpat_x_assum `!s1. P` IMP_RES_TAC
-\\ fs[state_with_refs_eq]
-\\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[]
-\\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[MONAD_def]
-\\ fs[with_same_refs]
-\\ fs[REFS_PRED_FRAME_def]
-\\ fs[evaluate_ck_def]
-\\ `(H refs * (\s. s = h_k)) (st2heap p st)` by (rw[STAR_def] \\ SATISFY_TAC)
-\\ qpat_assum `!F. P` IMP_RES_TAC
-\\ IMP_RES_TAC HPROP_SPLIT3
-\\ fs[] \\ rw[]
-\\ IMP_RES_TAC evaluate_Rval_bigStep_to_evaluate
-\\ qexists_tac `Val v`
-\\ qexists_tac `h1`
-\\ qexists_tac `h3`
-\\ qexists_tac `st with <|clock := 0; refs := st.refs ++ junk|>`
-\\ qexists_tac `c`
-\\ fs[st2heap_clock_inv]
-\\ fs[SEP_EXISTS_THM]
-\\ fs[SEP_CLAUSES]
-\\ metis_tac[]); *)
+val REFS_PRED_Mem_Only_def = Define `REFS_PRED_Mem_Only H = !state h. H state h ==> !x. x IN h ==> ?n v. x = Mem n v`;
 
-val ArrowP_MONAD_to_unit_app = Q.store_thm("ArrowP_MONAD_to_unit_app",
-`!A B C f fv H x xv refs p.
-A x xv ==>
-ArrowP H (PURE A) (MONAD B C) f fv ==>
-app (p : unit ffi_proj) fv [xv] (H refs)
-(POST
-     (\rv. SEP_EXISTS refs' r. H refs' * &(f x refs = (Success r, refs')) * &(B r rv))
-     (\ev. SEP_EXISTS refs' e. H refs' * &(f x refs = (Failure e, refs')) * &(C e ev)))`,
-rw[app_def]
-\\ metis_tac[ArrowP_MONAD_to_app_basic_unit_thm]);
-
-val ArrowP_PURE_to_unit_app = Q.store_thm("ArrowP_PURE_to_unit_app",
-`!A B f fv x1 xv1 xv2 xvl H Q p.
-A x1 xv1 ==>
-(!state gv. B (f x1) gv ==>
-app (p : unit ffi_proj) gv (xv2::xvl) (H state) (Q state)) ==>
-(!state. ArrowP H (PURE A) (PURE B) f fv ==>
-app p fv (xv1::xv2::xvl) (H state) (Q state))`,
-rw[app_def]
-\\ rw[app_basic_def]
-\\ fs[ArrowP_def]
-\\ fs[PURE_def]
-\\ last_x_assum (qspec_then `x1` ASSUME_TAC)
-\\ POP_ASSUM IMP_RES_TAC
-\\ first_x_assum(qspecl_then[`st`, `st`, `[]`] ASSUME_TAC)
-\\ fs[state_component_equality]
-\\ IMP_RES_TAC REFS_PRED_lemma
-\\ qpat_x_assum `!s1. P` IMP_RES_TAC
-\\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[REFS_PRED_FRAME_def]
-\\ fs[evaluate_ck_def]
+val REFS_PRED_Mem_Only_IMP = Q.store_thm("REFS_PRED_Mem_Only_IMP",
+`!H. REFS_PRED_Mem_Only H ==> ((!p st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)))`,
+rw[REFS_PRED_Mem_Only_def]
+\\ fs[SPLIT_def]
+\\ qexists_tac `store2heap st.refs DIFF h1`
 \\ rw[]
-\\ `(H refs3 * (\s. s = h_k)) (st2heap p st)` by (rw[STAR_def] \\ SATISFY_TAC)
-\\ qpat_assum `!F. P` IMP_RES_TAC
-\\ IMP_RES_TAC HPROP_SPLIT3
-\\ fs[with_same_refs] \\ rw[]
-\\ IMP_RES_TAC evaluate_Rval_bigStep_to_evaluate
-\\ qexists_tac `Val v`
-\\ qexists_tac `h1`
-\\ qexists_tac `h3`
-\\ qexists_tac `st with <| clock := 0; refs := st.refs ++ junk |>`
-\\ qexists_tac `c`
-\\ fs[st2heap_def, state_component_equality, with_same_clock]
-\\ rw[SEP_EXISTS_THM]
-\\ qexists_tac `H refs3`
-\\ rw[STAR_def]
-\\ qexists_tac `h1`
-\\ qexists_tac `{}`
-\\ fs[SPLIT_def, cond_def]
-\\ metis_tac[]);
+>-(
+    rw[SET_EQ_SUBSET, SUBSET_DEF]
+    \\ `x IN st2heap p st` by metis_tac[IN_UNION]
+    \\ fs[st2heap_def]
+    \\ last_x_assum IMP_RES_TAC
+    \\ fs[Mem_NOT_IN_ffi2heap])
+\\ fs[DISJOINT_ALT]);
+
+val REFS_PRED_Mem_Only_STAR_IMP = Q.store_thm("REFS_PRED_Mem_Only_STAR_IMP",
+`!H1 H2. REFS_PRED_Mem_Only H1 ==> REFS_PRED_Mem_Only H2 ==> REFS_PRED_Mem_Only (\state. H1 state * H2 state)`,
+rw[REFS_PRED_Mem_Only_def]
+\\ fs[STAR_def, SPLIT_def]
+\\ metis_tac[IN_DEF, IN_UNION]);
+
+val REFS_PRED_Mem_Only_REF_REL = Q.store_thm("REFS_PRED_Mem_Only_REF_REL",
+`!A get_val r. REFS_PRED_Mem_Only (\state. REF_REL A r (get_val state))`,
+rw[REFS_PRED_Mem_Only_def]
+\\ fs[REF_REL_def, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def]
+\\ rw[]
+\\ fs[IN_SING]);
+
+val REFS_PRED_Mem_Only_RARRAY_REL = Q.store_thm("REFS_PRED_Mem_Only_RARRAY_REL",
+`!A get_arr r. REFS_PRED_Mem_Only (\state. RARRAY_REL A r (get_arr state))`,
+rw[REFS_PRED_Mem_Only_def]
+\\ fs[RARRAY_REL_def, RARRAY_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def, GSYM STAR_ASSOC]
+\\ fs[STAR_def, SPLIT_def, cond_def]
+\\ rw[]
+\\ fs[IN_SING]);
+
+val REFS_PRED_Mem_Only_emp = Q.store_thm("REFS_PRED_Mem_Only_emp",
+`REFS_PRED_Mem_Only (\(state : 'a). emp)`,
+rw[REFS_PRED_Mem_Only_def]
+\\ fs[REF_REL_def, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def, emp_def]
+\\ rw[]
+\\ fs[]);
 
 (*
  * ffi of any type
@@ -260,10 +180,25 @@ rw[]
 \\ `{} x` by metis_tac[]
 \\ fs[]);
 
+(* fun apply_REFS_PRED_Mem_Only_IMP ty = let
+    val lemma = Q.SPEC `H` REFS_PRED_Mem_Only_IMP |> UNDISCH
+    val v = concl lemma |> dest_forall |> fst
+    val ty_src = dest_type (type_of v) |> snd |> hd |> dest_type
+			   |> snd |> hd
+    val lemma = INST_TYPE [ty_src |-> ty] lemma |> UNDISCH_ALL
+in (drule lemma \\ rw[] \\ first_x_assum IMP_RES_TAC) end *)
+
+val apply_REFS_PRED_Mem_Only_IMP =
+  first_assum (fn x => let val lemma = (MATCH_MP REFS_PRED_Mem_Only_IMP x)
+  in first_assum (fn x => (MATCH_MP lemma x) |> drule) end)
+
+val apply_REFS_PRED_Mem_Only_IMP2 =
+  first_assum (fn x => let val lemma = (MATCH_MP REFS_PRED_Mem_Only_IMP x)
+  in last_assum (fn x => (MATCH_MP lemma x) |> drule) end)
+
 val ArrowP_PURE_to_app = Q.store_thm("ArrowP_PURE_to_app",
 `!A B f fv x1 xv1 xv2 xvl H Q p.
-(!(p : 'a ffi_proj) st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)) ==>
-(!(p : unit ffi_proj) st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)) ==>
+REFS_PRED_Mem_Only H ==>
 A x1 xv1 ==>
 (!state gv. B (f x1) gv ==>
 app (p : 'a ffi_proj) gv (xv2::xvl) (H state) (Q state)) ==>
@@ -279,7 +214,8 @@ rw[app_def]
 \\ fs[state_component_equality]
 \\ sg `!p. ?h2. SPLIT (st2heap p (empty_state with refs := st.refs)) (h_i, h2)`
 >-(
-    last_x_assum IMP_RES_TAC
+    (* last_x_assum IMP_RES_TAC *)
+    apply_REFS_PRED_Mem_Only_IMP \\ rw[]
     \\ rw[st2heap_def]
     \\ qexists_tac `h3 UNION (ffi2heap p' empty_state.ffi)`
     \\ fs[SPLIT_def, UNION_ASSOC]
@@ -288,18 +224,20 @@ rw[app_def]
     \\ ASSUME_TAC (ISPECL [``p':unit ffi_proj``, ``empty_state with refs := st.refs``] st2heap_SPLIT_FFI)
     \\ fs[SPLIT_def]
     \\ qpat_x_assum `h_i UNION h3 = h` (fn x => fs[SYM x]))
-\\ first_x_assum(qspec_then `pu` STRIP_ASSUME_TAC)
+\\ first_x_assum(qspec_then `ARB` STRIP_ASSUME_TAC)
 \\ IMP_RES_TAC REFS_PRED_lemma
-\\ qpat_x_assum `!refs1 p. R ==> ?env. R2` IMP_RES_TAC
+\\ qpat_x_assum `!refs. R` (fn x => ALL_TAC)
+\\ qpat_x_assum `!refs1 p. R ==> ?env. R2` drule \\ rw[]
 \\ POP_ASSUM(qspec_then `[]` STRIP_ASSUME_TAC)
 \\ fs[REFS_PRED_FRAME_def]
 \\ fs[evaluate_ck_def]
 \\ rw[]
-\\ `(H refs3 * (\s. s = h2)) (st2heap pu (empty_state with refs := st.refs))` by (rw[STAR_def] \\ SATISFY_TAC)
-\\ qpat_assum `!F. P` IMP_RES_TAC
-\\ IMP_RES_TAC HPROP_SPLIT3
+\\ `(H st3 * (\s. s = h2)) (st2heap ARB (empty_state with refs := st.refs))` by (rw[STAR_def] \\ SATISFY_TAC)
+\\ qpat_assum `!F. P` drule \\ rw[]
+\\ first_x_assum drule \\ strip_tac
+\\ drule HPROP_SPLIT3 \\ rw[]
 \\ fs[with_same_refs] \\ rw[]
-\\ IMP_RES_TAC evaluate_Rval_bigStep_to_evaluate
+\\ drule evaluate_Rval_bigStep_to_evaluate \\ rw[]
 \\ qexists_tac `Val v`
 \\ qexists_tac `h1`
 \\ qexists_tac `(st2heap p (st with refs := st.refs ++ junk)) DIFF h1 DIFF h_k`
@@ -307,24 +245,17 @@ rw[app_def]
 \\ qexists_tac `c`
 \\ fs[SEP_CLAUSES, SEP_EXISTS_THM]
 \\ rw[]
->-(
-    (* Clean up the assumptions *)
-    ntac 2 (POP_ASSUM (fn x => ALL_TAC))
-    \\ last_x_assum IMP_RES_TAC
-    \\ sg `SPLIT (st2heap pu (empty_state with refs := st.refs ++ junk)) (h1, h2 UNION h3)`
+>-(    
+    sg `SPLIT (st2heap ARB (empty_state with refs := st.refs ++ junk)) (h1, h2 UNION h3)`
     >-(fs[SPLIT_def, SPLIT3_def, UNION_ASSOC] \\ metis_tac[DISJOINT_SYM])
-    \\ last_x_assum IMP_RES_TAC
+    \\ apply_REFS_PRED_Mem_Only_IMP
+    \\ apply_REFS_PRED_Mem_Only_IMP2 \\ rw[]
     \\ fs[state_component_equality]
-    \\ ntac 2 (last_x_assum (fn x => ALL_TAC))
-    \\ last_x_assum ASSUME_TAC
-    \\ last_x_assum (fn x => ALL_TAC)
-    \\ last_x_assum ASSUME_TAC
-    \\ ntac 8 (last_x_assum (fn x => ALL_TAC))
     \\ fs[SPLIT_def, SPLIT3_def]
     \\ sg `!x. x IN h_i ==> x IN store2heap st.refs`
     >-(
 	rw[]
-	\\ `x IN (h_i UNION h3''')` by fs[]
+	\\ `x IN (h_i UNION h3')` by fs[]
 	\\ metis_tac[UNION_DEF, IN_DEF])
     \\ sg `h2 INTER (store2heap st.refs) = h_k INTER (store2heap st.refs)`
     >-(
@@ -396,20 +327,23 @@ rw[app_def]
     \\ Cases_on `x IN h1` >> fs[]
     \\ Cases_on `x IN h_k` >> fs[]
     \\ fs[IN_DEF, st2heap_def])
->-(qexists_tac `H refs3` \\ fs[HCOND_EXTRACT])
+>-(qexists_tac `H st3` \\ fs[HCOND_EXTRACT])
 \\ ASSUME_TAC (Thm.INST_TYPE[``:'a`` |-> ``:unit``, ``:'b`` |-> ``:'a``] (CONJUNCT1 evaluatePropsTheory.evaluate_ffi_intro))
 \\ first_x_assum IMP_RES_TAC
 \\ fs[state_component_equality, ml_translatorTheory.empty_state_def, ffiTheory.initial_ffi_state_def]);
 
-val prove_ArrowP_MONAD_to_app_SPLIT3 = ntac 2 (POP_ASSUM (fn x => ALL_TAC))
-  \\ last_x_assum IMP_RES_TAC
+val prove_ArrowP_MONAD_to_app_SPLIT3 =
+  ntac 3 (POP_ASSUM (fn x => ALL_TAC))
   \\ sg `SPLIT (st2heap pu (empty_state with refs := refs')) (h1, h2 UNION h3)`
   >-(fs[SPLIT_def, SPLIT3_def, UNION_ASSOC] \\ metis_tac[DISJOINT_SYM])
-  \\ last_x_assum IMP_RES_TAC
-  \\ last_x_assum (fn x => ALL_TAC)
+  \\ apply_REFS_PRED_Mem_Only_IMP
+  \\ apply_REFS_PRED_Mem_Only_IMP2 \\ rw[]
+  (* cleanup *)
+  \\ ntac 2 (last_x_assum (fn x => ALL_TAC))
   \\ fs[state_component_equality, st2heap_clock]
   \\ ntac 3 (last_x_assum ASSUME_TAC)
   \\ ntac 6 (last_x_assum (fn x => ALL_TAC))
+  (* end of cleanup *)
   \\ fs[SPLIT_def, SPLIT3_def]
   \\ `!x. x IN h_i ==> x IN store2heap st.refs` by metis_tac[IN_UNION]
   \\ sg `h2 INTER (store2heap refs') = h_k INTER (store2heap refs')`
@@ -486,8 +420,7 @@ val prove_ArrowP_MONAD_to_app_SPLIT3 = ntac 2 (POP_ASSUM (fn x => ALL_TAC))
 
 val ArrowP_MONAD_to_app = Q.store_thm("ArrowP_MONAD_to_app",
 `!A B C f fv H x xv refs p.
-(!(p : 'a ffi_proj) st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)) ==>
-(!(p : unit ffi_proj) st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)) ==>
+REFS_PRED_Mem_Only H ==>
 A x xv ==>
 ArrowP H (PURE A) (MONAD B C) f fv ==>
 app (p : 'a ffi_proj) fv [xv] (H refs)
@@ -504,8 +437,8 @@ rw[app_def]
 \\ first_x_assum(qspecl_then[`empty_state with refs := st.refs`, `[]`] ASSUME_TAC)
 \\ sg `!p. ?h2. SPLIT (st2heap p (empty_state with refs := st.refs)) (h_i, h2)`
 >-(
-    last_x_assum IMP_RES_TAC
-    \\ last_x_assum IMP_RES_TAC
+    apply_REFS_PRED_Mem_Only_IMP
+    \\ apply_REFS_PRED_Mem_Only_IMP2 \\ rw[]
     \\ rw[st2heap_def]
     \\ qexists_tac `h3 UNION (ffi2heap p' empty_state.ffi)`
     \\ fs[SPLIT_def, UNION_ASSOC]
@@ -555,49 +488,5 @@ THENL[IMP_RES_TAC evaluate_Rval_bigStep_to_evaluate \\ qexists_tac `Val a`,
 \\ ASSUME_TAC (Thm.INST_TYPE[``:'a`` |-> ``:unit``, ``:'b`` |-> ``:'a``] (CONJUNCT1 evaluatePropsTheory.evaluate_ffi_intro))
 \\ first_x_assum IMP_RES_TAC
 \\ fs[state_component_equality, ml_translatorTheory.empty_state_def, ffiTheory.initial_ffi_state_def]);
-
-val REFS_PRED_Mem_Only_def = Define `REFS_PRED_Mem_Only H = !state h. H state h ==> !x. x IN h ==> ?n v. x = Mem n v`;
-
-val REFS_PRED_Mem_Only_IMP = Q.store_thm("REFS_PRED_Mem_Only_IMP",
-`!H. REFS_PRED_Mem_Only H ==> ((!p st state h1 h2. SPLIT (st2heap p st) (h1, h2) ==> H state h1 ==> ?h3. SPLIT (store2heap st.refs) (h1, h3)))`,
-rw[REFS_PRED_Mem_Only_def]
-\\ fs[SPLIT_def]
-\\ qexists_tac `store2heap st.refs DIFF h1`
-\\ rw[]
->-(
-    rw[SET_EQ_SUBSET, SUBSET_DEF]
-    \\ `x IN st2heap p st` by metis_tac[IN_UNION]
-    \\ fs[st2heap_def]
-    \\ last_x_assum IMP_RES_TAC
-    \\ fs[Mem_NOT_IN_ffi2heap])
-\\ fs[DISJOINT_ALT]);
-
-val REFS_PRED_Mem_Only_STAR_IMP = Q.store_thm("REFS_PRED_Mem_Only_STAR_IMP",
-`!H1 H2. REFS_PRED_Mem_Only H1 ==> REFS_PRED_Mem_Only H2 ==> REFS_PRED_Mem_Only (\state. H1 state * H2 state)`,
-rw[REFS_PRED_Mem_Only_def]
-\\ fs[STAR_def, SPLIT_def]
-\\ metis_tac[IN_DEF, IN_UNION]);
-
-val REFS_PRED_Mem_Only_REF_REL = Q.store_thm("REFS_PRED_Mem_Only_REF_REL",
-`!A get_val r. REFS_PRED_Mem_Only (\state. REF_REL A r (get_val state))`,
-rw[REFS_PRED_Mem_Only_def]
-\\ fs[REF_REL_def, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def]
-\\ rw[]
-\\ fs[IN_SING]);
-
-val REFS_PRED_Mem_Only_RARRAY_REL = Q.store_thm("REFS_PRED_Mem_Only_RARRAY_REL",
-`!A get_arr r. REFS_PRED_Mem_Only (\state. RARRAY_REL A r (get_arr state))`,
-rw[REFS_PRED_Mem_Only_def]
-\\ fs[RARRAY_REL_def, RARRAY_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def, GSYM STAR_ASSOC]
-\\ fs[STAR_def, SPLIT_def, cond_def]
-\\ rw[]
-\\ fs[IN_SING]);
-
-val REFS_PRED_Mem_Only_emp = Q.store_thm("REFS_PRED_Mem_Only_emp",
-`REFS_PRED_Mem_Only (\(state : 'a). emp)`,
-rw[REFS_PRED_Mem_Only_def]
-\\ fs[REF_REL_def, SEP_EXISTS_THM, HCOND_EXTRACT, REF_def, cell_def, one_def, emp_def]
-\\ rw[]
-\\ fs[]);
 
 val _ = export_theory();

--- a/translator/monadic/examples/exceptionProgScript.sml
+++ b/translator/monadic/examples/exceptionProgScript.sml
@@ -57,7 +57,7 @@ val handle_fail_def = Define `handle_fail x f = \(state : state_refs). dtcase x 
  *)
 
 val assert_def = Define `assert b = if b then failwith "assert" else return ()`
-val decrease_def = Define `decrease n = monad_ignore_bind (assert (n > 0)) (return (n-1))`;
+val decrease_def = Define `decrease n = monad_ignore_bind (assert (n > (0:num))) (return (n-1))`;
 val handle_decrease_def = Define `handle_decrease n = handle_fail (decrease n) (\e. return 0)`;
 
 (* ... *)

--- a/translator/monadic/examples/runProgScript.sml
+++ b/translator/monadic/examples/runProgScript.sml
@@ -103,7 +103,6 @@ val test3_v_th = m_translate test3_def;
 
 (* Several non recursive functions *)
 val run_test3_def = Define `run_test3 n m z refs = run (test3 n m z) refs`;
-val def = run_test3_def;
 val run_test3_v_th = m_translate_run run_test3_def;
 
 (* Recursive function *)

--- a/translator/monadic/examples/testAssumScript.sml
+++ b/translator/monadic/examples/testAssumScript.sml
@@ -109,11 +109,18 @@ val mf6_def = Define `mf6 l = dtcase l of [] => return 0 | x::l => return 1`;
 val def = mf6_def;
 
 val length_v_thm = translate listTheory.LENGTH;
-val zip_v_thm = translate listTheory.ZIP;
+val ZIP_def2 = Q.prove(`ZIP (l1,l2) = dtcase (l1,l2) of
+    (x::l1,y::l2) => (x,y)::(ZIP (l1,l2))
+ |  ([],[]) => []
+ | other => []`,
+Cases_on `l1`
+\\ Cases_on `l2`
+\\ fs[ZIP_def]);
 
+val zip_v_thm = translate ZIP_def2;
+	
 val mf7_def = Define `mf7 l1 l2 = do z <- if LENGTH l1 = LENGTH l2 then return () else failwith ""; return (ZIP (l1, l2)) od`;
 val def = mf7_def;
 val mf7_v_thm = m_translate def;
-val mf7_side_def = definition"mf7_side_def"
 
 val _ = export_theory ();

--- a/translator/monadic/ml_monadStoreLib.sml
+++ b/translator/monadic/ml_monadStoreLib.sml
@@ -5,9 +5,10 @@ open astTheory libTheory bigStepTheory semanticPrimitivesTheory
 open terminationTheory ml_progLib ml_progTheory
 open set_sepTheory cfTheory cfStoreTheory cfTacticsLib
 open cfHeapsBaseTheory basisFunctionsLib
-open ml_monadBaseTheory ml_monad_translatorTheory Redblackmap AC_Sort Satisfy
+open ml_monadBaseTheory ml_monad_translatorBaseTheory ml_monad_translatorTheory ml_monadStoreTheory
+open Redblackmap AC_Sort Satisfy
 
-fun ERR fname msg = mk_HOL_ERR "ml_monadProgLib" fname msg;
+fun ERR fname msg = mk_HOL_ERR "ml_monadStoreLib" fname msg;
 
 val HCOND_EXTRACT = cfLetAutoTheory.HCOND_EXTRACT
 
@@ -47,6 +48,8 @@ val EXTRACT_PURE_FACTS_CONV =
   THENC (SIMP_CONV pure_ss [HCOND_EXTRACT])
   THENC (SIMP_CONV pure_ss [STAR_ASSOC]);
 
+val SEPARATE_SEP_EXISTS_CONV = ((SIMP_CONV pure_ss [GSYM STAR_ASSOC, SEP_EXISTS_INWARD]) THENC (SIMP_CONV pure_ss [STAR_ASSOC, SEP_EXISTS_SEPARATE]))
+
 (* TODO: use EXTRACT_PURE_FACT_CONV to rewrite EXTRACT_PURE_FACTS_TAC *)
 fun EXTRACT_PURE_FACTS_TAC (g as (asl, w)) =
   let
@@ -61,20 +64,6 @@ fun EXTRACT_PURE_FACTS_TAC (g as (asl, w)) =
 (******* End of COPY/PASTE from ml_monadProgScipt.sml *****************************************)
 
 (* Normalize the heap predicate before using the get_heap_constant_thm theorem  *)
-val SEP_EXISTS_SEPARATE_lemma = List.hd(SPEC_ALL SEP_CLAUSES |> CONJUNCTS) |> GSYM |> GEN_ALL
-val SEP_EXISTS_INWARD_lemma = List.nth(SPEC_ALL SEP_CLAUSES |> CONJUNCTS, 1) |> GSYM |> GEN_ALL
-
-val SEPARATE_SEP_EXISTS_CONV = ((SIMP_CONV pure_ss [GSYM STAR_ASSOC, SEP_EXISTS_INWARD_lemma])
-				 THENC (SIMP_CONV pure_ss [STAR_ASSOC, SEP_EXISTS_SEPARATE_lemma]))
-
-val ALLOCATE_EMPTY_RARRAY_lemma = Q.prove(
-`!env s. evaluate F env s (App Opref [App AallocEmpty [Con NONE []]])
-(s with refs := s.refs ++ [Varray []] ++ [Refv (Loc (LENGTH s.refs))], Rval (Loc (LENGTH s.refs + 1)))`,
-rw[]
-\\ ntac 10 (rw[Once evaluate_cases])
-\\ rw[do_opapp_def, do_con_check_def, build_conv_def, do_app_def, store_alloc_def]
-\\ rw[state_component_equality]);
-
 fun get_refs_manip_funs (l : (string * thm * thm * thm) list) =
   List.map (fn (x, _, y, z) => (x, y, z)) l;
 fun get_arrays_manip_funs (l : (string * thm * thm * thm * thm * thm * thm * thm) list) =
@@ -97,7 +86,7 @@ fun derive_eval_thm_ALLOCATE_EMPTY_ARRAY v_name value_def = let
     (***)
 
     (* Expand the definitions *)
-    val th = SPECL [env, s] ALLOCATE_EMPTY_RARRAY_lemma
+    val th = SPECL [env, s] ALLOCATE_EMPTY_RARRAY_evaluate
     val th = SIMP_RULE pure_ss [GSYM array_v_def] th
     val res_pair = rand(concl th)
     val res_pair_eq = EVAL res_pair
@@ -362,125 +351,7 @@ val (g as (asl, w)) = top_goal();
 	  tac g
       end
 
-    val GC_INWARDS = Q.prove(`GC * A = A * GC`, SIMP_TAC std_ss [STAR_COMM])
-
-    val GC_DUPLICATE_0 = Q.prove(`H * GC = H * GC * GC`, rw[GSYM STAR_ASSOC, GC_STAR_GC])
-
-    val GC_DUPLICATE_1 = Q.prove(`A * (B * GC * C) = A * GC * (B * GC * C)`,
-				 SIMP_TAC std_ss [GSYM STAR_ASSOC, GC_INWARDS, GC_STAR_GC])
-
-    val GC_DUPLICATE_2 = Q.prove(`A * (B * GC) = A * GC * (B * GC)`,
-	ASSUME_TAC (Thm.INST [``C : hprop`` |-> ``emp : hprop``] GC_DUPLICATE_1)
-        \\ FULL_SIMP_TAC std_ss [GSYM STAR_ASSOC, SEP_CLAUSES])
-
-    val GC_DUPLICATE_3 = Q.prove(`A * GC * B = GC * (A * GC * B)`,
-	SIMP_TAC std_ss [GSYM STAR_ASSOC, GC_INWARDS, GC_STAR_GC])
-
-    val store2heap_aux_decompose_store1 = Q.prove(
-      `H (store2heap_aux n (a ++ (b ++ c))) =
-      (DISJOINT (store2heap_aux n (a ++ b)) (store2heap_aux (n + LENGTH (a ++b)) c) ==>
-      H ((store2heap_aux n (a ++ b)) UNION (store2heap_aux (n + LENGTH (a ++b)) c)))`,
-      EQ_TAC
-      >-(
-	 rw[]
-	 \\ FULL_SIMP_TAC pure_ss [GSYM APPEND_ASSOC]
-	 \\ FULL_SIMP_TAC pure_ss [store2heap_aux_append_many, ADD_ASSOC]
-	 \\ metis_tac[UNION_COMM, UNION_ASSOC]
-      )
-      \\ rw[]
-      \\ qspecl_then [`n`, `a ++ b`, `c`] ASSUME_TAC store2heap_aux_DISJOINT \\ fs[]
-      \\ PURE_REWRITE_TAC [Once store2heap_aux_append_many]
-      \\ fs[UNION_COMM])
-
-    val store2heap_aux_decompose_store2 = Q.prove(
-      `H (store2heap_aux n (a ++ b)) =
-      (DISJOINT (store2heap_aux n a) (store2heap_aux (n + LENGTH a) b) ==>
-      H ((store2heap_aux (n + LENGTH a) b) UNION (store2heap_aux n a)))`,
-      ASSUME_TAC (Thm.INST [``b:v store`` |-> ``[] : v store``] store2heap_aux_decompose_store1
-         |> GEN_ALL)
-      \\ fs[UNION_COMM])
-
-    val cons_to_append = Q.prove(`a::b::c = [a; b]++c`, fs[])
-
-    val append_empty = Q.prove(`a = a ++ []`, fs[])
-
-    val H_STAR_GC_SAT_IMP = Q.prove(`H s ==> (H * GC) s`,
-	rw[STAR_def]
-	\\ qexists_tac `s`
-        \\ qexists_tac `{}`
-        \\ rw[SPLIT_emp2, SAT_GC])
-
-    val store2heap_REF_SAT = Q.prove(`((Loc l) ~~> v) (store2heap_aux l [Refv v])`,
-        fs[store2heap_aux_def] >> fs[REF_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def])
-
-    val store2heap_eliminate_ffi_thm = Q.prove(
-      `H (store2heap s.refs) ==> (GC * H) (st2heap p s)`,
-      rw[] 
-      \\ Cases_on `p`
-      \\ fs[st2heap_def, STAR_def]
-      \\ instantiate
-      \\ qexists_tac `ffi2heap (q, r) s.ffi`
-      \\ fs[SAT_GC]
-      \\ PURE_ONCE_REWRITE_TAC[SPLIT_SYM]
-      \\ fs[st2heap_SPLIT_FFI]);
-
-    val rarray_exact_thm = Q.prove(
-	`((l = l' + 1) /\ (n = l')) ==>
-	 RARRAY (Loc l) av (store2heap_aux n [Varray av; Refv (Loc l')])`,
-        rw[]
-        \\ rw[RARRAY_def]
-	\\ rw[SEP_EXISTS_THM]
-	\\ qexists_tac `Loc l'`
-        \\ PURE_REWRITE_TAC[Once STAR_COMM]
-	\\ `[Varray av; Refv (Loc l')] = [Varray av] ++ [Refv (Loc l')]` by fs[]
-        \\ POP_ASSUM(fn x => PURE_REWRITE_TAC[x])
-	\\ PURE_REWRITE_TAC[store2heap_aux_decompose_store2]
-	\\ DISCH_TAC
-	\\ rw[STAR_def, SPLIT_def]
-	\\ instantiate
-	\\ rw[]
-	>-(rw[Once UNION_COMM])
-	>-(rw[ARRAY_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def, store2heap_aux_def])
-	\\ rw[REF_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def, store2heap_aux_def]);
-	
-     val eliminate_inherited_references_thm = Q.prove(
-       `!a b. H (store2heap_aux (LENGTH a) b) ==> (GC * H) (store2heap_aux 0 (a++b))`,
-       rw[]
-       \\ fs[STAR_def]
-       \\ instantiate
-       \\ qexists_tac `store2heap_aux 0 a`
-       \\ fs[SPEC_ALL store2heap_aux_SPLIT |> Thm.INST [``n:num`` |-> ``0:num``]
-		      |> SIMP_RULE arith_ss [], SAT_GC]);
-
-     val eliminate_substore_thm = Q.prove(
-       `(H1 * GC * H2) (store2heap_aux (n + LENGTH a) b) ==>
-        (H1 * GC * H2) (store2heap_aux n (a++b))`,
-       rw[]
-       \\ PURE_ONCE_REWRITE_TAC[GC_DUPLICATE_3]
-       \\ rw[Once STAR_def]
-       \\ qexists_tac `store2heap_aux n a`
-       \\ qexists_tac `store2heap_aux (n + LENGTH a) b`
-       \\ simp[SAT_GC, store2heap_aux_SPLIT])
-
-     val eliminate_store_elem_thm = Q.prove(
-       `(H1 * GC * H2) (store2heap_aux (n + 1) b) ==>
-        (H1 * GC * H2) (store2heap_aux n (a::b))`,
-       rw[]
-       \\ PURE_ONCE_REWRITE_TAC[GC_DUPLICATE_3]
-       \\ rw[Once STAR_def]
-       \\ PURE_ONCE_REWRITE_TAC[CONS_APPEND]
-       \\ qexists_tac `store2heap_aux n [a]`
-       \\ qexists_tac `store2heap_aux (n + (LENGTH [a])) b`
-       \\ simp[SAT_GC, store2heap_aux_SPLIT])
-
      fun eliminate_inherited_store_rec remaining_store =
-       (*
-       val remaining_store = remaining_store'
-       val (binder, remaining_store') = dest_comb remaining_store
-       val (binder, e) = dest_comb binder
-       (irule eliminate_store_elem_thm)
-       (irule eliminate_substore_thm)
-       *)
        if same_const remaining_store ``[] : 'a list`` then ALL_TAC
        else let
 	   fun decompose_store remaining_store = let
@@ -502,34 +373,6 @@ val (g as (asl, w)) = top_goal();
          \\ eliminate_inherited_store_rec remaining_store
          \\ PURE_REWRITE_TAC [APPEND_ASSOC]
      end
-
-     (* val eliminate_store_init_refs_thm = Q.prove(
-       `(H1 * H2) (store2heap_aux (n + LENGTH a) b) ==>
-        (H1 * GC * H2) (store2heap_aux n (a++b))`,
-       rw[STAR_def]
-       \\ qexists_tac `
-       \\ qexists_tac `store2heap_aux n a`
-       \\ qexists_tac `store2heap_aux (n + (LENGTH a)) b`
-       \\ simp[SAT_GC, store2heap_aux_SPLIT]) *)
-
-     (* fun eliminate_inherited_references current_store =
-       if same_const initial_store ``[] : 'a list`` then ALL_TAC
-       else let
-	   val initial_store = PURE_REWRITE_CONV[GSYM APPEND_ASSOC] initial_store |> concl |> rhs
-			       handle UNCHANGED => initial_store
-	   fun num_sublists l = let
-	       val (l', b) = dest_comb l
-	       val (conc, a) = dest_comb l'
-	   in if same_const ``list$APPEND : 'a list -> 'a list -> 'a list`` conc then
-		  1 + num_sublists b
-	      else 1
-	   end handle HOL_ERR _ => 1
-
-	   val repeat_num = num_sublists initial_store
-	   val tac = PURE_REWRITE_TAC[GSYM APPEND_ASSOC]
-		     \\ ntac repeat_num (irule eliminate_substore_thm)		     
-                     \\ PURE_REWRITE_TAC [APPEND_ASSOC]
-       in tac end *)
 
      fun check_ref (g as (asl, w)) = let
 	    val hprop = PURE_REWRITE_CONV [GSYM STAR_ASSOC] w
@@ -655,7 +498,11 @@ fun prove_exists_store_X_hprop save_th state_type store_hprop_name valid_store_X
       val ty_subst = Type.match_type (type_of current_state) ``:unit semanticPrimitives$state``
       val current_state = Term.inst ty_subst current_state
 
-      val ([refs_var, ffi_var], hyps) = concl valid_store_X_hprop_thm |> strip_forall
+      val (vars, hyps) =
+	  concl valid_store_X_hprop_thm |> strip_forall
+      val (refs_var, ffi_var) = if List.length vars = 2
+            then (hd vars, hd(tl vars))
+            else failwith "prove_exists_store_X_hprop"
       val hyps = dest_imp hyps |> fst handle HOL_ERR _ => ``T``
       val interm_goal = ``?(^refs_var) (^ffi_var). ^hyps``
       val interm_solve_tac =  srw_tac[QI_ss][]
@@ -709,9 +556,6 @@ local
 
     fun PICK_PINV_CONV field_pat = AC_Sort.sort{assoc = STAR_ASSOC, comm = STAR_COMM, dest = dest_star, mk = mk_star, cmp = pick_pinv_order field_pat, combine = ALL_CONV, preprocess = ALL_CONV}
 
-    val H_STAR_empty = Q.prove(`H * emp = H`, rw[SEP_CLAUSES])
-
-    val H_STAR_TRUE = Q.prove(`(H * &T = H) /\ (&T * H = H)`, fs[SEP_CLAUSES])
 in
 
 fun prove_store_access_specs refs_manip_list arrays_manip_list refs_locs_defs arrays_refs_locs_defs store_X_hprop_def state_type exn_ri_def store_pinv_def_opt = let
@@ -758,13 +602,12 @@ fun prove_store_access_specs refs_manip_list arrays_manip_list refs_locs_defs ar
 
 	fun rewrite_thm th = let
 	    val th = PURE_ONCE_REWRITE_RULE[GSYM loc_def] th
-	    val th = PURE_REWRITE_RULE[GSYM get_fun_def, GSYM set_fun_def, GSYM STAR_ASSOC,
-				       COMBINE_INV_SIMP] th
+	    val th = PURE_REWRITE_RULE[GSYM get_fun_def, GSYM set_fun_def, GSYM STAR_ASSOC] th
 	    val th = CONV_RULE (DEPTH_CONV BETA_CONV) th
 	    val th = PURE_REWRITE_RULE[H_STAR_empty, H_STAR_TRUE, GSYM H_eq] th
 	    val th = PURE_REWRITE_RULE[GSYM get_fun_def, GSYM set_fun_def] th
 	    val th = PURE_REWRITE_RULE[GSYM H_eq] th
-	    val th = PURE_REWRITE_RULE[GSYM get_fun_def, GSYM set_fun_def, COMBINE_INV_SIMP] th
+	    val th = PURE_REWRITE_RULE[GSYM get_fun_def, GSYM set_fun_def] th
 	    val th = PURE_REWRITE_RULE[PRECONDITION_T, ConseqConvTheory.IMP_CLAUSES_TX] th
 	in th end
 

--- a/translator/monadic/ml_monadStoreScript.sml
+++ b/translator/monadic/ml_monadStoreScript.sml
@@ -1,0 +1,151 @@
+(* This file defines theorems and lemma used in the ml_monadStoreLib *)
+
+open preamble bigStepTheory semanticPrimitivesTheory
+open set_sepTheory cfTheory cfStoreTheory cfTacticsLib
+open cfHeapsBaseTheory cfAppTheory ml_monad_translatorBaseTheory
+
+val _ = new_theory "ml_monadStore"
+
+val HCOND_EXTRACT = save_thm("HCOND_EXTRACT", cfLetAutoTheory.HCOND_EXTRACT);
+
+val SEP_EXISTS_SEPARATE = save_thm("SEP_EXISTS_SEPARATE", List.hd(SPEC_ALL SEP_CLAUSES |> CONJUNCTS) |> GSYM |> GEN_ALL);
+val SEP_EXISTS_INWARD = save_thm("SEP_EXISTS_INWARD", List.nth(SPEC_ALL SEP_CLAUSES |> CONJUNCTS, 1) |> GSYM |> GEN_ALL);
+
+val ALLOCATE_EMPTY_RARRAY_evaluate = Q.store_thm("ALLOCATE_EMPTY_RARRAY_evaluate",
+`!env s. evaluate F env s (App Opref [App AallocEmpty [Con NONE []]])
+(s with refs := s.refs ++ [Varray []] ++ [Refv (Loc (LENGTH s.refs))], Rval (Loc (LENGTH s.refs + 1)))`,
+rw[]
+\\ ntac 10 (rw[Once evaluate_cases])
+\\ rw[do_opapp_def, do_con_check_def, build_conv_def, do_app_def, store_alloc_def]
+\\ rw[state_component_equality]);
+
+val GC_INWARDS = Q.store_thm("GC_INWARDS",
+  `GC * A = A * GC`, SIMP_TAC std_ss [STAR_COMM]);
+
+val GC_DUPLICATE_0 = Q.store_thm("GC_DUPLICATE_0",
+  `H * GC = H * GC * GC`, rw[GSYM STAR_ASSOC, GC_STAR_GC]);
+
+val GC_DUPLICATE_1 = Q.store_thm("GC_DUPLICATE_1",
+ `A * (B * GC * C) = A * GC * (B * GC * C)`,
+  SIMP_TAC std_ss [GSYM STAR_ASSOC, GC_INWARDS, GC_STAR_GC]);
+
+val GC_DUPLICATE_2 = Q.store_thm("GC_DUPLICATE_2",
+ `A * (B * GC) = A * GC * (B * GC)`,
+  ASSUME_TAC (Thm.INST [``C : hprop`` |-> ``emp : hprop``] GC_DUPLICATE_1)
+  \\ FULL_SIMP_TAC std_ss [GSYM STAR_ASSOC, SEP_CLAUSES])
+
+val GC_DUPLICATE_3 = Q.store_thm("GC_DUPLICATE_3",
+ `A * GC * B = GC * (A * GC * B)`,
+  SIMP_TAC std_ss [GSYM STAR_ASSOC, GC_INWARDS, GC_STAR_GC])
+
+val store2heap_aux_decompose_store1 = Q.store_thm(
+ "store2heap_aux_decompose_store1",
+ `H (store2heap_aux n (a ++ (b ++ c))) =
+  (DISJOINT (store2heap_aux n (a ++ b)) (store2heap_aux (n + LENGTH (a ++b)) c) ==>
+  H ((store2heap_aux n (a ++ b)) UNION (store2heap_aux (n + LENGTH (a ++b)) c)))`,
+  EQ_TAC
+  >-(
+      rw[]
+      \\ FULL_SIMP_TAC pure_ss [GSYM APPEND_ASSOC]
+      \\ FULL_SIMP_TAC pure_ss [store2heap_aux_append_many, ADD_ASSOC]
+      \\ metis_tac[UNION_COMM, UNION_ASSOC]
+  )
+  \\ rw[]
+  \\ qspecl_then [`n`, `a ++ b`, `c`] ASSUME_TAC store2heap_aux_DISJOINT \\ fs[]
+  \\ PURE_REWRITE_TAC [Once store2heap_aux_append_many]
+  \\ fs[UNION_COMM]);
+
+val store2heap_aux_decompose_store2 = Q.store_thm(
+ "store2heap_aux_decompose_store2",
+ `H (store2heap_aux n (a ++ b)) =
+  (DISJOINT (store2heap_aux n a) (store2heap_aux (n + LENGTH a) b) ==>
+  H ((store2heap_aux (n + LENGTH a) b) UNION (store2heap_aux n a)))`,
+  ASSUME_TAC (Thm.INST [``b:v store`` |-> ``[] : v store``] store2heap_aux_decompose_store1 |> GEN_ALL)
+  \\ fs[UNION_COMM]);
+
+val cons_to_append = Q.store_thm("cons_to_append", `a::b::c = [a; b]++c`, fs[]);
+
+val append_empty = Q.store_thm("append_empty", `a = a ++ []`, fs[]);
+
+val H_STAR_GC_SAT_IMP = Q.store_thm("H_STAR_GC_SAT_IMP",
+ `H s ==> (H * GC) s`,
+  rw[STAR_def]
+  \\ qexists_tac `s`
+  \\ qexists_tac `{}`
+  \\ rw[SPLIT_emp2, SAT_GC]);
+
+val store2heap_REF_SAT = Q.store_thm("store2heap_REF_SAT",
+ `((Loc l) ~~> v) (store2heap_aux l [Refv v])`,
+  fs[store2heap_aux_def]
+  >> fs[REF_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def]);
+
+val store2heap_eliminate_ffi_thm = Q.store_thm(
+  "store2heap_eliminate_ffi_thm", 
+  `H (store2heap s.refs) ==> (GC * H) (st2heap p s)`,
+  rw[] 
+  \\ Cases_on `p`
+  \\ fs[st2heap_def, STAR_def]
+  \\ qexists_tac `ffi2heap (q, r) s.ffi`
+  \\ qexists_tac `store2heap s.refs`
+  \\ fs[SAT_GC]
+  \\ PURE_ONCE_REWRITE_TAC[SPLIT_SYM]
+  \\ fs[st2heap_SPLIT_FFI]);
+
+val rarray_exact_thm = Q.store_thm("rarray_exact_thm", 
+ `((l = l' + 1) /\ (n = l')) ==>
+  RARRAY (Loc l) av (store2heap_aux n [Varray av; Refv (Loc l')])`,
+  rw[]
+  \\ rw[RARRAY_def]
+  \\ rw[SEP_EXISTS_THM]
+  \\ qexists_tac `Loc l'`
+  \\ PURE_REWRITE_TAC[Once STAR_COMM]
+  \\ `[Varray av; Refv (Loc l')] = [Varray av] ++ [Refv (Loc l')]` by fs[]
+  \\ POP_ASSUM(fn x => PURE_REWRITE_TAC[x])
+  \\ PURE_REWRITE_TAC[store2heap_aux_decompose_store2]
+  \\ DISCH_TAC
+  \\ rw[STAR_def, SPLIT_def]
+  \\ instantiate
+  \\ rw[]
+  >-(rw[Once UNION_COMM])
+  >-(rw[ARRAY_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def, store2heap_aux_def])
+  \\ rw[REF_def, SEP_EXISTS_THM, HCOND_EXTRACT, cell_def, one_def, store2heap_aux_def]);
+	
+val eliminate_inherited_references_thm = Q.store_thm(
+  "eliminate_inherited_references_thm", 
+ `!a b. H (store2heap_aux (LENGTH a) b) ==>
+  (GC * H) (store2heap_aux 0 (a++b))`,
+  rw[]
+  \\ fs[STAR_def]
+  \\ instantiate
+  \\ qexists_tac `store2heap_aux 0 a`
+  \\ fs[SPEC_ALL store2heap_aux_SPLIT |> Thm.INST [``n:num`` |-> ``0:num``]
+		 |> SIMP_RULE arith_ss [], SAT_GC]);
+
+val eliminate_substore_thm = Q.store_thm("eliminate_substore_thm", 
+ `(H1 * GC * H2) (store2heap_aux (n + LENGTH a) b) ==>
+  (H1 * GC * H2) (store2heap_aux n (a++b))`,
+  rw[]
+  \\ PURE_ONCE_REWRITE_TAC[GC_DUPLICATE_3]
+  \\ rw[Once STAR_def]
+  \\ qexists_tac `store2heap_aux n a`
+  \\ qexists_tac `store2heap_aux (n + LENGTH a) b`
+  \\ simp[SAT_GC, store2heap_aux_SPLIT]);
+
+val eliminate_store_elem_thm = Q.store_thm("eliminate_store_elem_thm",
+ `(H1 * GC * H2) (store2heap_aux (n + 1) b) ==>
+  (H1 * GC * H2) (store2heap_aux n (a::b))`,
+  rw[]
+  \\ PURE_ONCE_REWRITE_TAC[GC_DUPLICATE_3]
+  \\ rw[Once STAR_def]
+  \\ PURE_ONCE_REWRITE_TAC[CONS_APPEND]
+  \\ qexists_tac `store2heap_aux n [a]`
+  \\ qexists_tac `store2heap_aux (n + (LENGTH [a])) b`
+  \\ simp[SAT_GC, store2heap_aux_SPLIT]);
+
+val H_STAR_empty = Q.store_thm("H_STAR_empty",
+`H * emp = H`, rw[SEP_CLAUSES]);
+
+val H_STAR_TRUE = Q.store_thm("H_STAR_TRUE",
+`(H * &T = H) /\ (&T * H = H)`, fs[SEP_CLAUSES]);
+
+val _ = export_theory();

--- a/translator/monadic/ml_monad_translatorBaseScript.sml
+++ b/translator/monadic/ml_monad_translatorBaseScript.sml
@@ -1,0 +1,545 @@
+open preamble ml_translatorTheory ml_translatorLib ml_pmatchTheory patternMatchesTheory
+open astTheory libTheory bigStepTheory semanticPrimitivesTheory
+open terminationTheory ml_progLib ml_progTheory
+open set_sepTheory Satisfy
+open cfHeapsBaseTheory basisFunctionsLib AC_Sort
+open determTheory ml_monadBaseTheory
+open cfStoreTheory cfTheory cfTacticsLib
+
+val _ = new_theory "ml_monad_translatorBase";
+
+val HCOND_EXTRACT = cfLetAutoTheory.HCOND_EXTRACT;
+
+val _ = temp_type_abbrev("state",``:'ffi semanticPrimitives$state``);
+
+(* a few basics *)
+val with_same_refs = Q.store_thm("with_same_refs",
+  `(s with refs := s.refs) = s`,
+  simp[state_component_equality])
+
+val with_same_ffi = Q.store_thm("with_same_ffi",
+  `(s with ffi := s.ffi) = s`,
+  simp[state_component_equality]);
+
+val with_same_clock = Q.store_thm("with_same_clock",
+  `(s with clock := s.clock) = s`,
+  simp[state_component_equality]);
+
+(* REF_REL *)
+val REF_REL_def = Define `REF_REL TYPE r x = SEP_EXISTS v. REF r v * &TYPE x v`;
+
+(* REFS_PRED *)
+val REFS_PRED_def = Define `REFS_PRED H refs p s = (H refs * GC) (st2heap p s)`;
+val VALID_REFS_PRED_def = Define `VALID_REFS_PRED H = ?(s : unit state) p refs. REFS_PRED H refs p s`;
+
+(* Frame rule for EvalM *)
+val REFS_PRED_FRAME_def = Define
+`REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) =
+?refs. s2 = s1 with refs := refs /\
+!F. (H refs1 * F) (st2heap p s1) ==> (H refs2 * F * GC) (st2heap p s2)`;
+
+val EMP_STAR_H = Q.store_thm("EMP_STAR_GC",
+`!H. emp * H = H`,
+fs[STAR_def, emp_def, SPLIT_def, ETA_THM]);
+
+val SAT_GC = Q.store_thm("SAT_GC",
+`!h. GC h`,
+fs[GC_def, SEP_EXISTS_THM] \\ STRIP_TAC \\ qexists_tac `\s. T` \\ fs[]);
+
+val REFS_PRED_FRAME_imp = Q.store_thm("REFS_PRED_FRAME_imp",
+`REFS_PRED H refs1 p s1 ==> REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) ==> REFS_PRED H refs2 p s2`,
+rw[REFS_PRED_def, REFS_PRED_FRAME_def]
+\\ Cases_on `p`
+\\ fs[st2heap_def]
+\\ metis_tac[GC_STAR_GC, STAR_ASSOC]);
+
+val REFS_PRED_FRAME_trans = Q.store_thm("REFS_PRED_FRAME_trans",
+`REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) ==>
+REFS_PRED_FRAME H p (refs2, s2) (refs3, s3) ==>
+REFS_PRED_FRAME H p (refs1, s1) (refs3, s3)`,
+rw[REFS_PRED_FRAME_def] >>
+PURE_REWRITE_TAC[Once (GSYM GC_STAR_GC), STAR_ASSOC] >>
+qexists_tac `refs'` >> rw[] >>
+`H refs3 * F' * GC * GC = H refs3 * (F' * GC) * GC` by fs[STAR_ASSOC] >>
+POP_ASSUM (fn x => PURE_REWRITE_TAC[x]) >>
+fs[state_component_equality] >>
+first_x_assum irule >>
+fs[STAR_ASSOC]);
+
+
+(*
+ * Proof of REFS_PRED_APPEND:
+ * `REFS_PRED H refs s ==> REFS_PRED H refs (s with refs := s.refs ++ junk)`
+ *)
+val store2heap_aux_Mem = Q.store_thm("store2heap_aux_Mem",
+`!s n x. x IN (store2heap_aux n s) ==> ?n' v. x = Mem n' v`,
+Induct_on `s`
+ >-(rw[IN_DEF, store2heap_def, store2heap_aux_def]) >>
+rw[] >> fs[IN_DEF, store2heap_def, store2heap_aux_def] >>
+last_x_assum IMP_RES_TAC >>
+fs[]);
+
+val store2heap_aux_IN_LENGTH = Q.store_thm ("store2heap_aux_IN_LENGTH",
+`!s r x n. Mem r x IN (store2heap_aux n s) ==> r < n + LENGTH s`,
+Induct THENL [all_tac, Cases] \\
+fs [store2heap_aux_def] \\
+Cases_on `r` \\ fs [] \\ rewrite_tac [ONE] \\
+rpt strip_tac \\ fs[ADD_CLAUSES, GSYM store2heap_aux_suc] \\
+metis_tac[]
+);
+
+val NEG_DISJ_TO_IMP = Q.prove(
+`!A B. ~A \/ ~B <=> A /\ B ==> F`,
+rw[]);
+
+val store2heap_aux_DISJOINT = Q.store_thm("store2heap_aux_DISJOINT",
+`!n s1 s2. DISJOINT (store2heap_aux n s1) (store2heap_aux (n + LENGTH s1) s2)`,
+rw[DISJOINT_DEF, INTER_DEF, EMPTY_DEF] >>
+fs[GSPECIFICATION_applied] >>
+sg `!x. {x | x ∈ store2heap_aux n s1 ∧ x ∈ store2heap_aux (n + LENGTH s1) s2} x = (\x. F) x`
+>-(
+    rw[] >>
+    PURE_REWRITE_TAC[NEG_DISJ_TO_IMP] >>
+    DISCH_TAC >> rw[] >>
+    IMP_RES_TAC store2heap_aux_Mem >>
+    rw[] >>
+    IMP_RES_TAC store2heap_aux_IN_bound >>
+    IMP_RES_TAC store2heap_aux_IN_LENGTH >>
+    bossLib.DECIDE_TAC
+) >>
+POP_ASSUM (fn x => ASSUME_TAC (EXT x)) >> fs[]);
+
+val store2heap_aux_SPLIT = Q.store_thm("store2heap_aux_SPLIT",
+`!s1 s2 n. SPLIT (store2heap_aux n (s1 ++ s2)) (store2heap_aux n s1, store2heap_aux (n + LENGTH s1) s2)`,
+fs[SPLIT_def] >> fs[store2heap_aux_append_many] >>
+metis_tac[UNION_COMM, store2heap_aux_append_many, store2heap_aux_DISJOINT]);
+
+val store2heap_DISJOINT = Q.store_thm("store2heap_DISJOINT",
+`DISJOINT (store2heap s1) (store2heap_aux (LENGTH s1) s2)`,
+fs[store2heap_def] >> metis_tac[store2heap_aux_DISJOINT, arithmeticTheory.ADD]);
+
+(* If the goal is: (\x. P x) = (\x. Q x), applies SUFF_TAC ``!x. P x = Q x`` *)
+fun SUFF_ABS_TAC (g as (asl, w)) =
+  let
+      val (e1, e2) = dest_eq w
+      val (x1, e1') = dest_abs e1
+      val (x2, e2') = dest_abs e2
+      val _ = if x1 <> x2 then failwith "" else ()
+      val w' = mk_forall(x1,  mk_eq(e1', e2'))
+  in
+      (SUFF_TAC w' THEN rw[]) g
+  end;
+
+val store2heap_SPLIT = Q.store_thm("store2heap_SPLIT",
+`!s1 s2. SPLIT (store2heap (s1 ++ s2)) (store2heap s1, store2heap_aux (LENGTH s1) s2)`,
+fs[store2heap_def] >> metis_tac[store2heap_aux_SPLIT, arithmeticTheory.ADD]);
+
+val SPLIT_DECOMPOSWAP = Q.store_thm("SPLIT_DECOMPOSWAP",
+`SPLIT s1 (s2, s3) ==> SPLIT s2 (u, v) ==> SPLIT s1 (u, v UNION s3)`,
+fs[SPLIT_def, UNION_ASSOC, DISJOINT_SYM] >> rw[] >> fs[DISJOINT_SYM, DISJOINT_UNION_BOTH]);
+
+val STORE_APPEND_JUNK = Q.store_thm("STORE_APPEND_JUNK",
+`!H s junk. H (store2heap s) ==> (H * GC) (store2heap (s ++ junk))`,
+rw[] >>
+qspecl_then [`s`, `junk`] ASSUME_TAC store2heap_SPLIT >>
+fs[STAR_def] >>
+qexists_tac `store2heap s` >>
+qexists_tac `store2heap_aux (LENGTH s) junk` >>
+`!H. GC H` by (rw[cfHeapsBaseTheory.GC_def, SEP_EXISTS] >> qexists_tac `\x. T` >> fs[]) >>
+POP_ASSUM (fn x => fs[x]));
+
+val st2heap_SPLIT_FFI = Q.store_thm("st2heap_SPLIT_FFI",
+`!f st. SPLIT ((store2heap st.refs) UNION (ffi2heap f st.ffi)) (store2heap st.refs, ffi2heap f st.ffi)`,
+rw[SPLIT_def]
+\\ fs[IN_DISJOINT]
+\\ STRIP_TAC
+\\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
+\\ STRIP_TAC
+\\ rw[]
+\\ fs[store2heap_def]
+\\ Cases_on `x`
+\\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux]);
+
+val SPLIT3_swap12 = Q.store_thm("SPLIT3_swap12",
+`!h h1 h2 h3. SPLIT3 h (h1, h2, h3) = SPLIT3 h (h2, h1, h3)`,
+rw[SPLIT3_def, UNION_COMM, CONJ_COMM] >> metis_tac[DISJOINT_SYM]);
+
+val SPLIT_of_SPLIT3_1u3 = Q.store_thm("SPLIT_of_SPLIT3_1u3",
+`∀h h1 h2 h3. SPLIT3 h (h1,h2,h3) ⇒ SPLIT h (h2, h1 ∪ h3)`,
+metis_tac[SPLIT3_swap12, SPLIT_of_SPLIT3_2u3]);
+
+val SPLIT2_SPLIT3 = Q.store_thm("SPLIT2_SPLIT3",
+`SPLIT s1 (s2, t3) /\ SPLIT s2 (t1, t2) ==> SPLIT3 s1 (t1, t2, t3)`,
+rw[SPLIT_def] \\ fs[SPLIT3_def]);
+
+val SPLIT_SYM = Q.store_thm("SPLIT_SYM",
+`SPLIT s (s1, s2) = SPLIT s (s2, s1)`,
+fs[SPLIT_def, DISJOINT_SYM, UNION_COMM]);
+
+val STATE_APPEND_JUNK = Q.store_thm("STATE_APPEND_JUNK",
+`!H p s refs junk. H (st2heap p (s with refs := refs)) ==>
+(H * GC) (st2heap p (s with refs := refs ++ junk))`,
+rw[]
+\\ Cases_on `p`
+\\ fs[st2heap_def]
+\\ Q.PAT_ABBREV_TAC `h = A UNION B`
+\\ sg `SPLIT3 h (store2heap refs, store2heap_aux (LENGTH refs) junk, ffi2heap (q,r) s.ffi)`
+>-(
+   fs[markerTheory.Abbrev_def] \\ rw[]
+   \\ irule SPLIT2_SPLIT3
+   \\ qexists_tac `store2heap (refs ++ junk)`
+   \\ fs[store2heap_SPLIT, SPLIT_def, IN_DISJOINT, store2heap_def]
+   \\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
+   \\ rpt STRIP_TAC
+   \\ Cases_on `x`
+   \\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux])
+\\ fs[markerTheory.Abbrev_def] \\ rw[]
+\\ POP_ASSUM(fn x => MATCH_MP SPLIT_of_SPLIT3_1u3 x |> ASSUME_TAC)
+\\ fs[Once SPLIT_SYM]
+\\ rw[STAR_def]
+\\ metis_tac[SAT_GC]);
+
+val STATE_SPLIT_REFS = Q.store_thm("STATE_SPLIT_REFS",
+`!a b p s. SPLIT (st2heap p (s with refs := a ++ b))
+((st2heap p (s with refs := a)), (store2heap_aux (LENGTH a) b))`,
+rw[] \\ Cases_on `p` \\ fs[st2heap_def] \\
+sg `SPLIT3 (store2heap (a ++ b) ∪ ffi2heap (q,r) s.ffi) (store2heap a, store2heap_aux (LENGTH a) b, ffi2heap (q,r) s.ffi)`
+>-(
+   irule SPLIT2_SPLIT3
+   \\ qexists_tac `store2heap (a ++ b)`
+   \\ fs[store2heap_SPLIT, SPLIT_def, IN_DISJOINT, store2heap_def]
+   \\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
+   \\ rpt STRIP_TAC
+   \\ Cases_on `x`
+   \\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux])
+\\ POP_ASSUM(fn x => MATCH_MP SPLIT_of_SPLIT3_1u3 x |> ASSUME_TAC)
+\\ fs[Once SPLIT_SYM]
+\\ rw[STAR_def]);
+
+val REFS_PRED_append = Q.store_thm("REFS_PRED_append",
+`!H refs s. REFS_PRED H refs p s ==> REFS_PRED H refs p (s with refs := s.refs ++ junk)`,
+rw[REFS_PRED_def] >> PURE_ONCE_REWRITE_TAC [GSYM GC_STAR_GC] >> fs[STAR_ASSOC] >>
+metis_tac[with_same_refs, STATE_APPEND_JUNK]);
+
+val REFS_PRED_FRAME_append = Q.store_thm("REFS_PRED_FRAME_append",
+`!H refs s. REFS_PRED_FRAME H p (refs, s) (refs, s with refs := s.refs ++ junk)`,
+rw[REFS_PRED_FRAME_def] \\ metis_tac[with_same_refs, STATE_APPEND_JUNK]);
+
+(*
+ * Proof of STORE_EXTRACT_FROM_HPROP:
+ * `!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==> ?ps. ((ps ++ [Refv xv]) ≼ s) /\ LENGTH ps = l`
+ *)
+
+val HEAP_LOC_MEM = Q.store_thm("HEAP_LOC_MEM",
+`(l ~~>> rv * H) h ==> Mem l rv IN h`,
+rw[STAR_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]);
+
+(* val HEAP_REF_MEM = Q.store_thm("HEAP_REF_MEM",
+`(Loc l ~~> xv * H) h ==> Mem l (Refv xv) IN h`,
+rw[STAR_def, REF_def, ARRAY_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]); 
+
+val HEAP_ARRAY_MEM = Q.store_thm("HEAP_ARRAY_MEM",
+`(ARRAY (Loc l) av * H) h ==> Mem l (Varray av) IN h`,
+rw[STAR_def, REF_def, ARRAY_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]); *)
+
+val st2heap_CELL_MEM = Q.store_thm("st2heap_CELL_MEM",
+`(l ~~>> rv * H) (st2heap p s) ==> Mem l rv IN (store2heap s.refs)`,
+Cases_on `p` \\ rw[st2heap_def] \\ IMP_RES_TAC HEAP_LOC_MEM
+\\ fs[IN_UNION]
+\\ fs[Mem_NOT_IN_ffi2heap]);
+
+val st2heap_REF_MEM = Q.store_thm("st2heap_REF_MEM",
+`(Loc l ~~> xv * H) (st2heap p s) ==> Mem l (Refv xv) IN (store2heap s.refs)`,
+rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+metis_tac[st2heap_CELL_MEM]);
+
+val st2heap_ARRAY_MEM = Q.store_thm("st2heap_ARRAY_MEM",
+`(ARRAY (Loc l) av * H) (st2heap p s) ==> Mem l (Varray av) IN (store2heap s.refs)`,
+rw[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+metis_tac[st2heap_CELL_MEM]);
+
+val store2heap_aux_LOC_MEM = Q.store_thm("store2heap_aux_LOC_MEM",
+`!l rv H n s. (l ~~>> rv * H) (store2heap_aux n s) ==> Mem l rv IN (store2heap_aux n s)`,
+rw[] \\ IMP_RES_TAC HEAP_LOC_MEM);
+
+(* val store2heap_aux_REF_MEM = Q.store_thm("store2heap_aux_REF_MEM",
+`!l xv H n s. (REF (Loc l) xv * H) (store2heap_aux n s) ==> Mem l (Refv xv) IN (store2heap_aux n s)`,
+rw[] \\ IMP_RES_TAC HEAP_REF_MEM);
+
+val store2heap_aux_ARRAY_MEM = Q.store_thm("store2heap_aux_ARRAY_MEM",
+`!l av H n s. (ARRAY (Loc l) av * H) (store2heap_aux n s) ==> Mem l (Varray av) IN (store2heap_aux n s)`,
+rw[] \\ IMP_RES_TAC HEAP_ARRAY_MEM); *)
+
+val store2heap_LOC_MEM = Q.store_thm("store2heap_LOC_MEM",
+`!l rv H s. (l ~~>> rv * H) (store2heap s) ==> Mem l rv IN (store2heap s)`,
+rw[] \\ IMP_RES_TAC HEAP_LOC_MEM);
+
+(* val store2heap_REF_MEM = Q.store_thm("store2heap_REF_MEM",
+`!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==> Mem l (Refv xv) IN (store2heap s)`,
+rw[] \\ IMP_RES_TAC HEAP_REF_MEM);
+
+val store2heap_ARRAY_MEM = Q.store_thm("store2heap_REF_MEM",
+`!l av H s. (ARRAY (Loc l) av * H) (store2heap s) ==> Mem l (Varray av) IN (store2heap s)`,
+rw[] \\ IMP_RES_TAC HEAP_ARRAY_MEM); *)
+
+val isPREFIX_TAKE = Q.store_thm("isPREFIX_TAKE",
+`!l s. isPREFIX (TAKE l s) s`,
+rw[] >>
+`isPREFIX (TAKE l s) (TAKE l s ++ DROP l s)` by fs[TAKE_DROP] >>
+metis_tac[TAKE_DROP]);
+
+val isPREFIX_APPEND_EQ = Q.store_thm("isPREFIX_APPEND_EQ",
+`!a1 a2 b1 b2. LENGTH a1 = LENGTH a2 ==> (isPREFIX (a1 ++ b1) (a2 ++ b2) <=> a2 = a1 /\ isPREFIX b1 b2)`,
+Induct_on `a1` >- fs[LENGTH_NIL_SYM] >>
+rw[] >>
+Cases_on `a2` >- fs[] >>
+fs[] >> metis_tac[]);
+
+val STATE_DECOMPOS_FROM_HPROP = Q.store_thm("STATE_DECOMPOS_FROM_HPROP",
+`!l rv H p s. (l ~~>> rv * H) (st2heap p s) ==> ?ps. ((ps ++ [rv]) ≼ s.refs) /\ LENGTH ps = l`,
+rw[] >>
+IMP_RES_TAC st2heap_CELL_MEM >>
+IMP_RES_TAC store2heap_IN_EL >>
+qexists_tac `TAKE l s.refs` >>
+Cases_on `l + 1 <= LENGTH s.refs`
+>-(
+    fs[LENGTH_TAKE] >>
+    SUFF_TAC ``isPREFIX [rv : v store_v] (DROP l s.refs)``
+    >- metis_tac[LENGTH_TAKE, LENGTH_DROP, GSYM isPREFIX_APPEND_EQ, TAKE_DROP] >>
+    FIRST_ASSUM (fn x => PURE_REWRITE_TAC[x]) >>
+    SUFF_TAC ``(rv : v store_v) = HD(DROP l s.refs)``
+    >-( fs[] >> Cases_on `DROP l s.refs` >- fs[DROP_NIL] >> fs[]) >>
+    fs[hd_drop]
+) >>
+irule FALSITY >>
+IMP_RES_TAC store2heap_IN_LENGTH >>
+fs[]);
+
+val STATE_DECOMPOS_FROM_HPROP_REF = Q.store_thm("STATE_DECOMPOS_FROM_HPROP_REF",
+`!l xv H p s. (REF (Loc l) xv * H) (st2heap p s) ==> ?ps. ((ps ++ [Refv xv]) ≼ s.refs) /\ LENGTH ps = l`,
+rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_DECOMPOS_FROM_HPROP >>
+instantiate);
+
+val STATE_DECOMPOS_FROM_HPROP_ARRAY = Q.store_thm("STATE_DECOMPOS_FROM_HPROP_ARRAY",
+`!l av H p s. (ARRAY (Loc l) av * H) (st2heap p s) ==> ?ps. ((ps ++ [Varray av]) ≼ s.refs) /\ LENGTH ps = l`,
+rw[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_DECOMPOS_FROM_HPROP >>
+instantiate);
+
+(* val STORE_EXTRACT_FROM_HPROP_REF = Q.store_thm("STORE_EXTRACT_REF_FROM_HPROP",
+`!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==>
+!junk. EL l (s ++ junk) = Refv xv`,
+rw[] >>
+IMP_RES_TAC STORE_DECOMPOS_REF_FROM_HPROP >>
+fs[IS_PREFIX_APPEND] >>
+first_x_assum(fn x => CONV_RULE (CHANGED_CONV (SIMP_CONV pure_ss [GSYM APPEND_ASSOC])) x |> ASSUME_TAC) >>
+`~NULL ([Refv xv] ++ (l' ++ junk))` by fs[NULL_EQ] >>
+IMP_RES_TAC EL_LENGTH_APPEND >>
+fs[HD] >>
+metis_tac[]); *)
+
+val STATE_EXTRACT_FROM_HPROP = Q.store_thm("STATE_EXTRACT_FROM_HPROP",
+`!l rv H p s. (l ~~>> rv * H) (st2heap p s) ==>
+!junk. EL l (s.refs ++ junk) = rv`,
+rw[] >>
+IMP_RES_TAC STATE_DECOMPOS_FROM_HPROP >>
+fs[IS_PREFIX_APPEND] >>
+first_x_assum(fn x => CONV_RULE (CHANGED_CONV (SIMP_CONV pure_ss [GSYM APPEND_ASSOC])) x |> ASSUME_TAC) >>
+`~NULL ([rv] ++ (l' ++ junk))` by fs[NULL_EQ] >>
+IMP_RES_TAC EL_LENGTH_APPEND >>
+fs[HD] >>
+metis_tac[]);
+
+val STATE_EXTRACT_FROM_HPROP_REF = Q.store_thm("STATE_EXTRACT_FROM_HPROP_REF",
+`!l xv H p s. ((Loc l) ~~> xv * H) (st2heap p s) ==>
+!junk. EL l (s.refs ++ junk) = Refv xv`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_EXTRACT_FROM_HPROP >>
+instantiate);
+
+val STATE_EXTRACT_FROM_HPROP_ARRAY = Q.store_thm("STATE_EXTRACT_FROM_HPROP_ARRAY",
+`!l av H p s. (ARRAY (Loc l) av * H) (st2heap p s) ==>
+!junk. EL l (s.refs ++ junk) = Varray av`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_EXTRACT_FROM_HPROP >>
+instantiate);
+
+val SEPARATE_STORE_ELEM_IN_HEAP = Q.store_thm("SEPARATE_STORE_ELEM_IN_HEAP",
+`!s0 x s1. SPLIT3 (store2heap (s0 ++ [x] ++ s1)) (store2heap s0, {Mem (LENGTH s0) x}, store2heap_aux (LENGTH s0 + 1) s1)`,
+sg `!(s0 : v store) s1 x. SPLIT (store2heap_aux (LENGTH s0) (x::s1)) ({Mem (LENGTH s0) x}, store2heap_aux (LENGTH s0 + 1) s1)`
+>-(
+    rw[store2heap_def] >>
+    PURE_REWRITE_TAC[Once rich_listTheory.CONS_APPEND] >>
+    PURE_REWRITE_TAC [GSYM (EVAL ``store2heap_aux (LENGTH (s0 : v store)) [x]``)] >>
+    ASSUME_TAC (EVAL ``LENGTH [x : v store_v]``) >>
+    metis_tac[store2heap_aux_SPLIT, ADD_COMM]
+) >>
+rw[] >>
+qspecl_then [`s0`, `[x] ++ s1`] ASSUME_TAC store2heap_SPLIT >> fs[] >>
+last_x_assum(qspecl_then [`s0`, `s1`, `x`] ASSUME_TAC) >>
+fs[SPLIT_def, SPLIT3_def] >>
+rw[]
+>-(metis_tac[UNION_ASSOC, EQ_REFL])
+>-(DISCH_TAC >> IMP_RES_TAC store2heap_IN_LENGTH >> fs[]) >>
+metis_tac[DISJOINT_UNION_BOTH, EQ_REFL]);
+
+val CELL_HPROP_SAT_EQ = Q.store_thm("CELL_HPROP_SAT_EQ",
+`!l xv s. (l ~~>> xv) s <=> s = {Mem l xv}`,
+fs[REF_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
+
+val REF_HPROP_SAT_EQ = Q.store_thm("REF_HPROP_SAT_EQ",
+`!l xv s. REF (Loc l) xv s <=> s = {Mem l (Refv xv)}`,
+fs[REF_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
+
+val ARRAY_HPROP_SAT_EQ = Q.store_thm("ARRAY_HPROP_SAT_EQ",
+`!l av s. ARRAY (Loc l) av s <=> s = {Mem l (Varray av)}`,
+fs[ARRAY_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
+
+val SPLIT_UNICITY_R = Q.store_thm("SPLIT_UNICITY_R",
+`SPLIT s (u, v) ==> (SPLIT s (u, v') <=> v' = v)`,
+fs[SPLIT_EQ]);
+
+(* val STORE_SAT_LOC_STAR_H_EQ = Q.store_thm("STORE_SAT_LOC_STAR_H_EQ",
+`!s0 xv s1 H. (Loc (LENGTH s0) ~~> xv * H) (store2heap (s0 ++ [Refv xv] ++ s1)) <=>
+H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1))`,
+rw[] >>
+qspecl_then [`s0`, `Refv xv`, `s1`] ASSUME_TAC SEPARATE_STORE_ELEM_IN_HEAP >>
+IMP_RES_TAC SPLIT_of_SPLIT3_1u3 >>
+last_x_assum(fn x => ALL_TAC) >>
+EQ_TAC
+>-(
+    rw[STAR_def, REF_HPROP_SAT_EQ] >>
+    IMP_RES_TAC SPLIT_UNICITY_R >>
+    fs[]
+) >>
+DISCH_TAC >>
+rw[STAR_def] >>
+instantiate >>
+rw[REF_HPROP_SAT_EQ]); *)
+
+val DIFF_UNION_COMM = Q.store_thm("DIFF_UNION_COMM",
+`DISJOINT s2 s3 ==>
+(s1 UNION s2) DIFF s3 = (s1 DIFF s3) UNION s2`,
+rw[SET_EQ_SUBSET]
+\\ fs[SUBSET_DEF, IN_DISJOINT] \\rw[]
+\\ last_x_assum (fn x => PURE_ONCE_REWRITE_RULE [NEG_DISJ_TO_IMP] x |> IMP_RES_TAC)
+\\ fs[]);
+
+val STATE_SAT_CELL_STAR_H_EQ = Q.store_thm("STATE_SAT_CELL_STAR_H_EQ",
+`!p s s0 rv s1 H. ((LENGTH s0) ~~>> rv * H) (st2heap p (s with refs := s0 ++ [rv] ++ s1)) <=>
+H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
+rw[] >>
+Cases_on `p` >>
+fs[st2heap_def] >>
+qspecl_then [`p`, `s with refs := s0 ++ [rv] ++ s1`] ASSUME_TAC st2heap_SPLIT_FFI >>
+fs[] >>
+qspecl_then [`s0`, `rv`, `s1`] ASSUME_TAC SEPARATE_STORE_ELEM_IN_HEAP >>
+IMP_RES_TAC SPLIT_of_SPLIT3_1u3 >>
+EQ_TAC
+>-(
+    rw[STAR_def, CELL_HPROP_SAT_EQ] >>
+    fs[SPLIT_EQ] >>
+    rw[] >>
+    fs[st2heap_def] >>
+    `DISJOINT (ffi2heap (q, r) s.ffi) {Mem (LENGTH s0) rv}` by fs[DISJOINT_DEF, Mem_NOT_IN_ffi2heap] >>
+    fs[Once DIFF_UNION_COMM]
+) >>
+DISCH_TAC >>
+rw[STAR_def] >>
+instantiate >>
+qexists_tac `{Mem (LENGTH s0) rv}` >>
+fs[CELL_HPROP_SAT_EQ] >>
+fs[SPLIT_def, SPLIT3_def] >>
+rw[]
+>-(
+    rw[store2heap_append_many, store2heap_aux_append_many]
+    >> metis_tac[store2heap_aux_def, UNION_COMM, UNION_ASSOC])
+\\ fs[Mem_NOT_IN_ffi2heap]
+);
+
+val STATE_SAT_REF_STAR_H_EQ = Q.store_thm("STATE_SAT_REF_STAR_H_EQ",
+`!p s s0 xv s1 H. (Loc (LENGTH s0) ~~> xv * H) (st2heap p (s with refs := s0 ++ [Refv xv] ++ s1)) <=>
+H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+fs[STATE_SAT_CELL_STAR_H_EQ]);
+
+val STATE_SAT_ARRAY_STAR_H_EQ = Q.store_thm("STATE_SAT_ARRAY_STAR_H_EQ",
+`!p s s0 av s1 H. (ARRAY (Loc (LENGTH s0)) av * H) (st2heap p (s with refs := s0 ++ [Varray av] ++ s1)) <=>
+H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+fs[STATE_SAT_CELL_STAR_H_EQ]);
+
+(* val STORE_UPDATE_HPROP = Q.store_thm("STORE_UPDATE_HPROP",
+`(Loc l ~~> xv * H) (store2heap s) ==> (Loc l ~~> xv' * H) (store2heap (LUPDATE (Refv xv') l s))`,
+DISCH_TAC >>
+sg `?s0 s1. s = s0 ++ [Refv xv] ++ s1 /\ LENGTH s0 = l`
+>-(
+    IMP_RES_TAC STORE_DECOMPOS_FROM_HPROP >>
+    IMP_RES_TAC rich_listTheory.IS_PREFIX_APPEND >>
+    SATISFY_TAC
+) >>
+rw[LUPDATE_APPEND1, LUPDATE_APPEND2, LUPDATE_def] >>
+metis_tac[STORE_SAT_LOC_STAR_H_EQ, REF_HPROP_SAT_EQ, STAR_def]); *)
+
+val STATE_UPDATE_HPROP_CELL = Q.store_thm("STATE_UPDATE_HPROP_CELL",
+`(l ~~>> rv * H) (st2heap p s) ==> (l ~~>> rv' * H) (st2heap p (s with refs := (LUPDATE rv' l s.refs)))`,
+DISCH_TAC >>
+sg `?s0 s1. s.refs = s0 ++ [rv] ++ s1 /\ LENGTH s0 = l`
+>-(
+    IMP_RES_TAC STATE_DECOMPOS_FROM_HPROP >>
+    IMP_RES_TAC rich_listTheory.IS_PREFIX_APPEND >>
+    SATISFY_TAC
+) >>
+rw[LUPDATE_APPEND1, LUPDATE_APPEND2, LUPDATE_def] >>
+fs[STATE_SAT_CELL_STAR_H_EQ] >>
+sg `(st2heap p s) = st2heap p (s with refs := s0 ++ [rv] ++ s1)` 
+>-(
+   `s = (s with refs := s0 ++ [rv] ++ s1)` by POP_ASSUM (fn x => rw[GSYM x, with_same_refs])
+   >> POP_ASSUM(fn x => rw[GSYM x])
+) >>
+POP_ASSUM(fn x => fs[x]) >>
+fs[STATE_SAT_CELL_STAR_H_EQ]);
+
+val STATE_UPDATE_HPROP_REF = Q.store_thm("STATE_UPDATE_HPROP_REF",
+`(Loc l ~~> xv * H) (st2heap p s) ==> (Loc l ~~> xv' * H) (st2heap p (s with refs := (LUPDATE (Refv xv') l s.refs)))`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_UPDATE_HPROP_CELL >>
+instantiate
+);
+
+val STATE_UPDATE_HPROP_ARRAY = Q.store_thm("STATE_UPDATE_HPROP_ARRAY",
+`(ARRAY (Loc l) av * H) (st2heap p s) ==> (ARRAY (Loc l) av' * H) (st2heap p (s with refs := (LUPDATE (Varray av') l s.refs)))`,
+rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
+irule STATE_UPDATE_HPROP_CELL >>
+instantiate
+);
+
+val evaluate_empty_state_IMP_junk = Q.store_thm("evaluate_empty_state_IMP_junk",
+`!junk refs' env s exp x. evaluate F env (empty_state with refs := s.refs ++ junk) exp
+ (empty_state with refs := s.refs ++ junk ++ refs',Rval x) ⇒
+ evaluate F env (s with refs := s.refs ++ junk) exp (s with refs := s.refs ++ junk ++ refs',Rval x)`,
+rw[]
+\\ ASSUME_TAC (
+Thm.INST_TYPE [``:'ffi`` |-> ``:'a``] evaluate_empty_state_IMP |>
+Thm.INST[``s:'a state`` |-> ``(s:'a state) with refs := s.refs ++ junk``])
+\\ fs[]);
+
+(* Resizable arrays *)
+val RARRAY_def = Define `
+RARRAY rv av = SEP_EXISTS arv. REF rv arv * ARRAY arv av`;
+
+val RARRAY_REL_def = Define `
+RARRAY_REL TYPE rv l = SEP_EXISTS av. RARRAY rv av * &LIST_REL TYPE l av`;
+
+val _ = export_theory();

--- a/translator/monadic/ml_monad_translatorBaseScript.sml
+++ b/translator/monadic/ml_monad_translatorBaseScript.sml
@@ -542,4 +542,22 @@ RARRAY rv av = SEP_EXISTS arv. REF rv arv * ARRAY arv av`;
 val RARRAY_REL_def = Define `
 RARRAY_REL TYPE rv l = SEP_EXISTS av. RARRAY rv av * &LIST_REL TYPE l av`;
 
+val RARRAY_HPROP_SAT_EQ = Q.store_thm("RARRAY_HPROP_SAT_EQ",
+`RARRAY (Loc l) av s <=>
+?l'. s = {Mem l' (Varray av); Mem l (Refv (Loc l'))}`,
+fs[RARRAY_def, ARRAY_def, REF_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def, STAR_def]
+\\ EQ_TAC
+>-(
+    rw[SPLIT_def, cond_def]
+    \\ qexists_tac `y'`
+    \\ PURE_ONCE_REWRITE_TAC[UNION_COMM]
+    \\ irule EQ_EXT
+    \\ rw[])
+\\ rw[SPLIT_def, cond_def]
+\\ qexists_tac `Loc l'`
+\\ rw[]
+\\ PURE_ONCE_REWRITE_TAC[UNION_COMM]
+\\ irule EQ_EXT
+\\ rw[]);
+
 val _ = export_theory();

--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -1593,6 +1593,10 @@ fun apply_ind thms ind = let
 	val state_var = th |> UNDISCH_ALL |> concl |> rator
 			   |> rator |> rator |> rand
 	val forall_st_tm = mk_forall(state_var, th |> UNDISCH_ALL |> concl)
+	(* *)
+	val st_eq_tm = REWRITE_RULE[ArrowM_def ]th |> UNDISCH_ALL |> concl |> rator |> rand |> rator |> rand |> get_EqSt_var |> the
+	val forall_st_tm = mk_forall(st_eq_tm, forall_st_tm)
+        (* *)
 	val hyp_tm = list_mk_abs(rev rev_params, forall_st_tm)
 	val goal = list_mk_forall(rev rev_params, forall_st_tm)
     in (hyp_tm,(th,(hs,goal))) end
@@ -1603,7 +1607,7 @@ fun apply_ind thms ind = let
     val goal = mk_imp(hs,gs)
     val ind_thm = (the ind)
 		      |> rename_bound_vars_rule "i" |> SIMP_RULE std_ss []
-		      |> ISPECL (goals |> List.map fst |> )
+		      |> ISPECL (goals |> List.map fst)
 		      |> CONV_RULE (DEPTH_CONV BETA_CONV)
     fun POP_MP_TACs ([],gg) = ALL_TAC ([],gg)
       | POP_MP_TACs (ws,gg) =

--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -693,12 +693,12 @@ fun prove_EvalMPatBind goal m2deep = let
   val exp = res |> concl |> get_Eval_exp
   val th = D res
   val is_var_assum = can (match_term var_assum)
-  val vs = find_terms is_var_assum (concl th |> remove_Eval_storePred)
-  (**)
   val is_nslookup_assum = can (match_term nsLookup_assum)
   val is_lookup_cons_assum = can (match_term lookup_cons_assum)
-  val vs = List.concat[vs, find_terms is_nslookup_assum (concl th |> remove_Eval_storePred), find_terms is_lookup_cons_assum (concl th |> remove_Eval_storePred)]
-  (**)
+  fun is_var_lookup_assum x = is_var_assum x
+			      orelse is_nslookup_assum x
+			      orelse is_lookup_cons_assum x
+  val vs = find_terms is_var_lookup_assum (concl th |> remove_Eval_storePred)
   fun delete_var tm =
     if mem tm vs then MATCH_MP IMP_EQ_T (ASSUME tm) else NO_CONV tm
   val th = CONV_RULE ((RATOR_CONV) (DEPTH_CONV delete_var)) th
@@ -736,7 +736,7 @@ fun prove_EvalMPatBind goal m2deep = let
     (* \\ FIRST[rpt (qpat_x_assum `!x. P` IMP_RES_TAC)
 	    \\ EVAL_TAC,
 	     EVAL_TAC]) *)
-    EVAL_TAC)
+    \\ EVAL_TAC)
     (***************)
   in UNDISCH_ALL th end handle HOL_ERR e => failwith "prove_EvalMPatBind failed";
 

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -2560,7 +2560,7 @@ val evaluate_Var_same_state = Q.prove(
   evaluate F env s1 (Var (Short name)) (s2, res) /\ s2 = s1`,
   EQ_TAC \\ ntac 2 (rw[Once evaluate_cases]));
 
-val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
+(* val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
 `!exp get_ref_name get_ref loc_name STATE_TYPE TYPE st_name env H P st.
 Eval env (Var (Short get_ref_name)) ((Arrow STATE_TYPE TYPE) get_ref) ==>
 Eval env (Var (Short st_name)) (STATE_TYPE st) ==>
@@ -2643,12 +2643,83 @@ rw[EvalSt_def]
 \\ first_x_assum(fn x => PURE_ONCE_REWRITE_RULE[STAR_COMM] x |> ASSUME_TAC)
 \\ fs[STAR_ASSOC]
 \\ first_x_assum(fn x => MATCH_MP GC_ABSORB_R x |> ASSUME_TAC)
+\\ fs[]);*)
+
+val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
+`!exp get_ref_exp get_ref loc_name TYPE st_name env H P st.
+Eval env get_ref_exp (TYPE (get_ref st)) ==>
+(!loc. EvalSt (write loc_name loc env) st exp P (\st. REF_REL TYPE loc (get_ref st) * H st)) ==>
+EvalSt env st
+(Let (SOME loc_name) (App Opref [get_ref_exp]) exp) P H`,
+rw[EvalSt_def]
+\\ ntac 3 (rw[Once evaluate_cases])
+\\ fs[Eval_def]
+\\ fs[PULL_EXISTS]
+\\ last_x_assum (qspec_then `s.refs++junk` strip_assume_tac)
+\\ first_x_assum(fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> ASSUME_TAC)
+\\ evaluate_unique_result_tac
+\\ rw[Once evaluate_cases]
+\\ rw[do_app_def,store_alloc_def,namespaceTheory.nsOptBind_def]
+\\ rw[state_component_equality,with_same_ffi]
+\\ last_x_assum(qspecl_then [`Loc (LENGTH (s.refs ++ junk ++ refs'))`, `s with refs := s.refs ++ junk ++ refs' ++ [Refv res]`, `p`] ASSUME_TAC)
+\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
+>-(
+    POP_ASSUM (fn x => ALL_TAC)
+    \\ SIMP_TAC bool_ss [REFS_PRED_def]
+    \\ PURE_REWRITE_TAC[GSYM STAR_ASSOC]
+    \\ SIMP_TAC bool_ss [Once STAR_def]
+    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv res]`
+    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
+    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
+    \\ SIMP_TAC bool_ss [STATE_SPLIT_REFS]
+    \\ SIMP_TAC bool_ss [GSYM REFS_PRED_def, REFS_PRED_append, GSYM APPEND_ASSOC]
+    \\ drule (GEN_ALL REFS_PRED_append) \\ strip_tac
+    \\ ASM_SIMP_TAC bool_ss []
+    \\ rw[REF_REL_def]
+    \\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
+    \\ qexists_tac `res`
+    \\ EXTRACT_PURE_FACTS_TAC
+    \\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
+\\ first_x_assum drule \\ rw[]
+\\ first_x_assum (qspec_then `[]` strip_assume_tac)
+\\ fs[merge_env_def, write_def]
+\\ evaluate_unique_result_tac
+\\ fs[REFS_PRED_FRAME_def]
+\\ rw[state_component_equality]
+\\ qexists_tac `st2` \\ rw[]
+\\ first_x_assum(qspec_then `F' * GC` ASSUME_TAC)
+\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
+>-(
+    rw[GSYM STAR_ASSOC]
+    \\ rw[Once STAR_def]
+    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv res]`
+    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
+    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
+    \\ rw[STATE_SPLIT_REFS]
+    >-(
+	rw[REF_REL_def]
+	\\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
+	\\ qexists_tac `res`
+        \\ EXTRACT_PURE_FACTS_TAC
+	\\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
+    \\ rw[STAR_ASSOC]
+    \\ rw[Once STAR_def]
+    \\ qexists_tac `st2heap p (s with refs := s.refs)`
+    \\ qexists_tac `store2heap_aux (LENGTH s.refs) (junk ++ refs')`
+    \\ PURE_REWRITE_TAC[GSYM APPEND_ASSOC]
+    \\ rw[STATE_SPLIT_REFS, SAT_GC]
+    \\ fs[REFS_PRED_def, with_same_refs])
+\\ qpat_x_assum `A ==> R` IMP_RES_TAC
+\\ fs[GSYM STAR_ASSOC, GC_STAR_GC]
+\\ first_x_assum(fn x => PURE_ONCE_REWRITE_RULE[STAR_COMM] x |> ASSUME_TAC)
+\\ fs[STAR_ASSOC]
+\\ first_x_assum(fn x => MATCH_MP GC_ABSORB_R x |> ASSUME_TAC)
 \\ fs[]);
 
 val EQ_def = Define `EQ x y <=> x = y`;
 
-val EvalSt_Aalloc = Q.store_thm("EvalSt_Alloc",
-`!exp get_ref_name get_ref loc_name STATE_TYPE TYPE st_name env H P st.
+val EvalSt_Alloc = Q.store_thm("EvalSt_Alloc",
+`!exp get_ref loc_name STATE_TYPE TYPE st_name env H P st.
 EQ (get_ref st) [] ==>
 Eval env (Var (Short st_name)) (STATE_TYPE st) ==>
 (!loc. EvalSt (write loc_name loc env) st exp P (\st. RARRAY_REL TYPE loc (get_ref st) * H st)) ==>
@@ -2801,8 +2872,11 @@ rw[Eval_def]
 
 val nsLookup_write_simp = Q.store_thm(
   "nsLookup_write_simp",
- `nsLookup (write name exp env).v (Short name) = SOME exp`,
- fs[namespaceTheory.nsLookup_def, merge_env_def, write_def]);
+ `nsLookup (write name1 exp env).v (Short name2) =
+  if name1 = name2 then SOME exp
+  else nsLookup env.v (Short name2)`,
+  Cases_on `name1 = name2`
+  \\ fs[namespaceTheory.nsLookup_def, merge_env_def, write_def]);
 
 val lookup_cons_write_simp = Q.store_thm(
   "lookup_cons_write_simp",

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -857,6 +857,17 @@ val LOOKUP_VAR_EvalM_ArrowM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_ArrowM_IMP",
   \\ first_x_assum drule \\ rw[]
   \\ fs[state_component_equality]);
 
+(* val LOOKUP_VAR_EvalM_ArrowM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_ArrowM_IMP",
+  `(!env. LOOKUP_VAR n env v ==> EvalM env st (Var (Short n)) (ArrowM H a b f) H) ==>
+    ArrowP H (EqSt a st) b f v`,
+  fs [LOOKUP_VAR_def,lookup_var_def,EvalM_def,ArrowP_def,ArrowM_def,PURE_def,AND_IMP_INTRO,
+      Once evaluate_cases,PULL_EXISTS, VALID_REFS_PRED_def]
+  \\ `nsLookup (<|v := nsBind n v nsEmpty|>).v (Short n) = SOME v` by EVAL_TAC
+  \\ rw[EqSt_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ fs[state_component_equality]); *)
+
 val EvalM_ArrowM_IMP = Q.store_thm("EvalM_ArrowM_IMP",
   `VALID_REFS_PRED H ==>
    (!st. EvalM env st (Var x) ((ArrowM H a b) f) H) ==>

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -2632,8 +2632,8 @@ rw[Eval_def]
 \\ rw[state_component_equality]);
 
 val nsBind_to_write = Q.prove(
- `<|v := nsBind name v env1.v; c := env2.c|> =
-  write name v <|v := env1.v; c := env2.c|>`,
+ `<|v := nsBind name v env1; c := env2|> =
+  write name v <|v := env1; c := env2|>`,
  fs[write_def,sem_env_component_equality]);
 
 val nsLookup_write_simp = Q.prove(

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -759,6 +759,34 @@ val EvalM_ArrowM = Q.store_thm("EvalM_ArrowM",
   \\ evaluate_unique_result_tac
   \\ rw[] \\ metis_tac[]);
 
+val EvalM_ArrowM_EqSt = Q.store_thm("EvalM_ArrowM_EqSt",
+  `EvalM env st x1 ((ArrowM H (EqSt (PURE a) st) b) f) H ==>
+    EvalM env st x2 (PURE a x) H ==>
+    EvalM env st (App Opapp [x1;x2]) (b (f x)) H`,
+  rw[EvalM_def,ArrowM_def,ArrowP_def,PURE_def,PULL_EXISTS]
+  \\ rw[Once evaluate_cases,evaluate_list_cases,PULL_EXISTS]
+  \\ first_x_assum drule \\ rw[]
+  \\ srw_tac[DNF_ss][] \\ disj1_tac
+  \\ first_x_assum(qspec_then`junk`strip_assume_tac)
+  \\ evaluate_unique_result_tac
+  \\ last_x_assum drule \\ rw[]
+  \\ first_x_assum(qspec_then`junk'`strip_assume_tac)
+  \\ fs[GSYM AND_IMP_INTRO]
+  \\ fs[EqSt_def]
+  \\ `PURE a x (st,s) (st,s with refs := s.refs ++ ARB,Rval v)`
+     by fs[PURE_def, state_component_equality]
+  \\ qpat_assum `!p. P` IMP_RES_TAC
+  \\ fs[state_component_equality] \\ rw[]
+  \\ evaluate_unique_result_tac
+  \\ POP_ASSUM(fn x => ALL_TAC)
+  \\ `PURE a x (st,s) (st,s with refs := s.refs ++ junk'',Rval v)`
+     by fs[PURE_def, state_component_equality]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum (qspec_then `[]` STRIP_ASSUME_TAC) \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ metis_tac[]);
+
 val EvalM_Fun = Q.store_thm("EvalM_Fun",
   `(!v x. a x v ==> EvalM (write name v env) n_st body (b (f x)) H) ==>
     EvalM env st (Fun name body) (ArrowM H (EqSt (PURE a) n_st) b f) H`,

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -319,20 +319,6 @@ val EvalM_Fun = Q.store_thm("EvalM_Fun",
   \\ evaluate_unique_result_tac
   \\ SATISFY_TAC);
 
-(* val EvalM_Fun = Q.store_thm("EvalM_Fun",
-  `(!st v x. a x v ==> EvalM (write name v env) st body (b (f x)) H) ==>
-    EvalM env st (Fun name body) ((ArrowM H (PURE a) b) f) H`,
-  rw[EvalM_def,ArrowM_def,ArrowP_def,PURE_def,Eq_def]
-  \\ rw[Once evaluate_cases,PULL_EXISTS]
-  \\ reverse(rw[Once state_component_equality, REFS_PRED_append]) >-(fs[REFS_PRED_FRAME_append])
-  \\ rw[Once state_component_equality]
-  \\ rw[do_opapp_def,GSYM write_def]
-  \\ last_x_assum drule \\ rw[]
-  \\ first_x_assum drule \\ rw[]
-  \\ first_x_assum(qspec_then `junk ++ junk'` strip_assume_tac)
-  \\ fs[]
-  \\ SATISFY_TAC); *)
-
 val EvalM_Fun_Var_intro = Q.store_thm("EvalM_Fun_Var_intro",
   `EvalM cl_env st (Fun n exp) (PURE P f) H ==>
    ∀name. LOOKUP_VAR name env (Closure cl_env n exp) ==>
@@ -382,15 +368,6 @@ val EvalM_Fun_PURE_IMP = Q.store_thm("EvalM_Fun_PURE_IMP",
   fs [EvalM_def,PURE_def,PULL_EXISTS,Once evaluate_cases, VALID_REFS_PRED_def]
      \\ rw [] \\ metis_tac[]);
 
-(* val LOOKUP_VAR_EvalM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_IMP",
-  `VALID_REFS_PRED H ==>
-    (!st env. LOOKUP_VAR n env v ==> EvalM env st (Var (Short n)) (PURE P g) H) ==>
-    P g v`,
-  fs [LOOKUP_VAR_def,lookup_var_def,EvalM_def,PURE_def,AND_IMP_INTRO,
-      Once evaluate_cases,PULL_EXISTS,PULL_FORALL, VALID_REFS_PRED_def]
-  \\ `nsLookup (<|v := nsBind n v nsEmpty|>).v (Short n) = SOME v` by EVAL_TAC
-  \\ metis_tac[]); *)
-
 val LOOKUP_VAR_EvalM_ArrowM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_ArrowM_IMP",
   `(!st env. LOOKUP_VAR n env v ==> EvalM env st (Var (Short n)) (ArrowM H a b f) H) ==>
     ArrowP H a b f v`,
@@ -401,17 +378,6 @@ val LOOKUP_VAR_EvalM_ArrowM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_ArrowM_IMP",
   \\ first_x_assum drule \\ rw[]
   \\ first_x_assum drule \\ rw[]
   \\ fs[state_component_equality]);
-
-(* val LOOKUP_VAR_EvalM_ArrowM_IMP = Q.store_thm("LOOKUP_VAR_EvalM_ArrowM_IMP",
-  `(!env. LOOKUP_VAR n env v ==> EvalM env st (Var (Short n)) (ArrowM H a b f) H) ==>
-    ArrowP H (EqSt a st) b f v`,
-  fs [LOOKUP_VAR_def,lookup_var_def,EvalM_def,ArrowP_def,ArrowM_def,PURE_def,AND_IMP_INTRO,
-      Once evaluate_cases,PULL_EXISTS, VALID_REFS_PRED_def]
-  \\ `nsLookup (<|v := nsBind n v nsEmpty|>).v (Short n) = SOME v` by EVAL_TAC
-  \\ rw[EqSt_def]
-  \\ first_x_assum drule \\ rw[]
-  \\ first_x_assum drule \\ rw[]
-  \\ fs[state_component_equality]); *)
 
 val EvalM_ArrowM_IMP = Q.store_thm("EvalM_ArrowM_IMP",
   `VALID_REFS_PRED H ==>
@@ -442,22 +408,6 @@ val EvalM_Var_SIMP = Q.store_thm("EvalM_Var_SIMP",
   SIMP_TAC std_ss [EvalM_def] \\ SRW_TAC [] []
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases,write_def]);
-
-(* val EvalM_Var_SIMP_PURE = Q.store_thm("EvalM_Var_SIMP_PURE",
-  `VALID_REFS_PRED H ==>
-   (!st. EvalM (write nv v env) st (Var (Short n)) (PURE P x) H) =
-    if nv = n then P x v else (!st. EvalM env st (Var (Short n)) (PURE P x) H)`,
-  SIMP_TAC std_ss [EvalM_def, PURE_def, VALID_REFS_PRED_def]
-  \\ SRW_TAC [] []
-  >-(
-      ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
-      \\ ASM_SIMP_TAC (srw_ss()) [write_def]
-      \\ EQ_TAC
-      >-(metis_tac[])
-      \\ metis_tac[REFS_PRED_FRAME_append])
-  \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
-  \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
-  \\ ASM_SIMP_TAC (srw_ss()) [write_def]); *)
 
 val EvalM_Var_SIMP_ArrowM = Q.store_thm("EvalM_Var_SIMP_ArrowM",
   `(!st. EvalM (write nv v env) st (Var (Short n)) (ArrowM H a b x) H) =
@@ -589,21 +539,6 @@ val EvalM_Recclosure = Q.store_thm("EvalM_Recclosure",
   \\ reverse(rw[Eq_def,do_opapp_def,Once find_recfun_def,REFS_PRED_append])  >-(fs[REFS_PRED_FRAME_append])
   \\ fs[build_rec_env_def,write_rec_def,FOLDR,write_def]
   \\ METIS_TAC[APPEND_ASSOC]);
-
-(* val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
-  `VALID_REFS_PRED H ==>
-    LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
-    (P f (Recclosure x1 x2 x3) =
-     (!st. EvalM env st (Var (Short name)) (PURE P f) H))`,
-  rw[EvalM_Var_SIMP, EvalM_def, LOOKUP_VAR_def, lookup_var_def, PURE_def]
-  \\ EQ_TAC
-  >-(
-      rw[]
-      \\ rw[Once evaluate_cases]
-      \\ fs[state_component_equality]
-      \\ fs[REFS_PRED_FRAME_append])
-  \\ fs [AND_IMP_INTRO, Once evaluate_cases,PULL_EXISTS,PULL_FORALL, VALID_REFS_PRED_def]
-  \\ metis_tac[]); *)
 
 val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
   `LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
@@ -2468,18 +2403,6 @@ rw[Eval_def]
 \\ rw[Once evaluate_cases]
 \\ rw[with_same_ffi]);
 
-(* val EvalSt_Let_Fun = Q.store_thm("EvalSt_Let_Fun",
-`EvalSt (merge_env (write vname (Closure (merge_env env1 env0) xv fexp) env1) env0) st exp P H ==>
-EvalSt (merge_env env1 env0) st (Let (SOME vname) (Fun xv fexp) exp) P H`,
-rw[EvalSt_def]
-\\ last_x_assum IMP_RES_TAC
-\\ first_x_assum(qspec_then `junk` STRIP_ASSUME_TAC)
-\\ rw[Once evaluate_cases]
-\\ rw[Once evaluate_cases]
-\\ rw[namespaceTheory.nsOptBind_def]
-\\ fs[write_def, merge_env_def]
-\\ metis_tac[]); *)
-
 val EvalSt_Let_Fun = Q.store_thm("EvalSt_Let_Fun",
 `EvalSt (write vname (Closure env xv fexp) env) st exp P H ==>
 EvalSt env st (Let (SOME vname) (Fun xv fexp) exp) P H`,
@@ -2559,91 +2482,6 @@ val evaluate_Var_same_state = Q.prove(
  `evaluate F env s1 (Var (Short name)) (s2, res) <=>
   evaluate F env s1 (Var (Short name)) (s2, res) /\ s2 = s1`,
   EQ_TAC \\ ntac 2 (rw[Once evaluate_cases]));
-
-(* val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
-`!exp get_ref_name get_ref loc_name STATE_TYPE TYPE st_name env H P st.
-Eval env (Var (Short get_ref_name)) ((Arrow STATE_TYPE TYPE) get_ref) ==>
-Eval env (Var (Short st_name)) (STATE_TYPE st) ==>
-(!loc. EvalSt (write loc_name loc env) st exp P (\st. REF_REL TYPE loc (get_ref st) * H st)) ==>
-EvalSt env st
-(Let (SOME loc_name) (App Opref [App Opapp [Var (Short get_ref_name); Var (Short st_name)]]) exp) P H`,
-rw[EvalSt_def]
-\\ ntac 9 (rw[Once evaluate_cases])
-\\ fs[Eval_def]
-\\ last_x_assum (qspec_then `s.refs++junk` strip_assume_tac)
-\\ drule evaluate_Var_IMP \\ rw[]
-\\ first_x_assum (qspec_then `s.refs++junk` strip_assume_tac)
-\\ drule evaluate_Var_IMP \\ rw[]
-\\ first_x_assum(fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> ASSUME_TAC)
-\\ first_x_assum(fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> ASSUME_TAC)
-\\ fs[Once evaluate_Var_same_state]
-\\ fs[PULL_EXISTS]
-\\ fs[state_component_equality] 
-\\ rw[]
-\\ fs[Arrow_def]
-\\ first_x_assum (qspec_then `st` strip_assume_tac)
-\\ fs[AppReturns_def]
-\\ first_x_assum drule \\ rw[]
-\\ first_x_assum (qspec_then `s.refs ⧺ junk` strip_assume_tac)
-\\ first_x_assum(fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> ASSUME_TAC)
-\\ rw[] \\ evaluate_unique_result_tac
-\\ rw[Once evaluate_cases]
-\\ rw[do_app_def,store_alloc_def,namespaceTheory.nsOptBind_def]
-\\ rw[state_component_equality,with_same_ffi]
-\\ last_x_assum(qspecl_then [`Loc (LENGTH (s.refs ++ junk ++ refs'))`, `s with refs := s.refs ++ junk ++ refs' ++ [Refv u]`, `p`] ASSUME_TAC)
-\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
->-(
-    POP_ASSUM (fn x => ALL_TAC)
-    \\ SIMP_TAC bool_ss [REFS_PRED_def]
-    \\ PURE_REWRITE_TAC[GSYM STAR_ASSOC]
-    \\ SIMP_TAC bool_ss [Once STAR_def]
-    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv u]`
-    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
-    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
-    \\ SIMP_TAC bool_ss [STATE_SPLIT_REFS]
-    \\ SIMP_TAC bool_ss [GSYM REFS_PRED_def, REFS_PRED_append, GSYM APPEND_ASSOC]
-    \\ drule (GEN_ALL REFS_PRED_append) \\ strip_tac
-    \\ ASM_SIMP_TAC bool_ss []
-    \\ rw[REF_REL_def]
-    \\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
-    \\ qexists_tac `u`
-    \\ EXTRACT_PURE_FACTS_TAC
-    \\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
-\\ first_x_assum drule \\ rw[]
-\\ first_x_assum (qspec_then `[]` strip_assume_tac)
-\\ fs[merge_env_def, write_def]
-\\ evaluate_unique_result_tac
-\\ fs[REFS_PRED_FRAME_def]
-\\ rw[state_component_equality]
-\\ qexists_tac `st2` \\ rw[]
-\\ first_x_assum(qspec_then `F' * GC` ASSUME_TAC)
-\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
->-(
-    rw[GSYM STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv u]`
-    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
-    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
-    \\ rw[STATE_SPLIT_REFS]
-    >-(
-	rw[REF_REL_def]
-	\\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
-	\\ qexists_tac `u`
-        \\ EXTRACT_PURE_FACTS_TAC
-	\\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
-    \\ rw[STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `st2heap p (s with refs := s.refs)`
-    \\ qexists_tac `store2heap_aux (LENGTH s.refs) (junk ++ refs')`
-    \\ PURE_REWRITE_TAC[GSYM APPEND_ASSOC]
-    \\ rw[STATE_SPLIT_REFS, SAT_GC]
-    \\ fs[REFS_PRED_def, with_same_refs])
-\\ qpat_x_assum `A ==> R` IMP_RES_TAC
-\\ fs[GSYM STAR_ASSOC, GC_STAR_GC]
-\\ first_x_assum(fn x => PURE_ONCE_REWRITE_RULE[STAR_COMM] x |> ASSUME_TAC)
-\\ fs[STAR_ASSOC]
-\\ first_x_assum(fn x => MATCH_MP GC_ABSORB_R x |> ASSUME_TAC)
-\\ fs[]);*)
 
 val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
 `!exp get_ref_exp get_ref loc_name TYPE st_name env H P st.
@@ -2782,84 +2620,6 @@ rw[EvalSt_def]
 \\ fs[STAR_ASSOC]
 \\ first_x_assum(fn x => MATCH_MP GC_ABSORB_R x |> ASSUME_TAC)
 \\ fs[]);
-
-(* val EvalSt_Opref = Q.store_thm("EvalSt_Opref",
-`!exp field_expr get_ref TYPE loc_name env H P state.
-Eval env field_expr (TYPE (get_ref state)) ==>
-(!loc. EvalSt (write loc_name loc env) state exp P (\state. REF_REL TYPE loc (get_ref state) * H state)) ==>
-EvalSt env state
-(Let (SOME loc_name) (App Opref [field_expr]) exp) P H`,
-rw[EvalSt_def]
-\\ rw[Once evaluate_cases]
-\\ rw[Once evaluate_cases]
-\\ rw[Once evaluate_cases]
-\\ fs[Eval_def]
-\\ last_x_assum(qspec_then `s.refs ++ junk` STRIP_ASSUME_TAC)
-\\ first_x_assum(fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> ASSUME_TAC)
-\\ evaluate_unique_result_tac
-\\ rw[Once evaluate_cases]
-\\ rw[do_app_def, store_alloc_def]
-\\ rw[namespaceTheory.nsOptBind_def]
-\\ rw[with_same_ffi]
-\\ qpat_abbrev_tac `loc = LENGTH junk + L`
-\\ last_x_assum(qspecl_then [`Loc loc`, `s with refs := s.refs ++ junk ++ refs' ++ [Refv res]`, `p`] ASSUME_TAC)
-\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
->-(
-    rw[REFS_PRED_def]
-    \\ rw[GSYM STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv res]`
-    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
-    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
-    \\ rw[STATE_SPLIT_REFS]
-    >-(
-	rw[REF_REL_def]
-	\\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
-	\\ qexists_tac `res`
-        \\ EXTRACT_PURE_FACTS_TAC
-	\\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
-    \\ rw[Once (GSYM GC_STAR_GC), STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `st2heap p (s with refs := s.refs)`
-    \\ qexists_tac `store2heap_aux (LENGTH s.refs) (junk ++ refs')`
-    \\ PURE_REWRITE_TAC[GSYM APPEND_ASSOC]
-    \\ rw[STATE_SPLIT_REFS, SAT_GC]
-    \\ fs[REFS_PRED_def, with_same_refs])
-\\ qpat_x_assum `A ==> R` IMP_RES_TAC
-\\ first_x_assum(qspec_then `[]` STRIP_ASSUME_TAC)
-\\ fs[merge_env_def, write_def]
-\\ evaluate_unique_result_tac
-\\ qexists_tac `st2`
-\\ fs[REFS_PRED_FRAME_def]
-\\ rw[state_component_equality]
-\\ first_x_assum(qspec_then `F' * GC` ASSUME_TAC)
-\\ first_assum(fn x => let val a = concl x |> dest_imp |> fst in sg `^a` end)
->-(
-    rw[GSYM STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `store2heap_aux (LENGTH (s.refs ++ junk ++ refs')) [Refv res]`
-    \\ qexists_tac `st2heap p (s with refs := s.refs ++ junk ++ refs')`
-    \\ PURE_REWRITE_TAC[Once SPLIT_SYM]
-    \\ rw[STATE_SPLIT_REFS]
-    >-(
-	rw[REF_REL_def]
-	\\ rw[SEP_CLAUSES, SEP_EXISTS_THM]
-	\\ qexists_tac `res`
-        \\ EXTRACT_PURE_FACTS_TAC
-	\\ rw[REF_HPROP_SAT_EQ, cfStoreTheory.store2heap_aux_def])
-    \\ rw[STAR_ASSOC]
-    \\ rw[Once STAR_def]
-    \\ qexists_tac `st2heap p (s with refs := s.refs)`
-    \\ qexists_tac `store2heap_aux (LENGTH s.refs) (junk ++ refs')`
-    \\ PURE_REWRITE_TAC[GSYM APPEND_ASSOC]
-    \\ rw[STATE_SPLIT_REFS, SAT_GC]
-    \\ fs[REFS_PRED_def, with_same_refs])
-\\ qpat_x_assum `A ==> R` IMP_RES_TAC
-\\ fs[GSYM STAR_ASSOC, GC_STAR_GC]
-\\ first_x_assum(fn x => PURE_ONCE_REWRITE_RULE[STAR_COMM] x |> ASSUME_TAC)
-\\ fs[STAR_ASSOC]
-\\ first_x_assum(fn x => MATCH_MP GC_ABSORB_R x |> ASSUME_TAC)
-\\ fs[]); *)
 
 val Eval_lookup_var = Q.store_thm("Eval_lookup_var",
 `!env vname xv x TYPE. nsLookup env.v (Short vname) = SOME xv ==>

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -140,7 +140,7 @@ val EvalM_return = Q.store_thm("EvalM_return",
 val EvalM_bind = Q.store_thm("EvalM_bind",
   `(a1 ==> EvalM env st e1 (MONAD b c (x:('refs, 'b, 'c) M)) H) /\
    (!z v. b z v ==> a2 z ==> EvalM (write name v env) (SND (x st)) e2 (MONAD a c ((f z):('refs, 'a, 'c) M)) H) ==>
-   (!z. a1 /\ (CONTAINER(FST(x st) = Success z) ==> a2 z)) ==>
+   (a1 /\ !z. (CONTAINER(FST(x st) = Success z) ==> a2 z)) ==>
    EvalM env st (Let (SOME name) e1 e2) (MONAD a c (ex_bind x f)) H`,
   rw[EvalM_def,MONAD_def,st_ex_return_def,PULL_EXISTS, CONTAINER_def] \\ fs[] \\
   rw[Once evaluate_cases] \\
@@ -699,7 +699,7 @@ val ArrowP_EqSt_elim = Q.store_thm("ArrowP_EqSt_elim",
 val EvalM_otherwise = Q.store_thm("EvalM_otherwise",
   `!H b n. ((a1 ==> EvalM env st exp1 (MONAD a b x1) H) /\
    (!st i. a2 st ==> EvalM (write n i env) st exp2 (MONAD a b x2) H)) ==>
-   (!st'. a1 /\ (CONTAINER(SND(x1 st) = st') ==> a2 st')) ==>
+   (a1 /\ !st'. (CONTAINER(SND(x1 st) = st') ==> a2 st')) ==>
    EvalM env st (Handle exp1 [(Pvar n,exp2)]) (MONAD a b (x1 otherwise x2)) H`,
   SIMP_TAC std_ss [EvalM_def, EvalM_def] \\ REPEAT STRIP_TAC
   \\ SIMP_TAC (srw_ss()) [Once evaluate_cases]

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -3,8 +3,8 @@ open astTheory libTheory bigStepTheory semanticPrimitivesTheory
 open terminationTheory ml_progLib ml_progTheory
 open set_sepTheory Satisfy
 open cfHeapsBaseTheory basisFunctionsLib AC_Sort
-open determTheory ml_monadBaseTheory
-open cfStoreTheory cfTheory cfTacticsLib
+open determTheory ml_monadBaseTheory ml_monad_translatorBaseTheory
+open cfStoreTheory cfTheory cfTacticsLib packLib
 
 val _ = new_theory "ml_monad_translator";
 
@@ -19,6 +19,18 @@ val _ = temp_overload_on ("CONTAINER", ``ml_translator$CONTAINER``);
 val _ = hide "state";
 
 val HCOND_EXTRACT = cfLetAutoTheory.HCOND_EXTRACT;
+
+val REF_EXISTS_LOC = Q.prove(`(rv ~~> v * H) s ==> ?l. rv = Loc l`,
+rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM, GSYM STAR_ASSOC, HCOND_EXTRACT]);
+
+val ARRAY_EXISTS_LOC  = Q.prove(`(ARRAY rv v * H) s ==> ?l. rv = Loc l`,
+rw[STAR_def, SEP_EXISTS_THM, SEP_CLAUSES, REF_def, ARRAY_def, cond_def]);
+
+val UNIQUE_CELLS = Q.prove(
+`!p s. !l xv xv' H H'. (l ~~>> xv * H) (st2heap p s) /\ (l ~~>> xv' * H') (st2heap p s) ==> xv' = xv`,
+rw[] >>
+IMP_RES_TAC st2heap_CELL_MEM >>
+IMP_RES_TAC store2heap_IN_unique_key);
 
 (* Should be moved *)
 fun list_dest f tm =
@@ -75,549 +87,7 @@ fun EXTRACT_PURE_FACTS_TAC (g as (asl, w)) =
 
 val _ = temp_type_abbrev("state",``:'ffi semanticPrimitives$state``);
 
-(* a few basics *)
-val with_same_refs = Q.store_thm("with_same_refs",
-  `(s with refs := s.refs) = s`,
-  simp[state_component_equality])
-
-val with_same_ffi = Q.store_thm("with_same_ffi",
-  `(s with ffi := s.ffi) = s`,
-  simp[state_component_equality]);
-
-val with_same_clock = Q.store_thm("with_same_clock",
-  `(s with clock := s.clock) = s`,
-  simp[state_component_equality]);
-
-(* For the assumptions given by the heap invariants *)
-val COMBINE_INV_def = Define `COMBINE_INV P Q = \x v. P x v /\ Q x`;
-
-val COMBINE_INV_SIMP = Q.store_thm("COMBINE_INV_SIMP",
-`!P. COMBINE_INV P (\x. T) = P`,
-rw[COMBINE_INV_def] \\ metis_tac[EQ_EXT]);
-
-val MONAD_EMPTY_STORE_def = Define `MONAD_EMPTY_STORE = [] : v store`;
-
-(* REF_REL *)
-val REF_REL_def = Define `REF_REL TYPE r x = SEP_EXISTS v. REF r v * &TYPE x v`;
-
-(* REFS_PRED *)
-val REFS_PRED_def = Define `REFS_PRED H refs p s = (H refs * GC) (st2heap p s)`;
-val VALID_REFS_PRED_def = Define `VALID_REFS_PRED H = ?(s : unit state) p refs. REFS_PRED H refs p s`;
-
-(* Frame rule for EvalM *)
-val REFS_PRED_FRAME_def = Define
-`REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) =
-?refs. s2 = s1 with refs := refs /\
-!F. (H refs1 * F) (st2heap p s1) ==> (H refs2 * F * GC) (st2heap p s2)`;
-
-val EMP_STAR_H = Q.store_thm("EMP_STAR_GC",
-`!H. emp * H = H`,
-fs[STAR_def, emp_def, SPLIT_def, ETA_THM]);
-
-val SAT_GC = Q.store_thm("SAT_GC",
-`!h. GC h`,
-fs[GC_def, SEP_EXISTS_THM] \\ STRIP_TAC \\ qexists_tac `\s. T` \\ fs[]);
-
-val REFS_PRED_FRAME_imp = Q.store_thm("REFS_PRED_FRAME_imp",
-`REFS_PRED H refs1 p s1 ==> REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) ==> REFS_PRED H refs2 p s2`,
-rw[REFS_PRED_def, REFS_PRED_FRAME_def]
-\\ Cases_on `p`
-\\ fs[st2heap_def]
-\\ metis_tac[GC_STAR_GC, STAR_ASSOC]);
-
-val REFS_PRED_FRAME_trans = Q.store_thm("REFS_PRED_FRAME_trans",
-`REFS_PRED_FRAME H p (refs1, s1) (refs2, s2) ==>
-REFS_PRED_FRAME H p (refs2, s2) (refs3, s3) ==>
-REFS_PRED_FRAME H p (refs1, s1) (refs3, s3)`,
-rw[REFS_PRED_FRAME_def] >>
-PURE_REWRITE_TAC[Once (GSYM GC_STAR_GC), STAR_ASSOC] >>
-qexists_tac `refs'` >> rw[] >>
-`H refs3 * F' * GC * GC = H refs3 * (F' * GC) * GC` by fs[STAR_ASSOC] >>
-POP_ASSUM (fn x => PURE_REWRITE_TAC[x]) >>
-fs[state_component_equality] >>
-first_x_assum irule >>
-fs[STAR_ASSOC]);
-
-
-(*
- * Proof of REFS_PRED_APPEND:
- * `REFS_PRED H refs s ==> REFS_PRED H refs (s with refs := s.refs ++ junk)`
- *)
-val store2heap_aux_Mem = Q.store_thm("store2heap_aux_Mem",
-`!s n x. x IN (store2heap_aux n s) ==> ?n' v. x = Mem n' v`,
-Induct_on `s`
- >-(rw[IN_DEF, store2heap_def, store2heap_aux_def]) >>
-rw[] >> fs[IN_DEF, store2heap_def, store2heap_aux_def] >>
-last_x_assum IMP_RES_TAC >>
-fs[]);
-
-val store2heap_aux_IN_LENGTH = Q.store_thm ("store2heap_aux_IN_LENGTH",
-`!s r x n. Mem r x IN (store2heap_aux n s) ==> r < n + LENGTH s`,
-Induct THENL [all_tac, Cases] \\
-fs [store2heap_aux_def] \\
-Cases_on `r` \\ fs [] \\ rewrite_tac [ONE] \\
-rpt strip_tac \\ fs[ADD_CLAUSES, GSYM store2heap_aux_suc] \\
-metis_tac[]
-);
-
-val NEG_DISJ_TO_IMP = Q.prove(
-`!A B. ~A \/ ~B <=> A /\ B ==> F`,
-rw[]);
-
-val store2heap_aux_DISJOINT = Q.store_thm("store2heap_aux_DISJOINT",
-`!n s1 s2. DISJOINT (store2heap_aux n s1) (store2heap_aux (n + LENGTH s1) s2)`,
-rw[DISJOINT_DEF, INTER_DEF, EMPTY_DEF] >>
-fs[GSPECIFICATION_applied] >>
-sg `!x. {x | x ∈ store2heap_aux n s1 ∧ x ∈ store2heap_aux (n + LENGTH s1) s2} x = (\x. F) x`
->-(
-    rw[] >>
-    PURE_REWRITE_TAC[NEG_DISJ_TO_IMP] >>
-    DISCH_TAC >> rw[] >>
-    IMP_RES_TAC store2heap_aux_Mem >>
-    rw[] >>
-    IMP_RES_TAC store2heap_aux_IN_bound >>
-    IMP_RES_TAC store2heap_aux_IN_LENGTH >>
-    bossLib.DECIDE_TAC
-) >>
-POP_ASSUM (fn x => ASSUME_TAC (EXT x)) >> fs[]);
-
-val store2heap_aux_SPLIT = Q.store_thm("store2heap_aux_SPLIT",
-`!s1 s2 n. SPLIT (store2heap_aux n (s1 ++ s2)) (store2heap_aux n s1, store2heap_aux (n + LENGTH s1) s2)`,
-fs[SPLIT_def] >> fs[store2heap_aux_append_many] >>
-metis_tac[UNION_COMM, store2heap_aux_append_many, store2heap_aux_DISJOINT]);
-
-val store2heap_DISJOINT = Q.store_thm("store2heap_DISJOINT",
-`DISJOINT (store2heap s1) (store2heap_aux (LENGTH s1) s2)`,
-fs[store2heap_def] >> metis_tac[store2heap_aux_DISJOINT, arithmeticTheory.ADD]);
-
-(* If the goal is: (\x. P x) = (\x. Q x), applies SUFF_TAC ``!x. P x = Q x`` *)
-fun SUFF_ABS_TAC (g as (asl, w)) =
-  let
-      val (e1, e2) = dest_eq w
-      val (x1, e1') = dest_abs e1
-      val (x2, e2') = dest_abs e2
-      val _ = if x1 <> x2 then failwith "" else ()
-      val w' = mk_forall(x1,  mk_eq(e1', e2'))
-  in
-      (SUFF_TAC w' THEN rw[]) g
-  end;
-
-val store2heap_SPLIT = Q.store_thm("store2heap_SPLIT",
-`!s1 s2. SPLIT (store2heap (s1 ++ s2)) (store2heap s1, store2heap_aux (LENGTH s1) s2)`,
-fs[store2heap_def] >> metis_tac[store2heap_aux_SPLIT, arithmeticTheory.ADD]);
-
-val SPLIT_DECOMPOSWAP = Q.store_thm("SPLIT_DECOMPOSWAP",
-`SPLIT s1 (s2, s3) ==> SPLIT s2 (u, v) ==> SPLIT s1 (u, v UNION s3)`,
-fs[SPLIT_def, UNION_ASSOC, DISJOINT_SYM] >> rw[] >> fs[DISJOINT_SYM, DISJOINT_UNION_BOTH]);
-
-val STORE_APPEND_JUNK = Q.store_thm("STORE_APPEND_JUNK",
-`!H s junk. H (store2heap s) ==> (H * GC) (store2heap (s ++ junk))`,
-rw[] >>
-qspecl_then [`s`, `junk`] ASSUME_TAC store2heap_SPLIT >>
-fs[STAR_def] >>
-qexists_tac `store2heap s` >>
-qexists_tac `store2heap_aux (LENGTH s) junk` >>
-`!H. GC H` by (rw[cfHeapsBaseTheory.GC_def, SEP_EXISTS] >> qexists_tac `\x. T` >> fs[]) >>
-POP_ASSUM (fn x => fs[x]));
-
-val st2heap_SPLIT_FFI = Q.store_thm("st2heap_SPLIT_FFI",
-`!f st. SPLIT ((store2heap st.refs) UNION (ffi2heap f st.ffi)) (store2heap st.refs, ffi2heap f st.ffi)`,
-rw[SPLIT_def]
-\\ fs[IN_DISJOINT]
-\\ STRIP_TAC
-\\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
-\\ STRIP_TAC
-\\ rw[]
-\\ fs[store2heap_def]
-\\ Cases_on `x`
-\\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux]);
-
-val SPLIT3_swap12 = Q.store_thm("SPLIT3_swap12",
-`!h h1 h2 h3. SPLIT3 h (h1, h2, h3) = SPLIT3 h (h2, h1, h3)`,
-rw[SPLIT3_def, UNION_COMM, CONJ_COMM] >> metis_tac[DISJOINT_SYM]);
-
-val SPLIT_of_SPLIT3_1u3 = Q.store_thm("SPLIT_of_SPLIT3_1u3",
-`∀h h1 h2 h3. SPLIT3 h (h1,h2,h3) ⇒ SPLIT h (h2, h1 ∪ h3)`,
-metis_tac[SPLIT3_swap12, SPLIT_of_SPLIT3_2u3]);
-
-val SPLIT2_SPLIT3 = Q.store_thm("SPLIT2_SPLIT3",
-`SPLIT s1 (s2, t3) /\ SPLIT s2 (t1, t2) ==> SPLIT3 s1 (t1, t2, t3)`,
-rw[SPLIT_def] \\ fs[SPLIT3_def]);
-
-val SPLIT_SYM = Q.store_thm("SPLIT_SYM",
-`SPLIT s (s1, s2) = SPLIT s (s2, s1)`,
-fs[SPLIT_def, DISJOINT_SYM, UNION_COMM]);
-
-val STATE_APPEND_JUNK = Q.store_thm("STATE_APPEND_JUNK",
-`!H p s refs junk. H (st2heap p (s with refs := refs)) ==>
-(H * GC) (st2heap p (s with refs := refs ++ junk))`,
-rw[]
-\\ Cases_on `p`
-\\ fs[st2heap_def]
-\\ Q.PAT_ABBREV_TAC `h = A UNION B`
-\\ sg `SPLIT3 h (store2heap refs, store2heap_aux (LENGTH refs) junk, ffi2heap (q,r) s.ffi)`
->-(
-   fs[markerTheory.Abbrev_def] \\ rw[]
-   \\ irule SPLIT2_SPLIT3
-   \\ qexists_tac `store2heap (refs ++ junk)`
-   \\ fs[store2heap_SPLIT, SPLIT_def, IN_DISJOINT, store2heap_def]
-   \\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
-   \\ rpt STRIP_TAC
-   \\ Cases_on `x`
-   \\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux])
-\\ fs[markerTheory.Abbrev_def] \\ rw[]
-\\ POP_ASSUM(fn x => MATCH_MP SPLIT_of_SPLIT3_1u3 x |> ASSUME_TAC)
-\\ fs[Once SPLIT_SYM]
-\\ rw[STAR_def]
-\\ metis_tac[SAT_GC]);
-
-val STATE_SPLIT_REFS = Q.store_thm("STATE_SPLIT_REFS",
-`!a b p s. SPLIT (st2heap p (s with refs := a ++ b))
-((st2heap p (s with refs := a)), (store2heap_aux (LENGTH a) b))`,
-rw[] \\ Cases_on `p` \\ fs[st2heap_def] \\
-sg `SPLIT3 (store2heap (a ++ b) ∪ ffi2heap (q,r) s.ffi) (store2heap a, store2heap_aux (LENGTH a) b, ffi2heap (q,r) s.ffi)`
->-(
-   irule SPLIT2_SPLIT3
-   \\ qexists_tac `store2heap (a ++ b)`
-   \\ fs[store2heap_SPLIT, SPLIT_def, IN_DISJOINT, store2heap_def]
-   \\ PURE_REWRITE_TAC[NEG_DISJ_TO_IMP]
-   \\ rpt STRIP_TAC
-   \\ Cases_on `x`
-   \\ fs[Mem_NOT_IN_ffi2heap, FFI_split_NOT_IN_store2heap_aux, FFI_full_NOT_IN_store2heap_aux, FFI_part_NOT_IN_store2heap_aux])
-\\ POP_ASSUM(fn x => MATCH_MP SPLIT_of_SPLIT3_1u3 x |> ASSUME_TAC)
-\\ fs[Once SPLIT_SYM]
-\\ rw[STAR_def]);
-
-val REFS_PRED_append = Q.store_thm("REFS_PRED_append",
-`!H refs s. REFS_PRED H refs p s ==> REFS_PRED H refs p (s with refs := s.refs ++ junk)`,
-rw[REFS_PRED_def] >> PURE_ONCE_REWRITE_TAC [GSYM GC_STAR_GC] >> fs[STAR_ASSOC] >>
-metis_tac[with_same_refs, STATE_APPEND_JUNK]);
-
-val REFS_PRED_FRAME_append = Q.store_thm("REFS_PRED_FRAME_append",
-`!H refs s. REFS_PRED_FRAME H p (refs, s) (refs, s with refs := s.refs ++ junk)`,
-rw[REFS_PRED_FRAME_def] \\ metis_tac[with_same_refs, STATE_APPEND_JUNK]);
-
-val REF_EXISTS_LOC = Q.prove(`(rv ~~> v * H) s ==> ?l. rv = Loc l`,
-rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM, GSYM STAR_ASSOC, HCOND_EXTRACT]);
-
-val ARRAY_EXISTS_LOC  = Q.prove(`(ARRAY rv v * H) s ==> ?l. rv = Loc l`,
-rw[STAR_def, SEP_EXISTS_THM, SEP_CLAUSES, REF_def, ARRAY_def, cond_def]);
-
-(*
- * Proof of STORE_EXTRACT_FROM_HPROP:
- * `!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==> ?ps. ((ps ++ [Refv xv]) ≼ s) /\ LENGTH ps = l`
- *)
-
-val HEAP_LOC_MEM = Q.store_thm("HEAP_LOC_MEM",
-`(l ~~>> rv * H) h ==> Mem l rv IN h`,
-rw[STAR_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]);
-
-(* val HEAP_REF_MEM = Q.store_thm("HEAP_REF_MEM",
-`(Loc l ~~> xv * H) h ==> Mem l (Refv xv) IN h`,
-rw[STAR_def, REF_def, ARRAY_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]); 
-
-val HEAP_ARRAY_MEM = Q.store_thm("HEAP_ARRAY_MEM",
-`(ARRAY (Loc l) av * H) h ==> Mem l (Varray av) IN h`,
-rw[STAR_def, REF_def, ARRAY_def, SEP_EXISTS_THM, cond_def, cell_def, one_def, SPLIT_def] \\ rw[IN_UNION]); *)
-
-val st2heap_CELL_MEM = Q.store_thm("st2heap_CELL_MEM",
-`(l ~~>> rv * H) (st2heap p s) ==> Mem l rv IN (store2heap s.refs)`,
-Cases_on `p` \\ rw[st2heap_def] \\ IMP_RES_TAC HEAP_LOC_MEM
-\\ fs[IN_UNION]
-\\ fs[Mem_NOT_IN_ffi2heap]);
-
-val st2heap_REF_MEM = Q.store_thm("st2heap_REF_MEM",
-`(Loc l ~~> xv * H) (st2heap p s) ==> Mem l (Refv xv) IN (store2heap s.refs)`,
-rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-metis_tac[st2heap_CELL_MEM]);
-
-val st2heap_ARRAY_MEM = Q.store_thm("st2heap_ARRAY_MEM",
-`(ARRAY (Loc l) av * H) (st2heap p s) ==> Mem l (Varray av) IN (store2heap s.refs)`,
-rw[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-metis_tac[st2heap_CELL_MEM]);
-
-val store2heap_aux_LOC_MEM = Q.store_thm("store2heap_aux_LOC_MEM",
-`!l rv H n s. (l ~~>> rv * H) (store2heap_aux n s) ==> Mem l rv IN (store2heap_aux n s)`,
-rw[] \\ IMP_RES_TAC HEAP_LOC_MEM);
-
-(* val store2heap_aux_REF_MEM = Q.store_thm("store2heap_aux_REF_MEM",
-`!l xv H n s. (REF (Loc l) xv * H) (store2heap_aux n s) ==> Mem l (Refv xv) IN (store2heap_aux n s)`,
-rw[] \\ IMP_RES_TAC HEAP_REF_MEM);
-
-val store2heap_aux_ARRAY_MEM = Q.store_thm("store2heap_aux_ARRAY_MEM",
-`!l av H n s. (ARRAY (Loc l) av * H) (store2heap_aux n s) ==> Mem l (Varray av) IN (store2heap_aux n s)`,
-rw[] \\ IMP_RES_TAC HEAP_ARRAY_MEM); *)
-
-val store2heap_LOC_MEM = Q.store_thm("store2heap_LOC_MEM",
-`!l rv H s. (l ~~>> rv * H) (store2heap s) ==> Mem l rv IN (store2heap s)`,
-rw[] \\ IMP_RES_TAC HEAP_LOC_MEM);
-
-(* val store2heap_REF_MEM = Q.store_thm("store2heap_REF_MEM",
-`!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==> Mem l (Refv xv) IN (store2heap s)`,
-rw[] \\ IMP_RES_TAC HEAP_REF_MEM);
-
-val store2heap_ARRAY_MEM = Q.store_thm("store2heap_REF_MEM",
-`!l av H s. (ARRAY (Loc l) av * H) (store2heap s) ==> Mem l (Varray av) IN (store2heap s)`,
-rw[] \\ IMP_RES_TAC HEAP_ARRAY_MEM); *)
-
-val isPREFIX_TAKE = Q.store_thm("isPREFIX_TAKE",
-`!l s. isPREFIX (TAKE l s) s`,
-rw[] >>
-`isPREFIX (TAKE l s) (TAKE l s ++ DROP l s)` by fs[TAKE_DROP] >>
-metis_tac[TAKE_DROP]);
-
-val isPREFIX_APPEND_EQ = Q.store_thm("isPREFIX_APPEND_EQ",
-`!a1 a2 b1 b2. LENGTH a1 = LENGTH a2 ==> (isPREFIX (a1 ++ b1) (a2 ++ b2) <=> a2 = a1 /\ isPREFIX b1 b2)`,
-Induct_on `a1` >- fs[LENGTH_NIL_SYM] >>
-rw[] >>
-Cases_on `a2` >- fs[] >>
-fs[] >> metis_tac[]);
-
-val STATE_DECOMPOS_FROM_HPROP = Q.store_thm("STATE_DECOMPOS_FROM_HPROP",
-`!l rv H p s. (l ~~>> rv * H) (st2heap p s) ==> ?ps. ((ps ++ [rv]) ≼ s.refs) /\ LENGTH ps = l`,
-rw[] >>
-IMP_RES_TAC st2heap_CELL_MEM >>
-IMP_RES_TAC store2heap_IN_EL >>
-qexists_tac `TAKE l s.refs` >>
-Cases_on `l + 1 <= LENGTH s.refs`
->-(
-    fs[LENGTH_TAKE] >>
-    SUFF_TAC ``isPREFIX [rv : v store_v] (DROP l s.refs)``
-    >- metis_tac[LENGTH_TAKE, LENGTH_DROP, GSYM isPREFIX_APPEND_EQ, TAKE_DROP] >>
-    FIRST_ASSUM (fn x => PURE_REWRITE_TAC[x]) >>
-    SUFF_TAC ``(rv : v store_v) = HD(DROP l s.refs)``
-    >-( fs[] >> Cases_on `DROP l s.refs` >- fs[DROP_NIL] >> fs[]) >>
-    fs[hd_drop]
-) >>
-irule FALSITY >>
-IMP_RES_TAC store2heap_IN_LENGTH >>
-fs[]);
-
-val STATE_DECOMPOS_FROM_HPROP_REF = Q.store_thm("STATE_DECOMPOS_FROM_HPROP_REF",
-`!l xv H p s. (REF (Loc l) xv * H) (st2heap p s) ==> ?ps. ((ps ++ [Refv xv]) ≼ s.refs) /\ LENGTH ps = l`,
-rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_DECOMPOS_FROM_HPROP >>
-instantiate);
-
-val STATE_DECOMPOS_FROM_HPROP_ARRAY = Q.store_thm("STATE_DECOMPOS_FROM_HPROP_ARRAY",
-`!l av H p s. (ARRAY (Loc l) av * H) (st2heap p s) ==> ?ps. ((ps ++ [Varray av]) ≼ s.refs) /\ LENGTH ps = l`,
-rw[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_DECOMPOS_FROM_HPROP >>
-instantiate);
-
-(* val STORE_EXTRACT_FROM_HPROP_REF = Q.store_thm("STORE_EXTRACT_REF_FROM_HPROP",
-`!l xv H s. (REF (Loc l) xv * H) (store2heap s) ==>
-!junk. EL l (s ++ junk) = Refv xv`,
-rw[] >>
-IMP_RES_TAC STORE_DECOMPOS_REF_FROM_HPROP >>
-fs[IS_PREFIX_APPEND] >>
-first_x_assum(fn x => CONV_RULE (CHANGED_CONV (SIMP_CONV pure_ss [GSYM APPEND_ASSOC])) x |> ASSUME_TAC) >>
-`~NULL ([Refv xv] ++ (l' ++ junk))` by fs[NULL_EQ] >>
-IMP_RES_TAC EL_LENGTH_APPEND >>
-fs[HD] >>
-metis_tac[]); *)
-
-val STATE_EXTRACT_FROM_HPROP = Q.store_thm("STATE_EXTRACT_FROM_HPROP",
-`!l rv H p s. (l ~~>> rv * H) (st2heap p s) ==>
-!junk. EL l (s.refs ++ junk) = rv`,
-rw[] >>
-IMP_RES_TAC STATE_DECOMPOS_FROM_HPROP >>
-fs[IS_PREFIX_APPEND] >>
-first_x_assum(fn x => CONV_RULE (CHANGED_CONV (SIMP_CONV pure_ss [GSYM APPEND_ASSOC])) x |> ASSUME_TAC) >>
-`~NULL ([rv] ++ (l' ++ junk))` by fs[NULL_EQ] >>
-IMP_RES_TAC EL_LENGTH_APPEND >>
-fs[HD] >>
-metis_tac[]);
-
-val STATE_EXTRACT_FROM_HPROP_REF = Q.store_thm("STATE_EXTRACT_FROM_HPROP_REF",
-`!l xv H p s. ((Loc l) ~~> xv * H) (st2heap p s) ==>
-!junk. EL l (s.refs ++ junk) = Refv xv`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_EXTRACT_FROM_HPROP >>
-instantiate);
-
-val STATE_EXTRACT_FROM_HPROP_ARRAY = Q.store_thm("STATE_EXTRACT_FROM_HPROP_ARRAY",
-`!l av H p s. (ARRAY (Loc l) av * H) (st2heap p s) ==>
-!junk. EL l (s.refs ++ junk) = Varray av`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_EXTRACT_FROM_HPROP >>
-instantiate);
-
-val SEPARATE_STORE_ELEM_IN_HEAP = Q.store_thm("SEPARATE_STORE_ELEM_IN_HEAP",
-`!s0 x s1. SPLIT3 (store2heap (s0 ++ [x] ++ s1)) (store2heap s0, {Mem (LENGTH s0) x}, store2heap_aux (LENGTH s0 + 1) s1)`,
-sg `!(s0 : v store) s1 x. SPLIT (store2heap_aux (LENGTH s0) (x::s1)) ({Mem (LENGTH s0) x}, store2heap_aux (LENGTH s0 + 1) s1)`
->-(
-    rw[store2heap_def] >>
-    PURE_REWRITE_TAC[Once rich_listTheory.CONS_APPEND] >>
-    PURE_REWRITE_TAC [GSYM (EVAL ``store2heap_aux (LENGTH (s0 : v store)) [x]``)] >>
-    ASSUME_TAC (EVAL ``LENGTH [x : v store_v]``) >>
-    metis_tac[store2heap_aux_SPLIT, ADD_COMM]
-) >>
-rw[] >>
-qspecl_then [`s0`, `[x] ++ s1`] ASSUME_TAC store2heap_SPLIT >> fs[] >>
-last_x_assum(qspecl_then [`s0`, `s1`, `x`] ASSUME_TAC) >>
-fs[SPLIT_def, SPLIT3_def] >>
-rw[]
->-(metis_tac[UNION_ASSOC, EQ_REFL])
->-(DISCH_TAC >> IMP_RES_TAC store2heap_IN_LENGTH >> fs[]) >>
-metis_tac[DISJOINT_UNION_BOTH, EQ_REFL]);
-
-val CELL_HPROP_SAT_EQ = Q.store_thm("CELL_HPROP_SAT_EQ",
-`!l xv s. (l ~~>> xv) s <=> s = {Mem l xv}`,
-fs[REF_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
-
-val REF_HPROP_SAT_EQ = Q.store_thm("REF_HPROP_SAT_EQ",
-`!l xv s. REF (Loc l) xv s <=> s = {Mem l (Refv xv)}`,
-fs[REF_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
-
-val ARRAY_HPROP_SAT_EQ = Q.store_thm("ARRAY_HPROP_SAT_EQ",
-`!l av s. ARRAY (Loc l) av s <=> s = {Mem l (Varray av)}`,
-fs[ARRAY_def, SEP_EXISTS, HCOND_EXTRACT, cell_def, one_def]);
-
-val SPLIT_UNICITY_R = Q.store_thm("SPLIT_UNICITY_R",
-`SPLIT s (u, v) ==> (SPLIT s (u, v') <=> v' = v)`,
-fs[SPLIT_EQ]);
-
-(* val STORE_SAT_LOC_STAR_H_EQ = Q.store_thm("STORE_SAT_LOC_STAR_H_EQ",
-`!s0 xv s1 H. (Loc (LENGTH s0) ~~> xv * H) (store2heap (s0 ++ [Refv xv] ++ s1)) <=>
-H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1))`,
-rw[] >>
-qspecl_then [`s0`, `Refv xv`, `s1`] ASSUME_TAC SEPARATE_STORE_ELEM_IN_HEAP >>
-IMP_RES_TAC SPLIT_of_SPLIT3_1u3 >>
-last_x_assum(fn x => ALL_TAC) >>
-EQ_TAC
->-(
-    rw[STAR_def, REF_HPROP_SAT_EQ] >>
-    IMP_RES_TAC SPLIT_UNICITY_R >>
-    fs[]
-) >>
-DISCH_TAC >>
-rw[STAR_def] >>
-instantiate >>
-rw[REF_HPROP_SAT_EQ]); *)
-
-val DIFF_UNION_COMM = Q.store_thm("DIFF_UNION_COMM",
-`DISJOINT s2 s3 ==>
-(s1 UNION s2) DIFF s3 = (s1 DIFF s3) UNION s2`,
-rw[SET_EQ_SUBSET]
-\\ fs[SUBSET_DEF, IN_DISJOINT] \\rw[]
-\\ last_x_assum (fn x => PURE_ONCE_REWRITE_RULE [NEG_DISJ_TO_IMP] x |> IMP_RES_TAC)
-\\ fs[]);
-
-val STATE_SAT_CELL_STAR_H_EQ = Q.store_thm("STATE_SAT_CELL_STAR_H_EQ",
-`!p s s0 rv s1 H. ((LENGTH s0) ~~>> rv * H) (st2heap p (s with refs := s0 ++ [rv] ++ s1)) <=>
-H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
-rw[] >>
-Cases_on `p` >>
-fs[st2heap_def] >>
-qspecl_then [`p`, `s with refs := s0 ++ [rv] ++ s1`] ASSUME_TAC st2heap_SPLIT_FFI >>
-fs[] >>
-qspecl_then [`s0`, `rv`, `s1`] ASSUME_TAC SEPARATE_STORE_ELEM_IN_HEAP >>
-IMP_RES_TAC SPLIT_of_SPLIT3_1u3 >>
-EQ_TAC
->-(
-    rw[STAR_def, CELL_HPROP_SAT_EQ] >>
-    fs[SPLIT_EQ] >>
-    rw[] >>
-    fs[st2heap_def] >>
-    `DISJOINT (ffi2heap (q, r) s.ffi) {Mem (LENGTH s0) rv}` by fs[DISJOINT_DEF, Mem_NOT_IN_ffi2heap] >>
-    fs[Once DIFF_UNION_COMM]
-) >>
-DISCH_TAC >>
-rw[STAR_def] >>
-instantiate >>
-qexists_tac `{Mem (LENGTH s0) rv}` >>
-fs[CELL_HPROP_SAT_EQ] >>
-fs[SPLIT_def, SPLIT3_def] >>
-rw[]
->-(
-    rw[store2heap_append_many, store2heap_aux_append_many]
-    >> metis_tac[store2heap_aux_def, UNION_COMM, UNION_ASSOC])
-\\ fs[Mem_NOT_IN_ffi2heap]
-);
-
-val STATE_SAT_REF_STAR_H_EQ = Q.store_thm("STATE_SAT_REF_STAR_H_EQ",
-`!p s s0 xv s1 H. (Loc (LENGTH s0) ~~> xv * H) (st2heap p (s with refs := s0 ++ [Refv xv] ++ s1)) <=>
-H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-fs[STATE_SAT_CELL_STAR_H_EQ]);
-
-val STATE_SAT_ARRAY_STAR_H_EQ = Q.store_thm("STATE_SAT_ARRAY_STAR_H_EQ",
-`!p s s0 av s1 H. (ARRAY (Loc (LENGTH s0)) av * H) (st2heap p (s with refs := s0 ++ [Varray av] ++ s1)) <=>
-H ((store2heap s0) UNION (store2heap_aux (LENGTH s0 + 1) s1) UNION (ffi2heap p s.ffi))`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-fs[STATE_SAT_CELL_STAR_H_EQ]);
-
-(* val STORE_UPDATE_HPROP = Q.store_thm("STORE_UPDATE_HPROP",
-`(Loc l ~~> xv * H) (store2heap s) ==> (Loc l ~~> xv' * H) (store2heap (LUPDATE (Refv xv') l s))`,
-DISCH_TAC >>
-sg `?s0 s1. s = s0 ++ [Refv xv] ++ s1 /\ LENGTH s0 = l`
->-(
-    IMP_RES_TAC STORE_DECOMPOS_FROM_HPROP >>
-    IMP_RES_TAC rich_listTheory.IS_PREFIX_APPEND >>
-    SATISFY_TAC
-) >>
-rw[LUPDATE_APPEND1, LUPDATE_APPEND2, LUPDATE_def] >>
-metis_tac[STORE_SAT_LOC_STAR_H_EQ, REF_HPROP_SAT_EQ, STAR_def]); *)
-
-val STATE_UPDATE_HPROP_CELL = Q.store_thm("STATE_UPDATE_HPROP_CELL",
-`(l ~~>> rv * H) (st2heap p s) ==> (l ~~>> rv' * H) (st2heap p (s with refs := (LUPDATE rv' l s.refs)))`,
-DISCH_TAC >>
-sg `?s0 s1. s.refs = s0 ++ [rv] ++ s1 /\ LENGTH s0 = l`
->-(
-    IMP_RES_TAC STATE_DECOMPOS_FROM_HPROP >>
-    IMP_RES_TAC rich_listTheory.IS_PREFIX_APPEND >>
-    SATISFY_TAC
-) >>
-rw[LUPDATE_APPEND1, LUPDATE_APPEND2, LUPDATE_def] >>
-fs[STATE_SAT_CELL_STAR_H_EQ] >>
-sg `(st2heap p s) = st2heap p (s with refs := s0 ++ [rv] ++ s1)` 
->-(
-   `s = (s with refs := s0 ++ [rv] ++ s1)` by POP_ASSUM (fn x => rw[GSYM x, with_same_refs])
-   >> POP_ASSUM(fn x => rw[GSYM x])
-) >>
-POP_ASSUM(fn x => fs[x]) >>
-fs[STATE_SAT_CELL_STAR_H_EQ]);
-
-val STATE_UPDATE_HPROP_REF = Q.store_thm("STATE_UPDATE_HPROP_REF",
-`(Loc l ~~> xv * H) (st2heap p s) ==> (Loc l ~~> xv' * H) (st2heap p (s with refs := (LUPDATE (Refv xv') l s.refs)))`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_UPDATE_HPROP_CELL >>
-instantiate
-);
-
-val STATE_UPDATE_HPROP_ARRAY = Q.store_thm("STATE_UPDATE_HPROP_ARRAY",
-`(ARRAY (Loc l) av * H) (st2heap p s) ==> (ARRAY (Loc l) av' * H) (st2heap p (s with refs := (LUPDATE (Varray av') l s.refs)))`,
-rw[REF_def, ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
-fs[GSYM STAR_ASSOC, HCOND_EXTRACT] >>
-irule STATE_UPDATE_HPROP_CELL >>
-instantiate
-);
-
-val evaluate_empty_state_IMP_junk = Q.store_thm("evaluate_empty_state_IMP_junk",
-`!junk refs' env s exp x. evaluate F env (empty_state with refs := s.refs ++ junk) exp
- (empty_state with refs := s.refs ++ junk ++ refs',Rval x) ⇒
- evaluate F env (s with refs := s.refs ++ junk) exp (s with refs := s.refs ++ junk ++ refs',Rval x)`,
-rw[]
-\\ ASSUME_TAC (
-Thm.INST_TYPE [``:'ffi`` |-> ``:'a``] evaluate_empty_state_IMP |>
-Thm.INST[``s:'a state`` |-> ``(s:'a state) with refs := s.refs ++ junk``])
-\\ fs[]);
-
-val UNIQUE_CELLS = Q.prove(
-`!p s. !l xv xv' H H'. (l ~~>> xv * H) (st2heap p s) /\ (l ~~>> xv' * H') (st2heap p s) ==> xv' = xv`,
-rw[] >>
-IMP_RES_TAC st2heap_CELL_MEM >>
-IMP_RES_TAC store2heap_IN_unique_key);
+(***)
 
 val evaluate_unique_result = Q.store_thm("evaluate_unique_result",
 `!expr env s s1 s2 res1 res2. evaluate F env s expr (s1, res1) ==>
@@ -781,6 +251,53 @@ val EvalM_ArrowM_EqSt = Q.store_thm("EvalM_ArrowM_EqSt",
   \\ POP_ASSUM(fn x => ALL_TAC)
   \\ `PURE a x (st,s) (st,s with refs := s.refs ++ junk'',Rval v)`
      by fs[PURE_def, state_component_equality]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum (qspec_then `[]` STRIP_ASSUME_TAC) \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ metis_tac[]);
+
+val EvalM_ArrowM_Eq = Q.store_thm("EvalM_ArrowM_Eq",
+  `EvalM env st x1 ((ArrowM H (PURE (Eq a x)) b) f) H ==>
+    EvalM env st x2 (PURE a x) H ==>
+    EvalM env st (App Opapp [x1;x2]) (b (f x)) H`,
+  rw[EvalM_def,ArrowM_def,ArrowP_def,PURE_def,PULL_EXISTS]
+  \\ rw[Once evaluate_cases,evaluate_list_cases,PULL_EXISTS]
+  \\ first_x_assum drule \\ rw[]
+  \\ srw_tac[DNF_ss][] \\ disj1_tac
+  \\ first_x_assum(qspec_then`junk`strip_assume_tac)
+  \\ evaluate_unique_result_tac
+  \\ last_x_assum IMP_RES_TAC
+  \\ first_x_assum(qspec_then`junk'`strip_assume_tac)
+  \\ fs[GSYM AND_IMP_INTRO,Eq_def]
+  \\ qpat_x_assum `!p. P` IMP_RES_TAC
+  \\ first_x_assum (qspec_then `[]` STRIP_ASSUME_TAC) \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ first_x_assum (qspec_then `junk''` STRIP_ASSUME_TAC)
+  \\ evaluate_unique_result_tac
+  \\ rw[] \\ metis_tac[]);
+
+val EvalM_ArrowM_EqSt_Eq = Q.store_thm("EvalM_ArrowM_EqSt_Eq",
+  `EvalM env st x1 ((ArrowM H (EqSt (PURE (Eq a x)) st) b) f) H ==>
+    EvalM env st x2 (PURE a x) H ==>
+    EvalM env st (App Opapp [x1;x2]) (b (f x)) H`,
+  rw[EvalM_def,ArrowM_def,ArrowP_def,PURE_def,PULL_EXISTS]
+  \\ rw[Once evaluate_cases,evaluate_list_cases,PULL_EXISTS]
+  \\ first_x_assum drule \\ rw[]
+  \\ srw_tac[DNF_ss][] \\ disj1_tac
+  \\ first_x_assum(qspec_then`junk`strip_assume_tac)
+  \\ evaluate_unique_result_tac
+  \\ last_x_assum drule \\ rw[]
+  \\ first_x_assum(qspec_then`junk'`strip_assume_tac)
+  \\ fs[GSYM AND_IMP_INTRO]
+  \\ fs[EqSt_def]
+  \\ `PURE a x (st,s) (st,s with refs := s.refs ++ ARB,Rval v)`
+     by fs[PURE_def, state_component_equality]
+  \\ qpat_assum `!p. P` IMP_RES_TAC
+  \\ fs[state_component_equality] \\ rw[]
+  \\ evaluate_unique_result_tac
+  \\ `PURE (Eq a x) x (st,s) (st,s with refs := s.refs ++ junk'',Rval v)`
+     by fs[PURE_def, Eq_def, state_component_equality]
   \\ first_x_assum drule \\ rw[]
   \\ first_x_assum drule \\ rw[]
   \\ first_x_assum (qspec_then `[]` STRIP_ASSUME_TAC) \\ fs[]
@@ -2093,12 +1610,6 @@ rw[]
 val ABS_NUM_EQ = Q.prove(`Num(ABS(&n))=n`,
 rw[DB.fetch "integer" "Num", integerTheory.INT_ABS]);
 
-val RARRAY_def = Define `
-RARRAY rv av = SEP_EXISTS arv. REF rv arv * ARRAY arv av`;
-
-val RARRAY_REL_def = Define `
-RARRAY_REL TYPE rv l = SEP_EXISTS av. RARRAY rv av * &LIST_REL TYPE l av`;
-
 val evaluate_Opdref_REF = Q.prove(
 `nsLookup env.v (Short vname) = SOME (Loc loc) ==>
 (REF (Loc loc) v * H refs) (st2heap p s) ==>
@@ -3122,6 +2633,15 @@ rw[Eval_def]
 >-(simp[Once evaluate_cases] \\ rw[] \\ metis_tac[])
 \\ rw[Once evaluate_cases]
 \\ rw[state_component_equality]);
+
+(* Terms used by the ml_monad_translatorLib *)
+val m_translator_terms = save_thm("m_translator_terms",
+  pack_list (pack_pair pack_string pack_term)
+    [("EqSt remove",``!a st. EqSt a st = (a : ('a, 'b) H)``),
+     ("PURE ArrowP eq", ``PURE(ArrowP H (PURE (Eq a x)) b)``),
+     ("ArrowP PURE", ``ArrowP H a (PURE b)``),
+     ("ArrowP EqSt", ``ArrowP H (EqSt a st) b``)
+]);
 
 val _ = (print_asts := true);
 

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -1060,6 +1060,42 @@ val EvalM_Var = Q.store_thm("EvalM_Var",
       \\ fs[with_same_refs, evaluate_Var])
   \\ metis_tac[evaluate_Var, REFS_PRED_FRAME_append]);
 
+val EvalM_Var_ArrowP = Q.store_thm("EvalM_Var_ArrowP",
+  `(!st. EvalM env st (Var (Short n)) (ArrowM H (PURE a) b x) H) ==>
+   LOOKUP_VAR n env v ==>
+   ArrowP H (PURE a) b x v`,
+  rw[EvalM_def]
+  \\fs[Once evaluate_cases]
+  \\ fs[ArrowP_def, ArrowM_def] \\ rw[]  
+  \\ fs[LOOKUP_VAR_def, lookup_var_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum (qspec_then `[]` strip_assume_tac)
+  \\ fs[PURE_def] \\ fs[state_component_equality]
+  \\ rw[] \\ fs[ArrowP_def]
+  \\ `PURE a x' (st1,s1) (st1,s2,Rval v')`
+     by fs[PURE_def,state_component_equality]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ fs[state_component_equality]);
+
+val EvalM_Var_ArrowP_EqSt = Q.store_thm("EvalM_Var_ArrowP_EqSt",
+  `(!st. EvalM env st (Var (Short n)) (ArrowM H (EqSt (PURE a) n_st) b x) H) ==>
+   LOOKUP_VAR n env v ==>
+   ArrowP H (EqSt (PURE a) n_st) b x v`,
+  rw[EvalM_def]
+  \\ fs[Once evaluate_cases]
+  \\ fs[ArrowP_def, ArrowM_def] \\ rw[]  
+  \\ fs[LOOKUP_VAR_def, lookup_var_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum (qspec_then `[]` strip_assume_tac)
+  \\ fs[Once PURE_def, EqSt_def] \\ fs[state_component_equality]
+  \\ rw[] \\ fs[ArrowP_def]
+  \\ `PURE a x' (n_st,s1) (n_st,s2,Rval v')`
+     by fs[PURE_def,state_component_equality]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ fs[state_component_equality]);
+
 (* Eq simps *)
 
 val EvalM_FUN_FORALL = Q.store_thm("EvalM_FUN_FORALL",
@@ -1102,12 +1138,18 @@ val M_FUN_FORALL_PUSH2 = Q.prove(
   FULL_SIMP_TAC std_ss [ArrowP_def,FUN_EQ_THM,AppReturns_def,
     FUN_FORALL,FUN_EXISTS,PURE_def] \\ METIS_TAC []) |> GEN_ALL;
 
+val M_FUN_FORALL_PUSH3 = Q.prove(
+  `(FUN_FORALL st. ArrowP H (EqSt a st) b) =
+    (ArrowP H a b)`,
+  FULL_SIMP_TAC std_ss [ArrowP_def,FUN_EQ_THM,AppReturns_def,
+    FUN_FORALL,FUN_EXISTS,EqSt_def] \\ METIS_TAC []) |> GEN_ALL;
+
 val FUN_EXISTS_Eq = Q.prove(
   `(FUN_EXISTS x. Eq a x) = a`,
   SIMP_TAC std_ss [FUN_EQ_THM,FUN_EXISTS,Eq_def]) |> GEN_ALL;
 
 val M_FUN_QUANT_SIMP = save_thm("M_FUN_QUANT_SIMP",
-  LIST_CONJ [FUN_EXISTS_Eq,M_FUN_FORALL_PUSH1,M_FUN_FORALL_PUSH2]);
+  LIST_CONJ [FUN_EXISTS_Eq,M_FUN_FORALL_PUSH1,M_FUN_FORALL_PUSH2,M_FUN_FORALL_PUSH3]);
 
 val EvalM_Eq = Q.store_thm("EvalM_Eq",
 `EvalM env st exp (PURE a x) H ==> EvalM env st exp (PURE (Eq a x) x) H`,

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -978,19 +978,83 @@ val EvalM_Recclosure_ALT = Q.store_thm("EvalM_Recclosure_ALT",
   \\ first_x_assum (fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> STRIP_ASSUME_TAC)
   \\ evaluate_unique_result_tac
   \\ fs[state_component_equality]
-  \\ rw[]
-  >-(
-      `s2 = s1 with refs := s1.refs ++ junk'` by rw[state_component_equality]
-      \\ rw[do_opapp_def]
-      \\ fs[state_component_equality] \\ rw[]
-      \\ fs[Eq_def]
-      \\ first_x_assum drule \\ rw[]
-      \\ first_x_assum drule \\ rw[]
-      \\ first_x_assum(qspec_then `junk' ++ junk''` STRIP_ASSUME_TAC)
-      \\ fs[]
-      \\ evaluate_unique_result_tac
-      \\ metis_tac[])
-  \\ metis_tac[APPEND_ASSOC, REFS_PRED_FRAME_append]);
+  \\ reverse(rw[])
+  >-(metis_tac[APPEND_ASSOC, REFS_PRED_FRAME_append])
+  \\ `s2 = s1 with refs := s1.refs ++ junk'` by rw[state_component_equality]
+  \\ rw[do_opapp_def]
+  \\ fs[state_component_equality] \\ rw[]
+  \\ fs[Eq_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum(qspec_then `junk' ++ junk''` STRIP_ASSUME_TAC)
+  \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ metis_tac[]);
+
+val EvalM_Recclosure_ALT2 = Q.store_thm("EvalM_Recclosure_ALT2",
+`!H funs fname.
+     A n_st ==>
+     !name body.
+     ALL_DISTINCT (MAP (λ(f,x,e). f) funs) ==>
+     (∀st v.
+        A st ==>
+        a n v ==>
+        EvalM (write name v (write_rec funs env2 env2)) st body (b (f n)) H) ==>
+     LOOKUP_VAR fname env (Recclosure env2 funs fname) ==>
+     find_recfun fname funs = SOME (name,body) ==>
+     EvalM env st (Var (Short fname)) ((ArrowM H (EqSt (PURE (Eq a n)) n_st) b) f) H`,
+  rw[write_rec_thm,write_def]
+  \\ IMP_RES_TAC LOOKUP_VAR_THM
+  \\ fs[Eval_def, EvalM_def,ArrowM_def, ArrowP_def, PURE_def, EqSt_def] \\ REPEAT STRIP_TAC
+  \\ first_x_assum(qspec_then`s.refs ++ junk` STRIP_ASSUME_TAC)
+  \\ first_x_assum (fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> STRIP_ASSUME_TAC)
+  \\ evaluate_unique_result_tac
+  \\ fs[state_component_equality]
+  \\ reverse(rw[])
+  >-(metis_tac[APPEND_ASSOC, REFS_PRED_FRAME_append])
+  \\ `s2 = s1 with refs := s1.refs ++ junk'` by rw[state_component_equality]
+  \\ rw[do_opapp_def]
+  \\ fs[state_component_equality] \\ rw[]
+  \\ fs[Eq_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum(qspec_then `junk' ++ junk''` STRIP_ASSUME_TAC)
+  \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ metis_tac[]);
+
+val EvalM_Recclosure_ALT3 = Q.store_thm("EvalM_Recclosure_ALT3",
+`!H funs fname name body.
+     (∀st v.
+        A st ==>
+        a n v ==>
+        EvalM (write name v (write_rec funs env2 env2)) st body (b (f n)) H) ==>
+     A n_st ==>
+     ALL_DISTINCT (MAP (λ(f,x,e). f) funs) ==>
+     LOOKUP_VAR fname env (Recclosure env2 funs fname) ==>
+     find_recfun fname funs = SOME (name,body) ==>
+     EvalM env st (Var (Short fname)) ((ArrowM H (EqSt (PURE (Eq a n)) n_st) b) f) H`,
+  rw[write_rec_thm,write_def]
+  \\ IMP_RES_TAC LOOKUP_VAR_THM
+  \\ fs[Eval_def, EvalM_def,ArrowM_def, ArrowP_def, PURE_def, EqSt_def] \\ REPEAT STRIP_TAC
+  \\ first_x_assum(qspec_then`s.refs ++ junk` STRIP_ASSUME_TAC)
+  \\ first_x_assum (fn x => MATCH_MP evaluate_empty_state_IMP_junk x |> STRIP_ASSUME_TAC)
+  \\ evaluate_unique_result_tac
+  \\ fs[state_component_equality]
+  \\ reverse(rw[])
+  >-(metis_tac[APPEND_ASSOC, REFS_PRED_FRAME_append])
+  \\ `s2 = s1 with refs := s1.refs ++ junk'` by rw[state_component_equality]
+  \\ rw[do_opapp_def]
+  \\ fs[state_component_equality] \\ rw[]
+  \\ fs[Eq_def]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum drule \\ rw[]
+  \\ first_x_assum(qspec_then `junk' ++ junk''` STRIP_ASSUME_TAC)
+  \\ fs[]
+  \\ evaluate_unique_result_tac
+  \\ metis_tac[]);
 
 val EvalM_Recclosure = Q.store_thm("EvalM_Recclosure",
   `!H. (!st v. a n v ==>

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -926,7 +926,7 @@ val EvalM_Var_SIMP = Q.store_thm("EvalM_Var_SIMP",
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases,write_def]);
 
-val EvalM_Var_SIMP_PURE = Q.store_thm("EvalM_Var_SIMP_PURE",
+(* val EvalM_Var_SIMP_PURE = Q.store_thm("EvalM_Var_SIMP_PURE",
   `VALID_REFS_PRED H ==>
    (!st. EvalM (write nv v env) st (Var (Short n)) (PURE P x) H) =
     if nv = n then P x v else (!st. EvalM env st (Var (Short n)) (PURE P x) H)`,
@@ -938,6 +938,26 @@ val EvalM_Var_SIMP_PURE = Q.store_thm("EvalM_Var_SIMP_PURE",
       \\ EQ_TAC
       >-(metis_tac[])
       \\ metis_tac[REFS_PRED_FRAME_append])
+  \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
+  \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
+  \\ ASM_SIMP_TAC (srw_ss()) [write_def]); *)
+
+val EvalM_Var_SIMP_ArrowM = Q.store_thm("EvalM_Var_SIMP_ArrowM",
+  `(!st. EvalM (write nv v env) st (Var (Short n)) (ArrowM H a b x) H) =
+    if nv = n then ArrowP H a b x v
+    else (!st. EvalM env st (Var (Short n)) (ArrowM H a b x) H)`,
+  SIMP_TAC std_ss [EvalM_def, ArrowM_def, VALID_REFS_PRED_def]
+  \\ SRW_TAC [] []
+  >-(
+      ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
+      \\ ASM_SIMP_TAC (srw_ss()) [write_def]
+      \\ EQ_TAC
+      >-(
+	  fs[PURE_def]
+	  \\ rw[ArrowP_def]
+	  \\ first_x_assum drule \\ rw[]
+	  \\ fs[state_component_equality])
+      \\ metis_tac[PURE_def, REFS_PRED_FRAME_append])
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [Once evaluate_cases]
   \\ ASM_SIMP_TAC (srw_ss()) [write_def]);
@@ -989,7 +1009,7 @@ val EvalM_Recclosure = Q.store_thm("EvalM_Recclosure",
   \\ fs[build_rec_env_def,write_rec_def,FOLDR,write_def]
   \\ METIS_TAC[APPEND_ASSOC]);
 
-val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
+(* val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
   `VALID_REFS_PRED H ==>
     LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
     (P f (Recclosure x1 x2 x3) =
@@ -1002,7 +1022,23 @@ val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
       \\ fs[state_component_equality]
       \\ fs[REFS_PRED_FRAME_append])
   \\ fs [AND_IMP_INTRO, Once evaluate_cases,PULL_EXISTS,PULL_FORALL, VALID_REFS_PRED_def]
-  \\ metis_tac[]);
+  \\ metis_tac[]); *)
+
+val EvalM_Eq_Recclosure = Q.store_thm("EvalM_Eq_Recclosure",
+  `LOOKUP_VAR name env (Recclosure x1 x2 x3) ==>
+    (ArrowP H a b f (Recclosure x1 x2 x3) =
+     (!st. EvalM env st (Var (Short name)) (ArrowM H a b f) H))`,
+  rw[EvalM_Var_SIMP, EvalM_def, ArrowM_def, LOOKUP_VAR_def, lookup_var_def, PURE_def]
+  \\ EQ_TAC
+  >-(
+      rw[]
+      \\ rw[Once evaluate_cases]
+      \\ fs[state_component_equality]
+      \\ fs[REFS_PRED_FRAME_append])
+  \\ fs [AND_IMP_INTRO, Once evaluate_cases,PULL_EXISTS,PULL_FORALL, VALID_REFS_PRED_def]
+  \\ simp[state_component_equality]
+  \\ simp[ArrowP_def]
+  \\ metis_tac[REFS_PRED_FRAME_append]);
 
 val write_rec_one = Q.store_thm("write_rec_one",
   `write_rec [(x,y,z)] env env = write x (Recclosure env [(x,y,z)] x) env`,
@@ -1077,7 +1113,7 @@ val EvalM_Eq = Q.store_thm("EvalM_Eq",
 `EvalM env st exp (PURE a x) H ==> EvalM env st exp (PURE (Eq a x) x) H`,
 fs[EvalM_def, PURE_def, Eq_def]);
 
-val ArrowM_EqSt_elim = Q.store_thm("ArrowP_EqSt_elim",
+val ArrowM_EqSt_elim = Q.store_thm("ArrowM_EqSt_elim",
   `(!st_v. EvalM env st exp (ArrowM H (EqSt a st_v) b f) H) ==>
    EvalM env st exp (ArrowM H a b f) H`,
   fs[EvalM_def, ArrowP_def, ArrowM_def]


### PR DESCRIPTION
Improve the precondition generation for the monadic translator by lifting the monadic state as a parameter of the EvalM predicate. Improve the m_translate_run mechanism to output shorter theorems to make debugging easier (application of simplifications, introduction of abbreviations).