### PR TITLE
Silent ffi

### DIFF
--- a/basis/RuntimeProgScript.sml
+++ b/basis/RuntimeProgScript.sml
@@ -15,6 +15,12 @@ val fullGC_def = Define `
 val () = next_ml_names := ["fullGC"];
 val result = translate fullGC_def;
 
+val debugMsg_def = Define `
+  debugMsg s = silent_ffi s`;
+
+val () = next_ml_names := ["debugMsg"];
+val result = translate debugMsg_def;
+
 val _ = ml_prog_update (close_module NONE);
 
 val _ = export_theory();

--- a/basis/basis_ffiScript.sml
+++ b/basis/basis_ffiScript.sml
@@ -165,11 +165,12 @@ val RTC_call_FFI_rel_IMP_basis_events = Q.store_thm ("RTC_call_FFI_rel_IMP_basis
      = fsFFI$decode (basis_proj1 st.ffi_state ' "write") ==>
    extract_fs fs st'.io_events
      = fsFFI$decode (basis_proj1 st'.ffi_state ' "write"))`,
-     strip_tac
+  strip_tac
   \\ HO_MATCH_MP_TAC RTC_INDUCT \\ rw [] \\ fs []
   \\ fs [evaluatePropsTheory.call_FFI_rel_def]
   \\ fs [ffiTheory.call_FFI_def]
   \\ Cases_on `st.final_event = NONE` \\ fs [] \\ rw []
+  \\ Cases_on `n = ""` \\ fs [] THEN1 (rveq \\ fs [])
   \\ FULL_CASE_TAC \\ fs [] \\ rw [] \\ fs []
   \\ FULL_CASE_TAC \\ fs [] \\ rw [] \\ fs []
   \\ Cases_on `f` \\ fs []

--- a/characteristic/cfHeapsBaseScript.sml
+++ b/characteristic/cfHeapsBaseScript.sml
@@ -147,7 +147,7 @@ val W8ARRAY_def = Define `
     SEP_EXISTS loc. cond (av = Loc loc) * cell loc (W8array wl)`
 
 val IO_def = Define `
-  IO s u ns = SEP_EXISTS events. one (FFI_part s u ns events)`;
+  IO s u ns = SEP_EXISTS events. one (FFI_part s u ns events) * cond (~MEM "" ns)`;
 
 val IOx_def = Define`
   IOx (encode,decode,ls) s =

