### PR TITLE
Remove @plt annotation from export_x64

### DIFF
--- a/compiler/backend/x64/export_x64Script.sml
+++ b/compiler/backend/x64/export_x64Script.sml
@@ -48,11 +48,11 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     callq   cdecl(cml_exit@plt)";
+       "     callq   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     callq   cdecl(cml_exit@plt)";
+       "     callq   cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_main:";


### PR DESCRIPTION
This causes cc to fail on Mac OS, and is not needed for Unix
as long as we are calling functions in basis.c (which is the
case now.)