### PR TITLE
Symbol support etc

### DIFF
--- a/basis/pure/basisComputeLib.sml
+++ b/basis/pure/basisComputeLib.sml
@@ -2,7 +2,7 @@
   compset for the pure basis functions.
 *)
 structure basisComputeLib :> basisComputeLib = struct
-open mlstringTheory mlintTheory
+open mlstringTheory mlintTheory mloptionTheory
 
 val add_basis_compset = computeLib.extend_compset
   [computeLib.Tys
@@ -13,6 +13,7 @@ val add_basis_compset = computeLib.extend_compset
      mlstringTheory.str_def,
      mlstringTheory.concat_thm,
      mlstringTheory.explode_thm,
+     mloptionTheory.getOpt_def,
      mlintTheory.zero_pad_def,
      mlintTheory.toChar_def,
      mlintTheory.simple_toChars_def,

--- a/compiler/backend/ag32/ag32_configScript.sml
+++ b/compiler/backend/ag32/ag32_configScript.sml
@@ -18,7 +18,7 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val ag32_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=F; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val ag32_word_conf = ``<| bitmaps := []:32 word list; stack_frame_size := LN |>``
 val ag32_stack_conf = ``<|jump:=T;reg_names:=ag32_names|>``
-val ag32_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=ag32_config;init_clock:=5;hash_size:=104729n|>``
+val ag32_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=ag32_config;init_clock:=5;hash_size:=104729n|>``
 
 val ag32_backend_config_def = Define`
   ag32_backend_config =
@@ -30,6 +30,7 @@ val ag32_backend_config_def = Define`
                word_conf:=^(ag32_word_conf);
                stack_conf:=^(ag32_stack_conf);
                lab_conf:=^(ag32_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/backend/ag32/export_ag32Script.sml
+++ b/compiler/backend/ag32/export_ag32Script.sml
@@ -1,12 +1,13 @@
 (*
   Define the format of the compiler-generated output file for ag32
 *)
-open preamble exportTheory
+open preamble exportTheory mlstringTheory
 
 val () = new_theory "export_ag32";
 
 val ag32_export_def = Define `
-  ag32_export (ffi_names:string list) bytes (data:word32 list) =
+  ag32_export (ffi_names:string list) bytes (data:word32 list)
+      (syms: (mlstring # num # num) list) =
     SmartAppend
      (split16 (words_line (strlit".data_word ") word_to_string) data)
      (split16 (words_line (strlit".code_byte ") byte_to_string) bytes)`;

--- a/compiler/backend/arm7/arm7_configScript.sml
+++ b/compiler/backend/arm7/arm7_configScript.sml
@@ -36,7 +36,7 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val arm7_data_conf = ``<| tag_bits:=0; len_bits:=0; pad_bits:=1; len_size:=20; has_div:=F; has_longdiv:=F; has_fp_ops:=T; has_fp_tern:=T; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm7_word_conf = ``<| bitmaps := []:32 word list; stack_frame_size := LN |>``
 val arm7_stack_conf = ``<|jump:=T;reg_names:=arm7_names|>``
-val arm7_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm7_config;init_clock:=5;hash_size:=104729n|>``
+val arm7_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=arm7_config;init_clock:=5;hash_size:=104729n|>``
 
 val arm7_backend_config_def = Define`
   arm7_backend_config =
@@ -48,6 +48,7 @@ val arm7_backend_config_def = Define`
                word_conf:=^(arm7_word_conf);
                stack_conf:=^(arm7_stack_conf);
                lab_conf:=^(arm7_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/backend/arm7/export_arm7Script.sml
+++ b/compiler/backend/arm7/export_arm7Script.sml
@@ -71,12 +71,13 @@ val ffi_code =
        ""])))`` |> EVAL |> concl |> rand
 
 val arm7_export_def = Define `
-  arm7_export ffi_names bytes (data:word32 list) =
+  arm7_export ffi_names bytes (data:word32 list) syms =
     SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".long"))
       (SmartAppend (split16 (words_line (strlit"\t.long ") word_to_string) data)
       (SmartAppend (List ((strlit"\n")::^startup)) ^ffi_code))))
-      (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)`;
+      (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
+      (emit_symbols syms))`;
 
 val _ = export_theory ();

--- a/compiler/backend/arm8/arm8_configScript.sml
+++ b/compiler/backend/arm8/arm8_configScript.sml
@@ -33,7 +33,7 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val arm8_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val arm8_word_conf = ``<| bitmaps := []:64 word list; stack_frame_size := LN |>``
 val arm8_stack_conf = ``<|jump:=T;reg_names:=arm8_names|>``
-val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=arm8_config;init_clock:=5;hash_size:=104729n|>``
+val arm8_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=arm8_config;init_clock:=5;hash_size:=104729n|>``
 
 val arm8_backend_config_def = Define`
   arm8_backend_config =
@@ -45,6 +45,7 @@ val arm8_backend_config_def = Define`
                word_conf:=^(arm8_word_conf);
                stack_conf:=^(arm8_stack_conf);
                lab_conf:=^(arm8_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -71,12 +71,13 @@ val ffi_code =
        ""])))`` |> EVAL |> concl |> rand
 
 val arm8_export_def = Define `
-  arm8_export ffi_names bytes (data:word64 list) =
+  arm8_export ffi_names bytes (data:word64 list) syms =
     SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".quad"))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List ((strlit"\n")::^startup)) ^ffi_code))))
-      (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)`;
+      (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
+      (emit_symbols syms))`;
 
 val _ = export_theory ();

--- a/compiler/backend/backendComputeLib.sml
+++ b/compiler/backend/backendComputeLib.sml
@@ -525,6 +525,7 @@ val add_backend_compset = computeLib.extend_compset
     ,data_to_wordTheory.comp_def
     ,data_to_wordTheory.compile_part_def
     ,data_to_wordTheory.stubs_def
+    ,data_to_wordTheory.stub_names_def
     ,data_to_wordTheory.compile_def
       (* word_bignum *)
     ,word_bignumTheory.mc_cmp_code_def
@@ -733,6 +734,7 @@ val add_backend_compset = computeLib.extend_compset
     ,word_to_stackTheory.StackArgs_def
     ,word_to_stackTheory.comp_def
     ,word_to_stackTheory.raise_stub_def
+    ,word_to_stackTheory.stub_names_def
     ,word_to_stackTheory.compile_prog_def
     ,word_to_stackTheory.compile_word_to_stack_def
     ,word_to_stackTheory.compile_def
@@ -748,6 +750,7 @@ val add_backend_compset = computeLib.extend_compset
     ,stack_allocTheory.comp_def
     ,stack_allocTheory.next_lab_def
     ,stack_allocTheory.stubs_def
+    ,stack_allocTheory.stub_names_def
     ,stack_allocTheory.SetNewTrigger_def
     ,stack_allocTheory.word_gc_code_def
     ,stack_allocTheory.word_gc_partial_or_full_def
@@ -777,6 +780,7 @@ val add_backend_compset = computeLib.extend_compset
     ,stack_removeTheory.upshift_def
     ,stack_removeTheory.compile_def
     ,stack_removeTheory.init_stubs_def
+    ,stack_removeTheory.stub_names_def
     ,stack_removeTheory.init_code_def
     ,stack_removeTheory.store_init_def
     ,stack_removeTheory.init_memory_def
@@ -871,6 +875,7 @@ val add_backend_compset = computeLib.extend_compset
     ,lab_to_targetTheory.list_add_if_fresh_def
     ,lab_to_targetTheory.get_ffi_index_def
     ,lab_to_targetTheory.sec_length_def
