### PR TITLE
two riscv fixes

### DIFF
--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -41,8 +41,7 @@ val ffi_asm_def = Define `
   (ffi_asm (ffi::ffis) =
       SmartAppend (List [
        strlit"cake_ffi"; implode ffi; strlit":\n";
-       strlit"     la     t6,cdecl(ffi"; implode ffi; strlit")\n";
-       strlit"     jr     t6\n";
+       strlit"     tail cdecl(ffi"; implode ffi; strlit")\n";
        strlit"     .p2align 4\n";
        strlit"\n"]) (ffi_asm ffis))`
 
@@ -57,13 +56,11 @@ val ffi_code =
      (ffi_asm (REVERSE ffi_names))
      (List (MAP (\n. strlit(n ++ "\n"))
       ["cake_clear:";
-       "     la   t6,cdecl(cml_exit)";
-       "     jr   t6";
+       "     tail cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_exit:";
-       "     la   t6,cdecl(cml_exit)";
-       "     jr   t6";
+       "     tail cdecl(cml_exit)";
        "     .p2align 4";
        "";
        "cake_main:";

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -28,12 +28,11 @@ val startup =
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
        "cdecl(cml_main):";
-       "     la      a0,cake_main           # arg1: entry address";
-       "     la      a1,cdecl(cml_heap)     # arg2: first address of heap";
+       "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap";
        "     la      t3,cake_bitmaps";
        "     sd      t3, 0(a1)              # store bitmap pointer";
-       "     la      a2,cdecl(cml_stack)    # arg3: first address of stack";
-       "     la      a3,cdecl(cml_stackend) # arg4: first address past the stack";
+       "     ld      a2,cdecl(cml_stack)    # arg3: first address of stack";
+       "     ld      a3,cdecl(cml_stackend) # arg4: first address past the stack";
        "     j       cake_main";
        ""])`` |> EVAL |> concl |> rand
 

--- a/compiler/backend/riscv/proofs/riscv_configProofScript.sml
+++ b/compiler/backend/riscv/proofs/riscv_configProofScript.sml
@@ -15,7 +15,7 @@ val is_riscv_machine_config_def = Define`
   mc.ptr_reg = 10 ∧
   mc.len2_reg = 13  ∧
   mc.ptr2_reg = 12 ∧
-  mc.callee_saved_regs = [25;26;27]`;
+  mc.callee_saved_regs = [24;25;26]`;
 
 val names_tac =
   simp[tlookup_bij_iff] \\ EVAL_TAC

--- a/compiler/backend/riscv/riscv_configScript.sml
+++ b/compiler/backend/riscv/riscv_configScript.sml
@@ -12,14 +12,15 @@ val riscv_names_def = Define `
      temporaries: 5-7, 28-31
      return address: 1
      saved regs: 8-9, 18-27
-     3 = global pointer, 4 = thread pointer (not sure if they need to be avoided)
+     3 = global pointer, 4 = thread pointer
      0 avoided (hardwired zero)
      2 avoided (stack pointer)
      3 avoided (global pointer)
+     4 avoided (thread pointer)
      31 avoided (used by encoder)
-     4 avoid regs means 28 regs available for CakeML
+     5 avoid regs means 27 regs available for CakeML
      constraints:
-       the last 3 of these (25, 26, 27) must be mapped to callee saved regs
+       the last 3 of these (24, 25, 26) must be mapped to callee saved regs
        0 must be mapped to link reg (1)
        1-4 must be mapped to 1st-4st args (10-13)
   *)
@@ -29,13 +30,14 @@ val riscv_names_def = Define `
    insert 3 12 o
    insert 4 13 o
    (* the rest to make the mapping well-formed *)
-   insert 10 29 o
-   insert 11 30 o
-   insert 12 4 o
-   insert 13 28 o
-   insert 28 0 o
-   insert 29 2 o
-   insert 30 3) LN:num num_map`;
+   insert 10 27 o
+   insert 11 28 o
+   insert 12 29 o
+   insert 13 30 o
+   insert 27 0 o
+   insert 28 2 o
+   insert 29 3 o
+   insert 30 4) LN:num num_map`;
 
 val riscv_names_def = save_thm("riscv_names_def[compute]",
   CONV_RULE (RAND_CONV EVAL) riscv_names_def);

--- a/compiler/encoders/riscv/riscv_targetScript.sml
+++ b/compiler/encoders/riscv/riscv_targetScript.sml
@@ -252,9 +252,10 @@ val riscv_config_def = Define`
        0 - hardwired zero
        2 - stack pointer
        3 - global pointer
+       4 - thread pointer
        31 - used by encoder above
     *)
-    ; avoid_regs := [0; 2; 3; 31]
+    ; avoid_regs := [0; 2; 3; 4; 31]
     ; fp_reg_count := 0
     ; link_reg := SOME 1
     ; two_reg_arith := F


### PR DESCRIPTION
1. `cml_heap` was not being correctly dereferenced in the export code, so programs were starting with a 1 word heap and stack and immediately crashing with an out of memory error.
2. `tp` was being allocated as a general register, causing crashes at program termination when glibc tried to access thread local storage.  Added it to the avoid list.

Tested by building a `--target=riscv` compiler from `unverified/sexpr-bootstrap`, then running that compiler under qemu to generate a second compiler identical to the first; also ran the proof scripts under `compiler/proofs` and `compiler/backend/riscv/proofs`.