### PR TITLE
Remove unnecessary FFI states in compiler correctness theorems

### DIFF
--- a/compiler/backend/ag32/proofs/ag32_machine_configScript.sml
+++ b/compiler/backend/ag32/proofs/ag32_machine_configScript.sml
@@ -41,6 +41,7 @@ val ag32_ffi_mem_update_def = Define`
       if (HD new_bytes = 0w) then
         case bytes of
         | (n1 :: n0 :: off1 :: off0 :: tll) =>
+          if LENGTH conf ≠ 8 then mem else
           let k = MIN (w22n [n1; n0]) output_buffer_size in
           let written = TAKE k (DROP (w22n [off1; off0]) tll) in
             asm_write_bytearray (n2w output_offset) (conf ++ [0w;0w;n1;n0] ++ written) mem

--- a/compiler/backend/ag32/proofs/ag32_machine_configScript.sml
+++ b/compiler/backend/ag32/proofs/ag32_machine_configScript.sml
@@ -39,17 +39,21 @@ val ag32_ffi_mem_update_def = Define`
   ag32_ffi_mem_update name conf bytes new_bytes mem =
     if (name = "write") then
       if (HD new_bytes = 0w) then
-        case bytes of (n1 :: n0 :: off1 :: off0 :: tll) =>
+        case bytes of
+        | (n1 :: n0 :: off1 :: off0 :: tll) =>
           let k = MIN (w22n [n1; n0]) output_buffer_size in
           let written = TAKE k (DROP (w22n [off1; off0]) tll) in
             asm_write_bytearray (n2w output_offset) (conf ++ [0w;0w;n1;n0] ++ written) mem
+        | _ => mem
       else ((n2w output_offset) =+ 1w) mem
     else if (name = "read") then
-      case new_bytes of (zz :: k1 :: k0 :: _) =>
+      case new_bytes of
+      | (zz :: k1 :: k0 :: _) =>
         if (zz = 0w) then
           set_mem_word (n2w stdin_offset)
             (get_mem_word mem (n2w stdin_offset) + n2w (w22n [k1; k0])) mem
         else mem
+      | _ => mem
     else mem`;
 
 val ag32_ffi_interfer_def = Define`