+    ,lab_to_targetTheory.get_symbols_def
     ,lab_to_targetTheory.zero_labs_acc_of_def
     ,lab_to_targetTheory.line_get_zero_labs_acc_def
     ,lab_to_targetTheory.sec_get_zero_labs_acc_def

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -60,15 +60,18 @@ val compile_tap_def = Define`
     let _ = empty_ffi (strlit "finished: bvi_to_data") in
     let (col,p) = data_to_word$compile c.data_conf c.word_to_word_conf c.lab_conf.asm_conf p in
     let c = c with word_to_word_conf updated_by (λc. c with col_oracle := col) in
-    let td = tap_word c.tap_conf p td in
+    let names = sptree$union (sptree$fromAList $ data_to_word$stub_names ()) names in
+    let td = tap_word c.tap_conf (p,names) td in
     let _ = empty_ffi (strlit "finished: data_to_word") in
     let (c',fs,p) = word_to_stack$compile c.lab_conf.asm_conf p in
+    let td = tap_stack c.tap_conf (p,names) td in
     let c = c with word_conf := c' in
     let _ = empty_ffi (strlit "finished: word_to_stack") in
     let p = stack_to_lab$compile
       c.stack_conf c.data_conf (2 * max_heap_limit (:'a) c.data_conf - 1)
       (c.lab_conf.asm_conf.reg_count - (LENGTH c.lab_conf.asm_conf.avoid_regs +3))
       (c.lab_conf.asm_conf.addr_offset) p in
+    let td = tap_lab c.tap_conf (p,names) td in
     let _ = empty_ffi (strlit "finished: stack_to_lab") in
     let res = attach_bitmaps c
       (lab_to_target$compile c.lab_conf (p:'a prog)) in

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -56,7 +56,7 @@ val compile_tap_def = Define`
     let c = c with bvl_conf updated_by (λc. c with <| inlines := l; next_name1 := n1; next_name2 := n2 |>) in
     let _ = empty_ffi (strlit "finished: bvl_to_bvi") in
     let p = bvi_to_data$compile_prog p in
-    let td = tap_data_lang c.tap_conf p td in
+    let td = tap_data_lang c.tap_conf (p,names) td in
     let _ = empty_ffi (strlit "finished: bvi_to_data") in
     let (col,p) = data_to_word$compile c.data_conf c.word_to_word_conf c.lab_conf.asm_conf p in
     let c = c with word_to_word_conf updated_by (λc. c with col_oracle := col) in

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -2225,6 +2225,40 @@ val stubs_def = Define`
     (Dummy_location,0,Skip)
   ] ++ generated_bignum_stubs Bignum_location`;
 
+val stub_names_def = Define`
+  stub_names () = [
+    (FromList_location,strlit "_FromList");
+    (FromList1_location,strlit "_FromList1");
+    (RefByte_location,strlit "_RefByte");
+    (RefArray_location,strlit "_RefArray");
+    (Replicate_location,strlit "_Replicate");
+    (AnyArith_location,strlit "_AnyArith");
+    (Add_location,strlit "_Add");
+    (Sub_location,strlit "_Sub");
+    (Mul_location,strlit "_Mul");
+    (Div_location,strlit "_Div");
+    (Mod_location,strlit "_Mod");
+    (Compare1_location,strlit "_Compare1");
+    (Compare_location,strlit "_Compare");
+    (Equal1_location,strlit "_Equal1");
+    (Equal_location,strlit "_Equal");
+    (LongDiv1_location,strlit "_LongDiv1");
+    (LongDiv_location,strlit "_LongDiv");
+    (Install_location,strlit "_Install");
+    (InstallCode_location,strlit "_InstallCode");
+    (InstallData_location,strlit "_InstallData");
+    (Append_location,strlit "_Append");
+    (AppendMainLoop_location,strlit "_AppendMainLoop");
+    (AppendLenLoop_location,strlit "_AppendLenLoop");
+    (AppendFastLoop_location,strlit "_AppendFastLoop");
+    (MemCopy_location,strlit "_MemCopy");
+    (ByteCopy_location,strlit "_ByteCopy");
+    (ByteCopyAdd_location,strlit "_ByteCopyAdd");
+    (ByteCopySub_location,strlit "_ByteCopySub");
+    (ByteCopyNew_location,strlit "_ByteCopyNew");
+    (Dummy_location,strlit "_Dummy")
+  ]`; (* TODO bignum *)
+
 Theorem check_stubs_length:
    word_num_stubs + LENGTH (stubs (:α) c) = data_num_stubs
 Proof

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -2227,37 +2227,38 @@ val stubs_def = Define`
 
 val stub_names_def = Define`
   stub_names () = [
-    (FromList_location,strlit "_FromList");
-    (FromList1_location,strlit "_FromList1");
-    (RefByte_location,strlit "_RefByte");
-    (RefArray_location,strlit "_RefArray");
-    (Replicate_location,strlit "_Replicate");
-    (AnyArith_location,strlit "_AnyArith");
-    (Add_location,strlit "_Add");
-    (Sub_location,strlit "_Sub");
-    (Mul_location,strlit "_Mul");
-    (Div_location,strlit "_Div");
-    (Mod_location,strlit "_Mod");
-    (Compare1_location,strlit "_Compare1");
-    (Compare_location,strlit "_Compare");
-    (Equal1_location,strlit "_Equal1");
-    (Equal_location,strlit "_Equal");
-    (LongDiv1_location,strlit "_LongDiv1");
-    (LongDiv_location,strlit "_LongDiv");
-    (Install_location,strlit "_Install");
-    (InstallCode_location,strlit "_InstallCode");
-    (InstallData_location,strlit "_InstallData");
-    (Append_location,strlit "_Append");
-    (AppendMainLoop_location,strlit "_AppendMainLoop");
-    (AppendLenLoop_location,strlit "_AppendLenLoop");
-    (AppendFastLoop_location,strlit "_AppendFastLoop");
-    (MemCopy_location,strlit "_MemCopy");
-    (ByteCopy_location,strlit "_ByteCopy");
-    (ByteCopyAdd_location,strlit "_ByteCopyAdd");
-    (ByteCopySub_location,strlit "_ByteCopySub");
-    (ByteCopyNew_location,strlit "_ByteCopyNew");
-    (Dummy_location,strlit "_Dummy")
-  ]`; (* TODO bignum *)
+    (FromList_location,«_FromList»);
+    (FromList1_location,«_FromList1»);
+    (RefByte_location,«_RefByte»);
+    (RefArray_location,«_RefArray»);
+    (Replicate_location,«_Replicate»);
+    (AnyArith_location,«_AnyArith»);
+    (Add_location,«_Add»);
+    (Sub_location,«_Sub»);
+    (Mul_location,«_Mul»);
+    (Div_location,«_Div»);
+    (Mod_location,«_Mod»);
+    (Compare1_location,«_Compare1»);
+    (Compare_location,«_Compare»);
+    (Equal1_location,«_Equal1»);
+    (Equal_location,«_Equal»);
+    (LongDiv1_location,«_LongDiv1»);
+    (LongDiv_location,«_LongDiv»);
+    (Install_location,«_Install»);
+    (InstallCode_location,«_InstallCode»);
+    (InstallData_location,«_InstallData»);
+    (Append_location,«_Append»);
+    (AppendMainLoop_location,«_AppendMainLoop»);
+    (AppendLenLoop_location,«_AppendLenLoop»);
+    (AppendFastLoop_location,«_AppendFastLoop»);
+    (MemCopy_location,«_MemCopy»);
+    (ByteCopy_location,«_ByteCopy»);
+    (ByteCopyAdd_location,«_ByteCopyAdd»);
+    (ByteCopySub_location,«_ByteCopySub»);
+    (ByteCopyNew_location,«_ByteCopyNew»);
+    (Dummy_location,«_Dummy»)
+  ] ++ GENLIST (\i. (i + Bignum_location, «_Bignum»))
+    (data_num_stubs - Bignum_location)`;
 
 Theorem check_stubs_length:
    word_num_stubs + LENGTH (stubs (:α) c) = data_num_stubs

