### PR TITLE
Prepare to branch off after stackLang

### DIFF
--- a/basis/pure/mlprettyprinterScript.sml
+++ b/basis/pure/mlprettyprinterScript.sml
@@ -35,7 +35,7 @@ val fromWord8_def = Define`
 
 val fromWord64_def = Define`
   fromWord64 (w : 64 word) =
-  List [strlit "0wx", mlnum$toString (words$w2n w)]
+  List [strlit "0wx"; mlnum$toString (words$w2n w)]
 `
 
 val fromRat_def = Define`

--- a/compiler/backend/arm6/arm6_presetScript.sml
+++ b/compiler/backend/arm6/arm6_presetScript.sml
@@ -1,6 +1,6 @@
 open preamble backendTheory arm6_targetTheory arm6_targetLib
 
-val _ = new_theory"arm6_config";
+val _ = new_theory"arm6_preset";
 
 val arm6_names_def = Define `
   arm6_names =
@@ -33,10 +33,10 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val arm6_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm6_word_conf = ``<| bitmaps := []:32 word list |>``
 val arm6_stack_conf = ``<|jump:=T;reg_names:=arm6_names|>``
-val arm6_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm6_config;init_clock:=5|>``
+val arm6_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;init_clock:=5|>``
 
-val arm6_backend_config_def = Define`
-  arm6_backend_config =
+val arm6_backend_preset_def = Define`
+  arm6_backend_preset =
              <|source_conf:=^(source_conf);
                clos_conf:=^(clos_conf);
                bvl_conf:=^(bvl_conf);
@@ -44,7 +44,8 @@ val arm6_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(arm6_word_conf);
                stack_conf:=^(arm6_stack_conf);
-               lab_conf:=^(arm6_lab_conf)
+               lab_conf:=^(arm6_lab_conf);
+               asm_conf:=arm6_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/arm8/arm8_presetScript.sml
+++ b/compiler/backend/arm8/arm8_presetScript.sml
@@ -1,6 +1,6 @@
 open preamble backendTheory arm8_targetTheory arm8_targetLib
 
-val _ = new_theory"arm8_config";
+val _ = new_theory"arm8_preset";
 
 val arm8_names_def = Define `
   arm8_names =
@@ -30,10 +30,10 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm8_word_conf = ``<| bitmaps := []:64 word list |>``
 val arm8_stack_conf = ``<|jump:=T;reg_names:=arm8_names|>``
-val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm8_config;init_clock:=5|>``
+val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;init_clock:=5|>``
 
-val arm8_backend_config_def = Define`
-  arm8_backend_config =
+val arm8_backend_preset_def = Define`
+  arm8_backend_preset =
              <|source_conf:=^(source_conf);
                clos_conf:=^(clos_conf);
                bvl_conf:=^(bvl_conf);
@@ -41,7 +41,8 @@ val arm8_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(arm8_word_conf);
                stack_conf:=^(arm8_stack_conf);
-               lab_conf:=^(arm8_lab_conf)
+               lab_conf:=^(arm8_lab_conf);
+               asm_conf:=arm8_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/mips/mips_presetScript.sml
+++ b/compiler/backend/mips/mips_presetScript.sml
@@ -1,6 +1,6 @@
 open preamble backendTheory mips_targetTheory mips_targetLib
 
