### PR TITLE
Add more funs to Word64 and Word8 modules in basis

### DIFF
--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -89,17 +89,17 @@ val var_word_asr_thm = store_thm("var_word_asr_thm[simp]",
     \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD]))
   \\ ntac 9 (once_rewrite_tac [var_word_asr_def] \\ fs []));
 
-val _ = (next_ml_names := ["lsl"]);
+val _ = (next_ml_names := ["<<"]);
 val _ = translate var_word_lsl_def;
 
-val _ = (next_ml_names := ["lsr"]);
+val _ = (next_ml_names := [">>"]);
 val _ = translate var_word_lsr_def;
 
-val _ = (next_ml_names := ["asr"]);
+val _ = (next_ml_names := ["~>>"]);
 val _ = translate var_word_asr_def;
 
 val sigs = module_signatures ["fromInt", "toInt", "andb",
-  "orb", "xorb", "notb", "+", "-", "lsl", "lsr", "asr"];
+  "orb", "xorb", "notb", "+", "-", "<<", ">>", "~>>"];
 
 val _ = ml_prog_update (close_module (SOME sigs));
 

--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -1,5 +1,5 @@
 open preamble ml_translatorLib ml_progLib basisFunctionsLib
-     CharProgTheory wordsTheory
+     CharProgTheory
 
 val _ = new_theory "Word64Prog";
 

--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -46,7 +46,7 @@ val var_word_lsl_def = Define `
     else if n < 7 then w << 6
     else w << 7 else var_word_lsl (w << 8) (n − 8)`
 
-val var_word_lsl_thm = store_thm("var_word_lsl_thm",
+val var_word_lsl_thm = store_thm("var_word_lsl_thm[simp]",
   ``var_word_lsl w n = word_lsl w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD])
@@ -64,7 +64,7 @@ val var_word_lsr_def = Define `
     else if n < 7 then w >>> 6
     else w >>> 7 else var_word_lsr (w >>> 8) (n − 8)`
 
-val var_word_lsr_thm = store_thm("var_word_lsr_thm",
+val var_word_lsr_thm = store_thm("var_word_lsr_thm[simp]",
   ``var_word_lsr w n = word_lsr w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD])
@@ -82,7 +82,7 @@ val var_word_asr_def = Define `
     else if n < 7 then w >> 6
     else w >> 7 else var_word_asr (w >> 8) (n − 8)`
 
-val var_word_asr_thm = store_thm("var_word_asr_thm",
+val var_word_asr_thm = store_thm("var_word_asr_thm[simp]",
   ``var_word_asr w n = word_asr w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD])

--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -1,5 +1,5 @@
 open preamble ml_translatorLib ml_progLib basisFunctionsLib
-     CharProgTheory
+     CharProgTheory wordsTheory
 
 val _ = new_theory "Word64Prog";
 
@@ -12,11 +12,94 @@ val _ = ml_prog_update (open_module "Word64");
 val () = generate_sigs := true;
 
 val _ = append_dec ``Dtabbrev unknown_loc [] "word" (Tapp [] TC_word64)``;
+
+(* to/from int *)
 val _ = trans "fromInt" `n2w:num->word64`
 val _ = trans "toInt" `w2n:word64->num`
-val _ = trans "andb" `word_and:word64->word64->word64`;
 
