### PR TITLE
Mention unit of measure for heap/stack sizes

### DIFF
--- a/compiler/bootstrap/compilation/x64/32/Makefile
+++ b/compiler/bootstrap/compilation/x64/32/Makefile
@@ -3,7 +3,8 @@
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o

--- a/compiler/bootstrap/compilation/x64/64/Makefile
+++ b/compiler/bootstrap/compilation/x64/64/Makefile
@@ -6,7 +6,8 @@
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -382,7 +382,7 @@ val parse_target_32_def = Define`
     if rest = strlit"arm6" then INL (arm6_backend_config,arm6_export)
     else INR (concat [strlit"Unrecognized 32-bit target option: ";rest])`
 
-(* Default stack and heap limits *)
+(* Default stack and heap limits. Unit of measure is mebibytes, i.e. 1024^2B. *)
 val default_heap_sz_def = Define`
   default_heap_sz = 1000n`
 

--- a/unverified/sexpr-bootstrap/x64/32/Makefile
+++ b/unverified/sexpr-bootstrap/x64/32/Makefile
@@ -1,12 +1,13 @@
 # To support large stack+heap, use -mcmodel=medium.
-# CFLAGS += -mcmodel=medium 
+# CFLAGS += -mcmodel=medium
 
 # To set the stack and heap available to the CakeML compiler,
 # also edit the .space directives in cake.S.
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o
@@ -20,10 +21,10 @@ result: result.o basis_ffi.o
 
 # Build the sexpr printed compiler.
 # This may fail if heap/stack isn't set sufficiently high.
-bootstrap.S: cake-sexpr-x64-32 cake 
-	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@ 
+bootstrap.S: cake-sexpr-x64-32 cake
+	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@
 
 bootstrap: bootstrap.o basis_ffi.o
 
-clean: 
+clean:
 	rm -f cake basis_ffi.o result.o cake.o result result.S bootstrap.S bootstrap.o bootstrap

--- a/unverified/sexpr-bootstrap/x64/64/Makefile
+++ b/unverified/sexpr-bootstrap/x64/64/Makefile
@@ -1,12 +1,13 @@
 # To support large stack+heap, use -mcmodel=medium.
-# CFLAGS += -mcmodel=medium 
+# CFLAGS += -mcmodel=medium
 
 # To set the stack and heap available to the CakeML compiler,
 # also edit the .space directives in cake.S.
 
 # To set the stack and heap directives available to your own
 # CakeML programs, use the --stack_size and --heap_size
-# command-line arguments to the CakeML compiler.
+# command-line arguments to the CakeML compiler. The unit of
+# measure for both arguments is mebibytes, i.e. 1024^2 bytes.
 
 # Build the CakeML compiler.
 cake: cake.o basis_ffi.o
@@ -20,10 +21,10 @@ result: result.o basis_ffi.o
 
 # Build the sexpr printed compiler.
 # This may fail if heap/stack isn't set sufficiently high.
-bootstrap.S: cake-sexpr-x64-64 cake 
-	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@ 
+bootstrap.S: cake-sexpr-x64-64 cake
+	./cake --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true <$< >$@
 
 bootstrap: bootstrap.o basis_ffi.o
 
-clean: 
+clean:
 	rm -f cake basis_ffi.o result.o cake.o result result.S bootstrap.S bootstrap.o bootstrap


### PR DESCRIPTION
I needed to know whether the numbers are actually bytes or "something bigger". I figured that it must be mebibytes judging from [`x64_exportTheory`](https://github.com/CakeML/cakeml/blob/1bb8663a0aeb377eb22aeb600de4bc536e647744/compiler/backend/x64/export_x64Script.sml#L67) and its use of [`exportTheory`](https://github.com/CakeML/cakeml/blob/1bb8663a0aeb377eb22aeb600de4bc536e647744/compiler/backend/exportScript.sml#L29-L30).
For people more involved with CakeML, this is probably trivial. But when trying to find out for the first time, it would be quite helpful to have this information more prominent.