--- a/compiler/backend/mips/export_mipsScript.sml
+++ b/compiler/backend/mips/export_mipsScript.sml
@@ -74,12 +74,13 @@ val ffi_code =
        ""])))`` |> EVAL |> concl |> rand
 
 val mips_export_def = Define `
-  mips_export ffi_names bytes (data:word64 list) =
+  mips_export ffi_names bytes (data:word64 list) syms =
     SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".quad"))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List ((strlit"\n")::^startup)) ^ffi_code))))
-      (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)`;
+      (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
+      (emit_symbols syms))`;
 
 val _ = export_theory ();

--- a/compiler/backend/mips/mips_configScript.sml
+++ b/compiler/backend/mips/mips_configScript.sml
@@ -39,7 +39,7 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val mips_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; has_fp_tern := F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val mips_word_conf = ``<| bitmaps := []:64 word list; stack_frame_size := LN |>``
 val mips_stack_conf = ``<|jump:=F;reg_names:=mips_names|>``
-val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=mips_config;init_clock:=5;hash_size:=104729n|>``
+val mips_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=mips_config;init_clock:=5;hash_size:=104729n|>``
 
 val mips_backend_config_def = Define`
   mips_backend_config =
@@ -51,6 +51,7 @@ val mips_backend_config_def = Define`
                word_conf:=^(mips_word_conf);
                stack_conf:=^(mips_stack_conf);
                lab_conf:=^(mips_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -550,6 +550,17 @@ val asm_memop_to_display_def = Define `
     | Store => empty_item (strlit "Store")
     | Store8 => empty_item (strlit "Store8")`;
 
+val asm_cmp_to_display_def = Define`
+  asm_cmp_to_display op = case op of
+    | Equal => empty_item «Equal»
+    | Lower => empty_item «Lower»
+    | Less => empty_item «Less»
+    | Test => empty_item «Test»
+    | NotEqual => empty_item «NotEqual»
+    | NotLower => empty_item «NotLower»
+    | NotLess => empty_item «NotLess»
+    | NotTest => empty_item «NotTest»`
+
 val asm_fp_to_display_def = Define `
   asm_fp_to_display op = case op of
     | FPLess n1 n2 n3 => item_with_nums (strlit "FPLess") [n1; n2; n3]
@@ -578,73 +589,99 @@ val asm_inst_to_display_def = Define `
         num_to_display r; asm_addr_to_display addr]
     | FP fp => Item NONE (strlit "FP") [asm_fp_to_display fp]`;
 
+val asm_asm_to_display_def = Define `
+  asm_asm_to_display inst = case inst of
+    | Inst i => asm_inst_to_display i
+    | Jump w => item_with_num «Jump» (w2n w)
+    | JumpCmp c r to w => Item NONE «JumpCmp»
+      [asm_cmp_to_display c; num_to_display r; asm_reg_imm_to_display to;
+       num_to_display (w2n w)]
+    | Call w => item_with_num «Call» (w2n w)
+    | JumpReg r => item_with_num «JumpReg>» r
+    | Loc r w => item_with_nums «Loc» [r; w2n w]`
+
 (* stackLang *)
 
 val store_name_to_display_def = Define `
   store_name_to_display st = case st of
-    | NextFree => empty_item (strlit "NextFree")
-    | EndOfHeap => empty_item (strlit "EndOfHeap")
-    | TriggerGC => empty_item (strlit "TriggerGC")
-    | HeapLength => empty_item (strlit "HeapLength")
-    | ProgStart => empty_item (strlit "ProgStart")
-    | BitmapBase => empty_item (strlit "BitmapBase")
-    | CurrHeap => empty_item (strlit "CurrHeap")
-    | OtherHeap => empty_item (strlit "OtherHeap")
-    | AllocSize => empty_item (strlit "AllocSize")
-    | Globals => empty_item (strlit "Globals")
-    | Handler => empty_item (strlit "Handler")
-    | GenStart => empty_item (strlit "GenStart")
-    | CodeBuffer => empty_item (strlit "CodeBuffer")
-    | CodeBufferEnd => empty_item (strlit "CodeBufferEnd")
-    | BitmapBuffer => empty_item (strlit "BitmapBuffer")
-    | BitmapBufferEnd => empty_item (strlit "BitmapBufferEnd")
-    | Temp n => item_with_num (strlit "Temp") (w2n n)`;
+    | NextFree => empty_item «NextFree»
+    | EndOfHeap => empty_item «EndOfHeap»
+    | TriggerGC => empty_item «TriggerGC»
+    | HeapLength => empty_item «HeapLength»
+    | ProgStart => empty_item «ProgStart»
+    | BitmapBase => empty_item «BitmapBase»
+    | CurrHeap => empty_item «CurrHeap»
+    | OtherHeap => empty_item «OtherHeap»
+    | AllocSize => empty_item «AllocSize»
+    | Globals => empty_item «Globals»
+    | Handler => empty_item «Handler»
+    | GenStart => empty_item «GenStart»
+    | CodeBuffer => empty_item «CodeBuffer»
+    | CodeBufferEnd => empty_item «CodeBufferEnd»
+    | BitmapBuffer => empty_item «BitmapBuffer»
+    | BitmapBufferEnd => empty_item «BitmapBufferEnd»
+    | Temp n => item_with_num «Temp» (w2n n)`;
 
 val stack_prog_to_display_def = Define`
   stack_prog_to_display prog = case prog of
-    | stackLang$Skip => empty_item (strlit "Skip")
+    | stackLang$Skip => empty_item «Skip»
     | Inst i => asm_inst_to_display i
