### PR TITLE
edit export scripts to handle cml_*

### DIFF
--- a/compiler/backend/arm7/export_arm7Script.sml
+++ b/compiler/backend/arm7/export_arm7Script.sml
@@ -30,10 +30,13 @@ val startup =
        "cdecl(cml_main):";
        "     ldr    r0,=cake_main            /* arg1: entry address */";
        "     ldr    r1,=cdecl(cml_heap)      /* arg2: first address of heap */";
+       "     ldr    r1,[r1]";
        "     ldr    r2,=cake_bitmaps";
        "     str    r2,[r1]                  /* store bitmap pointer */";
        "     ldr    r2,=cdecl(cml_stack)     /* arg3: first address of stack */";
-       "     ldr    r3,=cdecl(cml_stackend)  /* arg4: first address past the stack */ ";
+       "     ldr    r2,[r2]";
+       "     ldr    r3,=cdecl(cml_stackend)  /* arg4: first address past the stack */";
+       "     ldr    r3,[r3]";
        "     b      cake_main";
        "     .ltorg";
        ""])`` |> EVAL |> concl |> rand

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -30,10 +30,13 @@ val startup =
        "cdecl(cml_main):";
        "     ldr    x0,=cake_main            /* arg1: entry address */";
        "     ldr    x1,=cdecl(cml_heap)      /* arg2: first address of heap */";
+       "     ldr    x1,[x1]";
        "     ldr    x2,=cake_bitmaps";
        "     str    x2,[x1]                  /* store bitmap pointer */";
        "     ldr    x2,=cdecl(cml_stack)     /* arg3: first address of stack */";
-       "     ldr    x3,=cdecl(cml_stackend)  /* arg4: first address past the stack */ ";
+       "     ldr    x2,[x2]";
+       "     ldr    x3,=cdecl(cml_stackend)  /* arg4: first address past the stack */";
+       "     ldr    x3,[x3]";
        "     b      cake_main";
        "     .ltorg";
        ""])`` |> EVAL |> concl |> rand

--- a/compiler/backend/mips/export_mipsScript.sml
+++ b/compiler/backend/mips/export_mipsScript.sml
@@ -29,11 +29,11 @@ val startup =
        "     .globl  cdecl(cml_stackend)";
        "cdecl(cml_main):";
        "     dla     $a0,cake_main           # arg1: entry address";
-       "     dla     $a1,cdecl(cml_heap)     # arg2: first address of heap";
+       "     ld      $a1,cdecl(cml_heap)     # arg2: first address of heap";
        "     dla     $t0,cake_bitmaps";
        "     sd      $t0, 0($a1)             # store bitmap pointer";
-       "     dla     $a2,cdecl(cml_stack)    # arg3: first address of stack";
-       "     dla     $a3,cdecl(cml_stackend) # arg4: first address past the stack";
+       "     ld      $a2,cdecl(cml_stack)    # arg3: first address of stack";
+       "     ld      $a3,cdecl(cml_stackend) # arg4: first address past the stack";
        "     j       cake_main";
        "     nop";
        ""])`` |> EVAL |> concl |> rand

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -28,6 +28,7 @@ val startup =
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
        "cdecl(cml_main):";
+       "     la      a0,cake_main           # arg1: entry address";
        "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap";
        "     la      t3,cake_bitmaps";
        "     sd      t3, 0(a1)              # store bitmap pointer";


### PR DESCRIPTION
Follows the fixes from #752

- These changes were tested with gcc cross-compilers for arm, arm8, mips64 (works with -fPIC) on my x64 machine.

- It is not clear to me whether the line `la      a0,cake_main` (which was deleted in #752) is currently necessary. However, @myreen  pointed out that it will be used when `Install` is enabled.