### PR TITLE
Improvements to the OpenTheory checker

### DIFF
--- a/compiler/inference/Holmakefile
+++ b/compiler/inference/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = $(HOLDIR)/examples/unification/triangular/first-order\
+INCLUDES = $(HOLDIR)/examples/algorithms/unification/triangular/first-order\
 					 $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs\
 					 $(CAKEMLDIR)/basis/pure
 

--- a/examples/opentheory/README.md
+++ b/examples/opentheory/README.md
@@ -9,7 +9,7 @@ This directory contains a version of the OpenTheory article checker
 where the I/O part is built using the monadic translator.
 
 [prettyScript.sml](prettyScript.sml):
-A pretty printer producing strings.
+A pretty printer producing mlstring app_lists.
 Based on the pretty printer from "ML from the working programmer".
 
 [readerProgScript.sml](readerProgScript.sml):

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
@@ -136,7 +136,7 @@ Theorem reader_extract_writes:
               MEM (Sequent asl c) s.thms ⇒
                 (thyof refs.the_context, asl) |= c)) ∧
          refs.the_context extends init_ctxt ∧
-         (out = explode (msg_success s refs.the_context)) ∧
+         (out = explode (concat (append (msg_success s refs.the_context)))) ∧
          (err = "")
      | _ => F
 Proof

--- a/examples/opentheory/readerProgScript.sml
+++ b/examples/opentheory/readerProgScript.sml
@@ -2,11 +2,10 @@
   Deeply embedded CakeML program that implements an OpenTheory article
   checker.
 *)
-open preamble basis
-     ml_monadBaseTheory ml_monad_translatorLib cfMonadTheory cfMonadLib
-     holKernelTheory holKernelProofTheory ml_hol_kernelProgTheory readerTheory
-     readerProofTheory prettyTheory
-     reader_commonProgTheory reader_initTheory
+open preamble basis ml_monadBaseTheory ml_monad_translatorLib cfMonadTheory
+     cfMonadLib holKernelTheory holKernelProofTheory ml_hol_kernelProgTheory
+     readerTheory readerProofTheory prettyTheory reader_commonProgTheory
+     reader_initTheory;
 
 val _ = new_theory "readerProg"
 val _ = m_translation_extends "reader_commonProg"
@@ -82,7 +81,7 @@ Theorem l2c_aux_spec:
 Proof
   Induct_on ‘linesFD fs fd’
   \\ rpt strip_tac
-  \\ xcf "l2c_aux" (get_ml_prog_state ())
+  \\ xcf_with_def "l2c_aux" (fetch "-" "l2c_aux_v_def")
   \\ qpat_x_assum ‘_ = linesFD fs fd’ (assume_tac o SYM) \\ fs []
   \\ ‘IS_SOME (get_file_content fs fd)’
       by fs []
@@ -134,7 +133,7 @@ Theorem l2c_spec:
         STDIO (fastForwardFD fs fd))
 Proof
   strip_tac
-  \\ xcf "l2c" (get_ml_prog_state ())
+  \\ xcf_with_def "l2c" (fetch "-" "l2c_v_def")
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ xapp
   \\ Q.LIST_EXISTS_TAC [‘emp’, ‘[]’]
@@ -176,7 +175,7 @@ Theorem l2c_from_spec:
         STDIO fs)
 Proof
   strip_tac
-  \\ xcf "l2c_from" (get_ml_prog_state ())
+  \\ xcf_with_def "l2c_from" (fetch "-" "l2c_from_v_def")
   \\ ‘CARD (set (MAP FST fs.infds)) < fs.maxFD’
     by fs []
   \\ reverse (Cases_on ‘STD_streams fs’)
@@ -256,7 +255,7 @@ val _ = (append_prog o process_topdecs) `
     let
       val st = fst (readlines init_state (l2c TextIO.stdIn))
     in
-      TextIO.print (msg_success st (Kernel.context ()))
+      print_app_list (msg_success st (Kernel.context ()))
     end
     handle Kernel.Fail e => TextIO.output TextIO.stdErr e;
   `;
@@ -275,7 +274,7 @@ val _ = (append_prog o process_topdecs) `
         let
           val st = fst (readlines init_state (List.concat ls))
         in
-          TextIO.print (msg_success st (Kernel.context ()))
+          print_app_list (msg_success st (Kernel.context ()))
         end
         handle Kernel.Fail e => TextIO.output TextIO.stdErr e;
   `;
@@ -302,7 +301,7 @@ Theorem read_stdin_spec:
         STDIO (FST (read_stdin fs refs)) *
         HOL_STORE (FST (SND (read_stdin fs refs))))
 Proof
-  xcf "read_stdin" (get_ml_prog_state ())
+  xcf_with_def "read_stdin" (fetch "-" "read_stdin_v_def")
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ fs [UNIT_TYPE_def, read_stdin_def]
@@ -393,7 +392,7 @@ Theorem read_file_spec:
         STDIO (FST (read_file fs refs fnm)) *
         HOL_STORE (FST (SND (read_file fs refs fnm))))
 Proof