-    | Get n sn => Item NONE (strlit "Get") [num_to_display n;
+    | Get n sn => Item NONE «Get» [num_to_display n;
         store_name_to_display sn]
-    | Set sn n => Item NONE (strlit "Set") [store_name_to_display sn;
+    | Set sn n => Item NONE «Set» [store_name_to_display sn;
         num_to_display n]
-    | Call rh tgt eh => empty_item (strlit "Call TODO")
-    | Seq x y => Item NONE (strlit "Seq")
+    | Call rh tgt eh => Item NONE «Call»
+        [(case rh of
+            | NONE => empty_item «Tail»
+            | SOME (p,lr,l1,l2) => Item NONE «Return»
+              [num_to_display lr; num_to_display l1; num_to_display l2;
+               stack_prog_to_display p]);
+         (case tgt of
+            | INL l => item_with_num «Direct» l
+            | INR r => item_with_num «Reg» r);
+         (case eh of
+            | NONE => empty_item «NoHandle»
+            | SOME (p,l1,l2) => Item NONE «Handle»
+              [num_to_display l1; num_to_display l2; stack_prog_to_display p])]
+    | Seq x y => Item NONE «Seq»
         [stack_prog_to_display x; stack_prog_to_display y]
-    | If c n to x y => Item NONE (strlit "If TODO")
-        [stack_prog_to_display x; stack_prog_to_display y]
-    | While c n to x => Item NONE (strlit "While TODO")
-        [stack_prog_to_display x]
-    | JumpLower n1 n2 n3 => item_with_nums (strlit "JumpLower") [n1; n2; n3]
-    | Alloc n => item_with_num (strlit "Alloc") n
-    | Raise n => item_with_num (strlit "Raise") n
-    | Return n1 n2 => item_with_nums (strlit "Return") [n1; n2]
-    | FFI nm cp cl ap al ra => Item NONE (strlit "FFI")
+    | If c n to x y => Item NONE «If»
+        [asm_cmp_to_display c; num_to_display n;
+         asm_reg_imm_to_display to; stack_prog_to_display x;
+         stack_prog_to_display y]
+    | While c n to x => Item NONE «While»
+        [asm_cmp_to_display c; num_to_display n;
+         asm_reg_imm_to_display to; stack_prog_to_display x]
+    | JumpLower n1 n2 n3 => item_with_nums «JumpLower» [n1; n2; n3]
+    | Alloc n => item_with_num «Alloc» n
+    | Raise n => item_with_num «Raise» n
+    | Return n1 n2 => item_with_nums «Return» [n1; n2]
+    | FFI nm cp cl ap al ra => Item NONE «FFI»
         (string_imp nm :: MAP num_to_display [cp; cl; ap; al; ra])
-    | Tick => empty_item (strlit "Tick")
-    | LocValue n1 n2 n3 => item_with_nums (strlit "LocValue") [n1; n2; n3]
-    | Install n1 n2 n3 n4 n5 => item_with_nums (strlit "Install")
+    | Tick => empty_item «Tick»
+    | LocValue n1 n2 n3 => item_with_nums «LocValue» [n1; n2; n3]
+    | Install n1 n2 n3 n4 n5 => item_with_nums «Install»
         [n1; n2; n3; n4; n5]
-    | CodeBufferWrite n1 n2 => item_with_nums (strlit "CodeBufferWrite")
+    | CodeBufferWrite n1 n2 => item_with_nums «CodeBufferWrite»
         [n1; n2]
-    | DataBufferWrite n1 n2 => item_with_nums (strlit "DataBufferWrite")
+    | DataBufferWrite n1 n2 => item_with_nums «DataBufferWrite»
         [n1; n2]
-    | RawCall n => item_with_num (strlit "RawCall") n
-    | StackAlloc n => item_with_num (strlit "StackAlloc") n
-    | StackFree n => item_with_num (strlit "StackFree") n
-    | StackStore n m => item_with_nums (strlit "StackStore") [n; m]
-    | StackStoreAny n m => item_with_nums (strlit "StackStoreAny") [n; m]
-    | StackLoad n m => item_with_nums (strlit "StackLoad") [n; m]
-    | StackLoadAny n m => item_with_nums (strlit "StackLoadAny") [n; m]
-    | StackGetSize n => item_with_num (strlit "RawCall") n
-    | StackSetSize n => item_with_num (strlit "RawCall") n
-    | BitmapLoad n m => item_with_nums (strlit "BitmapLoad") [n; m]
-    | Halt n => item_with_num (strlit "Halt") n`;
+    | RawCall n => item_with_num «RawCall» n
+    | StackAlloc n => item_with_num «StackAlloc» n
+    | StackFree n => item_with_num «StackFree» n
+    | StackStore n m => item_with_nums «StackStore» [n; m]
+    | StackStoreAny n m => item_with_nums «StackStoreAny» [n; m]
+    | StackLoad n m => item_with_nums «StackLoad» [n; m]
+    | StackLoadAny n m => item_with_nums «StackLoadAny» [n; m]
+    | StackGetSize n => item_with_num «RawCall» n
+    | StackSetSize n => item_with_num «RawCall» n
+    | BitmapLoad n m => item_with_nums «BitmapLoad» [n; m]
+    | Halt n => item_with_num «Halt» n`;
 
 val stack_progs_to_display_def = Define`
   stack_progs_to_display (ps,names) = list_to_display
     (\(n1, prog). displayLang$Tuple [num_to_display n1;
-        String (getOpt (sptree$lookup n1 names) (strlit "NOT FOUND"));
+        String (getOpt (sptree$lookup n1 names) «NOT FOUND»);
         stack_prog_to_display prog]) ps`;
 
 (* labLang *)
@@ -652,7 +689,9 @@ val stack_progs_to_display_def = Define`
 val lab_asm_to_display_def = Define`
   lab_asm_to_display la = case la of
     | labLang$Jump (Lab s n) => item_with_nums «Jump» [s; n]
-    | JumpCmp c r ri (Lab s n) => item_with_nums «JumpCmp TODO» [s; n]
+    | JumpCmp c r ri (Lab s n) => Item NONE «JumpCmp»
+      [asm_cmp_to_display c; num_to_display r;
+       asm_reg_imm_to_display ri; num_to_display s; num_to_display n]
     | Call (Lab s n) => item_with_nums «Call» [s; n]
     | LocValue r (Lab s n) => item_with_nums «LocValue» [r; s; n]
     | CallFFI name => Item NONE «CallFFI» [string_imp name]
@@ -661,14 +700,16 @@ val lab_asm_to_display_def = Define`
 
 val lab_line_to_display_def = Define`
   lab_line_to_display line = case line of
-    | Label se nu le => item_with_nums (strlit "Label") [se; nu; le]
-    | Asm i enc len => empty_item (strlit "TODO ASM")
+    | Label se nu le => item_with_nums «Label» [se; nu; le]
+    | Asm aoc enc len => (case aoc of
+      | Asmi i => Item NONE «Asm» [asm_asm_to_display i]
+      | Cbw r1 r2 => item_with_nums «Cbw» [r1; r2])
     | LabAsm la pos enc len => lab_asm_to_display la`
 
 val lab_secs_to_display_def = Define`
   lab_secs_to_display (ss,names) = list_to_display (\sec.
     case sec of Section n lines => displayLang$Tuple [num_to_display n;
-        String (getOpt (sptree$lookup n names) (strlit "NOT FOUND"));
+        String (getOpt (sptree$lookup n names) «NOT FOUND»);
         list_to_display lab_line_to_display lines]) ss`
 
 (* wordLang *)

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -2,7 +2,7 @@
   Functions for converting various intermediate languages
   into displayLang representations.
 *)
-open preamble astTheory mlintTheory
+open preamble astTheory mlintTheory mloptionTheory
 open flatLangTheory closLangTheory
      displayLangTheory source_to_flatTheory
      dataLangTheory wordLangTheory;
@@ -504,8 +504,9 @@ val data_prog_to_display_def  = Define `
     | Tick => empty_item (strlit "Tick")`;
 
 val data_progs_to_display_def = Define`
-  data_progs_to_display ps = list_to_display
+  data_progs_to_display (ps, names) = list_to_display
     (\(n1, n2, prog). displayLang$Tuple [num_to_display n1;
+        String (getOpt (sptree$lookup n1 names) (strlit "_unmatched"));
         num_to_display n2; data_prog_to_display prog]) ps`;
 
 (* stackLang *)

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -139,6 +139,12 @@ Proof
   rw[mc_init_ok_def]
 QED
 
+Theorem mc_init_ok_with_clos_conf_updated[simp]:
+   mc_init_ok (cc with clos_conf updated_by f) mc ⇔ mc_init_ok cc mc
+Proof
+  rw[mc_init_ok_def]
+QED
+
 Theorem mc_init_ok_call_empty_ffi[simp]:
    mc_init_ok (cc with
       data_conf updated_by (λc. c with call_empty_ffi updated_by x)) =

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -73,12 +73,13 @@ val ffi_code =
        ""])))`` |> EVAL |> concl |> rand
 
 val riscv_export_def = Define `
-  riscv_export ffi_names bytes (data:word64 list) =
+  riscv_export ffi_names bytes (data:word64 list) syms =
     SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".quad"))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List ((strlit"\n")::^startup)) ^ffi_code))))
-      (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)`;
+      (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
+      (emit_symbols syms))`;
 
 val _ = export_theory ();

