### PR TITLE
Enable empty_ffi and linear scan allocator for REPL

### DIFF
--- a/compiler/backend/README.md
+++ b/compiler/backend/README.md
@@ -11,7 +11,7 @@ This directory contains the ARMv7-specific part of the compiler backend.
 This directory contains the ARMv8-specific part of the compiler backend.
 
 [arm8_asl](arm8_asl):
-This directory contains the ASL-derived ARMv8-specific part of the
+This directory contains proofs for the ASL-derived ARMv8-specific part of the
 compiler backend.
 
 [backendComputeLib.sml](backendComputeLib.sml):

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -562,17 +562,22 @@ val compile_inc_progs_def = Define`
     let (env_id,p) = p_tup in
     let ps = empty_progs with <| env_id := env_id; source_prog := p |> in
     let (c',p) = source_to_flat$inc_compile env_id c.source_conf p in
+    let _ = empty_ffi (strlit "finished: source_to_flat") in
     let ps = ps with <| flat_prog := keep_progs k p |> in
     let c = c with source_conf := c' in
     let p = flat_to_clos_inc_compile p in
+    let _ = empty_ffi (strlit "finished: flat_to_clos") in
     let ps = ps with <| clos_prog := (keep_progs k ## keep_progs k) p |> in
     let (c',p) = clos_to_bvl_compile_inc c.clos_conf p in
+    let _ = empty_ffi (strlit "finished: clos_to_bvl") in
     let c = c with clos_conf := c' in
     let ps = ps with <| bvl_prog := keep_progs k p |> in
     let (c', p) = bvl_to_bvi_compile_inc_all c.bvl_conf p in
+    let _ = empty_ffi (strlit "finished: bvl_to_bvi") in
     let c = c with <| bvl_conf := c' |> in
     let ps = ps with <| bvi_prog := keep_progs k p |> in
     let p = bvi_to_data_compile_prog p in
+    let _ = empty_ffi (strlit "finished: bvi_to_data") in
     let ps = ps with <| data_prog := keep_progs k p |> in
     let asm_c = c.lab_conf.asm_conf in
     let dc = ensure_fp_conf_ok asm_c c.data_conf in
@@ -580,9 +585,11 @@ val compile_inc_progs_def = Define`
     let reg_count1 = asm_c.reg_count - (5 + LENGTH asm_c.avoid_regs) in
     let p = MAP (\p. full_compile_single asm_c.two_reg_arith reg_count1
         c.word_to_word_conf.reg_alg asm_c (p, NONE)) p in
+    let _ = empty_ffi (strlit "finished: data_to_word") in
     let ps = ps with <| word_prog := keep_progs k p |> in
     let bm0 = c.word_conf.bitmaps_length in
     let (p, fs, bm) = compile_word_to_stack reg_count1 p (Nil, bm0) in
+    let _ = empty_ffi (strlit "finished: word_to_stack") in
     let cur_bm = append (FST bm) in
     let c = c with word_conf := (c.word_conf with bitmaps_length := SND bm) in
     let ps = ps with <| stack_prog := keep_progs k p ; cur_bm := cur_bm |> in
