### PR TITLE
Use the monadic translator to translate reg_allocMonad

### DIFF
--- a/compiler/backend/reg_alloc/monadic/Holmakefile
+++ b/compiler/backend/reg_alloc/monadic/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = ../../../../translator/monadic
+INCLUDES = ../../../../translator ../../../../translator/monadic
 OPTIONS = QUIT_ON_FAILURE
 
 ifdef POLY

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
@@ -139,7 +139,7 @@ val r = translate empty_ra_state_def;
 val r = m_translate_run reg_alloc_def;
 
 val reg_alloc_side = Q.prove (
-  `reg_alloc_side k mtable ct forced <=> T`
+  `reg_alloc_side k mtable ct forced <=> T`,
   rw [fetch"-""reg_alloc_side_def", empty_ra_state_def])
   |> update_precondition;
 

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
@@ -1,6 +1,6 @@
-open reg_allocMonadTheory
+open preamble reg_allocMonadTheory
 open ml_translatorTheory ml_translatorLib
-open ml_monadStoreLib ml_monad_translatorTheory 
+open ml_monadStoreLib ml_monad_translatorTheory
 open ml_monad_translatorLib
 
 val _ = new_theory "reg_allocMonadProg"
@@ -106,48 +106,41 @@ val _ = m_translate add_stack_def;
 val _ = m_translate split_degree_def;
 val _ = m_translate unspill_def;
 val _ = m_translate do_simplify_def;
-
 val _ = m_translate st_ex_list_MAX_deg_def;
 val _ = m_translate do_spill_def;
 val _ = m_translate do_step_def;
 val _ = m_translate rpt_do_step_def;
-
 val _ = m_translate remove_colours_def;
-
 val _ = m_translate assign_Atemp_tag_def;
 val _ = m_translate assign_Atemps_def;
-
 val _ = translate tag_col_def
 val _ = translate unbound_colour_def
-
-(*val r = translate mk_comb_PMATCHI*)
 val _ = m_translate assign_Stemp_tag_def;
 val _ = m_translate assign_Stemps_def;
-
 val _ = m_translate (first_match_col_def |> REWRITE_RULE [MEMBER_INTRO]);
-
 val _ = m_translate biased_pref_def;
-
 val _ = m_translate (insert_edge_def |> REWRITE_RULE [MEMBER_INTRO]);
 val _ = m_translate list_insert_edge_def;
 val _ = m_translate clique_insert_edge_def;
 val _ = m_translate (extend_clique_def |> REWRITE_RULE [MEMBER_INTRO]);
 val _ = m_translate (mk_graph_def |> REWRITE_RULE [MEMBER_INTRO]);
 val _ = m_translate extend_graph_def;
-
 val _ = m_translate mk_tags_def;
-
 val _ = m_translate init_ra_state_def;
 val _ = m_translate is_Atemp_def;
-
 val _ = m_translate init_alloc1_heu_def
 val _ = m_translate do_alloc1_def
-
 val _ = m_translate extract_color_def;
-
 val _ = m_translate do_reg_alloc_def;
 
 (* m_translate_run *)
