### PR TITLE
Use classic pattern matching heuristic

### DIFF
--- a/compiler/backend/bvl_handleScript.sml
+++ b/compiler/backend/bvl_handleScript.sml
@@ -81,7 +81,7 @@ val compile_exp_def = Define `
   compile_exp cut_size arity e =
     HD (FST (compile cut_size arity [bvl_const$compile_exp e]))`;
 
-val dest_Seq_def = Define `
+val dest_Seq_def = PmatchHeuristics.with_classic_heuristic Define `
   (dest_Seq (Let [e1;e2] (Var 1)) = SOME (e1,e2)) /\
   (dest_Seq _ = NONE)`
 

--- a/semantics/cmlPtreeConversionScript.sml
+++ b/semantics/cmlPtreeConversionScript.sml
@@ -597,7 +597,7 @@ val Papply_def = Define`
     | _ => pat
 `;
 
-val maybe_handleRef_def = Define‘
+val maybe_handleRef_def = PmatchHeuristics.with_classic_heuristic Define‘
   maybe_handleRef (Pcon (SOME (Short "Ref")) [pat]) = Pref pat ∧
   maybe_handleRef p = p
 ’;


### PR DESCRIPTION
@immler and I have come across a couple of definitions that seem to fall back on the "classic" pattern matching heuristic after attempting to use some other heuristic. This presents a problem for our HOL4/Isabelle kernel, since it currently cannot handle constant redefinitions.  
Telling the definitions to use the appropriate heuristic helps us avoid this and should not change the result.