-  xcf "read_file" (get_ml_prog_state())
+  xcf_with_def "read_file" (fetch "-" "read_file_v_def")
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [TextIOProofTheory.STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -496,7 +495,7 @@ Theorem reader_main_spec:
         &UNIT_TYPE () u *
         STDIO (FST (reader_main fs refs (TL cl))))
 Proof
-  xcf "reader_main" (get_ml_prog_state ())
+  xcf_with_def "reader_main" (fetch "-" "reader_main_v_def")
   \\ reverse (Cases_on ‘wfcl cl’)
   >- (simp [COMMANDLINE_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)

--- a/examples/opentheory/readerScript.sml
+++ b/examples/opentheory/readerScript.sml
@@ -2,18 +2,25 @@
   Shallowly embedded (monadic) functions that implement the OpenTheory
   article checker.
 *)
-open preamble ml_hol_kernelProgTheory
-     mlintTheory StringProgTheory
-     prettyTheory
+open preamble ml_hol_kernelProgTheory mlintTheory StringProgTheory prettyTheory;
 
-val _ = new_theory"reader"
+val _ = new_theory "reader";
 
-Overload monad_bind[local] = “st_ex_bind”
-Overload monad_unitbind[local] = “λx y. st_ex_bind x (λ z. y)”
-Overload monad_ignore_bind[local] = “λx y. st_ex_bind x (λz. y)”
-Overload return[local] = “st_ex_return”
-Overload failwith[local] = “raise_Fail”
-val _ = temp_add_monadsyntax()
+val st_ex_monadinfo : monadinfo = {
+  bind = “st_ex_bind”,
+  ignorebind = SOME “st_ex_ignore_bind”,
+  unit = “st_ex_return”,
+  fail = SOME “raise_Fail”,
+  choice = SOME “$otherwise”,
+  guard = NONE
+  };
+
+val _ = declare_monad ("st_ex", st_ex_monadinfo);
+val _ = enable_monadsyntax ();
+val _ = enable_monad "st_ex";
+
+Overload return[local] = “st_ex_return”;
+Overload failwith[local] = “raise_Fail”;
 
 (* -------------------------------------------------------------------------
  * Commands.
@@ -65,63 +72,55 @@ Datatype:
 End
 
 (*
- * TODO fromString is broken, so here's this:
- *)
-
-Definition s2i_def:
-  s2i s = if s = «» then NONE:int option else fromString s
-End
-
-val _ = export_rewrites ["s2i_def"]
-
-(*
  * Expensive (string-comparisons) way of tokenizing the input.
- * (Better but more verbose: read one character at a time, fail early.)
+ * TODO: Maybe: hash string?
  *)
 
 Definition s2c_def:
   s2c s =
-    if s = «absTerm» then absTerm
-    else if s = «absThm» then absThm
-    else if s = «appTerm» then appTerm
-    else if s = «appThm» then appThm
-    else if s = «assume» then assume
-    else if s = «axiom» then axiom
-    else if s = «betaConv» then betaConv
-    else if s = «cons» then cons
-    else if s = «const» then const
-    else if s = «constTerm» then constTerm
-    else if s = «deductAntisym» then deductAntisym
-    else if s = «def» then def
-    else if s = «defineConst» then defineConst
-    else if s = «defineConstList» then defineConstList
-    else if s = «defineTypeOp» then defineTypeOp
-    else if s = «eqMp» then eqMp
-    else if s = «hdTl» then hdTl
-    else if s = «nil» then nil
-    else if s = «opType» then opType
-    else if s = «pop» then popc
-    else if s = «pragma» then pragma
-    else if s = «proveHyp» then proveHyp
-    else if s = «ref» then ref
-    else if s = «refl» then refl
-    else if s = «remove» then remove
-    else if s = «subst» then subst
-    else if s = «sym» then sym
-    else if s = «thm» then thm
-    else if s = «trans» then trans
-    else if s = «typeOp» then typeOp
-    else if s = «var» then var
-    else if s = «varTerm» then varTerm
-    else if s = «varType» then varType
-    else if s = «version» then version
-    else case s2i s of
-           SOME i => intc i
-         | NONE =>
-             case explode s of
-               #"\""::c::cs => strc (implode (FRONT (c::cs)))
-             | #"#"::_ => skipc
-             | _ => unknownc s
+    if strlen s = 0 then unknownc s else
+      let c = strsub s 0 in
+        if c = #"#" then skipc
+        else if c = #"\"" then strc (substring s 1 (strlen s - 2))
+        else if isDigit c then
+          case fromString s of
+            NONE => unknownc s
+          | SOME i => intc i
+        else if s = «absTerm» then absTerm
+        else if s = «absThm» then absThm
+        else if s = «appTerm» then appTerm
+        else if s = «appThm» then appThm
+        else if s = «assume» then assume
+        else if s = «axiom» then axiom
+        else if s = «betaConv» then betaConv
+        else if s = «cons» then cons
+        else if s = «const» then const
+        else if s = «constTerm» then constTerm
+        else if s = «deductAntisym» then deductAntisym
+        else if s = «def» then def
+        else if s = «defineConst» then defineConst
+        else if s = «defineConstList» then defineConstList
+        else if s = «defineTypeOp» then defineTypeOp
+        else if s = «eqMp» then eqMp
+        else if s = «hdTl» then hdTl
+        else if s = «nil» then nil
+        else if s = «opType» then opType
+        else if s = «pop» then popc
+        else if s = «pragma» then pragma
+        else if s = «proveHyp» then proveHyp
+        else if s = «ref» then ref
+        else if s = «refl» then refl
+        else if s = «remove» then remove
+        else if s = «subst» then subst
+        else if s = «sym» then sym
+        else if s = «thm» then thm
+        else if s = «trans» then trans
+        else if s = «typeOp» then typeOp
+        else if s = «var» then var
+        else if s = «varTerm» then varTerm
+        else if s = «varType» then varType
+        else if s = «version» then version
+        else unknownc s
 End
 
 (*
@@ -357,20 +356,15 @@ End
  * ------------------------------------------------------------------------- *)
 
 Definition commas_def:
-  commas xs =
-    case xs of
-      [] => []
-    | x::xs => mk_str «, » :: x :: commas xs
+  commas [] = [] ∧
+  commas (x::xs) = mk_str «, » :: x :: commas xs
 End
 
 Definition listof_def:
   listof xs =
     case xs of
       [] => mk_str «[]»
-    | x::xs =>
-        mk_blo 0 ([mk_str «[»; x] ++
-                  commas xs ++
-                  [mk_str «]»])
+    | x::xs => mk_blo 0 ([mk_str «[»; x] ++ commas xs ++ [mk_str «]»])
 End
 
 Definition obj_t_def:
@@ -380,12 +374,11 @@ Definition obj_t_def:
     | Name s => mk_str (name_of s)
     | List ls => listof (MAP obj_t ls)
     | TypeOp s => mk_str s
-    | Type ty => mk_str (pp_type 0 ty)
+    | Type ty => pp_type 0 ty
     | Const s => mk_str s
     | Term tm => pp_term 0 tm
     | Thm th => pp_thm th
-    | Var (s,ty) => mk_blo 0
-        [mk_str (s ^ «:»); mk_brk 1; mk_str (pp_type 0 ty)]
+    | Var (s,ty) => mk_blo 0 [mk_str s; mk_str «:»; mk_brk 1; pp_type 0 ty]
 Termination
   WF_REL_TAC ‘measure object_size’
   \\ Induct \\ rw [definition"object_size_def"]
@@ -393,19 +386,21 @@ Termination
   \\ decide_tac
 End
 
-Definition obj_to_string_def:
-  obj_to_string t = pr (obj_t t) pp_margin
+Definition obj2str_applist_def:
+  obj2str_applist t = pr (obj_t t) pp_margin
 End
 
-Definition state_to_string_def:
-  state_to_string s =
-    let stack = concat (MAP (λt. obj_to_string t ^ «\n») s.stack) in
-    let dict  = concat [«dict: [»;
-                        toString (LENGTH (toAList s.dict));
-                        «]\n»] in
-    let thm   = concat [toString (LENGTH s.thms); « theorems:\n»] in
-    let thms  = concat (MAP (λt. thm2str t ^ «\n») s.thms) in
-      concat [stack; «\n»; dict; thm; thms]
+Overload AppendList[local] = “FOLDL SmartAppend Nil”;
+
+Definition st2str_applist_def:
+  st2str_applist s =
+    let stack = AppendList (MAP (λt. Append (obj2str_applist t)
+                                            (List [«\n»])) s.stack);
+        dict  = List [«dict :[»; toString (LENGTH (toAList s.dict)); «]»];
+        thm   = List [toString (LENGTH s.thms); « theorems:\n»];
+        thms  = AppendList (MAP (λt. Append (thm2str_applist t)
+                                            (List [«\n»])) s.thms) in
+      AppendList [stack; List [«\n»]; dict; thm; thms]
 End
 
 (* -------------------------------------------------------------------------
@@ -413,17 +408,10 @@ End
  * ------------------------------------------------------------------------- *)
 
 Definition pp_namepair_def:
-  pp_namepair nts =
-    case nts of
-      [] => []
-    | (nm,tm)::nts =>
-        [mk_str («(» ^ nm ^ «, »);
-         pp_term 0 tm;
-         mk_str «)»] ++
-         (if nts = [] then
-            []
-          else
-            mk_str «;»::mk_brk 1::pp_namepair nts)
+  pp_namepair [] = [] ∧
+  pp_namepair ((nm,tm)::t) =
+    [mk_str «(»; mk_str nm; mk_str «, »; pp_term 0 tm; mk_str «)»] ++
+    if t = [] then [] else mk_str «;»::mk_brk 1::pp_namepair t
 End
 
 Definition pp_update_def:
@@ -431,49 +419,34 @@ Definition pp_update_def:
     case upd of
       ConstSpec nts tm =>
         mk_blo 11
-          ([mk_str «ConstSpec»;
-            mk_brk 1;
-            mk_str «[»] ++
+          ([mk_str «ConstSpec»; mk_brk 1; mk_str «[»] ++
             pp_namepair nts ++
-           [mk_str «]»;
-            mk_brk 1;
-            mk_str «with definition»;
-            mk_brk 1;
+           [mk_str «]»; mk_brk 1; mk_str «with definition»; mk_brk 1;
             pp_term 0 tm])
     | TypeDefn nm pred abs_nm rep_nm =>
         mk_blo 9
-          [mk_str «TypeDefn»;
-           mk_brk 1;
-           mk_str nm;
-           mk_brk 1;
-           mk_str («(absname » ^ abs_nm ^ «)»);
-           mk_brk 1;
-           mk_str («(repname » ^ rep_nm ^ «)»);
-           mk_brk 1;
+          [mk_str «TypeDefn»; mk_brk 1; mk_str nm; mk_brk 1;
+           mk_str «(absname »; mk_str abs_nm; mk_str «)»; mk_brk 1;
+           mk_str «(repname »; mk_str rep_nm; mk_str «)»; mk_brk 1;
            pp_term 0 pred]
     | NewType nm arity =>
         mk_blo 8
-          [mk_str «NewType»;
-           mk_brk 1;
-           mk_str nm;
-           mk_brk 1;
-           mk_str («(arity » ^ toString arity ^ «)»)]
+          [mk_str «NewType»; mk_brk 1;
+           mk_str nm; mk_brk 1;
+           mk_str «(arity »; mk_str (toString arity); mk_str «)»]
     | NewConst nm ty =>
         mk_blo 9
-          [mk_str «NewConst»;
-           mk_brk 1;
-           mk_str (nm ^ « :»);
-           mk_brk 1;
-           mk_str (pp_type 0 ty)]
+          [mk_str «NewConst»; mk_brk 1;
+           mk_str nm; mk_str « :»; mk_brk 1;
+           pp_type 0 ty]
     | NewAxiom tm =>
         mk_blo 9
-          [mk_str «NewAxiom»;
-           mk_brk 1;
+          [mk_str «NewAxiom»; mk_brk 1;
            pp_thm (Sequent [] tm)]
 End
 
-Definition upd2str_def:
-  upd2str upd = pr (pp_update upd) pp_margin
+Definition upd2str_applist_def:
+  upd2str_applist upd = pr (pp_update upd) pp_margin
 End
 
 (* -------------------------------------------------------------------------
@@ -656,10 +629,12 @@ Definition readLine_def:
           (obj,s) <- pop s;
           nm <- handle_Fail (getName obj)
                     (λe. return «bogus»);
-          if nm = «debug» then
-            failwith (state_to_string s)
-          else
-            return s
+          (* TODO Had to drop the debug pragma because of the rigidity
+           * of the exception types: we inherit a single exception from
+           * Candle and it takes a string. I can't make one up on the fly:
+           *)
+          (* if nm = «debug» then failwith (st2str_applist s) else return s *)
+          return s
         od
     | proveHyp =>
         do
@@ -775,6 +750,7 @@ Definition str_prefix_def:
   str_prefix str = extract str 0 (SOME (strlen str - 1))
 End
 
+(* This is terrible: *)
 Definition unescape_def:
   unescape str =
     case str of
@@ -804,13 +780,14 @@ End
 
 Definition msg_success_def:
   msg_success s ctxt =
-    let upds = concat (MAP (λupd. upd2str upd ^ «\n») ctxt) in
-    let thm  = concat [toString (LENGTH s.thms); « theorems:\n»] in
-    let thms = concat (MAP (λt. thm2str t ^ «\n») s.thms) in
-      concat
-        [«OK!\n»;
-         «CONTEXT:\n»; upds; «\n»;
-         thm; «\n»; thms]
+    let upds = AppendList (MAP (λt. Append (upd2str_applist t)
+                                           (List [«\n»])) (REVERSE ctxt));
+        thm  = List [toString (LENGTH s.thms); « theorems:\n»];
+        thms = AppendList (MAP (λt. Append (thm2str_applist t)
+                                           (List [«\n»])) (REVERSE s.thms))
+    in AppendList [List [«OK!\n»; «CONTEXT:\n»];
+                   upds; List [«\n»];
+                   thm; List [«\n»]; thms]
 End
 
 (* -------------------------------------------------------------------------

--- a/examples/opentheory/readerScript.sml
+++ b/examples/opentheory/readerScript.sml
@@ -76,6 +76,19 @@ End
  * TODO: Maybe: hash string?
  *)
 
+Definition strh_aux_def:
+  strh_aux s a n =
+    if n ≥ strlen s then a else strh_aux s (13 * a + ORD (strsub s n)) (n + 1)
+Termination
+  WF_REL_TAC ‘measure (λ(s,a,n). strlen s - n)’
+End
+
+Definition strh_def:
+  strh s = strh_aux s 0 0
+End
+
+fun str_hash mls = rconc (EVAL “strh ^(mls)”);
+
 Definition s2c_def:
   s2c s =
     if strlen s = 0 then unknownc s else
@@ -86,41 +99,43 @@ Definition s2c_def:
           case fromString s of
             NONE => unknownc s
           | SOME i => intc i
-        else if s = «absTerm» then absTerm
-        else if s = «absThm» then absThm
-        else if s = «appTerm» then appTerm
-        else if s = «appThm» then appThm
-        else if s = «assume» then assume
-        else if s = «axiom» then axiom
-        else if s = «betaConv» then betaConv
-        else if s = «cons» then cons
-        else if s = «const» then const
-        else if s = «constTerm» then constTerm
-        else if s = «deductAntisym» then deductAntisym
-        else if s = «def» then def
-        else if s = «defineConst» then defineConst
-        else if s = «defineConstList» then defineConstList
-        else if s = «defineTypeOp» then defineTypeOp
-        else if s = «eqMp» then eqMp
-        else if s = «hdTl» then hdTl
-        else if s = «nil» then nil
-        else if s = «opType» then opType
-        else if s = «pop» then popc
-        else if s = «pragma» then pragma
-        else if s = «proveHyp» then proveHyp
-        else if s = «ref» then ref
-        else if s = «refl» then refl
-        else if s = «remove» then remove
-        else if s = «subst» then subst
-        else if s = «sym» then sym
-        else if s = «thm» then thm
-        else if s = «trans» then trans
-        else if s = «typeOp» then typeOp
-        else if s = «var» then var
-        else if s = «varTerm» then varTerm
-        else if s = «varType» then varType
-        else if s = «version» then version
-        else unknownc s
+        else
+          let h = strh s in
+            if h = ^(str_hash “«absTerm»”) then absTerm
+            else if h = ^(str_hash “«absThm»”) then absThm
+            else if h = ^(str_hash “«appTerm»”) then appTerm
+            else if h = ^(str_hash “«appThm»”) then appThm
+            else if h = ^(str_hash “«assume»”) then assume
+            else if h = ^(str_hash “«axiom»”) then axiom
+            else if h = ^(str_hash “«betaConv»”) then betaConv
+            else if h = ^(str_hash “«cons»”) then cons
+            else if h = ^(str_hash “«const»”) then const
+            else if h = ^(str_hash “«constTerm»”) then constTerm
+            else if h = ^(str_hash “«deductAntisym»”) then deductAntisym
+            else if h = ^(str_hash “«def»”) then def
+            else if h = ^(str_hash “«defineConst»”) then defineConst
+            else if h = ^(str_hash “«defineConstList»”) then defineConstList
+            else if h = ^(str_hash “«defineTypeOp»”) then defineTypeOp
+            else if h = ^(str_hash “«eqMp»”) then eqMp
+            else if h = ^(str_hash “«hdTl»”) then hdTl
+            else if h = ^(str_hash “«nil»”) then nil
+            else if h = ^(str_hash “«opType»”) then opType
+            else if h = ^(str_hash “«pop»”) then popc
+            else if h = ^(str_hash “«pragma»”) then pragma
+            else if h = ^(str_hash “«proveHyp»”) then proveHyp
+            else if h = ^(str_hash “«ref»”) then ref
+            else if h = ^(str_hash “«refl»”) then refl
+            else if h = ^(str_hash “«remove»”) then remove
+            else if h = ^(str_hash “«subst»”) then subst
+            else if h = ^(str_hash “«sym»”) then sym
+            else if h = ^(str_hash “«thm»”) then thm
+            else if h = ^(str_hash “«trans»”) then trans
+            else if h = ^(str_hash “«typeOp»”) then typeOp
+            else if h = ^(str_hash “«var»”) then var
+            else if h = ^(str_hash “«varTerm»”) then varTerm
+            else if h = ^(str_hash “«varType»”) then varType
+            else if h = ^(str_hash “«version»”) then version
+            else unknownc s
 End
 
 (*

--- a/examples/opentheory/readerSoundnessScript.sml
+++ b/examples/opentheory/readerSoundnessScript.sml
@@ -2,7 +2,7 @@
   Proves soundness of the OpenTheory article checker. The soundness
   theorem makes the connection to the semantics of HOL explicit.
 *)
-open preamble readerProofTheory holSoundnessTheory
+open preamble readerProofTheory holSoundnessTheory;
 
 val _ = new_theory "readerSoundness";
 
@@ -12,7 +12,8 @@ val mem = ``mem:'U->'U-> bool``;
 Theorem reader_sound:
   reader_main fs init_refs cl = (outp,refs,SOME s) ⇒
     refs.the_context extends init_ctxt ∧
-    outp = add_stdout (flush_stdin cl fs) (msg_success s refs.the_context) ∧
+    outp = add_stdout (flush_stdin cl fs)
+                      (concat (append (msg_success s refs.the_context))) ∧
     ∀asl c.
       MEM (Sequent asl c) s.thms ∧
       is_set_theory ^mem ⇒

--- a/examples/opentheory/reader_commonProgScript.sml
+++ b/examples/opentheory/reader_commonProgScript.sml
@@ -3,11 +3,10 @@
   translations of the functions which are used by both versions so that we
   do not translate more than once.
 *)
-open preamble basis
-     ml_monadBaseTheory ml_monad_translator_interfaceLib
-     cfMonadTheory cfMonadLib
-     holKernelTheory holKernelProofTheory ml_hol_kernelProgTheory readerTheory
-     readerProofTheory reader_initTheory prettyTheory
+open preamble basis ml_monadBaseTheory ml_monad_translator_interfaceLib
+     cfMonadTheory cfMonadLib holKernelTheory holKernelProofTheory
+     ml_hol_kernelProgTheory readerTheory readerProofTheory reader_initTheory
+     prettyTheory;
 
 val _ = temp_delsimps ["NORMEQ_CONV"]
 val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
@@ -23,176 +22,192 @@ val _ = use_full_type_names := true;
 
 (* printer functions *)
 
-val r = translate newline_def
-val r = translate breakdist_def
-val r = translate REPLICATE
-val r = translate blanks_def
-val r = translate printing_def
-val r = translate pr_def
-val r = translate tlength_def
-val r = translate mk_blo_def
-val r = translate mk_str_def
-val r = translate mk_brk_def
-val r = translate pp_margin_def
+val r = translate newline_def;
+val r = translate breakdist_def;
+val r = translate REPLICATE;
+val r = translate blanks_def;
+val r = translate SmartAppend_def;
+val r = translate print_list_def;
+val r = translate pr_def;
+val r = translate tlength_def;
+val r = translate mk_blo_def;
+val r = translate mk_str_def;
+val r = translate mk_brk_def;
+val r = translate pp_margin_def;
 
 (* type printer *)
 
-val r = translate pp_tyop_def
-val r = translate pp_type_def
+val r = translate pp_tyop_aux_def;
+val r = translate pp_tyop_def;
+val r = translate pp_with_sep_def;
+val r = translate pp_type_def;
 
 (* term printer *)
 
-val r = translate fixity_of_def
-val r = translate name_of_def
-val r = translate is_binop_PMATCH
-val r = translate is_binder_PMATCH
-val r = translate is_cond_PMATCH
-val r = translate is_neg_PMATCH
-val r = translate collect_vars_PMATCH
-val r = translate dest_binary_PMATCH
-val r = translate dest_binder_PMATCH
-val r = translate pp_paren_blk_def
-val r = translate pp_seq_def
-val r = translate interleave_def
-val r = translate pp_term_def
+val r = translate fixity_of_def;
+val r = translate name_of_def;
+val r = translate is_binop_PMATCH;
+val r = translate is_binder_PMATCH;
+val r = translate is_cond_PMATCH;
+val r = translate is_neg_PMATCH;
+val r = translate collect_vars_PMATCH;
+val r = translate dest_binary_PMATCH;
+val r = translate dest_binder_PMATCH;
+val r = translate pp_paren_blk_def;
+val r = translate pp_seq_def;
+val r = translate interleave_def;
+val r = translate pp_term_def;
 
-Theorem pp_term_side = Q.prove(`
-  !x y. pp_term_side x y <=> T`,
+Theorem pp_term_side[local]:
+  ∀x y. pp_term_side x y
+Proof
   recInduct pp_term_ind \\ rw []
   \\ rw [Once (fetch "-" "pp_term_side_def")]
   \\ TRY strip_tac \\ rw []
-  \\ fs [is_binop_def, is_binder_def, is_cond_def])
-  |> update_precondition;
+  \\ fs [is_binop_def, is_binder_def, is_cond_def]
+QED
+
+val _ = update_precondition pp_term_side;
 
 (* theorem printer *)
 
-val r = translate pp_thm_def
+val r = translate pp_thm_def;
 
-val r = translate term2str_def
-val r = translate thm2str_def
+val r = translate term2str_applist_def;
+val r = translate thm2str_applist_def;
 
 (* ------------------------------------------------------------------------- *)
 (* Translate readerTheory                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val r = translate init_state_def
-val r = translate mk_BN_def
-val r = translate mk_BS_def
-val r = translate insert_def
-val r = translate delete_def
-val r = translate lookup_def
-val r = translate push_def
-val r = translate insert_dict_def
-val r = translate delete_dict_def
-val r = translate first_def
-val r = translate stringTheory.isDigit_def
+val r = translate init_state_def;
+val r = translate mk_BN_def;
+val r = translate mk_BS_def;
+val r = translate insert_def;
+val r = translate delete_def;
+val r = translate lookup_def;
+val r = translate push_def;
+val r = translate insert_dict_def;
+val r = translate delete_dict_def;
+val r = translate first_def;
+val r = translate stringTheory.isDigit_def;
 
 (* TODO This could be done in the Kernel module *)
 
-val _ = (use_mem_intro := true)
+val _ = (use_mem_intro := true);
 val tymatch_ind = save_thm ("tymatch_ind",
-  REWRITE_RULE [GSYM rev_assocd_thm] holSyntaxExtraTheory.tymatch_ind)
+  REWRITE_RULE [GSYM rev_assocd_thm] holSyntaxExtraTheory.tymatch_ind);
 val _ = add_preferred_thy"-";
 val r = holSyntaxExtraTheory.tymatch_def
         |> REWRITE_RULE [GSYM rev_assocd_thm]
-        |> translate
-val _ = (use_mem_intro := false)
-val r = translate OPTION_MAP_DEF
-val r = translate holSyntaxExtraTheory.match_type_def
+        |> translate;
+val _ = (use_mem_intro := false);
+val r = translate OPTION_MAP_DEF;
+val r = translate holSyntaxExtraTheory.match_type_def;
 
-val r = m_translate find_axiom_def
-val r = m_translate getNum_PMATCH
-val r = m_translate getName_PMATCH
-val r = m_translate getList_PMATCH
-val r = m_translate getTypeOp_PMATCH
-val r = m_translate getType_PMATCH
-val r = m_translate getConst_PMATCH
-val r = m_translate getVar_PMATCH
-val r = m_translate getTerm_PMATCH
-val r = m_translate getThm_PMATCH
-val r = m_translate pop_def
-val r = m_translate peek_def
-val r = m_translate getPair_PMATCH
-val r = m_translate getNvs_def
-val r = m_translate getCns_def
-val r = m_translate getTys_def
-val r = m_translate getTms_def
-val r = m_translate BETA_CONV_def
+val r = m_translate find_axiom_def;
+val r = m_translate getNum_PMATCH;
+val r = m_translate getName_PMATCH;
+val r = m_translate getList_PMATCH;
+val r = m_translate getTypeOp_PMATCH;
+val r = m_translate getType_PMATCH;
+val r = m_translate getConst_PMATCH;
+val r = m_translate getVar_PMATCH;
+val r = m_translate getTerm_PMATCH;
+val r = m_translate getThm_PMATCH;
+val r = m_translate pop_def;
+val r = m_translate peek_def;
+val r = m_translate getPair_PMATCH;
+val r = m_translate getNvs_def;
+val r = m_translate getCns_def;
+val r = m_translate getTys_def;
+val r = m_translate getTms_def;
+val r = m_translate BETA_CONV_def;
 
 (* stack and dictionary dumping *)
-val r = translate commas_def
-val r = translate listof_def
-val r = translate obj_t_def
-val r = translate sptreeTheory.lrnext_def
-val r = translate foldi_def
-val r = translate toAList_def
-val r = translate obj_to_string_def
-val r = translate state_to_string_def
+val r = translate commas_def;
+val r = translate listof_def;
+val r = translate obj_t_def;
+val r = translate sptreeTheory.lrnext_def;
+val r = translate foldi_def;
+val r = translate toAList_def;
+val r = translate obj2str_applist_def;
+val r = translate st2str_applist_def;
 
-val r = translate s2i_def
-val r = m_translate readLine_def
+val r = m_translate readLine_def;
 
-Theorem readline_side = Q.prove(`
-  !st1 l s. readline_side st1 l s <=> T`,
-  rw [fetch "-" "readline_side_def"] \\ intLib.COOPER_TAC)
-  |> update_precondition;
+Theorem readline_side[local]:
+  ∀st1 l s. readline_side st1 l s
+Proof
+  rw [fetch "-" "readline_side_def"]
+  \\ intLib.COOPER_TAC
+QED
 
-val readline_spec = save_thm ("readline_spec",
-  mk_app_of_ArrowP (theorem "readline_v_thm"));
+val _ = update_precondition readline_side;
 
-val r = translate unescape_PMATCH
-val r = translate unescape_ml_def
-val r = translate fix_fun_typ_def
-val r = translate current_line_def
-val r = translate lines_read_def
-val r = translate next_line_def
-val r = translate line_Fail_def
-val r = translate s2c_def
-val r = translate str_prefix_def
-val r = translate tokenize_def
+Theorem readline_spec = mk_app_of_ArrowP (theorem "readline_v_thm");
 
-val r = m_translate readLines_def
+val r = translate unescape_PMATCH;
+val r = translate unescape_ml_def;
+val r = translate fix_fun_typ_def;
+val r = translate current_line_def;
+val r = translate lines_read_def;
+val r = translate next_line_def;
+val r = translate line_Fail_def;
+val r = translate s2c_def;
 
-Theorem readLines_spec =
-  mk_app_of_ArrowP (theorem "readlines_v_thm");
+Theorem s2c_side[local]:
+  ∀s. s2c_side s
+Proof
+  namedCases ["x"]
+  \\ rw [fetch "-" "s2c_side_def"]
+  \\ Cases_on ‘x’ \\ fs []
+QED
+val _ = update_precondition s2c_side;
+
+val r = translate str_prefix_def;
+val r = translate tokenize_def;
+
+val r = m_translate readLines_def;
+
+Theorem readLines_spec = mk_app_of_ArrowP (theorem "readlines_v_thm");
 
 (* ------------------------------------------------------------------------- *)
 (* Translate reader_initTheory                                               *)
 (* ------------------------------------------------------------------------- *)
 
-val r = m_translate mk_true_def
-val r = m_translate mk_univ_def
-val r = m_translate mk_forall_def
-val r = m_translate mk_eta_ax_def
-val r = translate select_const_def
-val r = m_translate mk_conj_const_def
-val r = m_translate mk_conj_def
-val r = m_translate mk_imp_const_def
-val r = m_translate mk_imp_def
-val r = m_translate mk_select_ax_def
-val r = m_translate mk_ex_def
-val r = m_translate mk_exists_def
-val r = m_translate mk_surj_def
-val r = m_translate mk_inj_def
-val r = m_translate mk_false_def
-val r = m_translate mk_neg_const_def
-val r = m_translate mk_neg_def
-val r = m_translate mk_infinity_ax_def
-val r = translate select_sym_def
-val r = translate ind_type_def
-val r = m_translate init_reader_def
+val r = m_translate mk_true_def;
+val r = m_translate mk_univ_def;
+val r = m_translate mk_forall_def;
+val r = m_translate mk_eta_ax_def;
+val r = translate select_const_def;
+val r = m_translate mk_conj_const_def;
+val r = m_translate mk_conj_def;
+val r = m_translate mk_imp_const_def;
+val r = m_translate mk_imp_def;
+val r = m_translate mk_select_ax_def;
+val r = m_translate mk_ex_def;
+val r = m_translate mk_exists_def;
+val r = m_translate mk_surj_def;
+val r = m_translate mk_inj_def;
+val r = m_translate mk_false_def;
+val r = m_translate mk_neg_const_def;
+val r = m_translate mk_neg_def;
+val r = m_translate mk_infinity_ax_def;
+val r = translate select_sym_def;
+val r = translate ind_type_def;
+val r = m_translate init_reader_def;
 
-Theorem init_reader_spec =
-  mk_app_of_ArrowP (theorem "init_reader_v_thm");
+Theorem init_reader_spec = mk_app_of_ArrowP (theorem "init_reader_v_thm");
 
-val r = translate pp_namepair_def
-val r = translate pp_update_def
-val r = translate upd2str_def
+val r = translate pp_namepair_def;
+val r = translate pp_update_def;
+val r = translate upd2str_applist_def;
 
-val r = translate msg_success_def
-val r = translate msg_usage_def
-val r = translate msg_bad_name_def
-val r = translate str_prefix_def
+val r = translate msg_success_def;
+val r = translate msg_usage_def;
+val r = translate msg_bad_name_def;
+val r = translate str_prefix_def;
 
 (* ------------------------------------------------------------------------- *)
 (* Things needed by whole_prog_spec                                          *)
@@ -288,3 +303,4 @@ Theorem context_spec =
   mk_app_of_ArrowP (fetch "ml_hol_kernelProg" "context_v_thm");
 
 val _ = export_theory ();
+

--- a/examples/opentheory/reader_commonProgScript.sml
+++ b/examples/opentheory/reader_commonProgScript.sml
@@ -38,7 +38,6 @@ val r = translate pp_margin_def;
 (* type printer *)
 
 val r = translate pp_tyop_aux_def;
-val r = translate pp_tyop_def;
 val r = translate pp_with_sep_def;
 val r = translate pp_type_def;
 

--- a/examples/opentheory/reader_commonProgScript.sml
+++ b/examples/opentheory/reader_commonProgScript.sml
@@ -154,6 +154,17 @@ val r = translate current_line_def;
 val r = translate lines_read_def;
 val r = translate next_line_def;
 val r = translate line_Fail_def;
+val r = translate strh_aux_def;
+
+Theorem strh_aux_side[local]:
+  ∀a b c. strh_aux_side a b c
+Proof
+  ho_match_mp_tac strh_aux_ind \\ rw []
+  \\ simp [Once (fetch "-" "strh_aux_side_def")]
+QED
+val _ = update_precondition strh_aux_side;
+
+val r = translate strh_def;
 val r = translate s2c_def;
 
 Theorem s2c_side[local]:


### PR DESCRIPTION
The OpenTheory checker spends a lot of time doing nonsense:
- concatenating strings (and thereby dynamically allocating many new ones) while pretty-printing results
- repeatedly allocating string literals in 'hot' code, as well as doing expensive and unnecessary string comparisons

It now does a little less of this nonsense, resulting in a speed gain of roughly 30 % on my machine. There are probably more speed gains to be had if the VM dictionary sptree (which is accessed quite often) is replaced by a resizable array.