### PR TITLE
Translator performance changes

### DIFF
--- a/characteristic/cfMainScript.sml
+++ b/characteristic/cfMainScript.sml
@@ -36,8 +36,7 @@ val call_main_thm1 = Q.store_thm("call_main_thm1",
   \\ fs [terminationTheory.evaluate_def,PULL_EXISTS,pair_case_eq,
          result_case_eq,do_con_check_def,build_conv_def,bool_case_eq,
          ml_progTheory.lookup_var_def,option_case_eq,match_result_case_eq,
-         EVAL ``nsLookup (merge_env env2 env1).v (Short fname)``,app_def,
-         app_basic_def]
+         ml_progTheory.nsLookup_merge_env,app_def,app_basic_def]
   \\ first_x_assum drule \\ fs [] \\ strip_tac \\ fs []
   \\ fs [cfHeapsBaseTheory.POSTv_def]
   \\ Cases_on `r` \\ fs [cond_STAR] \\ fs [cond_def]

--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -95,6 +95,8 @@ val reducible_pats = [
   ``do_con_check _ _ _``,
   ``build_conv _ _ _``,
   ``nsLookup _ _``,
+  ``nsLookup_Short _ _``,
+  ``nsLookup_Mod1 _ _``,
   ``Fun_body _``
 ]
 

--- a/misc/Holmakefile
+++ b/misc/Holmakefile
@@ -2,7 +2,7 @@ INCLUDES = ../developers lem_lib_stub $(HOLDIR)/examples/machine-code/hoare-trip
 
 CLINE_OPTIONS = --qof
 
-all: README.md preamble.uo miscTheory.uo basicComputeLib.uo
+all: README.md preamble.uo miscTheory.uo basicComputeLib.uo alist_treeTheory.uo alist_treeLib.uo
 .PHONY: all
 
 README_SOURCES = preamble.sml miscScript.sml basicComputeLib.sml

