### PR TITLE
Add coalescing info to oracle allocator

### DIFF
--- a/compiler/backend/reg_alloc/reg_allocComputeLib.sml
+++ b/compiler/backend/reg_alloc/reg_allocComputeLib.sml
@@ -203,6 +203,7 @@ fun alloc_aux alg k [] n = (print"\n";[])
 *)
 fun alloc_all alg t =
   let val (k,ls) = pairSyntax.dest_pair t
+      val _ = print ("Num regs: "^Int.toString (int_of_term k) ^" Alg: "^Int.toString alg^ "\n")
     val clash_mov_ls = map pairSyntax.strip_pair (fst(listSyntax.dest_list ls)) in
     alloc_aux alg (int_of_term k) clash_mov_ls 0
   end

--- a/unverified/reg_alloc/reg_alloc.sml
+++ b/unverified/reg_alloc/reg_alloc.sml
@@ -2,12 +2,12 @@ structure reg_alloc = struct
 
   type one = unit;
 
-  fun  hd x1 = 
+  fun  hd x1 =
     case  x1
     of  []  =>  (raise  Bind)
     |   v2::v1 =>  v2;
 
-  fun  tl x1 = 
+  fun  tl x1 =
     case  x1
     of  []  =>  (raise  Bind)
     |   v2::v1 =>  v1;
@@ -42,7 +42,7 @@ structure reg_alloc = struct
 
   fun  s v3 =  (fn  v2 => (fn  v1 => v3 v1 (v2 v1)));
 