--- a/characteristic/cfLetAutoScript.sml
+++ b/characteristic/cfLetAutoScript.sml
@@ -209,6 +209,7 @@ val FRAME_UNIQUE_IO = Q.store_thm("FRAME_UNIQUE_IO",
 s2 = s1 /\ u2 = u1 /\ ns2 = ns1`,
 rpt (FIRST[GEN_TAC, DISCH_TAC]) >>
 fs[IO_def, SEP_CLAUSES, SEP_EXISTS_THM] >>
+full_simp_tac (std_ss++sep_cond_ss) [cond_STAR] >>
 IMP_RES_TAC FFI_PORT_IN_HEAP_LEM >>
 IMP_RES_TAC NON_OVERLAP_FFI_PART >>
 fs[]);

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -2142,7 +2142,6 @@ val cf_ffi_sound = Q.prove (
    first_assum progress \\ fs [SPLIT_emp1] \\ rveq \\
    fs [SPLIT_SING_2] \\ rveq \\
    rename1 `F' u2` \\
-
    `store_lookup y st.refs = SOME (W8array ws) /\
     Mem y (W8array ws) IN st2heap p st` by
      (`Mem y (W8array ws) IN st2heap p st` by SPLIT_TAC
@@ -2150,9 +2149,9 @@ val cf_ffi_sound = Q.prove (
       \\ imp_res_tac store2heap_IN_EL
       \\ imp_res_tac store2heap_IN_LENGTH
       \\ fs [store_lookup_def] \\ NO_TAC) \\
-
    fs [ffiTheory.call_FFI_def] \\
-   fs [IO_def,one_def,SEP_EXISTS_THM] \\ rveq \\
+   fs [IO_def,SEP_EXISTS_THM,cond_STAR] \\ rveq \\
+   fs [one_def] \\ rveq \\
    fs [st2heap_def,
        FFI_split_NOT_IN_store2heap,
        FFI_part_NOT_IN_store2heap,
@@ -2170,6 +2169,7 @@ val cf_ffi_sound = Q.prove (
          (fn th => mp_tac th \\ assume_tac th) \\
    simp_tac std_ss [parts_ok_def] \\ strip_tac \\
    qpat_x_assum `!x. _ ==> _` kall_tac \\
+   `ffi_index ≠ ""` by (strip_tac \\ fs []) \\ fs [] \\
    first_x_assum progress \\ fs [store_assign_def] \\
    imp_res_tac store2heap_IN_EL \\
    imp_res_tac store2heap_IN_LENGTH \\ fs [] \\

--- a/compiler/backend/arm6/arm6_configScript.sml
+++ b/compiler/backend/arm6/arm6_configScript.sml
@@ -31,7 +31,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val arm6_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; gc_kind:=Simple|>``
+val arm6_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=T; gc_kind:=Simple|>``
 val arm6_word_conf = ``<| bitmaps := []:32 word list |>``
 val arm6_stack_conf = ``<|jump:=T;reg_names:=arm6_names|>``
 val arm6_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm6_config;init_clock:=5|>``

--- a/compiler/backend/arm8/arm8_configScript.sml
+++ b/compiler/backend/arm8/arm8_configScript.sml
@@ -28,7 +28,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 (* TODO: this config may need to change *)
-val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; gc_kind:=Simple|>``
+val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
 val arm8_word_conf = ``<| bitmaps := []:64 word list |>``
 val arm8_stack_conf = ``<|jump:=T;reg_names:=arm8_names|>``
 val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm8_config;init_clock:=5|>``

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -21,6 +21,7 @@ val _ = Datatype `
             ; has_div : bool (* Div available in target *)
             ; has_longdiv : bool (* LongDiv available in target *)
             ; has_fp_ops : bool (* can compile floating-point ops *)
+            ; call_empty_ffi : bool (* emit (T) / omit (F) calls to FFI "" *)
             ; gc_kind : gc_kind (* GC settings *) |>`
 
 val adjust_var_def = Define `
@@ -1453,6 +1454,7 @@ local val assign_quotation = `
                         (WriteWord32_on_32 c header1 dest 11)])],l)))
       | _ => (Skip, l))
     | FFI ffi_index =>
