### PR TITLE
Annotate build-sequence with artefacts

### DIFF
--- a/developers/build-sequence
+++ b/developers/build-sequence
@@ -82,11 +82,11 @@ compiler/parsing/tests
 compiler/bootstrap/translation
 
 # compiler sexpr bootstrap
-unverified/sexpr-bootstrap/x64/64
-unverified/sexpr-bootstrap/x64/32
+unverified/sexpr-bootstrap/x64/64:unverified/sexpr-bootstrap/x64/64/cake-unverified-x64-64.tar.gz
+unverified/sexpr-bootstrap/x64/32:unverified/sexpr-bootstrap/x64/32/cake-unverified-x64-32.tar.gz
 
 # compiler HOL bootstrap
-compiler/bootstrap/compilation/x64/64
+compiler/bootstrap/compilation/x64/64:compiler/bootstrap/compilation/x64/64/cake-x64-64.tar.gz
 compiler/bootstrap/compilation/x64/64/proofs
-compiler/bootstrap/compilation/x64/32
+compiler/bootstrap/compilation/x64/32:compiler/bootstrap/compilation/x64/32/cake-x64-32.tar.gz
 compiler/bootstrap/compilation/x64/32/proofs

--- a/developers/build-sequence
+++ b/developers/build-sequence
@@ -82,11 +82,11 @@ compiler/parsing/tests
 compiler/bootstrap/translation
 
 # compiler sexpr bootstrap
-unverified/sexpr-bootstrap/x64/64:unverified/sexpr-bootstrap/x64/64/cake-unverified-x64-64.tar.gz
-unverified/sexpr-bootstrap/x64/32:unverified/sexpr-bootstrap/x64/32/cake-unverified-x64-32.tar.gz
+unverified/sexpr-bootstrap/x64/64:cake-unverified-x64-64.tar.gz
+unverified/sexpr-bootstrap/x64/32:cake-unverified-x64-32.tar.gz
 
 # compiler HOL bootstrap
-compiler/bootstrap/compilation/x64/64:compiler/bootstrap/compilation/x64/64/cake-x64-64.tar.gz
+compiler/bootstrap/compilation/x64/64:cake-x64-64.tar.gz
 compiler/bootstrap/compilation/x64/64/proofs
-compiler/bootstrap/compilation/x64/32:compiler/bootstrap/compilation/x64/32/cake-x64-32.tar.gz
+compiler/bootstrap/compilation/x64/32:cake-x64-32.tar.gz
 compiler/bootstrap/compilation/x64/32/proofs


### PR DESCRIPTION
The regression worker has been recently extended to support
early upload artefacts based on annotations in the
build-sequence. This change makes use of these annotations to
upload results from verified and unverified bootstraps.