-  fun  update v3 = 
+  fun  update v3 =
     (fn  v4 =>
       (fn  v2 =>
         (fn  v1 =>
@@ -52,28 +52,28 @@ structure reg_alloc = struct
 
   fun  w v2 =  (fn  v1 => v2 v1 v1);
 
-  fun  the x1 = 
+  fun  the x1 =
     case  x1
     of  NONE =>  (raise  Bind)
     |   SOME(v1) =>  v1;
 
-  fun  is_none v2 = 
+  fun  is_none v2 =
     case  v2
     of  NONE =>  (0 <= 0)
     |   SOME(v1) =>  (0 < 0);
 
-  fun  is_some v2 = 
+  fun  is_some v2 =
     case  v2
     of  NONE =>  (0 < 0)
     |   SOME(v1) =>  (0 <= 0);
 
-  fun  option_map v2 = 
+  fun  option_map v2 =
     (fn  v3 =>
       case  v3
       of  NONE =>  NONE
       |   SOME(v1) =>  (SOME(v2 v1)));
 
-  fun  option_map2 v1 = 
+  fun  option_map2 v1 =
     (fn  v2 =>
       (fn  v3 =>
         if  ((is_some v2) andalso  (is_some v3))
@@ -83,27 +83,27 @@ structure reg_alloc = struct
   datatype ( 'a  ,  'b ) sum =  Inr of  'b
                               |  Inl of  'a ;
 
-  fun  isl v3 = 
+  fun  isl v3 =
     case  v3
     of  Inl(v1) =>  (0 <= 0)
     |   Inr(v2) =>  (0 < 0);
 
-  fun  isr v3 = 
+  fun  isr v3 =
     case  v3
     of  Inl(v1) =>  (0 < 0)
     |   Inr(v2) =>  (0 <= 0);
 
-  fun  outl x1 = 
+  fun  outl x1 =
     case  x1
     of  Inl(v1) =>  v1
     |   Inr(v2) =>  (raise  Bind);
 
-  fun  outr x1 = 
+  fun  outr x1 =
     case  x1
     of  Inl(v1) =>  (raise  Bind)
     |   Inr(v2) =>  v2;
 
-  fun  f v3 = 
+  fun  f v3 =
     (fn  v4 =>
       (fn  v5 =>
         case  v5
@@ -208,7 +208,7 @@ structure reg_alloc = struct
                                              else  k
                                            end)));
 
-  fun  pad_right v1 = 
+  fun  pad_right v1 =
     (fn  v2 =>
       (fn  v3 =>
         append v3 (genlist (k v1) (let val  k = v2 - (length v3)
@@ -218,7 +218,7 @@ structure reg_alloc = struct
                                       else  k
                                     end))));
 
-  fun  pad_left v1 = 
+  fun  pad_left v1 =
     (fn  v2 =>
       (fn  v3 =>
         append (genlist (k v1) (let val  k = v2 - (length v3)
@@ -319,13 +319,13 @@ structure reg_alloc = struct
 
   fun  exp v1 =  (fn  v2 => exp_aux v1 v2 1);
 
-  fun  min v1 = 
+  fun  min v1 =
     (fn  v2 =>
       if  (v1 < v2)
       then  v1
        else  v2);
 
-  fun  max v1 = 
+  fun  max v1 =
     (fn  v2 =>
       if  (v1 < v2)
       then  v2
@@ -345,7 +345,7 @@ structure reg_alloc = struct
                           else  k
                         end) (v1 v3));
 
-  fun  abs_diff v2 = 
+  fun  abs_diff v2 =
     (fn  v1 =>
       if  (v2 < v1)
       then  (let val  k = v1 - v2
@@ -361,7 +361,7 @@ structure reg_alloc = struct
                 else  k
               end));
 
-  fun  pre v1 = 
+  fun  pre v1 =
     let val  k = v1 - 1
      in
       if  (k < 0)
@@ -419,7 +419,7 @@ structure reg_alloc = struct
     then  (owhile v1 v2 (v2 v3))
     else  (SOME(v3));
 
-  fun  least v3 = 
+  fun  least v3 =
     while_1 (fn  v1 => ((v3 v1) = (0 < 0))) (fn  v2 => (v2 + 1)) 0;
 
   datatype 'a sptree_spt =  Bs of  'a sptree_spt *  'a  *  'a sptree_spt
@@ -429,124 +429,124 @@ structure reg_alloc = struct
 
   datatype reg_alloc_ra_state =  Recordtypera_state of  one sptree_spt sptree_spt *  int *  int sptree_spt *  int list *  int list *  int list *  int list *  int sptree_spt *  one sptree_spt *  (int *  (int *  int)) list *  (int *  (int *  int)) list *  (int *  (int *  int)) list *  int;
 
-  fun  ra_state_graph v14 = 
+  fun  ra_state_graph v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v13;
 
-  fun  ra_state_colours v14 = 
+  fun  ra_state_colours v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v12;
 
-  fun  ra_state_degs v14 = 
+  fun  ra_state_degs v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v11;
 
-  fun  ra_state_simp_worklist v14 = 
+  fun  ra_state_simp_worklist v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v10;
 
-  fun  ra_state_freeze_worklist v14 = 
+  fun  ra_state_freeze_worklist v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v9;
 
-  fun  ra_state_spill_worklist v14 = 
+  fun  ra_state_spill_worklist v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v8;
 
-  fun  ra_state_stack v14 = 
+  fun  ra_state_stack v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v7;
 
-  fun  ra_state_coalesced v14 = 
+  fun  ra_state_coalesced v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v6;
 
-  fun  ra_state_move_related v14 = 
+  fun  ra_state_move_related v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v5;
 
-  fun  ra_state_avail_moves_pri v14 = 
+  fun  ra_state_avail_moves_pri v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v4;
 
-  fun  ra_state_avail_moves v14 = 
+  fun  ra_state_avail_moves v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v3;
 
-  fun  ra_state_unavail_moves v14 = 
+  fun  ra_state_unavail_moves v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v2;
 
-  fun  ra_state_clock v14 = 
+  fun  ra_state_clock v14 =
     case  v14
     of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  v1;
 
-  fun  ra_state_graph_fupd v14 = 
+  fun  ra_state_graph_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v14 v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_colours_fupd v14 = 
+  fun  ra_state_colours_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v14 v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_degs_fupd v14 = 
+  fun  ra_state_degs_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v14 v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_simp_worklist_fupd v14 = 
+  fun  ra_state_simp_worklist_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v14 v10,v9,v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_freeze_worklist_fupd v14 = 
+  fun  ra_state_freeze_worklist_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v14 v9,v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_spill_worklist_fupd v14 = 
+  fun  ra_state_spill_worklist_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v14 v8,v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_stack_fupd v14 = 
+  fun  ra_state_stack_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v14 v7,v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_coalesced_fupd v14 = 
+  fun  ra_state_coalesced_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v14 v6,v5,v4,v3,v2,v1)));
 
-  fun  ra_state_move_related_fupd v14 = 
+  fun  ra_state_move_related_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v14 v5,v4,v3,v2,v1)));
 
-  fun  ra_state_avail_moves_pri_fupd v14 = 
+  fun  ra_state_avail_moves_pri_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v14 v4,v3,v2,v1)));
 
