### PR TITLE
Make translator aware of datatype constructors that live inside modules

### DIFF
--- a/basis/MapProgScript.sml
+++ b/basis/MapProgScript.sml
@@ -6,13 +6,11 @@ val _ = new_theory "MapProg"
 
 val _ = translation_extends "CompareProg";
 
-(* TODO: move this definition below open_module once the translater
-         has better support for defining datatypes inside modules. *)
+val _ = ml_prog_update (open_module "Map");
+
 val _ = (use_full_type_names := false);
 val _ = register_type ``:('a,'b) balanced_map$balanced_map``;
 val _ = (use_full_type_names := true);
-
-val _ = ml_prog_update (open_module "Map");
 
 val _ = next_ml_names := ["size", "singleton"];
 val _ = translate size_def;

--- a/basis/TextIOProgScript.sml
+++ b/basis/TextIOProgScript.sml
@@ -17,7 +17,7 @@ val _ = process_topdecs `
 ` |> append_prog
 
 fun get_exn_conv name =
-  EVAL ``lookup_cons ^name ^(get_env (get_ml_prog_state ()))``
+  EVAL ``lookup_cons (Short ^name) ^(get_env (get_ml_prog_state ()))``
   |> concl |> rand |> rand |> rand
 
 val BadFileName = get_exn_conv ``"BadFileName"``

--- a/basis/TextIOProofScript.sml
+++ b/basis/TextIOProofScript.sml
@@ -1073,7 +1073,7 @@ val print_def = Define `
 
 val EvalM_print = Q.store_thm("EvalM_print",
   `Eval env exp (STRING_TYPE x) /\
-    (nsLookup env.v (Short "print") = SOME TextIO_print_v) ==>
+   (nsLookup env.v (Short "print") = SOME TextIO_print_v) ==>
     EvalM F env st (App Opapp [Var (Short "print"); exp])
       (MONAD UNIT_TYPE exc_ty (print x))
       (MONAD_IO,p:'ffi ffi_proj)`,

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -481,7 +481,7 @@ val lookup_var_def = Define `
   lookup_var name (env:v sem_env) = nsLookup env.v (Short name)`;
 
 val lookup_cons_def = Define `
-  lookup_cons name (env:v sem_env) = nsLookup env.c (Short name)`;
+  lookup_cons name (env:v sem_env) = nsLookup env.c name`;
 
 (* theorems about lookup functions *)
 
@@ -719,19 +719,21 @@ val lookup_var_write = Q.store_thm("lookup_var_write",
 
 val lookup_var_write_mod = Q.store_thm("lookup_var_write_mod",
   `(lookup_var v (write_mod mn e1 env) = lookup_var v env) /\
-    (*(lookup_mod m (write_mod mn e1 env) =
-     if m = mn then SOME e1.v else lookup_mod m env) /\*)
-    (lookup_cons name (write_mod mn e1 env) = lookup_cons name env)`,
-  fs [lookup_var_def,write_mod_def,
-      lookup_cons_def] \\ rw [] \\ Cases_on`name` \\ fs[namespacePropsTheory.nsLookup_nsLift_append]);
- (*fs [lookup_var_id_def,lookup_var_def,write_mod_def,
-      lookup_cons_thm,lookup_mod_def] \\ rw []
-  \\ Cases_on `env.c` \\ fs [] \\ fs [lookup_alist_mod_env_def]);*)
+   (lookup_cons (Long mn1 (Short name)) (write_mod mn2 e1 env) =
+    if mn1 = mn2 then
+      lookup_cons (Short name) e1
+    else
+      lookup_cons (Long mn1 (Short name)) env) /\
+   (lookup_cons (Short name) (write_mod mn2 e1 env) =
+    lookup_cons (Short name) env)`,
+  fs [lookup_var_def,write_mod_def, lookup_cons_def] \\ rw []);
 
 val lookup_var_write_cons = Q.store_thm("lookup_var_write_cons",
   `(lookup_var v (write_cons n d env) = lookup_var v env) /\
-   (lookup_cons name (write_cons n d env) =
-     if name = n then SOME d else lookup_cons name env) /\
+   (lookup_cons (Short name) (write_cons n d env) =
+     if name = n then SOME d else lookup_cons (Short name) env) /\
+   (lookup_cons (Long l full_name) (write_cons n d env) =
+    lookup_cons (Long l full_name) env) /\
    (nsLookup (write_cons n d env).v x = nsLookup env.v x)`,
   fs [lookup_var_def,write_cons_def,lookup_cons_def] \\ rw []);
 
