### PR TITLE
Reword top -> t_op also in lem semantics

### DIFF
--- a/semantics/semanticPrimitives.lem
+++ b/semantics/semanticPrimitives.lem
@@ -500,8 +500,8 @@ let do_app ((s:store v),(t:ffi_state 'ffi)) op vs =
         Just ((s,t), Rval (Litv (Word8 (opw8_lookup op w1 w2))))
     | (Opw W64 op, [Litv (Word64 w1); Litv (Word64 w2)]) ->
         Just ((s,t), Rval (Litv (Word64 (opw64_lookup op w1 w2))))
-    | (FP_top top, [Litv (Word64 w1); Litv (Word64 w2); Litv (Word64 w3)]) ->
-        Just ((s,t), Rval (Litv (Word64 (fp_top top w1 w2 w3))))
+    | (FP_top t_op, [Litv (Word64 w1); Litv (Word64 w2); Litv (Word64 w3)]) ->
+        Just ((s,t), Rval (Litv (Word64 (fp_top t_op w1 w2 w3))))
     | (FP_bop bop, [Litv (Word64 w1); Litv (Word64 w2)]) ->
         Just ((s,t),Rval (Litv (Word64 (fp_bop bop w1 w2))))
     | (FP_uop uop, [Litv (Word64 w)]) ->


### PR DESCRIPTION
This is only a minor change to the lem semantics in `semanticPrimitives.lem`. 
df30bf50b46fc366b9af4840506b199138767565 has changed the semanticPrimitivesScript file but left the lem files unchanged, which will lead to issues if lem is installed.