### PR TITLE
Extend FFI type used for CF assertions

### DIFF
--- a/basis/CommandlineProofScript.sml
+++ b/basis/CommandlineProofScript.sml
@@ -65,9 +65,9 @@ val Commandline_cline_spec = Q.store_thm("Commandline_cline_spec",
     \\ qmatch_goalsub_abbrev_tac`IO s u ns`
     \\ map_every qexists_tac [`emp`, `s`, `s`, `u`, `ns`]
     \\ xsimpl
-    \\ fs[Abbr`u`,Abbr`ns`,cfHeapsBaseTheory.mk_ffi_next_def,ffi_getArgs_def,decode_def,GSYM cfHeapsBaseTheory.encode_list_def]
+    \\ fs[Abbr`u`,Abbr`ns`,cfHeapsBaseTheory.mk_ffi_next_def,ffi_getArgs_def,GSYM cfHeapsBaseTheory.encode_list_def,Abbr`s`]
     \\ simp[EVERY_MAP, LENGTH_REPLICATE, Abbr`l`]
-    \\ rw[Abbr`s`,encode_def] \\ fs[EVERY_REPLICATE])
+    \\ rw[encode_def] \\ fs[EVERY_REPLICATE])
   \\ xfun_spec`foo``∀c cv. CHAR c cv ⇒ app p foo [cv] emp (POSTv v. &(BOOL (CHR 0 = c) v))`
   >- (
     rw[]
@@ -108,8 +108,7 @@ val Commandline_cline_spec = Q.store_thm("Commandline_cline_spec",
   \\ DEP_REWRITE_TAC[FILTER_EQ_ID |> SPEC_ALL |> EQ_IMP_RULE |> #2]
   \\ simp[EVERY_MAP,NULL_EQ]
   \\ DEP_REWRITE_TAC[TOKENS_FLAT_MAP_SNOC]
-  \\ fs[EVERY_SNOC,validArg_def,EVERY_MEM,NULL_EQ,MAP_SNOC]
-);
+  \\ fs[EVERY_SNOC,validArg_def,EVERY_MEM,NULL_EQ,MAP_SNOC]);
 
 val hd_v_thm = fetch "ListProg" "hd_v_thm";
 val mlstring_hd_v_thm = hd_v_thm |> INST_TYPE [alpha |-> mlstringSyntax.mlstring_ty]

--- a/basis/TextIOProofScript.sml
+++ b/basis/TextIOProofScript.sml
@@ -17,7 +17,7 @@ val IOFS_iobuff_def = Define`
     SEP_EXISTS v. W8ARRAY iobuff_loc v * cond (LENGTH v = 258) `;
 
 val IOFS_def = Define `
-  IOFS fs = IOx fs_ffi_part fs * IOFS_iobuff * &wfFS fs`
+  IOFS fs = IOx (fs_ffi_part) fs * IOFS_iobuff * &wfFS fs`
 
 val UNIQUE_IOFS = Q.store_thm("UNIQUE_IOFS",
 `!s. VALID_HEAP s ==> !fs1 fs2 H1 H2. (IOFS fs1 * H1) s /\
@@ -25,7 +25,7 @@ val UNIQUE_IOFS = Q.store_thm("UNIQUE_IOFS",
   rw[IOFS_def,cfHeapsBaseTheory.IOx_def, fs_ffi_part_def,
      GSYM STAR_ASSOC,encode_def] >>
   IMP_RES_TAC FRAME_UNIQUE_IO >>
-  fs[encode_files_11,encode_fds_11,IO_fs_component_equality]);
+  fs[IO_fs_component_equality]);
 
 val IOFS_FFI_part_hprop = Q.store_thm("IOFS_FFI_part_hprop",
   `FFI_part_hprop (IOFS fs)`,
@@ -477,7 +477,7 @@ val openIn_spec = Q.store_thm(
         map_every qexists_tac[`ns`,`f`,`encode (openFileFS s fs 0)`,`st`]
         >> xsimpl >>
         simp[Abbr`f`,Abbr`st`,Abbr`ns`, mk_ffi_next_def,
-             ffi_open_in_def, decode_encode_FS, Abbr`fnm`,
+             ffi_open_in_def, (* decode_encode_FS, *) Abbr`fnm`,
              getNullTermStr_insert_atI, MEM_MAP, ORD_BOUND, ORD_eq_0,
              dimword_8, MAP_MAP_o, o_DEF, char_BIJ,
              implode_explode, LENGTH_explode] >>
@@ -513,7 +513,7 @@ val openIn_spec = Q.store_thm(
       CONV_TAC(RESORT_EXISTS_CONV List.rev) >>
       map_every qexists_tac[`ns`,`f`,`st`,`st`] >> xsimpl >>
       simp[Abbr`f`,Abbr`st`,Abbr`ns`, mk_ffi_next_def,
-	   ffi_open_in_def, decode_encode_FS, Abbr`fnm`,
+	   ffi_open_in_def, (* decode_encode_FS, *) Abbr`fnm`,
 	   getNullTermStr_insert_atI, MEM_MAP, ORD_BOUND, ORD_eq_0,
 	   dimword_8, MAP_MAP_o, o_DEF, char_BIJ,
 	   implode_explode, LENGTH_explode] >>
@@ -577,7 +577,7 @@ val close_spec = Q.store_thm(
      CONV_TAC(RESORT_EXISTS_CONV List.rev) >>
      map_every qexists_tac[`ns`,`f`,`encode fs'`,`st`] >> xsimpl >>
      unabbrev_all_tac >> CASE_TAC >> rw[] >>
-     fs[mk_ffi_next_def, ffi_close_def, decode_encode_FS,
+     fs[mk_ffi_next_def, ffi_close_def, (* decode_encode_FS, *)
         getNullTermStr_insert_atI, ORD_BOUND, ORD_eq_0,option_eq_some,
         dimword_8, MAP_MAP_o, o_DEF, char_BIJ,
         implode_explode, LENGTH_explode,closeFD_def,LUPDATE_def] >>
@@ -653,7 +653,7 @@ val writei_spec = Q.store_thm("writei_spec",
         CONV_TAC(RESORT_EXISTS_CONV List.rev) >>
         map_every qexists_tac[`ns`,`f`,`encode fs'`,`st`] >> xsimpl >>
         fs[Abbr`f`,Abbr`st`,Abbr`ns`,mk_ffi_next_def,
-           ffi_write_def,decode_encode_FS,MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
+           ffi_write_def,(* decode_encode_FS, *)MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
            dimword_8, MAP_MAP_o,o_DEF,char_BIJ,implode_explode,LENGTH_explode,
            HD_LUPDATE,LUPDATE_def,option_eq_some,validFD_def,write_def,
            get_file_content_def] >>
@@ -687,7 +687,7 @@ val writei_spec = Q.store_thm("writei_spec",
      CONV_TAC(RESORT_EXISTS_CONV List.rev) >>
      map_every qexists_tac[`ns`,`f`,`encode fs'`,`st`] >> xsimpl >>
      fs[Abbr`f`,Abbr`st`,Abbr`ns`,mk_ffi_next_def,
-        ffi_write_def,decode_encode_FS,MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
+        ffi_write_def,(* decode_encode_FS, *)MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
         dimword_8, MAP_MAP_o,o_DEF,char_BIJ,implode_explode,LENGTH_explode,
         HD_LUPDATE,LUPDATE_def,option_eq_some,validFD_def,write_def,
         get_file_content_def] >>
@@ -940,7 +940,7 @@ val read_spec = Q.store_thm("read_spec",
          map_every qexists_tac[`ns`,`f`] >>
          xsimpl >>
          fs[Abbr`f`,Abbr`st`,Abbr`ns`,mk_ffi_next_def, ffi_read_def,
-            decode_encode_FS,MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
+            (* decode_encode_FS, *)MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
             dimword_8, MAP_MAP_o,o_DEF,char_BIJ,implode_explode,LENGTH_explode,
             HD_LUPDATE,LUPDATE_def,option_eq_some,validFD_def,read_def,
             get_file_content_def,n2w_w2n,w2n_n2w] >> rfs[] >>
@@ -964,7 +964,7 @@ val read_spec = Q.store_thm("read_spec",
       map_every qexists_tac[`ns`,`f`] >>
       xsimpl >>
       fs[Abbr`f`,Abbr`st`,Abbr`ns`,mk_ffi_next_def,
-         ffi_read_def,decode_encode_FS,MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
+         ffi_read_def,(* decode_encode_FS, *)MEM_MAP, ORD_BOUND,ORD_eq_0,wfFS_LDROP,
          dimword_8, MAP_MAP_o,o_DEF,char_BIJ,implode_explode,LENGTH_explode,
          HD_LUPDATE,LUPDATE_def,option_eq_some,validFD_def,read_def,
          get_file_content_def] >> rfs[] >>

--- a/basis/basis_ffiScript.sml
+++ b/basis/basis_ffiScript.sml
@@ -154,7 +154,7 @@ val RTC_call_FFI_rel_IMP_basis_events = Q.store_thm ("RTC_call_FFI_rel_IMP_basis
    extract_fs fs st'.io_events
      = fsFFI$decode (basis_proj1 st'.ffi_state ' "write"))`,
      strip_tac
-  \\ HO_MATCH_MP_TAC RTC_INDUCT \\ rw [] \\ fs [fsFFITheory.decode_def]
+  \\ HO_MATCH_MP_TAC RTC_INDUCT \\ rw [] \\ fs []
   \\ fs [evaluatePropsTheory.call_FFI_rel_def]
   \\ fs [ffiTheory.call_FFI_def]
   \\ Cases_on `st.final_event = NONE` \\ fs [] \\ rw []

--- a/basis/clFFIScript.sml
+++ b/basis/clFFIScript.sml
@@ -41,11 +41,16 @@ val ffi_getArgs_length = Q.store_thm("ffi_getArgs_length",
 (* FFI part for the commandline *)
 
 val encode_def = Define`encode = encode_list Str`;
-val decode_def = Define`decode = decode_list destStr`;
 
-val decode_encode = Q.store_thm("decode_encode[simp]",
-  `decode (encode cls) = SOME cls`,
-  EVAL_TAC \\ simp[OPT_MMAP_MAP_o]);
+val encode_11 = prove(
+  ``!x y. encode x = encode y <=> x = y``,
+  Induct \\ Cases_on `y`
+  \\ fs [encode_list_def,encode_def]);
+
+val decode_encode = new_specification("decode_encode",["decode"],
+  prove(``?decode. !cls. decode (encode cls) = SOME cls``,
+        qexists_tac `\f. some c. encode c = f` \\ fs [encode_11]));
+val _ = export_rewrites ["decode_encode"];
 
 val cl_ffi_part_def = Define`
   cl_ffi_part = (encode,decode,[("getArgs",ffi_getArgs)])`;

--- a/basis/fsFFIPropsScript.sml
+++ b/basis/fsFFIPropsScript.sml
@@ -277,51 +277,6 @@ val inFS_fname_numchars = Q.store_thm("inFS_fname_numchars",
  `!s fs ll. inFS_fname (fs with numchars := ll) s = inFS_fname fs s`,
   rw[] >> EVAL_TAC >> rpt(CASE_TAC >> fs[]));
 
-(* encode/ decode *)
-
-val decode_encode_inode = Q.store_thm(
-  "decode_encode_inode",
-  `∀f. decode_inode (encode_inode f) = return f`,
-  strip_tac >> cases_on`f` >>
-  rw[encode_inode_def, decode_inode_def] >>
-  rpt CASE_TAC >> fs[decode_pair_def]);
-
-val decode_encode_files = Q.store_thm(
-  "decode_encode_files",
-  `∀l. decode_files (encode_files l) = return l`,
-  rw[encode_files_def, decode_files_def] >>
-  match_mp_tac decode_encode_list >>
-  match_mp_tac decode_encode_pair >>
-  simp[implode_explode,decode_encode_inode]);
-
-val encode_files_11 = Q.store_thm("encode_files_11",
-  `encode_files l1 = encode_files l2 ⇒ l1 = l2`,
-  rw[] >>
-  `decode_files (encode_files l1) = decode_files(encode_files l2)` by fs[] >>
-  fs[decode_encode_files]);
-
-val decode_encode_fds = Q.store_thm(
-  "decode_encode_fds",
-  `decode_fds (encode_fds fds) = return fds`,
-  simp[decode_fds_def, encode_fds_def] >>
-  simp[decode_encode_list, decode_encode_pair,decode_encode_inode]);
-
-val encode_fds_11 = Q.store_thm("encode_fds_11",
-  `encode_fds l1 = encode_fds l2 ⇒ l1 = l2`,
-  rw[] >> `decode_fds (encode_fds l1) = decode_fds(encode_fds l2)` by fs[] >>
-  fs[decode_encode_fds]);
-
-val decode_encode_FS = Q.store_thm(
-  "decode_encode_FS[simp]",
-  `decode (encode fs) = return fs`,
-  simp[decode_def, encode_def, decode_encode_files, decode_encode_fds] >>
-  simp[IO_fs_component_equality]);
-
-val encode_11 = Q.store_thm(
-  "encode_11[simp]",
-  `encode fs1 = encode fs2 ⇔ fs1 = fs2`,
-  metis_tac[decode_encode_FS, SOME_11]);
-
 (* ffi lengths *)
 
 val ffi_open_in_length = Q.store_thm("ffi_open_in_length",

--- a/characteristic/cfFFITypeScript.sml
+++ b/characteristic/cfFFITypeScript.sml
@@ -225,12 +225,6 @@ val destSeq_def = new_specification("destSeq_def",["destSeq"],prove(``
   \\ fs [] \\ rw [] \\ EVAL_TAC));
 val _ = export_rewrites ["destSeq_def"];
 
-val encode_pair_def = Define`
-  encode_pair e1 e2 (x,y) = Cons (e1 x) (e2 y)`;
-
-val encode_list_def = Define`
-  encode_list e l = List (MAP e l)`;
-
 (*
 
 val decode_pair_def = Define`
@@ -258,13 +252,5 @@ val decode_encode_list = Q.store_thm(
   simp[OPT_MMAP_def]);
 
 *)
-
-(* make an ffi_next function from base functions and encode/decode *)
-val mk_ffi_next_def = Define`
-  mk_ffi_next (encode,decode,ls) name conf bytes s =
-    OPTION_BIND (ALOOKUP ls name) (λf.
-    OPTION_BIND (decode s) (λs.
-    OPTION_BIND (f conf bytes s) (λ(bytes,s).
-    SOME (bytes,encode s))))`;
 
 val _ = export_theory()

--- a/characteristic/cfFFITypeScript.sml
+++ b/characteristic/cfFFITypeScript.sml
@@ -28,25 +28,25 @@ val _ = type_abbrev("ffi",``:num -> inner_ffi``)
 
 (* constructors *)
 
-val Num_def = Define `
+val Num_def = zDefine `
   ((Num i):ffi) =
     \n. if n = 0 then iNum 0 else iNum i`
 
-val Str_def = Define `
+val Str_def = zDefine `
   ((Str i):ffi) =
     \n. if n = 0 then iNum 1 else iStr i`
 
-val Cons_def = Define `
+val Cons_def = zDefine `
   ((Cons (x:ffi) (y:ffi)):ffi) =
     \n. if n = 0 then iNum 2 else
           let n = n - 1 in
             if EVEN n then x (n DIV 2) else y (n DIV 2)`
 
-val List_def = Define `
+val List_def = zDefine `
   ((List (xs:ffi list)):ffi) =
     \n. if n = 0 then iNum 3 else FOLDR Cons (Num 0) xs (n-1) `
 
-val Stream_def = Define `
+val Stream_def = zDefine `
   ((Stream i):ffi) =
     \n. if n = 0 then iNum 4 else iStream i`
 
@@ -56,7 +56,7 @@ val factor_count_def = Define `
     if n = 0n then 0 else
     if n MOD k = 0 then 1 + factor_count k (n DIV k) else 0`
 
-val Seq_def = Define `
+val Seq_def = zDefine `
   ((Seq (f:num -> ffi)):ffi) =
     \n. if n = 0 then iNum 5 else
           let n = n - 1 in
@@ -94,7 +94,7 @@ val Cons_11 = store_thm("Cons_11[simp]",
 
 val Cons_NOT_Num = prove(
   ``Cons x y <> Num z``,
-  fs [FUN_EQ_THM] \\ qexists_tac `0` \\ EVAL_TAC);
+  fs [FUN_EQ_THM] \\ qexists_tac `0` \\ fs [Cons_def,Num_def]);
 
 val List_11 = store_thm("List_11[simp]",
   ``!xs ys. List xs = List ys <=> xs = ys``,
@@ -142,7 +142,8 @@ val Seq_11 = store_thm("Seq_11[simp]",
 
 val ffi_distinct = prove(
   ``ALL_DISTINCT [Num n; Str s; Cons x y; List l; Stream ll; Seq f]``,
-  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `0` \\ EVAL_TAC)
+  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `0`
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def])
   |> SIMP_RULE std_ss [ALL_DISTINCT,MEM,GSYM CONJ_ASSOC] |> GEN_ALL
   |> curry save_thm "ffi_distinct[simp]";
 
@@ -157,7 +158,7 @@ val destNum_def = new_specification("destNum_def",["destNum"],prove(``
     (!ll. destNum (Stream ll) = NONE) /\
     (!f. destNum (Seq f) = NONE)``,
   qexists_tac `\f. if f 0 = iNum 0 then SOME (@n. Num n = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC));
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
 val _ = export_rewrites ["destNum_def"];
 
 val destStr_def = new_specification("destStr_def",["destStr"],prove(``
@@ -169,7 +170,7 @@ val destStr_def = new_specification("destStr_def",["destStr"],prove(``
     (!ll. destStr (Stream ll) = NONE) /\
     (!f. destStr (Seq f) = NONE)``,
   qexists_tac `\f. if f 0 = iNum 1 then SOME (@n. Str n = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC));
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
 val _ = export_rewrites ["destStr_def"];
 
 val destStr_o_Str = Q.store_thm("destStr_o_Str[simp]",
@@ -184,7 +185,7 @@ val destCons_def = new_specification("destCons_def",["destCons"],prove(``
     (!ll. destCons (Stream ll) = NONE) /\
     (!f. destCons (Seq f) = NONE)``,
   qexists_tac `\f. if f 0 = iNum 2 then SOME (@n. Cons (FST n) (SND n) = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]
   \\ `!n. FST n = x ∧ SND n = y <=> n = (x,y)` by fs [FORALL_PROD]
   \\ asm_rewrite_tac [] \\ fs []));
 val _ = export_rewrites ["destCons_def"];
@@ -198,7 +199,7 @@ val destList_def = new_specification("destList_def",["destList"],prove(``
     (!ll. destList (Stream ll) = NONE) /\
     (!f. destList (Seq f) = NONE)``,
   qexists_tac `\f. if f 0 = iNum 3 then SOME (@n. List n = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC));
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
 val _ = export_rewrites ["destList_def"];
 
 val destStream_def = new_specification("destStream_def",["destStream"],prove(``
@@ -210,7 +211,7 @@ val destStream_def = new_specification("destStream_def",["destStream"],prove(``
     (!ll. destStream (Stream ll) = SOME ll) /\
     (!f. destStream (Seq f) = NONE)``,
   qexists_tac `\f. if f 0 = iNum 4 then SOME (@n. Stream n = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC));
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
 val _ = export_rewrites ["destStream_def"];
 
 val destSeq_def = new_specification("destSeq_def",["destSeq"],prove(``
@@ -222,35 +223,7 @@ val destSeq_def = new_specification("destSeq_def",["destSeq"],prove(``
     (!ll. destSeq (Stream ll) = NONE) /\
     (!f. destSeq (Seq f) = SOME f)``,
   qexists_tac `\f. if f 0 = iNum 5 then SOME (@n. Seq n = f) else NONE`
-  \\ fs [] \\ rw [] \\ EVAL_TAC));
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
 val _ = export_rewrites ["destSeq_def"];
-
-(*
-
-val decode_pair_def = Define`
-  (decode_pair d1 d2 (Cons f1 f2) =
-      OPTION_BIND (d1 f1)
-      (λx. OPTION_BIND (d2 f2)
-      (λy. SOME (x,y)))) ∧
-  (decode_pair _ _ _ = NONE)`;
-
-val decode_encode_pair = Q.store_thm(
-  "decode_encode_pair",
-  `(∀x. d1 (e1 x) = SOME x) ∧ (∀y. d2 (e2 y) = SOME y) ⇒
-   ∀p. decode_pair d1 d2 (encode_pair e1 e2 p) = SOME p`,
-  strip_tac >> Cases >> simp[encode_pair_def, decode_pair_def]);
-
-val decode_list_def = Define`
-  (decode_list d (List fs) = OPT_MMAP d fs) ∧
-  (decode_list d _ = NONE)`;
-
-val decode_encode_list = Q.store_thm(
-  "decode_encode_list[simp]",
-  `(∀x. d (e x) = SOME x) ⇒
-   ∀l. decode_list d (encode_list e l) = SOME l`,
-  strip_tac >> simp[decode_list_def, encode_list_def] >> Induct >>
-  simp[OPT_MMAP_def]);
-
-*)
 
 val _ = export_theory()

--- a/characteristic/cfFFITypeScript.sml
+++ b/characteristic/cfFFITypeScript.sml
@@ -4,8 +4,7 @@ val _ = new_theory "cfFFIType"
 
 (*
 
-This file defines a type (abbreviation) that behaves like the
-following type:
+This file defines a type that behaves like the following type:
 
   ffi = Str string
       | Num num
@@ -20,7 +19,8 @@ following type:
             | iList (ffi_inner list)
             | iStream (num llist)
 
-The type is missing a cases thm and an ind thm.
+The ffi type is missing an nchotomy thm and an induction thm, but the
+important injectivity (suffix: "_11") are here.
 
 *)
 
@@ -31,59 +31,48 @@ val _ = Datatype `
             | iList (ffi_inner list)
             | iStream (num llist)`
 
-val _ = type_abbrev("ffi",``:ffi_inner -> ffi_inner``)
+val _ = Datatype `
+  ffi = FFI_TYPE (ffi_inner -> ffi_inner)`
+
+val ffi_app_def = Define `
+  ffi_app x n = case x of FFI_TYPE f => f n`;
 
 (* constructors *)
 
 val Num_def = zDefine `
   ((Num i):ffi) =
-    \n. if n = iNum 0 then iNum 0 else iNum i`
+    FFI_TYPE (\n. if n = iNum 0 then iNum 0 else iNum i)`
 
 val Str_def = zDefine `
   ((Str i):ffi) =
-    \n. if n = iNum 0 then iNum 1 else iStr i`
+    FFI_TYPE (\n. if n = iNum 0 then iNum 1 else iStr i)`
 
 val Cons_def = zDefine `
   ((Cons (x:ffi) (y:ffi)):ffi) =
-    \n. if n = iNum 0 then iNum 2 else
-          case n of
-          | iCons (iNum 0) m => x m
-          | iCons (iNum 1) m => y m
-          | _ => iNum 0`
+    FFI_TYPE (\n. if n = iNum 0 then iNum 2 else
+                    case n of
+                    | iCons (iNum 0) m => ffi_app x m
+                    | iCons (iNum 1) m => ffi_app y m
+                    | _ => iNum 0)`
 
 val List_def = zDefine `
   ((List (xs:ffi list)):ffi) =
-    \n. if n = iNum 0 then iNum 3 else
-        if n = iNum 1 then iNum (LENGTH xs) else
-          case n of
-          | iCons (iNum k) m => EL k xs m
-          | _ => iNum 0`
+    FFI_TYPE (\n. if n = iNum 0 then iNum 3 else
+                  if n = iNum 1 then iNum (LENGTH xs) else
+                    case n of
+                    | iCons (iNum k) m => ffi_app (EL k xs) m
+                    | _ => iNum 0)`
 
 val Stream_def = zDefine `
   ((Stream i):ffi) =
-    \n. if n = iNum 0 then iNum 4 else iStream i`
+    FFI_TYPE (\n. if n = iNum 0 then iNum 4 else iStream i)`
 
 val Fun_def = zDefine `
   ((Fun (f:ffi_inner -> ffi)):ffi) =
-    \n. if n = iNum 0 then iNum 5 else
-          case n of
-          | iCons x y => f x y
-          | _ => iNum 0`;
-
-(*
-
-val factor_count_def = Define `
-  factor_count k n =
-    if k <= 1 then 0n else
-    if n = 0n then 0 else
-    if n MOD k = 0 then 1 + factor_count k (n DIV k) else 0`
-
-val Fun_def = zDefine `
-  ((Fun (f:num -> ffi)):ffi) =
-    \n. if n = 0 then iNum 5 else
-          let n = n - 1 in
-            f (factor_count 2 n) (factor_count 3 n)`;
-*)
+    FFI_TYPE (\n. if n = iNum 0 then iNum 5 else
+                    case n of
+                    | iCons x y => ffi_app (f x) y
+                    | _ => iNum 0)`;
 
 (* injectivity *)
 
@@ -99,7 +88,8 @@ val Str_11 = store_thm("Str_11[simp]",
 
 val Cons_11 = store_thm("Cons_11[simp]",
   ``!x1 x2 y1 y2. Cons x1 x2 = Cons y1 y2 <=> x1 = y1 /\ x2 = y2``,
-  fs [Cons_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  rpt Cases
+  \\ fs [Cons_def,FUN_EQ_THM,ffi_app_def] \\ rw [] \\ eq_tac \\ rw []
   THEN1 (pop_assum (qspec_then `iCons (iNum 0) x` mp_tac) \\ fs [])
   THEN1 (pop_assum (qspec_then `iCons (iNum 1) x` mp_tac) \\ fs []));
 
@@ -108,9 +98,11 @@ val List_11 = store_thm("List_11[simp]",
   fs [List_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
   \\ fs [LIST_EQ_REWRITE] \\ rw []
   THEN1 (pop_assum (qspec_then `iNum 1` mp_tac) \\ fs [])
+  \\ Cases_on `EL x xs`
+  \\ Cases_on `EL x ys`
   \\ fs [FUN_EQ_THM] \\ rw []
-  \\ qmatch_goalsub_rename_tac `EL i _ j`
-  \\ first_x_assum (qspec_then `iCons (iNum i) j` mp_tac) \\ fs []);
+  \\ first_x_assum (qspec_then `iCons (iNum x) x'` mp_tac)
+  \\ fs [ffi_app_def]);
 
 val Stream_11 = store_thm("Stream_11[simp]",
   ``!n1 n2. Stream n1 = Stream n2 <=> n1 = n2``,
@@ -120,15 +112,17 @@ val Stream_11 = store_thm("Stream_11[simp]",
 val Fun_11 = store_thm("Fun_11[simp]",
   ``Fun f1 = Fun f2 <=> f1 = f2``,
   eq_tac \\ rw [] \\ fs [FUN_EQ_THM,Fun_def] \\ rw []
-  \\ qmatch_goalsub_rename_tac `f1 i j`
-  \\ first_x_assum (qspec_then `iCons i j` mp_tac) \\ fs []);
+  \\ Cases_on `f1 x`
+  \\ Cases_on `f2 x`
+  \\ fs [FUN_EQ_THM] \\ rw []
+  \\ first_x_assum (qspec_then `iCons x x'` mp_tac) \\ fs [ffi_app_def]);
 
 (* distinctness *)
 
 val ffi_distinct = prove(
   ``ALL_DISTINCT [Num n; Str s; Cons x y; List l; Stream ll; Fun f]``,
-  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `iNum 0`
-  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def])
+  rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,FUN_EQ_THM]
+  \\ qexists_tac `iNum 0` \\ fs [])
   |> SIMP_RULE std_ss [ALL_DISTINCT,MEM,GSYM CONJ_ASSOC] |> GEN_ALL
   |> curry save_thm "ffi_distinct[simp]";
 
@@ -142,8 +136,10 @@ val destNum_def = new_specification("destNum_def",["destNum"],prove(``
     (!l. destNum (List l) = NONE) /\
     (!ll. destNum (Stream ll) = NONE) /\
     (!f. destNum (Fun f) = NONE)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 0 then SOME (@n. Num n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 0
+                    then SOME (@n. Num n = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]));
 val _ = export_rewrites ["destNum_def"];
 
 val destStr_def = new_specification("destStr_def",["destStr"],prove(``
@@ -154,8 +150,10 @@ val destStr_def = new_specification("destStr_def",["destStr"],prove(``
     (!l. destStr (List l) = NONE) /\
     (!ll. destStr (Stream ll) = NONE) /\
     (!f. destStr (Fun f) = NONE)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 1 then SOME (@n. Str n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 1
+                    then SOME (@n. Str n = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]));
 val _ = export_rewrites ["destStr_def"];
 
 val destStr_o_Str = Q.store_thm("destStr_o_Str[simp]",
@@ -169,9 +167,10 @@ val destCons_def = new_specification("destCons_def",["destCons"],prove(``
     (!l. destCons (List l) = NONE) /\
     (!ll. destCons (Stream ll) = NONE) /\
     (!f. destCons (Fun f) = NONE)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 2
-                   then SOME (@n. Cons (FST n) (SND n) = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 2
+                    then SOME (@n. Cons (FST n) (SND n) = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]
   \\ `!n. FST n = x ∧ SND n = y <=> n = (x,y)` by fs [FORALL_PROD]
   \\ asm_rewrite_tac [] \\ fs []));
 val _ = export_rewrites ["destCons_def"];
@@ -184,8 +183,10 @@ val destList_def = new_specification("destList_def",["destList"],prove(``
     (!l. destList (List l) = SOME l) /\
     (!ll. destList (Stream ll) = NONE) /\
     (!f. destList (Fun f) = NONE)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 3 then SOME (@n. List n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 3
+                    then SOME (@n. List n = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]));
 val _ = export_rewrites ["destList_def"];
 
 val destStream_def = new_specification("destStream_def",["destStream"],prove(``
@@ -196,8 +197,10 @@ val destStream_def = new_specification("destStream_def",["destStream"],prove(``
     (!l. destStream (List l) = NONE) /\
     (!ll. destStream (Stream ll) = SOME ll) /\
     (!f. destStream (Fun f) = NONE)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 4 then SOME (@n. Stream n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 4
+                    then SOME (@n. Stream n = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]));
 val _ = export_rewrites ["destStream_def"];
 
 val destFun_def = new_specification("destFun_def",["destFun"],prove(``
@@ -208,11 +211,17 @@ val destFun_def = new_specification("destFun_def",["destFun"],prove(``
     (!l. destFun (List l) = NONE) /\
     (!ll. destFun (Stream ll) = NONE) /\
     (!f. destFun (Fun f) = SOME f)``,
-  qexists_tac `\f. if f (iNum 0) = iNum 5 then SOME (@n. Fun n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+  qexists_tac `(\f. if ffi_app f (iNum 0) = iNum 5
+                    then SOME (@n. Fun n = f) else NONE)`
+  \\ rw []
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def,ffi_app_def]));
 val _ = export_rewrites ["destFun_def"];
 
-val _ = map delete_binding ["Num_def","Str_def",
-          "Cons_def","List_def","Stream_def","Fun_def"]
+(* clean up *)
+
+val _ = map delete_binding ["ffi_app_def","Num_def","Str_def",
+          "Cons_def","List_def","Stream_def","Fun_def"];
+
+val _ = delete_const "ffi_app";
 
 val _ = export_theory()

--- a/characteristic/cfFFITypeScript.sml
+++ b/characteristic/cfFFITypeScript.sml
@@ -1,0 +1,270 @@
+open preamble;
+
+val _ = new_theory "cfFFIType"
+
+(*
+
+This file defines a tyep (abbreviation) that behaves like the
+following type:
+
+val _ = Datatype `
+  ffi = Str string
+      | Num num
+      | Cons ffi ffi
+      | List (ffi list)
+      | Stream (num llist)
+      | Seq (num -> ffi)
+
+The type is missing a cases thm and an ind thm.
+
+*)
+
+val _ = Datatype `
+  inner_ffi = iNum num
+            | iStr string
+            | iStream (num llist)`
+
+val _ = type_abbrev("ffi",``:num -> inner_ffi``)
+
+(* constructors *)
+
+val Num_def = Define `
+  ((Num i):ffi) =
+    \n. if n = 0 then iNum 0 else iNum i`
+
+val Str_def = Define `
+  ((Str i):ffi) =
+    \n. if n = 0 then iNum 1 else iStr i`
+
+val Cons_def = Define `
+  ((Cons (x:ffi) (y:ffi)):ffi) =
+    \n. if n = 0 then iNum 2 else
+          let n = n - 1 in
+            if EVEN n then x (n DIV 2) else y (n DIV 2)`
+
+val List_def = Define `
+  ((List (xs:ffi list)):ffi) =
+    \n. if n = 0 then iNum 3 else FOLDR Cons (Num 0) xs (n-1) `
+
+val Stream_def = Define `
+  ((Stream i):ffi) =
+    \n. if n = 0 then iNum 4 else iStream i`
+
+val factor_count_def = Define `
+  factor_count k n =
+    if k <= 1 then 0n else
+    if n = 0n then 0 else
+    if n MOD k = 0 then 1 + factor_count k (n DIV k) else 0`
+
+val Seq_def = Define `
+  ((Seq (f:num -> ffi)):ffi) =
+    \n. if n = 0 then iNum 5 else
+          let n = n - 1 in
+            f (factor_count 2 n) (factor_count 3 n)`;
+
+(* injectivity *)
+
+val Num_11 = store_thm("Num_11[simp]",
+  ``!n1 n2. Num n1 = Num n2 <=> n1 = n2``,
+  fs [Num_def,FUN_EQ_THM]
+  \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+
+val Str_11 = store_thm("Str_11[simp]",
+  ``!n1 n2. Str n1 = Str n2 <=> n1 = n2``,
+  fs [Str_def,FUN_EQ_THM]
+  \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+
+val Cons_11 = store_thm("Cons_11[simp]",
+  ``!x1 x2 y1 y2. Cons x1 x2 = Cons y1 y2 <=> x1 = y1 /\ x2 = y2``,
+  fs [Cons_def,FUN_EQ_THM]
+  \\ rw [] \\ eq_tac \\ rw []
+  THEN1
+   (pop_assum (qspec_then `2 * x + 1` mp_tac) \\ fs []
+    \\ fs [FUN_EQ_THM,EVEN_DOUBLE]
+    \\ once_rewrite_tac [MULT_COMM]
+    \\ simp [MULT_DIV,DIV_MULT] \\ rw [])
+  THEN1
+   (pop_assum (qspec_then `2 * x + 2` mp_tac) \\ fs []
+    \\ fs [FUN_EQ_THM,EVEN_DOUBLE]
+    \\ once_rewrite_tac [MULT_COMM]
+    \\ simp [MULT_DIV,DIV_MULT] \\ rw []
+    \\ fs [EVEN_ODD,GSYM ADD1,ODD_DOUBLE]));
+
+val Cons_NOT_Num = prove(
+  ``Cons x y <> Num z``,
+  fs [FUN_EQ_THM] \\ qexists_tac `0` \\ EVAL_TAC);
+
+val List_11 = store_thm("List_11[simp]",
+  ``!xs ys. List xs = List ys <=> xs = ys``,
+  rw [] \\ eq_tac \\ rw []
+  \\ fs [List_def,FUN_EQ_THM]
+  \\ pop_assum (mp_tac o Q.GEN `n` o Q.SPEC `n+1`)
+  \\ fs [GSYM FUN_EQ_THM]
+  \\ CONV_TAC (DEPTH_CONV ETA_CONV)
+  \\ qspec_tac (`ys`,`ys`)
+  \\ Induct_on `xs` \\ Cases_on `ys` \\ fs [Cons_NOT_Num]);
+
+val Stream_11 = store_thm("Stream_11[simp]",
+  ``!n1 n2. Stream n1 = Stream n2 <=> n1 = n2``,
+  fs [Stream_def,FUN_EQ_THM]
+  \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+
+val factor_count_2 = prove(
+  ``!m n. factor_count 2 (2 ** m * 3 ** n) = m``,
+  Induct \\ once_rewrite_tac [factor_count_def] \\ fs []
+  \\ fs [EXP,ADD1] \\ once_rewrite_tac [MULT_COMM] \\ fs [MULT_DIV]);
+
+val factor_count_3 = prove(
+  ``!m n. factor_count 3 (3 ** m * 2 ** n) = m``,
+  Induct \\ once_rewrite_tac [factor_count_def] \\ fs []
+  \\ fs [EXP,ADD1] \\ once_rewrite_tac [MULT_COMM] \\ fs [MULT_DIV]
+  \\ rw [] \\ pop_assum mp_tac \\ fs []
+  \\ Induct_on `n` \\ fs [EXP]
+  \\ once_rewrite_tac [GSYM (MATCH_MP MOD_TIMES2 (DECIDE ``0<3n``))]
+  \\ Cases_on `2 ** n MOD 3` \\ fs []
+  \\ Cases_on `n'` \\ fs []
+  \\ Cases_on `n''` \\ fs []
+  \\ `2 ** n MOD 3 < 3` by fs []
+  \\ rev_full_simp_tac bool_ss [] \\ fs [ADD1]);
+
+val Seq_11 = store_thm("Seq_11[simp]",
+  ``Seq f1 = Seq f2 <=> f1 = f2``,
+  eq_tac \\ rw [] \\ fs [FUN_EQ_THM,Seq_def] \\ rw []
+  \\ pop_assum (qspec_then `2 ** x * 3 ** x' + 1` mp_tac)
+  \\ fs [factor_count_3,factor_count_2]
+  \\ once_rewrite_tac [MULT_COMM]
+  \\ fs [factor_count_3,factor_count_2]);
+
+(* distinctness *)
+
+val ffi_distinct = prove(
+  ``ALL_DISTINCT [Num n; Str s; Cons x y; List l; Stream ll; Seq f]``,
+  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `0` \\ EVAL_TAC)
+  |> SIMP_RULE std_ss [ALL_DISTINCT,MEM,GSYM CONJ_ASSOC] |> GEN_ALL
+  |> curry save_thm "ffi_distinct[simp]";
+
+(* destructors *)
+
+val destNum_def = new_specification("destNum_def",["destNum"],prove(``
+  ?destNum.
+    (!n. destNum (Num n) = SOME n) /\
+    (!s. destNum (Str s) = NONE) /\
+    (!x y. destNum (Cons x y) = NONE) /\
+    (!l. destNum (List l) = NONE) /\
+    (!ll. destNum (Stream ll) = NONE) /\
+    (!f. destNum (Seq f) = NONE)``,
+  qexists_tac `\f. if f 0 = iNum 0 then SOME (@n. Num n = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC));
+val _ = export_rewrites ["destNum_def"];
+
+val destStr_def = new_specification("destStr_def",["destStr"],prove(``
+  ?destStr.
+    (!n. destStr (Num n) = NONE) /\
+    (!s. destStr (Str s) = SOME s) /\
+    (!x y. destStr (Cons x y) = NONE) /\
+    (!l. destStr (List l) = NONE) /\
+    (!ll. destStr (Stream ll) = NONE) /\
+    (!f. destStr (Seq f) = NONE)``,
+  qexists_tac `\f. if f 0 = iNum 1 then SOME (@n. Str n = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC));
+val _ = export_rewrites ["destStr_def"];
+
+val destStr_o_Str = Q.store_thm("destStr_o_Str[simp]",
+  `destStr o Str = SOME`, rw[FUN_EQ_THM]);
+
+val destCons_def = new_specification("destCons_def",["destCons"],prove(``
+  ?destCons.
+    (!n. destCons (Num n) = NONE) /\
+    (!s. destCons (Str s) = NONE) /\
+    (!x y. destCons (Cons x y) = SOME (x,y)) /\
+    (!l. destCons (List l) = NONE) /\
+    (!ll. destCons (Stream ll) = NONE) /\
+    (!f. destCons (Seq f) = NONE)``,
+  qexists_tac `\f. if f 0 = iNum 2 then SOME (@n. Cons (FST n) (SND n) = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC
+  \\ `!n. FST n = x ∧ SND n = y <=> n = (x,y)` by fs [FORALL_PROD]
+  \\ asm_rewrite_tac [] \\ fs []));
+val _ = export_rewrites ["destCons_def"];
+
+val destList_def = new_specification("destList_def",["destList"],prove(``
+  ?destList.
+    (!n. destList (Num n) = NONE) /\
+    (!s. destList (Str s) = NONE) /\
+    (!x y. destList (Cons x y) = NONE) /\
+    (!l. destList (List l) = SOME l) /\
+    (!ll. destList (Stream ll) = NONE) /\
+    (!f. destList (Seq f) = NONE)``,
+  qexists_tac `\f. if f 0 = iNum 3 then SOME (@n. List n = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC));
+val _ = export_rewrites ["destList_def"];
+
+val destStream_def = new_specification("destStream_def",["destStream"],prove(``
+  ?destStream.
+    (!n. destStream (Num n) = NONE) /\
+    (!s. destStream (Str s) = NONE) /\
+    (!x y. destStream (Cons x y) = NONE) /\
+    (!l. destStream (List l) = NONE) /\
+    (!ll. destStream (Stream ll) = SOME ll) /\
+    (!f. destStream (Seq f) = NONE)``,
+  qexists_tac `\f. if f 0 = iNum 4 then SOME (@n. Stream n = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC));
+val _ = export_rewrites ["destStream_def"];
+
+val destSeq_def = new_specification("destSeq_def",["destSeq"],prove(``
+  ?destSeq.
+    (!n. destSeq (Num n) = NONE) /\
+    (!s. destSeq (Str s) = NONE) /\
+    (!x y. destSeq (Cons x y) = NONE) /\
+    (!l. destSeq (List l) = NONE) /\
+    (!ll. destSeq (Stream ll) = NONE) /\
+    (!f. destSeq (Seq f) = SOME f)``,
+  qexists_tac `\f. if f 0 = iNum 5 then SOME (@n. Seq n = f) else NONE`
+  \\ fs [] \\ rw [] \\ EVAL_TAC));
+val _ = export_rewrites ["destSeq_def"];
+
+val encode_pair_def = Define`
+  encode_pair e1 e2 (x,y) = Cons (e1 x) (e2 y)`;
+
+val encode_list_def = Define`
+  encode_list e l = List (MAP e l)`;
+
+(*
+
+val decode_pair_def = Define`
+  (decode_pair d1 d2 (Cons f1 f2) =
+      OPTION_BIND (d1 f1)
+      (λx. OPTION_BIND (d2 f2)
+      (λy. SOME (x,y)))) ∧
+  (decode_pair _ _ _ = NONE)`;
+
+val decode_encode_pair = Q.store_thm(
+  "decode_encode_pair",
+  `(∀x. d1 (e1 x) = SOME x) ∧ (∀y. d2 (e2 y) = SOME y) ⇒
+   ∀p. decode_pair d1 d2 (encode_pair e1 e2 p) = SOME p`,
+  strip_tac >> Cases >> simp[encode_pair_def, decode_pair_def]);
+
+val decode_list_def = Define`
+  (decode_list d (List fs) = OPT_MMAP d fs) ∧
+  (decode_list d _ = NONE)`;
+
+val decode_encode_list = Q.store_thm(
+  "decode_encode_list[simp]",
+  `(∀x. d (e x) = SOME x) ⇒
+   ∀l. decode_list d (encode_list e l) = SOME l`,
+  strip_tac >> simp[decode_list_def, encode_list_def] >> Induct >>
+  simp[OPT_MMAP_def]);
+
+*)
+
+(* make an ffi_next function from base functions and encode/decode *)
+val mk_ffi_next_def = Define`
+  mk_ffi_next (encode,decode,ls) name conf bytes s =
+    OPTION_BIND (ALOOKUP ls name) (λf.
+    OPTION_BIND (decode s) (λs.
+    OPTION_BIND (f conf bytes s) (λ(bytes,s).
+    SOME (bytes,encode s))))`;
+
+val _ = export_theory()

--- a/characteristic/cfFFITypeScript.sml
+++ b/characteristic/cfFFITypeScript.sml
@@ -4,51 +4,73 @@ val _ = new_theory "cfFFIType"
 
 (*
 
-This file defines a tyep (abbreviation) that behaves like the
+This file defines a type (abbreviation) that behaves like the
 following type:
 
-val _ = Datatype `
   ffi = Str string
       | Num num
       | Cons ffi ffi
       | List (ffi list)
       | Stream (num llist)
-      | Seq (num -> ffi)
+      | Fun (ffi_inner -> ffi)
+
+  ffi_inner = iStr string
+            | iNum num
+            | iCons ffi_inner ffi_inner
+            | iList (ffi_inner list)
+            | iStream (num llist)
 
 The type is missing a cases thm and an ind thm.
 
 *)
 
 val _ = Datatype `
-  inner_ffi = iNum num
-            | iStr string
+  ffi_inner = iStr string
+            | iNum num
+            | iCons ffi_inner ffi_inner
+            | iList (ffi_inner list)
             | iStream (num llist)`
 
-val _ = type_abbrev("ffi",``:num -> inner_ffi``)
+val _ = type_abbrev("ffi",``:ffi_inner -> ffi_inner``)
 
 (* constructors *)
 
 val Num_def = zDefine `
   ((Num i):ffi) =
-    \n. if n = 0 then iNum 0 else iNum i`
+    \n. if n = iNum 0 then iNum 0 else iNum i`
 
 val Str_def = zDefine `
   ((Str i):ffi) =
-    \n. if n = 0 then iNum 1 else iStr i`
+    \n. if n = iNum 0 then iNum 1 else iStr i`
 
 val Cons_def = zDefine `
   ((Cons (x:ffi) (y:ffi)):ffi) =
-    \n. if n = 0 then iNum 2 else
-          let n = n - 1 in
-            if EVEN n then x (n DIV 2) else y (n DIV 2)`
+    \n. if n = iNum 0 then iNum 2 else
+          case n of
+          | iCons (iNum 0) m => x m
+          | iCons (iNum 1) m => y m
+          | _ => iNum 0`
 
 val List_def = zDefine `
   ((List (xs:ffi list)):ffi) =
-    \n. if n = 0 then iNum 3 else FOLDR Cons (Num 0) xs (n-1) `
+    \n. if n = iNum 0 then iNum 3 else
+        if n = iNum 1 then iNum (LENGTH xs) else
+          case n of
+          | iCons (iNum k) m => EL k xs m
+          | _ => iNum 0`
 
 val Stream_def = zDefine `
   ((Stream i):ffi) =
-    \n. if n = 0 then iNum 4 else iStream i`
+    \n. if n = iNum 0 then iNum 4 else iStream i`
+
+val Fun_def = zDefine `
+  ((Fun (f:ffi_inner -> ffi)):ffi) =
+    \n. if n = iNum 0 then iNum 5 else
+          case n of
+          | iCons x y => f x y
+          | _ => iNum 0`;
+
+(*
 
 val factor_count_def = Define `
   factor_count k n =
@@ -56,94 +78,57 @@ val factor_count_def = Define `
     if n = 0n then 0 else
     if n MOD k = 0 then 1 + factor_count k (n DIV k) else 0`
 
-val Seq_def = zDefine `
-  ((Seq (f:num -> ffi)):ffi) =
+val Fun_def = zDefine `
+  ((Fun (f:num -> ffi)):ffi) =
     \n. if n = 0 then iNum 5 else
           let n = n - 1 in
             f (factor_count 2 n) (factor_count 3 n)`;
+*)
 
 (* injectivity *)
 
 val Num_11 = store_thm("Num_11[simp]",
   ``!n1 n2. Num n1 = Num n2 <=> n1 = n2``,
-  fs [Num_def,FUN_EQ_THM]
-  \\ rw [] \\ eq_tac \\ rw []
-  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+  fs [Num_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `iNum 1` mp_tac) \\ fs []);
 
 val Str_11 = store_thm("Str_11[simp]",
   ``!n1 n2. Str n1 = Str n2 <=> n1 = n2``,
-  fs [Str_def,FUN_EQ_THM]
-  \\ rw [] \\ eq_tac \\ rw []
-  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+  fs [Str_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `iNum 1` mp_tac) \\ fs []);
 
 val Cons_11 = store_thm("Cons_11[simp]",
   ``!x1 x2 y1 y2. Cons x1 x2 = Cons y1 y2 <=> x1 = y1 /\ x2 = y2``,
-  fs [Cons_def,FUN_EQ_THM]
-  \\ rw [] \\ eq_tac \\ rw []
-  THEN1
-   (pop_assum (qspec_then `2 * x + 1` mp_tac) \\ fs []
-    \\ fs [FUN_EQ_THM,EVEN_DOUBLE]
-    \\ once_rewrite_tac [MULT_COMM]
-    \\ simp [MULT_DIV,DIV_MULT] \\ rw [])
-  THEN1
-   (pop_assum (qspec_then `2 * x + 2` mp_tac) \\ fs []
-    \\ fs [FUN_EQ_THM,EVEN_DOUBLE]
-    \\ once_rewrite_tac [MULT_COMM]
-    \\ simp [MULT_DIV,DIV_MULT] \\ rw []
-    \\ fs [EVEN_ODD,GSYM ADD1,ODD_DOUBLE]));
-
-val Cons_NOT_Num = prove(
-  ``Cons x y <> Num z``,
-  fs [FUN_EQ_THM] \\ qexists_tac `0` \\ fs [Cons_def,Num_def]);
+  fs [Cons_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  THEN1 (pop_assum (qspec_then `iCons (iNum 0) x` mp_tac) \\ fs [])
+  THEN1 (pop_assum (qspec_then `iCons (iNum 1) x` mp_tac) \\ fs []));
 
 val List_11 = store_thm("List_11[simp]",
   ``!xs ys. List xs = List ys <=> xs = ys``,
-  rw [] \\ eq_tac \\ rw []
-  \\ fs [List_def,FUN_EQ_THM]
-  \\ pop_assum (mp_tac o Q.GEN `n` o Q.SPEC `n+1`)
-  \\ fs [GSYM FUN_EQ_THM]
-  \\ CONV_TAC (DEPTH_CONV ETA_CONV)
-  \\ qspec_tac (`ys`,`ys`)
-  \\ Induct_on `xs` \\ Cases_on `ys` \\ fs [Cons_NOT_Num]);
+  fs [List_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  \\ fs [LIST_EQ_REWRITE] \\ rw []
+  THEN1 (pop_assum (qspec_then `iNum 1` mp_tac) \\ fs [])
+  \\ fs [FUN_EQ_THM] \\ rw []
+  \\ qmatch_goalsub_rename_tac `EL i _ j`
+  \\ first_x_assum (qspec_then `iCons (iNum i) j` mp_tac) \\ fs []);
 
 val Stream_11 = store_thm("Stream_11[simp]",
   ``!n1 n2. Stream n1 = Stream n2 <=> n1 = n2``,
-  fs [Stream_def,FUN_EQ_THM]
-  \\ rw [] \\ eq_tac \\ rw []
-  \\ pop_assum (qspec_then `1` mp_tac) \\ fs []);
+  fs [Stream_def,FUN_EQ_THM] \\ rw [] \\ eq_tac \\ rw []
+  \\ pop_assum (qspec_then `iNum 1` mp_tac) \\ fs []);
 
-val factor_count_2 = prove(
-  ``!m n. factor_count 2 (2 ** m * 3 ** n) = m``,
-  Induct \\ once_rewrite_tac [factor_count_def] \\ fs []
-  \\ fs [EXP,ADD1] \\ once_rewrite_tac [MULT_COMM] \\ fs [MULT_DIV]);
-
-val factor_count_3 = prove(
-  ``!m n. factor_count 3 (3 ** m * 2 ** n) = m``,
-  Induct \\ once_rewrite_tac [factor_count_def] \\ fs []
-  \\ fs [EXP,ADD1] \\ once_rewrite_tac [MULT_COMM] \\ fs [MULT_DIV]
-  \\ rw [] \\ pop_assum mp_tac \\ fs []
-  \\ Induct_on `n` \\ fs [EXP]
-  \\ once_rewrite_tac [GSYM (MATCH_MP MOD_TIMES2 (DECIDE ``0<3n``))]
-  \\ Cases_on `2 ** n MOD 3` \\ fs []
-  \\ Cases_on `n'` \\ fs []
-  \\ Cases_on `n''` \\ fs []
-  \\ `2 ** n MOD 3 < 3` by fs []
-  \\ rev_full_simp_tac bool_ss [] \\ fs [ADD1]);
-
-val Seq_11 = store_thm("Seq_11[simp]",
-  ``Seq f1 = Seq f2 <=> f1 = f2``,
-  eq_tac \\ rw [] \\ fs [FUN_EQ_THM,Seq_def] \\ rw []
-  \\ pop_assum (qspec_then `2 ** x * 3 ** x' + 1` mp_tac)
-  \\ fs [factor_count_3,factor_count_2]
-  \\ once_rewrite_tac [MULT_COMM]
-  \\ fs [factor_count_3,factor_count_2]);
+val Fun_11 = store_thm("Fun_11[simp]",
+  ``Fun f1 = Fun f2 <=> f1 = f2``,
+  eq_tac \\ rw [] \\ fs [FUN_EQ_THM,Fun_def] \\ rw []
+  \\ qmatch_goalsub_rename_tac `f1 i j`
+  \\ first_x_assum (qspec_then `iCons i j` mp_tac) \\ fs []);
 
 (* distinctness *)
 
 val ffi_distinct = prove(
-  ``ALL_DISTINCT [Num n; Str s; Cons x y; List l; Stream ll; Seq f]``,
-  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `0`
-  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def])
+  ``ALL_DISTINCT [Num n; Str s; Cons x y; List l; Stream ll; Fun f]``,
+  rw [] \\ fs [FUN_EQ_THM] \\ qexists_tac `iNum 0`
+  \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def])
   |> SIMP_RULE std_ss [ALL_DISTINCT,MEM,GSYM CONJ_ASSOC] |> GEN_ALL
   |> curry save_thm "ffi_distinct[simp]";
 
@@ -156,9 +141,9 @@ val destNum_def = new_specification("destNum_def",["destNum"],prove(``
     (!x y. destNum (Cons x y) = NONE) /\
     (!l. destNum (List l) = NONE) /\
     (!ll. destNum (Stream ll) = NONE) /\
-    (!f. destNum (Seq f) = NONE)``,
-  qexists_tac `\f. if f 0 = iNum 0 then SOME (@n. Num n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
+    (!f. destNum (Fun f) = NONE)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 0 then SOME (@n. Num n = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
 val _ = export_rewrites ["destNum_def"];
 
 val destStr_def = new_specification("destStr_def",["destStr"],prove(``
@@ -168,9 +153,9 @@ val destStr_def = new_specification("destStr_def",["destStr"],prove(``
     (!x y. destStr (Cons x y) = NONE) /\
     (!l. destStr (List l) = NONE) /\
     (!ll. destStr (Stream ll) = NONE) /\
-    (!f. destStr (Seq f) = NONE)``,
-  qexists_tac `\f. if f 0 = iNum 1 then SOME (@n. Str n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
+    (!f. destStr (Fun f) = NONE)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 1 then SOME (@n. Str n = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
 val _ = export_rewrites ["destStr_def"];
 
 val destStr_o_Str = Q.store_thm("destStr_o_Str[simp]",
@@ -183,9 +168,10 @@ val destCons_def = new_specification("destCons_def",["destCons"],prove(``
     (!x y. destCons (Cons x y) = SOME (x,y)) /\
     (!l. destCons (List l) = NONE) /\
     (!ll. destCons (Stream ll) = NONE) /\
-    (!f. destCons (Seq f) = NONE)``,
-  qexists_tac `\f. if f 0 = iNum 2 then SOME (@n. Cons (FST n) (SND n) = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]
+    (!f. destCons (Fun f) = NONE)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 2
+                   then SOME (@n. Cons (FST n) (SND n) = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]
   \\ `!n. FST n = x ∧ SND n = y <=> n = (x,y)` by fs [FORALL_PROD]
   \\ asm_rewrite_tac [] \\ fs []));
 val _ = export_rewrites ["destCons_def"];
@@ -197,9 +183,9 @@ val destList_def = new_specification("destList_def",["destList"],prove(``
     (!x y. destList (Cons x y) = NONE) /\
     (!l. destList (List l) = SOME l) /\
     (!ll. destList (Stream ll) = NONE) /\
-    (!f. destList (Seq f) = NONE)``,
-  qexists_tac `\f. if f 0 = iNum 3 then SOME (@n. List n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
+    (!f. destList (Fun f) = NONE)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 3 then SOME (@n. List n = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
 val _ = export_rewrites ["destList_def"];
 
 val destStream_def = new_specification("destStream_def",["destStream"],prove(``
@@ -209,21 +195,24 @@ val destStream_def = new_specification("destStream_def",["destStream"],prove(``
     (!x y. destStream (Cons x y) = NONE) /\
     (!l. destStream (List l) = NONE) /\
     (!ll. destStream (Stream ll) = SOME ll) /\
-    (!f. destStream (Seq f) = NONE)``,
-  qexists_tac `\f. if f 0 = iNum 4 then SOME (@n. Stream n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
+    (!f. destStream (Fun f) = NONE)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 4 then SOME (@n. Stream n = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
 val _ = export_rewrites ["destStream_def"];
 
-val destSeq_def = new_specification("destSeq_def",["destSeq"],prove(``
-  ?destSeq.
-    (!n. destSeq (Num n) = NONE) /\
-    (!s. destSeq (Str s) = NONE) /\
-    (!x y. destSeq (Cons x y) = NONE) /\
-    (!l. destSeq (List l) = NONE) /\
-    (!ll. destSeq (Stream ll) = NONE) /\
-    (!f. destSeq (Seq f) = SOME f)``,
-  qexists_tac `\f. if f 0 = iNum 5 then SOME (@n. Seq n = f) else NONE`
-  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Seq_def]));
-val _ = export_rewrites ["destSeq_def"];
+val destFun_def = new_specification("destFun_def",["destFun"],prove(``
+  ?destFun.
+    (!n. destFun (Num n) = NONE) /\
+    (!s. destFun (Str s) = NONE) /\
+    (!x y. destFun (Cons x y) = NONE) /\
+    (!l. destFun (List l) = NONE) /\
+    (!ll. destFun (Stream ll) = NONE) /\
+    (!f. destFun (Fun f) = SOME f)``,
+  qexists_tac `\f. if f (iNum 0) = iNum 5 then SOME (@n. Fun n = f) else NONE`
+  \\ rw [] \\ fs [Num_def,Str_def,Cons_def,List_def,Stream_def,Fun_def]));
+val _ = export_rewrites ["destFun_def"];
+
+val _ = map delete_binding ["Num_def","Str_def",
+          "Cons_def","List_def","Stream_def","Fun_def"]
 
 val _ = export_theory()

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -1,17 +1,19 @@
 open preamble set_sepTheory
-open cfTacticsBaseLib
+open cfTacticsBaseLib cfFFITypeTheory
 
 val _ = new_theory "cfHeapsBase"
 
 (*------------------------------------------------------------------*)
 (** Heaps *)
 
+(* the following is now defined in cfFFITypeTheory
 val _ = Datatype `
   ffi = Str string
       | Num num
       | Cons ffi ffi
       | List (ffi list)
       | Stream (num llist)`
+*)
 
 val _ = temp_type_abbrev("loc", ``:num``)
 
@@ -51,65 +53,6 @@ val SPLIT_TAC = fs [SPLIT_def,SPLIT3_def,SUBSET_DEF,DISJOINT_DEF,DELETE_DEF,IN_I
 val ffi_proj_pack = save_thm("ffi_proj_pack", packLib.pack_type ``:'ffi ffi_proj``);
 val heap_pack = save_thm("heap_pack", packLib.pack_type ``:heap``);
 val hprop_pack = save_thm("hprop_pack", packLib.pack_type ``:hprop``);
-
-(* encoding and decoding into ffi type *)
-
-val destStr_def = Define`
-  (destStr (Str s) = SOME s) ∧
-  (destStr _ = NONE)`;
-val _ = export_rewrites ["destStr_def"]
-
-val destNum_def = Define`
-  (destNum (Num n) = SOME n) ∧
-  (destNum _ = NONE)`;
-val _ = export_rewrites ["destNum_def"]
-
-val destStream_def = Define`
-  (destStream (Stream ll) = SOME ll) ∧
-  (destStream _ = NONE)`;
-val _ = export_rewrites ["destStream_def"]
-
-val destStr_o_Str = Q.store_thm("destStr_o_Str[simp]",
-  `destStr o Str = SOME`, rw[FUN_EQ_THM]);
-
-val encode_pair_def = Define`
-  encode_pair e1 e2 (x,y) = Cons (e1 x) (e2 y)`;
-
-val decode_pair_def = Define`
-  (decode_pair d1 d2 (Cons f1 f2) =
-      OPTION_BIND (d1 f1)
-      (λx. OPTION_BIND (d2 f2)
-      (λy. SOME (x,y)))) ∧
-  (decode_pair _ _ _ = NONE)`;
-
-val decode_encode_pair = Q.store_thm(
-  "decode_encode_pair",
-  `(∀x. d1 (e1 x) = SOME x) ∧ (∀y. d2 (e2 y) = SOME y) ⇒
-   ∀p. decode_pair d1 d2 (encode_pair e1 e2 p) = SOME p`,
-  strip_tac >> Cases >> simp[encode_pair_def, decode_pair_def]);
-
-val encode_list_def = Define`
-  encode_list e l = List (MAP e l)`;
-
-val decode_list_def = Define`
-  (decode_list d (List fs) = OPT_MMAP d fs) ∧
-  (decode_list d _ = NONE)
-`;
-
-val decode_encode_list = Q.store_thm(
-  "decode_encode_list[simp]",
-  `(∀x. d (e x) = SOME x) ⇒
-   ∀l. decode_list d (encode_list e l) = SOME l`,
-  strip_tac >> simp[decode_list_def, encode_list_def] >> Induct >>
-  simp[OPT_MMAP_def]);
-
-(* make an ffi_next function from base functions and encode/decode *)
-val mk_ffi_next_def = Define`
-  mk_ffi_next (encode,decode,ls) name conf bytes s =
-    OPTION_BIND (ALOOKUP ls name) (λf.
-    OPTION_BIND (decode s) (λs.
-    OPTION_BIND (f conf bytes s) (λ(bytes,s).
-    SOME (bytes,encode s))))`;
 
 (*------------------------------------------------------------------*)
 (** Heap predicates *)

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -15,6 +15,27 @@ val _ = Datatype `
       | Stream (num llist)`
 *)
 
+val encode_pair_def = Define`
+  encode_pair e1 e2 (x,y) = Cons (e1 x) (e2 y)`;
+
+val encode_list_def = Define`
+  encode_list e l = List (MAP e l)`;
+
+val encode_list_11 = store_thm("encode_list_11",
+  ``!xs ys.
+      encode_list f xs = encode_list f ys /\
+      (!x y. f x = f y <=> x = y) ==>
+      xs = ys``,
+  Induct \\ Cases_on `ys` \\ fs [encode_list_def] \\ rw [] \\ fs []);
+
+(* make an ffi_next function from base functions and encode/decode *)
+val mk_ffi_next_def = Define`
+  mk_ffi_next (encode,decode,ls) name conf bytes s =
+    OPTION_BIND (ALOOKUP ls name) (λf.
+    OPTION_BIND (decode s) (λs.
+    OPTION_BIND (f conf bytes s) (λ(bytes,s).
+    SOME (bytes,encode s))))`;
+
 val _ = temp_type_abbrev("loc", ``:num``)
 
 val _ = temp_type_abbrev("ffi_next", ``:string -> word8 list -> word8 list -> ffi -> (word8 list # ffi) option``);


### PR DESCRIPTION
These commits add a new constructor `Fun (ffi_inner -> ffi)` to the `ffi` type, which is used in the CF setup. Here `ffi_inner` is a copy of the `ffi` type prior to `Fun` (which some commits call `Seq`).