### PR TITLE
Simplify sptree reachability and update `word_elim`/`flat_elim`

### DIFF
--- a/compiler/backend/backendComputeLib.sml
+++ b/compiler/backend/backendComputeLib.sml
@@ -699,6 +699,10 @@ val add_backend_compset = computeLib.extend_compset
     ,sptreeTheory.spt_fold_def
     ,sptreeTheory.mapi_def
     ,sptreeTheory.mapi0_def
+    ,sptreeTheory.subspt_eq
+    ,sptreeTheory.spt_left_def
+    ,sptreeTheory.spt_center_def
+    ,sptreeTheory.spt_right_def
     ]
   ,computeLib.Tys
     [ (* ---- stackLang ---- *)

--- a/compiler/backend/flat_elimScript.sml
+++ b/compiler/backend/flat_elimScript.sml
@@ -214,44 +214,6 @@ val analyse_code_def = Define `
     analyse_code (_::cs) = analyse_code cs
 `
 
-(*
-
-(**************************** REACHABILITY FUNS *****************************)
-
-
-val superdomain_def = Define `
-    superdomain (t:num_set num_map) = spt_fold union LN t
-`
-
-val mk_wf_set_tree_def = Define `
-    mk_wf_set_tree t =
-        let t' = union t (map (K LN) (superdomain t)) in mk_wf (map (mk_wf) t')
-`
-
-Definition close_spt_def:
-    close_spt (reachable :num_set) (seen :num_set) (tree :num_set spt) =
-        let to_look = difference seen reachable in
-        let new_sets = inter tree to_look in
-            if new_sets = LN then reachable else
-                let new_set = spt_fold union LN new_sets in
-                    close_spt (union reachable to_look) (union seen new_set)
-                        tree
-Termination
-        WF_REL_TAC `measure (λ (r, _, t) . size (difference t r))` >>
-        rw[] >>
-        match_mp_tac size_diff_less >>
-        fs[domain_union, domain_difference] >>
-        fs[inter_eq_LN, IN_DISJOINT, domain_difference] >>
-        qexists_tac `x` >>
-        fs[]
-End
-
-val close_spt_ind = theorem "close_spt_ind";
-
-val closure_spt_def = Define
-    `closure_spt start tree = close_spt LN start tree`;
-
-*)
 
 (**************************** REMOVAL FUNCTIONS *****************************)
 

--- a/compiler/backend/flat_elimScript.sml
+++ b/compiler/backend/flat_elimScript.sml
@@ -275,7 +275,7 @@ val remove_unreachable_def = Define `
 val remove_flat_prog_def = Define `
     remove_flat_prog code =
         let (r, t) = analyse_code code in
-        let reachable = closure_spt r (mk_wf_set_tree t) in
+        let reachable = closure_spt r t in
         remove_unreachable reachable code
 `
 

--- a/compiler/backend/proofs/flat_elimProofScript.sml
+++ b/compiler/backend/proofs/flat_elimProofScript.sml
@@ -404,7 +404,7 @@ QED
 val decs_closed_def = Define `
     decs_closed (reachable : num_set) decs ⇔  ∀ r t . analyse_code decs = (r,t)
     ⇒ domain r ⊆ domain reachable ∧
-      (∀ n m . n ∈ domain reachable ∧ is_reachable (mk_wf_set_tree t) n m
+      (∀ n m . n ∈ domain reachable ∧ is_reachable t n m
       ⇒ m ∈ domain reachable)
 `
 
@@ -413,10 +413,12 @@ Theorem decs_closed_reduce:
 Proof
     fs[decs_closed_def] >> rw[] >> Cases_on `h` >> fs[analyse_code_def]
     >- (Cases_on `analyse_exp e` >> fs[code_analysis_union_def, domain_union])
-    >- (Cases_on `analyse_exp e` >> fs[code_analysis_union_def, domain_union] >>
+    >- (
+        Cases_on `analyse_exp e` >> fs[code_analysis_union_def, domain_union] >>
         first_x_assum drule >> rw[] >> pop_assum match_mp_tac >>
-        assume_tac is_reachable_wf_set_tree_num_set_tree_union >> fs[] >>
-        fs[Once num_set_tree_union_sym])
+        fs[Once num_set_tree_union_sym] >>
+        irule is_reachable_num_set_tree_union >> simp[]
+        )
     >> metis_tac[]
 QED
 
@@ -431,12 +433,10 @@ Proof
     >- (fs[Once num_set_tree_union_sym, num_set_tree_union_def] >>
         Cases_on `analyse_code t` >>
         fs[code_analysis_union_def, domain_union] >>
-        imp_res_tac is_reachable_wf_set_tree_num_set_tree_union >>
-        pop_assum (qspec_then `r` mp_tac) >> strip_tac >> res_tac)
-    >- (fs[EVAL ``mk_wf_set_tree LN``] >>
-        imp_res_tac reachable_domain >> fs[domain_def])
-    >- (fs[EVAL ``mk_wf_set_tree LN``] >>
-        imp_res_tac reachable_domain >> fs[domain_def])
+        first_x_assum irule >> goal_assum drule >>
+        irule is_reachable_num_set_tree_union >> simp[]
+        )
+    >> imp_res_tac reachable_domain >> gvs[]
 QED
 
 (* s = state, t = removed state *)
@@ -651,20 +651,6 @@ QED
 
 
 (**************************** MAIN LEMMAS *****************************)
-
-Theorem analysis_reachable_thm:
-    ∀ (compiled : dec list) start tree t .
-        ((start, t) = analyse_code compiled) ∧
-        (tree = mk_wf_set_tree t)
-    ⇒ domain (closure_spt start tree) =
-        {a | ∃ n . is_reachable tree n a ∧ n ∈ domain start}
-Proof
-    rw[] >> qspecl_then [`mk_wf_set_tree t`, `start`] mp_tac closure_spt_thm >>
-    rw[] >> `wf_set_tree(mk_wf_set_tree t)` by metis_tac[mk_wf_set_tree_thm] >>
-    qspecl_then [`compiled`, `start`, `t`] mp_tac analyse_code_thm >>
-    qspec_then `t` mp_tac mk_wf_set_tree_domain >> rw[] >>
-    metis_tac[SUBSET_TRANS]
-QED
 
 Theorem flat_state_rel_pmatch:
   (!(new_state:'a state) p a env.
@@ -1117,20 +1103,12 @@ Proof
     fs[Once num_set_tree_union_sym, num_set_tree_union_def] >>
     simp[SUBSET_DEF] >>
     rw[] >> first_x_assum match_mp_tac >>
-    fs[spt_eq_thm, wf_inter, wf_def] >> fs[lookup_inter_alt] >>
+    fs[spt_eq_thm, lookup_inter_alt] >>
     fs[lookup_def] >> Cases_on `lookup n (find_loc e)` >> fs[] >>
     fs[domain_lookup] >>
     asm_exists_tac >> fs[] >> fs[is_reachable_def] >>
     match_mp_tac RTC_SINGLE >> fs[is_adjacent_def] >>
-    `(lookup n (map (K (find_lookups e)) (find_loc e))) =
-        SOME (find_lookups e)` by fs[lookup_map] >>
-    imp_res_tac lookup_mk_wf_set_tree >> fs[] >>
-    `wf_set_tree (mk_wf_set_tree
-        (map (K (find_lookups e)) (find_loc e)))`
-        by metis_tac[mk_wf_set_tree_thm] >>
-    fs[wf_set_tree_def] >> res_tac >> `y = find_lookups e`
-        by metis_tac[wf_find_lookups, num_set_domain_eq] >>
-    rveq >> fs[] >> fs[SUBSET_DEF, domain_lookup]
+    fs[lookup_map]
   ) >>
   fs[] >> `r ≠ Rerr (Rabort Rtype_error)` by
     (CCONTR_TAC >> Cases_on `r` >> fs[]) >> fs[] >>
@@ -1541,7 +1519,7 @@ Theorem flat_removal_thm:
         (new_state, result) ∧
       result ≠ SOME (Rabort Rtype_error) ∧
       (roots, tree) = analyse_code decs ∧
-      reachable = closure_spt roots (mk_wf_set_tree tree) ∧
+      reachable = closure_spt roots tree ∧
       remove_unreachable reachable decs = removed_decs
   ⇒ ∃ s .
       s.ffi = new_state.ffi /\
@@ -1551,24 +1529,20 @@ Proof
   rpt strip_tac >> drule flat_decs_removal_lemma >>
   rpt (disch_then drule) >> strip_tac >>
   pop_assum (qspec_then `initial_state ffi k check_ctor` mp_tac) >>
-  reverse(impl_tac)
-  >- (rw[] >> fs[]) >>
-  qspecl_then [`decs`, `roots`, `mk_wf_set_tree tree`, `tree`]
-    mp_tac analysis_reachable_thm >>
-  impl_tac >> rw[initial_state_def]
+  impl_tac >> gvs[] >>
+  qspecl_then [`tree`,`roots`] mp_tac closure_spt_thm >> strip_tac >>
+  rw[initial_state_def]
   >- (
     fs[flat_state_rel_def, globals_rel_def] >>
     fs[find_refs_globals_def]
     )
   >- (
-    fs[decs_closed_def] >> rw[] >>
-    `(r,t) = (roots, tree)` by metis_tac[] >>
-    fs[] >> rveq
+    fs[decs_closed_def] >> rw[] >> gvs[]
     >- (rw[SUBSET_DEF] >> qexists_tac `x` >> fs[is_reachable_def])
     >- (
       qexists_tac `n'` >> fs[is_reachable_def] >>
-       metis_tac[transitive_RTC, transitive_def]
-       )
+      metis_tac[transitive_RTC, transitive_def]
+      )
     )
 QED
 

