### PR TITLE
Fix too many open files error

### DIFF
--- a/compiler/parsing/tests/cmlTestsScript.sml
+++ b/compiler/parsing/tests/cmlTestsScript.sml
@@ -19,11 +19,10 @@ Overload EREL =
                   [NN nElogicOR
                       [NN nElogicAND
                           [NN nEtyped [NN nEbefore [NN nEcomp l]]]]]]``
-Overaload EB =
-  ``λl. EREL [NN nErel [NN nElistop [NN nEadd [NN nEmult [NN nEapp [NN nEbase l]]]]]]``
+Overload EB = ``λl. EREL [NN nErel [NN nElistop [NN nEadd [NN nEmult [NN nEapp [NN nEbase l]]]]]]``
 
 Overload OLDAPP = ``λt1 t2. App Opapp [t1; t2]``
-Overload "" = ``λt1 t2. App Opapp [t1; t2]``
+(* Overload "" = ``λt1 t2. App Opapp [t1; t2]`` *)
 Overload vbinop = ``λopn a1 a2. App Opapp [App Opapp [Var opn; a1]; a2]``
 Overload V = ``λvnm. Var (Short vnm)``
 Overload Pc = ``λcnm. Pcon (SOME (Short cnm))``

--- a/developers/readme_gen.sml
+++ b/developers/readme_gen.sml
@@ -221,6 +221,7 @@ fun read_block_comment start_comment end_comment filename = let
     val all_lines =
       map (drop_chars (String.size blank_prefix)) (fst_line :: read_rest ())
     val _ = check_length_and_width all_lines
+    val _ = TextIO.closeIn(f)
     in all_lines end handle e => (TextIO.closeIn(f); raise e)
   end end;
 
@@ -256,6 +257,7 @@ fun read_comment_from_script filename = let
     val all_lines =
       map (drop_chars (String.size prefix)) (fst_line :: read_rest ())
     val _ = check_length_and_width all_lines
+    val _ = TextIO.closeIn(f)
     in all_lines end handle e => (TextIO.closeIn(f); raise e)
   end;
 
@@ -276,6 +278,7 @@ fun read_comment_from_raw filename = let
     val _ = not (String.isPrefix " " (hd all_lines)) orelse
             fail "first line must not start with a blank"
     val _ = check_length_and_width all_lines
+    val _ = TextIO.closeIn(f)
     in all_lines end handle e => (TextIO.closeIn(f); raise e)
   end;
 


### PR DESCRIPTION
I had problem running the recursive tests of `readme_gen.sml`. The `readme_gen.sml` program was not closing the files, I have made it close them. 