--- a/compiler/backend/arm8_asl/arm8_asl_configProofScript.sml
+++ b/compiler/backend/arm8_asl/arm8_asl_configProofScript.sml
@@ -43,7 +43,7 @@ Theorem arm8_asl_compile_correct:
   compile arm8_backend_config prog = SOME (bytes, bitmaps, config') ⇒
     let (s,env) = THE (prim_sem_env ffi) in
     ¬semantics_prog s env prog Fail ∧
-    installed bytes cbspace bitmaps data_sp config'.lab_conf.ffi_names ffi (1,3) mc ms
+    installed bytes cbspace bitmaps data_sp config'.lab_conf.ffi_names (1,3) mc ms
     ⇒ machine_sem mc ffi ms ⊆
         extend_with_resource_limit (semantics_prog s env prog)
 Proof

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -2966,7 +2966,7 @@ Theorem compile_correct':
    ¬semantics_prog s env prog Fail ∧
    backend_config_ok c ∧ lab_to_targetProof$mc_conf_ok mc ∧ mc_init_ok c mc ∧
    opt_eval_config_wf c' ev ∧
-   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names ffi (heap_regs c.stack_conf.reg_names) mc ms ⇒
+   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names (heap_regs c.stack_conf.reg_names) mc ms ⇒
      machine_sem (mc:(α,β,γ) machine_config) ffi ms ⊆
        extend_with_resource_limit'
          (is_safe_for_space ffi c prog (read_limits c mc ms))
@@ -3116,7 +3116,7 @@ Proof
   \\ disch_tac \\ fs []
   \\ fs [attach_bitmaps_def] \\ rveq \\ fs [] \\
   fs[targetSemTheory.installed_def] \\
-  qmatch_assum_abbrev_tac`good_init_state mc ms ffi bytes cbspace tar_st m dm io_regs cc_regs` \\
+  qmatch_assum_abbrev_tac`good_init_state mc ms bytes cbspace tar_st m dm io_regs cc_regs` \\
   qpat_x_assum`Abbrev(p7 = _)` mp_tac>>
   qmatch_goalsub_abbrev_tac`compile _ _ _ stk stoff`>>
   strip_tac \\
@@ -3337,11 +3337,12 @@ Proof
   `Fail ∉ y` by (fs [Abbr `y`] \\ fs [GSYM pure_co_def, simple_orac_eqs]) \\
   pop_assum mp_tac \\ simp[GSYM implements'_def] \\
   simp[Abbr`y`] \\
-  old_drule (GEN_ALL lab_to_targetProofTheory.semantics_compile) \\
+  old_drule $ GEN_ALL $
+    INST_TYPE [delta |-> ``:'ffi``] lab_to_targetProofTheory.semantics_compile \\
   disch_then(old_drule o CONV_RULE(STRIP_QUANT_CONV(LAND_CONV(move_conj_left(optionSyntax.is_some o rhs))))) \\
   simp[Abbr`c4`] \\
   disch_then(old_drule o CONV_RULE(STRIP_QUANT_CONV(LAND_CONV(move_conj_left(same_const``good_init_state`` o fst o strip_comb))))) \\
-  disch_then(qspec_then`lab_oracle`mp_tac)
+  disch_then(qspecl_then[`ffi`,`lab_oracle`]mp_tac)
   \\ old_drule (GEN_ALL bvi_tailrecProofTheory.compile_prog_next_mono)
   \\ strip_tac
   \\ pop_assum(assume_tac o Abbrev_intro)
@@ -3732,7 +3733,7 @@ Theorem compile_correct:
    let (s,env) = THE (prim_sem_env (ffi:'ffi ffi_state)) in
    ¬semantics_prog s env prog Fail ∧
    backend_config_ok c ∧ lab_to_targetProof$mc_conf_ok mc ∧ mc_init_ok c mc ∧
-   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names ffi
+   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names
         (heap_regs c.stack_conf.reg_names) mc ms ⇒
      machine_sem (mc:(α,β,γ) machine_config) ffi ms ⊆
        extend_with_resource_limit (semantics_prog s env prog)
@@ -3759,7 +3760,7 @@ Theorem compile_correct_is_safe_for_space:
   let (s,env) = THE (prim_sem_env (ffi:'ffi ffi_state)) in
   ¬semantics_prog s env prog Fail ∧
   backend_config_ok c ∧ lab_to_targetProof$mc_conf_ok mc ∧ mc_init_ok c mc ∧
-  installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names ffi
+  installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names
        (heap_regs c.stack_conf.reg_names) mc ms ⇒
   machine_sem (mc:(α,β,γ) machine_config) ffi ms =
   semantics_prog s env prog
@@ -3783,7 +3784,7 @@ Theorem compile_correct_eval:
    let (s0,env) = THE (prim_sem_env (ffi: 'ffi ffi_state)) in
    ¬semantics_prog (add_eval_state ev s0) env prog Fail ∧ backend_config_ok c ∧
    lab_to_targetProof$mc_conf_ok mc ∧ mc_init_ok c mc ∧ opt_eval_config_wf c' ev ∧
-   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names ffi
+   installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names
      (heap_regs c.stack_conf.reg_names) mc ms ⇒
    machine_sem mc ffi ms ⊆
      extend_with_resource_limit

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -6558,7 +6558,7 @@ val IMP_state_rel_make_init = Q.prove(
    list_subset (find_ffi_names code) mc_conf.ffi_names ∧
     remove_labels clock mc_conf.target.config 0 LN mc_conf.ffi_names code =
       SOME (code2,labs) /\
-    good_init_state mc_conf ms ffi (prog_to_bytes code2)
+    good_init_state mc_conf ms (prog_to_bytes code2)
       cbspace t m dm io_regs cc_regs
       ==>
     state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,
@@ -6584,8 +6584,9 @@ val IMP_state_rel_make_init = Q.prove(
         ccache_interfer_ok_def]
   \\ rfs[]
   \\ conj_tac >- (
-    rw[] \\ first_x_assum irule
-    \\ rw[] \\ asm_exists_tac \\ rw[] )
+    rw[] >> first_x_assum irule >> simp[] >>
+    gvs[call_FFI_def, AllCaseEqs()]
+    )
   \\ conj_tac >-
     (strip_tac >>
     pairarg_tac >> fs[]>>
@@ -6740,7 +6741,7 @@ val semantics_compile_lemma = Q.prove(
     lab_to_target$compile (c:'a lab_to_target$config) code = SOME (bytes,c') /\
     (* FFI is either given or computed *)
     c'.ffi_names = SOME mc_conf.ffi_names /\
-    good_init_state mc_conf ms ffi bytes cbspace t m dm io_regs cc_regs /\
+    good_init_state mc_conf ms bytes cbspace t m dm io_regs cc_regs /\
     semantics (make_init mc_conf ffi io_regs cc_regs t m dm ms code
       lab_to_target$compile (mc_conf.target.get_pc ms+n2w(LENGTH bytes)) cbspace
       coracle
@@ -6799,7 +6800,7 @@ Theorem semantics_compile:
    c.labels = LN ∧ c.pos = 0 ∧
    compile c code = SOME (bytes,c') ∧
    c'.ffi_names = SOME (mc_conf.ffi_names) /\
-   good_init_state mc_conf ms (ffi:'ffi ffi_state) bytes cbspace t m dm io_regs cc_regs ⇒
+   good_init_state mc_conf ms bytes cbspace t m dm io_regs cc_regs ⇒
    implements' T (machine_sem mc_conf ffi ms)
      {semantics
         (make_init mc_conf ffi io_regs cc_regs t m (dm ∩ byte_aligned) ms code

--- a/compiler/backend/semantics/targetSemScript.sml
+++ b/compiler/backend/semantics/targetSemScript.sml
@@ -181,6 +181,7 @@ val ffi_interfer_ok_def = Define`
        index < LENGTH mc_conf.ffi_names ∧
        read_ffi_bytearrays mc_conf ms2 = (SOME bytes, SOME bytes2) ∧
        LENGTH new_bytes = LENGTH bytes2 ∧
+       (EL index mc_conf.ffi_names = "" ⇒ new_bytes = bytes2) ∧
        (mc_conf.prog_addresses = t1.mem_domain) ∧
        target_state_rel mc_conf.target
          (t1 with pc := -n2w ((3 + index) * ffi_offset) + pc) ms2 ∧

--- a/compiler/backend/semantics/targetSemScript.sml
+++ b/compiler/backend/semantics/targetSemScript.sml
@@ -176,22 +176,20 @@ val get_reg_value_def = Define `
 (* ffi_interfer_ok: the FFI interference oracle is ok:
    target_state_rel is preserved for any FFI behaviour *)
 val ffi_interfer_ok_def = Define`
-  ffi_interfer_ok ffi pc io_regs mc_conf ⇔
-    (!ms2 k index new_bytes t1 bytes bytes2 st new_st.
+  ffi_interfer_ok pc io_regs mc_conf ⇔
+    (∀ms2 k index new_bytes t1 bytes bytes2.
        index < LENGTH mc_conf.ffi_names ∧
        read_ffi_bytearrays mc_conf ms2 = (SOME bytes, SOME bytes2) ∧
-       call_FFI_rel^* ffi st ∧
-       call_FFI st (EL index mc_conf.ffi_names) bytes bytes2 = FFI_return new_st new_bytes ∧
+       LENGTH new_bytes = LENGTH bytes2 ∧
        (mc_conf.prog_addresses = t1.mem_domain) ∧
        target_state_rel mc_conf.target
-         (t1 with
-          pc := -n2w ((3 + index) * ffi_offset) + pc)
-       ms2 /\
-       aligned mc_conf.target.config.code_alignment (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n)) ==>
-       target_state_rel mc_conf.target
+         (t1 with pc := -n2w ((3 + index) * ffi_offset) + pc) ms2 ∧
+       aligned mc_conf.target.config.code_alignment
+        (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n))
+    ⇒ target_state_rel mc_conf.target
         (t1 with
          <|regs :=
-            (\a.
+            (λa.
              get_reg_value
                (if MEM a mc_conf.callee_saved_regs then NONE else io_regs k (EL index mc_conf.ffi_names) a)
                (t1.regs a) I);
@@ -231,7 +229,7 @@ val ccache_interfer_ok_def = Define`
 
 val good_init_state_def = Define `
   good_init_state
-    (mc_conf: ('a,'state,'b) machine_config) ms ffi bytes
+    (mc_conf: ('a,'state,'b) machine_config) ms bytes
     cbspace
     t m dm
     io_regs cc_regs
@@ -245,7 +243,7 @@ val good_init_state_def = Define `
     (n2w (2 ** t.align - 1) && t.pc) = 0w /\
 
     interference_ok mc_conf.next_interfer (mc_conf.target.proj mc_conf.prog_addresses) /\
-    ffi_interfer_ok ffi t.pc io_regs mc_conf ∧
+    ffi_interfer_ok t.pc io_regs mc_conf ∧
     ccache_interfer_ok t.pc cc_regs mc_conf ∧
 
     (* code memory relation *)
@@ -270,10 +268,10 @@ val good_init_state_def = Define `
    i.e., the range of the data memory
 *)
 val installed_def = Define`
-  installed bytes cbspace bitmaps data_sp ffi_names ffi (r1,r2) mc_conf ms ⇔
+  installed bytes cbspace bitmaps data_sp ffi_names (r1,r2) mc_conf ms ⇔
     ∃t m io_regs cc_regs bitmap_ptr bitmaps_dm.
       let heap_stack_dm = { w | t.regs r1 <=+ w ∧ w <+ t.regs r2 } in
-      good_init_state mc_conf ms ffi bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) io_regs cc_regs ∧
+      good_init_state mc_conf ms bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) io_regs cc_regs ∧
       byte_aligned (t.regs r1) /\
       byte_aligned (t.regs r2) /\
       byte_aligned bitmap_ptr /\

--- a/compiler/bootstrap/compilation/ag32/32/proofs/ag32BootstrapProofScript.sml
+++ b/compiler/bootstrap/compilation/ag32/32/proofs/ag32BootstrapProofScript.sml
@@ -128,7 +128,7 @@ Theorem cake_installed:
    SUM (MAP strlen cl) + LENGTH cl ≤ cline_size ∧
    LENGTH inp ≤ stdin_size ∧
    is_ag32_init_state (init_memory code data (THE config.lab_conf.ffi_names) (cl,inp)) ms0 ⇒
-   installed code 0 data 0 config.lab_conf.ffi_names (basis_ffi cl fs)
+   installed code 0 data 0 config.lab_conf.ffi_names
      (heap_regs ag32_backend_config.stack_conf.reg_names)
      (cake_machine_config) (FUNPOW Next (cake_startup_clock ms0 inp cl) ms0)
 Proof

--- a/compiler/bootstrap/compilation/ag32/32/proofs/ag32BootstrapProofScript.sml
+++ b/compiler/bootstrap/compilation/ag32/32/proofs/ag32BootstrapProofScript.sml
@@ -144,6 +144,7 @@ Proof
   \\ conj_tac >- (simp[LENGTH_code] \\ EVAL_TAC)
   \\ conj_tac >- (simp[LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ asm_exists_tac \\ simp[]
+  \\ last_x_assum $ irule_at Any \\ fs []
 QED
 
 Theorem cake_machine_sem =

--- a/compiler/bootstrap/compilation/x64/64/proofs/x64BootstrapProofScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/proofs/x64BootstrapProofScript.sml
@@ -147,7 +147,7 @@ Definition repl_ready_to_run_def:
       file_content fs «config_enc_str.txt» = SOME config_env_str ∧
       mc_conf_ok mc ∧ mc_init_ok x64_backend_config mc ∧
       installed cake_code cbspace cake_data data_sp
-        cake_config.lab_conf.ffi_names (basis_ffi cl fs)
+        cake_config.lab_conf.ffi_names
         (heap_regs x64_backend_config.stack_conf.reg_names) mc ms
 End
 

--- a/compiler/proofs/compilerProofScript.sml
+++ b/compiler/proofs/compilerProofScript.sml
@@ -115,7 +115,7 @@ Theorem compile_correct_gen:
         (semantics st prelude input = Execute behaviours) ∧
         parse (lexer_fun input) = SOME source_decs ∧
         ∀ms.
-          installed code cbspace data data_sp c.lab_conf.ffi_names st.sem_st.ffi
+          installed code cbspace data data_sp c.lab_conf.ffi_names
             (heap_regs cc.backend_config.stack_conf.reg_names) mc ms
             ⇒
             machine_sem mc st.sem_st.ffi ms ⊆
@@ -188,7 +188,7 @@ Theorem compile_correct_lemma:
         (semantics_init ffi prelude input = Execute behaviours) ∧
         parse (lexer_fun input) = SOME source_decs ∧
         ∀ms.
-          installed code cbspace data data_sp c.lab_conf.ffi_names ffi (heap_regs cc.backend_config.stack_conf.reg_names) mc ms ⇒
+          installed code cbspace data data_sp c.lab_conf.ffi_names (heap_regs cc.backend_config.stack_conf.reg_names) mc ms ⇒
             machine_sem mc ffi ms ⊆
               extend_with_resource_limit'
                 (is_safe_for_space ffi cc
@@ -238,7 +238,7 @@ Theorem compile_correct_safe_for_space:
         ∀ms.
           is_safe_for_space ffi cc (prelude ++ source_decs)              (* cost semantics *)
             (read_limits cc mc ms) ∧
-          installed code cbspace data data_sp c.lab_conf.ffi_names ffi
+          installed code cbspace data data_sp c.lab_conf.ffi_names
             (heap_regs cc.backend_config.stack_conf.reg_names) mc ms ⇒
           machine_sem mc ffi ms = behaviours                             (* <-- equality *)
 Proof
@@ -272,7 +272,7 @@ Theorem compile_correct = Q.prove(`
       ∃behaviours.
         (semantics_init ffi prelude input = Execute behaviours) ∧
         ∀ms.
-          installed code cbspace data data_sp c.lab_conf.ffi_names ffi
+          installed code cbspace data data_sp c.lab_conf.ffi_names
             (heap_regs cc.backend_config.stack_conf.reg_names) mc ms ⇒
           machine_sem mc ffi ms ⊆
             extend_with_resource_limit behaviours

--- a/examples/compilation/ag32/proofs/helloProofScript.sml
+++ b/examples/compilation/ag32/proofs/helloProofScript.sml
@@ -81,7 +81,7 @@ Theorem hello_installed:
    SUM (MAP strlen cl) + LENGTH cl ≤ cline_size ∧
    LENGTH inp ≤ stdin_size ∧
    is_ag32_init_state (init_memory code data (THE config.lab_conf.ffi_names) (cl,inp)) ms0 ⇒
-   installed code 0 data 0 config.lab_conf.ffi_names (basis_ffi cl fs)
+   installed code 0 data 0 config.lab_conf.ffi_names
      (heap_regs ag32_backend_config.stack_conf.reg_names)
      (hello_machine_config) (FUNPOW Next (hello_startup_clock ms0 inp cl) ms0)
 Proof
@@ -97,9 +97,8 @@ Proof
   \\ conj_tac >- (simp[LENGTH_code] \\ EVAL_TAC)
   \\ conj_tac >- (simp[LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (EVAL_TAC)
-  \\ asm_exists_tac
+  \\ rpt $ goal_assum $ drule_at Any
   \\ simp[]
-  \\ fs[ffi_names]
 QED
 
 val hello_machine_sem =

--- a/examples/compilation/ag32/proofs/sortProofScript.sml
+++ b/examples/compilation/ag32/proofs/sortProofScript.sml
@@ -98,7 +98,7 @@ Theorem sort_installed:
    SUM (MAP strlen cl) + LENGTH cl ≤ cline_size ∧
    LENGTH inp ≤ stdin_size ∧
    is_ag32_init_state (init_memory code data (THE config.lab_conf.ffi_names) (cl,inp)) ms0 ⇒
-   installed code 0 data 0 config.lab_conf.ffi_names (basis_ffi cl fs)
+   installed code 0 data 0 config.lab_conf.ffi_names
      (heap_regs ag32_backend_config.stack_conf.reg_names)
      (sort_machine_config) (FUNPOW Next (sort_startup_clock ms0 inp cl) ms0)
 Proof
@@ -114,17 +114,16 @@ Proof
   \\ conj_tac >- (simp[LENGTH_code] \\ EVAL_TAC)
   \\ conj_tac >- (simp[LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (EVAL_TAC)
-  \\ asm_exists_tac
+  \\ rpt $ goal_assum $ drule_at Any
   \\ simp[]
-  \\ fs[ffi_names]
 QED
 
 val sort_machine_sem =
   compile_correct_applied
   |> C MATCH_MP (
       sort_installed
-       |> Q.GENL[`cl`,`fs`]
-       |> Q.SPECL[`[strlit"sort"]`,`stdin_fs inp`]
+       |> Q.GEN `cl`
+       |> Q.SPEC `[strlit"sort"]`
        |> SIMP_RULE(srw_ss())[cline_size_def]
        |> UNDISCH)
   |> DISCH_ALL
@@ -193,19 +192,15 @@ Proof
   \\ conj_tac >- simp[ffi_names]
   \\ conj_tac >- (simp[ffi_names, LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (simp[ffi_names] \\ EVAL_TAC)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ first_assum(mp_then Any mp_tac sort_startup_clock_def)
-  \\ disch_then(first_assum o mp_then Any mp_tac)
+  \\ rpt $ goal_assum $ drule_at Any
+  \\ drule_at Any sort_startup_clock_def
+  \\ simp[]
   \\ impl_tac >- EVAL_TAC
   \\ strip_tac
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
+  \\ rpt $ goal_assum $ drule_at Any
   \\ qmatch_goalsub_abbrev_tac`FUNPOW Next clk`
   \\ qexists_tac`clk` \\ simp[]
   \\ EVAL_TAC
-  \\ metis_tac[]
 QED
 
 val _ = export_theory();

--- a/examples/compilation/ag32/proofs/wordcountProofScript.sml
+++ b/examples/compilation/ag32/proofs/wordcountProofScript.sml
@@ -109,7 +109,7 @@ Theorem wordcount_installed:
    SUM (MAP strlen cl) + LENGTH cl ≤ cline_size ∧
    LENGTH inp ≤ stdin_size ∧
    is_ag32_init_state (init_memory code data (THE config.lab_conf.ffi_names) (cl,inp)) ms0 ⇒
-   installed code 0 data 0 config.lab_conf.ffi_names (basis_ffi cl fs)
+   installed code 0 data 0 config.lab_conf.ffi_names
      (heap_regs ag32_backend_config.stack_conf.reg_names)
      (wordcount_machine_config) (FUNPOW Next (wordcount_startup_clock ms0 inp cl) ms0)
 Proof
@@ -125,17 +125,16 @@ Proof
   \\ conj_tac >- (simp[LENGTH_code] \\ EVAL_TAC)
   \\ conj_tac >- (simp[LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (EVAL_TAC)
-  \\ asm_exists_tac
+  \\ rpt $ goal_assum $ drule_at Any
   \\ simp[]
-  \\ fs[ffi_names]
 QED
 
 val wordcount_machine_sem =
   wordcount_compile_correct_applied
   |> C MATCH_MP (
        wordcount_installed
-       |> Q.GENL[`cl`,`fs`]
-       |> Q.SPECL[`[strlit"wordcount"]`,`stdin_fs inp`]
+       |> Q.GEN `cl`
+       |> Q.SPEC `[strlit"wordcount"]`
        |> SIMP_RULE(srw_ss())[cline_size_def]
        |> UNDISCH)
   |> DISCH_ALL
@@ -202,19 +201,15 @@ Proof
   \\ conj_tac >- simp[ffi_names]
   \\ conj_tac >- (simp[ffi_names, LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (simp[ffi_names] \\ EVAL_TAC)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ first_assum(mp_then Any mp_tac wordcount_startup_clock_def)
-  \\ disch_then(first_assum o mp_then Any mp_tac)
+  \\ rpt $ goal_assum $ drule_at Any
+  \\ drule_at Any wordcount_startup_clock_def
+  \\ simp[]
   \\ impl_tac >- EVAL_TAC
   \\ strip_tac
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
-  \\ goal_assum(first_assum o mp_then Any mp_tac)
+  \\ rpt $ goal_assum $ drule_at Any
   \\ qmatch_goalsub_abbrev_tac`FUNPOW Next clk`
   \\ qexists_tac`clk` \\ simp[]
   \\ EVAL_TAC
-  \\ metis_tac[]
 QED
 
 val _ = export_theory();

--- a/examples/cost/yesProofScript.sml
+++ b/examples/cost/yesProofScript.sml
@@ -1272,7 +1272,7 @@ Theorem yes_has_space_for_dessert:
  (read_limits yes_x64_conf mc ms = (56,93)) ⇒
       mc_conf_ok mc ∧ mc_init_ok yes_x64_conf mc ∧
       installed yes_code cbspace yes_data data_sp
-        yes_config.lab_conf.ffi_names sio_ffi_state
+        yes_config.lab_conf.ffi_names
         (heap_regs yes_x64_conf.stack_conf.reg_names) mc ms ⇒
       machine_sem mc sio_ffi_state ms
         (Diverge (LREPEAT [put_str_event «y\n» ]))

--- a/examples/lpr_checker/array/compilation/proofs/lpr_arrayProofScript.sml
+++ b/examples/lpr_checker/array/compilation/proofs/lpr_arrayProofScript.sml
@@ -39,7 +39,7 @@ val check_unsat_compiled_thm =
 val installed_x64_def = Define `
   installed_x64 ((code, data, cfg) :
       (word8 list # word64 list # 64 backend$config))
-    ffi mc ms
+    mc ms
   <=>
     ?cbspace data_sp.
       is_x64_machine_config mc /\
@@ -47,7 +47,6 @@ val installed_x64_def = Define `
         code cbspace
         data data_sp
         cfg.lab_conf.ffi_names
-        ffi
         (heap_regs x64_backend_config.stack_conf.reg_names) mc ms
     `;
 
@@ -59,7 +58,7 @@ val check_unsat_code_def = Define `
 val cake_lpr_run_def = Define`
   cake_lpr_run cl fs mc ms ⇔
   wfcl cl ∧ wfFS fs ∧ STD_streams fs ∧ hasFreeFD fs ∧
-  installed_x64 check_unsat_code (basis_ffi cl fs) mc ms`
+  installed_x64 check_unsat_code mc ms`
 
 Theorem concat_success_str:
   ∀a b c. concat [strlit "s VERIFIED INTERVALS COVER 0-"; toString (d:num); strlit "\n"] ≠ success_str a b c

--- a/examples/lpr_checker/array/compilation/proofs/lpr_arrayRamseyProofScript.sml
+++ b/examples/lpr_checker/array/compilation/proofs/lpr_arrayRamseyProofScript.sml
@@ -40,7 +40,7 @@ val check_unsat_compiled_thm =
 val installed_x64_def = Define `
   installed_x64 ((code, data, cfg) :
       (word8 list # word64 list # 64 backend$config))
-    ffi mc ms
+    mc ms
   <=>
     ?cbspace data_sp.
       is_x64_machine_config mc /\
@@ -48,7 +48,6 @@ val installed_x64_def = Define `
         code cbspace
         data data_sp
         cfg.lab_conf.ffi_names
-        ffi
         (heap_regs x64_backend_config.stack_conf.reg_names) mc ms
     `;
 
@@ -60,7 +59,7 @@ val check_unsat_code_def = Define `
 val ramsey_run_def = Define`
   ramsey_run cl fs mc ms ⇔
   wfcl cl ∧ wfFS fs ∧ STD_streams fs ∧ hasFreeFD fs ∧
-  installed_x64 check_unsat_code (basis_ffi cl fs) mc ms`
+  installed_x64 check_unsat_code mc ms`
 
 Theorem machine_code_sound:
   ramsey_run cl fs mc ms ⇒

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
@@ -82,7 +82,7 @@ Theorem reader_installed:
    SUM (MAP strlen cl) + LENGTH cl ≤ cline_size ∧
    LENGTH inp ≤ stdin_size ∧
    is_ag32_init_state (init_memory code data (THE config.lab_conf.ffi_names) (cl,inp)) ms0 ⇒
-   installed code 0 data 0 config.lab_conf.ffi_names (basis_ffi cl fs)
+   installed code 0 data 0 config.lab_conf.ffi_names
      (heap_regs ag32_backend_config.stack_conf.reg_names)
      (reader_machine_config) (FUNPOW Next (reader_startup_clock ms0 inp cl) ms0)
 Proof

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
@@ -98,7 +98,7 @@ Proof
   \\ conj_tac >- (simp[LENGTH_code] \\ EVAL_TAC)
   \\ conj_tac >- (simp[LENGTH_code, LENGTH_data] \\ EVAL_TAC)
   \\ conj_tac >- (EVAL_TAC)
-  \\ asm_exists_tac
+  \\ rpt $ goal_assum $ drule_at Any
   \\ simp[]
   \\ fs[ffi_names]
 QED

--- a/examples/opentheory/compilation/proofs/readerProgProofScript.sml
+++ b/examples/opentheory/compilation/proofs/readerProgProofScript.sml
@@ -45,13 +45,13 @@ Theorem reader_compiled_thm =
 Definition installed_x64_def:
   installed_x64 ((code, data, cfg) :
       (word8 list # word64 list # 64 backend$config))
-    ffi mc ms ⇔
+    mc ms ⇔
     ∃cbspace data_sp.
       is_x64_machine_config mc ∧
       installed
         code cbspace
         data data_sp
-        cfg.lab_conf.ffi_names ffi
+        cfg.lab_conf.ffi_names
         (heap_regs x64_backend_config.stack_conf.reg_names) mc ms
 End
 
@@ -67,7 +67,7 @@ Theorem machine_code_sound:
    wfcl cl ∧
    wfFS fs ∧
    STD_streams fs ⇒
-     (installed_x64 reader_code (basis_ffi cl fs) mc ms ⇒
+     (installed_x64 reader_code mc ms ⇒
         machine_sem mc (basis_ffi cl fs) ms ⊆
           extend_with_resource_limit
             {Terminate Success (reader_io_events cl fs)}) ∧

--- a/tutorial/wordfreqProofScript.sml
+++ b/tutorial/wordfreqProofScript.sml
@@ -52,9 +52,9 @@ val wfFS_def = Define `
   wfFS fs <=> fsFFIProps$wfFS fs ∧ STD_streams fs`;
 
 val x64_installed_def = Define `
-  x64_installed (c,d,conf) cbspace data_sp ffi mc ms <=>
+  x64_installed (c,d,conf) cbspace data_sp mc ms <=>
     is_x64_machine_config mc ∧
-    targetSem$installed c cbspace d data_sp conf.lab_conf.ffi_names ffi
+    targetSem$installed c cbspace d data_sp conf.lab_conf.ffi_names
       (heap_regs x64_backend_config.stack_conf.reg_names) mc ms`
 
 (* -- *)
@@ -62,7 +62,7 @@ val x64_installed_def = Define `
 Theorem wordfreq_compiled_thm:
    wfcl [pname; fname] ∧ wfFS fs ∧ hasFreeFD fs ∧
     (get_file_contents fs fname = SOME file_contents) ∧
-    x64_installed compiler_output cbspace data_sp (basis_ffi [pname; fname] fs) mc ms ⇒
+    x64_installed compiler_output cbspace data_sp mc ms ⇒
     ∃io_events ascii_output.
       machine_sem mc (basis_ffi [pname; fname] fs) ms ⊆
       extend_with_resource_limit {Terminate Success io_events} ∧


### PR DESCRIPTION
This will allow lifting of compiler correctness to an FFI-independent result in PureCake.

Also fixes an omission in #866.

I have tested some of the obvious suspects for build failures, but regression testing will likely uncover more.