-  fun  ra_state_avail_moves_fupd v14 = 
+  fun  ra_state_avail_moves_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v14 v3,v2,v1)));
 
-  fun  ra_state_unavail_moves_fupd v14 = 
+  fun  ra_state_unavail_moves_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v14 v2,v1)));
 
-  fun  ra_state_clock_fupd v14 = 
+  fun  ra_state_clock_fupd v14 =
     (fn  v15 =>
       case  v15
       of  Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v1) =>  (Recordtypera_state(v13,v12,v11,v10,v9,v8,v7,v6,v5,v4,v3,v2,v14 v1)));
 
-  fun  bind v5 = 
+  fun  bind v5 =
     (fn  v4 => o_1 (fn  v3 => (case  v3 of  (v2,v1) =>  (v4 v2 v1))) v5);
 
   fun  unit v2 =  (fn  v1 => (v2,v1));
@@ -557,7 +557,7 @@ structure reg_alloc = struct
 
   fun  ignore_bind v2 =  (fn  v3 => bind v2 (fn  v1 => v3));
 
-  fun  dec_clock v1 = 
+  fun  dec_clock v1 =
     ((),ra_state_clock_fupd (k (let val  k = (ra_state_clock v1) - 1
                                  in
                                   if  (k < 0)
@@ -567,7 +567,7 @@ structure reg_alloc = struct
 
   fun  get_simp_worklist v1 =  unit (ra_state_simp_worklist v1) v1;
 
-  fun  set_simp_worklist v2 = 
+  fun  set_simp_worklist v2 =
     (fn  v1 => ((),ra_state_simp_worklist_fupd (k v2) v1));
 
   fun  get_graph v1 =  unit (ra_state_graph v1) v1;
@@ -622,7 +622,7 @@ structure reg_alloc = struct
                             foldi v9 (v10 + v5) (v9 v10 v7 (foldi v9 (v10 + (2 * v5)) v12 v8)) v6
                            end);
 
-  fun  toalist v4 = 
+  fun  toalist v4 =
     foldi (fn  v3 => (fn  v2 => (fn  v1 => ((v3,v2)::v1)))) 0 [] v4;
 
   fun  foreach v6 =
@@ -698,12 +698,12 @@ structure reg_alloc = struct
                                                              else  k
                                                            end) div 2) v8 v4))));
 
-  fun  set_deg v2 = 
+  fun  set_deg v2 =
     (fn  v3 =>
       (fn  v1 =>
         ((),ra_state_degs_fupd (k (insert v2 v3 (ra_state_degs v1))) v1)));
 
-  fun  dec_one v3 = 
+  fun  dec_one v3 =
     bind (get_deg v3) (fn  v2 =>
                         (case  v2
                          of  NONE =>  (unit ())
@@ -715,7 +715,7 @@ structure reg_alloc = struct
                                                             else  k
                                                           end))));
 
