### PR TITLE
Speed up accesses to globals

### DIFF
--- a/compiler/backend/bvl_to_bviScript.sml
+++ b/compiler/backend/bvl_to_bviScript.sml
@@ -209,8 +209,8 @@ local val compile_op_quotation = `
     dtcase op of
     | Const i => (dtcase c1 of [] => compile_int i
                   | _ => Let [Op (Const 0) c1] (compile_int i))
-    | Global n => Op El (c1++[compile_int(&(n+1)); Op GlobalsPtr []])
-    | SetGlobal n => Op Update (c1++[compile_int(&(n+1)); Op GlobalsPtr []])
+    | Global n => Op (Global (n+1)) c1
+    | SetGlobal n => Op (SetGlobal (n+1)) c1
     | AllocGlobal =>
         (dtcase c1 of [] => Call 0 (SOME AllocGlobal_location) [] NONE
          | _ => Let [Op (Const 0) c1] (Call 0 (SOME AllocGlobal_location) [] NONE))

--- a/compiler/backend/data_liveScript.sml
+++ b/compiler/backend/data_liveScript.sml
@@ -10,6 +10,7 @@ val _ = new_theory "data_live";
 val _ = patternMatchesLib.ENABLE_PMATCH_CASES();
 
 val is_pure_def = Define `
+  (is_pure (SetGlobal _) = F) /\
   (is_pure SetGlobalsPtr = F) /\
   (is_pure Ref = F) /\
   (is_pure (RefByte _) = F) /\
@@ -48,7 +49,8 @@ Theorem is_pure_pmatch:
   !op.
   is_pure op =
     case op of
-      SetGlobalsPtr => F
+    | SetGlobal _ => F
+    | SetGlobalsPtr => F
     | Ref => F
     | RefByte _ => F
     | RefArray => F

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -1037,6 +1037,19 @@ val def = assign_Define `
       : 'a wordLang$prog # num`;
 
 val def = assign_Define `
+  assign_Global (c:data_to_word$config) n (l:num) (dest:num) =
+      (Assign (adjust_var dest) (Load (Op Add [Lookup GlobReal;
+                                               Const (bytes_in_word * n2w (n+1))])),l)
+      : 'a wordLang$prog # num`;
+
+val def = assign_Define `
+  assign_SetGlobal (c:data_to_word$config) n (l:num) (dest:num) v1 =
+      (Seq (Store (Op Add [Lookup GlobReal; Const (bytes_in_word * n2w (n+1))])
+                  (adjust_var v1))
+           (Assign (adjust_var dest) Unit),l)
+      : 'a wordLang$prog # num`;
+
+val def = assign_Define `
   assign_El (c:data_to_word$config) (l:num) (dest:num) v1 v2 =
                          (Assign (adjust_var dest)
                             (Load (Op Add [real_addr c (adjust_var v1);
@@ -1981,6 +1994,8 @@ val assign_def = Define `
     | Const i => assign_Const i l dest
     | GlobalsPtr => (Assign (adjust_var dest) (Lookup Globals),l)
     | SetGlobalsPtr => arg1 args (assign_SetGlobalsPtr c l dest) (Skip,l)
+    | SetGlobal n => arg1 args (assign_SetGlobal c n l dest) (Skip,l)
+    | Global n => assign_Global c n l dest
     | El => arg2 args (assign_El c l dest) (Skip,l)
     | ElemAt n => arg1 args (assign_ElemAt c n l dest) (Skip,l)
     | DerefByte => arg2 args (assign_DerefByte c l dest) (Skip,l)

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -1030,15 +1030,8 @@ val def = assign_Define `
 val def = assign_Define `
   assign_SetGlobalsPtr (c:data_to_word$config) (l:num) (dest:num) v1 =
       (Seq (Set Globals (Var (adjust_var v1)))
-      (Seq (Set GlobReal (Op Add
-        [Lookup CurrHeap;
-          let k = shift (:'a) in
-          if k <= c.pad_bits + 1 then
-            Shift Lsr (Var (adjust_var v1)) (shift_length c - k)
-          else
-            Shift Lsl (Shift Lsr (Var (adjust_var v1)) (shift_length c)) k
-        ]))
-        (Assign (adjust_var dest) Unit)),l)
+      (Seq (Set GlobReal (real_addr c (adjust_var v1)))
+           (Assign (adjust_var dest) Unit)),l)
       : 'a wordLang$prog # num`;
 
 val def = assign_Define `

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -1030,10 +1030,15 @@ val def = assign_Define `
 val def = assign_Define `
   assign_SetGlobalsPtr (c:data_to_word$config) (l:num) (dest:num) v1 =
       (Seq (Set Globals (Var (adjust_var v1)))
-      (Seq (Set GlobReal (Op Add [Lookup CurrHeap;
-                                  Shift Lsl (Shift Lsr (Var (adjust_var v1))
-                                    (shift_length c)) (shift (:'a))]))
-           (Assign (adjust_var dest) Unit)),l)
+      (Seq (Set GlobReal (Op Add
+        [Lookup CurrHeap;
+          let k = shift (:'a) in
+          if k <= c.pad_bits + 1 then
+            Shift Lsr (Var (adjust_var v1)) (shift_length c - k)
+          else
+            Shift Lsl (Shift Lsr (Var (adjust_var v1)) (shift_length c)) k
+        ]))
+        (Assign (adjust_var dest) Unit)),l)
       : 'a wordLang$prog # num`;
 
 val def = assign_Define `

--- a/compiler/backend/data_to_wordScript.sml
+++ b/compiler/backend/data_to_wordScript.sml
@@ -1028,9 +1028,12 @@ val def = assign_Define `
       : 'a wordLang$prog # num`;
 
 val def = assign_Define `
-  assign_SetGlobalsPtr (l:num) (dest:num) v1 =
+  assign_SetGlobalsPtr (c:data_to_word$config) (l:num) (dest:num) v1 =
       (Seq (Set Globals (Var (adjust_var v1)))
-           (Assign (adjust_var dest) Unit),l)
+      (Seq (Set GlobReal (Op Add [Lookup CurrHeap;
+                                  Shift Lsl (Shift Lsr (Var (adjust_var v1))
+                                    (shift_length c)) (shift (:'a))]))
+           (Assign (adjust_var dest) Unit)),l)
       : 'a wordLang$prog # num`;
 
 val def = assign_Define `
@@ -1977,7 +1980,7 @@ val assign_def = Define `
     dtcase op of
     | Const i => assign_Const i l dest
     | GlobalsPtr => (Assign (adjust_var dest) (Lookup Globals),l)