--- a/compiler/backend/proofs/flat_elimProofScript.sml
+++ b/compiler/backend/proofs/flat_elimProofScript.sml
@@ -14,7 +14,7 @@ val grammar_ancestry =
 val _ = set_grammar_ancestry grammar_ancestry;
 
 
-(**************************** ANALYSIS LEMMAS *****************************)
+(************************** LEMMAS ***************************)
 
 Theorem is_pure_EVERY_aconv:
      ∀ es . EVERY (λ a . is_pure a) es = EVERY is_pure es
@@ -22,46 +22,6 @@ Proof
     Induct >> fs[]
 QED
 
-Theorem wf_find_loc_wf_find_locL:
-     (∀ e locs . find_loc  e = locs ⇒ wf locs) ∧
-    (∀ l locs . find_locL l = locs ⇒ wf locs)
-Proof
-    ho_match_mp_tac find_loc_ind >> rw[find_loc_def, wf_union] >> rw[wf_def] >>
-    Cases_on `dest_GlobalVarInit op` >> fs[wf_insert]
-QED
-
-Theorem wf_find_locL:
-     ∀ l . wf(find_locL l)
-Proof
-    metis_tac[wf_find_loc_wf_find_locL]
-QED
-
-Theorem wf_find_loc:
-     ∀ e . wf(find_loc e)
-Proof
-    metis_tac[wf_find_loc_wf_find_locL]
-QED
-
-Theorem wf_find_lookups_wf_find_lookupsL:
-     (∀ e lookups . find_lookups e = lookups ⇒ wf lookups) ∧
-    (∀ l lookups . find_lookupsL l = lookups ⇒ wf lookups)
-Proof
-    ho_match_mp_tac find_lookups_ind >>
-    rw[find_lookups_def, wf_union] >> rw[wf_def] >>
-    Cases_on `dest_GlobalVarLookup op` >> fs[wf_insert]
-QED
-
-Theorem wf_find_lookupsL:
-     ∀ l . wf(find_lookupsL l)
-Proof
-    metis_tac[wf_find_lookups_wf_find_lookupsL]
-QED
-
-Theorem wf_find_lookups:
-     ∀ e . wf(find_lookups e)
-Proof
-    metis_tac[wf_find_lookups_wf_find_lookupsL]
-QED
 
 Theorem find_lookupsL_MEM:
      ∀ e es . MEM e es ⇒ domain (find_lookups e) ⊆ domain (find_lookupsL es)
@@ -95,93 +55,6 @@ Proof
        fs[inter_union_empty]
 QED
 
-Theorem wf_analyse_exp:
-     ∀ e roots tree . analyse_exp e = (roots, tree) ⇒ (wf roots) ∧ (wf tree)
-Proof
-    simp[analyse_exp_def] >> rw[] >>
-    metis_tac[
-        wf_def, wf_map, wf_union, wf_find_loc, wf_find_lookups_wf_find_lookupsL]
-QED
-
-Theorem analyse_exp_domain:
-     ∀ e roots tree . analyse_exp e = (roots, tree)
-  ⇒ (domain roots ⊆ domain tree)
-Proof
-    simp[analyse_exp_def] >> rw[] >> rw[domain_def, domain_map]
-QED
-
-(**************************** ELIMINATION LEMMAS *****************************)
-
-Theorem keep_Dlet:
-     ∀ (reachable:num_set) h . ¬ keep reachable h ⇒ ∃ x . h = Dlet x
-Proof
-   Cases_on `h` >> rw[keep_def]
-QED
-
-Theorem wf_code_analysis_union:
-     ∀ r3 r2 r1 t1 t2 t3. wf r1 ∧ wf r2
-        ∧ code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒  wf r3
-Proof
-    rw[code_analysis_union_def] >> rw[wf_union]
-QED
-
-Theorem wf_code_analysis_union_strong:
-     ∀ r3:num_set r2 r1 (t1:num_set num_map) t2 t3.
-        wf r1 ∧ wf r2 ∧ wf t1 ∧ wf t2 ∧
-        code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒  wf r3 ∧ wf t3
-Proof
-    rw[code_analysis_union_def] >> rw[wf_union] >>
-    imp_res_tac wf_num_set_tree_union >> fs[]
-QED
-
-Theorem domain_code_analysis_union:
-     ∀ r1:num_set r2 r3 (t1:num_set num_map) t2 t3 .
-    domain r1 ⊆ domain t1 ∧ domain r2 ⊆ domain t2 ∧
-    code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒ domain r3 ⊆ domain t3
-Proof
-    rw[code_analysis_union_def] >> rw[domain_union] >>
-    rw[domain_num_set_tree_union] >> fs[SUBSET_DEF]
-QED
-
-Theorem wf_code_analysis_union:
-     ∀ r3 r2 r1 t1 t2 t3. wf r1 ∧ wf r2
-        ∧ code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒  wf r3
-Proof
-    rw[code_analysis_union_def] >> rw[wf_union]
-QED
-
-Theorem wf_code_analysis_union_strong:
-     ∀ r3:num_set r2 r1 (t1:num_set num_map) t2 t3.
-        wf r1 ∧ wf r2 ∧ wf t1 ∧ wf t2 ∧
-        code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒  wf r3 ∧ wf t3
-Proof
-    rw[code_analysis_union_def] >> rw[wf_union] >>
-    imp_res_tac wf_num_set_tree_union >> fs[]
-QED
-
-Theorem domain_code_analysis_union:
-     ∀ r1:num_set r2 r3 (t1:num_set num_map) t2 t3 .
-    domain r1 ⊆ domain t1 ∧ domain r2 ⊆ domain t2 ∧
-    code_analysis_union (r1, t1) (r2, t2) = (r3, t3) ⇒ domain r3 ⊆ domain t3
-Proof
-    rw[code_analysis_union_def] >> rw[domain_union] >>
-    rw[domain_num_set_tree_union] >> fs[SUBSET_DEF]
-QED
-
-Theorem analyse_code_thm:
-     ∀ code root tree . analyse_code code = (root, tree)
-    ⇒ (wf root) ∧ (domain root ⊆ domain tree)
-Proof
-    Induct
-    >-(rw[analyse_code_def] >> rw[wf_def])
-    >> Cases_on `h` >> simp[analyse_code_def] >> Cases_on `analyse_exp e` >>
-       Cases_on `analyse_code code` >>
-       first_x_assum (qspecl_then [`q'`, `r'`] mp_tac) >> simp[] >>
-       qspecl_then [`e`, `q`, `r`] mp_tac wf_analyse_exp >> simp[] >> rw[]
-       >- imp_res_tac wf_code_analysis_union
-       >> qspecl_then [`e`, `q`, `r`] mp_tac analyse_exp_domain >> rw[] >>
-          imp_res_tac domain_code_analysis_union
-QED
 
 (************************** DEFINITIONS ***************************)
 