--- a/misc/alist_treeLib.sig
+++ b/misc/alist_treeLib.sig
@@ -1,0 +1,52 @@
+(* Code to recall that some partial functions (of type 'a -> 'b option)
+can be represented as sorted alists, and derive a fast conversion on
+applications of those functions. *)
+
+signature alist_treeLib = sig
+
+include Abbrev
+
+(* Syntax *)
+val alookup_tm : term;
+val option_choice_tm : term;
+val repr_tm : term;
+
+(* The repr set type *)
+type 'a alist_reprs
+
+(*
+   Representations of partial functions using sorted trees.
+   Requires a relation R and a theorem that shows
+   it is irreflexive and transitive. The destructor maps terms
+   of the domain type to some type that can be sorted in ML.
+   The conversion must prove R x y for any x, y where x is
+   sorted before y by the destructor and comparison.
+*)
+val mk_alist_reprs : thm -> conv -> (term -> 'a)
+    -> (('a * 'a) -> order) -> 'a alist_reprs
+
+(*
+   The representation set contains representations of various
+   partial functions, initially none.
+*)
+val peek_functions_in_rs : 'a alist_reprs -> term list
+
+(*
+   Adds a function's representation.
+
+   Requires a theorem f = rhs with a valid rhs.
+   A valid rhs is:
+     - ALOOKUP xs
+     - a function g in the repr set.
+     - option_choice_f of two valid rhs values
+*)
+val add_alist_repr : 'a alist_reprs -> thm -> unit
+
+(*
+   Converts f x to a concrete value (SOME y/NONE)
+   for functions f in the repr set.
+*)
+val reprs_conv : 'a alist_reprs -> conv
+
+end
+

--- a/misc/alist_treeLib.sml
+++ b/misc/alist_treeLib.sml
@@ -1,0 +1,339 @@
+(* Code to recall that some partial functions (of type 'a -> 'b option)
+can be represented as sorted alists, and derive a fast conversion on
+applications of those functions. *)
+
+structure alist_treeLib = struct
+
+open preamble alist_treeTheory
+
+(* the repr set object *)
+datatype 'a alist_reprs = AList_Reprs of {R_thm: thm, conv: conv,
+    dest: term -> 'a, cmp: ('a * 'a) -> order,
+    dict: (term, thm) Redblackmap.dict ref}
+
+fun mk_alist_reprs R_thm conv dest cmp
+    = AList_Reprs {R_thm = R_thm, conv = conv, cmp = cmp,
+        dest = dest, dict = ref (Redblackmap.mkDict Term.compare)}
+
+(* constructing is_insert thms *)
+
+val count_append_tm = ``count_append``;
+
+fun find_key_rec is_last [] = raise Empty
+  | find_key_rec is_last (t :: ts) = if listSyntax.is_nil t
+  then find_key_rec is_last ts
+  else let
+    val (f, xs) = strip_comb t
+    val do_rev = if is_last then rev else I
+  in if same_const f count_append_tm
+    then find_key_rec is_last (do_rev (tl xs) @ ts)
+    else hd (do_rev (fst (listSyntax.dest_list t))) end
+
+fun hd_key t = find_key_rec false [t] |> pairSyntax.dest_pair |> fst
+fun last_key t = find_key_rec true [t] |> pairSyntax.dest_pair |> fst
+
+fun mk_singleton x = listSyntax.mk_list ([x], type_of x)
+
+val err = mk_HOL_ERR "mltree?"
+
+val simp_count_append = SIMP_CONV bool_ss [count_append_HD_LAST, pairTheory.FST]
+
+fun assume_prems thm = if not (is_imp (concl thm)) then thm
+  else let
+    val thm = CONV_RULE (RATOR_CONV simp_count_append) thm
+    val l_asm = fst (dest_imp (concl thm))
+    val prem = if l_asm = T then TRUTH else ASSUME l_asm
+  in
+    assume_prems (MP thm prem)
+  end
+
+val is_insert_tm = ``is_insert``
+val count_append_tm = ``count_append``
+
+fun do_inst_mp insts mp_thm arg_thm = let
+    val (prem, _) = dest_imp (concl mp_thm)
+    fun rerr e s = let
+        val m = s ^ ": " ^ #message e
+      in print ("error in do_inst_mp: " ^ m ^ "\n");
+        print_thm mp_thm; print "\n"; print_thm arg_thm; print "\n";
+        raise (err "do_inst_mp" m) end
+    val (more_insts, ty_insts) = match_term prem (concl arg_thm)
+      handle HOL_ERR e => rerr e "match_term"
+    val ty_i_thm = INST_TYPE ty_insts mp_thm
+    val ithm = INST (more_insts @ insts) ty_i_thm
+      handle HOL_ERR e => rerr e "INST"
+  in MP ithm arg_thm handle HOL_ERR e => rerr e "MP" end
+
+fun build_insert (dest : term -> 'a) cmp R k x =
+  let
+    val dest_k = dest k
+    fun chk thm = if same_const is_insert_tm (fst (strip_comb (concl thm)))
+      then thm
+      else (print "Not an insert_tm:\n"; print_thm thm; print "\n";
+        raise (err "build_insert" "check"))
+    val pp = chk o assume_prems
+    fun build t = if listSyntax.is_nil t
+      then pp (ISPECL [R, k, x] is_insert_to_empty)
+      else if listSyntax.is_cons t then let
+        val (xs, _) = listSyntax.dest_list t
+        val _ = length xs = 1 orelse raise (err "build_insert" "malformed")
+        val v = hd xs
+      in case cmp (dest_k, dest (fst (pairSyntax.dest_pair v))) of
+          EQUAL => pp (ISPECL [R, k, x, v] is_insert_overwrite)
+        | GREATER => pp (ISPECL [R, k, x, t] is_insert_far_right)
+        | LESS => pp (ISPECL [R, k, x, t] is_insert_far_left)
+      end else let
+        val (f, xs) = strip_comb t
+        val _ = same_const count_append_tm f
+           orelse raise (err "build_insert" "unknown")
+        val (n, l, r) = case xs of [n, l, r] => (n, l, r)
+           | _ => raise (err "build_insert" "num args")
+        fun vsub nm v = [mk_var (nm, type_of v) |-> v]
+      in if not (cmp (dest_k, dest (hd_key r)) = LESS)
+        then do_inst_mp (vsub "l" l) (SPEC n is_insert_r) (build r)
+        else if cmp (dest_k, dest (last_key l)) = GREATER
+        then pp (ISPECL [R, n, l, r, k, x] is_insert_centre)
+        else do_inst_mp (vsub "r" r) (SPEC n is_insert_l) (build l)
+      end
+  in build end
+
+fun prove_assum_by_conv conv thm = let
+    val (x,y) = dest_imp (concl thm)
+    val thm = CONV_RULE ((RATOR_CONV o RAND_CONV) conv) thm
+  in MP thm TRUTH handle HOL_ERR e =>
+    (print "Failed to prove assum by conv:\n";
+      print_term x;
+      print "\n  -- reduced to:\n";
+      print_term (fst (dest_imp (concl thm)));
+      raise HOL_ERR e)
+  end
+
+(* balancing count_append trees *)
+fun get_depth tm = let
+    val (f, xs) = strip_comb tm
+  in if same_const f count_append_tm
+    then numSyntax.int_of_term (hd xs)
+    else if listSyntax.is_cons tm then 1
+    else raise (err "get_depth" "unknown")
+  end
+
+fun balance iter bias tm = if iter > 1000 then
+    (print "error: looping balance\n"; print_term tm;
+        raise (err "balance" "looping"))
+  else let
+    val (f, xs) = strip_comb tm
+    val _ = same_const f count_append_tm orelse raise UNCHANGED
+    val _ = is_arb (hd xs) orelse bias <> "N" orelse raise UNCHANGED
+    val step_conv = (RAND_CONV (balance 0 "N"))
+        THENC (RATOR_CONV (RAND_CONV (balance 0 "N")))
+    val thm = QCONV step_conv tm
+    val tm = rhs (concl thm)
+    val l_sz = get_depth (rand (rator tm))
+    val r_sz = get_depth (rand tm)
+    val reb = if l_sz > (r_sz + 1) orelse (bias = "R" andalso l_sz > r_sz)
+        then "R"
+        else if r_sz > (l_sz + 1) orelse (bias = "L" andalso r_sz > l_sz)
+        then "L" else "N"
+    val conv1 = if reb = "R" then RATOR_CONV (RAND_CONV (balance 0 "L"))
+        else if reb = "L" then RAND_CONV (balance 0 "R") else ALL_CONV
+    val conv2 = if reb = "R" then REWR_CONV balance_r
+        else if reb = "L" then REWR_CONV balance_l else ALL_CONV
+    val thm = CONV_RULE (QCONV (RHS_CONV (conv1 THENC conv2 THENC step_conv))) thm
+    val tm = rhs (concl thm)
+    val l_sz = get_depth (rand (rator tm))
+    val r_sz = get_depth (rand tm)
+    val sz = numSyntax.term_of_int (1 + Int.max (l_sz, r_sz))
+    val set = REWR_CONV (set_count |> SPEC sz)
+    val final = if Int.abs (l_sz - r_sz) < 2 then set else balance (iter + 1) "N"
+  in CONV_RULE (RHS_CONV final) thm end
+
+fun prove_insert R conv dest cmp k x al = let
+    val thm = build_insert dest cmp R k x al
+    fun prove thm = if not (is_imp (concl thm)) then thm
+      else prove (prove_assum_by_conv conv thm)
+  in thm |> DISCH_ALL |> prove |> CONV_RULE (RAND_CONV (balance 0 "N")) end
+
+(* making repr theorems *)
+
+val alookup_tm = ``ALOOKUP``;
+val option_choice_tm = ``option_choice_f``;
+
+fun is_short_list xs = listSyntax.is_nil xs
+    orelse total (listSyntax.is_nil o snd o listSyntax.dest_cons) xs = SOME true
+
+fun mk_insert_repr (AList_Reprs rs) prev_repr k_x = let
+    val (k, x) = pairSyntax.dest_pair k_x
+    val (R, al) = case strip_comb (concl prev_repr)
+      of (_, [R, al, _]) => (R, al)
+        | _ => raise (err "mk_insert_repr" "unexpected")
+    val insert = prove_insert R (#conv rs) (#dest rs) (#cmp rs) k x al
+  in MATCH_MP repr_insert (CONJ prev_repr insert) end
+
+fun mk_repr_step rs tm = let
+    val (AList_Reprs inn_rs) = rs
+    val (f, xs) = strip_comb tm
+    val is_empty = total (optionSyntax.is_none o snd o dest_abs) tm = SOME true
+    val is_alookup = same_const alookup_tm f
+    val is_short = is_alookup andalso total (is_short_list o hd) xs = SOME true
+    val merge_lhs = if same_const option_choice_tm f then [hd xs] else []
+    val merge_unknown = exists ((fn t => not (same_const t alookup_tm
+        orelse same_const t option_choice_tm)) o fst o strip_comb) merge_lhs
+    val merge_alookup_xs = map strip_comb merge_lhs
+        |> filter (same_const alookup_tm o fst) |> map (hd o snd)
+    val is_insert = exists (fn xs => not (listSyntax.is_nil xs)
+        andalso is_short_list xs) merge_alookup_xs
+  in if is_empty
+    then MATCH_MP (MATCH_MP repr_empty (#R_thm inn_rs)) (REFL tm)
+    else if is_short
+    then MATCH_MP (ISPEC (hd xs) alist_repr_refl) (#R_thm inn_rs)
+        |> prove_assum_by_conv (SIMP_CONV list_ss [sortingTheory.SORTED_DEF])
+    else if is_insert
+    then mk_insert_repr rs (mk_repr rs (rand tm))
+        (fst (listSyntax.dest_cons (hd merge_alookup_xs)))
+    else if merge_unknown
+    then let
+        val l_repr_thm = mk_repr rs (hd xs)
+        val l_repr_al = rand (rator (concl l_repr_thm))
+        val look = mk_icomb (alookup_tm, l_repr_al)
+        val half_repr = list_mk_icomb (option_choice_tm, [look, List.last xs])
+        val next_repr = mk_repr rs half_repr
+      in MATCH_MP alist_repr_choice_trans_left (CONJ l_repr_thm next_repr) end
+    else if not (null merge_lhs) orelse is_alookup
+    then CHANGED_CONV (SIMP_CONV bool_ss [alookup_to_option_choice,
+                option_choice_f_assoc, alookup_empty_option_choice_f]) tm
+    else raise err "mk_repr_step" ("no step for: " ^ Parse.term_to_string f)
+  end
+and mk_repr_known_step (AList_Reprs inn_rs) tm =
+  case Redblackmap.peek (! (#dict inn_rs), tm) of
+    SOME thm => thm
+  | NONE => mk_repr_step (AList_Reprs inn_rs) tm
+and mk_repr rs tm = let
+    val thm = mk_repr_known_step rs tm
+  in if is_eq (concl thm)
+    then mk_repr_known_step rs (rhs (concl thm))
+      |> CONV_RULE (RAND_CONV (REWR_CONV (SYM thm)))
+    else thm
+  end
+
+fun add_alist_repr rs thm = let
+    val AList_Reprs inn_rs = rs
+    val (f, rhs) = dest_eq (concl thm)
+    val repr_thm = case Redblackmap.peek (! (#dict inn_rs), rhs) of
+        SOME rhs_thm => if is_eq (concl rhs_thm)
+          then TRANS thm rhs_thm
+          else thm
+      | NONE => (mk_repr rs rhs
+        |> CONV_RULE (RAND_CONV (REWR_CONV (SYM thm))))
+  in
+    #dict inn_rs := Redblackmap.insert (! (#dict inn_rs), f, repr_thm)
+  end
+
+fun timeit msg f v = let
+    val start = Portable.timestamp ()
+    val r = f v
+    val time = Portable.timestamp () - start
+  in print ("Time to " ^ msg ^ ": " ^ Portable.time_to_string time ^ "\n");
+    r end
+
+(* testing *)
+
+fun test_rs () = let
+    val _ = load "comparisonTheory";
+    val thm1 = DB.fetch "comparison" "good_cmp_Less_irrefl_trans"
+    val thm2 = DB.fetch "comparison" "num_cmp_good"
+    val R_thm = MATCH_MP thm1 thm2
+  in mk_alist_reprs R_thm EVAL numSyntax.int_of_term Int.compare end
+
+fun test_mk_alookup ns = let
+    open numSyntax
+    val _ = I
+    fun f i = ((i * 157) mod 1000)
+    fun el i = pairSyntax.mk_pair (term_of_int (f i), term_of_int i)
+  in mk_icomb (alookup_tm, listSyntax.mk_list (map el ns, type_of (el 0))) end
+
+fun test_200 rs = let
+    val al1 = test_mk_alookup (upto 1 200)
+    val al2 = test_mk_alookup [1, 4, 3]
+    val merge = list_mk_icomb (option_choice_tm, [al1, al2])
+  in mk_repr rs merge end
+
+(*
+val rs = test_rs ()
+val thm_200 = timeit "build repr" test_200 rs
+*)
+
+(* proving and using is_lookup thms *)
+val is_lookup_tm = ``is_lookup``;
+
+fun build_lookup (dest : term -> 'a) cmp R k =
+  let
+    val dest_k = dest k
+    fun chk thm = if same_const is_lookup_tm (fst (strip_comb (concl thm)))
+      then thm
+      else (print "Not a lookup_tm:\n"; print_thm thm; print "\n";
+        raise (err "build_lookup" "check"))
+    val pp = chk o assume_prems
+    fun build t = if listSyntax.is_nil t
+      then pp (ISPECL [R, k] is_lookup_empty)
+      else if listSyntax.is_cons t then let
+        val (xs, _) = listSyntax.dest_list t
+        val _ = length xs = 1 orelse raise (err "build_insert" "malformed")
+        val (k', v) = pairSyntax.dest_pair (hd xs)
+      in case cmp (dest_k, dest k') of
+          EQUAL => pp (ISPECL [R, k, k', v] is_lookup_hit)
+        | GREATER => pp (ISPECL [R, k, k', v] is_lookup_far_right)
+        | LESS => pp (ISPECL [R, k, k', v] is_lookup_far_left)
+      end else let
+        val (f, xs) = strip_comb t
+        val _ = same_const count_append_tm f
+           orelse raise (err "build_lookup" "unknown")
+        val (n, l, r) = case xs of [n, l, r] => (n, l, r)
+           | _ => raise (err "build_lookup" "num args")
+        fun vsub nm v = [mk_var (nm, type_of v) |-> v]
+      in if not (cmp (dest_k, dest (hd_key r)) = LESS)
+        then do_inst_mp (vsub "l" l) (SPEC n is_lookup_r) (build r)
+        else if cmp (dest_k, dest (last_key l)) = GREATER
+        then pp (ISPECL [R, n, l, r, k] is_lookup_centre)
+        else do_inst_mp (vsub "r" r) (SPEC n is_lookup_l) (build l)
+      end
+  in build end
+
+fun prove_lookup R conv dest cmp k al = let
+    val thm = build_lookup dest cmp R k al
+    fun prove thm = if not (is_imp (concl thm)) then thm
+      else prove (prove_assum_by_conv conv thm)
+  in thm |> DISCH_ALL |> prove end
+
+val repr_tm = ``sorted_alist_repr``;
+
+fun repr_prove_lookup conv dest cmp repr_thm k = let
+    val (f, xs) = strip_comb (concl repr_thm)
+    val f = same_const f repr_tm orelse
+        raise (err "repr_prove_lookup" "unexpected")
+    val (R, al, f) = case xs of [R, al, f] => (R, al, f)
+        | _ => raise (err "repr_prove_lookup" "num args")
+    val lookup = prove_lookup R conv dest cmp k al
+  in MATCH_MP lookup_repr (CONJ repr_thm lookup) end
+
+fun reprs_conv rs tm = let
+    val AList_Reprs inn_rs = rs
+    val (f, x) = dest_comb tm handle HOL_ERR _ => raise UNCHANGED
+    val repr_thm = case Redblackmap.peek (! (#dict inn_rs), f) of
+      NONE => raise UNCHANGED | SOME thm => thm
+  in repr_prove_lookup (#conv inn_rs) (#dest inn_rs) (#cmp inn_rs)
+    repr_thm x end
+
+fun test_f_def () = new_definition ("f", mk_eq (``f : num -> num option``,
+    test_mk_alookup (upto 1 300)));
+
+fun extract_test rs i = mk_comb (``f : num -> num option``,
+    numSyntax.term_of_int i)
+  |> reprs_conv rs
+
+fun extract_test_1000 rs = let
+    val res1 = timeit "add def" (add_alist_repr rs) (test_f_def ())
+    val res2 = timeit "map extract" (map (extract_test rs)) (upto 1 1000)
+  in res2 end
+
+end
+

--- a/misc/alist_treeLib.sml
+++ b/misc/alist_treeLib.sml
@@ -332,16 +332,14 @@ fun reprs_conv rs tm = let
         repr_thm x
   end
 
-fun test_f_def () = new_definition ("f", mk_eq (``f : num -> num option``,
-    test_mk_alookup (upto 1 300)));
-
-fun extract_test rs i = mk_comb (``f : num -> num option``,
-    numSyntax.term_of_int i)
-  |> reprs_conv rs
+fun extract_test f rs i = mk_comb (f, numSyntax.term_of_int i) |> reprs_conv rs
 
 fun extract_test_1000 rs = let
-    val res1 = timeit "add def" (add_alist_repr rs) (test_f_def ())
-    val res2 = timeit "map extract" (map (extract_test rs)) (upto 1 1000)
+    val alookup = test_mk_alookup (upto 1 300)
+    val f = mk_var ("f", type_of alookup)
+    val f_def = new_definition ("f", mk_eq (f, alookup))
+    val res1 = timeit "add def" (add_alist_repr rs) f_def
+    val res2 = timeit "map extract" (map (extract_test f rs)) (upto 1 1000)
   in res2 end
 
 end

--- a/misc/alist_treeScript.sml
+++ b/misc/alist_treeScript.sml
@@ -1,0 +1,315 @@
+open HolKernel bossLib boolLib boolSimps libTheory rich_listTheory
+
+val _ = new_theory "alist_tree";
+
+(* key property: a partial function f can be represented by an assoc list
+   al which is known to be sorted according to R *)
+val sorted_alist_repr_def = Define `
+  sorted_alist_repr R al f = (SORTED R (MAP FST al) /\ irreflexive R
+    /\ transitive R /\ (f = ALOOKUP al))`;
+
+(* inserts on sorted alists *)
+
+val count_append_def = Define `
+  count_append (n : num) xs ys = APPEND xs ys`;
+
+val is_insert_def = Define `
+  is_insert frame_l frame_r R k x al al'
+    = (irreflexive R /\ transitive R ==>
+        SORTED R (MAP FST al) ==> ((ALOOKUP al' = ALOOKUP ((k, x) :: al)) /\
+        (frame_l ==> ~ (al = []) /\ (FST (HD al') = FST (HD al))) /\
+        (frame_r ==> ~ (al = []) /\ (FST (LAST al') = FST (LAST al))) /\
+        SORTED R (MAP FST al')))`;
+
+val HD_APPEND = Q.store_thm ("HD_APPEND",
+  `HD (xs ++ ys) = (if xs = [] then HD ys else HD xs)`,
+  Induct_on `xs` \\ fs []);
+
+val LAST_APPEND = Q.store_thm ("HD_APPEND",
+  `LAST (xs ++ ys) = (if ys = [] then LAST xs else LAST ys)`,
+  Cases_on `ys` \\ fs []);
+
+val HD_MAP = Q.store_thm ("HD_MAP",
+  `~ (xs = []) ==> (HD (MAP f xs) = f (HD xs))`,
+  Cases_on `xs` \\ fs []);
+
+val HD_MEM = Q.store_thm ("HD_MEM",
+  `~ (xs = []) ==> MEM (HD xs) xs`,
+  Cases_on `xs` \\ fs []);
+
+val is_insert_l = Q.store_thm ("is_insert_l",
+  `!n. is_insert fl T R k x l l' ==>
+    is_insert fl T R k x (count_append n l r) (count_append ARB l' r)`,
+  fs [is_insert_def, count_append_def, sortingTheory.SORTED_APPEND_IFF,
+    alistTheory.ALOOKUP_APPEND, FUN_EQ_THM, HD_APPEND, LAST_APPEND,
+    listTheory.LAST_MAP]
+  \\ ((Cases_on `l'` \\ fs []) >- metis_tac [optionTheory.option_CLAUSES])
+  \\ (Cases_on `l = []` \\ fs [])
+  \\ fs [listTheory.LAST_MAP]
+  \\ (rpt strip_tac \\ fs [] \\ CASE_TAC)
+  );
+
+val SORTED_APPEND_trans_IFF = Q.store_thm ("SORTED_APPEND_trans_IFF",
+  `transitive R ==> (SORTED R (xs ++ ys) = (SORTED R xs /\ SORTED R ys /\
+    (!x y. MEM x xs ==> MEM y ys ==> R x y)))`,
+  Induct_on `xs` \\ fs [sortingTheory.SORTED_EQ] \\ metis_tac []);
+
+val insert_fl_R = Q.store_thm ("insert_fl_R",
+  `is_insert fl fr R k x al al' ==> fl ==> SORTED R (MAP FST al)
+    ==> irreflexive R /\ transitive R
+    ==> (k = FST (HD al)) \/ R (HD (MAP FST al)) k`,
+  fs [is_insert_def, FUN_EQ_THM]
+  \\ rpt strip_tac
+  \\ fs []
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `k`)
+  \\ fs []
+  \\ strip_tac
+  \\ FIRST_X_ASSUM (MP_TAC o MATCH_MP alistTheory.ALOOKUP_MEM)
+  \\ (Cases_on `al'` \\ fs [sortingTheory.SORTED_EQ])
+  \\ fs [listTheory.MEM_MAP, pairTheory.EXISTS_PROD, HD_MAP]
+  \\ metis_tac [pairTheory.FST]);
+
+val insert_fl_R_append = Q.store_thm ("insert_fl_R_append",
+  `is_insert T fr R k x r r'
+    ==> SORTED R (MAP FST (l ++ r))
+    ==> irreflexive R /\ transitive R
+    ==> ~ MEM k (MAP FST l)`,
+  strip_tac
+  \\ FIRST_ASSUM (MP_TAC o MATCH_MP insert_fl_R)
+  \\ fs [METIS_PROVE [] ``b \/ c <=> ~b ==> c``]
+  \\ rpt strip_tac
+  \\ fs [SORTED_APPEND_trans_IFF, is_insert_def]
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `k`)
+  \\ fs []
+  \\ (Cases_on `HD r` \\ Cases_on `r` \\ fs [])
+  \\ metis_tac [relationTheory.transitive_def, relationTheory.irreflexive_def]);
+
+val is_insert_r = Q.store_thm ("is_insert_r",
+  `!n. is_insert T fr R k x r r' ==>
+    is_insert T fr R k x (count_append n l r) (count_append ARB l r')`,
+  rpt strip_tac
+  \\ MP_TAC insert_fl_R_append
+  \\ fs [is_insert_def, count_append_def, sortingTheory.SORTED_APPEND_IFF,
+    alistTheory.ALOOKUP_APPEND, FUN_EQ_THM, HD_APPEND, LAST_APPEND, HD_MAP]
+  \\ ((Cases_on `r'` \\ fs []) >- metis_tac [optionTheory.option_CLAUSES])
+  \\ (rpt strip_tac \\ rpt (CHANGED_TAC (rfs [HD_MAP] \\ fs [])))
+  \\ rpt (CASE_TAC \\ fs [])
+  \\ FIRST_ASSUM (MP_TAC o MATCH_MP alistTheory.ALOOKUP_MEM)
+  \\ metis_tac [listTheory.MEM_MAP, pairTheory.FST]);
+
+val is_insert_to_empty = Q.store_thm ("is_insert_to_empty",
+  `!R k x. is_insert F F R k x [] [(k, x)]`,
+  fs [is_insert_def]);
+
+val is_insert_overwrite = Q.store_thm ("is_insert_overwrite",
+  `!R k x v. (FST v = k) ==> is_insert T T R k x [v] [(k, x)]`,
+  Cases_on `v` \\ fs [is_insert_def, FUN_EQ_THM]);
+
+val sorted_fst_insert_centre = Q.store_thm ("sorted_fst_insert_centre",
+  `!k. SORTED R (MAP FST l ++ MAP FST r) ==>
+    (~ (l = []) ==> R (FST (LAST l)) k) ==>
+    (~ (r = []) ==> R k (FST (HD r))) ==>
+    SORTED R (MAP FST l ++ (k :: MAP FST r))`,
+  Cases_on `r` \\ Cases_on `l` \\ fs [sortingTheory.SORTED_APPEND_IFF,
+        sortingTheory.SORTED_DEF, listTheory.LAST_MAP, HD_MAP]);
+
+val is_insert_centre_rule = Q.store_thm ("is_insert_centre_rule",
+  `(fl ==> ~ (l = [])) ==> (~ (l = []) ==> R (FST (LAST l)) k) ==>
+    (fr ==> ~ (r = [])) ==> (~ (r = []) ==> R k (FST (HD r))) ==>
+    is_insert fl fr R k x (count_append n l r)
+        (count_append ARB l (count_append ARB [(k, x)] r))`,
+  fs [is_insert_def, count_append_def, HD_APPEND, LAST_APPEND,
+    listTheory.LAST_CONS_cond]
+  \\ rpt disch_tac
+  \\ FIRST_X_ASSUM (MP_TAC o MATCH_MP (Q.SPEC `k` sorted_fst_insert_centre))
+  \\ fs [SORTED_APPEND_trans_IFF]
+  \\ fs [FUN_EQ_THM, alistTheory.ALOOKUP_APPEND]
+  \\ rpt (strip_tac \\ fs [])
+  \\ rpt (CASE_TAC \\ fs [])
+  \\ FIRST_ASSUM (MP_TAC o MATCH_MP alistTheory.ALOOKUP_MEM)
+  \\ fs [listTheory.MEM_MAP, pairTheory.EXISTS_PROD]
+  \\ metis_tac [relationTheory.irreflexive_def]); 
+
+val is_insert_centre = save_thm ("is_insert_centre",
+  is_insert_centre_rule |> Q.GENL [`fl`, `fr`, `R`, `n`, `l`, `r`, `k`, `x`]
+    |> SPECL [T, T] |> CONV_RULE (SIMP_CONV bool_ss []));
+
+val is_insert_far_left = Q.store_thm ("is_insert_far_left",
+  `!R k x xs. ~ (xs = []) ==> R k (FST (HD xs)) ==>
+    is_insert F T R k x xs (count_append ARB [(k, x)] xs)`,
+  Cases_on `xs` \\ fs [is_insert_def, count_append_def,
+    sortingTheory.SORTED_DEF]);
+
+val is_insert_far_right = Q.store_thm ("is_insert_far_right",
+  `!R k x xs. ~ (xs = []) ==> R (FST (LAST xs)) k ==>
+    is_insert T F R k x xs (count_append ARB xs [(k, x)])`,
+  rpt strip_tac
+  \\ MP_TAC (Q.GENL [`fl`, `fr`, `r`, `l`, `x`] is_insert_centre_rule
+    |> Q.SPECL [`T`, `F`, `[]`, `xs`, `x`])
+  \\ fs [is_insert_def, count_append_def]);
+
+(* bookkeeping and balancing count_append trees *)
+
+val count_append_HD_LAST = Q.store_thm ("count_append_HD_LAST",
+  `(HD (count_append i (count_append j xs ys) zs)
+    = HD (count_append 0 xs (count_append 0 ys zs))) /\
+    (HD (count_append i (x :: xs) ys) = x) /\
+    (HD (count_append i [] ys) = HD ys) /\
+    (LAST (count_append i xs (count_append j ys zs))
+        = LAST (count_append 0 (count_append 0 xs ys) zs)) /\
+    (LAST (count_append i xs (y :: ys)) = LAST (y :: ys)) /\
+    (LAST (count_append i xs []) = LAST xs) /\
+    (HD (x :: xs) = x) /\
+    (LAST (x :: y :: zs) = LAST (y :: zs)) /\
+    (LAST [x] = x) /\
+    ((count_append i (count_append j xs ys) zs = []) =
+        (count_append 0 xs (count_append 0 ys zs) = [])) /\
+    ((count_append i [] ys = []) = (ys = [])) /\
+    ((count_append i (x :: xs) ys = []) = F) /\
+    ((x :: xs = []) = F)`,
+  fs [count_append_def]);
+
+val balance_r = Q.store_thm ("balance_r",
+  `count_append i (count_append j xs ys) zs
+     = count_append ARB xs (count_append ARB ys zs)`,
+  fs [count_append_def]);
+
+val balance_l = Q.store_thm ("balance_l",
+  `count_append i xs (count_append j ys zs)
+     = count_append ARB (count_append ARB xs ys) zs`,
+  fs [count_append_def]);
+
+val set_count = Q.store_thm ("set_count",
+  `!j. count_append i xs ys = count_append j xs ys`,
+  fs [count_append_def]);
+
+(* reprs of various partial function constructions *)
+val option_choice_f_def = Define `
+  option_choice_f f g = (\x. OPTION_CHOICE (f x) (g x))`;
+
+val alookup_append_option_choice_f = Q.store_thm (
+  "alookup_append_option_choice_f",
+  `ALOOKUP (xs ++ ys) = option_choice_f (ALOOKUP xs) (ALOOKUP ys)`,
+  rpt (strip_tac ORELSE CASE_TAC
+    ORELSE fs [option_choice_f_def, alistTheory.ALOOKUP_APPEND, FUN_EQ_THM]));
+
+val alookup_empty_option_choice_f = Q.store_thm (
+  "alookup_empty_option_choice_f",
+  `(option_choice_f (ALOOKUP []) f = f)
+    /\ (option_choice_f f (ALOOKUP []) = f)`,
+  fs [FUN_EQ_THM, option_choice_f_def]);
+
+val option_choice_f_assoc = Q.store_thm ("option_choice_f_assoc",
+  `option_choice_f (option_choice_f f g) h
+    = option_choice_f f (option_choice_f g h)`,
+  fs [option_choice_f_def, FUN_EQ_THM]
+    \\ Cases_on `f x` \\ fs []);
+
+val repr_empty = Q.store_thm ("repr_empty",
+  `irreflexive R /\ transitive R ==>
+    (f = (\x. NONE)) ==> sorted_alist_repr R [] f`,
+  fs [FUN_EQ_THM, sorted_alist_repr_def]);
+
+val repr_insert = Q.store_thm ("repr_insert",
+  `sorted_alist_repr R al f /\ is_insert fl fr R k x al al' ==>
+    sorted_alist_repr R al' (option_choice_f (ALOOKUP [(k, x)]) f)`,
+  fs [sorted_alist_repr_def, is_insert_def,
+    GSYM alookup_append_option_choice_f]);
+
+val alookup_to_option_choice = Q.store_thm ("alookup_to_option_choice",
+  `(ALOOKUP (x :: y :: zs) = option_choice_f (ALOOKUP [x]) (ALOOKUP (y :: zs)))
+    /\ (option_choice_f (ALOOKUP []) g = g)`,
+  fs [GSYM alookup_append_option_choice_f]
+    \\ fs [FUN_EQ_THM, option_choice_f_def]);
+
+val alist_repr_choice_trans_left = Q.store_thm ("alist_repr_choice_trans_left",
+  `sorted_alist_repr R al f /\
+    sorted_alist_repr R al' (option_choice_f (ALOOKUP al) g) ==>
+    sorted_alist_repr R al' (option_choice_f f g)`,
+  fs [sorted_alist_repr_def]);
+
+val alist_repr_refl = Q.store_thm ("alist_repr_refl",
+  `!al. irreflexive R /\ transitive R ==> SORTED R (MAP FST al) ==>
+    sorted_alist_repr R al (ALOOKUP al)`,
+  fs [sorted_alist_repr_def]);
+
+(* lookups on sorted alists *)
+val is_lookup_def = Define `
+  is_lookup fl fr R al x r = (!xs ys. (fl \/ (xs = [])) ==>
+    (fr \/ (ys = [])) ==> irreflexive R /\ transitive R ==>
+    SORTED R (MAP FST (xs ++ al ++ ys)) ==>
+    (ALOOKUP (xs ++ al ++ ys) x = r))`;
+
+val lookup_repr = Q.store_thm ("lookup_repr",
+  `sorted_alist_repr R al f /\ is_lookup fl fr R al x r
+    ==> (f x = r)`,
+  fs [is_lookup_def, sorted_alist_repr_def]
+  \\ metis_tac [APPEND_NIL, MAP]);
+
+val is_lookup_l = Q.store_thm ("is_lookup_l",
+  `!n. is_lookup fl T R l x res
+    ==> is_lookup fl T R (count_append n l r) x res`,
+  fs [is_lookup_def, count_append_def]
+  \\ metis_tac [APPEND_ASSOC, MAP_APPEND]);
+
+val is_lookup_r = Q.store_thm ("is_lookup_r",
+  `!n. is_lookup T fr R r x res
+    ==> is_lookup T fr R (count_append n l r) x res`,
+  fs [is_lookup_def, count_append_def]
+  \\ metis_tac [APPEND_ASSOC, MAP_APPEND]);
+
+val is_lookup_far_left = Q.store_thm ("is_lookup_far_left",
+  `!R k k' v. R k k' ==> is_lookup F T R [(k', v)] k NONE`,
+  fs [is_lookup_def, sortingTheory.SORTED_EQ, listTheory.MEM_MAP,
+    pairTheory.EXISTS_PROD]
+  \\ rpt strip_tac
+  \\ Cases_on `ALOOKUP ys k` \\ CASE_TAC \\ fs []
+  \\ metis_tac [alistTheory.ALOOKUP_MEM, relationTheory.irreflexive_def,
+    relationTheory.transitive_def]);
+
+val is_lookup_far_right = Q.store_thm ("is_lookup_far_right",
+  `!R k k' v. R k' k ==> is_lookup T F R [(k', v)] k NONE`,
+  fs [is_lookup_def, SORTED_APPEND_trans_IFF, listTheory.MEM_MAP,
+    pairTheory.EXISTS_PROD, alistTheory.ALOOKUP_APPEND]
+  \\ rpt strip_tac
+  \\ Cases_on `ALOOKUP xs k` \\ CASE_TAC \\ fs []
+  \\ metis_tac [alistTheory.ALOOKUP_MEM, relationTheory.irreflexive_def,
+    relationTheory.transitive_def]);
+
+val is_lookup_hit = Q.store_thm ("is_lookup_hit",
+  `!R k k' v. (k' = k) ==> is_lookup T T R [(k', v)] k (SOME v)`,
+  fs [is_lookup_def, SORTED_APPEND_trans_IFF, listTheory.MEM_MAP,
+    pairTheory.EXISTS_PROD, alistTheory.ALOOKUP_APPEND]
+  \\ rpt strip_tac
+  \\ rpt (CASE_TAC \\ fs [])
+  \\ metis_tac [alistTheory.ALOOKUP_MEM, relationTheory.irreflexive_def,
+    relationTheory.transitive_def]);
+
+val DISJ_EQ_IMP = Q.store_thm ("DISJ_EQ_IMP",
+  `(P \/ Q) = (~ P ==> Q)`, metis_tac []);
+
+val sorted_fst_insert_centre2 = sorted_fst_insert_centre
+  |> Q.GENL [`l`, `r`] |> Q.SPECL [`lxs ++ lys`, `rxs ++ rys`]
+  |> SIMP_RULE list_ss []
+
+val is_lookup_centre = Q.store_thm ("is_lookup_centre",
+  `!R n l r k. ~ (l = []) ==> R (FST (LAST l)) k ==> ~ (r = []) ==> R k (FST (HD r)) ==>
+    is_lookup T T R (count_append n l r) k NONE`,
+  fs [is_lookup_def, listTheory.MEM_MAP,
+    pairTheory.EXISTS_PROD, alistTheory.ALOOKUP_APPEND, count_append_def]
+  \\ rpt strip_tac
+  \\ FIRST_X_ASSUM (MP_TAC o MATCH_MP (Q.SPEC `k` sorted_fst_insert_centre2))
+  \\ fs [LAST_APPEND, HD_APPEND]
+  \\ fs [SORTED_APPEND_trans_IFF, sortingTheory.SORTED_EQ,
+    listTheory.MEM_MAP, pairTheory.EXISTS_PROD]
+  \\ rpt strip_tac
+  \\ (Cases_on `ALOOKUP ys k` \\ rpt (CASE_TAC \\ fs [])
+    \\ metis_tac [alistTheory.ALOOKUP_MEM, relationTheory.irreflexive_def,
+        relationTheory.transitive_def]));
+
+val is_lookup_empty = Q.store_thm ("is_lookup_empty",
+  `!R k. is_lookup F F R [] k NONE`,
+  fs [is_lookup_def]);
+
+val _ = export_theory ();
+

--- a/misc/alist_treeScript.sml
+++ b/misc/alist_treeScript.sml
@@ -131,7 +131,7 @@ val is_insert_centre_rule = Q.store_thm ("is_insert_centre_rule",
   \\ metis_tac [relationTheory.irreflexive_def]); 
 
 val is_insert_centre = save_thm ("is_insert_centre",
-  is_insert_centre_rule |> Q.GENL [`fl`, `fr`, `R`, `n`, `l`, `r`, `k`, `x`]
+  is_insert_centre_rule |> Q.GENL [`fl`, `fr`, `R`, `n`, `k`, `x`]
     |> SPECL [T, T] |> CONV_RULE (SIMP_CONV bool_ss []));
 
 val is_insert_far_left = Q.store_thm ("is_insert_far_left",
@@ -308,7 +308,7 @@ val is_lookup_centre = Q.store_thm ("is_lookup_centre",
         relationTheory.transitive_def]));
 
 val is_lookup_empty = Q.store_thm ("is_lookup_empty",
-  `!R k. is_lookup F F R [] k NONE`,
+  `!R k al. (al = []) ==> is_lookup F F R al k NONE`,
   fs [is_lookup_def]);
 
 val _ = export_theory ();

--- a/translator/ml_progLib.sig
+++ b/translator/ml_progLib.sig
@@ -47,6 +47,8 @@ sig
                      (string -> string) (* pick name for v abbrev const *) ->
                      ml_prog_state -> ml_prog_state
 
+  val nsLookup_conv : conv
+
   val remove_snocs : ml_prog_state -> ml_prog_state
   val clean_state  : ml_prog_state -> ml_prog_state
 

--- a/translator/ml_progLib.sml
+++ b/translator/ml_progLib.sml
@@ -94,8 +94,9 @@ fun pfun_conv tm = let
 
 end
 
-val nsLookup_conv_arg1_xs = [``option_CASE``, ``COND``,
-  ``OPTION_CHOICE``, ``(/\)``, ``(\/)``, ``(=)``]
+val nsLookup_conv_arg1_xs = [boolSyntax.conjunction, boolSyntax.disjunction,
+  boolSyntax.equality, boolSyntax.conditional, optionSyntax.option_case_tm,
+  prim_mk_const {Name = "OPTION_CHOICE", Thy = "option"}]
 
 fun nsLookup_arg1_conv conv tm = let
     val (f, xs) = strip_comb tm

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -74,6 +74,10 @@ val nsLookup_Short_nsAppend = Q.store_thm("nsLookup_Short_nsAppend",
   \\ fs [nsLookup_Short_Bind, nsAppend_def,
     alookup_append_option_choice_f]);
 
+val nsLookup_Mod1_Bind = Q.store_thm("nsLookup_Mod1_Bind",
+  `nsLookup_Mod1 (Bind ss ms) nm = ALOOKUP ms nm`,
+  fs [nsLookup_Mod1_def]);
+
 val nsLookup_Mod1_nsAppend = Q.store_thm("nsLookup_Mod1_nsAppend",
   `nsLookup_Mod1 (nsAppend ns1 ns2)
     = option_choice_f (nsLookup_Mod1 ns1) (nsLookup_Mod1 ns2)`,
@@ -608,14 +612,27 @@ val lookup_var_def = Define `
 val lookup_cons_def = Define `
   lookup_cons name (env:v sem_env) = nsLookup env.c name`;
 
-(* theorems about old lookup functions *)
-(* FIXME: it's likely that nothing below this line is still needed *)
+(* the old lookup formulation worked via nsLookup/mod_defined,
+   and mod_defined is still used in various characteristic scripts
+   so we supply an eval theorem that maps to the new approach. *)
 
 val mod_defined_def = zDefine `
   mod_defined env n =
     ∃p1 p2 e3.
       p1 ≠ [] ∧ id_to_mods n = p1 ++ p2 ∧
       nsLookupMod env p1 = SOME e3`;
+
+val mod_defined_nsLookup_Mod1 = Q.store_thm(
+  "mod_defined_nsLookup_Mod1",
+  `mod_defined env id = (case id of Short _ => F
+        | Long mn _ => (case nsLookup_Mod1 env mn of NONE => F | _ => T))`,
+  PURE_CASE_TAC \\ fs [id_to_mods_def, mod_defined_def]
+    \\ Cases_on `env`
+    \\ fs [Once EXISTS_LIST, nsLookupMod_def, nsLookup_Mod1_def]
+    \\ PURE_CASE_TAC \\ fs [Once EXISTS_LIST, nsLookupMod_def]);
+
+(* theorems about old lookup functions *)
+(* FIXME: everything below this line is unlikely to be needed. *)
 
 val nsLookupMod_nsBind = Q.prove(`
   p ≠ [] ⇒

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -2,29 +2,16 @@
   Definitions and theorems supporting ml_progLib, which constructs a
   CakeML program and its semantic environment.
 *)
+
 open preamble
 open astTheory libTheory semanticPrimitivesTheory
      semanticPrimitivesPropsTheory evaluatePropsTheory;
 open mlstringTheory integerTheory;
 open terminationTheory;
 open namespaceTheory;
+open alist_treeTheory;
 
 val _ = new_theory "ml_prog";
-
-(* TODO: The translator might need a corresponding simplification for Longs too
-  Also, the translator should probably use a custom compset rather than [compute]
-  i.e. these automatic rewrites should be moved elsewhere
-*)
-val nsLookup_nsAppend_Short = Q.store_thm("nsLookup_nsAppend_Short[compute]",`
-  (nsLookup (nsAppend e1 e2) (Short id) =
-    case nsLookup e1 (Short id) of
-      NONE =>
-        nsLookup e2 (Short id)
-    | SOME v => SOME v)`,
-  every_case_tac>>
-  Cases_on`nsLookup e2(Short id)`>>
-  fs[namespacePropsTheory.nsLookup_nsAppend_some,
-     namespacePropsTheory.nsLookup_nsAppend_none,id_to_mods_def]);
 
 (* --- env operators --- *)
 
@@ -54,37 +41,122 @@ val merge_env_def = zDefine `
     <| v := nsAppend env2.v env1.v
      ; c := nsAppend env2.c env1.c|>`
 
-(* some theorems that can be used by EVAL to compute lookups *)
+(* the components of nsLookup are 'nicer' partial functions *)
 
-val write_simp = Q.store_thm("write_simp[compute]",
-  `(write n v env).c = env.c /\
-    nsLookup (write n v env).v (Short q) =
-      if n = q then SOME v else nsLookup env.v (Short q)`,
-  IF_CASES_TAC>>fs[write_def,namespacePropsTheory.nsLookup_nsBind]);
+val nsLookup_Short_def = zDefine `
+  nsLookup_Short ns nm = nsLookup ns (Short nm)`;
 
-val write_cons_simp = Q.store_thm("write_cons_simp[compute]",
-  `(write_cons n v env).v = env.v /\
-    nsLookup (write_cons n v env).c (Short q) =
-      if n = q then SOME v else nsLookup env.c (Short q)`,
-  IF_CASES_TAC>>fs[write_cons_def,namespacePropsTheory.nsLookup_nsBind]);
+val nsLookup_Mod1_def = zDefine `
+  nsLookup_Mod1 ns = (case ns of Bind _ ms => ALOOKUP ms)`;
 
-val write_mod_simp = Q.store_thm("write_mod_simp[compute]",
-  `(nsLookup (write_mod mn env env2).v (Short q) =
-    nsLookup env2.v (Short q)) ∧
-   (nsLookup (write_mod mn env env2).c (Short c) =
-    nsLookup env2.c (Short c)) ∧
-   (nsLookup (write_mod mn env env2).v (Long mn' r) =
-    if mn = mn' then nsLookup env.v r
-    else nsLookup env2.v (Long mn' r)) ∧
-   (nsLookup (write_mod mn env env2).c (Long mn' s) =
-    if mn = mn' then nsLookup env.c s
-    else nsLookup env2.c (Long mn' s))`,
-  rw[write_mod_def]);
+val nsLookup_eq = Q.store_thm("nsLookup_eq",
+  `nsLookup ns (Short nm) = nsLookup_Short ns nm /\
+    nsLookup ns (Long mnm id) = (case nsLookup_Mod1 ns mnm of
+      NONE => NONE | SOME ns2 => nsLookup ns2 id)`,
+  fs [nsLookup_Short_def]
+  \\ Cases_on `ns`
+  \\ fs[nsLookup_Mod1_def, nsLookup_def]);
 
-val empty_simp = Q.store_thm("empty_simp[compute]",
-  `nsLookup empty_env.v q = NONE /\
-   nsLookup empty_env.c q = NONE`,
-  fs [empty_env_def] );
+(* base facts about the partial functions *)
+
+val option_choice_f_apply = Q.store_thm("option_choice_f_apply",
+  `option_choice_f f g x = OPTION_CHOICE (f x) (g x)`,
+  fs [option_choice_f_def]);
+
+val nsLookup_Short_Bind = Q.store_thm("nsLookup_Short_Bind",
+  `nsLookup_Short (Bind ss ms) = ALOOKUP ss`,
+  fs [nsLookup_Short_def, nsLookup_def, FUN_EQ_THM]);
+
+val nsLookup_Short_nsAppend = Q.store_thm("nsLookup_Short_nsAppend",
+  `nsLookup_Short (nsAppend ns1 ns2)
+    = option_choice_f (nsLookup_Short ns1) (nsLookup_Short ns2)`,
+  Cases_on `ns1` \\ Cases_on `ns2`
+  \\ fs [nsLookup_Short_Bind, nsAppend_def,
+    alookup_append_option_choice_f]);
+
+val nsLookup_Mod1_nsAppend = Q.store_thm("nsLookup_Mod1_nsAppend",
+  `nsLookup_Mod1 (nsAppend ns1 ns2)
+    = option_choice_f (nsLookup_Mod1 ns1) (nsLookup_Mod1 ns2)`,
+  Cases_on `ns1` \\ Cases_on `ns2`
+  \\ fs [nsLookup_Mod1_def, nsAppend_def,
+    alookup_append_option_choice_f]);
+
+val nsLookup_Short_nsLift = Q.store_thm("nsLookup_Short_nsLift",
+  `nsLookup_Short (nsLift mnm ns) = ALOOKUP []`,
+  Cases_on `ns` \\ fs [nsLift_def, nsLookup_Short_Bind]);
+
+val nsLookup_Mod1_nsLift = Q.store_thm("nsLookup_Mod1_nsLift",
+  `nsLookup_Mod1 (nsLift mnm ns) = ALOOKUP [(mnm, ns)]`,
+  Cases_on `ns` \\ fs [nsLift_def, nsLookup_Mod1_def]);
+
+val nsLookup_pf_nsBind = Q.store_thm("nsLookup_pf_nsBind",
+  `nsLookup_Short (nsBind n v ns)
+        = option_choice_f (ALOOKUP [(n, v)]) (nsLookup_Short ns) /\
+  nsLookup_Mod1 (nsBind n v ns) = nsLookup_Mod1 ns`,
+  Cases_on `ns`
+  \\ fs [nsLookup_Short_def,nsLookup_Mod1_def, FUN_EQ_THM,
+    write_def,nsLookup_def,nsBind_def,option_choice_f_def]
+  \\ rpt strip_tac
+  \\ fs [] \\ CASE_TAC \\ fs []);
+
+(* equalities on these partial functions for the various env operators *)
+
+val nsLookup_write_eqs = Q.store_thm("nsLookup_write_eqs",
+  `nsLookup_Short ((write n v env).c) = nsLookup_Short env.c /\
+    nsLookup_Mod1 ((write n v env).c) = nsLookup_Mod1 env.c /\
+    nsLookup_Mod1 ((write n v env).v) = nsLookup_Mod1 env.v /\
+    nsLookup_Short ((write n v env).v) = option_choice_f (ALOOKUP [(n, v)])
+        (nsLookup_Short env.v)`,
+  fs[write_def, nsLookup_pf_nsBind]
+);
+
+val nsLookup_write_cons_eqs = Q.store_thm("nsLookup_write_cons_eqs",
+  `nsLookup_Short ((write_cons n v env).v) = nsLookup_Short env.v /\
+    nsLookup_Mod1 ((write_cons n v env).v) = nsLookup_Mod1 env.v /\
+    nsLookup_Mod1 ((write_cons n v env).c) = nsLookup_Mod1 env.c /\
+    nsLookup_Short ((write_cons n v env).c) = option_choice_f (ALOOKUP [(n, v)])
+        (nsLookup_Short env.c)`,
+  fs[write_cons_def, nsLookup_pf_nsBind]
+);
+
+val nsLookup_merge_env_eqs = Q.store_thm("nsLookup_merge_env_eqs",
+  `nsLookup_Short ((merge_env env env2).v)
+        = option_choice_f (nsLookup_Short env.v) (nsLookup_Short env2.v) /\
+    nsLookup_Mod1 ((merge_env env env2).v)
+        = option_choice_f (nsLookup_Mod1 env.v) (nsLookup_Mod1 env2.v) /\
+    nsLookup_Short ((merge_env env env2).c)
+        = option_choice_f (nsLookup_Short env.c) (nsLookup_Short env2.c) /\
+    nsLookup_Mod1 ((merge_env env env2).c)
+        = option_choice_f (nsLookup_Mod1 env.c) (nsLookup_Mod1 env2.c)`,
+  fs[merge_env_def, nsLookup_Short_nsAppend, nsLookup_Mod1_nsAppend]);
+
+val nsLookup_write_mod_eqs = Q.store_thm("nsLookup_write_mod_eqs",
+  `nsLookup_Short ((write_mod mnm env env2).v) = nsLookup_Short env2.v /\
+    nsLookup_Mod1 ((write_mod mnm env env2).v)
+        = option_choice_f (ALOOKUP [(mnm, env.v)]) (nsLookup_Mod1 env2.v) /\
+    nsLookup_Short ((write_mod mnm env env2).c) = nsLookup_Short env2.c /\
+    nsLookup_Mod1 ((write_mod mnm env env2).c)
+        = option_choice_f (ALOOKUP [(mnm, env.c)]) (nsLookup_Mod1 env2.c)`,
+  fs[write_mod_def, nsLookup_Short_nsAppend, nsLookup_Mod1_nsAppend,
+    nsLookup_Short_nsLift, nsLookup_Mod1_nsLift,
+    alookup_empty_option_choice_f]);
+
+val nsLookup_empty_eqs = Q.store_thm("nsLookup_empty_eqs",
+  `nsLookup_Short empty_env.v = ALOOKUP [] /\
+    nsLookup_Mod1 empty_env.v = ALOOKUP [] /\
+    nsLookup_Short empty_env.c = ALOOKUP [] /\
+    nsLookup_Mod1 empty_env.c = ALOOKUP []`,
+  fs[empty_env_def, nsEmpty_def, nsLookup_Short_Bind, nsLookup_Mod1_def]);
+
+(* nonsense theorem instantiated when env's are defined *)
+
+val nsLookup_eq_format = Q.store_thm("nsLookup_eq_format",
+  `!env:v sem_env.
+     (nsLookup_Short env.v = nsLookup_Short env.v) /\
+     (nsLookup_Short env.c = nsLookup_Short env.c) /\
+     (nsLookup_Mod1 env.v = nsLookup_Mod1 env.v) /\
+     (nsLookup_Mod1 env.c = nsLookup_Mod1 env.c)`,
+  rewrite_tac []);
 
 (* some shorthands that are allowed to EVAL are below *)
 
@@ -142,6 +214,54 @@ val merge_env_write_tdefs = prove(
       merge_env (write_tdefs n tds env1) env2 =
       write_tdefs n tds (merge_env env1 env2)``,
   Induct \\ fs [write_tdefs_def,FORALL_PROD,merge_env_write_conses]);
+
+(* it's not clear if these are still needed, but ml_progComputeLib and
+   cfTacticsLib want them to be present. *)
+
+val nsLookup_nsAppend_Short = Q.store_thm("nsLookup_nsAppend_Short[compute]",`
+  (nsLookup (nsAppend e1 e2) (Short id) =
+    case nsLookup e1 (Short id) of
+      NONE =>
+        nsLookup e2 (Short id)
+    | SOME v => SOME v)`,
+  every_case_tac>>
+  Cases_on`nsLookup e2(Short id)`>>
+  fs[namespacePropsTheory.nsLookup_nsAppend_some,
+     namespacePropsTheory.nsLookup_nsAppend_none,id_to_mods_def]);
+
+val write_simp = Q.store_thm("write_simp[compute]",
+  `(write n v env).c = env.c /\
+    nsLookup (write n v env).v (Short q) =
+      if n = q then SOME v else nsLookup env.v (Short q)`,
+  IF_CASES_TAC>>fs[write_def,namespacePropsTheory.nsLookup_nsBind]);
+
+val write_cons_simp = Q.store_thm("write_cons_simp[compute]",
+  `(write_cons n v env).v = env.v /\
+    nsLookup (write_cons n v env).c (Short q) =
+      if n = q then SOME v else nsLookup env.c (Short q)`,
+  IF_CASES_TAC>>fs[write_cons_def,namespacePropsTheory.nsLookup_nsBind]);
+
+val write_mod_simp = Q.store_thm("write_mod_simp[compute]",
+  `(nsLookup (write_mod mn env env2).v (Short q) =
+    nsLookup env2.v (Short q)) ∧
+   (nsLookup (write_mod mn env env2).c (Short c) =
+    nsLookup env2.c (Short c)) ∧
+   (nsLookup (write_mod mn env env2).v (Long mn' r) =
+    if mn = mn' then nsLookup env.v r
+    else nsLookup env2.v (Long mn' r)) ∧
+   (nsLookup (write_mod mn env env2).c (Long mn' s) =
+    if mn = mn' then nsLookup env.c s
+    else nsLookup env2.c (Long mn' s))`,
+  rw[write_mod_def]);
+
+val empty_simp = Q.store_thm("empty_simp[compute]",
+  `nsLookup empty_env.v q = NONE /\
+   nsLookup empty_env.c q = NONE`,
+  fs [empty_env_def] );
+(* the components of nsLookup are 'nicer' partial functions *)
+
+
+
 
 (* --- declarations --- *)
 
@@ -363,18 +483,19 @@ val init_state_env_thm = Q.store_thm("init_state_env_thm",
   `THE (prim_sem_env ffi) = (init_state ffi,init_env)`,
   CONV_TAC(RAND_CONV EVAL) \\ rewrite_tac[prim_sem_env_eq,THE_DEF]);
 
+val nsLookup_init_state_pfun_eqs = save_thm("nsLookup_init_state_pfun_eqs",
+  [``nsLookup_Short init_env.c``, ``nsLookup_Short init_env.v``,
+    ``nsLookup_Mod1 init_env.c``, ``nsLookup_Mod1 init_env.v``]
+  |> map (SIMP_CONV bool_ss
+        [init_env_def, nsLookup_Short_Bind, nsLookup_Mod1_def,
+            namespace_case_def, sem_env_accfupds, K_DEF])
+  |> LIST_CONJ);
+
 end
 
 val ML_code_NIL = Q.store_thm("ML_code_NIL",
   `ML_code init_env (init_state ffi) [] NONE empty_env (init_state ffi)`,
   fs [ML_code_def,Decls_NIL]);
-
-val nsLookup_init_env = save_thm("nsLookup_init_env[compute]",
-  init_env_def
-  |> concl
-  |> find_terms (can (match_term ``(s:string,_)``))
-  |> map (fn tm => EVAL ``nsLookup init_env.c (Short ^(rand(rator tm)))``)
-  |> LIST_CONJ);
 
 (* opening and closing of modules *)
 
@@ -487,7 +608,8 @@ val lookup_var_def = Define `
 val lookup_cons_def = Define `
   lookup_cons name (env:v sem_env) = nsLookup env.c name`;
 
-(* theorems about lookup functions *)
+(* theorems about old lookup functions *)
+(* FIXME: it's likely that nothing below this line is still needed *)
 
 val mod_defined_def = zDefine `
   mod_defined env n =
@@ -528,8 +650,8 @@ val nsLookup_empty = Q.store_thm("nsLookup_empty",
    (nsLookup empty_env.c b = NONE) /\
    (mod_defined empty_env.v x = F) /\
    (mod_defined empty_env.c x = F)`,
-  EVAL_TAC \\ rw [mod_defined_def]
-  \\ Cases_on`p1`>>fs[nsLookupMod_def,empty_env_def]);
+  rw[empty_env_def, nsLookup_def, mod_defined_def,
+    nsLookupMod_def] \\ Cases_on`p1` \\ fs[]);
 
 val nsLookupMod_nsAppend = Q.prove(`
   nsLookupMod (nsAppend env1 env2) p =
@@ -678,16 +800,6 @@ val nsLookup_merge_env = Q.store_thm("nsLookup_merge_env[compute]",
       first_x_assum(qspecl_then[`xx`,`p3++p2`]mp_tac) >>
       fs[])
   );
-
-val nsLookup_eq_format = Q.store_thm("nsLookup_eq_format",
-  `!env:v sem_env.
-     (nsLookup env.v (Short n) = nsLookup env.v (Short n)) /\
-     (nsLookup env.c (Short n) = nsLookup env.c (Short n)) /\
-     (nsLookup env.v (Long n1 n2) = nsLookup env.v (Long n1 n2)) /\
-     (nsLookup env.c (Long n1 n2) = nsLookup env.c (Long n1 n2)) /\
-     (mod_defined env.v (Long n1 n2) = mod_defined env.v (Long n1 n2)) /\
-     (mod_defined env.c (Long n1 n2) = mod_defined env.c (Long n1 n2))`,
-  rewrite_tac []);
 
 val nsLookup_nsBind_compute = Q.store_thm("nsLookup_nsBind_compute[compute]",
   `(nsLookup (nsBind n v e) (Short n1) =

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -4106,10 +4106,7 @@ fun prove_Eval_assumptions th =
     fun prove_Eval_assum tm =
       let
         val th1 =
-          (ONCE_DEPTH_CONV(
-            REWR_CONV Eval_Var THENC
-            PURE_REWRITE_CONV[(*lookup_var_eq_lookup_var_id*)] THENC
-            QUANT_CONV(LAND_CONV EVAL) THENC REWR_CONV UNWIND_THM1)) tm
+          (ONCE_DEPTH_CONV(REWR_CONV Eval_Var_nsLookup THENC nsLookup_conv)) tm
         val const =
           th1 |> concl |> rand |> strip_forall |> #2 |> repeat (#2 o dest_imp) |> rator |> rand
         val cert = get_cert (get_bare_v_thm const)

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -2752,14 +2752,14 @@ val th = D res
 *)
 
 fun clean_assumptions th = let
+  val start = start_timing "clean assumptions"
   val lhs1 = get_term "nsLookup_pat"
   val pattern1 = mk_eq(lhs1,mk_var("_",type_of lhs1))
   val lhs2 = lookup_cons_def (*lookup_cons_thm*) |> SPEC_ALL |> concl |> dest_eq |> fst
   val pattern2 = mk_eq(lhs2,mk_var("_",type_of lhs2))
   val lookup_assums = find_terms (fn tm => can (match_term pattern1) tm
                                     orelse can (match_term pattern2) tm) (concl th)
-  val lemmas = map EVAL lookup_assums
-
+  val lemmas = map (EVAL THENC nsLookup_conv THENC EVAL) lookup_assums
                |> filter (fn th => th |> concl |> rand |> is_const)
   val th = REWRITE_RULE lemmas th
   (* lift EqualityType assumptions out *)
@@ -2778,6 +2778,7 @@ fun clean_assumptions th = let
   val th1 = th |> REWRITE_RULE [GSYM PreImpEval_def]
   val th2 = CONV_RULE (QCONV (LAND_CONV (ONCE_DEPTH_CONV move_Eval_conv))) th1
   val th = REWRITE_RULE [PreImpEval_def] th2
+  val _ = end_timing start
   in th end;
 
 fun get_pre_var lhs fname = let

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -2031,7 +2031,8 @@ fun prove_EvalPatBind goal hol2deep = let
     \\ TRY tac3
     \\ fsrw_tac[][GSYM FORALL_PROD,(*lookup_var_id_def,*)lookup_cons_def,LIST_TYPE_IF_ELIM]
     \\ TRY tac2 \\ TRY (fs[CONTAINER_def] >> NO_TAC)
-    \\ EVAL_TAC \\ metis_tac [CONTAINER_def])
+    \\ TRY (EVAL_TAC >> NO_TAC)
+    \\ metis_tac [CONTAINER_def])
   in UNDISCH_ALL th end handle HOL_ERR e =>
   (prove_EvalPatBind_fail := goal;
    failwith "prove_EvalPatBind failed");

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -1698,17 +1698,26 @@ val Eval_Fun_rw = Q.store_thm("Eval_Fun_rw",
   `Eval env (Fun n exp) P <=> P (Closure env n exp)`,
   rw[Eval_rw,EQ_IMP_THM,empty_state_def]);
 
+val evaluate_Var_nsLookup = Q.prove(
+   `eval_rel s env (Var id) s' r <=>
+    ?v. nsLookup env.v id = SOME r ∧ s' = s`,
+  fs [eval_rel_def,evaluate_def,lookup_var_def,option_case_eq,
+      state_component_equality] \\ rw [] \\ eq_tac \\ rw []);
+
 val evaluate_Var = Q.prove(
    `eval_rel s env (Var (Short n)) s' r <=>
     ?v. lookup_var n env = SOME r ∧ s' = s`,
-  fs [eval_rel_def,evaluate_def,lookup_var_def,option_case_eq,
-      state_component_equality] \\ rw [] \\ eq_tac \\ rw []);
+  fs [evaluate_Var_nsLookup,lookup_var_def]);
+
+val Eval_Var_nsLookup = Q.store_thm("Eval_Var_nsLookup",
+  `Eval env (Var id) P <=> case nsLookup env.v id of NONE => F | SOME v => P v`,
+  fs [Eval_def,evaluate_Var_nsLookup, state_component_equality]
+  \\ PURE_CASE_TAC \\ fs []);
 
 val Eval_Var = Q.store_thm("Eval_Var",
   `Eval env (Var (Short n)) P <=>
    ?v. lookup_var n env = SOME v /\ P v`,
-  rw[Eval_def,evaluate_Var,EQ_IMP_THM]
-  \\ rw[state_component_equality] \\ metis_tac []);
+  rw[Eval_Var_nsLookup,lookup_var_def] \\ PURE_CASE_TAC \\ fs[]);
 
 val Eval_Fun_Var_intro = Q.store_thm("Eval_Fun_Var_intro",
   `Eval cl_env (Fun n exp) P ==>

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -164,6 +164,20 @@ val _ = Datatype `
 
 val _ = register_type ``:tt``;
 
+(* test no_ind again *)
+
+val test_def = xDefine "test" `test x = (case x of
+  | A1 => [()]
+  | B1 x => test x ++ [()]
+  | C1 NONE => []
+  | C1 (SOME x) => test x ++ REVERSE (test x)
+  | D1 tts => (case tts of [] => [(); ()]
+        | (tt :: tts) => test (D1 tts) ++ test tt)
+  | E1 (x, y) => REVERSE (test x) ++ test y)`
+;
+
+val _ = translate_no_ind test_def;
+
 (* registering types inside modules *)
 
 open ml_progLib

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -177,4 +177,17 @@ val r = register_type ``:my_type``;
 val _ = ml_prog_update (close_module NONE);
 val r = translate my_fun_def;
 
+(* test the abstract translator is working *)
+
+val map_again_def = Define `map_again f [] = []
+  /\ map_again f (x :: xs) = f x :: map_again f xs`;
+
+val inc_list_def = Define `inc_list xs = map_again (\x. x + SUC 0) xs`;
+
+val _ = reset_translation ();
+
+val r = abs_translate map_again_def;
+val r = abs_translate inc_list_def;
+val r = concretise [``map_again``, ``inc_list``];
+
 val _ = export_theory();


### PR DESCRIPTION
This is a union of two changes to the translator.

The first is to introduce yet another tree representation in HOL4. This one represents partial function trees as assoc-lists using ALOOKUP. These are given a tree structure where the assoc-list is sorted and the "node" operator is actually the append operator. The point is that balancing is actually a conv, and that decisions about sorting and balancing are made in ML rather than within the logic.

(EDITED) And the point of introducing the above type is to represent the lookups
(nsLookup auto_env1) using these alists. The representations are quite a bit faster to
build and look up than the previous solutions, which depended on the EVAL set caching a lot
of stuff for performance.

There's also a tweak in here to reduce the number of times that the translator code runs conversions that examine the program (SNOC list) within the translator state. This part isn't abbreviated, so simple adjustments to the convs and lookups to avoid looking at it can save a lot of CPU time.
