### PR TITLE
Add header file for compcert compatibility

### DIFF
--- a/basis/basis_ffi.c
+++ b/basis/basis_ffi.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 
 /* clFFI (command line) */


### PR DESCRIPTION
Currently, compiling `basis_ffi.c` with compcert (the newest release, version 3.4) results in the following error "use of undeclared identifier 'S_IRUSR'". This macro, along with the other mode arguments for open(), are defined in `sys/stat.h`. Including this header resolves the issue.

I'm not sure why this isn't a problem when compiling under gcc. I assume one of the other header files includes `sys/stat.h`, but I was also under the assumption that both compcert and gcc would use the same system-provided header files. Regardless, the [linux man page](http://man7.org/linux/man-pages/man2/open.2.html) for open() seems to suggest including `sys/stat.h` (as well as `sys/types.h`, although this was not necessary on my machine), so including these may be wise for portability reasons.