### PR TITLE
FFI: create files with sensible (0644) permissions

### DIFF
--- a/basis/basis_ffi.c
+++ b/basis/basis_ffi.c
@@ -77,7 +77,7 @@ void ffiopen_in (unsigned char *c, long clen, unsigned char *a, long alen) {
 }
 
 void ffiopen_out (unsigned char *c, long clen, unsigned char *a, long alen) {
-  int fd = open((const char *) c, O_RDWR|O_CREAT|O_TRUNC);
+  int fd = open((const char *) c, O_RDWR|O_CREAT|O_TRUNC, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
   if (0 <= fd){
     a[0] = 0;
     int_to_byte8(fd, &a[1]);


### PR DESCRIPTION
When creating a file on Unix using `open` and `O_CREAT`, we must also provide permissions flags to prevent the file being created with garbage permissions. We follow PolyML and default to 0644 (readable and writeable by the user, readable by group and others).

On macOS, not specifying permissions creates files with weird `---xr-x---` permissions (0150), while on Linux, not specifying permissions creates files with `----r-S--T` permissions (some set-uid bit and sticky bit nonsense happening there). An example CakeML program that can be compiled with the binary compiler to reproduce this outcome is:

```sml
fun main () =
    let
        val outstream = TextIO.openOut "test_file.txt"
    in
        TextIO.output outstream "Hello world!\n"
    end;

val _ = main ();
```

I discovered this issue a while back while implementing #459.