### PR TITLE
Split large encoding functions into smaller functions in bootstrap

### DIFF
--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -289,27 +289,54 @@ val _ = (next_ml_names := ["compare"]);
 val _ = translate mllistTheory.list_compare_def;
 
 val _ = ml_prog_update open_local_block;
-val res = translate sortingTheory.PART_DEF;
-val res = translate sortingTheory.PARTITION_DEF;
+
+Definition qsort_part_def:
+  qsort_part ord y [] ys zs = (ys,zs) ∧
+  qsort_part ord y (x::xs) ys zs =
+    if ord x y then qsort_part ord y xs (x::ys) zs
+               else qsort_part ord y xs ys (x::zs)
+End
+
+Triviality qsort_part_length:
+  ∀ord y xs ys zs ys1 zs1.
+    qsort_part ord y xs ys zs = (ys1,zs1) ⇒
+    LENGTH ys1 ≤ LENGTH xs + LENGTH ys ∧
+    LENGTH zs1 ≤ LENGTH xs + LENGTH zs
+Proof
+  Induct_on ‘xs’
+  \\ fs [qsort_part_def,AllCaseEqs()]
+  \\ rw [] \\ res_tac \\ fs []
+QED
+
 Definition qsort_acc_def:
   qsort_acc ord [] acc = acc ∧
   qsort_acc ord (x::xs) acc =
-    let (l1,l2) = PARTITION (λy. ord y x) xs in
+    let (l1,l2) = qsort_part ord x xs [] [] in
       qsort_acc ord l1 (x::qsort_acc ord l2 acc)
 Termination
-  WF_REL_TAC ‘measure $ λ(ord,xs,acc). LENGTH xs’
-  \\ fs [sortingTheory.PARTITION_DEF] \\ rw []
-  \\ imp_res_tac sortingTheory.PART_LENGTH \\ fs []
+  WF_REL_TAC ‘measure $ λ(ord,xs,acc). LENGTH xs’ \\ rw []
+  \\ imp_res_tac $ GSYM qsort_part_length \\ fs []
 End
+
+val res = translate qsort_part_def;
 val res = translate qsort_acc_def;
+
 val _ = ml_prog_update open_local_in_block;
+
+Triviality qsort_part_thm:
+  ∀xs ys zs ord x.
+    qsort_part ord x xs ys zs = PART (λy. ord y x) xs ys zs
+Proof
+  Induct \\ fs [qsort_part_def,sortingTheory.PART_DEF]
+QED
 
 Triviality qsort_acc:
   ∀ord xs acc. qsort_acc ord xs acc = QSORT ord xs ++ acc
 Proof
   ho_match_mp_tac qsort_acc_ind \\ rw []
   \\ simp [Once QSORT_DEF,Once qsort_acc_def]
-  \\ pairarg_tac \\ fs []
+  \\ pairarg_tac \\ fs [sortingTheory.PARTITION_DEF]
+  \\ pairarg_tac \\ fs [qsort_part_thm]
 QED
 
 Triviality qsort_acc_thm:

--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -291,10 +291,35 @@ val _ = translate mllistTheory.list_compare_def;
 val _ = ml_prog_update open_local_block;
 val res = translate sortingTheory.PART_DEF;
 val res = translate sortingTheory.PARTITION_DEF;
+Definition qsort_acc_def:
+  qsort_acc ord [] acc = acc ∧
+  qsort_acc ord (x::xs) acc =
+    let (l1,l2) = PARTITION (λy. ord y x) xs in
+      qsort_acc ord l1 (x::qsort_acc ord l2 acc)
+Termination
+  WF_REL_TAC ‘measure $ λ(ord,xs,acc). LENGTH xs’
+  \\ fs [sortingTheory.PARTITION_DEF] \\ rw []
+  \\ imp_res_tac sortingTheory.PART_LENGTH \\ fs []
+End
+val res = translate qsort_acc_def;
 val _ = ml_prog_update open_local_in_block;
 
+Triviality qsort_acc:
+  ∀ord xs acc. qsort_acc ord xs acc = QSORT ord xs ++ acc
+Proof
+  ho_match_mp_tac qsort_acc_ind \\ rw []
+  \\ simp [Once QSORT_DEF,Once qsort_acc_def]
+  \\ pairarg_tac \\ fs []
+QED
+
+Triviality qsort_acc_thm:
+  QSORT ord xs = qsort_acc ord xs []
+Proof
+  simp [qsort_acc]
+QED
+
 val _ = next_ml_names := ["sort"];