@@ -590,8 +597,10 @@ val compile_inc_progs_def = Define`
     let p = stack_to_lab$compile_no_stubs
         c.stack_conf.reg_names c.stack_conf.jump asm_c.addr_offset
         reg_count2 p in
+    let _ = empty_ffi (strlit "finished: stack_to_lab") in
     let ps = ps with <| lab_prog := keep_progs k p |> in
     let target = lab_to_target$compile c.lab_conf (p:'a prog) in
+    let _ = empty_ffi (strlit "finished: lab_to_target") in
     let ps = ps with <| target_prog := OPTION_MAP
         (\(bytes, _). (bytes, cur_bm)) target |> in
     let c = c with lab_conf updated_by (case target of NONE => I

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -562,22 +562,17 @@ val compile_inc_progs_def = Define`
     let (env_id,p) = p_tup in
     let ps = empty_progs with <| env_id := env_id; source_prog := p |> in
     let (c',p) = source_to_flat$inc_compile env_id c.source_conf p in
-    let _ = empty_ffi (strlit "finished: source_to_flat") in
     let ps = ps with <| flat_prog := keep_progs k p |> in
     let c = c with source_conf := c' in
     let p = flat_to_clos_inc_compile p in
-    let _ = empty_ffi (strlit "finished: flat_to_clos") in
     let ps = ps with <| clos_prog := (keep_progs k ## keep_progs k) p |> in
     let (c',p) = clos_to_bvl_compile_inc c.clos_conf p in
-    let _ = empty_ffi (strlit "finished: clos_to_bvl") in
     let c = c with clos_conf := c' in
     let ps = ps with <| bvl_prog := keep_progs k p |> in
     let (c', p) = bvl_to_bvi_compile_inc_all c.bvl_conf p in
-    let _ = empty_ffi (strlit "finished: bvl_to_bvi") in
     let c = c with <| bvl_conf := c' |> in
     let ps = ps with <| bvi_prog := keep_progs k p |> in
     let p = bvi_to_data_compile_prog p in
-    let _ = empty_ffi (strlit "finished: bvi_to_data") in
     let ps = ps with <| data_prog := keep_progs k p |> in
     let asm_c = c.lab_conf.asm_conf in
     let dc = ensure_fp_conf_ok asm_c c.data_conf in
@@ -585,11 +580,9 @@ val compile_inc_progs_def = Define`
     let reg_count1 = asm_c.reg_count - (5 + LENGTH asm_c.avoid_regs) in
     let p = MAP (\p. full_compile_single asm_c.two_reg_arith reg_count1
         c.word_to_word_conf.reg_alg asm_c (p, NONE)) p in
-    let _ = empty_ffi (strlit "finished: data_to_word") in
     let ps = ps with <| word_prog := keep_progs k p |> in
     let bm0 = c.word_conf.bitmaps_length in
     let (p, fs, bm) = compile_word_to_stack reg_count1 p (Nil, bm0) in
-    let _ = empty_ffi (strlit "finished: word_to_stack") in
     let cur_bm = append (FST bm) in
     let c = c with word_conf := (c.word_conf with bitmaps_length := SND bm) in
     let ps = ps with <| stack_prog := keep_progs k p ; cur_bm := cur_bm |> in
@@ -597,10 +590,8 @@ val compile_inc_progs_def = Define`
     let p = stack_to_lab$compile_no_stubs
         c.stack_conf.reg_names c.stack_conf.jump asm_c.addr_offset
         reg_count2 p in
-    let _ = empty_ffi (strlit "finished: stack_to_lab") in
     let ps = ps with <| lab_prog := keep_progs k p |> in
     let target = lab_to_target$compile c.lab_conf (p:'a prog) in
-    let _ = empty_ffi (strlit "finished: lab_to_target") in
     let ps = ps with <| target_prog := OPTION_MAP
         (\(bytes, _). (bytes, cur_bm)) target |> in
     let c = c with lab_conf updated_by (case target of NONE => I
@@ -727,28 +718,37 @@ Theorem compile_inc_progs_for_eval_eq:
   compile_inc_progs_for_eval asm_c' (env_id,inc_c,p) =
     let c = inc_config_to_config asm_c' inc_c in
     let (c',p) = source_to_flat$inc_compile env_id c.source_conf p in
+    let _ = empty_ffi (strlit "finished: source_to_flat") in
     let c = c with source_conf := c' in
     let p = flat_to_clos_inc_compile p in
+    let _ = empty_ffi (strlit "finished: flat_to_clos") in
     let (c',p) = clos_to_bvl_compile_inc c.clos_conf p in
+    let _ = empty_ffi (strlit "finished: clos_to_bvl") in
     let c = c with clos_conf := c' in
     let (c', p) = bvl_to_bvi_compile_inc_all c.bvl_conf p in
+    let _ = empty_ffi (strlit "finished: bvl_to_bvi") in
     let c = c with <| bvl_conf := c' |> in
     let p = bvi_to_data_compile_prog p in
+    let _ = empty_ffi (strlit "finished: bvi_to_data") in
     let asm_c = c.lab_conf.asm_conf in
     let dc = ensure_fp_conf_ok asm_c' c.data_conf in
     let p = MAP (compile_part dc) p in
     let reg_count1 = asm_c'.reg_count - (5 + LENGTH asm_c'.avoid_regs) in
     let p = MAP (\p. full_compile_single asm_c'.two_reg_arith reg_count1
         c.word_to_word_conf.reg_alg asm_c' (p, NONE)) p in
+    let _ = empty_ffi (strlit "finished: data_to_word") in
     let bm0 = c.word_conf.bitmaps_length in
     let (p, fs, bm) = compile_word_to_stack reg_count1 p (Nil, bm0) in
+    let _ = empty_ffi (strlit "finished: word_to_stack") in
     let cur_bm = append (FST bm) in
     let c = c with word_conf := (c.word_conf with bitmaps_length := SND bm) in
     let reg_count2 = asm_c'.reg_count - (3 + LENGTH asm_c'.avoid_regs) in
     let p = stack_to_lab$compile_no_stubs
         c.stack_conf.reg_names c.stack_conf.jump asm_c'.addr_offset
         reg_count2 p in
+    let _ = empty_ffi (strlit "finished: stack_to_lab") in
     let target = lab_to_target$compile c.lab_conf (p:'a prog) in
+    let _ = empty_ffi (strlit "finished: lab_to_target") in
     let c = c with lab_conf updated_by (case target of NONE => I
                                         | SOME (_, c') => K c') in
       OPTION_MAP (λx. (config_to_inc_config c,FST x,MAP upper_w2w cur_bm)) target

--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -734,7 +734,7 @@ Theorem compile_inc_progs_for_eval_eq:
     let dc = ensure_fp_conf_ok asm_c' c.data_conf in
     let p = MAP (compile_part dc) p in
     let reg_count1 = asm_c'.reg_count - (5 + LENGTH asm_c'.avoid_regs) in
-    let p = MAP (\p. full_compile_single asm_c'.two_reg_arith reg_count1
+    let p = MAP (\p. full_compile_single_for_eval asm_c'.two_reg_arith reg_count1
         c.word_to_word_conf.reg_alg asm_c' (p, NONE)) p in
     let _ = empty_ffi (strlit "finished: data_to_word") in
     let bm0 = c.word_conf.bitmaps_length in
@@ -753,7 +753,7 @@ Theorem compile_inc_progs_for_eval_eq:
                                         | SOME (_, c') => K c') in
       OPTION_MAP (λx. (config_to_inc_config c,FST x,MAP upper_w2w cur_bm)) target
 Proof
-  fs [compile_inc_progs_for_eval_def,compile_inc_progs_def]
+  fs [compile_inc_progs_for_eval_def,compile_inc_progs_def, full_compile_single_for_eval_eq]
   \\ rpt (pairarg_tac \\ gvs [EVAL “(inc_config_to_config asm_c' inc_c).lab_conf.asm_conf”])
   \\ fs [optionTheory.OPTION_MAP_COMPOSE]
   \\ AP_THM_TAC

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -39,7 +39,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=2; col_oracle := [] |>``
 
-val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=T; has_fp_tern:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
+val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=T; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps_length := 0; stack_frame_size := LN |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
 val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=x64_config;init_clock:=5;hash_size:=104729n|>``

--- a/compiler/backend/x64/x64_configScript.sml
+++ b/compiler/backend/x64/x64_configScript.sml
@@ -39,7 +39,7 @@ val clos_conf = rconc (EVAL ``clos_to_bvl$default_config``)
 val bvl_conf = rconc (EVAL``bvl_to_bvi$default_config``)
 val word_to_word_conf = ``<| reg_alg:=2; col_oracle := [] |>``
 
-val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=T; has_fp_tern:=F; call_empty_ffi:=F; gc_kind:=Simple|>``
+val x64_data_conf = ``<| tag_bits:=4; len_bits:=4; pad_bits:=2; len_size:=32; has_div:=F; has_longdiv:=T; has_fp_ops:=T; has_fp_tern:=F; call_empty_ffi:=T; gc_kind:=Simple|>``
 val x64_word_conf = ``<| bitmaps_length := 0; stack_frame_size := LN |>``
 val x64_stack_conf = ``<|jump:=T;reg_names:=x64_names|>``
 val x64_lab_conf = ``<|pos:=0;ffi_names:=NONE;labels:=LN;sec_pos_len:=[];asm_conf:=x64_config;init_clock:=5;hash_size:=104729n|>``

--- a/compiler/bootstrap/compilation/x64/64/x64_config_encScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/x64_config_encScript.sml
@@ -11,7 +11,8 @@ val confs = LIST_CONJ
    to_dataBootstrapTheory.bvi_conf_def]
 
 val encode_backend_config_cake_config_lemma =
-  “encode_backend_config (config_to_inc_config cake_config)”
+  “encode_backend_config $ config_to_inc_config $ cake_config with <|
+     word_to_word_conf := (cake_config.word_to_word_conf with reg_alg := 4) |>”
   |> (SIMP_CONV (srw_ss()) [cake_config_def,confs,encode_backend_config_def] THENC EVAL);
 
 Definition config_enc_str_def:

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -309,6 +309,7 @@ val r = translate (backendTheory.inc_config_to_config_def |> spec64);
 val r = translate (backendTheory.config_to_inc_config_def |> spec64);
 val r = translate (word_to_wordTheory.compile_single_def |> spec64);
 val r = translate (word_to_wordTheory.full_compile_single_def |> spec64);
+val r = translate (word_to_wordTheory.full_compile_single_for_eval_def |> spec64);
 val _ = (next_ml_names := ["compiler_for_eval"]);
 val r = translate compiler_for_eval_alt;
 


### PR DESCRIPTION
This PR:
- makes the incremental compiler issue empty_ffi calls (though the option to emit empty_ffi:s still defaults to off in the default config)
- makes the REPL use the linear scan register allocator, as it currently results in the best total runtime for Candle