### PR TITLE
Local blocks in ml_progLib

### DIFF
--- a/basis/basisFunctionsLib.sml
+++ b/basis/basisFunctionsLib.sml
@@ -11,10 +11,9 @@ open preamble
          library instead *)
 
 fun get_module_prefix () = let
-  val mod_tm = ml_progLib.get_thm (get_ml_prog_state ())
-               |> concl |> rator |> rator |> rand
-  in if optionSyntax.is_none mod_tm then "" else
-       stringSyntax.fromHOLstring (mod_tm |> rand |> rator |> rand) ^ "_"
+  val mods = ml_progLib.get_open_modules (get_ml_prog_state ())
+  in case mods of [] => ""
+    | (m :: ms) => m ^ "_"
   end
 
 fun trans ml_name rhs = let

--- a/basis/basis_ffiLib.sml
+++ b/basis/basis_ffiLib.sml
@@ -119,12 +119,13 @@ fun whole_prog_thm st name spec =
        else raise(call_ERR "Conclusion must be a whole_prog_spec or whole_prog_ffidiv_spec")
     val th =
       whole_prog_spec_thm
-        |> C MATCH_MP (st |> get_thm |> GEN_ALL |> ISPEC basis_ffi_tm)
+        |> C MATCH_MP (st |> get_Decls_thm |> GEN_ALL |> ISPEC basis_ffi_tm)
         |> SPEC(stringSyntax.fromMLstring name)
         |> CONV_RULE(QUANT_CONV(LAND_CONV(LAND_CONV EVAL THENC SIMP_CONV std_ss [])))
         |> CONV_RULE(HO_REWR_CONV UNWIND_FORALL_THM1)
         |> C HO_MATCH_MP spec
         |> SIMP_RULE bool_ss [option_case_def, set_sepTheory.SEP_CLAUSES]
+    (* TS: what is this doing? why not call remove_snocs? *)
     val prog_with_snoc = th |> concl |> find_term listSyntax.is_snoc
     val prog_rewrite = EVAL prog_with_snoc
     val th = PURE_REWRITE_RULE[prog_rewrite] th

--- a/basis/basis_ffiScript.sml
+++ b/basis/basis_ffiScript.sml
@@ -443,7 +443,7 @@ val whole_prog_ffidiv_spec_def = Define`
 
 Theorem whole_prog_spec_semantics_prog
   `∀fname fv.
