### PR TITLE
Eval type rep

### DIFF
--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -30,7 +30,7 @@ sig
     val add_type_inv   : term -> hol_type -> unit
     val get_type_inv   : hol_type -> term
 
-    val fetch_v_fun    : hol_type -> term
+    val fetch_v_fun    : hol_type -> term option
 
     val add_eval_thm   : thm -> thm
     val add_user_proved_v_thm : thm -> thm

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -30,7 +30,7 @@ sig
     val add_type_inv   : term -> hol_type -> unit
     val get_type_inv   : hol_type -> term
 
-    val fetch_v_fun    : hol_type -> term option
+    val fetch_v_fun    : hol_type -> term
 
     val add_eval_thm   : thm -> thm
     val add_user_proved_v_thm : thm -> thm

--- a/translator/ml_translatorLib.sig
+++ b/translator/ml_translatorLib.sig
@@ -30,6 +30,8 @@ sig
     val add_type_inv   : term -> hol_type -> unit
     val get_type_inv   : hol_type -> term
 
+    val fetch_v_fun    : hol_type -> term
+
     val add_eval_thm   : thm -> thm
     val add_user_proved_v_thm : thm -> thm
 

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -427,22 +427,6 @@ Proof
   fs [EqualityType_at_def, markerTheory.Case_def] \\ metis_tac []
 QED
 