@@ -1497,19 +1370,16 @@ Proof
           imp_res_tac evaluate_dec_state_unchanged >> fs[]
           )
         >>  reverse(EVERY_CASE_TAC) >> fs[] >> rveq >>
-            imp_res_tac keep_Dlet >> rveq >>
+            Cases_on `h` >> gvs[keep_def] >>
             fs[Once evaluate_dec_def] >> EVERY_CASE_TAC >> fs[] >>
             rveq >> rw[UNION_EMPTY]
-            >- (drule evaluate_sing_notKeep_flat_state_rel >> fs[] >>
+            >- (drule evaluate_sing_notKeep_flat_state_rel >> fs[keep_def] >>
                 strip_tac >>
                 pop_assum (qspecl_then [`reachable`, `removed_state`] mp_tac) >>
                 strip_tac >> fs[])
             >>  first_x_assum match_mp_tac >> fs[] >> asm_exists_tac >> fs[] >>
                 imp_res_tac decs_closed_reduce >> fs[] >>
-                drule evaluate_sing_notKeep_flat_state_rel >> fs[] >>
-                disch_then drule >>
-                disch_then drule >>
-                fs [flat_state_rel_def]
+                drule evaluate_sing_notKeep_flat_state_rel >> fs[keep_def]
 QED
 
 Theorem flat_removal_thm:

--- a/compiler/backend/reachability/README.md
+++ b/compiler/backend/reachability/README.md
@@ -1,7 +1,7 @@
-Generic reachability operations
+Generic closure operation over next-step sptrees (num_set num_maps)
 
 [proofs](proofs):
-Correctness proofs of reachability operations
+Proof of correctness of closure operation over next-step sptrees
 
 [reachable_sptScript.sml](reachable_sptScript.sml):
-Implementation of various closure operations for num_map and num_set
+Implementation of closure operation over num_set num_maps

--- a/compiler/backend/reachability/proofs/README.md
+++ b/compiler/backend/reachability/proofs/README.md
@@ -1,4 +1,4 @@
-Correctness proofs of reachability operations
+Proof of correctness of closure operation over next-step sptrees
 
 [reachable_sptProofScript.sml](reachable_sptProofScript.sml):
-Proofs of various closure operations for num_map and num_set
+Proof of correctness of closure operation over num_set num_maps

--- a/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
+++ b/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
@@ -6,8 +6,11 @@ open preamble reachable_sptTheory
 
 val _ = new_theory "reachable_sptProof";
 
+
+(**************************** num_set_tree_union *****************************)
+
 Theorem num_set_tree_union_empty:
-     ∀ t1 t2 . isEmpty(num_set_tree_union t1 t2) ⇔ isEmpty t1 ∧ isEmpty t2
+     ∀ t1 t2 . isEmpty (num_set_tree_union t1 t2) ⇔ isEmpty t1 ∧ isEmpty t2
 Proof
     Induct >> rw[num_set_tree_union_def] >> CASE_TAC >>
     rw[num_set_tree_union_def]
@@ -41,154 +44,25 @@ Proof
     fs[union_num_set_sym]
 QED
 
-Theorem lookup_domain_num_set_tree_union:
-     ∀ n (t1:num_set num_map) t2 x . lookup n t1 = SOME x
-  ⇒ ∃ y . lookup n (num_set_tree_union t1 t2) = SOME y ∧ domain x ⊆ domain y
-Proof
-    Induct_on `t1` >> rw[]
-    >- fs[lookup_def]
-    >- (fs[lookup_def, num_set_tree_union_def] >> CASE_TAC >>
-        fs[lookup_def, domain_union])
-    >- (fs[lookup_def, num_set_tree_union_def] >> CASE_TAC >>
-        fs[lookup_def, domain_union] >> Cases_on `EVEN n` >> fs[])
-    >- (fs[lookup_def, num_set_tree_union_def] >> CASE_TAC >>
-        fs[lookup_def, domain_union] >>
-        Cases_on `n = 0` >> fs[domain_union] >> Cases_on `EVEN n` >> fs[])
-QED
-
-Theorem lookup_NONE_num_set_tree_union:
-     ∀ n (t1:num_set num_map) t2 . lookup n t1 = NONE
-    ⇒ lookup n (num_set_tree_union t1 t2) = lookup n t2
-Proof
-    Induct_on `t1` >> rw[] >> fs[lookup_def, num_set_tree_union_def] >>
-    Cases_on `t2` >> fs[lookup_def] >> Cases_on `n = 0` >> fs[] >>
-    Cases_on `EVEN n` >> fs[]
-QED
-
-Theorem lookup_SOME_SOME_num_set_tree_union:
-     ∀ n (t1:num_set num_map) x1 t2 x2 .
-    lookup n t1 = SOME x1 ∧ lookup n t2 = SOME x2
-  ⇒ lookup n (num_set_tree_union t1 t2) = SOME (union x1 x2)
-Proof
-    Induct_on `t1` >> rw[] >> fs[lookup_def, num_set_tree_union_def] >>
-    Cases_on `t2` >> fs[lookup_def] >>
-    Cases_on `EVEN n` >> fs[] >>
-    Cases_on `n = 0` >> fs[]
-QED
-
 Theorem lookup_num_set_tree_union:
-     ∀ (t1 : num_set num_map) t2 n .
-        lookup n (num_set_tree_union t1 t2) = case (lookup n t1) of
-            | NONE => lookup n t2
-            | SOME s1 => case (lookup n t2) of
-                | NONE => SOME s1
-                | SOME s2 => SOME (union s1 s2)
+  ∀t1 t2 n.
+    lookup n (num_set_tree_union t1 t2) =
+    case lookup n t1 of
+      SOME x => (
+        case lookup n t2 of
+          SOME y => SOME (union x y)
+        | NONE => SOME x)
+    | NONE => lookup n t2
 Proof
-    rw[] >> Cases_on `lookup n t1` >> fs[]
-    >-  fs[lookup_NONE_num_set_tree_union]
-    >- (Cases_on `lookup n t2` >> fs[]
-        >- (fs[lookup_NONE_num_set_tree_union, num_set_tree_union_sym] >>
-            imp_res_tac lookup_NONE_num_set_tree_union >>
-            pop_assum (qspec_then `t1` mp_tac) >> rw[] >>
-            fs[num_set_tree_union_sym])
-        >-  fs[lookup_SOME_SOME_num_set_tree_union])
+  Induct >> rw[] >> gvs[lookup_def]
+  >- simp[num_set_tree_union_def] >>
+  IF_CASES_TAC >> gvs[lookup_def] >>
+  Cases_on `t2` >> gvs[lookup_def, num_set_tree_union_def] >>
+  EVERY_CASE_TAC >> gvs[]
 QED
 
 
-(**************************** REACHABILITY LEMMAS *****************************)
-
-Theorem subspt_superdomain:
-   ∀ t1 a t2 . subspt (superdomain t1) (superdomain (BS t1 a t2)) ∧
-               subspt (superdomain t2) (superdomain (BS t1 a t2)) ∧
-               subspt a (superdomain (BS t1 a t2)) ∧
-               subspt (superdomain t1) (superdomain (BN t1 t2)) ∧
-               subspt (superdomain t2) (superdomain (BN t1 t2))
-Proof
-    fs[subspt_domain, superdomain_def] >>
-    fs[SUBSET_DEF, domain_lookup, lookup_spt_fold_union_STRONG, lookup_def] >>
-    rw[]
-    >- (
-      qexists_tac `2 * n1 + 2` >>
-      fs[EVEN_DOUBLE, EVEN_ADD] >>
-      once_rewrite_tac[MULT_COMM] >> fs[DIV_MULT]
-      )
-    >- (
-      qexists_tac `2 * n1 + 1` >>
-      fs[EVEN_DOUBLE, EVEN_ADD] >>
-      once_rewrite_tac[MULT_COMM] >> fs[MULT_DIV]
-      )
-    >- (
-      qexists_tac `0` >>
-      fs[]
-      )
-    >- (
-      qexists_tac `2 * n1 + 2` >>
-      fs[EVEN_DOUBLE, EVEN_ADD] >>
-      once_rewrite_tac[MULT_COMM] >> fs[DIV_MULT]
-      )
-    >- (
-      qexists_tac `2 * n1 + 1` >>
-      fs[EVEN_DOUBLE, EVEN_ADD] >>
-      once_rewrite_tac[MULT_COMM] >> fs[MULT_DIV]
-      )
-QED
-
-Theorem superdomain_thm:
-   ∀ x y (tree : unit spt spt) . lookup x tree = SOME y
-  ⇒ domain y ⊆ domain (superdomain tree)
-Proof
-    fs[superdomain_def, domain_lookup, SUBSET_DEF] >>
-    fs[lookup_spt_fold_union_STRONG, lookup_def] >>
-    rw[] >> metis_tac[]
-QED
-
-Theorem superdomain_inverse_thm:
-   ∀ n tree . n ∈ domain (superdomain tree)
-  ⇒ ∃ k aSet . lookup k tree = SOME aSet ∧ n ∈ domain aSet
-Proof
-    fs[superdomain_def, domain_lookup] >>
-    fs[lookup_spt_fold_union_STRONG, lookup_def]
-QED
-
-Theorem superdomain_not_in_thm:
-   ∀ n tree . n ∉ domain (superdomain tree)
-  ⇒ ∀ k aSet . lookup k tree = SOME aSet ⇒ n ∉ domain aSet
-Proof
-    fs[superdomain_def, domain_lookup] >>
-    fs[lookup_spt_fold_union_STRONG, lookup_def] >>
-    rw[] >> metis_tac[]
-QED
-
-Theorem mk_wf_set_tree_domain:
-     ∀ tree . domain tree ⊆ domain (mk_wf_set_tree tree)
-Proof
-    Induct >>
-    rw[mk_wf_set_tree_def, domain_map, domain_mk_wf, domain_union, SUBSET_DEF]
-QED
-
-Theorem mk_wf_set_tree_thm:
-     ∀ x tree . x = mk_wf_set_tree tree ⇒ wf_set_tree x
-Proof
-    rw[mk_wf_set_tree_def, wf_set_tree_def] >> fs[lookup_map] >>
-    rw[domain_map, domain_union] >> fs[lookup_union] >>
-    Cases_on `lookup x' tree` >> fs[] >- fs[lookup_map] >> rw[] >>
-    qspecl_then [`x'`, `x`, `tree`] mp_tac superdomain_thm >> rw[SUBSET_DEF]
-QED
-
-Theorem lookup_mk_wf_set_tree:
-     ∀ n tree x . lookup n tree = SOME x
-  ⇒ ∃ y . lookup n (mk_wf_set_tree tree) = SOME y ∧ domain x = domain y
-Proof
-    rw[mk_wf_set_tree_def] >> rw[lookup_map] >> rw[lookup_union]
-QED
-
-Theorem lookup_domain_mk_wf_set_tree:
-     ∀ n t x y . lookup n (mk_wf_set_tree t) = SOME x ⇒
-        lookup n t = SOME y ⇒ domain y = domain x
-Proof
-    rw[mk_wf_set_tree_def] >> fs[lookup_map, lookup_union] >>
-    metis_tac[domain_mk_wf]
-QED
+(**************************** OTHER LEMMAS *****************************)
 
 Theorem wf_closure_spt:
   ∀ reachable tree.
@@ -200,72 +74,8 @@ Proof
     once_rewrite_tac [closure_spt_def] >> rw[] >> fs[] >>
     last_x_assum irule >> goal_assum drule >>
     irule wf_union >> simp[] >>
-    irule wf_spt_fold_tree >> simp[wf_def, lookup_inter] >>
+    irule wf_spt_fold_union_num_set >> simp[wf_def, lookup_inter] >>
     rw[] >> EVERY_CASE_TAC >> gvs[] >> res_tac
-QED
-
-
-(**************************** OTHER LEMMAS *****************************)
-
-Theorem domain_superdomain_num_set_tree_union:
-     ∀ t1 t2 . domain (superdomain t1)
-        ⊆ domain (superdomain (num_set_tree_union t1 t2))
-Proof
-    fs[SUBSET_DEF] >> rw[] >> imp_res_tac superdomain_inverse_thm >>
-    imp_res_tac lookup_domain_num_set_tree_union >>
-    pop_assum (qspec_then `t2` mp_tac) >>
-    rw[] >> imp_res_tac superdomain_thm >> metis_tac[SUBSET_DEF]
-QED
-
-Theorem domain_superdomain_num_set_tree_union_STRONG:
-     ∀ t1 t2 . domain (superdomain t1) ∪ domain (superdomain t2) =
-        domain (superdomain (num_set_tree_union t1 t2))
-Proof
-    fs[EXTENSION] >> rw[] >> EQ_TAC >> rw[]
-    >- metis_tac[domain_superdomain_num_set_tree_union,
-                 SUBSET_DEF, num_set_tree_union_sym]
-    >- metis_tac[domain_superdomain_num_set_tree_union,
-                 SUBSET_DEF, num_set_tree_union_sym]
-    >- (imp_res_tac superdomain_inverse_thm >> fs[lookup_num_set_tree_union] >>
-        EVERY_CASE_TAC >> fs[]
-        >- (disj1_tac >> imp_res_tac superdomain_thm >> fs[SUBSET_DEF])
-        >- (disj2_tac >> imp_res_tac superdomain_thm >> fs[SUBSET_DEF])
-        >- (rveq >> imp_res_tac superdomain_thm >>
-            fs[SUBSET_DEF, domain_union])
-       )
-QED
-
-Theorem mk_wf_set_tree_num_set_tree_union:
-     ∀ t1 t2 . mk_wf_set_tree (num_set_tree_union t1 t2) =
-        num_set_tree_union (mk_wf_set_tree t1) (mk_wf_set_tree t2)
-Proof
-    rw[] >>
-    `wf (mk_wf_set_tree (num_set_tree_union t1 t2))`
-        by metis_tac[mk_wf_set_tree_thm, wf_set_tree_def] >>
-    `wf (num_set_tree_union (mk_wf_set_tree t1) (mk_wf_set_tree t2))` by
-        metis_tac[mk_wf_set_tree_thm, wf_set_tree_def,
-                  wf_num_set_tree_union] >>
-    rw[spt_eq_thm] >> simp[mk_wf_set_tree_def] >> fs[lookup_map] >>
-    fs[lookup_union] >> fs[lookup_map] >>
-    fs[lookup_num_set_tree_union] >> fs[lookup_map] >>
-    fs[lookup_union] >> fs[lookup_map] >>
-    fs[OPTION_MAP_COMPOSE, mk_wf_def] >> Cases_on `lookup n t1` >>
-    Cases_on `lookup n t2` >> fs[] >>
-    EVERY_CASE_TAC >> fs[mk_wf_def, union_def] >>
-    fs[lookup_NONE_domain, GSYM domain_lookup] >>
-    qspecl_then [`t1`, `t2`] mp_tac
-        domain_superdomain_num_set_tree_union_STRONG >>
-    strip_tac >> fs[EXTENSION]
-    >-  metis_tac[]
-    >- (qsuff_tac `n ∈ domain (superdomain (num_set_tree_union t1 t2))`
-        >- rw[domain_lookup]
-        >> imp_res_tac domain_lookup >> metis_tac[])
-    >- (qsuff_tac `n ∈ domain (superdomain (num_set_tree_union t1 t2))`
-        >- rw[domain_lookup]
-        >> imp_res_tac domain_lookup >> metis_tac[])
-    >- (qsuff_tac `n ∈ domain (superdomain (num_set_tree_union t1 t2))`
-        >- rw[domain_lookup]
-        >> imp_res_tac domain_lookup >> metis_tac[])
 QED
 
 
@@ -285,82 +95,37 @@ Proof
     metis_tac[adjacent_domain]
 QED
 
-Theorem rtc_is_adjacent:
-     s ⊆ t ∧ (∀ k . k ∈ t ⇒ ∀ n . (is_adjacent fullTree k n ⇒ n ∈ t)) ⇒
-    ∀ x y . RTC(is_adjacent fullTree) x y ⇒ x ∈ s ⇒ y ∈ t
-Proof
-    strip_tac >>
-    ho_match_mp_tac RTC_INDUCT_RIGHT1 >>
-    fs[SUBSET_DEF] >>
-    metis_tac []
-QED
-
-Theorem is_adjacent_num_set_tree_union:
-     ∀ t1 t2 n m .
-        is_adjacent t1 n m ⇒ is_adjacent (num_set_tree_union t1 t2) n m
-Proof
-    rw[is_adjacent_def] >> imp_res_tac lookup_domain_num_set_tree_union >>
-    first_x_assum (qspec_then `t2` mp_tac) >> rw[] >>
-    goal_assum drule >>
-    fs[SUBSET_DEF, domain_lookup]
-QED
-
-Theorem is_adjacent_wf_set_tree_num_set_tree_union:
-     ∀ t1 t2 n m .
-        is_adjacent (mk_wf_set_tree t1) n m
-        ⇒ is_adjacent (mk_wf_set_tree (num_set_tree_union t1 t2)) n m
-Proof
-    rw[is_adjacent_def] >> fs[mk_wf_set_tree_def] >> fs[lookup_map] >>
-    fs[lookup_union] >> fs[lookup_map] >> fs[PULL_EXISTS] >>
-    fs[lookup_num_set_tree_union] >>
-    Cases_on `lookup n t1` >> fs[] >> Cases_on `lookup n t2` >> fs[] >>
-    rveq >> fs[lookup_def, mk_wf_def, lookup_union] >>
-    EVERY_CASE_TAC >> fs[] >>
-    qspecl_then [`t1`, `t2`] mp_tac domain_superdomain_num_set_tree_union >>
-    rw[SUBSET_DEF, domain_lookup]
-QED
-
-Theorem is_reachable_num_set_tree_union:
-     ∀ t1 t2 n m .
-        is_reachable t1 n m
-      ⇒ is_reachable (num_set_tree_union t1 t2) n m
-Proof
-    simp[is_reachable_def] >> strip_tac >> strip_tac >>
-    ho_match_mp_tac RTC_INDUCT_RIGHT1 >> rw[] >>
-    simp[Once RTC_CASES2] >> disj2_tac >> qexists_tac `m` >> fs[] >>
-    imp_res_tac is_adjacent_num_set_tree_union >> fs[]
-QED
-
-Theorem is_reachable_wf_set_tree_num_set_tree_union:
-     ∀ t1 t2 n m .
-        is_reachable (mk_wf_set_tree t1) n m
-      ⇒ is_reachable (mk_wf_set_tree (num_set_tree_union t1 t2)) n m
-Proof
-    simp[is_reachable_def] >> strip_tac >> strip_tac >>
-    ho_match_mp_tac RTC_INDUCT_RIGHT1 >> rw[] >>
-    simp[Once RTC_CASES2] >> disj2_tac >> qexists_tac `m` >> fs[] >>
-    imp_res_tac is_adjacent_wf_set_tree_num_set_tree_union >> fs[]
-QED
-
-Theorem is_reachable_LHS_NOTIN:
+Theorem reachable_LHS_NOTIN:
   ∀tree n x. is_reachable tree n x ∧ n ∉ domain tree ⇒ n = x
 Proof
   rw[is_reachable_def] >> gvs[Once RTC_CASES1, is_adjacent_def, domain_lookup]
 QED
 
-Theorem rtc_is_adjacent2:
-  ∀r s tree.
-    (∀k. k ∈ r ⇒ ∀n. is_adjacent tree k n ⇒ n ∈ s) ∧
-    (∀l. l ∈ s ∧ l ∉ r ⇒ l ∉ domain tree) ∧
-    r ⊆ s
-  ⇒ ∀x y. (is_adjacent tree)꙳ x y ⇒ x ∈ r ⇒ y ∈ s
+Theorem rtc_is_adjacent:
+  (∀ k . k ∈ t ⇒ ∀ n . (is_adjacent fullTree k n ⇒ n ∈ t)) ⇒
+  ∀ x y . RTC(is_adjacent fullTree) x y ⇒ x ∈ t ⇒ y ∈ t
 Proof
-  rpt gen_tac >> strip_tac >>
-  ho_match_mp_tac RTC_INDUCT_RIGHT1 >> fs[SUBSET_DEF] >>
-  rw[] >> gvs[] >>
-  reverse (Cases_on `y ∈ r`)
-  >- (res_tac >> gvs[is_adjacent_def, domain_lookup]) >>
-  metis_tac[]
+  strip_tac >> ho_match_mp_tac RTC_INDUCT_RIGHT1 >>
+  fs[SUBSET_DEF] >> metis_tac []
+QED
+
+Theorem is_adjacent_num_set_tree_union:
+  ∀ t1 t2 n m .
+    is_adjacent t1 n m ⇒ is_adjacent (num_set_tree_union t1 t2) n m
+Proof
+  rw[is_adjacent_def, lookup_num_set_tree_union] >> simp[] >>
+  EVERY_CASE_TAC >> gvs[lookup_union]
+QED
+
+Theorem is_reachable_num_set_tree_union:
+  ∀ t1 t2 n m .
+    is_reachable t1 n m
+  ⇒ is_reachable (num_set_tree_union t1 t2) n m
+Proof
+  simp[is_reachable_def] >> strip_tac >> strip_tac >>
+  ho_match_mp_tac RTC_INDUCT_RIGHT1 >> rw[] >>
+  simp[Once RTC_CASES2] >> disj2_tac >>
+  goal_assum drule >> irule is_adjacent_num_set_tree_union >> simp[]
 QED
 
 
@@ -375,25 +140,21 @@ Theorem closure_spt_lemma:
 Proof
   recInduct closure_spt_ind >> rw[] >>
   once_rewrite_tac[closure_spt_def] >> simp[] >>
-  IF_CASES_TAC
+  IF_CASES_TAC >> gvs[]
   >- (
-    gvs[domain_difference, domain_spt_fold_union_eq, PULL_EXISTS,
-        EXTENSION, SUBSET_DEF, superdomain_rewrite, subspt_domain] >>
+    gvs[subspt_domain, domain_spt_fold_union_num_set, EXTENSION,
+        SUBSET_DEF, PULL_EXISTS] >>
     rw[] >> eq_tac >> rw[] >>
-    gvs[DISJ_EQ_IMP, PULL_EXISTS] >>
     irule rtc_is_adjacent >>
-    irule_at Any SUBSET_REFL >> gvs[SUBSET_DEF, is_reachable_def] >>
+    gvs[is_reachable_def] >>
     goal_assum (drule_at Any) >> gvs[] >> rw[] >>
     first_x_assum irule >>
     gvs[lookup_inter, is_adjacent_def, domain_lookup] >>
     qexistsl_tac [`aSetx`,`k`] >> simp[]
     ) >>
-  first_x_assum irule >> simp[] >> reverse (rw[])
-  >- gvs[domain_union, SUBSET_DEF] >>
-  gvs[domain_union, domain_spt_fold_union_eq,
-      superdomain_rewrite, lookup_inter] >>
-  EVERY_CASE_TAC >> gvs[] >> rename1 `lookup r reachable` >>
-  gvs[domain_lookup] >>
+  first_x_assum irule >> simp[] >> rw[] >> gvs[domain_union, SUBSET_DEF] >>
+  gvs[domain_spt_fold_union_num_set, lookup_inter] >>
+  EVERY_CASE_TAC >> gvs[domain_lookup] >>
   first_x_assum drule >> strip_tac >>
   goal_assum drule >> gvs[is_reachable_def] >>
   irule (iffRL RTC_CASES2) >> DISJ2_TAC >>

--- a/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
+++ b/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
@@ -1,5 +1,5 @@
 (*
-  Proofs of various closure operations for num_map and num_set
+  Proof of correctness of closure operation over num_set num_maps
 *)
 
 open preamble reachable_sptTheory

--- a/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
+++ b/compiler/backend/reachability/proofs/reachable_sptProofScript.sml
@@ -320,6 +320,17 @@ Proof
     rw[SUBSET_DEF, domain_lookup]
 QED
 
+Theorem is_reachable_num_set_tree_union:
+     ∀ t1 t2 n m .
+        is_reachable t1 n m
+      ⇒ is_reachable (num_set_tree_union t1 t2) n m
+Proof
+    simp[is_reachable_def] >> strip_tac >> strip_tac >>
+    ho_match_mp_tac RTC_INDUCT_RIGHT1 >> rw[] >>
+    simp[Once RTC_CASES2] >> disj2_tac >> qexists_tac `m` >> fs[] >>
+    imp_res_tac is_adjacent_num_set_tree_union >> fs[]
+QED
+
 Theorem is_reachable_wf_set_tree_num_set_tree_union:
      ∀ t1 t2 n m .
         is_reachable (mk_wf_set_tree t1) n m

--- a/compiler/backend/reachability/proofs/readmePrefix
+++ b/compiler/backend/reachability/proofs/readmePrefix
@@ -1,1 +1,1 @@
-Correctness proofs of reachability operations
+Proof of correctness of closure operation over next-step sptrees

--- a/compiler/backend/reachability/reachable_sptScript.sml
+++ b/compiler/backend/reachability/reachable_sptScript.sml
@@ -33,33 +33,6 @@ val num_set_tree_union_def = Define `
                 (num_set_tree_union t2 t2'))
 `;
 
-val superdomain_def = Define `
-    superdomain (t:num_set num_map) = spt_fold union LN t
-`
-
-val mk_wf_set_tree_def = Define `
-    mk_wf_set_tree t =
-        let t' = union t (map (K LN) (superdomain t)) in mk_wf (map (mk_wf) t')
-`
-
-Theorem superdomain_rewrite:
-  ∀tree.
-    domain (superdomain tree) =
-    {n | ∃k aSet. lookup k tree = SOME aSet ∧ n ∈ domain aSet}
-Proof
-  rw[EXTENSION] >> eq_tac >> rw[] >>
-  fs[superdomain_def, domain_lookup,
-     lookup_spt_fold_union_STRONG, lookup_def] >>
-  goal_assum drule >> simp[]
-QED
-
-Theorem domain_spt_fold_union_eq:
-  ∀y tree. domain (spt_fold union y tree) = domain y ∪ domain (superdomain tree)
-Proof
-  simp[superdomain_rewrite] >>
-  rw[EXTENSION, domain_lookup, lookup_spt_fold_union_STRONG]
-QED
-
 Definition closure_spt_def:
   closure_spt (reachable: num_set) tree =
     let sets = inter tree reachable in
@@ -67,22 +40,17 @@ Definition closure_spt_def:
     if subspt nodes reachable then reachable
     else closure_spt (union reachable nodes) tree
 Termination
-  WF_REL_TAC `measure (λ (r,t). size (difference (superdomain t) r))` >> rw[] >>
+  WF_REL_TAC `measure (λ (r,t). size (difference (spt_fold union LN t) r))` >>
+  rw[] >>
   gvs[subspt_domain, SUBSET_DEF] >>
   irule size_diff_less >>
-  fs[domain_union, domain_difference, domain_spt_fold_union_eq,
-     GSYM MEMBER_NOT_EMPTY] >>
-  goal_assum drule >> simp[] >>
-  gvs[superdomain_rewrite, lookup_inter] >>
-  EVERY_CASE_TAC >> gvs[] >> goal_assum drule >> simp[]
+  gvs[domain_union, domain_spt_fold_union_num_set, lookup_inter] >>
+  EVERY_CASE_TAC >> gvs[] >>
+  simp[PULL_EXISTS, GSYM CONJ_ASSOC] >>
+  goal_assum drule >> goal_assum drule >> simp[] >>
+  goal_assum (drule_at Any) >>
+  qexists_tac `k` >> simp[]
 End
-
-val wf_set_tree_def = Define `
-    wf_set_tree tree ⇔
-        (∀ x  y . (lookup x tree = SOME y) ⇒ domain y ⊆ domain tree) ∧
-        (∀ n x . lookup n tree = SOME x ⇒ wf x) ∧
-        wf tree
-`
 
 val is_adjacent_def = Define `
     is_adjacent tree x y =

--- a/compiler/backend/reachability/reachable_sptScript.sml
+++ b/compiler/backend/reachability/reachable_sptScript.sml
@@ -1,5 +1,5 @@
 (*
-  Implementation of various closure operations for num_map and num_set
+  Implementation of closure operation over num_set num_maps
 *)
 
 open preamble sptreeTheory

--- a/compiler/backend/reachability/reachable_sptScript.sml
+++ b/compiler/backend/reachability/reachable_sptScript.sml
@@ -46,7 +46,7 @@ val close_spt_def = tDefine "close_spt" `
     close_spt (reachable :num_set) (seen :num_set) (tree :num_set spt) =
         let to_look = difference seen reachable in
         let new_sets = inter tree to_look in
-            if new_sets = LN then reachable else
+            if new_sets = LN then seen else
                 let new_set = spt_fold union LN new_sets in
                     close_spt (union reachable to_look) (union seen new_set)
                         tree
@@ -75,9 +75,8 @@ val wf_set_tree_def = Define `
 
 val is_adjacent_def = Define `
     is_adjacent tree x y =
-    ∃ aSetx aSety.
-        ( lookup x tree = SOME aSetx ) ∧ ( lookup y aSetx = SOME () ) ∧
-        ( lookup y tree = SOME aSety )
+    ∃ aSetx.
+        ( lookup x tree = SOME aSetx ) ∧ ( lookup y aSetx = SOME () )
 `;
 
 val is_reachable_def = Define `

--- a/compiler/backend/reachability/readmePrefix
+++ b/compiler/backend/reachability/readmePrefix
@@ -1,1 +1,1 @@
-Generic reachability operations
+Generic closure operation over next-step sptrees (num_set num_maps)

--- a/compiler/backend/word_elimScript.sml
+++ b/compiler/backend/word_elimScript.sml
@@ -7,7 +7,7 @@
   Removes unreachable functions from the code.
 *)
 
