### PR TITLE
Explorer

### DIFF
--- a/compiler/backend/arm6/arm6_configScript.sml
+++ b/compiler/backend/arm6/arm6_configScript.sml
@@ -44,7 +44,8 @@ val arm6_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(arm6_word_conf);
                stack_conf:=^(arm6_stack_conf);
-               lab_conf:=^(arm6_lab_conf)
+               lab_conf:=^(arm6_lab_conf);
+               tap_conf:=default_tap_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/arm8/arm8_configScript.sml
+++ b/compiler/backend/arm8/arm8_configScript.sml
@@ -41,7 +41,8 @@ val arm8_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(arm8_word_conf);
                stack_conf:=^(arm8_stack_conf);
-               lab_conf:=^(arm8_lab_conf)
+               lab_conf:=^(arm8_lab_conf);
+               tap_conf:=default_tap_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -36,7 +36,7 @@ val attach_bitmaps_def = Define `
 val compile_tap_def = Define`
   compile_tap c p =
     let (c',p) = source_to_flat$compile c.source_conf p in
-    let td = tap_flat c.tap_conf p empty_tap_data in
+    let td = tap_flat c.tap_conf p [] in
     let _ = empty_ffi (strlit "finished: source_to_flat") in
     let c = c with source_conf := c' in
     let p = flat_to_pat$compile p in

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -71,11 +71,8 @@ val compile_tap_def = Define`
     let _ = empty_ffi (strlit "finished: lab_to_target") in
       (res, td)`;
 
-val compile_def1 = Define`
+val compile_def = Define`
   compile c p = FST (compile_tap c p)`;
-
-val compile_def = CONV_RULE (TOP_DEPTH_CONV (REWR_CONV compile_tap_def))
-  compile_def1;
 
 val to_flat_def = Define`
   to_flat c p =
@@ -147,7 +144,7 @@ val to_target_def = Define`
 
 val compile_eq_to_target = Q.store_thm("compile_eq_to_target",
   `compile = to_target`,
-  srw_tac[][FUN_EQ_THM,compile_def,
+  srw_tac[][FUN_EQ_THM,compile_def,compile_tap_def,
      to_target_def,
      to_lab_def,
      to_stack_def,
@@ -226,7 +223,7 @@ val from_source_def = Define`
 
 val compile_eq_from_source = Q.store_thm("compile_eq_from_source",
   `compile = from_source`,
-  srw_tac[][FUN_EQ_THM,compile_def,
+  srw_tac[][FUN_EQ_THM,compile_def,compile_tap_def,
      from_source_def,
      from_lab_def,
      from_stack_def,
@@ -293,7 +290,7 @@ val compile_oracle = Q.store_thm("compile_oracle",`
      to_clos_def,
      to_pat_def,
      to_flat_def,to_livesets_def] >>
-  fs[compile_def]>>
+  fs[compile_def,compile_tap_def]>>
   pairarg_tac>>
   fs[data_to_wordTheory.compile_def,word_to_wordTheory.compile_def]>>
   fs[from_livesets_def,from_word_def,from_stack_def,from_lab_def]>>

--- a/compiler/backend/displayLangScript.sml
+++ b/compiler/backend/displayLangScript.sml
@@ -12,7 +12,7 @@ val _ = new_theory"displayLang";
 *   *)
 val _ = Datatype`
   sExp =
-    | Item (tra option) string (sExp list)
+    | Item (tra option) mlstring (sExp list)
     | Tuple (sExp list)
     | List (sExp list)`;
 
@@ -45,7 +45,7 @@ val MEM_sExp_size = store_thm("MEM_sExp_size",
 val display_to_json_def = tDefine"display_to_json" `
   (display_to_json (Item tra name es) =
     let es' = MAP display_to_json es in
-    let props = [("name", String name); ("args", Array es')] in
+    let props = [("name", String (explode name)); ("args", Array es')] in
     let props' = case tra of
                    | NONE => props
                    | SOME t => ("trace", trace_to_json t)::props in

--- a/compiler/backend/mips/mips_configScript.sml
+++ b/compiler/backend/mips/mips_configScript.sml
@@ -47,7 +47,8 @@ val mips_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(mips_word_conf);
                stack_conf:=^(mips_stack_conf);
-               lab_conf:=^(mips_lab_conf)
+               lab_conf:=^(mips_lab_conf);
+               tap_conf:=default_tap_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -14,10 +14,13 @@ val empty_item_def = Define`
   empty_item name = Item NONE name []`;
 
 val string_to_display_def = Define`
-  string_to_display s = empty_item ("\"" ++ s ++ "\"")`;
+  string_to_display s = empty_item (concat [strlit "\""; s; strlit "\""])`;
+
+val string_to_display2_def = Define`
+  string_to_display2 s = string_to_display (implode s)`;
 
 val num_to_display_def = Define`
-  num_to_display (n : num) = string_to_display (explode (toString n))`;
+  num_to_display (n : num) = string_to_display (toString n)`;
 
 val item_with_num_def = Define`
   item_with_num name n = Item NONE name [num_to_display n]`;
@@ -26,7 +29,7 @@ val item_with_nums_def = Define`
   item_with_nums name ns = Item NONE name (MAP num_to_display ns)`;
 
 val bool_to_display_def = Define`
-  bool_to_display b = empty_item (if b then "True" else "False")`;
+  bool_to_display b = empty_item (if b then strlit "True" else strlit "False")`;
 
 val num_to_hex_digit_def = Define `
   num_to_hex_digit n =
@@ -40,104 +43,99 @@ val num_to_hex_def = Define `
 
 val display_word_to_hex_string_def = Define `
   display_word_to_hex_string w =
-    empty_item ("0x" ++ words$word_to_hex_string w)`;
+    empty_item (implode ("0x" ++ words$word_to_hex_string w))`;
 
 val lit_to_display_def = Define`
   (lit_to_display (IntLit i) =
-    Item NONE "IntLit" [empty_item (explode (toString i))])
+    Item NONE (strlit "IntLit") [empty_item (toString i)])
   /\
   (lit_to_display (Char c) =
-    Item NONE "Char" [empty_item ("#\"" ++ [c] ++ "\"")])
+    Item NONE (strlit "Char") [empty_item (implode ("#\"" ++ [c] ++ "\""))])
   /\
   (lit_to_display (StrLit s) =
-    Item NONE "StrLit" [string_to_display s])
+    Item NONE (strlit "StrLit") [string_to_display2 s])
   /\
   (lit_to_display (Word8 w) =
-    Item NONE "Word8" [display_word_to_hex_string w])
+    Item NONE (strlit "Word8") [display_word_to_hex_string w])
   /\
   (lit_to_display (Word64 w) =
-    Item NONE "Word64" [display_word_to_hex_string w])`;
+    Item NONE (strlit "Word64") [display_word_to_hex_string w])`;
 
 val list_to_display_def = Define`
   (list_to_display f xs = displayLang$List (MAP f xs))`
 
 val option_to_display_def = Define`
   (option_to_display f opt = case opt of
-                      | NONE => empty_item "NONE"
-                      | SOME opt' => Item NONE "SOME" [f opt'])`
-
-val option_string_to_display_def = Define`
-  (option_string_to_display opt = case opt of
-                      | NONE => empty_item "NONE"
-                      | SOME opt' => Item NONE "SOME" [string_to_display opt'])`
+          | NONE => empty_item (strlit "NONE")
+          | SOME opt' => Item NONE (strlit "SOME") [f opt'])`
 
 (* semantic ops and values *)
 
 val fp_cmp_to_display_def = Define `
   fp_cmp_to_display cmp = case cmp of
-    | FP_Less => empty_item "FP_Less"
-    | FP_LessEqual => empty_item "FP_LessEqual"
-    | FP_Greater => empty_item "FP_Greater"
-    | FP_GreaterEqual => empty_item "FP_GreaterEqual"
-    | FP_Equal => empty_item "FP_Equal"`
+    | FP_Less => empty_item (strlit "FP_Less")
+    | FP_LessEqual => empty_item (strlit "FP_LessEqual")
+    | FP_Greater => empty_item (strlit "FP_Greater")
+    | FP_GreaterEqual => empty_item (strlit "FP_GreaterEqual")
+    | FP_Equal => empty_item (strlit "FP_Equal")`
 
 val fp_uop_to_display_def = Define `
   fp_uop_to_display op = case op of
-    | FP_Abs => empty_item "FP_Abs"
-    | FP_Neg => empty_item "FP_Neg"
-    | FP_Sqrt => empty_item "FP_Sqrt"`
+    | FP_Abs => empty_item (strlit "FP_Abs")
+    | FP_Neg => empty_item (strlit "FP_Neg")
+    | FP_Sqrt => empty_item (strlit "FP_Sqrt")`
 
 val fp_bop_to_display_def = Define `
   fp_bop_to_display op = case op of
-    | fpSem$FP_Add => empty_item "FP_Add"
-    | FP_Sub => empty_item "FP_Sub"
-    | FP_Mul => empty_item "FP_Mul"
-    | FP_Div => empty_item "FP_Div"`
+    | fpSem$FP_Add => empty_item (strlit "FP_Add")
+    | FP_Sub => empty_item (strlit "FP_Sub")
+    | FP_Mul => empty_item (strlit "FP_Mul")
+    | FP_Div => empty_item (strlit "FP_Div")`
 
 val word_size_to_display_def = Define`
-  (word_size_to_display W8 = empty_item "W8")
+  (word_size_to_display W8 = empty_item (strlit "W8"))
   /\
-  (word_size_to_display W64 = empty_item "W64")`;
+  (word_size_to_display W64 = empty_item (strlit "W64"))`;
 
 val opn_to_display_def = Define`
-  (opn_to_display Plus = empty_item "Plus")
+  (opn_to_display Plus = empty_item (strlit "Plus"))
   /\
-  (opn_to_display Minus = empty_item "Minus")
+  (opn_to_display Minus = empty_item (strlit "Minus"))
   /\
-  (opn_to_display Times = empty_item "Times")
+  (opn_to_display Times = empty_item (strlit "Times"))
   /\
-  (opn_to_display Divide = empty_item "Divide")
+  (opn_to_display Divide = empty_item (strlit "Divide"))
   /\
-  (opn_to_display Modulo = empty_item "Modulo")`;
+  (opn_to_display Modulo = empty_item (strlit "Modulo"))`;
 
 val opb_to_display_def = Define`
-  (opb_to_display Lt = empty_item "Lt")
+  (opb_to_display Lt = empty_item (strlit "Lt"))
   /\
-  (opb_to_display Gt = empty_item "Gt")
+  (opb_to_display Gt = empty_item (strlit "Gt"))
   /\
-  (opb_to_display Leq = empty_item "Leq")
+  (opb_to_display Leq = empty_item (strlit "Leq"))
   /\
-  (opb_to_display Geq = empty_item "Geq")`;
+  (opb_to_display Geq = empty_item (strlit "Geq"))`;
 
 val opw_to_display_def = Define`
-  (opw_to_display Andw = empty_item "Andw")
+  (opw_to_display Andw = empty_item (strlit "Andw"))
   /\
-  (opw_to_display Orw = empty_item "Orw")
+  (opw_to_display Orw = empty_item (strlit "Orw"))
   /\
-  (opw_to_display Xor = empty_item "Xor")
+  (opw_to_display Xor = empty_item (strlit "Xor"))
   /\
-  (opw_to_display Add = empty_item "Add")
+  (opw_to_display Add = empty_item (strlit "Add"))
   /\
-  (opw_to_display Sub = empty_item "Sub")`;
+  (opw_to_display Sub = empty_item (strlit "Sub"))`;
 
 val shift_to_display_def = Define`
-  (shift_to_display Lsl = empty_item "Lsl")
+  (shift_to_display Lsl = empty_item (strlit "Lsl"))
   /\
-  (shift_to_display Lsr = empty_item "Lsr")
+  (shift_to_display Lsr = empty_item (strlit "Lsr"))
   /\
-  (shift_to_display Asr = empty_item "Asr")
+  (shift_to_display Asr = empty_item (strlit "Asr"))
   /\
-  (shift_to_display Ror = empty_item "Ror")`;
+  (shift_to_display Ror = empty_item (strlit "Ror"))`;
 
 
  (* flatLang *)
@@ -148,19 +146,20 @@ val MEM_pat_size = prove(
 
 val opt_con_to_display_def = Define `
   opt_con_to_display ocon = case ocon of
-    | NONE => empty_item "ConIdNone"
-    | SOME (c, NONE) => item_with_num "ConIdUntyped" c
-    | SOME (c, SOME t) => item_with_nums "ConIdTyped" [c; t]`
+    | NONE => empty_item (strlit "ConIdNone")
+    | SOME (c, NONE) => item_with_num (strlit "ConIdUntyped") c
+    | SOME (c, SOME t) => item_with_nums (strlit "ConIdTyped") [c; t]`
 
 val flat_pat_to_display_def = tDefine "flat_pat_to_display" `
   flat_pat_to_display p =
     case p of
-       | flatLang$Pvar varN => Item NONE "Pvar" [string_to_display varN]
-       | Pany => empty_item "Pany"
-       | Plit lit => Item NONE "Plit" [lit_to_display lit]
-       | flatLang$Pcon id pats => Item NONE "Pcon"
+       | flatLang$Pvar varN => Item NONE (strlit "Pvar")
+            [string_to_display2 varN]
+       | Pany => empty_item (strlit "Pany")
+       | Plit lit => Item NONE (strlit "Plit") [lit_to_display lit]
+       | flatLang$Pcon id pats => Item NONE (strlit "Pcon")
             (MAP flat_pat_to_display pats)
-       | Pref pat => Item NONE "Pref" [flat_pat_to_display pat] `
+       | Pref pat => Item NONE (strlit "Pref") [flat_pat_to_display pat] `
   (WF_REL_TAC `measure pat_size` \\ rw []
    \\ imp_res_tac MEM_pat_size \\ fs [])
 
@@ -169,52 +168,52 @@ val flat_op_to_display_def = Define `
     | Opn op => opn_to_display op
     | Opb op => opb_to_display op
     | Opw ws op =>
-        Item NONE "Opw" [ word_size_to_display ws; opw_to_display op ]
-    | Shift ws sh num => Item NONE "Shift" [
+        Item NONE (strlit "Opw") [ word_size_to_display ws; opw_to_display op ]
+    | Shift ws sh num => Item NONE (strlit "Shift") [
       word_size_to_display ws;
       shift_to_display sh;
       num_to_display num
     ]
-    | Equality => empty_item "Equality"
+    | Equality => empty_item (strlit "Equality")
     | FP_cmp cmp => fp_cmp_to_display cmp
     | FP_uop op => fp_uop_to_display op
     | FP_bop op => fp_bop_to_display op
-    | Opapp => empty_item "Opapp"
-    | Opassign => empty_item "Opassign"
-    | Opref => empty_item "Opref"
-    | Opderef => empty_item "Opderef"
-    | Aw8alloc => empty_item "Aw8alloc"
-    | Aw8sub => empty_item "Aw8sub"
-    | Aw8length => empty_item "Aw8length"
-    | Aw8update => empty_item "Aw8update"
+    | Opapp => empty_item (strlit "Opapp")
+    | Opassign => empty_item (strlit "Opassign")
+    | Opref => empty_item (strlit "Opref")
+    | Opderef => empty_item (strlit "Opderef")
+    | Aw8alloc => empty_item (strlit "Aw8alloc")
+    | Aw8sub => empty_item (strlit "Aw8sub")
+    | Aw8length => empty_item (strlit "Aw8length")
+    | Aw8update => empty_item (strlit "Aw8update")
     | WordFromInt ws =>
-        Item NONE "WordFromInt" [word_size_to_display ws]
+        Item NONE (strlit "WordFromInt") [word_size_to_display ws]
     | WordToInt ws =>
-        Item NONE "WordToInt" [word_size_to_display ws]
-    | CopyStrStr => empty_item "CopyStrStr"
-    | CopyStrAw8 => empty_item "CopyStrAw8"
-    | CopyAw8Str => empty_item "CopyAw8Str"
-    | CopyAw8Aw8 => empty_item "CopyAw8Aw8"
-    | Ord => empty_item "Ord"
-    | Chr => empty_item "Chr"
-    | Chopb op => Item NONE "Chopb" [opb_to_display op]
-    | Implode => empty_item "Implode"
-    | Strsub => empty_item "Strsub"
-    | Strlen => empty_item "Strlen"
-    | Strcat => empty_item "Strcat"
-    | VfromList => empty_item "VfromList"
-    | Vsub => empty_item "Vsub"
-    | Vlength => empty_item "Vlength"
-    | Aalloc => empty_item "Aalloc"
-    | Asub => empty_item "Asub"
-    | Alength => empty_item "Alength"
-    | Aupdate => empty_item "Aupdate"
-    | ListAppend => empty_item "ListAppend"
-    | ConfigGC => empty_item "ConfigGC"
-    | FFI s => Item NONE "FFI" [string_to_display s]
-    | GlobalVarAlloc n => item_with_num "GlobalVarAlloc" n
-    | GlobalVarInit n => item_with_num "GlobalVarInit" n
-    | GlobalVarLookup n => item_with_num "GlobalVarLookup" n
+        Item NONE (strlit "WordToInt") [word_size_to_display ws]
+    | CopyStrStr => empty_item (strlit "CopyStrStr")
+    | CopyStrAw8 => empty_item (strlit "CopyStrAw8")
+    | CopyAw8Str => empty_item (strlit "CopyAw8Str")
+    | CopyAw8Aw8 => empty_item (strlit "CopyAw8Aw8")
+    | Ord => empty_item (strlit "Ord")
+    | Chr => empty_item (strlit "Chr")
+    | Chopb op => Item NONE (strlit "Chopb") [opb_to_display op]
+    | Implode => empty_item (strlit "Implode")
+    | Strsub => empty_item (strlit "Strsub")
+    | Strlen => empty_item (strlit "Strlen")
+    | Strcat => empty_item (strlit "Strcat")
+    | VfromList => empty_item (strlit "VfromList")
+    | Vsub => empty_item (strlit "Vsub")
+    | Vlength => empty_item (strlit "Vlength")
+    | Aalloc => empty_item (strlit "Aalloc")
+    | Asub => empty_item (strlit "Asub")
+    | Alength => empty_item (strlit "Alength")
+    | Aupdate => empty_item (strlit "Aupdate")
+    | ListAppend => empty_item (strlit "ListAppend")
+    | ConfigGC => empty_item (strlit "ConfigGC")
+    | FFI s => Item NONE (strlit "FFI") [string_to_display2 s]
+    | GlobalVarAlloc n => item_with_num (strlit "GlobalVarAlloc") n
+    | GlobalVarInit n => item_with_num (strlit "GlobalVarInit") n
+    | GlobalVarLookup n => item_with_num (strlit "GlobalVarLookup") n
     `
 
 val MEM_funs_size = prove(
@@ -234,42 +233,42 @@ val MEM_pats_size = prove(
 
 val flat_to_display_def = tDefine"flat_to_display" `
   (flat_to_display (flatLang$Raise tra exp) =
-    Item (SOME tra) "Raise" [flat_to_display exp])
+    Item (SOME tra) (strlit "Raise") [flat_to_display exp])
   /\
   (flat_to_display (Handle tra exp pes) =
-    Item (SOME tra) "Handle" (flat_to_display exp
+    Item (SOME tra) (strlit "Handle") (flat_to_display exp
         :: MAP (\(pat,exp). displayLang$Tuple [flat_pat_to_display pat; flat_to_display exp]) pes))
   /\
-  (flat_to_display (Lit tra lit) = Item (SOME tra) "Lit" [])
+  (flat_to_display (Lit tra lit) = Item (SOME tra) (strlit "Lit") [])
   /\
   (flat_to_display (flatLang$Con tra id_opt exps) =
-    Item (SOME tra) "Con" (opt_con_to_display id_opt
+    Item (SOME tra) (strlit "Con") (opt_con_to_display id_opt
         :: MAP flat_to_display exps))
   /\
   (flat_to_display (Var_local tra varN) =
-    Item (SOME tra) "Var_local" [string_to_display varN])
+    Item (SOME tra) (strlit "Var_local") [string_to_display2 varN])
   /\
   (flat_to_display (Fun tra varN exp) =
-    Item (SOME tra) "Fun" [string_to_display varN; flat_to_display exp])
+    Item (SOME tra) (strlit "Fun") [string_to_display2 varN; flat_to_display exp])
   /\
   (flat_to_display (App tra op exps) =
-    Item (SOME tra) "App" (flat_op_to_display op :: MAP flat_to_display exps))
+    Item (SOME tra) (strlit "App") (flat_op_to_display op :: MAP flat_to_display exps))
   /\
   (flat_to_display (If tra exp1 exp2 exp3) =
-    Item (SOME tra) "If" [flat_to_display exp1; flat_to_display exp2;
+    Item (SOME tra) (strlit "If") [flat_to_display exp1; flat_to_display exp2;
         flat_to_display exp3])
   /\
   (flat_to_display (Mat tra exp pes) =
-    Item (SOME tra) "Mat" (flat_to_display exp
+    Item (SOME tra) (strlit "Mat") (flat_to_display exp
         :: MAP (\(pat,exp). displayLang$Tuple [flat_pat_to_display pat; flat_to_display exp]) pes))
   /\
   (flat_to_display (Let tra varN_opt exp1 exp2) =
-    Item (SOME tra) "Let" [option_string_to_display varN_opt;
+    Item (SOME tra) (strlit "Let") [option_to_display string_to_display2 varN_opt;
         flat_to_display exp1; flat_to_display exp2])
   /\
   (flat_to_display (Letrec tra funs exp) =
-    Item (SOME tra) "Letrec"
-        [List (MAP (\(v1,v2,e). Tuple [string_to_display v1; string_to_display v2;
+    Item (SOME tra) (strlit "Letrec")
+        [List (MAP (\(v1,v2,e). Tuple [string_to_display2 v1; string_to_display2 v2;
               flat_to_display e]) funs); flat_to_display exp]
   )`
   (WF_REL_TAC `inv_image $< (flatLang$exp_size)`
@@ -282,9 +281,9 @@ val flat_to_display_def = tDefine"flat_to_display" `
 val flat_to_display_dec_def = Define`
   flat_to_display_dec d =
     case d of
-       | Dlet exp => Item NONE "Dlet" [flat_to_display exp]
-       | Dtype mods con_arities => item_with_num "Dtype" mods
-       | Dexn n1 n2 => item_with_nums "Dexn" [n1; n2]`
+       | Dlet exp => Item NONE (strlit "Dlet") [flat_to_display exp]
+       | Dtype mods con_arities => item_with_num (strlit "Dtype") mods
+       | Dexn n1 n2 => item_with_nums (strlit "Dexn") [n1; n2]`
 
 val flat_to_display_decs_def = Define`
   flat_to_display_decs = list_to_display flat_to_display_dec`;
@@ -297,17 +296,17 @@ val num_to_varn_def = tDefine "num_to_varn" `
   (WF_REL_TAC `measure I` \\ rw [] \\ fs [DIV_LT_X]);
 
 val display_num_as_varn_def = Define `
-  display_num_as_varn n = string_to_display (num_to_varn n)`;
+  display_num_as_varn n = string_to_display2 (num_to_varn n)`;
 
 val pat_op_to_display_def = Define `
   pat_op_to_display op = case op of
     | patLang$Op op2 => flat_op_to_display op2
-    | Run => empty_item "Run"
-    | Tag_eq n1 n2 => item_with_nums "Tag_eq" [n1; n2]
-    | El num => item_with_num "El" num
+    | Run => empty_item (strlit "Run")
+    | Tag_eq n1 n2 => item_with_nums (strlit "Tag_eq") [n1; n2]
+    | El num => item_with_num (strlit "El") num
   `
 
-val MEM_exps_size = prove(
+val MEM_pat_exps_size = prove(
   ``!exps e. MEM a exps ==> patLang$exp_size a < exp1_size exps``,
   Induct \\ fs [patLangTheory.exp_size_def] \\ rw []
   \\ fs [patLangTheory.exp_size_def] \\ res_tac \\ fs []);
@@ -319,39 +318,40 @@ val MEM_exps_size = prove(
 
 val pat_to_display_def = tDefine "pat_to_display" `
   (pat_to_display h (patLang$Raise t e) =
-    Item (SOME t) "Raise" [pat_to_display h e])
+    Item (SOME t) (strlit "Raise") [pat_to_display h e])
   /\
   (pat_to_display h (Handle t e1 e2) =
-    Item (SOME t) "Handle" [pat_to_display h e1; pat_to_display (h+1) e2])
+    Item (SOME t) (strlit "Handle")
+        [pat_to_display h e1; pat_to_display (h+1) e2])
   /\
   (pat_to_display h (Lit t lit) =
-    Item (SOME t) "Lit" [lit_to_display lit])
+    Item (SOME t) (strlit "Lit") [lit_to_display lit])
   /\
   (pat_to_display h (Con t num es) =
-    Item (SOME t) "Con" (num_to_display num :: MAP (pat_to_display h) es))
+    Item (SOME t) (strlit "Con") (num_to_display num :: MAP (pat_to_display h) es))
   /\
   (pat_to_display h (Var_local t var_index) =
-    Item (SOME t) "Var_local" [display_num_as_varn (h-var_index-1)])
+    Item (SOME t) (strlit "Var_local") [display_num_as_varn (h-var_index-1)])
   /\
   (pat_to_display h (Fun t e) =
-    Item (SOME t) "Fun" [display_num_as_varn h; pat_to_display (h+1) e])
+    Item (SOME t) (strlit "Fun") [display_num_as_varn h; pat_to_display (h+1) e])
   /\
   (pat_to_display h (App t op es) =
-    Item (SOME t) "App" (pat_op_to_display op :: MAP (pat_to_display h) es))
+    Item (SOME t) (strlit "App") (pat_op_to_display op :: MAP (pat_to_display h) es))
   /\
   (pat_to_display h (If t e1 e2 e3) =
-    Item (SOME t) "If" [pat_to_display h e1; pat_to_display h e2;
+    Item (SOME t) (strlit "If") [pat_to_display h e1; pat_to_display h e2;
         pat_to_display h e3])
   /\
   (pat_to_display h (Let t e1 e2) =
-    Item (SOME t) "Let" [display_num_as_varn h;
+    Item (SOME t) (strlit "Let") [display_num_as_varn h;
         pat_to_display h e1; pat_to_display (h+1) e2])
   /\
   (pat_to_display h (Seq t e1 e2) =
-    Item (SOME t) "Seq" [pat_to_display h e1; pat_to_display h e2])
+    Item (SOME t) (strlit "Seq") [pat_to_display h e1; pat_to_display h e2])
   /\
   (pat_to_display h (Letrec t es e) =
-    (let len = LENGTH es in Item (SOME t) "Letrec"
+    (let len = LENGTH es in Item (SOME t) (strlit "Letrec")
         [List (pat_to_display_rec_tups h (len-1) len es);
             pat_to_display (h+len) e]))
   /\
@@ -365,7 +365,7 @@ val pat_to_display_def = tDefine "pat_to_display" `
  (WF_REL_TAC `measure (\x. case x of INL (_,e) => exp_size e
                                    | INR (_,_,_,es) => exp1_size es)`
   \\ rw [patLangTheory.exp_size_def]
-  \\ imp_res_tac MEM_exps_size \\ fs []);
+  \\ imp_res_tac MEM_pat_exps_size \\ fs []);
 
 (* clos to displayLang *)
 
@@ -376,67 +376,67 @@ val num_to_varn_list_def = Define `
 
 val clos_op_to_display_def = Define `
   clos_op_to_display op = case op of
-    | Global num => item_with_num "Global" num
-    | SetGlobal num => item_with_num "SetGlobal" num
-    | AllocGlobal => empty_item "AllocGlobal"
-    | GlobalsPtr => empty_item "GlobalsPtr"
-    | SetGlobalsPtr => empty_item "SetGlobalsPtr"
-    | Cons num => item_with_num "Cons" num
-    | ConsExtend num => item_with_num "ConsExtend" num
-    | El => empty_item "El"
-    | LengthBlock => empty_item "LengthBlock"
-    | Length => empty_item "Length"
-    | LengthByte => empty_item "LengthByte"
-    | RefByte b => Item NONE "RefByte" [bool_to_display b]
-    | RefArray => empty_item "RefArray"
-    | DerefByte => empty_item "DerefByte"
-    | UpdateByte => empty_item "UpdateByte"
-    | ConcatByteVec => empty_item "ConcatByteVec"
-    | CopyByte b => Item NONE "CopyByte" [bool_to_display b]
-    | ListAppend => empty_item "ListAppend"
-    | FromList num => item_with_num "FromList" num
-    | closLang$String s => Item NONE "String" [string_to_display s]
-    | FromListByte => empty_item "FromListByte"
-    | LengthByteVec => empty_item "LengthByteVec"
-    | DerefByteVec => empty_item "DerefByteVec"
-    | TagLenEq n1 n2 => item_with_nums "TagLenEq" [n1; n2]
-    | TagEq num => item_with_num "TagEq" num
-    | Ref => empty_item "Ref"
-    | Deref => empty_item "Deref"
-    | Update => empty_item "Update"
-    | Label num => item_with_num "Label" num
-    | FFI s => Item NONE "FFI" [string_to_display s]
-    | Equal => empty_item "Equal"
-    | EqualInt i => empty_item "EqualIntWithMissingData"
-    | Const i => empty_item "ConstWithMissingData"
-    | Add => empty_item "Add"
-    | Sub => empty_item "Sub"
-    | Mult => empty_item "Mult"
-    | Div => empty_item "Div"
-    | Mod => empty_item "Mod"
-    | Less => empty_item "Less"
-    | LessEq => empty_item "LessEq"
-    | Greater => empty_item "Greater"
-    | GreaterEq => empty_item "GreaterEq"
+    | Global num => item_with_num (strlit "Global") num
+    | SetGlobal num => item_with_num (strlit "SetGlobal") num
+    | AllocGlobal => empty_item (strlit "AllocGlobal")
+    | GlobalsPtr => empty_item (strlit "GlobalsPtr")
+    | SetGlobalsPtr => empty_item (strlit "SetGlobalsPtr")
+    | Cons num => item_with_num (strlit "Cons") num
+    | ConsExtend num => item_with_num (strlit "ConsExtend") num
+    | El => empty_item (strlit "El")
+    | LengthBlock => empty_item (strlit "LengthBlock")
+    | Length => empty_item (strlit "Length")
+    | LengthByte => empty_item (strlit "LengthByte")
+    | RefByte b => Item NONE (strlit "RefByte") [bool_to_display b]
+    | RefArray => empty_item (strlit "RefArray")
+    | DerefByte => empty_item (strlit "DerefByte")
+    | UpdateByte => empty_item (strlit "UpdateByte")
+    | ConcatByteVec => empty_item (strlit "ConcatByteVec")
+    | CopyByte b => Item NONE (strlit "CopyByte") [bool_to_display b]
+    | ListAppend => empty_item (strlit "ListAppend")
+    | FromList num => item_with_num (strlit "FromList") num
+    | closLang$String s => Item NONE (strlit "String") [string_to_display2 s]
+    | FromListByte => empty_item (strlit "FromListByte")
+    | LengthByteVec => empty_item (strlit "LengthByteVec")
+    | DerefByteVec => empty_item (strlit "DerefByteVec")
+    | TagLenEq n1 n2 => item_with_nums (strlit "TagLenEq") [n1; n2]
+    | TagEq num => item_with_num (strlit "TagEq") num
+    | Ref => empty_item (strlit "Ref")
+    | Deref => empty_item (strlit "Deref")
+    | Update => empty_item (strlit "Update")
+    | Label num => item_with_num (strlit "Label") num
+    | FFI s => Item NONE (strlit "FFI") [string_to_display2 s]
+    | Equal => empty_item (strlit "Equal")
+    | EqualInt i => empty_item (strlit "EqualIntWithMissingData")
+    | Const i => empty_item (strlit "ConstWithMissingData")
+    | Add => empty_item (strlit "Add")
+    | Sub => empty_item (strlit "Sub")
+    | Mult => empty_item (strlit "Mult")
+    | Div => empty_item (strlit "Div")
+    | Mod => empty_item (strlit "Mod")
+    | Less => empty_item (strlit "Less")
+    | LessEq => empty_item (strlit "LessEq")
+    | Greater => empty_item (strlit "Greater")
+    | GreaterEq => empty_item (strlit "GreaterEq")
     | WordOp ws op =>
-        Item NONE "WordOp" [ word_size_to_display ws; opw_to_display op ]
-    | WordShift ws sh num => Item NONE "WordShift" [
+        Item NONE (strlit "WordOp") [ word_size_to_display ws; opw_to_display op ]
+    | WordShift ws sh num => Item NONE (strlit "WordShift") [
       word_size_to_display ws;
       shift_to_display sh;
       num_to_display num
     ]
-    | WordFromInt => empty_item "WordFromInt"
-    | WordToInt => empty_item "WordToInt"
-    | WordFromWord b => Item NONE "WordFromWord" [bool_to_display b]
+    | WordFromInt => empty_item (strlit "WordFromInt")
+    | WordToInt => empty_item (strlit "WordToInt")
+    | WordFromWord b => Item NONE (strlit "WordFromWord") [bool_to_display b]
     | FP_cmp cmp => fp_cmp_to_display cmp
     | FP_uop op => fp_uop_to_display op
     | FP_bop op => fp_bop_to_display op
-    | BoundsCheckBlock => empty_item "BoundsCheckBlock"
-    | BoundsCheckArray => empty_item "BoundsCheckArray"
-    | BoundsCheckByte b => Item NONE "BoundsCheckByte" [bool_to_display b]
-    | LessConstSmall num => item_with_num "LessConstSmall" num
-    | closLang$ConfigGC => empty_item "ConfigGC"
-    | Install => empty_item "Install"
+    | BoundsCheckBlock => empty_item (strlit "BoundsCheckBlock")
+    | BoundsCheckArray => empty_item (strlit "BoundsCheckArray")
+    | BoundsCheckByte b => Item NONE (strlit "BoundsCheckByte") [bool_to_display b]
+    | LessConstSmall num => item_with_num (strlit "LessConstSmall") num
+    | closLang$ConfigGC => empty_item (strlit "ConfigGC")
+    | Install => empty_item (strlit "Install")
 `
 
 val MEM_clos_exps_size = prove(
@@ -448,41 +448,43 @@ val MEM_clos_exps_size = prove(
    indices as the pat_to_display function *)
 val clos_to_display_def = tDefine "clos_to_display" `
   (clos_to_display h (Var t n) =
-    Item (SOME t) "Var" [display_num_as_varn (h-n-1)]) /\
+    Item (SOME t) (strlit "Var") [display_num_as_varn (h-n-1)]) /\
   (clos_to_display h (If t x1 x2 x3) =
-    Item (SOME t) "If" [clos_to_display h x1; clos_to_display h x2;
+    Item (SOME t) (strlit "If") [clos_to_display h x1; clos_to_display h x2;
         clos_to_display h x3]) /\
   (clos_to_display h (closLang$Let t xs x) =
-    Item (SOME t) "Let'" [List (clos_to_display_lets h (LENGTH xs - 1) xs);
-        clos_to_display (h + LENGTH xs) x]) /\
+    Item (SOME t) (strlit "Let'")
+        [List (clos_to_display_lets h (LENGTH xs - 1) xs);
+            clos_to_display (h + LENGTH xs) x]) /\
   (clos_to_display h (Raise t x) =
-    Item (SOME t) "Raise" [clos_to_display h x]) /\
+    Item (SOME t) (strlit "Raise") [clos_to_display h x]) /\
   (clos_to_display h (Tick t x) =
-    Item (SOME t) "Tick" [clos_to_display h x]) /\
+    Item (SOME t) (strlit "Tick") [clos_to_display h x]) /\
   (clos_to_display h (Handle t x y) =
-    Item (SOME t) "Handle" [clos_to_display h x; display_num_as_varn h;
-        clos_to_display (h+1) y]) /\
+    Item (SOME t) (strlit "Handle")
+        [clos_to_display h x; display_num_as_varn h;
+            clos_to_display (h+1) y]) /\
   (clos_to_display h (Call t ticks dest xs) =
-    Item (SOME t) "Call" [num_to_display ticks; num_to_display dest;
+    Item (SOME t) (strlit "Call") [num_to_display ticks; num_to_display dest;
        List (MAP (clos_to_display h) xs)]) /\
   (clos_to_display h (App t opt_n x xs) =
-    Item (SOME t) "App'"
+    Item (SOME t) (strlit "App'")
         [option_to_display num_to_display opt_n;
          clos_to_display h x; List (MAP (clos_to_display h) xs)]) /\
   (clos_to_display h (Fn t n1 n2 vn x) =
-    Item (SOME t) "Fn"
+    Item (SOME t) (strlit "Fn")
         [option_to_display num_to_display n1;
          option_to_display (list_to_display num_to_display) n2;
-         list_to_display string_to_display (num_to_varn_list h vn);
+         list_to_display string_to_display2 (num_to_varn_list h vn);
          clos_to_display h x]) /\
   (clos_to_display h (closLang$Letrec t n1 n2 es e) =
-    Item (SOME t) "Letrec'" 
+    Item (SOME t) (strlit "Letrec'")
         [option_to_display num_to_display n1;
          option_to_display (list_to_display num_to_display) n2;
          List (clos_to_display_letrecs h (LENGTH es-1) (LENGTH es) es);
          clos_to_display h e]) /\
   (clos_to_display h (Op t op xs) =
-    Item (SOME t) "Op" [clos_op_to_display op;
+    Item (SOME t) (strlit "Op") [clos_op_to_display op;
         List (MAP (clos_to_display h) xs)]) /\
   (clos_to_display_lets h i [] = []) /\
   (clos_to_display_lets h i (x::xs) =
@@ -490,7 +492,7 @@ val clos_to_display_def = tDefine "clos_to_display" `
   (clos_to_display_letrecs h i len [] = []) /\
   (clos_to_display_letrecs h i len ((vn,e)::es) =
     Tuple [display_num_as_varn (h+i); 
-        list_to_display string_to_display (num_to_varn_list (h+len-1) vn);
+        list_to_display string_to_display2 (num_to_varn_list (h+len-1) vn);
         clos_to_display (h+len+vn) e]
     :: clos_to_display_letrecs h (i-1) len es)`
  (WF_REL_TAC `measure (\x. case x of
@@ -505,91 +507,91 @@ val clos_to_display_def = tDefine "clos_to_display" `
 
 val store_name_to_display_def = Define `
   store_name_to_display st = case st of
-    | NextFree => empty_item "NextFree"
-    | EndOfHeap => empty_item "EndOfHeap"
-    | TriggerGC => empty_item "TriggerGC"
-    | HeapLength => empty_item "HeapLength"
-    | ProgStart => empty_item "ProgStart"
-    | BitmapBase => empty_item "BitmapBase"
-    | CurrHeap => empty_item "CurrHeap"
-    | OtherHeap => empty_item "OtherHeap"
-    | AllocSize => empty_item "AllocSize"
-    | Globals => empty_item "Globals"
-    | Handler => empty_item "Handler"
-    | GenStart => empty_item "GenStart"
-    | CodeBuffer => empty_item "CodeBuffer"
-    | CodeBufferEnd => empty_item "CodeBufferEnd"
-    | BitmapBuffer => empty_item "BitmapBuffer"
-    | BitmapBufferEnd => empty_item "BitmapBufferEnd"
-    | Temp n => item_with_num "Temp" (w2n n)`;
+    | NextFree => empty_item (strlit "NextFree")
+    | EndOfHeap => empty_item (strlit "EndOfHeap")
+    | TriggerGC => empty_item (strlit "TriggerGC")
+    | HeapLength => empty_item (strlit "HeapLength")
+    | ProgStart => empty_item (strlit "ProgStart")
+    | BitmapBase => empty_item (strlit "BitmapBase")
+    | CurrHeap => empty_item (strlit "CurrHeap")
+    | OtherHeap => empty_item (strlit "OtherHeap")
+    | AllocSize => empty_item (strlit "AllocSize")
+    | Globals => empty_item (strlit "Globals")
+    | Handler => empty_item (strlit "Handler")
+    | GenStart => empty_item (strlit "GenStart")
+    | CodeBuffer => empty_item (strlit "CodeBuffer")
+    | CodeBufferEnd => empty_item (strlit "CodeBufferEnd")
+    | BitmapBuffer => empty_item (strlit "BitmapBuffer")
+    | BitmapBufferEnd => empty_item (strlit "BitmapBufferEnd")
+    | Temp n => item_with_num (strlit "Temp") (w2n n)`;
 
 (* asm *)
 (* also, yuck. programming with python now *)
 
 val asm_binop_to_display_def = Define `
   asm_binop_to_display op = case op of
-    | asm$Add => empty_item "Add"
-    | Sub => empty_item "Sub"
-    | And => empty_item "And"
-    | Or => empty_item "Or"
-    | Xor => empty_item "Xor"`;
+    | asm$Add => empty_item (strlit "Add")
+    | Sub => empty_item (strlit "Sub")
+    | And => empty_item (strlit "And")
+    | Or => empty_item (strlit "Or")
+    | Xor => empty_item (strlit "Xor")`;
 
 val asm_reg_imm_to_display_def = Define `
   asm_reg_imm_to_display reg_imm = case reg_imm of
-    | asm$Reg reg => item_with_num "Reg" reg
-    | Imm imm => item_with_num "Imm" (w2n imm)`;
+    | asm$Reg reg => item_with_num (strlit "Reg") reg
+    | Imm imm => item_with_num (strlit "Imm") (w2n imm)`;
 
 val asm_arith_to_display_def = Define `
   asm_arith_to_display op = case op of
-    | asm$Binop bop n1 n2 reg_imm => Item NONE "Binop"
+    | asm$Binop bop n1 n2 reg_imm => Item NONE (strlit "Binop")
         [asm_binop_to_display bop; num_to_display n1; num_to_display n2;
             asm_reg_imm_to_display reg_imm]
-    | asm$Shift sh n1 n2 n3 => Item NONE "Shift"
+    | asm$Shift sh n1 n2 n3 => Item NONE (strlit "Shift")
         (shift_to_display sh :: MAP num_to_display [n1; n2; n3])
-    | Div n1 n2 n3 => item_with_nums "Div" [n1; n2; n3]
-    | LongMul n1 n2 n3 n4 => item_with_nums "LongMul" [n1; n2; n3; n4]
-    | LongDiv n1 n2 n3 n4 n5 => item_with_nums "LongDiv" [n1; n2; n3; n4; n5]
-    | AddCarry n1 n2 n3 n4 => item_with_nums "AddCarry" [n1; n2; n3; n4]
-    | AddOverflow n1 n2 n3 n4 => item_with_nums "AddOverflow" [n1; n2; n3; n4]
-    | SubOverflow n1 n2 n3 n4 => item_with_nums "SubOverflow" [n1; n2; n3; n4]`;
+    | Div n1 n2 n3 => item_with_nums (strlit "Div") [n1; n2; n3]
+    | LongMul n1 n2 n3 n4 => item_with_nums (strlit "LongMul") [n1; n2; n3; n4]
+    | LongDiv n1 n2 n3 n4 n5 => item_with_nums (strlit "LongDiv") [n1; n2; n3; n4; n5]
+    | AddCarry n1 n2 n3 n4 => item_with_nums (strlit "AddCarry") [n1; n2; n3; n4]
+    | AddOverflow n1 n2 n3 n4 => item_with_nums (strlit "AddOverflow") [n1; n2; n3; n4]
+    | SubOverflow n1 n2 n3 n4 => item_with_nums (strlit "SubOverflow") [n1; n2; n3; n4]`;
 
 val asm_addr_to_display_def = Define `
   asm_addr_to_display addr = case addr of
-    | Addr reg w => item_with_nums "Addr" [reg; w2n w]`;
+    | Addr reg w => item_with_nums (strlit "Addr") [reg; w2n w]`;
 
 val asm_memop_to_display_def = Define `
   asm_memop_to_display op = case op of
-    | Load => empty_item "Load"
-    | Load8 => empty_item "Load8"
-    | Store => empty_item "Store"
-    | Store8 => empty_item "Store8"`;
+    | Load => empty_item (strlit "Load")
+    | Load8 => empty_item (strlit "Load8")
+    | Store => empty_item (strlit "Store")
+    | Store8 => empty_item (strlit "Store8")`;
 
 val asm_fp_to_display_def = Define `
   asm_fp_to_display op = case op of
-    | FPLess n1 n2 n3 => item_with_nums "FPLess" [n1; n2; n3]
-    | FPLessEqual n1 n2 n3 => item_with_nums "FPLessEqual" [n1; n2; n3]
-    | FPEqual n1 n2 n3 => item_with_nums "FPEqual" [n1; n2; n3]
-    | FPAbs n1 n2 => item_with_nums "FPAbs" [n1; n2]
-    | FPNeg n1 n2 => item_with_nums "FPNeg" [n1; n2]
-    | FPSqrt n1 n2 => item_with_nums "FPSqrt" [n1; n2]
-    | FPAdd n1 n2 n3 => item_with_nums "FPAdd" [n1; n2; n3]
-    | FPSub n1 n2 n3 => item_with_nums "FPSub" [n1; n2; n3]
-    | FPMul n1 n2 n3 => item_with_nums "FPMul" [n1; n2; n3]
-    | FPDiv n1 n2 n3 => item_with_nums "FPDiv" [n1; n2; n3]
-    | FPMov n1 n2 => item_with_nums "FPMov" [n1; n2]
-    | FPMovToReg n1 n2 n3 => item_with_nums "FPMovToReg" [n1; n2; n3]
-    | FPMovFromReg n1 n2 n3 => item_with_nums "FPMovFromReg" [n1; n2; n3]
-    | FPToInt n1 n2 => item_with_nums "FPToInt" [n1; n2]
-    | FPFromInt n1 n2 => item_with_nums "FPFromInt" [n1; n2]`;
+    | FPLess n1 n2 n3 => item_with_nums (strlit "FPLess") [n1; n2; n3]
+    | FPLessEqual n1 n2 n3 => item_with_nums (strlit "FPLessEqual") [n1; n2; n3]
+    | FPEqual n1 n2 n3 => item_with_nums (strlit "FPEqual") [n1; n2; n3]
+    | FPAbs n1 n2 => item_with_nums (strlit "FPAbs") [n1; n2]
+    | FPNeg n1 n2 => item_with_nums (strlit "FPNeg") [n1; n2]
+    | FPSqrt n1 n2 => item_with_nums (strlit "FPSqrt") [n1; n2]
+    | FPAdd n1 n2 n3 => item_with_nums (strlit "FPAdd") [n1; n2; n3]
+    | FPSub n1 n2 n3 => item_with_nums (strlit "FPSub") [n1; n2; n3]
+    | FPMul n1 n2 n3 => item_with_nums (strlit "FPMul") [n1; n2; n3]
+    | FPDiv n1 n2 n3 => item_with_nums (strlit "FPDiv") [n1; n2; n3]
+    | FPMov n1 n2 => item_with_nums (strlit "FPMov") [n1; n2]
+    | FPMovToReg n1 n2 n3 => item_with_nums (strlit "FPMovToReg") [n1; n2; n3]
+    | FPMovFromReg n1 n2 n3 => item_with_nums (strlit "FPMovFromReg") [n1; n2; n3]
+    | FPToInt n1 n2 => item_with_nums (strlit "FPToInt") [n1; n2]
+    | FPFromInt n1 n2 => item_with_nums (strlit "FPFromInt") [n1; n2]`;
 
 val asm_inst_to_display_def = Define `
   asm_inst_to_display inst = case inst of
-    | asm$Skip => empty_item "Skip"
-    | Const reg w => item_with_nums "Const" [reg; w2n w]
-    | Arith a => Item NONE "Arith" [asm_arith_to_display a]
-    | Mem mop r addr => Item NONE "Mem" [asm_memop_to_display mop;
+    | asm$Skip => empty_item (strlit "Skip")
+    | Const reg w => item_with_nums (strlit "Const") [reg; w2n w]
+    | Arith a => Item NONE (strlit "Arith") [asm_arith_to_display a]
+    | Mem mop r addr => Item NONE (strlit "Mem") [asm_memop_to_display mop;
         num_to_display r; asm_addr_to_display addr]
-    | FP fp => Item NONE "FP" [asm_fp_to_display fp]`;
+    | FP fp => Item NONE (strlit "FP") [asm_fp_to_display fp]`;
 
 (* wordLang *)
 
@@ -598,18 +600,18 @@ val MEM_word_exps_size_ARB =
 
 val word_exp_to_display_def = tDefine "word_exp_to_display" `
   (word_exp_to_display (wordLang$Const v)
-    = item_with_num "Const" (w2n v)) /\
+    = item_with_num (strlit "Const") (w2n v)) /\
   (word_exp_to_display (Var n)
-    = item_with_num "Var" n) /\
+    = item_with_num (strlit "Var") n) /\
   (word_exp_to_display (Lookup st)
-    = Item NONE "Lookup" [store_name_to_display st]) /\
+    = Item NONE (strlit "Lookup") [store_name_to_display st]) /\
   (word_exp_to_display (Load exp2)
-    = Item NONE "Load" [word_exp_to_display exp2]) /\
+    = Item NONE (strlit "Load") [word_exp_to_display exp2]) /\
   (word_exp_to_display (Op bop exs)
-    = Item NONE "Op" (asm_binop_to_display bop
+    = Item NONE (strlit "Op") (asm_binop_to_display bop
         :: MAP word_exp_to_display exs)) /\
   (word_exp_to_display (Shift sh exp num)
-    = Item NONE "Shift" [
+    = Item NONE (strlit "Shift") [
       shift_to_display sh;
       word_exp_to_display exp;
       num_to_display num
@@ -625,53 +627,53 @@ val num_set_to_display_def = Define
     (MAP FST (sptree$toAList ns)))`;
 
 val word_prog_to_display_def = tDefine "word_prog_to_display" `
-  (word_prog_to_display Skip = empty_item "Skip") /\
-  (word_prog_to_display (Move n mvs) = Item NONE "Move"
+  (word_prog_to_display Skip = empty_item (strlit "Skip")) /\
+  (word_prog_to_display (Move n mvs) = Item NONE (strlit "Move")
     [num_to_display n; displayLang$List (MAP (\(n1, n2). Tuple
         [num_to_display n1; num_to_display n2]) mvs)]) /\
-  (word_prog_to_display (Inst i) = empty_item "Inst") /\
-  (word_prog_to_display (Assign n exp) = Item NONE "Assign"
+  (word_prog_to_display (Inst i) = empty_item (strlit "Inst")) /\
+  (word_prog_to_display (Assign n exp) = Item NONE (strlit "Assign")
     [num_to_display n; word_exp_to_display exp]) /\
-  (word_prog_to_display (Get n sn) = Item NONE "Get"
+  (word_prog_to_display (Get n sn) = Item NONE (strlit "Get")
     [num_to_display n; store_name_to_display sn]) /\
-  (word_prog_to_display (Set sn exp) = Item NONE "Set"
+  (word_prog_to_display (Set sn exp) = Item NONE (strlit "Set")
     [store_name_to_display sn; word_exp_to_display exp]) /\
-  (word_prog_to_display (Store exp n) = Item NONE "Store"
+  (word_prog_to_display (Store exp n) = Item NONE (strlit "Store")
     [word_exp_to_display exp; num_to_display n]) /\
-  (word_prog_to_display (MustTerminate prog) = Item NONE "MustTerminate"
+  (word_prog_to_display (MustTerminate prog) = Item NONE (strlit "MustTerminate")
     [word_prog_to_display prog]) /\
-  (word_prog_to_display (Call a b c d) = Item NONE "Call"
+  (word_prog_to_display (Call a b c d) = Item NONE (strlit "Call")
     [word_prog_to_display_ret a; option_to_display num_to_display b;
         list_to_display num_to_display c;
         word_prog_to_display_handler d]) /\
-  (word_prog_to_display (Seq prog1 prog2) = Item NONE "Seq"
+  (word_prog_to_display (Seq prog1 prog2) = Item NONE (strlit "Seq")
     [word_prog_to_display prog1; word_prog_to_display prog2]) /\
-  (word_prog_to_display (If cmp n reg p1 p2) = Item NONE "If"
+  (word_prog_to_display (If cmp n reg p1 p2) = Item NONE (strlit "If")
     [word_prog_to_display p1; word_prog_to_display p2]) /\
-  (word_prog_to_display (Alloc n ns) = Item NONE "Alloc"
+  (word_prog_to_display (Alloc n ns) = Item NONE (strlit "Alloc")
     [num_to_display n; num_set_to_display ns]) /\
-  (word_prog_to_display (Raise n) = item_with_num "Raise" n) /\
-  (word_prog_to_display (Return n1 n2) = item_with_nums "Return" [n1; n2]) /\
-  (word_prog_to_display Tick = empty_item "Tick") /\
+  (word_prog_to_display (Raise n) = item_with_num (strlit "Raise") n) /\
+  (word_prog_to_display (Return n1 n2) = item_with_nums (strlit "Return") [n1; n2]) /\
+  (word_prog_to_display Tick = empty_item (strlit "Tick")) /\
   (word_prog_to_display (LocValue n1 n2) =
-    item_with_nums "LocValue" [n1; n2]) /\
+    item_with_nums (strlit "LocValue") [n1; n2]) /\
   (word_prog_to_display (Install n1 n2 n3 n4 ns) =
-    Item NONE "Install" (MAP num_to_display [n1; n2; n3; n4]
+    Item NONE (strlit "Install") (MAP num_to_display [n1; n2; n3; n4]
         ++ [num_set_to_display ns])) /\
   (word_prog_to_display (CodeBufferWrite n1 n2) =
-    item_with_nums "CodeBufferWrite" [n1; n2]) /\
+    item_with_nums (strlit "CodeBufferWrite") [n1; n2]) /\
   (word_prog_to_display (DataBufferWrite n1 n2) =
-    item_with_nums "DataBufferWrite" [n1; n2]) /\
+    item_with_nums (strlit "DataBufferWrite") [n1; n2]) /\
   (word_prog_to_display (FFI nm n1 n2 n3 n4 ns) =
-    Item NONE "FFI" (string_to_display nm :: MAP num_to_display [n1; n2; n3; n4]
+    Item NONE (strlit "FFI") (string_to_display2 nm :: MAP num_to_display [n1; n2; n3; n4]
         ++ [num_set_to_display ns])) /\
-  (word_prog_to_display_ret NONE = empty_item "NONE") /\
+  (word_prog_to_display_ret NONE = empty_item (strlit "NONE")) /\
   (word_prog_to_display_ret (SOME (n1, ns, prog, n2, n3)) =
-    Item NONE "SOME" [Tuple [num_to_display n1; num_set_to_display ns;
+    Item NONE (strlit "SOME") [Tuple [num_to_display n1; num_set_to_display ns;
         word_prog_to_display prog; num_to_display n2; num_to_display n3]]) /\
-  (word_prog_to_display_handler NONE = empty_item "NONE") /\
+  (word_prog_to_display_handler NONE = empty_item (strlit "NONE")) /\
   (word_prog_to_display_handler (SOME (n1, prog, n2, n3)) =
-    Item NONE "SOME" [Tuple [num_to_display n1;
+    Item NONE (strlit "SOME") [Tuple [num_to_display n1;
         word_prog_to_display prog; num_to_display n2; num_to_display n3]])
 `
   (WF_REL_TAC `measure (\x. case x of
@@ -701,11 +703,11 @@ val lang_to_json_def = Define`
 
 val () = Datatype `
   tap_config = Tap_Config
-    (* save filename prefix *) string
-    (* bits which should be saved *) (string list)`;
+    (* save filename prefix *) mlstring
+    (* bits which should be saved *) (mlstring list)`;
 
 val () = Datatype `
-  tap_data = Tap_Data ((string # (unit -> jsonLang$obj)) list)`;
+  tap_data = Tap_Data ((mlstring # (unit -> jsonLang$obj)) list)`;
 
 val empty_tap_data_def = Define `
   empty_tap_data = Tap_Data []`;
@@ -716,28 +718,28 @@ val should_tap_def = Define `
 
 val tap_name_def = Define `
   tap_name (conf : tap_config) nm = case conf of
-    | Tap_Config fname _ => fname ++ "." ++ nm`;
+    | Tap_Config fname _ => concat [fname; strlit "."; nm]`;
 
 val add_tap_def = Define `
   add_tap conf nm (to_display : 'a -> displayLang$sExp) (v : 'a) td
     = if should_tap conf nm
     then (case td of Tap_Data tds
         => Tap_Data ((tap_name conf nm,
-            (\_. lang_to_json nm to_display v)) :: tds))
+            (\_. lang_to_json (explode nm) to_display v)) :: tds))
     else td`;
 
 val tap_flat_def = Define `
-  tap_flat conf v = add_tap conf "flat" flat_to_display_decs v`;
+  tap_flat conf v = add_tap conf (strlit "flat") flat_to_display_decs v`;
 
 val tap_word_def = Define `
-  tap_word conf v = add_tap conf "word" word_progs_to_display v`;
+  tap_word conf v = add_tap conf (strlit "word") word_progs_to_display v`;
 
 val tap_pat_def = Define`
-  tap_pat conf v = add_tap conf "pat"
+  tap_pat conf v = add_tap conf (strlit "pat")
     (list_to_display (pat_to_display 0)) v`;
 
 val tap_clos_def = Define`
-  tap_clos conf v = add_tap conf "clos"
+  tap_clos conf v = add_tap conf (strlit "clos")
     (list_to_display (clos_to_display 0)) v`;
 
 val _ = export_theory();

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -4,440 +4,11 @@ open flatLangTheory patLangTheory closLangTheory
 
 val _ = new_theory"presLang";
 
-(*
-(*
-* presLang is a presentation language, encompassing intermediate languages from
-* flatLang to patLang of the compiler, adopting their constructors. However, the
-* constructors for patLang differ a bit since we don't want to present
-* information using de bruijn indices but rather variable names.
-*
-* The purpose of presLang is to be an intermediate representation between an
-* intermediate language of the compiler and the display language. By translating
-* an intermediate language to presLang, it can be given a display representation
-* by calling pres_to_display on the presLang representation. presLang has no
-* semantics, as it is never evaluated, and may therefore mix operators,
-* declarations, patterns and expressions.
-*)
+(* Functions for converting various intermediate languages
+   into displayLang representations. *)
 
-(* Special operator wrapper for presLang *)
-val _ = Datatype`
-  op =
-    | Ast_op ast$op
-    | Modlang_op flatLang$op
-    | Conlang_op conLang$op
-    | Patlang_op patLang$op
-    | Closlang_op closLang$op`;
+(* basics *)
 
-(* The format of a constructor, which differs by language. A Nothing constructor
-* indicates a tuple pattern. *)
-val _ = Datatype`
-  conF =
-    | Modlang_con (((modN, conN) id) option)
-    | Conlang_con ((num # tid_or_exn) option)
-    | Exhlang_con num`;
-
-val _ = Datatype`
-  exp =
-    (* An entire program. Is divided into any number of top level prompts. *)
-    | Prog (exp(*prompt*) list)
-    | Prompt (modN option) (exp(*dec*) list)
-    | CodeTable ((num # (varN list) # exp) list)
-    (* Declarations *)
-    | Dlet num exp(*exp*)
-    | Dletrec ((varN # varN # exp(*exp*)) list)
-    | Dtype (modN list)
-    | Dexn (modN list) conN (t list)
-    (* Patterns *)
-    | Pany
-    | Pvar varN
-    | Plit lit
-    | Pcon conF (exp(*pat*) list)
-    | Pref exp(*pat*)
-    | Ptannot exp(*pat*) t
-    (* Expressions *)
-    | Raise tra exp
-    | Handle tra exp ((exp(*pat*) # exp) list)
-    | Handle' tra exp varN exp
-    | Var tra varN
-    | Var_local tra varN
-    | Var_global tra num
-    | Extend_global tra num (* Introduced in conLang *)
-    | Lit tra lit
-    | Con tra conF (exp list)
-      (* Application of a primitive operator to arguments.
-       Includes function application. *)
-    | App tra op (exp list)
-    | Fun tra varN exp
-    | Op tra op (exp list)
-    | App' tra (num option) exp (exp list)
-    | Call tra num num (exp list)
-      (* Logical operations (and, or) *)
-    | Log tra lop exp exp
-    | If tra exp exp exp
-      (* Pattern matching *)
-    | Mat tra exp ((exp(*pat*) # exp) list)
-      (* A let expression
-         A Nothing value for the binding indicates that this is a
-         sequencing expression, that is: (e1; e2). *)
-    | Let tra (varN option) exp exp
-    | Let' tra ((varN # exp) list) exp
-      (* Local definition of (potentially) mutually recursive
-         functions.
-         The first varN is the function's name, and the second varN
-         is its parameter. *)
-    | Letrec tra ((varN # varN # exp) list) exp
-    | Letrec' tra (num option) (num list option)
-        ((varN # varN list # exp) list) exp
-    | Fn tra (num option) (num list option) (varN list) exp
-    | Seq tra exp exp
-    | Tick tra exp`;
-
-val exp_size_def = fetch "-" "exp_size_def";
-
-(* Functions for converting intermediate languages to presLang. *)
-
-(* flatLang *)
-
-val MEM_pat_size = prove(
-  ``!pats a. MEM a (pats:ast$pat list) ==> pat_size a < pat1_size pats``,
-  Induct \\ rw [] \\ rw [astTheory.pat_size_def] \\ res_tac \\ fs []);
-
-val flat_to_pres_pat_def = tDefine "flat_to_pres_pat" `
-  flat_to_pres_pat p =
-    case p of
-       | ast$Pvar varN => presLang$Pvar varN
-       | Pany => presLang$Pany
-       | Plit lit => Plit lit
-       | Pcon id pats => Pcon (Modlang_con id) (MAP flat_to_pres_pat pats)
-       | Pref pat => Pref (flat_to_pres_pat pat)
-       (* Won't happen, these are removed in compilation from source to flat. *)
-       | Ptannot pat t => Ptannot (flat_to_pres_pat pat) t`
-  (WF_REL_TAC `measure pat_size` \\ rw []
-   \\ imp_res_tac MEM_pat_size \\ fs [])
-
-val MEM_funs_size = prove(
-  ``!fs v1 v2 e. MEM (v1,v2,e) fs ==> flatLang$exp_size e < exp1_size fs``,
-  Induct \\ fs [flatLangTheory.exp_size_def] \\ rw []
-  \\ fs [flatLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val MEM_exps_size = prove(
-  ``!exps e. MEM a exps ==> flatLang$exp_size a < exp6_size exps``,
-  Induct \\ fs [flatLangTheory.exp_size_def] \\ rw []
-  \\ fs [flatLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val flat_to_pres_exp_def = tDefine"flat_to_pres_exp" `
-  (flat_to_pres_exp (flatLang$Raise tra exp) = presLang$Raise tra (flat_to_pres_exp exp))
-  /\
-  (flat_to_pres_exp (Handle tra exp pes) =
-    Handle tra (flat_to_pres_exp exp) (flat_to_pres_pes pes))
-  /\
-  (flat_to_pres_exp (Lit tra lit) = Lit tra lit)
-  /\
-  (flat_to_pres_exp (Con tra id_opt exps) = Con tra (Modlang_con id_opt) (MAP flat_to_pres_exp exps))
-  /\
-  (flat_to_pres_exp (Var_local tra varN) = Var_local tra varN)
-  /\
-  (flat_to_pres_exp (Var_global tra num) = Var_global tra num)
-  /\
-  (flat_to_pres_exp (Fun tra varN exp) = Fun tra varN (flat_to_pres_exp exp))
-  /\
-  (flat_to_pres_exp (App tra op exps) = App tra (Modlang_op op) (MAP flat_to_pres_exp exps))
-  /\
-  (flat_to_pres_exp (If tra exp1 exp2 exp3) =
-    If tra (flat_to_pres_exp exp1) (flat_to_pres_exp exp2) (flat_to_pres_exp exp3))
-  /\
-  (flat_to_pres_exp (Mat tra exp pes) =
-    Mat tra (flat_to_pres_exp exp) (flat_to_pres_pes pes))
-  /\
-  (flat_to_pres_exp (Let tra varN_opt exp1 exp2) =
-    Let tra varN_opt (flat_to_pres_exp exp1) (flat_to_pres_exp exp2))
-  /\
-  (flat_to_pres_exp (Letrec tra funs exp) =
-    Letrec tra
-          (MAP (\(v1,v2,e).(v1,v2,flat_to_pres_exp e)) funs)
-          (flat_to_pres_exp exp))
-  /\
-  (* Pattern-expression pairs *)
-  (flat_to_pres_pes [] = [])
-  /\
-  (flat_to_pres_pes ((p,e)::pes) =
-    (flat_to_pres_pat p, flat_to_pres_exp e)::flat_to_pres_pes pes)`
-  (WF_REL_TAC `inv_image $< (\x. case x of INL e => flatLang$exp_size e
-                                         | INR pes => flatLang$exp3_size pes)`
-   \\ rw [flatLangTheory.exp_size_def]
-   \\ imp_res_tac MEM_funs_size \\ fs []
-   \\ imp_res_tac MEM_exps_size \\ fs []);
-
-val flat_to_pres_dec_def = Define`
-  flat_to_pres_dec d =
-    case d of
-       | flatLang$Dlet num exp => presLang$Dlet num (flat_to_pres_exp exp)
-       | Dletrec funs => Dletrec (MAP (\(v1,v2,e). (v1,v2,flat_to_pres_exp e)) funs)
-       | Dtype mods type_def => Dtype mods
-       | Dexn mods conN ts => Dexn mods conN ts`;
-
-val flat_to_pres_prompt_def = Define`
-  flat_to_pres_prompt (Prompt flatN decs) =
-    Prompt flatN (MAP flat_to_pres_dec decs)`;
-
-val flat_to_pres_def = Define`
-  flat_to_pres prompts = Prog (MAP flat_to_pres_prompt prompts)`;
-
-(* con_to_pres *)
-
-val MEM_pat_size = prove(
-  ``!pats p. MEM p pats ==> conLang$pat_size p < pat1_size pats``,
-  Induct \\ rw [conLangTheory.pat_size_def]  \\ rw [] \\ res_tac \\ fs []);
-
-val con_to_pres_pat_def = tDefine"con_to_pres_pat" `
-  con_to_pres_pat p =
-    case p of
-       | conLang$Pvar varN => presLang$Pvar varN
-       | Pany => Pany
-       | Plit lit => Plit lit
-       | Pcon opt ps => Pcon (Conlang_con opt) (MAP con_to_pres_pat ps)
-       | Pref pat => Pref (con_to_pres_pat pat)`
-  (WF_REL_TAC `measure pat_size` \\ rw []
-   \\ imp_res_tac MEM_pat_size \\ fs []);
-
-val MEM_funs_size = prove(
-  ``!fs v1 v2 e. MEM (v1,v2,e) fs ==> conLang$exp_size e < exp1_size fs``,
-  Induct \\ fs [conLangTheory.exp_size_def] \\ rw []
-  \\ fs [conLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val MEM_exps_size = prove(
-  ``!exps e. MEM a exps ==> conLang$exp_size a < exp6_size exps``,
-  Induct \\ fs [conLangTheory.exp_size_def] \\ rw []
-  \\ fs [conLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val con_to_pres_exp_def = tDefine"con_to_pres_exp" `
-  (con_to_pres_exp (conLang$Raise t e) = Raise t (con_to_pres_exp e))
-  /\
-  (con_to_pres_exp (Handle t e pes) = Handle t (con_to_pres_exp e) (con_to_pres_pes pes))
-  /\
-  (con_to_pres_exp (Lit t l) = Lit t l)
-  /\
-  (con_to_pres_exp (Con t ntOpt exps) = Con t (Conlang_con ntOpt) (MAP con_to_pres_exp exps))
-  /\
-  (con_to_pres_exp (Var_local t varN) = Var_local t varN)
-  /\
-  (con_to_pres_exp (Var_global t num) = Var_global t num)
-  /\
-  (con_to_pres_exp (Fun t varN e) = Fun t varN (con_to_pres_exp e))
-  /\
-  (con_to_pres_exp (App t op exps) = App t (Conlang_op op) (MAP con_to_pres_exp exps))
-  /\
-  (con_to_pres_exp (Mat t e pes) = Mat t (con_to_pres_exp e) (con_to_pres_pes pes))
-  /\
-  (con_to_pres_exp (Let t varN e1 e2) = Let t varN (con_to_pres_exp e1)
-  (con_to_pres_exp e2))
-  /\
-  (con_to_pres_exp (Letrec t funs e) = Letrec t (MAP (\(v1,v2,e).(v1,v2,con_to_pres_exp e)) funs) (con_to_pres_exp e))
-  /\
-  (con_to_pres_exp (Extend_global t num) = Extend_global t num)
-  /\
-  (con_to_pres_pes [] = [])
-  /\
-  (con_to_pres_pes ((p,e)::pes) =
-    (con_to_pres_pat p, con_to_pres_exp e)::con_to_pres_pes pes)`
-  (WF_REL_TAC `inv_image $< (\x. case x of INL e => conLang$exp_size e
-                                         | INR pes => conLang$exp3_size pes)`
-   \\ rw [conLangTheory.exp_size_def]
-   \\ imp_res_tac MEM_funs_size \\ fs []
-   \\ imp_res_tac MEM_exps_size \\ fs []);
-
-val con_to_pres_dec_def = Define`
-  con_to_pres_dec d =
-    case d of
-       | conLang$Dlet num exp => presLang$Dlet num (con_to_pres_exp exp)
-       | Dletrec funs => Dletrec (MAP (\(v1,v2,e). (v1,v2,con_to_pres_exp e)) funs)`;
-
-val con_to_pres_prompt_def = Define`
-  con_to_pres_prompt (Prompt decs) = Prompt NONE (MAP con_to_pres_dec decs)`;
-
-val con_to_pres_def = Define`
-  con_to_pres prompts = Prog (MAP con_to_pres_prompt prompts)`;
-
-(* exh_to_pres *)
-
-val MEM_pat_size = prove(
-  ``!pats p. MEM p pats ==> exhLang$pat_size p < pat1_size pats``,
-  Induct \\ rw [exhLangTheory.pat_size_def]  \\ rw [] \\ res_tac \\ fs []);
-
-val exh_to_pres_pat_def = tDefine"exh_to_pres_pat"`
-  exh_to_pres_pat p =
-    case p of
-       | exhLang$Pvar varN => presLang$Pvar varN
-       | Pany => Pany
-       | Plit lit => Plit lit
-       | Pcon num ps => Pcon (Exhlang_con num) (MAP exh_to_pres_pat ps)
-       | Pref pat => Pref (exh_to_pres_pat pat)`
-  (WF_REL_TAC `measure pat_size` \\ rw []
-   \\ imp_res_tac MEM_pat_size \\ fs []);
-
-val MEM_funs_size = prove(
-  ``!fs v1 v2 e. MEM (v1,v2,e) fs ==> exhLang$exp_size e < exp1_size fs``,
-  Induct \\ fs [exhLangTheory.exp_size_def] \\ rw []
-  \\ fs [exhLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val MEM_exps_size = prove(
-  ``!exps e. MEM a exps ==> exhLang$exp_size a < exp6_size exps``,
-  Induct \\ fs [exhLangTheory.exp_size_def] \\ rw []
-  \\ fs [exhLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-val exh_to_pres_exp_def = tDefine"exh_to_pres_exp"`
-  (exh_to_pres_exp (exhLang$Raise t e) = Raise t (exh_to_pres_exp e))
-  /\
-  (exh_to_pres_exp (Handle t e pes) = Handle t (exh_to_pres_exp e) (exh_to_pres_pes pes))
-  /\
-  (exh_to_pres_exp (Lit t l) = Lit t l)
-  /\
-  (exh_to_pres_exp (Con t n es) = Con t (Exhlang_con n) (MAP exh_to_pres_exp es))
-  /\
-  (exh_to_pres_exp (Var_local t varN) = Var_local t varN)
-  /\
-  (exh_to_pres_exp (Var_global t n) = Var_global t n)
-  /\
-  (exh_to_pres_exp (Fun t varN e) = Fun t varN (exh_to_pres_exp e))
-  /\
-  (exh_to_pres_exp (App t op es) = App t (Conlang_op op) (MAP exh_to_pres_exp es))
-  /\
-  (exh_to_pres_exp (Mat t e pes) = Mat t (exh_to_pres_exp e) (exh_to_pres_pes pes))
-  /\
-  (exh_to_pres_exp (Let t varN e1 e2) = Let t varN (exh_to_pres_exp e1) (exh_to_pres_exp e2))
-  /\
-  (exh_to_pres_exp (Letrec t funs e1) = Letrec t (MAP (\(v1,v2,e).(v1,v2,exh_to_pres_exp e)) funs) (exh_to_pres_exp e1))
-  /\
-  (exh_to_pres_exp (Extend_global t n) = Extend_global t n)
-  /\
-  (exh_to_pres_pes [] = [])
-  /\
-  (exh_to_pres_pes ((p,e)::pes) =
-    (exh_to_pres_pat p, exh_to_pres_exp e)::exh_to_pres_pes pes)`
-  (WF_REL_TAC `inv_image $< (\x. case x of INL e => exhLang$exp_size e
-                                         | INR pes => exhLang$exp3_size pes)`
-   \\ rw [exhLangTheory.exp_size_def]
-   \\ imp_res_tac MEM_funs_size \\ fs []
-   \\ imp_res_tac MEM_exps_size \\ fs []);
-
-(* pat to pres. *)
-
-val num_to_varn_def = tDefine "num_to_varn" `
-  num_to_varn n = if n < 26 then [CHR (97 + n)]
-                  else (num_to_varn ((n DIV 26)-1)) ++ ([CHR (97 + (n MOD 26))])`
-  (WF_REL_TAC `measure I` \\ rw [] \\ fs [DIV_LT_X]);
-
-val MEM_exps_size = prove(
-  ``!exps e. MEM a exps ==> patLang$exp_size a < exp1_size exps``,
-  Induct \\ fs [patLangTheory.exp_size_def] \\ rw []
-  \\ fs [patLangTheory.exp_size_def] \\ res_tac \\ fs []);
-
-(* The constructors in pat differ a bit because of de bruijn indices. This is
-* solved with the argument h, referring to head of our indexing. Combined with
-* num_to_varn this means we create varNs to match the presLang-constructors
-* where either nums or no name at all were provided. *)
-val pat_to_pres_exp_def = tDefine "pat_to_pres_exp" `
-  (pat_to_pres_exp h (Raise t e) = Raise t (pat_to_pres_exp h e))
-  /\
-  (pat_to_pres_exp h (Handle t e1 e2) =
-    Handle t (pat_to_pres_exp h e1) [(Pvar (num_to_varn h), pat_to_pres_exp (h+1) e2)])
-  /\
-  (pat_to_pres_exp h (Lit t lit) = Lit t lit)
-  /\
-  (pat_to_pres_exp h (Con t num es) =
-    Con t (Exhlang_con num) (MAP (pat_to_pres_exp h) es))
-  /\
-  (pat_to_pres_exp h (Var_local t var_index) = Var_local t (num_to_varn (h-var_index-1)))
-  /\
-  (pat_to_pres_exp h (Var_global t num) = Var_global t num)
-  /\
-  (pat_to_pres_exp h (Fun t e) = Fun t (num_to_varn h) (pat_to_pres_exp (h+1) e))
-  /\
-  (pat_to_pres_exp h (App t op es) =
-    App t (Patlang_op op) (MAP (pat_to_pres_exp h) es))
-  /\
-  (pat_to_pres_exp h (If t e1 e2 e3) =
-    If t (pat_to_pres_exp h e1) (pat_to_pres_exp h e2) (pat_to_pres_exp h e3))
-  /\
-  (pat_to_pres_exp h (Let t e1 e2) =
-    Let t (SOME (num_to_varn h)) (pat_to_pres_exp h e1) (pat_to_pres_exp (h+1) e2))
-  /\
-  (pat_to_pres_exp h (Seq t e1 e2) = Seq t (pat_to_pres_exp h e1) (pat_to_pres_exp h e2))
-  /\
-  (pat_to_pres_exp h (Letrec t es e) =
-    let len = LENGTH es in
-      Letrec t (es_to_pres_tups h (len-1) len es) (pat_to_pres_exp (h+len) e))
-  /\
-  (pat_to_pres_exp h (Extend_global t num) = Extend_global t num)
-  /\
-  (* Gives letrec functions names and variable names. *)
-  (es_to_pres_tups _ _ _ [] = [])
-  /\
-  (es_to_pres_tups h i len (e::es) =
-    (num_to_varn (h+i), num_to_varn (h+len), pat_to_pres_exp (h+len+1) e)
-    ::es_to_pres_tups h (i-1) len es)`
- (WF_REL_TAC `measure (\x. case x of INL (_,e) => exp_size e
-                                   | INR (_,_,_,es) => exp1_size es)`
-  \\ rw [patLangTheory.exp_size_def]
-  \\ imp_res_tac MEM_exps_size \\ fs []);
-
-(* clos to pres. *)
-
-val num_to_varn_list_def = Define `
-  num_to_varn_list h n =
-    if n = 0 then [] else
-      num_to_varn (h + n) :: num_to_varn_list h (n-1)`
-
-(* The clos_to_pres function uses the same approach to de bruijn
-* indices as the pat_to_pres function *)
-val clos_to_pres_def = tDefine "clos_to_pres" `
-  (clos_to_pres h (Var t n) = Var t (num_to_varn (h-n-1))) /\
-  (clos_to_pres h (closLang$Let t xs x) =
-     presLang$Let' t
-       (clos_to_pres_tups h (LENGTH xs - 1) xs)
-       (clos_to_pres (h + LENGTH xs) x)) /\
-  (clos_to_pres h (If t x1 x2 x3) =
-     If t (clos_to_pres h x1) (clos_to_pres h x2) (clos_to_pres h x3)) /\
-  (clos_to_pres h (Raise t x) = Raise t (clos_to_pres h x)) /\
-  (clos_to_pres h (Tick t x) = Tick t (clos_to_pres h x)) /\
-  (clos_to_pres h (Handle t x y) =
-     Handle' t (clos_to_pres h x) (num_to_varn h) (clos_to_pres (h+1) y)) /\
-  (clos_to_pres h (Call t n1 n2 xs) = Call t n1 n2 (clos_to_pres_list h xs)) /\
-  (clos_to_pres h (App t n0 x xs) =
-     App' t n0 (clos_to_pres h x) (clos_to_pres_list h xs)) /\
-  (clos_to_pres h (Op t op xs) =
-     Op t (Closlang_op op) (clos_to_pres_list h xs)) /\
-  (clos_to_pres h (Fn t n1 n2 vn x) =
-     Fn t n1 n2 (num_to_varn_list h vn) (clos_to_pres h x)) /\
-  (clos_to_pres h (closLang$Letrec t n1 n2 es e) =
-    let len = LENGTH es in
-      Letrec' t n1 n2 (fun_to_pres_tups h (len-1) len es)
-        (clos_to_pres (h+len) e)) /\
-  (clos_to_pres_list h [] = []) /\
-  (clos_to_pres_list h (x::xs) =
-     clos_to_pres h x :: clos_to_pres_list h xs) /\
-  (clos_to_pres_tups h i [] = []) /\
-  (clos_to_pres_tups h i (x::xs) =
-     (num_to_varn (h+i), clos_to_pres h x) :: clos_to_pres_tups h (i-1) xs) /\
-  (fun_to_pres_tups h i len [] = []:(varN # varN list # exp) list) /\
-  (fun_to_pres_tups h i len ((vn,e)::es) =
-    ((num_to_varn (h+i)):string,
-     num_to_varn_list (h+len-1) vn,
-     (clos_to_pres (h+len+vn) e):exp)
-    :: ((fun_to_pres_tups h (i-1) len es : (varN # varN list # exp) list)))`
- (WF_REL_TAC `measure (\x. case x of
-    | INL (_,e) => exp_size e
-    | INR (INL (_,es)) => exp3_size es
-    | INR (INR (INL (_,_,es))) => exp3_size es
-    | INR (INR (INR (_,_,_,es))) => exp1_size es)`)
-
-val clos_to_pres_code_def = Define `
-  clos_to_pres_code code_table =
-    CodeTable
-      (MAP (\(n,arity,body). (n,num_to_varn_list 0 arity,
-         clos_to_pres arity body)) code_table)`
-
-(* Helpers for converting pres to display. *)
 val empty_item_def = Define`
   empty_item name = Item NONE name []`;
 
@@ -445,7 +16,79 @@ val string_to_display_def = Define`
   string_to_display s = empty_item ("\"" ++ s ++ "\"")`;
 
 val num_to_display_def = Define`
-  num_to_display n = empty_item (explode (toString n))`;
+  num_to_display (n : num) = string_to_display (explode (toString n))`;
+
+val item_with_num_def = Define`
+  item_with_num name n = Item NONE name [num_to_display n]`;
+
+val bool_to_display_def = Define`
+  bool_to_display b = empty_item (if b then "True" else "False")`;
+
+val num_to_hex_digit_def = Define `
+  num_to_hex_digit n =
+    if n < 10 then [CHR (48 + n)] else
+    if n < 16 then [CHR (55 + n)] else []`;
+
+val num_to_hex_def = Define `
+  num_to_hex n =
+    (if n < 16 then [] else num_to_hex (n DIV 16)) ++
+    num_to_hex_digit (n MOD 16)`;
+
+val display_word_to_hex_string_def = Define `
+  display_word_to_hex_string w =
+    empty_item ("0x" ++ words$word_to_hex_string w)`;
+
+val lit_to_display_def = Define`
+  (lit_to_display (IntLit i) =
+    Item NONE "IntLit" [empty_item (explode (toString i))])
+  /\
+  (lit_to_display (Char c) =
+    Item NONE "Char" [empty_item ("#\"" ++ [c] ++ "\"")])
+  /\
+  (lit_to_display (StrLit s) =
+    Item NONE "StrLit" [string_to_display s])
+  /\
+  (lit_to_display (Word8 w) =
+    Item NONE "Word8" [display_word_to_hex_string w])
+  /\
+  (lit_to_display (Word64 w) =
+    Item NONE "Word64" [display_word_to_hex_string w])`;
+
+val list_to_display_def = Define`
+  (list_to_display f xs = displayLang$List (MAP f xs))`
+
+val option_to_display_def = Define`
+  (option_to_display f opt = case opt of
+                      | NONE => empty_item "NONE"
+                      | SOME opt' => Item NONE "SOME" [f opt'])`
+
+val option_string_to_display_def = Define`
+  (option_string_to_display opt = case opt of
+                      | NONE => empty_item "NONE"
+                      | SOME opt' => Item NONE "SOME" [string_to_display opt'])`
+
+(* semantic ops and values *)
+
+val fp_cmp_to_display_def = Define `
+  fp_cmp_to_display cmp = case cmp of
+    | FP_Less => empty_item "FP_Less"
+    | FP_LessEqual => empty_item "FP_LessEqual"
+    | FP_Greater => empty_item "FP_Greater"
+    | FP_GreaterEqual => empty_item "FP_GreaterEqual"
+    | FP_Equal => empty_item "FP_Equal"`
+
+val fp_uop_to_display_def = Define `
+  fp_uop_to_display op = case op of
+    | FP_Abs => empty_item "FP_Abs"
+    | FP_Neg => empty_item "FP_Neg"
+    | FP_Sqrt => empty_item "FP_Sqrt"`
+
+val fp_bop_to_display_def = Define `
+  fp_bop_to_display op = case op of
+    | fpSem$FP_Add => empty_item "FP_Add"
+    | FP_Sub => empty_item "FP_Sub"
+    | FP_Mul => empty_item "FP_Mul"
+    | FP_Div => empty_item "FP_Div"`
 
 val word_size_to_display_def = Define`
   (word_size_to_display W8 = empty_item "W8")
@@ -492,454 +135,386 @@ val shift_to_display_def = Define`
   /\
   (shift_to_display Ror = empty_item "Ror")`;
 
-val op_to_display_def = tDefine "op_to_display"`
-  (op_to_display (Patlang_op (Tag_eq n1 n2)) =
-    Item NONE "Tag_eq" [(num_to_display n1);(num_to_display n2)])
-  /\
-  (op_to_display (Patlang_op (El num)) = Item NONE "El" [num_to_display num])
-  /\
-  (op_to_display (Patlang_op (Op op)) = op_to_display (Conlang_op op))
-  /\
-  (op_to_display (Conlang_op (Init_global_var num)) =
-    Item NONE "Init_global_var" [num_to_display num])
-  /\
-  (op_to_display (Conlang_op (Op astop)) = Item NONE "Op" [op_to_display (Modlang_op (astop))])
-  /\
-  (op_to_display (Ast_op AallocEmpty) = empty_item "AallocEmpty")
-  /\
-  (op_to_display (Ast_op astop) = op_to_display (Modlang_op (astOp_to_flatOp astop)))
-  /\
-  (op_to_display (Modlang_op (Opn opn)) = Item NONE "Opn" [opn_to_display opn])
-  /\
-  (op_to_display (Modlang_op (Opb opb)) = Item NONE "Opb" [opb_to_display opb])
-  /\
-  (op_to_display (Modlang_op (Opw word_size opw)) =
-    Item NONE "Opw" [ word_size_to_display word_size; opw_to_display opw ])
-  /\
-  (op_to_display (Modlang_op (Shift word_size shift num)) =
-    Item NONE "Shift" [
-      word_size_to_display word_size;
-      shift_to_display shift;
+
+ (* flatLang *)
+
+val MEM_pat_size = prove(
+  ``!pats a. MEM a (pats:flatLang$pat list) ==> pat_size a < pat1_size pats``,
+  Induct \\ rw [] \\ rw [flatLangTheory.pat_size_def] \\ res_tac \\ fs []);
+
+val opt_con_to_display_def = Define `
+  opt_con_to_display ocon = case ocon of
+    | NONE => empty_item "ConIdNone"
+    | SOME (c, NONE) => item_with_num "ConIdUntyped" c
+    | SOME (c, SOME t) => Item NONE "ConIdTyped"
+        [num_to_display c; num_to_display t]`
+
+val flat_pat_to_display_def = tDefine "flat_pat_to_display" `
+  flat_pat_to_display p =
+    case p of
+       | flatLang$Pvar varN => Item NONE "Pvar" [string_to_display varN]
+       | Pany => empty_item "Pany"
+       | Plit lit => Item NONE "Plit" [lit_to_display lit]
+       | flatLang$Pcon id pats => Item NONE "Pcon"
+            (MAP flat_pat_to_display pats)
+       | Pref pat => Item NONE "Pref" [flat_pat_to_display pat] `
+  (WF_REL_TAC `measure pat_size` \\ rw []
+   \\ imp_res_tac MEM_pat_size \\ fs [])
+
+val flat_op_to_display_def = Define `
+  flat_op_to_display op = case op of
+    | Opn op => opn_to_display op
+    | Opb op => opb_to_display op
+    | Opw ws op =>
+        Item NONE "Opw" [ word_size_to_display ws; opw_to_display op ]
+    | Shift ws sh num => Item NONE "Shift" [
+      word_size_to_display ws;
+      shift_to_display sh;
       num_to_display num
-  ])
-  /\
-  (op_to_display (Modlang_op Equality) = empty_item "Equality")
-  /\
-  (op_to_display (Modlang_op Opapp) = empty_item "Opapp")
-  /\
-  (op_to_display (Modlang_op Opassign) = empty_item "Opassign")
-  /\
-  (op_to_display (Modlang_op Opref) = empty_item "Opref")
-  /\
-  (op_to_display (Modlang_op Opderef) = empty_item "Opderef")
-  /\
-  (op_to_display (Modlang_op Aw8alloc) = empty_item "Aw8alloc")
-  /\
-  (op_to_display (Modlang_op Aw8sub) = empty_item "Aw8sub")
-  /\
-  (op_to_display (Modlang_op Aw8length) = empty_item "Aw8length")
-  /\
-  (op_to_display (Modlang_op Aw8update) = empty_item "Aw8update")
-  /\
-  (op_to_display (Modlang_op (WordFromInt word_size)) =
-    Item NONE "WordFromInt" [word_size_to_display word_size])
-  /\
-  (op_to_display (Modlang_op (WordToInt word_size)) =
-    Item NONE "WordToInt" [word_size_to_display word_size])
-  /\
-  (op_to_display (Modlang_op CopyStrStr) = empty_item "CopyStrStr")
-  /\
-  (op_to_display (Modlang_op CopyStrAw8) = empty_item "CopyStrAw8")
-  /\
-  (op_to_display (Modlang_op CopyAw8Str) = empty_item "CopyAw8Str")
-  /\
-  (op_to_display (Modlang_op CopyAw8Aw8) = empty_item "CopyAw8Aw8")
-  /\
-  (op_to_display (Modlang_op Ord) = empty_item "Ord")
-  /\
-  (op_to_display (Modlang_op Chr) = empty_item "Chr")
-  /\
-  (op_to_display (Modlang_op (Chopb opb)) =
-    Item NONE "Chopb" [opb_to_display opb])
-  /\
-  (op_to_display (Modlang_op Implode) = empty_item "Implode")
-  /\
-  (op_to_display (Modlang_op Strsub) = empty_item "Strsub")
-  /\
-  (op_to_display (Modlang_op Strlen) = empty_item "Strlen")
-  /\
-  (op_to_display (Modlang_op Strcat) = empty_item "Strcat")
-  /\
-  (op_to_display (Modlang_op VfromList) = empty_item "VfromList")
-  /\
-  (op_to_display (Modlang_op Vsub) = empty_item "Vsub")
-  /\
-  (op_to_display (Modlang_op Vlength) = empty_item "Vlength")
-  /\
-  (op_to_display (Modlang_op Aalloc) = empty_item "Aalloc")
-  /\
-  (op_to_display (Modlang_op Asub) = empty_item "Asub")
-  /\
-  (op_to_display (Modlang_op Alength) = empty_item "Alength")
-  /\
-  (op_to_display (Modlang_op Aupdate) = empty_item "Aupdate")
-  /\
-  (op_to_display (Modlang_op (FFI str)) =
-    Item NONE "FFI" [string_to_display str])
-  /\
-  (op_to_display (Closlang_op op) = empty_item "TODO_some_closLang_op")
-  ∧
-  (op_to_display _ = empty_item "Unknown")`
-( wf_rel_tac`inv_image ($< LEX $<)
-    (λx. case x of (Ast_op op) => (1,op_size op) | x => (0n,op_size x))` )
+    ]
+    | Equality => empty_item "Equality"
+    | FP_cmp cmp => fp_cmp_to_display cmp
+    | FP_uop op => fp_uop_to_display op
+    | FP_bop op => fp_bop_to_display op
+    | Opapp => empty_item "Opapp"
+    | Opassign => empty_item "Opassign"
+    | Opref => empty_item "Opref"
+    | Opderef => empty_item "Opderef"
+    | Aw8alloc => empty_item "Aw8alloc"
+    | Aw8sub => empty_item "Aw8sub"
+    | Aw8length => empty_item "Aw8length"
+    | Aw8update => empty_item "Aw8update"
+    | WordFromInt ws =>
+        Item NONE "WordFromInt" [word_size_to_display ws]
+    | WordToInt ws =>
+        Item NONE "WordToInt" [word_size_to_display ws]
+    | CopyStrStr => empty_item "CopyStrStr"
+    | CopyStrAw8 => empty_item "CopyStrAw8"
+    | CopyAw8Str => empty_item "CopyAw8Str"
+    | CopyAw8Aw8 => empty_item "CopyAw8Aw8"
+    | Ord => empty_item "Ord"
+    | Chr => empty_item "Chr"
+    | Chopb op => Item NONE "Chopb" [opb_to_display op]
+    | Implode => empty_item "Implode"
+    | Strsub => empty_item "Strsub"
+    | Strlen => empty_item "Strlen"
+    | Strcat => empty_item "Strcat"
+    | VfromList => empty_item "VfromList"
+    | Vsub => empty_item "Vsub"
+    | Vlength => empty_item "Vlength"
+    | Aalloc => empty_item "Aalloc"
+    | Asub => empty_item "Asub"
+    | Alength => empty_item "Alength"
+    | Aupdate => empty_item "Aupdate"
+    | ListAppend => empty_item "ListAppend"
+    | ConfigGC => empty_item "ConfigGC"
+    | FFI s => Item NONE "FFI" [string_to_display s]
+    | GlobalVarAlloc n => item_with_num "GlobalVarAlloc" n
+    | GlobalVarInit n => item_with_num "GlobalVarInit" n
+    | GlobalVarLookup n => item_with_num "GlobalVarLookup" n
+    `
 
-val lop_to_display_def = Define`
-  (lop_to_display ast$And = empty_item "And")
-  /\
-  (lop_to_display Or = empty_item "Or")
-  /\
-  (lop_to_display _ = empty_item "Unknown")`;
+val MEM_funs_size = prove(
+  ``!fs v1 v2 e. MEM (v1,v2,e) fs ==> flatLang$exp_size e < exp1_size fs``,
+  Induct \\ fs [flatLangTheory.exp_size_def] \\ rw []
+  \\ fs [flatLangTheory.exp_size_def] \\ res_tac \\ fs []);
 
-val num_to_hex_digit_def = Define `
-  num_to_hex_digit n =
-    if n < 10 then [CHR (48 + n)] else
-    if n < 16 then [CHR (55 + n)] else []`;
+val MEM_exps_size = prove(
+  ``!exps e. MEM e exps ==> flatLang$exp_size e < exp6_size exps``,
+  Induct \\ fs [flatLangTheory.exp_size_def] \\ rw []
+  \\ fs [flatLangTheory.exp_size_def] \\ res_tac \\ fs []);
 
-val num_to_hex_def = Define `
-  num_to_hex n =
-    (if n < 16 then [] else num_to_hex (n DIV 16)) ++
-    num_to_hex_digit (n MOD 16)`;
+val MEM_pats_size = prove(
+  ``!pats p e. MEM (p, e) pats ==> flatLang$exp_size e < exp3_size pats``,
+  Induct \\ fs [flatLangTheory.exp_size_def] \\ rw []
+  \\ fs [flatLangTheory.exp_size_def] \\ res_tac \\ fs []);
 
-val word_to_hex_string_def = Define `
-  word_to_hex_string w = "0x" ++ num_to_hex (w2n (w:'a word))`;
+val flat_to_display_def = tDefine"flat_to_display" `
+  (flat_to_display (flatLang$Raise tra exp) =
+    Item (SOME tra) "Raise" [flat_to_display exp])
+  /\
+  (flat_to_display (Handle tra exp pes) =
+    Item (SOME tra) "Handle" (flat_to_display exp
+        :: MAP (\(pat,exp). displayLang$Tuple [flat_pat_to_display pat; flat_to_display exp]) pes))
+  /\
+  (flat_to_display (Lit tra lit) = Item (SOME tra) "Lit" [])
+  /\
+  (flat_to_display (flatLang$Con tra id_opt exps) =
+    Item (SOME tra) "Con" (opt_con_to_display id_opt
+        :: MAP flat_to_display exps))
+  /\
+  (flat_to_display (Var_local tra varN) =
+    Item (SOME tra) "Var_local" [string_to_display varN])
+  /\
+  (flat_to_display (Fun tra varN exp) =
+    Item (SOME tra) "Fun" [string_to_display varN; flat_to_display exp])
+  /\
+  (flat_to_display (App tra op exps) =
+    Item (SOME tra) "App" (flat_op_to_display op :: MAP flat_to_display exps))
+  /\
+  (flat_to_display (If tra exp1 exp2 exp3) =
+    Item (SOME tra) "If" [flat_to_display exp1; flat_to_display exp2;
+        flat_to_display exp3])
+  /\
+  (flat_to_display (Mat tra exp pes) =
+    Item (SOME tra) "Mat" (flat_to_display exp
+        :: MAP (\(pat,exp). displayLang$Tuple [flat_pat_to_display pat; flat_to_display exp]) pes))
+  /\
+  (flat_to_display (Let tra varN_opt exp1 exp2) =
+    Item (SOME tra) "Let" [option_string_to_display varN_opt;
+        flat_to_display exp1; flat_to_display exp2])
+  /\
+  (flat_to_display (Letrec tra funs exp) =
+    Item (SOME tra) "Letrec"
+        [List (MAP (\(v1,v2,e). Tuple [string_to_display v1; string_to_display v2;
+              flat_to_display e]) funs); flat_to_display exp]
+  )`
+  (WF_REL_TAC `inv_image $< (flatLang$exp_size)`
+   \\ rw [flatLangTheory.exp_size_def]
+   \\ imp_res_tac MEM_funs_size \\ fs []
+   \\ imp_res_tac MEM_exps_size \\ fs []
+   \\ imp_res_tac MEM_pats_size \\ fs []
+);
 
-val lit_to_display_def = Define`
-  (lit_to_display (IntLit i) =
-    Item NONE "IntLit" [empty_item (explode (toString i))])
-  /\
-  (lit_to_display (Char c) =
-    Item NONE "Char" [empty_item ("#\"" ++ [c] ++ "\"")])
-  /\
-  (lit_to_display (StrLit s) =
-    Item NONE "StrLit" [string_to_display s])
-  /\
-  (lit_to_display (Word8 w) =
-    Item NONE "Word8" [empty_item (word_to_hex_string w)])
-  /\
-  (lit_to_display (Word64 w) =
-    Item NONE "Word64" [empty_item (word_to_hex_string w)])`;
+val flat_to_display_dec_def = Define`
+  flat_to_display_dec d =
+    case d of
+       | Dlet exp => Item NONE "Dlet" [flat_to_display exp]
+       | Dtype mods con_arities => item_with_num "Dtype" mods
+       | Dexn n1 n2 => Item NONE "Dexn" [num_to_display n1; num_to_display n2]`
 
-val list_to_display_def = Define`
-  (list_to_display f xs = List (MAP f xs))`
+(* pat to displayLang *)
 
-val option_to_display_def = Define`
-  (option_to_display f opt = case opt of
-                      | NONE => empty_item "NONE"
-                      | SOME opt' => Item NONE "SOME" [f opt'])`
+val num_to_varn_def = tDefine "num_to_varn" `
+  num_to_varn n = if n < 26 then [CHR (97 + n)]
+                  else (num_to_varn ((n DIV 26)-1)) ++ ([CHR (97 + (n MOD 26))])`
+  (WF_REL_TAC `measure I` \\ rw [] \\ fs [DIV_LT_X]);
 
-val option_string_to_display_def = Define`
-  (option_string_to_display opt = case opt of
-                      | NONE => empty_item "NONE"
-                      | SOME opt' => Item NONE "SOME" [string_to_display opt'])`
+val display_num_as_varn_def = Define `
+  display_num_as_varn n = string_to_display (num_to_varn n)`;
 
-val id_to_display_def = Define`
-  (id_to_display (Long name i) = Item NONE "Long" [id_to_display i; string_to_display name])
-  /\
-  (id_to_display (Short name) = Item NONE "Short" [string_to_display name])`;
+val pat_op_to_display_def = Define `
+  pat_op_to_display op = case op of
+    | patLang$Op op2 => flat_op_to_display op2
+    | Run => empty_item "Run"
+    | Tag_eq n1 n2 =>
+        Item NONE "Tag_eq" [(num_to_display n1);(num_to_display n2)]
+    | El num => item_with_num "El" num
+  `
 
-val tctor_to_display_def = Define`
-  (tctor_to_display (ast$TC_name ids) =
-    let ids' = id_to_display ids in
-      Item NONE "TC_name" [ids'])
-  /\
-  (tctor_to_display TC_int = empty_item "TC_int")
-  /\
-  (tctor_to_display TC_char = empty_item "TC_char")
-  /\
-  (tctor_to_display TC_string = empty_item "TC_string")
-  /\
-  (tctor_to_display TC_ref = empty_item "TC_ref")
-  /\
-  (tctor_to_display TC_word8 = empty_item "TC_word8")
-  /\
-  (tctor_to_display TC_word64 = empty_item "TC_word64")
-  /\
-  (tctor_to_display TC_word8array = empty_item "TC_word8array")
-  /\
-  (tctor_to_display TC_fn = empty_item "TC_fn")
-  /\
-  (tctor_to_display TC_tup = empty_item "TC_tup")
-  /\
-  (tctor_to_display TC_exn = empty_item "TC_exp")
-  /\
-  (tctor_to_display TC_vector = empty_item "TC_vector")
-  /\
-  (tctor_to_display TC_array = empty_item "TC_array")`
+val MEM_exps_size = prove(
+  ``!exps e. MEM a exps ==> patLang$exp_size a < exp1_size exps``,
+  Induct \\ fs [patLangTheory.exp_size_def] \\ rw []
+  \\ fs [patLangTheory.exp_size_def] \\ res_tac \\ fs []);
 
-val MEM_t_size = prove(
-  ``!ts t. MEM t ts ==> t_size t < t1_size ts``,
-  Induct \\ fs [t_size_def] \\ rw [] \\ res_tac \\ fs []);
+(* The constructors in pat differ a bit because of de bruijn indices. This is
+* solved with the argument h, referring to head of our indexing. Combined with
+* num_to_varn this means we create varNs to match the presLang-constructors
+* where either nums or no name at all were provided. *)
 
-val t_to_display_def = tDefine "t_to_display" `
-  (t_to_display (Tvar tvarN) = Item NONE "Tvar" [string_to_display tvarN])
+val pat_to_display_def = tDefine "pat_to_display" `
+  (pat_to_display h (patLang$Raise t e) =
+    Item (SOME t) "Raise" [pat_to_display h e])
   /\
-  (t_to_display (Tvar_db n) = Item NONE "Tvar_db" [num_to_display n])
+  (pat_to_display h (Handle t e1 e2) =
+    Item (SOME t) "Handle" [pat_to_display h e1; pat_to_display (h+1) e2])
   /\
-  (t_to_display (Tapp ts tctor) = Item NONE "Tapp" [List (MAP t_to_display ts); tctor_to_display tctor])`
-  (WF_REL_TAC `measure t_size` \\ rw []
-   \\ imp_res_tac MEM_t_size \\ fs []);
+  (pat_to_display h (Lit t lit) =
+    Item (SOME t) "Lit" [lit_to_display lit])
+  /\
+  (pat_to_display h (Con t num es) =
+    Item (SOME t) "Con" (num_to_display num :: MAP (pat_to_display h) es))
+  /\
+  (pat_to_display h (Var_local t var_index) =
+    Item (SOME t) "Var_local" [display_num_as_varn (h-var_index-1)])
+  /\
+  (pat_to_display h (Fun t e) =
+    Item (SOME t) "Fun" [display_num_as_varn h; pat_to_display (h+1) e])
+  /\
+  (pat_to_display h (App t op es) =
+    Item (SOME t) "App" (pat_op_to_display op :: MAP (pat_to_display h) es))
+  /\
+  (pat_to_display h (If t e1 e2 e3) =
+    Item (SOME t) "If" [pat_to_display h e1; pat_to_display h e2;
+        pat_to_display h e3])
+  /\
+  (pat_to_display h (Let t e1 e2) =
+    Item (SOME t) "Let" [display_num_as_varn h;
+        pat_to_display h e1; pat_to_display (h+1) e2])
+  /\
+  (pat_to_display h (Seq t e1 e2) =
+    Item (SOME t) "Seq" [pat_to_display h e1; pat_to_display h e2])
+  /\
+  (pat_to_display h (Letrec t es e) =
+    (let len = LENGTH es in Item (SOME t) "Letrec"
+        [List (pat_to_display_rec_tups h (len-1) len es);
+            pat_to_display (h+len) e]))
+  /\
+  (* Gives letrec functions names and variable names. *)
+  (pat_to_display_rec_tups _ _ _ [] = [])
+  /\
+  (pat_to_display_rec_tups h i len (e::es) =
+    Tuple [display_num_as_varn (h+i); display_num_as_varn (h+len);
+        pat_to_display (h+len+1) e]
+        :: pat_to_display_rec_tups h (i-1) len es)`
+ (WF_REL_TAC `measure (\x. case x of INL (_,e) => exp_size e
+                                   | INR (_,_,_,es) => exp1_size es)`
+  \\ rw [patLangTheory.exp_size_def]
+  \\ imp_res_tac MEM_exps_size \\ fs []);
 
-val tid_or_exn_to_display_def = Define`
-  tid_or_exn_to_display te =
-   let (name, id) =
-     case te of
-       | TypeId id => ("TypeId", id)
-       | TypeExn id => ("TypeExn", id) in
-     Item NONE name [id_to_display id]`;
+(* clos to displayLang *)
 
-val conf_to_display_def = Define`
-  conf_to_display con =
-    let none = empty_item "NONE" in
-      case con of
-         | Modlang_con NONE => none
-         | Conlang_con NONE => none
-         | Modlang_con (SOME id) => Item NONE "SOME" [id_to_display id]
-         | Conlang_con (SOME (n,t)) =>
-            Item NONE "SOME" [Tuple [num_to_display n; tid_or_exn_to_display t]]
-         | Exhlang_con c => Item NONE "SOME" [num_to_display c]`;
+val num_to_varn_list_def = Define `
+  num_to_varn_list h n =
+    if n = 0 then [] else
+      num_to_varn (h + n) :: num_to_varn_list h (n-1)`
 
-(* Takes a presLang$exp and produces jsonLang$obj that mimics its structure. *)
+val clos_op_to_display_def = Define `
+  clos_op_to_display op = case op of
+    | Global num => item_with_num "Global" num
+    | SetGlobal num => item_with_num "SetGlobal" num
+    | AllocGlobal => empty_item "AllocGlobal"
+    | GlobalsPtr => empty_item "GlobalsPtr"
+    | SetGlobalsPtr => empty_item "SetGlobalsPtr"
+    | Cons num => item_with_num "Cons" num
+    | ConsExtend num => item_with_num "ConsExtend" num
+    | El => empty_item "El"
+    | LengthBlock => empty_item "LengthBlock"
+    | Length => empty_item "Length"
+    | LengthByte => empty_item "LengthByte"
+    | RefByte b => Item NONE "RefByte" [bool_to_display b]
+    | RefArray => empty_item "RefArray"
+    | DerefByte => empty_item "DerefByte"
+    | UpdateByte => empty_item "UpdateByte"
+    | ConcatByteVec => empty_item "ConcatByteVec"
+    | CopyByte b => Item NONE "CopyByte" [bool_to_display b]
+    | ListAppend => empty_item "ListAppend"
+    | FromList num => item_with_num "FromList" num
+    | closLang$String s => Item NONE "String" [string_to_display s]
+    | FromListByte => empty_item "FromListByte"
+    | LengthByteVec => empty_item "LengthByteVec"
+    | DerefByteVec => empty_item "DerefByteVec"
+    | TagLenEq n1 n2 => Item NONE "TagLenEq" [num_to_display n1; num_to_display n2]
+    | TagEq num => item_with_num "TagEq" num
+    | Ref => empty_item "Ref"
+    | Deref => empty_item "Deref"
+    | Update => empty_item "Update"
+    | Label num => item_with_num "Label" num
+    | FFI s => Item NONE "FFI" [string_to_display s]
+    | Equal => empty_item "Equal"
+    | EqualInt i => empty_item "EqualIntWithMissingData"
+    | Const i => empty_item "ConstWithMissingData"
+    | Add => empty_item "Add"
+    | Sub => empty_item "Sub"
+    | Mult => empty_item "Mult"
+    | Div => empty_item "Div"
+    | Mod => empty_item "Mod"
+    | Less => empty_item "Less"
+    | LessEq => empty_item "LessEq"
+    | Greater => empty_item "Greater"
+    | GreaterEq => empty_item "GreaterEq"
+    | WordOp ws op =>
+        Item NONE "WordOp" [ word_size_to_display ws; opw_to_display op ]
+    | WordShift ws sh num => Item NONE "WordShift" [
+      word_size_to_display ws;
+      shift_to_display sh;
+      num_to_display num
+    ]
+    | WordFromInt => empty_item "WordFromInt"
+    | WordToInt => empty_item "WordToInt"
+    | WordFromWord b => Item NONE "WordFromWord" [bool_to_display b]
+    | FP_cmp cmp => fp_cmp_to_display cmp
+    | FP_uop op => fp_uop_to_display op
+    | FP_bop op => fp_bop_to_display op
+    | BoundsCheckBlock => empty_item "BoundsCheckBlock"
+    | BoundsCheckArray => empty_item "BoundsCheckArray"
+    | BoundsCheckByte b => Item NONE "BoundsCheckByte" [bool_to_display b]
+    | LessConstSmall num => item_with_num "LessConstSmall" num
+    | closLang$ConfigGC => empty_item "ConfigGC"
+    | Install => empty_item "Install"
+`
 
-val MEM_exp_size = prove(
-  ``!xs x. MEM x xs ==> exp_size x < exp12_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
+val MEM_clos_exps_size = prove(
+  ``!exps e. MEM e exps ==> closLang$exp_size e < exp3_size exps``,
+  Induct \\ fs [closLangTheory.exp_size_def] \\ rw []
+  \\ fs [closLangTheory.exp_size_def] \\ res_tac \\ fs []);
 
-val MEM_expTup_size = prove(
-  ``!xs x y. MEM (x,y) xs ==>
-             exp_size x < exp10_size xs /\ exp_size y < exp10_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
-
-val MEM_varexpTup_size = prove(
-  ``!xs x y z. MEM (x,y,z) xs ==> exp_size z < exp4_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
-
-val MEM_varexpTup1_size = prove(
-  ``!xs x y z. MEM (x,y,z) xs ==> exp_size z < exp1_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
-
-val MEM_varexpTup3_size = prove(
-  ``!xs x y z. MEM (x,y,z) xs ==> exp_size z < exp3_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
-
-val MEM_varexpTup6_size = prove(
-  ``!xs x z. MEM (x,z) xs ==> exp_size z < exp8_size xs``,
-  Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
-
-val pres_to_display_def = tDefine"pres_to_display" `
-  (* Top level *)
-  (pres_to_display (presLang$Prog tops) =
-    let tops' = List (MAP pres_to_display tops) in
-      Item NONE "Prog" [tops'])
-  /\
-  (pres_to_display (Prompt modN decs) =
-    let decs' = List (MAP pres_to_display decs) in
-    let modN' = option_string_to_display modN in
-      Item NONE "Prompt" [modN'; decs'])
-  /\
-  (pres_to_display (Dlet num exp) =
-      Item NONE "Dlet" [num_to_display num; pres_to_display exp])
-  /\
-  (pres_to_display (Dletrec lst) =
-    let fields =
-      List (MAP (\ (v1, v2, exp) . Tuple [string_to_display v1; string_to_display v2; pres_to_display exp]) lst) in
-      Item NONE "Dletrec" [fields] )
-  /\
-  (pres_to_display (Dtype modNs) =
-    let modNs' = List (MAP string_to_display modNs) in
-      Item NONE "Dtype" [modNs'])
-  /\
-  (pres_to_display (Dexn modNs conN ts) =
-    let modNs' = List (MAP string_to_display modNs) in
-    let ts' = List (MAP t_to_display ts) in
-      Item NONE "Dexn" [modNs'; string_to_display conN; ts'])
-  /\
-  (pres_to_display Pany = empty_item "Pany")
-  /\
-  (pres_to_display (Pvar varN) =
-      Item NONE "Pvar" [string_to_display varN])
-  /\
-  (pres_to_display (Plit lit) =
-      Item NONE "Plit" [lit_to_display lit])
-  /\
-  (pres_to_display (Pcon conF exps) =
-    let exps' = List (MAP pres_to_display exps) in
-      Item NONE "Pcon" [conf_to_display conF; exps'])
-  /\
-  (pres_to_display (Pref exp) =
-      Item NONE "Pref" [pres_to_display exp])
-  /\
-  (pres_to_display (Ptannot exp t) =
-      Item NONE "Ptannot" [pres_to_display exp; t_to_display t])
-  /\
-  (pres_to_display (Raise tra exp) =
-      Item (SOME tra) "Raise" [pres_to_display exp])
-  /\
-  (pres_to_display (Tick tra exp) =
-      Item (SOME tra) "Tick" [pres_to_display exp])
-  /\
-  (pres_to_display (Handle tra exp expsTup) =
-    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_display e1; pres_to_display e2]) expsTup) in
-      Item (SOME tra) "Handle" [pres_to_display exp; expsTup'])
-  /\
-  (pres_to_display (Handle' tra exp varN exp2) =
-    Item (SOME tra) "Handle" [pres_to_display exp;
-                              string_to_display varN;
-                              pres_to_display exp])
-  /\
-  (pres_to_display (Var tra varN) =
-      Item (SOME tra) "Var" [string_to_display varN])
-  /\
-  (pres_to_display (Var_local tra varN) =
-      Item (SOME tra) "Var_local" [string_to_display varN])
-  /\
-  (pres_to_display (Var_global tra num) =
-      Item (SOME tra) "Var_global" [num_to_display num])
-  /\
-  (pres_to_display (Extend_global tra num) =
-      Item (SOME tra) "Extend_global" [num_to_display num])
-  /\
-  (pres_to_display (Lit tra lit) =
-      Item (SOME tra) "Lit" [lit_to_display lit])
-  /\
-  (pres_to_display (Con tra conF exps) =
-    let exps' = List (MAP pres_to_display exps) in
-      Item (SOME tra) "Pcon" [conf_to_display conF; exps'])
-  /\
-  (pres_to_display (App tra op exps) =
-    let exps' = List (MAP pres_to_display exps) in
-      Item (SOME tra) "App" [op_to_display op; exps'])
-  /\
-  (pres_to_display (Op tra op exps) =
-    let exps' = List (MAP pres_to_display exps) in
-      Item (SOME tra) "Op" [op_to_display op; exps'])
-  /\
-  (pres_to_display (Fun tra varN exp) =
-      Item (SOME tra) "Fun" [string_to_display varN; pres_to_display exp])
-  /\
-  (pres_to_display (Fn tra n0 n1 varN exp) =
-      Item (SOME tra) "Fn"
-        [option_to_display num_to_display n0;
-         option_to_display (list_to_display num_to_display) n1;
-         list_to_display string_to_display varN;
-         pres_to_display exp])
-  /\
-  (pres_to_display (Log tra lop exp1 exp2) =
-      Item (SOME tra) "Log" [lop_to_display lop; pres_to_display exp1; pres_to_display exp2])
-  /\
-  (pres_to_display (If tra exp1 exp2 exp3) =
-      Item (SOME tra) "If" [pres_to_display exp1; pres_to_display exp2; pres_to_display exp3])
-  /\
-  (pres_to_display (Mat tra exp expsTup) =
-    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_display e1; pres_to_display e2]) expsTup) in
-      Item (SOME tra) "Mat" [pres_to_display exp; expsTup'])
-  /\
-  (pres_to_display (Let tra varN exp1 exp2) =
-    let varN' = option_string_to_display varN in
-      Item (SOME tra) "Let" [varN'; pres_to_display exp1; pres_to_display exp2])
-  /\
-  (pres_to_display (Letrec tra varexpTup exp) =
-    let varexpTup' = List (MAP (\ (v1, v2, e) . Tuple [
-      string_to_display v1;
-      string_to_display v2;
-      pres_to_display e
-    ]) varexpTup) in
-      Item (SOME tra) "Letrec" [varexpTup'; pres_to_display exp])
-  /\
-  (pres_to_display (Letrec' tra n1 n2 varexpTup exp) =
-    let varexpTup' = List (MAP (\ (v1, args, e) . Tuple [
-      string_to_display v1;
-      List (MAP string_to_display args);
-      pres_to_display e
-    ]) varexpTup) in
-      Item (SOME tra) "Letrec"
+(* The clos_to_display function uses the same approach to de bruijn
+   indices as the pat_to_display function *)
+val clos_to_display_def = tDefine "clos_to_display" `
+  (clos_to_display h (Var t n) =
+    Item (SOME t) "Var" [display_num_as_varn (h-n-1)]) /\
+  (clos_to_display h (If t x1 x2 x3) =
+    Item (SOME t) "If" [clos_to_display h x1; clos_to_display h x2;
+        clos_to_display h x3]) /\
+  (clos_to_display h (closLang$Let t xs x) =
+    Item (SOME t) "Let'" [List (clos_to_display_lets h (LENGTH xs - 1) xs);
+        clos_to_display (h + LENGTH xs) x]) /\
+  (clos_to_display h (Raise t x) =
+    Item (SOME t) "Raise" [clos_to_display h x]) /\
+  (clos_to_display h (Tick t x) =
+    Item (SOME t) "Tick" [clos_to_display h x]) /\
+  (clos_to_display h (Handle t x y) =
+    Item (SOME t) "Handle" [clos_to_display h x; display_num_as_varn h;
+        clos_to_display (h+1) y]) /\
+  (clos_to_display h (Call t ticks dest xs) =
+    Item (SOME t) "Call" [num_to_display ticks; num_to_display dest;
+       List (MAP (clos_to_display h) xs)]) /\
+  (clos_to_display h (App t opt_n x xs) =
+    Item (SOME t) "App'"
+        [option_to_display num_to_display opt_n;
+         clos_to_display h x; List (MAP (clos_to_display h) xs)]) /\
+  (clos_to_display h (Fn t n1 n2 vn x) =
+    Item (SOME t) "Fn"
         [option_to_display num_to_display n1;
          option_to_display (list_to_display num_to_display) n2;
-         varexpTup';
-         pres_to_display exp])
-  /\
-  (pres_to_display (Let' tra varexpTup exp) =
-    let varexpTup' = List (MAP (\ (v1, e) . Tuple [
-      string_to_display v1;
-      pres_to_display e
-    ]) varexpTup) in
-      Item (SOME tra) "Let"
-        [varexpTup';
-         pres_to_display exp])
-  /\
-  (pres_to_display (Seq tra e1 e2) =
-    Item (SOME tra) "Seq" [pres_to_display e1; pres_to_display e2])
-  /\
-  (pres_to_display (Call tra ticks dest es) =
-    Item (SOME tra) "Call"
-      [num_to_display ticks;
-       num_to_display dest;
-       List (MAP (\e. pres_to_display e) es)])
-  /\
-  (pres_to_display (App' tra n1 e exps) =
-      Item (SOME tra) "App"
+         list_to_display string_to_display (num_to_varn_list h vn);
+         clos_to_display h x]) /\
+  (clos_to_display h (closLang$Letrec t n1 n2 es e) =
+    Item (SOME t) "Letrec'" 
         [option_to_display num_to_display n1;
-         pres_to_display e;
-         List (MAP (\e. pres_to_display e) exps)]) /\
-  (pres_to_display (CodeTable code_table) =
-    Item NONE "CodeTable"
-      [List (MAP (\(n,args,e).
-         Tuple [num_to_display n;
-                list_to_display string_to_display args;
-                pres_to_display e]) code_table)])`
- (WF_REL_TAC `measure exp_size` \\ rw []
-  \\ imp_res_tac MEM_exp_size \\ fs []
-  \\ imp_res_tac MEM_expTup_size \\ fs []
-  \\ imp_res_tac MEM_varexpTup_size \\ fs []
-  \\ imp_res_tac MEM_varexpTup1_size \\ fs []
-  \\ imp_res_tac MEM_varexpTup3_size \\ fs []
-  \\ imp_res_tac MEM_varexpTup6_size \\ fs []);
+         option_to_display (list_to_display num_to_display) n2;
+         List (clos_to_display_letrecs h (LENGTH es-1) (LENGTH es) es);
+         clos_to_display h e]) /\
+  (clos_to_display h (Op t op xs) =
+    Item (SOME t) "Op" [clos_op_to_display op;
+        List (MAP (clos_to_display h) xs)]) /\
+  (clos_to_display_lets h i [] = []) /\
+  (clos_to_display_lets h i (x::xs) =
+    Tuple [display_num_as_varn (h+i); clos_to_display h x] :: clos_to_display_lets h (i-1) xs) /\
+  (clos_to_display_letrecs h i len [] = []) /\
+  (clos_to_display_letrecs h i len ((vn,e)::es) =
+    Tuple [display_num_as_varn (h+i); 
+        list_to_display string_to_display (num_to_varn_list (h+len-1) vn);
+        clos_to_display (h+len+vn) e]
+    :: clos_to_display_letrecs h (i-1) len es)`
+ (WF_REL_TAC `measure (\x. case x of
+    | INL (_,e) => exp_size e
+    | INR (INL (_,_,es)) => exp3_size es
+    | INR (INR (_,_,_,es)) => exp1_size es)`
+  \\ rw [closLangTheory.exp_size_def]
+  \\ imp_res_tac MEM_clos_exps_size \\ fs []
+ );
 
 (* Function to construct general functions from a language to JSON. Call with
-* the name of the language and what fucntion to use to convert it to preslang to
-* obtain a function which takes a program in an intermediate language and
-* returns a JSON representation of that program. *)
+* the name of the language and what function to use to convert it to
+* displayLang to obtain a wrapper function which exports JSON. *)
 val lang_to_json_def = Define`
   lang_to_json langN func =
     \ p . Object [
       ("lang", String langN);
-      ("prog", display_to_json (pres_to_display (func p)))]`;
+      ("prog", display_to_json (func p))]`;
 
 val flat_to_json_def = Define`
-  flat_to_json = lang_to_json "flatLang" flat_to_pres`;
+  flat_to_json = lang_to_json "flatLang" flat_to_display_dec`;
 
-val con_to_json_def = Define`
-  con_to_json = lang_to_json "conLang" con_to_pres`;
-
-(* decLang uses the same structure as conLang, but the compilation step from con
-* to dec returns an expression rather than a prompt. *)
-val dec_to_json_def = Define`
-  dec_to_json = lang_to_json "decLang" con_to_pres_exp`;
-
-val exh_to_json_def = Define`
-  exh_to_json = lang_to_json "exhLang" exh_to_pres_exp`;
-
-(* pat_to_pres is initiated with a 0 because of how we want to convert de bruijn
+(* pat_to_display is initiated with a 0 because of how we want to convert de bruijn
 * indices to variable names and need to keep track of where head is at
 * currently, beginning at 0 *)
 val pat_to_json_def = Define`
-  pat_to_json = lang_to_json "patLang" (pat_to_pres_exp 0)`;
+  pat_to_json = lang_to_json "patLang" (pat_to_display 0)`;
 
 val clos_to_json_def = Define`
-  clos_to_json suffix = lang_to_json ("closLang" ++ suffix) (clos_to_pres 0)`;
-
-val clos_to_json_table_def = Define`
-  clos_to_json_table suffix =
-    lang_to_json ("closLang" ++ suffix) clos_to_pres_code`;
-    *)
+  clos_to_json suffix = lang_to_json ("closLang" ++ suffix) (clos_to_display 0)`;
 
 val _ = export_theory();

--- a/compiler/backend/riscv/riscv_configScript.sml
+++ b/compiler/backend/riscv/riscv_configScript.sml
@@ -55,7 +55,8 @@ val riscv_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(riscv_word_conf);
                stack_conf:=^(riscv_stack_conf);
-               lab_conf:=^(riscv_lab_conf)
+               lab_conf:=^(riscv_lab_conf);
+               tap_conf:=default_tap_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -51,7 +51,8 @@ val x64_backend_config_def = Define`
                word_to_word_conf:=^(word_to_word_conf);
                word_conf:=^(x64_word_conf);
                stack_conf:=^(x64_stack_conf);
-               lab_conf:=^(x64_lab_conf)
+               lab_conf:=^(x64_lab_conf);
+               tap_conf:=default_tap_config
                |>`;
 
 val _ = export_theory();

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -57,8 +57,12 @@ val def = spec32
 
 val res = translate def
 
-val def = spec32 backendTheory.compile_def
+val def = spec32 backendTheory.compile_tap_def
   |> REWRITE_RULE[max_heap_limit_32_thm]
+
+val res = translate def
+
+val def = spec32 backendTheory.compile_def
 
 val res = translate def
 
@@ -132,6 +136,7 @@ val res = translate parse_bool_def;
 val res = translate parse_num_def;
 
 val res = translate find_str_def;
+val res = translate find_strs_def;
 val res = translate find_bool_def;
 val res = translate find_num_def;
 val res = translate get_err_str_def;
@@ -149,6 +154,7 @@ val res = translate parse_wtw_conf_def;
 val res = translate parse_gc_def;
 val res = translate parse_data_conf_def;
 val res = translate parse_stack_conf_def;
+val res = translate parse_tap_conf_def;
 
 val res = translate (parse_top_config_def |> SIMP_RULE (srw_ss()) [default_heap_sz_def,default_stack_sz_def]);
 
@@ -171,6 +177,7 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 (* Rest of the translation *)
 val res = translate (extend_conf_def |> spec32 |> SIMP_RULE (srw_ss()) [MEMBER_INTRO]);
 val res = translate parse_target_32_def;
+val res = translate add_tap_output_def;
 
 val res = format_compiler_result_def
         |> Q.GENL[`bytes`,`heap`,`stack`,`c`]

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -60,8 +60,12 @@ val def = spec64
 
 val res = translate def
 
-val def = spec64 backendTheory.compile_def
+val def = spec64 backendTheory.compile_tap_def
   |> REWRITE_RULE[max_heap_limit_64_thm]
+
+val res = translate def
+
+val def = spec64 backendTheory.compile_def
 
 val res = translate def
 
@@ -135,6 +139,7 @@ val res = translate parse_bool_def;
 val res = translate parse_num_def;
 
 val res = translate find_str_def;
+val res = translate find_strs_def;
 val res = translate find_bool_def;
 val res = translate find_num_def;
 val res = translate get_err_str_def;
@@ -152,6 +157,7 @@ val res = translate parse_wtw_conf_def;
 val res = translate parse_gc_def;
 val res = translate parse_data_conf_def;
 val res = translate parse_stack_conf_def;
+val res = translate parse_tap_conf_def;
 
 val res = translate (parse_top_config_def |> SIMP_RULE (srw_ss()) [default_heap_sz_def,default_stack_sz_def]);
 
@@ -198,6 +204,7 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
 (* Rest of the translation *)
 val res = translate (extend_conf_def |> spec64 |> SIMP_RULE (srw_ss()) [MEMBER_INTRO]);
 val res = translate parse_target_64_def;
+val res = translate add_tap_output_def;
 
 val res = format_compiler_result_def
         |> Q.GENL[`bytes`,`heap`,`stack`,`c`]

--- a/compiler/bootstrap/translation/explorerProgScript.sml
+++ b/compiler/bootstrap/translation/explorerProgScript.sml
@@ -51,8 +51,6 @@ val ind_lemma = Q.prove(
   \\ fs [])
   |> update_precondition;
 
-(*
-
 val res = translate presLangTheory.num_to_hex_digit_def;
 
 val num_to_hex_digit_side = prove(
@@ -63,33 +61,16 @@ val num_to_hex_digit_side = prove(
 val res = translate presLangTheory.num_to_hex_def;
 
 val res = translate
-  (presLangTheory.word_to_hex_string_def |> INST_TYPE [``:'a``|->``:8``]);
+  (presLangTheory.display_word_to_hex_string_def |> INST_TYPE [``:'a``|->``:8``]);
 val res = translate
-  (presLangTheory.word_to_hex_string_def |> INST_TYPE [``:'a``|->``:64``]);
-
-*)
+  (presLangTheory.display_word_to_hex_string_def |> INST_TYPE [``:'a``|->``:64``]);
 
 val res = translate displayLangTheory.num_to_json_def;
 val res = translate displayLangTheory.trace_to_json_def;
 val res = translate displayLangTheory.display_to_json_def;
 
-(*
-
-val res = translate presLangTheory.op_to_display_def;
-
-val op_to_display_side = Q.prove(
-  `∀x. op_to_display_side x = T`,
-  recInduct presLangTheory.op_to_display_ind \\ rw[] \\
-  rw[Once (theorem"op_to_display_side_def")] \\
-  EVAL_TAC) |> update_precondition;
-
-val res = translate presLangTheory.pres_to_display_def;
-val res = translate presLangTheory.lang_to_json_def;
-
-val res1 = translate presLangTheory.mod_to_json_def;
-val res2 = translate presLangTheory.con_to_json_def;
-val res3 = translate presLangTheory.dec_to_json_def;
-val res4 = translate presLangTheory.exh_to_json_def;
+val res = translate presLangTheory.flat_op_to_display_def;
+val res = translate presLangTheory.tap_flat_def;
 
 val res = translate presLangTheory.num_to_varn_def;
 val num_to_varn_side = Q.prove(`
@@ -98,11 +79,17 @@ val num_to_varn_side = Q.prove(`
   rw[Once (theorem"num_to_varn_side_def")] \\
   `n MOD 26 < 26` by simp[] \\ decide_tac) |> update_precondition;
 
-val res5 = translate presLangTheory.pat_to_json_def;
-val res6 = translate presLangTheory.clos_to_json_def;
-val res7 = translate presLangTheory.clos_to_json_table_def;
+val res = translate presLangTheory.tap_flat_def;
+val res = translate presLangTheory.tap_pat_def;
+val res = translate presLangTheory.tap_clos_def;
 
-*)
+(* we can't translate the tap_word bits yet, because that's 32/64 specific.
+   that's done in the to_word* scripts. *)
+
+(* more parts of the external interface *)
+val res = translate presLangTheory.default_tap_config_def;
+val res = translate presLangTheory.mk_tap_config_def;
+val res = translate presLangTheory.tap_data_strings_def;
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -790,6 +790,10 @@ val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |>
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv32_RHS);
 
+(* translate some 32/64 specific parts of the tap/explorer
+   that can't be translated in explorerProgScript *)
+val res = translate (presLangTheory.tap_word_def |> conv32);
+
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 
 val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -790,6 +790,10 @@ val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |>
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv64_RHS);
 
+(* translate some 32/64 specific parts of the tap/explorer
+   that can't be translated in explorerProgScript *)
+val res = translate (presLangTheory.tap_word_def |> conv64);
+
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 
 val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -431,7 +431,7 @@ val format_compiler_result_def = Define`
 (* FIXME TODO: this is an awful workaround to avoid implementing a file writer
    right now. *)
 val add_tap_output_def = Define`
-  add_tap_output td out = if td = [] then out
+  add_tap_output td out = if NULL td then out
     else Append (List (strlit "compiler output with tap data\n\n"
       :: FLAT (MAP (\td. let (nm, data) = tap_data_strings td in
         [strlit "-- "; nm; strlit " --\n\n"; data;

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -90,7 +90,7 @@ val compile_def = Define`
       then OPTION_BIND (parse_sexp (add_locs input)) (sexplist sexpdec)
       else parse_prog (lexer_fun input)
     of
-    | NONE => Failure ParseError
+    | NONE => (Failure ParseError, [])
     | SOME prog =>
        let _ = empty_ffi (strlit "finished: lexing and parsing") in
        let full_prog = if c.exclude_prelude then prog else prelude ++ prog in
@@ -100,32 +100,13 @@ val compile_def = Define`
          else infertype_prog c.inferencer_config full_prog
        of
        | Failure (locs, msg) =>
-           Failure (TypeError (concat [msg; implode " at "; locs_to_string locs]))
+           (Failure (TypeError (concat [msg; implode " at ";
+               locs_to_string locs])), [])
        | Success ic =>
           let _ = empty_ffi (strlit "finished: type inference") in
-          case backend$compile c.backend_config (prelude ++ prog) of
-          | NONE => Failure CompileError
-          | SOME (bytes,c) => Success (bytes,c)`;
-
-(*
-val compile_explorer_def = Define`
-  compile_explorer c prelude input =
-    case
-      if c.input_is_sexp
-      then OPTION_BIND (parse_sexp (add_locs input)) (sexplist sexpdec)
-      else parse_prog (lexer_fun input)
-    of
-    | NONE => Failure ParseError
-    | SOME prog =>
-       let full_prog = if c.exclude_prelude then prog else prelude ++ prog in
-       case
-         if c.skip_type_inference
-         then Success c.inferencer_config
-         else infertype_prog c.inferencer_config full_prog
-       of
-       | Failure (locs, msg) => Failure (TypeError (concat [msg; implode " at "; locs_to_string locs]))
-       | Success ic => Success (backend$compile_explorer c.backend_config (prelude ++ prog))`
-*)
+          case backend$compile_tap c.backend_config (prelude ++ prog) of
+          | (NONE, td) => (Failure CompileError, td)
+          | (SOME (bytes,c), td) => (Success (bytes,c), td)`;
 
 (* The top-level compiler *)
 val error_to_str_def = Define`
@@ -159,6 +140,16 @@ val find_str_def = Define`
       SOME (extract x (strlen flag) NONE)
     else
       find_str flag xs)`
+
+(* Finds all occurences of the flag as a prefix, returning
+   the remainder in each occurence. *)
+val find_strs_def = Define`
+  (find_strs flag [] = []) /\
+  (find_strs flag (x::xs) =
+    if isPrefix flag x then
+      (extract x (strlen flag) NONE) :: find_strs flag xs
+    else
+      find_strs flag xs)`
 
 (* If flag is not present then F, else if it is present then
    we should not get any config string afterwards *)
@@ -345,6 +336,16 @@ val parse_stack_conf_def = Define`
     INL j => INL (stack with jump:=j)
   | INR s => INR s`
 
+(* tap *)
+val parse_tap_conf_def = Define`
+  parse_tap_conf ls stack =
+  let tap_all = find_str (strlit"--explore") ls in
+  let tap_all_star = (case tap_all of NONE => []
+    | SOME _ => [strlit"*"]) in
+  let taps = find_strs (strlit"--tap=") ls in
+  let fname = find_str (strlit"--tapfname=") ls in
+  INL (mk_tap_config fname (tap_all_star ++ taps))`
+
 val extend_conf_def = Define`
   extend_conf ls conf =
   let clos = parse_clos_conf ls conf.clos_conf in
@@ -352,20 +353,23 @@ val extend_conf_def = Define`
   let wtw = parse_wtw_conf ls conf.word_to_word_conf in
   let data = parse_data_conf ls conf.data_conf in
   let stack = parse_stack_conf ls conf.stack_conf in
-  case (clos,bvl,wtw,data,stack) of
-    (INL clos,INL bvl,INL wtw,INL data,INL stack) =>
+  let tap = parse_tap_conf ls conf.tap_conf in
+  case (clos,bvl,wtw,data,stack,tap) of
+    (INL clos,INL bvl,INL wtw,INL data,INL stack,INL tap) =>
       INL (conf with
         <|clos_conf         := clos;
           bvl_conf          := bvl;
           word_to_word_conf := wtw;
           data_conf         := data;
-          stack_conf        := stack|>)
+          stack_conf        := stack;
+          tap_conf          := tap|>)
     | _ =>
       INR (concat [get_err_str clos;
                get_err_str bvl;
                get_err_str wtw;
                get_err_str data;
-               get_err_str stack]) `
+               get_err_str stack;
+               get_err_str tap]) `
 
 (* Defaults to x64 if no target given *)
 val parse_target_64_def = Define`
@@ -424,6 +428,17 @@ val format_compiler_result_def = Define`
     (Success ((bytes:word8 list),(data:'a word list),(c:'a lab_to_target$config))) =
     (bytes_export (the [] c.ffi_names) heap stack bytes data, implode "")`;
 
+(* FIXME TODO: this is an awful workaround to avoid implementing a file writer
+   right now. *)
+val add_tap_output_def = Define`
+  add_tap_output td out = if td = [] then out
+    else Append (List (strlit "compiler output with tap data\n\n"
+      :: FLAT (MAP (\td. let (nm, data) = tap_data_strings td in
+        [strlit "-- "; nm; strlit " --\n\n"; data;
+          strlit "\n\n"]) td)
+      ++ [strlit "-- compiled data --\n\n"]))
+      out`;
+
 (* The top-level compiler with everything instantiated except it doesn't do exporting *)
 
 (* The top-level compiler with almost everything instantiated except the top-level configuration *)
@@ -443,20 +458,21 @@ val compile_64_def = Define`
              exclude_prelude     := prelude;
              skip_type_inference := typeinfer |> in
         (case compiler$compile compiler_conf basis input of
-          Success (bytes,data,c) =>
-            (export (the [] c.ffi_names) heap stack bytes data, implode "")
-        | Failure err => (List [],error_to_str err))
+          (Success (bytes,data,c), td) =>
+            (add_tap_output td (export (the [] c.ffi_names) heap stack bytes data),
+              implode "")
+        | (Failure err, td) => (add_tap_output td (List []), error_to_str err))
     | INR err =>
-    (List[],error_to_str (ConfigError (get_err_str ext_conf))))
+    (List[], error_to_str (ConfigError (get_err_str ext_conf))))
   | _ =>
-    (List[],error_to_str (ConfigError (concat [get_err_str confexp;get_err_str topconf])))`
+    (List[], error_to_str (ConfigError (concat [get_err_str confexp;get_err_str topconf])))`
 
 val full_compile_64_def = Define `
   full_compile_64 cl inp fs =
     if has_version_flag cl then
       add_stdout fs current_build_info_str
     else
-      let (out,err) = compile_64 cl inp in
+      let (out, err) = compile_64 cl inp in
       add_stderr (add_stdout (fastForwardFD fs 0) (concat (append out))) err`
 
 val compile_32_def = Define`
@@ -475,20 +491,21 @@ val compile_32_def = Define`
              exclude_prelude     := prelude;
              skip_type_inference := typeinfer |> in
         (case compiler$compile compiler_conf basis input of
-          Success (bytes,data,c) =>
-            (export (the [] c.ffi_names) heap stack bytes data, implode "")
-        | Failure err => (List [],error_to_str err))
+          (Success (bytes,data,c), td) =>
+            (add_tap_output td (export (the [] c.ffi_names) heap stack bytes data),
+              implode "")
+        | (Failure err, td) => (List [], error_to_str err))
     | INR err =>
-    (List[],error_to_str (ConfigError (get_err_str ext_conf))))
+    (List[], error_to_str (ConfigError (get_err_str ext_conf))))
   | _ =>
-    (List[],error_to_str (ConfigError (concat [get_err_str confexp;get_err_str topconf])))`
+    (List[], error_to_str (ConfigError (concat [get_err_str confexp;get_err_str topconf])))`
 
 val full_compile_32_def = Define `
   full_compile_32 cl inp fs =
     if has_version_flag cl then
       add_stdout fs current_build_info_str
     else
-      let (out,err) = compile_32 cl inp in
+      let (out, err) = compile_32 cl inp in
       add_stderr (add_stdout (fastForwardFD fs 0) (concat (append out))) err`
 
 val _ = export_theory();


### PR DESCRIPTION
These changes restore some of the presLang/explorer mechanism that has been largely commented out. Since the top-level is involved, there's a fair bit of extra fiddling scattered around in making sure the translation runs and the top-level theorems are intact.

The mechanism is fairly primitive at this stage. Few phases are tapped, and the performance is likely to be awful, and the output has to be clunked together with the compiler's actual output to avoid rephrasing a lot of the top-level theorems. Room for improvement, but it will be good to have something functioning.