### PR TITLE
Improved use of CurrHeap

### DIFF
--- a/compiler/backend/backendComputeLib.sml
+++ b/compiler/backend/backendComputeLib.sml
@@ -631,6 +631,7 @@ val add_backend_compset = computeLib.extend_compset
       (* ---- wordLang inst_select and inst flattening ---- *)
     ,word_instTheory.three_to_two_reg_def
     ,word_instTheory.pull_exp_def
+    ,word_instTheory.is_Lookup_CurrHeap_def
     ,word_instTheory.inst_select_def
     ,word_instTheory.inst_select_exp_def
     ,word_instTheory.flatten_exp_def

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -110,13 +110,13 @@ val ptr_bits_def = Define `
 val real_addr_def = Define `
   (real_addr (conf:data_to_word$config) r): 'a wordLang$exp =
     let k = shift (:'a) in
-      if k <= conf.pad_bits + 1 then
-        Op Add [Lookup CurrHeap;
-                Shift Lsr (Var r) (shift_length conf - k)]
+    let l = shift_length conf in
+      if k = l ∧ conf.len_bits = 0 ∧ conf.tag_bits = 0 then
+        Op Add [Lookup CurrHeap; Op Sub [Var r; Const 1w]]
+      else if k <= conf.pad_bits + 1 then
+        Op Add [Lookup CurrHeap; Shift Lsr (Var r) (l - k)]
       else
-        Op Add [Lookup CurrHeap;
-                Shift Lsl (Shift Lsr (Var r)
-                  (shift_length conf)) k]`
+        Op Add [Lookup CurrHeap; Shift Lsl (Shift Lsr (Var r) l) k]`
 
 val real_offset_def = Define `
   (real_offset (conf:data_to_word$config) r): 'a wordLang$exp =

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -111,11 +111,12 @@ val real_addr_def = Define `
   (real_addr (conf:data_to_word$config) r): 'a wordLang$exp =
     let k = shift (:'a) in
       if k <= conf.pad_bits + 1 then
-        OpLookup Add
-          (Shift Lsr (Var r) (shift_length conf - k)) CurrHeap
+        Op Add [Lookup CurrHeap;
+                Shift Lsr (Var r) (shift_length conf - k)]
       else
-        OpLookup Add
-          (Shift Lsl (Shift Lsr (Var r) (shift_length conf)) k) CurrHeap`
+        Op Add [Lookup CurrHeap;
+                Shift Lsl (Shift Lsr (Var r)
+                  (shift_length conf)) k]`
 
 val real_offset_def = Define `
   (real_offset (conf:data_to_word$config) r): 'a wordLang$exp =
@@ -330,7 +331,7 @@ val RefByte_code_def = Define `
                              Shift Lsl (Var 5) (shift (:'a))]);
            Set NextFree (Op Add [Var 1; Const bytes_in_word]);
            (* 3 := return value *)
-           Assign 3 (Op Or [Shift Lsl (OpLookup Sub (Var 9) CurrHeap)
+           Assign 3 (Op Or [Shift Lsl (Op Sub [Var 9; Lookup CurrHeap])
                (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Op Or [y; Const 7w]; Var 6]);
@@ -360,7 +361,7 @@ val Maxout_bits_code_def = Define `
 val Make_ptr_bits_code_def = Define `
   Make_ptr_bits_code c tag len dest =
     list_Seq [Assign dest (Op Or
-       [Const 1w; Shift Lsl (OpLookup Sub (Lookup NextFree) CurrHeap)
+       [Const 1w; Shift Lsl (Op Sub [Lookup NextFree; Lookup CurrHeap])
            (shift_length c − shift (:'a))]);
         Maxout_bits_code c.tag_bits (1 + c.len_bits) dest tag;
         Maxout_bits_code c.len_bits 1 dest len] :'a wordLang$prog`
@@ -414,7 +415,7 @@ val RefArray_code_def = Define `
            Assign 1 (Op Sub [Lookup EndOfHeap; Var 1]);
            Set EndOfHeap (Var 1);
            (* 3 := return value *)
-           Assign 3 (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
+           Assign 3 (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
                (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Shift Lsl (Var 2)
@@ -541,7 +542,7 @@ val AnyArith_code_def = Define `
                        ShiftVar Lsl 6 (dimindex (:'a) − c.len_size);
                        ShiftVar Lsl 8 4]);
       Store (Var 5) 7;
-      Assign 1 (OpLookup Sub (Var 5) CurrHeap);
+      Assign 1 (Op Sub [Var 5; Lookup CurrHeap]);
       Assign 1 (Op Or [ShiftVar Lsl 1 (shift_length c − shift (:'a)); Const 1w]);
       Set NextFree (Op Add [Var 5; Const bytes_in_word;
                             ShiftVar Lsl 6 (shift (:'a))]);
@@ -1093,7 +1094,7 @@ val def = assign_Define `
                          Assign 3 (Const header);
                          StoreEach 1 (3::MAP adjust_var args) 0w;
                          Assign (adjust_var dest)
-                           (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
+                           (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
                                      (shift_length c − shift (:'a));
                                    Const (1w ||
                                            (small_shift_length c − 1 -- 0)
@@ -1163,7 +1164,7 @@ val def = assign_Define `
                   Assign 3 (Const header);
                   StoreEach 1 (3::MAP adjust_var args) 0w;
                   Assign (adjust_var dest)
-                    (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
+                    (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
                               (shift_length c − shift (:'a));
                             Const 1w])],l))
       : 'a wordLang$prog # num`;

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -111,12 +111,11 @@ val real_addr_def = Define `
   (real_addr (conf:data_to_word$config) r): 'a wordLang$exp =
     let k = shift (:'a) in
       if k <= conf.pad_bits + 1 then
-        Op Add [Lookup CurrHeap;
-                Shift Lsr (Var r) (shift_length conf - k)]
+        OpLookup Add
+          (Shift Lsr (Var r) (shift_length conf - k)) CurrHeap
       else
-        Op Add [Lookup CurrHeap;
-                Shift Lsl (Shift Lsr (Var r)
-                  (shift_length conf)) k]`
+        OpLookup Add
+          (Shift Lsl (Shift Lsr (Var r) (shift_length conf)) k) CurrHeap`
 
 val real_offset_def = Define `
   (real_offset (conf:data_to_word$config) r): 'a wordLang$exp =
@@ -331,7 +330,7 @@ val RefByte_code_def = Define `
                              Shift Lsl (Var 5) (shift (:'a))]);
            Set NextFree (Op Add [Var 1; Const bytes_in_word]);
            (* 3 := return value *)
-           Assign 3 (Op Or [Shift Lsl (Op Sub [Var 9; Lookup CurrHeap])
+           Assign 3 (Op Or [Shift Lsl (OpLookup Sub (Var 9) CurrHeap)
                (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Op Or [y; Const 7w]; Var 6]);
@@ -361,7 +360,7 @@ val Maxout_bits_code_def = Define `
 val Make_ptr_bits_code_def = Define `
   Make_ptr_bits_code c tag len dest =
     list_Seq [Assign dest (Op Or
-       [Const 1w; Shift Lsl (Op Sub [Lookup NextFree; Lookup CurrHeap])
+       [Const 1w; Shift Lsl (OpLookup Sub (Lookup NextFree) CurrHeap)
            (shift_length c − shift (:'a))]);
         Maxout_bits_code c.tag_bits (1 + c.len_bits) dest tag;
         Maxout_bits_code c.len_bits 1 dest len] :'a wordLang$prog`
@@ -415,7 +414,7 @@ val RefArray_code_def = Define `
            Assign 1 (Op Sub [Lookup EndOfHeap; Var 1]);
            Set EndOfHeap (Var 1);
            (* 3 := return value *)
-           Assign 3 (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
+           Assign 3 (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
                (shift_length c − shift (:'a)); Const (1w:'a word)]);
            (* compute header *)
            Assign 5 (Op Or [Shift Lsl (Var 2)
@@ -542,7 +541,7 @@ val AnyArith_code_def = Define `
                        ShiftVar Lsl 6 (dimindex (:'a) − c.len_size);
                        ShiftVar Lsl 8 4]);
       Store (Var 5) 7;
-      Assign 1 (Op Sub [Var 5; Lookup CurrHeap]);
+      Assign 1 (OpLookup Sub (Var 5) CurrHeap);
       Assign 1 (Op Or [ShiftVar Lsl 1 (shift_length c − shift (:'a)); Const 1w]);
       Set NextFree (Op Add [Var 5; Const bytes_in_word;
                             ShiftVar Lsl 6 (shift (:'a))]);
@@ -1094,7 +1093,7 @@ val def = assign_Define `
                          Assign 3 (Const header);
                          StoreEach 1 (3::MAP adjust_var args) 0w;
                          Assign (adjust_var dest)
-                           (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
+                           (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
                                      (shift_length c − shift (:'a));
                                    Const (1w ||
                                            (small_shift_length c − 1 -- 0)
@@ -1164,7 +1163,7 @@ val def = assign_Define `
                   Assign 3 (Const header);
                   StoreEach 1 (3::MAP adjust_var args) 0w;
                   Assign (adjust_var dest)
-                    (Op Or [Shift Lsl (Op Sub [Var 1; Lookup CurrHeap])
+                    (Op Or [Shift Lsl (OpLookup Sub (Var 1) CurrHeap)
                               (shift_length c − shift (:'a));
                             Const 1w])],l))
       : 'a wordLang$prog # num`;

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -630,6 +630,8 @@ val stack_prog_to_display_def = Define`
         store_name_to_display sn]
     | Set sn n => Item NONE «Set» [store_name_to_display sn;
         num_to_display n]
+    | OpCurrHeap b n1 n2 => Item NONE «OpCurrHeap»
+        [asm_binop_to_display b; num_to_display n1; num_to_display n2]
     | Call rh tgt eh => Item NONE «Call»
         [(case rh of
             | NONE => empty_item «Tail»
@@ -761,6 +763,8 @@ val word_prog_to_display_def = tDefine "word_prog_to_display" `
     [word_prog_to_display_ret a; option_to_display num_to_display b;
         list_to_display num_to_display c;
         word_prog_to_display_handler d]) /\
+  (word_prog_to_display (OpCurrHeap b n1 n2) = Item NONE «OpCurrHeap»
+    [asm_binop_to_display b; num_to_display n1; num_to_display n2]) /\
   (word_prog_to_display (Seq prog1 prog2) = Item NONE (strlit "Seq")
     [word_prog_to_display prog1; word_prog_to_display prog2]) /\
   (word_prog_to_display (If cmp n reg p1 p2) = Item NONE (strlit "If")

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -8474,7 +8474,7 @@ Theorem word_exp_insert:
       word_exp t (real_addr c m)))
 Proof
   fs [wordSemTheory.word_exp_def,real_addr_def]
-  \\ IF_CASES_TAC \\ fs []
+  \\ rpt (IF_CASES_TAC \\ fs [])
   \\ fs [wordSemTheory.word_exp_def,real_addr_def] \\ fs [lookup_insert]
 QED
 

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -4609,15 +4609,27 @@ val get_real_addr_def = Define `
     let k = shift (:α) in
       case FLOOKUP st CurrHeap of
       | SOME (Word curr) =>
-          if k <= conf.pad_bits + 1
-          then SOME (curr + (w >>> (shift_length conf - k)))
-          else SOME (curr + (w >>> (shift_length conf) << k))
+          if k = shift_length conf ∧ conf.len_bits = 0 ∧ conf.tag_bits = 0
+          then SOME (curr + w - 1w)
+          else
+            if k <= conf.pad_bits + 1
+            then SOME (curr + (w >>> (shift_length conf - k)))
+            else SOME (curr + (w >>> (shift_length conf) << k))
       | _ => NONE`
 
 val get_real_offset_def = Define `
   get_real_offset (w:'a word) =
     if dimindex (:'a) = 32
     then SOME (w + bytes_in_word) else SOME (w << 1 + bytes_in_word)`
+
+Triviality or_1:
+  ∀w. (0 -- 0) w ‖ 1w = 1w :'a word
+Proof
+  fs [fcpTheory.CART_EQ,word_or_def,fcpTheory.FCP_BETA,word_lsl_def,
+      word_0,word_bits_def]
+  \\ once_rewrite_tac [wordsTheory.word_index_n2w] \\ fs []
+  \\ rw [] \\ eq_tac \\ rw []
+QED
 
 Theorem get_real_addr_get_addr:
    heap_length heap <= dimword (:'a) DIV 2 ** shift_length c /\
@@ -4635,6 +4647,23 @@ Proof
     \\ match_mp_tac LESS_LESS_EQ_TRANS
     \\ once_rewrite_tac [CONJ_COMM]
     \\ asm_exists_tac \\ fs [])
+  \\ IF_CASES_TAC
+  THEN1
+   (Cases_on ‘w’
+    \\ fs [get_lowerbits_def,small_shift_length_def,or_1]
+    \\ ‘0w = n2w n ≪ shift_length c && 1w’ by
+     (fs [fcpTheory.CART_EQ,word_and_def,fcpTheory.FCP_BETA,word_lsl_def,word_0]
+      \\ rewrite_tac [word_1comp_def]
+      \\ once_rewrite_tac [wordsTheory.word_index_n2w] \\ fs []
+      \\ gvs [good_dimindex_def,shift_def])
+    \\ drule (GSYM WORD_ADD_OR)
+    \\ pop_assum kall_tac
+    \\ fs []
+    \\ gvs [WORD_MUL_LSL,bytes_in_word_def,word_mul_n2w,good_dimindex_def,
+            dimword_def,shift_def]
+    \\ qpat_x_assum ‘_ = shift_length _’ (assume_tac o GSYM)
+    \\ fs [])
+  \\ pop_assum kall_tac
   \\ reverse IF_CASES_TAC THEN1
    (drule lsl_lsr \\ fs [get_lowerbits_LSL_shift_length]
     \\ fs [] \\ rw []

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -5215,6 +5215,19 @@ Proof
     \\ BasicProvers.TOP_CASE_TAC \\ fs[] \\ rw[]
     \\ imp_res_tac FLOOKUP_SUBMAP \\ fs[]
     \\ full_simp_tac(srw_ss())[state_component_equality] )
+  \\ conj_tac (* OpCurrHeap *) >- (
+    fs[Once comp_def,evaluate_def,get_var_def,word_exp_def]
+    \\ fs [AllCaseEqs(),set_var_def]
+    \\ full_simp_tac(srw_ss())[state_component_equality]
+    \\ rw [] \\ fs [PULL_EXISTS]
+    \\ gs [optionTheory.IS_SOME_EXISTS,AllCaseEqs()]
+    \\ qpat_x_assum`_ = t.regs`(assume_tac o SYM) \\ fs[]
+    \\ rename [‘FLOOKUP s.regs src = SOME (Word x7)’]
+    \\ ‘FLOOKUP regs src = SOME (Word x7)’ by fs [FLOOKUP_DEF,SUBMAP_DEF]
+    \\ fs []
+    \\ match_mp_tac SUBMAP_mono_FUPDATE
+    \\ rw[GSYM SUBMAP_DOMSUB_gen]
+    \\ metis_tac[SUBMAP_TRANS,SUBMAP_DOMSUB] )
   \\ conj_tac (* Tick *) >- (
     rpt strip_tac
     \\ qexists_tac `0` \\ full_simp_tac(srw_ss())[Once comp_def,evaluate_def,dec_clock_def]

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -208,7 +208,6 @@ val comp_correct = Q.prove(
      s.compile = (λcfg. c cfg o (stack_names$compile f))
      ==>
      evaluate (comp f p, rename_state c f s) = (r, rename_state c f t)`,
-
   recInduct evaluate_ind \\ rpt strip_tac
   THEN1 (fs [evaluate_def,comp_def] \\ rpt var_eq_tac)
   THEN1 (fs [evaluate_def,comp_def] \\ rpt var_eq_tac \\ CASE_TAC \\ fs []
@@ -217,6 +216,7 @@ val comp_correct = Q.prove(
   THEN1 (fs [evaluate_def,comp_def] >>
     every_case_tac >> fs[] >> rveq >> fs[] >>
     imp_res_tac inst_rename >> fs[])
+  THEN1 (fs [evaluate_def,comp_def,rename_state_def] >> rveq >> fs[])
   THEN1 (fs [evaluate_def,comp_def,rename_state_def] >> rveq >> fs[])
   THEN1 (fs [evaluate_def,comp_def,rename_state_def] >> rveq >> fs[])
   THEN1 (fs [evaluate_def,comp_def,rename_state_def] \\ rw []

--- a/compiler/backend/proofs/stack_rawcallProofScript.sml
+++ b/compiler/backend/proofs/stack_rawcallProofScript.sml
@@ -158,6 +158,8 @@ Proof
   THEN1
    (rename [`Set`] \\ simple_case)
   THEN1
+   (rename [`OpCurrHeap`] \\ simple_case)
+  THEN1
    (rename [`Tick`] \\ simple_case)
   THEN1
    (rename [`Seq`]
@@ -939,27 +941,5 @@ Proof
   \\ Cases_on `lookup dest i` \\ fs []  \\ rw []
   \\ simp [stack_get_handler_labels_def]
 QED
-
-(*
-Theorem get_code_labels_comp:
-  !i p.
-    get_code_labels (comp i p) = get_code_labels p /\
-    get_code_labels (comp_top i p) = get_code_labels p
-Proof
-  recInduct comp_ind \\ rpt gen_tac \\ strip_tac
-  \\ Cases_on `p` \\ fs [] \\ simp [comp_top_def]
-  \\ simp [Once comp_def]
-  \\ TRY (fs [get_code_labels_def] \\ NO_TAC)
-  THEN1 (every_case_tac \\ fs [get_code_labels_def])
-  \\ reverse conj_asm2_tac THEN1 fs [get_code_labels_def]
-  \\ rename [`comp_seq p1 p2`]
-  \\ Cases_on `comp_seq p1 p2 i (Seq (comp i p1) (comp i p2)) =
-               Seq (comp i p1) (comp i p2)` \\ simp []
-  \\ drule comp_seq_neq_IMP \\ strip_tac \\ rveq \\ fs []
-  \\ fs [comp_seq_def,dest_case_def,CaseEq"option",CaseEq"bool"]
-  \\ Cases_on `lookup dest i` \\ fs []  \\ rw []
-  \\ simp [get_code_labels_def]
-QED
-*)
 
 val _ = export_theory();

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -9,7 +9,7 @@ open preamble
      set_sepTheory
      semanticsPropsTheory
      helperLib
-local open dep_rewrite blastLib in end
+local open dep_rewrite blastLib labPropsTheory in end
 
 val _ = new_theory"stack_removeProof";
 
@@ -597,6 +597,7 @@ Theorem state_rel_word_exp:
    word_exp t e = SOME w
 Proof
   ho_match_mp_tac word_exp_ind
+  \\ rpt conj_tac
   \\ simp[word_exp_def]
   \\ rw[]
   \\ imp_res_tac state_rel_mem_load_imp
@@ -990,7 +991,7 @@ val name_cases = prove(
 (* Significantly faster than SEP_R_TAC *)
 val mem_load_lemma = Q.prove(`
   MEM name store_list ∧
-  FLOOKUP (s:('a,'c,'b)state).store name = SOME x ∧
+  FLOOKUP (s:('a,'c,'b)stackSem$state).store name = SOME x ∧
   (memory s.memory s.mdomain *
         word_list
           (the_SOME_Word (FLOOKUP s.store BitmapBase) ≪ word_shift (:α))
@@ -1001,7 +1002,7 @@ val mem_load_lemma = Q.prove(`
            bytes_in_word *
            n2w (LENGTH s.data_buffer.buffer + LENGTH s.bitmaps))
           s.data_buffer.space_left * word_store c s.store *
-        word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) state).mdomain)) ⇒
+        word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) stackSem$state).mdomain)) ⇒
   mem_load (c+store_offset name) t1 = SOME x`,
   strip_tac >>
   drule fun2set_STAR_IMP>>
@@ -1041,7 +1042,7 @@ val mem_load_lemma2 = Q.prove(`
            bytes_in_word *
            n2w (LENGTH s.data_buffer.buffer + LENGTH s.bitmaps))
           s.data_buffer.space_left * word_store c s.store *
-        word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) state).mdomain)) ⇒
+        word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) stackSem$state).mdomain)) ⇒
   c+store_offset name ∈ t1.mdomain`,
   strip_tac >>
   drule fun2set_STAR_IMP>>
@@ -1142,28 +1143,31 @@ Proof
   srw_tac[][FUN_EQ_THM,prog_comp_def,FORALL_PROD,LAMBDA_PROD]
 QED
 
-val comp_correct = Q.prove(
-  `!p s1 r s2 t1 k off jump.
+Theorem comp_correct[local]:
+  !p s1 r s2 t1 k off jump.
      evaluate (p,s1) = (r,s2) /\ r <> SOME Error /\
      state_rel jump off k s1 t1 /\ reg_bound p k ==>
      ?ck t2. evaluate (comp jump off k p,t1 with clock := ck + t1.clock) = (r,t2) /\
              (case r of
-               | SOME (Halt _) => t2.ffi = s2.ffi
-               | SOME TimeOut => t2.ffi = s2.ffi
-               | SOME (FinalFFI _) => t2.ffi = s2.ffi
-               | _ =>  (state_rel jump off k s2 t2))`,
+              | SOME (Halt _) => t2.ffi = s2.ffi
+              | SOME TimeOut => t2.ffi = s2.ffi
+              | SOME (FinalFFI _) => t2.ffi = s2.ffi
+              | _ =>  (state_rel jump off k s2 t2))
+Proof
   recInduct evaluate_ind \\ rpt strip_tac
-  THEN1 (full_simp_tac(srw_ss())[comp_def,evaluate_def] \\ rpt var_eq_tac \\ qexists_tac`0` \\ full_simp_tac(srw_ss())[])
-  THEN1
+  THEN1 (* Skip *)
+   (full_simp_tac(srw_ss())[comp_def,evaluate_def] \\ rpt var_eq_tac \\ qexists_tac`0` \\ full_simp_tac(srw_ss())[])
+  THEN1 (* Halt *)
    (full_simp_tac(srw_ss())[comp_def,evaluate_def,reg_bound_def]
     \\ imp_res_tac state_rel_get_var \\ full_simp_tac(srw_ss())[]
     \\ qexists_tac`0`
     \\ BasicProvers.TOP_CASE_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
     \\ BasicProvers.TOP_CASE_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
     \\ full_simp_tac(srw_ss())[state_rel_def])
-  THEN1 (full_simp_tac(srw_ss())[comp_def,evaluate_def] \\ full_simp_tac(srw_ss())[state_rel_def])
-  THEN1 (
-    full_simp_tac(srw_ss())[comp_def,evaluate_def]
+  THEN1 (* Alloc *)
+   (full_simp_tac(srw_ss())[comp_def,evaluate_def] \\ full_simp_tac(srw_ss())[state_rel_def])
+  THEN1 (* Inst *)
+   (full_simp_tac(srw_ss())[comp_def,evaluate_def]
     \\ last_x_assum mp_tac
     \\ BasicProvers.TOP_CASE_TAC \\ full_simp_tac(srw_ss())[]
     \\ strip_tac \\ rveq
@@ -1224,6 +1228,19 @@ val comp_correct = Q.prove(
     \\ Q.ABBREV_TAC `d = t1.mdomain`
     \\ drule name_cases
     \\ metis_tac[store_write_lemma])
+  THEN1 (* OpCurrHeap *)
+   (qexists_tac`0`
+    \\ `s.use_store` by full_simp_tac(srw_ss())[state_rel_def]
+    \\ full_simp_tac(srw_ss())[comp_def,evaluate_def,reg_bound_def]
+    \\ gvs [AllCaseEqs(),word_exp_def]
+    \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
+    \\ fs [inst_def,assign_def,word_exp_def]
+    \\ gvs [AllCaseEqs(),word_exp_def,PULL_EXISTS]
+    \\ rename [‘FLOOKUP s.regs src = SOME (Word c1)’]
+    \\ rename [‘FLOOKUP s.store CurrHeap = SOME (Word c2)’]
+    \\ qsuff_tac ‘FLOOKUP t1.regs src = SOME (Word c1) ∧
+                  FLOOKUP t1.regs (k + 2) = SOME (Word c2)’ THEN1 fs []
+    \\ fs [state_rel_def])
   THEN1 (* Tick *)
    (full_simp_tac(srw_ss())[comp_def,evaluate_def]
     \\ `s.clock = t1.clock` by full_simp_tac(srw_ss())[state_rel_def] \\ full_simp_tac(srw_ss())[]
@@ -1516,7 +1533,7 @@ val comp_correct = Q.prove(
     \\ disch_then(qspec_then`ck2`mp_tac)
     \\ simp[] \\ ntac 2 strip_tac
     \\ qexists_tac`ck' + ck2` \\  simp[] )
- THEN1 ( (* Install *)
+  THEN1 ( (* Install *)
     rw[comp_def]
     \\ fs[evaluate_def]
     \\ fs[reg_bound_def]
@@ -1968,7 +1985,8 @@ val comp_correct = Q.prove(
       \\ full_simp_tac(srw_ss())[mem_load_def]  \\ SEP_R_TAC \\ full_simp_tac(srw_ss())[])
     \\ `good_dimindex(:'a)` by full_simp_tac(srw_ss())[state_rel_def]
     \\ full_simp_tac(srw_ss())[labPropsTheory.good_dimindex_def,word_shift_def,FLOOKUP_UPDATE]
-    \\ full_simp_tac(srw_ss())[mem_load_def] \\ full_simp_tac(srw_ss())[GSYM mem_load_def] \\ full_simp_tac(srw_ss())[GSYM set_var_def]));
+    \\ full_simp_tac(srw_ss())[mem_load_def] \\ full_simp_tac(srw_ss())[GSYM mem_load_def] \\ full_simp_tac(srw_ss())[GSYM set_var_def])
+QED
 
 Theorem compile_semantics:
    state_rel jump off k s1 s2 /\ semantics start s1 <> Fail ==>
@@ -3442,8 +3460,8 @@ Proof
 QED
 
 Theorem stack_remove_lab_pres:
-    ∀jump off k p.
-  extract_labels p = extract_labels (comp jump off k p)
+  ∀jump off k p.
+    extract_labels p = extract_labels (comp jump off k p)
 Proof
   ho_match_mp_tac comp_ind>>Cases_on`p`>>rw[]>>
   once_rewrite_tac [comp_def]>>fs[extract_labels_def]>>
@@ -3474,25 +3492,26 @@ Proof
 QED
 
 Theorem stack_remove_comp_stack_asm_name:
-    ∀jump off k p.
-  stack_asm_name c p ∧ stack_asm_remove (c:'a asm_config) p ∧
-  addr_offset_ok c 0w ∧
-  good_dimindex (:'a) ∧
-  (∀n. n ≤ max_stack_alloc ⇒
-  c.valid_imm (INL Sub) (n2w (n * (dimindex (:'a) DIV 8))) ∧
-  c.valid_imm (INL Add) (n2w (n * (dimindex (:'a) DIV 8)))) ∧
-  (* Needed to implement the global store *)
-  (∀s. addr_offset_ok c (store_offset s)) ∧
-  reg_name (k+2) c ∧
-  reg_name (k+1) c ∧
-  reg_name k c ∧
-  off = c.addr_offset ⇒
-  stack_asm_name c (comp jump off k p)
+  ∀jump off k p.
+    stack_asm_name c p ∧ stack_asm_remove (c:'a asm_config) p ∧
+    addr_offset_ok c 0w ∧
+    good_dimindex (:'a) ∧
+    (∀n. n ≤ max_stack_alloc ⇒
+    c.valid_imm (INL Sub) (n2w (n * (dimindex (:'a) DIV 8))) ∧
+    c.valid_imm (INL Add) (n2w (n * (dimindex (:'a) DIV 8)))) ∧
+    (* Needed to implement the global store *)
+    (∀s. addr_offset_ok c (store_offset s)) ∧
+    reg_name (k+2) c ∧
+    reg_name (k+1) c ∧
+    reg_name k c ∧
+    off = c.addr_offset ⇒
+    stack_asm_name c (comp jump off k p)
 Proof
   ho_match_mp_tac comp_ind>>Cases_on`p`>>rw[]>>
   simp[Once comp_def]>>
   rw[]>>
-  fs[stack_asm_name_def,inst_name_def,stack_asm_remove_def,addr_name_def,arith_name_def,reg_imm_name_def,stackLangTheory.list_Seq_def]
+  fs[stack_asm_name_def,inst_name_def,stack_asm_remove_def,addr_name_def,
+     arith_name_def,reg_imm_name_def,stackLangTheory.list_Seq_def]
   >-
     (every_case_tac>>fs[])
   >-

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -1168,6 +1168,10 @@ Proof
     srw_tac[][stackSemTheory.evaluate_def,flatten_def] >>
     full_simp_tac(srw_ss())[state_rel_def] ) >>
   conj_tac >- (
+    rename [`OpCurrHeap`] >>
+    srw_tac[][stackSemTheory.evaluate_def,flatten_def] >>
+    full_simp_tac(srw_ss())[state_rel_def] ) >>
+  conj_tac >- (
     rename [`Tick`] >>
     simp[stackSemTheory.evaluate_def,flatten_def] >>
     rpt gen_tac >> strip_tac >>

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -2719,7 +2719,11 @@ Proof
   >- (* get *)
     rm_tac
   >- (* OpCurrHeap *)
-    cheat
+   (rm_tac \\ fs[evaluate_def,state_component_equality,set_var_def,word_exp_def,
+       the_words_def,AllCaseEqs(),PULL_EXISTS,get_live_exp_def,big_union_def]>>
+    first_x_assum (qspecl_then [‘t’,‘delete num live’] mp_tac) >>
+    impl_tac >- (fs [domain_delete] \\ metis_tac []) >>
+    strip_tac \\ fs [] \\ rw [lookup_insert])
   >- (* loc value *)
     rm_tac
   >- (* seq *)
@@ -5942,19 +5946,15 @@ Proof
     (exists_tac>>
     EVERY_CASE_TAC>>full_simp_tac(srw_ss())[call_env_def, flush_state_def,dec_clock_def])
   >- (* OpCurrHeap *)
-    (exists_tac>>
-    fs [word_exp_def,the_words_def] >>
-    Cases_on ‘lookup n0 st.locals’ >> fs []>> Cases_on ‘x’ \\ fs []>>
-    Cases_on ‘FLOOKUP st.store CurrHeap’ >> fs []>> Cases_on ‘x’ \\ fs []>>
-    Cases_on ‘word_op b [c; c']’ >> fs [] >>
-    full_simp_tac(srw_ss())[next_var_rename_def,ssa_cc_trans_inst_def,inst_def,
-      assign_def,word_exp_perm,evaluate_def,LET_THM,word_exp_def,the_words_def] >>
-    imp_res_tac ssa_locals_rel_get_var >>
-    fs[set_vars_def,get_var_def,lookup_alist_insert]>>
-    first_x_assum drule >> fs [set_var_def] >>
-    full_simp_tac(srw_ss())[ssa_locals_rel_def]>>
-    srw_tac[][]>>full_simp_tac(srw_ss())[lookup_insert] >>
-    pop_assum mp_tac >> cheat)
+    (last_x_assum kall_tac>>
+    exists_tac>>
+    EVERY_CASE_TAC>>full_simp_tac(srw_ss())[next_var_rename_def]>>
+    imp_res_tac ssa_locals_rel_get_var>>
+    imp_res_tac ssa_cc_trans_exp_correct>>full_simp_tac(srw_ss())[word_state_eq_rel_def]>>
+    rev_full_simp_tac(srw_ss())[word_exp_perm,evaluate_def]>>
+    fs[set_var_def,set_store_def,ssa_cc_trans_exp_def]>>
+    match_mp_tac ssa_locals_rel_set_var>>
+    full_simp_tac(srw_ss())[every_var_def])
   >-
     exp_tac
   >- (* Install *)

--- a/compiler/backend/proofs/word_depthProofScript.sml
+++ b/compiler/backend/proofs/word_depthProofScript.sml
@@ -275,6 +275,10 @@ Proof
    (fs [wordSemTheory.evaluate_def] \\ rveq
     \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []
     \\ fs [])
+  THEN1 (* OpCurrHeap *)
+   (fs [wordSemTheory.evaluate_def] \\ rveq
+    \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []
+    \\ fs [])
   THEN1 (* Store *)
    (fs [wordSemTheory.evaluate_def,mem_store_def] \\ rveq
     \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []

--- a/compiler/backend/proofs/word_elimProofScript.sml
+++ b/compiler/backend/proofs/word_elimProofScript.sml
@@ -141,6 +141,7 @@ Proof
     >- (EVERY_CASE_TAC >> fs[set_var_def] >> rw[] >> fs[])
     >- (EVERY_CASE_TAC >> fs[set_var_def] >> rw[] >> fs[])
     >- (EVERY_CASE_TAC >> fs[set_store_def] >> rw[] >> fs[])
+    >- (EVERY_CASE_TAC >> fs[set_var_def] >> rw[] >> fs[])
     >- (EVERY_CASE_TAC >> fs[mem_store_def] >> rw[] >> fs[])
     >- (EVERY_CASE_TAC >> fs[call_env_def, flush_state_def, dec_clock_def] >> rw[] >> fs[])
     >- (EVERY_CASE_TAC >> fs[] >> rename1 `evaluate (p, st)` >>
@@ -1558,6 +1559,14 @@ Proof
         `n ∈ domain reachable` by (imp_res_tac domain_get_locals_lookup >>
             fs[SUBSET_DEF]) >>
         fs[SUBSET_DEF] >> metis_tac[]
+        )
+    >- ( (* OpCurrHeap *)
+        simp[wordSemTheory.evaluate_def,word_exp_def,the_words_def]
+        \\ simp [AllCaseEqs(),PULL_EXISTS] \\ rpt gen_tac \\ strip_tac
+        \\ gvs [dest_result_loc_def,set_var_def]
+        \\ fs[word_state_rel_def, domain_find_loc_state, dest_result_loc_def]
+        \\ qspecl_then [`dst`, `Word z`, `s.locals`] mp_tac get_locals_insert
+        \\ fs[dest_word_loc_def] \\ metis_tac[SUBSET_TRANS]
         )
     >- ( (* Set *)
         simp[wordSemTheory.evaluate_def] >>

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -17,10 +17,12 @@ val _ = set_grammar_ancestry ["wordLang", "wordProps", "word_inst", "wordSem"];
 Type result[pp] = “:'a wordSem$result”
 
 (* TODO: Move, but some of these are specific instantiations *)
-val PERM_SWAP_SIMP = Q.prove(`
-  PERM (A ++ (B::C)) (B::(A++C))`,
+Theorem PERM_SWAP_SIMP[local]:
+  PERM (A ++ (B::C)) (B::(A++C))
+Proof
   match_mp_tac APPEND_PERM_SYM>>full_simp_tac(srw_ss())[]>>
-  metis_tac[PERM_APPEND]);
+  metis_tac[PERM_APPEND]
+QED
 
 val EL_FILTER = Q.prove(`
   ∀ls x. x < LENGTH (FILTER P ls) ⇒ P (EL x (FILTER P ls))`,

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -392,7 +392,6 @@ Theorem inst_select_exp_thm[local]:
     else if x < temp then lookup x loc' = lookup x s.locals
     else T
 Proof
-
   completeInduct_on`exp_size (K 0) exp`>>
   rpt strip_tac>>
   Cases_on`exp`>>
@@ -459,18 +458,46 @@ Proof
       simp[state_component_equality,set_var_def,lookup_insert]>>
       srw_tac[][]>>DISJ2_TAC>>strip_tac>>
       `x ≠ temp` by DECIDE_TAC>>metis_tac[])
-
   >-
     (rename [‘Op’]>>
     Cases_on`∃e1 e2. l = [e1;e2]`>>full_simp_tac(srw_ss())[inst_select_exp_def]
     >-
       (IF_CASES_TAC THEN1
-
-
-
-cheat >>
+       (gvs[PULL_FORALL] >>
+        first_x_assum (qspec_then ‘e1’ mp_tac) >>
+        fs [exp_size_def,binary_branch_exp_def] >>
+        ‘binary_branch_exp e1’ by
+           (Cases_on ‘b’ \\ fs [binary_branch_exp_def]) >> fs [] >>
+        disch_then drule >>
+        gvs [word_exp_def,AllCaseEqs(),the_words_def,GSYM PULL_FORALL] >>
+        disch_then (qspecl_then [‘c’,‘temp’] strip_assume_tac) >>
+        pop_assum drule >> fs [] >> strip_tac >>
+        gvs [evaluate_def,word_exp_def,the_words_def] >>
+        first_assum (qspec_then ‘temp’ assume_tac) >> fs [] >>
+        Cases_on ‘e2’ >> fs [is_Lookup_CurrHeap_def] >>
+        rename [‘Lookup ss’] \\ Cases_on ‘ss’ >> fs [is_Lookup_CurrHeap_def] >>
+        gvs [word_exp_def,set_var_def,state_component_equality,lookup_insert] >>
+        rw [] >> metis_tac [prim_recTheory.LESS_REFL]) >>
       pop_assum mp_tac >>
-      IF_CASES_TAC THEN1 cheat >>
+      IF_CASES_TAC THEN1
+       (gvs[PULL_FORALL] >>
+        first_x_assum (qspec_then ‘e2’ mp_tac) >>
+        fs [exp_size_def,binary_branch_exp_def] >>
+        ‘binary_branch_exp e2’ by
+           (Cases_on ‘b’ \\ fs [binary_branch_exp_def]) >> fs [] >>
+        disch_then drule >>
+        gvs [word_exp_def,AllCaseEqs(),the_words_def,GSYM PULL_FORALL] >>
+        disch_then (qspecl_then [‘c’,‘temp’] strip_assume_tac) >>
+        pop_assum drule >> fs [] >> strip_tac >>
+        gvs [evaluate_def,word_exp_def,the_words_def] >>
+        first_assum (qspec_then ‘temp’ assume_tac) >> fs [] >>
+        Cases_on ‘e1’ >> fs [is_Lookup_CurrHeap_def] >>
+        rename [‘Lookup ss’] \\ Cases_on ‘ss’ >> fs [is_Lookup_CurrHeap_def] >>
+        rename [‘word_op b [x1; x2] = SOME x3’] >>
+        ‘word_op b [x2; x1] = SOME x3’ by
+          (Cases_on ‘b’ \\ fs [word_op_def,AllCaseEqs()]) >>
+        gvs [word_exp_def,set_var_def,state_component_equality,lookup_insert] >>
+        rw [] >> metis_tac [prim_recTheory.LESS_REFL]) >>
       pop_assum mp_tac>>
       `binary_branch_exp e1` by
         (Cases_on`b`>>full_simp_tac(srw_ss())[binary_branch_exp_def])>>

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -590,7 +590,7 @@ Theorem inst_select_thm:
 Proof
   ho_match_mp_tac inst_select_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[inst_select_def,locals_rel_evaluate_thm]
-  >-
+  >- (* Assign *)
     (full_simp_tac(srw_ss())[evaluate_def]>>last_x_assum mp_tac>>FULL_CASE_TAC>>srw_tac[][]>>
     full_simp_tac(srw_ss())[every_var_def]>>
     imp_res_tac pull_exp_every_var_exp>>
@@ -606,7 +606,7 @@ Proof
     srw_tac[][]>>full_simp_tac(srw_ss())[lookup_insert]>>
     IF_CASES_TAC>>fs[]>>
     metis_tac[])
-  >-
+  >- (* Set *)
     (full_simp_tac(srw_ss())[evaluate_def]>>last_x_assum mp_tac>>
     ntac 2 FULL_CASE_TAC>>full_simp_tac(srw_ss())[]>>strip_tac>>
     full_simp_tac(srw_ss())[every_var_def]>>
@@ -819,8 +819,8 @@ val inst_select_exp_flat_exp_conventions = Q.prove(`
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_exp_def,LET_THM]);
 
 Theorem inst_select_flat_exp_conventions:
-    ∀c temp prog.
-  flat_exp_conventions (inst_select c temp prog)
+  ∀c temp prog.
+    flat_exp_conventions (inst_select c temp prog)
 Proof
   ho_match_mp_tac inst_select_ind >>srw_tac[][]>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_def,LET_THM]>>
@@ -840,11 +840,11 @@ val inst_select_exp_full_inst_ok_less = Q.prove(`
   );
 
 Theorem inst_select_full_inst_ok_less:
-    ∀c temp prog.
-  addr_offset_ok c 0w ∧
-  every_inst (inst_ok_less c) prog
-  ⇒
-  full_inst_ok_less c (inst_select c temp prog)
+  ∀c temp prog.
+    addr_offset_ok c 0w ∧
+    every_inst (inst_ok_less c) prog
+    ⇒
+    full_inst_ok_less c (inst_select c temp prog)
 Proof
   ho_match_mp_tac inst_select_ind>>
   rw[inst_select_def,full_inst_ok_less_def,every_inst_def]>>
@@ -857,11 +857,11 @@ QED
 
 (*Semantics preservation*)
 Theorem three_to_two_reg_correct:
-    ∀prog s res s'.
-  every_inst distinct_tar_reg prog ∧
-  evaluate (prog,s) = (res,s') ∧ res ≠ SOME Error
-  ⇒
-  evaluate(three_to_two_reg prog,s) = (res,s')
+  ∀prog s res s'.
+    every_inst distinct_tar_reg prog ∧
+    evaluate (prog,s) = (res,s') ∧ res ≠ SOME Error
+    ⇒
+    evaluate(three_to_two_reg prog,s) = (res,s')
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>
   srw_tac[][]>>full_simp_tac(srw_ss())[three_to_two_reg_def,evaluate_def,state_component_equality]>>
@@ -903,20 +903,20 @@ QED
 
 (* Syntactic three_to_two_reg *)
 Theorem three_to_two_reg_two_reg_inst:
-    ∀prog. every_inst two_reg_inst (three_to_two_reg prog)
+  ∀prog. every_inst two_reg_inst (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>full_simp_tac(srw_ss())[every_inst_def,two_reg_inst_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]
 QED
 
 Theorem three_to_two_reg_wf_cutsets:
-   ∀prog. wf_cutsets prog ⇒ wf_cutsets (three_to_two_reg prog)
+  ∀prog. wf_cutsets prog ⇒ wf_cutsets (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[wf_cutsets_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]
 QED
 
 Theorem three_to_two_reg_pre_alloc_conventions:
-   ∀prog. pre_alloc_conventions prog ⇒ pre_alloc_conventions (three_to_two_reg prog)
+  ∀prog. pre_alloc_conventions prog ⇒ pre_alloc_conventions (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[pre_alloc_conventions_def,every_stack_var_def,three_to_two_reg_def,LET_THM,call_arg_convention_def,inst_arg_convention_def]>>
@@ -927,15 +927,15 @@ Proof
 QED
 
 Theorem three_to_two_reg_flat_exp_conventions:
-   ∀prog. flat_exp_conventions prog ⇒ flat_exp_conventions (three_to_two_reg prog)
+  ∀prog. flat_exp_conventions prog ⇒ flat_exp_conventions (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def,three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]
 QED
 
 Theorem three_to_two_reg_full_inst_ok_less:
-   ∀prog. full_inst_ok_less c prog ⇒
-  full_inst_ok_less c (three_to_two_reg prog)
+  ∀prog. full_inst_ok_less c prog ⇒
+         full_inst_ok_less c (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[three_to_two_reg_def,LET_THM]>>EVERY_CASE_TAC>>fs[full_inst_ok_less_def]
@@ -955,8 +955,8 @@ val inst_select_exp_no_lab = Q.prove(`
   rpt(TOP_CASE_TAC>>fs[extract_labels_def,inst_select_exp_def]))
 
 Theorem inst_select_lab_pres:
-    ∀c temp prog.
-  extract_labels prog = extract_labels (inst_select c temp prog)
+  ∀c temp prog.
+    extract_labels prog = extract_labels (inst_select c temp prog)
 Proof
   ho_match_mp_tac inst_select_ind>>rw[inst_select_def,extract_labels_def]>>
   TRY(metis_tac[inst_select_exp_no_lab])>>
@@ -965,8 +965,8 @@ Proof
 QED
 
 Theorem three_to_two_reg_lab_pres:
-    ∀prog.
-  extract_labels prog = extract_labels (three_to_two_reg prog)
+  ∀prog.
+    extract_labels prog = extract_labels (three_to_two_reg prog)
 Proof
   ho_match_mp_tac three_to_two_reg_ind>>rw[three_to_two_reg_def,extract_labels_def]>>EVERY_CASE_TAC>>fs[]
 QED

--- a/compiler/backend/proofs/word_simpProofScript.sml
+++ b/compiler/backend/proofs/word_simpProofScript.sml
@@ -968,6 +968,10 @@ Proof
   (fs [const_fp_loop_def] \\ rw [evaluate_def] \\
   every_case_tac \\ fs [] \\ metis_tac [cs_delete_if_set])
 
+  >- (** OpCurrHeap **)
+  (fs [const_fp_loop_def] \\ rw [evaluate_def] \\
+  every_case_tac \\ fs [] \\ metis_tac [cs_delete_if_set])
+
   >- (** MustTerminate **)
   (rpt (rpt gen_tac \\ DISCH_TAC) \\ fs [const_fp_loop_def] \\ pairarg_tac \\
   fs [] \\ qpat_x_assum `_ = p'` (assume_tac o GSYM) \\ fs [evaluate_def] \\
@@ -998,6 +1002,7 @@ Proof
     \\ (* Otherwise *)
     (rpt (pairarg_tac \\ fs []) \\ every_case_tac \\ rw [evaluate_def] \\
     res_tac \\ fs [lookup_inter_eq] \\ every_case_tac \\ rw []))
+
   >- (** Call **)
   (rpt (rpt gen_tac \\ DISCH_TAC) \\ fs [const_fp_loop_def, evaluate_def] \\
   qpat_x_assum `_ = (res, s')` mp_tac \\
@@ -1038,6 +1043,7 @@ Proof
     >- (imp_res_tac evaluate_consts \\ imp_res_tac pop_env_gc_fun \\
        fs [set_var_def, push_env_gc_fun])
     >- rw[])
+
   >- (** FFI **)
   (fs [const_fp_loop_def] \\ rw [evaluate_def] \\
   every_case_tac \\ fs [] \\
@@ -1195,9 +1201,9 @@ val Seq_assoc_no_inst = Q.prove(`
   every_case_tac>>fs[])
 
 Theorem compile_exp_no_inst:
-    ∀prog.
-  every_inst (inst_ok_less ac) prog ⇒
-  every_inst (inst_ok_less ac) (compile_exp prog)
+  ∀prog.
+    every_inst (inst_ok_less ac) prog ⇒
+    every_inst (inst_ok_less ac) (compile_exp prog)
 Proof
   fs[compile_exp_def]>>
   metis_tac[simp_if_no_inst,Seq_assoc_no_inst,every_inst_def,

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -751,6 +751,8 @@ val inst_name_def = Define`
 
 val stack_asm_name_def = Define`
   (stack_asm_name c ((Inst i):'a stackLang$prog) ⇔ inst_name c i) ∧
+  (stack_asm_name c (OpCurrHeap b r1 r2) ⇔
+    (c.two_reg_arith ⇒ r1 = r2) ∧ reg_name r1 c ∧ reg_name r2 c) ∧
   (stack_asm_name c (CodeBufferWrite r1 r2) ⇔ reg_name r1 c ∧ reg_name r2 c) ∧
   (stack_asm_name c (DataBufferWrite r1 r2) ⇔ reg_name r1 c ∧ reg_name r2 c) ∧
   (stack_asm_name c (Seq p1 p2) ⇔ stack_asm_name c p1 ∧ stack_asm_name c p2) ∧
@@ -777,6 +779,7 @@ val fixed_names_def = Define`
 
 val stack_asm_remove_def = Define`
   (stack_asm_remove c ((Get n s):'a stackLang$prog) ⇔ reg_name n c) ∧
+  (stack_asm_remove c (OpCurrHeap binop v src) ⇔ reg_name v c ∧ reg_name src c) ∧
   (stack_asm_remove c (Set s n) ⇔ reg_name n c) ∧
   (stack_asm_remove c (StackStore n n0) ⇔ reg_name n c) ∧
   (stack_asm_remove c (StackStoreAny n n0) ⇔ reg_name n c ∧ reg_name n0 c) ∧
@@ -826,6 +829,7 @@ val reg_bound_exp_def = tDefine"reg_bound_exp"`
   (reg_bound_exp (Load e) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Shift _ e _) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Lookup _) _ ⇔ F) ∧
+  (reg_bound_exp (OpLookup _ _ _) _ ⇔ F) ∧
   (reg_bound_exp (Op _ es) k ⇔ EVERY (λe. reg_bound_exp e k) es) ∧
   (reg_bound_exp _ _ ⇔ T)`
   (WF_REL_TAC`measure ((exp_size ARB) o FST)` \\ simp[]
@@ -859,6 +863,8 @@ val reg_bound_def = Define `
      v1 < k) /\
   (reg_bound (Get v1 n) k <=>
      v1 < k) /\
+  (reg_bound (OpCurrHeap op v1 v2) k <=>
+     v1 < k ∧ v2 < k) /\
   (reg_bound (Set n v1) k <=>
      v1 < k /\ n <> BitmapBase) /\
   (reg_bound (LocValue v1 l1 l2) k <=>

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -829,7 +829,6 @@ val reg_bound_exp_def = tDefine"reg_bound_exp"`
   (reg_bound_exp (Load e) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Shift _ e _) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Lookup _) _ ⇔ F) ∧
-  (reg_bound_exp (OpLookup _ _ _) _ ⇔ F) ∧
   (reg_bound_exp (Op _ es) k ⇔ EVERY (λe. reg_bound_exp e k) es) ∧
   (reg_bound_exp _ _ ⇔ T)`
   (WF_REL_TAC`measure ((exp_size ARB) o FST)` \\ simp[]

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -547,9 +547,9 @@ val evaluate_def = tDefine "evaluate" `
      case get_var v s of
      | SOME w => (NONE, set_store name w s)
      | NONE => (SOME Error, s)) /\
-  (evaluate (GetOp binop v src name,s) =
+  (evaluate (OpCurrHeap binop v src,s) =
      if ¬s.use_store then (SOME Error,s) else
-     case word_exp s (OpLookup binop (Var src) name) of
+     case word_exp s (OpLookup binop (Var src) CurrHeap) of
      | SOME w => (NONE, set_var v (Word w) s)
      | _ => (SOME Error, s)) /\
   (evaluate (Tick,s) =

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -2477,11 +2477,11 @@ Proof
 QED
 
 Theorem locals_rel_word_exp:
-    ∀s exp w.
-  every_var_exp (λx. x < temp) exp ∧
-  word_exp s exp = SOME w ∧
-  locals_rel temp s.locals loc ⇒
-  word_exp (s with locals:=loc) exp = SOME w
+  ∀s exp w.
+    every_var_exp (λx. x < temp) exp ∧
+    word_exp s exp = SOME w ∧
+    locals_rel temp s.locals loc ⇒
+    word_exp (s with locals:=loc) exp = SOME w
 Proof
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,every_var_exp_def,locals_rel_def]

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -675,6 +675,7 @@ Proof
   >- tac
   >- tac
   >- tac
+  >- tac
   >- (tac>>imp_res_tac mem_store_const>>full_simp_tac(srw_ss())[])
   >- DECIDE_TAC
   >- `F`by DECIDE_TAC
@@ -1484,6 +1485,13 @@ Proof
     rpt strip_tac>>
     HINT_EXISTS_TAC>>
     full_simp_tac(srw_ss())[GEN_ALL(SYM(SPEC_ALL word_exp_stack_swap)),s_key_eq_refl])
+  >-(*OpCurrHeap*)
+    (fs[evaluate_def]>>every_case_tac>>
+    fs[set_var_def,s_key_eq_refl]>>
+    full_simp_tac(srw_ss())[set_store_def,s_key_eq_refl]>>
+    rpt strip_tac>>
+    HINT_EXISTS_TAC>>
+    full_simp_tac(srw_ss())[GEN_ALL(SYM(SPEC_ALL word_exp_stack_swap)),s_key_eq_refl])
   >-(*Store*)
     (full_simp_tac(srw_ss())[evaluate_def]>>every_case_tac>>
     full_simp_tac(srw_ss())[mem_store_def,state_component_equality,s_key_eq_refl]>>
@@ -2200,6 +2208,8 @@ Proof
   >-
     (fs[]>>every_case_tac>>fs[set_store_def,state_component_equality])
   >-
+    (fs[]>>every_case_tac>>fs[set_store_def,state_component_equality])
+  >-
     (fs[]>>every_case_tac>>fs[set_store_def,state_component_equality,mem_store_perm])
   >-
     (qexists_tac`perm`>>
@@ -2573,19 +2583,19 @@ val locals_rel_cut_env = Q.prove(`
 (*Extra temporaries not mentioned in program
   do not affect evaluation*)
 
-val srestac = qpat_x_assum`A=res`sym_sub_tac>>full_simp_tac(srw_ss())[]
+val srestac = qpat_x_assum`A=res`sym_sub_tac>>full_simp_tac(srw_ss())[];
 
 Theorem locals_rel_evaluate_thm:
-    ∀prog st res rst loc temp.
-  evaluate (prog,st) = (res,rst) ∧
-  res ≠ SOME Error ∧
-  every_var (λx.x < temp) prog ∧
-  locals_rel temp st.locals loc ⇒
-  ∃loc'.
-  evaluate (prog,st with locals:=loc) = (res,rst with locals:=loc') ∧
-  case res of
-    NONE => locals_rel temp rst.locals loc'
-  |  SOME _ => rst.locals = loc'
+  ∀prog st res rst loc temp.
+    evaluate (prog,st) = (res,rst) ∧
+    res ≠ SOME Error ∧
+    every_var (λx.x < temp) prog ∧
+    locals_rel temp st.locals loc ⇒
+    ∃loc'.
+      evaluate (prog,st with locals:=loc) = (res,rst with locals:=loc') ∧
+      case res of
+      | NONE => locals_rel temp rst.locals loc'
+      | SOME _ => rst.locals = loc'
 Proof
   completeInduct_on`prog_size (K 0) prog`>>
   rpt strip_tac>>
@@ -2760,6 +2770,12 @@ Proof
   >-
     (IF_CASES_TAC>>full_simp_tac(srw_ss())[call_env_def,flush_state_def,state_component_equality,dec_clock_def]>>
     srestac>>full_simp_tac(srw_ss())[]>>metis_tac[])
+  >-
+    (gvs[every_var_def,word_exp_def,AllCaseEqs(),the_words_def]>>
+     fs [PULL_EXISTS,state_component_equality,set_var_def] >>
+     imp_res_tac locals_rel_get_var>>
+     fs [get_var_def] \\ res_tac \\ fs [] >>
+     fs [locals_rel_def,lookup_insert])
   >-
     (rw[]>>fs[set_var_def,state_component_equality]>>rveq>>fs[]>>
     qpat_x_assum`A=rst.locals` sym_sub_tac>>
@@ -2936,6 +2952,8 @@ val full_inst_ok_less_def = Define`
     ((case ri of Imm w => c.valid_imm (INR cmp) w | _ => T) ∧
     full_inst_ok_less c c1 ∧ full_inst_ok_less c c2)) ∧
   (full_inst_ok_less c (MustTerminate p) ⇔ full_inst_ok_less c p) ∧
+  (full_inst_ok_less c (OpCurrHeap b r1 r2) ⇔
+    (c.two_reg_arith ==> (r2 = r1))) ∧
   (full_inst_ok_less c (Call ret dest args handler)
     ⇔ (case ret of
         NONE => T
@@ -3373,6 +3391,8 @@ Proof
    every_case_tac >> fs [set_vars_def] >> rveq >> fs [state_fn_updates])
   >- (
    every_case_tac >> fs [set_vars_def] >> rveq >> fs [state_fn_updates])
+  >- (
+   every_case_tac >> fs [set_store_def] >> rveq >> fs [state_fn_updates])
   >- (
    every_case_tac >> fs [set_store_def] >> rveq >> fs [state_fn_updates])
   >- (
@@ -3925,6 +3945,10 @@ Proof
     \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []
     \\ imp_res_tac assign_const \\ fs [set_var_def])
   THEN1 (* Set *)
+   (fs [wordSemTheory.evaluate_def] \\ rveq
+    \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []
+    \\ fs [set_var_def])
+  THEN1 (* OpCurrHeap *)
    (fs [wordSemTheory.evaluate_def] \\ rveq
     \\ fs [CaseEq"option",CaseEq"word_loc",bool_case_eq] \\ rveq \\ fs []
     \\ fs [set_var_def])

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -2929,10 +2929,11 @@ val two_reg_inst_def = Define`
   (two_reg_inst _ ⇔ T)`
 
 (* Recursor over instructions *)
-val every_inst_def = Define`
+Definition every_inst_def:
   (every_inst P (Inst i) ⇔ P i) ∧
   (every_inst P (Seq p1 p2) ⇔ (every_inst P p1 ∧ every_inst P p2)) ∧
   (every_inst P (If cmp r1 ri c1 c2) ⇔ every_inst P c1 ∧ every_inst P c2) ∧
+  (every_inst P (OpCurrHeap bop r1 r2) ⇔ P (Arith (Binop bop r1 r2 (Reg r2)))) ∧
   (every_inst P (MustTerminate p) ⇔ every_inst P p) ∧
   (every_inst P (Call ret dest args handler)
     ⇔ (case ret of
@@ -2941,7 +2942,8 @@ val every_inst_def = Define`
       (case handler of
         NONE => T
       | SOME (n,h,l1,l2) => every_inst P h))) ∧
-  (every_inst P prog ⇔ T)`
+  (every_inst P prog ⇔ T)
+End
 
 (* Every instruction is well-formed, including the jump hidden in If *)
 val full_inst_ok_less_def = Define`
@@ -2952,8 +2954,6 @@ val full_inst_ok_less_def = Define`
     ((case ri of Imm w => c.valid_imm (INR cmp) w | _ => T) ∧
     full_inst_ok_less c c1 ∧ full_inst_ok_less c c2)) ∧
   (full_inst_ok_less c (MustTerminate p) ⇔ full_inst_ok_less c p) ∧
-  (full_inst_ok_less c (OpCurrHeap b r1 r2) ⇔
-    (c.two_reg_arith ==> (r2 = r1))) ∧
   (full_inst_ok_less c (Call ret dest args handler)
     ⇔ (case ret of
         NONE => T

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -175,25 +175,10 @@ val the_words_def = Define `
      | SOME (Word x), SOME xs => SOME (x::xs)
      | _ => NONE)`
 
-Definition word_exp_size_def:
-  word_exp_size (Op _ xs) = SUM (MAP word_exp_size xs) + 1 ∧
-  word_exp_size (Shift _ x _) = word_exp_size x + 1 ∧
-  word_exp_size (OpLookup _ x _) = word_exp_size x + 3 ∧
-  word_exp_size (Load x) = word_exp_size x + 1 ∧
-  word_exp_size _ = 1
-Termination
-  WF_REL_TAC `measure (exp_size ARB)`
-  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
-  \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC
-End
-
 val word_exp_def = tDefine "word_exp" `
   (word_exp ^s (Const w) = SOME (Word w)) /\
   (word_exp s (Var v) = lookup v s.locals) /\
   (word_exp s (Lookup name) = FLOOKUP s.store name) /\
-  (word_exp s (OpLookup op x name) =
-     word_exp s (Op op [x; Lookup name])) /\
   (word_exp s (Load addr) =
      case word_exp s addr of
      | SOME (Word w) => mem_load w s
@@ -206,10 +191,10 @@ val word_exp_def = tDefine "word_exp" `
      case word_exp s wexp of
      | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
      | _ => NONE)`
-  (WF_REL_TAC `measure (word_exp_size o SND)`
-   \\ fs [word_exp_size_def]
-   \\ Induct \\ fs [] \\ rw []
-   \\ fs [] \\ res_tac \\ fs [])
+  (WF_REL_TAC `measure (exp_size ARB o SND)`
+   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
+   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
+   \\ DECIDE_TAC);
 
 val get_var_def = Define `
   get_var v ^s = sptree$lookup v s.locals`;
@@ -714,6 +699,10 @@ val evaluate_def = tDefine "evaluate" `
      case word_exp s exp of
      | NONE => (SOME Error, s)
      | SOME w => (NONE, set_store v w s)) /\
+  (evaluate (OpCurrHeap b dst src,s) =
+     case word_exp s (Op b [Var src; Lookup CurrHeap]) of
+     | NONE => (SOME Error, s)
+     | SOME w => (NONE, set_var dst w s)) /\
   (evaluate (Store exp v,s) =
      case (word_exp s exp, get_var v s) of
      | (SOME (Word a), SOME w) =>

--- a/compiler/backend/stackLangScript.sml
+++ b/compiler/backend/stackLangScript.sml
@@ -26,6 +26,7 @@ val _ = Datatype `
        | Inst ('a inst)
        | Get num store_name
        | Set store_name num
+       | GetOp binop num num store_name
        | Call ((stackLang$prog # num # num # num) option)
               (* return-handler code, link reg, labels l1,l2*)
               (num + num) (* target of call *)

--- a/compiler/backend/stackLangScript.sml
+++ b/compiler/backend/stackLangScript.sml
@@ -26,7 +26,7 @@ val _ = Datatype `
        | Inst ('a inst)
        | Get num store_name
        | Set store_name num
-       | GetOp binop num num store_name
+       | OpCurrHeap binop num num
        | Call ((stackLang$prog # num # num # num) option)
               (* return-handler code, link reg, labels l1,l2*)
               (num + num) (* target of call *)

--- a/compiler/backend/stack_removeScript.sml
+++ b/compiler/backend/stack_removeScript.sml
@@ -125,6 +125,8 @@ val comp_def = Define `
     | Set name r =>
         if name = CurrHeap then move (k+2) r
         else Inst (Mem Store r (Addr (k+1) (store_offset name)))
+    | OpCurrHeap op r n =>
+        Inst (Arith (Binop op r n (Reg (k+2))))
     (* remove stack operations *)
     | StackFree n => stack_free k n
     | StackAlloc n => stack_alloc jump k n

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -67,6 +67,7 @@ val raise_stub_location_eq = save_thm("raise_stub_location_eq",
 val every_var_exp_def = tDefine "every_var_exp" `
   (every_var_exp P (Var num) = P num) ∧
   (every_var_exp P (Load exp) = every_var_exp P exp) ∧
+  (every_var_exp P (OpLookup _ exp _) = every_var_exp P exp) ∧
   (every_var_exp P (Op wop ls) = EVERY (every_var_exp P) ls) ∧
   (every_var_exp P (Shift sh exp n) = every_var_exp P exp) ∧
   (every_var_exp P expr = T)`

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -15,6 +15,7 @@ val _ = Datatype `
       | Lookup store_name
       | Load exp
       | Op binop (exp list)
+      | OpLookup binop exp store_name
       | Shift shift exp num`
 
 Theorem MEM_IMP_exp_size:

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -15,7 +15,6 @@ val _ = Datatype `
       | Lookup store_name
       | Load exp
       | Op binop (exp list)
-      | OpLookup binop exp store_name
       | Shift shift exp num`
 
 Theorem MEM_IMP_exp_size:
@@ -47,6 +46,7 @@ val _ = Datatype `
        | Raise num
        | Return num num
        | Tick
+       | OpCurrHeap binop num num (* special case compiled well in stackLang *)
        | LocValue num num        (* assign v1 := Loc v2 0 *)
        | Install num num num num num_set (* code buffer start, length of new code,
                                       data buffer start, length of new data, cut-set *)
@@ -67,7 +67,6 @@ val raise_stub_location_eq = save_thm("raise_stub_location_eq",
 val every_var_exp_def = tDefine "every_var_exp" `
   (every_var_exp P (Var num) = P num) ∧
   (every_var_exp P (Load exp) = every_var_exp P exp) ∧
-  (every_var_exp P (OpLookup _ exp _) = every_var_exp P exp) ∧
   (every_var_exp P (Op wop ls) = EVERY (every_var_exp P) ls) ∧
   (every_var_exp P (Shift sh exp n) = every_var_exp P exp) ∧
   (every_var_exp P expr = T)`
@@ -143,6 +142,7 @@ val every_var_def = Define `
     (P num ∧ every_name P numset)) ∧
   (every_var P (Raise num) = P num) ∧
   (every_var P (Return num1 num2) = (P num1 ∧ P num2)) ∧
+  (every_var P (OpCurrHeap _ num1 num2) = (P num1 ∧ P num2)) ∧
   (every_var P Tick = T) ∧
   (every_var P (Set n exp) = every_var_exp P exp) ∧
   (every_var P p = T)`
@@ -247,6 +247,7 @@ val max_var_def = Define `
   (max_var (FFI ffi_index ptr1 len1 ptr2 len2 numset) =
     list_max (ptr1::len1::ptr2::len2::MAP FST (toAList numset))) ∧
   (max_var (Raise num) = num) ∧
+  (max_var (OpCurrHeap _ num1 num2) = MAX num1 num2) ∧
   (max_var (Return num1 num2) = MAX num1 num2) ∧
   (max_var Tick = 0) ∧
   (max_var (LocValue r l1) = r) ∧

--- a/compiler/backend/word_allocScript.sml
+++ b/compiler/backend/word_allocScript.sml
@@ -298,6 +298,10 @@ val ssa_cc_trans_def = Define`
     let num' = option_lookup ssa num in
     let mov = Move 0 [(2,num')] in
     (Seq mov (Raise 2),ssa,na)) ∧
+  (ssa_cc_trans (OpCurrHeap b num1 num2) ssa na=
+    let num1' = option_lookup ssa num1 in
+    let num2' = option_lookup ssa num2 in
+    (OpCurrHeap b num1' num2',ssa,na)) ∧
   (ssa_cc_trans (Return num1 num2) ssa na=
     let num1' = option_lookup ssa num1 in
     let num2' = option_lookup ssa num2 in
@@ -483,6 +487,7 @@ val apply_colour_def = Define `
   (apply_colour f (Return num1 num2) = Return (f num1) (f num2)) ∧
   (apply_colour f Tick = Tick) ∧
   (apply_colour f (Set n exp) = Set n (apply_colour_exp f exp)) ∧
+  (apply_colour f (OpCurrHeap b n1 n2) = OpCurrHeap b (f n1) (f n2)) ∧
   (apply_colour f p = p )`
 
 val _ = export_rewrites ["apply_nummap_key_def","apply_colour_exp_def"
@@ -622,6 +627,7 @@ val get_live_def = Define`
   (get_live Tick live = live) ∧
   (get_live (LocValue r l1) live = delete r live) ∧
   (get_live (Set n exp) live = union (get_live_exp exp) live) ∧
+  (get_live (OpCurrHeap b n1 n2) live = insert n2 () (delete n1 live)) ∧
   (*Cut-set must be live, args input must be live
     For tail calls, there shouldn't be a liveset since control flow will
     never return into the same instance
@@ -863,6 +869,7 @@ val get_clash_tree_def = Define`
   (get_clash_tree Tick = Delta [] []) ∧
   (get_clash_tree (LocValue r l1) = Delta [r] []) ∧
   (get_clash_tree (Set n exp) = Delta [] (get_reads_exp exp)) ∧
+  (get_clash_tree (OpCurrHeap b _ num) = Delta [] [num]) ∧
   (get_clash_tree (Call ret dest args h) =
     let args_set = numset_list_insert args LN in
     dtcase ret of

--- a/compiler/backend/word_instScript.sml
+++ b/compiler/backend/word_instScript.sml
@@ -426,6 +426,8 @@ val three_to_two_reg_def = Define`
     Seq (Move 0 [r1,r2]) (Inst (Arith (AddOverflow r1 r1 r3 r4)))) ∧
   (three_to_two_reg (Inst (Arith (SubOverflow r1 r2 r3 r4))) =
     Seq (Move 0 [r1,r2]) (Inst (Arith (SubOverflow r1 r1 r3 r4)))) ∧
+  (three_to_two_reg (OpCurrHeap bop r1 r2) =
+    Seq (Move 0 [r1,r2]) (OpCurrHeap bop r1 r1)) ∧
   (three_to_two_reg (Seq p1 p2) =
     Seq (three_to_two_reg p1) (three_to_two_reg p2)) ∧
   (three_to_two_reg (MustTerminate p1) =
@@ -459,6 +461,8 @@ Theorem three_to_two_reg_pmatch:
     Seq (Move 0 [r1,r2]) (Inst (Arith (AddOverflow r1 r1 r3 r4)))
   | (Inst (Arith (SubOverflow r1 r2 r3 r4))) =>
     Seq (Move 0 [r1,r2]) (Inst (Arith (SubOverflow r1 r1 r3 r4)))
+  | (OpCurrHeap bop r1 r2) =>
+    Seq (Move 0 [r1,r2]) (OpCurrHeap bop r1 r1)
   | (Seq p1 p2) =>
     Seq (three_to_two_reg p1) (three_to_two_reg p2)
   | (MustTerminate p1) =>

--- a/compiler/backend/word_instScript.sml
+++ b/compiler/backend/word_instScript.sml
@@ -175,6 +175,20 @@ val test = EVAL ``flatten_exp (pull_exp (Op Sub [Const 1w; Op Sub[Const 2w;Const
  Op Add [Const 4w; Const 5w; Op Add[Const 6w; Const 7w];Op Xor[Const 1w;Var y;Var x]] ; Const (8w:8 word)]))``
 *)
 
+Definition is_Lookup_CurrHeap_def:
+  is_Lookup_CurrHeap (Lookup CurrHeap) = T ∧
+  is_Lookup_CurrHeap _ = F
+End
+
+Theorem is_Lookup_CurrHeap_pmatch:
+  is_Lookup_CurrHeap e =
+    (case e of Lookup CurrHeap => T | _ => F)
+Proof
+  rpt(CONV_TAC(RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV) >> every_case_tac >>
+         PURE_ONCE_REWRITE_TAC[LET_DEF] >> BETA_TAC) >>
+  fs [is_Lookup_CurrHeap_def]
+QED
+
 (*
   Maximal Munch instruction selection on (binary) expressions
   c is an asm_config to check validity of imms (TODO: assume 0w is accepted?)
@@ -208,6 +222,13 @@ val inst_select_exp_def = tDefine "inst_select_exp" `
     Get tar store_name) ∧
   (*All ops are binary branching*)
   (inst_select_exp c tar temp (Op op [e1;e2]) =
+    if is_Lookup_CurrHeap e2 then
+      (let p1 = inst_select_exp c temp temp e1 in
+        Seq p1 (OpCurrHeap op tar temp))
+    else if is_Lookup_CurrHeap e1 ∧ op ≠ Sub then
+      (let p2 = inst_select_exp c temp temp e2 in
+        Seq p2 (OpCurrHeap op tar temp))
+    else
     let p1 = inst_select_exp c temp temp e1 in
     dtcase e2 of
     | Const w =>
@@ -262,7 +283,14 @@ Theorem inst_select_exp_pmatch:
     Get tar store_name
   (*All ops are binary branching*)
   | Op op [e1;e2] =>
-    (case e2 of
+    (if is_Lookup_CurrHeap e2 then
+      (let p1 = inst_select_exp c temp temp e1 in
+        Seq p1 (OpCurrHeap op tar temp))
+    else if is_Lookup_CurrHeap e1 ∧ op ≠ Sub then
+      (let p2 = inst_select_exp c temp temp e2 in
+        Seq p2 (OpCurrHeap op tar temp))
+    else
+     case e2 of
       Const w =>
       (*t = r op const*)
       if c.valid_imm (INL op) w then

--- a/compiler/backend/word_simpScript.sml
+++ b/compiler/backend/word_simpScript.sml
@@ -322,6 +322,7 @@ val const_fp_loop_def = Define `
          | Const c => (Assign v const_fp_e, insert v c cs)
          | _ => (Assign v const_fp_e, delete v cs)) /\
   (const_fp_loop (Get v name) cs = (Get v name, delete v cs)) /\
+  (const_fp_loop (OpCurrHeap b v w) cs = (OpCurrHeap b v w, delete v cs)) /\
   (const_fp_loop (MustTerminate p) cs =
     let (p', cs') = const_fp_loop p cs in
       (MustTerminate p', cs')) /\
@@ -363,6 +364,7 @@ Theorem const_fp_loop_pmatch:
        | Const c => (Assign v (Const c), insert v c cs)
        | const_fp_e => (Assign v const_fp_e, delete v cs))
   | (Get v name) => (Get v name, delete v cs)
+  | (OpCurrHeap b v w) => (OpCurrHeap b v w, delete v cs)
   | (MustTerminate p) =>
     (let (p', cs') = const_fp_loop p cs in
       (MustTerminate p', cs'))
@@ -400,6 +402,7 @@ Proof
   >- fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY]
   >- (CONV_TAC(patternMatchesLib.PMATCH_LIFT_BOOL_CONV true)
      >> rpt strip_tac >> fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY] >> every_case_tac >> fs[])
+  >- fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY]
   >- fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY]
   >- fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY]
   >- fs[const_fp_loop_def,pairTheory.ELIM_UNCURRY]

--- a/compiler/backend/word_to_stackScript.sml
+++ b/compiler/backend/word_to_stackScript.sml
@@ -252,6 +252,9 @@ val comp_def = Define `
      let (xs,x) = wReg1 v1 kf in
        (wStackLoad xs (SeqStackFree (FST (SND kf)) (Return x 1)),bs)) /\
   (comp (Raise v) bs kf = (Call NONE (INL raise_stub_location) NONE,bs)) /\
+  (comp (OpCurrHeap b dst src) bs kf =
+     let (xs,src_r) = wReg1 src kf in
+       (wStackLoad xs (wRegWrite1 (\dst_r. OpCurrHeap b dst_r src_r) dst kf),bs)) /\
   (comp (Tick) bs kf = (Tick,bs)) /\
   (comp (MustTerminate p1) gs kf = comp p1 gs kf) /\
   (comp (Seq p1 p2) bs kf =

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -251,6 +251,7 @@ val _ = translate (spec32 wordLangTheory.max_var_def)
 val _ = translate (conv32_RHS integer_wordTheory.WORD_LEi)
 
 val _ = translate (asmTheory.offset_ok_def |> SIMP_RULE std_ss [alignmentTheory.aligned_bitwise_and] |> conv32)
+val _ = translate (is_Lookup_CurrHeap_pmatch |> conv32)
 val res = translate_no_ind (inst_select_exp_pmatch |> conv32 |> SIMP_RULE std_ss [word_mul_def,word_2comp_def] |> conv32)
 
 val ind_lemma = Q.prove(

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -250,7 +250,7 @@ val _ = translate (spec64 wordLangTheory.max_var_def)
 val _ = translate (conv64_RHS integer_wordTheory.WORD_LEi)
 
 val _ = translate (asmTheory.offset_ok_def |> SIMP_RULE std_ss [alignmentTheory.aligned_bitwise_and] |> conv64)
-val _ = translate (is_Lookup_CurrHeap_pmatch |> conv32)
+val _ = translate (is_Lookup_CurrHeap_pmatch |> conv64)
 val res = translate_no_ind (inst_select_exp_pmatch |> conv64 |> SIMP_RULE std_ss [word_mul_def,word_2comp_def] |> conv64)
 
 val ind_lemma = Q.prove(

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -250,6 +250,7 @@ val _ = translate (spec64 wordLangTheory.max_var_def)
 val _ = translate (conv64_RHS integer_wordTheory.WORD_LEi)
 
 val _ = translate (asmTheory.offset_ok_def |> SIMP_RULE std_ss [alignmentTheory.aligned_bitwise_and] |> conv64)
+val _ = translate (is_Lookup_CurrHeap_pmatch |> conv32)
 val res = translate_no_ind (inst_select_exp_pmatch |> conv64 |> SIMP_RULE std_ss [word_mul_def,word_2comp_def] |> conv64)
 
 val ind_lemma = Q.prove(

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -101,6 +101,27 @@ val PreImpEval_def = Define`
 
 (* Theorems *)
 
+Theorem AppReturns_thm:
+  AppReturns P cl Q ⇔
+    ∀v. P v ⇒
+        ∃env exp.
+          do_opapp [cl;v] = SOME (env,exp) ∧
+          ∀refs.
+            ∃refs' u.
+              eval_rel (empty_state with refs := refs) env exp
+                       (empty_state with refs := refs++refs') u ∧
+              Q u
+Proof
+  fs [AppReturns_def] \\ eq_tac \\ rw []
+  \\ first_x_assum drule
+  \\ Cases_on ‘cl’ \\ fs [do_opapp_def,AllCaseEqs()]
+  \\ rename [‘find_recfun x1 x2’]
+  \\ Cases_on ‘find_recfun x1 x2’ \\ fs []
+  \\ PairCases_on ‘x’ \\ fs []
+  \\ rename [‘ALL_DISTINCT xx’]
+  \\ Cases_on ‘ALL_DISTINCT xx’ \\ fs []
+QED
+
 local
   val Eval_lemma = prove(
     ``∀env exp P.


### PR DESCRIPTION
These commits make it possible to use `CurrHeap` directly in a binop instruction (e.g. add or sub). Such use of `CurrHeap` was not previously possible without use of an intermediate register. 

An example: the code generated for `fromList1` used to contain:

    4c 89 f2                mov    %r14,%rdx
    48 01 d6                add    %rdx,%rsi

which now comes out as:

    4c 01 f6                add    %r14,%rsi

These tweaks to the compiler reduces the size of the generated code ever so slightly, e.g. the machine code for the [hello world](https://github.com/CakeML/cakeml/blob/master/examples/helloProgScript.sml) example is now 1.5 % smaller.

Closes issue #796