-  fun  dec_deg v4 = 
+  fun  dec_deg v4 =
     bind get_graph (fn  v3 =>
                      (case  (lookup v4 v3)
                       of  NONE =>  (unit ())
@@ -735,23 +735,23 @@ structure reg_alloc = struct
 
   fun  get_unavail_moves v1 =  unit (ra_state_unavail_moves v1) v1;
 
-  fun  split_priority v6 = 
+  fun  split_priority v6 =
     partition (fn  v5 =>
                 (case  v5
                  of  (v4,v3) =>  (case  v3 of  (v2,v1) =>  (v4 > 0)))) v6;
 
-  fun  add_avail_moves_pri v2 = 
+  fun  add_avail_moves_pri v2 =
     (fn  v1 =>
       ((),ra_state_avail_moves_pri_fupd (k (append v2 (ra_state_avail_moves_pri v1))) v1));
 
-  fun  add_avail_moves v2 = 
+  fun  add_avail_moves v2 =
     (fn  v1 =>
       ((),ra_state_avail_moves_fupd (k (append v2 (ra_state_avail_moves v1))) v1));
 
-  fun  set_unavail_moves v2 = 
+  fun  set_unavail_moves v2 =
     (fn  v1 => ((),ra_state_unavail_moves_fupd (k v2) v1));
 
-  fun  revive_moves v16 = 
+  fun  revive_moves v16 =
     bind get_graph (fn  v15 =>
                      (case  (lookup v16 v15)
                       of  NONE =>  (unit ())
@@ -775,18 +775,18 @@ structure reg_alloc = struct
                                                                        end))
                                            end)));
 
-  fun  set_spill_worklist v2 = 
+  fun  set_spill_worklist v2 =
     (fn  v1 => ((),ra_state_spill_worklist_fupd (k v2) v1));
 
-  fun  add_simp_worklist v2 = 
+  fun  add_simp_worklist v2 =
     (fn  v1 =>
       ((),ra_state_simp_worklist_fupd (k (append v2 (ra_state_simp_worklist v1))) v1));
 
-  fun  add_freeze_worklist v2 = 
+  fun  add_freeze_worklist v2 =
     (fn  v1 =>
       ((),ra_state_freeze_worklist_fupd (k (append v2 (ra_state_freeze_worklist v1))) v1));
 
-  fun  unspill v14 = 
+  fun  unspill v14 =
     bind get_spill_worklist (fn  v13 =>
                               (bind get_degs (fn  v12 =>
                                                (bind get_colours (fn  v11 =>
@@ -811,7 +811,7 @@ structure reg_alloc = struct
                                                                                                             end)
                                                                                          end)))))))) v14;
 
-  fun  simplify v4 = 
+  fun  simplify v4 =
     bind get_simp_worklist (fn  v3 =>
                              (case  v3
                               of  []  =>  (unit NONE)
@@ -828,7 +828,7 @@ structure reg_alloc = struct
                            else  (split_avail v3 v4 v1 (v2::v5)))
                     else  (split_avail v3 v4 v1 v5));
 
-  fun  lookup_g v3 = 
+  fun  lookup_g v3 =
     (fn  v4 =>
       (fn  v2 =>
         case  (lookup v3 v2)
@@ -840,7 +840,7 @@ structure reg_alloc = struct
 
   fun  is_phy_var v1 =  (v1 mod 2) <= 0;
 
-  fun  is_valid_move v6 = 
+  fun  is_valid_move v6 =
     (fn  v8 =>
       (fn  v7 =>
         let val  v5 = v7
@@ -864,7 +864,7 @@ structure reg_alloc = struct
                                                                                                                                                                                                                           end))))))
         end));
 
-  fun  mk_bn v13 = 
+  fun  mk_bn v13 =
     (fn  v14 =>
       case  v13
       of  Ln =>  (case  v14
@@ -876,7 +876,7 @@ structure reg_alloc = struct
       |   Bn(v9,v8) =>  (Bn(Bn(v9,v8),v14))
       |   Bs(v12,v11,v10) =>  (Bn(Bs(v12,v11,v10),v14)));
 
-  fun  mk_bs v13 = 
+  fun  mk_bs v13 =
     (fn  v14 =>
       (fn  v15 =>
         case  v15
@@ -915,7 +915,7 @@ structure reg_alloc = struct
                      of  NONE =>  (option_filter v2)
                      |   (SOME(v1)) =>  (v1::(option_filter v2)));
 
-  fun  george_ok v13 = 
+  fun  george_ok v13 =
     (fn  v15 =>
       (fn  v14 =>
         (fn  v16 =>
@@ -959,7 +959,7 @@ structure reg_alloc = struct
                              |   (Bn(v18,v17)) =>  (Bs(union v24 v18,v23,union v22 v17))
                              |   (Bs(v21,v20,v19)) =>  (Bs(union v24 v21,v23,union v22 v19)));
 
-  fun  briggs_ok v13 = 
+  fun  briggs_ok v13 =
     (fn  v15 =>
       (fn  v14 =>
         (fn  v16 =>
@@ -984,7 +984,7 @@ structure reg_alloc = struct
                                                                         end)))
           end)));
 
-  fun  is_coalesceable_move v6 = 
+  fun  is_coalesceable_move v6 =
     (fn  v8 =>
       (fn  v7 =>
         (fn  v9 =>
@@ -997,33 +997,33 @@ structure reg_alloc = struct
                                               else  (briggs_ok v6 v8 v7 (v2,v1))))
           end)));
 
