### PR TITLE
[WIP] Isabelle support

### DIFF
--- a/misc/lem_lib_stub/lib.lem
+++ b/misc/lem_lib_stub/lib.lem
@@ -170,28 +170,28 @@ declare isabelle target_rep function W64sub = `Groups.minus`
 
 val W8lsl : word8 -> nat -> word8
 declare hol target_rep function W8lsl = `word_lsl`
-declare isabelle target_rep function W8lsl = `undefined`
+declare isabelle target_rep function W8lsl = `word_lsl`
 val W8lsr : word8 -> nat -> word8
 declare hol target_rep function W8lsr = `word_lsr`
-declare isabelle target_rep function W8lsr = `undefined`
+declare isabelle target_rep function W8lsr = `word_lsr`
 val W8asr : word8 -> nat -> word8
 declare hol target_rep function W8asr = `word_asr`
-declare isabelle target_rep function W8asr = `undefined`
+declare isabelle target_rep function W8asr = `word_asr`
 val W8ror : word8 -> nat -> word8
 declare hol target_rep function W8ror = `word_ror`
-declare isabelle target_rep function W8ror = `undefined`
+declare isabelle target_rep function W8ror = `word_ror`
 val W64lsl : word64 -> nat -> word64
 declare hol target_rep function W64lsl = `word_lsl`
-declare isabelle target_rep function W64lsl = `undefined`
+declare isabelle target_rep function W64lsl = `word_lsl`
 val W64lsr : word64 -> nat -> word64
 declare hol target_rep function W64lsr = `word_lsr`
-declare isabelle target_rep function W64lsr = `undefined`
+declare isabelle target_rep function W64lsr = `word_lsr`
 val W64asr : word64 -> nat -> word64
 declare hol target_rep function W64asr = `word_asr`
-declare isabelle target_rep function W64asr = `undefined`
+declare isabelle target_rep function W64asr = `word_asr`
 val W64ror : word64 -> nat -> word64
 declare hol target_rep function W64ror = `word_ror`
-declare isabelle target_rep function W64ror = `undefined`
+declare isabelle target_rep function W64ror = `word_ror`
 
 open import {hol} `alistTheory`
 type alist 'a 'b = list ('a * 'b)

--- a/misc/lem_lib_stub/lib.lem
+++ b/misc/lem_lib_stub/lib.lem
@@ -9,9 +9,12 @@ import String
 
 val rtc : forall 'a. ('a -> 'a -> bool) -> ('a -> 'a -> bool)
 declare hol    target_rep function rtc = `RTC`
+declare isabelle target_rep function rtc = `rtranclp`
 
+open import {isabelle} `Isabelle_Support`
 val disjoint : forall 'a. set 'a -> set 'a -> bool
 declare hol    target_rep function disjoint = `DISJOINT`
+declare isabelle target_rep function disjoint = `disjoint`
 
 val all2 : forall 'a 'b. ('a -> 'b -> bool) -> list 'a -> list 'b -> bool
 
@@ -34,6 +37,7 @@ lunion (x::xs) s =
 open import {hol} `sptreeTheory`
 type nat_set
 declare hol target_rep type nat_set = `spt` unit
+declare isabelle target_rep type nat_set = set nat
 val nat_set_empty : nat_set
 val nat_set_is_empty : nat_set -> bool
 val nat_set_insert : nat_set -> nat -> nat_set
@@ -43,16 +47,20 @@ val nat_set_elem : nat_set -> nat -> bool
 val nat_set_from_list : list nat -> nat_set
 val nat_set_upto : nat -> nat_set
 declare hol target_rep function nat_set_empty = `sptree$LN`
+declare isabelle target_rep function nat_set_empty = `Set.empty`
 declare hol target_rep function nat_set_is_empty s = s = nat_set_empty
 declare hol target_rep function nat_set_insert s n = `sptree$insert` n () s
+declare isabelle target_rep function nat_set_insert s n = `Set.insert` n s
 declare hol target_rep function nat_set_delete s n = `sptree$delete` n s
 declare hol target_rep function nat_set_to_set s = `sptree$domain` s
+declare isabelle target_rep function nat_set_to_set s = `s`
 declare hol target_rep function nat_set_elem s n = n IN (nat_set_to_set s)
 declare hol target_rep function nat_set_from_list = List.foldl nat_set_insert nat_set_empty
 declare hol target_rep function nat_set_upto n = `sptree$fromList` (genlist (fun _ -> ()) n)
 
 type nat_map 'a
 declare hol target_rep type nat_map 'a = `spt` 'a
