### PR TITLE
Extend Double.fromString with a preprocessing step

### DIFF
--- a/basis/DoubleProgScript.sml
+++ b/basis/DoubleProgScript.sml
@@ -26,11 +26,18 @@ val _ = ml_prog_update open_local_block;
 
 val _ = ml_prog_update open_local_in_block;
 
+val replaceMLneg_def = Define ‘replaceMLneg x = if x = #"~" then #"-" else x’;
+val _ = translate replaceMLneg_def;
+
+val prepareString_def = Define ‘prepareString (s:mlstring) = if isPrefix (strlit "~") s then translate replaceMLneg s else s’
+val _ = translate prepareString_def;
+
 val _ = process_topdecs
   `fun fromString s =
     let
+      val sPrepped = preparestring s;
       val iobuff = Word8Array.array 8 (Word8.fromInt 0);
-      val _ = #(double_fromString) s iobuff;
+      val _ = #(double_fromString) sPrepped iobuff;
       val a = Word8Array.sub iobuff 0;
       val b = Word8Array.sub iobuff 1;
       val c = Word8Array.sub iobuff 2;

--- a/basis/DoubleProgScript.sml
+++ b/basis/DoubleProgScript.sml
@@ -29,7 +29,7 @@ val _ = ml_prog_update open_local_in_block;
 val replaceMLneg_def = Define ‘replaceMLneg x = if x = #"~" then #"-" else x’;
 val _ = translate replaceMLneg_def;
 
-val prepareString_def = Define ‘prepareString (s:mlstring) = if isPrefix (strlit "~") s then translate replaceMLneg s else s’
+val prepareString_def = Define ‘prepareString (s:mlstring) = translate replaceMLneg s’
 val _ = translate prepareString_def;
 
 val _ = process_topdecs

--- a/basis/DoubleProofScript.sml
+++ b/basis/DoubleProofScript.sml
@@ -83,7 +83,7 @@ Proof
       \\ xsimpl
       \\ rewrite_tac [one_one_eq] \\ fs[]
       \\ conj_tac
-      >- (fs[MAP_CHR_w2n_n2w_ORD_id, STRING_TYPE_def, prepareString_def] \\ TOP_CASE_TAC
+      >- (fs[MAP_CHR_w2n_n2w_ORD_id, STRING_TYPE_def, prepareString_def]
           \\ gs[STRING_TYPE_def, translate_thm, implode_def])
       \\ fs[mk_ffi_next_def, ffi_fromString_def]
       \\ xsimpl


### PR DESCRIPTION
As discussed in the CakeML slack and in #825 , `Double.fromString` was not properly handling the `~` in its input. This PR makes both `-` and `~` act like unary negation for the `fromString` function by adding a simple preprocessing function.