### PR TITLE
Change CLI for top-level compiler

### DIFF
--- a/compiler/backend/arm6/arm6_configScript.sml
+++ b/compiler/backend/arm6/arm6_configScript.sml
@@ -31,7 +31,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val arm6_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=T; gc_kind:=Simple|>``
+val arm6_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm6_word_conf = ``<| bitmaps := []:32 word list |>``
 val arm6_stack_conf = ``<|jump:=T;reg_names:=arm6_names|>``
 val arm6_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm6_config;init_clock:=5|>``

--- a/compiler/backend/arm6/export_arm6Script.sml
+++ b/compiler/backend/arm6/export_arm6Script.sml
@@ -46,11 +46,11 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     b   cdecl(exit)";
+       "     b   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     b   cdecl(exit)";
+       "     b   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_main:";

--- a/compiler/backend/arm8/arm8_configScript.sml
+++ b/compiler/backend/arm8/arm8_configScript.sml
@@ -28,7 +28,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 (* TODO: this config may need to change *)
-val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
+val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm8_word_conf = ``<| bitmaps := []:64 word list |>``
 val arm8_stack_conf = ``<|jump:=T;reg_names:=arm8_names|>``
 val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm8_config;init_clock:=5|>``

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -46,11 +46,11 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     b   cdecl(exit)";
+       "     b   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     b   cdecl(exit)";
+       "     b   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_main:";

--- a/compiler/backend/mips/export_mipsScript.sml
+++ b/compiler/backend/mips/export_mipsScript.sml
@@ -48,12 +48,12 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     dla   $t9,cdecl(exit)";
+       "     dla   $t9,cdecl(cml_exit)";
        "     jr    $t9";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     dla   $t9,cdecl(exit)";
+       "     dla   $t9,cdecl(cml_exit)";
        "     jr    $t9";
        "     .p2align 4";
        "";

--- a/compiler/backend/mips/mips_configScript.sml
+++ b/compiler/backend/mips/mips_configScript.sml
@@ -34,7 +34,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=T; gc_kind:=Simple|>``
+val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=F; gc_kind:=Simple|>``
 val mips_word_conf = ``<| bitmaps := []:64 word list |>``
 val mips_stack_conf = ``<|jump:=F;reg_names:=mips_names|>``
 val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=mips_config;init_clock:=5|>``

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -47,12 +47,12 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     la   t6,cdecl(exit)";
+       "     la   t6,cdecl(cml_exit)";
        "     jr   t6";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     la   t6,cdecl(exit)";
+       "     la   t6,cdecl(cml_exit)";
        "     jr   t6";
        "     .p2align 4";
        "";

--- a/compiler/backend/riscv/riscv_configScript.sml
+++ b/compiler/backend/riscv/riscv_configScript.sml
@@ -42,7 +42,7 @@ val mod_conf = rconc(EVAL``prim_config.mod_conf``)
 val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
-val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
+val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val riscv_word_conf = ``<| bitmaps := []:64 word list |>``
 val riscv_stack_conf = ``<|jump:=F;reg_names:=riscv_names|>``
 val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=riscv_config;init_clock:=5|>``

--- a/compiler/backend/x64/export_x64Script.sml
+++ b/compiler/backend/x64/export_x64Script.sml
@@ -48,11 +48,11 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     callq   cdecl(exit@plt)";
+       "     callq   cdecl(cml_exit@plt)";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     callq   cdecl(exit@plt)";
+       "     callq   cdecl(cml_exit@plt)";
        "     .p2align 4";
        "";
        "cake_main:";

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -38,7 +38,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 
-val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
+val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps := []:64 word list |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
 val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=x64_config;init_clock:=5|>``

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -119,6 +119,7 @@ val res = translate inferTheory.init_config_def;
 *)
 val res = translate error_to_str_def;
 
+val res = translate parse_bool_def;
 val res = translate parse_num_def;
 
 val res = translate find_str_def;

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -119,6 +119,7 @@ val res = translate inferTheory.init_config_def;
 *)
 val res = translate error_to_str_def;
 