--- a/compiler/backend/riscv/riscv_configScript.sml
+++ b/compiler/backend/riscv/riscv_configScript.sml
@@ -47,7 +47,7 @@ val word_to_word_conf = ``<| reg_alg:=3; col_oracle := λn. NONE |>``
 val riscv_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=T; has_longdiv:=F; has_fp_ops:=F; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val riscv_word_conf = ``<| bitmaps := []:64 word list; stack_frame_size := LN |>``
 val riscv_stack_conf = ``<|jump:=F;reg_names:=riscv_names|>``
-val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=riscv_config;init_clock:=5;hash_size:=104729n|>``
+val riscv_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=riscv_config;init_clock:=5;hash_size:=104729n|>``
 
 val riscv_backend_config_def = Define`
   riscv_backend_config =
@@ -59,6 +59,7 @@ val riscv_backend_config_def = Define`
                word_conf:=^(riscv_word_conf);
                stack_conf:=^(riscv_stack_conf);
                lab_conf:=^(riscv_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/backend/stack_allocScript.sml
+++ b/compiler/backend/stack_allocScript.sml
@@ -592,6 +592,9 @@ val word_gc_code_def = Define `
 val stubs_def = Define `
   stubs conf = [(gc_stub_location,Seq (word_gc_code conf) (Return 0 0))]`
 
+val stub_names_def = Define`
+  stub_names () = [(gc_stub_location,«_Gc»)]`
+
 (* compiler *)
 
 local

--- a/compiler/backend/stack_removeScript.sml
+++ b/compiler/backend/stack_removeScript.sml
@@ -3,7 +3,7 @@
   load/store operations.
 *)
 
-open preamble stackLangTheory
+open preamble stackLangTheory mlstringTheory
 
 val _ = new_theory "stack_remove";
 
@@ -271,6 +271,12 @@ val init_stubs_def = Define `
     [(0n,Seq (init_code gen_gc max_heap k) (Call NONE (INL start) NONE));
      (1n,halt_inst 0w);
      (2n,halt_inst 2w)]`
+
+val stub_names_def = Define`
+  stub_names () = [
+    (0n,mlstring$strlit "_Init");
+    (1n,mlstring$strlit "_Halt0");
+    (2n,mlstring$strlit "_Halt2")]`
 
 Theorem check_init_stubs_length:
    LENGTH (init_stubs gen_gc max_heap k start) + 1 (* gc *) =

--- a/compiler/backend/word_to_stackScript.sml
+++ b/compiler/backend/word_to_stackScript.sml
@@ -7,7 +7,7 @@
   stack frame.
 *)
 open preamble asmTheory wordLangTheory stackLangTheory parmoveTheory
-     word_allocTheory
+     word_allocTheory mlstringTheory
 
 val _ = new_theory "word_to_stack";
 
@@ -349,5 +349,9 @@ val compile_def = Define `
     let sfs = fromAList (MAP (λ((i,_),n). (i,n)) (ZIP (progs,fs))) in
       (<| bitmaps := bitmaps;
           stack_frame_size := sfs |>, 0::fs, (raise_stub_location,raise_stub k) :: progs)`
+
+val stub_names_def = Define`
+  stub_names () = [
+    (raise_stub_location,mlstring$strlit "_Raise")]`
 
 val _ = export_theory();

--- a/compiler/backend/x64/export_x64Script.sml
+++ b/compiler/backend/x64/export_x64Script.sml
@@ -102,14 +102,15 @@ val windows_ffi_code =
        ""])))`` |> EVAL |> concl |> rand
 
 val x64_export_def = Define `
-  x64_export ffi_names bytes (data:word64 list) =
+  x64_export ffi_names bytes (data:word64 list) syms =
     SmartAppend
       (SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".quad"))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List ((strlit"\n")::^startup)) ^ffi_code))))
-      (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes))
+      (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
+      (emit_symbols syms)))
       (^windows_ffi_code)`;
 
 (*

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -43,7 +43,7 @@ val word_to_word_conf = ``<| reg_alg:=2; col_oracle := λn. NONE |>``
 val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=T; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps := []:64 word list; stack_frame_size := LN |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
-val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;asm_conf:=x64_config;init_clock:=5;hash_size:=104729n|>``
+val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=x64_config;init_clock:=5;hash_size:=104729n|>``
 
 val x64_backend_config_def = Define`
   x64_backend_config =
@@ -55,6 +55,7 @@ val x64_backend_config_def = Define`
                word_conf:=^(x64_word_conf);
                stack_conf:=^(x64_stack_conf);
                lab_conf:=^(x64_lab_conf);
+               symbols:=[];
                tap_conf:=default_tap_config
                |>`;
 

--- a/compiler/bootstrap/compilation/.gitignore
+++ b/compiler/bootstrap/compilation/.gitignore
@@ -1,5 +1,7 @@
 *.tar.gz
 x64/64/cake
 x64/64/test-hello.cake
+x64/64/cake-sexpr-32
+x64/64/cake-sexpr-64
 x64/64/output
 x64/64/expected_output

--- a/compiler/bootstrap/compilation/ag32/32/ag32BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/ag32/32/ag32BootstrapScript.sml
@@ -11,7 +11,7 @@ val () = ml_translatorLib.reset_translation();
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_ag32
     stack_to_lab_thm lab_prog_def
-    "code" "data" "config" "cake.S";
+    "code" "data" "syms" "config" "cake.S";
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/ag32/32/ag32BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/ag32/32/ag32BootstrapScript.sml
@@ -11,7 +11,7 @@ val () = ml_translatorLib.reset_translation();
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_ag32
     stack_to_lab_thm lab_prog_def
-    "code" "data" "syms" "config" "cake.S";
+    "code" "data" "config" "cake.S";
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/ag32/32/to_lab_ag32BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/ag32/32/to_lab_ag32BootstrapScript.sml
@@ -21,10 +21,7 @@ val bootstrap_conf =
       with clos_conf := ^new_clos_conf)
      with
      bvl_conf updated_by
-       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))
-     with
-     data_conf updated_by
-       (λc. c with <| call_empty_ffi := T (* enables logging messages *) |>)``
+       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))``
 
 (* coerce the change_config thm to change between configs with the same type
    parameter, which in turn coerces to a particular instance of

--- a/compiler/bootstrap/compilation/x64/32/to_lab_x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/32/to_lab_x64BootstrapScript.sml
@@ -21,10 +21,7 @@ val bootstrap_conf =
       with clos_conf := ^new_clos_conf)
      with
      bvl_conf updated_by
