### PR TITLE
Allow patterns in position "let val <pattern> = e ... in ... end"

### DIFF
--- a/compiler/parsing/cmlPEGScript.sml
+++ b/compiler/parsing/cmlPEGScript.sml
@@ -438,7 +438,7 @@ val cmlPEG_def = zDefine`
                         seql [tokeq LparT; pnt nPatternList; tokeq RparT]
                              (bindNT nPtuple)]);
               (mkNT nLetDec,
-               choicel [seql [tokeq ValT; pnt nV; tokeq EqualsT; pnt nE]
+               choicel [seql [tokeq ValT; pnt nPattern; tokeq EqualsT; pnt nE]
                              (bindNT nLetDec);
                         seql [tokeq FunT; pnt nAndFDecls] (bindNT nLetDec)]);
               (mkNT nLetDecs,

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -3468,11 +3468,11 @@ val completeness = Q.store_thm(
            mkNd_def] >>
       rw[] >> fs[MAP_EQ_APPEND, MAP_EQ_CONS, DISJ_IMP_THM, FORALL_AND_THM] >>
       rw[] >> dsimp[peg_eval_tok_NONE] >> pmap_cases >>
-      rename [`ptree_head vpt = NN nV`,
-              `real_fringe vpt = MAP _ vf`,
+      rename [`ptree_head ppt = NN nPattern`,
+              `real_fringe ppt = MAP _ pf`,
               `ptree_head ept = NN nE`,
               `MAP _ ef = real_fringe ept`] >>
-      map_every qexists_tac [`[vpt]`, `ef ++ sfx`, `[ept]`] >>
+      map_every qexists_tac [`[ppt]`, `ef ++ sfx`, `[ept]`] >>
       normlist >>
       simp[Once EXISTS_PROD])
   >- (print_tac "nFQV" >>

--- a/compiler/parsing/proofs/pegSoundScript.sml
+++ b/compiler/parsing/proofs/pegSoundScript.sml
@@ -613,7 +613,8 @@ val peg_sound = Q.store_thm(
   >- (print_tac "nLetDec" >>
       rpt strip_tac >> rveq >> simp[cmlG_FDOM, cmlG_applied, MAP_EQ_SING] >> fs[]
       >- (dsimp[listTheory.APPEND_EQ_CONS, MAP_EQ_SING] >> csimp[] >>
-          asm_match`peg_eval cmlPEG (i1,nt (mkNT nV) I) (SOME(equalsT::i2,r))` >>
+          asm_match
+            `peg_eval cmlPEG (i1,nt (mkNT nPattern) I) (SOME(equalsT::i2,r))` >>
           `LENGTH i1 < SUC (LENGTH i1)` by decide_tac >>
           first_assum (erule strip_assume_tac) >> rveq >> simp[] >>
           `LENGTH (equalsT::i2) ≤ LENGTH i1`

--- a/compiler/parsing/tests/cmlTestsScript.sml
+++ b/compiler/parsing/tests/cmlTestsScript.sml
@@ -126,6 +126,32 @@ val tytest = parsetest ``nType`` ``ptree_Type nType``
 
 val elab_decls = ``OPTION_MAP (elab_decs NONE [] []) o ptree_Decls``
 
+val _ = parsetest0 ``nE`` ``ptree_Expr nE``
+         "let val _ = print \"foo\"\
+            \ val z = 10\
+            \ val (x,y) = g z\
+            \ fun h x = x + 1\
+         \ in x + y end"
+ (SOME ``Let NONE (App Opapp [V "print"; Lit (StrLit "foo")])
+           (Let (SOME "z") (Lit (IntLit 10))
+              (Mat (App Opapp [V "g"; V "z"])
+                   [(Pcon NONE [Pvar "x"; Pvar "y"],
+                     Letrec [("h", "x",
+                              vbinop (Short "+") (V "x") (Lit (IntLit 1)))]
+                            (vbinop (Short "+") (V "x") (V "y")))]))``)
+
+val _ = parsetest0 ``nE`` ``ptree_Expr nE``
+         "let val (x,y) = g z\
+            \ val [h] = f a\
+         \ in x + y * h end"
+ (SOME ``Mat (App Opapp [V "g"; V "z"])
+             [(Pcon NONE [Pvar "x"; Pvar "y"],
+               Mat (App Opapp [V "f"; V "a"])
+                   [(Pcon (SOME (Short "::"))
+                          [Pvar "h"; Pcon (SOME (Short "nil")) []],
+                     vbinop (Short "+") (V "x")
+                            (vbinop (Short "*") (V "y") (V "h")))])]``)
+
 val _ = parsetest0 ``nTopLevelDec`` ``ptree_TopLevelDec`` "val w = 0wx3"
           (SOME ``Tdec (Dlet locs (Pvar "w") (Lit (Word64 3w)))``)
 

--- a/semantics/cmlPtreeConversionScript.sml
+++ b/semantics/cmlPtreeConversionScript.sml
@@ -843,6 +843,14 @@ val bind_loc_def = Define`
   bind_loc e l = Lannot e l
 `
 
+val letFromPat_def = Define‘
+  letFromPat p rhs body =
+    dtcase p of
+      Pany => Let NONE rhs body
+    | Pvar v => Let (SOME v) rhs body
+    | _ => Mat rhs [(p,body)]
+’;
+
 local
   val ptree_Expr_quotation = `
   ptree_Expr ent (Lf _) = NONE ∧
