### PR TITLE
Remove num_exp from WordLang

### DIFF
--- a/compiler/backend/backendComputeLib.sml
+++ b/compiler/backend/backendComputeLib.sml
@@ -417,8 +417,7 @@ val add_backend_compset = computeLib.extend_compset
     ]
   ,computeLib.Tys
     [ (* wordLang *)
-     ``:'a wordLang$num_exp``
-    ,``:'a wordLang$exp``
+     ``:'a wordLang$exp``
     ,``:'a wordLang$prog``
       (* word_bignum *)
     ,``:word_bignum$address``
@@ -426,7 +425,6 @@ val add_backend_compset = computeLib.extend_compset
     ]
   ,computeLib.Defs
     [wordLangTheory.every_var_exp_def
-    ,wordLangTheory.num_exp_def
     ,wordLangTheory.word_sh_def
     ,wordLangTheory.word_op_def
     ,wordLangTheory.every_var_imm_def

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -98,21 +98,21 @@ val real_addr_def = Define `
     let k = shift (:'a) in
       if k <= conf.pad_bits + 1 then
         Op Add [Lookup CurrHeap;
-                Shift Lsr (Var r) (Nat (shift_length conf - k))]
+                Shift Lsr (Var r) (shift_length conf - k)]
       else
         Op Add [Lookup CurrHeap;
                 Shift Lsl (Shift Lsr (Var r)
-                  (Nat (shift_length conf))) (Nat k)]`
+                  (shift_length conf)) k]`
 
 val real_offset_def = Define `
   (real_offset (conf:data_to_word$config) r): 'a wordLang$exp =
      Op Add [Const bytes_in_word;
-             if dimindex (:'a) = 32 then Var r else Shift Lsl (Var r) (Nat 1)]`
+             if dimindex (:'a) = 32 then Var r else Shift Lsl (Var r) 1]`
 
 val real_byte_offset_def = Define`
   real_byte_offset r : 'a wordLang$exp =
     Op Add [Const bytes_in_word;
-            Shift Lsr (Var r) (Nat 2)]`;
+            Shift Lsr (Var r) 2]`;
 
 val _ = Datatype`
   word_op_type = Bitwise binop | Carried binop`;
@@ -227,9 +227,9 @@ val SilentFFI_def = Define `
 
 val AllocVar_def = Define `
   AllocVar c (limit:num) (names:num_set) =
-    list_Seq [Assign 1 (Shift Lsr (Var 1) (Nat 2));
+    list_Seq [Assign 1 (Shift Lsr (Var 1) 2);
               If Lower 1 (Imm (n2w limit))
-                (Assign 1 (Shift Lsl (Op Add [Var 1; Const 1w]) (Nat (shift (:'a)))))
+                (Assign 1 (Shift Lsl (Op Add [Var 1; Const 1w]) (shift (:'a))))
                 (Assign 1 (Const (-1w:'a word)));
               Assign 3 (Op Sub [Lookup TriggerGC; Lookup NextFree]);
               If Lower 3 (Reg 1)
@@ -239,15 +239,15 @@ val AllocVar_def = Define `
 
 val MakeBytes_def = Define `
   MakeBytes n =
-    list_Seq [Assign n (Shift Lsr (Var n) (Nat 2));
-              Assign n (Op Or [Var n; Shift Lsl (Var n) (Nat 8)]);
-              Assign n (Op Or [Var n; Shift Lsl (Var n) (Nat 16)]);
+    list_Seq [Assign n (Shift Lsr (Var n) 2);
+              Assign n (Op Or [Var n; Shift Lsl (Var n) 8]);
+              Assign n (Op Or [Var n; Shift Lsl (Var n) 16]);
               if dimindex (:'a) = 32 then Skip else
-                Assign n (Op Or [Var n; Shift Lsl (Var n) (Nat 32)])]
+                Assign n (Op Or [Var n; Shift Lsl (Var n) 32])]
                    :'a wordLang$prog`
 
 val SmallLsr_def = Define `
-  SmallLsr e n = if n = 0 then e else Shift Lsr e (Nat n)`;
+  SmallLsr e n = if n = 0 then e else Shift Lsr e n`;
 
 val WriteLastByte_aux_def = Define`
   WriteLastByte_aux offset a b n p =
@@ -269,24 +269,24 @@ val WriteLastBytes_def = Define`
 val RefByte_code_def = Define`
   RefByte_code c =
       let limit = MIN (2 ** c.len_size) (dimword (:'a) DIV 16) in
-      let h = Op Add [Shift Lsr (Var 2) (Nat 2); Const (bytes_in_word - 1w)] in
+      let h = Op Add [Shift Lsr (Var 2) 2; Const (bytes_in_word - 1w)] in
       let x = SmallLsr h (dimindex (:'a) - 63) in
-      let y = Shift Lsl h (Nat (dimindex (:'a) - shift (:'a) - c.len_size)) in
+      let y = Shift Lsl h (dimindex (:'a) - shift (:'a) - c.len_size) in
         list_Seq
           [BignumHalt 2;
            Assign 1 x;
            AllocVar c limit (fromList [();();()]);
            (* compute length *)
-           Assign 5 (Shift Lsr h (Nat (shift (:'a))));
-           Assign 7 (Shift Lsl (Var 5) (Nat 2));
+           Assign 5 (Shift Lsr h (shift (:'a)));
+           Assign 7 (Shift Lsl (Var 5) 2);
            Assign 9 (Lookup NextFree);
            (* adjust end of heap *)
            Assign 1 (Op Add [Var 9;
-                             Shift Lsl (Var 5) (Nat (shift (:'a)))]);
+                             Shift Lsl (Var 5) (shift (:'a))]);
            Set NextFree (Op Add [Var 1; Const bytes_in_word]);
            (* 3 := return value *)
            Assign 3 (Op Or [Shift Lsl (Op Sub [Var 9; Lookup CurrHeap])
-               (Nat (shift_length c − shift (:'a))); Const (1w:'a word)]);
+               (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Op Or [y; Const 7w]; Var 6]);
            (* compute repeated byte *)
@@ -297,7 +297,7 @@ val RefByte_code_def = Define`
            If Equal 7 (Imm 0w) (Return 0 3)
            (list_Seq [
              (* write last word of byte array *)
-             Assign 11 (Op And [Shift Lsr (Var 2) (Nat 2);
+             Assign 11 (Op And [Shift Lsr (Var 2) 2;
                                 Const (bytes_in_word - 1w)]);
              If Equal 11 (Imm 0w) Skip
              (list_Seq [
@@ -314,7 +314,7 @@ val RefByte_code_def = Define`
 val Maxout_bits_code_def = Define `
   Maxout_bits_code rep_len k dest n =
     If Lower n (Imm (n2w (2 ** rep_len)))
-      (Assign dest (Op Or [Var dest; Shift Lsl (Var n) (Nat k)]))
+      (Assign dest (Op Or [Var dest; Shift Lsl (Var n) k]))
       (Assign dest (Op Or [Var dest; Const (all_ones (k + rep_len) k)]))
          :'a wordLang$prog`
 
@@ -322,14 +322,14 @@ val Make_ptr_bits_code_def = Define `
   Make_ptr_bits_code c tag len dest =
     list_Seq [Assign dest (Op Or
        [Const 1w; Shift Lsl (Op Sub [Lookup NextFree; Lookup CurrHeap])
-           (Nat (shift_length c − shift (:'a)))]);
+           (shift_length c − shift (:'a))]);
         Maxout_bits_code c.tag_bits (1 + c.len_bits) dest tag;
         Maxout_bits_code c.len_bits 1 dest len] :'a wordLang$prog`
 
 val FromList_code_def = Define `
   FromList_code c =
     let limit = MIN (2 ** c.len_size) (dimword (:'a) DIV 16) in
-    let h = Shift Lsl (Var 2) (Nat (dimindex (:'a) - c.len_size - 2)) in
+    let h = Shift Lsl (Var 2) (dimindex (:'a) - c.len_size - 2) in
       If Equal 2 (Imm 0w)
         (list_Seq [Assign 6 (Op Add [Var 6; Const (2w:'a word)]);
                    Return 0 6])
@@ -338,8 +338,8 @@ val FromList_code_def = Define `
            Assign 1 (Var 2); AllocVar c limit (fromList [();();()]);
            Assign 1 (Lookup NextFree);
            Assign 5 (Op Or [h; Const 3w; Var 6]);
-           Assign 7 (Shift Lsr (Var 2) (Nat 2));
-           Assign 9 (Shift Lsr (Var 6) (Nat 4));
+           Assign 7 (Shift Lsr (Var 2) 2);
+           Assign 9 (Shift Lsr (Var 6) 4);
            Make_ptr_bits_code c 9 7 3;
            Call NONE (SOME FromList1_location) [0;1;4;2;3;5] NONE]):'a wordLang$prog`;
 
@@ -373,17 +373,17 @@ val RefArray_code_def = Define `
           [BignumHalt 2;
            Move 0 [(1,2)];
            AllocVar c limit (fromList [();()]);
-           Assign 1 (Shift Lsl (Op Add [(Shift Lsr (Var 2) (Nat 2)); Const 1w])
-                      (Nat (shift (:'a))));
+           Assign 1 (Shift Lsl (Op Add [(Shift Lsr (Var 2) 2); Const 1w])
+                      (shift (:'a)));
            Set TriggerGC (Op Sub [Lookup TriggerGC; Var 1]);
            Assign 1 (Op Sub [Lookup EndOfHeap; Var 1]);
            Set EndOfHeap (Var 1);
            (* 3 := return value *)
            Assign 3 (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-               (Nat (shift_length c − shift (:'a))); Const (1w:'a word)]);
+               (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Shift Lsl (Var 2)
-                              (Nat (dimindex (:'a) − c.len_size - 2));
+                              (dimindex (:'a) − c.len_size - 2);
                             Const (make_header c 2w 0)]);
            (* store header *)
            Store (Var 1) 5;
@@ -414,7 +414,7 @@ val AddNumSize_def = Define `
        (Assign 1 (Op Add [Var 1;
          (Shift Lsl (Shift Lsr
             (Load (real_addr c (adjust_var src)))
-               (Nat (dimindex (:'a) - c.len_size))) (Nat 2))]))):'a wordLang$prog`
+               (dimindex (:'a) - c.len_size))) 2]))):'a wordLang$prog`
 
 val AnyHeader_def = Define `
   AnyHeader c r a t1 (* header *) t2 (* pointer *) t3 (* payload *) =
@@ -428,30 +428,30 @@ val AnyHeader_def = Define `
         [Assign 7 (real_addr c r);
          Set (Temp t2) (Op Add [Var 7; Const bytes_in_word]);
          Set (Temp t1) (Op Add
-           [Shift Lsl (Shift Lsr (Load (Var 7)) (Nat ((dimindex (:'a)) - c.len_size))) (Nat 1);
-            Op And [Const 1w; Shift Lsr (Load (Var 7)) (Nat 4)]]);
+           [Shift Lsl (Shift Lsr (Load (Var 7)) ((dimindex (:'a)) - c.len_size)) 1;
+            Op And [Const 1w; Shift Lsr (Load (Var 7)) 4]]);
          Set (Temp t3) (Const 0w)])
    (If NotLess r (Imm 0w)
       (list_Seq
         [Set (Temp t1) (Const 2w);
          Set (Temp t2) (Lookup (if a then OtherHeap else NextFree));
-         Set (Temp t3) (Shift Lsr (Var r) (Nat 2));
+         Set (Temp t3) (Shift Lsr (Var r) 2);
          Assign 7 (Const 0w)])
       (list_Seq
         [Set (Temp t1) (Const 3w);
          Set (Temp t2) (Lookup (if a then OtherHeap else NextFree));
-         Set (Temp t3) (Op Sub [Const 0w; Shift Asr (Var r) (Nat 2)]);
+         Set (Temp t3) (Op Sub [Const 0w; Shift Asr (Var r) 2]);
          Assign 7 (Const 0w)])))`
 
 val ShiftVar_def = Define `
   ShiftVar sh v n =
     if sh = Ror then
       (let m = if n < dimindex (:'a) then n else n MOD (dimindex (:'a)) in
-         if m = 0 then Var v else Shift sh (Var v) (Nat m))
+         if m = 0 then Var v else Shift sh (Var v) m)
     else if n = 0 then Var v
     else if dimindex (:'a) <= n then
-      if sh = Asr then Shift sh (Var v) (Nat (dimindex (:'a) - 1)) else Const 0w
-    else (Shift sh (Var v) (Nat n)):'a wordLang$exp`
+      if sh = Asr then Shift sh (Var v) (dimindex (:'a) - 1) else Const 0w
+    else (Shift sh (Var v) n):'a wordLang$exp`
 
 val AnyArith_code_def = Define `
   AnyArith_code c = list_Seq [
@@ -471,7 +471,7 @@ val AnyArith_code_def = Define `
       Get 1 (Temp 29w);
       Assign 2 (Lookup NextFree);
       Set (Temp 29w) (Var 2);
-      Set (Temp 3w) (Shift Lsr (Var 6) (Nat 2));
+      Set (Temp 3w) (Shift Lsr (Var 6) 2);
       Assign 3 (Const 0w);
       (* zero out result array *)
       Call (SOME (0,fromList [()],Skip,AnyArith_location,1))
@@ -485,16 +485,16 @@ val AnyArith_code_def = Define `
       If Test 1 (Reg 1) (Return 0 1) Skip;
       Assign 3 (Load (Op Add [Lookup NextFree; Const bytes_in_word]));
       If Equal 1 (Imm 2w)
-        (Seq (Assign 5 (Shift Lsr (Var 3) (Nat (dimindex (:'a) - 3))))
+        (Seq (Assign 5 (Shift Lsr (Var 3) (dimindex (:'a) - 3)))
              (If Test 5 (Reg 5)
-                (Seq (Assign 1 (Shift Lsl (Var 3) (Nat 2)))
+                (Seq (Assign 1 (Shift Lsl (Var 3) 2))
                      (Return 0 1))
                 Skip))
         (If Equal 1 (Imm 3w)
           (Seq (Assign 5 (Shift Lsr (Op Sub [Var 3; Const 1w])
-                            (Nat (dimindex (:'a) - 3))))
+                            (dimindex (:'a) - 3)))
                (If Test 5 (Reg 5)
-                  (Seq (Assign 1 (Op Sub [Const 0w; Shift Lsl (Var 3) (Nat 2)]))
+                  (Seq (Assign 1 (Op Sub [Const 0w; Shift Lsl (Var 3) 2]))
                        (Return 0 1))
                   Skip))
           (Assign 5 (Const 0w)));
@@ -573,12 +573,12 @@ val Compare_code_def = Define `
                  Assign 1 (Load (Var 11)); (* loads header of 1st arg *)
                  Assign 13 (real_addr c 4);
                  Assign 3 (Load (Var 13)); (* loads header of 2nd arg *)
-                 Assign 6 (Shift Lsr (Var 1) (Nat ((dimindex(:'a) − c.len_size))));
-                 Assign 8 (Shift Lsr (Var 3) (Nat ((dimindex(:'a) − c.len_size))));
+                 Assign 6 (Shift Lsr (Var 1) ((dimindex(:'a) − c.len_size)));
+                 Assign 8 (Shift Lsr (Var 3) ((dimindex(:'a) − c.len_size)));
                  If Equal 1 (Reg 3) (* headers are the same *)
                    (list_Seq
-                     [Assign 2 (Op Add [Var 11;Shift Lsl (Var 6)(Nat(shift (:'a)))]);
-                      Assign 4 (Op Add [Var 13;Shift Lsl (Var 6)(Nat(shift (:'a)))]);
+                     [Assign 2 (Op Add [Var 11;Shift Lsl (Var 6)(shift (:'a))]);
+                      Assign 4 (Op Add [Var 13;Shift Lsl (Var 6)(shift (:'a))]);
                       If Test 1 (Imm 16w)
                        (Call NONE (SOME Compare1_location) [0;6;2;4] NONE)
                        (Call NONE (SOME Compare1_location) [0;6;4;2] NONE)])
@@ -708,7 +708,7 @@ val WriteWord64_def = Define ` (* also works for storing bignums of length 1 *)
               Set NextFree (Op Add [Var 1; Const (2w * bytes_in_word)]);
               Assign (adjust_var dest)
                 (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-                          (Nat (shift_length c − shift (:'a)));
+                          (shift_length c − shift (:'a));
                         Const 1w])]:'a wordLang$prog`;
 
 val WriteWord64_on_32_def = Define `
@@ -721,7 +721,7 @@ val WriteWord64_on_32_def = Define `
               Set NextFree (Op Add [Var 1; Const (3w * bytes_in_word)]);
               Assign (adjust_var dest)
                 (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-                          (Nat (shift_length c − shift (:'a)));
+                          (shift_length c − shift (:'a));
                         Const 1w])]:'a wordLang$prog`;
 
 val WriteWord32_on_32_def = Define `
@@ -734,7 +734,7 @@ val WriteWord32_on_32_def = Define `
         Assign (adjust_var dest)
           (Op Or
              [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-                (Nat (shift_length c − shift (:α))); Const (1w:'a word)])]`
+                (shift_length c − shift (:α)); Const (1w:'a word)])]`
 
 val WordOp64_on_32_def = Define `
   WordOp64_on_32 (opw:opw) =
@@ -877,7 +877,7 @@ local val assign_quotation = `
             Assign 1 (Op Add [real_addr c (adjust_var v1);
                               real_byte_offset (adjust_var v2)]);
             Inst (Mem Load8 3 (Addr 1 0w));
-            Assign (adjust_var dest) (Shift Lsl (Var 3) (Nat 2))
+            Assign (adjust_var dest) (Shift Lsl (Var 3) 2)
           ], l)
        | _ => (Skip,l))
     | Update => (dtcase args of
@@ -891,7 +891,7 @@ local val assign_quotation = `
       | [v1;v2;v3] => (list_Seq [
           Assign 1 (Op Add [real_addr c (adjust_var v1);
                             real_byte_offset (adjust_var v2)]);
-          Assign 3 (Shift Lsr (Var (adjust_var v3)) (Nat 2));
+          Assign 3 (Shift Lsr (Var (adjust_var v3)) 2);
           Inst (Mem Store8 3 (Addr 1 0w));
           Assign (adjust_var dest) Unit], l)
       | _ => (Skip,l))
@@ -908,7 +908,7 @@ local val assign_quotation = `
                          StoreEach 1 (3::MAP adjust_var args) 0w;
                          Assign (adjust_var dest)
                            (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-                                     (Nat (shift_length c − shift (:'a)));
+                                     (shift_length c − shift (:'a));
                                    Const (1w ||
                                            (small_shift_length c − 1 -- 0)
                                               (ptr_bits c tag (LENGTH args)))]);
@@ -931,19 +931,19 @@ local val assign_quotation = `
            | SOME header =>
               let limit = MIN (2 ** c.len_size) (dimword (:'a) DIV 16) in
               let h = Shift Lsl (Var (adjust_var tot))
-                        (Nat (dimindex (:'a) - c.len_size - 2)) in
+                        (dimindex (:'a) - c.len_size - 2) in
                 (list_Seq
                   [BignumHalt (adjust_var tot);
                    Assign 1 (Var (adjust_var tot));
                    AllocVar c limit (list_insert args (get_names names));
                    Assign 1 (Lookup NextFree);
                    Assign 5 (Op Or [h; Const header]);
-                   Assign 7 (Shift Lsr (Var (adjust_var tot)) (Nat 2));
+                   Assign 7 (Shift Lsr (Var (adjust_var tot)) 2);
                    Assign 9 (Const (n2w tag));
                    StoreEach 1 (5::MAP adjust_var rest) 0w;
                    Make_ptr_bits_code c 9 7 3;
                    Set NextFree (Op Add [Var 1; Const bytes_in_word;
-                     Shift Lsl (Var 7) (Nat (shift (:'a)))]);
+                     Shift Lsl (Var 7) (shift (:'a))]);
                    Assign 15 (Var (adjust_var len));
                    Assign 13 (Op Add [Var 1;
                      Const (bytes_in_word * n2w (LENGTH rest + 1))]);
@@ -968,7 +968,7 @@ local val assign_quotation = `
                   StoreEach 1 (3::MAP adjust_var args) 0w;
                   Assign (adjust_var dest)
                     (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
-                              (Nat (shift_length c − shift (:'a)));
+                              (shift_length c − shift (:'a));
                             Const 1w])],l))
     | RefByte immutable =>
       (dtcase args of
@@ -1028,7 +1028,7 @@ local val assign_quotation = `
                                 let extra = (if dimindex (:'a) = 32 then 2 else 3) in
                                 let k = dimindex (:'a) - c.len_size - extra in
                                 let kk = (if dimindex (:'a) = 32 then 3w else 7w) in
-                                  Op Sub [Shift Lsr header (Nat k); Const kk]);
+                                  Op Sub [Shift Lsr header k; Const kk]);
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               (if leq then If NotLower 1 (Reg 3) else
                                            If Lower 3 (Reg 1))
@@ -1041,7 +1041,7 @@ local val assign_quotation = `
                                (let addr = real_addr c (adjust_var v1) in
                                 let header = Load addr in
                                 let k = dimindex (:'a) - c.len_size in
-                                  Shift Lsr header (Nat k));
+                                  Shift Lsr header k);
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               If Lower 3 (Reg 1)
                                (Assign (adjust_var dest) TRUE_CONST)
@@ -1055,7 +1055,7 @@ local val assign_quotation = `
                                  (let addr = real_addr c (adjust_var v1) in
                                   let header = Load addr in
                                   let k = dimindex (:'a) - c.len_size in
-                                    Shift Lsr header (Nat k)));
+                                    Shift Lsr header k));
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               If Lower 3 (Reg 1)
                                (Assign (adjust_var dest) TRUE_CONST)
@@ -1111,16 +1111,16 @@ local val assign_quotation = `
                               (let addr = real_addr c (adjust_var v1) in
                                let header = Load addr in
                                let k = dimindex (:'a) - c.len_size in
-                               let len = Shift Lsr header (Nat k) in
-                                 (Shift Lsl len (Nat 2)))),l)
+                               let len = Shift Lsr header k in
+                                 (Shift Lsl len 2))),l)
                | _ => (Skip,l))
     | Length => (dtcase args of
                | [v1] => (Assign (adjust_var dest)
                               (let addr = real_addr c (adjust_var v1) in
                                let header = Load addr in
                                let k = dimindex (:'a) - c.len_size in
-                               let len = Shift Lsr header (Nat k) in
-                                 (Shift Lsl len (Nat 2))),l)
+                               let len = Shift Lsr header k in
+                                 (Shift Lsl len 2)),l)
                | _ => (Skip,l))
     | LengthByte => (
         dtcase args of
@@ -1129,9 +1129,9 @@ local val assign_quotation = `
                (let addr = real_addr c (adjust_var v1) in
                 let header = Load addr in
                 let k = dimindex(:'a) - shift(:'a) - c.len_size in
-                let fakelen = Shift Lsr header (Nat k) in
+                let fakelen = Shift Lsr header k in
                 let len = Op Sub [fakelen; Const (bytes_in_word-1w)] in
-                  (Shift Lsl len (Nat 2))),l)
+                  (Shift Lsl len 2)),l)
           | _ => (Skip,l))
     | TagLenEq tag len => (dtcase args of
                | [v1] => (if len = 0 then
@@ -1267,7 +1267,7 @@ local val assign_quotation = `
            (Assign (adjust_var dest)
             (dtcase lookup_word_op opw of
              | Bitwise op => Op op [Var (adjust_var v1); Var (adjust_var v2)]
-             | Carried op => let k = Nat (dimindex(:'a)-10) in
+             | Carried op => let k = dimindex(:'a)-10 in
                Shift Lsr (Shift Lsl
                  (Op op [Var (adjust_var v1); Var (adjust_var v2)]) k) k), l)
         | _ => (Skip,l))
@@ -1314,26 +1314,24 @@ local val assign_quotation = `
            (dtcase sh of
             | Lsl =>
               Shift Lsr
-                (Shift Lsl (Var (adjust_var v1)) (Nat(dimindex(:'a)-10+(MIN n 8))))
-                (Nat (dimindex(:'a) - 10))
+                (Shift Lsl (Var (adjust_var v1)) (dimindex(:'a)-10+(MIN n 8)))
+                (dimindex(:'a) - 10)
             | Lsr =>
               Shift Lsl
-                (Shift Lsr (Var (adjust_var v1)) (Nat ((MIN n 8)+2)))
-                (Nat 2)
+                (Shift Lsr (Var (adjust_var v1)) ((MIN n 8)+2)) 2
             | Asr =>
               Shift Lsl
                 (Shift Lsr
                    (Shift Asr
-                      (Shift Lsl (Var (adjust_var v1)) (Nat (dimindex(:'a) - 10)))
-                      (Nat (MIN n 8)))
-                   (Nat (dimindex(:'a) - 8)))
-                (Nat 2)
+                      (Shift Lsl (Var (adjust_var v1)) (dimindex(:'a) - 10))
+                      (MIN n 8))
+                   (dimindex(:'a) - 8)) 2
             | Ror =>
               (let n = n MOD 8 in
                  Op Or
-                  [Shift Lsl (ShiftVar Lsr (adjust_var v1) (n + 2)) (Nat 2);
+                  [Shift Lsl (ShiftVar Lsr (adjust_var v1) (n + 2)) 2;
                    Shift Lsr (ShiftVar Lsl (adjust_var v1)
-                     ((dimindex (:'a) - 2) - n)) (Nat (dimindex (:'a) - 10))])),l)
+                     ((dimindex (:'a) - 2) - n)) (dimindex (:'a) - 10)])),l)
       | _ => (Skip,l))
     | WordShift W64 sh n => (dtcase args of
        | [v1] =>
@@ -1371,10 +1369,10 @@ local val assign_quotation = `
                NONE => (GiveUp,l)
              | SOME header =>
                 (if len = 1 then
-                   (list_Seq [Assign 3 (Shift Lsr (Var (adjust_var v1)) (Nat 2));
+                   (list_Seq [Assign 3 (Shift Lsr (Var (adjust_var v1)) 2);
                               WriteWord64 c header dest 3],l)
                  else
-                   (list_Seq [Assign 5 (Shift Lsr (Var (adjust_var v1)) (Nat 2));
+                   (list_Seq [Assign 5 (Shift Lsr (Var (adjust_var v1)) 2);
                               Assign 3 (Const 0w);
                               WriteWord64_on_32 c header dest 5 3],l)))
       | _ => (Skip, l))
@@ -1389,7 +1387,7 @@ local val assign_quotation = `
                (* put the word value into 3 *)
                (If Test (adjust_var v1) (Imm 1w)
                    (* smallnum case *)
-                    (Assign 3 (Shift Asr (Var (adjust_var v1)) (Nat 2)))
+                    (Assign 3 (Shift Asr (Var (adjust_var v1)) 2))
                    (* bignum case *)
                    (Seq
                      (LoadBignum c 1 3 (adjust_var v1))
@@ -1398,8 +1396,8 @@ local val assign_quotation = `
                (WriteWord64 c header dest 3)
             else If Test (adjust_var v1) (Imm 1w)
               (list_Seq [
-                Assign 3 (Shift Asr (Var (adjust_var v1)) (Nat 2));
-                Assign 5 (Shift Asr (Var (adjust_var v1)) (Nat 31));
+                Assign 3 (Shift Asr (Var (adjust_var v1)) 2);
+                Assign 5 (Shift Asr (Var (adjust_var v1)) 31);
                 WriteWord64_on_32 c header dest 3 5
               ])
               (list_Seq [
@@ -1444,9 +1442,9 @@ local val assign_quotation = `
            | SOME header =>
              if len = 1 then
                (list_Seq [LoadWord64 c 3 (adjust_var v);
-                          Assign 1 (Shift Lsr (Var 3) (Nat 61));
+                          Assign 1 (Shift Lsr (Var 3) 61);
                           If Equal 1 (Imm 0w)
-                            (Assign (adjust_var dest) (Shift Lsl (Var 3) (Nat 2)))
+                            (Assign (adjust_var dest) (Shift Lsl (Var 3) 2))
                             (WriteWord64 c header dest 3)], l)
              else
               (dtcase encode_header c 3 1 of
@@ -1459,9 +1457,9 @@ local val assign_quotation = `
                   If NotEqual 13 (Imm 0w)
                     (WriteWord64_on_32 c header dest 13 11)
                     (list_Seq [
-                      Assign 1 (Shift Lsr (Var 11) (Nat 29));
+                      Assign 1 (Shift Lsr (Var 11) 29);
                       If Equal 1 (Imm 0w)
-                        (Assign (adjust_var dest) (Shift Lsl (Var 11) (Nat 2)))
+                        (Assign (adjust_var dest) (Shift Lsl (Var 11) 2))
                         (WriteWord32_on_32 c header1 dest 11)])],l)))
       | _ => (Skip, l))
     | FFI ffi_index =>
@@ -1471,10 +1469,10 @@ local val assign_quotation = `
         let addr1 = real_addr c (adjust_var v1) in
         let header1 = Load addr1 in
         let k = dimindex(:'a) - shift(:'a) - c.len_size in
-        let fakelen1 = Shift Lsr header1 (Nat k) in
+        let fakelen1 = Shift Lsr header1 k in
         let addr2 = real_addr c (adjust_var v2) in
         let header2 = Load addr2 in
-        let fakelen2 = Shift Lsr header2 (Nat k) in
+        let fakelen2 = Shift Lsr header2 k in
         (list_Seq [
           Assign 1 (Op Add [addr1; Const bytes_in_word]);
           Assign 3 (Op Sub [fakelen1; Const (bytes_in_word-1w)]);

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -31,8 +31,7 @@ val eval_tac = fs [wordSemTheory.evaluate_def,
   bvi_to_data_def, wordSemTheory.the_words_def,
   bviSemTheory.bvl_to_bvi_def, data_to_bvi_def,
   bviSemTheory.bvi_to_bvl_def,wordSemTheory.mem_load_def,
-  wordLangTheory.word_op_def, wordLangTheory.word_sh_def,
-  wordLangTheory.num_exp_def]
+  wordLangTheory.word_op_def, wordLangTheory.word_sh_def]
 
 (* This list must list all auxiliary definitions used in assign_def *)
 val assign_def_extras = save_thm("assign_def_extras",LIST_CONJ
@@ -2071,7 +2070,7 @@ val th = Q.store_thm("assign_WordFromWord",
         |> ONCE_REWRITE_RULE [CONJ_COMM])
   \\ strip_tac \\ rveq
   \\ TOP_CASE_TAC \\ fs [] \\ fs [good_dimindex_def,list_Seq_def] \\ rfs []
-  \\ fs [eq_eval,num_exp_def,word_sh_def,Smallnum_def]
+  \\ fs [eq_eval,word_sh_def,Smallnum_def]
   \\ qpat_abbrev_tac `ww = _ >>> 2`
   \\ `ww = n2w (w2n w)` by
    (unabbrev_all_tac
@@ -3266,7 +3265,7 @@ val th = Q.store_thm("assign_WordFromInt",
       \\ simp[word_exp_rw |> CONJUNCTS |> first(can(find_term(same_const``wordLang$Var``)) o concl)]
       \\ fs[wordSemTheory.get_var_def]
       \\ `31 < dimindex(:'a)` by fs[good_dimindex_def]
-      \\ simp[wordLangTheory.word_sh_def,wordLangTheory.num_exp_def]
+      \\ simp[wordLangTheory.word_sh_def]
       \\ simp[wordSemTheory.set_var_def]
       \\ simp[wordSemTheory.word_exp_def]
       \\ fs[adjust_var_def,lookup_insert]
@@ -3568,7 +3567,7 @@ val th = Q.store_thm("assign_WordFromInt",
     \\ simp[word_exp_rw |> CONJUNCTS |> first(can(find_term(same_const``wordLang$Shift``)) o concl)]
     \\ simp[word_exp_rw |> CONJUNCTS |> first(can(find_term(same_const``wordLang$Var``)) o concl)]
     \\ fs[wordSemTheory.get_var_def]
-    \\ simp[wordLangTheory.word_sh_def,wordLangTheory.num_exp_def]
+    \\ simp[wordLangTheory.word_sh_def]
     \\ simp[wordSemTheory.set_var_def]
     \\ rpt_drule memory_rel_Number_IMP
     \\ strip_tac \\ clean_tac
@@ -4515,7 +4514,7 @@ val assign_BoundsCheckBlock = store_thm("assign_BoundsCheckBlock",
                                  (let addr = real_addr c (adjust_var v1) in
                                   let header = Load addr in
                                   let k = dimindex (:'a) - c.len_size in
-                                    Shift Lsr header (Nat k)));
+                                    Shift Lsr header k));
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               If Lower 3 (Reg 1)
                                (Assign (adjust_var dest) TRUE_CONST)
@@ -4565,7 +4564,7 @@ val th = Q.store_thm("assign_BoundsCheckBlock",
   \\ `word_exp t (real_addr c (adjust_var a1)) = SOME (Word a)` by
        (match_mp_tac (GEN_ALL get_real_addr_lemma)
         \\ fs [wordSemTheory.get_var_def] \\ NO_TAC) \\ fs []
-  \\ fs [eq_eval,word_sh_def,num_exp_def]
+  \\ fs [eq_eval,word_sh_def]
   \\ fs [list_Seq_def,eq_eval]
   \\ once_rewrite_tac [word_exp_set_var_ShiftVar_lemma]
   \\ `c.len_size < dimindex (:α) /\
@@ -4595,7 +4594,7 @@ val assign_BoundsCheckArray = store_thm("assign_BoundsCheckArray",
                                (let addr = real_addr c (adjust_var v1) in
                                 let header = Load addr in
                                 let k = dimindex (:'a) - c.len_size in
-                                  Shift Lsr header (Nat k));
+                                  Shift Lsr header k);
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               If Lower 3 (Reg 1)
                                (Assign (adjust_var dest) TRUE_CONST)
@@ -4633,7 +4632,7 @@ val th = Q.store_thm("assign_BoundsCheckArray",
   \\ `word_exp t (real_addr c (adjust_var a1)) = SOME (Word a)` by
        (match_mp_tac (GEN_ALL get_real_addr_lemma)
         \\ fs [wordSemTheory.get_var_def] \\ NO_TAC) \\ fs []
-  \\ fs [eq_eval,word_sh_def,num_exp_def]
+  \\ fs [eq_eval,word_sh_def]
   \\ fs [list_Seq_def,eq_eval]
   \\ once_rewrite_tac [word_exp_set_var_ShiftVar_lemma]
   \\ `c.len_size < dimindex (:α) /\
@@ -4665,7 +4664,7 @@ val assign_BoundsCheckByte = store_thm("assign_BoundsCheckByte",
                                 let extra = (if dimindex (:'a) = 32 then 2 else 3) in
                                 let k = dimindex (:'a) - c.len_size - extra in
                                 let kk = (if dimindex (:'a) = 32 then 3w else 7w) in
-                                  Op Sub [Shift Lsr header (Nat k); Const kk]);
+                                  Op Sub [Shift Lsr header k; Const kk]);
                               Assign 3 (ShiftVar Ror (adjust_var v2) 2);
                               (if leq then If NotLower 1 (Reg 3) else
                                            If Lower 3 (Reg 1))
@@ -4704,7 +4703,7 @@ val th = Q.store_thm("assign_BoundsCheckByte",
   \\ `word_exp t (real_addr c (adjust_var a1)) = SOME (Word a)` by
        (match_mp_tac (GEN_ALL get_real_addr_lemma)
         \\ fs [wordSemTheory.get_var_def] \\ NO_TAC) \\ fs []
-  \\ fs [eq_eval,word_sh_def,num_exp_def]
+  \\ fs [eq_eval,word_sh_def]
   \\ fs [list_Seq_def,eq_eval]
   \\ once_rewrite_tac [word_exp_set_var_ShiftVar_lemma]
   \\ `c.len_size < dimindex (:α) /\
@@ -7893,7 +7892,7 @@ val th = Q.store_thm("assign_ConsExtend",
   \\ once_rewrite_tac [list_Seq_def]
   \\ `n2w (4 * tot_len) ⋙ 2 = n2w tot_len:'a word` by
       (rewrite_tac [GSYM w2n_11,w2n_lsr,w2n_n2w] \\ fs [] \\ rfs [] \\ NO_TAC)
-  \\ fs [eq_eval,wordLangTheory.word_sh_def,num_exp_def]
+  \\ fs [eq_eval,wordLangTheory.word_sh_def]
   \\ qpat_abbrev_tac `full_header = word_or _ _`
   \\ once_rewrite_tac [list_Seq_def] \\ fs [eq_eval]
   \\ qmatch_goalsub_abbrev_tac `evaluate (_,s2)`

--- a/compiler/backend/proofs/data_to_word_bignumProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_bignumProofScript.sml
@@ -26,8 +26,7 @@ val eval_tac = fs [wordSemTheory.evaluate_def,
   bvi_to_data_def, wordSemTheory.the_words_def,
   bviSemTheory.bvl_to_bvi_def, data_to_bvi_def,
   bviSemTheory.bvi_to_bvl_def,wordSemTheory.mem_load_def,
-  wordLangTheory.word_op_def, wordLangTheory.word_sh_def,
-  wordLangTheory.num_exp_def]
+  wordLangTheory.word_op_def, wordLangTheory.word_sh_def]
 
 val eq_eval = save_thm("eq_eval",
   LIST_CONJ [wordSemTheory.evaluate_def,wordSemTheory.get_var_def,
@@ -361,7 +360,7 @@ val evaluate_AddNumSize = store_thm("evaluate_AddNumSize",
             (real_addr c (adjust_var src)) = SOME (Word a)` by
     (match_mp_tac (GEN_ALL get_real_addr_lemma)
      \\ fs [wordSemTheory.get_var_def,lookup_insert] \\ NO_TAC) \\ fs []
-  \\ fs [num_exp_def,word_sh_def,decode_length_def]
+  \\ fs [word_sh_def,decode_length_def]
   \\ IF_CASES_TAC THEN1
    (rfs [memory_rel_def,heap_in_memory_store_def]
     \\ fs [good_dimindex_def]  \\ rfs [] \\ fs[])
@@ -431,7 +430,7 @@ val AnyHeader_thm = store_thm("AnyHeader_thm",
     \\ `word_exp t (real_addr c (adjust_var r)) = SOME (Word a)` by
      (match_mp_tac (GEN_ALL get_real_addr_lemma)
       \\ fs [wordSemTheory.get_var_def]) \\ fs []
-    \\ fs [word_sh_def,num_exp_def]
+    \\ fs [word_sh_def]
     \\ IF_CASES_TAC
     THEN1 (rfs [memory_rel_def,heap_in_memory_store_def]
            \\ rfs [good_dimindex_def])
@@ -476,7 +475,7 @@ val AnyHeader_thm = store_thm("AnyHeader_thm",
        \\ fs [ONCE_REWRITE_RULE [MULT_COMM] MULT_DIV])
     \\ fs [] \\ fs [eq_eval,list_Seq_def,wordSemTheory.set_store_def]
     \\ Cases_on `a` \\ fs [FLOOKUP_UPDATE,heap_in_memory_store_def,memory_rel_def]
-    \\ fs [word_sh_def,num_exp_def]
+    \\ fs [word_sh_def]
     \\ qexists_tac `Word 0w` \\ fs []
     \\ fs [wordSemTheory.state_component_equality]
     \\ fs [GSYM fmap_EQ,FUN_EQ_THM,FAPPLY_FUPDATE_THM]
@@ -513,7 +512,7 @@ val AnyHeader_thm = store_thm("AnyHeader_thm",
        \\ rewrite_tac [GSYM WORD_NEG_MUL] \\ fs [])
     \\ fs [] \\ fs [eq_eval,list_Seq_def,wordSemTheory.set_store_def]
     \\ Cases_on `a` \\ fs [FLOOKUP_UPDATE,heap_in_memory_store_def,memory_rel_def]
-    \\ fs [word_sh_def,num_exp_def]
+    \\ fs [word_sh_def]
     \\ qexists_tac `Word 0w` \\ fs []
     \\ fs [wordSemTheory.state_component_equality]
     \\ fs [GSYM fmap_EQ,FUN_EQ_THM,FAPPLY_FUPDATE_THM]
@@ -1006,7 +1005,7 @@ val AnyArith_thm = Q.store_thm("AnyArith_thm",
                     |> ONCE_REWRITE_RULE [CONJ_COMM])
     \\ fs [Smallnum_def] \\ NO_TAC)
   \\ fs [lookup_insert]
-  \\ fs [word_sh_def,num_exp_def]
+  \\ fs [word_sh_def]
   \\ Q.MATCH_GOALSUB_ABBREV_TAC `evaluate (_,t9)` \\ rveq
   \\ qabbrev_tac `dm = s9.mdomain`
   \\ qabbrev_tac `m = s9.memory`
@@ -1518,7 +1517,7 @@ val AnyArith_thm = Q.store_thm("AnyArith_thm",
   THEN1
    (qunabbrev_tac `if_stmt` \\ fs [eq_eval]
     \\ IF_CASES_TAC THEN1
-     (fs [num_exp_def,word_sh_def,lookup_insert]
+     (fs [word_sh_def,lookup_insert]
       \\ `v1 >>> (dimindex (:α) - 3) = 0w /\
           v1 << 2 = Smallnum v` by
        (ntac 2 (pop_assum mp_tac)
@@ -1542,7 +1541,7 @@ val AnyArith_thm = Q.store_thm("AnyArith_thm",
       \\ rpt_drule state_rel_Number_small_int
       \\ strip_tac \\ asm_exists_tac \\ asm_rewrite_tac [])
     \\ IF_CASES_TAC THEN1
-     (fs [num_exp_def,word_sh_def,lookup_insert]
+     (fs [word_sh_def,lookup_insert]
       \\ `(v1 + -1w) >>> (dimindex (:α) - 3) = 0w /\
           -1w * v1 << 2 = Smallnum v` by
        (ntac 3 (pop_assum mp_tac)
@@ -1572,7 +1571,7 @@ val AnyArith_thm = Q.store_thm("AnyArith_thm",
   \\ qmatch_goalsub_abbrev_tac `evaluate (if_stmt,t8)`
   \\ `?w. evaluate (if_stmt,t8) = (NONE, set_var 5 w t8)` by
    (qunabbrev_tac `t8` \\ qunabbrev_tac `if_stmt`
-    \\ simp [eq_eval,word_sh_def,num_exp_def]
+    \\ simp [eq_eval,word_sh_def]
     \\ IF_CASES_TAC \\ simp [] THEN1
      (full_simp_tac std_ss [HD]
       \\ reverse IF_CASES_TAC \\ full_simp_tac std_ss []

--- a/compiler/backend/proofs/data_to_word_gcProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_gcProofScript.sml
@@ -6311,7 +6311,6 @@ val word_exp_rw = save_thm("word_exp_rw",LIST_CONJ
    wordLangTheory.word_op_def,
    wordLangTheory.word_sh_def,
    wordSemTheory.get_var_imm_def,
-   wordLangTheory.num_exp_def,
    wordSemTheory.the_words_def,
    lookup_insert]);
 

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -323,14 +323,14 @@ val bytes_in_word_word_shift_n2w = Q.store_thm("bytes_in_word_word_shift_n2w",
 val tac = simp [list_Seq_def,evaluate_def,inst_def,word_exp_def,get_var_def,
        wordLangTheory.word_op_def,mem_load_def,assign_def,set_var_def,
        FLOOKUP_UPDATE,mem_store_def,dec_clock_def,get_var_imm_def,
-       asmTheory.word_cmp_def,wordLangTheory.num_exp_def,
+       asmTheory.word_cmp_def,
        labSemTheory.word_cmp_def,GREATER_EQ,GSYM NOT_LESS,FUPDATE_LIST,
        wordLangTheory.word_sh_def,word_shift_not_0,FLOOKUP_UPDATE]
 
 val tac1 = simp [Once list_Seq_def, evaluate_def,inst_def,word_exp_def,get_var_def,
        wordLangTheory.word_op_def,mem_load_def,assign_def,set_var_def,
        FLOOKUP_UPDATE,mem_store_def,dec_clock_def,get_var_imm_def,
-       asmTheory.word_cmp_def,wordLangTheory.num_exp_def,set_store_def,
+       asmTheory.word_cmp_def,set_store_def,
        labSemTheory.word_cmp_def,GREATER_EQ,GSYM NOT_LESS,FUPDATE_LIST,
        wordLangTheory.word_sh_def,word_shift_not_0,FLOOKUP_UPDATE]
 
@@ -4863,7 +4863,7 @@ val alloc_correct_lemma_None = Q.store_thm("alloc_correct_lemma_None",
        list_Seq_def,evaluate_def,inst_def,word_exp_def,get_var_def,
        wordLangTheory.word_op_def,mem_load_def,assign_def,set_var_def,
        FLOOKUP_UPDATE,mem_store_def,dec_clock_def,get_var_imm_def,
-       asmTheory.word_cmp_def,wordLangTheory.num_exp_def,FAPPLY_FUPDATE_THM,
+       asmTheory.word_cmp_def,FAPPLY_FUPDATE_THM,
        labSemTheory.word_cmp_def,GREATER_EQ,GSYM NOT_LESS,FUPDATE_LIST,
        wordLangTheory.word_sh_def,word_shift_not_0,FLOOKUP_UPDATE]
   \\ fs [labSemTheory.word_cmp_def,FAPPLY_FUPDATE_THM,FLOOKUP_DEF,set_store_def]

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -130,7 +130,7 @@ val inst_rename = Q.store_thm("inst_rename",
     simp[tlookup_def] ) >>
   CASE_TAC >> fs[assign_def,word_exp_def] >>
   CASE_TAC >> rfs[get_vars_def,get_fp_var_def] >>
-  every_case_tac >> fs[LET_THM,word_exp_def,ri_find_name_def,wordLangTheory.num_exp_def] >>
+  every_case_tac >> fs[LET_THM,word_exp_def,ri_find_name_def] >>
   rw[] >> fs[] >> rfs[] >> rw[set_var_find_name,set_fp_var_find_name]
   \\ every_case_tac \\ fs [wordLangTheory.word_op_def]
   \\ rw [] \\ fs [] \\ fs [BIJ_DEF,INJ_DEF] \\ res_tac

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -1634,7 +1634,7 @@ val comp_correct = Q.prove(
     \\ simp[wordLangTheory.word_op_def]
     \\ qexists_tac`0` \\ simp[]
     \\ simp[Once set_var_def,FLOOKUP_UPDATE]
-    \\ simp[wordLangTheory.word_sh_def,wordLangTheory.num_exp_def]
+    \\ simp[wordLangTheory.word_sh_def]
     \\ IF_CASES_TAC \\ simp[]
     >- (
       full_simp_tac(srw_ss())[word_shift_def]
@@ -1679,7 +1679,7 @@ val comp_correct = Q.prove(
     \\ simp[wordLangTheory.word_op_def]
     \\ qexists_tac`0` \\ simp[]
     \\ simp[Once set_var_def,FLOOKUP_UPDATE]
-    \\ simp[wordLangTheory.word_sh_def,wordLangTheory.num_exp_def]
+    \\ simp[wordLangTheory.word_sh_def]
     \\ IF_CASES_TAC \\ simp[]
     >- (
       full_simp_tac(srw_ss())[word_shift_def]
@@ -1717,7 +1717,7 @@ val comp_correct = Q.prove(
     \\ full_simp_tac(srw_ss())[LET_THM,stackSemTheory.inst_def,stackSemTheory.assign_def,
            word_exp_def,set_var_def,FLOOKUP_UPDATE,get_var_def]
     \\ `FLOOKUP t1.regs v = SOME (Word c)` by metis_tac [state_rel_def] \\ full_simp_tac(srw_ss())[]
-    \\ full_simp_tac(srw_ss())[wordLangTheory.word_op_def,FLOOKUP_UPDATE,wordLangTheory.num_exp_def,
+    \\ full_simp_tac(srw_ss())[wordLangTheory.word_op_def,FLOOKUP_UPDATE,
            wordLangTheory.word_sh_def]
     \\ `mem_load (c << word_shift (:'a) + ww << word_shift (:'a)) t1 =
         SOME (Word (EL (w2n c) s.bitmaps))` by
@@ -1981,7 +1981,7 @@ val compile_semantics = Q.store_thm("compile_semantics",
 val tac = simp [list_Seq_def,evaluate_def,inst_def,word_exp_def,get_var_def,
        wordLangTheory.word_op_def,mem_load_def,assign_def,set_var_def,
        FLOOKUP_UPDATE,mem_store_def,dec_clock_def,get_var_imm_def,
-       asmTheory.word_cmp_def,wordLangTheory.num_exp_def,
+       asmTheory.word_cmp_def,
        labSemTheory.word_cmp_def,GREATER_EQ,GSYM NOT_LESS,FUPDATE_LIST,
        wordLangTheory.word_sh_def,halt_inst_def]
 

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -474,7 +474,7 @@ val inst_correct = Q.store_thm("inst_correct",
   imp_res_tac state_rel_read_reg_FLOOKUP_regs >> rfs[] >> rw[] >>
   imp_res_tac state_rel_read_fp_reg_FLOOKUP_fp_regs >> rfs[] >> rw[] >>
   imp_res_tac word_sh_word_shift >>
-  full_simp_tac(srw_ss())[wordLangTheory.num_exp_def,wordLangTheory.word_op_def] >> srw_tac[][] >>
+  full_simp_tac(srw_ss())[wordLangTheory.word_op_def] >> srw_tac[][] >>
   imp_res_tac state_rel_read_reg_FLOOKUP_regs >> rfs[] >> rw[] >>
   TRY ( full_simp_tac(srw_ss())[binop_upd_def] >> match_mp_tac set_var_upd_reg >> full_simp_tac(srw_ss())[] >> NO_TAC) >>
   TRY ( match_mp_tac set_fp_var_upd_fp_reg >> full_simp_tac(srw_ss())[] >> NO_TAC) >>

--- a/compiler/backend/proofs/word_bignumProofScript.sml
+++ b/compiler/backend/proofs/word_bignumProofScript.sml
@@ -23,16 +23,16 @@ val eval_exp_def = Define `
   eval_exp s (Op And [x1;x2]) = word_and (eval_exp s x1) (eval_exp s x2) /\
   eval_exp s (Op Or [x1;x2]) = word_or (eval_exp s x1) (eval_exp s x2) /\
   eval_exp s (Op Xor [x1;x2]) = word_xor (eval_exp s x1) (eval_exp s x2) /\
-  eval_exp s (Shift Lsl x (Nat n)) = eval_exp s x << n /\
-  eval_exp s (Shift Asr x (Nat n)) = eval_exp s x >> n /\
-  eval_exp s (Shift Lsr x (Nat n)) = eval_exp s x >>> n /\
-  eval_exp s (Shift Ror x (Nat n)) = word_ror (eval_exp s x) n`
+  eval_exp s (Shift Lsl x n) = eval_exp s x << n /\
+  eval_exp s (Shift Asr x n) = eval_exp s x >> n /\
+  eval_exp s (Shift Lsr x n) = eval_exp s x >>> n /\
+  eval_exp s (Shift Ror x n) = word_ror (eval_exp s x) n`
 
 val eval_exp_pre_def = Define `
   (eval_exp_pre s (Const w) <=> T) /\
   (eval_exp_pre s (Var v) <=> v IN FDOM s.regs) /\
   (eval_exp_pre s (Op _ [x;y]) <=> eval_exp_pre s x /\ eval_exp_pre s y) /\
-  (eval_exp_pre s (Shift sh x (Nat n)) <=> eval_exp_pre s x /\ n = 1) /\
+  (eval_exp_pre s (Shift sh x n) <=> eval_exp_pre s x /\ n = 1) /\
   (eval_exp_pre s _ <=> F)`
 
 val eval_ri_pre_def = Define `
@@ -382,9 +382,9 @@ val compile_exp_thm = prove(
   \\ Cases_on `n`
   \\ fs [word_exp_def,eval_exp_def,eval_exp_pre_def,compile_exp_def] \\ rveq
   \\ fs [compile_exp_def]
-  \\ `exp_size (K 0) e < exp_size (K 0) (Shift s e (Nat 1))` by
+  \\ `exp_size (K 0) e < exp_size (K 0) (Shift s e 1)` by
        (fs [exp_size_def] \\ decide_tac)
-  \\ res_tac \\ fs [num_exp_def]
+  \\ res_tac \\ fs []
   \\ Cases_on `s`
   \\ fs [word_sh_def,eval_exp_def]
   \\ fs [good_dimindex_def]);
@@ -676,7 +676,7 @@ val compile_thm = store_thm("compile_thm",
          (fn th => assume_tac (REWRITE_RULE [state_rel_def] th))
     \\ fs [SeqIndex_def,evaluate_def,array_rel_def]
     \\ Cases_on `a`
-    \\ fs [word_exp_def,FLOOKUP_DEF,word_sh_def,num_exp_def]
+    \\ fs [word_exp_def,FLOOKUP_DEF,word_sh_def]
     \\ `shift (:α) < dimindex (:α)` by
           (fs [good_dimindex_def,shift_def] \\ NO_TAC)
     \\ fs [the_words_def,word_op_def,set_var_def,lookup_insert,
@@ -702,7 +702,7 @@ val compile_thm = store_thm("compile_thm",
          (fn th => assume_tac (REWRITE_RULE [state_rel_def] th))
     \\ fs [SeqIndex_def,evaluate_def,array_rel_def]
     \\ once_rewrite_tac [evaluate_SeqTemp] \\ fs [evaluate_def]
-    \\ fs [word_exp_def,FLOOKUP_DEF,word_sh_def,num_exp_def,set_var_def]
+    \\ fs [word_exp_def,FLOOKUP_DEF,word_sh_def,set_var_def]
     \\ `shift (:α) < dimindex (:α)` by
           (fs [good_dimindex_def,shift_def] \\ NO_TAC)
     \\ fs [the_words_def,word_op_def,set_var_def,lookup_insert,get_var_def,

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -537,7 +537,7 @@ val inst_select_exp_thm = Q.prove(`
     (simp[inst_select_exp_def]>>last_x_assum mp_tac>>simp[Once PULL_FORALL]>>disch_then (qspec_then`e`mp_tac)>>impl_tac>-(full_simp_tac(srw_ss())[exp_size_def]>>DECIDE_TAC)>>
     full_simp_tac(srw_ss())[LET_THM,word_exp_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]
     >-
-      (`word_sh s' c' (num_exp n) = SOME c'` by
+      (`word_sh s' c' n = SOME c'` by
         (full_simp_tac(srw_ss())[word_sh_def]>>EVERY_CASE_TAC>>
         fs[])>>
       srw_tac[][]>>res_tac>>
@@ -546,7 +546,7 @@ val inst_select_exp_thm = Q.prove(`
       `lookup temp loc'' = SOME (Word c')` by metis_tac[]>>
       full_simp_tac(srw_ss())[set_vars_def,alist_insert_def,state_component_equality,lookup_insert]>>
       srw_tac[][]>>rev_full_simp_tac(srw_ss())[]>>
-      `x ≠ temp` by DECIDE_TAC>>metis_tac[])
+      Cases_on `x = temp`>>fs[]>>metis_tac[])
     >-
       (assume_tac DIMINDEX_GT_0>>
       `0 ≠ dimindex(:'a)` by DECIDE_TAC>>full_simp_tac(srw_ss())[])
@@ -555,11 +555,11 @@ val inst_select_exp_thm = Q.prove(`
       first_assum(qspecl_then[`temp`,`c`] assume_tac)>>
       full_simp_tac(srw_ss())[evaluate_def,LET_THM,inst_def,mem_load_def,assign_def,word_exp_def]>>
       `lookup temp loc'' = SOME (Word c')` by metis_tac[]>>
-      full_simp_tac(srw_ss())[num_exp_def,set_var_def,state_component_equality,lookup_insert]>>
+      full_simp_tac(srw_ss())[set_var_def,state_component_equality,lookup_insert]>>
       srw_tac[][]>>DISJ2_TAC>>strip_tac>>`x ≠ temp` by DECIDE_TAC>>
       metis_tac[])
     >-
-      (`num_exp n ≥ dimindex(:'a)` by DECIDE_TAC>>
+      (`n ≥ dimindex(:'a)` by DECIDE_TAC>>
       full_simp_tac(srw_ss())[word_sh_def])));
 
 val locals_rm = Q.prove(`

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -116,10 +116,10 @@ val word_exp_def = tDefine "word_exp" `
   (word_exp s (Op op wexps) =
      let ws = MAP (word_exp s) wexps in
        if EVERY IS_SOME ws then word_op op (MAP THE ws) else NONE) /\
-  (word_exp s (Shift sh wexp nexp) =
+  (word_exp s (Shift sh wexp n) =
      case word_exp s wexp of
      | NONE => NONE
-     | SOME w => word_sh sh w (num_exp nexp))`
+     | SOME w => word_sh sh w n)`
   (WF_REL_TAC `measure (exp_size ARB o SND)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC wordLangTheory.MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
@@ -260,7 +260,7 @@ val inst_def = Define `
                                       | Imm w => Const w]) s
     | Arith (Shift sh r1 r2 n) =>
         assign r1
-          (Shift sh (Var r2) (Nat n)) s
+          (Shift sh (Var r2) n) s
     | Arith (Div r1 r2 r3) =>
        (let vs = get_vars[r3;r2] s in
        case vs of

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -148,9 +148,9 @@ val word_exp_def = tDefine "word_exp" `
      case the_words (MAP (word_exp s) wexps) of
      | SOME ws => (OPTION_MAP Word (word_op op ws))
      | _ => NONE) /\
-  (word_exp s (Shift sh wexp nexp) =
+  (word_exp s (Shift sh wexp n) =
      case word_exp s wexp of
-     | SOME (Word w) => OPTION_MAP Word (word_sh sh w (num_exp nexp))
+     | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
      | _ => NONE)`
   (WF_REL_TAC `measure (exp_size ARB o SND)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
@@ -381,7 +381,7 @@ val inst_def = Define `
                                     | Imm w => Const w]) s
     | Arith (Shift sh r1 r2 n) =>
         assign r1
-          (Shift sh (Var r2) (Nat n)) s
+          (Shift sh (Var r2) n) s
     | Arith (Div r1 r2 r3) =>
        (let vs = get_vars[r3;r2] s in
        case vs of

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -7,20 +7,12 @@ val _ = new_theory "wordLang";
 val _ = Parse.type_abbrev("shift",``:ast$shift``);
 
 val _ = Datatype `
-  num_exp = Nat num
-          | Add num_exp num_exp
-          | Sub num_exp num_exp
-          | Div2 num_exp
-          | Exp2 num_exp
-          | WordWidth ('a word)`
-
-val _ = Datatype `
   exp = Const ('a word)
       | Var num
       | Lookup store_name
       | Load exp
       | Op binop (exp list)
-      | Shift shift exp ('a num_exp)`
+      | Shift shift exp num`
 
 val MEM_IMP_exp_size = Q.store_thm("MEM_IMP_exp_size",
   `!xs a. MEM a xs ==> (exp_size l a < exp1_size l xs)`,
@@ -66,7 +58,7 @@ val every_var_exp_def = tDefine "every_var_exp" `
   (every_var_exp P (Var num) = P num) ∧
   (every_var_exp P (Load exp) = every_var_exp P exp) ∧
   (every_var_exp P (Op wop ls) = EVERY (every_var_exp P) ls) ∧
-  (every_var_exp P (Shift sh exp nexp) = every_var_exp P exp) ∧
+  (every_var_exp P (Shift sh exp n) = every_var_exp P exp) ∧
   (every_var_exp P expr = T)`
 (WF_REL_TAC `measure (exp_size ARB o SND)`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
@@ -170,7 +162,7 @@ val max_var_exp_def = tDefine "max_var_exp" `
   (max_var_exp (Var num) = num) ∧
   (max_var_exp (Load exp) = max_var_exp exp) ∧
   (max_var_exp (Op wop ls) = list_max (MAP (max_var_exp) ls))∧
-  (max_var_exp (Shift sh exp nexp) = max_var_exp exp) ∧
+  (max_var_exp (Shift sh exp n) = max_var_exp exp) ∧
   (max_var_exp exp = 0:num)`
 (WF_REL_TAC `measure (exp_size ARB )`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
@@ -238,15 +230,6 @@ val max_var_def = Define `
   (max_var (LocValue r l1) = r) ∧
   (max_var (Set n exp) = max_var_exp exp) ∧
   (max_var p = 0)`;
-
-(*Moved from wordSem, because we use them to simplify constant expressions in word_inst*)
-val num_exp_def = Define `
-  (num_exp (Nat n) = n) /\
-  (num_exp (Add x y) = num_exp x + num_exp y) /\
-  (num_exp (Sub x y) = num_exp x - num_exp y) /\
-  (num_exp (Div2 x) = num_exp x DIV 2) /\
-  (num_exp (Exp2 x) = 2 ** (num_exp x)) /\
-  (num_exp (WordWidth (w:'a word)) = dimindex (:'a))`
 
 val word_op_def = Define `
   word_op op (ws:('a word) list) =

--- a/compiler/backend/word_bignumScript.sml
+++ b/compiler/backend/word_bignumScript.sml
@@ -114,7 +114,7 @@ fun get_exp x =
   val (_,name) = first (fn (pat,_) => can (match_term pat) x) shifts
   val x1 = get_exp (x |> rator |> rand)
   val x2 = x |> rand
-  in wordLangSyntax.mk_Shift(name,x1,``Nat ^x2``) end
+  in wordLangSyntax.mk_Shift(name,x1,``^x2``) end
   handle HOL_ERR _ =>
   (* ~ *) let
   val r = wordsSyntax.dest_word_1comp x
@@ -430,7 +430,7 @@ val compile_exp_def = Define `
   compile_exp (Op b [x1;x2]) = Op b [compile_exp x1; compile_exp x2] /\
   compile_exp (Var n) = Lookup (Temp (n2w n)) /\
   compile_exp (Const w) = Const w /\
-  compile_exp (Shift sh x (Nat na)) = Shift sh (compile_exp x) (Nat na) /\
+  compile_exp (Shift sh x na) = Shift sh (compile_exp x) na /\
   compile_exp _ = Const 0w`
 
 val TempIn1_def = Define `TempIn1 = Temp 31w`
@@ -453,7 +453,7 @@ val SeqIndex_def = Define `
   SeqIndex i r arr p =
     let t = (case arr of Out => TempOut | In2 => TempIn2 | In1 => TempIn1) in
       Seq (Assign i (Op Add [Lookup t;
-           Shift Lsl (Lookup (Temp (n2w r))) (Nat (shift (:'a)))])) p
+           Shift Lsl (Lookup (Temp (n2w r))) (shift (:'a))])) p
               :'a wordLang$prog`
 
 val div_location_def = Define `

--- a/compiler/backend/word_instScript.sml
+++ b/compiler/backend/word_instScript.sml
@@ -208,8 +208,7 @@ val inst_select_exp_def = tDefine "inst_select_exp" `
     | _ =>
       let p2 = inst_select_exp c (temp+1) (temp+1) e2 in
       Seq p1 (Seq p2 (Inst (Arith (Binop op tar temp (Reg (temp+1))))))) ∧
-  (inst_select_exp c tar temp (Shift sh exp nexp) =
-    let n = num_exp nexp in
+  (inst_select_exp c tar temp (Shift sh exp n) =
     if (n < dimindex(:'a)) then
       let prog = inst_select_exp c temp temp exp in
       if n = 0 then
@@ -261,9 +260,8 @@ val inst_select_exp_pmatch = Q.store_thm("inst_select_exp_pmatch",`!c tar temp e
     | _ =>
       let p2 = inst_select_exp c (temp+1) (temp+1) e2 in
       Seq (inst_select_exp c temp temp e1) (Seq p2 (Inst (Arith (Binop op tar temp (Reg (temp+1)))))))
-  | Shift sh exp nexp =>
-    (let n = num_exp nexp in
-    if (n < dimindex(:'a)) then
+  | Shift sh exp n =>
+    (if (n < dimindex(:'a)) then
       let prog = inst_select_exp c temp temp exp in
       if n = 0 then
         Seq prog (Move 0 [tar,temp])
@@ -276,7 +274,8 @@ val inst_select_exp_pmatch = Q.store_thm("inst_select_exp_pmatch",`!c tar temp e
   rpt strip_tac
   >> rpt(CONV_TAC(RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV) >> every_case_tac >>
          PURE_ONCE_REWRITE_TAC[LET_DEF] >> BETA_TAC)
-  >> fs[inst_select_exp_def]);
+  >> fs[inst_select_exp_def] >> metis_tac[DIMINDEX_GT_0, NOT_ZERO_LT_ZERO]);
+
 (*
 
 First munch

--- a/compiler/backend/word_simpScript.sml
+++ b/compiler/backend/word_simpScript.sml
@@ -239,13 +239,13 @@ val const_fp_exp_def = tDefine "const_fp_exp" `
 			| SOME w => Const w
 		        | _ => Op op (MAP Const ws))
          | _ => Op op const_fp_args) /\
-  (const_fp_exp (Shift sh e ne) cs =
+  (const_fp_exp (Shift sh e n) cs =
      let const_fp_exp_e = const_fp_exp e cs in
        dtcase const_fp_exp_e of
-         | Const c => (dtcase word_sh sh c (num_exp ne) of
+         | Const c => (dtcase word_sh sh c n of
                         | SOME w => Const w
-                        | _ => Shift sh (Const c) ne)
-         | _ => Shift sh e ne) /\
+                        | _ => Shift sh (Const c) n)
+         | _ => Shift sh e n) /\
   (const_fp_exp e _ = e)`
 
   (WF_REL_TAC `measure (exp_size (\x.0) o FST)` \\ conj_tac

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -530,8 +530,6 @@ val res = translate (wordLangTheory.word_sh_def
   |> RW[shift_left_rwt,shift_right_rwt,arith_shift_right_rwt] |> conv32 |> we_simp |> SIMP_RULE (srw_ss()++ARITH_ss) [SHIFT_ZERO,MOD_LESS] |> gconv
   |> RW[shift_left_rwt,shift_right_rwt,arith_shift_right_rwt]  );
 
-val _ = translate (wordLangTheory.num_exp_def |> conv32);
-
 val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> spec32 |> REWRITE_RULE[word_msb_rw]);
 
 (* TODO: remove when pmatch is fixed *)

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -531,8 +531,6 @@ val _ = translate (wordLangTheory.word_sh_def
   |> REWRITE_RULE [miscTheory.word_ror_eq_any_word64_ror]
   |> RW[shift_left_rwt,shift_right_rwt,arith_shift_right_rwt] |> conv64)
 
-val _ = translate (wordLangTheory.num_exp_def |> conv64)
-
 val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> spec64 |> REWRITE_RULE[word_msb_rw])
 
 (* TODO: remove when pmatch is fixed *)


### PR DESCRIPTION
`num_exp` existing in WordLang to represent calculations
based only on constants, however, it was never used beyond
wrapping `num` values. This change removes `num_exp` and replaces
its uses with `num`.