### PR TITLE
Equality type

### DIFF
--- a/compiler/bootstrap/translation/parserProgScript.sml
+++ b/compiler/bootstrap/translation/parserProgScript.sml
@@ -57,123 +57,19 @@ val _ = (find_def_for_const := def_of_const);
 val res = register_type``:(token,MMLnonT,locs) parsetree``;
 val res = register_type``:MMLnonT``;
 
-local
-  val ths = ml_translatorLib.eq_lemmas();
-in
-  fun find_equality_type_thm tm =
-    first (can (C match_term tm) o rand o snd o strip_imp o concl) ths
-end
+fun EqualityType_conseq_conv dir tm = let
+    val cc = ConseqConv.CONSEQ_REWRITE_CONV (eq_lemmas (), [], [])
+  in cc dir tm end
 
-val EqualityType_CHAR = find_equality_type_thm``CHAR``
-val EqualityType_INT = find_equality_type_thm``INT``
-val EqualityType_NUM = find_equality_type_thm``NUM``
-val EqualityType_LOCN = find_equality_type_thm ``LOCATION_LOCN_TYPE``
-val EqualityType_LOCS = find_equality_type_thm ``LOCATION_LOCS_TYPE``
+val EqualityType_tac = ConseqConv.CONSEQ_CONV_TAC EqualityType_conseq_conv
+    \\ simp_tac bool_ss [];
 