-    | SetGlobalsPtr => arg1 args (assign_SetGlobalsPtr l dest) (Skip,l)
+    | SetGlobalsPtr => arg1 args (assign_SetGlobalsPtr c l dest) (Skip,l)
     | El => arg2 args (assign_El c l dest) (Skip,l)
     | ElemAt n => arg1 args (assign_ElemAt c n l dest) (Skip,l)
     | DerefByte => arg2 args (assign_DerefByte c l dest) (Skip,l)

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -615,6 +615,7 @@ val store_name_to_display_def = Define `
     | OtherHeap => empty_item «OtherHeap»
     | AllocSize => empty_item «AllocSize»
     | Globals => empty_item «Globals»
+    | GlobReal => empty_item «GlobReal»
     | Handler => empty_item «Handler»
     | GenStart => empty_item «GenStart»
     | CodeBuffer => empty_item «CodeBuffer»

--- a/compiler/backend/proofs/bvi_tailrecProofScript.sml
+++ b/compiler/backend/proofs/bvi_tailrecProofScript.sml
@@ -1093,6 +1093,7 @@ Proof
   \\ rveq \\ fs[bvl_to_bvi_id]
   \\ fs[do_app_aux_def]
   \\ fs[state_rel_def,bvl_to_bvi_def,bvi_to_bvl_def]
+  \\ fs[AllCaseEqs()]
 QED
 
 Theorem state_rel_do_app_err:
@@ -1110,6 +1111,7 @@ Proof
   \\ fs[bvlSemTheory.do_app_def]
   \\ TOP_CASE_TAC \\ fs[]
   \\ fs[case_eq_thms,do_app_aux_def]
+  \\ fs[AllCaseEqs()]
 QED
 
 Theorem do_app_to_op_state:

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -438,7 +438,9 @@ Theorem data_to_bvi_do_app:
        res = data_to_bvi_v pres ∧
        state_rel s1 s2
 Proof
-  Cases_on `op`
+  strip_tac
+  \\ ‘∃this_is_case. this_is_case op’ by (qexists_tac ‘K T’ \\ fs [])
+  \\ Cases_on `op`
   \\ ntac 2 (fs [ do_app_aux_def
                 , bvlSemTheory.do_app_def
                 , bviSemTheory.do_app_def
@@ -493,6 +495,13 @@ Proof
         ,FLOOKUP_UPDATE
         ,data_to_bvi_v_Unit
         ,data_to_bvi_v_Boolv]
+  >- (qpat_x_assum ‘SOME _ = _’ (assume_tac o GSYM) \\ fs []
+      \\ Cases_on ‘z’ \\ fs [data_to_bvi_ref_def] \\ gvs [] \\ gs [EL_MAP])
+  >- (qpat_x_assum ‘SOME _ = _’ (assume_tac o GSYM) \\ fs []
+      \\ Cases_on ‘z’ \\ fs [data_to_bvi_ref_def] \\ gvs []
+      \\ gs [EL_MAP,lookup_insert]
+      \\ conj_tac THEN1 EVAL_TAC
+      \\ rw [] \\ fs [data_to_bvi_ref_def,LUPDATE_MAP])
   >- METIS_TAC [data_to_bvi_v_def]
   >- (Cases_on `z`
      \\ Cases_on `t.tstamps`

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -2780,28 +2780,28 @@ val compile_exps_correct = Q.prove(
       \\ full_simp_tac(srw_ss())[EVERY_MEM] \\ REPEAT STRIP_TAC
       \\ Q.UNABBREV_TAC `b3` \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]
       \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[])
-    \\ Cases_on`∃n. op = Global n` \\ full_simp_tac(srw_ss())[] THEN1 (
+    \\ Cases_on`∃n. op = Global n` \\ full_simp_tac(srw_ss())[]
+    THEN1 (
          note_tac "Global" >> simp[compile_op_def] >>
          full_simp_tac(srw_ss())[bEvalOp_def] >>
          Cases_on`REVERSE a`>>full_simp_tac(srw_ss())[] >>
          imp_res_tac evaluate_IMP_LENGTH >>
-         full_simp_tac(srw_ss())[LENGTH_NIL] >>
+         full_simp_tac(srw_ss())[LENGTH_NIL] >> gvs [] >>
          simp[iEval_def,compile_int_thm] >>
          Q.LIST_EXISTS_TAC[`t2`,`b2`,`c`] >>
          simp[iEvalOp_def,do_app_aux_def] >>
          BasicProvers.CASE_TAC >> full_simp_tac(srw_ss())[] >>
          simp[bEvalOp_def] >>
          full_simp_tac(srw_ss())[closSemTheory.get_global_def] >>
-         imp_res_tac bvlPropsTheory.evaluate_IMP_LENGTH >> full_simp_tac(srw_ss())[LENGTH_NIL] >>
+         gvs [AllCaseEqs(),PULL_EXISTS] >>
+         imp_res_tac bvlPropsTheory.evaluate_IMP_LENGTH >>
+         full_simp_tac(srw_ss())[LENGTH_NIL] >>
          full_simp_tac(srw_ss())[bEval_def] >> rpt var_eq_tac >>
          full_simp_tac(srw_ss())[iEval_def] >> rpt var_eq_tac >>
          last_x_assum mp_tac >>
          simp[Once state_rel_def] >> strip_tac >>
          simp[LENGTH_REPLICATE,ADD1] >>
-         simp[EL_CONS,PRE_SUB1] >>
-         reverse IF_CASES_TAC >>
-         every_case_tac >> fsrw_tac[ARITH_ss][] >>
-         rpt var_eq_tac >>
+         simp[EL_CONS,PRE_SUB1,GSYM ADD1] >>
          simp[EL_APPEND1,EL_MAP,libTheory.the_def,bvl_to_bvi_with_clock,bvl_to_bvi_id] >>
          MATCH_MP_TAC (GEN_ALL bv_ok_IMP_adjust_bv_eq) >>
          qexists_tac`r.refs`>>simp[] >>

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -11884,7 +11884,9 @@ Proof
   \\ strip_tac
   \\ drule_all memory_rel_RefPtr_IMP' \\ strip_tac
   \\ ‘word_exp (set_store Globals (Word www) t) (real_addr c (adjust_var y)) =
-      word_exp t (real_addr c (adjust_var y))’ by cheat
+      word_exp t (real_addr c (adjust_var y))’ by
+      (rw[wordSemTheory.set_store_def,wordSemTheory.word_exp_def,real_addr_def]>>
+      simp[FLOOKUP_UPDATE])
   \\ first_assum (mp_then (Pos last) mp_tac get_real_addr_lemma)
   \\ gvs []
   \\ disch_then (qspec_then ‘adjust_var y’ mp_tac)

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -176,13 +176,6 @@ Proof
   metis_tac [WORD_NOT_LESS]
 QED
 
-Theorem heap_in_memory_store_IMP_UPDATE:
-   heap_in_memory_store heap a sp sp1 gens c st m dm l ==>
-    heap_in_memory_store heap a sp sp1 gens c (st |+ (Globals,h)) m dm l
-Proof
-  fs [heap_in_memory_store_def,FLOOKUP_UPDATE]
-QED
-
 Theorem get_vars_2_imp:
    wordSem$get_vars [x1;x2] s = SOME [y1;y2] ==>
     wordSem$get_var x1 s = SOME y1 /\
@@ -11783,10 +11776,36 @@ Proof
   \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
          adjust_var_11,libTheory.the_def,set_var_def,
          wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE]
-  \\ rpt_drule0 heap_in_memory_store_IMP_UPDATE
-  \\ disch_then (qspec_then `h` assume_tac)
+  \\ ‘isWord h’ by
+   (full_simp_tac std_ss [GSYM APPEND_ASSOC]
+    \\ drule0 (GEN_ALL word_ml_inv_get_vars_IMP)
+    \\ disch_then drule0
+    \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]
+    \\ strip_tac
+    \\ gvs [word_ml_inv_def,abs_ml_inv_def,bc_stack_ref_inv_def,v_inv_def]
+    \\ fs [word_addr_def,isWord_def])
+  \\ Cases_on ‘h’ \\ fs [isWord_def]
+  \\ ‘∃curr. FLOOKUP t.store CurrHeap = SOME (Word curr)’ by
+       fs [heap_in_memory_store_def]
+  \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
+         adjust_var_11,libTheory.the_def,set_var_def,word_sh_def,
+         wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE]
+  \\ IF_CASES_TAC THEN1
+   (qsuff_tac ‘F’ \\ rewrite_tac []
+    \\ pop_assum mp_tac \\ fs [good_dimindex_def,shift_def])
+  \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
+         adjust_var_11,libTheory.the_def,set_var_def,word_sh_def,
+         wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE,
+         wordSemTheory.the_words_def,word_op_def]
   \\ rw [] \\ fs [option_le_max_right]
-  \\ asm_exists_tac \\ fs [the_global_def,libTheory.the_def]
+  \\ qexists_tac ‘heap’
+  \\ qexists_tac ‘limit’
+  \\ qexists_tac ‘a’
+  \\ qexists_tac ‘sp’
+  \\ qexists_tac ‘sp1’
+  \\ qexists_tac ‘gens’
+  \\ fs [heap_in_memory_store_def,FLOOKUP_UPDATE,glob_real_inv_def]
+  \\ fs [the_global_def,libTheory.the_def]
   \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
   \\ drule0 (GEN_ALL word_ml_inv_get_vars_IMP)
   \\ disch_then drule0
@@ -11797,6 +11816,7 @@ Proof
   \\ match_mp_tac word_ml_inv_Unit
   \\ pop_assum mp_tac \\ fs []
   \\ match_mp_tac word_ml_inv_rearrange \\ rw [] \\ fs []
+  \\ fs [FAPPLY_FUPDATE_THM]
 QED
 
 Theorem IMP:

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -11755,6 +11755,95 @@ Proof
   \\ fs [] \\ rw [] \\ fs []
 QED
 
+Theorem assign_Global:
+   (∃n. op = Global n) ==> ^assign_thm_goal
+Proof
+  rpt strip_tac \\ drule0 (evaluate_GiveUp |> GEN_ALL) \\ rw [] \\ fs []
+  \\ `t.termdep <> 0` by fs[]
+  \\ rpt_drule0 state_rel_cut_IMP
+  \\ qpat_x_assum `state_rel c l1 l2 s t [] locs` kall_tac \\ strip_tac
+  \\ imp_res_tac get_vars_IMP_LENGTH \\ fs []
+  \\ fs [do_app,CaseEq"list",CaseEq"dataSem$v",CaseEq"bool"]
+  \\ gvs [AllCaseEqs(),set_var_def]
+  \\ rveq \\ fs []
+  \\ imp_res_tac state_rel_get_vars_IMP
+  \\ ‘∃curr.
+        FLOOKUP t.store CurrHeap = SOME (Word curr) ∧
+        glob_real_inv c curr (FLOOKUP t.store Globals) (FLOOKUP t.store GlobReal)’
+          by fs [memory_rel_def,heap_in_memory_store_def,state_rel_def]
+  \\ fs [glob_real_inv_def]
+  \\ fs [assign_def] \\ eval_tac \\ fs [state_rel_thm,option_le_max_right]
+  \\ gvs [the_global_def,libTheory.the_def]
+  \\ qmatch_asmsub_abbrev_tac ‘(xs1 ++ [(RefPtr ptr,t.store ' Globals)] ++ xs2)’
+  \\ ‘memory_rel c t.be (THE x.tstamps) x.refs x.space t.store t.memory
+          t.mdomain ((RefPtr ptr,t.store ' Globals) :: (xs1 ++ xs2))’ by
+      (first_x_assum (fn th => mp_tac th \\ match_mp_tac memory_rel_rearrange)
+       \\ fs [] \\ rw [] \\ fs [])
+  \\ drule0 (memory_rel_Deref' |> GEN_ALL) \\ fs []
+  \\ disch_then drule \\ strip_tac \\ fs []
+  \\ drule memory_rel_RefPtr_IMP' \\ fs [] \\ strip_tac
+  \\ gvs [get_real_simple_addr_def]
+  \\ gvs[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
+  \\ gvs [FLOOKUP_DEF]
+  \\ fs [lookup_insert,adjust_var_11]
+  \\ rw [] \\ fs [option_le_max_right]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
+  \\ match_mp_tac memory_rel_insert \\ fs []
+  \\ first_x_assum (fn th => mp_tac th THEN match_mp_tac memory_rel_rearrange)
+  \\ fs [] \\ rw [] \\ fs []
+QED
+
+Theorem assign_SetGlobal:
+   (∃n. op = SetGlobal n) ==> ^assign_thm_goal
+Proof
+  rpt strip_tac \\ drule0 (evaluate_GiveUp |> GEN_ALL) \\ rw [] \\ fs []
+  \\ `t.termdep <> 0` by fs[]
+  \\ rpt_drule0 state_rel_cut_IMP
+  \\ qpat_x_assum `state_rel c l1 l2 s t [] locs` kall_tac \\ strip_tac
+  \\ imp_res_tac get_vars_IMP_LENGTH \\ fs []
+  \\ fs [do_app,allowed_op_def] \\ every_case_tac \\ fs [] \\ clean_tac
+  \\ fs [integerTheory.NUM_OF_INT,LENGTH_EQ_1] \\ clean_tac
+  \\ imp_res_tac state_rel_get_vars_IMP
+  \\ fs [bvlSemTheory.Unit_def] \\ rveq
+  \\ fs [GSYM bvlSemTheory.Unit_def] \\ rveq
+  \\ fs [assign_def] \\ eval_tac \\ fs [state_rel_thm]
+  \\ rfs [the_global_def,libTheory.the_def]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
+  \\ drule0 (memory_rel_get_vars_IMP |> GEN_ALL)
+  \\ disch_then drule0 \\ fs []
+  \\ imp_res_tac get_vars_1_IMP \\ fs []
+  \\ fs [integerTheory.NUM_OF_INT,LENGTH_EQ_1] \\ clean_tac
+  \\ qmatch_goalsub_abbrev_tac ‘(_,_)::(xs1++[(RefPtr ref_ptr,_)]++xs2)’
+  \\ strip_tac
+  \\ ‘memory_rel c t.be (THE x.tstamps) x.refs x.space t.store t.memory t.mdomain
+        ((RefPtr ref_ptr,t.store ' Globals)::(h,a1')::(xs1 ++ xs2))’ by
+      (first_x_assum (fn th => mp_tac th \\ match_mp_tac memory_rel_rearrange)
+       \\ fs [] \\ rw [] \\ fs [])
+  \\ ‘∃curr.
+        FLOOKUP t.store CurrHeap = SOME (Word curr) ∧
+        glob_real_inv c curr (FLOOKUP t.store Globals) (FLOOKUP t.store GlobReal)’
+          by fs [memory_rel_def,heap_in_memory_store_def,state_rel_def]
+  \\ drule memory_rel_RefPtr_IMP' \\ fs [] \\ strip_tac
+  \\ fs [glob_real_inv_def]
+  \\ fs [wordSemTheory.get_vars_def,AllCaseEqs()]
+  \\ ‘memory_rel c t.be (THE x.tstamps) x.refs x.space t.store t.memory t.mdomain
+        ((h,a1')::(RefPtr ref_ptr,t.store ' Globals)::(xs1 ++ xs2))’ by
+      (first_x_assum (fn th => mp_tac th \\ match_mp_tac memory_rel_rearrange)
+       \\ fs [] \\ rw [] \\ fs [])
+  \\ drule0 (memory_rel_Update' |> GEN_ALL) \\ fs []
+  \\ disch_then drule \\ strip_tac
+  \\ fs [] \\ gvs[get_real_simple_addr_def]
+  \\ gvs[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB,wordSemTheory.mem_store_def]
+  \\ gvs [FLOOKUP_DEF,wordSemTheory.word_exp_def,data_to_wordTheory.Unit_def]
+  \\ fs [lookup_insert,adjust_var_11]
+  \\ rw [] \\ fs [option_le_max_right]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
+  \\ match_mp_tac memory_rel_insert \\ fs []
+  \\ match_mp_tac memory_rel_Unit \\ fs []
+  \\ first_x_assum (fn th => mp_tac th THEN match_mp_tac memory_rel_rearrange)
+  \\ rw [] \\ fs []
+QED
+
 Theorem assign_SetGlobalsPtr:
    op = SetGlobalsPtr ==> ^assign_thm_goal
 Proof
@@ -13307,10 +13396,6 @@ Theorem assign_thm:
    ^assign_thm_goal
 Proof
   Cases_on `op = AllocGlobal` \\ fs []
-  THEN1 (fs [do_app] \\ every_case_tac \\ fs [])
-  \\ Cases_on `?i. op = Global i` \\ fs []
-  THEN1 (fs [do_app] \\ every_case_tac \\ fs [])
-  \\ Cases_on `?i. op = SetGlobal i` \\ fs []
   THEN1 (fs [do_app] \\ every_case_tac \\ fs [])
   \\ Cases_on `op = Greater` \\ fs []
   THEN1 (fs [do_app] \\ every_case_tac \\ fs [])

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -11862,11 +11862,11 @@ Proof
   \\ pop_assum (fn th => assume_tac th THEN mp_tac th)
   \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]
   \\ every_case_tac \\ fs [] \\ rpt var_eq_tac
-  \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
+  \\ ‘isWord h’ by
+   (fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
          adjust_var_11,libTheory.the_def,set_var_def,
          wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE]
-  \\ ‘isWord h’ by
-   (full_simp_tac std_ss [GSYM APPEND_ASSOC]
+    \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
     \\ drule0 (GEN_ALL word_ml_inv_get_vars_IMP)
     \\ disch_then drule0
     \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]
@@ -11874,27 +11874,40 @@ Proof
     \\ gvs [word_ml_inv_def,abs_ml_inv_def,bc_stack_ref_inv_def,v_inv_def]
     \\ fs [word_addr_def,isWord_def])
   \\ Cases_on ‘h’ \\ fs [isWord_def]
-  \\ ‘∃curr. FLOOKUP t.store CurrHeap = SOME (Word curr)’ by
-       fs [heap_in_memory_store_def]
+  \\ rename [‘_ = SOME (Word www)’]
+  \\ fs [assign_def] \\ eval_tac \\ fs [state_rel_thm,option_le_max_right]
+  \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
+  \\ drule0 (memory_rel_get_vars_IMP |> GEN_ALL)
+  \\ disch_then drule0 \\ fs []
+  \\ imp_res_tac get_vars_1_IMP \\ fs []
+  \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]
+  \\ strip_tac
+  \\ drule_all memory_rel_RefPtr_IMP' \\ strip_tac
+  \\ ‘word_exp (set_store Globals (Word www) t) (real_addr c (adjust_var y)) =
+      word_exp t (real_addr c (adjust_var y))’ by cheat
+  \\ first_assum (mp_then (Pos last) mp_tac get_real_addr_lemma)
+  \\ gvs []
+  \\ disch_then (qspec_then ‘adjust_var y’ mp_tac)
+  \\ fs [wordSemTheory.get_vars_def,wordSemTheory.get_var_def]
+  \\ fs [wordSemTheory.set_store_def]
   \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
          adjust_var_11,libTheory.the_def,set_var_def,word_sh_def,
          wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE]
-  \\ IF_CASES_TAC THEN1
-   (qsuff_tac ‘F’ \\ rewrite_tac []
-    \\ pop_assum mp_tac \\ fs [good_dimindex_def,shift_def])
+  \\ rw [] \\ rw [] \\ fs []
   \\ fs [state_rel_def,wordSemTheory.set_var_def,lookup_insert,
          adjust_var_11,libTheory.the_def,set_var_def,word_sh_def,
          wordSemTheory.set_store_def,code_oracle_rel_def,FLOOKUP_UPDATE,
-         wordSemTheory.the_words_def,word_op_def]
+         wordSemTheory.the_words_def,word_op_def,memory_rel_def]
   \\ rw [] \\ fs [option_le_max_right]
   \\ qexists_tac ‘heap’
   \\ qexists_tac ‘limit’
-  \\ qexists_tac ‘a’
+  \\ qexists_tac ‘a'’
   \\ qexists_tac ‘sp’
   \\ qexists_tac ‘sp1’
   \\ qexists_tac ‘gens’
   \\ fs [heap_in_memory_store_def,FLOOKUP_UPDATE,glob_real_inv_def]
   \\ fs [the_global_def,libTheory.the_def]
+  \\ gvs [get_real_simple_addr_def]
   \\ full_simp_tac std_ss [GSYM APPEND_ASSOC]
   \\ drule0 (GEN_ALL word_ml_inv_get_vars_IMP)
   \\ disch_then drule0

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -4433,6 +4433,12 @@ Proof
   \\ Cases_on `x'` \\ fs [gen_starts_in_store_def]
 QED
 
