### PR TITLE
Improve compiler error messages

### DIFF
--- a/basis/basis_ffi.c
+++ b/basis/basis_ffi.c
@@ -158,16 +158,17 @@ int hasT = 0;
 void cml_exit(int arg) {
 
   #ifdef STDERR_MEM_EXHAUST
-  if(arg == 1) {
-    fprintf(stderr,"CakeML heap space exhausted.\n");
-  }
-  else if(arg == 2) {
-    fprintf(stderr,"CakeML stack space exhausted.\n");
-  }
+  fprintf(stderr,"Program exited with nonzero exit code.\n");
   #endif
 
   #ifdef DEBUG_FFI
   {
+    if(arg == 1) {
+      fprintf(stderr,"CakeML heap space exhausted.\n");
+    }
+    else if(arg == 2) {
+      fprintf(stderr,"CakeML stack space exhausted.\n");
+    }
     fprintf(stderr,"GCNum: %d, GCTime(us): %ld\n",numGC,microsecs);
   }
   #endif

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -131,7 +131,22 @@ val res = translate (spec32 word_to_string_def);
 
 (* compilerTheory *)
 
-val _ = translate compilerTheory.locn_to_string_def;
+val res = translate compilerTheory.find_next_newline_def;
+
+Theorem find_next_newline_side = prove(
+  “∀n s. compiler_find_next_newline_side n s”,
+  ho_match_mp_tac compilerTheory.find_next_newline_ind \\ rw []
+  \\ once_rewrite_tac [fetch "-" "compiler_find_next_newline_side_def"]
+  \\ fs []) |> update_precondition;
+
+val res = translate compilerTheory.safe_substring_def;
+
+Theorem safe_substring_side = prove(
+  “compiler_safe_substring_side s n l”,
+  fs [fetch "-" "compiler_safe_substring_side_def"])
+  |> update_precondition;
+
+val _ = translate compilerTheory.get_nth_line_def;
 val _ = translate compilerTheory.locs_to_string_def;
 val _ = translate compilerTheory.parse_cml_input_def;
 val _ = translate (compilerTheory.parse_sexp_input_def
@@ -236,7 +251,9 @@ val res = translate compilerTheory.help_string_def;
 val nonzero_exit_code_for_error_msg_def = Define `
   nonzero_exit_code_for_error_msg e =
     if compiler$is_error_msg e then
-      ml_translator$force_out_of_memory_error () else ()`;
+      (let a = empty_ffi (strlit "nonzero_exit") in
+         ml_translator$force_out_of_memory_error ())
+    else ()`;
 
 val res = translate compilerTheory.is_error_msg_def;
 val res = translate nonzero_exit_code_for_error_msg_def;

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -132,7 +132,22 @@ val res = translate (spec64 word_to_string_def);
 
 (* compilerTheory *)
 
-val _ = translate compilerTheory.locn_to_string_def;
+val res = translate compilerTheory.find_next_newline_def;
+
+Theorem find_next_newline_side = prove(
+  “∀n s. compiler_find_next_newline_side n s”,
+  ho_match_mp_tac compilerTheory.find_next_newline_ind \\ rw []
+  \\ once_rewrite_tac [fetch "-" "compiler_find_next_newline_side_def"]
+  \\ fs []) |> update_precondition;
+
+val res = translate compilerTheory.safe_substring_def;
+
+Theorem safe_substring_side = prove(
+  “compiler_safe_substring_side s n l”,
+  fs [fetch "-" "compiler_safe_substring_side_def"])
+  |> update_precondition;
+
+val _ = translate compilerTheory.get_nth_line_def;
 val _ = translate compilerTheory.locs_to_string_def;
 val _ = translate compilerTheory.parse_cml_input_def;
 val _ = translate (compilerTheory.parse_sexp_input_def
@@ -255,7 +270,9 @@ val res = translate compilerTheory.help_string_def;
 val nonzero_exit_code_for_error_msg_def = Define `
   nonzero_exit_code_for_error_msg e =
     if compiler$is_error_msg e then
-      ml_translator$force_out_of_memory_error () else ()`;
+      (let a = empty_ffi (strlit "nonzero_exit") in
+         ml_translator$force_out_of_memory_error ())
+    else ()`;
 
 val res = translate compilerTheory.is_error_msg_def;
 val res = translate nonzero_exit_code_for_error_msg_def;


### PR DESCRIPTION
The new parse error messages look as follows:
```
$ echo "val n = 5; val val" | ./cake
### ERROR: parse error
Parsing failed at line 1

val n = 5; val val
           ^^^

Program exited with nonzero exit code.
```

Similarly, errors in type inference look as follows:
```
$ echo "val n = 5    5 " | ./cake
### ERROR: type error
Type mismatch between int and int -> _0 at line 1

val n = 5    5
        ^^^^^^

Program exited with nonzero exit code.
```