-open preamble sptreeTheory wordLangTheory flat_elimTheory
+open preamble sptreeTheory reachable_sptTheory wordLangTheory
 
 val _ = new_theory "word_elim";
 

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -113,6 +113,8 @@ val _ = translate COUNT_LIST_compute
 
 *)
 
+val _ = translate difference_def;
+
 val _ = translate list_remap_def;
 val _ = translate mk_bij_aux_def;
 

--- a/compiler/bootstrap/translation/to_flatProgScript.sml
+++ b/compiler/bootstrap/translation/to_flatProgScript.sml
@@ -96,6 +96,7 @@ val res = translate source_to_flatTheory.compile_prog_def;
 (* flat_elim                                                                 *)
 (* ------------------------------------------------------------------------- *)
 
+val res = translate sptreeTheory.subspt_eq;
 val res = translate flat_elimTheory.remove_flat_prog_def;
 
 (* ------------------------------------------------------------------------- *)

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -759,6 +759,8 @@ QED
 Type num_set = ``:unit spt``
 Type num_map = ``:'a spt``
 
+Theorem subspt_eq[compute] = subspt_eq;
+
 Theorem toAList_domain:
     ∀x. MEM x (MAP FST (toAList t)) ⇔ x ∈ domain t
 Proof

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -3971,178 +3971,107 @@ Proof
     >- (qexists_tac `n DIV 2` >> fs[])
 QED
 