-       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))
-     with
-     data_conf updated_by
-       (λc. c with <| call_empty_ffi := T (* enables logging messages *) |>)``
+       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))``
 
 (* coerce the change_config thm to change between configs with the same type
    parameter, which in turn coerces to a particular instance of

--- a/compiler/bootstrap/compilation/x64/32/x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/32/x64BootstrapScript.sml
@@ -21,7 +21,7 @@ val filename = "cake.S"
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_x64
     stack_to_lab_thm lab_prog_def
-    "cake_code" "cake_data" "cake_syms" "cake_config" filename;
+    "cake_code" "cake_data" "cake_config" filename;
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/x64/32/x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/32/x64BootstrapScript.sml
@@ -21,7 +21,7 @@ val filename = "cake.S"
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_x64
     stack_to_lab_thm lab_prog_def
-    "cake_code" "cake_data" "cake_config" filename;
+    "cake_code" "cake_data" "cake_syms" "cake_config" filename;
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/x64/64/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/64/Holmakefile
@@ -1,6 +1,6 @@
 ARCH = x64
 WORD_SIZE = 64
-INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../..\
+INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../.. $(CAKEMLDIR)/unverified/sexpr-bootstrap \
 					 ../../../../encoders/asm ../../../../encoders/$(ARCH)\
 					 ../../../../backend/$(ARCH) ../../../translation
 
@@ -14,8 +14,11 @@ README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmeP
 
 cake.S: *$(ARCH)BootstrapScript.sml
 
-cake-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile how-to.md
-	tar -chzf $@ --transform='s|^|cake-$(ARCH)-$(WORD_SIZE)/|' cake.S basis_ffi.c Makefile how-to.md
+cake-sexpr-32: *sexprBootstrap32Script.sml
+cake-sexpr-64: *sexprBootstrap64Script.sml
+
+cake-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile how-to.md cake-sexpr-32 cake-sexpr-64
+	tar -chzf $@ --transform='s|^|cake-$(ARCH)-$(WORD_SIZE)/|' cake.S basis_ffi.c Makefile how-to.md cake-sexpr-32 cake-sexpr-64
 	make test-hello.cake   # the following lines are a basic test
 	./test-hello.cake >output
 	echo 'Hello!'>expected_output

--- a/compiler/bootstrap/compilation/x64/64/README.md
+++ b/compiler/bootstrap/compilation/x64/64/README.md
@@ -10,6 +10,14 @@ library, as a thin wrapper around the relevant system calls.
 This directory contains the end-to-end correctness theorem for the
 64-bit version of the CakeML compiler.
 
+[sexprBootstrap32Script.sml](sexprBootstrap32Script.sml):
+Produces an sexp print-out of the bootstrap translated compiler
+definition for the 32-bit version of the compiler.
+
+[sexprBootstrap64Script.sml](sexprBootstrap64Script.sml):
+Produces an sexp print-out of the bootstrap translated compiler
+definition for the 64-bit version of the compiler.
+
 [test-hello.cml](test-hello.cml):
 A hello world program used for testing that the bootstrapped
 compiler was built succesfully.

--- a/compiler/bootstrap/compilation/x64/64/sexprBootstrap32Script.sml
+++ b/compiler/bootstrap/compilation/x64/64/sexprBootstrap32Script.sml
@@ -1,0 +1,13 @@
+(*
+  Produces an sexp print-out of the bootstrap translated compiler
+  definition for the 32-bit version of the compiler.
+*)
+open preamble compiler32ProgTheory astToSexprLib
+
+val _ = new_theory"sexprBootstrap32";
+
+val filename = "cake-sexpr-32"
+
+val _ = ((write_ast_to_file filename) o rhs o concl) compiler32_prog_def;
+
+val _ = export_theory();

--- a/compiler/bootstrap/compilation/x64/64/sexprBootstrap64Script.sml
+++ b/compiler/bootstrap/compilation/x64/64/sexprBootstrap64Script.sml
@@ -1,0 +1,13 @@
+(*
+  Produces an sexp print-out of the bootstrap translated compiler
+  definition for the 64-bit version of the compiler.
+*)
+open preamble compiler64ProgTheory astToSexprLib
+
+val _ = new_theory"sexprBootstrap64";
+
+val filename = "cake-sexpr-64"
+
+val _ = ((write_ast_to_file filename) o rhs o concl) compiler64_prog_def;
+
+val _ = export_theory();

--- a/compiler/bootstrap/compilation/x64/64/to_lab_x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/to_lab_x64BootstrapScript.sml
@@ -21,10 +21,7 @@ val bootstrap_conf =
       with clos_conf := ^new_clos_conf)
      with
      bvl_conf updated_by
-       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))
-     with
-     data_conf updated_by
-       (λc. c with <| call_empty_ffi := T (* enables logging messages *) |>)``
+       (λc. c with <| inline_size_limit := 3; exp_cut := 200 |>))``
 
 (* coerce the change_config thm to change between configs with the same type
    parameter, which in turn coerces to a particular instance of

--- a/compiler/bootstrap/compilation/x64/64/x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/x64BootstrapScript.sml
@@ -21,7 +21,7 @@ val filename = "cake.S"
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_x64
     stack_to_lab_thm lab_prog_def
-    "cake_code" "cake_data" "cake_syms" "cake_config" filename;
+    "cake_code" "cake_data" "cake_config" filename;
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/x64/64/x64BootstrapScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/x64BootstrapScript.sml
@@ -21,7 +21,7 @@ val filename = "cake.S"
 val bootstrap_thm =
   compilationLib.cbv_to_bytes_x64
     stack_to_lab_thm lab_prog_def
-    "cake_code" "cake_data" "cake_config" filename;
+    "cake_code" "cake_data" "cake_syms" "cake_config" filename;
 
 val cake_compiled = save_thm("cake_compiled", bootstrap_thm);
 

--- a/compiler/bootstrap/compilation/x64/Makefile
+++ b/compiler/bootstrap/compilation/x64/Makefile
@@ -34,6 +34,29 @@ all: cake$(SUFF) $(CML_PROGS)
 cake$(SUFF): cake.o basis_ffi.o
 	$(CC) $(LDFLAGS) $< basis_ffi.o $(LOADLIBES) $(LDLIBS) -o $@
 
+# Note: While this Makefile is shared the sexpr files used in the example rules
+# below are only included in the verified cake-x64-64.tar.gz release package
+
+# *UNVERIFIED* build with GC and stage tracing; regenerating the .S will take
+# about five minutes
+
+cake_verbose$(SUFF): cake-sexpr-64 basis_ffi.c cake$(SUFF)
+	CML_STACK_SIZE=1000 CML_HEAP_SIZE=6000 $(PREF)cake$(SUFF) --sexp=true --exclude_prelude=true --skip_type_inference=true --emit_empty_ffi=true --reg_alg=0 < $< > $<.S
+	$(CC) $(CFLAGS) $(LDFLAGS) -DDEBUG_FFI -o $@ $<.S basis_ffi.c
+
+# *UNVERIFIED* compiler supporting 32-bit targets; see cake-x64-32.tar.gz for a
+# verified compiler
+
+cake_unverified32$(SUFF): cake-sexpr-32 basis_ffi.c cake$(SUFF)
+	CML_STACK_SIZE=1000 CML_HEAP_SIZE=6000 $(PREF)cake$(SUFF) --sexp=true --exclude_prelude=true --skip_type_inference=true --reg_alg=0 < $< > $<.S
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<.S basis_ffi.c
+
+# Example of cross-compiling the compiler itself
+RISCV_CC ?= riscv64-unknown-linux-gnu-cc
+cake_riscv_host: cake-sexpr-64 basis_ffi.c cake$(SUFF)
+	CML_STACK_SIZE=1000 CML_HEAP_SIZE=6000 $(PREF)cake$(SUFF) --sexp=true --exclude_prelude=true --skip_type_inference=true --target=riscv --reg_alg=0 < $< > $<.riscv.S
+	$(RISCV_CC) $(CFLAGS) $(LDFLAGS) -o $@ $<.riscv.S basis_ffi.c
+
 # Using the CakeML compiler
 
 # The conventions used here for extensions, namely,

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -84,6 +84,9 @@ val _ = res |> hyp |> null orelse
    should probably be moved up to to_dataProg or something*)
 val res = translate all_bytes_eq
 val res = translate byte_to_string_eq
+val res = translate escape_sym_char_def
+val res = translate emit_symbol_def
+val res = translate emit_symbols_def
 
 val export_byte_to_string_side_def = prove(
   ``!b. export_byte_to_string_side b``,

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -85,6 +85,9 @@ val _ = res |> hyp |> null orelse
    should probably be moved up to to_dataProg or something*)
 val res = translate all_bytes_eq
 val res = translate byte_to_string_eq
+val res = translate escape_sym_char_def
+val res = translate emit_symbol_def
+val res = translate emit_symbols_def
 
 val export_byte_to_string_side_def = prove(
   ``!b. export_byte_to_string_side b``,

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -487,6 +487,9 @@ val _ = translate(LongDiv_code_def|> inline_simp |> conv32)
 val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |> conv32)
 
 val _ = translate data_to_wordTheory.stub_names_def