+      if ¬c.call_empty_ffi ∧ ffi_index = "" then (Assign (adjust_var dest) Unit,l) else
       (dtcase args of
        | [v1; v2] =>
         let addr1 = real_addr c (adjust_var v1) in
@@ -1465,8 +1467,8 @@ local val assign_quotation = `
         (list_Seq [
           Assign 1 (Op Add [addr1; Const bytes_in_word]);
           Assign 3 (Op Sub [fakelen1; Const (bytes_in_word-1w)]);
-          Assign 5 (Op Add [addr2; Const bytes_in_word]);
-          Assign 7 (Op Sub [fakelen2; Const (bytes_in_word-1w)]);
+          Assign 5 (if ffi_index = "" then Const 0w else (Op Add [addr2; Const bytes_in_word]));
+          Assign 7 (if ffi_index = "" then Const 0w else (Op Sub [fakelen2; Const (bytes_in_word-1w)]));
           FFI ffi_index 1 3 5 7 (adjust_set (dtcase names of SOME names => names | NONE => LN));
           Assign (adjust_var dest) Unit]
         , l)

--- a/compiler/backend/mips/mips_configScript.sml
+++ b/compiler/backend/mips/mips_configScript.sml
@@ -18,11 +18,11 @@ val mips_names_def = Define `
      insert 1 4 o
      insert 2 5 o
      insert 3 6 o
-     insert 4 7 o     
+     insert 4 7 o
      (* the rest just ensures that the mapping is well-formed *)
      insert 7 2 o
      insert 5 24 o
-     insert 6 3 o     
+     insert 6 3 o
      insert 24 0 o
      insert 31 1) LN:num num_map`
 
@@ -34,7 +34,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=T; gc_kind:=Simple|>``
+val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=T; gc_kind:=Simple|>``
 val mips_word_conf = ``<| bitmaps := []:64 word list |>``
 val mips_stack_conf = ``<|jump:=F;reg_names:=mips_names|>``
 val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=mips_config;init_clock:=5|>``

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -8208,6 +8208,27 @@ val th = Q.store_thm("assign_FFI",
   \\ qpat_x_assum `get_var _ _ = SOME (Word _)`
      (fn thm => rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ simp[]
+  \\ rename1`_ ∧ ffi_name = ""`
+  \\ Cases_on`¬c.call_empty_ffi ∧ ffi_name = ""`
+  >- (
+    fs[wordSemTheory.evaluate_def]
+    \\ ntac 2 strip_tac
+    \\ simp[Unit_def,wordSemTheory.word_exp_def]
+    \\ conj_tac
+    >- (
+      qhdtm_x_assum`call_FFI`mp_tac
+      \\ simp[ffiTheory.call_FFI_def] )
+    \\ simp[wordSemTheory.set_var_def,lookup_insert]
+    \\ conj_tac >- (rw[] \\ metis_tac[])
+    >> full_simp_tac std_ss [GSYM APPEND_ASSOC]
+    \\ match_mp_tac memory_rel_insert
+    >> full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+    \\ match_mp_tac memory_rel_Unit
+    \\ DEP_REWRITE_TAC[FUPDATE_ELIM]
+    \\ fs[FLOOKUP_DEF,ffiTheory.call_FFI_def])
+  \\ pop_assum (SUBST_ALL_TAC o EQF_INTRO)
+  \\ rewrite_tac[]
+  \\ eval_tac
   \\ qpat_abbrev_tac`tt = t with locals := _`
   \\ `get_var (adjust_var e1) tt = get_var (adjust_var e1) t`
   by fs[Abbr`tt`,wordSemTheory.get_var_def,lookup_insert]
@@ -8219,6 +8240,8 @@ val th = Q.store_thm("assign_FFI",
      (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `tt.store = t.store` by simp[Abbr`tt`]
   \\ simp[]
+  \\ qpat_abbrev_tac`ex1 = if ffi_name = "" then _ else _`
+  \\ qpat_abbrev_tac`ex2 = if ffi_name = "" then _ else _`
   \\ IF_CASES_TAC >- ( fs[shift_def] )
   \\ simp[wordSemTheory.get_var_def,lookup_insert]
   \\ qpat_x_assum`¬_`kall_tac
@@ -8238,6 +8261,72 @@ val th = Q.store_thm("assign_FFI",
      (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `ttt.store = t.store` by simp[Abbr`ttt`]
   \\ simp[]
+  \\ qunabbrev_tac`ex1`
+  \\ qunabbrev_tac`ex2`
+  \\ Cases_on`ffi_name = ""` \\ fs[]
+  >- (
+    eval_tac
+    \\ fs[lookup_insert,wordSemTheory.word_exp_def,ffiTheory.call_FFI_def]
+    \\ fs[read_bytearray_def,wordSemTheory.write_bytearray_def]
+    \\ fs[cut_env_adjust_set_insert_ODD]
+    \\ fs[wordSemTheory.cut_env_def] \\ clean_tac
+    \\ reverse IF_CASES_TAC >- (
+      `F` suffices_by rw[]
+      >> pop_assum mp_tac
+      >> fs[cut_state_opt_def]
+      >> drule (#1(EQ_IMP_RULE cut_state_eq_some))
+      >> strip_tac
+      >> clean_tac
+      >> rw[SUBSET_DEF,domain_lookup]
+      >> fs[dataSemTheory.cut_env_def]
+      >> clean_tac >> fs[]
+      >> Cases_on`x=0` >- metis_tac[]
+      >> qmatch_assum_abbrev_tac`lookup x ss = SOME _`
+      >> `x ∈ domain ss` by metis_tac[domain_lookup]
+      >> qunabbrev_tac`ss`
+      >> imp_res_tac domain_adjust_set_EVEN
+      >> `∃z. x = adjust_var z`
+      by (
+          simp[adjust_var_def]
+          \\ fs[EVEN_EXISTS]
+          \\ Cases_on`m` \\ fs[ADD1,LEFT_ADD_DISTRIB] )
+      >> rveq
+      >> fs[lookup_adjust_var_adjust_set_SOME_UNIT]
+      >> last_x_assum(qspec_then`z`mp_tac)
+      >> simp[lookup_inter]
+      >> fs[IS_SOME_EXISTS]
+      >> disch_then match_mp_tac
+      >> BasicProvers.CASE_TAC
+      >> fs[SUBSET_DEF,domain_lookup]
+      >> res_tac >> fs[])
+    \\ fs[]
+    \\ qmatch_goalsub_abbrev_tac`read_bytearray aa len g`
+    \\ qmatch_asmsub_rename_tac`LENGTH ls + 3`
+    \\ qispl_then[`ls`,`LENGTH ls`,`aa`]mp_tac IMP_read_bytearray_GENLIST
+    \\ impl_tac >- simp[]
+    \\ `len = LENGTH ls`
+    by (
+      simp[Abbr`len`]
+      \\ rfs[good_dimindex_def] \\ rfs[shift_def]
+      \\ simp[bytes_in_word_def,GSYM word_add_n2w]
+      \\ simp[dimword_def] )
+    \\ fs[] \\ strip_tac
+    \\ simp[Unit_def]
+    \\ eval_tac
+    \\ simp[lookup_insert,lookup_inter_alt]
+    \\ ntac 6 strip_tac
+    \\ conj_tac >- fs[adjust_set_def,domain_fromAList]
+    \\ simp[adjust_var_IN_adjust_set]
+    \\ conj_tac >- (
+      rw[] \\
+      fs[cut_state_opt_def] \\
+      fs[cut_state_eq_some] \\
+      clean_tac \\
+      fs[cut_env_def] \\ clean_tac \\
+      simp[lookup_inter_alt] )
+    >> full_simp_tac std_ss [GSYM APPEND_ASSOC]
+    \\ cheat )
+  \\ eval_tac
   \\ qpat_abbrev_tac`tttt = t with locals := _`
   \\ `get_var (adjust_var e1) tttt = get_var (adjust_var e1) t`
   by fs[Abbr`tttt`,wordSemTheory.get_var_def,lookup_insert]
@@ -8249,11 +8338,14 @@ val th = Q.store_thm("assign_FFI",
      (fn thm=> rpt_drule get_var_get_real_addr_lemma >> assume_tac thm)
   \\ `tttt.store = t.store` by simp[Abbr`tttt`]
   \\ simp[]
+  \\ IF_CASES_TAC >- ( fs[shift_def] )
+  \\ simp[]
   \\ qpat_abbrev_tac`ttttt = t with locals := _`
   \\ `get_var (adjust_var e1) ttttt = get_var (adjust_var e1) t`
   by fs[Abbr`ttttt`,wordSemTheory.get_var_def,lookup_insert]
   \\ `get_var (adjust_var e2) tttt = get_var (adjust_var e2) t`
   by fs[Abbr`ttttt`,wordSemTheory.get_var_def,lookup_insert]
+  \\ qpat_x_assum`¬_` kall_tac
   \\ rfs[]
   \\ rpt_drule get_var_get_real_addr_lemma
   \\ qpat_x_assum `get_var _ _ = SOME (WORD _)`
@@ -8443,35 +8535,35 @@ val th = Q.store_thm("assign_FFI",
           \\ drule memory_rel_tl \\ match_mp_tac memory_rel_rearrange
           \\ simp[join_env_def,MEM_MAP,PULL_EXISTS,MEM_FILTER,MEM_toAList,EXISTS_PROD,lookup_inter_alt]
           \\ rw[] \\ rw[] \\ metis_tac[])
-     >> `F` suffices_by rw[]
-     >> pop_assum mp_tac
-     >> fs[cut_state_opt_def]
-     >> drule (#1(EQ_IMP_RULE cut_state_eq_some))
-     >> strip_tac
-     >> clean_tac
-     >> simp[wordSemTheory.cut_env_def]
-     >> rw[SUBSET_DEF,domain_lookup]
-     >> fs[dataSemTheory.cut_env_def]
-     >> clean_tac >> fs[]
-     >> Cases_on`x=0` >- metis_tac[]
-     >> qmatch_assum_abbrev_tac`lookup x ss = SOME _`
-     >> `x ∈ domain ss` by metis_tac[domain_lookup]
-     >> qunabbrev_tac`ss`
-     >> imp_res_tac domain_adjust_set_EVEN
-     >> `∃z. x = adjust_var z`
-     by (
-         simp[adjust_var_def]
-         \\ fs[EVEN_EXISTS]
-         \\ Cases_on`m` \\ fs[ADD1,LEFT_ADD_DISTRIB] )
-     >> rveq
-     >> fs[lookup_adjust_var_adjust_set_SOME_UNIT]
-     >> last_x_assum(qspec_then`z`mp_tac)
-     >> simp[lookup_inter]
-     >> fs[IS_SOME_EXISTS]
-     >> disch_then match_mp_tac
-     >> BasicProvers.CASE_TAC
-     >> fs[SUBSET_DEF,domain_lookup]
-     >> res_tac >> fs[]);
+   >> `F` suffices_by rw[]
+   >> pop_assum mp_tac
+   >> fs[cut_state_opt_def]
+   >> drule (#1(EQ_IMP_RULE cut_state_eq_some))
+   >> strip_tac
+   >> clean_tac
+   >> simp[wordSemTheory.cut_env_def]
+   >> rw[SUBSET_DEF,domain_lookup]
+   >> fs[dataSemTheory.cut_env_def]
+   >> clean_tac >> fs[]
+   >> Cases_on`x=0` >- metis_tac[]
+   >> qmatch_assum_abbrev_tac`lookup x ss = SOME _`
+   >> `x ∈ domain ss` by metis_tac[domain_lookup]
+   >> qunabbrev_tac`ss`
+   >> imp_res_tac domain_adjust_set_EVEN
+   >> `∃z. x = adjust_var z`
+   by (
+       simp[adjust_var_def]
+       \\ fs[EVEN_EXISTS]
+       \\ Cases_on`m` \\ fs[ADD1,LEFT_ADD_DISTRIB] )
+   >> rveq
+   >> fs[lookup_adjust_var_adjust_set_SOME_UNIT]
+   >> last_x_assum(qspec_then`z`mp_tac)
+   >> simp[lookup_inter]
+   >> fs[IS_SOME_EXISTS]
+   >> disch_then match_mp_tac
+   >> BasicProvers.CASE_TAC
+   >> fs[SUBSET_DEF,domain_lookup]
+   >> res_tac >> fs[]);
 
 val assign_thm = Q.store_thm("assign_thm",
   `^assign_thm_goal`,

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -8325,7 +8325,16 @@ val th = Q.store_thm("assign_FFI",
       fs[cut_env_def] \\ clean_tac \\
       simp[lookup_inter_alt] )
     >> full_simp_tac std_ss [GSYM APPEND_ASSOC]
-    \\ cheat )
+    \\ DEP_REWRITE_TAC[FUPDATE_ELIM]
+    \\ conj_tac >- fs[FLOOKUP_DEF]
+    \\ match_mp_tac memory_rel_insert
+    >> full_simp_tac std_ss [GSYM APPEND_ASSOC,APPEND]
+    \\ match_mp_tac memory_rel_Unit \\ fs[]
+    \\ match_mp_tac (MP_CANON (GEN_ALL memory_rel_rearrange))
+    \\ last_assum(part_match_exists_tac rand o concl)
+    \\ simp[] \\ rw[] \\ fs[]
+    \\ fs[join_env_def,MEM_MAP,PULL_EXISTS,MEM_FILTER,MEM_toAList,EXISTS_PROD,lookup_inter_alt]
+    \\ metis_tac[])
   \\ eval_tac
   \\ qpat_abbrev_tac`tttt = t with locals := _`
   \\ `get_var (adjust_var e1) tttt = get_var (adjust_var e1) t`

--- a/compiler/backend/riscv/riscv_configScript.sml
+++ b/compiler/backend/riscv/riscv_configScript.sml
@@ -29,7 +29,7 @@ val riscv_names_def = Define `
    insert 10 29 o
    insert 11 30 o
    insert 12 4 o