-val EqualityType_LIST_TYPE_CHAR = find_equality_type_thm``LIST_TYPE CHAR``
-  |> Q.GEN`a` |> Q.ISPEC`CHAR` |> SIMP_RULE std_ss [EqualityType_CHAR]
-
-val EqualityType_SUM_TYPE = find_equality_type_thm``SUM_TYPE a b``
-
-val EqualityType_TOKENS_TOKEN_TYPE = find_equality_type_thm``TOKENS_TOKEN_TYPE``
-  |> SIMP_RULE std_ss [EqualityType_CHAR,EqualityType_LIST_TYPE_CHAR,EqualityType_INT,EqualityType_NUM]
-
-val EqualityType_GRAM_MMLNONT_TYPE = find_equality_type_thm``GRAM_MMLNONT_TYPE``
-  |> SIMP_RULE std_ss []
-
-val GRAMMAR_SYMBOL_TYPE_def = theorem"GRAMMAR_SYMBOL_TYPE_def";
-
-val EqualityType_GRAMMAR_SYMBOL_TYPE = Q.prove(
-  `∀a b. EqualityType a ∧ EqualityType b ⇒ EqualityType (GRAMMAR_SYMBOL_TYPE a b)`,
-  rw[EqualityType_def] >- (
-    Cases_on`x1`>>fs[GRAMMAR_SYMBOL_TYPE_def]>>rw[]>>
-    rw[no_closures_def] >- METIS_TAC[] >>
-    METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def] )
-  >- (
-    Cases_on`x1`>>Cases_on`x2`>>fs[GRAMMAR_SYMBOL_TYPE_def]>>
-    rw[types_match_def] >>
-    METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def] )
-  >- (
-    Cases_on`x1`>>Cases_on`x2`>>fs[GRAMMAR_SYMBOL_TYPE_def]>>
-    rw[types_match_def,ctor_same_type_def] >>
-    METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def] ))
-
-val GRAMMAR_PARSETREE_TYPE_def = theorem"GRAMMAR_PARSETREE_TYPE_def";
-val GRAMMAR_PARSETREE_TYPE_ind = theorem"GRAMMAR_PARSETREE_TYPE_ind";
-
-val EqualityType_PAIR_TYPE = find_equality_type_thm``PAIR_TYPE a b``;
-val EqualityType_LOCATION_LOCN_TYPE = find_equality_type_thm``LOCATION_LOCN_TYPE`` |> SIMP_RULE std_ss[EqualityType_NUM]
-
-val GRAMMAR_PARSETREE_TYPE_no_closures = Q.prove(
-  `∀a b c d e.
-     EqualityType a ∧ EqualityType b ∧ EqualityType c ∧
-     GRAMMAR_PARSETREE_TYPE a b c d e ⇒
-     no_closures e`,
-  ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
-  simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS,no_closures_def] >>
-  rw[] >- METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def,EqualityType_PAIR_TYPE,EqualityType_LOCATION_LOCN_TYPE]
-  >- (
-    pop_assum mp_tac >>
-    Q.ID_SPEC_TAC`v2_2` >>
-    Induct_on`x_2` >> simp[LIST_TYPE_def,no_closures_def,PULL_EXISTS] >>
-    rw[] >> METIS_TAC[]) >>
-  METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def,EqualityType_LOCATION_LOCN_TYPE,EqualityType_PAIR_TYPE])
-
-val GRAMMAR_PARSETREE_TYPE_types_match = Q.prove(
-  `∀a b c d1 e1 d2 e2.
-      EqualityType a ∧ EqualityType b ∧ EqualityType c ∧
-      GRAMMAR_PARSETREE_TYPE a b c d1 e1 ∧
-      GRAMMAR_PARSETREE_TYPE a b c d2 e2 ⇒ types_match e1 e2`,
-  ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
-  simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS,types_match_def] >>
-  rw[] >- (
-    Cases_on`d2`>>fs[GRAMMAR_PARSETREE_TYPE_def,types_match_def,ctor_same_type_def] >>
-    conj_tac >- METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def,EqualityType_LOCATION_LOCN_TYPE,EqualityType_PAIR_TYPE] >>
-    rw[] >> rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
-    last_x_assum mp_tac >>
-    rename [`MEM _ l1`, `LIST_TYPE _ l1 vl1`, `types_match vl1 vl2`,
-            `LIST_TYPE _ l2 vl2`] >>
-    map_every qid_spec_tac[`vl1`,`vl2`,`l1`,`l2`] >>
-    Induct >> simp[LIST_TYPE_def,PULL_EXISTS] >> rw[] >>
-    Cases_on`l1`>>fs[LIST_TYPE_def,types_match_def,ctor_same_type_def] >>
-    METIS_TAC[]) >>
-  Cases_on`d2`>>fs[GRAMMAR_PARSETREE_TYPE_def,types_match_def,ctor_same_type_def] >>
-  METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def,EqualityType_LOCATION_LOCN_TYPE,EqualityType_PAIR_TYPE])
-
-val GRAMMAR_PARSETREE_TYPE_11 = Q.prove(
-  `∀a b c d1 e1 d2 e2.
-      EqualityType a ∧ EqualityType b ∧ EqualityType c ∧
-      GRAMMAR_PARSETREE_TYPE a b c d1 e1 ∧
-      GRAMMAR_PARSETREE_TYPE a b c d2 e2 ⇒ (d1 = d2 ⇔ e1 = e2)`,
-  ho_match_mp_tac GRAMMAR_PARSETREE_TYPE_ind >>
-  simp[GRAMMAR_PARSETREE_TYPE_def,PULL_EXISTS] >>
-  rw[] >- (
-    Cases_on`d2`>>fs[GRAMMAR_PARSETREE_TYPE_def] >>
-    rename [`MEM _ ptl1`, `LIST_TYPE _ ptl1 vl1`, `ptl1 = ptl2`, `vl1 = vl2`,
-           `_ = Conv _ [ntv2; locv2]`, `ntv1 = ntv2`, `locv1 = locv2`,
-           `PAIR_TYPE _ _ ndp1 ntv1`, `PAIR_TYPE _ _ ndp2 ntv2`] >>
-    `ndp1 = ndp2 ⇔ ntv1 = ntv2` by METIS_TAC[EqualityType_SUM_TYPE,EqualityType_NUM,EqualityType_def,EqualityType_LOCATION_LOCN_TYPE,EqualityType_PAIR_TYPE] >>
-    rw[] >> rpt(qhdtm_x_assum`LIST_TYPE`mp_tac) >>
-    last_x_assum mp_tac >>
-    map_every qid_spec_tac[`locv1`,`locv2`,`ptl1`,`ptl2`] >>
-    Induct >> simp[LIST_TYPE_def,PULL_EXISTS] >> rw[] >>
-    Cases_on`ptl1`>>fs[LIST_TYPE_def] >>
-    METIS_TAC[]) >>
-  Cases_on`d2`>>fs[GRAMMAR_PARSETREE_TYPE_def] >>
-  METIS_TAC[EqualityType_GRAMMAR_SYMBOL_TYPE,EqualityType_def,EqualityType_LOCATION_LOCN_TYPE,EqualityType_PAIR_TYPE])
-
-val EqualityType_GRAMMAR_PARSETREE_TYPE_TOKENS_TOKEN_TYPE_GRAM_MMLNONT_TYPE = Q.prove(
+(* checking GRAMMAR_PARSETREE_TYPE etc is known to be an EqualityType *)
+val EqualityType_GRAMMAR_PARSETREE_TYPE_TOKENS_TOKEN_TYPE_GRAM_MMLNONT_TYPE
+    = Q.prove(
   `EqualityType (GRAMMAR_PARSETREE_TYPE TOKENS_TOKEN_TYPE GRAM_MMLNONT_TYPE
                                         LOCATION_LOCS_TYPE)`,
-  simp[EqualityType_def] >>
-  assume_tac EqualityType_TOKENS_TOKEN_TYPE >>
-  assume_tac EqualityType_GRAM_MMLNONT_TYPE >>
-  assume_tac EqualityType_LOCS >>
-  assume_tac EqualityType_LOCN >>
-  conj_tac >- METIS_TAC[GRAMMAR_PARSETREE_TYPE_no_closures, EqualityType_NUM] >>
-  METIS_TAC[GRAMMAR_PARSETREE_TYPE_types_match,GRAMMAR_PARSETREE_TYPE_11,
-            EqualityType_NUM])
-  |> store_eq_thm
+  EqualityType_tac);
 
 val _ = translate (def_of_const ``cmlPEG``);
 

