### PR TITLE
Make compilerTheory pick up Globals.HOLDIR

### DIFF
--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -19,13 +19,7 @@ val _ = new_theory"compiler";
 val current_version_tm = mlstring_from_proc "git" ["rev-parse", "HEAD"]
 (*"*)
 val poly_version_tm = mlstring_from_proc "poly" ["-v"]
-val hol_version_tm =
-  let
-    val holdir = Option.valOf (OS.Process.getEnv "HOLDIR")
-  in
-    mlstring_from_proc_from holdir "git" ["rev-parse", "HEAD"]
-  end
-  handle _ => Term `NONE : mlstring option`
+val hol_version_tm = mlstring_from_proc_from Globals.HOLDIR "git" ["rev-parse", "HEAD"]
 
 val date_str = Date.toString (Date.fromTimeUniv (Time.now ())) ^ " UTC\n"
 val date_tm = Term `strlit^(stringSyntax.fromMLstring date_str)`


### PR DESCRIPTION
Fixes the issue that some compiled binaries do not show the HOL commit by using `Globals.HOLDIR` instead of relying on the `HOLDIR` environment variable.