-   insert 13 28 o   
+   insert 13 28 o
    insert 28 0 o
    insert 29 2 o
    insert 30 3) LN:num num_map`;
@@ -42,7 +42,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; gc_kind:=Simple|>``
+val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
 val riscv_word_conf = ``<| bitmaps := []:64 word list |>``
 val riscv_stack_conf = ``<|jump:=F;reg_names:=riscv_names|>``
 val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=riscv_config;init_clock:=5|>``

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -65,13 +65,13 @@ val update_simps = Q.store_thm("update_simps[simp]",
     ((labSem$dec_clock s).link_reg = s.link_reg) ∧
     ((labSem$dec_clock s).code = s.code) ∧
     ((labSem$dec_clock s).ptr_reg = s.ptr_reg) ∧
-    ((labSem$dec_clock s).ptr2_reg = s.ptr2_reg) ∧    
+    ((labSem$dec_clock s).ptr2_reg = s.ptr2_reg) ∧
     ((labSem$dec_clock s).ffi = s.ffi) ∧
     ((labSem$upd_pc x s).len_reg = s.len_reg) ∧
-    ((labSem$upd_pc x s).len2_reg = s.len2_reg) ∧    
+    ((labSem$upd_pc x s).len2_reg = s.len2_reg) ∧
     ((labSem$upd_pc x s).link_reg = s.link_reg) ∧
     ((labSem$upd_pc x s).code = s.code) ∧
-    ((labSem$upd_pc x s).ptr_reg = s.ptr_reg) ∧    
+    ((labSem$upd_pc x s).ptr_reg = s.ptr_reg) ∧
     ((labSem$upd_pc x s).ptr2_reg = s.ptr2_reg) ∧
     ((labSem$upd_pc x s).mem_domain = s.mem_domain) ∧
     ((labSem$upd_pc x s).failed = s.failed) ∧
@@ -81,9 +81,9 @@ val update_simps = Q.store_thm("update_simps[simp]",
     ((labSem$upd_pc x s).fp_regs = s.fp_regs) ∧
     ((labSem$upd_pc x s).ffi = s.ffi) ∧
     ((labSem$inc_pc s).ptr_reg = s.ptr_reg) ∧
-    ((labSem$inc_pc s).ptr2_reg = s.ptr2_reg) ∧    
+    ((labSem$inc_pc s).ptr2_reg = s.ptr2_reg) ∧
     ((labSem$inc_pc s).len_reg = s.len_reg) ∧
-    ((labSem$inc_pc s).len2_reg = s.len2_reg) ∧    
+    ((labSem$inc_pc s).len2_reg = s.len2_reg) ∧
     ((labSem$inc_pc s).link_reg = s.link_reg) ∧
     ((labSem$inc_pc s).code = s.code) ∧
     ((labSem$inc_pc s).be = s.be) ∧
@@ -133,7 +133,7 @@ val fp_upd_consts = Q.store_thm("fp_upd_consts[simp]",
    (labSem$fp_upd f x).ptr_reg = x.ptr_reg ∧
    (labSem$fp_upd f x).len_reg = x.len_reg ∧
    (labSem$fp_upd f x).ptr2_reg = x.ptr2_reg ∧
-   (labSem$fp_upd f x).len2_reg = x.len2_reg ∧                                                                                   
+   (labSem$fp_upd f x).len2_reg = x.len2_reg ∧
    (labSem$fp_upd f x).link_reg = x.link_reg ∧
    (labSem$fp_upd f x).code = x.code ∧
    (labSem$fp_upd f x).be = x.be ∧
@@ -281,10 +281,9 @@ val evaluate_io_events_mono = Q.store_thm("evaluate_io_events_mono",
   Cases_on`x`>>fs[] >- (
     every_case_tac >> rw[] >> fs[] >>
     fs[inc_pc_def,dec_clock_def,asm_inst_consts] ) >>
-  Cases_on`a`>>fs[] >>
-  every_case_tac >> rw[] >> fs[] >>
+  Cases_on`a`>>fs[case_eq_thms] >> rw[] >> fs[] >>
   fs[inc_pc_def,dec_clock_def,asm_inst_consts,upd_reg_def] >>
-  pairarg_tac >> fs[] >>
+  TRY(qpat_x_assum`(_,_) = _`(assume_tac o SYM)) \\ fs[] \\
   fs[call_FFI_def] >>
   every_case_tac >> fs[] >> rfs[] >>
   rpt var_eq_tac >> fs[] >>
@@ -346,7 +345,7 @@ val evaluate_add_clock_io_events_mono = Q.store_thm("evaluate_add_clock_io_event
     drule (GEN_ALL evaluate_pres_final_event) >>
     unabbrev_all_tac >> fs[] >>
     every_case_tac >> fs[] >> rw[] >>
-    fs[IS_PREFIX_APPEND] ) >>
+    fs[IS_PREFIX_APPEND,IS_SOME_EXISTS] ) >>
   fs[asm_fetch_def] >>
   Cases_on`asm_fetch_aux s.pc s.code`>>fs[] >>
   Cases_on`x`>>fs[] >>

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -38,7 +38,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 
-val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=F; gc_kind:=Simple|>``
+val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps := []:64 word list |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
 val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=x64_config;init_clock:=5|>``

--- a/semantics/ffi/ffi.lem
+++ b/semantics/ffi/ffi.lem
@@ -35,7 +35,7 @@ let initial_ffi_state oc ffi =
 
 val call_FFI : forall 'ffi. ffi_state 'ffi -> string -> list word8 -> list word8 -> ffi_state 'ffi * list word8
 let call_FFI st s conf bytes =
-  if st.final_event = Nothing || s = "" then
+  if st.final_event = Nothing && s <> "" then
     match st.oracle s st.ffi_state conf bytes with
     | Oracle_return ffi' bytes' ->
         if length bytes' = length bytes then

--- a/semantics/ffi/ffi.lem
+++ b/semantics/ffi/ffi.lem
@@ -35,7 +35,7 @@ let initial_ffi_state oc ffi =
 
 val call_FFI : forall 'ffi. ffi_state 'ffi -> string -> list word8 -> list word8 -> ffi_state 'ffi * list word8
 let call_FFI st s conf bytes =
-  if st.final_event = Nothing then
+  if st.final_event = Nothing || s = "" then
     match st.oracle s st.ffi_state conf bytes with
     | Oracle_return ffi' bytes' ->
         if length bytes' = length bytes then

--- a/semantics/ffi/ffiScript.sml
+++ b/semantics/ffi/ffiScript.sml
@@ -58,7 +58,7 @@ val _ = Define `
 (*val call_FFI : forall 'ffi. ffi_state 'ffi -> string -> list word8 -> list word8 -> ffi_state 'ffi * list word8*)
 val _ = Define `
  (call_FFI st s conf bytes=  
- (if st.final_event = NONE then
+ (if (st.final_event = NONE) \/ (s = "") then
     (case st.oracle s st.ffi_state conf bytes of
       Oracle_return ffi' bytes' =>
         if LENGTH bytes' = LENGTH bytes then

--- a/semantics/ffi/ffiScript.sml
+++ b/semantics/ffi/ffiScript.sml
@@ -58,7 +58,7 @@ val _ = Define `
 (*val call_FFI : forall 'ffi. ffi_state 'ffi -> string -> list word8 -> list word8 -> ffi_state 'ffi * list word8*)
 val _ = Define `
  (call_FFI st s conf bytes=  
- (if (st.final_event = NONE) \/ (s = "") then
+ (if (st.final_event = NONE) /\ ~ (s = "") then
     (case st.oracle s st.ffi_state conf bytes of
       Oracle_return ffi' bytes' =>
         if LENGTH bytes' = LENGTH bytes then

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -2367,6 +2367,7 @@ val builtin_monops =
    Eval_vector,
    Eval_int_of_num,
    Eval_num_of_int,
+   Eval_silent_ffi,
    Eval_Chr,
    Eval_Ord]
   |> map SPEC_ALL

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -1566,6 +1566,30 @@ val Eval_force_gc_to_run = Q.store_thm("Eval_force_gc_to_run",
   asm_exists_tac >> fs [] >>
   fs [do_app_def,INT_def,UNIT_TYPE_def]);
 
+val silent_ffi_def = Define `
+  silent_ffi (s:mlstring) = ()`;
+
+val Eval_silent_ffi = Q.store_thm("Eval_silent_ffi",
+  `Eval env x (STRING_TYPE s) ==>
+   Eval env (App (FFI "") [x; App Aw8alloc [Lit (IntLit 0); Lit (Word8 0w)]])
+     (UNIT_TYPE (silent_ffi s))`,
+  rw [Eval_def]
+  \\ ntac 8 (rw [Once evaluate_cases,PULL_EXISTS,empty_state_with_refs_eq])
+  \\ fs [do_app_def,store_alloc_def]
+  \\ ntac 1 (rw [Once evaluate_cases,PULL_EXISTS,empty_state_with_refs_eq])
+  \\ pop_assum (qspec_then `refs ⧺ [W8array []]` mp_tac)
+  \\ fs [empty_state_def]
+  \\ strip_tac \\ asm_exists_tac \\ fs []
+  \\ ntac 1 (rw [Once evaluate_cases,PULL_EXISTS,empty_state_with_refs_eq])
+  \\ Cases_on `s` \\ fs [STRING_TYPE_def]
+  \\ rveq \\ fs [store_lookup_def]
+  \\ simp_tac std_ss [APPEND,GSYM APPEND_ASSOC]
+  \\ fs [EL_LENGTH_APPEND]
+  \\ fs [ffiTheory.call_FFI_def]
+  \\ fs [store_assign_def]
+  \\ simp_tac std_ss [APPEND,GSYM APPEND_ASSOC]
+  \\ fs [EL_LENGTH_APPEND]
+  \\ EVAL_TAC \\ fs []);
 
 (* a few misc. lemmas that help the automation *)
 


### PR DESCRIPTION
Makes the semantics of the FFI call with no name (empty string) special: it is assumed to do nothing and return.

The aim was to use this to trace GC calls and other things, although that is not included in this pull request.

Closes #385 