-  fun  set_avail_moves_pri v2 = 
+  fun  set_avail_moves_pri v2 =
     (fn  v1 => ((),ra_state_avail_moves_pri_fupd (k v2) v1));
 
-  fun  add_unavail_moves v2 = 
+  fun  add_unavail_moves v2 =
     (fn  v1 =>
       ((),ra_state_unavail_moves_fupd (k (append v2 (ra_state_unavail_moves v1))) v1));
 
   fun  get_avail_moves v1 =  unit (ra_state_avail_moves v1) v1;
 
-  fun  set_avail_moves v2 = 
+  fun  set_avail_moves v2 =
     (fn  v1 => ((),ra_state_avail_moves_fupd (k v2) v1));
 
-  fun  add_coalesce v2 = 
+  fun  add_coalesce v2 =
     (fn  v3 =>
       (fn  v1 =>
         ((),ra_state_coalesced_fupd (k (insert v3 v2 (ra_state_coalesced v1))) v1)));
 
-  fun  get_edges v2 = 
+  fun  get_edges v2 =
     (fn  v1 => unit (lookup v2 (ra_state_graph v1)) v1);
 
-  fun  inc_one v3 = 
+  fun  inc_one v3 =
     bind (get_deg v3) (fn  v2 =>
                         (case  v2
                          of  NONE =>  (unit ())
                          |   (SOME(v1)) =>  (set_deg v3 (v1 + 1))));
 
-  fun  dir_g_insert v4 = 
+  fun  dir_g_insert v4 =
     (fn  v5 =>
       (fn  v3 =>
         let val  v1 =
@@ -1034,15 +1034,15 @@ structure reg_alloc = struct
           insert v4 v1 v3
          end));
 
-  fun  undir_g_insert v2 = 
+  fun  undir_g_insert v2 =
     (fn  v3 => (fn  v1 => dir_g_insert v2 v3 (dir_g_insert v3 v2 v1)));
 
-  fun  force_add v2 = 
+  fun  force_add v2 =
     (fn  v3 =>
       (fn  v1 =>
         ((),ra_state_graph_fupd (k (undir_g_insert v2 v3 (ra_state_graph v1))) v1)));
 
-  fun  do_coalesce v13 = 
+  fun  do_coalesce v13 =
     let val  v12 = v13
      in
       case  v12
@@ -1065,7 +1065,7 @@ structure reg_alloc = struct
                                                                                                                                                                                           end))))))))))))
     end;
 
-  fun  pair_rename v10 = 
+  fun  pair_rename v10 =
     (fn  v8 =>
       (fn  v9 =>
         let val  v7 = v9
@@ -1087,14 +1087,14 @@ structure reg_alloc = struct
 
   fun  get_freeze_worklist v1 =  unit (ra_state_freeze_worklist v1) v1;
 
-  fun  add_spill_worklist v2 = 
+  fun  add_spill_worklist v2 =
     (fn  v1 =>
       ((),ra_state_spill_worklist_fupd (k (append v2 (ra_state_spill_worklist v1))) v1));
 
-  fun  set_freeze_worklist v2 = 
+  fun  set_freeze_worklist v2 =
     (fn  v1 => ((),ra_state_freeze_worklist_fupd (k v2) v1));
 
-  fun  respill v6 = 
+  fun  respill v6 =
     bind get_colours (fn  v5 =>
                        (bind (get_deg v6) (fn  v4 =>
                                             (case  v4
@@ -1107,7 +1107,7 @@ structure reg_alloc = struct
                                                                                                                                                                                 ((v1 = v6) = (0 < 0))) v2)))
                                                                                                     else  (unit ())))))))));
 