+val res = translate parse_bool_def;
 val res = translate parse_num_def;
 
 val res = translate find_str_def;

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -285,7 +285,7 @@ val parse_data_conf_def = Define`
   let len_bits = find_num (strlit "--len_bits=") ls data.len_bits in
   let pad_bits = find_num (strlit "--pad_bits=") ls data.pad_bits in
   let len_size = find_num (strlit "--len_size=") ls data.len_size in
-  let empty_FFI= find_bool (strlit"--call_empty_ffi=") ls data.call_empty_ffi in
+  let empty_FFI= find_bool (strlit"--emit_empty_ffi=") ls data.call_empty_ffi in
   let gc = parse_gc ls data.gc_kind in
   case (tag_bits,len_bits,pad_bits,len_size,gc,empty_FFI) of
     (INL tb,INL lb,INL pb,INL ls,INL gc, INL empty_FFI) =>

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -278,6 +278,7 @@ val parse_data_conf_def = Define`
   let len_bits = find_num (strlit "--len_bits=") ls data.len_bits in
   let pad_bits = find_num (strlit "--pad_bits=") ls data.pad_bits in
   let len_size = find_num (strlit "--len_size=") ls data.len_size in
+  let gc_FFI   = find_bool (strlit"--log_gc") in
   let gc = parse_gc ls data.gc_kind in
   case (tag_bits,len_bits,pad_bits,len_size,gc) of
     (INL tb,INL lb,INL pb,INL ls,INL gc) =>
@@ -287,7 +288,8 @@ val parse_data_conf_def = Define`
          len_bits := lb;
          pad_bits := pb;
          len_size := ls;
-         gc_kind  := gc |>)
+         gc_kind  := gc;
+         call_empty_ffi := gc_FFI |>)
   | _ =>
      INR (concat [get_err_str tag_bits;
                   get_err_str len_bits;

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -127,6 +127,12 @@ val parse_num_def = Define`
     SOME (num_from_dec_string_alt str)
   else NONE `
 
+val parse_bool_def = Define`
+  parse_bool str =
+  if str = strlit "true" then SOME T
+  else if str = strlit "false" then SOME F
+  else NONE`
+
 (* Finds the first occurence of the flag and
   returns the rest of the string after it *)
 val find_str_def = Define`
@@ -140,12 +146,13 @@ val find_str_def = Define`
 (* If flag is not present then F, else if it is present then
    we should not get any config string afterwards *)
 val find_bool_def = Define`
-  find_bool flag ls =
+  find_bool flag ls default =
   case find_str flag ls of
-    NONE => INL F
+    NONE => INL default
   | SOME rest =>
-    if rest = strlit "" then INL T
-    else INR (concat [strlit"Did not expect the argument: ";rest;strlit " for flag: ";flag])`
+    case parse_bool rest of
+      SOME b => INL b
+    | NONE => INR (concat [strlit"Unable to parse as bool: ";rest;strlit " for flag: ";flag])`
 
 (* If flag is not present then INL default, else if it is present then
    the rest of the config string should be a number *)
@@ -186,8 +193,8 @@ val parse_nums_def = Define `
   parse_nums str = (parse_num_list (comma_tokens [] [] (explode str)))`
 
 (*
-  EVAL``find_bool (strlit "--nomul") [strlit "asf";strlit"--nomul"]``
-  EVAL``find_bool (strlit "--nomul") [strlit "asf";strlit"--nomul=fdsa"]``
+  EVAL``find_bool (strlit "--mul=") [strlit "asf";strlit"--mul=fse"] F``
+  EVAL``find_bool (strlit "--nomul") [strlit "asf";strlit"--nomul=fdsa"] T``
   EVAL``find_num (strlit "--fl") [strlit "asf";strlit"--f1234"] 5n``
 *)
 
@@ -200,17 +207,17 @@ val parse_nums_def = Define `
 (* clos_conf *)
 val parse_clos_conf_def = Define`
   parse_clos_conf ls clos =