-Theorem wf_spt_fold_tree:
-     ∀ tree : num_set num_map y : num_set.
-        wf tree ∧ (∀ n x . (lookup n tree = SOME x) ⇒ wf x) ∧ wf y
-      ⇒ wf(spt_fold union y tree)
+Theorem wf_spt_fold_union_num_set:
+  ∀ tree : num_set num_map y : num_set.
+    (∀ n x . (lookup n tree = SOME x) ⇒ wf x) ∧ wf y
+  ⇒ wf(spt_fold union y tree)
 Proof
-    Induct >> rw[] >> fs[spt_fold_def]
-    >- (fs[wf_def] >> metis_tac[lookup_def, wf_union])
-    >> `wf(spt_fold union y tree)` by (
-            last_x_assum match_mp_tac >>
-            fs[] >> rw[]
-            >- fs[wf_def]
-            >> last_x_assum match_mp_tac >>
-               qexists_tac `2 * n + 2` >>
-               fs[lookup_def] >> fs[EVEN_DOUBLE, EVEN_ADD] >>
-               once_rewrite_tac[MULT_COMM] >> fs[DIV_MULT])
-    >> (last_x_assum match_mp_tac >> fs[] >> rw[]
-        >-  fs[wf_def]
-        >- (last_x_assum match_mp_tac >>
-            qexists_tac `2 * n + 1` >> fs[lookup_def, EVEN_DOUBLE, EVEN_ADD] >>
-            once_rewrite_tac[MULT_COMM] >> fs[MULT_DIV])
-        >>  `wf a` by (last_x_assum match_mp_tac >>
-                qexists_tac `0` >> fs[lookup_def]) >>
-            fs[wf_union])
-QED
-
-Theorem lookup_spt_fold_union:
-     ∀ tree : num_set num_map y : num_set n : num .
-        lookup n (spt_fold union y tree) = SOME ()
-      ⇒ lookup n y = SOME () ∨
-        ∃ n1 s . lookup n1 tree = SOME s ∧ lookup n s = SOME ()
-Proof
-    Induct >> rw[]
-    >-  fs[spt_fold_def]
-    >-  (fs[spt_fold_def, lookup_union] >> BasicProvers.EVERY_CASE_TAC >>
-        fs[] >>
-        DISJ2_TAC >>
-        qexists_tac `0` >> qexists_tac `a` >> fs[lookup_def])
+  Induct >> rw[] >> fs[spt_fold_def, wf_def]
+  >- metis_tac[lookup_def, wf_union]
+  >- (
+    last_x_assum irule >> last_x_assum (irule_at Any) >> simp[] >>
+    gvs[lookup_def] >> rw[] >>
+    last_x_assum irule
     >- (
-        fs[spt_fold_def] >>
-        res_tac
-        >- (
-            res_tac >> fs[]
-            >- (
-               DISJ2_TAC >>
-               fs[lookup_def] >>
-               qexists_tac `n1 * 2 + 2` >> qexists_tac `s` >>
-               fs[EVEN_DOUBLE, EVEN_ADD] >>
-               once_rewrite_tac[MULT_COMM] >>
-               fs[DIV_MULT]
-               )
-            >- (
-               DISJ2_TAC >>
-               fs[lookup_def] >>
-               qexists_tac `n1' * 2 + 2` >> qexists_tac `s'` >>
-               fs[EVEN_DOUBLE, EVEN_ADD] >>
-               once_rewrite_tac[MULT_COMM] >>
-               fs[DIV_MULT]
-               )
-            )
-        >- (
-            res_tac >> fs[] >>
-            DISJ2_TAC >>
-            fs[lookup_def] >>
-            qexists_tac `2 * n1 + 1` >> qexists_tac `s` >>
-            fs[EVEN_DOUBLE, EVEN_ADD] >>
-            once_rewrite_tac[MULT_COMM] >>
-            fs[MULT_DIV]
-            )
-        )
+      qexists_tac `2 * n + 2` >>
+      simp[EVEN_ADD, EVEN_DOUBLE] >>
+      once_rewrite_tac [MULT_COMM] >> simp[DIV_MULT]
+      )
     >- (
-        fs[spt_fold_def] >>
-        res_tac
-        >- (
-            fs[lookup_union] >>
-            BasicProvers.EVERY_CASE_TAC
-            >- (
-                res_tac >> fs[]
-                >- (
-                   DISJ2_TAC >>
-                   fs[lookup_def] >>
-                   qexists_tac `n1 * 2 + 2` >> qexists_tac `s` >>
-                   fs[EVEN_DOUBLE, EVEN_ADD] >>
-                   once_rewrite_tac[MULT_COMM] >>
-                   fs[DIV_MULT]
-                   )
-                >- (
-                   DISJ2_TAC >>
-                   fs[lookup_def] >>
-                   qexists_tac `n1' * 2 + 2` >> qexists_tac `s'` >>
-                   fs[EVEN_DOUBLE, EVEN_ADD] >>
-                   once_rewrite_tac[MULT_COMM] >>
-                   fs[DIV_MULT]
-                   )
-                )
-            >- (
-                DISJ2_TAC >>
-                qexists_tac `0` >> qexists_tac `a` >>
-                fs[lookup_def]
-                )
-            )
-        >- (
-            DISJ2_TAC >>
-            fs[lookup_def] >>
-            qexists_tac `2 * n1 + 1` >> qexists_tac `s` >>
-            fs[EVEN_DOUBLE, EVEN_ADD] >>
-            once_rewrite_tac[MULT_COMM] >>
-            fs[MULT_DIV]
-            )
+      qexists_tac `2 * n + 1` >>
+      simp[EVEN_ADD, EVEN_DOUBLE] >>
+      once_rewrite_tac [MULT_COMM] >> simp[MULT_DIV]
+      )
+    )
+  >- (
+    last_x_assum irule >> irule_at Any wf_union >>
+    last_x_assum (irule_at Any) >> simp[] >> rw[] >>
+    last_x_assum irule >> simp[lookup_def]
+    >- (
+      qexists_tac `2 * n + 2` >>
+      simp[EVEN_ADD, EVEN_DOUBLE] >>
+      once_rewrite_tac [MULT_COMM] >> simp[DIV_MULT]
+      )
+    >- (qexists_tac `0` >> simp[])
+    >- (
+      qexists_tac `2 * n + 1` >>
+      simp[EVEN_ADD, EVEN_DOUBLE] >>
+      once_rewrite_tac [MULT_COMM] >> simp[MULT_DIV]
+      )
     )
 QED
 
