### PR TITLE
Array.appi fix

### DIFF
--- a/basis/ArrayProgScript.sml
+++ b/basis/ArrayProgScript.sml
@@ -113,7 +113,8 @@ val array_appi_aux = process_topdecs
   `fun appi_aux f arr max n =
     if n = max
       then ()
-    else (f n (sub arr n); app_aux f arr max (n + 1))`
+    else (f n (sub arr n): unit;
+          appi_aux f arr max (n + 1))`
 
 val _ = append_prog array_appi_aux;
 

--- a/basis/ArrayProofScript.sml
+++ b/basis/ArrayProofScript.sml
@@ -383,6 +383,79 @@ Proof
   rw [NUM_def]
 QED
 
+Theorem array_appi_aux_spec:
+   ∀l idx len_v idx_v a_v f_v eff.
+   NUM (LENGTH l) len_v ∧
+   NUM idx idx_v ∧
+   idx ≤ LENGTH l ∧
+   (!n n_v.
+      n < LENGTH l ∧
+      NUM n n_v ⇒
+      app p f_v [n_v; EL n l] (eff l n)
+                (POSTv v. &UNIT_TYPE () v * (eff l (n+1))))
+   ⇒
+   app (p:'ffi ffi_proj) Array_appi_aux_v [f_v; a_v; len_v; idx_v]
+     (eff l idx * ARRAY a_v l)
+     (POSTv v. &UNIT_TYPE () v * (eff l (LENGTH l)) * ARRAY a_v l)
+Proof
+  ntac 2 gen_tac >>
+  completeInduct_on `LENGTH l - idx` >>
+  xcf_with_def "Array.appi_aux" Array_appi_aux_v_def >>
+  rw [] >>
+  xlet `POSTv env_v. eff l idx * ARRAY a_v l * &BOOL (idx = LENGTH l) env_v`
+  >- (
+    xapp_spec eq_num_v_thm >>
+    xsimpl >>
+    fs [NUM_def, BOOL_def, INT_def]) >>
+  xif
+  >- (
+    xret >>
+    xsimpl) >>
+  xlet `POSTv x_v. eff l idx * ARRAY a_v l * &(EL idx l = x_v)`
+  >- (
+    xapp >>
+    xsimpl >>
+    qexists_tac `idx` >>
+    rw []) >>
+  xlet `POSTv u_v. eff l (idx + 1) * ARRAY a_v l`
+  >- (
+    first_x_assum (qspec_then `idx` mp_tac) >>
+    simp [] >>
+    disch_then xapp_spec >>
+    xsimpl) >>
+  xlet `POSTv next_idx_v. eff l (idx + 1) * ARRAY a_v l * & NUM (idx + 1) next_idx_v`
+  >- (
+    xapp >>
+    xsimpl >>
+    fs [NUM_def, INT_def] >>
+    intLib.ARITH_TAC) >>
+  first_x_assum xapp_spec >>
+  simp []
+QED
+
+(* eff is the effect of executing the function on the first n elements of l *)
+Theorem array_appi_spec:
+   ∀l a_v f_v eff.
+   (!n n_v.
+     n < LENGTH l ∧
+     NUM n n_v ⇒
+     app p f_v [n_v; EL n l] (eff l n)
+               (POSTv v. &UNIT_TYPE () v * (eff l (n+1))))
+   ⇒
+   app (p:'ffi ffi_proj) ^(fetch_v "Array.appi" array_st) [f_v; a_v]
+     (eff l 0 * ARRAY a_v l)
+     (POSTv v. &UNIT_TYPE () v * (eff l (LENGTH l)) * ARRAY a_v l)
+Proof
+  rw [] >>
+  xcf "Array.appi" array_st  >>
+  xlet `POSTv len_v. eff l 0 * ARRAY a_v l * &NUM (LENGTH l) len_v`
+  >- (
+    xapp >>
+    xsimpl) >>
+  xapp >>
+  rw [NUM_def]
+QED
+
 val list_rel_take_thm = Q.prove(
   `!A xs ys n.
       LIST_REL A xs ys ==> LIST_REL A (TAKE n xs) (TAKE n ys)`,


### PR DESCRIPTION
Fixes `Array.appi`. The implementation of `Array.appi` accidentally called `Array.app` in its recursive call, giving the function a strange type signature (and probably a strange behavior, too). This also adds a CF spec. theorem for `appi` to ArrayProofScript.sml.

Closes #876.