### PR TITLE
Generate ML signatures for HOL functions in basis

### DIFF
--- a/basis/CharProgScript.sml
+++ b/basis/CharProgScript.sml
@@ -9,6 +9,8 @@ val _ = translation_extends "RatProg";
 
 val _ = ml_prog_update (open_module "Char");
 
+val () = generate_sigs := true;
+
 val _ = append_dec ``Dtabbrev unknown_loc [] "char" (Tapp [] TC_char)``;
 val _ = trans "ord" `ORD`
 val _ = trans "chr" `CHR`
@@ -20,6 +22,16 @@ val _ = trans ">=" `string$char_ge`
 val _ = next_ml_names := ["isSpace"];
 val res = translate stringTheory.isSpace_def;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures [
+  "ord",
+  "chr",
+  "<",
+  ">",
+  "<=",
+  ">=",
+  "isSpace"
+];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory()

--- a/basis/IntProgScript.sml
+++ b/basis/IntProgScript.sml
@@ -8,6 +8,8 @@ val _ = translation_extends "mlbasicsProg";
 
 val _ = ml_prog_update (open_module "Int");
 
+val () = generate_sigs := true;
+
 val _ = ml_prog_update (add_dec ``Dtabbrev unknown_loc [] "int" (Tapp [] TC_int)`` I);
 val _ = trans "+" `(+):int->int->int`
 val _ = trans "-" `(-):int->int->int`
@@ -125,6 +127,22 @@ val gcd_side = prove(
   \\ fs [ADD1] \\ rw [] \\ fs [])
   |> update_precondition;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures [
+  "+",
+  "-",
+  "*",
+  "div",
+  "mod",
+  "<",
+  ">",
+  "<=",
+  ">=",
+  "~",
+  "toString",
+  "fromString",
+  "gcd"
+];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory();

--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -7,6 +7,8 @@ val _ = translation_extends "OptionProg"
 
 val _ = ml_prog_update (open_module "List");
 
+val () = generate_sigs := true;
+
 val _ = ml_prog_update (add_dec ``Dtabbrev unknown_loc ["'a"] "list" (Tapp [Tvar "'a"] (TC_name (Short "list")))`` I);
 
 val result = translate LENGTH;
@@ -113,6 +115,7 @@ val result = translate (ALL_DISTINCT |> REWRITE_RULE [MEMBER_INTRO]);
 val _ = next_ml_names := ["isPrefix"];
 val result = translate isPREFIX;
 val result = translate FRONT_DEF;
+val _ = next_ml_names := ["splitAtPki"];
 val result = translate (splitAtPki_def |> REWRITE_RULE [SUC_LEMMA])
 
 