-val _ = m_translate_run reg_alloc_def;
+
+val r = translate empty_ra_state_def;
+val r = m_translate_run reg_alloc_def;
+
+val reg_alloc_side = Q.prove (
+  `reg_alloc_side k mtable ct forced <=> T`
+  rw [fetch"-""reg_alloc_side_def", empty_ra_state_def])
+  |> update_precondition;
 
 val _ = export_theory();

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadProgScript.sml
@@ -1,0 +1,153 @@
+open reg_allocMonadTheory
+open ml_translatorTheory ml_translatorLib
+open ml_monadStoreLib ml_monad_translatorTheory 
+open ml_monad_translatorLib
+
+val _ = new_theory "reg_allocMonadProg"
+
+val _ = hide "state";
+
+(* ------------------------------------------------------------------------- *)
+(* Translation                                                               *)
+(* ------------------------------------------------------------------------- *)
+
+(* Those calls to register_type should be removed once the monadic
+   register allocater is integrated in the compiler *)
+val _ = register_type ``:'a # 'b``;
+val _ = register_type ``:'a list``;
+val _ = register_type ``:'a option``;
+val _ = register_type ``:unit``;
+val _ = register_type ``:tag``;
+val _ = register_type ``:clash_tree``;
+
+(* Accessor functions are defined (and used) previously together
+   with exceptions, etc. *)
+
+val state_type = ``:ra_state``;
+val exn_type   = ``:state_exn``;
+val _          = register_exn_type exn_type;
+
+val STATE_EXN_TYPE_def =  theorem "REG_ALLOCMONAD_STATE_EXN_TYPE_def"
+val exn_ri_def         = STATE_EXN_TYPE_def;
+val store_hprop_name   = "RA_STATE";
+
+val exn_functions = [
+    (raise_Fail_def, handle_Fail_def),
+    (raise_ReadError_def, handle_ReadError_def),
+    (raise_WriteError_def, handle_WriteError_def)
+];
+
+val refs_manip_list = [
+    ("dim", get_dim_def, set_dim_def),
+    ("simp_wl", get_simp_wl_def, set_simp_wl_def),
+    ("spill_wl", get_spill_wl_def, set_spill_wl_def),
+    ("stack", get_stack_def, set_stack_def)
+];
+
+val arrays_manip_list = [
+    ("adj_ls", get_adj_ls_def, set_adj_ls_def, adj_ls_length_def, adj_ls_sub_def, update_adj_ls_def, alloc_adj_ls_def),
+    ("node_tag", get_node_tag_def, set_node_tag_def, node_tag_length_def, node_tag_sub_def, update_node_tag_def, alloc_node_tag_def),
+    ("degrees", get_degrees_def, set_degrees_def, degrees_length_def, degrees_sub_def, update_degrees_def, alloc_degrees_def)
+];
+
+val add_type_theories  = ([] : string list);
+val store_pinv_def_opt = NONE : thm option;
+
+(* Initialize the translation *)
+
+val (trans_params, exn_specs) =
+  start_dynamic_init_fixed_store_translation
+    refs_manip_list
+    arrays_manip_list
+    store_hprop_name
+    state_type
+    exn_ri_def
+    exn_functions
+    add_type_theories
+    store_pinv_def_opt;
+
+(* Rest of the translation *)
+
+val _ = m_translate st_ex_FOREACH_def;
+val _ = m_translate st_ex_MAP_def;
+val _ = m_translate st_ex_PARTITION_def;
+val _ = m_translate st_ex_FILTER_def;
+
+val _ = translate FST
+val _ = translate EVEN
+val _ = translate lookup_def
+val _ = translate insert_def
+val _ = translate list_remap_def
+val _ = translate lrnext_def
+val _ = translate foldi_def
+val _ = translate toAList_def
+val _ = translate MAP
+val _ = translate mk_bij_aux_def
+val _ = translate mk_bij_def
+val _ = translate MEMBER_def
+val _ = translate FILTER
+val _ = translate SNOC
+val _ = translate NULL
+val _ = translate GENLIST
+val _ = translate APPEND
+val _ = translate PART_DEF
+val _ = translate PARTITION_DEF
+val _ = translate QSORT_DEF
+val _ = translate lookup_any_def
+val _ = translate sp_default_def
+val _ = translate LENGTH
+val _ = translate extract_tag_def
+val _ = translate fromAList_def
+
+val _ = m_translate dec_deg_def;
+val _ = m_translate dec_degree_def;
+val _ = m_translate add_simp_wl_def;
+val _ = m_translate add_stack_def;
+val _ = m_translate split_degree_def;
+val _ = m_translate unspill_def;
+val _ = m_translate do_simplify_def;
+
+val _ = m_translate st_ex_list_MAX_deg_def;
+val _ = m_translate do_spill_def;
+val _ = m_translate do_step_def;
+val _ = m_translate rpt_do_step_def;
+
+val _ = m_translate remove_colours_def;
+
+val _ = m_translate assign_Atemp_tag_def;
+val _ = m_translate assign_Atemps_def;
+
+val _ = translate tag_col_def
+val _ = translate unbound_colour_def
+
+(*val r = translate mk_comb_PMATCHI*)
+val _ = m_translate assign_Stemp_tag_def;
+val _ = m_translate assign_Stemps_def;
+
+val _ = m_translate (first_match_col_def |> REWRITE_RULE [MEMBER_INTRO]);
+
+val _ = m_translate biased_pref_def;
+
+val _ = m_translate (insert_edge_def |> REWRITE_RULE [MEMBER_INTRO]);
+val _ = m_translate list_insert_edge_def;
+val _ = m_translate clique_insert_edge_def;
+val _ = m_translate (extend_clique_def |> REWRITE_RULE [MEMBER_INTRO]);
+val _ = m_translate (mk_graph_def |> REWRITE_RULE [MEMBER_INTRO]);
+val _ = m_translate extend_graph_def;
+
+val _ = m_translate mk_tags_def;
+
+val _ = m_translate init_ra_state_def;
+val _ = m_translate is_Atemp_def;
+
+val _ = m_translate init_alloc1_heu_def
+val _ = m_translate do_alloc1_def
+
+val _ = m_translate extract_color_def;
+
+val _ = m_translate do_reg_alloc_def;
+
+(* m_translate_run *)
+val _ = m_translate_run reg_alloc_def;
+
+val _ = export_theory();

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
@@ -4,8 +4,6 @@
 
 open preamble state_transformerTheory
 open ml_monadBaseLib ml_monadBaseTheory
-open ml_translatorTheory
-open ml_monadStoreLib ml_monad_translatorTheory ml_monad_translatorLib
 open sortingTheory
 
 val _ = new_theory "reg_allocMonad"
@@ -18,8 +16,6 @@ val _ = temp_overload_on ("monad_ignore_bind", ``\x y. st_ex_bind x (\z. y)``);
 val _ = temp_overload_on ("return", ``st_ex_return``);
 
 val _ = hide "state";
-
-val _ = (use_full_type_names := false);
 
 (* The graph-coloring register allocator *)
 