@@ -890,7 +898,7 @@ local
               eseq <- ptree_Eseq ept;
               e <- Eseq_encode eseq;
               SOME(FOLDR (λdf acc. dtcase df of
-                                       INL (v,e0) => Let (SOME v) e0 acc
+                                       INL (p,e0) => letFromPat p e0 acc
                                      | INR fds => Letrec fds acc)
                          e
                          letdecs)
@@ -1161,12 +1169,12 @@ local
                 fds <- ptree_AndFDecls andfdecls_pt;
                 SOME (INR fds)
               od
-            | [valtok; v_pt; eqtok; e_pt] =>
+            | [valtok; p_pt; eqtok; e_pt] =>
               do
                 assert(tokcheckl [valtok;eqtok] [ValT; EqualsT]);
-                v <- ptree_V v_pt;
+                p <- ptree_Pattern nPattern p_pt;
                 e <- ptree_Expr nE e_pt;
-                SOME (INL(v,e))
+                SOME (INL(p,e))
               od
             | _ => NONE) ∧
   (ptree_PEs (Lf _) = NONE) ∧

--- a/semantics/gramScript.sml
+++ b/semantics/gramScript.sml
@@ -151,7 +151,7 @@ val cmlG_def = mk_grammar_def ginfo
        |  "exception" Dconstructor
        | TypeAbbrevDec ;
  Decls ::= Decl Decls | ";" Decls | ;
- LetDec ::= "val" V "=" E | "fun" AndFDecls ;
+ LetDec ::= "val" Pattern "=" E | "fun" AndFDecls ;
  LetDecs ::= LetDec LetDecs | ";" LetDecs | ;
 
  (* patterns *)

--- a/semantics/proofs/cmlPtreeConversionPropsScript.sml
+++ b/semantics/proofs/cmlPtreeConversionPropsScript.sml
@@ -349,7 +349,7 @@ val E_OK0 = Q.store_thm(
   >- (rw[])
   >- (erule strip_assume_tac (n Pattern_OK) >> std)
   >- (erule strip_assume_tac (n Pattern_OK) >> std)
-  >- (erule strip_assume_tac (n V_OK) >> std)
+  >- (erule strip_assume_tac (n Pattern_OK) >> std)
   >- (dsimp[] >>
       map_every (erule strip_assume_tac o n) [V_OK, PbaseList1_OK] >>
       asm_match `0 < LENGTH pl` >> Cases_on `pl` >> fs[oHD_def] >> std))


### PR DESCRIPTION
Previously, this position had to be filled by a variable.

Add parsing tests for this form, fix various proofs.