### PR TITLE
Add CAKE_BIN as a dependency to cake.S in unverified bootstrap

### DIFF
--- a/unverified/sexpr-bootstrap/x64/32/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/32/Holmakefile
@@ -15,7 +15,7 @@ README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmeP
 
 cake-sexpr-$(ARCH)-$(WORD_SIZE): *$(ARCH)SexprScript.sml
 
-cake.S: cake-sexpr-$(ARCH)-$(WORD_SIZE)
+cake.S: cake-sexpr-$(ARCH)-$(WORD_SIZE) $(CAKE_BIN)
 	$(CAKE_BIN) --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true --heap_size=$(HEAP_MB) --stack_size=$(STACK_MB) --reg_alg=0 <$< >$@
 
 cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile cake-sexpr-$(ARCH)-$(WORD_SIZE) how-to.md

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -24,10 +24,10 @@ cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile cake-se
 # the following extracts the code from how-to.md, compiles it and runs it
 
 how-to.output: how-to.cake
-	exec $< >$@
+	./$< >$@
 
 how-to.cake: extract_code.cake how-to.md cake
-	exec $< how-to.md >how-to.cml
+	./$< how-to.md >how-to.cml
 	make $@
 	rm -f how-to.cml
 

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -28,13 +28,13 @@ how-to.output: how-to.cake
 
 how-to.cake: extract_code.cake how-to.md cake
 	exec $< how-to.md >how-to.cml
-	make how-to.cake
+	make $@
 	rm -f how-to.cml
 
 extract_code.cake: extract_code.cml cake
-	make extract_code.cake
+	make $@
 
 cake: cake.S basis_ffi.c
-	make cake
+	make $@
 
 EXTRA_CLEANS = cake.S cake-sexpr-$(ARCH)-$(WORD_SIZE) cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz how-to.output how-to.cake how-to.cml extract_code.cake cake

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -28,13 +28,13 @@ how-to.output: how-to.cake
 
 how-to.cake: extract_code.cake how-to.md cake
 	exec $< how-to.md >how-to.cml
-	make $@
+	make how-to.cake
 	rm -f how-to.cml
 
 extract_code.cake: extract_code.cml cake
-	make $@
+	make extract_code.cake
 
 cake: cake.S basis_ffi.c
-	make $@
+	make cake
 
 EXTRA_CLEANS = cake.S cake-sexpr-$(ARCH)-$(WORD_SIZE) cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz how-to.output how-to.cake how-to.cml extract_code.cake cake

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -15,7 +15,7 @@ README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmeP
 
 cake-sexpr-$(ARCH)-$(WORD_SIZE): *$(ARCH)SexprScript.sml
 
-cake.S: cake-sexpr-$(ARCH)-$(WORD_SIZE)
+cake.S: cake-sexpr-$(ARCH)-$(WORD_SIZE) $(CAKE_BIN)
 	$(CAKE_BIN) --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true --heap_size=$(HEAP_MB) --stack_size=$(STACK_MB) --reg_alg=0 <$< >$@
 
 cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile cake-sexpr-$(ARCH)-$(WORD_SIZE) how-to.md how-to.output

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -24,10 +24,10 @@ cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile cake-se
 # the following extracts the code from how-to.md, compiles it and runs it
 
 how-to.output: how-to.cake
-	./$< >$@
+	exec $< >$@
 
 how-to.cake: extract_code.cake how-to.md cake
-	./$< how-to.md >how-to.cml
+	exec $< how-to.md >how-to.cml
 	make $@
 	rm -f how-to.cml
 


### PR DESCRIPTION
The binary used in the unverified bootstrap was not being downloaded when building `cake.S`, because it was not listed as a dependency. This fixes this issue.

~~Building the rest of the unverified bootstrap will still get stuck though, because of HOL-Theorem-Prover/HOL#752.~~
