### PR TITLE
Improvement (again) in printing failure handling

### DIFF
--- a/basis/pure/mlprettyprinterScript.sml
+++ b/basis/pure/mlprettyprinterScript.sml
@@ -85,7 +85,7 @@ End
 
 Definition pp_val_hidden_type_def:
   pp_val_hidden_type nm ty = PP_Data F
-    (List [strlit "val "; nm; strlit ": <hidden type "; ty; strlit ">\n"])
+    (List [strlit "val "; nm; strlit " <not printable> : "; ty; strlit "\n"])
 End
 
 Definition pp_failure_message_def:

--- a/compiler/printing/printTweaksScript.sml
+++ b/compiler/printing/printTweaksScript.sml
@@ -16,14 +16,29 @@ Definition print_failure_message_def:
 End
 
 Definition add_err_message_def:
-  add_err_message s decs tn ienv inf_st =
+  add_err_message s decs_ext st =
   (* something's gone wrong, try to add a message *)
+  let (tn, ienv, inf_st) = st in
   let pmsg = [print_failure_message s] in
   case infer_ds ienv pmsg inf_st of
-  (Success msg_ienv, inf_st2) =>
-      (Success (decs ++ pmsg, (tn, extend_dec_ienv msg_ienv ienv, inf_st2)))
+  | (Success msg_ienv, inf_st2) =>
+        (pmsg ++ decs_ext, (tn, extend_dec_ienv msg_ienv ienv, inf_st2))
   (* if even that fails, skip it *)
-  | (Failure _, _) => Success (decs, (tn, ienv, inf_st))
+  | (Failure _, _) => (decs_ext, (tn, ienv, inf_st))
+End
+
+Definition add_print_from_opts_def:
+  add_print_from_opts nm [] (decs_ext, st) =
+  add_err_message (strlit "exhausted print options for " ^ strlit nm) decs_ext st /\
+  add_print_from_opts nm (print_opt :: xs) (decs_ext, st) =
+  let (tn, ienv, inf_st) = st in
+  case infer_ds ienv [print_opt] inf_st of
+  | (Success ienv2, inf_st2) =>
+        (print_opt :: decs_ext, (tn, extend_dec_ienv ienv2 ienv, inf_st2))
+  | (Failure x, _) =>
+  let (decs_ext, st) = add_err_message
+        (strlit "adding val pretty-print: " ^ SND x) decs_ext st in
+  add_print_from_opts nm xs (decs_ext, st)
 End
 
 Definition add_print_features_def:
@@ -34,17 +49,16 @@ Definition add_print_features_def:
   (Success decs_ienv, inf_st) =>
   let (prints, tn2) = val_prints tn ienv decs_ienv in
   let ienv2 = extend_dec_ienv decs_ienv ienv in
-  (case infer_ds ienv2 prints inf_st of
-  (Success prints_ienv, inf_st2) =>
-      (Success (decs2 ++ prints, (tn2, extend_dec_ienv prints_ienv ienv2, inf_st2)))
-  | (Failure x, _) => add_err_message (strlit "adding val pretty-prints: " ^ SND x)
-        decs2 tn2 ienv2 inf_st
-  )
+  let (print_decs_ext, st) = FOLDR (\(nm, opts). add_print_from_opts nm opts)
+        ([], (tn2, ienv2, inf_st)) prints in
+  (Success (decs2 ++ REVERSE print_decs_ext, st))
   | (Failure x, _) =>
   (* maybe the default pretty-printer decs are the problem *)
   (case infer_ds ienv decs (init_infer_state <| next_id := next_id |>) of
-  (Success ienv3, inf_st3) => add_err_message (strlit "adding type pp funs: " ^ SND x)
-        decs tn (extend_dec_ienv ienv3 ienv) inf_st3
+  (Success ienv3, inf_st3) =>
+  let (decs_ext, st) = add_err_message (strlit "adding type pp funs: " ^ SND x)
+        [] (tn, extend_dec_ienv ienv3 ienv, inf_st3) in
+  (Success (decs ++ REVERSE decs_ext, st))
   | (Failure x, _) => Failure x
   )
 End
@@ -96,19 +110,103 @@ Proof
   )
 QED
 
