### PR TITLE
word_to_word_compile_semantics (for Pancake)

### DIFF
--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -3333,7 +3333,7 @@ Proof
     match_mp_tac ALOOKUP_ALL_DISTINCT_MEM \\
     simp[MAP_MAP_o,o_DEF,LAMBDA_PROD,data_to_wordTheory.compile_part_def,FST_triple,MEM_MAP,EXISTS_PROD] \\
     metis_tac[ALOOKUP_MEM] ) \\
-  `data_to_wordProof$code_rel_ext (fromAList t_code) (fromAList p5)` by metis_tac[code_rel_ext_word_to_word] \\
+  `word_to_wordProof$code_rel_ext (fromAList t_code) (fromAList p5)` by metis_tac[word_to_wordProofTheory.code_rel_ext_word_to_word] \\
   qpat_x_assum`Abbrev(tar_st = _)`kall_tac \\
   (* syntactic properties from stack_to_lab *)
   `all_enc_ok_pre c4.lab_conf.asm_conf p7` by (

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -1097,17 +1097,6 @@ Proof
   \\ disch_then drule \\ fs [extend_with_resource_limit'_def]
 QED
 
-val code_rel_ext_def = Define`
-  code_rel_ext code l ⇔
-  (∀n p_1 p_2.
-        SOME (p_1,p_2) = lookup n code ⇒
-        ∃t' k' a' c' col.
-          SOME
-            (SND (full_compile_single t' k' a' c' ((n,p_1,p_2),col))) =
-          lookup n l)`
-
-val code_rel_ext_def = definition"code_rel_ext_def";
-
 Definition get_limits_def:
   get_limits c (t :('a, 'c, 'ffi) wordSem$state) =
     <| stack_limit := t.stack_limit
@@ -1601,35 +1590,6 @@ Theorem MAP_FST_stubs_bound:
 Proof
   Cases_on`a` \\ EVAL_TAC
   \\ strip_tac \\ rveq \\ EVAL_TAC
-QED
-
-Theorem code_rel_ext_word_to_word:
-   ∀code c1 col code'.
-   compile c1 c2 code = (col,code') ⇒
-   code_rel_ext (fromAList code) (fromAList code')
-Proof
-  simp[word_to_wordTheory.compile_def,code_rel_ext_def] \\
-  rw[]>>
-  pairarg_tac>>fs[]>>rw[]>>
-  `LENGTH n_oracles = LENGTH code` by
-    (fs[word_to_wordTheory.next_n_oracle_def]>>
-    every_case_tac>>rw[]>>fs[])>>
-  last_x_assum mp_tac>>
-  pop_assum mp_tac>>
-  pop_assum kall_tac>>
-  map_every qid_spec_tac [`n_oracles`,`p_1`,`p_2`,`n`]>>
-  Induct_on`code` \\ rw[] \\
-  fs[lookup_fromAList]>>
-  Cases_on`n_oracles`>>fs[]>>
-  Cases_on`h`>>fs[]>>
-  simp[word_to_wordTheory.full_compile_single_def,SimpRHS] \\
-  pairarg_tac \\ fs[] \\
-  qmatch_asmsub_rename_tac`((q,p),h)` \\
-  PairCases_on`p` \\ fs[word_to_wordTheory.compile_single_def] \\
-  rveq \\ fs[] \\
-  IF_CASES_TAC \\ fs[] \\
-  simp[word_to_wordTheory.full_compile_single_def,word_to_wordTheory.compile_single_def]>>
-  metis_tac[]
 QED
 
 Theorem max_heap_limit_has_fp_ops[simp]:

--- a/compiler/backend/proofs/word_to_wordProofScript.sml
+++ b/compiler/backend/proofs/word_to_wordProofScript.sml
@@ -2070,6 +2070,26 @@ Proof
   irule apply_colour_no_mt>>rw[]
 QED
 
+Theorem word_common_subexp_elim_no_mt:
+  no_mt prog ⇒
+  no_mt (word_common_subexp_elim prog)
+Proof
+  fs [word_cseTheory.word_common_subexp_elim_def]
+  \\ pairarg_tac \\ fs []
+  \\ rename [‘_ e p = (a,np)’]
+  \\ pop_assum mp_tac
+  \\ MAP_EVERY qid_spec_tac [‘np’,‘e’,‘a’,‘p’]
+  \\ ho_match_mp_tac word_simpTheory.simp_if_ind
+  \\ rpt strip_tac \\ fs []
+  \\ fs [word_cseTheory.word_cse_def]
+  \\ rpt (pairarg_tac \\ fs [])
+  \\ gvs [no_mt_def,AllCaseEqs(),word_cseTheory.add_to_data_aux_def]
+  \\ res_tac \\ fs []
+  \\ gvs [word_cseTheory.word_cseInst_def |> DefnBase.one_line_ify NONE,AllCaseEqs()]
+  \\ gvs [no_mt_def,AllCaseEqs(),word_cseTheory.add_to_data_aux_def,
+          word_cseTheory.add_to_data_def]
+QED
+
 Theorem compile_single_no_mt:
   no_mt prog /\
   (q, r) = (SND (compile_single two_reg_arith reg_count alg c
@@ -2080,6 +2100,7 @@ Proof
   irule word_alloc_no_mt>>
   TRY (irule three_to_two_reg_no_mt)>>
   irule remove_dead_no_mt>>
+  irule word_common_subexp_elim_no_mt>>
   irule full_ssa_cc_trans_no_mt>>
   irule inst_select_no_mt>>
   irule compile_exp_no_mt>>rw[]

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -4314,7 +4314,7 @@ Proof
        first_x_assum drule >>
        disch_then(qspec_then ‘perm’ mp_tac) >>
        rw[] >>
-       drule_then drule no_alloc_no_install_evaluate_const_code >>
+       drule_then drule no_install_evaluate_const_code >>
        simp[] >>
        disch_then $ ASSUME_TAC o GSYM >>
        simp[state_component_equality])
@@ -4476,14 +4476,14 @@ Proof
                gvs[]
                >- (first_x_assum match_mp_tac >>
                    simp[] >>
-                   drule_then drule no_alloc_no_install_evaluate_const_code >>
+                   drule_then drule no_install_evaluate_const_code >>
                    simp[] >>
                    disch_then $ ASSUME_TAC o GSYM >>
                    simp[] >>
                    gvs[no_alloc_def,no_install_def])
                >- (first_x_assum match_mp_tac >>
                    simp[] >>
-                   drule_then drule no_alloc_no_install_evaluate_const_code >>
+                   drule_then drule no_install_evaluate_const_code >>
                    simp[] >>
                    disch_then $ ASSUME_TAC o GSYM >>
                    simp[] >>
@@ -4513,14 +4513,14 @@ Proof
            gvs[]
            >- (first_x_assum match_mp_tac >>
                simp[] >>
-               drule_then drule no_alloc_no_install_evaluate_const_code >>
+               drule_then drule no_install_evaluate_const_code >>
                simp[] >>
                disch_then $ ASSUME_TAC o GSYM >>
                simp[] >>
                gvs[no_alloc_def,no_install_def])
            >- (first_x_assum match_mp_tac >>
                simp[] >>
-               drule_then drule no_alloc_no_install_evaluate_const_code >>
+               drule_then drule no_install_evaluate_const_code >>
                simp[] >>
                disch_then $ ASSUME_TAC o GSYM >>
                simp[] >>
@@ -4566,7 +4566,7 @@ Proof
            gvs[pop_env_def,AllCaseEqs(),PULL_EXISTS,cut_env_def] >>
            first_x_assum match_mp_tac >>
            simp[] >>
-           drule_then drule no_alloc_no_install_evaluate_const_code >>
+           drule_then drule no_install_evaluate_const_code >>
            simp[] >>
            disch_then $ ASSUME_TAC o GSYM >>
            simp[] >>

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -4229,7 +4229,7 @@ Proof
   simp[lookup_fromAList] >>
   rw[] >>
   Cases_on ‘ALOOKUP l2 n’
-  >- (dxrule MEM_PERM >> rw[ALOOKUP_NONE,MEM_MAP]) >>
+  >- (dxrule MEM_PERM >> strip_tac >> gvs[ALOOKUP_NONE,MEM_MAP]) >>
   drule_then assume_tac ALOOKUP_MEM >>
   match_mp_tac ALOOKUP_ALL_DISTINCT_MEM >>
   metis_tac[MEM_PERM]

--- a/pancake/proofs/Holmakefile
+++ b/pancake/proofs/Holmakefile
@@ -2,6 +2,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 					 $(CAKEMLDIR)/misc\
                                          $(CAKEMLDIR)/basis/pure\
 					 $(CAKEMLDIR)/compiler/backend/\
+					 $(CAKEMLDIR)/compiler/backend/proofs\
 					 $(CAKEMLDIR)/compiler/encoders/asm\
                                          $(CAKEMLDIR)/pancake\
                                          $(CAKEMLDIR)/pancake/semantics


### PR DESCRIPTION
- proves another permute_swap_lemma with existential
   quantification on target state instead of source state
- adds `no_mt` and its lemmas (no `MustTerminate`)
- moves `code_rel_ext` from data_to_wordTheory to word_to_wordTheory
- proves a correctness lemma for word_to_word$compile