### PR TITLE
Remove references to sptreeScript.ADD_1_SUC

### DIFF
--- a/compiler/backend/proofs/clos_to_bvlProofScript.sml
+++ b/compiler/backend/proofs/clos_to_bvlProofScript.sml
@@ -6792,7 +6792,7 @@ Proof
   \\ fs []
   \\ Cases_on `prog` \\ fs [closPropsTheory.ignore_table_def]
   \\ pairarg_tac \\ fs []
-  \\ rveq \\ fs [sptreeTheory.ADD_1_SUC]
+  \\ rveq \\ fs [GSYM arithmeticTheory.ADD1]
 QED
 
 Theorem number_oracle_FST_strict_mono:
@@ -6802,7 +6802,7 @@ Proof
   disch_tac \\ Induct \\ fs []
   \\ drule (GEN_ALL number_oracle_FST_inc)
   \\ disch_then (assume_tac o GSYM)
-  \\ fs [sptreeTheory.ADD_1_SUC]
+  \\ fs [GSYM arithmeticTheory.ADD1]
   \\ fs [clos_numberProofTheory.compile_inc_def]
   \\ pairarg_tac \\ fs []
   \\ imp_res_tac clos_numberProofTheory.renumber_code_locs_imp_inc
@@ -6839,7 +6839,7 @@ Proof
     FST_SND_ignore_table]
   \\ rw [] \\ imp_res_tac MEM_number_compile_inc_locs
   \\ drule_then assume_tac (GEN_ALL number_oracle_FST_inc)
-  \\ fs [sptreeTheory.ADD_1_SUC]
+  \\ fs [GSYM arithmeticTheory.ADD1]
   >- (
     mp_tac (Q.SPECL [`i`, `j`] arithmeticTheory.LESS_EQ)
     \\ disch_then (fn t => fs [t])
@@ -7758,7 +7758,7 @@ Proof
   \\ rw [] \\ imp_res_tac MEM_number_req
   \\ fs [] \\ rfs []
   \\ drule_then assume_tac (GEN_ALL number_oracle_FST_inc)
-  \\ fs [sptreeTheory.ADD_1_SUC]
+  \\ fs [GSYM arithmeticTheory.ADD1]
   >- (
     mp_tac (Q.SPECL [`i`, `j`] arithmeticTheory.LESS_EQ)
     \\ disch_then (fn t => fs [t])

--- a/compiler/backend/semantics/backendPropsScript.sml
+++ b/compiler/backend/semantics/backendPropsScript.sml
@@ -174,7 +174,7 @@ Theorem is_state_oracle_shift:
         FST (FST (co 1)) = FST (compile_inc_f (FST (FST (co 0))) (SND (co 0))))
 Proof
   fs [is_state_oracle_def, shift_seq_def]
-  \\ EQ_TAC \\ rw [] \\ fs [sptreeTheory.ADD_1_SUC]
+  \\ EQ_TAC \\ rw [] \\ fs [GSYM arithmeticTheory.ADD1]
   \\ full_simp_tac bool_ss [arithmeticTheory.ONE]
   \\ Cases_on `n`
   \\ fs []

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -42,7 +42,7 @@ val _ = numLib.prefer_num();
 (* theorem behind impl_tac *)
 val IMP_IMP = save_thm("IMP_IMP",METIS_PROVE[]``(P /\ (Q ==> R)) ==> ((P ==> Q) ==> R)``);
 
-(* never used *)
+(* used elsewhere in cakeml *)
 Theorem SUBSET_IMP:
    s SUBSET t ==> (x IN s ==> x IN t)
 Proof
@@ -2322,6 +2322,10 @@ Proof
   Cases_on`ls` \\ rw[]
 QED
 
+Theorem EL_CONS_IF:
+  EL n (x :: xs) = (if n = 0 then x else EL (PRE n) xs)
+Proof    Cases_on `n` \\ fs []
+QED
 
 Theorem EVERY_TOKENS:
    ∀P ls. EVERY (EVERY ($~ o P)) (TOKENS P ls)


### PR DESCRIPTION
The sptree theory at one point contained some trivial results about
arithmetic (added by me as proof helpers) which were reused at some
points in CakemL (by me) and then deleted in a cleanup of sptree
(by me). These now need to be updated.