@@ -761,16 +757,25 @@ val do_reg_alloc_def = Define`
 (* The top-level (non-monadic) reg_alloc call which should be modified to fit
    the translator's requirements *)
 
-val reg_alloc_def = Define`
+(* val reg_alloc_def = Define`
   reg_alloc k mtable ct forced =
   let init = <|adj_ls := []; dim := 0; node_tag := [] ; degrees := [] |> in
   do_reg_alloc k mtable ct forced init`
+
+val run_reg_alloc_def = Define`
+  run_reg_alloc k mtable ct forced state = run (do_reg_alloc k mtable ct forced)  state` *)
+
+val reg_alloc_def = Define`
+  reg_alloc k mtable ct forced =
+    run (do_reg_alloc k mtable ct forced) <|adj_ls := []; dim := 0; node_tag := [] ; degrees := [] |>`;
+
+
 
 (* ------------------------------------------------------------------------- *)
 (* Translation                                                               *)
 (* ------------------------------------------------------------------------- *)
 
-val run_reg_alloc_def = Define`
+(* val run_reg_alloc_def = Define`
   run_reg_alloc k mtable ct forced state = run (do_reg_alloc k mtable ct forced)  state`
 
 (* Accessor functions are defined (and used) previously together
@@ -854,7 +859,7 @@ val r = m_translate mk_tags_def           (* broken: st_ex_FOREACH *)
 
 val r = m_translate init_ra_state_def
 val r = m_translate do_reg_alloc_def;
-val r = m_translate_run run_reg_alloc_def;
+val r = m_translate_run run_reg_alloc_def; *)
 
 
 val _ = export_theory();

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
@@ -757,109 +757,18 @@ val do_reg_alloc_def = Define`
 (* The top-level (non-monadic) reg_alloc call which should be modified to fit
    the translator's requirements *)
 
-(* val reg_alloc_def = Define`
-  reg_alloc k mtable ct forced =
-  let init = <|adj_ls := []; dim := 0; node_tag := [] ; degrees := [] |> in
-  do_reg_alloc k mtable ct forced init`
-
-val run_reg_alloc_def = Define`
-  run_reg_alloc k mtable ct forced state = run (do_reg_alloc k mtable ct forced)  state` *)
+val empty_ra_state_def = Define `
+  empty_ra_state =
+    <| adj_ls   := []
+     ; node_tag := []
+     ; degrees  := []
+     ; dim      := 0n
+     ; simp_wl  := []
+     ; spill_wl := []
+     ; stack    := [] |>`
 
 val reg_alloc_def = Define`
   reg_alloc k mtable ct forced =
-    run (do_reg_alloc k mtable ct forced) <|adj_ls := []; dim := 0; node_tag := [] ; degrees := [] |>`;
-
-
-
-(* ------------------------------------------------------------------------- *)
-(* Translation                                                               *)
-(* ------------------------------------------------------------------------- *)
-
-(* val run_reg_alloc_def = Define`
-  run_reg_alloc k mtable ct forced state = run (do_reg_alloc k mtable ct forced)  state`
-
-(* Accessor functions are defined (and used) previously together
-   with exceptions, etc. *)
-
-val _ = register_type ``:'a # 'b``;
-val _ = register_type ``:'a list``;
-val _ = register_type ``:'a option``;
-val _ = register_type ``:unit``;
-val _ = register_type ``:tag``;
-val _ = register_type ``:clash_tree``;
-
-val state_type = ``:ra_state``;
-val exn_type   = ``:state_exn``;
-val _          = register_exn_type exn_type;
-
-val STATE_EXN_TYPE_def = theorem "STATE_EXN_TYPE_def";
-val exn_ri_def         = STATE_EXN_TYPE_def;
-val store_hprop_name   = "RA_STATE";
-
-val refs_manip_list = [el 4 accessors, el 5 accessors, el 6 accessors, el 7 accessors]
-val add_type_theories  = [];
-val store_pinv_def_opt = NONE;
-
-(* Initialize the translation *)
-
-val (trans_params, exn_specs) =
-  start_dynamic_init_fixed_store_translation
-    refs_manip_list
-    arr_manip
-    store_hprop_name
-    state_type
-    exn_ri_def
-    exn_functions
-    add_type_theories
-    store_pinv_def_opt;
-
-(* Rest of the translation *)
-
-val r = m_translate st_ex_FOREACH_def;    (* broken: list_CASE *)
-val r = m_translate st_ex_MAP_def;        (* broken: list_CASE*)
-
-val r = translate FILTER;
-val r = translate SNOC;
-val r = translate GENLIST;
-val r = m_translate remove_colours_def;
-
-val r = m_translate assign_Atemp_tag_def; (* broken: tag_CASE *)
-val r = m_translate assign_Atemps_def;    (* broken: st_ex_FOREACH *)
-
-val r = translate tag_col_def;
-val r = translate unbound_colour_def;
-val r = translate APPEND
-val r = translate PART_DEF
-val r = translate PARTITION_DEF
-val r = translate QSORT_DEF
-val r = translate MAP
-(*val r = translate mk_comb_PMATCHI*)
-val r = m_translate assign_Stemp_tag_def; (* broken: tag_CASE *)
-val r = m_translate assign_Stemps_def;    (* broken: st_ex_FOREACH *)
-
-val r = translate FST
-val r = translate EVEN
-val r = translate lookup_def
-val r = translate insert_def
-val r = translate list_remap_def
-val r = translate lrnext_def
-val r = translate foldi_def
-val r = translate toAList_def
-val r = translate mk_bij_aux_def
-val r = translate mk_bij_def
-val r = translate MEMBER_def
-val r = m_translate (insert_edge_def |> REWRITE_RULE [MEMBER_INTRO])
-val r = m_translate list_insert_edge_def
-val r = m_translate clique_insert_edge_def
-val r = m_translate (extend_clique_def |> REWRITE_RULE [MEMBER_INTRO])
-val r = m_translate (mk_graph_def |> REWRITE_RULE [MEMBER_INTRO])
-val r = m_translate extend_graph_def
-
-val r = m_translate mk_tags_def           (* broken: st_ex_FOREACH *)
-
-val r = m_translate init_ra_state_def
-val r = m_translate do_reg_alloc_def;
-val r = m_translate_run run_reg_alloc_def; *)
-
+    run (do_reg_alloc k mtable ct forced) empty_ra_state`;
 
 val _ = export_theory();

--- a/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
+++ b/compiler/backend/reg_alloc/monadic/reg_allocMonadScript.sml
@@ -4,6 +4,7 @@
 
 open preamble state_transformerTheory
 open ml_monadBaseLib ml_monadBaseTheory
+open ml_translatorTheory
 open ml_monadStoreLib ml_monad_translatorTheory ml_monad_translatorLib
 open sortingTheory
 
@@ -760,13 +761,100 @@ val do_reg_alloc_def = Define`
 (* The top-level (non-monadic) reg_alloc call which should be modified to fit
    the translator's requirements *)
 
-(* Use this instead:
-val run_reg_alloc_def = Define`
-  run_reg_alloc k mtable ct state = run (do_reg_alloc k mtable ct) state`*)
-
 val reg_alloc_def = Define`
   reg_alloc k mtable ct forced =
   let init = <|adj_ls := []; dim := 0; node_tag := [] ; degrees := [] |> in
   do_reg_alloc k mtable ct forced init`
+
+(* ------------------------------------------------------------------------- *)
+(* Translation                                                               *)
+(* ------------------------------------------------------------------------- *)
+
+val run_reg_alloc_def = Define`
+  run_reg_alloc k mtable ct forced state = run (do_reg_alloc k mtable ct forced)  state`
+
+(* Accessor functions are defined (and used) previously together
+   with exceptions, etc. *)
+
+val _ = register_type ``:'a # 'b``;
+val _ = register_type ``:'a list``;
+val _ = register_type ``:'a option``;
+val _ = register_type ``:unit``;
+val _ = register_type ``:tag``;
+val _ = register_type ``:clash_tree``;
+
+val state_type = ``:ra_state``;
+val exn_type   = ``:state_exn``;
+val _          = register_exn_type exn_type;
+
+val STATE_EXN_TYPE_def = theorem "STATE_EXN_TYPE_def";
+val exn_ri_def         = STATE_EXN_TYPE_def;
+val store_hprop_name   = "RA_STATE";
+
+val refs_manip_list = [el 4 accessors, el 5 accessors, el 6 accessors, el 7 accessors]
+val add_type_theories  = [];
+val store_pinv_def_opt = NONE;
+
+(* Initialize the translation *)
+
+val (trans_params, exn_specs) =
+  start_dynamic_init_fixed_store_translation
+    refs_manip_list
+    arr_manip
+    store_hprop_name
+    state_type
+    exn_ri_def
+    exn_functions
+    add_type_theories
+    store_pinv_def_opt;
+
+(* Rest of the translation *)
+
+val r = m_translate st_ex_FOREACH_def;    (* broken: list_CASE *)
+val r = m_translate st_ex_MAP_def;        (* broken: list_CASE*)
+
+val r = translate FILTER;
+val r = translate SNOC;
+val r = translate GENLIST;
+val r = m_translate remove_colours_def;
+
+val r = m_translate assign_Atemp_tag_def; (* broken: tag_CASE *)
+val r = m_translate assign_Atemps_def;    (* broken: st_ex_FOREACH *)
+
+val r = translate tag_col_def;
+val r = translate unbound_colour_def;
+val r = translate APPEND
+val r = translate PART_DEF
+val r = translate PARTITION_DEF
+val r = translate QSORT_DEF
+val r = translate MAP
+(*val r = translate mk_comb_PMATCHI*)
+val r = m_translate assign_Stemp_tag_def; (* broken: tag_CASE *)
+val r = m_translate assign_Stemps_def;    (* broken: st_ex_FOREACH *)
+
+val r = translate FST
+val r = translate EVEN
+val r = translate lookup_def
+val r = translate insert_def
+val r = translate list_remap_def
+val r = translate lrnext_def
+val r = translate foldi_def
+val r = translate toAList_def
+val r = translate mk_bij_aux_def
+val r = translate mk_bij_def
+val r = translate MEMBER_def
+val r = m_translate (insert_edge_def |> REWRITE_RULE [MEMBER_INTRO])
+val r = m_translate list_insert_edge_def
+val r = m_translate clique_insert_edge_def
+val r = m_translate (extend_clique_def |> REWRITE_RULE [MEMBER_INTRO])
+val r = m_translate (mk_graph_def |> REWRITE_RULE [MEMBER_INTRO])
+val r = m_translate extend_graph_def
+
+val r = m_translate mk_tags_def           (* broken: st_ex_FOREACH *)
+
+val r = m_translate init_ra_state_def
+val r = m_translate do_reg_alloc_def;
+val r = m_translate_run run_reg_alloc_def;
+
 
 val _ = export_theory();

--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -739,7 +739,7 @@ fun inst_case_thm_for tm = let
 val tm = (!last_fail)
 val original_tm = tm;
 
-val tm = dest_conj hyps |> snd
+val tm = dest_conj hyps |> fst |> dest_conj |> fst |> dest_conj |> snd
 sat_hyps tm
 *)
 
@@ -1282,7 +1282,7 @@ fun m2deep_normal_fun_app tm m2deep = let
       else NO_CONV tm
     val thx = CONV_RULE ((RATOR_CONV) (DEPTH_CONV delete_assums)) thx
     val thx = CONV_RULE ((RATOR_CONV o RAND_CONV)
-              (SIMP_CONV (srw_ss()) [CONTAINER_def])) thx
+              (SIMP_CONV (srw_ss()) [CONTAINER_def, ml_translatorTheory.PRECONDITION_def])) thx
     val thx =  MP thx TRUTH
 	       handle HOL_ERR _ => failwith "normal function application"
     val thx = force_remove_fix thx |> PURE_REWRITE_RULE[ArrowM_def]