-     ML_code env1 (init_state (basis_ffi cl fs)) prog NONE env2 st2 ==>
+     Decls env1 (init_state (basis_ffi cl fs)) prog env2 st2 ==>
      lookup_var fname env2 = SOME fv ==>
      whole_prog_spec fv cl fs sprop Q ==>
      (?h1 h2. SPLIT (st2heap (basis_proj1, basis_proj2) st2) (h1,h2) /\
@@ -492,7 +492,7 @@ Theorem whole_prog_spec_semantics_prog
 
 Theorem whole_prog_spec_semantics_prog_ffidiv
   `∀fname fv.
-     ML_code env1 (init_state (basis_ffi cl fs)) prog NONE env2 st2 ==>
+     Decls env1 (init_state (basis_ffi cl fs)) prog env2 st2 ==>
      lookup_var fname env2 = SOME fv ==>
      whole_prog_ffidiv_spec fv cl fs Q ==>
      (?h1 h2. SPLIT (st2heap (basis_proj1, basis_proj2) st2) (h1,h2) /\
@@ -618,8 +618,13 @@ Theorem oracle_parts_div
   \\ disj2_tac
   \\ CCONTR_TAC \\ fs[] \\ rfs[]);
 
+val _ = translation_extends "TextIOProg";
+val st_f = get_ml_prog_state () |> get_state |> strip_comb |> fst;
+val st = mk_icomb (st_f, ``basis_ffi cls fs``);
+val _ = reset_translation ()
+
 Theorem parts_ok_basis_st
-  `parts_ok (auto_state_1 (basis_ffi cls fs)).ffi (basis_proj1, basis_proj2)`
+  `parts_ok (^st).ffi (basis_proj1, basis_proj2)`
   (qmatch_goalsub_abbrev_tac`st.ffi`
   \\ `st.ffi.oracle = basis_ffi_oracle`
   by( simp[Abbr`st`] \\ EVAL_TAC \\ NO_TAC)

--- a/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
@@ -326,8 +326,7 @@ fun define_abbrev_conv name tm = let
   in GSYM def |> SPEC_ALL end
 
 val candle_prog_thm =
-  get_thm (get_ml_prog_state()) (* (get_curr_prog_state ()) *)
-  |> REWRITE_RULE [ML_code_def]
+  get_Decls_thm (get_ml_prog_state()) (* (get_curr_prog_state ()) *)
   |> CONV_RULE ((RATOR_CONV o RATOR_CONV o RAND_CONV)
                 (EVAL THENC define_abbrev_conv "candle_code"))
   |> CONV_RULE ((RATOR_CONV o RAND_CONV)

--- a/characteristic/cfMainScript.sml
+++ b/characteristic/cfMainScript.sml
@@ -22,14 +22,14 @@ val fname = mk_var("fname",``:string``);
 val main_call = mk_main_call fname;
 
 Theorem call_main_thm1
-`ML_code env1 st1 prog NONE env2 st2 ==> (* get this from the current ML prog state *)
+`Decls env1 st1 prog env2 st2 ==> (* get this from the current ML prog state *)
  lookup_var fname env2 = SOME fv ==> (* get this by EVAL *)
   app p fv [Conv NONE []] P (POSTv uv. &UNIT_TYPE () uv * Q) ==> (* this should be the CF spec you prove for the "main" function *)
     SPLIT (st2heap p st2) (h1,h2) /\ P h1 ==>  (* this might need simplification, but some of it may need to stay on the final theorem *)
     ∃st3.
       Decls env1 st1 (SNOC ^main_call prog) env2 st3 /\
       (?h3 h4. SPLIT3 (st2heap p st3) (h3,h2,h4) /\ Q h3)`
-  (rw[ml_progTheory.ML_code_def,SNOC_APPEND,ml_progTheory.Decls_APPEND,PULL_EXISTS]
+  (rw[SNOC_APPEND,ml_progTheory.Decls_APPEND,PULL_EXISTS]
   \\ simp[ml_progTheory.Decls_def]
   \\ fs [terminationTheory.evaluate_decs_def,PULL_EXISTS,
          EVAL ``(pat_bindings (Pcon NONE []) [])``,pair_case_eq,result_case_eq]
@@ -143,7 +143,7 @@ Theorem FFI_part_hprop_SEP_EXISTS
   (rw[FFI_part_hprop_def,SEP_EXISTS_THM] \\ res_tac);
 
 Theorem call_main_thm2
-  `ML_code env1 st1 prog NONE env2 st2 ==>
+  `Decls env1 st1 prog env2 st2 ==>
    lookup_var fname env2 = SOME fv ==>
   app (proj1, proj2) fv [Conv NONE []] P (POSTv uv. &UNIT_TYPE () uv * Q) ==>
   FFI_part_hprop Q ==>
@@ -160,7 +160,7 @@ Theorem call_main_thm2
          suffices_by metis_tac[prog_to_semantics_prog]
   \\ reverse (sg `?st3. Decls env1 st1 (SNOC ^main_call prog) env2 st3 ∧ B st3`)
   THEN1 (asm_exists_tac \\ fs [Abbr`C`]
-         \\ fs [ml_progTheory.ML_code_def,ml_progTheory.Decls_def]
+         \\ fs [ml_progTheory.Decls_def]
          \\ imp_res_tac evaluate_decs_call_FFI_rel_imp \\ fs [])
   \\ simp[Abbr`A`,Abbr`B`]
   \\ drule (GEN_ALL call_main_thm1)
@@ -169,7 +169,7 @@ Theorem call_main_thm2
   \\ asm_exists_tac \\ simp[]);
 
 Theorem call_main_thm2_ffidiv
-  `ML_code env1 st1 prog NONE env2 st2 ==>
+  `Decls env1 st1 prog env2 st2 ==>
    lookup_var fname env2 = SOME fv ==>
   app (proj1, proj2) fv [Conv NONE []] P (POSTf n. λ c b. Q n c b) ==>
   SPLIT (st2heap (proj1, proj2) st2) (h1,h2) /\ P h1
@@ -187,7 +187,7 @@ Theorem call_main_thm2_ffidiv
                                      st4.ffi.io_events)
                        /\ B st4 n c b /\ C st1 st4`
        suffices_by metis_tac[prog_SNOC_semantics_prog]
-  \\ fs[ml_progTheory.ML_code_def]
+  \\ fs[]
   \\ asm_exists_tac \\ fs[app_def,app_basic_def]
   \\ first_x_assum drule \\ impl_tac >- simp[]
   \\ rpt strip_tac

--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -44,6 +44,9 @@ val () = ml_progComputeLib.add_env_compset cs
 val () = cfComputeLib.add_cf_aux_compset cs
 val () = computeLib.extend_compset [
   computeLib.Defs [
+(*  TS: it's quite unclear to me why CF does this, when ml_progScript is so
+    careful to ensure that these definitions aren't in the compset. I've tried
+    adjusting it, but it results in far too much work. *)
     ml_progTheory.merge_env_def,
     ml_progTheory.write_def,
     ml_progTheory.write_mod_def,

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -364,12 +364,10 @@ misc code to generate the unverified register allocator in SML
 
 open ml_progLib astPP
 
-val ML_code_prog =
+val prog =
   get_ml_prog_state ()
   |> clean_state |> remove_snocs
-  |> get_thm
-
-val prog = ML_code_prog |> concl |> strip_comb |> #2 |> el 3
+  |> ml_progLib.get_prog
 
 val _ = enable_astPP()
 val _ = trace("pp_avoids_symbol_merges",0)

--- a/misc/alist_treeLib.sml
+++ b/misc/alist_treeLib.sml
@@ -210,7 +210,10 @@ fun mk_repr_step rs tm = let
       in MATCH_MP alist_repr_choice_trans_left (CONJ l_repr_thm next_repr) end
     else if not (null merge_lhs) orelse is_alookup
     then CHANGED_CONV (SIMP_CONV bool_ss [alookup_to_option_choice,
-                option_choice_f_assoc, alookup_empty_option_choice_f]) tm
+                option_choice_f_assoc, alookup_empty_option_choice_f,
+                count_append_def, alookup_append_option_choice_f]) tm
+        handle HOL_ERR _ => raise err "mk_repr_step" ("failed to SIMP_CONV: "
+            ^ Parse.term_to_string tm)
     else raise err "mk_repr_step" ("no step for: " ^ Parse.term_to_string f)
   end
 and mk_repr_known_step (AList_Reprs inn_rs) tm =

--- a/misc/alist_treeScript.sml
+++ b/misc/alist_treeScript.sml
@@ -207,10 +207,9 @@ Theorem option_choice_f_assoc
   (fs [option_choice_f_def, FUN_EQ_THM]
     \\ Cases_on `f x` \\ fs []);
 
-Theorem repr_empty
-  `irreflexive R /\ transitive R ==>
-    (f = (\x. NONE)) ==> sorted_alist_repr R [] f`
-  (fs [FUN_EQ_THM, sorted_alist_repr_def]);
+Theorem empty_is_ALOOKUP
+  `(\x. NONE) = ALOOKUP []`
+  (fs [FUN_EQ_THM]);
 
 Theorem repr_insert
   `sorted_alist_repr R al f /\ is_insert fl fr R k x al al' ==>

--- a/semantics/proofs/evaluatePropsScript.sml
+++ b/semantics/proofs/evaluatePropsScript.sml
@@ -875,7 +875,9 @@ Theorem is_clock_io_mono_set_clock
   \\ rpt (FIRST (map CHANGED_TAC [fs [], strip_tac]))
   \\ metis_tac []);
 