-Theorem lookup_spt_fold_union_STRONG:
-     ∀ tree : num_set num_map y : num_set n : num .
-        lookup n (spt_fold union y tree) = SOME ()
-      <=> lookup n y = SOME () ∨
-        ∃ n1 s . lookup n1 tree = SOME s ∧ lookup n s = SOME ()
+Theorem lookup_spt_fold_union_num_set:
+  ∀ tree y n.
+    lookup n (spt_fold union y tree) =
+    if lookup n y = SOME () then SOME ()
+    else if ∃m s. lookup m tree = SOME s ∧ lookup n s = SOME () then SOME ()
+    else NONE
 Proof
-    Induct >> rw[] >> EQ_TAC >> fs[lookup_spt_fold_union] >> rw[] >>
-    fs[spt_fold_def, lookup_def, lookup_union]
-    >- (BasicProvers.EVERY_CASE_TAC >> fs[])
-    >- (BasicProvers.EVERY_CASE_TAC >> fs[]
-        >- (DISJ1_TAC >> DISJ2_TAC >>
-            qexists_tac `(n1 - 1) DIV 2` >> qexists_tac `s` >> fs[])
-        >- (DISJ2_TAC >>
-            qexists_tac `(n1 - 1) DIV 2` >> qexists_tac `s` >> fs[])
-        )
-    >- (BasicProvers.EVERY_CASE_TAC >> fs[])
-    >- (BasicProvers.EVERY_CASE_TAC >> fs[]
-        >- (rw[] >> fs[NOT_NONE_SOME])
-        >- (DISJ1_TAC >> DISJ2_TAC >>
-            qexists_tac `(n1 - 1) DIV 2` >> qexists_tac `s` >> fs[])
-        >- (DISJ2_TAC >>
-            qexists_tac `(n1 - 1) DIV 2` >> qexists_tac `s` >> fs[])
-        )
-QED
-
-Theorem subspt_domain_spt_fold_union:
-     ∀ t1 : num_set num_map t2 y : num_set .
-        subspt t1 t2
-      ⇒ domain (spt_fold union y t1) ⊆ domain (spt_fold union y t2)
-Proof
-    rw[SUBSET_DEF] >> fs[domain_lookup] >>
-    qspecl_then [`t1`, `y`] mp_tac lookup_spt_fold_union_STRONG >>
-    qspecl_then [`t2`, `y`] mp_tac lookup_spt_fold_union_STRONG >>
-    ntac 2 strip_tac >> res_tac
+  Induct >> rw[] >> gvs[spt_fold_def, lookup_def, lookup_union]
+  >- (Cases_on `lookup n y` >> gvs[])
+  >- (CASE_TAC >> gvs[])
+  >- (CASE_TAC >> gvs[] >> Cases_on `lookup n y` >> gvs[])
+  >- (IF_CASES_TAC >> gvs[] >> FULL_CASE_TAC >> gvs[] >> metis_tac[])
+  >- (
+    IF_CASES_TAC >> gvs[]
+    >- (
+      first_x_assum (qspecl_then [`(m + 1) * 2`,`s`] mp_tac) >>
+      simp[EVEN_DOUBLE] >> simp[LEFT_ADD_DISTRIB] >>
+      once_rewrite_tac[MULT_COMM] >> simp[DIV_MULT]
+      )
+    >- (
+      CCONTR_TAC >> gvs[] >>
+      last_x_assum (qspecl_then [`m * 2 + 1`,`s`] mp_tac) >>
+      simp[EVEN_DOUBLE, EVEN_ADD] >>
+      once_rewrite_tac[MULT_COMM] >> simp[MULT_DIV]
+      )
+    )
+  >- (IF_CASES_TAC >> gvs[] >> FULL_CASE_TAC >> gvs[])
+  >- (
+    Cases_on `m = 0` >> gvs[] >>
+    IF_CASES_TAC >> gvs[] >>
+    Cases_on `lookup n a` >> gvs[] >>
+    FULL_CASE_TAC >> metis_tac[]
+    )
+  >- (
+    IF_CASES_TAC >> gvs[] >>
+    Cases_on `lookup n a` >> gvs[]
+    >- (
+      first_x_assum (qspecl_then [`(m + 1) * 2`,`s`] mp_tac) >>
+      simp[EVEN_DOUBLE] >> simp[LEFT_ADD_DISTRIB] >>
+      once_rewrite_tac[MULT_COMM] >> simp[DIV_MULT]
+      )
     >- metis_tac[]
-    >> ntac 2 (first_x_assum kall_tac) >>
-       `lookup n1 t2 = SOME s` by fs[subspt_def, domain_lookup] >>
-       metis_tac[]
+    >- (
+      CCONTR_TAC >> gvs[] >>
+      last_x_assum (qspecl_then [`m * 2 + 1`,`s`] mp_tac) >>
+      simp[EVEN_DOUBLE, EVEN_ADD] >>
+      once_rewrite_tac[MULT_COMM] >> simp[MULT_DIV]
+      )
+    )
 QED
 
