### PR TITLE
Improve scripts by fixing ShellCheck warnings

### DIFF
--- a/build-instructions.sh
+++ b/build-instructions.sh
@@ -39,6 +39,6 @@ git clone https://github.com/CakeML/cakeml
 cd cakeml
 ## optionally switch to a released version, e.g., version2
 # git checkout version2
-$HOME/HOL/bin/Holmake
+"$HOME/HOL/bin/Holmake"
 ## or just Holmake if you set up your PATH as above
 # Holmake

--- a/compiler/benchmarks/ocaml/time_all.sh
+++ b/compiler/benchmarks/ocaml/time_all.sh
@@ -1,16 +1,18 @@
+#!/bin/sh
+
 TIMEFORMAT=%R
 for benchmark in ocamlc_*; do
-  echo $benchmark
-  for i in `seq 30`
+  echo "$benchmark"
+  for _ in $(seq 30)
   do
-    time ./$benchmark
+    time "./$benchmark"
   done
 done
 
 for benchmark in ocamlopt_*; do
-  echo $benchmark
-  for i in `seq 30`
+  echo "$benchmark"
+  for _ in $(seq 30)
   do
-    time ./$benchmark
+    time "./$benchmark"
   done
 done

--- a/compiler/benchmarks/run_all.sh
+++ b/compiler/benchmarks/run_all.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
-pushd $(dirname $0)
-cd ocaml
-make
-cd ..
-cd cakeml
-make
-cd ..
-cd sml
-make
-cd ..
-python benchmark.py
-popd
+
+set -eu
+
+( cd "$(dirname "$0")"
+
+  ( cd ocaml
+    make
+  )
+
+  ( cd cakeml
+    make
+  )
+
+  ( cd sml
+    make
+  )
+
+  python benchmark.py
+)

--- a/developers/wc.sh
+++ b/developers/wc.sh
@@ -2,7 +2,7 @@
 ## A script that counts non-blank lines.
 
 find . -name '*Script.sml' -o -name '*Lib.sml' |
-egrep -v 'hollogs|candle|flame|lem_lib|examples|tests|unverified|_demo' |
+grep -E -v 'hollogs|candle|flame|lem_lib|examples|tests|unverified|_demo' |
 xargs cat |
 sed '/(\*/{: a ; /\*)/b b ; N ; b a ; : b ; d}' | # delete comments
 sed '/^\s*$/d' | # delete blank lines


### PR DESCRIPTION
Hi,

I used `shellcheck $(find -O3 cakeml -type f -name '*.sh' -o -name "*.sh.in") > sc.out` and got the following warnings:

```sh
In cakeml/compiler/benchmarks/ocaml/time_all.sh line 1:
TIMEFORMAT=%R
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 3:
  echo $benchmark
       ^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 4:
  for i in `seq 30`
           ^-- SC2006: Use $(..) instead of legacy `..`.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 6:
    time ./$benchmark
           ^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 11:
  echo $benchmark
       ^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 12:
  for i in `seq 30`
  ^-- SC2034: i appears unused. Verify it or export it.
           ^-- SC2006: Use $(..) instead of legacy `..`.


In cakeml/compiler/benchmarks/ocaml/time_all.sh line 14:
    time ./$benchmark
           ^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/compiler/benchmarks/run_all.sh line 2:
pushd $(dirname $0)
^-- SC2039: In POSIX sh, 'pushd' is undefined.
      ^-- SC2046: Quote this to prevent word splitting.
                ^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/compiler/benchmarks/run_all.sh line 3:
cd ocaml
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/compiler/benchmarks/run_all.sh line 6:
cd cakeml
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/compiler/benchmarks/run_all.sh line 9:
cd sml
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/compiler/benchmarks/run_all.sh line 11:
cd ..
^-- SC2103: Use a ( subshell ) to avoid having to cd back.


In cakeml/compiler/benchmarks/run_all.sh line 13:
popd
^-- SC2039: In POSIX sh, 'popd' is undefined.


In cakeml/build-instructions.sh line 7:
cd
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 9:
cd polyml
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 22:
cd
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 24:
cd HOL
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 37:
cd
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 39:
cd cakeml
^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.


In cakeml/build-instructions.sh line 42:
$HOME/HOL/bin/Holmake
^-- SC2086: Double quote to prevent globbing and word splitting.


In cakeml/developers/wc.sh line 5:
egrep -v 'hollogs|candle|flame|lem_lib|examples|tests|unverified|_demo' |
^-- SC2196: egrep is non-standard and deprecated. Use grep -E instead.
```

I fixed all of them and what I did should be OK, let me know if you want me to do something in a different way.

The only thing I'm not sure about is the `set -eu` added in `build-instructions.sh`, it's useless but that's the cleanest way to remove the warnings related to `cd`...

Thanks !