@@ -138,7 +141,47 @@ val nth_side_def = Q.prove(
 val _ = next_ml_names := ["update"];
 val result = translate LUPDATE_def;
 
-val _ =  ml_prog_update (close_module NONE);
+(* TODO: signature for `app` is missing because it's written in CakeML *)
+val sigs = module_signatures [
+  "length",
+  "null",
+  "revAppend",
+  "rev",
+  "append",
+  "hd",
+  "tl",
+  "last",
+  "getItem",
+  "nth",
+  "take",
+  "drop",
+  "concat",
+  "map",
+  "mapPartial",
+  "find",
+  "filter",
+  "partition",
+  "foldl",
+  "foldr",
+  "exists",
+  "all",
+  "snoc",
+  "tabulate",
+  "collate",
+  "zip",
+  "member",
+  "sum",
+  "unzip",
+  "pad_right",
+  "pad_left",
+  "all_distinct",
+  "isPrefix",
+  "front",
+  "splitAtPki",
+  "update"
+];
+
+val _ =  ml_prog_update (close_module (SOME sigs));
 
 (* sorting -- included here because it depends on List functions like append  *)
 

--- a/basis/OptionProgScript.sml
+++ b/basis/OptionProgScript.sml
@@ -5,6 +5,8 @@ val _ = new_theory"OptionProg"
 
 val _ = translation_extends "RuntimeProg"
 
+val () = generate_sigs := true;
+
 val _ = ml_prog_update (open_module "Option");
 
 val _ = ml_prog_update (add_dec ``Dtabbrev unknown_loc ["'a"] "option" (Tapp [Tvar "'a"] (TC_name (Short "option")))`` I);
@@ -43,5 +45,18 @@ val res = translate IS_NONE_DEF;
 val () = next_ml_names := ["map2"];
 val res = translate OPTION_MAP2_DEF;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures [
+  "getOpt",
+  "isSome",
+  "valOf",
+  "join",
+  "map",
+  "mapPartial",
+  "compose",
+  "composePartial",
+  "isNone",
+  "map2"
+];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 val _ = export_theory();

--- a/basis/RatProgScript.sml
+++ b/basis/RatProgScript.sml
@@ -8,6 +8,8 @@ val _ = translation_extends "IntProg";
 
 val _ = ml_prog_update (open_module "Rat");
 
+val () = generate_sigs := true;
+
 (* connection between real and rat *)
 
 val real_of_rat_def = Define `
@@ -724,6 +726,23 @@ val EqualityType_REAL_TYPE = store_thm("EqualityType_REAL_TYPE",
   \\ metis_tac [])
   |> store_eq_thm;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures [
+  "fromInt",
+  "<=",
+  ">=",
+  "<",
+  ">",
+  "min",
+  "max",
+  "+",
+  "-",
+  "~",
+  "*",
+  "inv",
+  "/",
+  "toString"
+];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory ()

--- a/basis/RuntimeProgScript.sml
+++ b/basis/RuntimeProgScript.sml
@@ -5,6 +5,8 @@ val _ = new_theory"RuntimeProg"
 
 val _ = translation_extends"std_prelude"
 
+val () = generate_sigs := true;
+
 val _ = concretise_all () (* TODO: better to leave more abstract longer... *)
 
 val _ = ml_prog_update (open_module "Runtime");
@@ -21,6 +23,8 @@ val debugMsg_def = Define `
 val () = next_ml_names := ["debugMsg"];
 val result = translate debugMsg_def;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures ["fullGC", "debugMsg"];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory();

--- a/basis/StringProgScript.sml
+++ b/basis/StringProgScript.sml
@@ -8,6 +8,7 @@ val _ = translation_extends "VectorProg";
 
 val _ = ml_prog_update (open_module "String");
 
+val () = generate_sigs := true;
 
 val _ = ml_prog_update (add_dec ``Dtabbrev unknown_loc [] "string" (Tapp [] TC_string)`` I);
 val _ = trans "sub" `strsub`
@@ -178,7 +179,32 @@ val collate_side_thm = Q.prove (
   `!f s1 s2. collate_1_side f s1 s2`,
   rw [collate_side_def, collate_aux_side_thm] ) |> update_precondition
 
+val sigs = module_signatures [
+  "sub",
+  "implode",
+  "size",
+  "concat",
+  "substring",
+  "^",
+  "explode",
+  "extract",
+  "concatWith",
+  "str",
+  "translate",
+  "splitl",
+  "tokens",
+  "fields",
+  "isPrefix",
+  "isSuffix",
+  "isSubstring",
+  "compare",
+  "<",
+  "<=",
+  ">=",
+  ">",
+  "collate"
+];
 
-val _ = ml_prog_update (close_module NONE);
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory()

--- a/basis/TextIOProgScript.sml
+++ b/basis/TextIOProgScript.sml
@@ -8,6 +8,8 @@ val _ = translation_extends "CommandLineProg";
 
 val _ = ml_prog_update (open_module "TextIO");
 
+val () = generate_sigs := true;
+
 val _ = process_topdecs `
   exception BadFileName;
   exception InvalidFD;
@@ -289,6 +291,9 @@ val () = (append_prog o process_topdecs)`
         end
       in inputAll_aux (Word8Array.array 127 (Word8.fromInt 0)) 0 end`;
 
-val _ = ml_prog_update (close_module NONE);
+(* TODO: need signatures for the non-translated functions as well *)
+val sigs_subset = module_signatures ["stdIn", "stdOut", "stdErr"];
+
+val _ = ml_prog_update (close_module (SOME sigs_subset));
 
 val _ = export_theory();

--- a/basis/VectorProgScript.sml
+++ b/basis/VectorProgScript.sml
@@ -7,6 +7,8 @@ val _ = translation_extends "ListProg";
 
 val _ = ml_prog_update (open_module "Vector");
 
+val () = generate_sigs := true;
+
 val _ = ml_prog_update (add_dec ``Dtabbrev unknown_loc ["'a"] "vector" (Tapp [Tvar "'a"] TC_vector)`` I);
 
 val _ = trans "fromList" `Vector`
@@ -199,6 +201,27 @@ val collate_side_thm = Q.prove (
   `!f vec1 vec2. collate_1_side f vec1 vec2`,
   rw[collate_side_def, collate_aux_side_thm] ) |> update_precondition
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures [
+  "fromList",
+  "length",
+  "sub",
+  "tabulate",
+  "toList",
+  "update",
+  "concat",
+  "map",
+  "mapi",
+  "foldli",
+  "foldl",
+  "foldri",
+  "foldr",
+  "findi",
+  "find",
+  "exists",
+  "all",
+  "collate"
+];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory ()

--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -9,11 +9,15 @@ val _ = translation_extends "CharProg";
 
 val _ = ml_prog_update (open_module "Word64");
 
+val () = generate_sigs := true;
+
 val _ = append_dec ``Dtabbrev unknown_loc [] "word" (Tapp [] TC_word64)``;
 val _ = trans "fromInt" `n2w:num->word64`
 val _ = trans "toInt" `w2n:word64->num`
 val _ = trans "andb" `word_and:word64->word64->word64`;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures ["fromInt", "toInt", "andb"];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 val _ = export_theory();

--- a/basis/Word8ProgScript.sml
+++ b/basis/Word8ProgScript.sml
@@ -9,12 +9,16 @@ val _ = translation_extends "Word64Prog";
 
 val _ = ml_prog_update (open_module "Word8");
 
+val () = generate_sigs := true;
+
 val _ = append_dec ``Dtabbrev unknown_loc [] "word" (Tapp [] TC_word8)``;
 val _ = trans "fromInt" `n2w:num->word8`
 val _ = trans "toInt" `w2n:word8->num`
 val _ = trans "andb" `word_and:word8->word8->word8`;
 
-val _ = ml_prog_update (close_module NONE);
+val sigs = module_signatures ["fromInt", "toInt", "andb"];
+
+val _ = ml_prog_update (close_module (SOME sigs));
 
 (* if any more theorems get added here, probably should create Word8ProofTheory *)
 

--- a/characteristic/cfTacticsBaseLib.sig
+++ b/characteristic/cfTacticsBaseLib.sig
@@ -34,7 +34,6 @@ sig
   val parse_decl : string quotation -> term
   val parse_topdecs : string quotation -> term
 
-  val pick_name : string -> string
   val fetch_v : string -> ml_progLib.ml_prog_state -> term
   val fetch_def : string -> ml_progLib.ml_prog_state -> thm
 

--- a/characteristic/cfTacticsBaseLib.sml
+++ b/characteristic/cfTacticsBaseLib.sml
@@ -163,21 +163,6 @@ val parse_exp = parse ``nE`` ``ptree_Expr nE``
 val parse_decl = parse ``nDecl`` ``ptree_Decl``
 val parse_topdecs = parse ``nTopLevelDecs`` ``ptree_TopLevelDecs``
 
-fun pick_name str =
-  if str = "<" then "lt" else
-  if str = ">" then "gt" else
-  if str = "<=" then "le" else
-  if str = ">=" then "ge" else
-  if str = "=" then "eq" else
-  if str = "<>" then "neq" else
-  if str = "~" then "uminus" else
-  if str = "+" then "plus" else
-  if str = "-" then "minus" else
-  if str = "*" then "times" else
-  if str = "!" then "deref" else
-  if str = ":=" then "assign" else
-  if str = "^" then "strcat" else str (* name is fine *)
-
 (* for debugging
 val st = (basis_st())
 val name = "Word8Array.array"

--- a/characteristic/examples/cf_examplesScript.sml
+++ b/characteristic/examples/cf_examplesScript.sml
@@ -4,6 +4,8 @@ local open ml_progLib basisProgTheory in end
 
 val _ = new_theory "cf_examples";
 
+val pick_name = ml_progLib.pick_name;
+
 val basis_st =
   ml_progLib.unpack_ml_prog_state
     basisProgTheory.basis_prog_state

--- a/characteristic/examples/cf_tutorialScript.sml
+++ b/characteristic/examples/cf_tutorialScript.sml
@@ -49,7 +49,7 @@ val bytearray_fromlist = process_topdecs
 
 (* Now add these definitions to the basis ml_prog_state.
 *)
-val st = ml_progLib.add_prog bytearray_fromlist pick_name basis_st
+val st = ml_progLib.add_prog bytearray_fromlist ml_progLib.pick_name basis_st
 
 (* We can start proving a specification for length.
 

--- a/examples/insertSortProgScript.sml
+++ b/examples/insertSortProgScript.sml
@@ -35,7 +35,7 @@ in
   if Array.length a = 0 then () else outer_loop 0
 end;
 `;
-val insertsort_st = ml_progLib.add_prog insertsort pick_name (basis_st());
+val insertsort_st = ml_progLib.add_prog insertsort ml_progLib.pick_name (basis_st());
 
 val list_rel_perm_help = Q.prove (
   `!l1 l2.

--- a/semantics/astSyntax.sml
+++ b/semantics/astSyntax.sml
@@ -12,6 +12,7 @@ structure astSyntax = struct
   val decs_ty = listSyntax.mk_list_type dec_ty;
   val top_ty = mk_thy_type{Thy="ast",Tyop="top",Args=[]};
   val t_ty = mk_thy_type{Thy="ast",Tyop="t",Args=[]};
+  val spec_ty = mk_thy_type{Thy="ast",Tyop="spec",Args=[]};
   val TC_int = prim_mk_const{Thy="ast",Name="TC_int"};
   val TC_char = prim_mk_const{Thy="ast",Name="TC_char"};
   val TC_string = prim_mk_const{Thy="ast",Name="TC_string"};
@@ -45,6 +46,7 @@ structure astSyntax = struct
   val (TC_name_tm,mk_TC_name,dest_TC_name,is_TC_name) = s "TC_name"
   val (Tdec_tm,mk_Tdec,dest_Tdec,is_Tdec) = s "Tdec"
   val (Lit_tm,mk_Lit,dest_Lit,is_Lit) = s "Lit"
+  val (Stype_tm,mk_Stype,dest_Stype,is_Stype) = s "Stype"
   end
   local val s = HolKernel.syntax_fns2 "ast" in
   val (Dtype_tm,mk_Dtype,dest_Dtype,is_Dtype) = s "Dtype"
@@ -60,6 +62,9 @@ structure astSyntax = struct
   val (Tannot_tm,mk_Tannot,dest_Tannot,is_Tannot) = s "Tannot"
   val (Lannot_tm,mk_Lannot,dest_Lannot,is_Lannot) = s "Lannot"
   val (Ptannot_tm,mk_Ptannot,dest_Ptannot,is_Ptannot) = s "Ptannot"
+  val (Sval_tm,mk_Sval,dest_Sval,is_Sval) = s "Sval"
+  val (Stype_opq_tm,mk_Stype_opq,dest_Stype_opq,is_Stype_opq) = s "Stype_opq"
+  val (Sexn_tm,mk_Sexn,dest_Sexn,is_Sexn) = s "Sexn"
   end
   local val s = HolKernel.syntax_fns3 "ast" in
   val (Dexn_tm,mk_Dexn,dest_Dexn,is_Dexn) = s "Dexn"
@@ -68,6 +73,7 @@ structure astSyntax = struct
   val (Let_tm,mk_Let,dest_Let,is_Let) = s "Let"
   val (Log_tm,mk_Log,dest_Log,is_Log) = s "Log"
   val (If_tm,mk_If,dest_If,is_If) = s "If"
+  val (Stabbrev_tm,mk_Stabbrev,dest_Stabbrev,is_Stabbrev) = s "Stabbrev"
   end
   local val s = HolKernel.syntax_fns4 "ast" in
   val (Dtabbrev_tm,mk_Dtabbrev,dest_Dtabbrev,is_Dtabbrev) = s "Dtabbrev"

--- a/translator/ml_progLib.sig
+++ b/translator/ml_progLib.sig
@@ -59,4 +59,5 @@ sig
 
   val define_abbrev : bool -> string -> term -> thm
 
+  val pick_name : string -> string
 end

--- a/translator/ml_progLib.sml
+++ b/translator/ml_progLib.sml
@@ -348,21 +348,23 @@ fun clean_state (ML_code (ss,envs,vs,th)) = let
   val () = app delete_def vs
   in (ML_code (dd ss, dd envs, [], th)) end
 
-(*
-
 fun pick_name str =
   if str = "<" then "lt" else
   if str = ">" then "gt" else
   if str = "<=" then "le" else
   if str = ">=" then "ge" else
   if str = "=" then "eq" else
+  if str = "<>" then "neq" else
   if str = "~" then "uminus" else
   if str = "+" then "plus" else
   if str = "-" then "minus" else
   if str = "*" then "times" else
+  if str = "/" then "div" else
   if str = "!" then "deref" else
-  if str = ":=" then "update" else str
+  if str = ":=" then "assign" else
+  if str = "^" then "strcat" else str (* name is fine *)
 
+(*
 val s = init_state
 val dec1_tm = ``Dlet (Pvar "f") (Fun "x" (Var (Short "x")))``
 val dec2_tm = ``Dlet (Pvar "g") (Fun "x" (Var (Short "x")))``

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -41,6 +41,15 @@ sig
     val case_of             : hol_type -> thm
     val eq_lemmas           : unit -> thm list
 
+    (* CakeML signature generation and extraction *)
+    (* Get the CakeML signature of a named CakeML function which was created by translation *)
+    (* Returns ``:spec`` *)
+    val sig_of_mlname : string -> term
+
+    (* Get the CakeML signatures for a list of CakeML functions which were created by translation *)
+    (* Returns ``:spec list`` *)
+    val module_signatures : string list -> term
+
     (* loading / storing state of translator *)
 
     val translation_extends   : string -> unit
@@ -62,6 +71,7 @@ sig
     val add_preferred_thy    : string -> unit
     val find_def_for_const   : (term -> thm) ref
     val clean_on_exit        : bool ref
+    val generate_sigs        : bool ref
 
     (* internals, for the monadic translation *)
 

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -2713,6 +2713,35 @@ fun dest_word_shift tm =
   if wordsSyntax.is_word_ror tm then Eval_word_ror else
     failwith("not a word shift")
 
+(* CakeML signature generation and manipulation *)
+val generate_sigs = ref false;
+
+fun sig_of_mlname name = definition (ml_progLib.pick_name name ^ "_sig") |> concl |> rhs;
+
+fun module_signatures names = listSyntax.mk_list(map sig_of_mlname names, spec_ty);
+
+fun sig_of_const cake_name tm =
+  mk_Sval (stringSyntax.fromMLstring (ml_progLib.pick_name cake_name), type2t (type_of tm));
+
+fun generate_sig_thms results = let
+  fun const_from_def th = th |> concl |> strip_conj |> hd |> strip_forall |> #2
+                             |> dest_eq |> #1 |> strip_comb |> #1;
+
+  fun mk_sig_thm sval = let
+    val cake_name = dest_Sval sval |> #1 |> fromHOLstring;
+    val sig_const_nm = cake_name ^ "_sig";
+    val sig_const_tm = mk_var(sig_const_nm, spec_ty);
+
+    val def = new_definition(sig_const_nm, mk_eq(sig_const_tm, sval));
+    in def
+  end
+
+  val signatures = map (fn (_, ml_fname, def, _, _) => sig_of_const ml_fname (const_from_def def))
+                       results;
+
+  in map mk_sig_thm signatures
+end
+
 (*
 val tm = rhs
 val tm = rhs_tm
@@ -3584,6 +3613,11 @@ val (th,(fname,ml_fname,def,_,pre)) = hd (zip results thms)
 fun translate def =
   let
     val (is_rec,is_fun,results) = translate_main translate register_type def
+
+    val () =
+      if !generate_sigs then
+        let val _ = generate_sig_thms results in () end
+      else ();
   in
     if is_rec then
     let


### PR DESCRIPTION
This commit generates CakeML signatures for the HOL functions in basis, and stores them in the current translation by passing them into `close_module`.

The signature generation is turned on for each relevant module using ml_translateLib's `generate_sigs` flag.

The generated signatures are saved as definitions of the following form:

```
<cakeML name>_sig = Sval ...
```

For example, for a HOL function called `get_opt` that is translated to
`getOpt`, the theorem storing the signature looks like this:

```
getOpt_sig = Sval ... : thm
```

Some care is also taken to translate operator names into names appropriate for definitions, e.g. `div_sig` instead of `/_sig`.

Partially addresses #344 (still need a way to get signatures for pure CakeML code)