### PR TITLE
Expose primitive with which the user can force the GC to run

### DIFF
--- a/basis/OptionProgScript.sml
+++ b/basis/OptionProgScript.sml
@@ -1,11 +1,9 @@
-open preamble ml_translatorLib ml_progLib std_preludeTheory
+open preamble ml_translatorLib ml_progLib RuntimeProgTheory
      mloptionTheory
 
 val _ = new_theory"OptionProg"
 
-val _ = translation_extends"std_prelude"
-
-val _ = concretise_all () (* TODO: better to leave more abstract longer... *)
+val _ = translation_extends "RuntimeProg"
 
 val _ = ml_prog_update (open_module "Option");
 

--- a/basis/RuntimeProgScript.sml
+++ b/basis/RuntimeProgScript.sml
@@ -1,0 +1,20 @@
+open preamble ml_translatorLib ml_progLib std_preludeTheory
+     mloptionTheory
+
+val _ = new_theory"RuntimeProg"
+
+val _ = translation_extends"std_prelude"
+
+val _ = concretise_all () (* TODO: better to leave more abstract longer... *)
+
+val _ = ml_prog_update (open_module "Runtime");
+
+val fullGC_def = Define `
+  fullGC (u:unit) = force_gc_to_run 0 0`;
+
+val () = next_ml_names := ["fullGC"];
+val result = translate fullGC_def;
+
+val _ = ml_prog_update (close_module NONE);
+
+val _ = export_theory();

--- a/basis/dependency-order
+++ b/basis/dependency-order
@@ -10,6 +10,7 @@ be selected than simple prefixes of the current ordering.
 *)
 
 std_prelude
+Runtime
 Option
 List
 Vector

