### PR TITLE
Add an unverified sexpression AST printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ compiler/benchmarks/sml/polyc_*
 compiler/benchmarks/sml/sml_*
 compiler/benchmarks/*.dat
 compiler/benchmarks/*.eps
+
+# sexpression build
+unverified/sexp-bootstrap/build
+compiler-sexp*

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -56,7 +56,9 @@ val _ = Datatype`
   config =
     <| inferencer_config : inferencer_config
      ; backend_config : α backend$config
-     ; input_is_sexp : bool
+     ; input_is_sexp       : bool
+     ; exclude_prelude     : bool
+     ; skip_type_inference : bool
      |>`;
 
 val _ = Datatype`compile_error = ParseError | TypeError mlstring | CompileError | ConfigError mlstring`;
@@ -91,7 +93,12 @@ val compile_def = Define`
     | NONE => Failure ParseError
     | SOME prog =>
        let _ = empty_ffi (strlit "finished: lexing and parsing") in
-       case infertype_prog c.inferencer_config (prelude ++ prog) of
+       let full_prog = if c.exclude_prelude then prog else prelude ++ prog in
+       case
+         if c.skip_type_inference
+         then Success c.inferencer_config
+         else infertype_prog c.inferencer_config full_prog
+       of
        | Failure (Exc (locs, msg)) =>
            Failure (TypeError (concat [msg; implode " at "; locs_to_string locs]))
        | Success ic =>
@@ -109,7 +116,12 @@ val compile_explorer_def = Define`
     of
     | NONE => Failure ParseError
     | SOME prog =>
-       case infertype_prog c.inferencer_config (prelude ++ prog) of
+       let full_prog = if c.exclude_prelude then prog else prelude ++ prog in
+       case
+         if c.skip_type_inference
+         then Success c.inferencer_config
+         else infertype_prog c.inferencer_config full_prog
+       of
        | Failure (Exc (locs, msg)) => Failure (TypeError (concat [msg; implode " at "; locs_to_string locs]))
        | Success ic => Success (backend$compile_explorer c.backend_config (prelude ++ prog))`
 
@@ -371,12 +383,16 @@ val parse_top_config_def = Define`
   let heap = find_num (strlit"--heap_size=") ls default_heap_sz in
   let stack = find_num (strlit"--stack_size=") ls default_stack_sz in
   let sexp = find_bool (strlit"--sexp=") ls F in
-  case (heap,stack,sexp) of
-    (INL heap,INL stack,INL sexp) =>
-      INL (heap,stack,sexp)
+  let prelude = find_bool (strlit"--exclude_prelude=") ls F in
+  let typeinference = find_bool (strlit"--skip_type_inference=") ls F in
+  case (heap,stack,sexp,prelude,typeinference) of
+    (INL heap,INL stack,INL sexp,INL prelude,INL typeinference) =>
+      INL (heap,stack,sexp,prelude,typeinference)
   | _ => INR (concat [get_err_str heap;
                get_err_str stack;
-               get_err_str sexp])`
+               get_err_str sexp;
+               get_err_str prelude;
+               get_err_str typeinference])`
 
 (* Check for version flag
    TODO: fix this
@@ -399,14 +415,16 @@ val compile_64_def = Define`
   let confexp = parse_target_64 cl in
   let topconf = parse_top_config cl in
   case (confexp,topconf) of
-    (INL (conf,export), INL(heap,stack,sexp)) =>
+    (INL (conf,export), INL(heap,stack,sexp,prelude,typeinfer)) =>
     (let ext_conf = extend_conf cl conf in
     case ext_conf of
       INL ext_conf =>
         let compiler_conf =
-          <| inferencer_config := init_config;
-             backend_config    := ext_conf;
-             input_is_sexp     := sexp |> in
+          <| inferencer_config   := init_config;
+             backend_config      := ext_conf;
+             input_is_sexp       := sexp;
+             exclude_prelude     := prelude;
+             skip_type_inference := typeinfer |> in
         (case compiler$compile compiler_conf basis input of
           Success (bytes,data,c) =>
             (export (the [] c.ffi_names) heap stack bytes data, implode "")
@@ -421,14 +439,16 @@ val compile_32_def = Define`
   let confexp = parse_target_32 cl in
   let topconf = parse_top_config cl in
   case (confexp,topconf) of
-    (INL (conf,export), INL(heap,stack,sexp)) =>
+    (INL (conf,export), INL(heap,stack,sexp,prelude,typeinfer)) =>
     (let ext_conf = extend_conf cl conf in
     case ext_conf of
       INL ext_conf =>
         let compiler_conf =
-          <| inferencer_config := init_config;
-             backend_config    := ext_conf;
-             input_is_sexp     := sexp |> in
+          <| inferencer_config   := init_config;
+             backend_config      := ext_conf;
+             input_is_sexp       := sexp;
+             exclude_prelude     := prelude;
+             skip_type_inference := typeinfer |> in
         (case compiler$compile compiler_conf basis input of
           Success (bytes,data,c) =>
             (export (the [] c.ffi_names) heap stack bytes data, implode "")

--- a/compiler/proofs/compilerProofScript.sml
+++ b/compiler/proofs/compilerProofScript.sml
@@ -13,6 +13,8 @@ val config_ok_def = Define`
     env_rel prim_tenv cc.inferencer_config.inf_env ∧
     prim_tdecs = convert_decls cc.inferencer_config.inf_decls ∧
     ¬cc.input_is_sexp ∧
+    ¬cc.exclude_prelude ∧
+    ¬cc.skip_type_inference ∧
     backend_config_ok cc.backend_config ∧ mc_conf_ok mc ∧ mc_init_ok cc.backend_config mc`;
 
 val initial_condition_def = Define`
@@ -22,6 +24,8 @@ val initial_condition_def = Define`
     env_rel st.tenv cc.inferencer_config.inf_env ∧
     st.tdecs = convert_decls cc.inferencer_config.inf_decls ∧
     ¬cc.input_is_sexp ∧
+    ¬cc.exclude_prelude ∧
+    ¬cc.skip_type_inference ∧
     backend_config_ok cc.backend_config ∧ mc_conf_ok mc ∧ mc_init_ok cc.backend_config mc`;
 
 val parse_prog_correct = Q.store_thm("parse_prog_correct",
@@ -123,7 +127,7 @@ val compile_correct_gen = Q.store_thm("compile_correct_gen",
   \\ simp[compilerTheory.compile_def]
   \\ simp[parse_prog_correct]
   \\ BasicProvers.CASE_TAC
-  >- fs[initial_condition_def]
+  \\ fs[initial_condition_def]
   \\ BasicProvers.CASE_TAC
   \\ simp[semantics_def]
   \\ fs[initial_condition_def]

--- a/unverified/sexp-bootstrap/Holmakefile
+++ b/unverified/sexp-bootstrap/Holmakefile
@@ -1,0 +1,46 @@
+INCLUDES = ../../compiler/bootstrap/translation
+CLINE_OPTIONS = --qof
+
+ARCH = x64
+WORD_SIZE = 64
+BUILDDIR = build
+CAKEDIR = $(BUILDDIR)/existing-$(ARCH)-$(WORD_SIZE)
+STRAPDIR = $(BUILDDIR)/bootstrapped-$(ARCH)-$(WORD_SIZE)
+
+ifdef POLY
+HOLHEAP = heap
+PARENT_HOLHEAP = ../../compiler/bootstrap/translation/heap
+EXTRA_CLEANS = $(HOLHEAP) $(HOLHEAP).o
+
+THYFILES = $(patsubst %Script.sml,%Theory.uo,$(wildcard *.sml))
+TARGETS0 = $(patsubst %Theory.sml,,$(THYFILES))
+TARGETS = $(patsubst %.sml,%.uo,$(TARGETS0))
+
+all: $(TARGETS) $(HOLHEAP) $(STRAPDIR)/cake
+.PHONY: all
+
+BARE_THYS = ../../compiler/bootstrap/translation/compiler$(WORD_SIZE)ProgTheory
+
+DEPS = $(patsubst %,%.uo,$(BARE_THYS)) $(PARENT_HOLHEAP)
+
+$(HOLHEAP): $(DEPS)
+	$(protect $(HOLDIR)/bin/buildheap) -b $(PARENT_HOLHEAP) -o $(HOLHEAP) $(BARE_THYS)
+
+endif
+
+$(BUILDDIR)/cake.tar.gz:
+	mkdir -p $(BUILDDIR)
+	wget https://cakeml.org/cake-$(ARCH)-$(WORD_SIZE).tar.gz -O $(BUILDDIR)/cake.tar.gz
+
+$(CAKEDIR)/cake: $(BUILDDIR)/cake.tar.gz
+	mkdir -p $(CAKEDIR)
+	tar -xvzf $(BUILDDIR)/cake.tar.gz -C $(CAKEDIR) --strip-components 1
+	make -C $(CAKEDIR) cake
+
+$(STRAPDIR)/cake: $(CAKEDIR)/cake toSexpressionTheory.sml
+	mkdir -p $(STRAPDIR)
+	tar -xvzf $(BUILDDIR)/cake.tar.gz -C $(STRAPDIR) --strip-components 1
+	$(CAKEDIR)/cake --sexp=true --exclude_prelude=true --skip_type_inference=true < compiler-sexp-$(ARCH)-$(WORD_SIZE) > $(STRAPDIR)/cake.S
+	make -C $(STRAPDIR) cake
+
+EXTRA_CLEANS = $(BUILDDIR) compiler-sexp-$(ARCH)-$(WORD_SIZE)

--- a/unverified/sexp-bootstrap/toSexpressionScript.sml
+++ b/unverified/sexp-bootstrap/toSexpressionScript.sml
@@ -1,0 +1,183 @@
+open preamble fromSexpTheory compiler64ProgTheory
+
+val _ = new_theory"toSexpression";
+
+datatype exp = exp_tuple of exp list | exp_list of exp list | exp_str of string;
+
+fun escape_wrap c = "\"" ^ c ^ "\""
+fun escape_char c =
+  let
+    val to_hex = (StringCvt.padLeft #"0" 2) o (Int.fmt StringCvt.HEX) o Char.ord
+  in
+    if c = #"\\" then "\\\\\\\\"
+    else if c = #"\"" then "\\\""
+    else if Char.isPrint c then Char.toString c
+    else "\\\\" ^ (to_hex c)
+  end
+
+val fromHOLchar =
+  escape_wrap o escape_char o stringSyntax.fromHOLchar;
+val fromHOLstring =
+  escape_wrap o (String.translate escape_char) o stringSyntax.fromHOLstring;
+val fromHOLnum = Arbnumcore.toString o numSyntax.dest_numeral;
+
+fun char_to_exp c = exp_list [exp_str "char", exp_str (fromHOLchar c)]
+val string_to_exp = exp_str o fromHOLstring;
+val num_to_exp = exp_str o fromHOLnum;
+
+fun word_to_exp lit_name w =
+  let 
+    val str = Arbnumcore.toString (wordsSyntax.dest_word_literal w)
+  in
+    exp_list [exp_str lit_name, exp_str str]
+  end
+
+fun int_to_exp i =
+  let
+    fun via_num i = (num_to_exp o rhs o concl o EVAL) ``Num (^i)``
+  in
+    if intSyntax.is_negated i
+      then exp_list [exp_str "-", via_num (intSyntax.mk_negated i)]
+      else via_num i
+  end
+
+val loc_to_exp = exp_list [exp_str "0 0 0 0 0 0"];
+
+val int_lit = ``ast$IntLit``;
+val char_lit = ``ast$Char``;
+val word8_lit = ``ast$Word8``;
+val word64_lit = ``ast$Word64``;
+fun lit_to_exp t =
+  let
+    val (x, xs) = strip_comb t
+    val h = hd xs
+  in
+    if same_const x int_lit then int_to_exp h
+    else if same_const x char_lit then char_to_exp h
+    else if same_const x word8_lit then word_to_exp "word8" h
+    else if same_const x word64_lit then word_to_exp "word64" h
+    else string_to_exp h
+  end
+
+val shift_op = ``ast$Shift``;
+val to_int_op = ``ast$WordToInt``;
+val from_int_op = ``ast$WordFromInt``;
+val ffi_op = ``ast$FFI``;
+fun op_to_exp arg =
+  let
+    val underscore_filter =
+      String.implode o filter (fn n => n <> #"_") o String.explode
+    val to_string = #1 o dest_const
+    fun filtered_string t =
+      case to_string t of "W8" => "8"
+                        | "W64" => "64"
+                        | s => underscore_filter s
+    fun wordInt xs s = exp_str ((hd (map to_string xs)) ^ s)
+    fun ffi xs = exp_tuple [exp_str "FFI", string_to_exp (hd xs)]
+    fun shift xs =
+      let
+        val consts = List.take (xs, 2)
+        val str = "Shift" ^ String.concat (map filtered_string consts)
+      in
+        exp_tuple [exp_str str, num_to_exp (last xs)]
+      end
+    val (x, xs) = strip_comb arg
+  in
+    if same_const x shift_op then shift xs
+    else if same_const x to_int_op then wordInt xs "toInt"
+    else if same_const x from_int_op then wordInt xs "fromInt"
+    else if same_const x ffi_op then ffi xs
+    else exp_str (String.concat (map filtered_string (x::xs)))
+  end
+
+val cons = ``CONS : 'a -> 'a list -> 'a list``;
+val comma = ``$, : 'a -> 'b -> 'a # 'b``;
+val pvar = ``ast$Pvar``;
+val locs = ``Locs``;
+val nil_l = ``[] : 'a list``;
+val app = ``ast$App``;
+val lit = ``ast$Lit``;
+val plit = ``ast$Plit``;
+fun ast_to_exp term =
+  let 
+    val list_to_exp = map ast_to_exp
+    fun app_to_exp const args =
+      let
+        val exp = (exp_str o #1 o dest_const) const
+        val op_exp = op_to_exp (hd args)
+        val args_exp = list_to_exp (tl args)
+      in
+        exp_list (exp::op_exp::args_exp)
+      end
+    fun generic_to_exp const args =
+      let
+        val exp = (exp_str o #1 o dest_const) const
+        val args_exp = list_to_exp args
+      in 
+        case args of [] => exp
+                   | _ => exp_list (exp::args_exp)
+      end
+    fun cons_to_exp term =
+      if stringSyntax.is_string_literal term
+        then string_to_exp term
+        else (exp_list o list_to_exp o #1 o listSyntax.dest_list) term
+    val tuple_to_exp =
+      exp_tuple o list_to_exp o pairSyntax.spine_pair
+    val (x, xs) = strip_comb term
+  in
+    if same_const x pvar then ast_to_exp (hd xs)
+    else if same_const x lit then
+      exp_list [exp_str "Lit", lit_to_exp (hd xs)]
+    else if same_const x plit then
+      exp_list [exp_str "Plit", lit_to_exp (hd xs)]
+    else if same_const x locs then loc_to_exp
+    else if same_const x nil_l then exp_list []
+    else if same_const x cons then cons_to_exp term
+    else if same_const x comma then tuple_to_exp term
+    else if same_const x app then app_to_exp x xs
+    else generic_to_exp x xs
+  end
+
+fun exp_to_string e =
+  let
+    val list_to_string =
+      (String.concatWith " ") o (map exp_to_string)
+    fun tuple_to_string t =
+      case t of [] => ""
+              | [x, exp_list l] => (exp_to_string x) ^ " " ^ (list_to_string l)
+              | [x, y] => (exp_to_string x) ^ " . " ^ (exp_to_string y)
+              | x::xs => (exp_to_string x) ^ " " ^ (tuple_to_string xs)
+  in
+    case e of exp_str s => s
+            | exp_tuple l => "(" ^ (tuple_to_string l) ^ ")"
+            | exp_list [] => "nil"
+            | exp_list l => "(" ^ (list_to_string l) ^ ")"
+  end
+
+fun print_prog pf prog =
+  let
+    val out = pf o exp_to_string o ast_to_exp
+    fun step pl =
+      case pl of [] => ()
+               | [x] => out x
+               | x::xs => (out x; pf " "; step xs)
+    val _ = pf "("
+    val (pl, _) = listSyntax.dest_list prog
+    val _ = step pl
+  in
+    pf ")"
+  end
+
+fun dump_prog_exp file prog =
+  let
+    val fd = TextIO.openOut file
+    fun out s = TextIO.output(fd, s)
+    val _ = print_prog out prog
+  in
+    TextIO.closeOut fd
+  end
+
+val print = dump_prog_exp "compiler-sexp-x64-64";
+val _ = (print o rhs o concl) compiler64_prog_def;
+
+val _ = export_theory();


### PR DESCRIPTION
This change adds an unverified sexpression printer for
the CakeML AST, which enables bootstrapped compiler builds.
The translated compiler AST is printed as sexpressions
and then fed into a prior built compiler. This approach
reduces build times and has a lower memory footprint,
as the compilation process is not carried out in logic.
However, it does not provide the same correctness
guarantees and will fail if the compiler is implemented
with features newer than the built compiler.

The change also adds two compiler flags: `--exclude_prelude`
and `--skip_type_inference`. These toggle certain
behaviour off in the compilation process. They are
necessary when building the compiler using this approach
as the translated AST already includes the prelude
functions and will fail type inference checks.