### PR TITLE
Use modules in bootstrap translation.

### DIFF
--- a/compiler/bootstrap/translation/arm6ProgScript.sml
+++ b/compiler/bootstrap/translation/arm6ProgScript.sml
@@ -9,6 +9,8 @@ val _ = new_theory "arm6Prog"
 
 val _ = translation_extends "to_target32Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "arm6Prog");
+
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
@@ -203,6 +205,8 @@ val res = translate arm6_enc_thm
 val res = translate (arm6_config_def |> SIMP_RULE std_ss[valid_immediate_def] |> gconv)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/arm8ProgScript.sml
+++ b/compiler/bootstrap/translation/arm8ProgScript.sml
@@ -9,6 +9,8 @@ val _ = new_theory "arm8Prog"
 
 val _ = translation_extends "x64Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "arm8Prog");
+
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
@@ -305,6 +307,8 @@ val _ = translate (valid_immediate_def |> SIMP_RULE bool_ss [IN_INSERT,NOT_IN_EM
 val res = translate (arm8_config_def |> SIMP_RULE bool_ss [IN_INSERT,NOT_IN_EMPTY]|> econv)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -8,6 +8,8 @@ val _ = new_theory"compiler32Prog";
 
 val _ = translation_extends "arm6Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "compiler32Prog");
+
 val () = Globals.max_print_depth := 15;
 
 val () = use_long_names := true;
@@ -161,6 +163,10 @@ val res = translate export_arm6Theory.arm6_export_def;
 val res = translate
   (arm6_configTheory.arm6_backend_config_def
    |> SIMP_RULE(srw_ss())[FUNION_FUPDATE_1]);
+
+(* Leave the module now, so that key things are available in the toplevel
+   namespace for main. *)
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 (* Rest of the translation *)
 val res = translate (extend_conf_def |> spec32 |> SIMP_RULE (srw_ss()) [MEMBER_INTRO]);

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -8,6 +8,8 @@ val _ = new_theory"compiler64Prog";
 
 val _ = translation_extends "mipsProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "compiler64Prog");
+
 val _ = (ml_translatorLib.trace_timing_to
     := SOME "compiler64Prog_translate_timing.txt")
 
@@ -188,6 +190,10 @@ val res = translate export_arm8Theory.arm8_export_def;
 val res = translate
   (arm8_configTheory.arm8_backend_config_def
    |> SIMP_RULE(srw_ss())[FUNION_FUPDATE_1]);
+
+(* Leave the module now, so that key things are available in the toplevel
+   namespace for main. *)
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 (* Rest of the translation *)
 val res = translate (extend_conf_def |> spec64 |> SIMP_RULE (srw_ss()) [MEMBER_INTRO]);

--- a/compiler/bootstrap/translation/explorerProgScript.sml
+++ b/compiler/bootstrap/translation/explorerProgScript.sml
@@ -6,6 +6,8 @@ val _ = new_theory "explorerProg"
 
 val _ = translation_extends "inferProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "explorerProg");
+
 (* TODO: this is copied in many bootstrap translation files - should be in a lib? *)
 fun def_of_const tm = let
   val res = dest_thy_const tm handle HOL_ERR _ =>
@@ -103,6 +105,9 @@ val res7 = translate presLangTheory.clos_to_json_table_def;
 *)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
+
 val _ = (ml_translatorLib.clean_on_exit := true);
 
 val _ = export_theory();

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "inferProg"
 
 val _ = translation_extends "reg_allocProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "inferProg");
+
 (* translator setup *)
 
 val RW = REWRITE_RULE
@@ -1141,6 +1143,8 @@ val infertype_prog_side_thm = store_thm("infertype_prog_side_thm",
   |> update_precondition;
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/lexerProgScript.sml
+++ b/compiler/bootstrap/translation/lexerProgScript.sml
@@ -6,6 +6,8 @@ val _ = new_theory "lexerProg"
 
 val _ = translation_extends "to_dataProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "lexerProg");
+
 val RW = REWRITE_RULE
 val RW1 = ONCE_REWRITE_RULE
 fun list_dest f tm =
@@ -107,6 +109,8 @@ val lexer_fun_side = Q.prove(`
   EVAL_TAC>>fs[lexer_fun_aux_side]) |> update_precondition
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/mipsProgScript.sml
+++ b/compiler/bootstrap/translation/mipsProgScript.sml
@@ -9,6 +9,8 @@ val _ = new_theory "mipsProg"
 
 val _ = translation_extends "riscvProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "mipsProg");
+
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
@@ -160,6 +162,8 @@ val res = translate mips_enc_thm
 val res = translate (mips_config_def |> SIMP_RULE bool_ss [IN_INSERT,NOT_IN_EMPTY]|> econv)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/parserProgScript.sml
+++ b/compiler/bootstrap/translation/parserProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "parserProg"
 
 val _ = translation_extends "lexerProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "parserProg");
+
 (* translator setup *)
 
 val RW = REWRITE_RULE
@@ -225,6 +227,8 @@ val parse_prog_side_lemma = Q.store_thm("parse_prog_side_lemma",
   |> update_precondition;
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -424,8 +424,6 @@ val res = translate linear_scan_reg_alloc_def;
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 
-val _ = export_theory();
-
 (*
 TODO: update the following code (comes from the non-monadic register allocator
 

--- a/compiler/bootstrap/translation/riscvProgScript.sml
+++ b/compiler/bootstrap/translation/riscvProgScript.sml
@@ -9,6 +9,8 @@ val _ = new_theory "riscvProg"
 
 val _ = translation_extends "arm8Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "riscvProg");
+
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
@@ -171,6 +173,8 @@ val res = translate riscv_enc_thm
 val res = translate (riscv_config_def |> SIMP_RULE bool_ss [IN_INSERT,NOT_IN_EMPTY]|> econv)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/sexp_parserProgScript.sml
+++ b/compiler/bootstrap/translation/sexp_parserProgScript.sml
@@ -5,6 +5,8 @@ open preamble explorerProgTheory
 val _ = new_theory"sexp_parserProg";
 val _ = translation_extends "explorerProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "sexp_parserProg");
+
 (* TODO: this is duplicated in parserProgTheory *)
 val monad_unitbind_assert = Q.prove(
   `!b x. monad_unitbind (assert b) x = if b then x else NONE`,
@@ -256,5 +258,7 @@ val sexpdec_alt_side = Q.prove(
   \\ rw[Once(fetch"-""sexpdec_alt_side_def")]
   \\ fs[LENGTH_EQ_NUM_compute])
   |> update_precondition;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = export_theory();

--- a/compiler/bootstrap/translation/to_dataProgScript.sml
+++ b/compiler/bootstrap/translation/to_dataProgScript.sml
@@ -6,6 +6,8 @@ open basisProgTheory;
 val _ = new_theory "to_dataProg"
 val _ = translation_extends "basisProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_dataProg");
+
 (* This is the compiler "preamble" that translates the compile functions down to dataLang *)
 
 val RW = REWRITE_RULE
@@ -1472,6 +1474,8 @@ val bvi_to_data_compile_prog_side = Q.prove(`∀prog. bvi_to_data_compile_prog_s
      data_space_space_side]) |> update_precondition; *)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/to_target32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_target32ProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "to_target32Prog"
 
 val _ = translation_extends "to_word32Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_target32Prog");