+Theorem add_err_message_infer:
+  add_err_message s decs_ext (tn, extend_dec_ienv ienv init_ienv, inf_st) =
+    (decs_ext2, st2) /\
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  ?tn2 ienv_res inf_st2 ienv2.
+  st2 = (tn2, ienv_res, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  ienv_res = extend_dec_ienv ienv2 init_ienv
+Proof
+  simp [add_err_message_def]
+  \\ every_case_tac
+  \\ rw []
+  \\ simp [infer_ds_append]
+  \\ simp [extend_dec_ienv_def]
+QED
+
+Theorem add_print_from_opts_infer:
+  !opts decs_ext tn ienv inf_st decs_ext2 tn2 ienv_res inf_st2.
+  add_print_from_opts nm opts (decs_ext, (tn, extend_dec_ienv ienv init_ienv, inf_st)) =
+    (decs_ext2, st2) /\
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  ?tn2 ienv_res inf_st2 ienv2.
+  st2 = (tn2, ienv_res, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  ienv_res = extend_dec_ienv ienv2 init_ienv
+Proof
+  Induct
+  \\ rw [add_print_from_opts_def]
+  >- (
+    drule_then drule add_err_message_infer
+    \\ rw [] \\ simp []
+  )
+  \\ every_case_tac
+  >- (
+    gvs []
+    \\ simp [infer_ds_append]
+    \\ simp [extend_dec_ienv_def]
+  )
+  >- (
+    rpt (pairarg_tac \\ fs [])
+    \\ drule_then drule add_err_message_infer
+    \\ rw []
+    \\ first_x_assum (drule_then drule)
+    \\ simp []
+  )
+QED
+
+Triviality fold_add_print_from_opts_infer:
+  !xs decs_ext tn ienv inf_st decs_ext2 st2 tn2 ienv_res inf_st2.
+  FOLDR (\(nm, opts). add_print_from_opts nm opts)
+    (decs_ext, (tn, extend_dec_ienv ienv init_ienv, inf_st)) xs =
+    (decs_ext2, st2) /\
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  ?tn2 ienv_res inf_st2 ienv2.
+  st2 = (tn2, ienv_res, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  ienv_res = extend_dec_ienv ienv2 init_ienv
+Proof
+  Induct \\ rw [] \\ simp []
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ qmatch_asmsub_abbrev_tac `add_print_from_opts _ _ tup`
+  \\ Cases_on `tup`
+  \\ gvs [markerTheory.Abbrev_def, Q.ISPEC `(_, _)` EQ_SYM_EQ]
+  \\ first_x_assum (drule_then drule)
+  \\ rw []
+  \\ drule_then drule add_print_from_opts_infer
+  \\ simp []
+QED
+
+Triviality extend_none:
+  extend_dec_ienv <|inf_v := nsEmpty; inf_c := nsEmpty; inf_t := nsEmpty|> ienv = ienv
+Proof
+  simp [extend_dec_ienv_def, inf_env_component_equality]
+QED
+
+Triviality fold_add_print_from_opts_infer2 =
+    Q.SPECL [`xs`, `[]`] fold_add_print_from_opts_infer
+    |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
+
+Triviality add_err_message_infer2 = add_err_message_infer
+    |> Q.GENL [`decs_ext`, `ienv`, `inf_st`] |> Q.SPEC `[]`
+    |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
+
 Theorem add_print_features_succ:
   add_print_features st decs = (infer$Success (decs2, st2)) ==>
   ?tn ienv next_id tn2 ienv2 inf_st2.
   st = (tn, ienv, next_id) /\ st2 = (tn2, extend_dec_ienv ienv2 ienv, inf_st2) /\
   infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) = (Success ienv2, inf_st2)
 Proof
-  fs [add_print_features_def, add_err_message_def]
+  fs [add_print_features_def]
   \\ rpt (pairarg_tac \\ fs [])
   \\ simp [pairTheory.pair_case_eq, exc_case_eq]
   \\ rw []
   \\ rpt (pairarg_tac \\ fs [])
-  \\ fs [pairTheory.pair_case_eq, exc_case_eq]
-  \\ rpt VAR_EQ_TAC
+  \\ gvs []
+  \\ (drule fold_add_print_from_opts_infer2 ORELSE drule add_err_message_infer2)
+  \\ rw []
   \\ simp [infer_ds_append]
   \\ simp [extend_dec_ienv_def]
 QED

--- a/compiler/printing/printTweaksScript.sml
+++ b/compiler/printing/printTweaksScript.sml
@@ -236,16 +236,20 @@ QED
 Theorem print_features_infer_st_invs:
   (! env ds st x st2. infer_ds env ds st = (Success x, st2) /\ P st ==> P st2) ==>
   (! s ds env inf_st x y.
-    add_err_message s ds (env, inf_st) = (x, y) /\ P inf_st ==>
+    printTweaks$add_err_message s ds (env, inf_st) = (x, y) /\ P inf_st ==>
         P (SND y))
   /\
   (! opts nm ds env inf_st x y.
-  add_print_from_opts nm opts (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
+  printTweaks$add_print_from_opts nm opts (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
     P (SND y))
   /\
   (! xs ds env inf_st x y.
-  add_prints_from_opts xs (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
+  printTweaks$add_prints_from_opts xs (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
     P (SND y))
+  /\
+  (! st ds x. printTweaks$add_print_features st ds = Success x /\
+    P (init_infer_state <| next_id := SND (SND st) |>) ==> P (SND (SND (SND x)))
+  )
 Proof
   disch_tac
   \\ rpt conj_asm1_tac
@@ -272,6 +276,14 @@ Proof
     \\ PairCases_on `tup`
     \\ gvs [markerTheory.Abbrev_def, Q.ISPEC `(_, _)` EQ_SYM_EQ]
     \\ res_tac \\ fs []
+  )
+  >- (
+    simp [pairTheory.FORALL_PROD, add_print_features_def]
+    \\ rw [exc_case_eq, pairTheory.pair_case_eq]
+    \\ rpt (pairarg_tac \\ fs [])
+    \\ gvs []
+    \\ res_tac
+    \\ fs []
   )
 QED
 

--- a/compiler/printing/printTweaksScript.sml
+++ b/compiler/printing/printTweaksScript.sml
@@ -18,27 +18,34 @@ End
 Definition add_err_message_def:
   add_err_message s decs_ext st =
   (* something's gone wrong, try to add a message *)
-  let (tn, ienv, inf_st) = st in
+  let (ienv, inf_st) = st in
   let pmsg = [print_failure_message s] in
   case infer_ds ienv pmsg inf_st of
   | (Success msg_ienv, inf_st2) =>
-        (pmsg ++ decs_ext, (tn, extend_dec_ienv msg_ienv ienv, inf_st2))
+        (pmsg ++ decs_ext, (extend_dec_ienv msg_ienv ienv, inf_st2))
   (* if even that fails, skip it *)
-  | (Failure _, _) => (decs_ext, (tn, ienv, inf_st))
+  | (Failure _, _) => (decs_ext, (ienv, inf_st))
 End
 
 Definition add_print_from_opts_def:
   add_print_from_opts nm [] (decs_ext, st) =
-  add_err_message (strlit "exhausted print options for " ^ strlit nm) decs_ext st /\
+  add_err_message (strlit "exhausted print options for " ^ implode nm) decs_ext st /\
   add_print_from_opts nm (print_opt :: xs) (decs_ext, st) =
-  let (tn, ienv, inf_st) = st in
+  let (ienv, inf_st) = st in
   case infer_ds ienv [print_opt] inf_st of
   | (Success ienv2, inf_st2) =>
-        (print_opt :: decs_ext, (tn, extend_dec_ienv ienv2 ienv, inf_st2))
+        (print_opt :: decs_ext, (extend_dec_ienv ienv2 ienv, inf_st2))
   | (Failure x, _) =>
   let (decs_ext, st) = add_err_message
         (strlit "adding val pretty-print: " ^ SND x) decs_ext st in
   add_print_from_opts nm xs (decs_ext, st)
+End
+
+(* really just FOLDR but the translator can't get that right *)
+Definition add_prints_from_opts_def:
+  add_prints_from_opts [] decs_plus_st = decs_plus_st /\
+  add_prints_from_opts ((nm, opts) :: xs) decs_plus_st =
+  add_prints_from_opts xs (add_print_from_opts nm opts decs_plus_st)
 End
 
 Definition add_print_features_def:
@@ -49,16 +56,15 @@ Definition add_print_features_def:
   (Success decs_ienv, inf_st) =>
   let (prints, tn2) = val_prints tn ienv decs_ienv in
   let ienv2 = extend_dec_ienv decs_ienv ienv in
-  let (print_decs_ext, st) = FOLDR (\(nm, opts). add_print_from_opts nm opts)
-        ([], (tn2, ienv2, inf_st)) prints in
-  (Success (decs2 ++ REVERSE print_decs_ext, st))
+  let (print_decs_ext, i_st) = add_prints_from_opts prints ([], (ienv2, inf_st)) in
+  (Success (decs2 ++ REVERSE print_decs_ext, (tn2, i_st)))
   | (Failure x, _) =>
   (* maybe the default pretty-printer decs are the problem *)
   (case infer_ds ienv decs (init_infer_state <| next_id := next_id |>) of
   (Success ienv3, inf_st3) =>
-  let (decs_ext, st) = add_err_message (strlit "adding type pp funs: " ^ SND x)
-        [] (tn, extend_dec_ienv ienv3 ienv, inf_st3) in
-  (Success (decs ++ REVERSE decs_ext, st))
+  let (decs_ext, i_st) = add_err_message (strlit "adding type pp funs: " ^ SND x)
+        [] (extend_dec_ienv ienv3 ienv, inf_st3) in
+  (Success (decs ++ REVERSE decs_ext, (tn, i_st)))
   | (Failure x, _) => Failure x
   )
 End
@@ -111,11 +117,11 @@ Proof
 QED
 
 Theorem add_err_message_infer:
-  add_err_message s decs_ext (tn, extend_dec_ienv ienv init_ienv, inf_st) =
+  add_err_message s decs_ext (extend_dec_ienv ienv init_ienv, inf_st) =
     (decs_ext2, st2) /\
   infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
-  ?tn2 ienv_res inf_st2 ienv2.
-  st2 = (tn2, ienv_res, inf_st2) /\
+  ?ienv_res inf_st2 ienv2.
+  st2 = (ienv_res, inf_st2) /\
   infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
@@ -127,12 +133,12 @@ Proof
 QED
 
 Theorem add_print_from_opts_infer:
-  !opts decs_ext tn ienv inf_st decs_ext2 tn2 ienv_res inf_st2.
-  add_print_from_opts nm opts (decs_ext, (tn, extend_dec_ienv ienv init_ienv, inf_st)) =
+  !opts decs_ext ienv inf_st decs_ext2 ienv_res inf_st2.
+  add_print_from_opts nm opts (decs_ext, (extend_dec_ienv ienv init_ienv, inf_st)) =
     (decs_ext2, st2) /\
   infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
-  ?tn2 ienv_res inf_st2 ienv2.
-  st2 = (tn2, ienv_res, inf_st2) /\
+  ?ienv_res inf_st2 ienv2.
+  st2 = (ienv_res, inf_st2) /\
   infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
@@ -157,25 +163,25 @@ Proof
   )
 QED
 
-Triviality fold_add_print_from_opts_infer:
-  !xs decs_ext tn ienv inf_st decs_ext2 st2 tn2 ienv_res inf_st2.
-  FOLDR (\(nm, opts). add_print_from_opts nm opts)
-    (decs_ext, (tn, extend_dec_ienv ienv init_ienv, inf_st)) xs =
+Triviality add_prints_from_opts_infer:
+  !opts decs_ext ienv inf_st decs_ext2 st2 ienv_res inf_st2.
+  add_prints_from_opts opts
+    (decs_ext, (extend_dec_ienv ienv init_ienv, inf_st)) =
     (decs_ext2, st2) /\
   infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
-  ?tn2 ienv_res inf_st2 ienv2.
-  st2 = (tn2, ienv_res, inf_st2) /\
+  ?ienv_res inf_st2 ienv2.
+  st2 = (ienv_res, inf_st2) /\
   infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
-  Induct \\ rw [] \\ simp []
-  \\ rpt (pairarg_tac \\ fs [])
-  \\ qmatch_asmsub_abbrev_tac `add_print_from_opts _ _ tup`
+  Induct \\ simp [pairTheory.FORALL_PROD, add_prints_from_opts_def] \\ rw [] \\ simp []
+  \\ qmatch_asmsub_abbrev_tac `add_prints_from_opts _ tup`
   \\ Cases_on `tup`
   \\ gvs [markerTheory.Abbrev_def, Q.ISPEC `(_, _)` EQ_SYM_EQ]
+  \\ drule_then drule add_print_from_opts_infer
+  \\ rw []
   \\ first_x_assum (drule_then drule)
   \\ rw []
-  \\ drule_then drule add_print_from_opts_infer
   \\ simp []
 QED
 
@@ -185,12 +191,12 @@ Proof
   simp [extend_dec_ienv_def, inf_env_component_equality]
 QED
 
-Triviality fold_add_print_from_opts_infer2 =
-    Q.SPECL [`xs`, `[]`] fold_add_print_from_opts_infer
-    |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
-
 Triviality add_err_message_infer2 = add_err_message_infer
     |> Q.GENL [`decs_ext`, `ienv`, `inf_st`] |> Q.SPEC `[]`
+    |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
+
+Triviality add_prints_from_opts_infer2 =
+    Q.SPECL [`xs`, `[]`] add_prints_from_opts_infer
     |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
 
 Theorem add_print_features_succ:
@@ -205,7 +211,7 @@ Proof
   \\ rw []
   \\ rpt (pairarg_tac \\ fs [])
   \\ gvs []
-  \\ (drule fold_add_print_from_opts_infer2 ORELSE drule add_err_message_infer2)
+  \\ (drule add_prints_from_opts_infer2 ORELSE drule add_err_message_infer2)
   \\ rw []
   \\ simp [infer_ds_append]
   \\ simp [extend_dec_ienv_def]
@@ -224,6 +230,49 @@ Proof
   \\ gvs []
   \\ simp [infer_ds_append]
   \\ simp [extend_dec_ienv_def]
+QED
+
+(* preservation of inference invariants will be needed in translation *)
+Theorem print_features_infer_st_invs:
+  (! env ds st x st2. infer_ds env ds st = (Success x, st2) /\ P st ==> P st2) ==>
+  (! s ds env inf_st x y.
+    add_err_message s ds (env, inf_st) = (x, y) /\ P inf_st ==>
+        P (SND y))
+  /\
+  (! opts nm ds env inf_st x y.
+  add_print_from_opts nm opts (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
+    P (SND y))
+  /\
+  (! xs ds env inf_st x y.
+  add_prints_from_opts xs (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
+    P (SND y))
+Proof
+  disch_tac
+  \\ rpt conj_asm1_tac
+  >- (
+    rw [add_err_message_def]
+    \\ every_case_tac
+    \\ gvs []
+    \\ res_tac
+  )
+  >- (
+    Induct
+    \\ simp [pairTheory.FORALL_PROD, add_print_from_opts_def]
+    \\ rw [exc_case_eq, pairTheory.pair_case_eq]
+    \\ rpt (pairarg_tac \\ fs [])
+    \\ TRY (qmatch_asmsub_abbrev_tac `add_print_from_opts _ _ (_, tup) = _`
+      \\ Cases_on `tup`)
+    \\ res_tac \\ fs []
+  )
+  >- (
+    Induct
+    \\ simp [pairTheory.FORALL_PROD, add_prints_from_opts_def]
+    \\ rw [exc_case_eq, pairTheory.pair_case_eq]
+    \\ qmatch_asmsub_abbrev_tac `add_prints_from_opts _ tup`
+    \\ PairCases_on `tup`
+    \\ gvs [markerTheory.Abbrev_def, Q.ISPEC `(_, _)` EQ_SYM_EQ]
+    \\ res_tac \\ fs []
+  )
 QED
 
 val _ = export_theory ();

--- a/compiler/printing/test/printingTestScript.sml
+++ b/compiler/printing/test/printingTestScript.sml
@@ -114,7 +114,8 @@ val () = computeLib.extend_compset
       basicComputeLib.add_basic_compset
       ],
      computeLib.Defs
-      [test_prog_def, test_prog_pp_def, basis_ienv_def
+      [test_prog_def, test_prog_pp_def, basis_ienv_def,
+        add_print_from_opts_def
       ],
     computeLib.Tys
     [    ]
@@ -138,30 +139,30 @@ val infer_example_st = infer_example |> dest_pair |> snd
 val _ = if can (match_term ``(infer$Success _, _)``) infer_example then () else
     (print_term infer_example; failwith ("type inference failed on example prog"))
 
-val _ = print "Fetching type-name info and adding print statements.\n"
+val _ = print "Fetching type-name info and getting print decs.\n";
 
 val example_prints_eval = EVAL ``val_prints ^basis_tn basis_ienv ^infer_example_ienv``
-val example_print_decs = concl example_prints_eval |> rhs |> dest_pair |> fst
+val example_print_data = concl example_prints_eval |> rhs |> dest_pair |> fst
+val example_print_decs_eval = EVAL ``FLAT (MAP SND ^example_print_data)``
+val example_print_decs = concl example_print_decs_eval |> rhs |> listSyntax.dest_list |> fst
 
-val _ = print "Type-checking extended program.\n"
+val _ = print "Type-checking print decs.\n";
 
-val infer_with_prints_eval = inf_eval
-    ``infer_ds (extend_dec_ienv ^infer_example_ienv basis_ienv)
-        ^example_print_decs ^infer_example_st``
-val infer_with_prints = concl infer_with_prints_eval |> rhs
+val dec_tc_evals = map (fn d => inf_eval ``infer_ds (extend_dec_ienv ^infer_example_ienv basis_ienv)
+        [^d] ^infer_example_st``) example_print_decs
 
-val _ = if can (match_term ``(infer$Success _, _)``) infer_with_prints then () else
-    (print_term infer_with_prints;
+val fails = filter (not o can (match_term ``(infer$Success _, _)``) o rhs o concl) dec_tc_evals
+val _ = if null fails then () else
+    (print_thm (hd fails);
         failwith ("type inference failed on example prog with prints"))
 
-val _ = print "Combining to single theorem.\n"
+val _ = print "Assembling canonical extended prog.\n";
 
-(* show the above is a step-by-step evaluation of add_print_features *)
 val assembled = ``add_print_features (^basis_tn, basis_ienv, basis_infer_st.next_id) test_prog``
   |> (SIMP_CONV (srw_ss ()) [add_print_features_def, LET_THM,
         REWRITE_RULE [GSYM test_prog_pp_def] with_pp_eval,
-        start_st_eval, infer_example_eval, example_prints_eval,
-        infer_with_prints_eval]
+        start_st_eval, infer_example_eval, example_prints_eval]
+    THENC inf_eval
   )
 
 val prog_rhs = assembled |> concl |> rhs

--- a/compiler/printing/test/printingTestScript.sml
+++ b/compiler/printing/test/printingTestScript.sml
@@ -115,7 +115,8 @@ val () = computeLib.extend_compset
       ],
      computeLib.Defs
       [test_prog_def, test_prog_pp_def, basis_ienv_def,
-        add_print_from_opts_def
+        add_print_from_opts_def,
+        add_prints_from_opts_def
       ],
     computeLib.Tys
     [    ]


### PR DESCRIPTION
There are situations where the injected print code for "val _ = _ : _" may fail
to type check, e.g. if the necessary pp_X functions have somehow been shadowed
and got the wrong type, or maybe other ways.

To (yet again) try to handle this better, type check each val-print declaration
in isolation, handling the type error by replacing just that declaration with
a safer version from a range of 3 progressively safer options.

This should provide a little more information to the user in this case, rather
than a single error and the loss of information for the whole block.