### PR TITLE
Add concatAll to the signature of Word64Prog

### DIFF
--- a/basis/DoubleProgScript.sml
+++ b/basis/DoubleProgScript.sml
@@ -24,15 +24,6 @@ val _ = ml_prog_update (add_dec
 
 val _ = ml_prog_update open_local_block;
 
-val concat_all_def = Define `
-  concat_all (a:word8) b c d e f g h =
-    concat_word_list [a;b;c;d;e;f;g;h]:64 word`
-
-val concat_all_impl = REWRITE_RULE [concat_word_list_def, dimindex_8, ZERO_SHIFT, WORD_OR_CLAUSES] concat_all_def;
-
-val _ = (next_ml_names := ["concat_all"]);
-val _ = translate concat_all_impl;
-
 val _ = ml_prog_update open_local_in_block;
 
 val _ = process_topdecs
@@ -49,7 +40,7 @@ val _ = process_topdecs
       val g = Word8Array.sub iobuff 6;
       val h = Word8Array.sub iobuff 7;
     in
-      concat_all a b c d e f g h
+      Word64.concatAll a b c d e f g h
     end;` |> append_prog;
 
 val _ = ml_prog_update close_local_blocks;

--- a/basis/DoubleProofScript.sml
+++ b/basis/DoubleProofScript.sml
@@ -5,6 +5,7 @@
 *)
 open preamble
      ml_translatorTheory ml_translatorLib ml_progLib cfLib
+     Word64ProgTheory
      Word8ArrayProgTheory
      Word8ArrayProofTheory
      OptionProgTheory

--- a/basis/Word64ProgScript.sml
+++ b/basis/Word64ProgScript.sml
@@ -108,8 +108,18 @@ val _ = translate var_word_lsr_def;
 val _ = (next_ml_names := ["~>>"]);
 val _ = translate var_word_asr_def;
 
+val concat_all_def = Define `
+  concat_all (a:word8) b c d e f g h =
+    concat_word_list [a;b;c;d;e;f;g;h]:64 word`
+
+val concat_all_impl =
+  REWRITE_RULE [concat_word_list_def, dimindex_8, ZERO_SHIFT, WORD_OR_CLAUSES] concat_all_def;
+
+val _ = (next_ml_names := ["concatAll"]);
+val _ = translate concat_all_impl;
+
 val sigs = module_signatures ["fromInt", "toInt", "andb",
-  "orb", "xorb", "notb", "+", "-", "<<", ">>", "~>>"];
+  "orb", "xorb", "notb", "+", "-", "<<", ">>", "~>>", "concatAll"];
 
 val _ = ml_prog_update (close_module (SOME sigs));
 


### PR DESCRIPTION
This adds the (translated) `concatAll` function which previously was in DoubleProg to Word64Prog to make it available as a conversion from Word8 to Word64.
`concatAll` takes as input 8 `Word8`'s and returns their concatenation into a `Word64`.