### PR TITLE
Itree semantics for CakeML

### DIFF
--- a/compiler/backend/proofs/README.md
+++ b/compiler/backend/proofs/README.md
@@ -4,6 +4,9 @@ different phases of the compiler backend.
 [backendProofScript.sml](backendProofScript.sml):
 Composes the correctness theorems for all of the compiler phases.
 
+[backend_itreeProofScript.sml](backend_itreeProofScript.sml):
+Compiler correctness for the itree CakeML semantics
+
 [bvi_letProofScript.sml](bvi_letProofScript.sml):
 Correctness proof for bvi_let
 

--- a/compiler/backend/proofs/backend_itreeProofScript.sml
+++ b/compiler/backend/proofs/backend_itreeProofScript.sml
@@ -3,7 +3,7 @@
 *)
 open preamble;
 open semanticsPropsTheory evaluatePropsTheory ffiTheory targetPropsTheory
-     backendProofTheory primSemEnvTheory;
+     backendProofTheory primSemEnvTheory alt_semanticsTheory;
 open target_itreeSemTheory target_itreePropsTheory target_itreeEquivTheory
      itree_semanticsTheory itree_semanticsPropsTheory itree_semanticsEquivTheory;
 

--- a/compiler/backend/proofs/backend_itreeProofScript.sml
+++ b/compiler/backend/proofs/backend_itreeProofScript.sml
@@ -1,0 +1,624 @@
+(*
+  Compiler correctness for the itree CakeML semantics
+*)
+open preamble;
+open semanticsPropsTheory evaluatePropsTheory ffiTheory targetPropsTheory
+     backendProofTheory primSemEnvTheory;
+open target_itreeSemTheory target_itreePropsTheory target_itreeEquivTheory
+     itree_semanticsTheory itree_semanticsPropsTheory itree_semanticsEquivTheory;
+
+
+val _ = new_theory "backend_itreeProof"
+
+
+(*********** Definitions **********)
+
+CoInductive prune:
+  prune exact Div                          Div                  ∧
+  prune exact (Ret Termination)            (Ret Termination)    ∧
+  prune exact (Ret itree_semantics$Error) (Ret Error)          ∧
+  prune F     t                            (Ret OutOfMemory)    ∧
+  prune exact (Ret (FinalFFI x y))         (Ret (FinalFFI x y)) ∧
+  ((∀x. prune exact (f x) (g x)) ⇒ prune exact (Vis d f) (Vis d g))
+End
+
+Definition same_up_to_oom_def:
+  (same_up_to_oom exact a b [] = T) ∧
+  (same_up_to_oom exact a b (x::xs) ⇔
+     (a = Div ∧ b = Div) ∨
+     (a = Ret Termination ∧ b = Ret Termination) ∨
+     (a = Ret (itree_semantics$Error) ∧ b = Ret Error) ∨
+     (¬exact ∧ b = Ret OutOfMemory) ∨
+     (∃x y. a = Ret (FinalFFI x y) ∧ b = Ret (FinalFFI x y)) ∨
+     ∃d f g.
+       a = Vis d f ∧ b = Vis d g ∧
+       same_up_to_oom exact (f x) (g x) xs)
+End
+
+Definition bisimilar_up_to_oom_def:
+  bisimilar_up_to_oom exact a b = ∀xs. same_up_to_oom exact a b xs
+End
+
+Definition list_oracle_def:
+  list_oracle name [] bytes1 bytes2 = Oracle_final FFI_diverged ∧
+  list_oracle name (INR x::rest) bytes1 bytes2 = Oracle_return rest x ∧
+  list_oracle name (INL l::rest) bytes1 bytes2 = Oracle_final l
+End
+
+Definition make_ffi_def:
+  make_ffi xs = <|
+       io_events := [] ;
+       ffi_state := xs ;
+       oracle := list_oracle
+     |>
+End
+
+Inductive trace_rel:
+  trace_rel exact (io, NONE) (io, NONE) ∧
+
+  trace_rel exact (io, SOME itree_semantics$Termination) (io, SOME Termination) ∧
+  trace_rel exact (io, SOME $ FinalFFI e r) (io, SOME $ FinalFFI e r) ∧
+
+  (isPREFIX io' io ⇒
+    trace_rel F (io, res) (io', SOME OutOfMemory))
+End
+
+CoInductive ffi_invariant:
+  ((∀e input. x ≠ f e input) ⇒ ffi_invariant f (Ret x)) ∧
+  ffi_invariant f Div ∧
+  ((∀outcome. g (INL outcome) = Ret $ f e outcome) ∧
+   (∀input. LENGTH input ≠ LENGTH (SND $ SND e) ⇒ g (INR input) = Ret $ f e FFI_failed) ∧
+   (∀input. LENGTH input = LENGTH (SND $ SND e) ⇒ ffi_invariant f (g (INR input)))
+      ⇒ ffi_invariant f (Vis e g))
+End
+
+CoInductive safe_itree:
+  (safe_itree (Ret itree_semantics$Termination)) ∧
+  (safe_itree (Ret $ FinalFFI e f)) ∧
+  (safe_itree Div) ∧
+  ((∀s. safe_itree (rest s)) ⇒ safe_itree (Vis e rest))
+End
+
+val (_,start_env) =
+    prim_sem_env_eq |> Q.INST [`ffi` |-> `ARB`] |>
+      concl |> rhs |> optionSyntax.dest_some |> pairSyntax.dest_pair;
+
+Definition start_dstate_def:
+  start_dstate : dstate =
+    <| refs := []; next_type_stamp := 2; next_exn_stamp := 4; eval_state := NONE |>
+End
+
+Definition start_env_def:
+  start_env = ^start_env
+End
+
+Definition itree_semantics_def:
+  itree_semantics prog =
+  interp start_env (Dstep start_dstate (Decl (Dlocal [] prog)) [])
+End
+
+
+(*********** Lemmas **********)
+
+Theorem prune_eq_bisimilar_up_to_oom:
+  bisimilar_up_to_oom exact a b ⇔ prune exact a b
+Proof
+  eq_tac >> rw[]
+  >- (
+    pop_assum mp_tac >> map_every qid_spec_tac [`b`,`a`,`exact`] >>
+    ho_match_mp_tac prune_coind >> rw[bisimilar_up_to_oom_def] >>
+    pop_assum $ qspec_then `x::xs` $ assume_tac o GEN_ALL >>
+    gvs[same_up_to_oom_def] >> Cases_on `a` >> gvs[] >> Cases_on `b` >> gvs[]
+    )
+  >- (
+    rw[bisimilar_up_to_oom_def] >>
+    pop_assum mp_tac >> map_every qid_spec_tac [`b`,`a`,`xs`] >>
+    Induct >> rw[same_up_to_oom_def] >>
+    pop_assum mp_tac >> rw[Once prune_cases]
+    )
+QED
+
+Triviality make_ffi_simps[simp]:
+  (make_ffi l).oracle = list_oracle ∧
+  (make_ffi l).io_events = [] ∧
+  (make_ffi l).ffi_state = l
+Proof
+  rw[make_ffi_def]
+QED
+
+Triviality list_oracle_apply =
+  SIMP_CONV (srw_ss()) [DefnBase.one_line_ify NONE list_oracle_def]
+    ``list_oracle name l ws1 ws2``;
+
+Triviality trace_rel_simps[simp] =
+  trace_rel_rules |> CONJUNCTS |> butlast |> LIST_CONJ;
+
+Triviality trace_rel_prefix:
+  trace_rel exact a b ⇒ isPREFIX (FST b) (FST a)
+Proof
+  rw[trace_rel_cases] >> simp[]
+QED
+
+Theorem trace_rel_CONS:
+  trace_rel exact (io1::ios1, res1) (io2::ios2, res2) ⇔
+  io1 = io2 ∧ trace_rel exact (ios1, res1) (ios2, res2)
+Proof
+  eq_tac >> simp[] >>
+  Induct_on `trace_rel` >> rw[] >> gvs[trace_rel_cases, IS_PREFIX]
+QED
+
+Triviality ffi_invariant_simps[simp]:
+  ffi_invariant f (Ret x) = (∀e input. x ≠ f e input) ∧
+  ffi_invariant f Div = T ∧
+  ffi_invariant f (Vis e g) = (
+     (∀outcome. g (INL outcome) = Ret (f e outcome)) ∧
+     (∀input.
+        LENGTH input ≠ LENGTH (SND (SND e)) ⇒
+        g (INR input) = Ret (f e FFI_failed)) ∧
+     ∀input.
+       LENGTH input = LENGTH (SND (SND e)) ⇒
+       ffi_invariant f (g (INR input)))
+Proof
+  rw[] >> simp[Once ffi_invariant_cases]
+QED
+
+Theorem ffi_invariant_itree_of:
+  ffi_invariant FinalFFI (itree_of st env prog)
+Proof
+  rw[itree_of_def] >>
+  `∀t. (∃env e. t = interp env e) ⇒ ffi_invariant FinalFFI t`
+    suffices_by rw[PULL_EXISTS] >>
+  ho_match_mp_tac ffi_invariant_coind >> rw[] >>
+  Cases_on `interp env e` >> rw[] >>
+  gvs[Once interp] >> every_case_tac >> gvs[] >> irule_at Any EQ_REFL
+QED
+
+Theorem ffi_invariant_machine_sem_itree:
+  ffi_invariant FinalFFI (machine_sem_itree (mc,ms))
+Proof
+  rw[] >>
+  `∀t. (∃mc ms. t = machine_sem_itree (mc,ms)) ⇒ ffi_invariant FinalFFI t`
+    suffices_by rw[PULL_EXISTS] >>
+  ho_match_mp_tac ffi_invariant_coind >> rw[] >>
+  Cases_on `machine_sem_itree (mc,ms)` >> rw[] >>
+  gvs[Once machine_sem_itree] >> every_case_tac >> gvs[]
+  >- (
+    CCONTR_TAC >> gvs[eval_alt_def, AllCaseEqs()] >>
+    pairarg_tac >> gvs[eval_to'_Ret_FinalFFI]
+    )
+  >- (Cases_on `f input` >> irule_at Any EQ_REFL)
+QED
+
+Theorem extend_no_oom:
+  extend_with_resource_limit' exact behaviours behaviour ∧
+  (∀io. behaviour ≠ Terminate Resource_limit_hit io) ⇒
+  behaviours behaviour
+Proof
+  rw[extend_with_resource_limit'_def, extend_with_resource_limit_def] >>
+  gvs[IN_DEF]
+QED
+
+Theorem safe_itree_trace_prefix_Error:
+  ∀n ffi io t.
+    safe_itree t ⇒ trace_prefix n ffi t ≠ (io, SOME Error)
+Proof
+  Induct >> rw[] >> PairCases_on `ffi` >> gvs[] >>
+  simp[trace_prefix_def] >> Cases_on `t` >> gvs[trace_prefix_def] >>
+  pop_assum mp_tac >> rw[Once safe_itree_cases] >>
+  PairCases_on `a` >> simp[trace_prefix_def] >> CASE_TAC >> gvs[] >>
+  pairarg_tac >> gvs[] >> qsuff_tac `res ≠ SOME Error` >> rw[] >> gvs[] >>
+  first_x_assum $ qspecl_then [`ffi0,f`,`io'`,`g (INR l)`] assume_tac >> gvs[]
+QED
+
+Theorem start_dstate:
+  ∀ffi:'ffi ffi_state. dstate_of (FST $ THE $ prim_sem_env ffi) = start_dstate
+Proof
+  rw[prim_sem_env_eq, dstate_of_def, start_dstate_def]
+QED
+
+Theorem start_env:
+  ∀ffi:'ffi ffi_state. SND $ THE $ prim_sem_env ffi = start_env
+Proof
+  rw[prim_sem_env_eq, start_env_def]
+QED
+
+Triviality prim_sem_env_change_ffi[simp]:
+  (FST $ THE $ prim_sem_env f) with ffi := f' = (FST $ THE $ prim_sem_env f')
+Proof
+  rw[prim_sem_env_eq, semanticPrimitivesTheory.state_component_equality]
+QED
+
+Theorem itree_semantics_itree_of:
+  ∀(ffi:'ffi ffi_state) prog.
+    itree_of (FST $ THE $ prim_sem_env ffi) start_env prog =
+    itree_semantics prog
+Proof
+  rw[itree_semantics_def, itree_of_def, start_dstate]
+QED
+
+
+(*********** Theorems **********)
+
+Theorem trace_rel_IMP_bisimilar_up_to_oom:
+  ∀exact ffi_st src trgt.
+    ffi_invariant FinalFFI src ∧
+    ffi_invariant FinalFFI trgt ∧
+    (∀n.
+      trace_rel exact
+        (trace_prefix n (list_oracle, ffi_st) src)
+        (trace_prefix n (list_oracle, ffi_st) trgt))
+  ⇒ same_up_to_oom exact src trgt ffi_st
+Proof
+  gen_tac >> Induct >> rw[same_up_to_oom_def] >>
+  Cases_on `trgt = Ret OutOfMemory` >> gvs[]
+  >- (
+    CCONTR_TAC >> gvs[] >>
+    pop_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def, Once trace_rel_cases]
+    ) >>
+  Cases_on `src` >> gvs[]
+  >- ( (* Ret *)
+    first_x_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >>
+    simp[trace_prefix_def, trace_rel_cases] >>
+    Cases_on `trgt` >> gvs[trace_prefix_def] >>
+    PairCases_on `a` >> simp[trace_prefix_def, list_oracle_apply] >>
+    CASE_TAC >> simp[] >> qexists_tac `SUC n` >> simp[trace_prefix_def] >>
+    Cases_on `LENGTH a2 = LENGTH y` >> gvs[UNCURRY, trace_prefix_def]
+    )
+  >- ( (* Div *)
+    first_x_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >>
+    simp[trace_prefix_def, trace_rel_cases] >>
+    Cases_on `trgt` >> gvs[trace_prefix_def] >>
+    PairCases_on `a` >> simp[trace_prefix_def, list_oracle_apply] >>
+    CASE_TAC >> simp[] >> qexists_tac `SUC n` >> simp[trace_prefix_def] >>
+    Cases_on `LENGTH a2 = LENGTH y` >> gvs[UNCURRY, trace_prefix_def]
+    )
+  >- ( (* Vis *)
+    first_x_assum $ qspec_then `SUC n` $ assume_tac o GEN_ALL >>
+    PairCases_on `a` >> gvs[trace_prefix_def, list_oracle_apply] >>
+    Cases_on `h` >> gvs[]
+    >- (
+      pop_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >>
+      simp[trace_prefix_def, Once trace_rel_cases] >>
+      Cases_on `trgt` >> simp[trace_prefix_def] >> gvs[] >>
+      PairCases_on `a` >> simp[trace_prefix_def, list_oracle_apply] >>
+      rw[] >> gvs[] >> Cases_on `ffi_st` >> simp[same_up_to_oom_def]
+      ) >>
+    reverse $ Cases_on `LENGTH a2 = LENGTH y` >> gvs[]
+    >- (
+      first_x_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >>
+      simp[trace_prefix_def, trace_rel_cases] >>
+      Cases_on `trgt` >> gvs[trace_prefix_def] >>
+      PairCases_on `a` >> simp[trace_prefix_def, list_oracle_apply, UNCURRY] >>
+      strip_tac >> `LENGTH a2' ≠ LENGTH y` by (CCONTR_TAC >> gvs[]) >> gvs[] >>
+      Cases_on `ffi_st` >> simp[same_up_to_oom_def]
+      ) >>
+    first_x_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >>
+    Cases_on `trgt` >> gvs[]
+    >- (
+      simp[trace_prefix_def, trace_rel_cases] >>
+      qexists_tac `0` >> pairarg_tac >> gvs[]
+      )
+    >- (
+      simp[trace_prefix_def, trace_rel_cases] >>
+      qexists_tac `0` >> pairarg_tac >> gvs[]
+      ) >>
+    PairCases_on `a` >> gvs[trace_prefix_def, list_oracle_apply, UNCURRY] >>
+    strip_tac >>
+    `LENGTH a2' = LENGTH y` by (
+      CCONTR_TAC >> gvs[] >> first_x_assum $ qspec_then `SUC n` mp_tac >>
+      simp[trace_prefix_def, trace_rel_cases]) >>
+    conj_asm1_tac
+    >- (
+      first_x_assum $ qspec_then `n` assume_tac >>
+      imp_res_tac trace_rel_prefix >> gvs[LIST_EQ_REWRITE, EL_ZIP]
+      ) >>
+    gvs[] >> last_x_assum irule >> rw[] >>
+    Cases_on `n` >> simp[trace_prefix_def] >>
+    first_x_assum $ qspec_then `n'` assume_tac >> gvs[trace_rel_CONS]
+    )
+QED
+
+Theorem oracle_IMP_itree_preservation:
+  s.eval_state = NONE ∧
+  (∀f:((ffi_outcome + word8 list) list) ffi_state.
+    Fail ∉ semantics_prog (s with ffi := f) env prog ∧
+    machine_sem (mc:(α,β,γ) machine_config) f ms ⊆
+      extend_with_resource_limit' safe_for_space
+        (semantics_prog (s with ffi := f) env prog))
+  ⇒ prune safe_for_space (itree_of s env prog) (machine_sem_itree (mc,ms))
+Proof
+  rw[GSYM prune_eq_bisimilar_up_to_oom, bisimilar_up_to_oom_def] >>
+  irule trace_rel_IMP_bisimilar_up_to_oom >> reverse conj_asm2_tac
+  >- simp[ffi_invariant_itree_of, ffi_invariant_machine_sem_itree] >>
+  first_x_assum $ qspec_then `make_ffi xs` assume_tac >> gvs[] >>
+  qabbrev_tac `st = s with ffi := make_ffi xs` >>
+  `st.eval_state = NONE` by (unabbrev_all_tac >> gvs[]) >> last_x_assum kall_tac >>
+  `∀n io. trace_prefix n (list_oracle,xs) (itree_of st env prog) ≠ (io, SOME Error)` by (
+    drule $ cj 3 itree_semantics >> disch_then $ qspecl_then [`prog`,`env`] assume_tac >>
+    unabbrev_all_tac >> gvs[IN_DEF]) >>
+  qpat_x_assum `Fail ∉ _` kall_tac >>
+  qspecl_then [`make_ffi xs`,`ms`,`mc`] assume_tac $ GEN_ALL machine_sem_total >>
+  gvs[SUBSET_DEF, IN_DEF] >> last_x_assum drule >> strip_tac >>
+  qmatch_asmsub_abbrev_tac `trace_prefix _ _ src` >>
+  qabbrev_tac `trgt = machine_sem_itree (mc,ms)` >>
+  `itree_ffi st = (list_oracle,xs)` by (unabbrev_all_tac >> rw[]) >>
+  gvs[] >> qabbrev_tac `xs = st.ffi.ffi_state` >> gvs[Abbr `st`] >>
+  `itree_of s env prog = src` by (
+    unabbrev_all_tac >> gvs[itree_of_def, dstate_of_def]) >>
+  pop_assum SUBST_ALL_TAC >>
+  Cases_on `b` >> imp_res_tac extend_no_oom >>
+  gvs[itree_semantics, itree_machine_semantics] >>
+  qpat_x_assum `∀n io. _ ≠ _` kall_tac
+  >- (
+    qpat_x_assum `extend_with_resource_limit' _ _ _` kall_tac >>
+    qpat_x_assum `_ = NONE `kall_tac >> rpt $ qpat_x_assum `Abbrev _` kall_tac >>
+    gen_tac >> rpt $ pop_assum mp_tac >>
+    map_every qid_spec_tac [`l`,`trgt`,`src`,`xs`,`n`] >>
+    Induct >> rw[trace_prefix_def] >>
+    ntac 2 $ last_x_assum $ qspec_then `SUC n` $ assume_tac o GEN_ALL >>
+    Cases_on `src` >> gvs[trace_prefix_def]
+    >- (
+      last_x_assum kall_tac >> gvs[PULL_EXISTS] >>
+      simp[trace_rel_cases] >> disj1_tac >> metis_tac[]
+      ) >>
+    Cases_on `trgt` >> gvs[trace_prefix_def, PULL_EXISTS]
+    >- (
+      PairCases_on `a` >> gvs[trace_prefix_def, list_oracle_apply] >>
+      CASE_TAC >> gvs[]
+      >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def]) >>
+      CASE_TAC >> gvs[]
+      >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def]) >>
+      qpat_x_assum `∀io n' res. _ ⇒ io = []` mp_tac >> simp[Once SWAP_FORALL_THM] >>
+      disch_then $ qspec_then `SUC n` $ mp_tac >>
+      simp[trace_prefix_def, list_oracle_apply] >>
+      reverse $ CASE_TAC >> gvs[] >> pairarg_tac >> simp[] >>
+      first_x_assum $ qspec_then `n` assume_tac >> gvs[]
+      ) >>
+    PairCases_on `a` >> PairCases_on `a'` >>
+    gvs[trace_prefix_def, list_oracle_apply] >> CASE_TAC >> gvs[]
+    >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def]) >>
+    CASE_TAC >> gvs[]
+    >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def]) >>
+    CASE_TAC >> gvs[] >> CASE_TAC >> gvs[]
+    >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def])
+    >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def])
+    >- (last_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def]) >>
+    simp[UNCURRY, trace_rel_CONS] >> Cases_on `l` >> gvs[PULL_EXISTS]
+    >- (
+      irule FALSITY >> qpat_x_assum `∀io n res. _` mp_tac >> simp[] >>
+      simp[Once SWAP_EXISTS_THM] >> qexists_tac `SUC n` >>
+      simp[trace_prefix_def, list_oracle_apply] >> pairarg_tac >> simp[]
+      ) >>
+    conj_asm1_tac >> gvs[]
+    >- (
+      imp_res_tac lprefix_lub_LCONS >> gvs[PULL_EXISTS] >>
+      ntac 2 $ pop_assum mp_tac >>
+      ntac 2 (simp[Once SWAP_FORALL_THM] >>
+              disch_then $ qspec_then `SUC n` assume_tac) >>
+      gvs[trace_prefix_def, list_oracle_apply] >> ntac 2 (pairarg_tac >> gvs[])
+      ) >>
+    last_x_assum irule >> rw[]
+    >- (
+      ntac 2 $ first_x_assum $ qspec_then `n` assume_tac >> rpt (pairarg_tac >> gvs[])
+      )
+    >- (
+      ntac 2 $ first_x_assum $ qspec_then `n` assume_tac >> rpt (pairarg_tac >> gvs[])
+      ) >>
+    qexists_tac `t'` >> rw[]
+    >- (
+      irule lprefix_lub_LTL >> goal_assum $ drule_at Any >>
+      rw[PULL_EXISTS, LTL_fromList, EXTENSION] >> eq_tac >> rw[]
+      >- (
+        simp[Once SWAP_EXISTS_THM] >> qexists_tac `SUC n` >>
+        simp[trace_prefix_def, list_oracle_apply]
+        )
+      >- (
+        Cases_on `n'` >> gvs[trace_prefix_def, list_oracle_apply] >>
+        pairarg_tac >> gvs[SF SFY_ss]
+        )
+      )
+    >- (
+      irule lprefix_lub_LTL >> goal_assum $ rev_drule_at Any >>
+      rw[PULL_EXISTS, LTL_fromList, EXTENSION] >> eq_tac >> rw[]
+      >- (
+        simp[Once SWAP_EXISTS_THM] >> qexists_tac `SUC n` >>
+        simp[trace_prefix_def, list_oracle_apply]
+        )
+      >- (
+        Cases_on `n` >> gvs[trace_prefix_def, list_oracle_apply] >>
+        pairarg_tac >> gvs[SF SFY_ss]
+        )
+      )
+    ) >>
+  rename1 `outcome = Success` >>
+  reverse $ Cases_on `outcome = Resource_limit_hit` >> gvs[]
+  >- (
+    rename1 `trace_prefix m _ _ = (_, SOME res)` >>
+    rename1 `trace_prefix m' _ _ = (_, SOME res')` >>
+    qpat_x_assum `extend_with_resource_limit' _ _ _` kall_tac >>
+    qpat_x_assum `_ = NONE `kall_tac >> rpt $ qpat_x_assum `Abbrev _` kall_tac >>
+    gen_tac >> rpt $ pop_assum mp_tac >>
+    map_every qid_spec_tac [`l`,`m`,`trgt`,`m'`,`src`,`xs`,`n`] >>
+    Induct >> rw[trace_prefix_def]
+    >- (
+      Cases_on `m` >> gvs[trace_prefix_def] >>
+      Cases_on `m'` >> gvs[trace_prefix_def] >>
+      Cases_on `src` >> gvs[trace_prefix_def] >>
+      Cases_on `trgt` >> gvs[trace_prefix_def]
+      >- (
+        PairCases_on `a` >> gvs[trace_prefix_def, AllCaseEqs()] >>
+        rpt (pairarg_tac >> gvs[]) >> every_case_tac >> gvs[] >>
+        Cases_on `n'` >> gvs[trace_prefix_def]
+        )
+      >- (
+        PairCases_on `a` >> gvs[trace_prefix_def, AllCaseEqs()] >>
+        rpt (pairarg_tac >> gvs[]) >> every_case_tac >> gvs[] >>
+        Cases_on `n''` >> gvs[trace_prefix_def]
+        ) >>
+      PairCases_on `a` >> PairCases_on `a'` >>
+      gvs[trace_prefix_def, list_oracle_apply] >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n''` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      simp[UNCURRY, trace_rel_CONS] >>
+      conj_asm1_tac >- rpt (pairarg_tac >> gvs[]) >> gvs[] >>
+      first_x_assum irule >> simp[] >> rpt (pairarg_tac >> gvs[]) >> simp[SF SFY_ss]
+      )
+    >- (
+      Cases_on `m` >> gvs[trace_prefix_def] >>
+      Cases_on `m'` >> gvs[trace_prefix_def] >>
+      Cases_on `src` >> gvs[trace_prefix_def] >>
+      Cases_on `trgt` >> gvs[trace_prefix_def] >>
+      PairCases_on `a` >> PairCases_on `a'` >>
+      gvs[trace_prefix_def, list_oracle_apply] >>
+      CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      rpt (pairarg_tac >> gvs[]) >>
+      `IO_event a'0 a'1 (ZIP (a'2,y)) = IO_event a0 a1 (ZIP (a2,y))` by (
+        every_case_tac >> gvs[] >>
+        Cases_on `n'` >> Cases_on `n''` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >> CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def])
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def])
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      simp[trace_rel_CONS] >>
+      first_x_assum $ drule_at Any >> simp[] >> disch_then $ drule_at Any >> simp[]
+      )
+    ) >>
+  gvs[extend_with_resource_limit'_def, extend_with_resource_limit_def] >>
+  gvs[COND_RATOR, IN_DEF, itree_semantics]
+  >- (
+    rename1 `trace_prefix m _ _ = (_, SOME res)` >>
+    rename1 `trace_prefix m' _ _ = (_, SOME OutOfMemory)` >>
+    qpat_x_assum `_ = NONE `kall_tac >> rpt $ qpat_x_assum `Abbrev _` kall_tac >>
+    gen_tac >> rpt $ pop_assum mp_tac >>
+    map_every qid_spec_tac [`l'`,`l`,`m`,`trgt`,`m'`,`src`,`xs`,`n`] >>
+    Induct >> rw[trace_prefix_def]
+    >- (
+      Cases_on `m` >> gvs[trace_prefix_def] >>
+      Cases_on `m'` >> gvs[trace_prefix_def] >>
+      Cases_on `trgt` >> gvs[trace_prefix_def]
+      >- (simp[trace_rel_cases] >> metis_tac[PAIR]) >>
+      Cases_on `src` >> gvs[trace_prefix_def]
+      >- (
+        PairCases_on `a` >> gvs[trace_prefix_def, list_oracle_apply] >>
+        rpt (CASE_TAC >> gvs[]) >> Cases_on `n''` >> gvs[trace_prefix_def] >>
+        rpt (pairarg_tac >> gvs[])
+        ) >>
+      PairCases_on `a` >> PairCases_on `a'` >>
+      gvs[trace_prefix_def, list_oracle_apply] >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[] >- (Cases_on `n''` >> gvs[trace_prefix_def]) >>
+      simp[UNCURRY, trace_rel_CONS] >>
+      conj_asm1_tac >- rpt (pairarg_tac >> gvs[]) >> gvs[] >>
+      first_x_assum irule >> simp[] >> rpt (pairarg_tac >> gvs[]) >> simp[SF SFY_ss]
+      )
+    >- (
+      Cases_on `m` >> gvs[trace_prefix_def] >>
+      Cases_on `m'` >> gvs[trace_prefix_def] >>
+      Cases_on `src` >> gvs[trace_prefix_def] >>
+      Cases_on `trgt` >> gvs[trace_prefix_def]
+      >- (simp[trace_rel_cases] >> metis_tac[PAIR]) >>
+      PairCases_on `a` >> PairCases_on `a'` >>
+      gvs[trace_prefix_def, list_oracle_apply] >>
+      CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      rpt (pairarg_tac >> gvs[]) >>
+      `IO_event a'0 a'1 (ZIP (a'2,y)) = IO_event a0 a1 (ZIP (a2,y))` by (
+        every_case_tac >> gvs[] >>
+        Cases_on `n'` >> Cases_on `n''` >> gvs[trace_prefix_def]) >>
+      gvs[] >> CASE_TAC >> gvs[] >> CASE_TAC >> gvs[]
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def])
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def])
+      >- (map_every Cases_on [`n`,`n'`,`n''`] >> gvs[trace_prefix_def]) >>
+      simp[trace_rel_CONS] >>
+      first_x_assum $ drule_at Any >> simp[] >> disch_then $ drule_at Any >> simp[]
+      )
+    )
+  >- (
+    rename1 `trace_prefix m _ _ = (_, SOME OutOfMemory)` >>
+    qpat_x_assum `_ = NONE `kall_tac >> rpt $ qpat_x_assum `Abbrev _` kall_tac >>
+    gen_tac >> rpt $ pop_assum mp_tac >>
+    map_every qid_spec_tac [`ll`,`l`,`m`,`trgt`,`src`,`xs`,`n`] >>
+    Induct >> rw[trace_prefix_def] >>
+    Cases_on `m` >> gvs[trace_prefix_def] >>
+    Cases_on `trgt` >> gvs[trace_prefix_def]
+    >- (simp[trace_rel_cases] >> metis_tac[PAIR]) >>
+    first_x_assum $ qspec_then `SUC n` $ assume_tac o GEN_ALL >>
+    Cases_on `src` >> gvs[trace_prefix_def]
+    >- (
+      PairCases_on `a` >> gvs[trace_prefix_def, AllCaseEqs()] >>
+      rpt (pairarg_tac >> gvs[]) >> every_case_tac >> gvs[] >>
+      Cases_on `n'` >> gvs[trace_prefix_def]
+      ) >>
+    PairCases_on `a` >> PairCases_on `a'` >> gvs[trace_prefix_def, list_oracle_apply] >>
+    CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+    CASE_TAC >> gvs[] >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+    CASE_TAC >> gvs[] >> CASE_TAC >> gvs[]
+    >- (Cases_on `n'` >> gvs[trace_prefix_def])
+    >- (first_x_assum $ qspec_then `SUC n` mp_tac >> simp[trace_prefix_def])
+    >- (Cases_on `n'` >> gvs[trace_prefix_def]) >>
+    simp[UNCURRY, trace_rel_CONS] >> Cases_on `ll` >> gvs[PULL_EXISTS]
+    >- (
+      irule FALSITY >> qpat_x_assum `∀io n res. _` mp_tac >> simp[] >>
+      simp[Once SWAP_EXISTS_THM] >> qexists_tac `SUC n` >>
+      simp[trace_prefix_def, list_oracle_apply] >> pairarg_tac >> simp[]
+      ) >>
+    conj_asm1_tac >> gvs[]
+    >- (
+      imp_res_tac lprefix_lub_LCONS >> gvs[PULL_EXISTS] >>
+      pop_assum mp_tac >> simp[Once SWAP_FORALL_THM] >>
+      disch_then $ qspec_then `SUC n'` mp_tac >>
+      simp[trace_prefix_def, list_oracle_apply] >>
+      rpt (pairarg_tac >> gvs[]) >> strip_tac >> gvs[LPREFIX_LCONS]
+      ) >>
+    last_x_assum irule >> rw[]
+    >- (first_x_assum $ qspec_then `n''` assume_tac >> pairarg_tac >> gvs[]) >>
+    pairarg_tac >> gvs[LPREFIX_LCONS] >> rpt $ goal_assum drule >>
+    irule lprefix_lub_LTL >> goal_assum $ drule_at Any >>
+    rw[PULL_EXISTS, LTL_fromList, EXTENSION] >> eq_tac >> rw[]
+    >- (
+      simp[Once SWAP_EXISTS_THM] >> qexists_tac `SUC n''` >>
+      simp[trace_prefix_def, list_oracle_apply]
+      )
+    >- (
+      Cases_on `n''` >> gvs[trace_prefix_def, list_oracle_apply] >>
+      pairarg_tac >> gvs[SF SFY_ss]
+      )
+    )
+QED
+
+Theorem itree_compile_correct:
+  safe_itree (itree_semantics prog) ∧
+  compile c prog = SOME (bytes,bitmaps,c') ∧
+  backend_config_ok c ∧ mc_conf_ok mc ∧ mc_init_ok c mc ∧
+  installed bytes cbspace bitmaps data_sp c'.lab_conf.ffi_names
+    (heap_regs c.stack_conf.reg_names) mc ms
+  ⇒ prune F (itree_semantics prog) (machine_sem_itree (mc,ms))
+Proof
+  rw[] >>
+  simp[Q.ISPEC `ARB:((ffi_outcome + word8 list) list) ffi_state` $
+        GSYM itree_semantics_itree_of] >>
+  irule oracle_IMP_itree_preservation >> simp[extend_with_resource_limit'_def] >>
+  reverse conj_tac >- simp[prim_sem_env_eq] >>
+  gen_tac >>
+  `(FST $ THE $ prim_sem_env f).eval_state = NONE` by simp[prim_sem_env_eq] >>
+  conj_asm1_tac >> gvs[IN_DEF]
+  >- (
+    simp[itree_semantics, itree_semantics_itree_of] >>
+    irule safe_itree_trace_prefix_Error >> simp[]
+    ) >>
+  irule $ SRULE [LET_THM, UNCURRY, start_env] compile_correct >> simp[SF SFY_ss]
+QED
+
+
+(**********)
+
+val _ = export_theory();

--- a/compiler/backend/semantics/Holmakefile
+++ b/compiler/backend/semantics/Holmakefile
@@ -1,5 +1,7 @@
 INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs \
-					 .. ../../encoders/asm ../reg_alloc
+           $(CAKEMLDIR)/semantics/alt_semantics \
+           $(CAKEMLDIR)/semantics/alt_semantics/proofs \
+           .. ../../encoders/asm ../reg_alloc
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all

--- a/compiler/backend/semantics/README.md
+++ b/compiler/backend/semantics/README.md
@@ -60,6 +60,15 @@ The formal semantics of the target machine language. This semantics
 is parametrised by the target configuration, which includes the next
 state function of the target architecture.
 
+[target_itreeEquivScript.sml](target_itreeEquivScript.sml):
+Theorem expressing `machine_sem` in terms of target itree semantics
+
+[target_itreePropsScript.sml](target_itreePropsScript.sml):
+Properties about the itree target semantics
+
+[target_itreeSemScript.sml](target_itreeSemScript.sml):
+An itree-based semantics for the target machine code
+
 [wordPropsScript.sml](wordPropsScript.sml):
 Properties about wordLang and its semantics
 

--- a/compiler/backend/semantics/targetPropsScript.sml
+++ b/compiler/backend/semantics/targetPropsScript.sml
@@ -344,6 +344,32 @@ Proof
   \\ metis_tac[LESS_EQ_CASES,evaluate_add_clock_io_events_mono]
 QED
 
+Theorem machine_sem_unique:
+  machine_sem mc ffi ms b1 ∧ machine_sem mc ffi ms b2 ⇒ b1 = b2
+Proof
+  rw[DefnBase.one_line_ify NONE machine_sem_def] >>
+  Cases_on `b1` >> gvs[] >> Cases_on `b2` >> gvs[]
+  >- imp_res_tac unique_lprefix_lub
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (
+    Cases_on `k < k'` >> gvs[LESS_OR_EQ, NOT_LESS] >>
+    imp_res_tac LESS_ADD >> gvs[] >> imp_res_tac evaluate_add_clock >> gvs[]
+    )
+  >- (
+    qmatch_asmsub_abbrev_tac `FST ev = Error` >> PairCases_on `ev` >> gvs[] >>
+    Cases_on `k < k'` >> gvs[LESS_OR_EQ, NOT_LESS] >>
+    imp_res_tac LESS_ADD >> gvs[] >> imp_res_tac evaluate_add_clock >> gvs[]
+    )
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (
+    qmatch_asmsub_abbrev_tac `FST ev = Error` >> PairCases_on `ev` >> gvs[] >>
+    Cases_on `k < k'` >> gvs[LESS_OR_EQ, NOT_LESS] >>
+    imp_res_tac LESS_ADD >> gvs[] >> imp_res_tac evaluate_add_clock >> gvs[]
+    )
+QED
+
 Theorem read_ffi_bytearray_IMP_SUBSET_prog_addresses:
    (read_ffi_bytearray mc a l ms = SOME bytes) ==>
     all_words (mc.target.get_reg ms a) (LENGTH bytes) SUBSET

--- a/compiler/backend/semantics/target_itreeEquivScript.sml
+++ b/compiler/backend/semantics/target_itreeEquivScript.sml
@@ -243,30 +243,6 @@ Proof
   eq_tac >> rw[] >> gvs[call_FFI_def, AllCaseEqs()]
 QED
 
-Theorem machine_sem_unique:
-  machine_sem mc ffi ms b1 ∧ machine_sem mc ffi ms b2 ⇒ b1 = b2
-Proof
-  rw[DefnBase.one_line_ify NONE machine_sem_def] >>
-  Cases_on `b1` >> gvs[] >> Cases_on `b2` >> gvs[]
-  >- imp_res_tac unique_lprefix_lub
-  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
-  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
-  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
-  >- (
-    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
-    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
-    )
-  >- (
-    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
-    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
-    )
-  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
-  >- (
-    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
-    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
-    )
-QED
-
 
 (*********** halt_rel **********)
 

--- a/compiler/backend/semantics/target_itreeEquivScript.sml
+++ b/compiler/backend/semantics/target_itreeEquivScript.sml
@@ -1,0 +1,1066 @@
+(*
+  Theorem expressing `machine_sem` in terms of target itree semantics
+*)
+open preamble;
+open semanticsPropsTheory evaluatePropsTheory ffiTheory
+     targetSemTheory targetPropsTheory;
+open target_itreeSemTheory target_itreePropsTheory
+     itree_semanticsTheory itree_semanticsPropsTheory itree_semanticsEquivTheory;
+
+
+val _ = new_theory "target_itreeEquiv"
+
+
+(*********** evaluate' **********)
+
+Definition evaluate'_def:
+  evaluate' mc (ffi:'ffi ffi_state) k (ms:'a) =
+    if k = 0 then (TimeOut,mc,ms,ffi)
+    else
+      if mc.target.get_pc ms ∈ mc.prog_addresses then
+        if encoded_bytes_in_mem
+            mc.target.config (mc.target.get_pc ms)
+            (mc.target.get_byte ms) mc.prog_addresses then
+          let ms1 = mc.target.next ms in
+          let (ms2,new_oracle) = apply_oracle mc.next_interfer ms1 in
+          let mc = mc with next_interfer := new_oracle in
+            if EVERY mc.target.state_ok [ms;ms1;ms2] ∧
+               (∀x. x ∉ mc.prog_addresses ⇒
+                   mc.target.get_byte ms1 x =
+                   mc.target.get_byte ms x)
+            then
+              evaluate' mc ffi (k - 1) ms2
+            else
+              (Error,mc,ms,ffi)
+        else (Error,mc,ms,ffi)
+      else if mc.target.get_pc ms = mc.halt_pc then
+        (if mc.target.get_reg ms mc.ptr_reg = 0w
+         then Halt Success else Halt Resource_limit_hit,mc,ms,ffi)
+      else if mc.target.get_pc ms = mc.ccache_pc then
+        let (ms1,new_oracle) =
+          apply_oracle mc.ccache_interfer
+            (mc.target.get_reg ms mc.ptr_reg,
+             mc.target.get_reg ms mc.len_reg,
+             ms) in
+        let mc = mc with ccache_interfer := new_oracle in
+          evaluate' mc ffi (k-1) ms1
+      else
+        case find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 of
+        | NONE => (Error,mc,ms,ffi)
+        | SOME ffi_index =>
+          case read_ffi_bytearrays mc ms of
+          | SOME bytes, SOME bytes2 =>
+            (case call_FFI ffi (EL ffi_index mc.ffi_names) bytes bytes2 of
+             | FFI_final outcome => (Halt (FFI_outcome outcome),mc,ms,ffi)
+             | FFI_return new_ffi new_bytes =>
+                let (ms1,new_oracle) = apply_oracle mc.ffi_interfer
+                  (ffi_index,new_bytes,ms) in
+                let mc = mc with ffi_interfer := new_oracle in
+                  evaluate' mc new_ffi (k - 1:num) ms1)
+          | _ => (Error,mc,ms,ffi)
+End
+
+Theorem evaluate'_0[simp]:
+  evaluate' mc ffi 0 ms = (TimeOut,mc,ms,ffi)
+Proof
+  rw[Once evaluate'_def]
+QED
+
+Theorem evaluate_evaluate':
+  ∀mc ffi k ms. evaluate mc ffi k ms = (λ(a,b,c,d).(a,c,d)) (evaluate' mc ffi k ms)
+Proof
+  ho_match_mp_tac evaluate_ind >> rw[] >>
+  simp[Once evaluate_def, Once evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[] >>
+  IF_CASES_TAC >> gvs[apply_oracle_def] >> IF_CASES_TAC >> gvs[] >>
+  rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem evaluate'_step:
+  evaluate' mc ffi 0 ms = (TimeOut,mc,ms,ffi) ∧
+  evaluate' mc ffi (SUC n) ms =
+    case evaluate' mc ffi 1 ms of
+    | (TimeOut,mc',ms',ffi') => evaluate' mc' ffi' n ms'
+    | res => res
+Proof
+  simp[] >> simp[Once evaluate'_def, SimpRHS] >> simp[Once evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem evaluate'_step_alt:
+  evaluate' mc ffi 0 ms = (TimeOut,mc,ms,ffi) ∧
+  evaluate' mc ffi (SUC n) ms =
+    case evaluate' mc ffi n ms of
+    | (TimeOut,mc',ms',ffi') => evaluate' mc' ffi' 1 ms'
+    | res => res
+Proof
+  simp[] >> map_every qid_spec_tac [`ms`,`ffi`,`mc`,`n`] >>
+  Induct >- rw[] >> rpt gen_tac >>
+  rewrite_tac[evaluate'_step] >>
+  qabbrev_tac `ev = evaluate' mc ffi 1 ms` >> PairCases_on `ev` >> gvs[] >>
+  TOP_CASE_TAC >> simp[] >> simp[GSYM evaluate'_step]
+QED
+
+Theorem evaluate'_add:
+  ∀a b.
+    evaluate' mc ffi (a + b) ms =
+    case evaluate' mc ffi b ms of
+    | (TimeOut,mc',ms',ffi') => evaluate' mc' ffi' a ms'
+    | res => res
+Proof
+  Induct >> rw[evaluate'_step, ADD_CLAUSES] >>
+  qabbrev_tac `ev = evaluate' mc ffi b ms` >> PairCases_on `ev` >> gvs[] >>
+  Cases_on `ev0` >> gvs[] >> simp[GSYM evaluate'_step] >> simp[evaluate'_step_alt]
+QED
+
+Theorem evaluate'_add_alt:
+  ∀a b.
+    evaluate' mc ffi (a + b) ms =
+    case evaluate' mc ffi a ms of
+    | (TimeOut,mc',ms',ffi') => evaluate' mc' ffi' b ms'
+    | res => res
+Proof
+  once_rewrite_tac[ADD_COMM] >> simp[evaluate'_add]
+QED
+
+Theorem evaluate'_io_events_mono:
+   ∀mc ffi k ms res mc' ms' ffi'.
+    evaluate' mc ffi k ms = (res,mc',ms',ffi') ⇒ io_events_mono ffi ffi'
+Proof
+  ho_match_mp_tac evaluate'_ind >> rw[] >>
+  pop_assum mp_tac >> simp[Once evaluate'_def] >>
+  ntac 4 (IF_CASES_TAC >> gvs[apply_oracle_def]) >>
+  ntac 5 (TOP_CASE_TAC >> gvs[]) >> rw[] >> gvs[] >>
+  irule io_events_mono_trans >> goal_assum $ drule_at Any >>
+  irule call_FFI_rel_io_events_mono >>
+  irule RTC_SUBSET >> simp[call_FFI_rel_def, SF SFY_ss]
+QED
+
+Theorem evaluate'_add_clock:
+  ∀mc ffi k ms res.
+    evaluate' mc ffi k ms = res ∧ FST res ≠ TimeOut
+  ⇒ ∀k'. k ≤ k' ⇒ evaluate' mc ffi k' ms = res
+Proof
+  recInduct evaluate'_ind >> rw[] >>
+  qpat_x_assum `FST _ ≠ _` mp_tac >> once_rewrite_tac[evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[] >>
+  IF_CASES_TAC >> gvs[apply_oracle_def] >> IF_CASES_TAC >> gvs[] >>
+  rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem evaluate'_agree:
+  evaluate' mc ffi k1 ms = res1 ∧
+  evaluate' mc ffi k2 ms = res2 ∧
+  FST res1 ≠ TimeOut ∧ FST res2 ≠ TimeOut
+  ⇒ res1 = res2
+Proof
+  rw[] >> wlog_tac `k1 < k2` [`k1`,`k2`] >- gvs[NOT_LESS, LESS_OR_EQ] >>
+  Cases_on `evaluate' mc ffi k1 ms` >> Cases_on `evaluate' mc ffi k2 ms` >>
+  gvs[] >> PairCases_on `r` >> PairCases_on `r'` >>
+  rev_dxrule evaluate'_add_clock >> simp[] >>
+  disch_then $ qspec_then `k2` assume_tac >> gvs[]
+QED
+
+Theorem evaluate'_remove_clock:
+  evaluate' mc ffi k ms = res ∧ FST res = TimeOut ∧ k' ≤ k ⇒
+  FST (evaluate' mc ffi k' ms) = TimeOut
+Proof
+  metis_tac[evaluate'_add_clock, PAIR]
+QED
+
+Theorem evaluate'_min:
+  ∀k mc ffi ms res.
+    evaluate' mc ffi k ms = res ∧ FST res ≠ TimeOut
+  ⇒ ∃k'. k' ≤ k ∧ evaluate' mc ffi k' ms = res ∧
+      ∀m. m < k' ⇒ ∃mc' ms' ffi'. evaluate' mc ffi m ms = (TimeOut,mc',ms',ffi')
+Proof
+  Induct >> rw[] >>
+  qabbrev_tac `res = evaluate' mc ffi (SUC k) ms` >> PairCases_on `res` >> gvs[] >>
+
+  gvs[evaluate'_step_alt] >>
+  Cases_on `evaluate' mc ffi k ms` >> gvs[] >> Cases_on `q` >> gvs[]
+  >- (
+    first_x_assum $ qspecl_then [`mc`,`ffi`,`ms`] assume_tac >> gvs[] >>
+    qexists_tac `k'` >> simp[]
+    )
+  >- (
+    first_x_assum $ qspecl_then [`mc`,`ffi`,`ms`] assume_tac >> gvs[] >>
+    qexists_tac `k'` >> simp[]
+    ) >>
+  PairCases_on `r` >> gvs[] >>
+  qexists_tac `SUC k` >> simp[evaluate'_step_alt] >> rw[] >>
+  drule evaluate'_remove_clock >> simp[] >>
+  disch_then $ qspec_then `m` mp_tac >> simp[] >> metis_tac[PAIR]
+QED
+
+Theorem evaluate'_1_ffi_unchanged:
+  evaluate' mc (ffi:'ffi ffi_state) 1 ms = (res,mc',ms',ffi') ∧ res ≠ TimeOut
+  ⇒ ffi = ffi'
+Proof
+  simp[Once evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[]) >> rw[] >> gvs[]
+QED
+
+Theorem evaluate'_1_ffi_changed:
+  evaluate' mc (ffi:'ffi ffi_state) 1 ms = (res,mc',ms',ffi') ∧ ffi' ≠ ffi ⇔
+    res = TimeOut ∧
+    mc.target.get_pc ms ∉ mc.prog_addresses ∧
+    mc.target.get_pc ms ≠ mc.halt_pc ∧
+    mc.target.get_pc ms ≠ mc.ccache_pc ∧
+    mc' = mc with ffi_interfer := shift_seq 1 mc.ffi_interfer ∧
+    ∃n ws1 ws2 l.
+      find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME n ∧
+      EL n mc.ffi_names ≠ "" ∧
+      read_ffi_bytearrays mc ms = (SOME ws1,SOME ws2) ∧
+      call_FFI ffi (EL n mc.ffi_names) ws1 ws2 = FFI_return ffi' l ∧
+      ms' = mc.ffi_interfer 0 (n,l,ms)
+Proof
+  simp[Once evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[]) >>
+  eq_tac >> rw[] >>
+  gvs[call_FFI_def, AllCaseEqs(), ffi_state_component_equality] >>
+  qpat_x_assum `_ = f.io_events` $ assume_tac o GSYM >> simp[]
+QED
+
+Theorem evaluate'_1_ffi_failed:
+  evaluate' mc (ffi:'ffi ffi_state) 1 ms = (Halt (FFI_outcome outcome),mc',ms',ffi') ⇔
+    mc.target.get_pc ms ∉ mc.prog_addresses ∧
+    mc.target.get_pc ms ≠ mc.halt_pc ∧
+    mc.target.get_pc ms ≠ mc.ccache_pc ∧
+    ms = ms' ∧ mc = mc' ∧ ffi = ffi' ∧
+    ∃n ws1 ws2 l.
+      find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME n ∧
+      EL n mc.ffi_names ≠ "" ∧
+      read_ffi_bytearrays mc ms = (SOME ws1,SOME ws2) ∧
+      call_FFI ffi (EL n mc.ffi_names) ws1 ws2 = FFI_final outcome
+Proof
+  simp[Once evaluate'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[]) >>
+  eq_tac >> rw[] >> gvs[call_FFI_def, AllCaseEqs()]
+QED
+
+Theorem machine_sem_unique:
+  machine_sem mc ffi ms b1 ∧ machine_sem mc ffi ms b2 ⇒ b1 = b2
+Proof
+  rw[DefnBase.one_line_ify NONE machine_sem_def] >>
+  Cases_on `b1` >> gvs[] >> Cases_on `b2` >> gvs[]
+  >- imp_res_tac unique_lprefix_lub
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (
+    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
+    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
+    )
+  >- (
+    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
+    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
+    )
+  >- (last_x_assum $ qspec_then `k` assume_tac >> gvs[])
+  >- (
+    gvs[evaluate_evaluate'] >> rpt (pairarg_tac >> gvs[]) >>
+    dxrule evaluate'_agree >> disch_then dxrule >> rw[]
+    )
+QED
+
+
+(*********** halt_rel **********)
+
+Definition halt_rel_def:
+  halt_rel Termination h = (h = Success) ∧
+  halt_rel OutOfMemory h = (h = Resource_limit_hit) ∧
+  halt_rel _ _ = F
+End
+
+Triviality halt_rel_alt_def:
+  halt_rel h Success = (h = Termination) ∧
+  halt_rel h Resource_limit_hit = (h = OutOfMemory) ∧
+  halt_rel h (FFI_outcome _) = F
+Proof
+  Cases_on `h` >> rw[halt_rel_def]
+QED
+
+Triviality halt_rel_imps:
+  halt_rel r h ⇒ r ≠ Error ∧ (∀p out. r ≠ FinalFFI p out)
+Proof
+  rw[] >> CCONTR_TAC >> gvs[halt_rel_def]
+QED
+
+
+(*********** eval_to' / evaluate' - non-FFI steps **********)
+
+Theorem eval_to'_evaluate'_halt_rel:
+  halt_rel r h ⇒ (
+  eval_to' k mc ms = (Ret' r,mc',ms') ⇔
+  evaluate' mc (ffi :'ffi ffi_state) k ms = (Halt h,mc',ms',ffi))
+Proof
+  rw[] >> imp_res_tac halt_rel_imps >>
+  eq_tac >> rw[] >> pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ffi`,`ms`,`mc`,`k`] >>
+    ho_match_mp_tac eval_to'_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- (rw[] >> gvs[halt_rel_def]) >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      ntac 5 (TOP_CASE_TAC >> gvs[]) >>
+      strip_tac >> gvs[call_FFI_def, apply_oracle_def]
+      )
+    )
+  >- (
+    map_every qid_spec_tac [`ms`,`k`,`ffi`,`mc`] >>
+    ho_match_mp_tac evaluate'_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- (rw[] >> Cases_on `r` >> gvs[halt_rel_def]) >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      reverse $ ntac 5 (TOP_CASE_TAC >> gvs[])
+      >- (strip_tac >> gvs[] >> Cases_on `r` >> gvs[halt_rel_def]) >>
+      strip_tac >> gvs[apply_oracle_def] >>
+      qsuff_tac `ffi = f`
+      >- (strip_tac >> gvs[call_FFI_def, AllCaseEqs(), ffi_state_component_equality]) >>
+      irule io_events_mono_antisym >>
+      imp_res_tac evaluate'_io_events_mono >> simp[] >>
+      irule call_FFI_rel_io_events_mono >> irule RTC_SUBSET >>
+      simp[call_FFI_rel_def, SF SFY_ss]
+      )
+    )
+QED
+
+Theorem eval_to'_evaluate'_error:
+  eval_to' k mc ms = (Ret' Error,mc',ms') ⇔
+  evaluate' mc (ffi :'ffi ffi_state) k ms = (Error,mc',ms', ffi)
+Proof
+  eq_tac >> rw[] >> pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ffi`,`ms`,`mc`,`k`] >>
+    ho_match_mp_tac eval_to'_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- rw[] >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      ntac 5 (TOP_CASE_TAC >> gvs[]) >>
+      strip_tac >> gvs[call_FFI_def, apply_oracle_def]
+      )
+    )
+  >- (
+    map_every qid_spec_tac [`ms`,`k`,`ffi`,`mc`] >>
+    ho_match_mp_tac evaluate'_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- (rw[] >> CCONTR_TAC >> gvs[]) >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      ntac 5 (TOP_CASE_TAC >> gvs[]) >>
+      strip_tac >> gvs[apply_oracle_def] >>
+      qsuff_tac `ffi = f`
+      >- (strip_tac >> gvs[call_FFI_def, AllCaseEqs(), ffi_state_component_equality]) >>
+      irule io_events_mono_antisym >>
+      imp_res_tac evaluate'_io_events_mono >> simp[] >>
+      irule call_FFI_rel_io_events_mono >> irule RTC_SUBSET >>
+      simp[call_FFI_rel_def, SF SFY_ss]
+      )
+    )
+QED
+
+Theorem eval_to'_evaluate'_timeout:
+  eval_to' k mc ms = (Div',mc',ms') ⇔
+  evaluate' mc (ffi :'ffi ffi_state) k ms = (TimeOut,mc',ms',ffi)
+Proof
+  eq_tac >> rw[] >> pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ffi`,`ms`,`mc`,`k`] >>
+    ho_match_mp_tac eval_to_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- rw[] >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      ntac 5 (TOP_CASE_TAC >> gvs[]) >>
+      strip_tac >> gvs[call_FFI_def, apply_oracle_def]
+      )
+    )
+  >- (
+    map_every qid_spec_tac [`ms`,`k`,`ffi`,`mc`] >>
+    ho_match_mp_tac evaluate_ind >> rw[] >>
+    pop_assum mp_tac >> simp[Once eval_to'_def, Once evaluate'_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[]
+    >- (IF_CASES_TAC >> gvs[] >> pairarg_tac >> gvs[] >> IF_CASES_TAC >> gvs[])
+    >- (
+      IF_CASES_TAC >> gvs[] >- (rw[] >> CCONTR_TAC >> gvs[]) >>
+      IF_CASES_TAC >> gvs[] >- (pairarg_tac >> gvs[]) >>
+      ntac 5 (TOP_CASE_TAC >> gvs[]) >>
+      strip_tac >> gvs[apply_oracle_def] >>
+      qsuff_tac `ffi = f`
+      >- (strip_tac >> gvs[call_FFI_def, AllCaseEqs(), ffi_state_component_equality]) >>
+      irule io_events_mono_antisym >>
+      imp_res_tac evaluate'_io_events_mono >> simp[] >>
+      irule call_FFI_rel_io_events_mono >> irule RTC_SUBSET >>
+      simp[call_FFI_rel_def, SF SFY_ss]
+      )
+    )
+QED
+
+
+(*********** eval / evaluate - non-FFI steps **********)
+
+Theorem eval_evaluate_halt_rel:
+  halt_rel r h ⇒ (
+  eval (mc,ms) = Ret' r ⇔
+  ∃k ms'. evaluate mc (ffi :'ffi ffi_state) k ms = (Halt h, ms', ffi))
+Proof
+  rw[] >> simp[eval_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[] >>
+  gvs[eval_to_eval_to', evaluate_evaluate']
+  >- (
+    CCONTR_TAC >> gvs[] >> pairarg_tac >> gvs[] >>
+    drule_all $ SRULE [PULL_EXISTS] $ iffRL eval_to'_evaluate'_halt_rel >> rw[] >>
+    first_x_assum $ qspec_then `k` assume_tac >> gvs[] >>
+    Cases_on `eval_to' k mc ms` >> gvs[]
+    ) >>
+  eq_tac >> rw[]
+  >- (
+    qmatch_asmsub_abbrev_tac `FST res = _` >> PairCases_on `res` >> gvs[] >>
+    drule_all $ iffLR eval_to'_evaluate'_halt_rel >>
+    rw[] >> qexists_tac `x` >> pairarg_tac >> gvs[]
+    )
+  >- (
+    pairarg_tac >> gvs[] >>
+    drule_all $ SRULE [PULL_EXISTS] $ iffRL eval_to'_evaluate'_halt_rel >> rw[] >>
+    dxrule eval_to'_agree >> simp[] >> disch_then drule >>
+    disch_then $ assume_tac o GSYM >> gvs[]
+    )
+QED
+
+Theorem eval_evaluate_error:
+  eval (mc,ms) = Ret' Error ⇔
+  ∃k ms'. evaluate mc (ffi :'ffi ffi_state) k ms = (Error, ms', ffi)
+Proof
+  rw[] >> simp[eval_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[] >>
+  gvs[eval_to_eval_to', evaluate_evaluate']
+  >- (
+    CCONTR_TAC >> gvs[] >> pairarg_tac >> gvs[] >>
+    drule_all $ SRULE [PULL_EXISTS] $ iffRL eval_to'_evaluate'_error >> rw[] >>
+    first_x_assum $ qspec_then `k` assume_tac >> gvs[] >>
+    Cases_on `eval_to' k mc ms` >> gvs[]
+    ) >>
+  eq_tac >> rw[]
+  >- (
+    qmatch_asmsub_abbrev_tac `FST res = _` >> PairCases_on `res` >> gvs[] >>
+    drule_all $ iffLR eval_to'_evaluate'_error >>
+    rw[] >> qexists_tac `x` >> pairarg_tac >> gvs[]
+    )
+  >- (
+    pairarg_tac >> gvs[] >>
+    drule_all $ SRULE [PULL_EXISTS] $ iffRL eval_to'_evaluate'_error >> rw[] >>
+    drule eval_to'_agree >> simp[] >> disch_then drule >>
+    disch_then $ assume_tac o GSYM >> gvs[]
+    )
+QED
+
+Theorem eval_evaluate_timeout:
+  eval (mc,ms) = Div' ⇔
+  ∀k. ∃ms'. evaluate mc (ffi :'ffi ffi_state) k ms = (TimeOut, ms', ffi)
+Proof
+  eq_tac >> simp[eval_def] >> DEEP_INTRO_TAC some_intro >> rw[] >>
+  gvs[eval_to_eval_to', evaluate_evaluate']
+  >- (
+    pairarg_tac >> gvs[] >>
+    first_x_assum $ qspec_then `k` assume_tac >>
+    qmatch_asmsub_abbrev_tac `FST res` >> PairCases_on `res` >> gvs[] >>
+    imp_res_tac eval_to'_evaluate'_timeout >> gvs[]
+    )
+  >- (
+    CCONTR_TAC >> gvs[] >> last_x_assum mp_tac >> simp[] >>
+    first_x_assum $ qspec_then `x` assume_tac >> pairarg_tac >> gvs[] >>
+    imp_res_tac eval_to'_evaluate'_timeout >> gvs[]
+    )
+QED
+
+
+(*********** eval_to' / evaluate' - FFI steps **********)
+
+Theorem evaluate'_1_ffi_changed_eval_to':
+  evaluate' mc (ffi:'ffi ffi_state) 1 ms = (res,mc',ms',ffi') ∧ ffi' ≠ ffi ⇒
+  ∃s conf ws f ms''. eval_to' 1 mc ms = (Vis' (s,conf,ws) f,mc',ms'')
+Proof
+  rw[evaluate'_1_ffi_changed, eval_to'_1_Vis] >> simp[SF SFY_ss]
+QED
+
+Theorem evaluate'_1_ffi_failed_eval_to':
+  evaluate' mc (ffi:'ffi ffi_state) 1 ms = (Halt (FFI_outcome outcome),mc',ms',ffi') ⇒
+  ∃s conf ws f mc''. eval_to' 1 mc ms = (Vis' (s,conf,ws) f,mc'',ms')
+Proof
+  rw[evaluate'_1_ffi_failed, eval_to'_1_Vis] >> simp[SF SFY_ss]
+QED
+
+Theorem eval_to'_1_ffi_evaluate:
+  eval_to' 1 mc ms = (Vis' (s,conf,ws) f,mc',ms') ⇒
+  (∃ms'' ffi'.
+    evaluate' mc (ffi:'ffi ffi_state) 1 ms = (TimeOut,mc',ms'',ffi') ∧ ffi' ≠ ffi) ∨
+  (∃out mc''.  evaluate' mc ffi 1 ms = (Halt (FFI_outcome out),mc'',ms',ffi))
+Proof
+  rw[evaluate'_1_ffi_changed, evaluate'_1_ffi_failed,eval_to'_1_Vis] >>
+  simp[call_FFI_def, AllCaseEqs(), SF DNF_ss] >>
+  Cases_on `ffi.oracle (EL n mc.ffi_names) ffi.ffi_state conf ws` >> simp[]
+QED
+
+
+(*********** trace_prefix **********)
+
+Overload mk_ffi[local] =
+  ``λffi oracle st. ffi with <| oracle := oracle; ffi_state := st |>``;
+
+Triviality mk_ffi_I[simp]:
+  mk_ffi ffi ffi.oracle ffi.ffi_state = ffi
+Proof
+  rw[ffi_state_component_equality]
+QED
+
+Theorem trace_prefix_machine_error:
+  (∃n. trace_prefix n (oracle, ffi_st:'ffi)
+        (machine_sem_itree (mc,ms)) = (io, SOME Error)) ⇔
+  (∃k mc' ms' ffi'.
+    evaluate' mc (mk_ffi ffi oracle ffi_st) k ms = (Error,mc',ms',ffi') ∧
+    ffi'.io_events = ffi.io_events ++ io)
+Proof
+  eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`n`] >>
+    Induct >> rw[trace_prefix_machine_sem_itree] >>
+    pop_assum mp_tac >> TOP_CASE_TAC >> gvs[]
+    >- (
+      rw[] >> gvs[] >> gvs[eval_alt_def] >> every_case_tac >> gvs[] >>
+      pairarg_tac >> gvs[] >>
+      drule $ iffLR eval_to'_evaluate'_error >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> gvs[] >>
+      goal_assum drule >> unabbrev_all_tac >> gvs[]
+      ) >>
+    PairCases_on `e` >> gvs[] >>
+    every_case_tac >> gvs[] >> simp[trace_prefix_def] >>
+    pairarg_tac >> rw[] >> gvs[] >>
+    qpat_x_assum `eval _ = _` mp_tac >> simp[eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> rw[] >> gvs[] >> pairarg_tac >> gvs[] >>
+    drule eval_to'_min >> rw[] >> gvs[] >>
+    qpat_x_assum `_ ≤ _` kall_tac >> qpat_x_assum `eval_to' x _ _ = _` kall_tac >>
+    Cases_on `k'` >> gvs[] >> pop_assum $ qspec_then `n'` assume_tac >> gvs[] >>
+    gvs[eval_to'_step_alt] >>
+    drule eval_to'_1_ffi_evaluate >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> reverse $ gvs[]
+    >- (
+      gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis] >>
+      unabbrev_all_tac >> gvs[call_FFI_def, AllCaseEqs()]
+      ) >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[] >>
+    gvs[eval_to'_1_Vis, call_FFI_def, AllCaseEqs()] >>
+    Q.REFINE_EXISTS_TAC `k + SUC n'` >> simp[evaluate'_add, evaluate'_step_alt] >>
+    drule $ iffLR eval_to'_evaluate'_timeout >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> gvs[] >>
+    qmatch_goalsub_abbrev_tac `evaluate' mc0 (mk_ffi ffi0 _ _)` >>
+    last_x_assum drule >> disch_then $ qspec_then `ffi0` assume_tac >> gvs[] >>
+    goal_assum drule >> unabbrev_all_tac >> gvs[]
+    )
+  >- (
+    map_every qid_spec_tac
+      [`ms'`,`mc'`,`ffi'`,`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`k`] >>
+    Induct >> rw[evaluate'_step] >>
+    qabbrev_tac `res = evaluate' mc (mk_ffi ffi oracle ffi_st) 1 ms` >>
+    PairCases_on `res` >> gvs[] >> FULL_CASE_TAC >> gvs[]
+    >- (
+      imp_res_tac evaluate'_1_ffi_unchanged >> gvs[] >>
+      gvs[GSYM eval_to'_evaluate'_error] >>
+      simp[machine_sem_itree, eval_alt_def] >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `1` >> simp[]) >>
+      dxrule eval_to'_agree >> simp[] >> disch_then $ qspec_then `x` $ mp_tac o GSYM >>
+      impl_tac >- metis_tac[PAIR] >> rw[] >> gvs[] >>
+      qexists_tac `SUC n` >> rw[trace_prefix_def]
+      ) >>
+    Cases_on `res3 = mk_ffi ffi oracle ffi_st` >> gvs[]
+    >- (
+      last_x_assum drule >> disch_then drule >> rw[] >>
+      qsuff_tac `eval (mc,ms) = eval (res1,res2)`
+      >- (rw[] >> imp_res_tac machine_sem_itree_eq >> gvs[SF SFY_ss]) >>
+      irule eval_prefix >> gvs[GSYM eval_to'_evaluate'_timeout] >> goal_assum drule
+      ) >>
+    drule_all evaluate'_1_ffi_changed_eval_to' >> rw[] >> gvs[] >>
+    simp[machine_sem_itree, eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[] >> gvs[]
+    >- (qexists_tac `1` >> simp[]) >>
+    pairarg_tac >> gvs[] >> dxrule_then drule eval_to'_agree >> rw[] >> gvs[] >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[eval_to'_1_Vis] >>
+    gvs[call_FFI_def, AllCaseEqs()] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> simp[trace_prefix_def] >>
+    gvs[ffi_state_component_equality] >>
+    imp_res_tac evaluate'_io_events_mono >> gvs[io_events_mono_def] >>
+    Cases_on `io` >> gvs[] >>
+    last_x_assum drule >> simp[] >> rw[] >> qexists_tac `n'` >> simp[]
+    )
+QED
+
+Theorem trace_prefix_machine_halt:
+  halt_rel r h ⇒ (
+  (∃n. trace_prefix n (oracle, ffi_st:'ffi)
+        (machine_sem_itree (mc,ms)) = (io, SOME r)) ⇔
+  (∃k mc' ms' ffi'.
+    evaluate' mc (mk_ffi ffi oracle ffi_st) k ms = (Halt h,mc',ms',ffi') ∧
+    ffi'.io_events = ffi.io_events ++ io))
+Proof
+  rw[] >> imp_res_tac halt_rel_imps >> eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`n`] >>
+    Induct >> rw[trace_prefix_machine_sem_itree] >>
+    pop_assum mp_tac >> TOP_CASE_TAC >> gvs[]
+    >- (
+      rw[] >> gvs[] >> gvs[eval_alt_def] >> every_case_tac >> gvs[] >>
+      pairarg_tac >> gvs[] >>
+      drule_all $ iffLR eval_to'_evaluate'_halt_rel >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> gvs[] >>
+      goal_assum drule >> unabbrev_all_tac >> gvs[]
+      ) >>
+    PairCases_on `e` >> gvs[] >>
+    every_case_tac >> gvs[] >> simp[trace_prefix_def] >>
+    pairarg_tac >> rw[] >> gvs[] >>
+    qpat_x_assum `eval _ = _` mp_tac >> simp[eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> rw[] >> gvs[] >> pairarg_tac >> gvs[] >>
+    drule eval_to'_min >> rw[] >> gvs[] >>
+    qpat_x_assum `_ ≤ _` kall_tac >> qpat_x_assum `eval_to' x _ _ = _` kall_tac >>
+    Cases_on `k'` >> gvs[] >> pop_assum $ qspec_then `n'` assume_tac >> gvs[] >>
+    gvs[eval_to'_step_alt] >>
+    drule eval_to'_1_ffi_evaluate >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> reverse $ gvs[]
+    >- (
+      gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis] >>
+      unabbrev_all_tac >> gvs[call_FFI_def, AllCaseEqs()]
+      ) >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[] >>
+    gvs[eval_to'_1_Vis, call_FFI_def, AllCaseEqs()] >>
+    Q.REFINE_EXISTS_TAC `k + SUC n'` >> simp[evaluate'_add, evaluate'_step_alt] >>
+    drule $ iffLR eval_to'_evaluate'_timeout >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> gvs[] >>
+    qmatch_goalsub_abbrev_tac `evaluate' mc0 (mk_ffi ffi0 _ _)` >>
+    last_x_assum drule >> disch_then $ qspec_then `ffi0` assume_tac >> gvs[] >>
+    goal_assum drule >> unabbrev_all_tac >> gvs[]
+    )
+  >- (
+    map_every qid_spec_tac
+      [`ms'`,`mc'`,`ffi'`,`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`k`] >>
+    Induct >> rw[evaluate'_step] >>
+    qabbrev_tac `res = evaluate' mc (mk_ffi ffi oracle ffi_st) 1 ms` >>
+    PairCases_on `res` >> gvs[] >> FULL_CASE_TAC >> gvs[]
+    >- (
+      imp_res_tac evaluate'_1_ffi_unchanged >> gvs[] >>
+      drule $ GSYM eval_to'_evaluate'_halt_rel >> disch_then $ gvs o single >>
+      simp[machine_sem_itree, eval_alt_def] >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `1` >> simp[]) >>
+      dxrule eval_to'_agree >> simp[] >> disch_then $ qspec_then `x` $ mp_tac o GSYM >>
+      impl_tac >- metis_tac[PAIR] >> rw[] >> gvs[] >>
+      qexists_tac `SUC n` >> rw[trace_prefix_def]
+      ) >>
+    Cases_on `res3 = mk_ffi ffi oracle ffi_st` >> gvs[]
+    >- (
+      last_x_assum drule >> disch_then drule >> rw[] >>
+      qsuff_tac `eval (mc,ms) = eval (res1,res2)`
+      >- (rw[] >> imp_res_tac machine_sem_itree_eq >> gvs[SF SFY_ss]) >>
+      irule eval_prefix >> gvs[GSYM eval_to'_evaluate'_timeout] >> goal_assum drule
+      ) >>
+    drule_all evaluate'_1_ffi_changed_eval_to' >> rw[] >> gvs[] >>
+    simp[machine_sem_itree, eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[] >> gvs[]
+    >- (qexists_tac `1` >> simp[]) >>
+    pairarg_tac >> gvs[] >> dxrule_then drule eval_to'_agree >> rw[] >> gvs[] >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[eval_to'_1_Vis] >>
+    gvs[call_FFI_def, AllCaseEqs()] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> simp[trace_prefix_def] >>
+    gvs[ffi_state_component_equality] >>
+    imp_res_tac evaluate'_io_events_mono >> gvs[io_events_mono_def] >>
+    Cases_on `io` >> gvs[] >>
+    last_x_assum drule >> simp[] >> rw[] >> qexists_tac `n'` >> simp[]
+    )
+QED
+
+Theorem trace_prefix_machine_ffi_error:
+  (∃n. trace_prefix n (oracle, ffi_st:'ffi)
+        (machine_sem_itree (mc,ms)) = (io, SOME (FinalFFI (s,conf,ws) out))) ⇔
+  (∃k mc' ms' ffi'.
+    evaluate' mc (mk_ffi ffi oracle ffi_st) k ms =
+      (Halt (FFI_outcome (Final_event s conf ws out)),mc',ms',ffi') ∧
+    ffi'.io_events = ffi.io_events ++ io)
+Proof
+  rw[] >> imp_res_tac halt_rel_imps >> eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`n`] >>
+    Induct >> rw[trace_prefix_machine_sem_itree] >>
+    pop_assum mp_tac >> TOP_CASE_TAC >> gvs[]
+    >- (
+      rw[] >> gvs[] >> gvs[eval_alt_def] >> every_case_tac >> gvs[] >>
+      pairarg_tac >> gvs[eval_to'_Ret_FinalFFI]
+      ) >>
+    PairCases_on `e` >> gvs[] >>
+    every_case_tac >> gvs[] >> rw[trace_prefix_def] >> gvs[] >>
+    qpat_x_assum `eval _ = _` mp_tac >> simp[eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> rw[] >> gvs[] >> pairarg_tac >> gvs[] >>
+    drule eval_to'_min >> rw[] >> gvs[] >>
+    qpat_x_assum `_ ≤ _` kall_tac >> qpat_x_assum `eval_to' x _ _ = _` kall_tac >>
+    Cases_on `k'` >> gvs[] >> pop_assum $ qspec_then `n'` assume_tac >> gvs[] >>
+    gvs[eval_to'_step_alt] >>
+    drule eval_to'_1_ffi_evaluate >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> reverse $ gvs[]
+    >- (
+      qexists_tac `SUC n'` >> simp[evaluate'_step_alt] >>
+      drule $ iffLR eval_to'_evaluate'_timeout >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> simp[] >>
+      gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis] >>
+      unabbrev_all_tac >> gvs[call_FFI_def, AllCaseEqs()]
+      )
+    >- (
+      drule_all $ iffLR evaluate'_1_ffi_changed >> rw[] >> gvs[] >>
+      gvs[call_FFI_def, AllCaseEqs(), eval_to'_1_Vis]
+      )
+    >- (
+      qexists_tac `SUC n'` >> simp[evaluate'_step_alt] >>
+      drule $ iffLR eval_to'_evaluate'_timeout >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> simp[] >>
+      gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis] >>
+      unabbrev_all_tac >> gvs[call_FFI_def, AllCaseEqs()]
+      )
+    >- (
+      pairarg_tac >> gvs[] >> rename [`Div',mc1,ms1`,`Vis' _ _,mc2,ms2`] >>
+      drule $ iffLR eval_to'_evaluate'_timeout >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >>
+      Q.REFINE_EXISTS_TAC `SUC n' + k` >>
+      simp[evaluate'_add_alt, evaluate'_step_alt] >>
+      drule_all $ iffLR evaluate'_1_ffi_changed >> rw[] >> gvs[] >>
+      gvs[call_FFI_def, AllCaseEqs(), eval_to'_1_Vis, ffi_state_component_equality] >>
+      qmatch_goalsub_abbrev_tac `evaluate' mc1' _ _ ms1'` >>
+      last_x_assum drule >> disch_then $ qspec_then `ffi'` assume_tac >> gvs[SF SFY_ss]
+      )
+    >- (
+      qexists_tac `SUC n'` >> simp[evaluate'_step_alt] >>
+      drule $ iffLR eval_to'_evaluate'_timeout >>
+      disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> simp[] >>
+      gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis] >>
+      unabbrev_all_tac >> gvs[call_FFI_def, AllCaseEqs()]
+      )
+    >- (
+      drule_all $ iffLR evaluate'_1_ffi_changed >> rw[] >> gvs[] >>
+      gvs[call_FFI_def, AllCaseEqs(), eval_to'_1_Vis]
+      )
+    )
+  >- (
+    map_every qid_spec_tac
+      [`ms'`,`mc'`,`ffi'`,`ms`,`mc`,`ffi`,`ffi_st`,`oracle`,`io`,`k`] >>
+    Induct >> rw[evaluate'_step] >>
+    qabbrev_tac `res = evaluate' mc (mk_ffi ffi oracle ffi_st) 1 ms` >>
+    PairCases_on `res` >> gvs[] >> FULL_CASE_TAC >> gvs[]
+    >- (
+      imp_res_tac evaluate'_1_ffi_failed_eval_to' >>
+      gvs[evaluate'_1_ffi_failed, call_FFI_def, AllCaseEqs()] >>
+      simp[machine_sem_itree, eval_alt_def] >>
+      (DEEP_INTRO_TAC some_intro >> reverse $ rw[] >- (qexists_tac `1` >> simp[])) >>
+      pairarg_tac >> gvs[] >>
+      dxrule_then drule eval_to'_agree >> rw[] >> gvs[] >>
+      qexists_tac `SUC (SUC n)` >> gvs[eval_to'_1_Vis, trace_prefix_def]
+      ) >>
+    Cases_on `res3 = mk_ffi ffi oracle ffi_st` >> gvs[]
+    >- (
+      last_x_assum drule >> disch_then drule >> rw[] >>
+      qsuff_tac `eval (mc,ms) = eval (res1,res2)`
+      >- (rw[] >> imp_res_tac machine_sem_itree_eq >> gvs[SF SFY_ss]) >>
+      irule eval_prefix >> gvs[GSYM eval_to'_evaluate'_timeout] >> goal_assum drule
+      ) >>
+    drule_all evaluate'_1_ffi_changed_eval_to' >> rw[] >> gvs[] >>
+    simp[machine_sem_itree, eval_alt_def] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[] >> gvs[]
+    >- (qexists_tac `1` >> simp[]) >>
+    pairarg_tac >> gvs[] >> dxrule_then drule eval_to'_agree >> rw[] >> gvs[] >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[eval_to'_1_Vis] >>
+    gvs[call_FFI_def, AllCaseEqs()] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> simp[trace_prefix_def] >>
+    gvs[ffi_state_component_equality] >>
+    imp_res_tac evaluate'_io_events_mono >> gvs[io_events_mono_def] >>
+    Cases_on `io` >> gvs[] >>
+    last_x_assum drule >> simp[] >> rw[] >> qexists_tac `n'` >> simp[]
+    )
+QED
+
+Theorem trace_prefix_evaluate'_io_events:
+  ∀n oracle ffi ffi_st mc ms io.
+    trace_prefix n (oracle, ffi_st:'ffi)
+      (machine_sem_itree (mc,ms)) = (io, NONE)
+  ⇒ ∃k mc' ms' ffi'.
+      evaluate' mc (mk_ffi ffi oracle ffi_st) k ms =
+        (TimeOut,mc',ms',ffi') ∧
+      ffi'.io_events = ffi.io_events ++ io
+Proof
+  Induct >> rw[trace_prefix_def] >- (qexists_tac `0` >> simp[]) >>
+  gvs[trace_prefix_machine_sem_itree, eval_alt_def] >>
+  pop_assum mp_tac >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+  >- (qexists_tac `0` >> simp[]) >>
+  pop_assum mp_tac >> pairarg_tac >> gvs[] >>
+  TOP_CASE_TAC >> gvs[] >> PairCases_on `e` >> gvs[] >>
+  every_case_tac >> rw[] >> gvs[]
+  >- (qexists_tac `0` >> simp[])
+  >- (
+    gvs[trace_prefix_def] >>
+    drule eval_to'_min >> rw[] >> gvs[] >>
+    qpat_x_assum `_ ≤ _` kall_tac >> qpat_x_assum `eval_to' x _ _ = _` kall_tac >>
+    Cases_on `k'` >> gvs[] >> pop_assum $ qspec_then `n` assume_tac >> gvs[] >>
+    gvs[eval_to'_step_alt] >>
+    drule $ iffLR eval_to'_evaluate'_timeout >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >>
+    qexists_tac `SUC n` >> simp[evaluate'_step_alt] >>
+    drule eval_to'_1_ffi_evaluate >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> reverse $ gvs[]
+    >- gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis, call_FFI_def] >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> rw[] >> gvs[] >>
+    gvs[eval_to'_1_Vis, call_FFI_def]
+    )
+  >- (qexists_tac `0` >> simp[])
+  >- (
+    pairarg_tac >> gvs[] >>
+    drule eval_to'_min >> rw[] >> gvs[] >>
+    qpat_x_assum `_ ≤ _` kall_tac >> qpat_x_assum `eval_to' x _ _ = _` kall_tac >>
+    Cases_on `k'` >> gvs[] >> pop_assum $ qspec_then `n'` assume_tac >> gvs[] >>
+    gvs[eval_to'_step_alt] >>
+    drule $ iffLR eval_to'_evaluate'_timeout >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >>
+    Q.REFINE_EXISTS_TAC `SUC n' + k` >>
+    simp[evaluate'_add_alt, evaluate'_step_alt] >>
+    drule eval_to'_1_ffi_evaluate >>
+    disch_then $ qspec_then `mk_ffi ffi oracle ffi_st` assume_tac >> reverse $ gvs[]
+    >- gvs[evaluate'_1_ffi_failed, eval_to'_1_Vis, call_FFI_def] >>
+    drule_all $ iffLR evaluate'_1_ffi_changed >> rw[] >> gvs[] >>
+    gvs[eval_to'_1_Vis, call_FFI_def] >>
+    qmatch_goalsub_abbrev_tac `mk_ffi ffi0 _ _` >>
+    last_x_assum drule >> disch_then $ qspec_then `ffi0` assume_tac >> gvs[] >>
+    goal_assum drule >> unabbrev_all_tac >> gvs[]
+    )
+QED
+
+Theorem evaluate'_trace_prefix_io_events:
+  ∀k mc (ffi:'ffi ffi_state) ms mc' ms' ffi'.
+    evaluate' mc ffi k ms = (TimeOut,mc',ms',ffi')
+  ⇒ ∃n io.
+      trace_prefix n (ffi.oracle,ffi.ffi_state)
+        (machine_sem_itree (mc,ms)) = (io,NONE) ∧
+      ffi'.io_events = ffi.io_events ++ io
+Proof
+  Induct >> rw[evaluate'_step] >- (qexists_tac `0` >> rw[trace_prefix_def]) >>
+  qabbrev_tac `res = evaluate' mc ffi 1 ms` >> PairCases_on `res` >> gvs[] >>
+  Cases_on `res0` >> gvs[] >> Cases_on `res3 = ffi` >> gvs[]
+  >- (
+    last_x_assum drule >> rw[] >>
+    qsuff_tac `eval (mc,ms) = eval (res1,res2)`
+    >- (rw[] >> imp_res_tac machine_sem_itree_eq >> gvs[SF SFY_ss]) >>
+    irule eval_prefix >> gvs[GSYM eval_to'_evaluate'_timeout] >> goal_assum drule
+    ) >>
+  drule_all evaluate'_1_ffi_changed_eval_to' >> rw[] >> gvs[] >>
+  simp[machine_sem_itree, eval_alt_def] >>
+  DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+  >- (pop_assum $ qspec_then `1` assume_tac >> gvs[]) >>
+  pairarg_tac >> gvs[] >> dxrule_then drule eval_to'_agree >> rw[] >> gvs[] >>
+  drule_all $ iffLR evaluate'_1_ffi_changed >> strip_tac >> gvs[eval_to'_1_Vis] >>
+  gvs[call_FFI_def, AllCaseEqs()] >>
+  Q.REFINE_EXISTS_TAC `SUC m` >> simp[trace_prefix_def] >>
+  gvs[ffi_state_component_equality] >>
+  last_x_assum drule >> rw[] >> qexists_tac `n'` >> simp[]
+QED
+
+Theorem evaluate'_trace_prefix_diverge:
+  (∀n. ∃io. trace_prefix n (oracle,ffi_st:'ffi)
+    (machine_sem_itree (mc,ms)) = (io,NONE)) ⇔
+  (∀k. ∃mc' ms' ffi'.
+    evaluate' mc (mk_ffi ffi oracle ffi_st) k ms = (TimeOut,mc',ms',ffi'))
+Proof
+  eq_tac >> rw[]
+  >- (
+    CCONTR_TAC >> gvs[] >>
+    qabbrev_tac `res = evaluate' mc (mk_ffi ffi oracle ffi_st) k ms` >>
+    PairCases_on `res` >> gvs[] >> imp_res_tac evaluate'_io_events_mono >>
+    gvs[io_events_mono_def, IS_PREFIX_APPEND] >>
+    reverse $ Cases_on `res0` >> gvs[]
+    >- (
+      drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_error >>
+      strip_tac >> gvs[] >> last_x_assum $ qspec_then `n` mp_tac >> simp[]
+      ) >>
+    Cases_on `∃h. halt_rel h o'` >> gvs[]
+    >- (
+      drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_halt >>
+      strip_tac >> gvs[] >> last_x_assum $ qspec_then `n` mp_tac >> simp[]
+      ) >>
+    Cases_on `o'` >> gvs[halt_rel_alt_def] >> Cases_on `f` >>
+    drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_ffi_error >>
+    strip_tac >> gvs[] >> last_x_assum $ qspec_then `n` mp_tac >> simp[]
+    )
+  >- (
+    CCONTR_TAC >> gvs[] >>
+    Cases_on `trace_prefix n (oracle,ffi_st) (machine_sem_itree (mc,ms))` >> gvs[] >>
+    Cases_on `r` >> gvs[] >> Cases_on `x` >> gvs[]
+    >- (
+      `halt_rel Termination Success` by gvs[halt_rel_def] >>
+      drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_halt >>
+      disch_then $ qspec_then `ffi` assume_tac >> gvs[] >>
+      last_x_assum $ qspec_then `k` assume_tac >> gvs[]
+      )
+    >- (
+      `halt_rel OutOfMemory Resource_limit_hit` by gvs[halt_rel_def] >>
+      drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_halt >>
+      disch_then $ qspec_then `ffi` assume_tac >> gvs[] >>
+      last_x_assum $ qspec_then `k` assume_tac >> gvs[]
+      )
+    >- (
+      drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_error >>
+      disch_then $ qspec_then `ffi` assume_tac >> gvs[] >>
+      last_x_assum $ qspec_then `k` assume_tac >> gvs[]
+      )
+    >- (
+      PairCases_on `p` >>
+      drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_ffi_error >>
+      disch_then $ qspec_then `ffi` assume_tac >> gvs[] >>
+      last_x_assum $ qspec_then `k` assume_tac >> gvs[]
+      )
+    )
+QED
+
+Triviality trace_prefix_machine_halt_alt =
+  Q.INST [`oracle` |-> `ffi.oracle`, `ffi_st` |-> `ffi.ffi_state`]
+    trace_prefix_machine_halt |> SRULE [];
+
+Triviality trace_prefix_machine_error_alt =
+  Q.INST [`oracle` |-> `ffi.oracle`, `ffi_st` |-> `ffi.ffi_state`]
+    trace_prefix_machine_error |> SRULE [];
+
+Triviality trace_prefix_machine_ffi_error_alt =
+  Q.INST [`oracle` |-> `ffi.oracle`, `ffi_st` |-> `ffi.ffi_state`]
+    trace_prefix_machine_ffi_error |> SRULE [];
+
+Theorem lprefix_chain_evaluate':
+  lprefix_chain
+    (IMAGE (λk. fromList (SND (SND (SND (evaluate' mc st k ms)))).io_events) 𝕌(:num))
+Proof
+  rw[lprefix_chain_def] >> simp[LPREFIX_fromList, from_toList] >>
+  wlog_tac `k ≤ k'` [`k`,`k'`] >- (`k' ≤ k` by gvs[] >> metis_tac[]) >>
+  disj1_tac >> imp_res_tac LESS_EQUAL_ADD >> gvs[] >>
+  simp[evaluate'_add_alt] >>
+  qabbrev_tac `res = evaluate' mc st k ms` >> PairCases_on `res` >> gvs[] >>
+  CASE_TAC >> gvs[] >>
+  qpat_abbrev_tac `res' = evaluate' _ _ _ _` >> PairCases_on `res'` >> gvs[] >>
+  imp_res_tac evaluate'_io_events_mono >> gvs[io_events_mono_def]
+QED
+
+Theorem itree_machine_semantics:
+  (machine_sem mc (ffi:'ffi ffi_state) ms (Terminate outcome io_list) ⇔
+    ∃n io res.
+      trace_prefix n (ffi.oracle, ffi.ffi_state)
+        (machine_sem_itree (mc,ms)) = (io, SOME res) ∧
+      io_list = ffi.io_events ++ io ∧
+      if outcome = Success then res = Termination
+      else if outcome = Resource_limit_hit then res = OutOfMemory
+      else ∃s conf ws f.
+              outcome = FFI_outcome (Final_event s conf ws f) ∧
+              res = FinalFFI (s,conf,ws) f) ∧
+
+  (machine_sem mc ffi ms (Diverge io_trace) ⇔
+    (∀n. ∃io. trace_prefix n (ffi.oracle, ffi.ffi_state)
+                (machine_sem_itree (mc,ms)) = (io, NONE)) ∧
+    lprefix_lub
+      { fromList (ffi.io_events ++ io) | io |
+          ∃n res. trace_prefix n (ffi.oracle, ffi.ffi_state)
+                    (machine_sem_itree (mc,ms)) = (io, res) }
+      io_trace) ∧
+
+  (machine_sem mc ffi ms Fail ⇔
+    ∃n io. trace_prefix n (ffi.oracle, ffi.ffi_state)
+            (machine_sem_itree (mc,ms)) = (io, SOME Error))
+Proof
+  rw[machine_sem_def, evaluate_evaluate']
+  >- ( (* termination *)
+    Cases_on `∃h. halt_rel h outcome` >> gvs[]
+    >- (
+      eq_tac >> rw[]
+      >- (
+        pairarg_tac >> gvs[] >> imp_res_tac evaluate'_io_events_mono >>
+        gvs[io_events_mono_def, IS_PREFIX_APPEND] >>
+        drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_halt_alt >>
+        strip_tac >> goal_assum drule >>
+        Cases_on `h` >> gvs[halt_rel_def]
+        )
+      >- (
+        `res = h` by (Cases_on `h` >> gvs[halt_rel_def]) >> gvs[] >>
+        drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_halt_alt >>
+        rw[] >> qexists_tac `k` >> simp[]
+        )
+      )
+    >- (
+      Cases_on `outcome` >> gvs[halt_rel_alt_def] >> eq_tac >> rw[]
+      >- (
+        pairarg_tac >> gvs[] >> imp_res_tac evaluate'_io_events_mono >>
+        gvs[io_events_mono_def, IS_PREFIX_APPEND] >> Cases_on `f` >>
+        drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_ffi_error_alt >>
+        strip_tac >> goal_assum drule >> simp[]
+        )
+      >- (
+        drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_ffi_error_alt >>
+        rw[] >> qexists_tac `k` >> simp[]
+        )
+      )
+    )
+  >- ( (* divergence *)
+    irule $ DECIDE ``a = c ∧ (a ∧ c ⇒ b = d) ⇒ (a ∧ b ⇔ c ∧ d)`` >> rw[]
+    >- (
+      eq_tac >> rw[]
+      >- (
+        irule $ iffRL evaluate'_trace_prefix_diverge >> qexists_tac `ffi` >> rw[] >>
+        pop_assum $ qspec_then `k` assume_tac >> pairarg_tac >> gvs[]
+        )
+      >- (
+        pairarg_tac >> gvs[] >> drule $ iffLR evaluate'_trace_prefix_diverge >>
+        disch_then $ qspecl_then [`ffi`,`k`] assume_tac >> gvs[]
+        )
+      ) >>
+    irule lprefix_lub_equiv_chain >> irule_at Any IMP_equiv_lprefix_chain >>
+    simp[UNCURRY, lprefix_chain_trace_prefix, lprefix_chain_evaluate'] >>
+    rw[lprefix_rel_def, PULL_EXISTS, LPREFIX_fromList, from_toList]
+    >- (
+      last_x_assum $ qspec_then `k` assume_tac >> pairarg_tac >> gvs[] >>
+      drule evaluate'_trace_prefix_io_events >> rw[] >> goal_assum drule >> simp[]
+      )
+    >- (
+      first_x_assum $ qspec_then `n` assume_tac >> gvs[] >>
+      drule trace_prefix_evaluate'_io_events >>
+      disch_then $ qspec_then `ffi` assume_tac >> gvs[] >> qexists_tac `k` >> simp[]
+      )
+    )
+  >- ( (* type error *)
+    eq_tac >> rw[]
+    >- (
+      pairarg_tac >> gvs[] >> imp_res_tac evaluate'_io_events_mono >>
+      gvs[io_events_mono_def, IS_PREFIX_APPEND] >>
+      drule_all $ SRULE [PULL_EXISTS] $ iffRL trace_prefix_machine_error_alt >>
+      strip_tac >> goal_assum drule
+      )
+    >- (
+      drule_all $ SRULE [PULL_EXISTS] $ iffLR trace_prefix_machine_error_alt >>
+      rw[] >> qexists_tac `k` >> simp[]
+      )
+    )
+QED
+
+
+(**********)
+
+val _ = export_theory();
+

--- a/compiler/backend/semantics/target_itreePropsScript.sml
+++ b/compiler/backend/semantics/target_itreePropsScript.sml
@@ -1,0 +1,372 @@
+(*
+  Properties about the itree target semantics
+*)
+open preamble targetSemTheory targetPropsTheory;
+open itreeTheory target_itreeSemTheory
+     itree_semanticsTheory itree_semanticsPropsTheory;
+
+
+val _ = new_theory "target_itreeProps"
+
+
+(********** machine_sem_itree **********)
+
+Theorem machine_sem_itree:
+  machine_sem_itree (mc, ms) =
+  case eval (mc, ms) of
+  | Ret' r => Ret r
+  | Div' => Div
+  | Vis' (s, ws1, ws2) f =>
+      Vis (s, ws1, ws2) (λa.
+        case a of
+        | INL x => Ret (FinalFFI (s, ws1, ws2) x)
+        | INR y =>
+            if LENGTH ws2 = LENGTH y then machine_sem_itree (f y)
+            else Ret $ FinalFFI (s, ws1, ws2) FFI_failed)
+Proof
+  rw[machine_sem_itree_def, Once itree_unfold_err] >>
+  CASE_TAC >> gvs[] >> PairCases_on `e` >> gvs[] >>
+  rw[FUN_EQ_THM] >> CASE_TAC >> gvs[] >> CASE_TAC >> gvs[] >>
+  Cases_on `f y` >> simp[machine_sem_itree_def]
+QED
+
+Theorem trace_prefix_machine_sem_itree:
+  trace_prefix 0 (oracle,ffi_st) (machine_sem_itree (mc, ms)) = ([], NONE) ∧
+  trace_prefix (SUC n) (oracle,ffi_st) (machine_sem_itree (mc, ms)) =
+    case eval (mc, ms) of
+    | Ret' r => ([], SOME r)
+    | Div' => ([], NONE)
+    | Vis' (s, conf, ws) f =>
+        case oracle s ffi_st conf ws of
+        | Oracle_return ffi_st' ws' =>
+            if LENGTH ws ≠ LENGTH ws' ∧ n = 0 then ([],NONE)
+            else if LENGTH ws ≠ LENGTH ws' then
+              ([],SOME (FinalFFI (s,conf,ws) FFI_failed))
+            else let
+              (io,res) = trace_prefix n (oracle,ffi_st') (machine_sem_itree (f ws')) in
+              (IO_event s conf (ZIP (ws,ws'))::io,res)
+        | Oracle_final outcome =>
+            if n = 0 then ([], NONE)
+            else ([], SOME (FinalFFI (s,conf,ws) outcome))
+Proof
+  rw[trace_prefix_def] >> rw[Once machine_sem_itree] >>
+  CASE_TAC >> gvs[trace_prefix_def] >>
+  PairCases_on `e` >> gvs[trace_prefix_def] >>
+  reverse CASE_TAC >> gvs[]
+  >- (Cases_on `n` >> gvs[trace_prefix_def]) >>
+  IF_CASES_TAC >> gvs[] >>
+  Cases_on `n` >> gvs[trace_prefix_def]
+QED
+
+Theorem machine_sem_itree_eq:
+  eval (mc,ms) = eval (mc',ms') ⇒
+  machine_sem_itree (mc,ms) = machine_sem_itree (mc',ms')
+Proof
+  rw[machine_sem_itree]
+QED
+
+
+(*********** eval_to' **********)
+
+Definition eval_to'_def:
+  eval_to' k mc (ms:'a) =
+    if k = 0n then (Div',mc,ms)
+    else
+      if mc.target.get_pc ms IN mc.prog_addresses then
+        if encoded_bytes_in_mem
+            mc.target.config (mc.target.get_pc ms)
+            (mc.target.get_byte ms) mc.prog_addresses then
+          let ms1 = mc.target.next ms in
+          let (ms2,new_oracle) = apply_oracle mc.next_interfer ms1 in
+          let mc = mc with next_interfer := new_oracle in
+            if EVERY mc.target.state_ok [ms;ms1;ms2] ∧
+               (∀x. x ∉ mc.prog_addresses ⇒
+                   mc.target.get_byte ms1 x =
+                   mc.target.get_byte ms x)
+            then
+              eval_to' (k - 1) mc ms2
+            else
+              (Ret' Error,mc,ms)
+        else (Ret' Error,mc,ms)
+      else if mc.target.get_pc ms = mc.halt_pc then
+        (if mc.target.get_reg ms mc.ptr_reg = 0w
+         then (Ret' Termination,mc,ms) else (Ret' OutOfMemory,mc,ms))
+      else if mc.target.get_pc ms = mc.ccache_pc then
+        let (ms1,new_oracle) =
+          apply_oracle mc.ccache_interfer
+            (mc.target.get_reg ms mc.ptr_reg,
+             mc.target.get_reg ms mc.len_reg,
+             ms) in
+        let mc = mc with ccache_interfer := new_oracle in
+          eval_to' (k-1) mc ms1
+      else
+        case find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 of
+        | NONE => (Ret' Error,mc,ms)
+        | SOME ffi_index =>
+          case read_ffi_bytearrays mc ms of
+          | SOME bytes, SOME bytes2 =>
+             let mc1 = mc with ffi_interfer := shift_seq 1 mc.ffi_interfer in
+             if EL ffi_index mc.ffi_names = "" then
+              eval_to' (k - 1) mc1 (mc.ffi_interfer 0 (ffi_index,bytes2,ms))
+             else (Vis' (EL ffi_index mc.ffi_names, bytes, bytes2)
+                    (λnew_bytes. (mc1, mc.ffi_interfer 0 (ffi_index,new_bytes,ms))),
+                   mc1,ms)
+          | _ => (Ret' Error,mc,ms)
+End
+
+Theorem eval_to'_0[simp]:
+  eval_to' 0 mc ms = (Div',mc,ms)
+Proof
+  rw[Once eval_to'_def]
+QED
+
+Theorem eval_to_eval_to':
+  ∀k mc ms. eval_to k mc ms = FST (eval_to' k mc ms)
+Proof
+  recInduct eval_to_ind >> rw[] >>
+  simp[Once eval_to_def, Once eval_to'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[] >>
+  IF_CASES_TAC >> gvs[apply_oracle_def] >> IF_CASES_TAC >> gvs[] >>
+  rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem eval_to'_step:
+  eval_to' 0 mc ms = (Div',mc,ms) ∧
+  eval_to' (SUC n) mc ms =
+    case eval_to' 1 mc ms of
+    | (Div',mc',ms') => eval_to' n mc' ms'
+    | res => res
+Proof
+  simp[] >> simp[Once eval_to'_def, SimpRHS] >> simp[Once eval_to'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem eval_to'_step_alt:
+  eval_to' 0 mc ms = (Div',mc,ms) ∧
+  eval_to' (SUC n) mc ms =
+    case eval_to' n mc ms of
+    | (Div',mc',ms') => eval_to' 1 mc' ms'
+    | res => res
+Proof
+  simp[] >> map_every qid_spec_tac [`ms`,`mc`,`n`] >>
+  Induct >- rw[] >> rpt gen_tac >>
+  rewrite_tac[eval_to'_step] >>
+  qabbrev_tac `ev = eval_to' 1 mc ms` >> PairCases_on `ev` >> gvs[] >>
+  TOP_CASE_TAC >> simp[] >> simp[GSYM eval_to'_step]
+QED
+
+Theorem eval_to'_add:
+  ∀a b.
+    eval_to' (a + b) mc ms =
+    case eval_to' b mc ms of
+    | (Div',mc',ms') => eval_to' a mc' ms'
+    | res => res
+Proof
+  Induct >> rw[eval_to'_step, ADD_CLAUSES] >>
+  qabbrev_tac `ev = eval_to' b mc ms` >> PairCases_on `ev` >> gvs[] >>
+  Cases_on `ev0` >> gvs[] >> simp[GSYM eval_to'_step] >> simp[eval_to'_step_alt]
+QED
+
+Theorem eval_to'_add_alt:
+  ∀a b.
+    eval_to' (a + b) mc ms =
+    case eval_to' a mc ms of
+    | (Div',mc',ms') => eval_to' b mc' ms'
+    | res => res
+Proof
+  once_rewrite_tac[ADD_COMM] >> simp[eval_to'_add]
+QED
+
+Theorem eval_to'_add_clock:
+  ∀k mc ms res k'.
+    eval_to' k mc ms = res ∧ FST res ≠ Div' ∧ k ≤ k'
+  ⇒ eval_to' k' mc ms = res
+Proof
+  recInduct eval_to'_ind >> rw[] >>
+  qpat_x_assum `FST _ ≠ _` mp_tac >> once_rewrite_tac[eval_to'_def] >>
+  TOP_CASE_TAC >> gvs[] >> TOP_CASE_TAC >> gvs[] >>
+  TOP_CASE_TAC >> gvs[apply_oracle_def] >> rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem eval_to'_agree:
+  ∀k mc ms res1 res2 k'.
+    eval_to' k mc ms = res1 ∧ eval_to' k' mc ms = res2 ∧
+    FST res1 ≠ Div' ∧ FST res2 ≠ Div'
+  ⇒ res1 = res2
+Proof
+  recInduct eval_to_ind >> rw[] >>
+  ntac 2 $ pop_assum mp_tac >> once_rewrite_tac[eval_to'_def] >> strip_tac >>
+  Cases_on `k = 0` >> Cases_on `k' = 0` >> gvs[] >>
+  TOP_CASE_TAC >> gvs[] >> TOP_CASE_TAC >> gvs[apply_oracle_def] >>
+  rpt (TOP_CASE_TAC >> gvs[])
+QED
+
+Theorem eval_to'_remove_clock:
+  eval_to' k mc ms = res ∧ FST res = Div' ∧ k' ≤ k ⇒
+  FST (eval_to' k' mc ms) = Div'
+Proof
+  metis_tac[eval_to'_add_clock, PAIR]
+QED
+
+Theorem eval_to'_min:
+  ∀k mc ffi ms res.
+    eval_to' k mc ms = res ∧ FST res ≠ Div'
+  ⇒ ∃k'. k' ≤ k ∧ eval_to' k' mc ms = res ∧
+      ∀m. m < k' ⇒ ∃mc' ms'. eval_to' m mc ms = (Div',mc',ms')
+Proof
+  Induct >> rw[] >>
+  qabbrev_tac `res = eval_to' (SUC k) mc ms` >> PairCases_on `res` >> gvs[] >>
+  gvs[eval_to'_step_alt] >>
+  Cases_on `eval_to' k mc ms` >> gvs[] >> Cases_on `q` >> gvs[]
+  >- (
+    first_x_assum $ qspecl_then [`mc`,`ms`] assume_tac >> gvs[] >>
+    qexists_tac `k'` >> simp[]
+    )
+  >- (
+    PairCases_on `r` >> gvs[] >>
+    qexists_tac `SUC k` >> simp[eval_to'_step_alt] >> rw[] >>
+    drule eval_to'_remove_clock >> simp[] >>
+    disch_then $ qspec_then `m` mp_tac >> simp[] >> metis_tac[PAIR]
+    )
+  >- (
+    first_x_assum $ qspecl_then [`mc`,`ms`] assume_tac >> gvs[] >>
+    qexists_tac `k'` >> simp[]
+    )
+QED
+
+Theorem eval_to'_Ret_FinalFFI:
+  ∀k mc ms p out mc' ms'. eval_to' k mc ms ≠ (Ret' (FinalFFI p out),mc',ms')
+Proof
+  ho_match_mp_tac eval_to'_ind >> rw[] >> simp[Once eval_to'_def] >>
+  gvs[AllCaseEqs(), apply_oracle_def] >>
+  rw[DISJ_EQ_IMP] >> gvs[] >> metis_tac[]
+QED
+
+Theorem eval_to'_1_Vis:
+  eval_to' 1 mc ms = (Vis' (s,conf,ws) f,mc',ms') ⇔
+    mc.target.get_pc ms ∉ mc.prog_addresses ∧
+    mc.target.get_pc ms ≠ mc.halt_pc ∧
+    mc.target.get_pc ms ≠ mc.ccache_pc ∧
+    ∃n.
+      find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME n ∧
+      read_ffi_bytearrays mc ms = (SOME conf,SOME ws) ∧
+      s ≠ "" ∧ s = EL n mc.ffi_names ∧
+      mc' = mc with ffi_interfer := shift_seq 1 mc.ffi_interfer ∧ ms' = ms ∧
+      f = (λnew_bytes. (mc', mc.ffi_interfer 0 (n,new_bytes,ms)))
+Proof
+  simp[Once eval_to'_def] >>
+  IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[apply_oracle_def] >>
+  IF_CASES_TAC >> gvs[] >> rpt (TOP_CASE_TAC >> gvs[]) >>
+  eq_tac >> rw[] >> gvs[]
+QED
+
+
+(*********** eval **********)
+
+Theorem eval:
+  eval (mc, ms) =
+    if mc.target.get_pc ms IN mc.prog_addresses
+    then
+      if encoded_bytes_in_mem
+          mc.target.config (mc.target.get_pc ms)
+          (mc.target.get_byte ms) mc.prog_addresses
+      then
+        let ms1 = mc.target.next ms in
+        let (ms2,new_oracle) = apply_oracle mc.next_interfer ms1 in
+        let mc = mc with next_interfer := new_oracle in
+          if EVERY mc.target.state_ok [ms;ms1;ms2] ∧
+             (∀x. x ∉ mc.prog_addresses ⇒
+                 mc.target.get_byte ms1 x =
+                 mc.target.get_byte ms x)
+          then eval (mc, ms2)
+          else Ret' Error
+      else Ret' Error
+    else if mc.target.get_pc ms = mc.halt_pc then
+      (if mc.target.get_reg ms mc.ptr_reg = 0w
+       then Ret' Termination else Ret' OutOfMemory)
+    else if mc.target.get_pc ms = mc.ccache_pc then
+      let (ms1,new_oracle) =
+        apply_oracle mc.ccache_interfer
+          (mc.target.get_reg ms mc.ptr_reg,
+           mc.target.get_reg ms mc.len_reg,
+           ms) in
+      let mc = mc with ccache_interfer := new_oracle in
+        eval (mc, ms1)
+    else
+      case find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 of
+      | NONE => Ret' Error
+      | SOME ffi_index =>
+        case read_ffi_bytearrays mc ms of
+        | SOME bytes, SOME bytes2 =>
+           let mc1 = mc with ffi_interfer := shift_seq 1 mc.ffi_interfer in
+           if EL ffi_index mc.ffi_names = "" then
+            eval (mc1, mc.ffi_interfer 0 (ffi_index,bytes2,ms))
+           else Vis' (EL ffi_index mc.ffi_names, bytes, bytes2)
+                  (λnew_bytes. (mc1, mc.ffi_interfer 0 (ffi_index,new_bytes,ms)))
+        | _ => Ret' Error
+Proof
+  simp[Once eval_def] >>
+  DEEP_INTRO_TAC some_intro >> simp[] >> conj_tac >> rpt strip_tac >> gvs[]
+  >- (
+    pop_assum mp_tac >> once_rewrite_tac[eval_to_def] >>
+    IF_CASES_TAC >> gvs[] >> IF_CASES_TAC >> gvs[] >>
+    TOP_CASE_TAC >> gvs[apply_oracle_def] >>
+    rpt (TOP_CASE_TAC >> gvs[]) >>
+    rw[eval_def] >> DEEP_INTRO_TAC some_intro >> rw[] >>
+    gvs[eval_to_eval_to'] >> AP_TERM_TAC >> irule eval_to'_agree >> simp[] >>
+    metis_tac[]
+    )
+  >- (
+    pop_assum $ qspec_then `SUC n` $ mp_tac o GEN_ALL >> simp[Once eval_to_def] >>
+    IF_CASES_TAC >> gvs[] >> TOP_CASE_TAC >> gvs[] >>
+    TOP_CASE_TAC >> gvs[apply_oracle_def] >>
+    simp[eval_def] >> rpt (TOP_CASE_TAC >> gvs[])
+    )
+QED
+
+Theorem eval_alt_def:
+  eval (mc,ms) =
+    case some k. ∀mc' ms'. eval_to' k mc ms ≠ (Div',mc',ms') of
+    | NONE => Div'
+    | SOME k => let (t,mc',ms') = eval_to' k mc ms in t
+Proof
+  rw[eval_def, eval_to_eval_to'] >>
+  DEEP_INTRO_TAC some_intro >> rw[]
+  >- (
+    qmatch_goalsub_abbrev_tac `FST res` >> PairCases_on `res` >> gvs[] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[] >- (qexists_tac `x` >> simp[]) >>
+    pairarg_tac >> gvs[] >> dxrule_then dxrule eval_to'_agree >> simp[]
+    )
+  >- (
+    DEEP_INTRO_TAC some_intro >> rw[] >>
+    pairarg_tac >> gvs[] >> metis_tac[FST]
+    )
+QED
+
+Theorem eval_prefix:
+  eval_to' k mc ms = (Div',mc',ms') ⇒ eval (mc,ms) = eval (mc',ms')
+Proof
+  rw[eval_alt_def] >>
+  reverse (DEEP_INTRO_TAC some_intro >> rw[] >> DEEP_INTRO_TAC some_intro >> rw[]) >>
+  rpt (pairarg_tac >> gvs[])
+  >- (first_x_assum $ qspec_then `x + k` assume_tac >> gvs[eval_to'_add])
+  >- (
+    `k < x` by (
+      CCONTR_TAC >> gvs[NOT_LESS] >>
+      rev_dxrule eval_to'_remove_clock >> simp[] >> goal_assum drule >> simp[]) >>
+    imp_res_tac LESS_ADD >> gvs[eval_to'_add_alt] >>
+    first_x_assum $ qspec_then `p` assume_tac >> gvs[]
+    )
+  >- (
+    `k < x` by (
+      CCONTR_TAC >> gvs[NOT_LESS] >>
+      rev_dxrule eval_to'_remove_clock >> simp[] >> goal_assum drule >> simp[]) >>
+    imp_res_tac LESS_ADD >> gvs[eval_to'_add_alt] >>
+    dxrule eval_to'_agree >> disch_then dxrule >> simp[]
+    )
+QED
+
+(**********)
+
+val _ = export_theory();

--- a/compiler/backend/semantics/target_itreeSemScript.sml
+++ b/compiler/backend/semantics/target_itreeSemScript.sml
@@ -1,0 +1,78 @@
+(*
+  An itree-based semantics for the target machine code
+*)
+open preamble;
+open targetSemTheory;
+open itreeTheory;
+
+val _ = new_theory "target_itreeSem"
+
+Datatype:
+  result = Termination
+         | OutOfMemory
+         | Error
+         | FinalFFI (string # word8 list # word8 list) ffi_outcome
+End
+
+Definition eval_to_def:
+  eval_to k mc (ms:'a) =
+    if k = 0n then Div'
+    else
+      if mc.target.get_pc ms IN mc.prog_addresses then
+        if encoded_bytes_in_mem
+            mc.target.config (mc.target.get_pc ms)
+            (mc.target.get_byte ms) mc.prog_addresses then
+          let ms1 = mc.target.next ms in
+          let (ms2,new_oracle) = apply_oracle mc.next_interfer ms1 in
+          let mc = mc with next_interfer := new_oracle in
+            if EVERY mc.target.state_ok [ms;ms1;ms2] ∧
+               (∀x. x ∉ mc.prog_addresses ⇒
+                   mc.target.get_byte ms1 x =
+                   mc.target.get_byte ms x)
+            then
+              eval_to (k - 1) mc ms2
+            else
+              Ret' Error
+        else Ret' Error
+      else if mc.target.get_pc ms = mc.halt_pc then
+        (if mc.target.get_reg ms mc.ptr_reg = 0w
+         then Ret' Termination else Ret' OutOfMemory)
+      else if mc.target.get_pc ms = mc.ccache_pc then
+        let (ms1,new_oracle) =
+          apply_oracle mc.ccache_interfer
+            (mc.target.get_reg ms mc.ptr_reg,
+             mc.target.get_reg ms mc.len_reg,
+             ms) in
+        let mc = mc with ccache_interfer := new_oracle in
+          eval_to (k-1) mc ms1
+      else
+        case find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 of
+        | NONE => Ret' Error
+        | SOME ffi_index =>
+          case read_ffi_bytearrays mc ms of
+          | SOME bytes, SOME bytes2 =>
+             let mc1 = mc with ffi_interfer := shift_seq 1 mc.ffi_interfer in
+             if EL ffi_index mc.ffi_names = "" then
+              eval_to (k - 1) mc1 (mc.ffi_interfer 0 (ffi_index,bytes2,ms))
+             else Vis' (EL ffi_index mc.ffi_names, bytes, bytes2)
+                    (λnew_bytes. (mc1, mc.ffi_interfer 0 (ffi_index,new_bytes,ms)))
+          | _ => Ret' Error
+End
+
+Definition eval_def:
+  eval (mc, ms) =
+    case some k. eval_to k mc (ms:'a) ≠ Div' of
+      NONE => Div'
+    | SOME k => eval_to k mc (ms:'a)
+End
+
+Definition machine_sem_itree_def:
+  machine_sem_itree (mc, ms) =
+    itree_unfold_err eval
+      ((λ(_,_,ws) r. LENGTH ws = LENGTH r),
+      FinalFFI, (λe. FinalFFI e FFI_failed)) (mc, ms)
+End
+
+(**********)
+
+val _ = export_theory();

--- a/semantics/alt_semantics/README.md
+++ b/semantics/alt_semantics/README.md
@@ -6,6 +6,9 @@ Alternative definitions of the semantics:
 A clocked relational big-step semantics for CakeML. This semantics
 is no longer used in the CakeML development.
 
+[itree_semanticsScript.sml](itree_semanticsScript.sml):
+An itree-based semantics for CakeML
+
 [proofs](proofs):
 The direcory contains proofs about the old relational semantics for
 CakeML. This directory might be deleted in the future.

--- a/semantics/alt_semantics/itree_semanticsScript.sml
+++ b/semantics/alt_semantics/itree_semanticsScript.sml
@@ -1,0 +1,656 @@
+(*
+  An itree-based semantics for CakeML
+*)
+open HolKernel Parse boolLib bossLib BasicProvers dep_rewrite;
+open namespaceTheory astTheory
+     ffiTheory semanticPrimitivesTheory smallStepTheory;
+open itreeTheory;
+
+val _ = new_theory "itree_semantics"
+
+(******************** do_app ********************)
+
+Datatype:
+  app_result = Rval v | Rraise v
+End
+
+Definition do_app_def:
+  do_app s op vs = case (op, vs) of
+      (ListAppend, [x1; x2]) => (
+        case (v_to_list x1, v_to_list x2) of
+          (SOME xs, SOME ys) => SOME (s, Rval (list_to_v (xs ++ ys)))
+        | _ => NONE
+      )
+    | (Opn op, [Litv (IntLit n1); Litv (IntLit n2)]) =>
+        if (op = Divide ∨ op = Modulo) ∧ n2 = 0 then
+          SOME (s, Rraise div_exn_v)
+        else
+          SOME (s, Rval (Litv (IntLit (opn_lookup op n1 n2))))
+    | (Opb op, [Litv (IntLit n1); Litv (IntLit n2)]) =>
+        SOME (s, Rval (Boolv (opb_lookup op n1 n2)))
+    | (Opw W8 op, [Litv (Word8 w1); Litv (Word8 w2)]) =>
+        SOME (s, Rval (Litv (Word8 (opw8_lookup op w1 w2))))
+    | (Opw W64 op, [Litv (Word64 w1); Litv (Word64 w2)]) =>
+        SOME (s, Rval (Litv (Word64 (opw64_lookup op w1 w2))))
+    | (FP_top t_op, [Litv (Word64 w1); Litv (Word64 w2); Litv (Word64 w3)]) =>
+        SOME (s, Rval (Litv (Word64 (fp_top t_op w1 w2 w3))))
+    | (FP_bop bop, [Litv (Word64 w1); Litv (Word64 w2)]) =>
+        SOME (s,Rval (Litv (Word64 (fp_bop bop w1 w2))))
+    | (FP_uop uop, [Litv (Word64 w)]) =>
+        SOME (s,Rval (Litv (Word64 (fp_uop uop w))))
+    | (FP_cmp cmp, [Litv (Word64 w1); Litv (Word64 w2)]) =>
+        SOME (s,Rval (Boolv (fp_cmp cmp w1 w2)))
+    | (Shift W8 op n, [Litv (Word8 w)]) =>
+        SOME (s, Rval (Litv (Word8 (shift8_lookup op w n))))
+    | (Shift W64 op n, [Litv (Word64 w)]) =>
+        SOME (s, Rval (Litv (Word64 (shift64_lookup op w n))))
+    | (Equality, [v1; v2]) =>
+        (case do_eq v1 v2 of
+            Eq_type_error => NONE
+          | Eq_val b => SOME (s, Rval (Boolv b))
+        )
+    | (Opassign, [Loc lnum; v]) =>
+        (case store_assign lnum (Refv v) s of
+            SOME s' => SOME (s', Rval (Conv NONE []))
+          | NONE => NONE
+        )
+    | (Opref, [v]) =>
+        let (s',n) = (store_alloc (Refv v) s) in
+          SOME (s', Rval (Loc n))
+    | (Opderef, [Loc n]) =>
+        (case store_lookup n s of
+            SOME (Refv v) => SOME (s,Rval v)
+          | _ => NONE
+        )
+    | (Aw8alloc, [Litv (IntLit n); Litv (Word8 w)]) =>
+        if n <( 0 : int) then
+          SOME (s, Rraise sub_exn_v)
+        else
+          let (s',lnum) =
+            (store_alloc (W8array (REPLICATE (Num (ABS (I n))) w)) s)
+          in
+            SOME (s', Rval (Loc lnum))
+    | (Aw8sub, [Loc lnum; Litv (IntLit i)]) =>
+        (case store_lookup lnum s of
+            SOME (W8array ws) =>
+              if i <( 0 : int) then
+                SOME (s, Rraise sub_exn_v)
+              else
+                let n = (Num (ABS (I i))) in
+                  if n >= LENGTH ws then
+                    SOME (s, Rraise sub_exn_v)
+                  else
+                    SOME (s, Rval (Litv (Word8 (EL n ws))))
+          | _ => NONE
+        )
+    | (Aw8sub_unsafe, [Loc lnum; Litv (IntLit i)]) =>
+        (case store_lookup lnum s of
+            SOME (W8array ws) =>
+              if i <( 0 : int) then
+                NONE
+              else
+                let n = (Num (ABS (I i))) in
+                  if n >= LENGTH ws then
+                    NONE
+                  else
+                    SOME (s, Rval (Litv (Word8 (EL n ws))))
+          | _ => NONE
+        )
+    | (Aw8length, [Loc n]) =>
+        (case store_lookup n s of
+            SOME (W8array ws) =>
+              SOME (s,Rval (Litv(IntLit(int_of_num(LENGTH ws)))))
+          | _ => NONE
+         )
+    | (Aw8update, [Loc lnum; Litv(IntLit i); Litv(Word8 w)]) =>
+        (case store_lookup lnum s of
+          SOME (W8array ws) =>
+            if i <( 0 : int) then
+              SOME (s, Rraise sub_exn_v)
+            else
+              let n = (Num (ABS (I i))) in
+                if n >= LENGTH ws then
+                  SOME (s, Rraise sub_exn_v)
+                else
+                  (case store_assign lnum (W8array (LUPDATE w n ws)) s of
+                      NONE => NONE
+                    | SOME s' => SOME (s', Rval (Conv NONE []))
+                  )
+        | _ => NONE
+      )
+    | (Aw8update_unsafe, [Loc lnum; Litv(IntLit i); Litv(Word8 w)]) =>
+        (case store_lookup lnum s of
+          SOME (W8array ws) =>
+            if i <( 0 : int) then
+              NONE
+            else
+              let n = (Num (ABS (I i))) in
+                if n >= LENGTH ws then
+                  NONE
+                else
+                  (case store_assign lnum (W8array (LUPDATE w n ws)) s of
+                      NONE => NONE
+                    | SOME s' => SOME (s', Rval (Conv NONE []))
+                  )
+        | _ => NONE
+      )
+    | (WordFromInt W8, [Litv(IntLit i)]) =>
+        SOME (s, Rval (Litv (Word8 (i2w i))))
+    | (WordFromInt W64, [Litv(IntLit i)]) =>
+        SOME (s, Rval (Litv (Word64 (i2w i))))
+    | (WordToInt W8, [Litv (Word8 w)]) =>
+        SOME (s, Rval (Litv (IntLit (int_of_num(w2n w)))))
+    | (WordToInt W64, [Litv (Word64 w)]) =>
+        SOME (s, Rval (Litv (IntLit (int_of_num(w2n w)))))
+    | (CopyStrStr, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len)]) =>
+        SOME (s,
+        (case copy_array (EXPLODE str,off) len NONE of
+          NONE => Rraise sub_exn_v
+        | SOME cs => Rval (Litv(StrLit(IMPLODE(cs))))
+        ))
+    | (CopyStrAw8, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len);
+                    Loc dst;Litv(IntLit dstoff)]) =>
+        (case store_lookup dst s of
+          SOME (W8array ws) =>
+            (case copy_array (EXPLODE str,off) len (SOME(ws_to_chars ws,dstoff)) of
+              NONE => SOME (s, Rraise sub_exn_v)
+            | SOME cs =>
+              (case store_assign dst (W8array (chars_to_ws cs)) s of
+                SOME s' =>  SOME (s', Rval (Conv NONE []))
+              | _ => NONE
+              )
+            )
+        | _ => NONE
+        )
+    | (CopyAw8Str, [Loc src;Litv(IntLit off);Litv(IntLit len)]) =>
+      (case store_lookup src s of
+        SOME (W8array ws) =>
+        SOME (s,
+          (case copy_array (ws,off) len NONE of
+            NONE => Rraise sub_exn_v
+          | SOME ws => Rval (Litv(StrLit(IMPLODE(ws_to_chars ws))))
+          ))
+      | _ => NONE
+      )
+    | (CopyAw8Aw8, [Loc src;Litv(IntLit off);Litv(IntLit len);
+                    Loc dst;Litv(IntLit dstoff)]) =>
+      (case (store_lookup src s, store_lookup dst s) of
+        (SOME (W8array ws), SOME (W8array ds)) =>
+          (case copy_array (ws,off) len (SOME(ds,dstoff)) of
+            NONE => SOME (s, Rraise sub_exn_v)
+          | SOME ws =>
+              (case store_assign dst (W8array ws) s of
+                SOME s' => SOME (s', Rval (Conv NONE []))
+              | _ => NONE
+              )
+          )
+      | _ => NONE
+      )
+    | (Ord, [Litv (Char c)]) =>
+          SOME (s, Rval (Litv(IntLit(int_of_num(ORD c)))))
+    | (Chr, [Litv (IntLit i)]) =>
+        SOME (s,
+          (if (i <( 0 : int)) \/ (i >( 255 : int)) then
+            Rraise chr_exn_v
+          else
+            Rval (Litv(Char(CHR(Num (ABS (I i))))))))
+    | (Chopb op, [Litv (Char c1); Litv (Char c2)]) =>
+        SOME (s, Rval (Boolv (opb_lookup op (int_of_num(ORD c1)) (int_of_num(ORD c2)))))
+    | (Implode, [v]) =>
+          (case v_to_char_list v of
+            SOME ls =>
+              SOME (s, Rval (Litv (StrLit (IMPLODE ls))))
+          | NONE => NONE
+          )
+    | (Explode, [v]) =>
+          (case v of
+            Litv (StrLit str) =>
+              SOME (s, Rval (list_to_v (MAP (\ c .  Litv (Char c)) (EXPLODE str))))
+          | _ => NONE
+          )
+    | (Strsub, [Litv (StrLit str); Litv (IntLit i)]) =>
+        if i <( 0 : int) then
+          SOME (s, Rraise sub_exn_v)
+        else
+          let n = (Num (ABS (I i))) in
+            if n >= STRLEN str then
+              SOME (s, Rraise sub_exn_v)
+            else
+              SOME (s, Rval (Litv (Char (EL n (EXPLODE str)))))
+    | (Strlen, [Litv (StrLit str)]) =>
+        SOME (s, Rval (Litv(IntLit(int_of_num(STRLEN str)))))
+    | (Strcat, [v]) =>
+        (case v_to_list v of
+          SOME vs =>
+            (case vs_to_string vs of
+              SOME str =>
+                SOME (s, Rval (Litv(StrLit str)))
+            | _ => NONE
+            )
+        | _ => NONE
+        )
+    | (VfromList, [v]) =>
+          (case v_to_list v of
+              SOME vs =>
+                SOME (s, Rval (Vectorv vs))
+            | NONE => NONE
+          )
+    | (Vsub, [Vectorv vs; Litv (IntLit i)]) =>
+        if i <( 0 : int) then
+          SOME (s, Rraise sub_exn_v)
+        else
+          let n = (Num (ABS (I i))) in
+            if n >= LENGTH vs then
+              SOME (s, Rraise sub_exn_v)
+            else
+              SOME (s, Rval (EL n vs))
+    | (Vlength, [Vectorv vs]) =>
+        SOME (s, Rval (Litv (IntLit (int_of_num (LENGTH vs)))))
+    | (Aalloc, [Litv (IntLit n); v]) =>
+        if n <( 0 : int) then
+          SOME (s, Rraise sub_exn_v)
+        else
+          let (s',lnum) =
+            (store_alloc (Varray (REPLICATE (Num (ABS (I n))) v)) s)
+          in
+            SOME (s', Rval (Loc lnum))
+    | (AallocEmpty, [Conv NONE []]) =>
+        let (s',lnum) = (store_alloc (Varray []) s) in
+          SOME (s', Rval (Loc lnum))
+    | (AallocFixed, vs) =>
+        let (s',lnum) =
+          (store_alloc (Varray vs) s)
+        in
+          SOME (s', Rval (Loc lnum))
+    | (Asub, [Loc lnum; Litv (IntLit i)]) =>
+        (case store_lookup lnum s of
+            SOME (Varray vs) =>
+              if i <( 0 : int) then
+                SOME (s, Rraise sub_exn_v)
+              else
+                let n = (Num (ABS (I i))) in
+                  if n >= LENGTH vs then
+                    SOME (s, Rraise sub_exn_v)
+                  else
+                    SOME (s, Rval (EL n vs))
+          | _ => NONE
+        )
+    | (Asub_unsafe, [Loc lnum; Litv (IntLit i)]) =>
+        (case store_lookup lnum s of
+            SOME (Varray vs) =>
+              if i <( 0 : int) then
+                NONE
+              else
+                let n = (Num (ABS (I i))) in
+                  if n >= LENGTH vs then
+                    NONE
+                  else
+                    SOME (s, Rval (EL n vs))
+          | _ => NONE
+        )
+    | (Alength, [Loc n]) =>
+        (case store_lookup n s of
+            SOME (Varray ws) =>
+              SOME (s,Rval (Litv(IntLit(int_of_num(LENGTH ws)))))
+          | _ => NONE
+         )
+    | (Aupdate, [Loc lnum; Litv (IntLit i); v]) =>
+        (case store_lookup lnum s of
+          SOME (Varray vs) =>
+            if i <( 0 : int) then
+              SOME (s, Rraise sub_exn_v)
+            else
+              let n = (Num (ABS (I i))) in
+                if n >= LENGTH vs then
+                  SOME (s, Rraise sub_exn_v)
+                else
+                  (case store_assign lnum (Varray (LUPDATE v n vs)) s of
+                      NONE => NONE
+                    | SOME s' => SOME (s', Rval (Conv NONE []))
+                  )
+        | _ => NONE
+      )
+    | (Aupdate_unsafe, [Loc lnum; Litv (IntLit i); v]) =>
+        (case store_lookup lnum s of
+          SOME (Varray vs) =>
+            if i <( 0 : int) then
+              NONE
+            else
+              let n = (Num (ABS (I i))) in
+                if n >= LENGTH vs then
+                  NONE
+                else
+                  (case store_assign lnum (Varray (LUPDATE v n vs)) s of
+                      NONE => NONE
+                    | SOME s' => SOME (s', Rval (Conv NONE []))
+                  )
+        | _ => NONE
+      )
+    | (ConfigGC, [Litv (IntLit i); Litv (IntLit j)]) =>
+        SOME (s, Rval (Conv NONE []))
+    | (Env_id, [Env env (gen, id)]) => SOME (s,
+            Rval (Conv NONE [nat_to_v gen; nat_to_v id]))
+    | (Env_id, [Conv NONE [gen; id]]) => SOME (s,
+            Rval (Conv NONE [gen; id]))
+    | _ => NONE
+End
+
+
+(******************** expressions ********************)
+
+Datatype:
+  ctxt_frame = Craise
+             | Chandle ((pat # exp) list)
+             | Capp op (v list) (exp list)
+             | Clog lop exp
+             | Cif exp exp
+             | Cmat_check ((pat # exp) list) v
+             | Cmat ((pat # exp) list) v
+             | Clet (varN option) exp
+             | Ccon (((modN, conN) id) option) (v list) (exp list)
+             | Ctannot ast_t
+             | Clannot locs
+End
+
+Type "ctxt"[pp] = ``:ctxt_frame # v sem_env``;
+
+Type "small_state"[pp] = ``:v sem_env # v store # exp_or_val # ctxt list``;
+
+Datatype:
+  estep_result = Estep small_state
+               | Effi string (word8 list) (word8 list) num
+                        (v sem_env) (v store) (ctxt list)
+               | Edone
+               | Etype_error
+End
+
+Definition push_def:
+  push env s e c cs : estep_result = Estep (env, s, Exp e, (c,env)::cs)
+End
+
+(* This is value_def in stateLang *)
+Definition return_def:
+  return env s v c : estep_result = Estep (env, s, Val v, c)
+End
+
+Definition application_def:
+  application op env s vs c : estep_result =
+    case op of
+      Opapp => (
+        case do_opapp vs of
+          SOME (env, e) => Estep (env, s, Exp e, c)
+        | NONE => Etype_error)
+    | FFI n => (
+        case vs of
+          [Litv (StrLit conf); Loc lnum] => (
+            case store_lookup lnum s of
+              SOME (W8array ws) =>
+                if n = "" then Estep (env, s, Val $ Conv NONE [], c)
+                else Effi n (MAP (λc. n2w $ ORD c) (EXPLODE conf)) ws lnum env s c
+            | _ => Etype_error)
+        | _ => Etype_error)
+    | _ => (
+        case do_app s op vs of
+          SOME (s', Rraise v) => Estep (env, s', Val v, (Craise, env)::c)
+        | SOME (s', Rval v)   => return env s' v c
+        | NONE                => Etype_error)
+End
+
+(* This is return_def in stateLang *)
+Definition continue_def:
+  continue s v [] : estep_result = Edone ∧
+  continue s v ((Craise, env)::cs) = (
+    case cs of
+      [] => Edone
+    | (Chandle pes, env') :: c =>
+        Estep (env, s, Val v, (Cmat_check pes v, env')::c)
+    | _::c => Estep (env, s, Val v, (Craise, env)::c)) ∧
+  continue s v ((Chandle pes, env)::c) = return env s v c ∧
+  continue s v ((Capp op vs [], env) :: c) = application op env s (v::vs) c ∧
+  continue s v ((Capp op vs (e::es), env) :: c) = push env s e (Capp op (v::vs) es) c ∧
+  continue s v ((Clog l e, env) :: c) = (
+    case do_log l v e of
+      SOME (Exp e) => Estep (env, s, Exp e, c)
+    | SOME (Val v) => return env s v c
+    | NONE => Etype_error) ∧
+  continue s v ((Cif e1 e2, env) :: c) = (
+    case do_if v e1 e2 of
+      SOME e => Estep (env, s, Exp e, c)
+    | NONE => Etype_error) ∧
+  continue s v ((Cmat_check pes err_v, env) :: c) = (
+    if can_pmatch_all env.c s (MAP FST pes) v then
+      Estep (env, s, Val v, (Cmat pes err_v, env)::c)
+    else Etype_error) ∧
+  continue s v ((Cmat [] err_v, env) :: c) =
+    Estep (env, s, Val err_v, (Craise, env)::c) ∧
+  continue s v ((Cmat ((p,e)::pes) err_v, env) :: c) = (
+    if ALL_DISTINCT (pat_bindings p []) then (
+      case pmatch env.c s p v [] of
+        Match_type_error => Etype_error
+      | No_match => Estep (env, s, Val v, (Cmat pes err_v, env)::c)
+      | Match env' =>
+          Estep (
+            env with <| v := nsAppend (alist_to_ns env') env.v |>, s, Exp e, c))
+    else Etype_error) ∧
+  continue s v ((Clet n e, env) :: c) =
+    Estep (env with <| v := nsOptBind n v env.v |>, s, Exp e, c) ∧
+  continue s v ((Ccon n vs [], env) :: c) = (
+    if do_con_check env.c n (LENGTH vs + 1n) then (
+      case build_conv env.c n (v::vs) of
+        NONE => Etype_error
+      | SOME v => return env s v c)
+    else Etype_error) ∧
+  continue s v ((Ccon n vs (e::es), env) :: c) = (
+    if do_con_check env.c n (LENGTH vs + 1n + 1n + LENGTH es) then
+      push env s e (Ccon n (v::vs) es) c
+    else Etype_error) ∧
+  continue s v ((Ctannot t, env) :: c) = return env s v c ∧
+  continue s v ((Clannot l, env) :: c) = return env s v c
+End
+
+Definition estep_def:
+  estep (env, s, Val v, c) : estep_result = continue s v c ∧
+  estep (env, s, Exp $ Lit l, c) = return env s (Litv l) c ∧
+  estep (env, s, Exp $ Raise e, c) = push env s e Craise c ∧
+  estep (env, s, Exp $ Handle e pes, c) = push env s e (Chandle pes) c ∧
+  estep (env, s, Exp $ Con n es, c) = (
+    if do_con_check env.c n (LENGTH es) then (
+      case REVERSE es of
+        [] => (
+          case build_conv env.c n [] of
+            NONE => Etype_error
+          | SOME v => return env s v c)
+      | e::es => push env s e (Ccon n [] es) c)
+    else Etype_error) ∧
+  estep (env, s, Exp $ Var n, c) = (
+    case nsLookup env.v n of
+      NONE => Etype_error
+    | SOME v => return env s v c) ∧
+  estep (env, s, Exp $ Fun n e, c) = return env s (Closure env n e) c ∧
+  estep (env, s, Exp $ App op es, c) = (
+    case REVERSE es of
+      [] => application op env s [] c
+    | (e::es) => push env s e (Capp op [] es) c) ∧
+  estep (env, s, Exp $ Log l e1 e2, c) = push env s e1 (Clog l e2) c ∧
+  estep (env, s, Exp $ If e1 e2 e3, c) = push env s e1 (Cif e2 e3) c ∧
+  estep (env, s, Exp $ Mat e pes, c) = push env s e (Cmat_check pes bind_exn_v) c ∧
+  estep (env, s, Exp $ Let n e1 e2, c) = push env s e1 (Clet n e2) c ∧
+  estep (env, s, Exp $ Letrec funs e, c) = (
+    if ¬ALL_DISTINCT (MAP FST funs) then Etype_error
+    else Estep (env with <| v := build_rec_env funs env env.v |>, s, Exp e, c)) ∧
+  estep (env, s, Exp $ Tannot e t, c) = push env s e (Ctannot t) c ∧
+  estep (env, s, Exp $ Lannot e l, c) = push env s e (Clannot l) c
+End
+
+
+(******************** Declarations ********************)
+
+(* State omits FFI and clock *)
+Datatype:
+  dstate =
+  <| refs  : v store
+   ; next_type_stamp : num
+   ; next_exn_stamp : num
+   ; eval_state : eval_state option
+   |>
+End
+
+Datatype:
+  deval =
+  | Decl dec
+  | ExpVal (v sem_env) (exp_or_val) (ctxt list) locs pat
+  | Env (v sem_env)
+End
+
+Datatype:
+  dstep_result =
+  | Dstep dstate deval decl_ctxt
+  | Dtype_error
+  | Ddone
+  | Draise v
+  | Dffi dstate
+      (string # word8 list # word8 list # num # v sem_env # ctxt list)
+      locs pat decl_ctxt
+End
+
+Definition dreturn_def[simp]:
+  dreturn st cs dev = Dstep st dev cs
+End
+
+Definition dpush_def[simp]:
+  dpush st cs dev c = Dstep st dev (c::cs)
+End
+
+Definition dcontinue_def:
+  dcontinue env' st [] = Ddone ∧
+  dcontinue env' st (Cdmod mn env [] :: cs) =
+    dreturn st cs (Env $ lift_dec_env mn (extend_dec_env env' env)) ∧
+  dcontinue env' st (Cdmod mn env (d::ds) :: cs) =
+    dpush st cs (Decl d) (Cdmod mn (extend_dec_env env' env) ds) ∧
+  dcontinue env' st (CdlocalL lenv [] gds :: cs) =
+    dpush st cs (Env empty_dec_env)
+      (CdlocalG (extend_dec_env env' lenv) empty_dec_env gds) ∧
+  dcontinue env' st (CdlocalL lenv (ld::lds) gds :: cs) =
+    dpush st cs (Decl ld) (CdlocalL (extend_dec_env env' lenv) lds gds) ∧
+  dcontinue env' st (CdlocalG lenv genv [] :: cs) =
+    dreturn st cs (Env $ extend_dec_env env' genv) ∧
+  dcontinue env' st (CdlocalG lenv genv (gd::gds) :: cs) =
+    dpush st cs (Decl gd) (CdlocalG lenv (extend_dec_env env' genv) gds)
+End
+
+Definition dstep_def:
+  dstep benv st (Decl $ Dlet locs p e) c = (
+    if ALL_DISTINCT (pat_bindings p []) then
+      dreturn st c (ExpVal (collapse_env benv c) (Exp e) [] locs p)
+    else Dtype_error) ∧
+  dstep benv st (Decl $ Dletrec locs funs) c = (
+    if ALL_DISTINCT (MAP FST funs) then
+      dreturn st c (Env $
+        <| v := build_rec_env funs (collapse_env benv c) nsEmpty; c := nsEmpty |>)
+    else Dtype_error) ∧
+  dstep benv st (Decl $ Dtype locs tds) c = (
+    if EVERY check_dup_ctors tds then
+      dreturn (st with next_type_stamp := st.next_type_stamp + LENGTH tds) c
+        (Env <| v := nsEmpty; c := build_tdefs st.next_type_stamp tds |>)
+    else Dtype_error) ∧
+  dstep benv st (Decl $ Dtabbrev locs tvs n t) c = dreturn st c (Env empty_dec_env) ∧
+  dstep benv st (Decl $ Dexn locs cn ts) c =
+    dreturn (st with next_exn_stamp := st.next_exn_stamp + 1) c
+      (Env <| v := nsEmpty; c := nsSing cn (LENGTH ts, ExnStamp st.next_exn_stamp) |>) ∧
+  dstep benv st (Decl $ Dmod mn ds) c =
+    dpush st c (Env empty_dec_env) (Cdmod mn empty_dec_env ds) ∧
+  dstep benv st (Decl $ Dlocal lds gds) c =
+    dpush st c (Env empty_dec_env) (CdlocalL empty_dec_env lds gds) ∧
+  dstep benv st (Decl $ Denv n) c = (
+    case declare_env st.eval_state (collapse_env benv c) of
+    | SOME (x, es') =>
+      dreturn (st with eval_state := es') c (Env <| v := nsSing n x; c := nsEmpty|>)
+    | NONE => Dtype_error) ∧
+
+  dstep benv st (Env env) c = dcontinue env st c ∧
+
+  dstep benv st (ExpVal env (Val v) [] locs p) c = (
+    if ALL_DISTINCT (pat_bindings p []) then
+      case pmatch (collapse_env benv c).c st.refs p v [] of
+      | Match new_vals =>
+          dreturn st c (Env <| v := alist_to_ns new_vals; c := nsEmpty |>)
+      | No_match => Draise bind_exn_v
+      | Match_type_error => Dtype_error
+    else Dtype_error) ∧
+  dstep benv st (ExpVal env (Val v) [(Craise,env')] locs p) c = Draise v ∧
+  dstep benv st (ExpVal env ev ec locs p) c =
+    case estep (env, st.refs, ev, ec) of
+    | Estep (env', refs', ev', ec') =>
+        dreturn (st with refs := refs') c (ExpVal env' ev' ec' locs p)
+    | Etype_error => Dtype_error
+    | Edone => Ddone (* cannot happen *)
+    | Effi s ws1 ws2 n env' refs' ec' =>
+        Dffi (st with refs := refs') (s, ws1, ws2, n, env', ec') locs p c
+End
+
+Definition is_halt_def:
+  is_halt (Dffi _ _ _ _ _) = T ∧
+  is_halt Ddone = T ∧
+  is_halt (Draise _) = T ∧
+  is_halt Dtype_error = T ∧
+  is_halt _ = F
+End
+
+Definition step_n_def:
+  step_n benv 0 e = e ∧
+  step_n benv (SUC n) (Dstep st dev c) = step_n benv n (dstep benv st dev c) ∧
+  step_n benv _ e = e
+End
+
+Datatype:
+  next_res =
+  | Ret
+  | Div
+  | Err
+  | Act dstate
+      (string # word8 list # word8 list # num # v sem_env # ctxt list)
+      locs pat decl_ctxt
+End
+
+Definition step_until_halt_def:
+  step_until_halt benv d =
+    case some n. is_halt (step_n benv n d) of
+      NONE => Div
+    | SOME n =>
+        case step_n benv n d of
+        | Dtype_error => Err
+        | Dffi st ev locs pat c => Act st ev locs pat c
+        | _ => Ret
+End
+
+Datatype:
+  result = Termination
+         | Error
+         | FinalFFI (string # word8 list # word8 list) ffi_outcome
+End
+
+Definition cml_itree_unfold_err_def:
+  cml_itree_unfold_err f =
+    itree_unfold_err f
+      ((λ(_,_,ws) r. LENGTH ws = LENGTH r),
+      FinalFFI, (λe. FinalFFI e FFI_failed))
+End
+
+Definition interp_def:
+  interp benv e =
+    cml_itree_unfold_err
+      (λe.
+        case step_until_halt benv e of
+        | Ret => Ret' Termination
+        | Err => Ret' Error
+        | Div => Div'
+        | Act st (s, ws1, ws2, n, env, cs) locs p c =>
+            Vis' (s, ws1, ws2)
+              (λr:word8 list.
+                dreturn (st with refs := LUPDATE (W8array r) n st.refs) c
+                  (ExpVal env (Val $ Conv NONE []) cs locs p)))
+      e
+End
+
+val _ = export_theory();
+

--- a/semantics/alt_semantics/proofs/README.md
+++ b/semantics/alt_semantics/proofs/README.md
@@ -33,5 +33,11 @@ Compset for evaluating the functional big-step semantics.
 [interpScript.sml](interpScript.sml):
 Deriviation of a functional big-step semantics from the relational one.
 
+[itree_semanticsEquivScript.sml](itree_semanticsEquivScript.sml):
+Relating the itree- and FFI state-based CakeML semantics
+
+[itree_semanticsPropsScript.sml](itree_semanticsPropsScript.sml):
+Properties about the itree- and FFI state-based CakeML semantics
+
 [smallStepPropsScript.sml](smallStepPropsScript.sml):
 Properties about the small-step semantics.

--- a/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
+++ b/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
@@ -1,0 +1,1764 @@
+(*
+  Relating the itree- and FFI state-based CakeML semantics
+*)
+open HolKernel Parse boolLib bossLib BasicProvers dep_rewrite;
+open optionTheory relationTheory pairTheory listTheory arithmeticTheory llistTheory;
+open namespaceTheory astTheory ffiTheory lprefix_lubTheory semanticPrimitivesTheory
+     semanticsTheory alt_semanticsTheory evaluatePropsTheory
+     smallStepTheory smallStepPropsTheory;
+open itreeTheory itree_semanticsTheory itree_semanticsPropsTheory;
+
+val _ = new_theory "itree_semanticsEquiv";
+
+
+(******************** Useful simplifications ********************)
+
+(* Deliberately no `application_def` here *)
+val smallstep_ss = simpLib.named_rewrites "smallstep_ss" [
+    smallStepTheory.continue_def,
+    smallStepTheory.return_def,
+    smallStepTheory.push_def,
+    smallStepTheory.e_step_def
+    ];
+
+val dsmallstep_ss = simpLib.named_rewrites "dsmallstep_ss" [
+    smallStepPropsTheory.collapse_env_def,
+    smallStepTheory.decl_continue_def,
+    smallStepTheory.decl_step_def
+    ];
+
+val itree_ss = simpLib.named_rewrites "itree_ss" [
+    itree_semanticsTheory.continue_def,
+    itree_semanticsTheory.return_def,
+    itree_semanticsTheory.push_def,
+    itree_semanticsTheory.estep_def,
+    get_ffi_def
+    ];
+
+val ditree_ss = simpLib.named_rewrites "ditree_ss" [
+    itree_semanticsTheory.dcontinue_def,
+    itree_semanticsTheory.dreturn_def,
+    itree_semanticsTheory.dpush_def,
+    itree_semanticsTheory.dstep_def,
+    dget_ffi_def
+    ];
+
+
+(******************** Simpler lemmas ********************)
+
+Theorem do_app_cases =
+  ``do_app st op vs = SOME (st',v)`` |> SIMP_CONV (srw_ss()) [
+    do_app_def, AllCaseEqs(), SF DNF_ss, LET_THM, GSYM DISJ_ASSOC];
+
+Theorem do_app_rel:
+  (∀s. op ≠ FFI s) ⇒
+  OPTREL (λ(a,b) (c,d). a = c ∧ result_rel b d)
+    (do_app st op vs)
+    (OPTION_MAP (λ(a,b). (FST a, b)) (do_app (st, ffi) op vs))
+Proof
+  rw[] >> reverse $ Cases_on `do_app (st,ffi) op vs` >> gvs[]
+  >- (
+    PairCases_on `x` >> gvs[semanticPrimitivesPropsTheory.do_app_cases] >>
+    simp[do_app_def, result_rel_cases] >> every_case_tac >> gvs[]
+    ) >>
+  Cases_on `do_app st op vs` >> gvs[] >> PairCases_on `x` >>
+  gvs[do_app_cases, semanticPrimitivesTheory.do_app_def, store_alloc_def] >>
+  every_case_tac >> gvs[]
+QED
+
+Theorem application_rel:
+  (∀s. op ≠ FFI s) ∧
+  ctxt_rel cs1 cs2 ⇒
+  step_result_rel
+    (application op env st vs cs1)
+    (application op env (st,ffi) vs cs2)
+Proof
+  rw[] >>
+  drule do_app_rel >> disch_then $ qspecl_then [`vs`,`st`,`ffi`] assume_tac >>
+  rw[application_def, cml_application_thm]
+  >- (
+    simp[step_result_rel_cases, AllCaseEqs(), PULL_EXISTS] >>
+    Cases_on `do_opapp vs` >> simp[] >> PairCases_on `x` >> simp[]
+    ) >>
+  Cases_on `do_app (st,ffi) op vs` >> gvs[] >>
+  Cases_on `do_app st op vs` >> gvs[]
+  >- (simp[step_result_rel_cases, AllCaseEqs()] >> Cases_on `op` >> gvs[]) >>
+  PairCases_on `x` >> PairCases_on `x'` >> gvs[] >>
+  gvs[result_rel_cases, SF smallstep_ss, SF itree_ss] >>
+  simp[step_result_rel_cases, AllCaseEqs()]
+  >- (qexists_tac `cs1` >> simp[] >> Cases_on `op` >> gvs[])
+  >- (
+    qexists_tac `(Craise,env)::cs1` >> simp[] >> Cases_on `op` >> gvs[] >>
+    gvs[ctxt_rel_def] >> simp[ctxt_frame_rel_cases]
+    )
+QED
+
+Theorem application_rel_FFI_type_error:
+  application (FFI s) env st vs cs1 = Etype_error ⇔
+  application (FFI s) env (st, ffi) vs cs2 = Eabort Rtype_error
+Proof
+  rw[application_def, cml_application_thm] >>
+  simp[semanticPrimitivesTheory.do_app_def] >>
+  every_case_tac >> gvs[SF smallstep_ss] >>
+  gvs[store_lookup_def, store_assign_def, store_v_same_type_def]
+QED
+
+Theorem application_rel_FFI_step:
+  application (FFI s) env st vs cs1 = Estep (env, st, Val v, cs1) ⇔
+  application (FFI s) env (st, ffi) vs cs2 = Estep (env, (st,ffi), Val v, cs2)
+Proof
+  rw[application_def, cml_application_thm] >>
+  simp[semanticPrimitivesTheory.do_app_def] >>
+  every_case_tac >> gvs[SF smallstep_ss] >>
+  gvs[call_FFI_def, store_lookup_def, store_assign_def, store_v_same_type_def]
+  >- (eq_tac >> rw[] >> metis_tac[LUPDATE_SAME]) >>
+  every_case_tac >> gvs[] >> rw[] >> gvs[ffi_state_component_equality]
+QED
+
+
+(******************** Relating non-FFI steps ********************)
+
+Triviality FST_THM:
+  FST = λ(x,y). x
+Proof
+  rw[FUN_EQ_THM, UNCURRY]
+QED
+
+Theorem step_result_rel_single:
+  ∀ea eb.
+    step_result_rel (Estep ea) (Estep eb) ∧
+    ¬ is_Effi (estep ea)
+  ⇒ step_result_rel (estep ea) (e_step eb) ∧
+    ∀ffi. get_ffi (e_step eb) = SOME ffi ⇒ get_ffi (Estep eb) = SOME ffi
+Proof
+  rpt PairCases >> rename1 `_ (_ (env,st,ev,cs1)) (_ (env',(st',ffi),ev',cs2))` >>
+  gvs[e_step_def] >>
+  every_case_tac >> gvs[estep_def, step_result_rel_cases] >> strip_tac >>
+  gvs[SF smallstep_ss, SF itree_ss, ctxt_rel_def, ctxt_frame_rel_cases, get_ffi_def] >>
+  gvs[GSYM ctxt_frame_rel_cases, GSYM step_result_rel_cases]
+  >- (
+    rename1 `application op _ _ _ _` >>
+    reverse $ Cases_on `∃s. op = FFI s` >> gvs[]
+    >- (
+      reverse $ rw[]
+      >- (
+        drule application_ffi_unchanged >>
+        Cases_on `application op env (st,ffi) [] cs2` >> gvs[get_ffi_def] >>
+        PairCases_on `p` >> disch_then drule >> gvs[get_ffi_def]
+        )
+      >- (
+        drule application_rel >> gvs[ctxt_rel_def] >> disch_then drule >>
+        disch_then $ qspecl_then [`[]`,`st`,`ffi`,`env`] assume_tac >>
+        gvs[step_result_rel_cases, ctxt_rel_def]
+        )
+      ) >>
+    qspecl_then [`[]`,`st`,`s`,`env`,`cs1`]
+      assume_tac $ GEN_ALL application_FFI_results >> gvs[] >>
+    csimp[] >> gvs[is_Effi_def, get_ffi_def]
+    >- metis_tac[application_rel_FFI_type_error] >>
+    imp_res_tac application_rel_FFI_step >> simp[get_ffi_def]
+    )
+  >- gvs[FST_THM, LAMBDA_PROD]
+  >- gvs[FST_THM, LAMBDA_PROD] >>
+  CASE_TAC >- gvs[continue_def, get_ffi_def] >>
+  PairCases_on `h` >> gvs[] >> PairCases_on `x` >> gvs[] >>
+  rename1 `ctxt_frame_rel c1 c2` >> rename1 `(c1,env)` >>
+  rename1 `LIST_REL _ rest1 rest2` >>
+  Cases_on `c1` >> gvs[SF itree_ss, ctxt_frame_rel_cases] >>
+  gvs[GSYM ctxt_frame_rel_cases, get_ffi_def]
+  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+  >- (
+    reverse CASE_TAC >>
+    gvs[PULL_EXISTS, EXISTS_PROD, get_ffi_def, SF itree_ss]
+    >- simp[ctxt_frame_rel_cases] >>
+    rename1 `application op _ _ vs _` >>
+    reverse $ Cases_on `∃s. op = FFI s` >> gvs[]
+    >- (
+      reverse $ rw[]
+      >- (
+        drule application_ffi_unchanged >>
+        Cases_on `application op env (st,ffi) vs rest2` >> gvs[get_ffi_def] >>
+        PairCases_on `p` >> disch_then drule >> gvs[get_ffi_def]
+        )
+      >- (
+        drule application_rel >> gvs[ctxt_rel_def] >> disch_then drule >>
+        disch_then $ qspecl_then [`vs`,`st`,`ffi`,`env`] assume_tac >>
+        gvs[step_result_rel_cases, ctxt_rel_def]
+        )
+      ) >>
+    qspecl_then [`vs`,`st`,`s`,`env`,`rest1`]
+      assume_tac $ GEN_ALL application_FFI_results >> gvs[] >>
+    csimp[] >> gvs[is_Effi_def, get_ffi_def]
+    >- metis_tac[application_rel_FFI_type_error] >>
+    imp_res_tac application_rel_FFI_step >> gvs[get_ffi_def]
+    )
+  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+  >- (
+    CASE_TAC >> gvs[PULL_EXISTS, EXISTS_PROD, get_ffi_def, SF itree_ss]
+    >- simp[ctxt_frame_rel_cases] >>
+    CASE_TAC >>  gvs[SF itree_ss] >>
+    EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
+    )
+  >- (
+    TOP_CASE_TAC >> gvs[SF itree_ss] >>
+    EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
+    )
+QED
+
+Theorem is_Dffi_eq_is_Effi_single:
+  is_Dffi (dstep env dsta (ExpVal env' ev cs l p) dcs) ⇔
+  is_Effi (estep (env',dsta.refs,ev,cs))
+Proof
+  Cases_on `ev` >> rw[SF ditree_ss, SF itree_ss]
+  >- (every_case_tac >> gvs[is_Effi_def, is_Dffi_def]) >>
+  Cases_on `cs` >> rw[SF ditree_ss, SF itree_ss, is_Effi_def, is_Dffi_def]
+  >- (every_case_tac >> gvs[]) >>
+  PairCases_on `h` >> Cases_on `h0` >> Cases_on `t` >>
+  rw[SF ditree_ss, SF itree_ss, is_Effi_def, is_Dffi_def] >>
+  every_case_tac >> gvs[]
+QED
+
+Theorem dstep_result_rel_single:
+  ∀dsta deva dcsa db env.
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep db) ∧
+    ¬is_Dffi (dstep env dsta deva dcsa)
+  ⇒ dstep_result_rel (dstep env dsta deva dcsa) (decl_step env db) ∧
+    ∀ffi. dget_ffi (decl_step env db) = SOME ffi ⇒ dget_ffi (Dstep db) = SOME ffi
+Proof
+  ntac 3 gen_tac >> PairCases >> gen_tac >>
+  simp[Once dstep_result_rel_cases] >> strip_tac >> gvs[deval_rel_cases]
+  >- (
+    Cases_on `d` >> gvs[decl_step_def, dstep_def] >>
+    every_case_tac >> gvs[FST_THM, LAMBDA_PROD] >>
+    simp[dstep_result_rel_cases, deval_rel_cases, ctxt_rel_def] >>
+    gvs[dstate_rel_def, dget_ffi_def]
+    )
+  >- (
+    Cases_on `db2` >> gvs[SF dsmallstep_ss, SF ditree_ss]
+    >- simp[dstep_result_rel_cases] >>
+    Cases_on `h` >> gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    Cases_on `l` >> gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    simp[dstep_result_rel_cases, deval_rel_cases, dget_ffi_def]
+    ) >>
+  Cases_on `ev` >> gvs[SF dsmallstep_ss, SF ditree_ss]
+  >- (
+    `¬is_Effi (estep (env',dsta.refs,Exp e,cs))` by (
+      every_case_tac >> gvs[is_Effi_def, is_Dffi_def]) >>
+    drule_at Any step_result_rel_single >>
+    simp[Once step_result_rel_cases, PULL_EXISTS] >>
+    disch_then drule >> disch_then $ qspec_then `db0.ffi` assume_tac >>
+    rgs[dstate_rel_def, get_ffi_def] >>
+    pop_assum mp_tac >> rw[step_result_rel_cases] >> gvs[dget_ffi_def, get_ffi_def] >>
+    simp[dstep_result_rel_cases, deval_rel_cases, dstate_rel_def]
+    ) >>
+  Cases_on `cs` >> gvs[]
+  >- (
+    gvs[ctxt_rel_def, SF dsmallstep_ss, SF ditree_ss, dstate_rel_def] >>
+    every_case_tac >> gvs[] >>
+    gvs[dstep_result_rel_cases, deval_rel_cases, dstate_rel_def, dget_ffi_def]
+    ) >>
+  gvs[ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >>
+  pairarg_tac >> gvs[] >> pairarg_tac >> gvs[] >>
+  gvs[is_Dffi_eq_is_Effi_single] >>
+  drule_at Any step_result_rel_single >> simp[FORALL_PROD] >>
+  simp[step_result_rel_cases, ctxt_rel_def] >>
+  simp[GSYM ctxt_rel_def, PULL_EXISTS, FORALL_PROD] >> disch_then drule_all >>
+  disch_then $ qspec_then `db0.ffi` mp_tac >> rw[] >> gvs[] >>
+  gvs[dstate_rel_def, dget_ffi_def, get_ffi_def] >>
+  every_case_tac >> gvs[ctxt_frame_rel_cases, SF ditree_ss] >>
+  Cases_on `t` >> gvs[ctxt_rel_def, SF ditree_ss] >>
+  gvs[dstep_result_rel_cases, dstate_rel_def, deval_rel_cases, ctxt_rel_def]
+QED
+
+Theorem dstep_result_rel_n:
+  ∀n dsta deva dcsa db env.
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep db) ∧
+    ¬ is_Dffi (step_n env n (Dstep dsta deva dcsa))
+  ⇒ dstep_result_rel
+      (step_n env n (Dstep dsta deva dcsa)) (step_n_cml env n (Dstep db))∧
+    ∀ffi. dget_ffi (step_n_cml env n (Dstep db)) = SOME ffi
+      ⇒ dget_ffi (Dstep db) = SOME ffi
+Proof
+  Induct >- simp[step_n_def, step_n_cml_def] >>
+  simp[step_n_alt_def, step_n_cml_alt_def] >>
+  rpt gen_tac >> strip_tac >>
+  last_x_assum drule >> disch_then $ qspec_then `env` mp_tac >>
+  impl_tac >- (every_case_tac >> gvs[is_Dffi_def]) >> strip_tac >>
+  imp_res_tac dstep_result_rel_cases >> gvs[dget_ffi_def] >>
+  drule dstep_result_rel_single >> disch_then $ qspec_then `env` mp_tac >>
+  simp[] >> rw[] >> gvs[dget_ffi_def]
+QED
+
+
+(******************** Relating FFI steps ********************)
+
+Theorem estep_to_Effi:
+  estep ea = Effi s conf ws lnum env st cs ⇔
+  ∃env' conf'.
+    conf = MAP (λc. n2w (ORD c)) (EXPLODE conf') ∧
+    ea = (env',st,Val (Litv (StrLit conf')),
+            (Capp (FFI s) [Loc lnum] [],env)::cs) ∧
+    store_lookup lnum st = SOME (W8array ws) ∧ s ≠ ""
+Proof
+  PairCases_on `ea` >> Cases_on `ea2` >> gvs[SF itree_ss]
+  >- (
+    Cases_on `e` >> gvs[SF itree_ss] >> every_case_tac >> gvs[] >>
+    simp[application_thm] >> every_case_tac >> gvs[SF itree_ss]
+    ) >>
+  Cases_on `ea3` >> gvs[SF itree_ss] >>
+  PairCases_on `h` >> reverse $ Cases_on `h0` >> gvs[SF itree_ss] >>
+  every_case_tac >> gvs[]
+  >- (Cases_on `l0` >> gvs[SF itree_ss] >> every_case_tac >> gvs[])
+  >- (
+    Cases_on `l` >> gvs[SF itree_ss] >>
+    Cases_on `h` >> gvs[SF itree_ss] >> every_case_tac >> gvs[]
+    ) >>
+  Cases_on `l0` >> gvs[SF itree_ss] >> reverse eq_tac >> rw[]
+  >- simp[application_thm] >>
+  drule application_eq_Effi_fields >> rw[] >>
+  gvs[application_thm] >> every_case_tac >> gvs[]
+QED
+
+Theorem dstep_to_Dffi:
+  dstep env dst dev dcs = Dffi dst' (s,ws1,ws2,lnum,env',cs) locs pat dcs' ⇔
+  ∃env'' conf.
+    dst = dst' ∧ dcs = dcs' ∧
+    dev = ExpVal env'' (Val (Litv (StrLit conf)))
+            ((Capp (FFI s) [Loc lnum] [],env')::cs) locs pat ∧
+    ws1 = MAP (λc. n2w (ORD c)) (EXPLODE conf) ∧
+    store_lookup lnum dst.refs = SOME (W8array ws2) ∧ s ≠ ""
+Proof
+  Cases_on `∃d. dev = Decl d` >> gvs[dstep_def]
+  >- (Cases_on `d` >> gvs[dstep_def] >> every_case_tac >> gvs[]) >>
+  Cases_on `∃e. dev = Env e` >> gvs[dstep_def]
+  >- (
+    Cases_on `dcs` >> gvs[SF ditree_ss] >>
+    Cases_on `h` >> Cases_on `l` >> gvs[SF ditree_ss]
+    ) >>
+  Cases_on `dev` >> gvs[SF ditree_ss] >> rw[] >> reverse eq_tac >> rw[]
+  >- simp[SF ditree_ss, SF itree_ss, application_thm, dstate_component_equality] >>
+  `is_Dffi (dstep env dst (ExpVal s' e l l0 p) dcs)` by gvs[is_Dffi_def] >>
+  gvs[is_Dffi_eq_is_Effi_single, is_Effi_def, estep_to_Effi] >>
+  rw[] >> gvs[SF ditree_ss, SF itree_ss, application_thm] >>
+  simp[dstate_component_equality]
+QED
+
+Theorem decl_step_ffi_changed_dstep_to_Dffi:
+  decl_step env (dst2, dev2, dcs) = Dstep (dst2', dev2', dcs') ∧
+  dst2.ffi ≠ dst2'.ffi ∧
+  dstate_rel dst1 dst2 ∧ deval_rel dev1 dev2 ⇒
+  ∃env' env'' conf s lnum ccs locs pat ws.
+    dev1 = ExpVal env' (Val $ Litv $ StrLit conf)
+            ((Capp (FFI s) [Loc lnum] [], env'') :: ccs) locs pat ∧
+    store_lookup lnum dst1.refs = SOME (W8array ws) ∧
+    dstep env dst1 dev1 dcs = Dffi dst1
+      (s,(MAP (λc. n2w $ ORD c) (EXPLODE conf)),ws,lnum,env'',ccs) locs pat dcs'
+Proof
+  rw[] >> drule_all decl_step_ffi_changed >> rw[] >>
+  gvs[deval_rel_cases, ctxt_rel_def, dstate_rel_def] >>
+  pairarg_tac >> gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >>
+  gvs[SF ditree_ss, SF itree_ss] >>
+  simp[application_thm, dstate_component_equality] >>
+  gvs[SF dsmallstep_ss, SF smallstep_ss, cml_application_thm] >>
+  gvs[semanticPrimitivesTheory.do_app_def, ffiTheory.call_FFI_def] >>
+  gvs[store_assign_def, store_lookup_def, store_v_same_type_def]
+QED
+
+Theorem dstep_result_rel_single_FFI:
+  ∀dsta deva dcsa db env dsta' s ws1 ws2 n env' cs ffi_call locs pat dcsa'.
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep db) ∧
+    dstep env dsta deva dcsa = Dffi dsta' (s,ws1,ws2,n,env',cs) locs pat dcsa'
+  ⇒ ∃ffi.
+      dget_ffi (Dstep db) = SOME ffi ∧
+      ((∃ffi'. dget_ffi (decl_step env db) = SOME ffi' ∧ ffi' ≠ ffi) ∨
+       (∃outcome.
+          decl_step env db = Dabort (Rffi_error $ Final_event s ws1 ws2 outcome)))
+Proof
+  ntac 3 gen_tac >> PairCases >> rw[] >>
+  gvs[dstep_result_rel_cases, dstep_to_Dffi, dget_ffi_def] >>
+  gvs[deval_rel_cases, ctxt_rel_def] >>
+  gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> pairarg_tac >> gvs[] >>
+  simp[SF dsmallstep_ss, SF smallstep_ss, cml_application_thm] >>
+  simp[semanticPrimitivesTheory.do_app_def, ffiTheory.call_FFI_def] >>
+  every_case_tac >> gvs[dget_ffi_def] >>
+  gvs[store_lookup_def, store_assign_def, store_v_same_type_def, dstate_rel_def] >>
+  rw[ffi_state_component_equality]
+QED
+
+Theorem step_result_rel_single_FFI_error:
+  ∀ea eb.
+    step_result_rel (Estep ea) (Estep eb) ∧
+    e_step eb = Eabort (Rffi_error (Final_event s conf ws outcome))
+  ⇒ ∃lnum env. estep ea =
+    Effi s conf ws lnum env (FST $ SND ea) (TL $ SND $ SND $ SND ea)
+Proof
+  rpt $ PairCases >> rw[e_step_def] >> gvs[AllCaseEqs(), SF smallstep_ss] >>
+  gvs[cml_application_thm, AllCaseEqs(), SF smallstep_ss] >>
+  gvs[semanticPrimitivesPropsTheory.do_app_cases, AllCaseEqs()] >>
+  gvs[step_result_rel_cases, ctxt_rel_def] >>
+  gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> pairarg_tac >> gvs[] >>
+  simp[SF itree_ss, application_def] >> gvs[call_FFI_def, AllCaseEqs()]
+QED
+
+Theorem dstep_result_rel_single_FFI_strong:
+  ∀dsta deva dcsa dstb devb dcsb env dsta' s conf ws lnum eenv cs1 locs pat dcsa'.
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep (dstb, devb, dcsb)) ∧
+    dstep env dsta deva dcsa = Dffi dsta' (s,conf,ws,lnum,eenv,cs1) locs pat dcsa'
+  ⇒ ∃env' ffi conf' cs2.
+      conf = MAP (λc. n2w (ORD c)) (EXPLODE conf') ∧
+      deva = ExpVal env' (Val (Litv $ StrLit conf'))
+              ((Capp (FFI s) [Loc lnum] [], eenv)::cs1) locs pat ∧
+      devb = ExpVal env' (Val (Litv $ StrLit conf'))
+              ((Capp (FFI s) [Loc lnum] () [], eenv)::cs2) locs pat ∧
+      store_lookup lnum dsta.refs = SOME (W8array ws) ∧ s ≠ "" ∧
+      dget_ffi (Dstep (dstb, devb, dcsb)) = SOME ffi ∧
+      decl_step env (dstb, devb, dcsb) =
+        case ffi.oracle s ffi.ffi_state conf ws of
+        | Oracle_return ffi' ws' =>
+            if LENGTH ws' ≠ LENGTH ws then
+              Dabort $ Rffi_error $ Final_event s conf ws FFI_failed
+            else
+              Dstep (
+                dstb with <|
+                  refs := LUPDATE (W8array ws') lnum dstb.refs;
+                  ffi := dstb.ffi with <|
+                    ffi_state := ffi';
+                    io_events := dstb.ffi.io_events ++ [IO_event s conf (ZIP (ws,ws'))]
+                    |>
+                  |>,
+                ExpVal eenv (Val $ Conv NONE []) cs2 locs pat, dcsb)
+        | Oracle_final outcome =>
+            Dabort $ Rffi_error $ Final_event s conf ws outcome
+Proof
+  rw[] >> gvs[dstep_to_Dffi, dstep_result_rel_cases, deval_rel_cases, ctxt_rel_def] >>
+  gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> pairarg_tac >> gvs[] >>
+  simp[dget_ffi_def, SF dsmallstep_ss, SF smallstep_ss, cml_application_thm] >>
+  simp[semanticPrimitivesTheory.do_app_def, ffiTheory.call_FFI_def] >>
+  gvs[dstate_rel_def] >> every_case_tac >> gvs[] >>
+  gvs[store_assign_def, store_lookup_def, store_v_same_type_def]
+QED
+
+Theorem dstep_result_rel_single_FFI_error:
+  ∀dsta deva dcsa dstb devb dcsb.
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep (dstb,devb,dcsb)) ∧
+    decl_step env (dstb,devb,dcsb) = Dabort (Rffi_error (Final_event s conf ws outcome))
+  ⇒ ∃lnum env' cs locs pat.
+      dstep env dsta deva dcsa = Dffi dsta (s,conf,ws,lnum,env',cs) locs pat dcsa
+Proof
+  rw[] >> Cases_on `∃d. deva = Decl d` >> gvs[]
+  >- (
+    gvs[dstep_result_rel_cases, deval_rel_cases] >>
+    Cases_on `d` >> gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    every_case_tac >> gvs[]
+    ) >>
+  Cases_on `∃e. deva = Env e` >> gvs[]
+  >- (
+    gvs[dstep_result_rel_cases, deval_rel_cases] >>
+    Cases_on `e` >> gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    every_case_tac >> gvs[]
+    ) >>
+  Cases_on `deva` >> gvs[dstep_result_rel_cases, deval_rel_cases] >>
+  gvs[SF dsmallstep_ss] >>
+  qmatch_asmsub_abbrev_tac `e_step_result_CASE foo` >>
+  qspec_then `(s',(dstb.refs,dstb.ffi),e,scs)` mp_tac $
+    SIMP_RULE std_ss [Once SWAP_FORALL_THM] step_result_rel_single_FFI_error >>
+  simp[step_result_rel_cases, PULL_EXISTS] >> disch_then drule >>
+  simp[estep_to_Effi] >> strip_tac >> unabbrev_all_tac >>
+  Cases_on `e` >> gvs[] >- (every_case_tac >> gvs[]) >>
+  Cases_on `scs` >> gvs[ctxt_rel_def] >- (every_case_tac >> gvs[]) >>
+  gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >>
+  pairarg_tac >> gvs[] >> pairarg_tac >> gvs[] >>
+  every_case_tac >> gvs[] >>
+  gvs[SF ditree_ss, SF itree_ss, application_thm, dstate_rel_def] >>
+  simp[dstate_component_equality]
+QED
+
+Theorem dstep_result_rel_single':
+  ∀dsta deva dcsa d2 env.
+    (∀ffi. dget_ffi (decl_step env d2) = SOME ffi ⇒ dget_ffi (Dstep d2) = SOME ffi) ∧
+    (∀a. decl_step env d2 ≠ Dabort $ Rffi_error a) ∧
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep d2)
+    ⇒ dstep_result_rel (dstep env dsta deva dcsa) (decl_step env d2)
+Proof
+  rw[] >> drule dstep_result_rel_single >> rw[] >>
+  gvs[IMP_CONJ_THM, FORALL_AND_THM] >>
+  first_x_assum irule >> CCONTR_TAC >> gvs[is_Dffi_def] >>
+  PairCases_on `ev` >> drule_all dstep_result_rel_single_FFI >> rw[] >> gvs[]
+QED
+
+Theorem dstep_result_rel_n':
+  ∀n dsta deva dcsa db env.
+    dget_ffi (step_n_cml env n (Dstep db)) = dget_ffi (Dstep db) ∧
+    dstep_result_rel (Dstep dsta deva dcsa) (Dstep db)
+  ⇒ dstep_result_rel
+      (step_n env n (Dstep dsta deva dcsa)) (step_n_cml env n (Dstep db))
+Proof
+  Induct >- rw[step_n_def, step_n_cml_def] >> rw[] >>
+  `dstep_result_rel
+    (step_n env n (Dstep dsta deva dcsa)) (step_n_cml env n (Dstep db))` by (
+    last_x_assum irule >> simp[] >>
+    qspecl_then [`SUC n`,`Dstep db`] mp_tac step_n_cml_preserved_FFI >>
+    Cases_on `step_n_cml env (SUC n) (Dstep db)` >> gvs[dget_ffi_def] >>
+    PairCases_on `db` >> gvs[dget_ffi_def]) >>
+  simp[step_n_alt_def, step_n_cml_alt_def] >>
+  rgs[dstep_result_rel_cases] >> gvs[] >>
+  gvs[GSYM dstep_result_rel_cases, PULL_EXISTS, dget_ffi_def] >>
+  qspecl_then [`SUC n`,`Dstep (st',dev2',dcsa)`]
+    mp_tac step_n_cml_preserved_FFI >>
+  gvs[step_n_cml_alt_def] >>
+  Cases_on `decl_step env (st,dev2,dcs)` >> gvs[dget_ffi_def] >>
+  disch_then $ qspecl_then [`p`,`env`] mp_tac >> simp[] >>
+  disch_then $ qspec_then `n` mp_tac >> simp[dget_ffi_def] >> rw[] >> gvs[] >>
+  qpat_assum `decl_step _ _ = _` $ once_rewrite_tac o single o GSYM >>
+  irule dstep_result_rel_single' >>
+  simp[dget_ffi_def, dstep_result_rel_cases]
+QED
+
+
+(******************** interp ********************)
+
+Theorem interp_Ret_Termination:
+  dstate_rel dst st ∧ deval_rel deva devb ⇒
+  (
+    interp env (Dstep dst deva dcs) = Ret Termination ⇔
+    (∃v st'. small_eval_dec env (st,devb,dcs) (st', Rval v) ∧ st.ffi = st'.ffi) ∨
+    (∃v st'. small_eval_dec env (st,devb,dcs) (st', Rerr (Rraise v)) ∧ st.ffi = st'.ffi)
+  )
+Proof
+  rw[Once interp] >> eq_tac >> rw[]
+  >- (
+    every_case_tac >> gvs[step_until_halt_def] >>
+    pop_assum mp_tac >> DEEP_INTRO_TAC some_intro >> rw[] >> gvs[] >>
+    every_case_tac >> gvs[is_halt_def]
+    >- (
+      Induct_on `x` >> gvs[step_n_alt_def] >>
+      reverse every_case_tac >> gvs[] >- metis_tac[] >- metis_tac[] >>
+      rw[dstep_to_Ddone] >> disj1_tac >>
+      rw[small_eval_dec_eq_step_n_cml, PULL_EXISTS] >>
+      qspecl_then [`x`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+        assume_tac dstep_result_rel_n >>
+      gvs[is_Dffi_def, dstep_result_rel_cases, deval_rel_cases] >>
+      goal_assum drule >> gvs[dget_ffi_def]
+      )
+    >- (
+      Induct_on `x` >> gvs[step_n_alt_def] >>
+      every_case_tac >> gvs[] >> rw[] >>
+      rw[small_eval_dec_eq_step_n_cml, PULL_EXISTS] >> disj2_tac >>
+      qspecl_then [`x`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+        assume_tac dstep_result_rel_n >>
+      gvs[is_Dffi_def, dstep_result_rel_cases] >> goal_assum drule >>
+      qspecl_then [`d`,`d0`,`l`,`(st',dev2,l)`,`env`]
+        assume_tac dstep_result_rel_single >>
+      gvs[is_Dffi_def, dstep_result_rel_cases, dget_ffi_def]
+      )
+    )
+  >- (
+    gvs[small_eval_dec_eq_step_n_cml, step_until_halt_def] >>
+    qspecl_then [`n`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n >>
+    gvs[dstep_result_rel_cases, dget_ffi_def] >>
+    pop_assum mp_tac >> impl_tac
+    >- (
+      irule dstep_result_rel_not_Dffi >> irule_at Any dstep_result_rel_n' >>
+      qexists_tac `(st,devb,dcs)` >> simp[dget_ffi_def, dstep_result_rel_cases]
+      ) >>
+    strip_tac >> pop_assum mp_tac >> rw[deval_rel_cases] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (qexists_tac `SUC n` >> simp[step_n_alt_def, SF ditree_ss, is_halt_def]) >>
+    `step_n env x (Dstep dst deva dcs) = step_n env (SUC n) (Dstep dst deva dcs)` by (
+      irule is_halt_step_n_eq >> simp[step_n_alt_def, SF ditree_ss, is_halt_def]) >>
+    gvs[step_n_alt_def, SF ditree_ss]
+    )
+  >- (
+    gvs[small_eval_dec_eq_step_n_cml, step_until_halt_def] >>
+    qspecl_then [`n`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n >>
+    gvs[dstep_result_rel_cases, dget_ffi_def] >>
+    pop_assum mp_tac >> impl_tac
+    >- (
+      irule dstep_result_rel_not_Dffi >> irule_at Any dstep_result_rel_n' >>
+      qexists_tac `(st,devb,dcs)` >> simp[dget_ffi_def, dstep_result_rel_cases]
+      ) >>
+    strip_tac >>
+    qspecl_then [`dst'`,`dev1`,`dcs'`,`(st',dev,dcs')`,`env`]
+      assume_tac dstep_result_rel_single' >>
+    gvs[dget_ffi_def, dstep_result_rel_cases] >>
+    DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (qexists_tac `SUC n` >> simp[step_n_alt_def, SF ditree_ss, is_halt_def]) >>
+    `step_n env x (Dstep dst deva dcs) = step_n env (SUC n) (Dstep dst deva dcs)` by (
+      irule is_halt_step_n_eq >> simp[step_n_alt_def, SF ditree_ss, is_halt_def]) >>
+    gvs[step_n_alt_def, SF ditree_ss]
+    )
+QED
+
+Theorem interp_Ret_Error:
+  dstate_rel dst st ∧ deval_rel deva devb ⇒
+  (
+    interp env (Dstep dst deva dcs) = Ret Error ⇔
+    ∃st'. small_eval_dec env (st,devb,dcs) (st',Rerr $ Rabort Rtype_error) ∧
+          st.ffi = st'.ffi
+  )
+Proof
+  rw[Once interp] >> eq_tac >> rw[]
+  >- (
+    every_case_tac >> gvs[step_until_halt_def] >>
+    pop_assum mp_tac >> DEEP_INTRO_TAC some_intro >> rw[] >>
+    every_case_tac >> gvs[is_halt_def] >>
+    simp[small_eval_dec_eq_step_n_cml, PULL_EXISTS] >>
+    qspecl_then [`x`,`env`,`Dstep dst deva dcs`]
+      assume_tac is_halt_step_n_min >>
+    gvs[is_halt_def] >> qpat_x_assum `step_n _ x _ = _` kall_tac >>
+    Cases_on `m` >> gvs[step_n_alt_def] >>
+    reverse every_case_tac >> gvs[]
+    >- (first_x_assum $ qspec_then `n` mp_tac >> simp[is_halt_def]) >>
+    qspecl_then [`n`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n >>
+    gvs[dstep_result_rel_cases, is_Dffi_def] >> goal_assum drule >>
+    qspecl_then [`d`,`d0`,`l`,`(st',dev2,l)`,`env`]
+      assume_tac dstep_result_rel_single >>
+    gvs[dstep_result_rel_cases, is_Dffi_def, dget_ffi_def]
+    )
+  >- (
+    gvs[small_eval_dec_eq_step_n_cml] >>
+    qspecl_then [`n`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n' >>
+    gvs[dstep_result_rel_cases, is_Dffi_def, dget_ffi_def] >>
+    qspecl_then [`dst'`,`dev1`,`dcs'`,`(st',dev,dcs')`,`env`]
+      assume_tac dstep_result_rel_single' >>
+    gvs[dstep_result_rel_cases, dget_ffi_def] >>
+    simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (qexists_tac `SUC n` >> simp[step_n_alt_def, is_halt_def]) >>
+    `step_n env x (Dstep dst deva dcs) = step_n env (SUC n) (Dstep dst deva dcs)` by (
+      irule is_halt_step_n_eq >> simp[step_n_alt_def, is_halt_def]) >>
+    gvs[step_n_alt_def]
+    )
+QED
+
+Theorem interp_Div:
+  dstate_rel dst st ∧ deval_rel deva devb ⇒
+  (
+    interp env (Dstep dst deva dcs) = Div ⇔
+    ∀n. ∃st2.
+      step_n_cml env n (Dstep (st,devb,dcs)) = Dstep st2 ∧
+      ¬is_halt_cml (Dstep st2) ∧
+      dget_ffi (Dstep st2) = SOME st.ffi
+  )
+Proof
+  rw[Once interp] >> eq_tac >> rw[]
+  >- (
+    gvs[step_until_halt_def] >> every_case_tac >> gvs[] >>
+    pop_assum mp_tac >> DEEP_INTRO_TAC some_intro >> rw[] >>
+    pop_assum $ qspec_then `n` assume_tac >>
+    Cases_on `step_n env n (Dstep dst deva dcs)` >> gvs[is_halt_def] >>
+    qspecl_then [`n`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n >>
+    gvs[dstep_result_rel_cases, is_Dffi_def] >>
+    gvs[is_halt_cml_def, dget_ffi_def]
+    )
+  >- (
+    simp[step_until_halt_def] >>
+    DEEP_INTRO_TAC some_intro >> rw[] >>
+    first_x_assum $ qspec_then `x` assume_tac >> gvs[is_halt_cml_def] >>
+    qspecl_then [`x`,`dst`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      assume_tac dstep_result_rel_n' >>
+    gvs[dstep_result_rel_cases, dget_ffi_def, is_halt_def]
+    )
+QED
+
+
+(******************** trace_prefix ********************)
+
+Theorem trace_prefix_dec_Error:
+  dstate_rel dsta st ∧ deval_rel deva devb ⇒
+
+  ((∃n. trace_prefix n (oracle, ffi_st)
+    (interp env (Dstep dsta deva dcs)) = (io, SOME Error)) ⇔
+
+  ∃dst ffi'.
+    (decl_step_reln env)^*
+      (st with ffi := st.ffi with <| oracle := oracle; ffi_state := ffi_st |>,
+       devb, dcs) dst ∧
+    dget_ffi (Dstep dst) = SOME ffi' ∧
+    ffi'.io_events = st.ffi.io_events ++ io ∧
+    decl_step env dst = Dabort (Rtype_error))
+Proof
+  rw[] >> eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`devb`,`env`,`io`,`n`] >>
+    Induct >> rw[trace_prefix_interp] >>
+    gvs[step_until_halt_def] >> every_case_tac >> gvs[]
+    >- (
+      qpat_x_assum `(some n. _ ) = _` mp_tac >>
+      DEEP_INTRO_TAC some_intro >> rw[] >>
+      drule is_halt_step_n_min >> strip_tac >> gvs[] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      `∃l. m = SUC l` by (Cases_on `m` >> gvs[step_n_def]) >> gvs[] >>
+      pop_assum $ qspec_then `l` assume_tac >> gvs[] >>
+      Cases_on `step_n env l (Dstep dsta deva dcs)` >> gvs[] >>
+      gvs[step_n_alt_def, is_halt_def] >>
+      rename1 `_ = Dstep dsta' deva' dcs'` >>
+      qmatch_goalsub_abbrev_tac `RTC _ (st',_)` >>
+      qspecl_then [`l`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[dstep_result_rel_cases, is_Dffi_def] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      rw[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >> goal_assum drule >>
+      simp[dget_ffi_def] >> unabbrev_all_tac >>
+      gvs[state_component_equality, ffi_state_component_equality] >>
+      qspecl_then [`dsta'`,`deva'`,`dcs'`,`(st'',dev2,dcs')`,`env`]
+        mp_tac dstep_result_rel_single >>
+      simp[dstep_result_rel_cases, is_Dffi_def]
+      )
+    >- (pairarg_tac >> gvs[trace_prefix_def])
+    >- (
+      pairarg_tac >> gvs[] >>
+      rename1 `ExpVal env' _ cs locs pat` >>
+      rename1 `Dffi dst (s,ws1,ws2,lnum,env'',_) _ _ dcs'` >>
+      rename1 `_ conf ws = Oracle_return ffi_st' ws'` >>
+      qpat_x_assum `(some n. _ ) = _` mp_tac >>
+      DEEP_INTRO_TAC some_intro >> rw[] >>
+      drule is_halt_step_n_min >> strip_tac >> gvs[] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      `∃l. m = SUC l` by (Cases_on `m` >> gvs[step_n_def]) >> gvs[] >>
+      pop_assum $ qspec_then `l` assume_tac >> gvs[] >>
+      Cases_on `step_n env l (Dstep dsta deva dcs)` >> gvs[is_halt_def] >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      qspecl_then [`l`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[dstep_result_rel_cases, is_Dffi_def, dget_ffi_def] >>
+      impl_tac >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      gvs[step_n_alt_def] >>
+      rw[Once RTC_CASES_RTC_TWICE, PULL_EXISTS] >>
+      rw[Once RTC_CASES2] >> irule_at Any OR_INTRO_THM2 >>
+      simp[PULL_EXISTS, GSYM CONJ_ASSOC] >>
+      rw[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      goal_assum drule >> rw[decl_step_reln_def] >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases, PULL_EXISTS] >>
+      disch_then drule_all >> strip_tac >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[ffi_state_component_equality] >>
+      qmatch_goalsub_abbrev_tac `Dstep (st2,ev,ll)` >>
+      last_x_assum $ drule_at $ Pos last >>
+      qpat_x_assum `deval_rel _ _` mp_tac >>
+      simp[deval_rel_cases, ctxt_rel_def, PULL_EXISTS] >>
+      simp[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> strip_tac >>
+      disch_then $ drule_at Any >>
+      disch_then $ qspec_then `st2` mp_tac >>
+      impl_tac >- (unabbrev_all_tac >> gvs[dstate_rel_def, dstep_to_Dffi]) >>
+      simp[decl_step_reln_eq_step_n_cml] >> rw[] >> gvs[] >>
+      qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st3,_))` >>
+      `st3 = st2` by (unabbrev_all_tac >>
+        gvs[semanticPrimitivesTheory.state_component_equality,
+            ffi_state_component_equality]) >>
+      gvs[dstep_to_Dffi] >> goal_assum drule >> simp[] >>
+      unabbrev_all_tac >> gvs[]
+      )
+    )
+  >- (
+    simp[decl_step_reln_eq_step_n_cml] >>
+    simp[PULL_EXISTS, AND_IMP_INTRO, GSYM CONJ_ASSOC] >> gen_tac >>
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`ffi'`,
+        `dst`,`devb`,`env`,`io`,`n`] >>
+    Induct >> rw[]
+    >- (
+      gvs[step_n_cml_def] >>
+      qexists_tac `SUC 0` >> once_rewrite_tac[trace_prefix_interp] >>
+      simp[step_until_halt_def] >>
+      `dstep env dsta deva dcs = Dtype_error` by (
+        qmatch_asmsub_abbrev_tac `Dstep (st',_)` >>
+        qspecl_then [`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+          assume_tac dstep_result_rel_single' >>
+        gvs[dget_ffi_def, dstep_result_rel_cases] >>
+        pop_assum irule >> unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >> simp[is_halt_def]) >>
+      Cases_on `x` >> gvs[step_n_def, is_halt_def] >> gvs[dget_ffi_def]
+      ) >>
+    gvs[step_n_cml_def] >>
+    qmatch_asmsub_abbrev_tac `(st2,_)` >>
+    Cases_on `decl_step env (st2,devb,dcs)` >> gvs[] >>
+    Cases_on `dget_ffi (Dstep p) = SOME st2.ffi`
+    >- (
+      qspecl_then [`dsta`,`deva`,`dcs`,`(st2,devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_single' >>
+      simp[dget_ffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[] >>
+      last_x_assum $ qspecl_then [
+        `io`,`env`,`dev2`,`dst`,`ffi'`,
+        `st'`,`ffi_st`,`oracle`,`dcs'`,`dev1`,`dst'`] mp_tac >>
+      simp[] >> qpat_x_assum `_.ffi = _` $ assume_tac o GSYM >> simp[] >>
+      `st' with ffi := st'.ffi = st'` by
+        rw[semanticPrimitivesTheory.state_component_equality] >> rw[] >>
+      qexists_tac `n'` >> pop_assum mp_tac >>
+      Cases_on `n'` >> once_rewrite_tac[trace_prefix_interp] >> rw[] >>
+      DEP_ONCE_REWRITE_TAC[step_until_halt_take_step] >> simp[is_halt_def]
+      ) >>
+    PairCases_on `p` >> gvs[dget_ffi_def] >>
+    rename1 `dget_ffi _ = SOME ffi_new` >>
+    rename1 `Dstep (st2',devb',dcs')` >>
+    drule decl_step_ffi_changed >> simp[] >>
+    drule decl_step_ffi_changed_dstep_to_Dffi >> simp[] >>
+    disch_then $ qspecl_then [`dsta`,`deva`] mp_tac >> simp[] >> impl_tac
+    >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+    strip_tac >> strip_tac >> gvs[] >>
+    unabbrev_all_tac >>
+    qpat_x_assum `dstate_rel _ _` mp_tac >> rw[dstate_rel_def] >> gvs[] >>
+    gvs[ffi_state_component_equality] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> once_rewrite_tac[trace_prefix_interp] >>
+    simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (
+      qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >>
+      simp[dstep_def, SF ditree_ss, is_halt_def]
+      ) >>
+    Cases_on `x` >> gvs[step_n_def, is_halt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >> simp[deval_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> rw[] >> gvs[] >>
+    qmatch_asmsub_abbrev_tac `_ ++ [new_event]` >>
+    qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st2,dev2,_))` >>
+    last_x_assum $ qspecl_then [
+      `TL io`,`env`,`dev2`,`dst`,`ffi_new`,`st2`,`ffi_st'`,`oracle`,`dcs`] mp_tac >>
+    simp[Abbr `dev2`, deval_rel_cases, PULL_EXISTS] >> disch_then $ drule_at Any >>
+    disch_then $
+      qspec_then `dsta with refs := LUPDATE (W8array ws'') lnum dsta.refs` mp_tac >>
+    qmatch_goalsub_abbrev_tac `Dstep (st3,_)` >>
+    `st3 = st2` by (unabbrev_all_tac >> gvs[dstate_rel_def]) >> gvs[] >>
+    simp[] >> reverse $ impl_keep_tac >> gvs[] >> rw[] >> unabbrev_all_tac >> gvs[]
+    >- (qexists_tac `n'` >> simp[])
+    >- gvs[dstate_rel_def] >>
+    imp_res_tac io_events_mono_decl_step >>
+    imp_res_tac io_events_mono_step_n_cml >> gvs[io_events_mono_def] >>
+    PairCases_on `dst` >> gvs[dget_ffi_def] >>
+    Cases_on `io` >> gvs[]
+    )
+QED
+
+Theorem trace_prefix_dec_Termination:
+  dstate_rel dsta st ∧ deval_rel deva devb ⇒
+
+  ((∃n. trace_prefix n (oracle, ffi_st)
+    (interp env (Dstep dsta deva dcs)) = (io, SOME Termination)) ⇔
+
+  ∃dst ffi'.
+    (decl_step_reln env)^*
+      (st with ffi := st.ffi with <| oracle := oracle; ffi_state := ffi_st |>,
+       devb, dcs) dst ∧
+    dget_ffi (Dstep dst) = SOME ffi' ∧
+    ffi'.io_events = st.ffi.io_events ++ io ∧
+    (decl_step env dst = Ddone ∨ ∃v. decl_step env dst = Draise v))
+Proof
+  rw[] >> eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`devb`,`env`,`io`,`dcs`,`n`] >>
+    Induct >> rw[trace_prefix_interp] >>
+    gvs[step_until_halt_def] >> every_case_tac >> gvs[]
+    >- (
+      qpat_x_assum `(some n. _ ) = _` mp_tac >>
+      DEEP_INTRO_TAC some_intro >> rw[] >>
+      Cases_on `x` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> every_case_tac >> gvs[is_halt_def]
+      )
+    >- (
+      qpat_x_assum `(some n. _ ) = _` mp_tac >>
+      DEEP_INTRO_TAC some_intro >> rw[] >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      drule is_halt_step_n_min >> strip_tac >> gvs[] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> simp[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[ffi_state_component_equality] >>
+      disj1_tac >> rgs[dstep_to_Ddone, Once deval_rel_cases, SF dsmallstep_ss]
+      )
+    >- (
+      qpat_x_assum `(some n. _ ) = _` mp_tac >>
+      DEEP_INTRO_TAC some_intro >> rw[] >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      drule is_halt_step_n_min >> strip_tac >> gvs[] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> simp[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[ffi_state_component_equality] >>
+      disj2_tac >>
+      qspecl_then [`d`,`d0`,`l`,`(st'',dev2,l)`,`env`]
+       mp_tac dstep_result_rel_single >>
+      simp[is_Dffi_def, dstep_result_rel_cases]
+      )
+    >- gvs[trace_prefix_interp]
+    >- (
+      pairarg_tac >> gvs[] >>
+      last_x_assum $ drule_at $ Pos last >> simp[deval_rel_cases, PULL_EXISTS] >>
+      strip_tac >> qmatch_goalsub_abbrev_tac `(st',_)` >>
+      qspecl_then [`x`,`env`,`Dstep dsta deva dcs`]
+        assume_tac is_halt_step_n_min >> gvs[is_halt_def] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >>
+      simp[Once RTC_CASES_RTC_TWICE, PULL_EXISTS, GSYM CONJ_ASSOC] >>
+      simp[Once decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      rename1 `Dffi dst (s,conf,ws,lnum,env',cs) locs pat` >>
+      rename1 `_ = Dstep dsta' deva' dcs'` >>
+      qmatch_goalsub_abbrev_tac `_ ++ [new_event]` >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases] >> disch_then drule_all >>
+      strip_tac >> gvs[Abbr `st'`] >>
+      gvs[dget_ffi_def, ffi_state_component_equality] >>
+      rgs[Once deval_rel_cases, ctxt_rel_def] >> gvs[] >>
+      gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >>
+      first_x_assum $ drule_at Any >>
+      disch_then $ qspec_then
+        `st'' with <|
+          refs := LUPDATE (W8array l') lnum st''.refs;
+          ffi := st''.ffi with io_events := st''.ffi.io_events ++ [new_event]
+          |>` mp_tac >>
+      impl_tac >- (unabbrev_all_tac >> gvs[dstep_to_Dffi, dstate_rel_def]) >>
+      strip_tac >> gvs[] >>
+      simp[Once RTC_CASES1] >> irule_at Any OR_INTRO_THM2 >> simp[PULL_EXISTS] >>
+      simp[decl_step_reln_def] >>
+      qmatch_goalsub_abbrev_tac `(sta,_)` >>
+      qmatch_asmsub_abbrev_tac `RTC _ (stb,_)` >>
+      `sta = stb` by (
+        unabbrev_all_tac >> gvs[dstep_to_Dffi] >>
+        rw[semanticPrimitivesTheory.state_component_equality,
+           ffi_state_component_equality]) >>
+      unabbrev_all_tac >> gvs[dstep_to_Dffi] >>
+      goal_assum drule >> goal_assum drule >> simp[]
+      )
+    )
+  >- (
+    simp[decl_step_reln_eq_step_n_cml] >>
+    simp[PULL_EXISTS, AND_IMP_INTRO, GSYM CONJ_ASSOC] >> gen_tac >>
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`ffi'`,
+        `dst`,`devb`,`env`,`io`,`n`] >>
+    Induct >> rw[]
+    >- (
+      gvs[step_n_cml_def] >>
+      qexists_tac `SUC 0` >> once_rewrite_tac[trace_prefix_interp] >>
+      simp[step_until_halt_def] >>
+      `dstep env dsta deva dcs = Ddone` by (
+        qmatch_asmsub_abbrev_tac `Dstep (st',_)` >>
+        qspecl_then [`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+          assume_tac dstep_result_rel_single' >>
+        gvs[dget_ffi_def, dstep_result_rel_cases] >>
+        pop_assum irule >> unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >> simp[is_halt_def]) >>
+      Cases_on `x` >> gvs[step_n_def, is_halt_def] >> gvs[dget_ffi_def]
+      ) >>
+    gvs[step_n_cml_def] >>
+    qmatch_asmsub_abbrev_tac `(st2,_)` >>
+    Cases_on `decl_step env (st2,devb,dcs)` >> gvs[] >>
+    Cases_on `dget_ffi (Dstep p) = SOME st2.ffi`
+    >- (
+      qspecl_then [`dsta`,`deva`,`dcs`,`(st2,devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_single' >>
+      simp[dget_ffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[] >>
+      last_x_assum $ qspecl_then [
+        `io`,`env`,`dev2`,`dst`,`ffi'`,
+        `st'`,`ffi_st`,`oracle`,`dcs'`,`dev1`,`dst'`] mp_tac >>
+      simp[] >> qpat_x_assum `_.ffi = _` $ assume_tac o GSYM >> simp[] >>
+      `st' with ffi := st'.ffi = st'` by
+        rw[semanticPrimitivesTheory.state_component_equality] >> rw[] >>
+      qexists_tac `n'` >> pop_assum mp_tac >>
+      Cases_on `n'` >> once_rewrite_tac[trace_prefix_interp] >> rw[] >>
+      DEP_ONCE_REWRITE_TAC[step_until_halt_take_step] >> simp[is_halt_def]
+      ) >>
+    PairCases_on `p` >> gvs[dget_ffi_def] >>
+    rename1 `dget_ffi _ = SOME ffi_new` >>
+    rename1 `Dstep (st2',devb',dcs')` >>
+    drule decl_step_ffi_changed >> simp[] >>
+    drule decl_step_ffi_changed_dstep_to_Dffi >> simp[] >>
+    disch_then $ qspecl_then [`dsta`,`deva`] mp_tac >> simp[] >> impl_tac
+    >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+    strip_tac >> strip_tac >> gvs[] >>
+    unabbrev_all_tac >>
+    qpat_x_assum `dstate_rel _ _` mp_tac >> rw[dstate_rel_def] >> gvs[] >>
+    gvs[ffi_state_component_equality] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> once_rewrite_tac[trace_prefix_interp] >>
+    simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (
+      qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >>
+      simp[dstep_def, SF ditree_ss, is_halt_def]
+      ) >>
+    Cases_on `x` >> gvs[step_n_def, is_halt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >> simp[deval_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> rw[] >> gvs[] >>
+    qmatch_asmsub_abbrev_tac `_ ++ [new_event]` >>
+    qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st2,dev2,_))` >>
+    last_x_assum $ qspecl_then [
+      `TL io`,`env`,`dev2`,`dst`,`ffi_new`,`st2`,`ffi_st'`,`oracle`,`dcs`] mp_tac >>
+    simp[Abbr `dev2`, deval_rel_cases, PULL_EXISTS] >> disch_then $ drule_at Any >>
+    disch_then $
+      qspec_then `dsta with refs := LUPDATE (W8array ws'') lnum dsta.refs` mp_tac >>
+    qmatch_goalsub_abbrev_tac `Dstep (st3,_)` >>
+    `st3 = st2` by (unabbrev_all_tac >> gvs[dstate_rel_def]) >> gvs[] >>
+    simp[] >> reverse $ impl_keep_tac >> gvs[] >> rw[] >> unabbrev_all_tac >> gvs[]
+    >- (qexists_tac `n'` >> simp[])
+    >- gvs[dstate_rel_def] >>
+    imp_res_tac io_events_mono_decl_step >>
+    imp_res_tac io_events_mono_step_n_cml >> gvs[io_events_mono_def] >>
+    PairCases_on `dst` >> gvs[dget_ffi_def] >>
+    Cases_on `io` >> gvs[]
+    )
+  >- (
+    simp[decl_step_reln_eq_step_n_cml] >>
+    simp[PULL_EXISTS, AND_IMP_INTRO, GSYM CONJ_ASSOC] >> gen_tac >>
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`ffi'`,
+        `dst`,`devb`,`env`,`io`,`v`,`n`] >>
+    Induct >> rw[]
+    >- (
+      gvs[step_n_cml_def] >>
+      qexists_tac `SUC 0` >> once_rewrite_tac[trace_prefix_interp] >>
+      simp[step_until_halt_def] >>
+      `dstep env dsta deva dcs = Draise v` by (
+        qmatch_asmsub_abbrev_tac `Dstep (st',_)` >>
+        qspecl_then [`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+          assume_tac dstep_result_rel_single' >>
+        gvs[dget_ffi_def, dstep_result_rel_cases] >>
+        pop_assum irule >> unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >> simp[is_halt_def]) >>
+      Cases_on `x` >> gvs[step_n_def, is_halt_def] >> gvs[dget_ffi_def]
+      ) >>
+    gvs[step_n_cml_def] >>
+    qmatch_asmsub_abbrev_tac `(st2,_)` >>
+    Cases_on `decl_step env (st2,devb,dcs)` >> gvs[] >>
+    Cases_on `dget_ffi (Dstep p) = SOME st2.ffi`
+    >- (
+      qspecl_then [`dsta`,`deva`,`dcs`,`(st2,devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_single' >>
+      simp[dget_ffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[] >>
+      last_x_assum $ qspecl_then [
+        `v`,`io`,`env`,`dev2`,`dst`,`ffi'`,
+        `st'`,`ffi_st`,`oracle`,`dcs'`,`dev1`,`dst'`] mp_tac >>
+      simp[] >> qpat_x_assum `_.ffi = _` $ assume_tac o GSYM >> simp[] >>
+      `st' with ffi := st'.ffi = st'` by
+        rw[semanticPrimitivesTheory.state_component_equality] >> rw[] >>
+      qexists_tac `n'` >> pop_assum mp_tac >>
+      Cases_on `n'` >> once_rewrite_tac[trace_prefix_interp] >> rw[] >>
+      DEP_ONCE_REWRITE_TAC[step_until_halt_take_step] >> simp[is_halt_def]
+      ) >>
+    PairCases_on `p` >> gvs[dget_ffi_def] >>
+    rename1 `dget_ffi _ = SOME ffi_new` >>
+    rename1 `Dstep (st2',devb',dcs')` >>
+    drule decl_step_ffi_changed >> simp[] >>
+    drule decl_step_ffi_changed_dstep_to_Dffi >> simp[] >>
+    disch_then $ qspecl_then [`dsta`,`deva`] mp_tac >> simp[] >> impl_tac
+    >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+    strip_tac >> strip_tac >> gvs[] >>
+    unabbrev_all_tac >>
+    qpat_x_assum `dstate_rel _ _` mp_tac >> rw[dstate_rel_def] >> gvs[] >>
+    gvs[ffi_state_component_equality] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> once_rewrite_tac[trace_prefix_interp] >>
+    simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (
+      qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >>
+      simp[dstep_def, SF ditree_ss, is_halt_def]
+      ) >>
+    Cases_on `x` >> gvs[step_n_def, is_halt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >> simp[deval_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> rw[] >> gvs[] >>
+    qmatch_asmsub_abbrev_tac `_ ++ [new_event]` >>
+    qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st2,dev2,_))` >>
+    last_x_assum $ qspecl_then [
+      `v`,`TL io`,`env`,`dev2`,`dst`,`ffi_new`,`st2`,`ffi_st'`,`oracle`,`dcs`] mp_tac >>
+    simp[Abbr `dev2`, deval_rel_cases, PULL_EXISTS] >> disch_then $ drule_at Any >>
+    disch_then $
+      qspec_then `dsta with refs := LUPDATE (W8array ws'') lnum dsta.refs` mp_tac >>
+    qmatch_goalsub_abbrev_tac `Dstep (st3,_)` >>
+    `st3 = st2` by (unabbrev_all_tac >> gvs[dstate_rel_def]) >> gvs[] >>
+    simp[] >> reverse $ impl_keep_tac >> gvs[] >> rw[] >> unabbrev_all_tac >> gvs[]
+    >- (qexists_tac `n'` >> simp[])
+    >- gvs[dstate_rel_def] >>
+    imp_res_tac io_events_mono_decl_step >>
+    imp_res_tac io_events_mono_step_n_cml >> gvs[io_events_mono_def] >>
+    PairCases_on `dst` >> gvs[dget_ffi_def] >>
+    Cases_on `io` >> gvs[]
+    )
+QED
+
+Theorem trace_prefix_dec_FinalFFI:
+  dstate_rel dsta st ∧ deval_rel deva devb ⇒
+
+  ((∃n. trace_prefix n (oracle, ffi_st)
+    (interp env (Dstep dsta deva dcs)) = (io, SOME $ FinalFFI (s,conf,ws) outcome)) ⇔
+
+  ∃dst ffi'.
+    (decl_step_reln env)^*
+      (st with ffi := st.ffi with <| oracle := oracle; ffi_state := ffi_st |>,
+       devb, dcs) dst ∧
+    dget_ffi (Dstep dst) = SOME ffi' ∧
+    ffi'.io_events = st.ffi.io_events ++ io ∧
+    decl_step env dst = Dabort (Rffi_error $ Final_event s conf ws outcome))
+Proof
+  rw[] >> eq_tac >> rw[] >> rpt $ pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`devb`,`env`,`io`,`n`] >>
+    Induct >> rw[trace_prefix_interp] >>
+    gvs[step_until_halt_def] >> every_case_tac >> gvs[]
+    >- gvs[trace_prefix_interp]
+    >- (
+      qspecl_then [`x`,`env`,`Dstep dsta deva dcs`]
+        assume_tac is_halt_step_n_min >> gvs[is_halt_def] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >>
+      simp[Once decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      rename1 `Dffi dst (s,conf,ws,lnum,env',cs) locs pat dcs''` >>
+      rename1 `_ = Dstep dsta' deva' dcs'` >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases] >> disch_then drule_all >>
+      strip_tac >> gvs[Abbr `st'`] >>
+      gvs[dget_ffi_def, ffi_state_component_equality]
+      )
+    >- (
+      pairarg_tac >> gvs[] >>
+      last_x_assum $ drule_at $ Pos last >>
+      simp[deval_rel_cases, PULL_EXISTS] >> strip_tac >>
+      qspecl_then [`x`,`env`,`Dstep dsta deva dcs`]
+        assume_tac is_halt_step_n_min >> gvs[is_halt_def] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> simp[Once RTC_CASES_RTC_TWICE, PULL_EXISTS, GSYM CONJ_ASSOC] >>
+      simp[Once decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      rename1 `Dffi dst (s',conf',ws',lnum,env',cs) locs pat dcs''` >>
+      rename1 `_ = Dstep dsta' deva' dcs'` >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases] >> disch_then drule_all >>
+      strip_tac >> gvs[Abbr `st'`] >>
+      gvs[dget_ffi_def, ffi_state_component_equality] >>
+      rgs[Once deval_rel_cases, ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >>
+      simp[Once RTC_CASES1] >> irule_at Any OR_INTRO_THM2 >> simp[PULL_EXISTS] >>
+      simp[decl_step_reln_def] >>
+      first_x_assum $ drule_at Any >> gvs[dstep_to_Dffi] >>
+      qmatch_goalsub_abbrev_tac `RTC _ (st1,_)` >>
+      disch_then $ qspec_then `st1` mp_tac >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >> strip_tac >> gvs[] >>
+      qmatch_asmsub_abbrev_tac `RTC _ (st2,_)` >>
+      `st1 = st2` by (
+        unabbrev_all_tac >>
+        rw[semanticPrimitivesTheory.state_component_equality,
+           ffi_state_component_equality]) >>
+      gvs[] >> goal_assum drule >> simp[] >>
+      unabbrev_all_tac >> gvs[]
+      )
+    >- (
+      qspecl_then [`x`,`env`,`Dstep dsta deva dcs`]
+        assume_tac is_halt_step_n_min >> gvs[is_halt_def] >>
+      qpat_x_assum `step_n _ x _ = _` kall_tac >>
+      qpat_x_assum `_ ≤ x` kall_tac >>
+      Cases_on `m` >- gvs[step_n_def, is_halt_def] >>
+      gvs[step_n_alt_def] >> reverse every_case_tac >> gvs[] >> rename1 `SUC m`
+      >- (first_x_assum $ qspec_then `m` assume_tac >> gvs[is_halt_def]) >>
+      qmatch_goalsub_abbrev_tac `(st',_)` >>
+      qspecl_then [`m`,`dsta`,`deva`,`dcs`,`(st',devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_n >>
+      simp[is_Dffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >>
+      simp[Once decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+      rename1 `Dffi dst (s',conf',ws',lnum,env',cs) locs pat dcs''` >>
+      rename1 `_ = Dstep dsta' deva' dcs'` >>
+      goal_assum drule >> gvs[dget_ffi_def] >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases] >> disch_then drule_all >>
+      strip_tac >> gvs[Abbr `st'`] >>
+      gvs[dget_ffi_def, ffi_state_component_equality]
+      )
+    )
+  >- (
+    simp[decl_step_reln_eq_step_n_cml] >>
+    simp[PULL_EXISTS, AND_IMP_INTRO, GSYM CONJ_ASSOC] >> gen_tac >>
+    map_every qid_spec_tac
+      [`dsta`,`deva`,`dcs`,`oracle`,`ffi_st`,`st`,`ffi'`,
+        `dst`,`devb`,`env`,`io`,`n`] >>
+    Induct >> rw[]
+    >- (
+      gvs[step_n_cml_def] >>
+      qexists_tac `SUC $ SUC 0` >> once_rewrite_tac[trace_prefix_interp] >>
+      simp[step_until_halt_def] >>
+      drule_at Any dstep_result_rel_single_FFI_error >>
+      simp[dstep_result_rel_cases] >> disch_then $ drule_at Any >>
+      disch_then $ qspec_then `dsta` mp_tac >>
+      impl_tac >- gvs[dstate_rel_def] >> strip_tac >> gvs[] >>
+      DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+      >- (qexists_tac `SUC 0` >> simp[step_n_def, is_halt_def]) >>
+      drule_at Any is_halt_step_n_eq >>
+      disch_then $ qspec_then `SUC 0` $ mp_tac >> simp[step_n_def, is_halt_def] >>
+      disch_then kall_tac >> pop_assum kall_tac >>
+      drule_at Any dstep_result_rel_single_FFI_strong >>
+      simp[dstep_result_rel_cases] >> disch_then $ drule_at Any >>
+      qmatch_asmsub_abbrev_tac `Dstep (st1,_)` >>
+      disch_then $ qspec_then `st1` mp_tac >>
+      impl_tac >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[] >> unabbrev_all_tac >> gvs[dget_ffi_def] >>
+      every_case_tac >> rgs[]
+      ) >>
+    gvs[step_n_cml_def] >>
+    qmatch_asmsub_abbrev_tac `(st2,_)` >>
+    Cases_on `decl_step env (st2,devb,dcs)` >> gvs[] >>
+    Cases_on `dget_ffi (Dstep p) = SOME st2.ffi`
+    >- (
+      qspecl_then [`dsta`,`deva`,`dcs`,`(st2,devb,dcs)`,`env`]
+        mp_tac dstep_result_rel_single' >>
+      simp[dget_ffi_def, dstep_result_rel_cases] >> impl_tac
+      >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+      strip_tac >> gvs[dget_ffi_def] >>
+      unabbrev_all_tac >> gvs[] >>
+      last_x_assum $ qspecl_then [
+        `io`,`env`,`dev2`,`dst`,`ffi'`,
+        `st'`,`ffi_st`,`oracle`,`dcs'`,`dev1`,`dst'`] mp_tac >>
+      simp[] >> qpat_x_assum `_.ffi = _` $ assume_tac o GSYM >> simp[] >>
+      `st' with ffi := st'.ffi = st'` by
+        rw[semanticPrimitivesTheory.state_component_equality] >> rw[] >>
+      qexists_tac `n'` >> pop_assum mp_tac >>
+      Cases_on `n'` >> once_rewrite_tac[trace_prefix_interp] >> rw[] >>
+      DEP_ONCE_REWRITE_TAC[step_until_halt_take_step] >> simp[is_halt_def]
+      ) >>
+    PairCases_on `p` >> gvs[dget_ffi_def] >>
+    rename1 `dget_ffi _ = SOME ffi_new` >>
+    rename1 `Dstep (st2',devb',dcs')` >>
+    drule decl_step_ffi_changed >> simp[] >>
+    drule decl_step_ffi_changed_dstep_to_Dffi >> simp[] >>
+    disch_then $ qspecl_then [`dsta`,`deva`] mp_tac >> simp[] >> impl_tac
+    >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+    strip_tac >> strip_tac >> gvs[] >>
+    unabbrev_all_tac >>
+    qpat_x_assum `dstate_rel _ _` mp_tac >> rw[dstate_rel_def] >> gvs[] >>
+    gvs[ffi_state_component_equality] >>
+    Q.REFINE_EXISTS_TAC `SUC m` >> once_rewrite_tac[trace_prefix_interp] >>
+    simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+    >- (
+      qexists_tac `SUC 0` >> rewrite_tac[step_n_def] >>
+      simp[dstep_def, SF ditree_ss, is_halt_def]
+      ) >>
+    Cases_on `x` >> gvs[step_n_def, is_halt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >> simp[deval_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >> rw[] >> gvs[] >>
+    qmatch_asmsub_abbrev_tac `_ ++ [new_event]` >>
+    qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st2,dev2,_))` >>
+    rename1 `ZIP (ws1,ws2)` >>
+    last_x_assum $ qspecl_then [
+      `TL io`,`env`,`dev2`,`dst`,`ffi_new`,`st2`,`ffi_st'`,`oracle`,`dcs`] mp_tac >>
+    simp[Abbr `dev2`, deval_rel_cases, PULL_EXISTS] >> disch_then $ drule_at Any >>
+    disch_then $
+      qspec_then `dsta with refs := LUPDATE (W8array ws2) lnum dsta.refs` mp_tac >>
+    qmatch_goalsub_abbrev_tac `Dstep (st3,_)` >>
+    `st3 = st2` by (unabbrev_all_tac >> gvs[dstate_rel_def]) >> gvs[] >>
+    simp[] >> reverse $ impl_keep_tac >> gvs[] >> rw[] >> unabbrev_all_tac >> gvs[]
+    >- (qexists_tac `n'` >> simp[])
+    >- gvs[dstate_rel_def] >>
+    imp_res_tac io_events_mono_decl_step >>
+    imp_res_tac io_events_mono_step_n_cml >> gvs[io_events_mono_def] >>
+    PairCases_on `dst` >> gvs[dget_ffi_def] >>
+    Cases_on `io` >> gvs[]
+    )
+QED
+
+Theorem decl_step_trace_prefix_io_events_lemma:
+  dstate_rel dsta st ∧ deval_rel deva devb ∧
+  (decl_step_reln env)^* (st, devb, dcs) dst ∧
+  (FST dst).ffi.io_events = st.ffi.io_events ++ io ⇒
+  ∃n.
+    trace_prefix n (st.ffi.oracle, st.ffi.ffi_state)
+      (interp env (Dstep dsta deva dcs)) = (io, NONE)
+Proof
+  simp[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >> gen_tac >>
+  map_every qid_spec_tac
+    [`dsta`,`deva`,`dcs`,`st`,`devb`,`env`,`io`,`dst`,`n`] >>
+  Induct >> rw[step_n_cml_def] >> gvs[]
+  >- (qexists_tac `0` >> simp[trace_prefix_interp]) >>
+  Cases_on `decl_step env (st,devb,dcs)` >> gvs[] >>
+  Cases_on `dget_ffi (Dstep p) = SOME st.ffi`
+  >- (
+    qspecl_then [`dsta`,`deva`,`dcs`,`(st,devb,dcs)`,`env`]
+      mp_tac dstep_result_rel_single' >>
+    simp[dget_ffi_def, dstep_result_rel_cases] >> strip_tac >> gvs[] >>
+    last_x_assum drule >> disch_then drule >>
+    disch_then $ drule_at Any >> gvs[dget_ffi_def] >> rw[] >> gvs[] >>
+    rename1 `trace_prefix m _` >> qexists_tac `m` >> pop_assum mp_tac >>
+    Cases_on `m` >> once_rewrite_tac[trace_prefix_interp] >> rw[] >>
+    DEP_ONCE_REWRITE_TAC[step_until_halt_take_step] >> simp[is_halt_def]
+    ) >>
+  PairCases_on `p` >> gvs[dget_ffi_def] >>
+  rename1 `Dstep (st',devb',dcs')` >>
+  drule decl_step_ffi_changed >> simp[] >>
+  drule decl_step_ffi_changed_dstep_to_Dffi >> simp[] >> disch_then $ drule_all >>
+  strip_tac >> strip_tac >> gvs[] >>
+  rgs[Once deval_rel_cases, ctxt_rel_def] >> gvs[] >>
+  gvs[GSYM ctxt_rel_def, ctxt_frame_rel_cases] >>
+  Q.REFINE_EXISTS_TAC `SUC m` >> once_rewrite_tac[trace_prefix_interp] >>
+  simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> reverse $ rw[]
+  >- (
+    pop_assum $ qspec_then `SUC 0` mp_tac >> rewrite_tac[step_n_def] >>
+    simp[SF ditree_ss, is_halt_def]
+    ) >>
+  drule_at Any is_halt_step_n_eq >>
+  disch_then $ qspec_then `SUC 0` mp_tac >> simp[step_n_def, is_halt_def] >>
+  strip_tac >> rgs[dstep_to_Dffi, Once dstate_rel_def] >>
+  qmatch_asmsub_abbrev_tac `step_n_cml _ _ (Dstep (st1,ev,dcs))` >>
+  last_x_assum $ qspecl_then [
+    `dst`,`TL io`,`env`,`ev`,`st1`,`dcs`] mp_tac >>
+  simp[Abbr `ev`, deval_rel_cases, PULL_EXISTS] >>
+  disch_then $ drule_at Any >>
+  disch_then $ qspec_then
+    `dsta with refs := LUPDATE (W8array ws'') lnum st.refs` mp_tac >>
+  unabbrev_all_tac >> simp[dstate_rel_def] >> reverse impl_keep_tac >> gvs[] >> rw[]
+  >- (qexists_tac `n'` >> simp[])
+  >- (
+    imp_res_tac io_events_mono_decl_step >>
+    imp_res_tac io_events_mono_step_n_cml >> gvs[io_events_mono_def] >>
+    Cases_on `io` >> gvs[]
+    )
+QED
+
+Theorem trace_prefix_decl_step_io_events_lemma:
+  ∀env n io oracle ffi_st dsta st deva devb dcs.
+  dstate_rel dsta st ∧ deval_rel deva devb ∧
+  trace_prefix n (oracle, ffi_st) (interp env (Dstep dsta deva dcs)) = (io, NONE)
+  ⇒ ∃st' devb' dcs'.
+      RTC (decl_step_reln env)
+        (st with ffi := st.ffi with <| oracle := oracle; ffi_state := ffi_st |>,devb,dcs)
+        (st',devb',dcs') ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  gen_tac >> Induct >> rw[] >> gvs[trace_prefix_interp]
+  >- (irule_at Any RTC_REFL >> rw[]) >>
+  pop_assum mp_tac >> TOP_CASE_TAC >> rw[] >- (irule_at Any RTC_REFL >> simp[]) >>
+  qpat_x_assum `step_until_halt _ _ = _` mp_tac >>
+  simp[step_until_halt_def] >> DEEP_INTRO_TAC some_intro >> rw[] >>
+  pop_assum mp_tac >> simp[AllCaseEqs()] >> strip_tac >>
+  drule is_halt_step_n_min >> strip_tac >> gvs[] >>
+  qpat_x_assum `step_n _ x _ = _` kall_tac >>
+  qpat_x_assum `_ ≤ x` kall_tac >>
+  `∃l. m = SUC l` by (Cases_on `m` >> gvs[step_n_def]) >> gvs[] >>
+  pop_assum $ qspec_then `l'` assume_tac >> gvs[] >>
+  gvs[step_n_alt_def] >> FULL_CASE_TAC >> gvs[] >>
+  PairCases_on `p` >> gvs[dstep_to_Dffi] >>
+  simp[decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+  qmatch_goalsub_abbrev_tac `st0,_,_` >>
+  qspecl_then [`l'`,`dsta`,`deva`,`dcs`,`(st0,devb,dcs)`,`env`]
+    mp_tac dstep_result_rel_n >>
+  simp[dstep_result_rel_cases, is_Dffi_def, get_ffi_def] >>
+  impl_keep_tac >- (unabbrev_all_tac >> gvs[dstate_rel_def]) >>
+  rw[] >> gvs[dget_ffi_def] >> every_case_tac >> gvs[]
+  >- (goal_assum drule >> unabbrev_all_tac >> gvs[ffi_state_component_equality])
+  >- (
+    gvs[trace_prefix_interp] >>
+    `step_n_cml env (SUC l') (Dstep (st0,devb,dcs)) = decl_step env (st',dev2,l'')` by
+      simp[step_n_cml_alt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >>
+    simp[deval_rel_cases, ctxt_rel_def] >> simp[GSYM ctxt_rel_def] >>
+    simp[ctxt_frame_rel_cases, EXISTS_PROD] >> rw[] >> gvs[] >>
+    qpat_x_assum `_ = decl_step _ _` mp_tac >>
+    simp[decl_step_def, e_step_def, smallStepTheory.continue_def, cml_application_thm,
+         semanticPrimitivesTheory.do_app_def, call_FFI_def] >>
+    unabbrev_all_tac >> simp[] >>
+    gvs[dstate_rel_def] >> gvs[ffi_state_component_equality] >>
+    gvs[store_assign_def, store_lookup_def, store_v_same_type_def] >>
+    rw[smallStepTheory.return_def] >> goal_assum drule >> simp[]
+    )
+  >- (goal_assum drule >> unabbrev_all_tac >> gvs[ffi_state_component_equality])
+  >- (
+    pairarg_tac >> gvs[] >>
+    `step_n_cml env (SUC l') (Dstep (st0,devb,dcs)) = decl_step env (st',dev2,l'')` by
+      simp[step_n_cml_alt_def] >>
+    qpat_x_assum `deval_rel _ _` mp_tac >>
+    simp[deval_rel_cases, ctxt_rel_def] >> simp[GSYM ctxt_rel_def] >>
+    simp[ctxt_frame_rel_cases, EXISTS_PROD] >> rw[] >> gvs[] >>
+    qpat_x_assum `_ = decl_step _ _` mp_tac >>
+    simp[decl_step_def, e_step_def, smallStepTheory.continue_def, cml_application_thm,
+         semanticPrimitivesTheory.do_app_def, call_FFI_def] >>
+    unabbrev_all_tac >> simp[] >>
+    gvs[dstate_rel_def] >> gvs[ffi_state_component_equality] >>
+    gvs[store_assign_def, store_lookup_def, store_v_same_type_def] >>
+    rw[smallStepTheory.return_def] >>
+    qmatch_asmsub_abbrev_tac `Dstep (st1,ExpVal _ _ _ _ _,_)` >>
+    last_x_assum $ drule_at $ Pos last >> simp[deval_rel_cases, PULL_EXISTS] >>
+    disch_then $ drule_at Any >> disch_then $ qspec_then `st1` mp_tac >>
+    impl_tac >- (unabbrev_all_tac >> gvs[]) >>
+    rw[decl_step_reln_eq_step_n_cml] >> rename1 `_ = Dstep (st3,_,_)` >>
+    qexistsl_tac [`st3`,`devb''`,`dcs'`,`n' + SUC l'`] >>
+    simp[step_n_cml_add] >>
+    qmatch_asmsub_abbrev_tac `_ (Dstep (st1',_,_)) = _` >>
+    `st1' = st1` by (unabbrev_all_tac >>
+      simp[semanticPrimitivesTheory.state_component_equality,
+           ffi_state_component_equality]) >>
+    gvs[] >> unabbrev_all_tac >> gvs[]
+    )
+QED
+
+
+(******************** Collected results for declarations ********************)
+
+Definition dstate_of_def:
+  dstate_of (st :α semanticPrimitives$state) :dstate = <|
+    refs := st.refs;
+    next_type_stamp := st.next_type_stamp;
+    next_exn_stamp := st.next_exn_stamp;
+    eval_state := st.eval_state |>
+End
+
+Theorem dstate_rel_dstate_of:
+  dstate_rel dst st ⇔ dstate_of st = dst
+Proof
+  rw[dstate_of_def, dstate_rel_def] >>
+  eq_tac >> rw[] >> gvs[state_component_equality, dstate_component_equality]
+QED
+
+Definition itree_of_def:
+  itree_of st env prog =
+  interp env (Dstep (dstate_of st) (Decl (Dlocal [] prog)) [])
+End
+
+Overload itree_ffi = `` λst. (st.ffi.oracle,st.ffi.ffi_state)``;
+
+Triviality evaluate_decs_NIL[simp]:
+  evaluate_decs ck env st [] res ⇔ res = (st, Rval empty_dec_env)
+Proof
+  simp[Once bigStepTheory.evaluate_dec_cases, empty_dec_env_def]
+QED
+
+Triviality small_eval_decs_eq_Dlocal:
+  small_eval_dec env (st,Decl (Dlocal [] prog),[]) = small_eval_decs env st prog
+Proof
+  rw[FUN_EQ_THM] >> rename1 `_ prog res` >>
+  rw[GSYM bigSmallEquivTheory.small_big_dec_equiv,
+     GSYM bigSmallEquivTheory.small_big_decs_equiv] >>
+  map_every qid_spec_tac [`env`,`st`,`res`,`prog`] >>
+  Induct >> rw[] >> simp[Once bigStepTheory.evaluate_dec_cases]
+QED
+
+Theorem small_eval_decs_trace_prefix_termination:
+  (small_eval_decs env st ds (st',Rval e) ∨
+   small_eval_decs env st ds (st',Rerr (Rraise v)))
+  ⇒ ∃n io.
+      trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, SOME Termination) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def] >>
+  gvs[small_eval_dec_def, decl_step_reln_eq_step_n_cml] >>
+  imp_res_tac io_events_mono_step_n_cml >>
+  gvs[io_events_mono_def, rich_listTheory.IS_PREFIX_APPEND] >>
+  qpat_x_assum `_ ⇒ _` kall_tac >> rename1 `_ ++ io` >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffRL trace_prefix_dec_Termination >>
+  disch_then $ qspecl_then [`st.ffi.oracle`,`io`,`st.ffi.ffi_state`,
+    `env`,`Decl (Dlocal [] ds)`,`Decl (Dlocal [] ds)`,`[]`] mp_tac >>
+  simp[deval_rel_cases, decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >>
+  disch_then drule >> simp[dget_ffi_def, SF dsmallstep_ss]
+QED
+
+Theorem trace_prefix_small_eval_decs_termination:
+  trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, SOME Termination)
+  ⇒ ∃st' e v.
+      (small_eval_decs env st ds (st', Rval e) ∨
+       small_eval_decs env st ds (st', Rerr (Rraise v))) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def, small_eval_dec_def] >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffLR trace_prefix_dec_Termination >> simp[PULL_EXISTS] >>
+  disch_then $ drule_at Any >> simp[deval_rel_cases, PULL_EXISTS] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >> rw[] >> gvs[] >>
+  PairCases_on `dst` >> gvs[decl_step_to_Ddone]
+  >- (irule_at Any OR_INTRO_THM1 >> goal_assum drule >> gvs[dget_ffi_def])
+  >- (
+    irule_at Any OR_INTRO_THM2 >> simp[PULL_EXISTS, GSYM CONJ_ASSOC, EXISTS_PROD] >>
+    goal_assum drule >> gvs[dget_ffi_def]
+    )
+QED
+
+Theorem small_eval_decs_trace_prefix_type_error:
+  small_eval_decs env st ds (st', Rerr (Rabort Rtype_error))
+  ⇒ ∃n io.
+      trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, SOME Error) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def] >>
+  gvs[small_eval_dec_def, decl_step_reln_eq_step_n_cml] >>
+  imp_res_tac io_events_mono_step_n_cml >>
+  gvs[io_events_mono_def, rich_listTheory.IS_PREFIX_APPEND] >>
+  qpat_x_assum `_ ⇒ _` kall_tac >> rename1 `_ ++ io` >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffRL trace_prefix_dec_Error >>
+  disch_then $ qspecl_then [`st.ffi.oracle`,`io`,`st.ffi.ffi_state`,
+    `env`,`Decl (Dlocal [] ds)`,`Decl (Dlocal [] ds)`,`[]`] mp_tac >>
+  simp[deval_rel_cases, PULL_EXISTS, decl_step_reln_eq_step_n_cml] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >>
+  disch_then drule >> simp[dget_ffi_def]
+QED
+
+Theorem trace_prefix_small_eval_decs_type_error:
+  trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, SOME Error)
+  ⇒ ∃st'. small_eval_decs env st ds (st', Rerr (Rabort Rtype_error))
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def] >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffLR trace_prefix_dec_Error >> simp[PULL_EXISTS] >>
+  disch_then $ drule_at Any >> simp[deval_rel_cases] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >>
+  simp[small_eval_dec_def, PULL_EXISTS, EXISTS_PROD] >> rw[] >> gvs[] >>
+  PairCases_on `dst` >> goal_assum drule >> simp[]
+QED
+
+Theorem small_eval_decs_trace_prefix_ffi_error:
+  small_eval_decs env st ds
+    (st', Rerr (Rabort $ Rffi_error $ Final_event s conf ws outcome))
+  ⇒ ∃n io.
+      trace_prefix n (itree_ffi st) (itree_of st env ds) =
+        (io, SOME $ FinalFFI (s,conf,ws) outcome) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def] >>
+  gvs[small_eval_dec_def, decl_step_reln_eq_step_n_cml] >>
+  imp_res_tac io_events_mono_step_n_cml >>
+  gvs[io_events_mono_def, rich_listTheory.IS_PREFIX_APPEND] >>
+  qpat_x_assum `_ ⇒ _` kall_tac >> rename1 `_ ++ io` >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffRL trace_prefix_dec_FinalFFI >>
+  disch_then $ qspecl_then [`ws`,`s`,`outcome`,`st.ffi.oracle`,`io`,`st.ffi.ffi_state`,
+    `env`,`Decl (Dlocal [] ds)`,`Decl (Dlocal [] ds)`,`[]`,`conf`] mp_tac >>
+  simp[deval_rel_cases, PULL_EXISTS, decl_step_reln_eq_step_n_cml] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >>
+  disch_then drule >> simp[dget_ffi_def]
+QED
+
+Theorem trace_prefix_small_eval_decs_ffi_error:
+  trace_prefix n (itree_ffi st) (itree_of st env ds) =
+    (io, SOME $ FinalFFI (s,conf,ws) outcome)
+  ⇒ ∃st'. small_eval_decs env st ds
+            (st', Rerr (Rabort $ Rffi_error $ Final_event s conf ws outcome)) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  rw[GSYM small_eval_decs_eq_Dlocal, itree_of_def] >>
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >>
+  drule $ iffLR trace_prefix_dec_FinalFFI >> simp[PULL_EXISTS] >>
+  disch_then $ drule_at Any >> simp[deval_rel_cases] >>
+  qmatch_goalsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >>
+  simp[small_eval_dec_def, PULL_EXISTS, EXISTS_PROD] >> rw[] >> gvs[] >>
+  PairCases_on `dst` >> goal_assum drule >> gvs[dget_ffi_def]
+QED
+
+Theorem decl_step_trace_prefix_io_events:
+  (decl_step_reln env)^* (st,Decl (Dlocal [] ds),[]) (st',dev,dcs)
+  ⇒ ∃n io.
+      trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, NONE) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >> rw[] >>
+  drule decl_step_trace_prefix_io_events_lemma >>
+  disch_then $ drule_at Any >> simp[deval_rel_cases] >> strip_tac >>
+  gvs[decl_step_reln_eq_step_n_cml] >>
+  imp_res_tac io_events_mono_step_n_cml >>
+  gvs[io_events_mono_def, rich_listTheory.IS_PREFIX_APPEND, itree_of_def] >>
+  goal_assum drule
+QED
+
+Theorem trace_prefix_decl_step_io_events:
+  trace_prefix n (itree_ffi st) (itree_of st env ds) = (io, NONE)
+  ⇒ ∃st' dev dcs.
+      (decl_step_reln env)^* (st,Decl (Dlocal [] ds),[]) (st',dev,dcs) ∧
+      st'.ffi.io_events = st.ffi.io_events ++ io
+Proof
+  `dstate_rel (dstate_of st) st` by gvs[dstate_rel_dstate_of] >> rw[] >>
+  drule trace_prefix_decl_step_io_events_lemma >> gvs[itree_of_def] >>
+  disch_then $ drule_at Any >> simp[deval_rel_cases] >> strip_tac >>
+  qmatch_asmsub_abbrev_tac `(st1,_)` >>
+  `st1 = st` by (unabbrev_all_tac >>
+    rw[semanticPrimitivesTheory.state_component_equality,
+       ffi_state_component_equality]) >>
+  unabbrev_all_tac >> gvs[] >> goal_assum drule >> simp[]
+QED
+
+
+(******************** semantics_prog ********************)
+
+Theorem itree_semantics:
+  st.eval_state = NONE ⇒ (
+  (semantics_prog st env prog (Terminate outcome io_list) ⇔
+    ∃n io res.
+      trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, SOME res) ∧
+      io_list = st.ffi.io_events ++ io ∧
+      if outcome = Success then res = Termination
+      else ∃s conf ws f.
+              outcome = FFI_outcome (Final_event s conf ws f) ∧
+              res = FinalFFI (s,conf,ws) f) ∧
+  (semantics_prog st env prog (Diverge io_trace) ⇔
+    (∀n. ∃io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, NONE)) ∧
+    lprefix_lub
+      { fromList (st.ffi.io_events ++ io) | io |
+        ∃n res. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io,res) }
+      io_trace) ∧
+  (semantics_prog st env prog Fail ⇔
+    ∃n io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, SOME Error))
+  )
+Proof
+  rw[small_step_semantics]
+  >- ( (* termination *)
+    eq_tac >> rw[] >> Cases_on `outcome` >> gvs[]
+    >- (imp_res_tac small_eval_decs_trace_prefix_termination >> simp[SF SFY_ss])
+    >- (imp_res_tac small_eval_decs_trace_prefix_termination >> simp[SF SFY_ss])
+    >- (
+      Cases_on `f` >>
+      imp_res_tac small_eval_decs_trace_prefix_ffi_error >> simp[SF SFY_ss]
+      )
+    >- (drule trace_prefix_small_eval_decs_termination >> rw[SF SFY_ss, SF DNF_ss])
+    >- (imp_res_tac trace_prefix_small_eval_decs_ffi_error >> simp[SF SFY_ss])
+    )
+  >- ( (* divergence *)
+    `small_decl_diverges env (st,Decl (Dlocal [] prog),[]) =
+     (∀n. ∃io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io,NONE))` by (
+      eq_tac >> rw[]
+      >- (
+        CCONTR_TAC >> gvs[] >>
+        qpat_x_assum `small_decl_diverges _ _` mp_tac >> simp[] >>
+        rw[GSYM small_decl_total, small_eval_decs_eq_Dlocal] >>
+        Cases_on `trace_prefix n (itree_ffi st) (itree_of st env prog)` >> gvs[] >>
+        Cases_on `r` >> gvs[] >> Cases_on `x` >> gvs[]
+        >- (imp_res_tac trace_prefix_small_eval_decs_termination >> simp[SF SFY_ss])
+        >- (imp_res_tac trace_prefix_small_eval_decs_type_error >> simp[SF SFY_ss])
+        >- (
+          PairCases_on `p` >>
+          imp_res_tac trace_prefix_small_eval_decs_ffi_error >> simp[SF SFY_ss]
+          )
+        )
+      >- (
+        CCONTR_TAC >> gvs[GSYM small_decl_total, small_eval_decs_eq_Dlocal] >>
+        last_x_assum assume_tac >> last_x_assum mp_tac >> simp[] >>
+        PairCases_on `b` >> Cases_on `b1` >> gvs[]
+        >- (
+          imp_res_tac small_eval_decs_trace_prefix_termination >>
+          qexists_tac `n` >> simp[]
+          ) >>
+        Cases_on `e` >> gvs[]
+        >- (
+          imp_res_tac small_eval_decs_trace_prefix_termination >>
+          qexists_tac `n` >> simp[]
+          ) >>
+        Cases_on `a` >> gvs[]
+        >- (
+          imp_res_tac small_eval_decs_trace_prefix_type_error >>
+          qexists_tac `n` >> simp[]
+          )
+        >- (
+          gvs[GSYM bigSmallEquivTheory.small_big_decs_equiv] >>
+          imp_res_tac bigClockTheory.big_dec_unclocked_no_timeout >> gvs[]
+          )
+        >- (
+          Cases_on `f` >> imp_res_tac small_eval_decs_trace_prefix_ffi_error >>
+          qexists_tac `n` >> simp[]
+          )
+        )
+      ) >>
+    reverse $ Cases_on `small_decl_diverges env (st,Decl (Dlocal [] prog),[])` >>
+    gvs[] >- metis_tac[] >>
+    irule lprefix_lub_equiv_chain >> irule_at Any IMP_equiv_lprefix_chain >>
+    simp[lprefix_chain_RTC_decl_step_reln, lprefix_chain_trace_prefix] >>
+    rw[lprefix_rel_def, PULL_EXISTS, LPREFIX_fromList, from_toList]
+    >- (
+      PairCases_on `s` >> drule decl_step_trace_prefix_io_events >> rw[] >>
+      goal_assum drule >> simp[]
+      )
+    >- (
+      `res = NONE` by (first_x_assum $ qspec_then `n` assume_tac >> gvs[]) >> gvs[] >>
+      drule trace_prefix_decl_step_io_events >> rw[] >> goal_assum drule >> simp[]
+      )
+    )
+  >- ( (* type error *)
+    eq_tac >> rw[]
+    >- (drule small_eval_decs_trace_prefix_type_error >> rw[] >> simp[SF SFY_ss])
+    >- (drule trace_prefix_small_eval_decs_type_error >> rw[SF SFY_ss])
+    )
+QED
+
+
+(****************************************)
+
+val _ = export_theory();
+

--- a/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
+++ b/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
@@ -4,8 +4,7 @@
 open HolKernel Parse boolLib bossLib BasicProvers dep_rewrite;
 open optionTheory relationTheory pairTheory listTheory arithmeticTheory llistTheory;
 open namespaceTheory astTheory ffiTheory lprefix_lubTheory semanticPrimitivesTheory
-     semanticsTheory alt_semanticsTheory evaluatePropsTheory
-     smallStepTheory smallStepPropsTheory;
+     semanticsTheory evaluatePropsTheory smallStepTheory smallStepPropsTheory;
 open itreeTheory itree_semanticsTheory itree_semanticsPropsTheory;
 
 val _ = new_theory "itree_semanticsEquiv";
@@ -1479,7 +1478,7 @@ Proof
   simp[Once bigStepTheory.evaluate_dec_cases, empty_dec_env_def]
 QED
 
-Triviality small_eval_decs_eq_Dlocal:
+Theorem small_eval_decs_eq_Dlocal:
   small_eval_dec env (st,Decl (Dlocal [] prog),[]) = small_eval_decs env st prog
 Proof
   rw[FUN_EQ_THM] >> rename1 `_ prog res` >>
@@ -1654,107 +1653,6 @@ Proof
     rw[semanticPrimitivesTheory.state_component_equality,
        ffi_state_component_equality]) >>
   unabbrev_all_tac >> gvs[] >> goal_assum drule >> simp[]
-QED
-
-
-(******************** semantics_prog ********************)
-
-Theorem itree_semantics:
-  st.eval_state = NONE ⇒ (
-  (semantics_prog st env prog (Terminate outcome io_list) ⇔
-    ∃n io res.
-      trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, SOME res) ∧
-      io_list = st.ffi.io_events ++ io ∧
-      if outcome = Success then res = Termination
-      else ∃s conf ws f.
-              outcome = FFI_outcome (Final_event s conf ws f) ∧
-              res = FinalFFI (s,conf,ws) f) ∧
-  (semantics_prog st env prog (Diverge io_trace) ⇔
-    (∀n. ∃io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, NONE)) ∧
-    lprefix_lub
-      { fromList (st.ffi.io_events ++ io) | io |
-        ∃n res. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io,res) }
-      io_trace) ∧
-  (semantics_prog st env prog Fail ⇔
-    ∃n io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io, SOME Error))
-  )
-Proof
-  rw[small_step_semantics]
-  >- ( (* termination *)
-    eq_tac >> rw[] >> Cases_on `outcome` >> gvs[]
-    >- (imp_res_tac small_eval_decs_trace_prefix_termination >> simp[SF SFY_ss])
-    >- (imp_res_tac small_eval_decs_trace_prefix_termination >> simp[SF SFY_ss])
-    >- (
-      Cases_on `f` >>
-      imp_res_tac small_eval_decs_trace_prefix_ffi_error >> simp[SF SFY_ss]
-      )
-    >- (drule trace_prefix_small_eval_decs_termination >> rw[SF SFY_ss, SF DNF_ss])
-    >- (imp_res_tac trace_prefix_small_eval_decs_ffi_error >> simp[SF SFY_ss])
-    )
-  >- ( (* divergence *)
-    `small_decl_diverges env (st,Decl (Dlocal [] prog),[]) =
-     (∀n. ∃io. trace_prefix n (itree_ffi st) (itree_of st env prog) = (io,NONE))` by (
-      eq_tac >> rw[]
-      >- (
-        CCONTR_TAC >> gvs[] >>
-        qpat_x_assum `small_decl_diverges _ _` mp_tac >> simp[] >>
-        rw[GSYM small_decl_total, small_eval_decs_eq_Dlocal] >>
-        Cases_on `trace_prefix n (itree_ffi st) (itree_of st env prog)` >> gvs[] >>
-        Cases_on `r` >> gvs[] >> Cases_on `x` >> gvs[]
-        >- (imp_res_tac trace_prefix_small_eval_decs_termination >> simp[SF SFY_ss])
-        >- (imp_res_tac trace_prefix_small_eval_decs_type_error >> simp[SF SFY_ss])
-        >- (
-          PairCases_on `p` >>
-          imp_res_tac trace_prefix_small_eval_decs_ffi_error >> simp[SF SFY_ss]
-          )
-        )
-      >- (
-        CCONTR_TAC >> gvs[GSYM small_decl_total, small_eval_decs_eq_Dlocal] >>
-        last_x_assum assume_tac >> last_x_assum mp_tac >> simp[] >>
-        PairCases_on `b` >> Cases_on `b1` >> gvs[]
-        >- (
-          imp_res_tac small_eval_decs_trace_prefix_termination >>
-          qexists_tac `n` >> simp[]
-          ) >>
-        Cases_on `e` >> gvs[]
-        >- (
-          imp_res_tac small_eval_decs_trace_prefix_termination >>
-          qexists_tac `n` >> simp[]
-          ) >>
-        Cases_on `a` >> gvs[]
-        >- (
-          imp_res_tac small_eval_decs_trace_prefix_type_error >>
-          qexists_tac `n` >> simp[]
-          )
-        >- (
-          gvs[GSYM bigSmallEquivTheory.small_big_decs_equiv] >>
-          imp_res_tac bigClockTheory.big_dec_unclocked_no_timeout >> gvs[]
-          )
-        >- (
-          Cases_on `f` >> imp_res_tac small_eval_decs_trace_prefix_ffi_error >>
-          qexists_tac `n` >> simp[]
-          )
-        )
-      ) >>
-    reverse $ Cases_on `small_decl_diverges env (st,Decl (Dlocal [] prog),[])` >>
-    gvs[] >- metis_tac[] >>
-    irule lprefix_lub_equiv_chain >> irule_at Any IMP_equiv_lprefix_chain >>
-    simp[lprefix_chain_RTC_decl_step_reln, lprefix_chain_trace_prefix] >>
-    rw[lprefix_rel_def, PULL_EXISTS, LPREFIX_fromList, from_toList]
-    >- (
-      PairCases_on `s` >> drule decl_step_trace_prefix_io_events >> rw[] >>
-      goal_assum drule >> simp[]
-      )
-    >- (
-      `res = NONE` by (first_x_assum $ qspec_then `n` assume_tac >> gvs[]) >> gvs[] >>
-      drule trace_prefix_decl_step_io_events >> rw[] >> goal_assum drule >> simp[]
-      )
-    )
-  >- ( (* type error *)
-    eq_tac >> rw[]
-    >- (drule small_eval_decs_trace_prefix_type_error >> rw[] >> simp[SF SFY_ss])
-    >- (drule trace_prefix_small_eval_decs_type_error >> rw[SF SFY_ss])
-    )
 QED
 
 

--- a/semantics/alt_semantics/proofs/itree_semanticsPropsScript.sml
+++ b/semantics/alt_semantics/proofs/itree_semanticsPropsScript.sml
@@ -1,0 +1,748 @@
+(*
+  Properties about the itree- and FFI state-based CakeML semantics
+*)
+open HolKernel Parse boolLib bossLib BasicProvers dep_rewrite;
+open optionTheory relationTheory pairTheory listTheory
+     arithmeticTheory llistTheory pred_setTheory;
+open namespaceTheory astTheory ffiTheory semanticPrimitivesTheory
+     evaluatePropsTheory smallStepTheory smallStepPropsTheory lprefix_lubTheory;
+open itreeTheory itree_semanticsTheory;
+
+val _ = new_theory "itree_semanticsProps";
+
+(******************** Definitions ********************)
+
+
+(***** Step-counting version of smallStep RTC definitions *****)
+
+Definition step_n_cml_def:
+  step_n_cml 0 e = e ∧
+  step_n_cml (SUC n) (Estep st) = step_n_cml n (e_step st) ∧
+  step_n_cml _ e = e
+End
+
+Definition is_halt_cml_def:
+  is_halt_cml (Estep (env, st_ffi, Val v, [])) = T ∧
+  is_halt_cml (Estep (env, st_ffi, Val v, [Craise (), env'])) = T ∧
+  is_halt_cml (Eabort a) = T ∧
+  is_halt_cml _ = F
+End
+
+Definition step_to_halt_cml_def:
+  step_to_halt_cml e =
+    case some n. is_halt_cml (step_n_cml n e) of
+    | NONE => NONE
+    | SOME n => SOME $ step_n_cml n e
+End
+
+Definition step_n_cml_def:
+  step_n_cml env 0 d = d ∧
+  step_n_cml env (SUC n) (Dstep st) = step_n_cml env n (decl_step env st) ∧
+  step_n_cml env _ d = d
+End
+
+Definition is_halt_cml_def:
+  is_halt_cml (Dstep step) = F ∧
+  is_halt_cml (Dabort err) = T ∧
+  is_halt_cml Ddone = T ∧
+  is_halt_cml (Draise v) = T
+End
+
+Definition dstep_to_halt_cml_def:
+  dstep_to_halt_cml env e =
+    case some n. is_halt_cml (step_n_cml env n e) of
+    | NONE => NONE
+    | SOME n => SOME $ step_n_cml env n e
+End
+
+
+(***** Relating smallStep and itree-based semantics for expressions *****)
+
+Inductive result_rel:
+  result_rel (Rval v) (Rval v) ∧
+  result_rel (Rraise v) (Rerr $ Rraise v)
+End
+
+Inductive ctxt_frame_rel:
+  ctxt_frame_rel Craise (Craise ()) ∧
+  ctxt_frame_rel (Chandle pes) (Chandle () pes) ∧
+  ctxt_frame_rel (Capp op vs es) (Capp op vs () es) ∧
+  ctxt_frame_rel (Clog lop e) (Clog lop () e) ∧
+  ctxt_frame_rel (Cif e1 e2) (Cif () e1 e2) ∧
+  ctxt_frame_rel (Cmat_check pes v) (Cmat_check () pes v) ∧
+  ctxt_frame_rel (Cmat pes v) (Cmat () pes v) ∧
+  ctxt_frame_rel (Clet vopt e) (Clet vopt () e) ∧
+  ctxt_frame_rel (Ccon idopt vs es) (Ccon idopt vs () es) ∧
+  ctxt_frame_rel (Ctannot ty) (Ctannot () ty) ∧
+  ctxt_frame_rel (Clannot ls) (Clannot () ls)
+End
+
+Definition ctxt_rel_def:
+  ctxt_rel cs1 cs2 =
+    LIST_REL (λ(c1,env1) (c2,env2). ctxt_frame_rel c1 c2 ∧ env1 = env2) cs1 cs2
+End
+
+Inductive step_result_rel:
+  (ctxt_rel cs1 cs2 ⇒
+    step_result_rel (Estep (env, st, ev, cs1)) (Estep (env, (st, ffi), ev, cs2))) ∧
+  step_result_rel Edone Estuck ∧
+  step_result_rel Etype_error (Eabort $ Rtype_error)
+End
+
+(***** Relating smallStep and itree-based semantics for declarations *****)
+
+Definition dstate_rel_def:
+  dstate_rel (dst : dstate) (st : 'a state) ⇔
+    dst.refs = st.refs ∧
+    dst.next_type_stamp = st.next_type_stamp ∧
+    dst.next_exn_stamp = st.next_exn_stamp ∧
+    dst.eval_state = st.eval_state
+End
+
+Inductive deval_rel:
+  deval_rel (itree_semantics$Decl d) (smallStep$Decl d) ∧
+  deval_rel (Env e) (Env e) ∧
+  (ctxt_rel cs scs ⇒
+    deval_rel (ExpVal env ev cs l p) (ExpVal env ev scs l p))
+End
+
+Inductive dstep_result_rel:
+  (dstate_rel dst st ∧ deval_rel dev1 dev2 ⇒
+    dstep_result_rel
+      (itree_semantics$Dstep dst dev1 dcs) (smallStep$Dstep (st, dev2, dcs))) ∧
+  dstep_result_rel Ddone Ddone ∧
+  dstep_result_rel (Draise v) (Draise v) ∧
+  dstep_result_rel Dtype_error (Dabort $ Rtype_error)
+End
+
+(***** Play out a particular trace prefix from a given itree, modelling the
+       environment as an FFI oracle with associated FFI state (as in CakeML) *****)
+Definition trace_prefix_def:
+  trace_prefix 0 (oracle, ffi_st) itree = ([], NONE) ∧
+  trace_prefix (SUC n) (oracle, ffi_st) (Ret r) = ([], SOME r) ∧
+  trace_prefix (SUC n) (oracle, ffi_st)  Div    = ([], NONE) ∧
+  trace_prefix (SUC n) (oracle, ffi_st) (Vis (s, conf, ws) f) =
+    case oracle s ffi_st conf ws of
+    | Oracle_return ffi_st' ws' =>
+        let (io, res) = trace_prefix n (oracle, ffi_st') (f $ INR ws') in
+        if LENGTH ws ≠ LENGTH ws' then (io, res)
+        else (IO_event s conf (ZIP (ws,ws'))::io, res)
+    | Oracle_final outcome => trace_prefix n (oracle, ffi_st) (f $ INL outcome)
+End
+
+
+(***** Misc definitions *****)
+
+Definition is_Effi_def:
+  is_Effi (Effi _ _ _ _ _ _ _) = T ∧
+  is_Effi _ = F
+End
+
+Definition is_Dffi_def:
+  is_Dffi (Dffi _ _ _ _ _) = T ∧
+  is_Dffi _ = F
+End
+
+Definition get_ffi_def:
+  get_ffi (Estep (env, (st, ffi), ev, cs)) = SOME ffi ∧
+  get_ffi _ = NONE
+End
+
+Definition dget_ffi_def:
+  dget_ffi (Dstep (st, dev, dcs)) = SOME st.ffi ∧
+  dget_ffi _ = NONE
+End
+
+
+(******************** Useful simplifications ********************)
+
+(* Deliberately no `application_def` here *)
+val smallstep_ss = simpLib.named_rewrites "smallstep_ss" [
+    smallStepTheory.continue_def,
+    smallStepTheory.return_def,
+    smallStepTheory.push_def,
+    smallStepTheory.e_step_def
+    ];
+
+val dsmallstep_ss = simpLib.named_rewrites "dsmallstep_ss" [
+    smallStepTheory.collapse_env_def,
+    smallStepTheory.decl_continue_def,
+    smallStepTheory.decl_step_def
+    ];
+
+val itree_ss = simpLib.named_rewrites "itree_ss" [
+    itree_semanticsTheory.continue_def,
+    itree_semanticsTheory.return_def,
+    itree_semanticsTheory.push_def,
+    itree_semanticsTheory.estep_def,
+    get_ffi_def
+    ];
+
+val ditree_ss = simpLib.named_rewrites "ditree_ss" [
+    itree_semanticsTheory.dcontinue_def,
+    itree_semanticsTheory.dreturn_def,
+    itree_semanticsTheory.dpush_def,
+    itree_semanticsTheory.dstep_def,
+    dget_ffi_def
+    ];
+
+Theorem step_n_same[simp]:
+  (∀env n. step_n env n Ddone = Ddone) ∧
+  (∀env n. step_n env n Dtype_error = Dtype_error) ∧
+  (∀env n st ev l p dcs.  step_n env n (Dffi st ev l p dcs) = Dffi st ev l p dcs) ∧
+  (∀env n v. step_n env n (Draise v) = Draise v) ∧
+  (∀env n. step_n_cml env n Ddone = Ddone) ∧
+  (∀env n err. step_n_cml env n (Dabort err) = (Dabort err)) ∧
+  (∀env n v. step_n_cml env n (Draise v) = Draise v)
+Proof
+  rpt conj_tac >> strip_tac >>
+  Cases >> rw[step_n_def, step_n_cml_def]
+QED
+
+Theorem is_Effi_def:
+  is_Effi e ⇔ ∃ s ws1 ws2 n env st cs. e = Effi s ws1 ws2 n env st cs
+Proof
+  Cases_on `e` >> simp[is_Effi_def]
+QED
+
+Theorem is_Dffi_def:
+  is_Dffi d ⇔ ∃st ev l p dcs. d = Dffi st ev l p dcs
+Proof
+  Cases_on `d` >> simp[is_Dffi_def]
+QED
+
+Theorem step_result_rel_not_Effi:
+  ∀e1 e2. step_result_rel e1 e2 ⇒ ¬ is_Effi e1
+Proof
+  rw[step_result_rel_cases, is_Effi_def]
+QED
+
+Theorem dstep_result_rel_not_Dffi:
+  ∀a b. dstep_result_rel a b ⇒ ¬ is_Dffi a
+Proof
+  rw[dstep_result_rel_cases, is_Dffi_def]
+QED
+
+
+(******************** Relate smallStep RTC and step-counting ********************)
+
+(***** Lemmas *****)
+
+Theorem cml_application_thm = smallStepPropsTheory.application_thm;
+
+Theorem application_not_Estuck:
+  application op env st_ffi vs cs ≠ Estuck
+Proof
+  rw[cml_application_thm] >>
+  EVERY_CASE_TAC >> gvs[SF smallstep_ss]
+QED
+
+Theorem e_step_to_Estuck:
+  e_step (env, st_ffi, ev, cs) = Estuck ⇔
+  (∃v. ev = Val v ∧ cs = []) ∨
+  (∃v env'. ev = Val v ∧ cs = [Craise (), env'])
+Proof
+  reverse $ eq_tac
+  >- (rw[] >> gvs[SF smallstep_ss]) >>
+  gvs[e_step_def] >> CASE_TAC >> gvs[]
+  >- (every_case_tac >> gvs[SF smallstep_ss, application_not_Estuck]) >>
+  Cases_on `cs` >> gvs[SF smallstep_ss] >>
+  every_case_tac >> gvs[application_not_Estuck]
+QED
+
+Theorem step_n_cml_eq_Dstep:
+  ∀env n e st.
+    step_n_cml env n e = Dstep st
+  ⇒ ∀m. m < n ⇒ ∃st'. step_n_cml env m e = Dstep st'
+Proof
+  strip_tac >> Induct >> rw[step_n_cml_def] >>
+  Cases_on `e` >> gvs[step_n_cml_def] >>
+  Cases_on `m` >> gvs[step_n_cml_def]
+QED
+
+Theorem step_n_cml_alt_def:
+  step_n_cml env 0 e = e ∧
+  step_n_cml env (SUC n) e = (
+    case step_n_cml env n e of
+    | Dstep st => decl_step env st
+    | e => e)
+Proof
+  rw[step_n_cml_def] >>
+  qid_spec_tac `e` >> qid_spec_tac `n` >>
+  Induct >> Cases >> rewrite_tac[step_n_cml_def] >> simp[]
+QED
+
+Theorem step_n_cml_add:
+  ∀env a b e. step_n_cml env (a + b) e = step_n_cml env a (step_n_cml env b e)
+Proof
+  strip_tac >> Induct >> rw[step_n_cml_def] >>
+  simp[ADD_CLAUSES, step_n_cml_alt_def]
+QED
+
+Theorem is_halt_cml_step_n_cml_eq:
+  ∀n m e env.
+    is_halt_cml (step_n_cml env n e) ∧
+    is_halt_cml (step_n_cml env m e)
+  ⇒ step_n_cml env n e = step_n_cml env m e
+Proof
+  rw[] >> wlog_tac `n < m` [`n`,`m`]
+  >- (Cases_on `n = m` >> gvs[]) >>
+  imp_res_tac LESS_STRONG_ADD >> gvs[] >>
+  gvs[step_n_cml_add |> ONCE_REWRITE_RULE[ADD_COMM]] >>
+  Cases_on `step_n_cml env n e` >> gvs[is_halt_cml_def]
+QED
+
+
+(***** Results *****)
+
+Theorem decl_step_reln_eq_step_n_cml:
+  (decl_step_reln env)^* st1 st2 ⇔
+  ∃n. step_n_cml env n (Dstep st1) = Dstep st2
+Proof
+  reverse $ eq_tac >> rw[] >> pop_assum mp_tac
+  >- (
+    map_every qid_spec_tac [`st2`,`st1`,`n`] >>
+    Induct >> rw[step_n_cml_alt_def] >>
+    every_case_tac >> gvs[] >>
+    rw[Once relationTheory.RTC_CASES2] >> disj2_tac >>
+    last_x_assum $ irule_at Any >> gvs[decl_step_reln_def]
+    )
+  >- (
+    Induct_on `(decl_step_reln env)^*` >> rw[]
+    >- (qexists_tac `0` >> gvs[step_n_cml_def])
+    >- (qexists_tac `SUC n` >> gvs[step_n_cml_def, decl_step_reln_def])
+    )
+QED
+
+Theorem small_eval_dec_eq_step_n_cml:
+  (small_eval_dec env dst (st, Rval e) ⇔
+    ∃n. step_n_cml env n (Dstep dst) = Dstep (st, Env e, [])) ∧
+  (small_eval_dec env dst (st, Rerr (Rraise v)) ⇔
+    ∃n dev dcs.
+      step_n_cml env n (Dstep dst) = Dstep (st, dev, dcs) ∧
+      decl_step env (st, dev, dcs) = Draise v) ∧
+  (small_eval_dec env dst (st, Rerr (Rabort err)) ⇔
+    ∃n dev dcs.
+      step_n_cml env n (Dstep dst) = Dstep (st, dev, dcs) ∧
+      decl_step env (st, dev, dcs) = Dabort err)
+Proof
+  rw[small_eval_dec_def, decl_step_reln_eq_step_n_cml] >>
+  eq_tac >> rw[PULL_EXISTS] >> rpt $ goal_assum drule
+QED
+
+Theorem dec_diverges_eq_step_to_halt_cml:
+  small_decl_diverges env dst ⇔ dstep_to_halt_cml env (Dstep dst) = NONE
+Proof
+  rw[dstep_to_halt_cml_def, small_decl_diverges_def,
+     decl_step_reln_eq_step_n_cml, PULL_EXISTS] >>
+  eq_tac >> rw[] >> gvs[e_step_reln_def]
+  >- (
+    DEEP_INTRO_TAC some_intro >> rw[] >>
+    Induct_on `x` >> rw[] >> gvs[step_n_cml_alt_def, is_halt_cml_def] >>
+    CASE_TAC >> gvs[] >>
+    last_x_assum drule >> strip_tac >> gvs[decl_step_reln_def, is_halt_cml_def]
+    )
+  >- (
+    last_x_assum mp_tac >> DEEP_INTRO_TAC some_intro >> rw[] >>
+    first_x_assum $ qspec_then `SUC n` assume_tac >>
+    gvs[step_n_cml_alt_def] >>
+    Cases_on `decl_step env b` >> gvs[is_halt_cml_def, decl_step_reln_def]
+    )
+QED
+
+
+(******************** Lemmas ********************)
+
+(***** trace_prefix *****)
+
+Theorem trace_prefix_prefix:
+  ∀n m oracle ffi t io res io' res'. n ≤ m ∧
+    trace_prefix n (oracle,ffi) t = (io,res) ∧
+    trace_prefix m (oracle,ffi) t = (io',res')
+  ⇒ io ≼ io'
+Proof
+  Induct >> rw[] >> gvs[trace_prefix_def] >>
+  Cases_on `m` >> gvs[] >> rename1 `_ ≤ m` >>
+  first_x_assum drule >> rw[] >>
+  Cases_on `t` >> gvs[trace_prefix_def] >>
+  PairCases_on `a` >> gvs[trace_prefix_def] >>
+  every_case_tac >> gvs[] >> rpt (pairarg_tac >> gvs[]) >> res_tac
+QED
+
+Theorem lprefix_chain_trace_prefix:
+  lprefix_chain
+    { fromList (a ++ io) | ∃n res. trace_prefix n (oracle,ffi) t = (io,res) }
+Proof
+  rw[lprefix_chain_def] >> simp[LPREFIX_fromList, from_toList] >>
+  Cases_on `n ≤ n'` >> imp_res_tac trace_prefix_prefix >> gvs[]
+QED
+
+Theorem trace_prefix_Div[simp]:
+  ∀n. trace_prefix n (oracle,ffi_st) Div = ([],NONE)
+Proof
+  Cases >> rw[trace_prefix_def]
+QED
+
+Theorem trace_prefix_SOME_mono:
+  ∀m n oracle ffi_st t io res.
+    trace_prefix n (oracle,ffi_st) t = (io, SOME res) ∧ n ≤ m
+  ⇒ trace_prefix m (oracle,ffi_st) t = (io, SOME res)
+Proof
+  Induct >> rw[] >> gvs[trace_prefix_def] >>
+  Cases_on `n` >> gvs[trace_prefix_def] >>
+  Cases_on `t` >> gvs[trace_prefix_def] >>
+  PairCases_on `a` >> gvs[trace_prefix_def] >> reverse CASE_TAC >> gvs[]
+  >- (first_x_assum drule_all >> simp[]) >>
+  CASE_TAC >> gvs[] >> rpt (pairarg_tac >> gvs[]) >>
+  first_x_assum drule_all >> simp[]
+QED
+
+Theorem trace_prefix_NONE_mono:
+  ∀m n oracle ffi_st t io res.
+    trace_prefix m (oracle,ffi_st) t = (io, NONE) ∧ n ≤ m
+  ⇒ ∃io'. isPREFIX io' io ∧ trace_prefix n (oracle,ffi_st) t = (io', NONE)
+Proof
+  Induct >> rw[] >> gvs[trace_prefix_def] >>
+  Cases_on `n` >> gvs[trace_prefix_def] >>
+  Cases_on `t` >> gvs[trace_prefix_def] >>
+  PairCases_on `a` >> gvs[trace_prefix_def] >> CASE_TAC >> gvs[] >>
+  CASE_TAC >> gvs[] >> rpt (pairarg_tac >> gvs[]) >>
+  first_x_assum drule_all >> rw[]
+QED
+
+
+(***** lprefix_lub *****)
+
+Theorem lprefix_lub_SING[simp]:
+  lprefix_lub { a } l ⇔ l = a
+Proof
+  eq_tac >> rw[lprefix_lub_def] >>
+  first_x_assum $ qspec_then `a` assume_tac >> gvs[LPREFIX_ANTISYM]
+QED
+
+Theorem lprefix_lub_LNIL[simp]:
+  lprefix_lub {fromList io | io = [] : io_event list} l = (l = [| |]) ∧
+  lprefix_lub ll [| |] = (∀l. l ∈ ll ⇒ l = [| |])
+Proof
+  rw[EXTENSION, lprefix_lub_def] >> eq_tac >> rw[] >>
+  pop_assum $ qspec_then `[||]` mp_tac >> simp[]
+QED
+
+Theorem lprefix_lub_LCONS:
+  lprefix_lub ls (h:::t) ⇒
+  ∀l. l ∈ ls ⇒ LHD l = NONE ∨ LHD l = SOME h
+Proof
+  rw[lprefix_lub_def] >> Cases_on `l` >> gvs[] >>
+  last_x_assum drule >> gvs[LPREFIX_LCONS]
+QED
+
+Theorem lprefix_lub_LTL:
+  lprefix_lub ls (h:::t) ∧
+  ltls = { ltl | ∃l. l ∈ ls ∧ LTL l = SOME ltl }
+  ⇒ lprefix_lub ltls t
+Proof
+  rw[lprefix_lub_def] >> gvs[LPREFIX_LCONS, PULL_EXISTS]
+  >- (first_x_assum drule >> rw[] >> gvs[]) >>
+  qpat_x_assum `∀ub. (∀ll. _) ⇒ _` $ qspec_then `h:::ub` mp_tac >>
+  simp[] >> disch_then irule >> rw[] >>
+  last_x_assum drule >> rw[] >> gvs[LPREFIX_LCONS] >>
+  last_x_assum irule >> goal_assum $ drule_at Any >> simp[]
+QED
+
+
+(***** smallStep FFI-state lemmas *****)
+
+Theorem io_events_mono_step_n_cml:
+  ∀env n dst1 dst2.
+    step_n_cml env n (Dstep dst1) = Dstep dst2
+  ⇒ io_events_mono (FST dst1).ffi (FST dst2).ffi
+Proof
+  strip_tac >> Induct >> rw[step_n_cml_alt_def] >>
+  irule io_events_mono_trans >>
+  last_x_assum $ irule_at Any >>
+  qspecl_then [`env`,`SUC n`,`Dstep dst1`,`dst2`] mp_tac step_n_cml_eq_Dstep >>
+  gvs[step_n_cml_alt_def] >>
+  disch_then $ qspec_then `n` mp_tac >> gvs[] >> strip_tac >> gvs[] >>
+  irule io_events_mono_decl_step >> simp[] >> goal_assum drule
+QED
+
+Theorem step_n_cml_preserved_FFI:
+  ∀n e e' env.
+    step_n_cml env n e = Dstep e' ∧ dget_ffi (Dstep e') = dget_ffi e
+  ⇒ ∀m. m < n ⇒ dget_ffi (step_n_cml env m e) = dget_ffi (Dstep e')
+Proof
+  rw[] >> imp_res_tac LESS_STRONG_ADD >>
+  gvs[step_n_cml_add |> ONCE_REWRITE_RULE[ADD_COMM]] >> rename1 `SUC n` >>
+  Cases_on `step_n_cml env m e` >> gvs[] >>
+  PairCases_on `p` >> rename1 `(dst1,dev1,dcs1)` >>
+  Cases_on `e` >> gvs[] >>
+  PairCases_on `p` >> rename1 `_ = dget_ffi $ _ (dst,dev,dcs)` >>
+  PairCases_on `e'` >>
+  rename1 `step_n_cml _ (SUC _) _ = Dstep (dst2,dev2,dcs2)` >>
+  imp_res_tac io_events_mono_step_n_cml >> gvs[dget_ffi_def] >>
+  imp_res_tac io_events_mono_antisym >> gvs[]
+QED
+
+
+(***** itree-based lemmas *****)
+
+Theorem step_n_alt_def:
+  step_n env 0 e = e ∧
+  step_n env (SUC n) e = (
+    case step_n env n e of
+    | Dstep dst dev dcs => dstep env dst dev dcs
+    | e => e)
+Proof
+  rw[step_n_def] >>
+  qid_spec_tac `e` >> qid_spec_tac `n` >>
+  Induct >> Cases >> rewrite_tac[step_n_def] >> simp[]
+QED
+
+Theorem step_n_add:
+  ∀a b. step_n env (a + b) e = step_n env a (step_n env b e)
+Proof
+  Induct >> rw[step_n_def] >>
+  simp[ADD_CLAUSES, step_n_alt_def]
+QED
+
+Theorem is_halt_step_n_eq:
+  ∀n m env e.
+    is_halt (step_n env n e) ∧
+    is_halt (step_n env m e)
+  ⇒ step_n env n e = step_n env m e
+Proof
+  rw[] >> wlog_tac `n < m` [`n`,`m`]
+  >- (Cases_on `n = m` >> gvs[]) >>
+  imp_res_tac LESS_STRONG_ADD >> gvs[] >>
+  gvs[step_n_add |> ONCE_REWRITE_RULE[ADD_COMM]] >>
+  Cases_on `step_n env n e` >> gvs[is_halt_def, step_n_def]
+QED
+
+Theorem application_thm:
+  ∀op env s vs c.
+    application op env s vs c =
+    if op = Opapp then
+      case do_opapp vs of
+      | NONE => Etype_error
+      | SOME (env,e) => Estep (env,s,Exp e,c)
+    else if ∃n. op = FFI n then (
+      case op of FFI n => (
+        case vs of
+          [Litv (StrLit conf); Loc lnum] => (
+            case store_lookup lnum s of
+              SOME (W8array ws) =>
+                if n = "" then Estep (env, s, Val $ Conv NONE [], c)
+                else Effi n (MAP (λc. n2w $ ORD c) (EXPLODE conf)) ws lnum env s c
+            | _ => Etype_error)
+        | _ => Etype_error)
+      | _ => ARB)
+    else
+      case do_app s op vs of
+      | NONE => Etype_error
+      | SOME (v1,Rval v') => return env v1 v' c
+      | SOME (v1,Rraise v) => Estep (env,v1,Val v,(Craise,env)::c)
+Proof
+  reverse $ rw[application_def] >> gvs[SF itree_ss] >>
+  TOP_CASE_TAC >> gvs[]
+QED
+
+Theorem application_FFI_results:
+  (application (FFI s) env st vs cs = Etype_error) ∨
+  (application (FFI s) env st vs cs = Estep (env, st, Val $ Conv NONE [], cs)) ∨
+  ∃conf ws lnum.
+    (application (FFI s) env st vs cs) = Effi s conf ws lnum env st cs
+Proof
+  rw[application_thm] >> every_case_tac >> gvs[]
+QED
+
+Theorem application_eq_Effi_fields:
+  application op env st vs cs = Effi s conf ws lnum env' st' cs' ⇒
+  op = FFI s ∧ env = env' ∧ st = st' ∧ cs' = cs ∧
+  ∃conf'.
+    vs = [Litv $ StrLit conf'; Loc lnum] ∧
+    conf = MAP (λc. n2w $ ORD c) (EXPLODE conf')
+Proof
+  Cases_on `op` >> simp[application_def, SF itree_ss] >>
+  every_case_tac >> gvs[] >> rw[]
+QED
+
+Theorem application_not_Edone:
+  application op env st_ffi vs cs ≠ Edone
+Proof
+  rw[application_thm] >>
+  every_case_tac >> gvs[SF itree_ss]
+QED
+
+Theorem estep_to_Edone:
+  estep (env, st, ev, cs) = Edone ⇔
+  (∃v. ev = Val v ∧ cs = []) ∨
+  (∃v env'. ev = Val v ∧ cs = [Craise, env'])
+Proof
+  reverse $ eq_tac
+  >- (rw[] >> gvs[SF itree_ss]) >>
+  Cases_on `ev` >> gvs[estep_def]
+  >- (
+    Cases_on `e` >> gvs[estep_def, SF itree_ss] >>
+    every_case_tac >> gvs[] >> rw[application_not_Edone]
+    ) >>
+  Cases_on `cs` >> gvs[SF itree_ss] >>
+  PairCases_on `h` >> Cases_on `h0` >> gvs[SF itree_ss] >>
+  every_case_tac >> gvs[]
+  >- (
+    rename1 `Capp _ _ es` >>
+    Cases_on `es` >> gvs[SF itree_ss, application_not_Edone]
+    )
+  >- (
+    rename1 `Cmat l _` >> Cases_on `l` >> gvs[SF itree_ss] >>
+    PairCases_on `h` >> gvs[SF itree_ss] >> every_case_tac >> gvs[]
+    )
+  >- (
+    rename1 `Ccon _ _ es` >> Cases_on `es` >> gvs[SF itree_ss] >>
+    every_case_tac >> gvs[]
+    )
+QED
+
+Theorem dstep_to_Ddone:
+  dstep env dst dev dcs = Ddone ⇔
+    ∃e. dev = Env e ∧ dcs = []
+Proof
+  Cases_on `∃d. dev = Decl d` >> gvs[]
+  >- (Cases_on `d` >> gvs[dstep_def] >> every_case_tac >> gvs[]) >>
+  Cases_on `∃e. dev = Env e` >> gvs[]
+  >- (
+    Cases_on `dcs` >> gvs[SF ditree_ss] >>
+    Cases_on `h` >> Cases_on `l` >> gvs[SF ditree_ss]
+    ) >>
+  Cases_on `dev` >> gvs[] >>
+  Cases_on `e` >> gvs[dstep_def]
+  >- (every_case_tac >> gvs[estep_to_Edone]) >>
+  Cases_on `l` >> gvs[dstep_def]
+  >- (every_case_tac >> gvs[]) >>
+  PairCases_on `h` >>
+  Cases_on `h0` >> Cases_on `t` >> gvs[dstep_def] >>
+  every_case_tac >> gvs[estep_to_Edone]
+QED
+
+Theorem is_halt_step_n_const:
+  ∀n env e. is_halt (step_n env n e) ⇒
+    ∀m. n < m ⇒ step_n env n e = step_n env m e
+Proof
+  Induct >> rw[step_n_def]
+  >- (Cases_on `e` >> gvs[is_halt_def]) >>
+  Cases_on `e` >> gvs[step_n_def, is_halt_def] >>
+  Cases_on `m` >> gvs[step_n_def]
+QED
+
+Theorem is_halt_step_n_min:
+  ∀n env e. is_halt (step_n env n e) ⇒
+  ∃m. m ≤ n ∧ step_n env m e = step_n env n e ∧
+      ∀l. l < m ⇒ ¬is_halt (step_n env l e)
+Proof
+  Induct >> rw[step_n_alt_def] >>
+  every_case_tac >> gvs[is_halt_def]
+  >- (
+    last_x_assum kall_tac >>
+    qexists_tac `SUC n` >> simp[step_n_alt_def] >> rw[] >>
+    CCONTR_TAC >> gvs[] >>
+    Cases_on `l' = n` >> gvs[is_halt_def] >>
+    drule is_halt_step_n_const >>
+    disch_then $ qspec_then `n` assume_tac >> gvs[is_halt_def]
+    ) >>
+  last_x_assum $ qspecl_then [`env`,`e`] assume_tac >> gvs[is_halt_def] >>
+  qexists_tac `m` >> simp[]
+QED
+
+Theorem step_until_halt_take_step:
+  ∀dst dev dcs env. ¬ is_halt (Dstep dst dev dcs)
+  ⇒ step_until_halt env (Dstep dst dev dcs) =
+    step_until_halt env (dstep env dst dev dcs)
+Proof
+  rw[step_until_halt_def] >>
+  DEEP_INTRO_TAC some_intro >> rw[] >>
+  DEEP_INTRO_TAC some_intro >> rw[]
+  >- (
+    qspecl_then [`x`,`SUC x'`,`env`,`Dstep dst dev dcs`]
+      assume_tac is_halt_step_n_eq >>
+    gvs[step_n_def]
+    )
+  >- (Cases_on `x` >> gvs[step_n_def])
+  >- (first_x_assum $ qspec_then `SUC x` assume_tac >> gvs[step_n_def])
+QED
+
+Theorem cml_itree_unfold_err:
+  cml_itree_unfold_err f seed =
+    case f seed of
+    | Ret' r => Ret r
+    | Div' => Div
+    | Vis' (s, ws1, ws2) g =>
+        Vis (s, ws1, ws2)
+          (λa. case a of
+                  INL x => Ret $ FinalFFI (s, ws1, ws2) x
+                | INR y =>
+                    if LENGTH ws2 = LENGTH y then cml_itree_unfold_err f (g y)
+                    else Ret $ FinalFFI (s, ws1, ws2) FFI_failed)
+Proof
+  CASE_TAC >> gvs[cml_itree_unfold_err_def] >>
+  simp[Once itree_unfold_err] >>
+  PairCases_on `e` >> gvs[]
+QED
+
+Theorem interp:
+  interp env e =
+    case step_until_halt env e of
+    | Ret => Ret Termination
+    | Err => Ret Error
+    | Div => Div
+    | Act dst (s,ws1,ws2,n,env',cs) locs p dcs =>
+        Vis (s, ws1, ws2)
+          (λa. case a of
+                | INL x => Ret $ FinalFFI (s, ws1, ws2) x
+                | INR y =>
+                    if LENGTH ws2 = LENGTH y then
+                      interp env $
+                        Dstep (dst with refs := LUPDATE (W8array y) n dst.refs)
+                          (ExpVal env' (Val $ Conv NONE []) cs locs p) dcs
+                    else Ret $ FinalFFI (s, ws1, ws2) FFI_failed)
+Proof
+  rw[interp_def] >> rw[Once cml_itree_unfold_err] >> simp[] >>
+  CASE_TAC >> gvs[] >> rw[FUN_EQ_THM] >> PairCases_on `p` >> gvs[]
+QED
+
+Theorem trace_prefix_interp:
+  trace_prefix 0 (oracle, ffi_st) (interp env e) = ([], NONE) ∧
+  trace_prefix (SUC n) (oracle, ffi_st) (interp env e) =
+    case step_until_halt env e of
+    | Ret => ([], SOME Termination)
+    | Err => ([], SOME Error)
+    | Div => ([], NONE)
+    | Act dst (s,conf,ws,lnum,env',cs) locs pat dcs =>
+        case oracle s ffi_st conf ws of
+        | Oracle_return ffi_st' ws' =>
+            if LENGTH ws ≠ LENGTH ws' ∧ n = 0 then
+              ([], NONE)
+            else if LENGTH ws ≠ LENGTH ws' then
+              ([], SOME $ FinalFFI (s, conf, ws) FFI_failed)
+            else let (io, res) =
+              trace_prefix n (oracle, ffi_st')
+                (interp env $
+                  Dstep (dst with refs := LUPDATE (W8array ws') lnum dst.refs)
+                    (ExpVal env' (Val $ Conv NONE []) cs locs pat) dcs)
+            in ((IO_event s conf (ZIP (ws,ws')))::io, res)
+        | Oracle_final outcome =>
+            if n = 0 then ([], NONE) else
+            ([], SOME $ FinalFFI (s, conf, ws) outcome)
+Proof
+  rw[trace_prefix_def] >> rw[Once interp] >>
+  CASE_TAC >> gvs[trace_prefix_def] >>
+  PairCases_on `p` >> gvs[trace_prefix_def] >>
+  reverse $ CASE_TAC >> gvs[]
+  >- (Cases_on `n` >> gvs[trace_prefix_def]) >>
+  IF_CASES_TAC >> gvs[] >>
+  Cases_on `n` >> gvs[trace_prefix_def]
+QED
+
+
+(****************************************)
+
+val _ = export_theory();
+


### PR DESCRIPTION
Create a version of the CakeML semantics based on interaction trees ("itrees"). Builds on #866 to lift the CEK-style semantics to a version producing itrees rather than using FFI oracles. Uses #869 to produce a compiler correctness theorem which is independent of FFI oracles.