@@ -741,31 +743,24 @@ val lookup_var_empty_env = Q.store_thm("lookup_var_empty_env",
     (nsLookup empty_env.v (Long mn m) = NONE) /\
     (lookup_cons name empty_env = NONE)`,
   fs[lookup_var_def,empty_env_def,lookup_cons_def]);
-  (*fs [lookup_var_id_def,lookup_var_def,empty_env_def,lookup_cons_thm] \\ rw []
-  \\ fs [lookup_alist_mod_env_def]);*)
 
+(*
 val lookup_var_merge_env = Q.store_thm("lookup_var_merge_env",
   `(lookup_var v1 (merge_env e1 e2) =
        case lookup_var v1 e1 of
        | NONE => lookup_var v1 e2
        | res => res) /\
-    (lookup_cons v1 (merge_env e1 e2) =
-       case lookup_cons v1 e1 of
-       | NONE => lookup_cons v1 e2
-       | res => res)
-    (*(lookup_mod v1 (merge_env e1 e2) =
-       case lookup_mod v1 e1 of
-       | NONE => lookup_mod v1 e2
-       | res => res)*)`,
+    (lookup_cons name (merge_env e1 e2) =
+       case lookup_cons name e1 of
+       | NONE => lookup_cons name e2
+       | res => res)`,
   fs [lookup_var_def,lookup_cons_def,merge_env_def] \\ rw[] \\ every_case_tac \\
   fs[namespacePropsTheory.nsLookup_nsAppend_some]
   >-
     (Cases_on`nsLookup e2.v (Short v1)`>>
     fs[namespacePropsTheory.nsLookup_nsAppend_none,
        namespacePropsTheory.nsLookup_nsAppend_some,namespaceTheory.id_to_mods_def])
-  >>
-    (Cases_on`nsLookup e2.c (Short v1)`>>
-    fs[namespacePropsTheory.nsLookup_nsAppend_none,
-       namespacePropsTheory.nsLookup_nsAppend_some,namespaceTheory.id_to_mods_def]));
+  \\ cheat (* TODO *)));
+*)
 
 val _ = export_theory();

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -120,6 +120,12 @@ sig
     val get_v_thms_ref : unit -> (string * string * term * thm * thm * string option) list ref
     val remove_Eq_from_v_thm : thm -> thm
 
+    (* Internal - handling type constructor names *)
+    val mk_tyname : term -> string
+    val enter_tyname : term * term -> string
+    val lookup_tyname : string -> term * string option
+    val instantiate_lookup_cons : thm -> thm
+
     (* Internal - for preprocess_monadic_def *)
     val force_eqns                   : thm -> thm
     val is_rec_def                   : thm -> bool

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -121,10 +121,10 @@ sig
     val remove_Eq_from_v_thm : thm -> thm
 
     (* Internal - handling type constructor names *)
-    val mk_tyname : term -> string
-    val enter_tyname : term * term -> string
-    val lookup_tyname : string -> term * string option
-    val instantiate_lookup_cons : thm -> thm
+    val mk_cons_name : term -> string
+    val enter_cons_name : term * term -> string
+    val lookup_cons_name : string -> term * string option
+    val instantiate_cons_name : thm -> thm
 
     (* Internal - for preprocess_monadic_def *)
     val force_eqns                   : thm -> thm

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -125,6 +125,7 @@ sig
     val enter_cons_name : term * term -> string
     val lookup_cons_name : string -> term * string option
     val instantiate_cons_name : thm -> thm
+    val get_cons_names : unit -> (string * (term * string option)) list
 
     (* Internal - for preprocess_monadic_def *)
     val force_eqns                   : thm -> thm

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -1099,7 +1099,7 @@ val (ml_ty_name,x::xs,ty,lhs,input) = hd ys
   val ys2 = map (fn ((_,th),(ml_ty_name,xs,ty,lhs,input)) =>
                    (ml_ty_name,xs,ty,sub lhs th,input)) (zip inv_defs ys)
   val _ = map reg_type ys2
-  (* equality type -- TODO: make this work for mutrec *)
+  (* equality type *)
   val eq_lemmas = let
     val tms = inv_defs |> map (rator o rator o fst o dest_eq o concl o SPEC_ALL o hd o CONJUNCTS o snd)
     val xss = inv_def |> RW [GSYM CONJ_ASSOC] |> SPEC_ALL |> CONJUNCTS

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -768,7 +768,7 @@ let
       write_cons_def |> SPEC_ALL |> concl |> dest_eq |> fst |> rator
     fun is_taken_name name =
       (lookup_cons_def
-        |> SPEC (stringSyntax.fromMLstring name)
+        |> SPEC (mk_Short (stringSyntax.fromMLstring name))
         |> SPEC (get_curr_env ()) |> concl |> dest_eq |> fst
         |> EVAL |> concl |> rand
         |> optionSyntax.is_some)
