### PR TITLE
Update handling of exceptions in small-step semantics

### DIFF
--- a/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
+++ b/semantics/alt_semantics/proofs/bigSmallEquivScript.sml
@@ -61,7 +61,9 @@ Proof
    >- (srw_tac[][return_def, small_eval_def, Once RTC_CASES1, e_step_reln_def, e_step_def] >>
        metis_tac [RTC_REFL])
    >- (full_simp_tac(srw_ss())[small_eval_def] >>
-       metis_tac [APPEND,e_step_add_ctxt])
+       simp[Once RTC_CASES2] >>
+       drule e_step_add_ctxt >> simp[] >> disch_then $ irule_at Any >>
+       simp[e_step_reln_def, e_step_def, continue_def])
    >- (`small_eval env (to_small_st s) e ([] ++ [(Craise (),env)]) (to_small_st s2, Rerr err)`
                by (match_mp_tac small_eval_err_add_ctxt >>
                    srw_tac[][]) >>
@@ -74,12 +76,12 @@ Proof
        metis_tac [transitive_def, transitive_RTC, RTC_SINGLE])
    >- (full_simp_tac(srw_ss())[small_eval_def] >>
        `e_step_reln^* (env,to_small_st s,Exp e,[(Chandle () pes,env)])
-                      (env',to_small_st s',Val v,[(Craise (),env'');(Chandle () pes,env)])`
+                      (env',to_small_st s',Exn v,[(Chandle () pes,env)])`
                   by metis_tac [APPEND,e_step_add_ctxt] >>
-       `e_step_reln (env',to_small_st s',Val v,[(Craise (),env'');(Chandle () pes,env)])
-                    (env'',to_small_st s',Val v,[(Cmat_check () pes v, env)])`
+       `e_step_reln (env',to_small_st s',Exn v,[(Chandle () pes,env)])
+                    (env',to_small_st s',Val v,[(Cmat_check () pes v, env)])`
                    by (srw_tac[][e_step_reln_def, e_step_def, continue_def, return_def]) >>
-       `e_step_reln (env'',to_small_st s',Val v,[(Cmat_check () pes v, env)])
+       `e_step_reln (env',to_small_st s',Val v,[(Cmat_check () pes v, env)])
                     (env,to_small_st s',Val v,[(Cmat () pes v, env)])`
                    by (srw_tac[][e_step_reln_def, e_step_def, continue_def, return_def]
                        \\ fs [to_small_st_def]) >>
@@ -95,12 +97,12 @@ Proof
                    transitive_def, e_single_error_add_ctxt])
    >- (full_simp_tac(srw_ss())[small_eval_def] >>
        `e_step_reln^* (env,to_small_st s,Exp e,[(Chandle () pes,env)])
-                      (env',to_small_st s2,Val v,[(Craise (),env'');(Chandle () pes,env)])`
+                      (env',to_small_st s2,Exn v,[(Chandle () pes,env)])`
                   by metis_tac [APPEND,e_step_add_ctxt] >>
-       `e_step_reln (env',to_small_st s2,Val v,[(Craise (),env'');(Chandle () pes,env)])
-                    (env'',to_small_st s2,Val v,[(Cmat_check () pes v, env)])`
+       `e_step_reln (env',to_small_st s2,Exn v,[(Chandle () pes,env)])
+                    (env',to_small_st s2,Val v,[(Cmat_check () pes v, env)])`
                    by (srw_tac[][e_step_reln_def, e_step_def, continue_def, return_def]) >>
-        `e_step (env'',to_small_st s2,Val v,[(Cmat_check () pes v, env)]) =
+        `e_step (env',to_small_st s2,Val v,[(Cmat_check () pes v, env)]) =
          Eabort Rtype_error` by
           (srw_tac[][e_step_reln_def, e_step_def, continue_def, return_def]
            \\ fs [to_small_st_def]) >>
@@ -133,23 +135,33 @@ Proof
           metis_tac [SRULE [SNOC_APPEND] SNOC_CASES] >>
        srw_tac[][small_eval_con] >>
        full_simp_tac(srw_ss())[Once small_eval_list_cases] >>
-       srw_tac[][small_eval_def] >|
-       [`e_step_reln^* (env,to_small_st s,Exp e,[(Ccon cn [] () (REVERSE es'),env)])
-                       (env',to_small_st s',Val err_v,[(Craise (), env'');(Ccon cn [] () (REVERSE es'),env)])`
+       srw_tac[][small_eval_def]
+       >- (
+        `e_step_reln^* (env,to_small_st s,Exp e,[(Ccon cn [] () (REVERSE es'),env)])
+                       (env',to_small_st s',Exn err_v,[(Ccon cn [] () (REVERSE es'),env)])`
                    by metis_tac [APPEND,e_step_add_ctxt] >>
-            `e_step_reln (env',to_small_st s',Val err_v,[(Craise (), env'');(Ccon cn [] () (REVERSE es'),env)])
-                         (env'',to_small_st s',Val err_v,[(Craise (), env'')])`
-                   by (srw_tac[][e_step_reln_def, e_step_def, continue_def, return_def]) >>
-            metis_tac [transitive_def, transitive_RTC, RTC_SINGLE],
+            `e_step_reln^* (env',to_small_st s',Exn err_v,[(Ccon cn [] () (REVERSE es'),env)])
+                         (env',to_small_st s',Exn err_v,[])`
+                   by (irule e_step_raise_lemma >> simp[]) >>
+            metis_tac [transitive_def, transitive_RTC, RTC_SINGLE]
+          )
+        >- (
         `LENGTH ([]:v list) + 1 + LENGTH es' = SUC (LENGTH es')` by
                    (full_simp_tac(srw_ss())[] >>
                     DECIDE_TAC) >>
-            metis_tac [small_eval_list_err, LENGTH_REVERSE, arithmeticTheory.ADD1],
-        metis_tac [APPEND, e_step_add_ctxt, transitive_RTC, transitive_def, e_single_error_add_ctxt],
+            metis_tac [small_eval_list_err, LENGTH_REVERSE, arithmeticTheory.ADD1]
+            )
+        >- (
+          metis_tac [APPEND, e_step_add_ctxt, transitive_RTC, transitive_def,
+                     e_single_error_add_ctxt]
+          )
+        >- (
         `LENGTH ([]:v list) + 1 + LENGTH es' = SUC (LENGTH es')` by
                    (full_simp_tac(srw_ss())[] >>
                     DECIDE_TAC) >>
-            metis_tac [small_eval_list_terr, arithmeticTheory.ADD1, LENGTH_REVERSE]])
+            metis_tac [small_eval_list_terr, arithmeticTheory.ADD1, LENGTH_REVERSE]
+          )
+        )
    >- (srw_tac[][small_eval_def] >>
        qexists_tac `env` >>
        srw_tac[][Once RTC_CASES1, e_step_reln_def, return_def, e_step_def])
@@ -355,7 +367,10 @@ Proof
      first_x_assum(qspec_then`ctx`strip_assume_tac)>>full_simp_tac(srw_ss())[] >>
      srw_tac[][Once RTC_CASES_RTC_TWICE,PULL_EXISTS] >>
      first_assum(match_exists_tac o concl) >> srw_tac[][] >>
-     srw_tac[][Once RTC_CASES1,e_step_reln_def,e_step_def,continue_def,Abbr`ctx`])
+     srw_tac[][Once RTC_CASES1,e_step_reln_def,e_step_def,continue_def,Abbr`ctx`] >>
+     srw_tac[][Once RTC_CASES1,e_step_reln_def,e_step_def,continue_def] >>
+     irule_at Any RTC_REFL
+     )
    >- (full_simp_tac(srw_ss())[small_eval_def] >>
        `e_step_reln^* (env,to_small_st s,Exp e,[(Clog op () e2,env)])
                       (env',to_small_st s',Val v,[(Clog op () e2,env)])`
@@ -470,11 +485,8 @@ Proof
      >- (
        fs [small_eval_def]
        >> simp [Once RTC_CASES2]
-       >> qexists_tac `env''`
-       >> qexists_tac `env''`
-       >> qexists_tac `(env',to_small_st (FST r),Val a,[(Craise (), env''); (Ctannot () t,env)])`
-       >> rw []
-       >- metis_tac [APPEND,e_step_add_ctxt]
+       >> qexists_tac `env'`
+       >> drule e_step_add_ctxt >> simp[] >> disch_then $ irule_at Any
        >> simp [e_step_reln_def, e_step_def, continue_def, return_def])
      >- (
        fs [small_eval_def]
@@ -500,11 +512,8 @@ Proof
      >- (
        fs [small_eval_def]
        >> simp [Once RTC_CASES2]
-       >> qexists_tac `env''`
-       >> qexists_tac `env''`
-       >> qexists_tac `(env',to_small_st (FST r),Val a,[(Craise (), env''); (Clannot () l,env)])`
-       >> rw []
-       >- metis_tac [APPEND,e_step_add_ctxt]
+       >> qexists_tac `env'`
+       >> drule e_step_add_ctxt >> simp[] >> disch_then $ irule_at Any
        >> simp [e_step_reln_def, e_step_def, continue_def, return_def])
      >- (
        fs [small_eval_def]
@@ -520,7 +529,8 @@ Proof
        metis_tac [APPEND,e_step_add_ctxt, small_eval_list_rules])
    >- (cases_on `err` >>
        full_simp_tac(srw_ss())[small_eval_def] >>
-       metis_tac [APPEND,e_step_add_ctxt, small_eval_list_rules])
+       metis_tac [APPEND,e_step_add_ctxt, small_eval_list_rules]
+       )
    >- (cases_on `err` >>
        full_simp_tac(srw_ss())[small_eval_def] >-
        metis_tac [APPEND,e_step_add_ctxt, small_eval_list_rules] >-
@@ -656,9 +666,19 @@ Proof
     >>~ [`evaluate_match`]
     >- simp[Once evaluate_cases, SF SFY_ss]
     >- simp[Once evaluate_cases, SF SFY_ss]
-    >- simp[Once evaluate_cases, SF SFY_ss] >>
+    >- simp[Once evaluate_cases, SF SFY_ss]
+    >- (
+      once_rewrite_tac[cj 2 evaluate_cases] >> simp[] >>
+      every_case_tac >> gvs[SF DNF_ss, SF SFY_ss] >>
+      gvs[evaluate_ctxts_cons] >> gvs[evaluate_ctxt_cases, SF SFY_ss]
+      ) >>
     once_rewrite_tac[cj 2 evaluate_cases] >> simp[SF DNF_ss] >>
     metis_tac[CONS_APPEND, APPEND_ASSOC]
+    )
+  >- (
+    gvs[AllCaseEqs()] >>
+    gvs[evaluate_state_cases, evaluate_ctxts_cons, evaluate_ctxt_cases,
+        evaluate_ctxts_cons, evaluate_ctxt_cases, ADD1, SF SFY_ss]
     )
 QED
 
@@ -816,13 +836,24 @@ Proof
     simp[state_component_equality] >> irule_at Any EQ_REFL >> simp[] >>
     qsuff_tac `s' with <| refs := s'.refs; ffi := s'.ffi |> = s'` >>
     rw[] >> simp[state_component_equality]
-    ) >>
-  pop_assum $ qspecl_then [`s'`,`s'.clock`] assume_tac >>
-  imp_res_tac evaluate_ignores_types_exns_eval >> gvs[] >>
-  pop_assum $ qspecl_then
-    [`s.eval_state`,`s.next_exn_stamp`,`s.next_type_stamp`] assume_tac >>
-  irule evaluate_change_state >> first_x_assum $ irule_at Any >>
-  imp_res_tac big_unclocked >> gvs[state_component_equality]
+    )
+  >- (
+    gvs[Once evaluate_state_cases] >> gvs[Once evaluate_ctxts_cases, PULL_EXISTS] >>
+    pop_assum $ qspecl_then [`s'`,`s'.clock`] assume_tac >>
+    imp_res_tac evaluate_ignores_types_exns_eval >> gvs[] >>
+    pop_assum $ qspecl_then
+      [`s.eval_state`,`s.next_exn_stamp`,`s.next_type_stamp`] assume_tac >>
+    irule evaluate_change_state >> first_x_assum $ irule_at Any >>
+    imp_res_tac big_unclocked >> gvs[state_component_equality]
+    )
+  >- (
+    pop_assum $ qspecl_then [`s'`,`s'.clock`] assume_tac >>
+    imp_res_tac evaluate_ignores_types_exns_eval >> gvs[] >>
+    pop_assum $ qspecl_then
+      [`s.eval_state`,`s.next_exn_stamp`,`s.next_type_stamp`] assume_tac >>
+    irule evaluate_change_state >> first_x_assum $ irule_at Any >>
+    imp_res_tac big_unclocked >> gvs[state_component_equality]
+    )
 QED
 
 Theorem e_diverges_big_clocked:
@@ -1695,22 +1726,23 @@ Proof
       imp_res_tac one_step_backward >>
       qsuff_tac `st with <| refs := st.refs; ffi := st.ffi |> = st` >>
       rw[] >> gvs[state_component_equality, SF SFY_ss]
-      ) >>
-    Cases_on `l = []` >> gvs[]
+      )
     >- (
-      every_case_tac >> gvs[evaluate_dec_state_cases] >>
-      simp[evaluate_state_val_no_ctxt_alt, PULL_EXISTS, SF SFY_ss]
-      ) >>
-    Cases_on `∃env. l = [Craise (), env]` >> gvs[] >>
-    `∃env' refs' ffi' ev' ec'.
-      e_step (s,(st.refs,st.ffi),Val v,l) = Estep (env',(refs',ffi'),ev',ec') ∧
-      st' = st with <| refs := refs'; ffi := ffi' |> ∧
-      dev' = ExpVal env' ev' ec' l0 p ∧ dcs' = dcs` by gvs[AllCaseEqs()] >>
-    last_x_assum kall_tac >> gvs[] >>
-    gvs[evaluate_dec_state_cases] >>
-    imp_res_tac one_step_backward >>
-    qsuff_tac `st with <| refs := st.refs; ffi := st.ffi |> = st` >>
-    rw[] >> gvs[state_component_equality, SF SFY_ss]
+      Cases_on `l = []` >> gvs[AllCaseEqs()]
+      >- (
+        gvs[evaluate_dec_state_cases] >>
+        simp[evaluate_state_val_no_ctxt_alt, PULL_EXISTS, SF SFY_ss]
+        ) >>
+      gvs[evaluate_dec_state_cases] >> imp_res_tac one_step_backward >>
+      qsuff_tac `st with <| refs := st.refs; ffi := st.ffi |> = st` >>
+      rw[] >> gvs[state_component_equality, SF SFY_ss]
+      )
+    >- (
+      gvs[AllCaseEqs()] >>
+      gvs[evaluate_dec_state_cases] >> imp_res_tac one_step_backward >>
+      qsuff_tac `st with <| refs := st.refs; ffi := st.ffi |> = st` >>
+      rw[] >> gvs[state_component_equality, SF SFY_ss]
+      )
     )
   >- (
     gvs[decl_continue_def] >> Cases_on `dcs` >> gvs[] >>

--- a/semantics/alt_semantics/proofs/bigSmallInvariantsScript.sml
+++ b/semantics/alt_semantics/proofs/bigSmallInvariantsScript.sml
@@ -127,7 +127,10 @@ Inductive evaluate_state:
       ⇒ evaluate_state ck (env, s, Exp e, c) bv) ∧
 
   (evaluate_ctxts ck (s with clock := clk) c (Rval v) bv
-      ⇒ evaluate_state ck (env, s, Val v, c) bv)
+      ⇒ evaluate_state ck (env, s, Val v, c) bv) ∧
+
+  (evaluate_ctxts ck (s with clock := clk) c (Rerr (Rraise v)) bv
+      ⇒ evaluate_state ck (env, s, Exn v, c) bv)
 End
 
 Definition lift_dec_result_def:

--- a/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
+++ b/semantics/alt_semantics/proofs/itree_semanticsEquivScript.sml
@@ -27,6 +27,7 @@ val dsmallstep_ss = simpLib.named_rewrites "dsmallstep_ss" [
     ];
 
 val itree_ss = simpLib.named_rewrites "itree_ss" [
+    itree_semanticsTheory.exn_continue_def,
     itree_semanticsTheory.continue_def,
     itree_semanticsTheory.return_def,
     itree_semanticsTheory.push_def,
@@ -84,12 +85,8 @@ Proof
   >- (simp[step_result_rel_cases, AllCaseEqs()] >> Cases_on `op` >> gvs[]) >>
   PairCases_on `x` >> PairCases_on `x'` >> gvs[] >>
   gvs[result_rel_cases, SF smallstep_ss, SF itree_ss] >>
-  simp[step_result_rel_cases, AllCaseEqs()]
-  >- (qexists_tac `cs1` >> simp[] >> Cases_on `op` >> gvs[])
-  >- (
-    qexists_tac `(Craise,env)::cs1` >> simp[] >> Cases_on `op` >> gvs[] >>
-    gvs[ctxt_rel_def] >> simp[ctxt_frame_rel_cases]
-    )
+  simp[step_result_rel_cases, AllCaseEqs()] >>
+  qexists_tac `cs1` >> simp[] >> Cases_on `op` >> gvs[]
 QED
 
 Theorem application_rel_FFI_type_error:
@@ -114,6 +111,32 @@ Proof
   every_case_tac >> gvs[] >> rw[] >> gvs[ffi_state_component_equality]
 QED
 
+Theorem dstep_ExpVal_Exp:
+  dstep env st (ExpVal env' (Exp e) cs locs p) dcs =
+  case estep (env',st.refs,Exp e,cs) of
+  | Estep (env',refs',ev',ec') =>
+      dreturn (st with refs := refs') dcs (ExpVal env' ev' ec' locs p)
+  | Effi s ws1 ws2 n env'' refs'' ec'' =>
+    Dffi (st with refs := refs'') (s,ws1,ws2,n,env'',ec'') locs p dcs
+  | Edone => Ddone
+  | Etype_error => Dtype_error
+Proof
+  Cases_on `cs` >> rw[SF ditree_ss]
+QED
+
+Theorem decl_step_ExpVal_Exp:
+  decl_step env (st,ExpVal env' (Exp e) ec locs p,c) =
+  case e_step (env',(st.refs,st.ffi),Exp e,ec) of
+    Estep (env',(refs',ffi'),ev',ec') =>
+      Dstep
+        (st with <|refs := refs'; ffi := ffi'|>,
+         ExpVal env' ev' ec' locs p,c)
+  | Eabort a => Dabort a
+  | Estuck => Ddone
+Proof
+  rw[decl_step_def] >> TOP_CASE_TAC >> simp[]
+QED
+
 
 (******************** Relating non-FFI steps ********************)
 
@@ -131,11 +154,70 @@ Theorem step_result_rel_single:
     ∀ffi. get_ffi (e_step eb) = SOME ffi ⇒ get_ffi (Estep eb) = SOME ffi
 Proof
   rpt PairCases >> rename1 `_ (_ (env,st,ev,cs1)) (_ (env',(st',ffi),ev',cs2))` >>
-  gvs[e_step_def] >>
-  every_case_tac >> gvs[estep_def, step_result_rel_cases] >> strip_tac >>
-  gvs[SF smallstep_ss, SF itree_ss, ctxt_rel_def, ctxt_frame_rel_cases, get_ffi_def] >>
-  gvs[GSYM ctxt_frame_rel_cases, GSYM step_result_rel_cases]
+  gvs[e_step_def] >> reverse $ TOP_CASE_TAC >> gvs[]
   >- (
+    simp[Once step_result_rel_cases] >> strip_tac >> gvs[] >>
+    TOP_CASE_TAC >> gvs[]
+    >- (gvs[ctxt_rel_def, SF smallstep_ss, SF itree_ss, step_result_rel_cases]) >>
+    TOP_CASE_TAC >> gvs[] >> TOP_CASE_TAC >> gvs[] >>
+    gvs[ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >> gvs[ctxt_frame_rel_cases] >>
+    pairarg_tac >> gvs[SF smallstep_ss, SF itree_ss, step_result_rel_cases] >>
+    simp[ctxt_rel_def] >> simp[GSYM ctxt_rel_def] >> simp[ctxt_frame_rel_cases]
+    )
+  >- (
+    gvs[estep_def, step_result_rel_cases] >> strip_tac >>
+    gvs[SF smallstep_ss, SF itree_ss, ctxt_rel_def, ctxt_frame_rel_cases, get_ffi_def] >>
+    gvs[GSYM ctxt_frame_rel_cases, GSYM step_result_rel_cases] >>
+    CASE_TAC >- gvs[continue_def, get_ffi_def] >>
+    PairCases_on `h` >> gvs[] >> PairCases_on `x` >> gvs[] >>
+    rename1 `ctxt_frame_rel c1 c2` >> rename1 `(c1,env)` >>
+    rename1 `LIST_REL _ rest1 rest2` >>
+    Cases_on `c1` >> gvs[SF itree_ss, ctxt_frame_rel_cases] >>
+    gvs[GSYM ctxt_frame_rel_cases, get_ffi_def]
+    >- (
+      reverse CASE_TAC >>
+      gvs[PULL_EXISTS, EXISTS_PROD, get_ffi_def, SF itree_ss]
+      >- simp[ctxt_frame_rel_cases] >>
+      rename1 `application op _ _ vs _` >>
+      reverse $ Cases_on `∃s. op = FFI s` >> gvs[]
+      >- (
+        reverse $ rw[]
+        >- (
+          drule application_ffi_unchanged >>
+          Cases_on `application op env (st,ffi) vs rest2` >> gvs[get_ffi_def] >>
+          PairCases_on `p` >> disch_then drule >> gvs[get_ffi_def]
+          )
+        >- (
+          drule application_rel >> gvs[ctxt_rel_def] >> disch_then drule >>
+          disch_then $ qspecl_then [`vs`,`st`,`ffi`,`env`] assume_tac >>
+          gvs[step_result_rel_cases, ctxt_rel_def]
+          )
+        ) >>
+      qspecl_then [`vs`,`st`,`s`,`env`,`rest1`]
+        assume_tac $ GEN_ALL application_FFI_results >> gvs[] >>
+      csimp[] >> gvs[is_Effi_def, get_ffi_def]
+      >- metis_tac[application_rel_FFI_type_error] >>
+      imp_res_tac application_rel_FFI_step >> gvs[get_ffi_def]
+      )
+    >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+    >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+    >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
+    >- (
+      CASE_TAC >> simp[SF itree_ss] >>
+      PairCases_on `h` >> simp[continue_def] >>
+      EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
+      )
+    >- (
+      TOP_CASE_TAC >> gvs[SF itree_ss] >>
+      EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
+      )
+    )
+  >- (
+    reverse $ every_case_tac >> gvs[estep_def, step_result_rel_cases] >> strip_tac >>
+    gvs[SF smallstep_ss, SF itree_ss, ctxt_rel_def, ctxt_frame_rel_cases, get_ffi_def] >>
+    gvs[GSYM ctxt_frame_rel_cases, GSYM step_result_rel_cases]
+    >- gvs[FST_THM, LAMBDA_PROD]
+    >- gvs[FST_THM, LAMBDA_PROD] >>
     rename1 `application op _ _ _ _` >>
     reverse $ Cases_on `∃s. op = FFI s` >> gvs[]
     >- (
@@ -157,66 +239,15 @@ Proof
     >- metis_tac[application_rel_FFI_type_error] >>
     imp_res_tac application_rel_FFI_step >> simp[get_ffi_def]
     )
-  >- gvs[FST_THM, LAMBDA_PROD]
-  >- gvs[FST_THM, LAMBDA_PROD] >>
-  CASE_TAC >- gvs[continue_def, get_ffi_def] >>
-  PairCases_on `h` >> gvs[] >> PairCases_on `x` >> gvs[] >>
-  rename1 `ctxt_frame_rel c1 c2` >> rename1 `(c1,env)` >>
-  rename1 `LIST_REL _ rest1 rest2` >>
-  Cases_on `c1` >> gvs[SF itree_ss, ctxt_frame_rel_cases] >>
-  gvs[GSYM ctxt_frame_rel_cases, get_ffi_def]
-  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
-  >- (
-    reverse CASE_TAC >>
-    gvs[PULL_EXISTS, EXISTS_PROD, get_ffi_def, SF itree_ss]
-    >- simp[ctxt_frame_rel_cases] >>
-    rename1 `application op _ _ vs _` >>
-    reverse $ Cases_on `∃s. op = FFI s` >> gvs[]
-    >- (
-      reverse $ rw[]
-      >- (
-        drule application_ffi_unchanged >>
-        Cases_on `application op env (st,ffi) vs rest2` >> gvs[get_ffi_def] >>
-        PairCases_on `p` >> disch_then drule >> gvs[get_ffi_def]
-        )
-      >- (
-        drule application_rel >> gvs[ctxt_rel_def] >> disch_then drule >>
-        disch_then $ qspecl_then [`vs`,`st`,`ffi`,`env`] assume_tac >>
-        gvs[step_result_rel_cases, ctxt_rel_def]
-        )
-      ) >>
-    qspecl_then [`vs`,`st`,`s`,`env`,`rest1`]
-      assume_tac $ GEN_ALL application_FFI_results >> gvs[] >>
-    csimp[] >> gvs[is_Effi_def, get_ffi_def]
-    >- metis_tac[application_rel_FFI_type_error] >>
-    imp_res_tac application_rel_FFI_step >> gvs[get_ffi_def]
-    )
-  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
-  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
-  >- (EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases])
-  >- (
-    CASE_TAC >> gvs[PULL_EXISTS, EXISTS_PROD, get_ffi_def, SF itree_ss]
-    >- simp[ctxt_frame_rel_cases] >>
-    CASE_TAC >>  gvs[SF itree_ss] >>
-    EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
-    )
-  >- (
-    TOP_CASE_TAC >> gvs[SF itree_ss] >>
-    EVERY_CASE_TAC >> gvs[get_ffi_def, ctxt_frame_rel_cases]
-    )
 QED
 
 Theorem is_Dffi_eq_is_Effi_single:
   is_Dffi (dstep env dsta (ExpVal env' ev cs l p) dcs) ⇔
   is_Effi (estep (env',dsta.refs,ev,cs))
 Proof
-  Cases_on `ev` >> rw[SF ditree_ss, SF itree_ss]
-  >- (every_case_tac >> gvs[is_Effi_def, is_Dffi_def]) >>
-  Cases_on `cs` >> rw[SF ditree_ss, SF itree_ss, is_Effi_def, is_Dffi_def]
-  >- (every_case_tac >> gvs[]) >>
-  PairCases_on `h` >> Cases_on `h0` >> Cases_on `t` >>
-  rw[SF ditree_ss, SF itree_ss, is_Effi_def, is_Dffi_def] >>
-  every_case_tac >> gvs[]
+  Cases_on `ev` >> rw[SF ditree_ss, SF itree_ss] >>
+  Cases_on `cs` >> rw[SF ditree_ss, SF itree_ss, is_Effi_def, is_Dffi_def] >>
+  every_case_tac >> gvs[is_Effi_def, is_Dffi_def]
 QED
 
 Theorem dstep_result_rel_single:
@@ -241,34 +272,52 @@ Proof
     Cases_on `l` >> gvs[SF dsmallstep_ss, SF ditree_ss] >>
     simp[dstep_result_rel_cases, deval_rel_cases, dget_ffi_def]
     ) >>
-  Cases_on `ev` >> gvs[SF dsmallstep_ss, SF ditree_ss]
+  Cases_on `ev` >> gvs[]
   >- (
-    `¬is_Effi (estep (env',dsta.refs,Exp e,cs))` by (
-      every_case_tac >> gvs[is_Effi_def, is_Dffi_def]) >>
+    `¬is_Effi (estep (env',dsta.refs,Exp e,cs))` by gvs[is_Dffi_eq_is_Effi_single] >>
+    simp[dstep_ExpVal_Exp, decl_step_ExpVal_Exp] >>
     drule_at Any step_result_rel_single >>
     simp[Once step_result_rel_cases, PULL_EXISTS] >>
     disch_then drule >> disch_then $ qspec_then `db0.ffi` assume_tac >>
     rgs[dstate_rel_def, get_ffi_def] >>
     pop_assum mp_tac >> rw[step_result_rel_cases] >> gvs[dget_ffi_def, get_ffi_def] >>
     simp[dstep_result_rel_cases, deval_rel_cases, dstate_rel_def]
-    ) >>
-  Cases_on `cs` >> gvs[]
+    )
   >- (
-    gvs[ctxt_rel_def, SF dsmallstep_ss, SF ditree_ss, dstate_rel_def] >>
-    every_case_tac >> gvs[] >>
-    gvs[dstep_result_rel_cases, deval_rel_cases, dstate_rel_def, dget_ffi_def]
-    ) >>
-  gvs[ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >>
-  pairarg_tac >> gvs[] >> pairarg_tac >> gvs[] >>
-  gvs[is_Dffi_eq_is_Effi_single] >>
-  drule_at Any step_result_rel_single >> simp[FORALL_PROD] >>
-  simp[step_result_rel_cases, ctxt_rel_def] >>
-  simp[GSYM ctxt_rel_def, PULL_EXISTS, FORALL_PROD] >> disch_then drule_all >>
-  disch_then $ qspec_then `db0.ffi` mp_tac >> rw[] >> gvs[] >>
-  gvs[dstate_rel_def, dget_ffi_def, get_ffi_def] >>
-  every_case_tac >> gvs[ctxt_frame_rel_cases, SF ditree_ss] >>
-  Cases_on `t` >> gvs[ctxt_rel_def, SF ditree_ss] >>
-  gvs[dstep_result_rel_cases, dstate_rel_def, deval_rel_cases, ctxt_rel_def]
+    Cases_on `cs` >> gvs[]
+    >- (
+      gvs[ctxt_rel_def, SF dsmallstep_ss, SF ditree_ss, dstate_rel_def] >>
+      every_case_tac >> gvs[] >>
+      gvs[dstep_result_rel_cases, deval_rel_cases, dstate_rel_def, dget_ffi_def]
+      ) >>
+    gvs[ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >>
+    pairarg_tac >> gvs[] >> pairarg_tac >> gvs[] >>
+    gvs[is_Dffi_eq_is_Effi_single] >>
+    drule_at Any step_result_rel_single >> simp[FORALL_PROD] >>
+    simp[step_result_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, PULL_EXISTS, FORALL_PROD] >> disch_then drule_all >>
+    disch_then $ qspec_then `db0.ffi` mp_tac >> rw[] >> gvs[] >>
+    gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    gvs[dstate_rel_def, dget_ffi_def, get_ffi_def] >>
+    gvs[dstep_result_rel_cases, dstate_rel_def, deval_rel_cases, ctxt_rel_def]
+    )
+  >- (
+    Cases_on `cs` >> gvs[]
+    >- (
+      gvs[ctxt_rel_def, SF dsmallstep_ss, SF ditree_ss, dstate_rel_def] >>
+      gvs[dstep_result_rel_cases]
+      ) >>
+    gvs[ctxt_rel_def] >> gvs[GSYM ctxt_rel_def] >>
+    pairarg_tac >> gvs[] >> pairarg_tac >> gvs[] >>
+    gvs[is_Dffi_eq_is_Effi_single] >>
+    drule_at Any step_result_rel_single >> simp[FORALL_PROD] >>
+    simp[step_result_rel_cases, ctxt_rel_def] >>
+    simp[GSYM ctxt_rel_def, PULL_EXISTS, FORALL_PROD] >> disch_then drule_all >>
+    disch_then $ qspec_then `db0.ffi` mp_tac >> rw[] >> gvs[] >>
+    gvs[SF dsmallstep_ss, SF ditree_ss] >>
+    gvs[dstate_rel_def, dget_ffi_def, get_ffi_def] >>
+    gvs[dstep_result_rel_cases, dstate_rel_def, deval_rel_cases, ctxt_rel_def]
+    )
 QED
 
 Theorem dstep_result_rel_n:


### PR DESCRIPTION
Ensures that the CESK-machine only inspects the top element of the stack. This is morally the same as before (and all the equivalences/top-level results are unchanged), so this is more of an aesthetic change.