-val evaluate_set_clock_lemmas = BODY_CONJUNCTS is_clock_io_mono_evaluate
+val evaluate_set_clock_lemmas
+  = (BODY_CONJUNCTS is_clock_io_mono_evaluate
+    @ BODY_CONJUNCTS is_clock_io_mono_evaluate_decs)
   |> map (BETA_RULE o MATCH_MP is_clock_io_mono_set_clock);
 
 Theorem evaluate_set_clock
@@ -883,6 +885,14 @@ Theorem evaluate_set_clock
       evaluate s env exps = (s1,res) /\
       res <> Rerr (Rabort Rtimeout_error) ==>
       !ck. ?ck1. evaluate (s with clock := ck1) env exps =
+                   (s1 with clock := ck,res)`
+  (metis_tac evaluate_set_clock_lemmas);
+
+Theorem evaluate_decs_set_clock
+  `!s env decs s1 res.
+      evaluate_decs s env decs = (s1,res) /\
+      res <> Rerr (Rabort Rtimeout_error) ==>
+      !ck. ?ck1. evaluate_decs (s with clock := ck1) env decs =
                    (s1 with clock := ck,res)`
   (metis_tac evaluate_set_clock_lemmas);
 

--- a/translator/ml_progLib.sig
+++ b/translator/ml_progLib.sig
@@ -57,6 +57,10 @@ sig
   val get_state    : ml_prog_state -> term (* state in ML_code thm *)
   val get_v_defs   : ml_prog_state -> thm list (* v abbrev defs *)
 
+  (* the list of (nested) module blocks that have been opened but not yet
+     closed, outermost first. *)
+  val get_open_modules : ml_prog_state -> string list
+
   val get_next_exn_stamp  : ml_prog_state -> int
   val get_next_type_stamp : ml_prog_state -> int
 

--- a/translator/ml_progLib.sig
+++ b/translator/ml_progLib.sig
@@ -69,6 +69,9 @@ sig
   val get_state    : ml_prog_state -> term (* state in ML_code thm *)
   val get_v_defs   : ml_prog_state -> thm list (* v abbrev defs *)
 
+  val get_Decls_thm : ml_prog_state -> thm (* Decls thm at top level *)
+  val get_prog      : ml_prog_state -> term (* program at top level *)
+
   val get_next_exn_stamp  : ml_prog_state -> int
   val get_next_type_stamp : ml_prog_state -> int
 

--- a/translator/ml_progLib.sig
+++ b/translator/ml_progLib.sig
@@ -16,6 +16,17 @@ sig
   val close_module : term option (* optional signature *) ->
                      ml_prog_state -> ml_prog_state
 
+  (* names of (nested) opened modules, outermost first *)
+  val get_open_modules : ml_prog_state -> string list
+
+  (* use of local/in/end blocks, by calling these three functions in order *)
+  val open_local_block    : ml_prog_state -> ml_prog_state
+  val open_local_in_block : ml_prog_state -> ml_prog_state
+  val close_local_block   : ml_prog_state -> ml_prog_state
+
+  (* close all local blocks up to the module/global scope *)
+  val close_local_blocks  : ml_prog_state -> ml_prog_state
+
   val add_Dtype    : term (* loc *) -> term (* tds *) ->
                      ml_prog_state -> ml_prog_state
 
@@ -48,6 +59,7 @@ sig
                      ml_prog_state -> ml_prog_state
 
   val nsLookup_conv : conv
+  val nsLookup_pf_conv : conv
 
   val remove_snocs : ml_prog_state -> ml_prog_state
   val clean_state  : ml_prog_state -> ml_prog_state
@@ -56,10 +68,6 @@ sig
   val get_env      : ml_prog_state -> term (* env in ML_code thm *)
   val get_state    : ml_prog_state -> term (* state in ML_code thm *)
   val get_v_defs   : ml_prog_state -> thm list (* v abbrev defs *)
-
-  (* the list of (nested) module blocks that have been opened but not yet
-     closed, outermost first. *)
-  val get_open_modules : ml_prog_state -> string list
 
   val get_next_exn_stamp  : ml_prog_state -> int
   val get_next_type_stamp : ml_prog_state -> int

--- a/translator/ml_progLib.sml
+++ b/translator/ml_progLib.sml
@@ -257,7 +257,7 @@ fun let_env_abbrev conv op_nm (th, ML_code (ss, envs, vs, ml_th)) = let
   in (th, ML_code (ss, abbrev_defs @ envs, vs, ml_th)) end
 
 fun let_v_abbrev nm conv op_nm (th, ML_code (ss, envs, vs, ml_th)) = let
-    val (th, abbrev_defs) = cond_let_abbrev false true nm conv op_nm th
+    val (th, abbrev_defs) = cond_let_abbrev false false nm conv op_nm th
   in (th, ML_code (ss, envs, abbrev_defs @ vs, ml_th)) end
 
 fun solve_ml_imp f nm (th, ML_code code) = let

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -386,6 +386,15 @@ Theorem Decls_Dmod
   \\ rw [] \\ eq_tac \\ rw [] \\ fs [pair_case_eq,result_case_eq]
   \\ rveq \\ fs [] \\ asm_exists_tac \\ fs []);
 
+Theorem Decls_Dlocal
+  `Decls env st lds env2 st2
+    ==> Decls (merge_env env2 env) st2 ds env3 st3
+    ==> Decls env st [Dlocal lds ds] env3 st3`
+  (fs [Decls_def,evaluate_decs_def,extend_dec_env_def,merge_env_def]
+  \\ rw [pair_case_eq, result_case_eq]
+  \\ imp_res_tac evaluate_decs_set_clock
+  \\ fs [] \\ metis_tac []);
+
 Theorem Decls_NIL
   `!env s n l env2 s2.
       Decls env s [] env2 s2 <=>
