### PR TITLE
Fix a bug in the monadic translator post-processing steps

### DIFF
--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -2409,7 +2409,8 @@ fun apply_ind thms ind = let
                    |> all_distinct |> list_mk_conj
     val goal = mk_imp(hs,gs)
     val ind_thm = (the ind)
-                      |> rename_bound_vars_rule "i" |> SIMP_RULE std_ss []
+                      |> rename_bound_vars_rule "i"
+                      (* |> SIMP_RULE std_ss [] *)
                       |> ISPECL (goals |> List.map fst)
                       |> CONV_RULE (DEPTH_CONV BETA_CONV)
     fun POP_MP_TACs ([],gg) = ALL_TAC ([],gg)


### PR DESCRIPTION
Removed unnecessary, aggressive simplifier step which caused bugs in the post-processing of the monadic translator.