-Theorem domain_spt_fold_union:
-     ∀ tree : num_set num_map y : num_set .
-        (∀ k v . lookup k tree = SOME v ⇒ domain v ⊆ domain tree)
-      ⇒ domain (spt_fold union y tree) ⊆ domain y ∪ domain tree
+Theorem domain_spt_fold_union_num_set:
+  ∀ tree : num_set num_map y : num_set .
+    domain (spt_fold union y tree) =
+    domain y ∪
+    {n | ∃k aSet. lookup k tree = SOME aSet ∧ n ∈ domain aSet}
 Proof
-    rw[] >> qspec_then `tree` mp_tac lookup_spt_fold_union >>
-    rw[] >> fs[SUBSET_DEF, domain_lookup] >> rw[] >> res_tac >> fs[] >>
-    metis_tac[]
-QED
-
-Theorem domain_spt_fold_union_LN:
-     ∀ tree : num_set num_map  .
-        (∀ k v . lookup k tree = SOME v ⇒ domain v ⊆ domain tree)
-      ⇔ domain (spt_fold union LN tree) ⊆ domain tree
-Proof
-    rw[] >> EQ_TAC >> rw[]
-    >- (drule domain_spt_fold_union >>
-        strip_tac >> first_x_assum (qspec_then `LN` mp_tac) >> fs[])
-    >- (qspec_then `tree` mp_tac lookup_spt_fold_union_STRONG >>
-        rw[] >> fs[SUBSET_DEF, domain_lookup, lookup_def] >> rw[] >>
-        metis_tac[])
+  rw[EXTENSION] >> eq_tac >> rw[] >>
+  gvs[domain_lookup, lookup_spt_fold_union_num_set] >>
+  EVERY_CASE_TAC >> gvs[] >>
+  metis_tac[]
 QED
 
 (* END TODO *)


### PR DESCRIPTION
Summary of changes:
- Simplify definition of sptree reachability so that `is_reachable tree x y` does not require `y IN domain tree`.
  - This also simplifies the proof of correctness for closure with respect to sptree reachability, by removing well-formedness preconditions (including the overly restrictive `wf_set_tree` condition).
- Further simplify the proof of correctness by simplifying the closure algorithm itself.
- Remove the call to `mk_wf_set_tree` in `flat_elim`/`word_elim` - this is no longer necessary with the new, simpler reachability theorems.
- Do some tidying in the above areas - in particular:
  - Delete `wf_set_tree`/`superdomain` and associated definitions/theorems from `reachable_spt`, as these are no longer necessary.
  - Combine several sets of unnecessarily weak sptree theorems into stronger versions, and rename appropriately.
  - Remove some trivial/unnecessary theorems which are only cluttering files.
  - Remove the unnecessary dependency of `word_elim` on `flat_elim`.