-  let multi = find_bool (strlit"--no_multi") ls in
-  let known = find_bool (strlit"--no_known") ls in
-  let call = find_bool (strlit"--no_call") ls in
+  let multi = find_bool (strlit"--multi=") ls clos.do_mti in
+  let known = find_bool (strlit"--known=") ls clos.do_known in
+  let call = find_bool (strlit"--call=") ls clos.do_call in
   let maxapp = find_num (strlit "--max_app=") ls clos.max_app in
   case (multi,known,call,maxapp) of
     (INL m,INL k,INL c,INL n) =>
     (INL
       (clos with <|
-        do_mti   := ¬m;
-        do_known := ¬k;
-        do_call  := ¬c;
+        do_mti   := m;
+        do_known := k;
+        do_call  := c;
         max_app  := n
        |>))
   | _ =>
@@ -224,14 +231,14 @@ val parse_bvl_conf_def = Define`
   parse_bvl_conf ls bvl =
   let inlinesz = find_num (strlit "--inline_size=") ls bvl.inline_size_limit in
   let expcut = find_num (strlit "--exp_cut=") ls bvl.exp_cut in
-  let splitmain = find_bool (strlit"--no_split") ls in
+  let splitmain = find_bool (strlit"--split=") ls bvl.split_main_at_seq in
   case (inlinesz,expcut,splitmain) of
     (INL i,INL e,INL m) =>
     INL
       (bvl with <|
         inline_size_limit := i;
         exp_cut           := e;
-        split_main_at_seq := ¬m
+        split_main_at_seq := m
       |>)
   | _ =>
     INR (concat [get_err_str inlinesz;
@@ -278,10 +285,10 @@ val parse_data_conf_def = Define`
   let len_bits = find_num (strlit "--len_bits=") ls data.len_bits in
   let pad_bits = find_num (strlit "--pad_bits=") ls data.pad_bits in
   let len_size = find_num (strlit "--len_size=") ls data.len_size in
-  let gc_FFI   = find_bool (strlit"--log_gc") in
+  let empty_FFI= find_bool (strlit"--call_empty_ffi=") ls data.call_empty_ffi in
   let gc = parse_gc ls data.gc_kind in
-  case (tag_bits,len_bits,pad_bits,len_size,gc) of
-    (INL tb,INL lb,INL pb,INL ls,INL gc) =>
+  case (tag_bits,len_bits,pad_bits,len_size,gc,empty_FFI) of
+    (INL tb,INL lb,INL pb,INL ls,INL gc, INL empty_FFI) =>
       (* TODO: check conf_ok here and raise error if violated *)
       INL (data with
       <| tag_bits := tb;
@@ -289,20 +296,21 @@ val parse_data_conf_def = Define`
          pad_bits := pb;
          len_size := ls;
          gc_kind  := gc;
-         call_empty_ffi := gc_FFI |>)
+         call_empty_ffi := empty_FFI |>)
   | _ =>
      INR (concat [get_err_str tag_bits;
                   get_err_str len_bits;
                   get_err_str pad_bits;
                   get_err_str len_size;
-                  get_err_str gc])`
+                  get_err_str gc;
+                  get_err_str empty_FFI])`
 
 (* stack *)
 val parse_stack_conf_def = Define`
   parse_stack_conf ls stack =
-  let jump = find_bool (strlit"--no_jump") ls in
+  let jump = find_bool (strlit"--jump=") ls stack.jump in
   case jump of
-    INL j => INL (stack with jump:=¬j)
+    INL j => INL (stack with jump:=j)
   | INR s => INR s`
 
 val extend_conf_def = Define`
@@ -359,7 +367,7 @@ val parse_top_config_def = Define`
   parse_top_config ls =
   let heap = find_num (strlit"--heap_size=") ls default_heap_sz in
   let stack = find_num (strlit"--stack_size=") ls default_stack_sz in
-  let sexp = find_bool (strlit"--sexp") ls in
+  let sexp = find_bool (strlit"--sexp=") ls F in
   case (heap,stack,sexp) of
     (INL heap,INL stack,INL sexp) =>
       INL (heap,stack,sexp)


### PR DESCRIPTION
1) Makes the silent FFIs emitted in data-to-word off by default
2) Adds a flag to enable the FFI
3) Changes the CLI for booleans to XXX=true/false as suggested by @xrchz 