### PR TITLE
Avoid warnings with -Wall

### DIFF
--- a/basis/basis_ffi.c
+++ b/basis/basis_ffi.c
@@ -230,7 +230,7 @@ typedef union {
 } double_bytes;
 
 // FFI calls for floating-point parsing
-void ffidouble_fromString (unsigned char *c, long clen, unsigned char *a, long alen) {
+void ffidouble_fromString (char *c, long clen, char *a, long alen) {
   double_bytes d;
   sscanf(c, "%lf",&d.d);
   assert (8 == alen);
@@ -239,7 +239,7 @@ void ffidouble_fromString (unsigned char *c, long clen, unsigned char *a, long a
   }
 }
 
-void ffidouble_toString (unsigned char *c, long clen, unsigned char *a, long alen) {
+void ffidouble_toString (char *c, long clen, char *a, long alen) {
   double_bytes d;
   assert (256 == alen);
   for (int i = 0; i < 8; i++){
@@ -253,7 +253,7 @@ void ffidouble_toString (unsigned char *c, long clen, unsigned char *a, long ale
   assert (bytes_written <= 255);
 }
 
-void main (int local_argc, char **local_argv) {
+int main (int local_argc, char **local_argv) {
 
   argc = local_argc;
   argv = local_argv;
@@ -328,4 +328,6 @@ void main (int local_argc, char **local_argv) {
   cml_stackend = cml_stack + cml_stack_sz;
 
   cml_main(); // Passing control to CakeML
+
+  return 0;
 }


### PR DESCRIPTION
On my machine, compiling basis_ffi.c with gcc -Wall gives:

`basis_ffi.c: In function ‘ffidouble_fromString’:
basis_ffi.c:235:10: warning: pointer targets in passing argument 1 of ‘sscanf’ differ in signedness [-Wpointer-sign]
   sscanf(c, "%lf",&d.d);
          ^
In file included from /usr/include/features.h:424:0,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from basis_ffi.c:5:
/usr/include/stdio.h:400:12: note: expected ‘const char * restrict’ but argument is of type ‘unsigned char *’
 extern int __REDIRECT_NTH (sscanf, (const char *__restrict __s,
            ^
basis_ffi.c: In function ‘ffidouble_toString’:
basis_ffi.c:249:32: warning: pointer targets in passing argument 1 of ‘snprintf’ differ in signedness [-Wpointer-sign]
   int bytes_written = snprintf(&a[0], 255, "%.20g", d.d);
                                ^
In file included from basis_ffi.c:5:0:
/usr/include/stdio.h:340:12: note: expected ‘char * restrict’ but argument is of type ‘unsigned char *’
 extern int snprintf (char *__restrict __s, size_t __maxlen,
            ^~~~~~~~
basis_ffi.c: At top level:
basis_ffi.c:256:6: warning: return type of ‘main’ is not ‘int’ [-Wmain]
 void main (int local_argc, char **local_argv) {
      ^~~~
`

This PR makes it so that those warnings are avoided.