@@ -514,10 +523,10 @@ Theorem ML_code_NIL
 
 (* opening and closing of modules *)
 
-Theorem ML_code_new_module
-  `!mn. ML_code inp_env ((comm, st, decls, env) :: bls) st2 ==>
+Theorem ML_code_new_block
+  `!comm2. ML_code inp_env ((comm, st, decls, env) :: bls) st2 ==>
     let env2 = ML_code_env inp_env ((comm, st, decls, env) :: bls) in
-    ML_code inp_env ((("Module", mn), st2, [], empty_env)
+    ML_code inp_env ((comm2, st2, [], empty_env)
         :: (comm, st, decls, env) :: bls) st2`
   (fs [ML_code_def] \\ rw [Decls_NIL] \\ EVAL_TAC);
 
@@ -532,6 +541,16 @@ Theorem ML_code_close_module
   \\ asm_exists_tac \\ fs [Decls_Dmod,PULL_EXISTS]
   \\ asm_exists_tac
   \\ fs [write_mod_def,merge_env_def,empty_env_def]);
+
+Theorem ML_code_close_local
+  `ML_code inp_env ((("Local", ln2), l2_i_st, l2_decls, l2_env)
+        :: (("Local", ln1), l1_i_st, l1_decls, l1_env)
+        :: (comm, st, decls, env) :: bls) st2
+    ==> let env2 = merge_env l2_env env
+        in ML_code inp_env ((comm, st, SNOC (Dlocal l1_decls l2_decls) decls,
+            env2) :: bls) st2`
+  (rw [ML_code_def, ML_code_env_def]
+  \\ fs [SNOC_APPEND,Decls_APPEND] \\ metis_tac [Decls_Dlocal]);
 
 (* appending a Dtype *)
 

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -481,6 +481,12 @@ val ML_code_def = Define `(ML_code env [] res_st <=> T)
         res_st <=> (ML_code env bls st
             /\ Decls (ML_code_env env bls) st decls res_env res_st))`;
 
+(* retreive the Decls from a toplevel ML_code *)
+Theorem ML_code_Decls
+  `ML_code env1 [(comm, st1, prog, env2)] st2 ==>
+    Decls env1 st1 prog env2 st2`
+  (fs [ML_code_def, ML_code_env_def]);
+
 (* an empty program *)
 local open primSemEnvTheory in
 

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -546,8 +546,7 @@ Theorem ML_code_Dtype
 (* appending a Dexn *)
 
 Theorem ML_code_Dexn
-  `ML_code ((comm, env1, s1, prog, env2) :: bls) s2 ==>
-   !n l locs.
+  `!n l locs. ML_code ((comm, env1, s1, prog, env2) :: bls) s2 ==>
      let nes = s2.next_exn_stamp in
      let s3 = s2 with next_exn_stamp := nes + 1 in
      let env3 = write_cons n (LENGTH l,ExnStamp nes) env2 in
@@ -588,9 +587,9 @@ Theorem ML_code_Dletrec
 Theorem ML_code_Dlet_var
   `!e s3 x n locs. ML_code ((comm, env1, s1, prog, env2) :: bls) s2 ==>
     eval_rel s2 (merge_env env2 env1) e s3 x ==>