-val res = translate sortingTheory.QSORT_DEF;
+val res = translate qsort_acc_thm;
 
 val _ =  ml_prog_update close_local_blocks;
 val _ =  ml_prog_update (close_module NONE);

--- a/candle/prover/candle_kernel_permsScript.sml
+++ b/candle/prover/candle_kernel_permsScript.sml
@@ -80,16 +80,17 @@ Proof
   rw[perms_ok_def, ListProgTheory.every_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
 QED
 
-Theorem perms_ok_part_v[simp]:
-  perms_ok ps ListProg$part_v
+Theorem perms_ok_qsort_part_v[simp]:
+  perms_ok ps ListProg$qsort_part_v
 Proof
-  rw[perms_ok_def, ListProgTheory.part_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
+  rw[perms_ok_def, ListProgTheory.qsort_part_v_def, astTheory.pat_bindings_def,
+     perms_ok_env_def]
 QED
 
-Theorem perms_ok_partition_1_v[simp]:
-  perms_ok ps ListProg$partition_1_v
+Theorem perms_ok_qsort_acc_v[simp]:
+  perms_ok ps ListProg$qsort_acc_v
 Proof
-  rw[perms_ok_def, ListProgTheory.partition_1_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
+  rw[perms_ok_def, ListProgTheory.qsort_acc_v_def, astTheory.pat_bindings_def,perms_ok_env_def]
   \\ pop_assum mp_tac \\ eval_nsLookup_tac
   \\ rw[]
 QED

--- a/compiler/bootstrap/translation/ag32ProgScript.sml
+++ b/compiler/bootstrap/translation/ag32ProgScript.sml
@@ -90,7 +90,52 @@ fun format_def def = def
 
 val r = translate (format_def ag32_jump_constant_def);
 
-val r = translate (format_def ag32_enc_def);
+val ag32_enc_thm = (format_def ag32_enc_def);
+
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:asm$fp”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘ag32_enc_Const n c = ag32_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_JumpCmp_Imm cmp r i a =
+                          ag32_enc (JumpCmp cmp r (Imm i) a)’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_JumpCmp_Reg cmp r i a =
+                          ag32_enc (JumpCmp cmp r (Reg i) a)’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Loc i a =
+                          ag32_enc (Loc i a)’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Mem_Store a b c =
+                    ag32_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Mem_Store8 a b c =
+                    ag32_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Mem_Load a b c =
+                    ag32_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Mem_Load8 a b c =
+                    ag32_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘ag32_enc_Binop_Imm bop r1 r2 i =
+                    ag32_enc (Inst (Arith (Binop bop r1 r2 (Imm i))))’
+  |> SIMP_RULE std_ss [ag32_enc_thm,cases_defs,APPEND]
+
+val def = ag32_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 val r = translate (format_def ag32_config_def);
 

--- a/compiler/bootstrap/translation/arm7ProgScript.sml
+++ b/compiler/bootstrap/translation/arm7ProgScript.sml
@@ -227,7 +227,207 @@ val _ = translate (EncodeARMImmediate_def |> SIMP_RULE (srw_ss())
   [Ntimes EncodeARMImmediate_aux_def 16] |> finish |> SIMP_RULE
   (srw_ss()) [word_2comp_def])
 
-val res = translate arm7_enc_thm
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:asm$fp”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘arm7_enc_Const n c = arm7_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Skip = arm7_enc (Inst Skip)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Loc n c = arm7_enc (Loc n c)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Call c = arm7_enc (Call c)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotTest_Imm n c c0 =
+                           arm7_enc (JumpCmp NotTest n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotLess_Imm n c c0 =
+                           arm7_enc (JumpCmp NotLess n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotLower_Imm n c c0 =
+                           arm7_enc (JumpCmp NotLower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotEqual_Imm n c c0 =
+                           arm7_enc (JumpCmp NotEqual n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Test_Imm n c c0 =
+                           arm7_enc (JumpCmp Test n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Less_Imm n c c0 =
+                           arm7_enc (JumpCmp Less n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Lower_Imm n c c0 =
+                           arm7_enc (JumpCmp Lower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Equal_Imm n c c0 =
+                           arm7_enc (JumpCmp Equal n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotTest_Reg n c c0 =
+                           arm7_enc (JumpCmp NotTest n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotLess_Reg n c c0 =
+                           arm7_enc (JumpCmp NotLess n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotLower_Reg n c c0 =
+                           arm7_enc (JumpCmp NotLower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_NotEqual_Reg n c c0 =
+                           arm7_enc (JumpCmp NotEqual n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Test_Reg n c c0 =
+                           arm7_enc (JumpCmp Test n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Less_Reg n c c0 =
+                           arm7_enc (JumpCmp Less n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Lower_Reg n c c0 =
+                           arm7_enc (JumpCmp Lower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpCmp_Equal_Reg n c c0 =
+                           arm7_enc (JumpCmp Equal n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Jump c =
+                           arm7_enc (Jump c)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_JumpReg c =
+                           arm7_enc (JumpReg c)’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Mem_Store a b c =
+                    arm7_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Mem_Store8 a b c =
+                    arm7_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Mem_Load a b c =
+                    arm7_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Mem_Load8 a b c =
+                    arm7_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_SubOverflow a b c d =
+                    arm7_enc (Inst (Arith (SubOverflow a b c d)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_AddOverflow a b c d =
+                    arm7_enc (Inst (Arith (AddOverflow a b c d)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_AddCarry a b c d =
+                    arm7_enc (Inst (Arith (AddCarry a b c d)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_LongMul a b c d =
+                    arm7_enc (Inst (Arith (LongMul a b c d)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_LongDiv a b c d e =
+                    arm7_enc (Inst (Arith (LongDiv a b c d e)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Div a b c =
+                    arm7_enc (Inst (Arith (Div a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Shift_Ror a b c =
+                    arm7_enc (Inst (Arith (Shift Ror a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Shift_Asr a b c =
+                    arm7_enc (Inst (Arith (Shift Asr a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Shift_Lsr a b c =
+                    arm7_enc (Inst (Arith (Shift Lsr a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Shift_Lsl a b c =
+                    arm7_enc (Inst (Arith (Shift Lsl a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Add_Imm a b c =
+                    arm7_enc (Inst (Arith (Binop Add a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Sub_Imm a b c =
+                    arm7_enc (Inst (Arith (Binop Sub a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_And_Imm a b c =
+                    arm7_enc (Inst (Arith (Binop And a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Or_Imm a b c =
+                    arm7_enc (Inst (Arith (Binop Or a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Xor_Imm a b c =
+                    arm7_enc (Inst (Arith (Binop Xor a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Add_Reg a b c =
+                    arm7_enc (Inst (Arith (Binop Add a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Sub_Reg a b c =
+                    arm7_enc (Inst (Arith (Binop Sub a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_And_Reg a b c =
+                    arm7_enc (Inst (Arith (Binop And a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Or_Reg a b c =
+                    arm7_enc (Inst (Arith (Binop Or a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_Arith_Xor_Reg a b c =
+                    arm7_enc (Inst (Arith (Binop Xor a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPLess a b c =
+                    arm7_enc (Inst (FP (FPLess a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPLessEqual a b c =
+                    arm7_enc (Inst (FP (FPLessEqual a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPEqual a b c =
+                    arm7_enc (Inst (FP (FPEqual a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPAbs a b =
+                    arm7_enc (Inst (FP (FPAbs a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPNeg a b =
+                    arm7_enc (Inst (FP (FPNeg a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPSqrt a b =
+                    arm7_enc (Inst (FP (FPSqrt a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPAdd a b c =
+                    arm7_enc (Inst (FP (FPAdd a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPSub a b c =
+                    arm7_enc (Inst (FP (FPSub a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPMul a b c =
+                    arm7_enc (Inst (FP (FPMul a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPDiv a b c =
+                    arm7_enc (Inst (FP (FPDiv a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPMov a b =
+                    arm7_enc (Inst (FP (FPMov a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPToInt a b =
+                    arm7_enc (Inst (FP (FPToInt a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPFromInt a b =
+                    arm7_enc (Inst (FP (FPFromInt a b)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPMovToReg a b c =
+                    arm7_enc (Inst (FP (FPMovToReg a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPMovFromReg a b c =
+                    arm7_enc (Inst (FP (FPMovFromReg a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm7_enc_FPFma a b c =
+                    arm7_enc (Inst (FP (FPFma a b c)))’
+  |> SIMP_RULE std_ss [arm7_enc_thm,cases_defs,APPEND]
+
+val def = arm7_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 val res = translate (arm7_config_def |> SIMP_RULE std_ss[valid_immediate_def] |> gconv)
 

--- a/compiler/bootstrap/translation/arm8ProgScript.sml
+++ b/compiler/bootstrap/translation/arm8ProgScript.sml
@@ -316,7 +316,158 @@ val decodebitmasks_side = Q.prove(`
 val res = translate (INST_TYPE [``:'N``|->``:64``] EncodeBitMask_def
  |> SIMP_RULE std_ss [notw] |> gconv)
 
-val res = translate arm8_enc_thm
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:asm$fp”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘arm8_enc_Const n c = arm8_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Skip = arm8_enc (Inst Skip)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Loc n c = arm8_enc (Loc n c)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Call c = arm8_enc (Call c)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotTest_Imm n c c0 =
+                           arm8_enc (JumpCmp NotTest n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotLess_Imm n c c0 =
+                           arm8_enc (JumpCmp NotLess n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotLower_Imm n c c0 =
+                           arm8_enc (JumpCmp NotLower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotEqual_Imm n c c0 =
+                           arm8_enc (JumpCmp NotEqual n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Test_Imm n c c0 =
+                           arm8_enc (JumpCmp Test n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Less_Imm n c c0 =
+                           arm8_enc (JumpCmp Less n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Lower_Imm n c c0 =
+                           arm8_enc (JumpCmp Lower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Equal_Imm n c c0 =
+                           arm8_enc (JumpCmp Equal n (Imm c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotTest_Reg n c c0 =
+                           arm8_enc (JumpCmp NotTest n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotLess_Reg n c c0 =
+                           arm8_enc (JumpCmp NotLess n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotLower_Reg n c c0 =
+                           arm8_enc (JumpCmp NotLower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_NotEqual_Reg n c c0 =
+                           arm8_enc (JumpCmp NotEqual n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Test_Reg n c c0 =
+                           arm8_enc (JumpCmp Test n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Less_Reg n c c0 =
+                           arm8_enc (JumpCmp Less n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Lower_Reg n c c0 =
+                           arm8_enc (JumpCmp Lower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpCmp_Equal_Reg n c c0 =
+                           arm8_enc (JumpCmp Equal n (Reg c) c0)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Jump c =
+                           arm8_enc (Jump c)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_JumpReg c =
+                           arm8_enc (JumpReg c)’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Mem_Store a b c =
+                    arm8_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Mem_Store8 a b c =
+                    arm8_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Mem_Load a b c =
+                    arm8_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Mem_Load8 a b c =
+                    arm8_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_SubOverflow a b c d =
+                    arm8_enc (Inst (Arith (SubOverflow a b c d)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_AddOverflow a b c d =
+                    arm8_enc (Inst (Arith (AddOverflow a b c d)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_AddCarry a b c d =
+                    arm8_enc (Inst (Arith (AddCarry a b c d)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_LongMul a b c d =
+                    arm8_enc (Inst (Arith (LongMul a b c d)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_LongDiv a b c d e =
+                    arm8_enc (Inst (Arith (LongDiv a b c d e)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Div a b c =
+                    arm8_enc (Inst (Arith (Div a b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Shift_Ror a b c =
+                    arm8_enc (Inst (Arith (Shift Ror a b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Shift_Asr a b c =
+                    arm8_enc (Inst (Arith (Shift Asr a b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Shift_Lsr a b c =
+                    arm8_enc (Inst (Arith (Shift Lsr a b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Shift_Lsl a b c =
+                    arm8_enc (Inst (Arith (Shift Lsl a b c)))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Add_Imm a b c =
+                    arm8_enc (Inst (Arith (Binop Add a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Sub_Imm a b c =
+                    arm8_enc (Inst (Arith (Binop Sub a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_And_Imm a b c =
+                    arm8_enc (Inst (Arith (Binop And a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Or_Imm a b c =
+                    arm8_enc (Inst (Arith (Binop Or a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Xor_Imm a b c =
+                    arm8_enc (Inst (Arith (Binop Xor a b (Imm c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Add_Reg a b c =
+                    arm8_enc (Inst (Arith (Binop Add a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Sub_Reg a b c =
+                    arm8_enc (Inst (Arith (Binop Sub a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_And_Reg a b c =
+                    arm8_enc (Inst (Arith (Binop And a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Or_Reg a b c =
+                    arm8_enc (Inst (Arith (Binop Or a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘arm8_enc_Arith_Xor_Reg a b c =
+                    arm8_enc (Inst (Arith (Binop Xor a b (Reg c))))’
+  |> SIMP_RULE std_ss [arm8_enc_thm,cases_defs,APPEND]
+
+val def = arm8_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 val _ = translate (valid_immediate_def |> SIMP_RULE bool_ss
 [IN_INSERT,NOT_IN_EMPTY]|> econv)

--- a/compiler/bootstrap/translation/mipsProgScript.sml
+++ b/compiler/bootstrap/translation/mipsProgScript.sml
@@ -188,7 +188,198 @@ val mips_simp6 = mips_enc6
 val mips_enc_thm = reconstruct_case ``mips_enc i`` rand
 [mips_simp1,mips_simp2,mips_simp3,mips_simp4,mips_simp5,mips_simp6]
 
-val res = translate mips_enc_thm
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:asm$fp”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘mips_enc_Const n c = mips_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Skip = mips_enc (Inst Skip)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Loc n c = mips_enc (Loc n c)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Call c = mips_enc (Call c)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotTest_Imm n c c0 =
+                           mips_enc (JumpCmp NotTest n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotLess_Imm n c c0 =
+                           mips_enc (JumpCmp NotLess n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotLower_Imm n c c0 =
+                           mips_enc (JumpCmp NotLower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotEqual_Imm n c c0 =
+                           mips_enc (JumpCmp NotEqual n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Test_Imm n c c0 =
+                           mips_enc (JumpCmp Test n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Less_Imm n c c0 =
+                           mips_enc (JumpCmp Less n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Lower_Imm n c c0 =
+                           mips_enc (JumpCmp Lower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Equal_Imm n c c0 =
+                           mips_enc (JumpCmp Equal n (Imm c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotTest_Reg n c c0 =
+                           mips_enc (JumpCmp NotTest n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotLess_Reg n c c0 =
+                           mips_enc (JumpCmp NotLess n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotLower_Reg n c c0 =
+                           mips_enc (JumpCmp NotLower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_NotEqual_Reg n c c0 =
+                           mips_enc (JumpCmp NotEqual n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Test_Reg n c c0 =
+                           mips_enc (JumpCmp Test n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Less_Reg n c c0 =
+                           mips_enc (JumpCmp Less n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Lower_Reg n c c0 =
+                           mips_enc (JumpCmp Lower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpCmp_Equal_Reg n c c0 =
+                           mips_enc (JumpCmp Equal n (Reg c) c0)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Jump c =
+                           mips_enc (Jump c)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_JumpReg c =
+                           mips_enc (JumpReg c)’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Mem_Store a b c =
+                    mips_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Mem_Store8 a b c =
+                    mips_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Mem_Load a b c =
+                    mips_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Mem_Load8 a b c =
+                    mips_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_SubOverflow a b c d =
+                    mips_enc (Inst (Arith (SubOverflow a b c d)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_AddOverflow a b c d =
+                    mips_enc (Inst (Arith (AddOverflow a b c d)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_AddCarry a b c d =
+                    mips_enc (Inst (Arith (AddCarry a b c d)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_LongMul a b c d =
+                    mips_enc (Inst (Arith (LongMul a b c d)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_LongDiv a b c d e =
+                    mips_enc (Inst (Arith (LongDiv a b c d e)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Div a b c =
+                    mips_enc (Inst (Arith (Div a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Shift_Ror a b c =
+                    mips_enc (Inst (Arith (Shift Ror a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Shift_Asr a b c =
+                    mips_enc (Inst (Arith (Shift Asr a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Shift_Lsr a b c =
+                    mips_enc (Inst (Arith (Shift Lsr a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Shift_Lsl a b c =
+                    mips_enc (Inst (Arith (Shift Lsl a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Add_Imm a b c =
+                    mips_enc (Inst (Arith (Binop Add a b (Imm c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Sub_Imm a b c =
+                    mips_enc (Inst (Arith (Binop Sub a b (Imm c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_And_Imm a b c =
+                    mips_enc (Inst (Arith (Binop And a b (Imm c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Or_Imm a b c =
+                    mips_enc (Inst (Arith (Binop Or a b (Imm c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Xor_Imm a b c =
+                    mips_enc (Inst (Arith (Binop Xor a b (Imm c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Add_Reg a b c =
+                    mips_enc (Inst (Arith (Binop Add a b (Reg c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Sub_Reg a b c =
+                    mips_enc (Inst (Arith (Binop Sub a b (Reg c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_And_Reg a b c =
+                    mips_enc (Inst (Arith (Binop And a b (Reg c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Or_Reg a b c =
+                    mips_enc (Inst (Arith (Binop Or a b (Reg c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_Arith_Xor_Reg a b c =
+                    mips_enc (Inst (Arith (Binop Xor a b (Reg c))))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+
+val d1 = CONJ d1 $ Define ‘mips_enc_FPLess a b c =
+                    mips_enc (Inst (FP (FPLess a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPLessEqual a b c =
+                    mips_enc (Inst (FP (FPLessEqual a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPEqual a b c =
+                    mips_enc (Inst (FP (FPEqual a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPAbs a b =
+                    mips_enc (Inst (FP (FPAbs a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPNeg a b =
+                    mips_enc (Inst (FP (FPNeg a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPSqrt a b =
+                    mips_enc (Inst (FP (FPSqrt a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPAdd a b c =
+                    mips_enc (Inst (FP (FPAdd a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPSub a b c =
+                    mips_enc (Inst (FP (FPSub a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPMul a b c =
+                    mips_enc (Inst (FP (FPMul a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPDiv a b c =
+                    mips_enc (Inst (FP (FPDiv a b c)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPMov a b =
+                    mips_enc (Inst (FP (FPMov a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPToInt a b =
+                    mips_enc (Inst (FP (FPToInt a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘mips_enc_FPFromInt a b =
+                    mips_enc (Inst (FP (FPFromInt a b)))’
+  |> SIMP_RULE std_ss [mips_enc_thm,cases_defs,APPEND]
+
+val def = mips_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 Theorem mips_config_v_thm = translate (mips_config_def |> SIMP_RULE bool_ss
 [IN_INSERT,NOT_IN_EMPTY]|> econv)

--- a/compiler/bootstrap/translation/riscvProgScript.sml
+++ b/compiler/bootstrap/translation/riscvProgScript.sml
@@ -212,7 +212,157 @@ val riscv_enc_thm = reconstruct_case ``riscv_enc i`` rand
   [riscv_simp1, riscv_simp2, riscv_simp3, riscv_simp4, riscv_simp5,
   riscv_simp6];
 
-val res = translate riscv_enc_thm;
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘riscv_enc_Const n c = riscv_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Skip = riscv_enc (Inst Skip)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Loc n c = riscv_enc (Loc n c)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Call c = riscv_enc (Call c)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotTest_Imm n c c0 =
+                           riscv_enc (JumpCmp NotTest n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotLess_Imm n c c0 =
+                           riscv_enc (JumpCmp NotLess n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotLower_Imm n c c0 =
+                           riscv_enc (JumpCmp NotLower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotEqual_Imm n c c0 =
+                           riscv_enc (JumpCmp NotEqual n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Test_Imm n c c0 =
+                           riscv_enc (JumpCmp Test n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Less_Imm n c c0 =
+                           riscv_enc (JumpCmp Less n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Lower_Imm n c c0 =
+                           riscv_enc (JumpCmp Lower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Equal_Imm n c c0 =
+                           riscv_enc (JumpCmp Equal n (Imm c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotTest_Reg n c c0 =
+                           riscv_enc (JumpCmp NotTest n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotLess_Reg n c c0 =
+                           riscv_enc (JumpCmp NotLess n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotLower_Reg n c c0 =
+                           riscv_enc (JumpCmp NotLower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_NotEqual_Reg n c c0 =
+                           riscv_enc (JumpCmp NotEqual n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Test_Reg n c c0 =
+                           riscv_enc (JumpCmp Test n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Less_Reg n c c0 =
+                           riscv_enc (JumpCmp Less n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Lower_Reg n c c0 =
+                           riscv_enc (JumpCmp Lower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpCmp_Equal_Reg n c c0 =
+                           riscv_enc (JumpCmp Equal n (Reg c) c0)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Jump c =
+                           riscv_enc (Jump c)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_JumpReg c =
+                           riscv_enc (JumpReg c)’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Mem_Store a b c =
+                    riscv_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Mem_Store8 a b c =
+                    riscv_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Mem_Load a b c =
+                    riscv_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Mem_Load8 a b c =
+                    riscv_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_SubOverflow a b c d =
+                    riscv_enc (Inst (Arith (SubOverflow a b c d)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_AddOverflow a b c d =
+                    riscv_enc (Inst (Arith (AddOverflow a b c d)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_AddCarry a b c d =
+                    riscv_enc (Inst (Arith (AddCarry a b c d)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_LongMul a b c d =
+                    riscv_enc (Inst (Arith (LongMul a b c d)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_LongDiv a b c d e =
+                    riscv_enc (Inst (Arith (LongDiv a b c d e)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Div a b c =
+                    riscv_enc (Inst (Arith (Div a b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Shift_Ror a b c =
+                    riscv_enc (Inst (Arith (Shift Ror a b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Shift_Asr a b c =
+                    riscv_enc (Inst (Arith (Shift Asr a b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Shift_Lsr a b c =
+                    riscv_enc (Inst (Arith (Shift Lsr a b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Shift_Lsl a b c =
+                    riscv_enc (Inst (Arith (Shift Lsl a b c)))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Add_Imm a b c =
+                    riscv_enc (Inst (Arith (Binop Add a b (Imm c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Sub_Imm a b c =
+                    riscv_enc (Inst (Arith (Binop Sub a b (Imm c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_And_Imm a b c =
+                    riscv_enc (Inst (Arith (Binop And a b (Imm c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Or_Imm a b c =
+                    riscv_enc (Inst (Arith (Binop Or a b (Imm c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Xor_Imm a b c =
+                    riscv_enc (Inst (Arith (Binop Xor a b (Imm c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Add_Reg a b c =
+                    riscv_enc (Inst (Arith (Binop Add a b (Reg c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Sub_Reg a b c =
+                    riscv_enc (Inst (Arith (Binop Sub a b (Reg c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_And_Reg a b c =
+                    riscv_enc (Inst (Arith (Binop And a b (Reg c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Or_Reg a b c =
+                    riscv_enc (Inst (Arith (Binop Or a b (Reg c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘riscv_enc_Arith_Xor_Reg a b c =
+                    riscv_enc (Inst (Arith (Binop Xor a b (Reg c))))’
+  |> SIMP_RULE std_ss [riscv_enc_thm,cases_defs,APPEND]
+
+val def = riscv_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 Theorem riscv_config_v_thm = translate (riscv_config_def |> SIMP_RULE bool_ss [IN_INSERT, NOT_IN_EMPTY]|> econv);
 

--- a/compiler/bootstrap/translation/x64ProgScript.sml
+++ b/compiler/bootstrap/translation/x64ProgScript.sml
@@ -301,7 +301,204 @@ wc_simp |> we_simp |> gconv |> SIMP_RULE std_ss [SHIFT_ZERO] |>bconv
 val x64_enc_thm = reconstruct_case ``x64_enc i`` rand
 [x64_simp1,x64_simp2,x64_simp3,x64_simp4,x64_simp5,x64_simp6]
 
-val res = translate (GEN_ALL x64_enc_thm)
+val cases_defs = LIST_CONJ
+  [TypeBase.case_def_of “:'a asm$inst”,
+   TypeBase.case_def_of “:asm$cmp”,
+   TypeBase.case_def_of “:asm$memop”,
+   TypeBase.case_def_of “:asm$binop”,
+   TypeBase.case_def_of “:ast$shift”,
+   TypeBase.case_def_of “:asm$fp”,
+   TypeBase.case_def_of “:'a asm$arith”,
+   TypeBase.case_def_of “:'a asm$addr”,
+   TypeBase.case_def_of “:'a asm$reg_imm”,
+   TypeBase.case_def_of “:'a asm$asm”];
+
+val d1 = Define ‘x64_enc_Const n c = x64_enc (Inst (Const n c))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Skip = x64_enc (Inst Skip)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Loc n c = x64_enc (Loc n c)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Call c = x64_enc (Call c)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotTest_Imm n c c0 =
+                           x64_enc (JumpCmp NotTest n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotLess_Imm n c c0 =
+                           x64_enc (JumpCmp NotLess n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotLower_Imm n c c0 =
+                           x64_enc (JumpCmp NotLower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotEqual_Imm n c c0 =
+                           x64_enc (JumpCmp NotEqual n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Test_Imm n c c0 =
+                           x64_enc (JumpCmp Test n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Less_Imm n c c0 =
+                           x64_enc (JumpCmp Less n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Lower_Imm n c c0 =
+                           x64_enc (JumpCmp Lower n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Equal_Imm n c c0 =
+                           x64_enc (JumpCmp Equal n (Imm c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotTest_Reg n c c0 =
+                           x64_enc (JumpCmp NotTest n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotLess_Reg n c c0 =
+                           x64_enc (JumpCmp NotLess n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotLower_Reg n c c0 =
+                           x64_enc (JumpCmp NotLower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_NotEqual_Reg n c c0 =
+                           x64_enc (JumpCmp NotEqual n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Test_Reg n c c0 =
+                           x64_enc (JumpCmp Test n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Less_Reg n c c0 =
+                           x64_enc (JumpCmp Less n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Lower_Reg n c c0 =
+                           x64_enc (JumpCmp Lower n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpCmp_Equal_Reg n c c0 =
+                           x64_enc (JumpCmp Equal n (Reg c) c0)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Jump c =
+                           x64_enc (Jump c)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_JumpReg c =
+                           x64_enc (JumpReg c)’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Mem_Store a b c =
+                    x64_enc (Inst (Mem Store a (Addr b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Mem_Store8 a b c =
+                    x64_enc (Inst (Mem Store8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Mem_Load a b c =
+                    x64_enc (Inst (Mem Load a (Addr b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Mem_Load8 a b c =
+                    x64_enc (Inst (Mem Load8 a (Addr b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_SubOverflow a c d =
+                    x64_enc (Inst (Arith (SubOverflow a a c d)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_AddOverflow a c d =
+                    x64_enc (Inst (Arith (AddOverflow a a c d)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_AddCarry a c d =
+                    x64_enc (Inst (Arith (AddCarry a a c d)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_LongMul a =
+                    x64_enc (Inst (Arith (LongMul a a a a)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_LongDiv a =
+                    x64_enc (Inst (Arith (LongDiv a a a a a)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Div a b c =
+                    x64_enc (Inst (Arith (Div a b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Shift_Ror a c =
+                    x64_enc (Inst (Arith (Shift Ror a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Shift_Asr a c =
+                    x64_enc (Inst (Arith (Shift Asr a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Shift_Lsr a c =
+                    x64_enc (Inst (Arith (Shift Lsr a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Shift_Lsl a c =
+                    x64_enc (Inst (Arith (Shift Lsl a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Add_Imm a c =
+                    x64_enc (Inst (Arith (Binop Add a a (Imm c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Sub_Imm a c =
+                    x64_enc (Inst (Arith (Binop Sub a a (Imm c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_And_Imm a c =
+                    x64_enc (Inst (Arith (Binop And a a (Imm c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Or_Imm a c =
+                    x64_enc (Inst (Arith (Binop Or a a (Imm c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Xor_Imm a c =
+                    x64_enc (Inst (Arith (Binop Xor a a (Imm c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Add_Reg a c =
+                    x64_enc (Inst (Arith (Binop Add a a (Reg c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Sub_Reg a c =
+                    x64_enc (Inst (Arith (Binop Sub a a (Reg c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_And_Reg a c =
+                    x64_enc (Inst (Arith (Binop And a a (Reg c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Or_Reg a b c =
+                    x64_enc (Inst (Arith (Binop Or a b (Reg c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_Arith_Xor_Reg a c =
+                    x64_enc (Inst (Arith (Binop Xor a a (Reg c))))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+
+val d1 = CONJ d1 $ Define ‘x64_enc_FPLess a b c =
+                    x64_enc (Inst (FP (FPLess a b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPLessEqual a b c =
+                    x64_enc (Inst (FP (FPLessEqual a b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPEqual a b c =
+                    x64_enc (Inst (FP (FPEqual a b c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPAbs a b =
+                    x64_enc (Inst (FP (FPAbs a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPNeg a b =
+                    x64_enc (Inst (FP (FPNeg a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPSqrt a b =
+                    x64_enc (Inst (FP (FPSqrt a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPAdd a c =
+                    x64_enc (Inst (FP (FPAdd a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPSub a c =
+                    x64_enc (Inst (FP (FPSub a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPMul a c =
+                    x64_enc (Inst (FP (FPMul a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPDiv a c =
+                    x64_enc (Inst (FP (FPDiv a a c)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPMov a b =
+                    x64_enc (Inst (FP (FPMov a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPMovToReg a b =
+                    x64_enc (Inst (FP (FPMovToReg a a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPMovFromReg a b =
+                    x64_enc (Inst (FP (FPMovFromReg a b b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPToInt a b =
+                    x64_enc (Inst (FP (FPToInt a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+val d1 = CONJ d1 $ Define ‘x64_enc_FPFromInt a b =
+                    x64_enc (Inst (FP (FPFromInt a b)))’
+  |> SIMP_RULE std_ss [x64_enc_thm,cases_defs,APPEND]
+
+val def = x64_enc_thm |> SIMP_RULE std_ss [APPEND] |> SIMP_RULE std_ss [GSYM d1];
+
+val res = CONJUNCTS d1 |> map SPEC_ALL |> map translate;
+
+val res = translate def;
 
 Theorem x64_config_v_thm = translate (x64_config_def |> gconv);
 

--- a/translator/ml_translator_demoScript.sml
+++ b/translator/ml_translator_demoScript.sml
@@ -14,7 +14,8 @@ open ml_translatorLib ml_translatorTheory;
 
 val res = translate sortingTheory.PART_DEF;
 val res = translate sortingTheory.PARTITION_DEF;
-val res = translate sortingTheory.QSORT_DEF;
+val qsort = REWRITE_RULE [GSYM APPEND_ASSOC,APPEND] sortingTheory.QSORT_DEF;
+val res = translate qsort;
 
 
 (* --- all of the important lemmas about qsort --- *)


### PR DESCRIPTION
This PR splits the very large {arm8,arm7,mips,riscv,x64,ag32} instruction encoding functions into many small functions in the bootstrap translation. The hope is that this change will make the encoding functions easier to handle for many parts of the bootstrap compilation (in particular register allocation).

The PR also includes minor improvements to the translation of HOL's `sorting$QSORT` function which is called `List.sort` in the CakeML basis library. 