+declare isabelle target_rep type nat_map 'a = map nat 'a
 val nat_map_empty : forall 'a. nat_map 'a
 val nat_map_domain : forall 'a. nat_map 'a -> set nat
 val nat_map_insert : forall 'a. nat_map 'a -> nat -> 'a -> nat_map 'a
@@ -71,12 +79,15 @@ declare hol target_rep function nat_map_map f s = `sptree$map` f s
 open import {hol} `llistTheory`
 type llist 'a
 declare hol target_rep type llist 'a = `llist` 'a
+declare isabelle target_rep type llist 'a = `llist` 'a
 val lhd : forall 'a. llist 'a -> maybe 'a
 val ltl : forall 'a. llist 'a -> maybe (llist 'a)
 val lnil : forall 'a. llist 'a
 val lcons : forall 'a. 'a -> llist 'a -> llist 'a
 declare hol target_rep function lhd = `LHD`
+declare isabelle target_rep function lhd = `lhd'`
 declare hol target_rep function ltl = `LTL`
+declare isabelle target_rep function ltl = `ltl'`
 declare hol target_rep function lnil = `LNIL`
 declare hol target_rep function lcons = `LCONS`
 
@@ -85,14 +96,18 @@ declare hol target_rep function lcons = `LCONS`
 open import {hol} `wordsTheory` `integer_wordTheory`
 type word8
 declare hol target_rep type word8 = `word8`
+declare isabelle target_rep type word8 = `8 word`
 val natFromWord8 : word8 -> nat
 declare hol target_rep function natFromWord8 = `w2n`
+declare isabelle target_rep function natFromWord8 = `unat`
 val word_to_hex_string : word8 -> string
 declare hol target_rep function word_to_hex_string = `word_to_hex_string`
 val word8FromNat : nat -> word8
 declare hol target_rep function word8FromNat = `n2w`
+declare isabelle target_rep function word8FromNat = `of_nat`
 val word8FromInteger : integer -> word8
 declare hol target_rep function word8FromInteger = `i2w`
+declare isabelle target_rep function word8FromInteger = `word_of_int`
 val integerFromWord8 : word8 -> integer
 declare hol target_rep function integerFromWord8 = `w2i`
 instance (Numeral word8)
@@ -100,12 +115,16 @@ instance (Numeral word8)
 end
 type word64
 declare hol target_rep type word64 = `word64`
+declare isabelle target_rep type word64 = `64 word`
 val natFromWord64 : word64 -> nat
 declare hol target_rep function natFromWord64 = `w2n`
+declare isabelle target_rep function natFromWord64 = `unat`
 val word64FromNat : nat -> word64
 declare hol target_rep function word64FromNat = `n2w`
+declare isabelle target_rep function word64FromNat = `of_nat`
 val word64FromInteger : integer -> word64
 declare hol target_rep function word64FromInteger = `i2w`
+declare isabelle target_rep function word64FromInteger = `word_of_int`
 val integerFromWord64 : word64 -> integer
 declare hol target_rep function integerFromWord64 = `w2i`
 instance (Numeral word64)
@@ -117,41 +136,59 @@ val word64FromWord8 : word8 -> word64
 declare hol target_rep function word64FromWord8 = `w2w`
 val W8and : word8 -> word8 -> word8
 declare hol target_rep function W8and = `word_and`
+declare isabelle target_rep function W8and = `Bits.bitAND`
 val W8or : word8 -> word8 -> word8
 declare hol target_rep function W8or = `word_or`
+declare isabelle target_rep function W8or = `Bits.bitOR`
 val W8xor : word8 -> word8 -> word8
 declare hol target_rep function W8xor = `word_xor`
+declare isabelle target_rep function W8xor = `Bits.bitXOR`
 val W8add : word8 -> word8 -> word8
 declare hol target_rep function W8add = `word_add`
+declare isabelle target_rep function W8add = `Groups.plus`
 val W8sub : word8 -> word8 -> word8
 declare hol target_rep function W8sub = `word_sub`
+declare isabelle target_rep function W8sub = `Groups.minus`
 val W64and : word64 -> word64 -> word64
 declare hol target_rep function W64and = `word_and`
+declare isabelle target_rep function W64and = `Bits.bitAND`
 val W64or : word64 -> word64 -> word64
 declare hol target_rep function W64or = `word_or`
+declare isabelle target_rep function W64or = `Bits.bitOR`
 val W64xor : word64 -> word64 -> word64
 declare hol target_rep function W64xor = `word_xor`
+declare isabelle target_rep function W64xor = `Bits.bitXOR`
 val W64add : word64 -> word64 -> word64
 declare hol target_rep function W64add = `word_add`
+declare isabelle target_rep function W64add = `Groups.plus`
 val W64sub : word64 -> word64 -> word64
 declare hol target_rep function W64sub = `word_sub`
+declare isabelle target_rep function W64sub = `Groups.minus`
 
 val W8lsl : word8 -> nat -> word8
 declare hol target_rep function W8lsl = `word_lsl`
+declare isabelle target_rep function W8lsl = `undefined`
 val W8lsr : word8 -> nat -> word8
 declare hol target_rep function W8lsr = `word_lsr`
+declare isabelle target_rep function W8lsr = `undefined`
 val W8asr : word8 -> nat -> word8
 declare hol target_rep function W8asr = `word_asr`
+declare isabelle target_rep function W8asr = `undefined`
 val W8ror : word8 -> nat -> word8
 declare hol target_rep function W8ror = `word_ror`
+declare isabelle target_rep function W8ror = `undefined`
 val W64lsl : word64 -> nat -> word64
 declare hol target_rep function W64lsl = `word_lsl`
+declare isabelle target_rep function W64lsl = `undefined`
 val W64lsr : word64 -> nat -> word64
 declare hol target_rep function W64lsr = `word_lsr`
+declare isabelle target_rep function W64lsr = `undefined`
 val W64asr : word64 -> nat -> word64
 declare hol target_rep function W64asr = `word_asr`
+declare isabelle target_rep function W64asr = `undefined`
 val W64ror : word64 -> nat -> word64
 declare hol target_rep function W64ror = `word_ror`
+declare isabelle target_rep function W64ror = `undefined`
 
 open import {hol} `alistTheory`
 type alist 'a 'b = list ('a * 'b)

--- a/misc/lem_lib_stub/lib.lem
+++ b/misc/lem_lib_stub/lib.lem
@@ -19,6 +19,7 @@ declare isabelle target_rep function disjoint = `disjoint`
 val all2 : forall 'a 'b. ('a -> 'b -> bool) -> list 'a -> list 'b -> bool
 
 declare hol    target_rep function all2 = `EVERY2`
+declare isabelle    target_rep function all2 = `list_all2`
 
 let rec the _ (Just x) = x and the x Nothing = x
 
@@ -89,7 +90,9 @@ declare isabelle target_rep function lhd = `lhd'`
 declare hol target_rep function ltl = `LTL`
 declare isabelle target_rep function ltl = `ltl'`
 declare hol target_rep function lnil = `LNIL`
+declare isabelle target_rep function lnil = `lnil'`
 declare hol target_rep function lcons = `LCONS`
+declare isabelle target_rep function lcons = `lcons'`
 
 
 (* TODO: proper support for words... *)
@@ -195,6 +198,7 @@ type alist 'a 'b = list ('a * 'b)
 declare hol target_rep function lookup x y = `ALOOKUP` y x
 val alistToFmap : forall 'k 'v. alist 'k 'v -> Map.map 'k 'v
 declare hol target_rep function alistToFmap = `alist_to_fmap`
+declare isabelle target_rep function alistToFmap = `map_of`
 
 val opt_bind : forall 'a 'b. maybe 'a -> 'b -> alist 'a 'b -> alist 'a 'b
 let opt_bind n v e =
@@ -216,3 +220,4 @@ declare hol target_rep type locn = `locn`
 declare hol target_rep type locs = `locs`
 val unknown_loc : locs
 declare hol target_rep function unknown_loc = `unknown_loc`
+declare isabelle target_rep function unknown_loc = `unknown_loc`

--- a/semantics/fpSem.lem
+++ b/semantics/fpSem.lem
@@ -5,10 +5,14 @@ open import {hol} `machine_ieeeTheory`
 
 type rounding
 declare hol target_rep type rounding = `rounding`
+declare isabelle target_rep type rounding = `roundmode`
 
 type fp_cmp = FP_Less | FP_LessEqual | FP_Greater | FP_GreaterEqual | FP_Equal
 type fp_uop = FP_Abs | FP_Neg | FP_Sqrt
 type fp_bop = FP_Add | FP_Sub | FP_Mul | FP_Div
+declare {isabelle} rename type fp_cmp = fp_cmp_op
+declare {isabelle} rename type fp_uop = fp_uop_op
+declare {isabelle} rename type fp_bop = fp_bop_op
 
 val fp64_lessThan     : word64 -> word64 -> bool
 val fp64_lessEqual    : word64 -> word64 -> bool
@@ -20,6 +24,11 @@ declare hol    target_rep function fp64_lessEqual = `fp64_lessEqual`
 declare hol    target_rep function fp64_greaterThan = `fp64_greaterThan`
 declare hol    target_rep function fp64_greaterEqual = `fp64_greaterEqual`
 declare hol    target_rep function fp64_equal = `fp64_equal`
+declare isabelle    target_rep function fp64_lessThan = `fp64_lessThan`
+declare isabelle    target_rep function fp64_lessEqual = `fp64_lessEqual`
+declare isabelle    target_rep function fp64_greaterThan = `fp64_greaterThan`
+declare isabelle    target_rep function fp64_greaterEqual = `fp64_greaterEqual`
+declare isabelle    target_rep function fp64_equal = `fp64_equal`
 
 val fp64_abs    : word64 -> word64
 val fp64_negate : word64 -> word64
@@ -27,6 +36,9 @@ val fp64_sqrt   : rounding -> word64 -> word64
 declare hol    target_rep function fp64_abs = `fp64_abs`
 declare hol    target_rep function fp64_negate = `fp64_negate`
 declare hol    target_rep function fp64_sqrt = `fp64_sqrt`
+declare isabelle    target_rep function fp64_abs = `fp64_abs`
+declare isabelle    target_rep function fp64_negate = `fp64_negate`
+declare isabelle    target_rep function fp64_sqrt = `fp64_sqrt`
 
 val fp64_add : rounding -> word64 -> word64 -> word64
 val fp64_sub : rounding -> word64 -> word64 -> word64
@@ -36,9 +48,14 @@ declare hol    target_rep function fp64_add = `fp64_add`
 declare hol    target_rep function fp64_sub = `fp64_sub`
 declare hol    target_rep function fp64_mul = `fp64_mul`
 declare hol    target_rep function fp64_div = `fp64_div`
+declare isabelle    target_rep function fp64_add = `fp64_add`
+declare isabelle    target_rep function fp64_sub = `fp64_sub`
+declare isabelle    target_rep function fp64_mul = `fp64_mul`
+declare isabelle    target_rep function fp64_div = `fp64_div`
 
 val roundTiesToEven : rounding
 declare hol    target_rep function roundTiesToEven = `roundTiesToEven`
+declare isabelle    target_rep function roundTiesToEven = `To_nearest`
 
 val fp_cmp : fp_cmp -> word64 -> word64 -> bool
 let fp_cmp fop = match fop with

--- a/semantics/namespace.lem
+++ b/semantics/namespace.lem
@@ -1,4 +1,5 @@
 open import Pervasives
+open import Set_extra
 
 type alist 'k 'v = list ('k * 'v)
 
@@ -95,11 +96,11 @@ let nsAll2 r env1 env2 =
   nsSub r env1 env2 &&
   nsSub (fun x y z -> r x z y) env2 env1
 
-val nsDom : forall 'v 'm 'n. Eq 'm, Eq 'n, Eq 'v => namespace 'm 'n 'v -> set (id 'm 'n)
-let nsDom env = { n | forall v n | nsLookup env n = Just v }
+val nsDom : forall 'v 'm 'n. Eq 'm, Eq 'n, Eq 'v, SetType 'v => namespace 'm 'n 'v -> set (id 'm 'n)
+let nsDom env = { n | forall (v IN universal) (n IN universal) | nsLookup env n = Just v }
 
 val nsDomMod : forall 'v 'm 'n. SetType 'm, Eq 'm, Eq 'n, Eq 'v => namespace 'm 'n 'v -> set (list 'm)
-let nsDomMod env = { n | forall v n | nsLookupMod env n = Just v }
+let nsDomMod env = { n | forall (v IN universal) (n IN universal) | nsLookupMod env n = Just v }
 
 val nsMap : forall 'v 'w 'm 'n. ('v -> 'w) -> namespace 'm 'n 'v -> namespace 'm 'n 'w
 let rec nsMap f (Bind v m) =


### PR DESCRIPTION
_This is a work in progress._

This PR contains multiple additions to allow the Lem specification of CakeML to be exported to Isabelle. Some constants have been left unspecified, e.g. lazy lists and some operations on words.

In addition, @immler has created an "adapter interface" between the Isabelle and HOL4 floating point numbers (see e.g. [this commit](https://bitbucket.org/isa-afp/afp-devel/commits/5fc6589cb7f2000305ac500a8fb022dc96ba741f) in the AFP).

The few remaining unspecified constants are declared in an extra theory file `Isabelle_Support.thy` (not part of this PR). Before we can even talk about merging this, we want to remove them entirely, such that all required constants are present in one way or another in Isabelle.

The purpose of this PR is to kick off a discussion about the Isabelle adaptations in general, maintenance etc.