-val sigs = module_signatures ["fromInt", "toInt", "andb"];
+(* bitwise operations *)
+val _ = trans "andb" `word_and:word64->word64->word64`;
+val _ = trans "orb" `word_or:word64->word64->word64`;
+val _ = trans "xorb" `word_xor:word64->word64->word64`;
+
+val word_1comp_eq = prove(
+  ``word_1comp w = word_xor w 0xFFFFFFFFFFFFFFFFw:word64``,
+  fs []);
+
+val _ = (next_ml_names := ["notb"]);
+val _ = translate word_1comp_eq
+
+(* arithmetic *)
+val _ = trans "+" `word_add:word64->word64->word64`;
+val _ = trans "-" `word_sub:word64->word64->word64`;
+
+(* shifts *)
+
+val var_word_lsl_def = Define `
+  var_word_lsl (w:word64) (n:num) = if 64 < n then 0w
+    else if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w << 1
+      else if n < 3 then w << 2
+      else w << 3
+    else if n < 6 then if n < 5 then w << 4 else w << 5
+    else if n < 7 then w << 6
+    else w << 7 else var_word_lsl (w << 8) (n − 8)`
+
+val var_word_lsl_thm = store_thm("var_word_lsl_thm",
+  ``var_word_lsl w n = word_lsl w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_lsl_def] \\ fs []));
+
+val var_word_lsr_def = Define `
+  var_word_lsr (w:word64) (n:num) = if 64 < n then 0w
+    else if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w >>> 1
+      else if n < 3 then w >>> 2
+      else w >>> 3
+    else if n < 6 then if n < 5 then w >>> 4 else w >>> 5
+    else if n < 7 then w >>> 6
+    else w >>> 7 else var_word_lsr (w >>> 8) (n − 8)`
+
+val var_word_lsr_thm = store_thm("var_word_lsr_thm",
+  ``var_word_lsr w n = word_lsr w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_lsr_def] \\ fs []));
+
+val var_word_asr_def = Define `
+  var_word_asr (w:word64) (n:num) = if 64 < n then w >> 64
+    else if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w >> 1
+      else if n < 3 then w >> 2
+      else w >> 3
+    else if n < 6 then if n < 5 then w >> 4 else w >> 5
+    else if n < 7 then w >> 6
+    else w >> 7 else var_word_asr (w >> 8) (n − 8)`
+
+val var_word_asr_thm = store_thm("var_word_asr_thm",
+  ``var_word_asr w n = word_asr w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_asr_def] \\ fs []));
+
+val _ = (next_ml_names := ["lsl"]);
+val _ = translate var_word_lsl_def;
+
+val _ = (next_ml_names := ["lsr"]);
+val _ = translate var_word_lsr_def;
+
+val _ = (next_ml_names := ["asr"]);
+val _ = translate var_word_asr_def;
+
+val sigs = module_signatures ["fromInt", "toInt", "andb",
+  "orb", "xorb", "notb", "+", "-", "lsl", "lsr", "asr"];
 
 val _ = ml_prog_update (close_module (SOME sigs));
 

--- a/basis/Word8ProgScript.sml
+++ b/basis/Word8ProgScript.sml
@@ -12,11 +12,94 @@ val _ = ml_prog_update (open_module "Word8");
 val () = generate_sigs := true;
 
 val _ = append_dec ``Dtabbrev unknown_loc [] "word" (Tapp [] TC_word8)``;
+
+(* to/from int *)
 val _ = trans "fromInt" `n2w:num->word8`
 val _ = trans "toInt" `w2n:word8->num`
-val _ = trans "andb" `word_and:word8->word8->word8`;
 
-val sigs = module_signatures ["fromInt", "toInt", "andb"];
+(* bitwise operations *)
+val _ = trans "andb" `word_and:word8->word8->word8`;
+val _ = trans "orb" `word_or:word8->word8->word8`;
+val _ = trans "xorb" `word_xor:word8->word8->word8`;
+
+val word_1comp_eq = prove(
+  ``word_1comp w = word_xor w 0xFFw:word8``,
+  fs []);
+
+val _ = (next_ml_names := ["notb"]);
+val _ = translate word_1comp_eq
+
+(* arithmetic *)
+val _ = trans "+" `word_add:word8->word8->word8`;
+val _ = trans "-" `word_sub:word8->word8->word8`;
+
+(* shifts *)
+
+val var_word_lsl_def = Define `
+  var_word_lsl (w:word8) (n:num) =
+    if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w << 1
+      else if n < 3 then w << 2
+      else w << 3
+    else if n < 6 then if n < 5 then w << 4 else w << 5
+    else if n < 7 then w << 6
+    else w << 7 else 0w`
+
+val var_word_lsl_thm = store_thm("var_word_lsl_thm",
+  ``var_word_lsl w n = word_lsl w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_lsl_def] \\ fs []));
+
+val var_word_lsr_def = Define `
+  var_word_lsr (w:word8) (n:num) =
+    if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w >>> 1
+      else if n < 3 then w >>> 2
+      else w >>> 3
+    else if n < 6 then if n < 5 then w >>> 4 else w >>> 5
+    else if n < 7 then w >>> 6
+    else w >>> 7 else 0w`
+
+val var_word_lsr_thm = store_thm("var_word_lsr_thm",
+  ``var_word_lsr w n = word_lsr w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_lsr_def] \\ fs []));
+
+val var_word_asr_def = Define `
+  var_word_asr (w:word8) (n:num) =
+    if n < 8 then
+    if n < 4 then
+      if n < 2 then if n < 1 then w else w >> 1
+      else if n < 3 then w >> 2
+      else w >> 3
+    else if n < 6 then if n < 5 then w >> 4 else w >> 5
+    else if n < 7 then w >> 6
+    else w >> 7 else w >> 8`
+
+val var_word_asr_thm = store_thm("var_word_asr_thm",
+  ``var_word_asr w n = word_asr w n``,
+  ntac 32 (
+    Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD])
+    \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD]))
+  \\ ntac 9 (once_rewrite_tac [var_word_asr_def] \\ fs []));
+
+val _ = (next_ml_names := ["lsl"]);
+val _ = translate var_word_lsl_def;
+
+val _ = (next_ml_names := ["lsr"]);
+val _ = translate var_word_lsr_def;
+
+val _ = (next_ml_names := ["asr"]);
+val _ = translate var_word_asr_def;
+
+val sigs = module_signatures ["fromInt", "toInt", "andb",
+  "orb", "xorb", "notb", "+", "-", "lsl", "lsr", "asr"];
 
 val _ = ml_prog_update (close_module (SOME sigs));
 