-  fun  coalesce v29 = 
+  fun  coalesce v29 =
     bind get_graph (fn  v28 =>
                      (bind get_colours (fn  v27 =>
                                          (bind get_degs (fn  v26 =>
@@ -1158,10 +1158,10 @@ structure reg_alloc = struct
 
   fun  get_coalesced v1 =  unit (ra_state_coalesced v1) v1;
 
-  fun  set_move_rel v2 = 
+  fun  set_move_rel v2 =
     (fn  v1 => ((),ra_state_move_related_fupd (k v2) v1));
 
-  fun  freeze v27 = 
+  fun  freeze v27 =
     bind get_freeze_worklist (fn  v26 =>
                                (bind get_unavail_moves (fn  v25 =>
                                                          (bind get_graph (fn  v24 =>
@@ -1208,7 +1208,7 @@ structure reg_alloc = struct
                                                                                                                            else  (max_non_coalesced v16 v15 v10 (v11::v9) (v7,v6))))
                                                                                                 else  (max_non_coalesced v16 v15 v10 v9 (v7,v6)))))));
 
-  fun  spill v11 = 
+  fun  spill v11 =
     bind get_spill_worklist (fn  v10 =>
                               (bind get_coalesced (fn  v9 =>
                                                     (bind get_degs (fn  v8 =>
@@ -1261,11 +1261,11 @@ structure reg_alloc = struct
                                                                  else  k
                                                                end) div 2) v4))));
 
-  fun  push_stack v2 = 
+  fun  push_stack v2 =
     (fn  v1 =>
       ((),ra_state_degs_fupd (k (delete v2 (ra_state_degs v1))) (ra_state_stack_fupd (k (v2::(ra_state_stack v1))) (ra_state_move_related_fupd (k (delete v2 (ra_state_move_related v1))) v1))));
 
-  fun  do_step v9 = 
+  fun  do_step v9 =
     ignore_bind dec_clock (bind simplify (fn  v8 =>
                                            (case  v8
                                             of  NONE =>  (bind coalesce (fn  v6 =>
@@ -1280,10 +1280,10 @@ structure reg_alloc = struct
                                                                            |   (SOME(v5)) =>  (push_stack v5))))
                                             |   (SOME(v7)) =>  (push_stack v7)))) v9;
 
-  fun  rpt_do_step v1 = 
+  fun  rpt_do_step v1 =
     ((),while_1 (o_1 fst has_work) (o_1 snd do_step) v1);
 
-  fun  deg_comparator v3 = 
+  fun  deg_comparator v3 =
     (fn  v4 =>
       (fn  v5 =>
         case  (lookup v4 v3)
@@ -1292,44 +1292,44 @@ structure reg_alloc = struct
                           of  NONE =>  (0 <= 0)
                           |   (SOME(v1)) =>  (v2 <= v1))));
 
-  fun  full_simplify v5 = 
+  fun  full_simplify v5 =
     bind get_simp_worklist (fn  v4 =>
                              (bind get_degs (fn  v3 =>
                                               (case  (qsort (deg_comparator v3) v4)
                                                of  []  =>  (unit NONE)
                                                |   (v2::v1) =>  (ignore_bind (set_simp_worklist v1) (ignore_bind (dec_deg v2) (unit (SOME(v2))))))))) v5;
 
-  fun  do_step2 v3 = 
+  fun  do_step2 v3 =
     ignore_bind dec_clock (bind full_simplify (fn  v2 =>
                                                 (case  v2
                                                  of  NONE =>  (unit ())
                                                  |   (SOME(v1)) =>  (push_stack v1)))) v3;
 
-  fun  rpt_do_step2 v1 = 
+  fun  rpt_do_step2 v1 =
     ((),while_1 (o_1 fst has_work) (o_1 snd do_step2) v1);
 