@@ -1354,7 +1354,7 @@ fun m2deep tm =
     val inv = ONCE_REWRITE_CONV [ArrowM_def] inv |> concl |> rand |> rand
     val str = stringSyntax.fromMLstring name
     val result = ISPECL_TM [str,mk_comb(inv,tm)] Eval_name_RI_abs |> ASSUME
-    val result = MATCH_MP (ISPEC_EvalM Eval_IMP_PURE) result |> RW [GSYM ArrowM_def]
+    val result = MY_MATCH_MP (SPEC_ALL (ISPEC_EvalM Eval_IMP_PURE)) result |> RW [GSYM ArrowM_def]
     in check_inv "var" tm result end else
   (* raise *)
   if can (get_pattern (!exn_raises)) tm then let
@@ -1514,8 +1514,8 @@ fun m2deep tm =
     val h = ISPECL_TM [pre,str,inv,f,!H] PreImp_EvalM_abs |> ASSUME
             |> RW [PreImp_def] |> UNDISCH |> SPEC state_eq_var
     val h = INST [state_eq_var |-> state_var] h
-    val ys = List.map (fn tm => MATCH_MP (ISPEC_EvalM Eval_IMP_PURE)
-                             (MATCH_MP Eval_Eq (var_hol2deep tm))) xs
+    val ys = List.map (fn tm => MY_MATCH_MP (ISPEC_EvalM Eval_IMP_PURE |> SPEC_ALL)
+                             (MY_MATCH_MP Eval_Eq (var_hol2deep tm))) xs
     fun apply_arrow h [] = h
       | apply_arrow h (x::xs) = let
 	  val th = apply_arrow h xs
