### PR TITLE
fix duplicate rule name

### DIFF
--- a/semantics/alt_semantics/proofs/bigSmallInvariants.lem
+++ b/semantics/alt_semantics/proofs/bigSmallInvariants.lem
@@ -148,7 +148,7 @@ evaluate_ctxt env s (Ctannot () t) v (s, Rval v)
 
 and
 
-tannot : forall env v s l.
+lannot : forall env v s l.
 true
 ==>
 evaluate_ctxt env s (Clannot () l) v (s, Rval v)


### PR DESCRIPTION
Should ideally be backported to the `version2` branch.