-  fun  briggs_has_work v4 = 
+  fun  briggs_has_work v4 =
     bind get_clock (fn  v3 =>
                      (bind get_avail_moves (fn  v2 =>
                                              (bind get_avail_moves_pri (fn  v1 =>
                                                                          (unit ((v3 > 0) andalso  (((v2 = [] ) = (0 < 0)) orelse  ((v1 = [] ) = (0 < 0)))))))))) v4;
 
-  fun  do_briggs_step v3 = 
+  fun  do_briggs_step v3 =
     ignore_bind dec_clock (bind coalesce (fn  v2 =>
                                            (case  v2
                                             of  NONE =>  (unit ())
                                             |   (SOME(v1)) =>  (push_stack v1)))) v3;
 
-  fun  briggs_coalesce v1 = 
+  fun  briggs_coalesce v1 =
     ((),snd (set_unavail_moves [] (snd (set_move_rel Ln (while_1 (o_1 fst briggs_has_work) (o_1 snd do_briggs_step) v1)))));
 
   fun  is_alloc_var v1 =  (v1 mod 4) = 1;
 
-  fun  considered_var v1 = 
+  fun  considered_var v1 =
     (fn  v2 =>
       (is_alloc_var v2) orelse  ((is_phy_var v2) andalso  (v2 < (2 * v1))));
 
-  fun  count_degrees v1 = 
+  fun  count_degrees v1 =
     (fn  v2 => length (filter v1 (map fst (toalist v2))));
 
   fun  fromalist v5 =
@@ -1338,7 +1338,7 @@ structure reg_alloc = struct
     |   v4::v3 =>  (case  v4
                     of  (v2,v1) =>  (insert v2 v1 (fromalist v3)));
 
-  fun  init_ra_state v32 = 
+  fun  init_ra_state v32 =
     (fn  v33 =>
       (fn  v34 =>
         let val  v26 =
@@ -1379,7 +1379,7 @@ structure reg_alloc = struct
                              end)
         end));
 
-  fun  sec_ra_state v10 = 
+  fun  sec_ra_state v10 =
     (fn  v8 =>
       (fn  v9 =>
         (fn  v11 =>
@@ -1395,7 +1395,7 @@ structure reg_alloc = struct
             Recordtypera_state(v10,v8,v2,v6,[] ,[] ,v1,Ln,Ln,[] ,[] ,[] ,length v6)
           end)));
 
-  fun  maybe_flip v6 = 
+  fun  maybe_flip v6 =
     let val  v5 = v6
      in
       case  v5
@@ -1418,7 +1418,7 @@ structure reg_alloc = struct
                                                            else  (first_match_col v8 v7 v5)))
                     end);
 
-  fun  move_pref v4 = 
+  fun  move_pref v4 =
     (fn  v5 =>
       (fn  v3 =>
         (fn  v2 =>
@@ -1426,7 +1426,7 @@ structure reg_alloc = struct
           of  NONE =>  NONE
           |   SOME(v1) =>  (first_match_col v3 v2 v1))));
 
-  fun  resort_moves v12 = 
+  fun  resort_moves v12 =
     let val  v11 = toalist v12
         val  v1 =
       map (fn  v10 =>
@@ -1440,7 +1440,7 @@ structure reg_alloc = struct
       fromalist v1
      end;
 
-  fun  pri_move_insert v3 = 
+  fun  pri_move_insert v3 =
     (fn  v4 =>
       (fn  v5 =>
         (fn  v2 =>
@@ -1448,7 +1448,7 @@ structure reg_alloc = struct
           of  NONE =>  (insert v4 [(v3,v5)] v2)
           |   SOME(v1) =>  (insert v4 ((v3,v5)::v1) v2))));
 
-  fun  undir_move_insert v2 = 
+  fun  undir_move_insert v2 =
     (fn  v3 =>
       (fn  v4 =>
         (fn  v1 =>
@@ -1464,7 +1464,7 @@ structure reg_alloc = struct
                                        of  (v2,v1) =>  (moves_to_sp v6 (undir_move_insert v4 v2 v1 v8)))
                     end);
 
-  fun  aux_pref v5 = 
+  fun  aux_pref v5 =
     (fn  v6 =>
       (fn  v4 =>
         (fn  v3 =>
@@ -1476,7 +1476,7 @@ structure reg_alloc = struct
                                                 then  (SOME(v1))
                                                 else  NONE)))));
 