@@ -1268,14 +1268,14 @@ val th = inv_defs |> map #2 |> hd
       val (n,k) = dest_TypeStamp x
       val l = tm |> dest_eq |> fst |> rator |> rand |> list_dest dest_comb
                  |> tl |> length |> numSyntax.term_of_int
-      in mk_eq(mk_lookup_cons(n, env_tm),
+      in mk_eq(mk_lookup_cons(mk_Short n, env_tm),
                optionSyntax.mk_some(mk_pair(l,x))) end
     else let
       val x = find_term is_ExnStamp tm
       val n = dest_ExnStamp x
       val l = tm |> dest_eq |> fst |> rator |> rand |> list_dest dest_comb
                  |> tl |> length |> numSyntax.term_of_int
-      in mk_eq(mk_lookup_cons(rand n, env_tm),
+      in mk_eq(mk_lookup_cons(mk_Short (rand n), env_tm),
                optionSyntax.mk_some(mk_pair(l,mk_ExnStamp (rand (rator n))))) end
   val type_assum =
       inv_defs |> map (fn (_,x,_) => CONJUNCTS x) |> Lib.flatten
@@ -1357,7 +1357,7 @@ val (n,f,fxs,pxs,tm,exp,xs) = el 1 ts
                     else tag_name name cons_name
           val str = stringSyntax.fromMLstring str
           val vars = listSyntax.mk_list(map (fn (x,n,v) => n) xs,string_ty)
-          in list_mk_pair([str,vars,exp,get_stamp str]) end) ts
+          in list_mk_pair([mk_Short str,vars,exp,get_stamp str]) end) ts
         val (inr,x) = Mat_cases_def |> SPEC_ALL |> concl |> rand
                                     |> rator |> rand |> rand |> dest_comb
         val xty = type_of x |> dest_type |> snd |> hd
@@ -1486,7 +1486,7 @@ val (n,f,fxs,pxs,tm,exp,xs) = el 2 ts
     val cons_assum = type_assum
                      |> list_dest dest_conj
                      |> filter (fn tm => aconv
-                           (tm |> rator |> rand |> rator |> rand) str)
+                           (tm |> rator |> rand |> rator |> rand |> rand) str)
                      |> list_mk_conj
                      handle HOL_ERR _ => T
     val goal = mk_imp(cons_assum,mk_imp(tm,result))

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -152,8 +152,8 @@ local
                             thm (* certificate: Eval env exp (P tm) *)) list);
   val prog_state = ref ml_progLib.init_state;
   val cons_name_state = ref ([] : (string  *       (* %%thy%%type%%ctor *)
-                                (term *         (* constructor name  *)
-                                 string option) (* module name       *)) list);
+                                  (term *         (* constructor name  *)
+                                   string option) (* module name       *)) list);
 in
   fun get_ml_name (_:string,nm:string,_:term,_:thm,_:thm,_:string option) = nm
   fun get_const (_:string,_:string,tm:term,_:thm,_:thm,_:string option) = tm
@@ -163,8 +163,7 @@ in
   fun v_thms_reset () =
     (v_thms := [];
      eval_thms := [];
-     prog_state := ml_progLib.init_state
-     (* cons_name_state := []; *) (* TODO ?? *));
+     prog_state := ml_progLib.init_state);
   fun ml_prog_update f = (prog_state := f (!prog_state));
   fun get_ml_prog_state () = (!prog_state)
   fun get_curr_env () = get_env (!prog_state);

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -1126,43 +1126,38 @@ val (ml_ty_name,x::xs,ty,lhs,input) = hd ys
     val pull_no_closures = N_conj_conv (can (match_term no_closure_pat)) reps
     val pull_types_match = N_conj_conv (can (match_term types_match_pat)) reps
     val x2 = mk_var("x2",alpha)