+Definition glob_real_inv_def:
+  glob_real_inv c (curr:'a word) globals globreal ⇔
+    ∃w. globals = SOME (Word w) ∧
+        globreal = SOME (Word (curr + (w >>> (shift_length c) << shift (:α))))
+End
+
 val heap_in_memory_store_def = Define `
   heap_in_memory_store heap a sp sp1 gens c s m dm limit <=>
     heap_length heap <= dimword (:'a) DIV 2 ** shift_length c /\
@@ -4449,6 +4455,7 @@ val heap_in_memory_store_def = Define `
       (FLOOKUP s TriggerGC = SOME (Word (curr + bytes_in_word * n2w (a+sp)))) /\
       (FLOOKUP s EndOfHeap = SOME (Word (curr + bytes_in_word * n2w (a+sp+sp1)))) /\
       (FLOOKUP s HeapLength = SOME (Word (bytes_in_word * n2w limit))) /\
+      glob_real_inv c curr (FLOOKUP s Globals) (FLOOKUP s GlobReal) /\
       gen_starts_in_store c gens (FLOOKUP s GenStart) /\
       (word_heap curr heap c *
        word_heap other (heap_expand limit) c) (fun2set (m,dm))`

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -4626,6 +4626,13 @@ val get_real_offset_def = Define `
     if dimindex (:'a) = 32
     then SOME (w + bytes_in_word) else SOME (w << 1 + bytes_in_word)`
 
+Definition get_real_simple_addr_def:
+  get_real_simple_addr conf st (w:'a word) =
+    case FLOOKUP st CurrHeap of
+    | SOME (Word curr) => SOME (curr + w ⋙ shift_length conf ≪ shift (:α))
+    | _ => NONE
+End
+
 Theorem get_real_addr_get_addr:
    heap_length heap <= dimword (:'a) DIV 2 ** shift_length c /\
     heap_lookup n heap = SOME anything /\
@@ -7557,13 +7564,6 @@ Proof
      \\ qexists_tac `RefPtr p` \\ fs [get_refs_def])
   \\ fs [SUBSET_DEF,domain_lookup]
 QED
-
-Definition get_real_simple_addr_def:
-  get_real_simple_addr conf st (w:'a word) =
-    case FLOOKUP st CurrHeap of
-    | SOME (Word curr) => SOME (curr + w ⋙ shift_length conf ≪ shift (:α))
-    | _ => NONE
-End
 
 Theorem memory_rel_RefPtr_IMP':
   memory_rel c be ts refs sp st m dm ((RefPtr p,v)::vars) ∧

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -4663,6 +4663,11 @@ Proof
     \\ match_mp_tac LESS_LESS_EQ_TRANS
     \\ once_rewrite_tac [CONJ_COMM]
     \\ asm_exists_tac \\ fs [])
+  \\ conj_asm1_tac THEN1
+   (drule lsl_lsr \\ fs [get_lowerbits_LSL_shift_length]
+    \\ fs [] \\ rw []
+    \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
+    \\ rfs [WORD_MUL_LSL,word_mul_n2w,shift_def,bytes_in_word_def])
   \\ IF_CASES_TAC
   THEN1
    (Cases_on ‘w’
@@ -4680,11 +4685,6 @@ Proof
     \\ qpat_x_assum ‘_ = shift_length _’ (assume_tac o GSYM)
     \\ fs [])
   \\ pop_assum kall_tac
-  \\ conj_asm1_tac THEN1
-   (drule lsl_lsr \\ fs [get_lowerbits_LSL_shift_length]
-    \\ fs [] \\ rw []
-    \\ fs [labPropsTheory.good_dimindex_def,dimword_def] \\ rw []
-    \\ rfs [WORD_MUL_LSL,word_mul_n2w,shift_def,bytes_in_word_def])
   \\ reverse IF_CASES_TAC THEN1 fs []
   \\ fs []
   \\ `get_lowerbits c w ⋙ (shift_length c − shift (:α)) = 0w` by

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -5119,7 +5119,6 @@ Theorem memory_rel_Update':
         ((x + bytes_in_word + bytes_in_word * n2w index =+ w) m) dm
         ((h,w)::(RefPtr nn,ptr)::vars)
 Proof
-  cheat (*
   rewrite_tac [CONJ_ASSOC]
   \\ once_rewrite_tac [CONJ_COMM]
   \\ fs [memory_rel_def,PULL_EXISTS] \\ rw []
@@ -5135,7 +5134,7 @@ Proof
   \\ fs [heap_in_memory_store_def]
   \\ rpt_drule get_real_addr_get_addr \\ fs []
   \\ disch_then kall_tac
-  \\ `word_addr c v'' = Word (n2w (4 * index)) /\ n = LENGTH l` by
+  \\ `n = LENGTH l` by
    (qpat_x_assum `abs_ml_inv _ _ _ _ _ _` kall_tac
     \\ fs [abs_ml_inv_def,bc_stack_ref_inv_def,v_inv_def,BlockRep_def]
     \\ clean_tac
@@ -5148,13 +5147,7 @@ Proof
     \\ fs [FLOOKUP_DEF,RefBlock_def] \\ strip_tac \\ clean_tac
     \\ imp_res_tac heap_lookup_SPLIT
     \\ fs [word_heap_APPEND,word_heap_def,word_el_def,word_payload_def]
-    \\ full_simp_tac (std_ss++sep_cond_ss) [cond_STAR]
-    \\ `small_int (:α) (&index)` by
-     (fs [small_int_def,intLib.COOPER_CONV ``-&n <= &k:int``]
-      \\ fs [labPropsTheory.good_dimindex_def,dimword_def]
-      \\ rw [] \\ rfs [] \\ fs [] \\ NO_TAC)
-    \\ fs [] \\ clean_tac \\ fs [word_addr_def]
-    \\ fs [Smallnum_def,GSYM word_mul_n2w,word_ml_inv_num_lemma] \\ NO_TAC)
+    \\ full_simp_tac (std_ss++sep_cond_ss) [cond_STAR])
   \\ fs [] \\ fs [get_real_offset_thm]
   \\ fs [GSYM RefBlock_def]
   \\ imp_res_tac heap_lookup_SPLIT \\ fs [] \\ clean_tac
@@ -5174,7 +5167,7 @@ Proof
   \\ fs [el_length_def,SUM_APPEND]
   \\ fs [GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
   \\ SEP_R_TAC \\ fs []
-  \\ SEP_W_TAC \\ fs [AC STAR_ASSOC STAR_COMM] *)
+  \\ SEP_W_TAC \\ fs [AC STAR_ASSOC STAR_COMM]
 QED
 
 Theorem memory_rel_Update:

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -465,7 +465,8 @@ val word_gc_fun_thm = Q.prove(
               Word
                 (theWord (s ' OtherHeap) +
                  theWord (s ' HeapLength)));
-             (Globals,w1)]
+             (Globals,w1);
+             (GlobReal,glob_real conf (theWord (s ' OtherHeap)) w1)]
       in
         if word_gc_fun_assum conf s /\ c2 then SOME (ws2,m1,s1) else NONE`,
   full_simp_tac(srw_ss())[word_gc_fun_lemma,LET_THM]
@@ -540,7 +541,8 @@ val gc_thm = Q.prove(
              Word
                (theWord (s.store ' OtherHeap) +
                 theWord (s.store ' HeapLength)));
-            (Globals,w1)] in
+            (Globals,w1);
+            (GlobReal,glob_real conf (theWord (s.store ' OtherHeap)) w1)] in
        if word_gc_fun_assum conf s.store /\ c2 then SOME (s with
                        <|stack := unused ++ stack; store := s1;
                          regs := FEMPTY; memory := m1|>) else NONE`,
@@ -1586,10 +1588,18 @@ Proof
    (CCONTR_TAC \\ fs [NOT_LESS]
     \\ imp_res_tac DROP_LENGTH_TOO_LONG
     \\ fs [word_gc_move_roots_bitmaps_def,enc_stack_def] \\ NO_TAC)
+  \\ ‘∃globw. w1 = Word globw’ by
+   (fs [word_gc_fun_assum_def]
+    \\ fs [FAPPLY_FUPDATE_THM,isWord_thm] \\ fs []
+    \\ fs [word_gc_move_def,AllCaseEqs()] \\ gvs []
+    \\ rpt (pairarg_tac \\ fs [])
+    \\ TRY (qpat_x_assum ‘_ = s.store ' Globals’ (assume_tac o GSYM))
+    \\ gvs [])
+  \\ pop_assum (full_simp_tac bool_ss o single)
   \\ abbrev_under_exists ``s4:('a,'c,'b)stackSem$state``
    (qexists_tac `ck` \\ fs []
     \\ unabbrev_all_tac \\ fs [] \\ tac
-    \\ fs [FAPPLY_FUPDATE_THM]
+    \\ fs [FAPPLY_FUPDATE_THM,isWord_thm]
     \\ qpat_abbrev_tac `(s4:('a,'c,'b)stackSem$state) = _`)
   \\ qpat_x_assum `word_gc_move_roots_bitmaps _ _ = _` assume_tac
   \\ drule LESS_EQ_LENGTH
@@ -1612,7 +1622,7 @@ Proof
   \\ abbrev_under_exists ``s5:('a,'c,'b)stackSem$state``
    (qexists_tac `ck+ck'` \\ fs []
     \\ unabbrev_all_tac \\ fs [] \\ tac
-    \\ fs [FAPPLY_FUPDATE_THM]
+    \\ fs [FAPPLY_FUPDATE_THM,isWord_thm]
     \\ qpat_abbrev_tac `(s5:('a,'c,'b)stackSem$state) = _`)
   \\ drule (GEN_ALL word_gc_move_loop_code_thm
            |> REWRITE_RULE [GSYM AND_IMP_INTRO])
@@ -1639,7 +1649,7 @@ Proof
   \\ rpt (qpat_x_assum `evaluate _ = _` kall_tac)
   \\ qpat_x_assum `_ = t.store` (fn th => fs [GSYM th])
   \\ `TAKE t.stack_space (ys1 ++ ys2) = ys1` by metis_tac [TAKE_LENGTH_APPEND]
-  \\ fs [fmap_EXT,EXTENSION]
+  \\ fs [fmap_EXT,EXTENSION,glob_real_def]
   \\ rw [] \\ fs [FAPPLY_FUPDATE_THM]
   \\ fs [SUBMAP_DEF] \\ rw [] \\ fs [] \\ eq_tac \\ strip_tac \\ fs []
 QED
@@ -1680,6 +1690,7 @@ val word_gc_fun_thm = Q.prove(
                 (TriggerGC,Word (pa1 + new_trig (theWord (s ' EndOfHeap) - pa1)
                                          (theWord (s ' AllocSize)) gen_sizes));
                 (Globals,HD roots1);
+                (GlobReal,glob_real conf (theWord (s ' CurrHeap)) (HD roots1));
                 (Temp 0w,Word 0w); (Temp 1w,Word 0w)])
           else NONE)
          ((λ(roots,i,pa,m,c1).
@@ -1737,6 +1748,7 @@ val word_gc_fun_thm = Q.prove(
               (GenStart,Word (pa3 − theWord (s ' OtherHeap)));
               (TriggerGC,Word (pa3 + new_trig (pb3 - pa3) a gen_sizes));
               (EndOfHeap,Word pb3); (Globals,w1);
+              (GlobReal,glob_real conf (theWord (s ' OtherHeap)) w1);
               (Temp 0w,Word 0w);
               (Temp 1w,Word 0w);
               (Temp 2w,Word 0w);
@@ -1839,6 +1851,7 @@ val gc_thm = Q.prove(
                     (theWord (s.store ' EndOfHeap) - b1)
                     (theWord (s.store ' AllocSize)) gen_sizes));
                  (Globals,w1);
+                 (GlobReal,glob_real conf (theWord (s.store ' CurrHeap)) w1);
                  (Temp 0w,Word 0w);
                  (Temp 1w,Word 0w)] in
        let c6 = ((theWord (s.store ' AllocSize) ≤₊
@@ -1877,6 +1890,7 @@ val gc_thm = Q.prove(
                    (pb3 - pa3) (theWord (s.store ' AllocSize)) gen_sizes));
                 (EndOfHeap,Word pb3);
                 (Globals,w1);
+                (GlobReal,glob_real conf (theWord (s.store ' OtherHeap)) w1);
                 (Temp 0w, Word 0w);
                 (Temp 1w, Word 0w);
                 (Temp 2w, Word 0w);
@@ -4508,7 +4522,7 @@ Proof
   \\ fs [set_store_def] \\ IF_CASES_TAC THEN1 (fs [] \\ rw [] \\ fs [])
   \\ fs [FAPPLY_FUPDATE_THM]
   \\ IF_CASES_TAC THEN1 (fs [] \\ rw [] \\ fs [])
-  \\ IF_CASES_TAC THEN1
+  \\ IF_CASES_TAC THEN1 (* do_partial is true *)
    (rpt (pairarg_tac \\ fs [])
     \\ reverse IF_CASES_TAC THEN1 rw [] \\ fs []
     \\ fs [FLOOKUP_UPDATE,FUPDATE_LIST,has_space_def]
@@ -4520,6 +4534,7 @@ Proof
         isWord (s.store ' HeapLength) /\
         isWord (s.store ' TriggerGC) /\
         isWord (s.store ' EndOfHeap) /\
+        isWord (s.store ' Globals) /\
         good_dimindex (:'a) /\
         conf.len_size + 2 < dimindex (:'a) /\
         shift_length conf < dimindex (:'a) /\
@@ -4535,12 +4550,14 @@ Proof
     \\ rename1 `s.store ' HeapLength = Word len`
     \\ rename1 `s.store ' TriggerGC = Word trig`
     \\ rename1 `s.store ' EndOfHeap = Word endh`
+    \\ rename1 `s.store ' Globals = Word globw`
     \\ fs [word_gc_code_def]
     \\ `FLOOKUP s.store OtherHeap = SOME (Word other) /\
         FLOOKUP s.store CurrHeap = SOME (Word curr) /\
         FLOOKUP s.store HeapLength = SOME (Word len) /\
         FLOOKUP s.store TriggerGC = SOME (Word trig) /\
-        FLOOKUP s.store EndOfHeap = SOME (Word endh)` by fs [FLOOKUP_DEF]
+        FLOOKUP s.store EndOfHeap = SOME (Word endh) /\
+        FLOOKUP s.store Globals = SOME (Word globw)` by fs [FLOOKUP_DEF]
     \\ `!ck xs ys. evaluate
           (word_gc_partial_or_full gen_sizes xs ys,
            s with
@@ -4581,6 +4598,13 @@ Proof
       \\ fs [word_gen_gc_partial_move_roots_bitmaps_def,enc_stack_def] \\ NO_TAC)
     \\ fs [] \\ tac
     \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF,theWord_def]
+    \\ ‘∃globw2. w1 = Word globw2’ by
+      (fs [word_gc_fun_assum_def]
+      \\ fs [FAPPLY_FUPDATE_THM,isWord_thm] \\ fs []
+      \\ fs [word_gen_gc_partial_move_def,AllCaseEqs()] \\ gvs []
+      \\ rpt (pairarg_tac \\ fs [])
+      \\ TRY (qpat_x_assum ‘_ = s.store ' Globals’ (assume_tac o GSYM))
+      \\ gvs [])
     \\ abbrev_under_exists ``s4:('a,'c,'b)stackSem$state``
      (qexists_tac `ck` \\ fs []
       \\ unabbrev_all_tac \\ fs [] \\ tac
@@ -4702,7 +4726,7 @@ Proof
     \\ fs [FAPPLY_FUPDATE_THM,FUPDATE_LIST]
     \\ qpat_x_assum `_ = t.store` (fn th => fs [GSYM th])
     \\ `TAKE t.stack_space (ys1 ++ ys2) = ys1` by metis_tac [TAKE_LENGTH_APPEND]
-    \\ fs [fmap_EXT,EXTENSION]
+    \\ fs [fmap_EXT,EXTENSION,glob_real_def]
     \\ rw [] \\ fs [FAPPLY_FUPDATE_THM]
     \\ fs [SUBMAP_DEF] \\ rw [] \\ fs [] \\ eq_tac \\ strip_tac \\ fs [])
   \\ pairarg_tac \\ fs []
@@ -4718,6 +4742,7 @@ Proof
       isWord (s.store ' HeapLength) /\
       isWord (s.store ' TriggerGC) /\
       isWord (s.store ' EndOfHeap) /\
+      isWord (s.store ' Globals) /\
       good_dimindex (:'a) /\
       conf.len_size + 2 < dimindex (:'a) /\
       shift_length conf < dimindex (:'a) /\
@@ -4733,12 +4758,14 @@ Proof
   \\ rename1 `s.store ' HeapLength = Word len`
   \\ rename1 `s.store ' TriggerGC = Word trig`
   \\ rename1 `s.store ' EndOfHeap = Word endh`
+  \\ rename1 `s.store ' Globals = Word globw`
   \\ fs [word_gc_code_def]
   \\ `FLOOKUP s.store OtherHeap = SOME (Word other) /\
       FLOOKUP s.store CurrHeap = SOME (Word curr) /\
       FLOOKUP s.store HeapLength = SOME (Word len) /\
       FLOOKUP s.store TriggerGC = SOME (Word trig) /\
-      FLOOKUP s.store EndOfHeap = SOME (Word endh)` by fs [FLOOKUP_DEF]
+      FLOOKUP s.store EndOfHeap = SOME (Word endh) /\
+      FLOOKUP s.store Globals = SOME (Word globw)` by fs [FLOOKUP_DEF]
   \\ `!ck xs ys. evaluate
         (word_gc_partial_or_full gen_sizes xs ys,
          s with
@@ -4776,10 +4803,17 @@ Proof
     \\ imp_res_tac DROP_LENGTH_TOO_LONG
     \\ fs [word_gen_gc_move_roots_bitmaps_def,enc_stack_def] \\ NO_TAC)
   \\ ntac 3 tac1
+  \\ ‘∃globw2. w1 = Word globw2’ by
+      (fs [word_gc_fun_assum_def]
+      \\ fs [FAPPLY_FUPDATE_THM,isWord_thm] \\ fs []
+      \\ fs [word_gen_gc_move_def,AllCaseEqs()] \\ gvs []
+      \\ rpt (pairarg_tac \\ fs [])
+      \\ TRY (qpat_x_assum ‘_ = s.store ' Globals’ (assume_tac o GSYM))
+      \\ gvs [])
   \\ abbrev_under_exists ``s4:('a,'c,'b)stackSem$state``
    (qexists_tac `ck` \\ fs []
     \\ unabbrev_all_tac \\ fs [] \\ tac
-    \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF] \\ tac
+    \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF,set_store_def] \\ tac
     \\ qpat_abbrev_tac `(s4:('a,'c,'b)stackSem$state) = _`)
   \\ qpat_x_assum `word_gen_gc_move_roots_bitmaps _ _ = _` assume_tac
   \\ drule LESS_EQ_LENGTH
@@ -4802,7 +4836,8 @@ Proof
   \\ abbrev_under_exists ``s5:('a,'c,'b)stackSem$state``
    (qexists_tac `ck+ck'` \\ fs []
     \\ unabbrev_all_tac \\ fs [] \\ tac
-    \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF] \\ tac
+    \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF,set_store_def] \\ tac
+    \\ fs [FAPPLY_FUPDATE_THM,FLOOKUP_DEF,set_store_def] \\ tac
     \\ qpat_abbrev_tac `(s5:('a,'c,'b)stackSem$state) = _`)
   \\ drule (GEN_ALL word_gen_gc_move_loop_code_thm
            |> REWRITE_RULE [GSYM AND_IMP_INTRO])
@@ -4838,7 +4873,7 @@ Proof
   \\ rpt (qpat_x_assum `evaluate _ = _` kall_tac)
   \\ qpat_x_assum `_ = t.store` (fn th => fs [GSYM th])
   \\ `TAKE t.stack_space (ys1 ++ ys2) = ys1` by metis_tac [TAKE_LENGTH_APPEND]
-  \\ fs [fmap_EXT,EXTENSION]
+  \\ fs [fmap_EXT,EXTENSION,glob_real_def]
   \\ rw [] \\ fs [FAPPLY_FUPDATE_THM]
   \\ fs [SUBMAP_DEF] \\ rw [] \\ fs [] \\ eq_tac \\ strip_tac \\ fs []
 QED

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -2452,6 +2452,7 @@ val init_prop_def = Define `
        FLOOKUP s.store ProgStart = SOME (Word 0w) /\
        FLOOKUP s.store AllocSize = SOME (Word 0w) /\
        FLOOKUP s.store Globals = SOME (Word 0w) /\
+       FLOOKUP s.store GlobReal = SOME (Word curr) /\
        FLOOKUP s.store Handler = SOME (Word 0w) /\
        FLOOKUP s.store GenStart = SOME (Word 0w) /\
        FLOOKUP s.store CodeBuffer = SOME (Word s.code_buffer.position) ∧

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -61,6 +61,31 @@ val do_app_aux_def = Define `
         (case xs of
          | [RefPtr p] => SOME (SOME (Unit, s with global := SOME p))
          | _ => NONE)
+    | (Global n, xs) =>
+        (case xs of
+         | [] => (case s.global of
+                   | SOME ptr =>
+                       (case FLOOKUP s.refs ptr of
+                        | SOME (ValueArray xs) =>
+                            (if n < LENGTH xs
+                             then SOME (SOME (EL n xs, s))
+                             else NONE)
+                        | _ => NONE)
+                   | NONE => NONE)
+         | _ => NONE)
+    | (SetGlobal n, xs) =>
+        (case xs of
+         | [x] => (case s.global of
+                   | SOME ptr =>
+                       (case FLOOKUP s.refs ptr of
+                        | SOME (ValueArray xs) =>
+                            (if n < LENGTH xs
+                             then SOME (SOME (Unit, s with refs := s.refs |+
+                                               (ptr, ValueArray (LUPDATE x n xs)) ))
+                             else NONE)
+                        | _ => NONE)
+                   | NONE => NONE)
+         | _ => NONE)
     | (FromList n, xs) =>
         (case xs of
          | [len;lv] =>
@@ -79,8 +104,6 @@ val do_app_aux_def = Define `
                   (ptr, ByteArray f (REPLICATE (Num i) (i2w b)))))
             else NONE
           | _ => NONE)
-    | (Global n, _) => NONE
-    | (SetGlobal n, _) => NONE
     | (AllocGlobal, _) => NONE
     | (String _, _) => NONE
     | (FromListByte, _) => NONE

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -659,6 +659,31 @@ val do_app_aux_def = Define `
                   | SOME p => Rval (RefPtr p, s)
                   | NONE => Error)
          | _ => Error)
+    | (Global n,xs) =>
+        (case xs of
+         | [] => (case s.global of
+                  | SOME ptr =>
+                      (case lookup ptr s.refs of
+                       | SOME (ValueArray xs) =>
+                           (if n < LENGTH xs
+                            then Rval (EL n xs, s)
+                            else Error)
+                       | _ => Error)
+                  | NONE => Error)
+         | _ => Error)
+    | (SetGlobal n,xs) =>
+        (case xs of
+         | [x] => (case s.global of
+                   | SOME ptr =>
+                       (case lookup ptr s.refs of
+                        | SOME (ValueArray xs) =>
+                            (if n < LENGTH xs
+                             then Rval (Unit, s with refs := insert ptr
+                                          (ValueArray (LUPDATE x n xs)) s.refs)
+                             else Error)
+                        | _ => Error)
+                   | NONE => Error)
+         | _ => Error)
     | (SetGlobalsPtr,xs) =>
         (case xs of
          | [RefPtr p] => Rval (Unit, s with global := SOME p)
@@ -686,8 +711,6 @@ val do_app_aux_def = Define `
                   (ByteArray f (REPLICATE (Num i) (i2w b))) s.refs|>)
             else Rerr (Rabort Rtype_error)
           | _ => Rerr (Rabort Rtype_error))
-    | (Global n, _)      => Rerr (Rabort Rtype_error)
-    | (SetGlobal n, _)   => Rerr (Rabort Rtype_error)
     | (AllocGlobal, _)   => Rerr (Rabort Rtype_error)
     | (String _, _)      => Rerr (Rabort Rtype_error)
     | (FromListByte, _)  => Rerr (Rabort Rtype_error)

--- a/compiler/backend/stackLangScript.sml
+++ b/compiler/backend/stackLangScript.sml
@@ -17,7 +17,7 @@ val _ = set_grammar_ancestry["asm", "backend_common",
 val _ = Datatype `
   store_name =
     NextFree | EndOfHeap | TriggerGC | HeapLength | ProgStart | BitmapBase |
-    CurrHeap | OtherHeap | AllocSize | Globals | Handler | GenStart |
+    CurrHeap | OtherHeap | AllocSize | Globals | GlobReal | Handler | GenStart |
     CodeBuffer | CodeBufferEnd | BitmapBuffer | BitmapBufferEnd |
     Temp (5 word)`
 

--- a/compiler/backend/stack_allocScript.sml
+++ b/compiler/backend/stack_allocScript.sml
@@ -453,6 +453,12 @@ val word_gc_code_def = Define `
                move 8 1;
                word_gc_move_code conf;
                Set Globals 5;
+               move 7 5;
+               right_shift_inst 7 (shift_length conf);
+               left_shift_inst 7 (word_shift (:'a));
+               Get 9 OtherHeap;
+               add_inst 7 9;
+               Set GlobReal 7;
                const_inst 7 0w;
                StackLoadAny 9 8;
                move 8 7;
@@ -490,6 +496,12 @@ val word_gc_code_def = Define `
                move 6 3;
                word_gen_gc_partial_move_code conf;
                Set Globals 5;
+               move 8 5;
+               right_shift_inst 8 (shift_length conf);
+               left_shift_inst 8 (word_shift (:'a));
+               Get 9 CurrHeap;
+               add_inst 8 9;
+               Set GlobReal 8;
                const_inst 8 0w;
                StackLoadAny 9 8;
                word_gen_gc_partial_move_roots_bitmaps_code conf;
@@ -550,6 +562,12 @@ val word_gc_code_def = Define `
                move 8 1;
                word_gen_gc_move_code conf;
                Set Globals 5;
+               move 7 5;
+               Get 9 OtherHeap;
+               right_shift_inst 7 (shift_length conf);
+               left_shift_inst 7 (word_shift (:'a));
+               add_inst 7 9;
+               Set GlobReal 7;
                const_inst 7 0w;
                StackLoadAny 9 8;
                move 8 7;

--- a/compiler/backend/stack_removeScript.sml
+++ b/compiler/backend/stack_removeScript.sml
@@ -20,8 +20,8 @@ val word_offset_def = Define `
 
 val store_list_def = Define `
   store_list = [NextFree; EndOfHeap; HeapLength; OtherHeap; TriggerGC;
-                AllocSize; Handler; Globals; ProgStart; BitmapBase; GenStart;
-                CodeBuffer; CodeBufferEnd; BitmapBuffer; BitmapBufferEnd;
+                AllocSize; Handler; Globals; GlobReal; ProgStart; BitmapBase;
+                GenStart; CodeBuffer; CodeBufferEnd; BitmapBuffer; BitmapBufferEnd;
                 Temp 00w; Temp 01w; Temp 02w; Temp 03w; Temp 04w;
                 Temp 05w; Temp 06w; Temp 07w; Temp 08w; Temp 09w;
                 Temp 10w; Temp 11w; Temp 12w; Temp 13w; Temp 14w;
@@ -195,6 +195,7 @@ val store_init_def = Define `
   store_init gen_gc (k:num) =
     (K (INL 0w)) =++
       [(CurrHeap,INR (k+2));
+       (GlobReal,INR (k+2));
        (NextFree,INR (k+2));
        (TriggerGC,INR (if gen_gc then k+2 else 2));
        (EndOfHeap,INR 2);

--- a/examples/cost/README.md
+++ b/examples/cost/README.md
@@ -1,5 +1,11 @@
 Preliminary data-cost examples
 
+[allProgScript.sml](allProgScript.sml):
+A data-cost example of a list sum function using fold
+
+[allProofScript.sml](allProofScript.sml):
+Prove of sum space consumption
+
 [costLib.sml](costLib.sml):
 Tactics and utilities for data-cost proofs
 

--- a/examples/cost/allProofScript.sml
+++ b/examples/cost/allProofScript.sml
@@ -446,7 +446,7 @@ end
 QED
 
 Theorem data_safe_all:
-   ∀ffi.
+  ∀ffi.
   backend_config_ok ^all_x64_conf
   ⇒ is_safe_for_space ffi
        all_x64_conf
@@ -502,7 +502,7 @@ in
  \\ make_if
  \\ UNABBREV_ALL_TAC
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  \\ make_tailcall
  \\ ntac 2
     (strip_call
@@ -524,7 +524,7 @@ in
   \\ REWRITE_TAC [to_shallow_def]
   \\ ntac 2
      (strip_makespace
-     \\ ntac 6 strip_assign
+     \\ ntac 4 strip_assign
      \\ make_tailcall)
   \\ strip_makespace
   \\ ntac 17 strip_assign

--- a/examples/cost/cyesProofScript.sml
+++ b/examples/cost/cyesProofScript.sml
@@ -673,7 +673,7 @@ Proof
  \\ UNABBREV_ALL_TAC
  (* Continues after call *)
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  \\ make_tailcall
  \\ ntac 5
     (strip_call
@@ -697,7 +697,7 @@ Proof
   \\ make_tailcall
   \\ ntac 5
      (strip_makespace
-     \\ ntac 6 strip_assign
+     \\ ntac 4 strip_assign
      \\ make_tailcall)
   \\ strip_assign
   \\ ho_match_mp_tac data_safe_bind_some

--- a/examples/cost/lcgLoopProofScript.sml
+++ b/examples/cost/lcgLoopProofScript.sml
@@ -2606,7 +2606,7 @@ in
  \\ UNABBREV_ALL_TAC
  (* Continues after call *)
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  \\ make_tailcall
  \\ ntac 11
     (strip_call
@@ -2631,7 +2631,7 @@ in
   \\ make_tailcall
   \\ ntac 11
      (strip_makespace
-      \\ ntac 6 strip_assign
+      \\ ntac 4 strip_assign
       \\ make_tailcall)
   (* Place the arguments *)
   \\ ntac 4 strip_assign

--- a/examples/cost/pureLoopProofScript.sml
+++ b/examples/cost/pureLoopProofScript.sml
@@ -145,7 +145,7 @@ Proof
  \\ UNABBREV_ALL_TAC
  (* Continues after call *)
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  (* Another tailcall *)
  \\ make_tailcall
  \\ strip_call
@@ -163,7 +163,7 @@ Proof
  \\ strip_assign
  \\ make_tailcall
  \\ strip_makespace
- \\ ntac 6 strip_assign
+ \\ ntac 4 strip_assign
  \\ make_tailcall
  \\ strip_assign
  (* Finally we reach our function call *)

--- a/examples/cost/sumProofScript.sml
+++ b/examples/cost/sumProofScript.sml
@@ -799,7 +799,7 @@ in
   \\ conj_tac >- (Cases \\ simp [] \\ IF_CASES_TAC \\ simp [])
   \\ UNABBREV_ALL_TAC
   \\ strip_call
-  \\ ntac 4 strip_assign
+  \\ ntac 2 strip_assign
   \\ open_tailcall
   \\ qmatch_goalsub_abbrev_tac ‘(bind _ _) st’
   \\ qabbrev_tac ‘vl = THE(sptree$lookup (0:num) st.locals)’

--- a/examples/cost/sumProofScript.sml
+++ b/examples/cost/sumProofScript.sml
@@ -766,7 +766,7 @@ in
  \\ make_if
  \\ UNABBREV_ALL_TAC
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  \\ make_tailcall
  \\ ntac 3
     (strip_call
@@ -788,7 +788,7 @@ in
   \\ REWRITE_TAC [to_shallow_def]
   \\ ntac 3
      (strip_makespace
-     \\ ntac 6 strip_assign
+     \\ ntac 4 strip_assign
      \\ make_tailcall)
   \\ ntac 31 strip_assign
   \\ strip_makespace

--- a/examples/cost/yesProofScript.sml
+++ b/examples/cost/yesProofScript.sml
@@ -1120,7 +1120,7 @@ Proof
  \\ UNABBREV_ALL_TAC
  (* Continues after call *)
  \\ strip_makespace
- \\ ntac 49 strip_assign
+ \\ ntac 47 strip_assign
  \\ make_tailcall
  \\ ntac 5
     (strip_call
@@ -1144,7 +1144,7 @@ Proof
   \\ make_tailcall
   \\ ntac 5
      (strip_makespace
-     \\ ntac 6 strip_assign
+     \\ ntac 4 strip_assign
      \\ make_tailcall)
   \\ ntac 2 strip_assign
   \\ strip_assign


### PR DESCRIPTION
Closes issue #797. 

Example of code generated on current master:
```
000000000002287a <cml_dec_146>:
   2287a:       bf 60 06 00 00          mov    $0x660,%edi
   2287f:       49 8b 75 c0             mov    -0x40(%r13),%rsi
   22883:       48 d1 e7                shl    %rdi
   22886:       4c 01 f7                add    %r14,%rdi
   22889:       48 c1 ee 09             shr    $0x9,%rsi
   2288d:       48 01 f7                add    %rsi,%rdi
   22890:       48 8b 57 08             mov    0x8(%rdi),%rdx
   22894:       bf 34 07 00 00          mov    $0x734,%edi
   22899:       49 8b 75 c0             mov    -0x40(%r13),%rsi
   2289d:       48 d1 e7                shl    %rdi
   228a0:       4c 01 f7                add    %r14,%rdi
   228a3:       48 c1 ee 09             shr    $0x9,%rsi
   228a7:       48 01 f7                add    %rsi,%rdi
   228aa:       48 89 57 08             mov    %rdx,0x8(%rdi)
   228ae:       e9 01 00 00 00          jmpq   228b4 <cml_dec_147>
   228b3:       90                      nop
```
New version of the same code as of this pull request:
```
00000000000232f2 <cml_dec_146>:
   232f2:       49 8b 7d b8             mov    -0x48(%r13),%rdi
   232f6:       48 8b bf c8 0c 00 00    mov    0xcc8(%rdi),%rdi
   232fd:       49 8b 75 b8             mov    -0x48(%r13),%rsi
   23301:       48 89 be 70 0e 00 00    mov    %rdi,0xe70(%rsi)
   23308:       e9 01 00 00 00          jmpq   2330e <cml_dec_147>
   2330d:       90                      nop
```