--- a/translator/ml_progLib.sml
+++ b/translator/ml_progLib.sml
@@ -75,12 +75,15 @@ fun check_in_repr_set tms = let
         |> List.mapPartial (total get_pfun_thm)
     val (chain, set) = mk_chain consts [] (! pfun_eqs_in_repr)
     val _ = if null chain then raise Empty else ()
-    val msg = if length chain > 3
-        then "Adding repr thms for " ^ Int.toString (length chain) ^ " consts."
-        else "Adding repr thms for ["
-            ^ concat (commafy (map (fst o dest_const o fst) chain)) ^ "]."
+    val chain_names = map (fst o dest_const o fst) chain
+    val msg_names = if length chain > 3
+        then List.take (chain_names, 2) @ ["..."] @ [List.last chain_names]
+        else chain_names
+    val msg = "Adding nsLookup representation thms for "
+        ^ (if length chain > 3 then Int.toString (length chain) ^ " consts ["
+            else "[") ^ concat (commafy msg_names) ^ "]\n"
   in
-    print (msg ^ "\n"); List.app (add o snd) (rev chain);
+    print msg; List.app (add o snd) (rev chain);
         pfun_eqs_in_repr := set
   end handle Empty => ()
 

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -1101,6 +1101,8 @@ fun mk_EqualityType_proof typ = let
     val final_goal = ml_translatorSyntax.mk_EqualityType (get_type_inv typ)
   in (list_mk_imp (assums, final_goal),
     ASSUM_LIST (fn _ => let
+        val _ = print "Doing proof of: "
+        val _ = print_term final_goal
         val measure_thm = ISPEC (fst (hd mrec)) EqualityType_measure
         val t = TAC_PROOF ((assums, goal), prove_EqualityType_tac simps defs)
       in simp_tac bool_ss [measure_thm, DISCH_ALL t] end))

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -324,6 +324,27 @@ val EqualityType_NUM_BOOL = Q.store_thm("EqualityType_NUM_BOOL",
   \\ imp_res_tac Eq_lemma \\ fs []
   \\ fs [MULT_EXP_MONO |> Q.SPECL [`p`,`1`] |> SIMP_RULE bool_ss [EVAL ``SUC 1``]]);
 