+val _ = translate word_to_stackTheory.stub_names_def
+val _ = translate stack_allocTheory.stub_names_def
+val _ = translate stack_removeTheory.stub_names_def
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv32_RHS);
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -486,12 +486,21 @@ val _ = translate(LongDiv_code_def|> inline_simp |> conv32)
 
 val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |> conv32)
 
+val _ = translate data_to_wordTheory.stub_names_def
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv32_RHS);
 
 (* translate some 32/64 specific parts of the tap/explorer
    that can't be translated in explorerProgScript *)
 val res = translate (presLangTheory.tap_word_def |> conv32);
+val res = translate (presLangTheory.store_name_to_display_def |> conv32);
+val res = translate (presLangTheory.stack_prog_to_display_def |> conv32);
+val res = translate (presLangTheory.stack_progs_to_display_def |> conv32);
+val res = translate (presLangTheory.tap_stack_def |> conv32);
+val res = translate (presLangTheory.lab_asm_to_display_def |> conv32);
+val res = translate (presLangTheory.lab_line_to_display_def |> conv32);
+val res = translate (presLangTheory.lab_secs_to_display_def |> conv32);
+val res = translate (presLangTheory.tap_lab_def |> conv32);
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -487,6 +487,9 @@ val _ = translate(LongDiv_code_def|> inline_simp |> conv64)
 val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |> conv64)
 
 val _ = translate data_to_wordTheory.stub_names_def
+val _ = translate word_to_stackTheory.stub_names_def
+val _ = translate stack_allocTheory.stub_names_def
+val _ = translate stack_removeTheory.stub_names_def
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv64_RHS);
 

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -486,12 +486,21 @@ val _ = translate(LongDiv_code_def|> inline_simp |> conv64)
 
 val _ = translate (word_bignumTheory.generated_bignum_stubs_eq |> inline_simp |> conv64)
 
+val _ = translate data_to_wordTheory.stub_names_def
 val res = translate (data_to_wordTheory.compile_def
                      |> SIMP_RULE std_ss [data_to_wordTheory.stubs_def] |> conv64_RHS);
 
 (* translate some 32/64 specific parts of the tap/explorer
    that can't be translated in explorerProgScript *)
 val res = translate (presLangTheory.tap_word_def |> conv64);
+val res = translate (presLangTheory.store_name_to_display_def |> conv64);
+val res = translate (presLangTheory.stack_prog_to_display_def |> conv64);
+val res = translate (presLangTheory.stack_progs_to_display_def |> conv64);
+val res = translate (presLangTheory.tap_stack_def |> conv64);
+val res = translate (presLangTheory.lab_asm_to_display_def |> conv64);
+val res = translate (presLangTheory.lab_line_to_display_def |> conv64);
+val res = translate (presLangTheory.lab_secs_to_display_def |> conv64);
+val res = translate (presLangTheory.tap_lab_def |> conv64);
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0;
 

--- a/compiler/compilationLib.sml
+++ b/compiler/compilationLib.sml
@@ -136,7 +136,8 @@ fun compile_to_data cs conf_def prog_def data_prog_name =
         FORK_CONV(REWR_CONV(SYM bvi_conf_def),
                   FORK_CONV(REWR_CONV(SYM bvi_prog_def),
                             REWR_CONV(SYM bvi_names_def)))));
-    val () = computeLib.extend_compset [computeLib.Defs [bvi_prog_def]] cs;
+    val () = computeLib.extend_compset
+      [computeLib.Defs [bvi_prog_def,bvi_names_def]] cs;
 
     val to_data_thm0 =
       ``to_data ^conf_tm ^prog_tm``
@@ -678,7 +679,7 @@ type compilation_result = {
 
 fun extract_compilation_result th =
   let val ls = th |> rconc |> optionSyntax.dest_some |> pairSyntax.strip_pair
-  in { code = el 1 ls, data = el 2 ls, config = el 3 ls } end
+  in { code = el 1 ls, data = el 2 ls, syms = el 3 ls, config = el 4 ls } end
 
 fun cbv_compile_to_data cs conf_def prog_def data_prog_name =
   let
@@ -736,6 +737,8 @@ datatype 'a app_list = Nil | List of 'a list | Append of 'a app_list * 'a app_li
 val is_Nil = same_const (prim_mk_const{Thy="misc",Name="Nil"})
 val (List_tm,mk_List,dest_List,is_List) = HolKernel.syntax_fns1 "misc" "List"
 val (Append_tm,mk_Append,dest_Append,is_Append) = HolKernel.syntax_fns2 "misc" "Append"
+val (emit_symbols_tm,mk_emit_symbols,dest_emit_symbols,is_emit_symbols) =
+  HolKernel.syntax_fns1 "export" "emit_symbols"
 val (SmartAppend_tm,mk_SmartAppend,dest_SmartAppend,is_SmartAppend) = HolKernel.syntax_fns2 "misc" "SmartAppend"
 val (split16_tm,mk_split16,dest_split16,is_split16) = HolKernel.syntax_fns2 "export" "split16"
 
@@ -776,7 +779,30 @@ fun split16_ml_to_app_list (prefix,to_string) def =
     val ints = map wordsSyntax.uint_of_word ls
   in split16_to_app_list (words_line prefix to_string) ints end
 
-fun term_to_app_list word_directive eval code_def data_def =
+fun emit_symbols_to_app_list def =
+  let
+    val (ls,_) = listSyntax.dest_list(rconc def)
+    fun emit_symbol tpl =
+      let
+        val (name, baselen) = pairSyntax.dest_pair tpl
+        val (base, len) = pairSyntax.dest_pair baselen
+        val name = mlstring_to_string name
+        val base = Arbnum.toInt (numSyntax.dest_numeral base)
+        val len = Arbnum.toInt (numSyntax.dest_numeral len)
+        fun safe ch = ch = #"_" orelse
+                      (ch >= #"0" andalso ch <= #"9") orelse
+                      (ch >= #"a" andalso ch <= #"z") orelse
+                      (ch >= #"A" andalso ch <= #"Z")
+        fun esc ch = if safe ch then str ch else "$"^Int.toString (ord ch)^"_"
+      in
+        "    makesym("^concat (map esc (explode name))^", "^Int.toString base^
+        ", "^Int.toString len^")\n"
+      end
+  in
+    List (map emit_symbol ls)
+  end
+
+fun term_to_app_list word_directive eval code_def data_def syms_def =
   let
     fun ttal tm =
       if is_Nil tm then Nil
@@ -795,6 +821,8 @@ fun term_to_app_list word_directive eval code_def data_def =
         dest_List tm |> listSyntax.dest_list |> #1
         |> map mlstring_to_string
         |> List
+      else if is_emit_symbols tm then
+        emit_symbols_to_app_list syms_def
       else
         let
           val (t1,t2) =
@@ -823,7 +851,7 @@ fun split16_conv tm =
   RAND_CONV split16_conv ) )
 *)
 
-fun eval_export word_directive target_export_defs code_def data_def ffi_names_tm out =
+fun eval_export word_directive target_export_defs code_def data_def syms_def ffi_names_tm out =
   let
     val cs = wordsLib.words_compset()
     val eval = computeLib.CBV_CONV cs;
@@ -839,15 +867,17 @@ fun eval_export word_directive target_export_defs code_def data_def ffi_names_tm
       list_mk_comb(exporter_tm,
         [ffi_names_tm,
          lhs(concl code_def),
-         lhs(concl data_def)])
+         lhs(concl data_def),
+         lhs(concl syms_def)])
     val app_list = eval eval_export_tm |> rconc