-Theorem Case_tuple_helper_rule:
-  Case ((x,x2),(y,y2),(vx::vx2),(vy::vy2)) <=>
-    Case (x, y, vx, vy) /\ Case (x2, y2, vx2, vy2)
-Proof
-  REWRITE_TAC [markerTheory.Case_def]
-QED
-
-Theorem EqualityType_at_IMP:
-  !x y vx vy TY. EqualityType_at TY x ==>
-  TY x vx /\ TY y vy ==>
-  (x = y ==> vx = vy ==> no_closures vx)
-        /\ (vx = vy <=> x = y) /\ types_match vx vy
-Proof
-  fs [EqualityType_at_def] \\ metis_tac []
-QED
-
 Theorem EqualityType_def_rearranged:
    EqualityType abs = (!x y vx vy. abs x vx /\ abs y vy
     ==> (x = y ==> vx = vy ==> no_closures vx)
@@ -493,8 +477,8 @@ Proof
   \\ metis_tac (map TypeBase.one_one_of [``:stamp``, ``:'a option``, ``: v``])
 QED
 
-Definition UNIT_TYPE_v_def:
-  UNIT_TYPE_v (u:unit) = (Conv NONE [])
+Definition UNIT_v_def:
+  UNIT_v (u:unit) = (Conv NONE [])
 End
 
 Definition INT_v_def:
@@ -522,12 +506,12 @@ Definition CHAR_v_def:
   CHAR_v (c:char) = Litv (Char c)
 End
 
-Definition STRING_TYPE_v_def:
-  STRING_TYPE_v (strlit s) = Litv (StrLit s)
+Definition STRING_v_def:
+  STRING_v (strlit s) = Litv (StrLit s)
 End
 
-Definition HOL_STRING_TYPE_v_def:
-  HOL_STRING_TYPE_v cs = STRING_TYPE_v (implode cs)
+Definition HOL_STRING_v_def:
+  HOL_STRING_v cs = STRING_v (implode cs)
 End
 
 Triviality types_match_list_REPLICATE:
@@ -564,9 +548,9 @@ Theorem IsTypeRep_NUM_BOOL:
   IsTypeRep NUM_v NUM /\ IsTypeRep INT_v INT /\
   IsTypeRep BOOL_v BOOL /\
   IsTypeRep CHAR_v CHAR /\
-  IsTypeRep UNIT_TYPE_v UNIT_TYPE /\
-  IsTypeRep STRING_TYPE_v STRING_TYPE /\
-  IsTypeRep HOL_STRING_TYPE_v HOL_STRING_TYPE /\
+  IsTypeRep UNIT_v UNIT_TYPE /\
+  IsTypeRep STRING_v STRING_TYPE /\
+  IsTypeRep HOL_STRING_v HOL_STRING_TYPE /\
   (dimindex (:'a) <= 64 ==> IsTypeRep WORD_v (WORD : 'a word -> v -> bool))
 Proof
   EVAL_TAC \\ simp []

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -403,28 +403,52 @@ Proof
   \\ simp [GSYM dimword_def]
 QED
 
-Theorem EqualityType_measure:
-   !m. (!n : num. EqualityType (And TY (\x. m x < n))) ==> EqualityType TY
+Definition EqualityType_at_def:
+  EqualityType_at (abs:'a->v->bool) x <=>
+    (!v. abs x v ==> no_closures v) /\
+    (!v x2 v2. abs x v /\ abs x2 v2 ==> ((v = v2) = (x = x2))) /\
+    (!v x2 v2. abs x v /\ abs x2 v2 ==> types_match v v2)
+End
+
+Theorem EqualityType_eq_at:
+  EqualityType TY = (!x. EqualityType_at TY x)
 Proof
-  rpt strip_tac
-  \\ RULE_ASSUM_TAC (Q.GENL [`x`, `y`] o Q.SPEC `MAX (SUC (m x)) (SUC (m y))`)
-  \\ fs [EqualityType_def, And_def]
-  \\ metis_tac [prim_recTheory.LESS_SUC_REFL]
+  simp [EqualityType_def, EqualityType_at_def]
+  \\ metis_tac []
 QED
 
-val trivial4_def = Define `trivial4 x y a b = T`;
+Theorem EqualityType_at_eq_Case_rearranged:
+  EqualityType_at TY x <=>
+  !y vx vy. Case (x, y, vx, vy) ==>
+  TY x vx /\ TY y vy ==>
+  (x = y ==> vx = vy ==> no_closures vx)
+        /\ (vx = vy <=> x = y) /\ types_match vx vy
+Proof
+  fs [EqualityType_at_def, markerTheory.Case_def] \\ metis_tac []
+QED
 
-val Conv_args_def = Define `Conv_args v = (case v of
-  | Conv _ vs => vs
-  | _ => [v])`;
+Theorem Case_tuple_helper_rule:
+  Case ((x,x2),(y,y2),(vx::vx2),(vy::vy2)) <=>
+    Case (x, y, vx, vy) /\ Case (x2, y2, vx2, vy2)
+Proof
+  REWRITE_TAC [markerTheory.Case_def]
+QED
+
+Theorem EqualityType_at_IMP:
+  !x y vx vy TY. EqualityType_at TY x ==>
+  TY x vx /\ TY y vy ==>
+  (x = y ==> vx = vy ==> no_closures vx)
+        /\ (vx = vy <=> x = y) /\ types_match vx vy
+Proof
+  fs [EqualityType_at_def] \\ metis_tac []
+QED
 
 Theorem EqualityType_def_rearranged:
-   EqualityType abs = (!x y vx vy. trivial4 x y vx vy
-    ==> abs x vx /\ abs y vy
+   EqualityType abs = (!x y vx vy. abs x vx /\ abs y vy
     ==> (x = y ==> vx = vy ==> no_closures vx)
         /\ (vx = vy <=> x = y) /\ types_match vx vy)
 Proof
-  fs [EqualityType_def, trivial4_def] \\ metis_tac []
+  fs [EqualityType_def] \\ metis_tac []
 QED
 
 Theorem EqualityType_from_ONTO:

--- a/translator/ml_translatorSyntax.sig
+++ b/translator/ml_translatorSyntax.sig
@@ -17,9 +17,6 @@ sig
   val is_IsTypeRep   : term -> bool
   val mk_IsTypeRep   : term * term -> term
 
-  val dest_trivial4 : term -> (term * term * term * term)
-  val mk_Conv_args  : term -> term
-
   val mk_CONTAINER   : term -> term
   val dest_CONTAINER : term -> term
   val is_CONTAINER   : term -> bool

--- a/translator/ml_translatorSyntax.sig
+++ b/translator/ml_translatorSyntax.sig
@@ -12,6 +12,11 @@ sig
   val is_EqualityType   : term -> bool
   val EqualityType      : term
 
+  val IsTypeRep      : term
+  val dest_IsTypeRep : term -> term * term
+  val is_IsTypeRep   : term -> bool
+  val mk_IsTypeRep   : term * term -> term
+
   val dest_trivial4 : term -> (term * term * term * term)
   val mk_Conv_args  : term -> term
 

--- a/translator/ml_translatorSyntax.sml
+++ b/translator/ml_translatorSyntax.sml
@@ -17,9 +17,6 @@ val (CONTAINER,mk_CONTAINER,dest_CONTAINER,is_CONTAINER) = monop "CONTAINER";
 val (PRECONDITION,mk_PRECONDITION,dest_PRECONDITION,is_PRECONDITION) = monop "PRECONDITION";
 val (IsTypeRep,mk_IsTypeRep,dest_IsTypeRep,is_IsTypeRep) = binop "IsTypeRep";
 
-val (_, mk_Conv_args, _, _) = monop "Conv_args"
-val (_, mk_trivial4, dest_trivial4, _) = HolKernel.syntax_fns4 "ml_translator" "trivial4";
-
 val BOOL        = prim_mk_const{Thy="ml_translator",Name="BOOL"}
 val WORD       = prim_mk_const{Thy="ml_translator",Name="WORD"}
 val NUM         = prim_mk_const{Thy="ml_translator",Name="NUM"}

--- a/translator/ml_translatorSyntax.sml
+++ b/translator/ml_translatorSyntax.sml
@@ -10,10 +10,12 @@ open HolKernel boolLib ml_translatorTheory semanticPrimitivesSyntax;
 val ERR = Feedback.mk_HOL_ERR "ml_translatorSyntax";
 
 val monop = HolKernel.syntax_fns1 "ml_translator"
+val binop = HolKernel.syntax_fns2 "ml_translator"
 
 val (EqualityType,mk_EqualityType,dest_EqualityType,is_EqualityType) = monop "EqualityType";
 val (CONTAINER,mk_CONTAINER,dest_CONTAINER,is_CONTAINER) = monop "CONTAINER";
 val (PRECONDITION,mk_PRECONDITION,dest_PRECONDITION,is_PRECONDITION) = monop "PRECONDITION";
+val (IsTypeRep,mk_IsTypeRep,dest_IsTypeRep,is_IsTypeRep) = binop "IsTypeRep";
 
 val (_, mk_Conv_args, _, _) = monop "Conv_args"
 val (_, mk_trivial4, dest_trivial4, _) = HolKernel.syntax_fns4 "ml_translator" "trivial4";

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -300,8 +300,10 @@ Theorem EqTyp_test_lemmas:
     /\ EqualityType (^a_c_inv_num) /\ EqualityType (^st_inv)
     /\ EqualityType (^st2_inv)
 Proof
-  fs (eq_lemmas ())
+  fs (map (REWRITE_RULE [AND_IMP_INTRO]) (eq_lemmas ()))
 QED
+
+(* FIXME: mutually recursive datastructures don't seem to work *)
 
 (* translating within nested local blocks and modules *)
 


### PR DESCRIPTION
Definition of type-representation functions (a total 'a->v counterpart to the type invariant).

Works for translator tests. I'm putting this PR up so that the regression infrastructure will test it for the examples & bootstrap.