-val _ = new_theory"mips_config";
+val _ = new_theory"mips_preset";
 
 val mips_names_def = Define `
   mips_names =
@@ -36,10 +36,10 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=T; call_empty_ffi:=F; gc_kind:=Simple|>``
 val mips_word_conf = ``<| bitmaps := []:64 word list |>``
 val mips_stack_conf = ``<|jump:=F;reg_names:=mips_names|>``
-val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=mips_config;init_clock:=5|>``
+val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;init_clock:=5|>``
 
-val mips_backend_config_def = Define`
-  mips_backend_config =
+val mips_backend_preset_def = Define`
+  mips_backend_preset =
              <|source_conf:=^(source_conf);
                clos_conf:=^(clos_conf);
                bvl_conf:=^(bvl_conf);
@@ -47,7 +47,8 @@ val mips_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(mips_word_conf);
                stack_conf:=^(mips_stack_conf);
-               lab_conf:=^(mips_lab_conf)
+               lab_conf:=^(mips_lab_conf);
+               asm_conf:=mips_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -572,7 +572,8 @@ val state_rel_def = Define `
             (k = 0 ⇒
             cfg.labels = labs ∧
             cfg.pos = LENGTH (prog_to_bytes code2) ∧
-            cfg.asm_conf = mc_conf.target.config ∧
+            (* TODO: What is correct here? *)
+            (* cfg.asm_conf = mc_conf.target.config ∧ *)
             cfg.ffi_names = SOME(mc_conf.ffi_names)
             )) ∧
     (!l1 l2 x.
@@ -6029,7 +6030,8 @@ val compiler_oracle_ok_def = Define`
     (let (cfg,code) = coracle 0 in
         cfg.labels = init_labs ∧
         cfg.pos = init_pos ∧
-        cfg.asm_conf = c ∧
+        (* TODO: What to do here to ensure that config is correct? *)
+        (* cfg.asm_conf = c ∧ *)
         cfg.ffi_names = SOME ffis)`
 
 (* mc_conf_ok: conditions on the machine configuration
@@ -6131,7 +6133,7 @@ val make_init_filter_skip = Q.store_thm("make_init_filter_skip",
        compile_lab cbpos cbspace((λ(a,b). (a,filter_skip b)) o coracle)) =
    semantics
     (make_init mc_conf ffi io_regs cc_regs t m dm ms code
-      (λc p. compile_lab c (filter_skip p)) cbpos cbspace coracle)`,
+      (λc p. compile_lab c asm_conf (filter_skip p)) cbpos cbspace coracle)`,
   match_mp_tac (filter_skip_semantics)>>
   rw[]>>
   simp[make_init_def]>>
@@ -6221,11 +6223,11 @@ val list_subset_LENGTH = Q.store_thm("list_subset_LENGTH",`
 
 val semantics_compile_lemma = Q.prove(
   ` mc_conf_ok mc_conf ∧
-    compiler_oracle_ok coracle c'.labels (LENGTH bytes) c.asm_conf mc_conf.ffi_names ∧
+    compiler_oracle_ok coracle c'.labels (LENGTH bytes) asm_conf mc_conf.ffi_names ∧
     (* Assumptions on input code *)
     good_code mc_conf.target.config LN code ∧
     (* Config state *)
-    c.asm_conf = mc_conf.target.config /\
+    asm_conf = mc_conf.target.config /\
     c.labels = LN ∧ c.pos = 0 ∧
     lab_to_target$compile (c:'a lab_to_target$config) code = SOME (bytes,c') /\
     (* FFI is either given or computed *)
@@ -6253,7 +6255,7 @@ val semantics_compile_lemma = Q.prove(
   match_mp_tac (GEN_ALL semantics_make_init)>>
   fs[sec_ends_with_label_filter_skip,all_enc_ok_pre_filter_skip]>>
   fs[find_ffi_names_filter_skip,GSYM PULL_EXISTS]>>
-  conj_tac >- fs[mc_conf_ok_def] >>  
+  conj_tac >- fs[mc_conf_ok_def] >>
   conj_tac >- (
     fs[good_code_def] >>
     fs[sec_ends_with_label_filter_skip,all_enc_ok_pre_filter_skip]>>
@@ -6283,9 +6285,9 @@ val semantics_compile_lemma = Q.prove(
 
 val semantics_compile = Q.store_thm("semantics_compile",`
    mc_conf_ok mc_conf ∧
-   compiler_oracle_ok coracle c'.labels (LENGTH bytes) c.asm_conf mc_conf.ffi_names ∧
-   good_code c.asm_conf c.labels code ∧
-   c.asm_conf = mc_conf.target.config ∧
+   compiler_oracle_ok coracle c'.labels (LENGTH bytes) asm_conf mc_conf.ffi_names ∧
+   good_code asm_conf c.labels code ∧
+   asm_conf = mc_conf.target.config ∧
    c.labels = LN ∧ c.pos = 0 ∧
    compile c code = SOME (bytes,c') ∧
    c'.ffi_names = SOME (mc_conf.ffi_names) /\

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -3989,30 +3989,31 @@ val ssa_cc_trans_props = Q.prove(`
     (* Install *)
     (rpt gen_tac>> strip_tac>>
     simp[Once (GSYM markerTheory.Abbrev_def)]>>
-    qpat_x_assum`_= (_,_,_)` mp_tac>>LET_ELIM_TAC>>
-    fs[next_var_rename_def]>>rw[]>>
-    imp_res_tac list_next_var_rename_move_props_2>>
-    rw[]>>fs[]>>
-    rfs[]>>
-    qabbrev_tac`na2 = na''+2`>>
-    `is_alloc_var na2` by fs[Abbr`na2`,is_stack_var_flip]>>
-    rw[]>>
-    qmatch_asmsub_abbrev_tac`list_next_var_rename_move sss _ _ = _`>>
-    Q.ISPECL_THEN[`ls`,`sss`,`na''+6`] mp_tac list_next_var_rename_move_props>>
-    simp[]>>
-    `is_alloc_var (na2+4)` by metis_tac[is_alloc_var_add]>>
-    `na''+6 = na2+4` by fs[Abbr`na2`]>>
-    impl_tac>-
-      (simp[Abbr`sss`,Abbr`ssa_cut`]>>
-      match_mp_tac ssa_map_ok_extend>>
-      CONJ_TAC>-
-       (match_mp_tac ssa_map_ok_inter>>
-       fs[Abbr`na2`]>>
-       match_mp_tac (GEN_ALL ssa_map_ok_more)>>
-       asm_exists_tac>>fs[])>>
-      metis_tac[convention_partitions])>>
-    strip_tac>>
-    fs[Abbr`na2`,markerTheory.Abbrev_def])>>
+    qpat_x_assum`_= (_,_,_)` mp_tac>>LET_ELIM_TAC >>
+    ( (* multiple goals *)
+      fs[next_var_rename_def]>>rw[]>>
+      imp_res_tac list_next_var_rename_move_props_2>>
+      rw[]>>fs[]>>
+      rfs[]>>
+      qabbrev_tac`na2 = na''+2`>>
+      `is_alloc_var na2` by fs[Abbr`na2`,is_stack_var_flip]>>
+      rw[]>>
+      qmatch_asmsub_abbrev_tac`list_next_var_rename_move sss _ _ = _`>>
+      Q.ISPECL_THEN[`ls`,`sss`,`na''+6`] mp_tac list_next_var_rename_move_props>>
+      simp[]>>
+      `is_alloc_var (na2+4)` by metis_tac[is_alloc_var_add]>>
+      `na''+6 = na2+4` by fs[Abbr`na2`]>>
+      impl_tac>-
+        (simp[Abbr`sss`,Abbr`ssa_cut`]>>
+        match_mp_tac ssa_map_ok_extend>>
+        CONJ_TAC>-
+         (match_mp_tac ssa_map_ok_inter>>
+         fs[Abbr`na2`]>>
+         match_mp_tac (GEN_ALL ssa_map_ok_more)>>
+         asm_exists_tac>>fs[])>>
+        metis_tac[convention_partitions])>>
+      strip_tac>>
+      fs[Abbr`na2`,markerTheory.Abbrev_def]))>>
   strip_tac>-
     (* CBW *)
     (rw[]>>fs[])>>

--- a/compiler/backend/riscv/riscv_presetScript.sml
+++ b/compiler/backend/riscv/riscv_presetScript.sml
@@ -1,6 +1,6 @@
 open preamble backendTheory riscv_targetTheory riscv_targetLib
 
-val _ = new_theory"riscv_config";
+val _ = new_theory"riscv_preset";
 
 val riscv_names_def = Define `
   riscv_names =
@@ -44,10 +44,10 @@ val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val riscv_word_conf = ``<| bitmaps := []:64 word list |>``
 val riscv_stack_conf = ``<|jump:=F;reg_names:=riscv_names|>``
-val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=riscv_config;init_clock:=5|>``
+val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;init_clock:=5|>``
 
-val riscv_backend_config_def = Define`
-  riscv_backend_config =
+val riscv_backend_preset_def = Define`
+  riscv_backend_preset =
              <|source_conf:=^(source_conf);
                clos_conf:=^(clos_conf);
                bvl_conf:=^(bvl_conf);
@@ -55,7 +55,8 @@ val riscv_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(riscv_word_conf);
                stack_conf:=^(riscv_stack_conf);
-               lab_conf:=^(riscv_lab_conf)
+               lab_conf:=^(riscv_lab_conf);
+               asm_conf:=riscv_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/x64/x64_presetScript.sml
+++ b/compiler/backend/x64/x64_presetScript.sml
@@ -1,6 +1,6 @@
 open preamble backendTheory x64_targetTheory x64_targetLib
 
-val _ = new_theory"x64_config";
+val _ = new_theory"x64_preset";
 
 val x64_names_def = Define `
   x64_names =
@@ -40,10 +40,10 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps := []:64 word list |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
-val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=x64_config;init_clock:=5|>``
+val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;init_clock:=5|>``
 
-val x64_backend_config_def = Define`
-  x64_backend_config =
+val x64_backend_preset_def = Define`
+  x64_backend_preset =
              <|source_conf:=^(source_conf);
                clos_conf:=^(clos_conf);
                bvl_conf:=^(bvl_conf);
@@ -51,7 +51,8 @@ val x64_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(x64_word_conf);
                stack_conf:=^(x64_stack_conf);
-               lab_conf:=^(x64_lab_conf)
+               lab_conf:=^(x64_lab_conf);
+               asm_conf:=x64_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/bootstrap/compilation/x64/32/Makefile
+++ b/compiler/bootstrap/compilation/x64/32/Makefile
@@ -3,7 +3,8 @@
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o

--- a/compiler/bootstrap/compilation/x64/64/Makefile
+++ b/compiler/bootstrap/compilation/x64/64/Makefile
@@ -6,7 +6,8 @@
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -8,6 +8,9 @@ val _ = new_theory"compiler64Prog";
 
 val _ = translation_extends "mipsProg";
 
+val _ = (ml_translatorLib.trace_timing_to
+    := SOME "compiler64Prog_translate_timing.txt")
+
 val () = Globals.max_print_depth := 15;
 
 val () = use_long_names := true;

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -382,7 +382,7 @@ val parse_target_32_def = Define`
     if rest = strlit"arm6" then INL (arm6_backend_config,arm6_export)
     else INR (concat [strlit"Unrecognized 32-bit target option: ";rest])`
 
-(* Default stack and heap limits *)
+(* Default stack and heap limits. Unit of measure is mebibytes, i.e. 1024^2B. *)
 val default_heap_sz_def = Define`
   default_heap_sz = 1000n`
 

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -19,7 +19,7 @@ val _ = new_theory"compiler";
 val current_version_tm = mlstring_from_proc "git" ["rev-parse", "HEAD"]
 (*"*)
 val poly_version_tm = mlstring_from_proc "poly" ["-v"]
-val hol_version_tm = mlstring_from_proc_from Globals.HOLDIR "git" ["rev-parse", "HEAD"]
+val hol_version_tm = mlstring_from_proc "git" ["-C", Globals.HOLDIR, "rev-parse", "HEAD"]
 
 val date_str = Date.toString (Date.fromTimeUniv (Time.now ())) ^ " UTC\n"
 val date_tm = Term `strlit^(stringSyntax.fromMLstring date_str)`

--- a/developers/artefacts
+++ b/developers/artefacts
@@ -2,3 +2,4 @@ compiler/bootstrap/compilation/x64/64/cake-x64-64.tar.gz
 compiler/bootstrap/compilation/x64/32/cake-x64-32.tar.gz
 unverified/sexpr-bootstrap/x64/64/cake-unverified-x64-64.tar.gz
 unverified/sexpr-bootstrap/x64/32/cake-unverified-x64-32.tar.gz
+compiler/bootstrap/translation/compiler64Prog_translate_timing.txt

--- a/misc/preamble.sml
+++ b/misc/preamble.sml
@@ -479,11 +479,6 @@ fun mlstring_from_proc cmd args =
     NONE => Term `NONE : mlstring option`
   | SOME s => Term `SOME (strlit ^(stringSyntax.fromMLstring s))`
 
-fun mlstring_from_proc_from dir cmd args =
-  case read_process (cmd, args, SOME dir) of
-    NONE => Term `NONE : mlstring option`
-  | SOME s => Term `SOME (strlit ^(stringSyntax.fromMLstring s))`
-
 (* ========================================================================= *)
 (* ========================================================================= *)
 

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -148,6 +148,8 @@ sig
     val prove_EvalPatRel_fail : term ref
     val get_term :string -> term
 
+    val trace_timing_to : string option ref
+
     (* returns the induction theorem for the latest rec translation *)
     val latest_ind : unit -> thm
 

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -11,6 +11,11 @@ val ZIP2_def = Define `
   (ZIP2 ([],[]) z = []) /\
   (ZIP2 (x::xs,y::ys) z = (x,y) :: ZIP2 (xs, ys) (5:int))`
 
+(* test timing by setting this
+val _ = (ml_translatorLib.trace_timing_to
+    := SOME "ml_translator_test_timing.txt")
+*)
+
 val res = translate ZIP2_def;
 
 val res = translate APPEND;

--- a/unverified/sexpr-bootstrap/x64/32/Makefile
+++ b/unverified/sexpr-bootstrap/x64/32/Makefile
@@ -1,12 +1,13 @@
 # To support large stack+heap, use -mcmodel=medium.
-# CFLAGS += -mcmodel=medium 
+# CFLAGS += -mcmodel=medium
 
 # To set the stack and heap available to the CakeML compiler,
 # also edit the .space directives in cake.S.
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o
@@ -20,10 +21,10 @@ result: result.o basis_ffi.o
 
 # Build the sexpr printed compiler.
 # This may fail if heap/stack isn't set sufficiently high.
-bootstrap.S: cake-sexpr-x64-32 cake 
-	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@ 
+bootstrap.S: cake-sexpr-x64-32 cake
+	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@
 
 bootstrap: bootstrap.o basis_ffi.o
 
-clean: 
+clean:
 	rm -f cake basis_ffi.o result.o cake.o result result.S bootstrap.S bootstrap.o bootstrap

--- a/unverified/sexpr-bootstrap/x64/64/Makefile
+++ b/unverified/sexpr-bootstrap/x64/64/Makefile
@@ -1,12 +1,13 @@
 # To support large stack+heap, use -mcmodel=medium.
-# CFLAGS += -mcmodel=medium 
+# CFLAGS += -mcmodel=medium
 
 # To set the stack and heap available to the CakeML compiler,
 # also edit the .space directives in cake.S.
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o
@@ -20,10 +21,10 @@ result: result.o basis_ffi.o
 
 # Build the sexpr printed compiler.
 # This may fail if heap/stack isn't set sufficiently high.
-bootstrap.S: cake-sexpr-x64-64 cake 
-	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@ 
+bootstrap.S: cake-sexpr-x64-64 cake
+	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@
 
 bootstrap: bootstrap.o basis_ffi.o
 
-clean: 
+clean:
 	rm -f cake basis_ffi.o result.o cake.o result result.S bootstrap.S bootstrap.o bootstrap


### PR DESCRIPTION
TL;DR:
 * New notion and corresponding types: `preset` derived from `config`.
 * Refactoring: `backend_conf.lab_conf.asm_conf` is now `backend_conf.asm_conf`
 * Refactoring: `backend$compile` does not return `lab_to_target$config` anymore, but instead `string list` (FFI names).
 * New type: `backend$late_config = ToTarget ...` which will later also have `| ToWasm ...` to control branching after `stackLang`.
 * New command line switch: `--wasm=` (boolean, for 64bit archs only) which currently is a no-operation. (Note that this PR is not against `master` but against `wasm`.)

---

This PR aims to prepare the compiler for integration of the WebAssembly target, which will introduce a branch/fork: Instead of compiling `stack → lab → target → export`  it must accomodate `stack → wasm → export` as an alternative.

In the record `backend$config`, replace the fields `stack_conf` and `lab_conf` with a field `late_conf: late_config`. A late config is meant to configure what the "late stages" of the backend, i.e. after `stackLang` should do. Currently, there is only one constructor `ToTarget stack_to_lab$config lab_to_target$config` which is meant to behave the same as the "old" variant. However, I plan to expand this by providing a second constructor `ToWasm stack_to_wasm$config`.

With this change, I am introducing a mismatch between the "configuration" that target architectures define and the actual backend configuration. This is resolved by introducing "presets": A preset is a meant to as a blueprint for a configuration and defined by the architecture (`{x64,arm8,...}_preset`, previously `*_config`). A preset is then converted into a configuration at runtime, and further extended by merging with commandline prameters as before.

While theoretically the future wasm target would not require the architecture-specific details contained in those presets, this approach allows to generate wasm code that might actually be nicer to JIT for a particular architecture. Also, it allows to define a wasm preset, possibly synthesized from experiments regarding performance in the browser to in turn influence other translations.

While implementing these changes I noticed a hack: Early translations such as `word_to_stack` and `data_to_word` use the configuration for `lab_to_target` to access its `asm_config`. This does not fit well with the new-style configs, since there might not even be a `lab_to_target` translation to be planned, thus leaving `word_to_stack`/`data_to_word` with a dangling assumption. This is mitigated by promoting `backend_conf.lab_conf.asm_conf` to `backend_conf.asm_conf`.

Similarily, `backend$compile` previously returned `lab_to_target$conf`, which is something that the `stack_to_wasm` translation cannot provide. I saw that in `compileScript` only the field `ffi_names` of the returned config was used. That's why I changed `lab_to_target$compile` to return the FFI names only. In case exporters at some point need more information, this can be solved by introducing a `export_config` record, that the ultimate `compile` functions must return.

*I still need help* fixing stuff: Since I changed the definition of `lab_to_target$config`, also `lab_to_target$compile` and `lab_to_targetProof` need to be adjusted. Perhaps @xrchz or @tanyongkiam could take over this part, or at least help me do it?

I know that there are other theories dependent on those `*config_Theory`s that I changed, but I would like to see some sort of approval of my approach before I go ahead and refactor them.