-    let env3 = write n x env2 in
+    let env3 = write n x env2 in let s3_abbrev = s3 in
     ML_code ((comm, env1, s1, SNOC (Dlet locs (Pvar n) e) prog, env3)
-        :: bls) s3`
+        :: bls) s3_abbrev`
   (fs [ML_code_def,SNOC_APPEND,Decls_APPEND,Decls_Dlet]
   \\ rw [] \\ asm_exists_tac \\ fs [PULL_EXISTS]
   \\ fs [write_def,merge_env_def,empty_env_def,sem_env_component_equality]);

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -483,7 +483,9 @@ local
     |> (SIMP_CONV std_ss [primSemEnvTheory.prim_sem_env_eq] THENC EVAL)
     |> concl |> rand
 in
-  val init_env_def = Define `
+  (* init_env_def should not be unpacked by EVAL. Queries will be handled
+     by the nsLookup_conv apparatus, which will use the pfun_eqs thm below. *)
+  val init_env_def = zDefine `
     init_env = ^init_env_tm`;
   val init_state_def = Define `
     init_state ffi = ^init_state_tm`;
@@ -491,9 +493,9 @@ end
 
 Theorem init_state_env_thm
   `THE (prim_sem_env ffi) = (init_state ffi,init_env)`
-  (CONV_TAC(RAND_CONV EVAL) \\ rewrite_tac[prim_sem_env_eq,THE_DEF]);
+  (rewrite_tac[prim_sem_env_eq,THE_DEF,init_state_def,init_env_def]);
 
-val nsLookup_init_state_pfun_eqs = save_thm("nsLookup_init_state_pfun_eqs",
+val nsLookup_init_env_pfun_eqs = save_thm("nsLookup_init_env_pfun_eqs",
   [``nsLookup_Short init_env.c``, ``nsLookup_Short init_env.v``,
     ``nsLookup_Mod1 init_env.c``, ``nsLookup_Mod1 init_env.v``]
   |> map (SIMP_CONV bool_ss

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -120,15 +120,15 @@ sig
     val find_const_name : string -> string
     val add_v_thms : string * string * thm * thm -> unit
     val lookup_v_thm : term -> thm
-    val get_v_thms_ref : unit -> (string * string * term * thm * thm * string option) list ref
+    val get_v_thms_ref : unit -> (string * string * term * thm * thm * string list) list ref
     val remove_Eq_from_v_thm : thm -> thm
 
     (* Internal - handling type constructor names *)
     val mk_cons_name : term -> string
     val enter_cons_name : term * term -> string
-    val lookup_cons_name : string -> term * string option
+    val lookup_cons_name : string -> term * string list
     val instantiate_cons_name : thm -> thm
-    val get_cons_names : unit -> (string * (term * string option)) list
+    val get_cons_names : unit -> (string * (term * string list)) list
 
     (* Internal - for preprocess_monadic_def *)
     val force_eqns                   : thm -> thm

--- a/translator/ml_translatorLib.sml
+++ b/translator/ml_translatorLib.sml
@@ -896,7 +896,7 @@ fun prove_lookup_cons_eq tm =
     val _ = not (null (free_vars tm)) orelse aconv c T orelse aconv c F orelse
               failwith "prove_lookup_cons_eq failed to reduce to F or T"
   in res end
-  handle e => (prove_lookup_cons_eq_fail := tm; raise e);
+  handle e => (prove_lookup_cons_eq_fail := tm; print_term tm; raise e);
 
 fun tag_name type_name const_name =
   if (type_name = "LIST_TYPE") andalso (const_name = "NIL") then "nil" else
@@ -1860,10 +1860,12 @@ in
     in (case_lemma) end
   fun store_eq_thm th = (add_eq_lemma th; th)
   fun register_exn_type_main abstract_mode ty = let
+    val start = start_timing ("adding exn type " ^ Parse.type_to_string ty)
     val (rws1,rws2,res,dprog) = derive_thms_for_type true ty
     val _ = store_dprog abstract_mode dprog
-    val _ = add_type_thms (rws1,rws2,res)
-    val _ = map do_translate rws1
+    val _ = do_timing "add_type_thms" add_type_thms (rws1,rws2,res)
+    val _ = do_timing "map do_translate rws1" (map do_translate) rws1
+    val _ = end_timing start
     in () end
   val register_exn_type = register_exn_type_main false
   val abs_register_exn_type = register_exn_type_main true

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -195,18 +195,21 @@ Theorem Eval_Let
   \\ fs [namespaceTheory.nsOptBind_def]
   \\ fs [empty_state_def,state_component_equality]);
 
+Theorem Eval_Var_general
+  `P v ==> !iden. nsLookup env.v iden = SOME v ==> Eval env (Var iden) P`
+  (fs [Eval_rw,state_component_equality]);
+
 Theorem Eval_Var_Short
   `P v ==> !name env.
                (nsLookup env.v (Short name) = SOME v) ==>
                Eval env (Var (Short name)) P`
-  (fs [Eval_rw,state_component_equality]);
+  (fs [Eval_Var_general]);
 
-(*TODO: Single level mdule *)
 Theorem Eval_Var_Long
   `P v ==> !m name env.
                (nsLookup env.v (Long m (Short name)) = SOME v) ==>
                Eval env (Var (Long m (Short name))) P`
-  (fs [Eval_rw,state_component_equality]);
+  (fs [Eval_Var_general]);
 
 Theorem Eval_Var_SWAP_ENV
   `!env1.

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -265,4 +265,28 @@ val _ = ml_prog_update (close_module NONE);
 val _ = ml_prog_update close_local_block;
 val r = translate global_f6_def;
 