+val EqualityType_measure = Q.store_thm ("EqualityType_measure",
+  `!m. (!n : num. EqualityType (And TY (\x. m x < n))) ==> EqualityType TY`,
+  rpt strip_tac
+  \\ RULE_ASSUM_TAC (Q.GENL [`x`, `y`] o Q.SPEC `MAX (SUC (m x)) (SUC (m y))`)
+  \\ fs [EqualityType_def, And_def]
+  \\ metis_tac [prim_recTheory.LESS_SUC_REFL]);
+
+val trivial4_def = Define `trivial4 x y a b = T`;
+
+val Conv_args_def = Define `Conv_args v = (case v of
+  | Conv _ vs => vs
+  | _ => [v])`;
+
+val EqualityType_def_rearranged = Q.store_thm (
+  "EqualityType_def_rearranged",
+  `EqualityType abs = (!x y vx vy. trivial4 x y vx vy
+    ==> abs x vx /\ abs y vy
+    ==> (x = y ==> vx = vy ==> no_closures vx)
+        /\ (vx = vy <=> x = y) /\ types_match vx vy)`,
+  fs [EqualityType_def, trivial4_def] \\ metis_tac []);
+
 val types_match_list_length = Q.store_thm("types_match_list_length",
   `!vs1 vs2. types_match_list vs1 vs2 ==> LENGTH vs1 = LENGTH vs2`,
   Induct \\ Cases_on`vs2` \\ rw[types_match_def])

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -345,6 +345,26 @@ val EqualityType_def_rearranged = Q.store_thm (
         /\ (vx = vy <=> x = y) /\ types_match vx vy)`,
   fs [EqualityType_def, trivial4_def] \\ metis_tac []);
 
+val EqualityType_from_ONTO = Q.store_thm("EqualityType_from_ONTO",
+  `(!a. ?r. a = num2a r ∧ r < (N : num))
+    ==> (!TY stamps stn. GENLIST (\n v. TY (num2a n) v) N
+                = MAP (\st v. v = Conv (SOME (TypeStamp st stn)) []) stamps
+        ==> ALL_DISTINCT stamps
+        ==> EqualityType TY)`,
+  rpt strip_tac
+  \\ fs [EqualityType_def_rearranged]
+  \\ rpt GEN_TAC
+  \\ FIRST_X_ASSUM (fn a => ((dest_exists o snd o dest_forall o concl) a;
+        ASSUME_TAC (CONJ (Q.SPEC `x` a) (Q.SPEC `y` a))))
+  \\ fs []
+  \\ FIRST_X_ASSUM (fn a => MP_TAC (LIST_CONJ [Q.AP_TERM `LENGTH` a,
+        Q.AP_TERM `EL r` a, Q.AP_TERM `EL r'` a]))
+  \\ fs [EL_MAP, satTheory.AND_IMP, FUN_EQ_THM, no_closures_def,
+        types_match_def, ctor_same_type_def, listTheory.EL_ALL_DISTINCT_EL_EQ,
+        same_type_def]
+  \\ metis_tac (map TypeBase.one_one_of [``:stamp``, ``:'a option``, ``: v``]));
+
+
 val types_match_list_length = Q.store_thm("types_match_list_length",
   `!vs1 vs2. types_match_list vs1 vs2 ==> LENGTH vs1 = LENGTH vs2`,
   Induct \\ Cases_on`vs2` \\ rw[types_match_def])

--- a/translator/ml_translatorSyntax.sig
+++ b/translator/ml_translatorSyntax.sig
@@ -12,6 +12,9 @@ sig
   val is_EqualityType   : term -> bool
   val EqualityType      : term
 
+  val dest_trivial4 : term -> (term * term * term * term)
+  val mk_Conv_args  : term -> term
+
   val mk_CONTAINER   : term -> term
   val dest_CONTAINER : term -> term
   val is_CONTAINER   : term -> bool
@@ -35,6 +38,8 @@ sig
   val mk_lookup_cons   : term * term -> term
   val dest_lookup_cons : term -> term * term
   val is_lookup_cons   : term -> bool
+
+  val mk_And  : term * term -> term
 
   val TRUE  : term
   val FALSE : term

--- a/translator/ml_translatorSyntax.sml
+++ b/translator/ml_translatorSyntax.sml
@@ -15,6 +15,9 @@ val (EqualityType,mk_EqualityType,dest_EqualityType,is_EqualityType) = monop "Eq
 val (CONTAINER,mk_CONTAINER,dest_CONTAINER,is_CONTAINER) = monop "CONTAINER";
 val (PRECONDITION,mk_PRECONDITION,dest_PRECONDITION,is_PRECONDITION) = monop "PRECONDITION";
 
+val (_, mk_Conv_args, _, _) = monop "Conv_args"
+val (_, mk_trivial4, dest_trivial4, _) = HolKernel.syntax_fns4 "ml_translator" "trivial4";
+
 val BOOL        = prim_mk_const{Thy="ml_translator",Name="BOOL"}
 val WORD       = prim_mk_const{Thy="ml_translator",Name="WORD"}
 val NUM         = prim_mk_const{Thy="ml_translator",Name="NUM"}
@@ -31,6 +34,9 @@ val FALSE = prim_mk_const{Thy="ml_translator",Name="FALSE"}
 val binop = HolKernel.syntax_fns2 "ml_translator"
 val (TAG,mk_TAG,dest_TAG,is_TAG) = binop "TAG";
 val (PreImp,mk_PreImp,dest_PreImp,is_PreImp) = binop "PreImp";
+
+val And_tm = prim_mk_const{Thy="ml_translator",Name="And"}
+fun mk_And (x, y) = list_mk_icomb (And_tm, [x, y])
 
 val binop = HolKernel.syntax_fns2 "ml_prog"
 val (lookup_cons,mk_lookup_cons,dest_lookup_cons,is_lookup_cons) = binop "lookup_cons";

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -198,10 +198,29 @@ val map_again_def = Define `map_again f [] = []
 
 val inc_list_def = Define `inc_list xs = map_again (\x. x + SUC 0) xs`;
 
-val _ = reset_translation ();
-
 val r = abs_translate map_again_def;
 val r = abs_translate inc_list_def;
 val r = concretise [``map_again``, ``inc_list``];
+
+(* check EqualityType proves for some modestly complex datatypes *)
+
+val _ = Datatype `a_type = AT_Nil | AT_Rec (a_type list) ((a_type # num) list)`;
+val _ = Datatype `a_b_type = ABT_Nil
+  | ABT_Rec (bool list) ((a_b_type # num) list)`;
+val _ = Datatype.Hol_datatype `a_c_type = ACT_Nil
+  | ACT_One of 'a | ACT_Two of 'b | ACT_Rec of (a_c_type # num) list`;
+
+val r = register_type ``:a_type``;
+val r = register_type ``:a_b_type``;
+val r = register_type ``:('a, 'b) a_c_type``;
+
+val a_inv = get_type_inv ``:a_type``;
+val a_b_inv = get_type_inv ``:a_b_type``;
+val a_c_inv_num = get_type_inv ``:(num, num) a_c_type``;
+
+val EqTyp_test_lemmas = Q.store_thm ("EqTyp_test_lemmas",
+  `EqualityType (^a_inv) /\ EqualityType (^a_b_inv)
+    /\ EqualityType (^a_c_inv_num)`,
+  fs (eq_lemmas ()));
 
 val _ = export_theory();

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -209,18 +209,21 @@ val _ = Datatype `a_b_type = ABT_Nil
   | ABT_Rec (bool list) ((a_b_type # num) list)`;
 val _ = Datatype.Hol_datatype `a_c_type = ACT_Nil
   | ACT_One of 'a | ACT_Two of 'b | ACT_Rec of (a_c_type # num) list`;
+val _ = Datatype `simple_type = STA | STB | STC | STX | STY | STZ`;
 
 val r = register_type ``:a_type``;
 val r = register_type ``:a_b_type``;
 val r = register_type ``:('a, 'b) a_c_type``;
+val r = register_type ``:simple_type``;
 
 val a_inv = get_type_inv ``:a_type``;
 val a_b_inv = get_type_inv ``:a_b_type``;
 val a_c_inv_num = get_type_inv ``:(num, num) a_c_type``;
+val st_inv = get_type_inv ``:simple_type``;
 
 val EqTyp_test_lemmas = Q.store_thm ("EqTyp_test_lemmas",
   `EqualityType (^a_inv) /\ EqualityType (^a_b_inv)
-    /\ EqualityType (^a_c_inv_num)`,
+    /\ EqualityType (^a_c_inv_num) /\ EqualityType (^st_inv)`,
   fs (eq_lemmas ()));
 
 val _ = export_theory();


### PR DESCRIPTION
Replaces the EqualityType prover with one that can handle some more complex inductions.

I can then delete all the manual EqualityType proofs from parserProg.

I think I can eventually delete all the manual EqualityType proofs, however I haven't made those edits because I think it would lead to merge conflicts with the cleanup that @oskarabrahamsson is doing.
  - I expect this PR will be edited to fit with that work before it is merged.
  - I still want to test & discuss the PR as-is.

There's one issue in the code I'd like some feedback on. I'm using dest_thy_const/DB.fetch in a clunky way to guess the definitions of the type invariant functions (LIST_TYPE etc) and to fetch a theorem about the num2x operator defined by EnumType. There's a pattern where the constant is always defined together with some key theorem, and you can guess the name of the key theorem. How ugly is that? Is it OK to keep doing it? I could ml_translatorLib to track both the type invariant constant names and their definitions, but I can't do the equivalent for EnumType/TypeBase.