+
 val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
@@ -358,6 +360,8 @@ val _ = translate (spec32 asmTheory.asm_ok_def)
 val _ = translate (spec32 compile_def)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/to_target64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_target64ProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "to_target64Prog"
 
 val _ = translation_extends "to_word64Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_target64Prog");
+
 val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
@@ -358,6 +360,8 @@ val _ = translate (spec64 asmTheory.asm_ok_def)
 val _ = translate (spec64 compile_def)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "to_word32Prog"
 
 val _ = translation_extends "sexp_parserProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_word32Prog");
+
 val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
@@ -779,6 +781,8 @@ val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv32_RHS);
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -7,6 +7,8 @@ val _ = new_theory "to_word64Prog"
 
 val _ = translation_extends "sexp_parserProg";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_word64Prog");
+
 val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
@@ -779,6 +781,8 @@ val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv64_RHS);
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 

--- a/compiler/bootstrap/translation/x64ProgScript.sml
+++ b/compiler/bootstrap/translation/x64ProgScript.sml
@@ -9,6 +9,8 @@ val _ = new_theory "x64Prog"
 
 val _ = translation_extends "to_target64Prog";
 
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "x64Prog");
+
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
@@ -253,6 +255,8 @@ val res = translate (GEN_ALL x64_enc_thm)
 val _ = translate (x64_config_def |> gconv)
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 
 val _ = (ml_translatorLib.clean_on_exit := true);
 


### PR DESCRIPTION
If this succeeds and speeds things up, I'd like to merge it.

It groups the bootstrap translation elements into modules.

(It also removes a duplicate end_theory in reg_allocProgScript).

This should speed up bootstrap translation a bit, since the
number of things in the top-level namespace has an impact on
translator performance. Grouping many things in modules keeps
them out of the top-level namespace.