+(* translating within nested modules *)
+
+val m1_m2_f_def = Define `m1_m2_f i = SUC 1 + i`;
+val m1_m3_f_def = Define `m1_m3_f i = m1_m2_f (SUC i)`;
+val m1_f_def = Define `m1_f i = m1_m2_f (m1_m3_f i)`;
+val m4_f_def = Define `m4_f i = m1_f i + m1_m3_f (m1_m2_f i)`;
+val m4_m5_f_def = Define `m4_m5_f i = m1_f i + m4_f i + m1_m2_f i`;
+
+val _ = ml_prog_update (open_module "m1");
+val _ = ml_prog_update (open_module "m2");
+val r = translate m1_m2_f_def;
+val _ = ml_prog_update (close_module NONE);
+val _ = ml_prog_update (open_module "m3");
+val r = translate m1_m3_f_def;
+val _ = ml_prog_update (close_module NONE);
+val r = translate m1_f_def;
+val _ = ml_prog_update (close_module NONE);
+val _ = ml_prog_update (open_module "m4");
+val r = translate m4_f_def;
+val _ = ml_prog_update (open_module "m5");
+val r = translate m4_m5_f_def;
+val _ = ml_prog_update (close_module NONE);
+val _ = ml_prog_update (close_module NONE);
+
 val _ = export_theory();

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -238,4 +238,31 @@ Theorem EqTyp_test_lemmas
     /\ EqualityType (^st2_inv)`
   (fs (eq_lemmas ()));
 
+(* translating within nested local blocks and modules *)
+
+val hidden_f1_def = Define `hidden_f1 xs = REVERSE xs ++ [()]`;
+val global_f2_def = Define `global_f2 xs = hidden_f1 xs ++ [()]`;
+val hidden_f3_def = Define `hidden_f3 xs = global_f2 (hidden_f1 xs)`;
+val module_f4_def = Define `module_f4 xs = hidden_f3 (global_f2 xs)`;
+val module_f5_def = Define `module_f5 xs = module_f4 xs`;
+val global_f6_def = Define `global_f6 xs = module_f5 xs ++ module_f4 xs`;
+
+val r = translate REVERSE_DEF;
+val _ = ml_prog_update open_local_block;
+val r = translate hidden_f1_def;
+val _ = ml_prog_update open_local_in_block;
+val r = translate global_f2_def;
+val _ = ml_prog_update (open_module "f4_module");
+val _ = ml_prog_update open_local_block;
+val r = translate hidden_f3_def;
+val _ = ml_prog_update open_local_in_block;
+val r = translate module_f4_def;
+val _ = ml_prog_update open_local_block;
+val _ = ml_prog_update open_local_in_block;
+val r = translate module_f5_def;
+val _ = ml_prog_update close_local_blocks;
+val _ = ml_prog_update (close_module NONE);
+val _ = ml_prog_update close_local_block;
+val r = translate global_f6_def;
+
 val _ = export_theory();

--- a/translator/monadic/ml_monadStoreLib.sml
+++ b/translator/monadic/ml_monadStoreLib.sml
@@ -14,11 +14,13 @@ open ml_monadBaseTheory ml_monad_translatorBaseTheory ml_monad_translatorTheory 
 open Redblackmap AC_Sort Satisfy
 open ml_translatorLib
 
-(* COPY/PASTE from basisFunctionsLib *)
+(* COPY/PASTE from other manual eval_rel proofs *)
 fun derive_eval_thm for_eval v_name e = let
-  val th = get_ml_prog_state () |> get_thm
-  val th = MATCH_MP ml_progTheory.ML_code_Dlet_var th
-  val goal = th |> SPEC e |> SPEC_ALL |> concl |> dest_imp |> fst
+  val env = get_ml_prog_state () |> get_env
+  val st = get_ml_prog_state () |> get_state
+  val st2 = mk_var ("st2", type_of st)
+  val goal = list_mk_icomb (prim_mk_const {Thy="ml_prog", Name="eval_rel"},
+    [st, env, e, st2, mk_var ("x", semanticPrimitivesSyntax.v_ty)])
   val lemma = goal
     |> (NCONV 50 (SIMP_CONV (srw_ss()) [evaluate_def,ml_progTheory.eval_rel_alt,
             PULL_EXISTS,do_app_def,store_alloc_def,LET_THM]) THENC EVAL)
@@ -34,7 +36,7 @@ fun derive_eval_thm for_eval v_name e = let
   val v_tm = v_thm |> concl |> rand
   val v_def = define_abbrev for_eval v_name v_tm
   in v_thm |> REWRITE_RULE [GSYM v_def] end
-(* end of COPY/PASTE from basisFunctionsLib *)
+(* end of COPY/PASTE *)
 
 fun ERR fname msg = mk_HOL_ERR "ml_monadStoreLib" fname msg;
 


### PR DESCRIPTION
This collection of patches adds local-block support to ml_progLib.

For this to be useful, this requires supporting a stack of open blocks, rather than the 1-2 available previously (global + one module). Nested modules are now supported and have been very very lightly tested. Along the way, the ML_code theorem shape had to change, and rather than trying to make sense of all the RATOR_CONVs and RAND_CONVs, I refactored the way that the relevant theorems are defined and applied.


