### PR TITLE
add a .type to exporters

### DIFF
--- a/compiler/backend/arm7/export_arm7Script.sml
+++ b/compiler/backend/arm7/export_arm7Script.sml
@@ -27,6 +27,7 @@ val startup =
        "     .globl  cdecl(cml_heap)";
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
+       "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     ldr    r0,=cake_main            /* arg1: entry address */";
        "     ldr    r1,=cdecl(cml_heap)      /* arg2: first address of heap */";

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -27,6 +27,7 @@ val startup =
        "     .globl  cdecl(cml_heap)";
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
+       "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     ldr    x0,=cake_main            /* arg1: entry address */";
        "     ldr    x1,=cdecl(cml_heap)      /* arg2: first address of heap */";

--- a/compiler/backend/mips/export_mipsScript.sml
+++ b/compiler/backend/mips/export_mipsScript.sml
@@ -27,6 +27,7 @@ val startup =
        "     .globl  cdecl(cml_heap)";
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
+       "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     dla     $a0,cake_main           # arg1: entry address";
        "     ld      $a1,cdecl(cml_heap)     # arg2: first address of heap";

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -27,6 +27,7 @@ val startup =
        "     .globl  cdecl(cml_heap)";
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
+       "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     la      a0,cake_main           # arg1: entry address";
        "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap";

--- a/compiler/backend/x64/export_x64Script.sml
+++ b/compiler/backend/x64/export_x64Script.sml
@@ -27,6 +27,7 @@ val startup =
        "     .globl  cdecl(cml_heap)";
        "     .globl  cdecl(cml_stack)";
        "     .globl  cdecl(cml_stackend)";
+       "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     pushq   %rbp                        # push base pointer";
        "     movq    %rsp, %rbp                  # save stack pointer";


### PR DESCRIPTION
This fixes an issue with ARM7 backend when compiling for hard floats.

Issue reported and fixed by @ Grant Jurgensen on Slack