### PR TITLE
rename CompileError to AssembleError

### DIFF
--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -64,7 +64,7 @@ val _ = Datatype`
      ; only_print_sexp     : bool
      |>`;
 
-val _ = Datatype`compile_error = ParseError | TypeError mlstring | CompileError | ConfigError mlstring`;
+val _ = Datatype`compile_error = ParseError | TypeError mlstring | AssembleError | ConfigError mlstring`;
 
 val locs_to_string_def = Define `
   (locs_to_string NONE = implode "unknown location") ∧
@@ -115,7 +115,7 @@ val compile_def = Define`
             (Failure (TypeError (implode(print_sexp (listsexp (MAP decsexp full_prog))))),[])
           else
           case backend$compile_tap c.backend_config full_prog of
-          | (NONE, td) => (Failure CompileError, td)
+          | (NONE, td) => (Failure AssembleError, td)
           | (SOME (bytes,c), td) => (Success (bytes,c), td)`;
 
 (* The top-level compiler *)
@@ -128,7 +128,7 @@ val error_to_str_def = Define`
        concat [strlit "### ERROR: type error\n"; s; strlit "\n"]
      else s) /\
   (error_to_str (ConfigError s) = concat [strlit "### ERROR: config error\n"; s; strlit "\n"]) /\
-  (error_to_str CompileError = strlit "### ERROR: compile error\n")`;
+  (error_to_str AssembleError = strlit "### ERROR: assembly error\n")`;
 
 val is_error_msg_def = Define `
   is_error_msg x = mlstring$isPrefix (strlit "###") x`;

--- a/compiler/proofs/compilerProofScript.sml
+++ b/compiler/proofs/compilerProofScript.sml
@@ -143,7 +143,7 @@ Theorem compile_correct_gen:
     case FST (compiler$compile cc prelude input) of
     | Failure ParseError => semantics st prelude input = CannotParse
     | Failure (TypeError e) => semantics st prelude input = IllTyped
-    | Failure CompileError => T (* see theorem about to_lab to avoid CompileError *)
+    | Failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
     | Failure (ConfigError e) => T (* configuration string is malformed *)
     | Success (code,data,c) =>
       ∃behaviours.
@@ -209,7 +209,7 @@ Theorem compile_correct = Q.prove(`
     case FST (compiler$compile cc prelude input) of
     | Failure ParseError => semantics_init ffi prelude input = CannotParse
     | Failure (TypeError e) => semantics_init ffi prelude input = IllTyped
-    | Failure CompileError => T (* see theorem about to_lab to avoid CompileError *)
+    | Failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
     | Failure (ConfigError e) => T (* configuration string is malformed *)
     | Success (code,data,c) =>
       ∃behaviours.


### PR DESCRIPTION
Renames CompileError to AssembleError, as discussed in #675.