--- a/compiler/backend/bvi_to_dataScript.sml
+++ b/compiler/backend/bvi_to_dataScript.sml
@@ -23,6 +23,7 @@ val op_space_reset_def = Define `
   (op_space_reset (RefByte _) = T) /\
   (op_space_reset (ConsExtend _) = T) /\
   (op_space_reset (CopyByte new_flag) = new_flag) /\
+  (op_space_reset ConfigGC = T) /\
   (op_space_reset _ = F)`;
 
 val op_space_reset_pmatch = Q.store_thm("op_space_reset_pmatch",`! op.
@@ -43,6 +44,7 @@ val op_space_reset_pmatch = Q.store_thm("op_space_reset_pmatch",`! op.
     | RefByte _ => T
     | ConsExtend _ => T
     | CopyByte new_flag => new_flag
+    | ConfigGC => T
     | _ => F`,
   rpt strip_tac
   >> CONV_TAC(RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV)

--- a/compiler/backend/closLangScript.sml
+++ b/compiler/backend/closLangScript.sml
@@ -62,7 +62,8 @@ val _ = Datatype `
      | BoundsCheckBlock
      | BoundsCheckArray
      | BoundsCheckByte bool (* T = loose (<=) bound *)
-     | LessConstSmall num`
+     | LessConstSmall num
+     | ConfigGC`
 
 val _ = Datatype `
   exp = Var tra num

--- a/compiler/backend/data_liveScript.sml
+++ b/compiler/backend/data_liveScript.sml
@@ -36,6 +36,7 @@ val is_pure_def = Define `
   (is_pure WordToInt = F) /\
   (is_pure (FP_uop _) = F) /\
   (is_pure (FP_bop _) = F) /\
+  (is_pure ConfigGC = F) /\
   (is_pure _ = T)`
 
 val is_pure_pmatch = Q.store_thm("is_pure_pmatch",`!op.
@@ -68,6 +69,7 @@ val is_pure_pmatch = Q.store_thm("is_pure_pmatch",`!op.
     | WordToInt => F
     | FP_uop _ => F
     | FP_bop _ => F
+    | ConfigGC => F
     | _ => T`,
   rpt strip_tac
   >> CONV_TAC(RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV)

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -892,6 +892,13 @@ local val assign_quotation = `
                                               (ptr_bits c tag (LENGTH args)))]);
                          Set NextFree (Op Add [Var 1;
                            Const (bytes_in_word * n2w (LENGTH args + 1))])],l))
+    | ConfigGC =>
+        (dtcase args of
+         | [v1;v2] =>
+             (list_Seq [Assign 1 (Const 0w);
+                        Alloc 1 (adjust_set (get_names names)); (* runs GC *)
+                        Assign (adjust_var dest) (Const 2w)],l)
+         | _ => (Skip,l))
     | ConsExtend tag =>
         (dtcase args of
          | (old::start::len::tot::rest) =>
@@ -1366,7 +1373,7 @@ local val assign_quotation = `
         let fakelen1 = Shift Lsr header1 (Nat k) in
         let addr2 = real_addr c (adjust_var v2) in
         let header2 = Load addr2 in
-        let fakelen2 = Shift Lsr header2 (Nat k) in            
+        let fakelen2 = Shift Lsr header2 (Nat k) in
         (list_Seq [
           Assign 1 (Op Add [addr1; Const bytes_in_word]);
           Assign 3 (Op Sub [fakelen1; Const (bytes_in_word-1w)]);

--- a/compiler/backend/modLangScript.sml
+++ b/compiler/backend/modLangScript.sml
@@ -71,6 +71,8 @@ val _ = Datatype `
   | Asub
   | Alength
   | Aupdate
+  (* Configure the GC *)
+  | ConfigGC
   (* Call a given foreign function *)
   | FFI string`;
 

--- a/compiler/backend/pat_to_closScript.sml
+++ b/compiler/backend/pat_to_closScript.sml
@@ -191,6 +191,8 @@ val compile_def = tDefine"compile" `
                         Var (tra§8) 1; Var (tra§9) 2]]
             (Op (tra§10) (Cons tuple_tag) []))
          (Raise (tra§11) (Op (tra§12) (Cons subscript_tag) [])))) ∧
+  (compile (App tra (Op (Op ConfigGC)) es) =
+    Op tra ConfigGC (REVERSE (MAP compile es))) ∧
   (compile (App tra (Op (Op (FFI n))) es) =
     Op tra (FFI n) (REVERSE (MAP compile es))) ∧
   (compile (App tra (Op (Init_global_var n)) es) =

--- a/compiler/backend/proofs/clos_annotateProofScript.sml
+++ b/compiler/backend/proofs/clos_annotateProofScript.sml
@@ -274,7 +274,9 @@ val do_app_thm = Q.prove(
    (do_app op xs s1 = Rval (v,s2)) ==>
    ?w t2. (do_app op ys t1 = Rval (w,t2)) /\
           v_rel v w /\ state_rel s2 t2`,
-  Cases_on `?i. op = EqualInt i`
+  Cases_on `op = ConfigGC`
+  THEN1 (fs [do_app_cases_val] \\ rw [] \\ fs [v_rel_simp])
+  \\ Cases_on `?i. op = EqualInt i`
   THEN1 (fs [] \\ fs [do_app_def] \\ every_case_tac \\ fs [])
   \\ reverse (Cases_on `op`) \\ rpt STRIP_TAC
   \\ TRY (full_simp_tac(srw_ss())[do_app_def] >> NO_TAC)

--- a/compiler/backend/proofs/clos_callProofScript.sml
+++ b/compiler/backend/proofs/clos_callProofScript.sml
@@ -1336,6 +1336,15 @@ val do_app_thm = Q.prove(
   \\ qspec_tac (`REVERSE a`,`xs`)
   \\ qspec_tac (`REVERSE v`,`ys`)
   \\ fs [REVERSE_REVERSE,LIST_REL_REVERSE_EQ,EVERY_REVERSE]
+  \\ Cases_on `op = ConfigGC` THEN1 (
+    rveq \\ rpt gen_tac
+    \\ Cases_on `do_app ConfigGC xs r`
+    \\ TRY (Cases_on `e`)
+    \\ TRY (Cases_on `a`)
+    \\ fs [do_app_cases_val] \\ rveq
+    \\ fs [do_app_cases_err] \\ rveq
+    \\ fs [do_app_cases_timeout] \\ rveq
+    \\ rw [] \\ fs [Unit_def,PULL_EXISTS,v_rel_def])
   \\ Cases_on `op = ConcatByteVec` THEN1 (
     rw[] \\ fs[do_app_def,state_rel_def,PULL_EXISTS] \\
     fs[case_eq_thms] \\

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -3,7 +3,7 @@ open preamble bvlSemTheory dataSemTheory dataPropsTheory
      data_to_word_memoryProofTheory data_to_word_gcProofTheory
      data_to_word_bignumProofTheory data_to_wordTheory wordPropsTheory
      labPropsTheory whileTheory set_sepTheory semanticsPropsTheory
-     word_to_wordProofTheory helperLib alignmentTheory blastLib
+     helperLib alignmentTheory blastLib
      word_bignumTheory wordLangTheory word_bignumProofTheory
      gen_gc_partialTheory gc_sharedTheory;
 local open gen_gcTheory in end
@@ -2283,6 +2283,37 @@ val th = Q.store_thm("assign_CopyByte",
       \\ fs [lookup_inter_alt] \\ rw []
       \\ sg `F` \\ fs [] \\ pop_assum mp_tac \\ simp []
       \\ unabbrev_all_tac \\ fs [IN_domain_adjust_set_inter])));
+
+val th = Q.store_thm("assign_ConfigGC",
+  `op = ConfigGC ==> ^assign_thm_goal`,
+  rpt strip_tac \\ drule (evaluate_GiveUp |> GEN_ALL) \\ rw [] \\ fs []
+  \\ `t.termdep <> 0` by fs[]
+  \\ imp_res_tac state_rel_cut_IMP \\ pop_assum mp_tac \\ strip_tac
+  \\ imp_res_tac get_vars_IMP_LENGTH
+  \\ fs[do_app]
+  \\ every_case_tac \\ fs[]
+  \\ clean_tac
+  \\ imp_res_tac state_rel_get_vars_IMP
+  \\ fs[LENGTH_EQ_NUM_compute] \\ clean_tac
+  \\ fs[assign_def,EVAL ``op_requires_names ConfigGC``]
+  \\ fs [list_Seq_def,eq_eval]
+  \\ fs [case_eq_thms]
+  \\ qpat_abbrev_tac `alll = alloc _ _ _`
+  \\ `?x1 x2. alll = (x1,x2)` by (Cases_on `alll` \\ fs [])
+  \\ unabbrev_all_tac \\ fs []
+  \\ qpat_x_assum `state_rel c l1 l2 s t [] locs` assume_tac
+  \\ Cases_on `names_opt`
+  \\ fs [cut_state_opt_def,cut_state_def,case_eq_thms] \\ rveq \\ fs []
+  \\ rpt_drule (alloc_lemma |> Q.INST [`k`|->`0`])
+  \\ fs [EVAL ``alloc_size 0``,get_names_def]
+  \\ strip_tac \\ Cases_on `x1 = SOME NotEnoughSpace` \\ fs []
+  \\ fs [state_rel_thm,set_var_def,bvi_to_data_def,bviSemTheory.bvl_to_bvi_def,
+         data_to_bvi_def,bviSemTheory.bvi_to_bvl_def]
+  \\ fs [lookup_insert,adjust_var_11]
+  \\ strip_tac \\ rw []
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
+  \\ match_mp_tac memory_rel_insert
+  \\ fs [] \\ match_mp_tac memory_rel_Unit \\ fs []);
 
 val th = Q.store_thm("assign_WordToInt",
   `op = WordToInt ==> ^assign_thm_goal`,
@@ -7463,7 +7494,7 @@ val th = Q.store_thm("assign_FFI",
   \\ rfs[]
   \\ rpt_drule get_var_get_real_addr_lemma
   \\ qpat_x_assum `get_var _ _ = SOME (WORD _)`
-     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)  
+     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `tt.store = t.store` by simp[Abbr`tt`]
   \\ simp[]
   \\ IF_CASES_TAC >- ( fs[shift_def] )
@@ -7482,7 +7513,7 @@ val th = Q.store_thm("assign_FFI",
   \\ rfs[]
   \\ rpt_drule get_var_get_real_addr_lemma
   \\ qpat_x_assum `get_var _ _ = SOME (WORD _)`
-     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)  
+     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `ttt.store = t.store` by simp[Abbr`ttt`]
   \\ simp[]
   \\ qpat_abbrev_tac`tttt = t with locals := _`
@@ -7493,7 +7524,7 @@ val th = Q.store_thm("assign_FFI",
   \\ rfs[]
   \\ rpt_drule get_var_get_real_addr_lemma
   \\ qpat_x_assum `get_var _ _ = SOME (WORD _)`
-     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)  
+     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `tttt.store = t.store` by simp[Abbr`tttt`]
   \\ simp[]
   \\ qpat_abbrev_tac`ttttt = t with locals := _`
@@ -7504,9 +7535,9 @@ val th = Q.store_thm("assign_FFI",
   \\ rfs[]
   \\ rpt_drule get_var_get_real_addr_lemma
   \\ qpat_x_assum `get_var _ _ = SOME (WORD _)`
-     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)  
+     (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `ttttt.store = t.store` by simp[Abbr`ttttt`]
-  \\ simp[]  
+  \\ simp[]
   \\ simp[wordSemTheory.get_var_def,lookup_insert]
   \\ qmatch_goalsub_abbrev_tac`read_bytearray aa len g`
   \\ qmatch_asmsub_rename_tac`LENGTH ls + 3`
@@ -7527,7 +7558,7 @@ val th = Q.store_thm("assign_FFI",
     simp[Abbr`len2`]
     \\ rfs[good_dimindex_def] \\ rfs[shift_def]
     \\ simp[bytes_in_word_def,GSYM word_add_n2w]
-    \\ simp[dimword_def] )  
+    \\ simp[dimword_def] )
   \\ fs[]
   \\ rpt strip_tac
   \\ simp[Unit_def]
@@ -7591,7 +7622,7 @@ val th = Q.store_thm("assign_FFI",
             >> fs[]
             >> `LENGTH r' = LENGTH l''`
             by (
-             qhdtm_x_assum`call_FFI`mp_tac                         
+             qhdtm_x_assum`call_FFI`mp_tac
              \\ simp[ffiTheory.call_FFI_def]
              \\ rpt(pop_assum kall_tac)
              \\ every_case_tac \\ rpt strip_tac \\ fs[])
@@ -7621,7 +7652,7 @@ val th = Q.store_thm("assign_FFI",
                 \\ rw[]
                 )
               \\ rw[]
-              >- (qpat_x_assum `memory_rel _ _ _ _ _ _ _ (_ :: _ :: _)` mp_tac 
+              >- (qpat_x_assum `memory_rel _ _ _ _ _ _ _ (_ :: _ :: _)` mp_tac
                  \\ rw[] \\ drule memory_rel_tl \\ simp[])
               \\ first_x_assum drule
               \\ simp[]

--- a/compiler/backend/proofs/mod_to_conProofScript.sml
+++ b/compiler/backend/proofs/mod_to_conProofScript.sml
@@ -948,13 +948,14 @@ val do_app = Q.prove (
   rpt gen_tac >>
   Cases_on `s1` >>
   Cases_on `s1_i2` >>
+  Cases_on `op = ConfigGC` THEN1 tac >>
   cases_on `op` >>
   srw_tac[][]
   >- tac
   >- tac
   >- tac
   >- tac
-  >- (full_simp_tac(srw_ss())[modSemTheory.do_app_def] >> 
+  >- (full_simp_tac(srw_ss())[modSemTheory.do_app_def] >>
       cases_on `vs` >>
       full_simp_tac(srw_ss())[] >>
       cases_on `t` >>

--- a/compiler/backend/proofs/source_to_modProofScript.sml
+++ b/compiler/backend/proofs/source_to_modProofScript.sml
@@ -420,6 +420,11 @@ val do_app = Q.prove (
   rpt gen_tac >>
   Cases_on `s1` >>
   Cases_on `s1_i1` >>
+  Cases_on `op = ConfigGC` >-
+     (simp [astOp_to_modOp_def] >>
+      srw_tac[][semanticPrimitivesPropsTheory.do_app_cases, modSemTheory.do_app_def, semanticPrimitivesTheory.prim_exn_def, modSemTheory.prim_exn_def] >>
+      full_simp_tac(srw_ss())[v_rel_eqns, result_rel_cases, semanticPrimitivesTheory.prim_exn_def, modSemTheory.prim_exn_def]) >>
+  pop_assum mp_tac >>
   Cases_on `op` >>
   simp [astOp_to_modOp_def]
   >- ((* Opn *)

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -305,6 +305,7 @@ val do_app_def = Define `
          | [Number i] => if 0 <= i /\ i <= 1000000 /\ n < 1000000
                          then Rval (Boolv (i < &n),s) else Error
          | _ => Error)
+    | (ConfigGC,[Number _; Number _]) => (Rval (Unit, s))
     | _ => Error`;
 
 val dec_clock_def = Define `

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -306,6 +306,7 @@ val do_app_def = Define `
          | _ => Error)
     | (LessConstSmall n,[Number i]) =>
         (if 0 <= i /\ i <= 1000000 /\ n < 1000000 then Rval (Boolv (i < &n),s) else Error)
+    | (ConfigGC,[Number _; Number _]) => (Rval (Unit, s))
     | _ => Error`;
 
 val dec_clock_def = Define `

--- a/compiler/backend/semantics/clos_relationScript.sml
+++ b/compiler/backend/semantics/clos_relationScript.sml
@@ -1066,6 +1066,25 @@ val res_rel_do_app = Q.store_thm ("res_rel_do_app",
      Rval (v,s') => (Rval [v],s')
    | Rerr err => (Rerr err,s'))`,
  srw_tac[][] >>
+ Cases_on `op = ConfigGC` THEN1
+  (Cases_on `do_app op (REVERSE vs) s` >>
+   `?v s'. a = (v,s')` by metis_tac [pair_CASES] >>
+   srw_tac[][] >>
+   srw_tac[][res_rel_rw] >>
+   fs[do_app_cases_val,do_app_cases_err] >> rw[] >>
+   TRY (Cases_on `e`) >>
+   srw_tac[][res_rel_rw] >>
+   fs [do_app_cases_err] >>
+   TRY (Cases_on `a`) >>
+   full_simp_tac(srw_ss())[res_rel_rw] >>
+   fs [do_app_cases_timeout] >>
+   full_simp_tac(srw_ss())[] >>
+   fs[SWAP_REVERSE_SYM] >> rveq >> fs [] >>
+   full_simp_tac(srw_ss())[do_app_def, val_rel_rw] >>
+   Cases_on `y` >>
+   full_simp_tac(srw_ss())[do_app_def, val_rel_rw] >>
+   Cases_on `y'` >>
+   full_simp_tac(srw_ss())[do_app_def, val_rel_rw,Unit_def]) >>
  Cases_on `do_app op (REVERSE vs) s`
  >- (`?v s'. a = (v,s')` by metis_tac [pair_CASES] >>
      srw_tac[][] >>

--- a/compiler/backend/semantics/conSemScript.sml
+++ b/compiler/backend/semantics/conSemScript.sml
@@ -384,6 +384,8 @@ val do_app_def = Define `
             | NONE => NONE
             | SOME s' => SOME ((s',t), Rval (Conv NONE [])))
      | _ => NONE)
+  | (ConfigGC, [Litv (IntLit n1); Litv (IntLit n2)]) =>
+       SOME ((s,t), Rval (Conv NONE []))
   | (FFI n, [Litv (StrLit conf); Loc lnum]) =>
     (case store_lookup lnum s of
      | SOME (W8array ws) =>

--- a/compiler/backend/semantics/exhSemScript.sml
+++ b/compiler/backend/semantics/exhSemScript.sml
@@ -422,6 +422,8 @@ val do_app_def = Define `
             | NONE => NONE
             | SOME s' => SOME (s with refs := s', Rval (Conv tuple_tag [])))
      | _ => NONE)
+  | (ConfigGC, [Litv (IntLit n1); Litv (IntLit n2)]) =>
+       SOME (s, Rval (Conv tuple_tag []))
   | (FFI n, [Litv (StrLit conf); Loc lnum]) =>
     (case store_lookup lnum s.refs of
      | SOME (W8array ws) =>

--- a/compiler/backend/semantics/modSemScript.sml
+++ b/compiler/backend/semantics/modSemScript.sml
@@ -371,6 +371,8 @@ val do_app_def = Define `
             | NONE => NONE
             | SOME s' => SOME ((s',t), Rval (Conv NONE [])))
      | _ => NONE)
+  | (ConfigGC, [Litv (IntLit n1); Litv (IntLit n2)]) =>
+       SOME ((s,t), Rval (Conv NONE []))
   | (FFI n, [Litv(StrLit conf); Loc lnum]) =>
     (case store_lookup lnum s of
      | SOME (W8array ws) =>

--- a/compiler/backend/semantics/patSemScript.sml
+++ b/compiler/backend/semantics/patSemScript.sml
@@ -265,7 +265,6 @@ val do_app_def = Define `
                 SOME s' => SOME (s with refs := s', Rval (Conv tuple_tag []))
               | _ => NONE))
       | _ => NONE)
-
     | (Op (Op Ord), [Litv (Char c)]) =>
           SOME (s, Rval (Litv(IntLit(int_of_num(ORD c)))))
     | (Op (Op Chr), [Litv (IntLit i)]) =>
@@ -361,6 +360,8 @@ val do_app_def = Define `
                   )
         | _ => NONE
       )
+    | (Op (Op ConfigGC), [Litv (IntLit n1); Litv (IntLit n2)]) =>
+         SOME (s, Rval (Conv tuple_tag []))
     | (Op (Op (FFI n)), [Litv (StrLit conf); Loc lnum]) =>
         (case store_lookup lnum s.refs of
           SOME (W8array ws) =>

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -86,6 +86,7 @@ val astOp_to_modOp_def = Define `
   | Asub => modLang$Asub
   | Alength => modLang$Alength
   | Aupdate => modLang$Aupdate
+  | ConfigGC => modLang$ConfigGC
   | FFI string => modLang$FFI string`;
 
 (* The traces are passed along without being split for most expressions, since we

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -292,7 +292,7 @@ val pr_CASE = Q.prove(
   SRW_TAC [] []);
 
 val op_apply = Q.prove(
-  `!op. (ast$op_CASE op x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38) y =
+  `!op. (ast$op_CASE op x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39) y =
          (ast$op_CASE op
             (* Opn 1 *)
             (\z. x1 z y)
@@ -368,8 +368,10 @@ val op_apply = Q.prove(
             (x36 y)
             (* Aupdate *)
             (x37 y)
+            (* ConfigGC *)
+            (x38 y)
             (* FFI *)
-            (\z. x38 z y))`,
+            (\z. x39 z y))`,
   Cases THEN SRW_TAC [] []);
 
 val list_apply = Q.prove(

--- a/compiler/inference/inferScript.sml
+++ b/compiler/inference/inferScript.sml
@@ -434,9 +434,14 @@ constrain_op l op ts =
           () <- add_constraint l t2 (Infer_Tapp [] TC_int);
           return (Infer_Tapp [] TC_tup)
        od
+   | (ConfigGC, [t1;t2]) =>
+       do () <- add_constraint l t1 (Infer_Tapp [] TC_int);
+          () <- add_constraint l t2 (Infer_Tapp [] TC_int);
+          return (Infer_Tapp [] TC_tup)
+       od
    | (FFI n, [t1;t2]) =>
        do () <- add_constraint l t1 (Infer_Tapp [] TC_string);
-          () <- add_constraint l t2 (Infer_Tapp [] TC_word8array);          
+          () <- add_constraint l t2 (Infer_Tapp [] TC_word8array);
           return (Infer_Tapp [] TC_tup)
        od
    | _ => failwith l (implode "Wrong number of arguments to primitive")`;

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -536,7 +536,8 @@ val sexpop_def = Define`
   if s = "AallocEmpty" then SOME AallocEmpty else
   if s = "Asub" then SOME Asub else
   if s = "Alength" then SOME Alength else
-  if s = "Aupdate" then SOME Aupdate else NONE) ∧
+  if s = "Aupdate" then SOME Aupdate else
+  if s = "ConfigGC" then SOME ConfigGC else NONE) ∧
   (sexpop (SX_CONS (SX_SYM s) (SX_STR s')) =
      if s = "FFI" then OPTION_MAP FFI (decode_control s') else NONE
    ) ∧
@@ -913,6 +914,7 @@ val opsexp_def = Define`
   (opsexp Asub = SX_SYM "Asub") ∧
   (opsexp Alength = SX_SYM "Alength") ∧
   (opsexp Aupdate = SX_SYM "Aupdate") ∧
+  (opsexp ConfigGC = SX_SYM "ConfigGC") ∧
   (opsexp (FFI s) = SX_CONS (SX_SYM "FFI") (SEXSTR s))`;
 
 (* TODO: This proof is not very scalable... *)

--- a/semantics/ast.lem
+++ b/semantics/ast.lem
@@ -84,6 +84,8 @@ type op =
   | Asub
   | Alength
   | Aupdate
+  (* Configure the GC *)
+  | ConfigGC
   (* Call a given foreign function *)
   | FFI of string
 

--- a/semantics/astScript.sml
+++ b/semantics/astScript.sml
@@ -108,6 +108,8 @@ val _ = Hol_datatype `
   | Asub
   | Alength
   | Aupdate
+  (* Configure the GC *)
+  | ConfigGC
   (* Call a given foreign function *)
   | FFI of string`;
 

--- a/semantics/semanticPrimitives.lem
+++ b/semantics/semanticPrimitives.lem
@@ -683,6 +683,8 @@ let do_app ((s:store v),(t:ffi_state 'ffi)) op vs =
                   end
         | _ -> Nothing
       end
+    | (ConfigGC, [Litv (IntLit i); Litv (IntLit j)]) ->
+        Just ((s,t), Rval (Conv Nothing []))
     | (FFI n, [Litv(StrLit conf); Loc lnum]) ->
         match store_lookup lnum s with
         | Just (W8array ws) ->

--- a/semantics/semanticPrimitivesScript.sml
+++ b/semantics/semanticPrimitivesScript.sml
@@ -783,6 +783,8 @@ val _ = Define `
                   )
         | _ => NONE
       )
+    | (ConfigGC, [Litv (IntLit i); Litv (IntLit j)]) =>
+        SOME ((s,t), Rval (Conv NONE []))
     | (FFI n, [Litv(StrLit conf); Loc lnum]) =>
         (case store_lookup lnum s of
           SOME (W8array ws) =>

--- a/semantics/typeSystem.lem
+++ b/semantics/typeSystem.lem
@@ -232,6 +232,7 @@ let type_op op ts t =
     | (Asub, [Tapp [t1] TC_array; Tapp [] TC_int]) -> t = t1
     | (Alength, [Tapp [t1] TC_array]) -> t = Tapp [] TC_int
     | (Aupdate, [Tapp [t1] TC_array; Tapp [] TC_int; t2]) -> t1 = t2 && t = Tapp [] TC_tup
+    | (ConfigGC, [Tapp [] TC_int; Tapp [] TC_int]) -> t = Tapp [] TC_tup
     | (FFI n, [Tapp [] TC_string; Tapp [] TC_word8array]) -> t = Tapp [] TC_tup
     | _ -> false
   end

--- a/semantics/typeSystemScript.sml
+++ b/semantics/typeSystemScript.sml
@@ -276,6 +276,7 @@ val _ = Define `
     | (Asub, [Tapp [t1] TC_array; Tapp [] TC_int]) => t = t1
     | (Alength, [Tapp [t1] TC_array]) => t = Tapp [] TC_int
     | (Aupdate, [Tapp [t1] TC_array; Tapp [] TC_int; t2]) => (t1 = t2) /\ (t = Tapp [] TC_tup)
+    | (ConfigGC, [Tapp [] TC_int; Tapp [] TC_int]) => t = Tapp [] TC_tup
     | (FFI n, [Tapp [] TC_string; Tapp [] TC_word8array]) => t = Tapp [] TC_tup
     | _ => F
   )))`;

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -2352,6 +2352,7 @@ val builtin_binops =
    Eval_INT_LESS_EQ,
    Eval_INT_GREATER,
    Eval_INT_GREATER_EQ,
+   Eval_force_gc_to_run,
    Eval_strsub,
    Eval_sub,
    Eval_And,

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -1487,6 +1487,44 @@ val Eval_length = Q.store_thm("Eval_length",
   rw [] >>
   fs [VECTOR_TYPE_def, length_def, NUM_def, INT_def]);
 
+val Eval_length = Q.store_thm("Eval_length",
+  `!env x1 x2 a n v.
+      Eval env x1 (VECTOR_TYPE a v) ==>
+      Eval env (App Vlength [x1]) (NUM (length v))`,
+  rw [Eval_def] >>
+  rw [Once evaluate_cases,PULL_EXISTS,empty_state_with_refs_eq] >>
+  ntac 3 (rw [Once (hd (tl (CONJUNCTS evaluate_cases))),PULL_EXISTS]) >>
+  first_x_assum(qspec_then`refs`strip_assume_tac) >>
+  CONV_TAC(RESORT_EXISTS_CONV(sort_vars["ffi"])) >>
+  qexists_tac`empty_state.ffi` \\ simp[empty_state_with_ffi_elim] >>
+  asm_exists_tac >> fs[] >>
+  rw [do_app_cases] >>
+  rw [PULL_EXISTS] >>
+  `?l. v = Vector l` by metis_tac [vector_nchotomy] >>
+  rw [] >>
+  fs [VECTOR_TYPE_def, length_def, NUM_def, INT_def]);
+
+val force_gc_to_run_def = Define `
+  force_gc_to_run (i1:int) (i2:int) = ()`;
+
+val Eval_force_gc_to_run = Q.store_thm("Eval_force_gc_to_run",
+  `Eval env x1 (INT i1) ==>
+   Eval env x2 (INT i2) ==>
+   Eval env (App ConfigGC [x1; x2]) (UNIT_TYPE (force_gc_to_run i1 i2))`,
+  rw [Eval_def] >>
+  rw [Once evaluate_cases,PULL_EXISTS,empty_state_with_refs_eq] >>
+  ntac 3 (rw [Once (hd (tl (CONJUNCTS evaluate_cases))),PULL_EXISTS]) >>
+  first_x_assum(qspec_then`refs`strip_assume_tac) >>
+  asm_exists_tac >> fs [] >>
+  first_x_assum(qspec_then`refs ++ refs'`strip_assume_tac) >>
+  qexists_tac `Conv NONE []` >>
+  qexists_tac `refs' ⧺ refs''` >>
+  qexists_tac `refs ++ refs' ⧺ refs''` >>
+  fs [empty_state_def] >>
+  asm_exists_tac >> fs [] >>
+  fs [do_app_def,INT_def,UNIT_TYPE_def]);
+
+
 (* a few misc. lemmas that help the automation *)
 
 val IMP_PreImp = Q.store_thm("IMP_PreImp",


### PR DESCRIPTION
By calling `Runtime.fullGC()`, the user can force the GC to run. 

Later the underlying primitive will be made more versatile, e.g. a program might use a later version of this primitive to switch GC algorithm at run time (simple ⇄ generational) and possibly change the size of the nursery in the generational collector.

This new GC-configuring primitive has no observable effect at the level of the source semantics.