--- a/basis/Word8ProgScript.sml
+++ b/basis/Word8ProgScript.sml
@@ -89,17 +89,17 @@ val var_word_asr_thm = store_thm("var_word_asr_thm[simp]",
     \\ Cases_on `n'` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD]))
   \\ ntac 9 (once_rewrite_tac [var_word_asr_def] \\ fs []));
 
-val _ = (next_ml_names := ["lsl"]);
+val _ = (next_ml_names := ["<<"]);
 val _ = translate var_word_lsl_def;
 
-val _ = (next_ml_names := ["lsr"]);
+val _ = (next_ml_names := [">>"]);
 val _ = translate var_word_lsr_def;
 
-val _ = (next_ml_names := ["asr"]);
+val _ = (next_ml_names := ["~>>"]);
 val _ = translate var_word_asr_def;
 
 val sigs = module_signatures ["fromInt", "toInt", "andb",
-  "orb", "xorb", "notb", "+", "-", "lsl", "lsr", "asr"];
+  "orb", "xorb", "notb", "+", "-", "<<", ">>", "~>>"];
 
 val _ = ml_prog_update (close_module (SOME sigs));
 

--- a/basis/Word8ProgScript.sml
+++ b/basis/Word8ProgScript.sml
@@ -46,7 +46,7 @@ val var_word_lsl_def = Define `
     else if n < 7 then w << 6
     else w << 7 else 0w`
 
-val var_word_lsl_thm = store_thm("var_word_lsl_thm",
+val var_word_lsl_thm = store_thm("var_word_lsl_thm[simp]",
   ``var_word_lsl w n = word_lsl w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSL_ADD])
@@ -64,7 +64,7 @@ val var_word_lsr_def = Define `
     else if n < 7 then w >>> 6
     else w >>> 7 else 0w`
 
-val var_word_lsr_thm = store_thm("var_word_lsr_thm",
+val var_word_lsr_thm = store_thm("var_word_lsr_thm[simp]",
   ``var_word_lsr w n = word_lsr w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [LSR_ADD])
@@ -82,7 +82,7 @@ val var_word_asr_def = Define `
     else if n < 7 then w >> 6
     else w >> 7 else w >> 8`
 
-val var_word_asr_thm = store_thm("var_word_asr_thm",
+val var_word_asr_thm = store_thm("var_word_asr_thm[simp]",
   ``var_word_asr w n = word_asr w n``,
   ntac 32 (
     Cases_on `n` \\ fs [ADD1] THEN1 (EVAL_TAC \\ fs [ASR_ADD])

--- a/translator/ml_progLib.sml
+++ b/translator/ml_progLib.sml
@@ -364,7 +364,10 @@ fun pick_name str =
   if str = "!" then "deref" else
   if str = ":=" then "assign" else
   if str = "@" then "append" else
-  if str = "^" then "strcat" else str (* name is fine *)
+  if str = "^" then "strcat" else
+  if str = "<<" then "lsl" else
+  if str = ">>" then "lsr" else
+  if str = "~>>" then "asr" else str (* name is fine *)
 
 (*
 val s = init_state


### PR DESCRIPTION
The shift functions differ from SML in that they take
an integer argument for the shift length rather than
a word. Their names also differ: lsl, lsr, asr instead
of <<, >>, ->> (because the translator didn't like
the SML names for some reason).

The shift functions should be improved once CakeML
support variable length shift directly in the source.