-  fun  aux_move_pref v3 = 
+  fun  aux_move_pref v3 =
     (fn  v5 =>
       (fn  v6 =>
         (fn  v4 =>
@@ -1485,7 +1485,7 @@ structure reg_alloc = struct
             of  NONE =>  (move_pref v5 v6 v4 v2)
             |   SOME(v1) =>  (SOME(v1))))));
 
-  fun  id_colour v3 = 
+  fun  id_colour v3 =
     foldr (fn  v2 => (fn  v1 => (insert v2 v2 v1))) Ln v3;
 
   fun  remove_colours v9 v10 v8 =
@@ -1501,7 +1501,7 @@ structure reg_alloc = struct
                                                                                           ((v1 = v2) = (0 < 0))) (v7::v6)))
                                        end));
 
-  fun  assign_colour v14 = 
+  fun  assign_colour v14 =
     (fn  v10 =>
       (fn  v11 =>
         (fn  v13 =>
@@ -1540,7 +1540,7 @@ structure reg_alloc = struct
                       of  (v2,v1) =>  (alloc_colouring_aux v8 v10 v6 v4 v2 v1)
                     end);
 
-  fun  alloc_colouring v11 = 
+  fun  alloc_colouring v11 =
     (fn  v12 =>
       (fn  v14 =>
         (fn  v13 =>
@@ -1592,7 +1592,7 @@ structure reg_alloc = struct
                                                                                         end))))
                       end);
 
-  fun  full_coalesce v22 = 
+  fun  full_coalesce v22 =
     (fn  v23 =>
       (fn  v24 =>
         (fn  v25 =>
@@ -1625,7 +1625,7 @@ structure reg_alloc = struct
                             then  (unbound_colours (v3 + 2) v1)
                             else  (unbound_colours v3 v1)));
 
-  fun  assign_colour2 v13 = 
+  fun  assign_colour2 v13 =
     (fn  v15 =>
       (fn  v16 =>
         (fn  v17 =>
@@ -1665,7 +1665,12 @@ structure reg_alloc = struct
                       spill_colouring v4 v6 v8 v2 v1
                      end);
 
-  fun  reg_alloc v25 = 
+  val reg_alloc_verbose = ref true
+
+  fun mk_unique [] = []
+  |   mk_unique (x::xs) = x::mk_unique(filter (fn y => x=x) xs)
+
+  fun  reg_alloc v25 =
     (fn  v24 =>
       (fn  v26 =>
         (fn  v27 =>
@@ -1711,7 +1716,17 @@ structure reg_alloc = struct
                                                                                            of  (v4,v3) =>  (let val  v2 =
                                                                                                               spill_colouring v10 v26 v7 (ra_state_stack v3) v13
                                                                                                              in
-                                                                                                              spill_colouring v10 v26 Ln v12 v2
+                                                                                                              let val col = spill_colouring v10 v26 Ln v12 v2
+                                                                                                                  val moves = map snd v23
+                                                                                                                  val gmoves = filter (fn (v1,v2) => (((v2 = v1) = (0 < 0)) andalso  ((lookup_g v2 v1 v24) = (0 < 0)))) moves
+                                                                                                                  val cmoves = map (fn (v1,v2) => (the (lookup v1 col),the (lookup v2 col))) moves
+                                                                                                                  val good_c = filter (fn (v1,v2) => v1 = v2) cmoves
+                                                                                                                  val _ = (if !reg_alloc_verbose then
+                                                                                                                            print(" "^Int.toString (length moves)^" "^Int.toString (length gmoves)^" "^Int.toString (length good_c)^"\n")
+                                                                                                                          else
+                                                                                                                            ()) in
+                                                                                                                  col
+                                                                                                                  end
                                                                                                              end)
                                                                                          end))
                                                     end)


### PR DESCRIPTION
Adds a flag (default on) which makes the (unverified) allocator print out additional information about the code table entries.

For each code table entry, we get 1) the number of moves 2) the moves that don't clash and 3) the number of moves that got coalesced.