@@ -2076,9 +2076,10 @@ fun m_translate_main (* m_translate *) def = (let
 	val _ = uninstall_rec_patterns ()
     in thms end
 (*
+val i = 1
 val _ = List.map (fn (fname,ml_fname,lhs,_,_) =>
         install_rec_pattern lhs fname ml_fname) info
-val (fname,ml_name,lhs,rhs,def) = el 1 info
+val (fname,ml_name,lhs,rhs,def) = el i info
 can (find_term is_arb) (rhs |> rand |> rator)
 *)
     val _ = print ("Translating " ^ msg ^ "\n")
@@ -2148,7 +2149,7 @@ val (fname,ml_fname,th,def) = List.hd thms
       in
 	(is_fun,[(fname,ml_fname,def,th,pre)])
       end
-    else (* is_rec *) let
+    else (* recursive case *) let
       (* introduce Recclosure *)
       val (code_defs,thms) = let val x = List.map abbrev_code thms
                              in unzip x end
@@ -2240,7 +2241,7 @@ fun m_translate def =
       val ii = INST [cl_env_tm |-> get_curr_env()]
       val v_names = List.map (fn x => find_const_name (#1 x ^ "_v")) results
       val _ = if not (!dynamic_init_H) then ml_prog_update (add_Dletrec recc v_names) else ()
-      val v_defs = List.take(get_curr_v_defs (), length v_names)
+      val v_defs = if not (!dynamic_init_H) then List.take(get_curr_v_defs (), length v_names) else []
       val jj = INST (if !dynamic_init_H  then [] else [v_env |-> get_curr_env()])
       (*
       val (fname,ml_fname,def,th,pre) = hd results
@@ -2667,6 +2668,15 @@ fun m_translate_run def = let
       in monad_th end
       else monad_th
 
+    (* Retrieve information about the exc type *)
+    val EXC_TYPE_tm = get_type_inv exc_ty |> rator |> rator
+    val EXC_TYPE_def = DB.find "EXC_TYPE_def" |> List.hd |> snd |> fst
+		       handle Empty => raise (ERR "m_translate_run" "The `exc` type needs to be registered in the current program")
+    val MNAME = concl EXC_TYPE_def |> list_dest dest_conj |> List.hd
+		      |> strip_forall |> snd |> rhs |> strip_exists |> snd
+		      |> dest_conj |> fst |> rhs |> rator |> rand |> rand
+		      |> rand |> rand |> rand
+
     (* Translate the run construct *)
     val x = concl monad_th |> get_Eval_arg
     val exp = concl monad_th |> get_Eval_exp
@@ -2679,10 +2689,10 @@ fun m_translate_run def = let
     val th = case exn_module_name of
 		 SOME module_name =>
 		 ISPECL [cons_names, module_name, vname, TYPE, EXN_TYPE, x, exp,
-			 !H, state_var, env] EvalM_to_EvalSt_MODULE
+			 !H, state_var, MNAME, env] EvalM_to_EvalSt_MODULE
 	       | NONE =>
 		 ISPECL [cons_names, vname, TYPE, EXN_TYPE, x, exp,
-			 !H, state_var, env] EvalM_to_EvalSt_SIMPLE
+			 !H, state_var, MNAME, env] EvalM_to_EvalSt_SIMPLE
 
     (* Prove the assumptions *)
     val [EXN_assum, distinct_assum, vname_assum1, vname_assum2] = List.take(
@@ -2694,9 +2704,6 @@ fun m_translate_run def = let
     val vname_th1 = SIMP_CONV list_ss [] vname_assum1 |> EQT_ELIM
     val vname_th2 = SIMP_CONV list_ss [] vname_assum2 |> EQT_ELIM
 
-    val EXC_TYPE_tm = get_type_inv exc_ty |> rator |> rator
-    val EXC_TYPE_def = DB.find "EXC_TYPE_def" |> List.hd |> snd |> fst
-		       handle Empty => raise (ERR "m_translate_run" "The `exc` type needs to be registered in the current program")
     val EXC_RI_prove_tac =
 	irule EQ_EXT \\ gen_name_tac "A"
         \\ irule EQ_EXT \\ gen_name_tac "B"
@@ -2704,7 +2711,9 @@ fun m_translate_run def = let
         \\ irule EQ_EXT \\ gen_name_tac "v"
         \\ Cases_on `x`
         \\ simp[EXC_TYPE_def, EXC_TYPE_aux_def]
-    val EXN_rw = prove(mk_eq(EXC_TYPE_aux_const, EXC_TYPE_tm), EXC_RI_prove_tac)
+    val EXC_TYPE_aux_tm = mk_comb(EXC_TYPE_aux_const, MNAME)
+
+    val EXN_rw = prove(mk_eq(EXC_TYPE_aux_tm, EXC_TYPE_tm), EXC_RI_prove_tac)
 
     val th = List.foldl (fn (a, th) => MP th a) th [distinct_th, vname_th1, vname_th2]
     val th = PURE_REWRITE_RULE[EXN_rw] th

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -2372,16 +2372,6 @@ EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")
 (EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
 prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_SIMPLE);
 
-val EXC_TYPE_aux_def = Define `
-     (EXC_TYPE_aux a b (Failure x_2) v =
-      ?v2_1.
-        v = Conv (SOME ("Failure",TypeId (Short "exc"))) [v2_1] ∧
-        b x_2 v2_1) /\
-     (EXC_TYPE_aux a b (Success x_1) v <=>
-     ?v1_1.
-       v = Conv (SOME ("Success",TypeId (Short "exc"))) [v1_1] ∧
-		a x_1 v1_1)`;
-
 fun prove_EvalM_to_EvalSt handle_mult_CASE =
 rw[EvalM_def, EvalSt_def]
 \\ qpat_x_assum `!s p. P` IMP_RES_TAC
@@ -2397,7 +2387,8 @@ rw[EvalM_def, EvalSt_def]
     \\ Cases_on `x init_state'`
     \\ Cases_on `q` \\ fs[]
     \\ fs[EXC_TYPE_aux_def]
-    \\ metis_tac[])
+    \\ metis_tac[]
+    )
 \\ reverse(Cases_on `e`)
 (* res is an Rerr (Rabort ...) *)
 >-(
@@ -2445,36 +2436,44 @@ rw[EvalM_def, EvalSt_def]
 \\ metis_tac[];
 
 val EvalM_to_EvalSt_MODULE = Q.store_thm("EvalM_to_EvalSt_MODULE",
-`!cons_names module_name vname TYPE EXN_TYPE x exp H init_state env.
-(!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
-MEM cname cons_names /\
-ev = Conv (SOME (cname, TypeExn (Long module_name (Short cname)))) [ev']) ==>
-(ALL_DISTINCT cons_names) ==>
-vname <> "Success" ==>
-vname <> "Failure" ==>
-EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
-EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Long module_name (Short cname)))) cons_names ==>
-lookup_cons "Success" env = SOME (1,TypeId (Short "exc")) ==>
-lookup_cons "Failure" env = SOME (1,TypeId (Short "exc")) ==>
-EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp]) (Con (SOME (Short "Failure")) [Var (Short vname)]))
-(EXC_TYPE_aux TYPE EXN_TYPE (run x init_state)) H`,
-prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_MODULE);
+  `!cons_names module_name vname TYPE EXN_TYPE x exp H init_state MNAME env.
+     (!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
+      MEM cname cons_names /\
+      ev = Conv (SOME (cname, TypeExn (Long module_name (Short cname)))) [ev']) ==>
+     ALL_DISTINCT cons_names ==>
+     vname <> "Success" ==>
+     vname <> "Failure" ==>
+     EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
+     EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Long module_name (Short cname))))
+           cons_names ==>
+     lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
+     lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME)) ==>
+       EvalSt env init_state
+         (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp])
+           (Con (SOME (Short "Failure")) [Var (Short vname)]))
+         (EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
+  prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_MODULE);
 
 val EvalM_to_EvalSt_SIMPLE = Q.store_thm("EvalM_to_EvalSt_SIMPLE",
-`!cons_names vname TYPE EXN_TYPE x exp H init_state MNAME env.
-(!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
-MEM cname cons_names /\
-ev = Conv (SOME (cname, TypeExn (Short cname))) [ev']) ==>
-(ALL_DISTINCT cons_names) ==>
-vname <> "Success" ==>
-vname <> "Failure" ==>
-EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
-EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Short cname))) cons_names ==>
-lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
-lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME)) ==>
-EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp]) (Con (SOME (Short "Failure")) [Var (Short vname)]))
-(EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
-prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_SIMPLE);
+  `!cons_names vname TYPE EXN_TYPE x exp H init_state MNAME env.
+     (!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
+      MEM cname cons_names /\
+      ev = Conv (SOME (cname, TypeExn (Short cname))) [ev']) ==>
+     ALL_DISTINCT cons_names ==>
+     vname <> "Success" ==>
+     vname <> "Failure" ==>
+     EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
+     EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Short cname)))
+           cons_names ==>
+     lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
+     lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME))
+     ==>
+     EvalSt env init_state
+       (handle_mult vname cons_names
+         (Con (SOME (Short "Success")) [exp])
+         (Con (SOME (Short "Failure")) [Var (Short vname)]))
+       (EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
+  prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_SIMPLE);
 
 val evaluate_let_opref = Q.store_thm("evaluate_let_opref",
 `Eval env exp1 P ==>

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -2241,9 +2241,9 @@ evaluate F (write vname ev (write vname ev' env)) s2 exp2`,
 prove_evaluate_handle_mult_CASE);
 
 val evaluate_Success_CONS = Q.prove(
-`lookup_cons "Success" env = SOME (1,TypeId (Short "exc")) ==>
+`lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
 evaluate F env s e (s', Rval v) ==>
-evaluate F env s (Con (SOME (Short "Success")) [e]) (s', Rval (Conv (SOME ("Success",TypeId (Short "exc"))) [v]))`,
+evaluate F env s (Con (SOME (Short "Success")) [e]) (s', Rval (Conv (SOME ("Success",TypeId (Short MNAME))) [v]))`,
 rw[]
 \\ rw[Once evaluate_cases]
 \\ fs[lookup_cons_def]
@@ -2254,7 +2254,7 @@ rw[]
 \\ rw[Once evaluate_cases]);
 
 val evaluate_Success_CONS_err = Q.prove(
-`lookup_cons "Success" env = SOME (1,TypeId (Short "exc")) ==>
+`lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
 evaluate F env s e (s', Rerr v) ==>
 evaluate F env s (Con (SOME (Short "Success")) [e]) (s', Rerr v)`,
 rw[]
@@ -2269,7 +2269,111 @@ rw[]
 (* For the dynamic store initialisation *)
 (* It is not possible to use register_type here... *)
 val EXC_TYPE_aux_def = Define `
-      (EXC_TYPE_aux a b (Failure x_2) v =
+     (EXC_TYPE_aux MNAME a b (Failure x_2) v =
+      ?v2_1.
+        v = Conv (SOME ("Failure",TypeId (Short MNAME))) [v2_1] ∧
+        b x_2 v2_1) /\
+     (EXC_TYPE_aux MNAME a b (Success x_1) v <=>
+     ?v1_1.
+       v = Conv (SOME ("Success",TypeId (Short MNAME))) [v1_1] ∧
+		a x_1 v1_1)`;
+
+fun prove_EvalM_to_EvalSt handle_mult_CASE =
+rw[EvalM_def, EvalSt_def]
+\\ qpat_x_assum `!s p. P` IMP_RES_TAC
+\\ first_x_assum(qspec_then `junk` STRIP_ASSUME_TAC)
+\\ Cases_on `res`
+(* res is an Rval *)
+>-(
+    IMP_RES_TAC evaluate_Success_CONS
+    \\ first_x_assum (fn x => MATCH_MP evaluate_handle_mult_Rval x |> ASSUME_TAC)
+    \\ first_x_assum (qspecl_then [`cons_names`, `vname`, `(Con (SOME (Short "Failure")) [Var (Short vname)])`] ASSUME_TAC)
+    \\ evaluate_unique_result_tac
+    \\ fs[MONAD_def, run_def, EXC_TYPE_aux_def]
+    \\ Cases_on `x init_state'`
+    \\ Cases_on `q` \\ fs[]
+    \\ fs[EXC_TYPE_aux_def]
+    \\ metis_tac[])
+\\ reverse(Cases_on `e`)
+(* res is an Rerr (Rabort ...) *)
+>-(
+    irule FALSITY
+    \\ fs[MONAD_def]
+    \\ Cases_on `x init_state'`
+    >> Cases_on `q`
+    >> fs[])
+(* res is an Rerr (Rraise ...) *)
+\\ qpat_x_assum `MONAD A B X S1 S2` (fn x => RW[MONAD_def] x |> ASSUME_TAC)
+\\ fs[]
+\\ Cases_on `x init_state'` \\ fs[]
+\\ Cases_on `q` \\ fs[]
+\\ LAST_ASSUM IMP_RES_TAC
+\\ IMP_RES_TAC (Thm.INST_TYPE [``:'b`` |-> ``:unit``] handle_mult_CASE)
+\\ POP_ASSUM(fn x => ALL_TAC)
+\\ first_x_assum(qspecl_then [`vname`, `Con (SOME (Short "Failure")) [Var (Short vname)]`] ASSUME_TAC)
+\\ IMP_RES_TAC evaluate_Success_CONS_err
+\\ first_assum(fn x => sg `^(fst(dest_imp (concl x)))`)
+>-(
+    rw[]
+    \\ fs[EVERY_MEM]
+    \\ first_x_assum(qspec_then `cname` IMP_RES_TAC)
+    \\ fs[lookup_cons_def]
+    \\ rw[Eval_def]
+    \\ rw[Once evaluate_cases]
+    \\ fs[do_con_check_def, build_conv_def, namespaceTheory.nsOptBind_def]
+    \\ fs[namespaceTheory.id_to_n_def]
+    \\ fs[write_def]
+    \\ rw[Once evaluate_cases]
+    \\ rw[Once evaluate_cases]
+    \\ rw[Once evaluate_cases]
+    \\ rw[state_component_equality])
+\\ qpat_x_assum `P ==> Q` IMP_RES_TAC
+\\ ntac 2 (POP_ASSUM (fn x => ALL_TAC))
+\\ fs[]
+\\ rw[Once evaluate_cases]
+\\ fs[lookup_cons_def]
+\\ fs[do_con_check_def, build_conv_def, namespaceTheory.nsOptBind_def]
+\\ fs[namespaceTheory.id_to_n_def, write_def]
+\\ rw[Once evaluate_cases]
+\\ rw[Once evaluate_cases]
+\\ rw[Once evaluate_cases]
+\\ fs[run_def, EXC_TYPE_aux_def]
+\\ metis_tac[];
+
+val EvalM_to_EvalSt_MODULE = Q.store_thm("EvalM_to_EvalSt_MODULE",
+`!cons_names module_name vname TYPE EXN_TYPE x exp H init_state MNAME env.
+(!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
+MEM cname cons_names /\
+ev = Conv (SOME (cname, TypeExn (Long module_name (Short cname)))) [ev']) ==>
+(ALL_DISTINCT cons_names) ==>
+vname <> "Success" ==>
+vname <> "Failure" ==>
+EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
+EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Long module_name (Short cname)))) cons_names ==>
+lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
+lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME)) ==>
+EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp]) (Con (SOME (Short "Failure")) [Var (Short vname)]))
+(EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
+prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_MODULE);
+
+val EvalM_to_EvalSt_SIMPLE = Q.store_thm("EvalM_to_EvalSt_SIMPLE",
+`!cons_names vname TYPE EXN_TYPE x exp H init_state MNAME env.
+(!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
+MEM cname cons_names /\
+ev = Conv (SOME (cname, TypeExn (Short cname))) [ev']) ==>
+(ALL_DISTINCT cons_names) ==>
+vname <> "Success" ==>
+vname <> "Failure" ==>
+EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
+EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Short cname))) cons_names ==>
+lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
+lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME)) ==>
+EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp]) (Con (SOME (Short "Failure")) [Var (Short vname)]))
+(EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
+prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_SIMPLE);
+
+val EXC_TYPE_aux_def = Define `
+     (EXC_TYPE_aux a b (Failure x_2) v =
       ?v2_1.
         v = Conv (SOME ("Failure",TypeId (Short "exc"))) [v2_1] ∧
         b x_2 v2_1) /\
@@ -2357,7 +2461,7 @@ EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")
 prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_MODULE);
 
 val EvalM_to_EvalSt_SIMPLE = Q.store_thm("EvalM_to_EvalSt_SIMPLE",
-`!cons_names vname TYPE EXN_TYPE x exp H init_state env.
+`!cons_names vname TYPE EXN_TYPE x exp H init_state MNAME env.
 (!e ev. EXN_TYPE e ev ==> ?ev' e' cname.
 MEM cname cons_names /\
 ev = Conv (SOME (cname, TypeExn (Short cname))) [ev']) ==>
@@ -2366,10 +2470,10 @@ vname <> "Success" ==>
 vname <> "Failure" ==>
 EvalM env init_state exp (MONAD TYPE EXN_TYPE x) H ==>
 EVERY (\cname. lookup_cons cname env = SOME (1,TypeExn (Short cname))) cons_names ==>
-lookup_cons "Success" env = SOME (1,TypeId (Short "exc")) ==>
-lookup_cons "Failure" env = SOME (1,TypeId (Short "exc")) ==>
+lookup_cons "Success" env = SOME (1,TypeId (Short MNAME)) ==>
+lookup_cons "Failure" env = SOME (1,TypeId (Short MNAME)) ==>
 EvalSt env init_state (handle_mult vname cons_names (Con (SOME (Short "Success")) [exp]) (Con (SOME (Short "Failure")) [Var (Short vname)]))
-(EXC_TYPE_aux TYPE EXN_TYPE (run x init_state)) H`,
+(EXC_TYPE_aux MNAME TYPE EXN_TYPE (run x init_state)) H`,
 prove_EvalM_to_EvalSt evaluate_handle_mult_CASE_SIMPLE);
 
 val evaluate_let_opref = Q.store_thm("evaluate_let_opref",


### PR DESCRIPTION
This pull request adds previously missing support for translating higher-order functions to the monadic translator (see 02ee633).