-    (* avoid using stateful simpset in the eq_lemma proof *)
-    val extra_simps =
-      List.concat (List.map (fn ty => #rewrs (TypeBase.simpls_of ty)) tys)
-    val option_case_eq = CaseEq "option"
+    val ty_case_eq = LIST_CONJ
+      (List.concat (List.map (#rewrs o TypeBase.simpls_of) tys))
     (* set_goal ([], goal) *)
     val eq_lemma = auto_prove "EqualityType" (goal,
       strip_tac
-      \\ full_simp_tac std_ss [EqualityType_def]
+      \\ fs [EqualityType_def]
       \\ CONV_TAC pull_no_closures
       \\ reverse conj_tac
       >-
        ((Induct ORELSE Cases)
-        \\ simp_tac std_ss [inv_def, no_closures_def, PULL_EXISTS, EVERY_DEF]
+        \\ simp [inv_def, no_closures_def, PULL_EXISTS]
         \\ rpt strip_tac
         \\ res_tac)
       \\ CONV_TAC pull_types_match
       \\ CONJ_TAC
       >-
        ((Induct ORELSE Cases)
-        \\ simp_tac std_ss [inv_def, no_closures_def, PULL_EXISTS, EVERY_DEF]
+        \\ simp [inv_def, no_closures_def, PULL_EXISTS]
         \\ primCases_on x2
-        \\ simp_tac std_ss [inv_def, no_closures_def, PULL_EXISTS, EVERY_DEF,
-                            stamp_11, v_11]
+        \\ simp [inv_def, no_closures_def, PULL_EXISTS]
+        \\ simp [ty_case_eq]
         \\ rpt strip_tac
-        \\ CONV_TAC (DEPTH_CONV stringLib.string_EQ_CONV)
-        \\ full_simp_tac list_ss extra_simps
+        \\ fs [NUM_def, BOOL_def] \\ rw []
         \\ simp_tac std_ss [EQ_IMP_THM]
         \\ rpt strip_tac
         \\ res_tac)
       \\ (Induct ORELSE Cases)
-      \\ simp_tac std_ss [inv_def, no_closures_def, PULL_EXISTS, EVERY_DEF]
+      \\ simp [inv_def, no_closures_def, PULL_EXISTS]
       \\ TRY (primCases_on x2)
-      \\ simp_tac std_ss [inv_def, no_closures_def, PULL_EXISTS, EVERY_DEF,
-                          types_match_def, ctor_same_type_def,
-                          option_case_eq, pair_case_def, same_type_def,
-                          stamp_11, v_11]
-      \\ CONV_TAC (DEPTH_CONV stringLib.string_EQ_CONV)
+      \\ simp [inv_def, no_closures_def, PULL_EXISTS,
+               types_match_def, ctor_same_type_def, same_type_def]
+      \\ simp [ty_case_eq]
       \\ rpt strip_tac
       \\ res_tac)
     (* check that the result does not mention itself *)

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -151,9 +151,9 @@ local
                             term (* HOL term *) *
                             thm (* certificate: Eval env exp (P tm) *)) list);
   val prog_state = ref ml_progLib.init_state;
-  val tyname_state = ref ([] : (string  *     (* thy_type_ctor    *)
-                                (string *     (* constructor name *)
-                                 string option) (* module name *)) list);
+  val tyname_state = ref ([] : (string  *       (* %%thy%%type%%ctor *)
+                                (term *         (* constructor       *)
+                                 string option) (* module name       *)) list);
 in
   fun get_ml_name (_:string,nm:string,_:term,_:thm,_:thm,_:string option) = nm
   fun get_const (_:string,_:string,tm:term,_:thm,_:thm,_:string option) = tm
@@ -310,7 +310,7 @@ in
   fun pack_tynames () =
     let
       val pack_ns =
-        pack_pair pack_string (pack_pair pack_string (pack_option pack_string))
+        pack_pair pack_string (pack_pair pack_term (pack_option pack_string))
     in
       pack_list pack_ns (!tyname_state)
     end
@@ -318,7 +318,7 @@ in
     let
       val unpack_ns =
         unpack_pair unpack_string
-                    (unpack_pair unpack_string (unpack_option unpack_string))
+                    (unpack_pair unpack_term (unpack_option unpack_string))
       val tyns = unpack_list unpack_ns th
     in
       tyname_state := tyns
@@ -336,20 +336,21 @@ in
       (* separating with underscores is more prone to name clashes *)
       String.concat ["%%", thyn, "%%", tyn, "%%", name, "%%"]
     end
-  fun enter_tyname tm =
+  fun lookup_tyname key = Lib.assoc key (!tyname_state)
+  fun enter_tyname (tm, v_tm) =
     let
       val key   = mk_tyname tm
+      (* TODO remove: *)
       val _ = print ("tyname_state: entering constructor: " ^ key ^ "\n")
       val mname = get_curr_module_name ()
-      val ctor  = term_to_string tm
+      val (v_tm', mname') = lookup_tyname key handle HOL_ERR _ => (v_tm, mname)
     in
-      if List.exists (fn (key',_) => key = key') (!tyname_state) then
-        raise ERR "enter_tyname" ("constructor already entered: " ^ ctor)
+      if v_tm' = v_tm andalso mname = mname' then
+        key before tyname_state := (key, (v_tm, mname)) :: (!tyname_state)
       else
-        tyname_state := (key, (ctor, mname)) :: (!tyname_state);
-      key
+        raise ERR "enter_tyname"
+                ("already entered with different value: " ^ term_to_string v_tm)
     end
-  fun lookup_tyname key = Lib.assoc key (!tyname_state)
 end
 
 fun full_id n =
@@ -711,16 +712,18 @@ local
     val tag_lemma = ISPEC (mk_var("b",bool)) (ISPEC name_tm TAG_def) |> GSYM
     val p1 = pack_types()
     val p2 = pack_v_thms()
-    val p = pack_pair I I (p1,p2)
+    val p3 = pack_tynames()
+    val p = pack_triple I I I (p1,p2,p3)
     val th = PURE_ONCE_REWRITE_RULE [tag_lemma] p
     val _ = check_uptodate_term (concl th)
     in save_thm(name,th) end
   fun unpack_state name = let
     val th = fetch name (name ^ suffix)
     val th = PURE_ONCE_REWRITE_RULE [TAG_def] th
-    val (p1,p2) = unpack_pair I I th
+    val (p1,p2,p3) = unpack_triple I I I th
     val _ = unpack_types p1
     val _ = unpack_v_thms p2
+    val _ = unpack_tynames p3
     in () end;
   val finalised = ref false
 in
@@ -1125,6 +1128,7 @@ val (ml_ty_name,x::xs,ty,lhs,input) = hd ys
     val pull_no_closures = N_conj_conv (can (match_term no_closure_pat)) reps
     val pull_types_match = N_conj_conv (can (match_term types_match_pat)) reps
     val x2 = mk_var("x2",alpha)
+    (* set_goal ([], goal) *)
     val eq_lemma = auto_prove "EqualityType" (goal,
       strip_tac>> fs[EqualityType_def] \\
       CONV_TAC pull_no_closures \\
@@ -1147,7 +1151,11 @@ val (ml_ty_name,x::xs,ty,lhs,input) = hd ys
         \\ TRY (primCases_on x2)
         \\ SIMP_TAC (srw_ss()) [inv_def,no_closures_def,PULL_EXISTS, types_match_def]
         \\ (* Tries to get rid of obvious equality type *)
-        TRY (simp[ctor_same_type_def] \\ metis_tac[EqualityType_NUM_BOOL])
+           (* TODO
+            * - this metis_tac call is problematic; I'll remove it until
+            *   something breaks, and see how it can be replaced *)
+           ALL_TAC
+        (*TRY (simp[ctor_same_type_def] \\ metis_tac[EqualityType_NUM_BOOL])*)
         \\ EVAL_TAC
         \\ REPEAT STRIP_TAC
         \\ rpt var_eq_tac \\ every_case_tac \\ EVAL_TAC
@@ -1309,20 +1317,22 @@ val th = inv_defs |> map #2 |> hd
   (* cons assumption *)
   fun mk_assum tm =
     if not is_exn_type then let
-      val ctor = tm |> dest_eq |> fst |> rator |> rand |> repeat rator
-      val tname = enter_tyname ctor
       val x = find_term is_TypeStamp tm
       val (n,k) = dest_TypeStamp x
       val l = tm |> dest_eq |> fst |> rator |> rand |> list_dest dest_comb
                  |> tl |> length |> numSyntax.term_of_int
-      in mk_eq(mk_lookup_cons(mk_Short n, env_tm),
+      val ctor = tm |> dest_eq |> fst |> rator |> rand |> repeat rator
+      val cv = mk_var (enter_tyname (ctor, n), str_id_ty)
+      in mk_eq(mk_lookup_cons(cv, env_tm),
                optionSyntax.mk_some(mk_pair(l,x))) end
     else let
       val x = find_term is_ExnStamp tm
       val n = dest_ExnStamp x
       val l = tm |> dest_eq |> fst |> rator |> rand |> list_dest dest_comb
                  |> tl |> length |> numSyntax.term_of_int
-      in mk_eq(mk_lookup_cons(mk_Short (rand n), env_tm),
+      val ctor = tm |> dest_eq |> fst |> rator |> rand |> repeat rator
+      val cv = mk_var (enter_tyname (ctor, rand n), str_id_ty)
+      in mk_eq(mk_lookup_cons(cv, env_tm),
                optionSyntax.mk_some(mk_pair(l,mk_ExnStamp (rand (rator n))))) end
   val type_assum =
       inv_defs |> map (fn (_,x,_) => CONJUNCTS x) |> Lib.flatten
@@ -1398,13 +1408,17 @@ val (n,f,fxs,pxs,tm,exp,xs) = el 1 ts
           snd (first (fn (tm,_) => can (find_term (aconv str)) tm) stamps)
           |> rand |> rand
         val patterns = map (fn (n,f,fxs,pxs,tm,exp,xs) => let
+          (*
           val cons_name = (repeat rator tm |> dest_const |> fst)
           val str = if is_exn_type andalso is_primitive_exception cons_name
                     then cons_name
                     else tag_name name cons_name
           val str = stringSyntax.fromMLstring str
+          *)
+          val cons_name = repeat rator tm
+          val kv = mk_var (mk_tyname cons_name, str_id_ty)
           val vars = listSyntax.mk_list(map (fn (x,n,v) => n) xs,string_ty)
-          in list_mk_pair([mk_Short str,vars,exp,get_stamp str]) end) ts
+          in list_mk_pair([kv,vars,exp,get_stamp kv]) end) ts
         val (inr,x) = Mat_cases_def |> SPEC_ALL |> concl |> rand
                                     |> rator |> rand |> rand |> dest_comb
         val xty = type_of x |> dest_type |> snd |> hd
@@ -1495,29 +1509,30 @@ val (n,f,fxs,pxs,tm,exp,xs) = el 2 ts
     fun str_tl s = implode (tl (explode s))
     val exps = map (fn (x,_,_) => (x,mk_var("exp" ^ str_tl (fst (dest_var x)), astSyntax.exp_ty))) xs
     val tag =
-      if is_pair tm then "prod" else
-      if oneSyntax.is_one tm then "()" else
-      if is_exn_type
-      then inv_def
+      if is_pair tm then
+        "prod"
+      else if oneSyntax.is_one tm then
+        "()"
+      else
+        inv_def
         |> CONJUNCTS |> map (concl o SPEC_ALL)
         |> first (can (match_term tm) o rand o rator o fst o dest_eq)
-        |> rand |> find_term optionSyntax.is_some |> rand
-        |> rand |> rand |> stringSyntax.fromHOLstring
-      else inv_def
-        |> CONJUNCTS |> map (concl o SPEC_ALL)
-        |> first (can (match_term tm) o rand o rator o fst o dest_eq)
-        |> rand |> find_term optionSyntax.is_some |> rand
-        |> rator |> rand |> stringSyntax.fromHOLstring
-    val str = stringLib.fromMLstring tag
+        |> dest_eq |> fst |> rator |> rand |> repeat rator
+        |> mk_tyname
+    val str =
+      (tag |> lookup_tyname |> fst
+       handle HOL_ERR _ => stringLib.fromMLstring tag)
     val exps_tm = listSyntax.mk_list(map snd exps,astSyntax.exp_ty)
     val inv = inv_lhs |> rator |> rator
+    val cv = mk_var (tag, str_id_ty)
     val the_tag_name =
-                   if name = "PAIR_TYPE"
-                   then optionSyntax.mk_none(astSyntax.str_id_ty)
-                   else if name = "UNIT_TYPE"
-                   then optionSyntax.mk_none(astSyntax.str_id_ty)
-                   else optionSyntax.mk_some(astSyntax.mk_Short str)
-                (* else optionSyntax.mk_some(full_id str) *)
+      if name = "PAIR_TYPE" then
+        optionSyntax.mk_none(astSyntax.str_id_ty)
+      else if name = "UNIT_TYPE" then
+        optionSyntax.mk_none(astSyntax.str_id_ty)
+      else
+        optionSyntax.mk_some(cv)
+      (* else optionSyntax.mk_some(full_id str) *)
     fun find_inv tm =
       if type_of tm = ty then (mk_comb(rator (rator inv_lhs),tm)) else
         (mk_comb(get_type_inv (type_of tm),tm))
@@ -1533,7 +1548,7 @@ val (n,f,fxs,pxs,tm,exp,xs) = el 2 ts
     val cons_assum = type_assum
                      |> list_dest dest_conj
                      |> filter (fn tm => aconv
-                           (tm |> rator |> rand |> rator |> rand |> rand) str)
+                           (tm |> rator |> rand |> rator |> rand) cv)
                      |> list_mk_conj
                      handle HOL_ERR _ => T
     val goal = mk_imp(cons_assum,mk_imp(tm,result))
@@ -3584,6 +3599,47 @@ in
     case !latest_ind_thm of SOME th => th | _ => failwith "latest_ind";
 end;
 
+(* Instantiate constructor variables with their actual names. Names are
+ * constructed differently depending on whether types originate in a module
+ * which is not the one where translation currently takes place *)
+fun instantiate_lookup_cons th =
+  let
+    val hyps = fst (dest_thm th)
+    val lcons_tm =
+      lookup_cons_def
+      |> SPEC_ALL |> concl |> dest_eq |> fst |> repeat rator
+    val is_lcons = can (match_term lcons_tm o repeat rator o fst o dest_eq)
+    fun get_lcons acc tm =
+      if is_lcons tm then
+        mlibUseful.insert tm acc
+      else if can dest_comb tm then
+        get_lcons (mlibUseful.union (get_lcons acc (rator tm)) acc) (rand tm)
+      else if can dest_abs tm then
+        get_lcons acc (snd (dest_abs tm))
+      else
+        acc
+    val lcs = List.concat (List.map (get_lcons []) hyps)
+    val vars = List.filter (can dest_var)
+                           (List.map (rand o rator o fst o dest_eq) lcs)
+    val current_mname = get_curr_module_name ()
+    fun inst_var tm =
+      let
+        val (nm, mname) = lookup_tyname (fst (dest_var tm))
+        val s = mk_Short nm
+      in
+        case mname of
+          NONE => s
+        | SOME l =>
+          if current_mname = mname then
+            s
+          else
+            mk_Long (stringSyntax.fromMLstring l, s)
+      end
+    val tyis = List.map (fn tm => (tm |-> inst_var tm)) vars
+  in
+    INST tyis th
+  end
+
 (*
 
 val _ = (next_ml_names := ["+","+","+","+","+"]);
@@ -3632,6 +3688,8 @@ val (fname,ml_name,lhs,rhs,def) = el 1 info
 can (find_term is_arb) (rhs |> rand |> rator)
 *)
   val thms = loop info
+  val thms = map (fn (x0,x1,th,x2) => (x0,x1,instantiate_lookup_cons th,x2)) thms
+
   val _ = print ("Translating " ^ msg ^ "\n")
   (* postprocess raw certificates *)
 (*

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -1854,7 +1854,7 @@ val Mat_cases_def = Define `
   Mat_cases (INL (vars,x:exp)) = [(Pcon NONE (MAP Pvar vars),x)] /\
   Mat_cases (INR ps) =
     MAP (\(name,vars,x:exp,t:stamp).
-      (Pcon (SOME (Short name)) (MAP Pvar vars),x)) ps`;
+      (Pcon (SOME name) (MAP Pvar vars),x)) ps`;
 
 val good_cons_env_def = Define `
   good_cons_env ps env <=>
@@ -1875,7 +1875,7 @@ val evaluate_match_MAP = store_thm("evaluate_match_MAP",
       ~MEM t1 (MAP (SND o SND o SND) l1) ==>
       evaluate_match (s:'ffi state) env
         (Conv (SOME t1) vals)
-        (MAP (λ(name,vars,x,t). (Pcon (SOME (Short name))
+        (MAP (λ(name,vars,x,t). (Pcon (SOME name)
            (MAP Pvar vars),x)) l1 ++ xs) err =
       evaluate_match s env (Conv (SOME t1) vals) xs err``,
   Induct
@@ -2013,7 +2013,7 @@ val Eval_Con = store_thm("Eval_Con",
       (!vals.
          LIST_REL (\(p,x) v. p v) ps vals ==>
          q (Conv (SOME stamp) vals)) ==>
-      Eval env (Con (SOME (Short name)) (MAP SND ps)) q``,
+      Eval env (Con (SOME name) (MAP SND ps)) q``,
   rpt strip_tac \\ fs [EVERY_MEM,FORALL_PROD] \\ rw [Eval_def]
   \\ simp [eval_rel_def,PULL_EXISTS,evaluate_def,do_con_check_def]
   \\ fs [lookup_cons_def,build_conv_def]

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -157,4 +157,17 @@ val _ = Datatype `
 
 val _ = register_type ``:tt``;
 
+(* registering types inside modules *)
+
+open ml_progLib
+
+val _ = Datatype `my_type = my_case1 | my_case2 | my_case3`;
+val my_fun_def = Define `(my_fun my_case1 = 0n) /\ (my_fun my_case2 = 1n) /\
+                         (my_fun my_case3 = 2n)`;
+
+val _ = ml_prog_update (open_module "My_module");
+val r = register_type ``:my_type``;
+val _ = ml_prog_update (close_module NONE);
+val r = translate my_fun_def;
+
 val _ = export_theory();

--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -3289,6 +3289,9 @@ fun m_translate_run def =
     val params_evals = List.map var_create_Eval all_params
     val th = m_translate_run_abstract_parameters th def params_evals
 
+    (* Clean up any stray lookup_cons with variables in them *)
+    val th = instantiate_cons_name th
+
     (* Instantiate the environment 0 *)
     val global_env = get_env(get_curr_prog_state())
     val env = concl th |> get_Eval_env

--- a/translator/monadic/ml_monad_translatorLib.sml
+++ b/translator/monadic/ml_monad_translatorLib.sml
@@ -355,7 +355,9 @@ val get_EvalM_ro = rand o rator o rator o rator o rator o rator o concl o UNDISC
 (* ---- *)
 
 (* Prove the specifications for the exception handling *)
-(* val (raise_fun_def, cons, stamp) = el 1 raise_info *)
+(*
+val (raise_fun_def, cons, stamp) = el 1 raise_info
+*)
 fun prove_raise_spec exn_ri_def EXN_RI_tm (raise_fun_def, cons, stamp) = let
     val fun_tm = concl raise_fun_def |> strip_forall |> snd |> lhs |> strip_comb |> fst
     val exn_param_types = (fst o ml_monadBaseLib.dest_fun_type o type_of) cons
@@ -376,7 +378,8 @@ fun prove_raise_spec exn_ri_def EXN_RI_tm (raise_fun_def, cons, stamp) = let
     val exprs = listSyntax.mk_list (exprs_vars, exp_ty)
 
     (* Instantiate the raise specification *)
-    val raise_spec = ISPECL [cons_name, stamp, EXN_RI_tm, EVAL_CONDS,
+    val raise_spec = ISPECL [astSyntax.mk_Short cons_name, stamp,
+                             EXN_RI_tm, EVAL_CONDS,
 			     arity_tm, E, exprs, raise_fun] EvalM_raise
     val free_vars = strip_forall (concl raise_spec) |> fst
     val raise_spec = SPEC_ALL raise_spec
@@ -429,7 +432,9 @@ fun prove_raise_spec exn_ri_def EXN_RI_tm (raise_fun_def, cons, stamp) = let
     val _ = print ("Saved theorem __ \"" ^thm_name ^"\"\n")
 in raise_spec end
 
-(* val (handle_fun_def, cons, stamp) = el 1 handle_info *)
+(*
+val (handle_fun_def, cons, stamp) = el 1 handle_info
+*)
 fun prove_handle_spec exn_ri_def EXN_RI_tm (handle_fun_def, cons, stamp) = let
     (* Rename the variables in handle_fun_def *)
     val handle_fun_def = let
@@ -561,7 +566,7 @@ fun prove_handle_spec exn_ri_def EXN_RI_tm (handle_fun_def, cons, stamp) = let
     in a2_alt end
 
     (* Instantiate the specification *)
-    val handle_spec = ISPECL [cons_name, stamp, CORRECT_CONS,
+    val handle_spec = ISPECL [astSyntax.mk_Short cons_name, stamp, CORRECT_CONS,
 			      PARAMS_CONDITIONS, EXN_RI_tm, alt_handle_fun,
 			      alt_x1, alt_x2, arity_tm, a2_alt] EvalM_handle
     val free_vars = concl handle_spec |> strip_forall |> fst
@@ -604,8 +609,6 @@ fun prove_handle_spec exn_ri_def EXN_RI_tm (handle_fun_def, cons, stamp) = let
 	\\ FULL_SIMP_TAC bool_ss case_thms
 	\\ rpt (BasicProvers.PURE_CASE_TAC \\ fs[exn_ri_def]))
     val handle_spec = MP handle_spec ref_inv_eq_lemma
-
-(* TODO HERE *)
 
     (* refinement invariant inequality *)
     val ref_inv_ineq_assum = take_assumption handle_spec
@@ -860,7 +863,7 @@ fun derive_case_of ty = let
     val stamp = inv_def |> concl |> find_term
                   (fn tm => aconv (tm |> rator |> rand) cname
                             handle HOL_ERR _ => false)
-    in list_mk_pair [cname, vars, exp2, stamp] end
+    in list_mk_pair [astSyntax.mk_Short cname, vars, exp2, stamp] end
   val rw1_tm = goal |> rand |> rand |> rand |> rand |> rator
                     |> rator |> rand |> rand
   val y = let


### PR DESCRIPTION
This should hopefully fix issue #374.

The translator asks `ml_progLib` for the current module when a type is registered, so take care when calling `register_type` on types that would cause `register_type` to get called recursively, or those things might also end up as if they are living within your module.