### PR TITLE
Add stage to download latest cake binary

### DIFF
--- a/developers/README.md
+++ b/developers/README.md
@@ -11,6 +11,10 @@ A list of paths to files that are considered to be the (non-theory) outputs of
 a successful build. As with rebuild-excludes and build-sequence, these are
 paths relative to the root directory.
 
+[bin](bin):
+This directory represents a stage in the build sequence where the latest
+available cake binary is downloaded to perform testing and bootstrapping.
+
 [build-sequence](build-sequence):
 The regression test runs through this list of directories.
 

--- a/developers/bin/.gitignore
+++ b/developers/bin/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+cake*
+basis_ffi*

--- a/developers/bin/Holmakefile
+++ b/developers/bin/Holmakefile
@@ -1,0 +1,17 @@
+INCLUDES = 
+OPTIONS = QUIT_ON_FAILURE
+ARCH=x64
+WORD_SIZE=64
+
+all: cake-$(ARCH)-$(WORD_SIZE).tar.gz cake.S cake
+.PHONY: all
+
+cake-$(ARCH)-$(WORD_SIZE).tar.gz:
+	wget https://cakeml.org/cake-$(ARCH)-$(WORD_SIZE).tar.gz
+
+cake.S: cake-$(ARCH)-$(WORD_SIZE).tar.gz
+	tar -xvzf cake-$(ARCH)-$(WORD_SIZE).tar.gz --strip-components 1
+	sed -i'' -e 's/.space 1024 \* 1024 \* 1000/.space 1024 \* 1024 \* 2000/g' cake.S
+
+cake: cake.S
+	make -f Makefile CFLAGS=-mcmodel=medium

--- a/developers/bin/readmePrefix
+++ b/developers/bin/readmePrefix
@@ -1,0 +1,2 @@
+This directory represents a stage in the build sequence where the latest
+available cake binary is downloaded to perform testing and bootstrapping.

--- a/developers/build-sequence
+++ b/developers/build-sequence
@@ -1,5 +1,8 @@
 ## The regression test runs through this list of directories.
 
+# download the latest cake binary
+developers/bin
+
 # semantics and metatheory
 semantics/ffi
 semantics

--- a/unverified/sexpr-bootstrap/x64/32/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/32/Holmakefile
@@ -2,8 +2,8 @@ ARCH = x64
 WORD_SIZE = 32
 STACK_MB = 1000
 HEAP_MB = 1000
-CAKE_BIN = cake
-INCLUDES = ../../../../compiler/bootstrap/translation ../../../sexpr-bootstrap
+CAKE_BIN = ../../../../developers/bin/cake
+INCLUDES = ../../../../compiler/bootstrap/translation ../../../sexpr-bootstrap ../../../../developers/bin/
 CLINE_OPTIONS = --qof
 
 ifdef POLY

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -2,8 +2,8 @@ ARCH = x64
 WORD_SIZE = 64
 STACK_MB = 1000
 HEAP_MB = 1000
-CAKE_BIN = cake
-INCLUDES = ../../../../compiler/bootstrap/translation ../../../sexpr-bootstrap
+CAKE_BIN = ../../../../developers/bin/cake
+INCLUDES = ../../../../compiler/bootstrap/translation ../../../sexpr-bootstrap ../../../../developers/bin/
 CLINE_OPTIONS = --qof
 
 ifdef POLY


### PR DESCRIPTION
This changes adds a stage to the regression
worker to download the latest cake binary from
cakeml.org. This is then used by the sexpr bootstrap
and other testing stages.

Due to bootstrapping memory requirements, the downloaded
binary has its heap and stack increased to 2GB.