### PR TITLE
Fix double type printing and basis code generation

### DIFF
--- a/candle/prover/candle_kernel_funsScript.sml
+++ b/candle/prover/candle_kernel_funsScript.sml
@@ -479,7 +479,7 @@ Proof
     Cases_on ‘th’ \\ gs [THM_TYPE_def, do_opapp_cases])
   \\ rename [‘f ∈ kernel_funs’]
   \\ Cases_on ‘f ∈ { call_type_subst_v; call_freesin_v; call_vfree_in_v;
-                     call_variant_v; vsubst_v; inst_v; trans_v; abs_1_v; eq_mp_v;
+                     call_variant_v; vsubst_v; inst_v; trans_v; abs_v; eq_mp_v;
                      deduct_antisym_rule_v; inst_type_v; inst_1_v; trans_v }’ THEN1
    (gvs []
     \\ qpat_x_assum ‘do_opapp _ = _’ mp_tac
@@ -1974,10 +1974,10 @@ Proof
     \\ irule TERM_IMP_v_ok
     \\ first_assum $ irule_at $ Any
     \\ rw[])
-  \\ Cases_on ‘f = abs_1_v’ \\ gvs [] >- (
-    drule_all_then strip_assume_tac abs_1_v_head \\ gvs[]
+  \\ Cases_on ‘f = abs_v’ \\ gvs [] >- (
+    drule_all_then strip_assume_tac abs_v_head \\ gvs[]
     >- (first_assum $ irule_at Any \\ rw[])
-    \\ assume_tac abs_1_v_thm
+    \\ assume_tac abs_v_thm
     \\ drule_then drule v_ok_TERM_TYPE_HEAD \\ strip_tac
     \\ drule_then drule v_ok_THM_TYPE_HEAD \\ strip_tac
     \\ fs[state_ok_def]

--- a/candle/prover/candle_kernel_permsScript.sml
+++ b/candle/prover/candle_kernel_permsScript.sml
@@ -994,10 +994,10 @@ Proof
   \\ rw[]
 QED
 
-Theorem perms_ok_abs_1_v[simp]:
-  perms_ok kernel_perms abs_1_v
+Theorem perms_ok_abs_v[simp]:
+  perms_ok kernel_perms abs_v
 Proof
-  rw[perms_ok_def, abs_1_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
+  rw[perms_ok_def, abs_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
   \\ pop_assum mp_tac \\ eval_nsLookup_tac
   \\ rw[]
 QED

--- a/candle/prover/candle_kernel_valsScript.sml
+++ b/candle/prover/candle_kernel_valsScript.sml
@@ -68,7 +68,7 @@ Definition kernel_funs_def:
     refl_v;
     trans_v;
     mk_comb_1_v;
-    abs_1_v;
+    abs_v;
     beta_v;
     assume_v;
     eq_mp_v;
@@ -91,8 +91,10 @@ Theorem kernel_funs_v_def =
   |> filter (fn tm => not (mem (fst (dest_const tm)) ["INSERT","EMPTY"]))
   |> map (fn c => DB.find (fst (dest_const c) ^ "_def"))
   |> map (fn t => hd t |> snd |> fst)
-  |> curry (op @) [constants_v_def]
+  |> curry (op @) [constants_v_def,abs_v_def]
   |> LIST_CONJ;
+
+Theorem abs_v_def[compute] = abs_v_def;
 
 Definition kernel_locs_def:
   kernel_locs =
@@ -1362,8 +1364,8 @@ Proof
   prove_head_tac
 QED
 
-Theorem abs_1_v_head:
-  do_partial_app abs_1_v v = SOME g ∧
+Theorem abs_v_head:
+  do_partial_app abs_v v = SOME g ∧
   do_opapp [g; w] = SOME (env, exp) ∧
   evaluate ^s env [exp] = (s', res) ⇒
     ^safe_error_goal ∨

--- a/compiler/inference/infer_tScript.sml
+++ b/compiler/inference/infer_tScript.sml
@@ -59,6 +59,10 @@ val type_ident_to_string_def = Define `
     strlit "Word8.word"
   else if ti = Tword8array_num then
     strlit "byte_array"
+  else if ti = Tdouble_num then
+    strlit "Double.double"
+  else if ti = Treal_num then
+    strlit "Double.real"
   else
     case get_tyname ti tys of
     | NONE => mlint$toString (&ti)


### PR DESCRIPTION
With the new Icing tools and value trees, the type for double arithmetic is not word64 anymore. This was not reflected in the type inference pretty-printing and the basis functions. This PR changes this such that `Double.double` is a printed type and the basis functions in `DoubleProg` are properly generated