-  in print_app_list out (term_to_app_list word_directive eval code_def data_def app_list) end
+    in print_app_list out (term_to_app_list word_directive eval code_def
+    data_def syms_def app_list) end
 
 fun cbv_to_bytes
       word_directive
       add_encode_compset backend_config_def names_def target_export_defs
       stack_to_lab_thm lab_prog_def
-      code_name data_name config_name filename =
+      code_name data_name syms_name config_name filename =
   let
     val cs = compilation_compset()
     val () =
@@ -863,8 +893,10 @@ fun cbv_to_bytes
     val result = extract_compilation_result bootstrap_thm
     val code_def = mk_abbrev code_name (#code result)
     val data_def = mk_abbrev data_name (#data result)
+    val syms_def = mk_abbrev syms_name (#syms result)
     val config_def = mk_abbrev config_name (#config result)
-    val result_thm = PURE_REWRITE_RULE[GSYM code_def, GSYM data_def, GSYM config_def] bootstrap_thm
+    val result_thm = PURE_REWRITE_RULE[GSYM code_def, GSYM data_def,
+      GSYM syms_def, GSYM config_def] bootstrap_thm
 
     val ffi_names_tm = extract_ffi_names_tm (#config result)
 
@@ -872,11 +904,13 @@ fun cbv_to_bytes
 
     val () = Lib.say(pad_to 30 (" export: "))
     val () = time (
-      eval_export word_directive target_export_defs code_def data_def ffi_names_tm) out
+      eval_export word_directive target_export_defs code_def data_def syms_def ffi_names_tm) out
 
     val () = TextIO.closeOut out
 
   in
+ (*   eval_export word_directive target_export_defs code_def data_def syms_def
+      ffi_names_tm 0 *)
     result_thm
   end
 
@@ -937,9 +971,10 @@ fun compile backend_config_def cbv_to_bytes name prog_def =
     val lab_prog_def = definition(mk_abbrev_name lab_prog_name)
     val code_name = (!intermediate_prog_prefix) ^ "code"
     val data_name = (!intermediate_prog_prefix) ^ "data"
+    val syms_name = (!intermediate_prog_prefix) ^ "syms"
     val config_name = (!intermediate_prog_prefix) ^ "config"
     val result_thm =
-      cbv_to_bytes stack_to_lab_thm lab_prog_def code_name data_name config_name (name^".S")
+      cbv_to_bytes stack_to_lab_thm lab_prog_def code_name data_name syms_name config_name (name^".S")
   in result_thm end
 
 val compile_arm7 = compile arm7_backend_config_def cbv_to_bytes_arm7

--- a/compiler/compilationLib.sml
+++ b/compiler/compilationLib.sml
@@ -909,8 +909,6 @@ fun cbv_to_bytes
     val () = TextIO.closeOut out
 
   in
- (*   eval_export word_directive target_export_defs code_def data_def syms_def
-      ffi_names_tm 0 *)
     result_thm
   end
 

--- a/compiler/compilationLib.sml
+++ b/compiler/compilationLib.sml
@@ -782,7 +782,7 @@ fun split16_ml_to_app_list (prefix,to_string) def =
 fun emit_symbols_to_app_list def =
   let
     val (ls,_) = listSyntax.dest_list(rconc def)
-    fun emit_symbol tpl =
+    fun emit_symbol ix tpl =
       let
         val (name, baselen) = pairSyntax.dest_pair tpl
         val (base, len) = pairSyntax.dest_pair baselen
@@ -795,11 +795,11 @@ fun emit_symbols_to_app_list def =
                       (ch >= #"A" andalso ch <= #"Z")
         fun esc ch = if safe ch then str ch else "$"^Int.toString (ord ch)^"_"
       in
-        "    makesym("^concat (map esc (explode name))^", "^Int.toString base^
-        ", "^Int.toString len^")\n"
+        "    makesym(cml_"^concat (map esc (explode name))^"_"^Int.toString ix^
+        ", "^Int.toString base^", "^Int.toString len^")\n"
       end
   in
-    List (map emit_symbol ls)
+    List (mapi emit_symbol ls)
   end
 
 fun term_to_app_list word_directive eval code_def data_def syms_def =

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -116,7 +116,7 @@ val compile_def = Define`
           else
           case backend$compile_tap c.backend_config full_prog of
           | (NONE, td) => (Failure AssembleError, td)
-          | (SOME (bytes,data,syms,c), td) => (Success (bytes,data,syms,c), td)`;
+          | (SOME (bytes,data,c), td) => (Success (bytes,data,c), td)`;
 
 (* The top-level compiler *)
 val error_to_str_def = Define`
@@ -486,9 +486,9 @@ val compile_64_def = Define`
              only_print_types    := onlyprinttypes;
              only_print_sexp     := sexpprint|> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,syms,c), td) =>
+          (Success (bytes,data,c), td) =>
             (add_tap_output td (export (the [] c.lab_conf.ffi_names)
-                bytes data syms),
+                bytes data c.symbols),
               implode "")
         | (Failure err, td) => (add_tap_output td (List []), error_to_str err))
     | INR err =>
@@ -523,9 +523,9 @@ val compile_32_def = Define`
              only_print_sexp     := sexpprint
              |> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,syms,c), td) =>
+          (Success (bytes,data,c), td) =>
             (add_tap_output td (export (the [] c.lab_conf.ffi_names)
-                bytes data syms),
+                bytes data c.symbols),
               implode "")
         | (Failure err, td) => (List [], error_to_str err))
     | INR err =>

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -116,7 +116,7 @@ val compile_def = Define`
           else
           case backend$compile_tap c.backend_config full_prog of
           | (NONE, td) => (Failure AssembleError, td)
-          | (SOME (bytes,c), td) => (Success (bytes,c), td)`;
+          | (SOME (bytes,data,syms,c), td) => (Success (bytes,data,syms,c), td)`;
 
 (* The top-level compiler *)
 val error_to_str_def = Define`
@@ -486,9 +486,9 @@ val compile_64_def = Define`
              only_print_types    := onlyprinttypes;
              only_print_sexp     := sexpprint|> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,c), td) =>
+          (Success (bytes,data,syms,c), td) =>
             (add_tap_output td (export (the [] c.lab_conf.ffi_names)
-                bytes data),
+                bytes data syms),
               implode "")
         | (Failure err, td) => (add_tap_output td (List []), error_to_str err))
     | INR err =>
@@ -523,9 +523,9 @@ val compile_32_def = Define`
              only_print_sexp     := sexpprint
              |> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,c), td) =>
+          (Success (bytes,data,syms,c), td) =>
             (add_tap_output td (export (the [] c.lab_conf.ffi_names)
-                bytes data),
+                bytes data syms),
               implode "")
         | (Failure err, td) => (List [], error_to_str err))
     | INR err =>


### PR DESCRIPTION
* The exporters (except ag32 which may be using a different asm system) generate GNU assembler directives to generate symbols for all lab sections.  (Fixes #124)
* lab_to_target has been modified to provide section sizes, which are a field of ELF symbols.
* Names are now generated for stubs added in to_data and later passes.
* --explore has been modified to include name data and adds renderers for stackLang and labLang.
* call_empty_ffi has been turned off by default (Resolves #754)

I'm not wedded to the symbol format.  Decimal escaping is particularly ugly (I wanted hex, but my first few attempts were rejected by the translator).

Future cleanups:
* `lookup_any x y z` should be consistently used instead of `getOpt (lookup x y) z`
* Turning off call_empty_ffi means that DEBUG_FFI is unavailable with the precompiled compilers.  @tanyongkiam suggested adding the cake-sexpr-XXX files to the generated tarball and Makefile rules to build them.