### PR TITLE
Add multiplication to Pancake

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -249,6 +249,8 @@ open crep_to_loopTheory;
 
 val _ = translate $ spec32 prog_if_def;
 
+val _ = translate $ spec32 compile_crepop_def;
+
 val _ = translate $ spec32 compile_exp_def;
 
 val _ = translate $ spec32 compile_def;
@@ -429,6 +431,8 @@ val res = translate $ spec32 isSubOp_def;
 
 val res = translate $ preprocess $ spec32 conv_Shift_def;
 
+val res = translate $ conv_panop_def;
+
 Definition conv_Exp_alt_def:
   (conv_mmap_exp l =
    (case l of
@@ -441,79 +445,89 @@ Definition conv_Exp_alt_def:
                 NONE => NONE
               | SOME ys => SOME (y::ys))))) ∧
   (conv_ArgList_alt tree =
-        case argsNT tree ArgListNT of
-          NONE => NONE
-        | SOME [] => NONE
-        | SOME (t::ts) => conv_mmap_exp (t::ts)) ∧
+   case argsNT tree ArgListNT of
+     NONE => NONE
+   | SOME [] => NONE
+   | SOME (t::ts) => conv_mmap_exp (t::ts)) ∧
   (conv_Exp_alt tree =
    (case tree of
       Nd nodeNT args =>
-         if isNT nodeNT EBaseNT then
-           case args of
-             [] => NONE
-           | [t] =>
-               OPTION_CHOICE (OPTION_CHOICE (conv_const t) (conv_var t))
-                             (conv_Exp_alt t)
-           | t::v4::v5 =>
-               FOLDR (λt. OPTION_MAP2 Field (conv_nat t)) (conv_Exp_alt t) (v4::v5)
-         else if isNT nodeNT LabelNT then
-           case args of
-             [] => NONE
-           | [t] => OPTION_MAP Label (conv_ident t)
-           | t::v6::v7 => NONE
-         else if isNT nodeNT StructNT then
-           case args of
-             [] => NONE
-           | [ts] => do es <- conv_ArgList_alt ts; SOME (Struct es) od
-           | ts::v6::v7 => NONE
-         else if isNT nodeNT LoadByteNT then
-           case args of
-             [] => NONE
-           | [t] => OPTION_MAP LoadByte (conv_Exp_alt t)
-           | t::v6::v7 => NONE
-         else if isNT nodeNT LoadNT then
-           case args of
-             [] => NONE
-           | [t1] => NONE
-           | [t1; t2] =>
-               (case conv_Shape t1 of
-                  NONE => NONE
-                | SOME s =>
-                    (case conv_Exp_alt t2 of
-                       NONE => NONE
-                     | SOME e => SOME (Load s e)))
-           | t1::t2::v10::v11 => NONE
-         else if isNT nodeNT ECmpNT ∨ isNT nodeNT EEqNT then
-           case args of
-             [] => NONE
-           | [e] => conv_Exp_alt e
-           | [e; op] => NONE
-           | [e; op; e2] =>
-               (case conv_Exp_alt e of
-                  NONE => NONE
-                | SOME e1' =>
-                    (case conv_cmp op of
-                       NONE => NONE
-                     | SOME (op', b) =>
-                         (case conv_Exp_alt e2 of
-                            NONE => NONE
-                          | SOME e2' => if b then SOME (Cmp op' e2' e1')
-                                        else SOME (Cmp op' e1' e2'))))
-           | e::op::e2::v14::v15 => NONE
-         else if isNT nodeNT EShiftNT then
-           case args of
-             [] => NONE
-           | e::es => monad_bind (conv_Exp_alt e) (conv_Shift es)
-         else if EXISTS (isNT nodeNT) binaryExps then
-           case args of
-             [] => NONE
-           | e::es =>
-               (case conv_Exp_alt e of
-                  NONE => NONE
-                | SOME a => conv_binaryExps_alt es a)
-         else NONE
+        if isNT nodeNT EBaseNT then
+          case args of
+            [] => NONE
+          | [t] =>
+              OPTION_CHOICE (OPTION_CHOICE (conv_const t) (conv_var t))
+                            (conv_Exp_alt t)
+          | t::v4::v5 =>
+              FOLDR (λt. OPTION_MAP2 Field (conv_nat t)) (conv_Exp_alt t) (v4::v5)
+        else if isNT nodeNT LabelNT then
+          case args of
+            [] => NONE
+          | [t] => OPTION_MAP Label (conv_ident t)
+          | t::v6::v7 => NONE
+        else if isNT nodeNT StructNT then
+          case args of
+            [] => NONE
+          | [ts] => do es <- conv_ArgList_alt ts; SOME (Struct es) od
+          | ts::v6::v7 => NONE
+        else if isNT nodeNT LoadByteNT then
+          case args of
+            [] => NONE
+          | [t] => OPTION_MAP LoadByte (conv_Exp_alt t)
+          | t::v6::v7 => NONE
+        else if isNT nodeNT LoadNT then
+          case args of
+            [] => NONE
+          | [t1] => NONE
+          | [t1; t2] =>
+              (case conv_Shape t1 of
+                 NONE => NONE
+               | SOME s =>
+                   (case conv_Exp_alt t2 of
+                      NONE => NONE
+                    | SOME e => SOME (Load s e)))
+          | t1::t2::v10::v11 => NONE
+        else if isNT nodeNT ECmpNT ∨ isNT nodeNT EEqNT then
+          case args of
+            [] => NONE
+          | [e] => conv_Exp_alt e
+          | [e; op] => NONE
+          | [e; op; e2] =>
+              (case conv_Exp_alt e of
+                 NONE => NONE
+               | SOME e1' =>
+                   (case conv_cmp op of
+                      NONE => NONE
+                    | SOME (op', b) =>
+                        (case conv_Exp_alt e2 of
+                           NONE => NONE
+                         | SOME e2' => if b then SOME (Cmp op' e2' e1')
+                                       else SOME (Cmp op' e1' e2'))))
+          | e::op::e2::v14::v15 => NONE
+        else if isNT nodeNT EShiftNT then
+          case args of
+            [] => NONE
+          | e::es => monad_bind (conv_Exp_alt e) (conv_Shift es)
+        else if EXISTS (isNT nodeNT) binaryExps then
+          case args of
+            [] => NONE
+          | e::es =>
+              (case conv_Exp_alt e of
+                 NONE => NONE
+               | SOME a => conv_binaryExps_alt es a)
+        else if EXISTS (isNT nodeNT) panExps then
+          case args of
+            [] => NONE
+          | (e::es) =>
+              (case conv_Exp_alt e of
+                 NONE => NONE
+               | SOME a => conv_panops_alt es a)
+        else NONE
     | Lf v12 =>
-        if tokcheck (Lf v12) (kw BaseK) then SOME BaseAddr else NONE)) ∧
+        if tokcheck (Lf v12) (kw BaseK) then SOME BaseAddr
+        else if tokcheck (Lf v12) (kw TrueK) then SOME $ Const 1w
+                   else if tokcheck (Lf v12) (kw FalseK) then SOME $ Const 0w
+        else NONE)) ∧
   (conv_binaryExps_alt trees res =
    (case trees of
       [] => SOME res
@@ -526,25 +540,28 @@ Definition conv_Exp_alt_def:
                 NONE => NONE
               | SOME e' =>
                   (case res of
-                     Const v17 => conv_binaryExps_alt ts (Op op [Const v17; e'])
-                   | Var v18 => conv_binaryExps_alt ts (Op op [Var v18; e'])
-                   | Label v19 => conv_binaryExps_alt ts (Op op [Label v19; e'])
-                   | Struct v20 => conv_binaryExps_alt ts (Op op [Struct v20; e'])
-                   | Field v21 v22 => conv_binaryExps_alt ts (Op op [Field v21 v22; e'])
-                   | Load v23 v24 => conv_binaryExps_alt ts (Op op [Load v23 v24; e'])
-                   | LoadByte v25 => conv_binaryExps_alt ts (Op op [LoadByte v25; e'])
-                   | Op bop es =>
+                     Op bop es =>
                        if bop ≠ op ∨ isSubOp res then
-                         conv_binaryExps_alt ts (Op bop [res; e'])
+                         conv_binaryExps_alt ts (Op op [res; e'])
                        else conv_binaryExps_alt ts (Op bop (es ++ [e']))
-                   | Cmp v28 v29 v30 =>
-                       conv_binaryExps_alt ts (Op op [Cmp v28 v29 v30; e'])
-                   | Shift v31 v32 v33 =>
-                       conv_binaryExps_alt ts (Op op [Shift v31 v32 v33; e'])
-                   | BaseAddr => conv_binaryExps_alt ts (Op op [BaseAddr; e']))))))
+                   | e =>
+                       conv_binaryExps_alt ts (Op op [e; e'])))))) ∧
+  (conv_panops_alt trees res =
+   (case trees of
+      [] => SOME res
+    | [x] => NONE
+    | t1::t2::ts =>
+        (case conv_panop t1 of
+           NONE => NONE
+         | SOME op =>
+             (case conv_Exp_alt t2 of
+                NONE => NONE
+              | SOME e' =>
+                  conv_panops_alt ts (Panop op [res; e'])))))
 Termination
   WF_REL_TAC ‘measure (λx. case x of
-                             INR (INR (INR x)) => ptree1_size (FST x)
+                             INR (INR (INR (INL x))) => ptree1_size (FST x)
+                           | INR (INR (INR (INR x))) => ptree1_size (FST x)
                            | INR (INR (INL x)) => ptree_size x
                            | INR (INL x) => ptree_size x
                            | INL x => ptree1_size x)’ >> rw[]
@@ -562,7 +579,8 @@ Triviality conv_Exp_thm:
   ∧
   (∀tree. conv_Exp_alt ^tree = (conv_Exp ^tree:'a panLang$exp option))
   ∧
-  (∀trees res. conv_binaryExps_alt ^trees res = (conv_binaryExps ^trees res: 'a panLang$exp option))
+  (∀trees res. conv_binaryExps_alt ^trees res = (conv_binaryExps ^trees res: 'a panLang$exp option))  ∧
+  (∀trees res. conv_panops_alt ^trees res = (conv_panops (^trees) res: 'a panLang$exp option))
 Proof
   ho_match_mp_tac (fetch "-" "conv_Exp_alt_ind") \\ rpt strip_tac
   >- (Cases_on ‘trees’>-(fs[]>>gs[conv_Exp_alt_def])>>
@@ -572,7 +590,7 @@ Proof
       simp[conv_Exp_def]>>
       rename1 ‘_ = SOME x’>>Cases_on ‘x’>>gs[])
   >- (Cases_on ‘tree’>>fs[]
-      >- simp[conv_Exp_alt_def, conv_Exp_def]>>
+      >- (simp[conv_Exp_alt_def, conv_Exp_def])>>
       rename1 ‘Nd p l’>>
       rewrite_tac[Once conv_Exp_alt_def,Once conv_Exp_def]>>
       IF_CASES_TAC
@@ -591,11 +609,11 @@ Proof
       IF_CASES_TAC>>fs[]
       >- (rpt (CASE_TAC>>fs[]))>>
       IF_CASES_TAC>>fs[]>>rpt (CASE_TAC>>fs[]))>>
-  Cases_on ‘trees’>>fs[]
-  >- simp[Once conv_Exp_alt_def, Once conv_Exp_def]>>
-  rename1 ‘h::t’>>Cases_on ‘t’>>fs[]>>
-  simp[Once conv_Exp_alt_def, Once conv_Exp_def]>>
-  rpt (CASE_TAC>>fs[parserProgTheory.OPTION_BIND_THM])
+  (Cases_on ‘trees’>>fs[]
+   >- simp[Once conv_Exp_alt_def, Once conv_Exp_def]>>
+   rename1 ‘h::t’>>Cases_on ‘t’>>fs[]>>
+   simp[Once conv_Exp_alt_def, Once conv_Exp_def]>>
+   rpt (CASE_TAC>>fs[parserProgTheory.OPTION_BIND_THM]))
 QED
 
 val res = translate_no_ind $ spec32 $ SIMP_RULE std_ss [option_map_thm, OPTION_MAP2_thm, FOLDR_eta] conv_Exp_alt_def;
@@ -616,9 +634,8 @@ Proof
       ntac 3 strip_tac>>
       rename1 ‘tree = Nd p l’>>
       rpt (first_x_assum (qspecl_then [‘p’, ‘l’] assume_tac))>>
-      rw[]>>fs[])>>
-  last_x_assum match_mp_tac>>
-  ntac 9 strip_tac>>fs[]
+      rw[]>>fs[])
+  \\ last_x_assum match_mp_tac \\ metis_tac[CONS_11]
 QED
 
 val _ = conv_Exp_ind  |> update_precondition;

--- a/pancake/crepLangScript.sml
+++ b/pancake/crepLangScript.sml
@@ -19,6 +19,10 @@ Type varname = ``:num``
 Type funname = ``:mlstring``
 
 Datatype:
+  crepop = Div | Mul | Mod
+End
+
+Datatype:
   exp = Const ('a word)
       | Var varname
       | Label funname
@@ -26,6 +30,7 @@ Datatype:
       | LoadByte exp
       | LoadGlob  (5 word)
       | Op binop (exp list)
+      | Crepop crepop (exp list)
       | Cmp cmp exp exp
       | Shift shift exp num
       | BaseAddr
@@ -120,6 +125,7 @@ Definition var_cexp_def:
   (var_cexp (LoadByte e) = var_cexp e) ∧
   (var_cexp (LoadGlob a) = []) ∧
   (var_cexp (Op bop es) = FLAT (MAP var_cexp es)) ∧
+  (var_cexp (Crepop cop es) = FLAT (MAP var_cexp es)) ∧
   (var_cexp (Cmp c e1 e2) = var_cexp e1 ++ var_cexp e2) ∧
   (var_cexp (Shift sh e num) = var_cexp e) ∧
   (var_cexp BaseAddr = [])
@@ -185,6 +191,7 @@ Definition exps_def:
   (exps (LoadByte e) = exps e) ∧
   (exps (LoadGlob a) = [LoadGlob a]) ∧
   (exps (Op bop es) = FLAT (MAP exps es)) ∧
+  (exps (Crepop pop es) = FLAT (MAP exps es)) ∧
   (exps (Cmp c e1 e2) = exps e1 ++ exps e2) ∧
   (exps (Shift sh e num) = exps e) ∧
   (exps BaseAddr = [BaseAddr])

--- a/pancake/crepLangScript.sml
+++ b/pancake/crepLangScript.sml
@@ -19,7 +19,7 @@ Type varname = ``:num``
 Type funname = ``:mlstring``
 
 Datatype:
-  crepop = Div | Mul | Mod
+  crepop = (* Div | *)Mul (*| Mod*)
 End
 
 Datatype:

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -40,6 +40,11 @@ Definition prog_if_def:
     (Assign n (Const 1w)) (Assign n (Const 0w)) (list_insert [n; m] l)]
 End
 
+Definition compile_crepop_def:
+  compile_crepop crepLang$Div = loopLang$Div ∧
+  compile_crepop crepLang$Mul = loopLang$Mul ∧
+  compile_crepop crepLang$Mod = loopLang$Mod
+End
 
 Definition compile_exp_def:
   (compile_exp ctxt tmp l ((BaseAddr):'a crepLang$exp) = ([], BaseAddr, tmp, l)) /\
@@ -56,6 +61,9 @@ Definition compile_exp_def:
   (compile_exp ctxt tmp l (Op bop es) =
    let (p, les, tmp, l) = compile_exps ctxt tmp l es in
    (p, Op bop les, tmp, l)) /\
+  (compile_exp ctxt tmp l (Crepop cop es) =
+   let (p, les, tmp, l) = compile_exps ctxt tmp l es in
+   (p, Loopop (compile_crepop cop) les, tmp, l)) /\
   (compile_exp ctxt tmp l (Cmp cmp e e') =
    let (p, le, tmp, l) = compile_exp ctxt tmp l e in
    let (p', le', tmp', l) = compile_exp ctxt tmp l e' in

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -43,7 +43,7 @@ End
 Definition compile_crepop_def:
   compile_crepop crepLang$Div x y tmp = ([Arith (LDiv tmp x y)],tmp) ∧
   compile_crepop crepLang$Mul x y tmp = ([Arith (LLongMul tmp tmp x y)],tmp) ∧
-  compile_crepop crepLang$Mod x y tmp = ([Assign tmp (Const 0w);Arith (LLongDiv tmp (tmp+1) x y tmp)],
+  compile_crepop crepLang$Mod x y tmp = ([Assign tmp (Const 0w);Arith (LLongDiv tmp (tmp+1) tmp x y)],
                                          tmp+1)
 End
 
@@ -67,7 +67,7 @@ Definition compile_exp_def:
        (p',tmp') = compile_crepop cop (tmp) (tmp+1) (tmp+LENGTH les)
     in
    (p ++ MAPi (λn. Assign (tmp+n)) les ++ p',
-    Var tmp', tmp'+1, list_insert (GENLIST ($+ tmp) (tmp'-tmp)) l)) /\
+    Var tmp', tmp'+1, insert tmp' () $ list_insert (GENLIST ($+ tmp) (tmp'-tmp)) l)) /\
   (compile_exp ctxt tmp l (Cmp cmp e e') =
    let (p, le, tmp, l) = compile_exp ctxt tmp l e in
    let (p', le', tmp', l) = compile_exp ctxt tmp l e' in

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -42,58 +42,12 @@ Definition prog_if_def:
     (Assign n (Const 1w)) (Assign n (Const 0w)) (list_insert [n; m] l)]
 End
 
-(* The following code is based on the fact that the code in
-   data_to_wordTheory.LongDiv1_code is based on
-   multiwordTheory.single_div_loop_def *)
-Definition loop_div_def:
-  loop_div m n tmp l =
-  let l = insert tmp () $ insert (tmp+1) () $ insert (tmp+2) () $ insert (tmp+3) () l in
-    ([Assign tmp (Const (n2w(dimindex(:'a)):'a word)); (* k *)
-      Assign (tmp+1) (Var n); (* ns *)
-      Assign (tmp+2) (Const 0w); (* m *)
-      Assign (tmp+3) (Var m); (* is *)
-      Loop l
-           (If Equal tmp (Imm 0w) Break
-            (Seq
-             (Assign (tmp+1) $ Shift Lsr (Var $ tmp+1) 1) $ Seq
-             (Assign (tmp+1) $ Shift Lsl (Var $ tmp+2) 1) $
-             If Equal (tmp+1) (Reg $ tmp+3)
-             (Assign tmp (Op Sub [Var tmp; Const 1w]))
-             (Seq
-              (Assign (tmp+2) (Op Add [Var $ tmp+2; Const 1w])) $ Seq
-              (Assign (tmp+3) (Op Sub [Var $ tmp+3; Var $ tmp+1])) $
-              Assign tmp (Op Add [Var tmp;Const 1w]))
-             l)
-            l)
-           l;
-     Assign (tmp+3) (Var $ tmp + 2)],tmp+3)
-End
-
 Definition compile_crepop_def:
-  (compile_crepop crepLang$Div target x y tmp l =
-  if target = x86_64 then
-    ([Assign tmp (Const 0w);Arith (LLongDiv (tmp+1) tmp tmp x y)],tmp+1)
-  else if target = ARMv8 ∨ target = MIPS ∨ target = RISC_V then
-    ([Arith (LDiv tmp x y)],tmp)
-  else
-    loop_div x y tmp l) ∧
   (compile_crepop crepLang$Mul target x y tmp l =
   if target = ARMv7 then
-    ([Arith (LLongMul (tmp+1) tmp x y)],tmp+1)
+    ([Arith (LLongMul tmp (tmp+1) x y)],tmp+1)
   else
-    ([Arith (LLongMul tmp tmp x y)],tmp)) ∧
-  compile_crepop crepLang$Mod target x y tmp l =
-  if target = x86_64 then
-    ([Assign tmp (Const 0w);Arith (LLongDiv tmp (tmp+1) tmp x y)],tmp+1)
-  else if target = ARMv8 ∨ target = MIPS ∨ target = RISC_V then
-    ([Arith (LDiv (tmp+2) x y);
-      Assign (tmp+1) (Const 0w);
-      Arith (LLongMul tmp (tmp+1) (tmp+2) y);
-      Assign (tmp+2) (Op Sub [Var x;Var tmp])
-     ],tmp+2)
-  else
-    (* TODO: what is sensible behaviour here? *)
-    ([Assign tmp (Const 0w)],tmp)
+    ([Arith (LLongMul tmp tmp x y)],tmp))
 End
 
 Definition compile_exp_def:
@@ -111,9 +65,9 @@ Definition compile_exp_def:
   (compile_exp ctxt tmp l (Op bop es) =
    let (p, les, tmp, l) = compile_exps ctxt tmp l es in
    (p, Op bop les, tmp, l)) /\
-  (compile_exp ctxt tmp l (Crepop cop es) =
-   let (p, les, tmp, l) = compile_exps ctxt tmp l es;
-       (p',tmp') = compile_crepop cop ctxt.target (tmp) (tmp+1) (tmp+LENGTH les) l
+  (compile_exp ctxt tmp'' l (Crepop cop es) =
+   let (p, les, tmp, l) = compile_exps ctxt tmp'' l es;
+       (p',tmp') = compile_crepop cop ctxt.target (tmp) (tmp+1) (tmp+LENGTH les) $ list_insert (GENLIST ($+ tmp) (LENGTH les)) l
     in
    (p ++ MAPi (λn. Assign (tmp+n)) les ++ p',
     Var tmp', tmp'+1, insert tmp' () $ list_insert (GENLIST ($+ tmp) (tmp'-tmp)) l)) /\

--- a/pancake/loopLangScript.sml
+++ b/pancake/loopLangScript.sml
@@ -10,23 +10,23 @@ val _ = new_theory "loopLang";
 Type shift = ``:ast$shift``
 
 Datatype:
-  loopop = Div | Mul | Mod
-End
-
-Datatype:
   exp = Const ('a word)
       | Var num
       | Lookup (5 word)
       | Load exp
       | Op binop (exp list)
-      | Loopop loopop (exp list)
       | Shift shift exp num
       | BaseAddr
 End
 
 Datatype:
+  loop_arith = LLongMul num num num num | LLongDiv num num num num num | LDiv num num num
+End
+
+Datatype:
   prog = Skip
        | Assign num ('a exp)           (* dest, source *)
+       | Arith loop_arith
        | Store ('a exp) num            (* dest, source *)
        | SetGlobal (5 word) ('a exp)   (* dest, source *)
        | LoadByte num num               (* TODISC: have removed imm, why num num? *)
@@ -72,7 +72,6 @@ Definition locals_touched_def:
   (locals_touched (Lookup name) = []) /\
   (locals_touched (Load addr) = locals_touched addr) /\
   (locals_touched (Op op wexps) = FLAT (MAP locals_touched wexps)) /\
-  (locals_touched (Loopop op wexps) = FLAT (MAP locals_touched wexps)) /\
   (locals_touched (Shift sh wexp n) = locals_touched wexp) ∧
   (locals_touched BaseAddr = [])
 Termination
@@ -86,6 +85,11 @@ End
 Definition assigned_vars_def:
   (assigned_vars Skip = []) ∧
   (assigned_vars (Assign n e) = [n]) ∧
+  (assigned_vars (Arith arith) =
+   case arith of
+     LLongMul v1 v2 v3 v4 => [v1;v2]
+   | LLongDiv v1 v2 v3 v4 v5 => [v1;v2]
+   | LDiv v1 v2 v3 => [v1]) ∧
   (assigned_vars (LoadByte n m) = [m]) ∧
   (assigned_vars (Seq p q) = assigned_vars p ++ assigned_vars q) ∧
   (assigned_vars (If cmp n r p q ns) = assigned_vars p ++ assigned_vars q) ∧
@@ -105,6 +109,11 @@ Definition acc_vars_def:
   (acc_vars Continue l = l) ∧
   (acc_vars (Loop l1 body l2) l = acc_vars body l) ∧
   (acc_vars (If x1 x2 x3 p1 p2 l1) l = acc_vars p1 (acc_vars p2 l)) ∧
+  (acc_vars (Arith arith) l =
+   case arith of
+     LLongMul v1 v2 v3 v4 => insert v1 () $ insert v2 () l
+   | LLongDiv v1 v2 v3 v4 v5 => insert v1 () $ insert v2 () l
+   | LDiv v1 v2 v3 => insert v1 () l) ∧
   (acc_vars (Mark p1) l = acc_vars p1 l) /\
   (acc_vars Tick l = l) /\
   (acc_vars Skip l = l) /\

--- a/pancake/loopLangScript.sml
+++ b/pancake/loopLangScript.sml
@@ -10,11 +10,16 @@ val _ = new_theory "loopLang";
 Type shift = ``:ast$shift``
 
 Datatype:
+  loopop = Div | Mul | Mod
+End
+
+Datatype:
   exp = Const ('a word)
       | Var num
       | Lookup (5 word)
       | Load exp
       | Op binop (exp list)
+      | Loopop loopop (exp list)
       | Shift shift exp num
       | BaseAddr
 End
@@ -67,6 +72,7 @@ Definition locals_touched_def:
   (locals_touched (Lookup name) = []) /\
   (locals_touched (Load addr) = locals_touched addr) /\
   (locals_touched (Op op wexps) = FLAT (MAP locals_touched wexps)) /\
+  (locals_touched (Loopop op wexps) = FLAT (MAP locals_touched wexps)) /\
   (locals_touched (Shift sh wexp n) = locals_touched wexp) ∧
   (locals_touched BaseAddr = [])
 Termination

--- a/pancake/loop_callScript.sml
+++ b/pancake/loop_callScript.sml
@@ -50,6 +50,28 @@ Definition comp_def:
   (comp l Tick = (Tick, LN)) /\
   (comp l (Raise n) = (Raise n, LN)) /\
   (comp l (Return n) = (Return n, LN)) /\
+  (comp l (Arith arith) =
+   (Arith arith,
+    case arith of
+      LLongMul r1 r2 r3 r4 =>
+        (case (lookup r1 l, lookup r2 l) of
+           (NONE, NONE) => l
+         | (SOME _ , NONE) => delete r1 l
+         | (NONE, SOME loc) => delete r2 l
+         | _ => delete r1 $ delete r2 l
+        )
+    | LLongDiv r1 r2 r3 r4 r5 =>
+        (case (lookup r1 l, lookup r2 l) of
+           (NONE, NONE) => l
+         | (SOME _ , NONE) => delete r1 l
+         | (NONE, SOME loc) => delete r2 l
+         | _ => delete r1 $ delete r2 l
+        )
+    | LDiv r1 r2 r3 =>
+        (case lookup r1 l of
+           NONE => l
+         | _ => delete r1 l)
+    | _ => l)) ∧
   (comp l p = (p, l))
 End
 

--- a/pancake/loop_liveScript.sml
+++ b/pancake/loop_liveScript.sml
@@ -15,7 +15,6 @@ Definition vars_of_exp_def:
   vars_of_exp (Lookup _) l = l ∧
   vars_of_exp (Load a) l = vars_of_exp a l ∧
   vars_of_exp (Op x vs) l = vars_of_exp_list vs l ∧
-  vars_of_exp (Loopop x vs) l = vars_of_exp_list vs l ∧
   vars_of_exp (Shift _ x _) l = vars_of_exp x l ∧
   vars_of_exp_list xs l =
     (case xs of [] => l
@@ -47,6 +46,14 @@ Proof
 QED
 
 
+Definition arith_vars:
+  arith_vars (LLongMul r1 r2 r3 r4) l =
+  insert r3 () $ insert r4 () $ delete r1 $ delete r2 l ∧
+  arith_vars (LDiv r1 r2 r3) l = insert r2 () $ insert r3 () $ delete r1 l ∧
+  arith_vars (LLongDiv r1 r2 r3 r4 r5) l =
+  insert r3 () $ insert r4 () $ insert r5 () $ delete r1 $ delete r2 l
+End
+
 (* This optimisation shrinks all cutsets and also deletes assignments
    to unused variables. The Loop case is the interesting one: an
    auxiliary function is used to find a fixed-point. *)
@@ -76,6 +83,9 @@ Definition shrink_def:
   (shrink b Skip l = (Skip,l)) /\
   (shrink b (Return v) l = (Return v, insert v () LN)) /\
   (shrink b (Raise v) l = (Raise v, insert v () LN)) /\
+  (shrink b (Arith arith) l =
+   (Arith arith, arith_vars arith l)
+  ) ∧
   (shrink b (LocValue n m) l =
      case lookup n l of
      | NONE => (Skip,l)

--- a/pancake/loop_liveScript.sml
+++ b/pancake/loop_liveScript.sml
@@ -15,6 +15,7 @@ Definition vars_of_exp_def:
   vars_of_exp (Lookup _) l = l ∧
   vars_of_exp (Load a) l = vars_of_exp a l ∧
   vars_of_exp (Op x vs) l = vars_of_exp_list vs l ∧
+  vars_of_exp (Loopop x vs) l = vars_of_exp_list vs l ∧
   vars_of_exp (Shift _ x _) l = vars_of_exp x l ∧
   vars_of_exp_list xs l =
     (case xs of [] => l

--- a/pancake/loop_to_wordScript.sml
+++ b/pancake/loop_to_wordScript.sml
@@ -61,6 +61,16 @@ Definition comp_def:
   (comp ctxt Skip l = (wordLang$Skip,l)) /\
   (comp ctxt (Assign n e) l =
      (Assign (find_var ctxt n) (comp_exp ctxt e),l)) /\
+  (comp ctxt (Arith arith) l =
+     (case arith of
+        LLongMul r1 r2 r3 r4 =>
+        (Inst(Arith(LongMul (find_var ctxt r1) (find_var ctxt r2)
+                    (find_var ctxt r3) (find_var ctxt r4))),l)
+      | LLongDiv r1 r2 r3 r4 r5 =>
+        (Inst(Arith(LongDiv (find_var ctxt r1) (find_var ctxt r2)
+                    (find_var ctxt r3) (find_var ctxt r4) (find_var ctxt r5))),l)
+      | LDiv r1 r2 r3 =>
+        (Inst(Arith(Div (find_var ctxt r1) (find_var ctxt r2) (find_var ctxt r3))),l))) /\
   (comp ctxt (Store e v) l =
      (Store (comp_exp ctxt e) (find_var ctxt v), l)) /\
   (comp ctxt (SetGlobal a e) l =

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -198,5 +198,4 @@ Definition destruct_def:
   (destruct _ = [])
 End
 
-
 val _ = export_theory();

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -33,6 +33,10 @@ Datatype:
 End
 
 Datatype:
+  panop = Div | Mul | Mod
+End
+
+Datatype:
   exp = Const ('a word)
       | Var varname
       | Label funname
@@ -42,6 +46,7 @@ Datatype:
       | Load shape exp (* exp: start addr of value with given shape *)
       | LoadByte exp
       | Op binop (exp list)
+      | Panop panop (exp list)
       | Cmp cmp exp exp
       | Shift shift exp num
       | BaseAddr
@@ -176,6 +181,7 @@ Definition var_exp_def:
   (var_exp (Load sh e) = var_exp e) ∧
   (var_exp (LoadByte e) = var_exp e) ∧
   (var_exp (Op bop es) = FLAT (MAP var_exp es)) ∧
+  (var_exp (Panop op es) = FLAT (MAP var_exp es)) ∧
   (var_exp (Cmp c e1 e2) = var_exp e1 ++ var_exp e2) ∧
   (var_exp (Shift sh e num) = var_exp e)
 Termination

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -33,7 +33,7 @@ Datatype:
 End
 
 Datatype:
-  panop = Div | Mul | Mod
+  panop = (* Div | *)Mul (* | Mod*)
 End
 
 Datatype:

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -32,6 +32,12 @@ Definition comp_field_def:
    else comp_field (i-1) shs (DROP (size_of_shape sh) es))
 End
 
+Definition compile_panop_def:
+  compile_panop panLang$Div = crepLang$Div ∧
+  compile_panop panLang$Mul = crepLang$Mul ∧
+  compile_panop panLang$Mod = crepLang$Mod
+End
+
 Definition compile_exp_def:
   (compile_exp ctxt ((Const c):'a panLang$exp) =
    ([(Const c): 'a crepLang$exp], One)) /\
@@ -63,6 +69,11 @@ Definition compile_exp_def:
    let cexps = MAP FST (MAP (compile_exp ctxt) es) in
    case cexp_heads cexps of
    | SOME es => ([Op bop es], One)
+   | _ => ([Const 0w], One)) /\
+  (compile_exp ctxt (Panop pop es) =
+   let cexps = MAP FST (MAP (compile_exp ctxt) es) in
+   case cexp_heads cexps of
+   | SOME es => ([Crepop (compile_panop pop) es], One)
    | _ => ([Const 0w], One)) /\
   (compile_exp ctxt (Cmp cmp e e') =
    let ce  = FST (compile_exp ctxt e);

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -33,9 +33,7 @@ Definition comp_field_def:
 End
 
 Definition compile_panop_def:
-  compile_panop panLang$Div = crepLang$Div ∧
-  compile_panop panLang$Mul = crepLang$Mul ∧
-  compile_panop panLang$Mod = crepLang$Mod
+  compile_panop panLang$Mul = crepLang$Mul
 End
 
 Definition compile_exp_def:

--- a/pancake/pan_to_targetScript.sml
+++ b/pancake/pan_to_targetScript.sml
@@ -11,7 +11,7 @@ val _ = new_theory "pan_to_target";
 
 Definition compile_prog_def:
   compile_prog c prog =
-    let prog = pan_to_word$compile_prog prog in
+    let prog = pan_to_word$compile_prog c.lab_conf.asm_conf.ISA prog in
     let (col,prog) = word_to_word$compile c.word_to_word_conf c.lab_conf.asm_conf prog in
       from_word c LN prog
 End

--- a/pancake/pan_to_wordScript.sml
+++ b/pancake/pan_to_wordScript.sml
@@ -10,10 +10,10 @@ val _ = new_theory "pan_to_word";
 
 
 Definition compile_prog_def:
-  compile_prog prog =
+  compile_prog arch prog =
   let prog = pan_simp$compile_prog prog;
       prog = pan_to_crep$compile_prog prog;
-      prog = crep_to_loop$compile_prog prog in
+      prog = crep_to_loop$compile_prog arch prog in
     loop_to_word$compile prog
 End
 

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -138,6 +138,17 @@ val ex8 = ‘x = a < b;
 
 val treeEx8 = check_success $ parse_pancake ex8;
 
+(* Multiplication
+ *)
+
+val ex8_and_a_half = ‘x = a * b;
+                      x = a * b * c;
+                      x =  (a + b) * c;
+                      x = a + b * c;
+                      x = a * b + c;’;
+
+val treeEx8_and_a_half = check_success $ parse_pancake ex8_and_a_half;
+
 (** Statments. *)
 
 (** Small test modelled after the minimal working example. *)

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -64,14 +64,14 @@ val ex2 = ‘if b & (a ^ c) & d {
              goo(4, 5, 6);
            }’;
 
-val treeEx2 = parse_pancake ex2;
+val treeEx2 = check_success $ parse_pancake ex2;
 
 (** We also have a selection of boolean operators and
     a ‘return’ statement. *)
 (** FIXME: Add ‘true’ and ‘false’ to EBaseNT *)
 val ex3 = ‘if b & (a ^ c) & d { return true; } else { return false; }’;
 
-val treeEx3 = (* check_success $ *) parse_pancake ex3;
+val treeEx3 = check_success $ parse_pancake ex3;
 
 (** Loops: standard looping construct. *)
 

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -164,8 +164,6 @@ val ex10 = ‘
 val treeEx10 = check_success $ parse_pancake ex10;
 
 (** We can assign boolean expressions to variables. *)
-(** FIXME: Does not parse correctly. *)
-(** Expected: Xor (And b a) (And c d) *)
 val exN = ‘x = b & a ^ c & d;’;
 
 val treeExN = check_success $ parse_pancake exN;

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -19,7 +19,7 @@ val _ = new_theory "panLexer";
 Datatype:
   keyword = SkipK | StoreK | StoreBK | IfK | ElseK | WhileK
   | BrK | ContK | RaiseK | RetK | TicK | VarK | WithK | HandleK
-  | LdsK | LdbK | BaseK | InK
+  | LdsK | LdbK | BaseK | InK | TrueK | FalseK
 End
 
 Datatype:
@@ -27,7 +27,7 @@ Datatype:
   | EqT | NeqT | LessT | GreaterT | GeqT | LeqT
   | PlusT | MinusT | HashT | DotT | StarT
   | LslT | LsrT | AsrT | RorT
-  | TrueT | FalseT | IntT int | IdentT string
+  | IntT int | IdentT string
   | LParT | RParT | CommaT | SemiT | ColonT | DArrowT | AddrT
   | LBrakT | RBrakT | LCurT | RCurT
   | AssignT
@@ -110,8 +110,8 @@ Definition get_keyword_def:
   if s = "lds" then (KeywordT LdsK) else
   if s = "ldb" then (KeywordT LdbK) else
   if s = "@base" then (KeywordT BaseK) else
-  if s = "true" then TrueT else
-  if s = "false" then FalseT else
+  if s = "true" then (KeywordT TrueK) else
+  if s = "false" then (KeywordT FalseK) else
   if isPREFIX "@" s ∨ s = "" then LexErrorT else
   IdentT s
 End

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -202,9 +202,11 @@ Definition pancake_peg_def[nocompute]:
         (INL EBaseNT, seql [choicel [seql [consume_tok LParT;
                                            mknt ExpNT;
                                            consume_tok RParT] I;
+                                     keep_kw TrueK; keep_kw FalseK;
                                      keep_int; keep_ident; mknt LabelNT;
                                      mknt StructNT; mknt LoadNT;
-                                     mknt LoadByteNT; keep_kw BaseK];
+                                     mknt LoadByteNT; keep_kw BaseK;
+                                     ];
                             rpt (seql [consume_tok DotT; keep_nat] I)
                                 FLAT]
                            (mksubtree EBaseNT));

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -20,11 +20,11 @@ Datatype:
             | ExtCallNT | RaiseNT | ReturnNT
             | ArgListNT
             | EXorNT | EAndNT | EEqNT | ECmpNT
-            | EShiftNT | EAddNT
+            | EShiftNT | EAddNT | EMulNT
             | EBaseNT
             | StructNT | LoadNT | LoadByteNT | LabelNT
             | ShapeNT | ShapeCombNT
-            | EqOpsNT | CmpOpsNT | ShiftOpsNT | AddOpsNT
+            | EqOpsNT | CmpOpsNT | ShiftOpsNT | AddOpsNT | MulOpsNT
 End
 
 Definition mknt_def:
@@ -195,10 +195,13 @@ Definition pancake_peg_def[nocompute]:
                              rpt (seql [mknt ShiftOpsNT; keep_nat] I)
                                  FLAT]
                             (mksubtree EShiftNT));
-        (INL EAddNT, seql [mknt EBaseNT;
-                           rpt (seql [mknt AddOpsNT; mknt EBaseNT] I)
+        (INL EAddNT, seql [mknt EMulNT;
+                           rpt (seql [mknt AddOpsNT; mknt EMulNT] I)
                                FLAT]
                           (mksubtree EAddNT));
+        (INL EMulNT, seql [mknt EBaseNT;
+                           rpt (seql [mknt MulOpsNT; mknt EBaseNT] I) FLAT]
+                          (mksubtree EMulNT));
         (INL EBaseNT, seql [choicel [seql [consume_tok LParT;
                                            mknt ExpNT;
                                            consume_tok RParT] I;
@@ -232,7 +235,8 @@ Definition pancake_peg_def[nocompute]:
         (INL CmpOpsNT, choicel [keep_tok LessT; keep_tok GeqT; keep_tok GreaterT; keep_tok LeqT]);
         (INL ShiftOpsNT, choicel [keep_tok LslT; keep_tok LsrT;
                                   keep_tok AsrT; keep_tok RorT]);
-        (INL AddOpsNT, choicel [keep_tok PlusT; keep_tok MinusT])]
+        (INL AddOpsNT, choicel [keep_tok PlusT; keep_tok MinusT]);
+        (INL MulOpsNT, keep_tok StarT)]
         |>
 End
 
@@ -462,11 +466,11 @@ in
   th::acc
 end
 
-val topo_nts = [“AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”,
+val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”,
                 “EqOpsNT”, “ShapeNT”,
                 “ShapeCombNT”, “LabelNT”, “LoadByteNT”,
                 “LoadNT”, “StructNT”,
-                “EBaseNT”, “EAddNT”, “EShiftNT”, “ECmpNT”,
+                “EBaseNT”, “EMulNT”, “EAddNT”, “EShiftNT”, “ECmpNT”,
                 “EEqNT”, “EAndNT”, “EXorNT”,
                 “ExpNT”, “ArgListNT”, “ReturnNT”,
                 “RaiseNT”, “ExtCallNT”,

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -250,6 +250,8 @@ Definition conv_Exp_def:
       | (e::es) => conv_binaryExps es ' (conv_Exp e)
     else NONE) ∧
   (conv_Exp leaf = if tokcheck leaf (kw BaseK) then SOME BaseAddr
+                   else if tokcheck leaf (kw TrueK) then SOME $ Const 1w
+                   else if tokcheck leaf (kw FalseK) then SOME $ Const 0w
                   else NONE) ∧
   conv_binaryExps [] e = SOME e ∧
   (conv_binaryExps (t1::t2::ts) res =

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -99,6 +99,10 @@ Definition binaryExps_def:
   binaryExps = [ExpNT; EXorNT; EAndNT; EAddNT]
 End
 
+Definition panExps_def:
+  panExps = [EMulNT]
+End
+
 (** Subtraction must apply to only two subexpressions.
   * See the pancake semantics script. *)
 Definition isSubOp_def:
@@ -120,6 +124,18 @@ Definition conv_binop_def:
    else if tokcheck leaf AndT then SOME And
    else if tokcheck leaf OrT then SOME Or
    else if tokcheck leaf XorT then SOME Xor
+   else NONE
+End
+
+Definition conv_panop_def:
+  (conv_panop (Nd nodeNT args) =
+     if isNT nodeNT MulOpsNT then
+       case args of
+         [leaf] => conv_panop leaf
+       | _ => NONE
+     else NONE) ∧
+  conv_panop leaf =
+   if tokcheck leaf StarT then SOME Mul
    else NONE
 End
 
@@ -248,6 +264,10 @@ Definition conv_Exp_def:
       case args of
         [] => NONE
       | (e::es) => conv_binaryExps es ' (conv_Exp e)
+    else if EXISTS (isNT nodeNT) panExps then
+      case args of
+        [] => NONE
+      | (e::es) => conv_panops es ' (conv_Exp e)
     else NONE) ∧
   (conv_Exp leaf = if tokcheck leaf (kw BaseK) then SOME BaseAddr
                    else if tokcheck leaf (kw TrueK) then SOME $ Const 1w
@@ -259,16 +279,26 @@ Definition conv_Exp_def:
        e <- conv_Exp t2;
        case res of
          Op bop es => if bop ≠ op ∨ isSubOp res then
-                        conv_binaryExps ts (Op bop [res; e])
+                        conv_binaryExps ts (Op op [res; e])
                       else conv_binaryExps ts (Op bop (APPEND es [e]))
        | e' => conv_binaryExps ts (Op op [e'; e])
     od) ∧
-  conv_binaryExps _ _ = NONE (* Impossible: ruled out by grammar. *)
+  conv_binaryExps _ _ = NONE ∧ (* Impossible: ruled out by grammar. *)
+  conv_panops [] e = SOME e ∧
+  (conv_panops (t1::t2::ts) res =
+    do op <- conv_panop t1;
+       e <- conv_Exp t2;
+       case res of
+         Panop bop es => conv_panops ts (Panop op [res; e])
+       | e' => conv_panops ts (Panop op [e'; e])
+    od) ∧
+  conv_panops _ _ = NONE (* Impossible: ruled out by grammar. *)
 Termination
   WF_REL_TAC ‘measure (λx. case x of
-                             INR (INR x) => ptree1_size (FST x)
                            | INR (INL x) => ptree_size x
-                           | INL x => ptree_size x)’ >> rw[]
+                           | INL x => ptree_size x
+                           | INR (INR(INL x)) => ptree1_size (FST x)
+                           | INR (INR(INR x)) => ptree1_size (FST x))’ >> rw[]
   >> Cases_on ‘tree’
   >> gvs[argsNT_def,parsetree_size_def]
   >> drule_then assume_tac mem_ptree_thm >> gvs[]

--- a/pancake/proofs/crep_to_loopProofScript.sml
+++ b/pancake/proofs/crep_to_loopProofScript.sml
@@ -866,10 +866,15 @@ Proof
        rw[] >>
        imp_res_tac comp_exp_assigned_vars_tmp_bound_cases >>
        TRY DECIDE_TAC >>
-       (*      imp_res_tac locals_rel_intro >>
-      imp_re  s_tac compile_exp_le_tmp_domain >>*)
-       cheat
-      ) >>
+       MAP_FIRST match_mp_tac [cj 1 compile_exp_le_tmp_domain,
+                               cj 2 compile_exp_le_tmp_domain] >>
+       imp_res_tac locals_rel_intro >>
+       first_x_assum $ irule_at $ Pos last >>
+       ntac 2 $ first_x_assum $ irule_at $ Pos hd >>
+       simp[] >>
+       rw[] >>
+       drule_all eval_some_var_cexp_local_lookup >>
+       metis_tac[]) >>
      strip_tac >>
      simp[evaluate_def,nested_seq_def,eval_def,loop_arith_def] >>
      rename1 ‘eval(set_var tmp' (wlab_wloc ctxt.funcs (Word ww)) st') le'’ >>

--- a/pancake/proofs/loop_callProofScript.sml
+++ b/pancake/proofs/loop_callProofScript.sml
@@ -370,6 +370,16 @@ Proof
   fs [labels_in_def, lookup_def]
 QED
 
+Theorem compile_Arith:
+  ^(get_goal "comp _ (loopLang$Arith _)")
+Proof
+  rpt conj_tac >>
+  rpt gen_tac >> strip_tac >>
+  gvs [evaluate_def, labels_in_def, comp_def,AllCaseEqs(),
+      DefnBase.one_line_ify NONE loop_arith_def
+      ] >>
+  rw[set_var_def,lookup_insert,lookup_delete]
+QED
 
 Theorem compile_others:
   ^(get_goal "comp _ loopLang$Skip") ∧
@@ -398,7 +408,7 @@ Proof
   match_mp_tac (the_ind_thm()) >>
   EVERY (map strip_assume_tac
          [compile_others,compile_LocValue,compile_LoadByte,compile_StoreByte,
-          compile_Mark, compile_Assign, compile_Store,
+          compile_Mark, compile_Assign, compile_Store, compile_Arith,
           compile_Call, compile_Seq, compile_If, compile_FFI, compile_Loop]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED

--- a/pancake/proofs/loop_liveProofScript.sml
+++ b/pancake/proofs/loop_liveProofScript.sml
@@ -487,7 +487,7 @@ Proof
   rw[state_component_equality,set_var_def,lookup_insert] >>
   rw[] >> gvs[]
 QED
-        
+
 Theorem compile_correct:
   ^(compile_correct_tm())
 Proof

--- a/pancake/proofs/loop_liveProofScript.sml
+++ b/pancake/proofs/loop_liveProofScript.sml
@@ -192,7 +192,6 @@ Proof
   THEN1 fs [domain_insert,domain_union,EXTENSION]
   THEN1 fs [domain_insert,domain_union,EXTENSION]
   \\ TRY (rpt (pop_assum (qspec_then ‘l’ mp_tac)) \\ fs [] \\ NO_TAC)
-  \\ TRY (rpt (pop_assum (qspec_then ‘l'’ mp_tac)) \\ fs [] \\ NO_TAC)
   \\ Cases_on ‘exp’ \\ fs []
   \\ simp_tac std_ss [domain_union]
   \\ rpt (pop_assum (fn th => once_rewrite_tac [th]))
@@ -220,6 +219,26 @@ Proof
     \\ pop_assum mp_tac
     \\ qid_spec_tac ‘ws’
     \\ Induct_on ‘wexps’ \\ fs [] \\ rw []
+    \\ fs [wordSemTheory.the_words_def,CaseEq"option",CaseEq"word_loc",PULL_EXISTS]
+    \\ rveq \\ fs [] \\ conj_tac
+    \\ fs [PULL_FORALL,AND_IMP_INTRO]
+    \\ first_x_assum match_mp_tac
+    THEN1 (fs [Once vars_of_exp_def] \\ metis_tac [])
+    \\ pop_assum mp_tac \\ simp [Once vars_of_exp_def]
+    \\ rw [] THEN1 metis_tac []
+    \\ fs [subspt_lookup,lookup_inter_alt]
+    \\ pop_assum mp_tac
+    \\ once_rewrite_tac [vars_of_exp_acc]
+    \\ fs [domain_union])
+  THEN1
+   (fs [CaseEq"option",CaseEq"word_loc"] \\ rveq
+    \\ goal_assum (first_assum o mp_then Any mp_tac)
+    \\ pop_assum mp_tac
+    \\ once_rewrite_tac [vars_of_exp_def]
+    \\ pop_assum kall_tac
+    \\ pop_assum mp_tac
+    \\ qid_spec_tac ‘ws’
+    \\ Induct_on ‘es’ \\ fs [] \\ rw []
     \\ fs [wordSemTheory.the_words_def,CaseEq"option",CaseEq"word_loc",PULL_EXISTS]
     \\ rveq \\ fs [] \\ conj_tac
     \\ fs [PULL_FORALL,AND_IMP_INTRO]

--- a/pancake/proofs/loop_liveProofScript.sml
+++ b/pancake/proofs/loop_liveProofScript.sml
@@ -231,26 +231,6 @@ Proof
     \\ once_rewrite_tac [vars_of_exp_acc]
     \\ fs [domain_union])
   THEN1
-   (fs [CaseEq"option",CaseEq"word_loc"] \\ rveq
-    \\ goal_assum (first_assum o mp_then Any mp_tac)
-    \\ pop_assum mp_tac
-    \\ once_rewrite_tac [vars_of_exp_def]
-    \\ pop_assum kall_tac
-    \\ pop_assum mp_tac
-    \\ qid_spec_tac ‘ws’
-    \\ Induct_on ‘es’ \\ fs [] \\ rw []
-    \\ fs [wordSemTheory.the_words_def,CaseEq"option",CaseEq"word_loc",PULL_EXISTS]
-    \\ rveq \\ fs [] \\ conj_tac
-    \\ fs [PULL_FORALL,AND_IMP_INTRO]
-    \\ first_x_assum match_mp_tac
-    THEN1 (fs [Once vars_of_exp_def] \\ metis_tac [])
-    \\ pop_assum mp_tac \\ simp [Once vars_of_exp_def]
-    \\ rw [] THEN1 metis_tac []
-    \\ fs [subspt_lookup,lookup_inter_alt]
-    \\ pop_assum mp_tac
-    \\ once_rewrite_tac [vars_of_exp_acc]
-    \\ fs [domain_union])
-  THEN1
    (fs [CaseEq"option",CaseEq"word_loc",vars_of_exp_def,PULL_EXISTS] \\ rveq
     \\ res_tac \\ fs[] \\ fs [mem_load_def])
 QED
@@ -495,12 +475,25 @@ Proof
   \\ res_tac \\ fs [domain_lookup]
 QED
 
+Theorem compile_Arith:
+  ^(get_goal "loopLang$Arith")
+Proof
+  rpt strip_tac >>
+  gvs[evaluate_def, DefnBase.one_line_ify NONE loop_arith_def,
+      AllCaseEqs(),shrink_def,PULL_EXISTS,
+      subspt_lookup,lookup_inter_alt,domain_insert,
+         cut_state_def, domain_inter,arith_vars,SF DNF_ss
+     ] >>
+  rw[state_component_equality,set_var_def,lookup_insert] >>
+  rw[] >> gvs[]
+QED
+        
 Theorem compile_correct:
   ^(compile_correct_tm())
 Proof
   match_mp_tac (the_ind_thm())
   \\ EVERY (map strip_assume_tac [compile_Skip, compile_Continue,
-       compile_Mark, compile_Return, compile_Assign, compile_Store,
+       compile_Mark, compile_Return, compile_Assign, compile_Store, compile_Arith,
        compile_Call, compile_Seq, compile_If, compile_FFI, compile_Loop])
   \\ asm_rewrite_tac [] \\ rw [] \\ rpt (pop_assum kall_tac)
 QED

--- a/pancake/proofs/loop_removeProofScript.sml
+++ b/pancake/proofs/loop_removeProofScript.sml
@@ -959,6 +959,16 @@ Proof
   \\ fs [call_env_def]
 QED
 
+Theorem compile_Arith:
+  ^(get_goal "loopLang$Arith")
+Proof
+  fs [syntax_ok_def,no_Loop_def,every_prog_def] \\ rpt strip_tac
+  \\ gvs[evaluate_def,AllCaseEqs(),DefnBase.one_line_ify NONE loop_arith_def,
+         comp_no_loop_def,PULL_EXISTS
+        ]
+  \\ gvs[state_rel_def,set_var_def,state_component_equality] \\ metis_tac[]
+QED
+
 Theorem compile_correct:
   ^(compile_correct_tm())
 Proof
@@ -966,7 +976,7 @@ Proof
   \\ EVERY (map strip_assume_tac [compile_Skip, compile_Continue,
        compile_Mark, compile_Return, compile_Assign, compile_Store,
        compile_SetGlobal, compile_Call, compile_Seq, compile_If,
-       compile_FFI, compile_Loop])
+       compile_FFI, compile_Loop,compile_Arith])
   \\ asm_rewrite_tac [] \\ rw [] \\ rpt (pop_assum kall_tac)
 QED
 

--- a/pancake/proofs/loop_to_wordProofScript.sml
+++ b/pancake/proofs/loop_to_wordProofScript.sml
@@ -977,6 +977,26 @@ Proof
   fs [mk_new_cutset_def]
 QED
 
+Theorem compile_Arith:
+  ^(get_goal "loopLang$Arith")
+Proof
+  rpt strip_tac >>
+  gvs [loopSemTheory.evaluate_def,
+       comp_def, evaluate_def,DefnBase.one_line_ify NONE loop_arith_def,
+       AllCaseEqs(),inst_def,PULL_EXISTS,get_vars_def,find_var_def,get_var_def,
+       loopSemTheory.set_var_def,wordSemTheory.set_var_def,
+       state_rel_def,SUBSET_DEF,loopLangTheory.acc_vars_def,
+       SF DNF_ss
+      ] >>
+  imp_res_tac locals_rel_intro >>
+  gvs[lookup_insert,lookup_insert,domain_lookup] >>
+  rw[] >>
+  gvs[locals_rel_def,lookup_insert] >>
+  rw[] >>
+  res_tac >> gvs[] >> rw[] >>
+  gvs[INJ_DEF,domain_lookup,PULL_EXISTS,find_var_def]
+QED
+
 Theorem compile_correct:
   ^(compile_correct_tm())
 Proof
@@ -984,7 +1004,7 @@ Proof
   >> EVERY (map strip_assume_tac [compile_Skip, compile_Raise,
        compile_Mark, compile_Return, compile_Assign, compile_Store,
        compile_SetGlobal, compile_Call, compile_Seq, compile_If,
-       compile_FFI, compile_Loop, compile_LoadByte])
+       compile_FFI, compile_Loop, compile_LoadByte, compile_Arith])
   >> asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED
 
@@ -1721,6 +1741,7 @@ Proof
   ho_match_mp_tac loop_to_wordTheory.comp_ind>>
   rw[loop_to_wordTheory.comp_def]>>
   gs[wordPropsTheory.extract_labels_def]
+  >- gvs[AllCaseEqs(),extract_labels_def]
   >- (pairarg_tac>>gs[]>>
       pairarg_tac>>gs[]>>
       rveq>>gs[wordPropsTheory.extract_labels_def]>>
@@ -1756,6 +1777,7 @@ Proof
   ho_match_mp_tac loop_to_wordTheory.comp_ind>>
   rw[loop_to_wordTheory.comp_def]>>
   gs[wordPropsTheory.extract_labels_def]
+  >- gvs[AllCaseEqs(),extract_labels_def]
   >- (pairarg_tac>>gs[]>>
       pairarg_tac>>gs[]>>
       rveq>>gs[wordPropsTheory.extract_labels_def]>>
@@ -1802,6 +1824,7 @@ Proof
   ho_match_mp_tac loop_to_wordTheory.comp_ind>>
   rw[loop_to_wordTheory.comp_def]>>
   gs[wordPropsTheory.extract_labels_def]
+  >- gvs[AllCaseEqs(),extract_labels_def]
   >- (pairarg_tac>>gs[]>>
       pairarg_tac>>gs[]>>
       rveq>>
@@ -1954,7 +1977,8 @@ Proof
   TRY (Cases_on ‘ret’>-gs[wordPropsTheory.every_inst_def]>>
        rename1 ‘SOME x’>>PairCases_on ‘x’>>gs[]>>
        Cases_on ‘handler’>-gs[wordPropsTheory.every_inst_def]>>
-       rename1 ‘SOME x’>>PairCases_on ‘x’)>>
+       rename1 ‘SOME x’>>PairCases_on ‘x’)
+  >- (TOP_CASE_TAC \\ gvs[every_inst_def,inst_ok_less_def]
   gs[]>>rpt (pairarg_tac>>gs[])>>
   gs[wordPropsTheory.every_inst_def]
 QED

--- a/pancake/proofs/loop_to_wordProofScript.sml
+++ b/pancake/proofs/loop_to_wordProofScript.sml
@@ -1965,37 +1965,77 @@ Proof
   rename1 ‘SOME x’>>PairCases_on ‘x’>>gs[]
 QED
 
+(* TODO: move to loopProps *)
+Definition loop_inst_ok_def:
+  (loop_inst_ok c (Arith (LDiv r1 r2 r3)) ⇔ c.ISA ∈ {ARMv8; MIPS; RISC_V}) ∧
+  (loop_inst_ok c (Arith (LLongMul r1 r2 r3 r4)) ⇔
+     (c.ISA = ARMv7 ⇒ r1 ≠ r2) ∧
+     (c.ISA = ARMv8 ∨ c.ISA = RISC_V ∨ c.ISA = Ag32 ⇒ r1 ≠ r3 ∧ r1 ≠ r4)) ∧
+  (loop_inst_ok c (Arith (LLongDiv r1 r2 r3 r4 r5)) ⇔ c.ISA = x86_64) ∧
+  (loop_inst_ok c _ ⇔ T)
+End
+
 Theorem loop_to_word_comp_every_inst_ok_less:
   ∀ctxt prog l.
-    byte_offset_ok c 0w ⇒
+    byte_offset_ok c 0w ∧ every_prog (loop_inst_ok c) prog ∧
+    domain(acc_vars prog LN) ⊆ domain ctxt ∧
+    INJ (find_var ctxt) (domain ctxt) 𝕌(:num) ∧
+    (∀n m. lookup n ctxt = SOME m ⇒ m ≠ 0)
+    ⇒
     every_inst (inst_ok_less c) (FST (comp ctxt prog l))
 Proof
   ho_match_mp_tac loop_to_wordTheory.comp_ind >>
   rw[loop_to_wordTheory.comp_def,
      wordPropsTheory.every_inst_def,
-     wordPropsTheory.inst_ok_less_def] >>
+     wordPropsTheory.inst_ok_less_def,
+     every_prog_def,DefnBase.one_line_ify NONE loop_inst_ok_def,
+     loopLangTheory.acc_vars_def
+     ]
+  >~ [‘loop_arith_CASE arith’] >-
+   (Cases_on ‘arith’ >>
+    gvs[every_inst_def,inst_ok_less_def] >>
+    rw[] >>
+    res_tac >>
+    fs[INJ_DEF]
+    >- (spose_not_then strip_assume_tac \\ res_tac \\ simp[]) >>
+    rename1 ‘_ ≠ find_var _ nm’ >>
+    Cases_on ‘nm ∈ domain ctxt’ >- metis_tac[] >>
+    fs[GSYM lookup_NONE_domain] >>
+    fs[find_var_def,domain_lookup] >>
+    metis_tac[SOME_11]) >>
   TRY (Cases_on ‘ret’>-gs[wordPropsTheory.every_inst_def]>>
        rename1 ‘SOME x’>>PairCases_on ‘x’>>gs[]>>
        Cases_on ‘handler’>-gs[wordPropsTheory.every_inst_def]>>
-       rename1 ‘SOME x’>>PairCases_on ‘x’)
-  >- (TOP_CASE_TAC \\ gvs[every_inst_def,inst_ok_less_def]
+       rename1 ‘SOME x’>>PairCases_on ‘x’)>>
   gs[]>>rpt (pairarg_tac>>gs[])>>
-  gs[wordPropsTheory.every_inst_def]
+  gs[wordPropsTheory.every_inst_def,
+     PURE_ONCE_REWRITE_CONV [acc_vars_acc] “domain(acc_vars x (acc_vars y z))”,
+     PURE_ONCE_REWRITE_CONV [acc_vars_acc] “domain(acc_vars x (insert y () z))”
+     ]
 QED
 
 Theorem loop_to_word_comp_func_every_inst_ok_less:
   comp_func n params body = p ∧
+  every_prog (loop_inst_ok c) body ∧
   byte_offset_ok c 0w ⇒
   every_inst (inst_ok_less c) p
 Proof
   strip_tac>>gs[loop_to_wordTheory.comp_func_def]>>
   rveq>>
-  drule_then irule loop_to_word_comp_every_inst_ok_less
+  drule_then irule loop_to_word_comp_every_inst_ok_less >>
+  assume_tac $ DECIDE “0 < 2:num” >>
+  dxrule locals_rel_mk_ctxt_ln >>
+  qmatch_goalsub_abbrev_tac ‘make_ctxt _ lista’ >>
+  disch_then $ qspecl_then [‘lista’] mp_tac >>
+  rw[locals_rel_def,Abbr ‘lista’,domain_make_ctxt] >>
+  rw[SUBSET_DEF,set_fromNumSet,domain_difference,domain_toNumSet]
 QED
 
 Theorem loop_to_word_compile_prog_every_inst_ok_less:
   compile_prog lprog = wprog0 ∧
-  byte_offset_ok c 0w ⇒
+  byte_offset_ok c 0w ∧
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) lprog
+  ⇒
   EVERY (λ(n,m,p). every_inst (inst_ok_less c) p) wprog0
 Proof
   strip_tac>>gs[loop_to_wordTheory.compile_prog_def]>>
@@ -2003,17 +2043,124 @@ Proof
   pairarg_tac>>gs[]>>
   pairarg_tac>>gs[]>>
   drule_then irule loop_to_word_comp_func_every_inst_ok_less>>
-  gs[]
+  gs[] >>
+  first_x_assum drule >>
+  simp[]
+QED
+
+Triviality comp_with_loop_alt_ind =
+  loop_removeTheory.comp_with_loop_ind
+    |> PURE_REWRITE_RULE [METIS_PROVE [] “(a,b) = comp_with_loop x y z w ⇔ comp_with_loop x y z w = (a,b)”,
+                          METIS_PROVE [] “(a,b) = store_cont x y z ⇔ store_cont x y z = (a,b)”];
+
+
+Triviality eq_forall_elim:
+  (∀x. y = x ⇒ P x) = P y
+Proof
+  metis_tac[]
+QED
+
+Theorem every_loop_inst_ok_comp_no_loop:
+  ∀p prog.
+    every_prog (loop_inst_ok c) prog ∧
+    every_prog (loop_inst_ok c) (FST p) ∧
+    every_prog (loop_inst_ok c) (SND p)
+    ⇒
+    every_prog (loop_inst_ok c) (comp_no_loop p prog)
+Proof
+  ho_match_mp_tac loop_removeTheory.comp_no_loop_ind \\
+  rw[every_prog_def,loop_inst_ok_def, loop_removeTheory.comp_no_loop_def] \\
+  Cases_on ‘handler’ \\ gvs[] \\
+  PairCases_on ‘x’ \\ gvs[]
+QED
+
+Theorem every_loop_inst_ok_comp:
+  ∀p prog cont s body n funs.
+    comp_with_loop p prog cont s = (body,n,funs) ∧
+    every_prog (loop_inst_ok c) prog ∧
+    every_prog (loop_inst_ok c) cont ∧
+    EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) (SND s) ∧
+    every_prog (loop_inst_ok c) (FST p) ∧
+    every_prog (loop_inst_ok c) (SND p) ⇒
+    (every_prog (loop_inst_ok c) body ∧
+     EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) funs)
+Proof
+  (* slow *)
+  ho_match_mp_tac comp_with_loop_alt_ind \\
+  rw[loop_removeTheory.comp_with_loop_def,every_prog_def,loop_inst_ok_def] \\
+  rpt(pairarg_tac \\ fs[] \\ rveq)
+  >~ [‘option_CASE’] (* handler case*) >-
+   (PRED_ASSUM is_forall (fn thm =>
+      PRED_ASSUM is_forall (fn thm' =>
+                               fs[AllCaseEqs(),every_prog_def,loop_inst_ok_def] \\
+                               rpt(pairarg_tac \\ fs[]) \\
+                               gs[every_prog_def,loop_inst_ok_def,AllCaseEqs(),
+                                  DefnBase.one_line_ify NONE loop_removeTheory.store_cont_def] \\
+                               mp_tac thm \\ mp_tac thm')) \\
+    rveq \\ gvs[DefnBase.one_line_ify NONE loop_removeTheory.store_cont_def,
+                every_prog_def,loop_inst_ok_def] \\
+    metis_tac[FST,SND,PAIR])
+  >~ [‘option_CASE’] (* handler case, snd conjunct*) >-
+   (PRED_ASSUM is_forall (fn thm =>
+      PRED_ASSUM is_forall (fn thm' =>
+                               fs[AllCaseEqs(),every_prog_def,loop_inst_ok_def] \\
+                               rpt(pairarg_tac \\ fs[]) \\
+                               gs[every_prog_def,loop_inst_ok_def,AllCaseEqs(),
+                                  DefnBase.one_line_ify NONE loop_removeTheory.store_cont_def] \\
+                               mp_tac thm \\ mp_tac thm')) \\
+    rveq \\ gvs[DefnBase.one_line_ify NONE loop_removeTheory.store_cont_def,
+                every_prog_def,loop_inst_ok_def] \\
+    metis_tac[FST,SND,PAIR]) \\
+  rpt $ PRED_ASSUM is_forall mp_tac \\
+  gvs[AllCaseEqs(),every_prog_def,loop_inst_ok_def] \\
+  rpt(pairarg_tac \\ gvs[]) \\
+  gvs[every_prog_def,loop_inst_ok_def,AllCaseEqs(),
+      DefnBase.one_line_ify NONE loop_removeTheory.store_cont_def] \\
+  metis_tac[FST,SND,PAIR,every_loop_inst_ok_comp_no_loop]
+QED
+
+Theorem every_loop_inst_ok_comp:
+  every_prog (loop_inst_ok c) prog ∧
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) (SND s) ∧
+  comp (name,params,prog) s = (n,funs) ⇒
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) funs
+Proof
+  rw[loop_removeTheory.comp_def] \\
+  pairarg_tac \\ gvs[] \\
+  drule_then match_mp_tac every_loop_inst_ok_comp \\
+  rw[every_prog_def,loop_inst_ok_def]
+QED
+
+Theorem every_loop_inst_ok_comp_prog:
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) lprog ⇒
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) (comp_prog lprog)
+Proof
+  rw[loop_removeTheory.comp_prog_def,EVERY_MEM] \\
+  qmatch_asmsub_abbrev_tac ‘FOLDR comp acc’ \\
+  ‘EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) (SND acc)’
+    by(rw[Abbr ‘acc’]) \\
+  qhdtm_x_assum ‘Abbrev’ kall_tac \\
+  rpt $ pop_assum mp_tac \\
+  qid_spec_tac ‘acc’ \\
+  Induct_on ‘lprog’ using SNOC_INDUCT
+  THEN1 rw[EVERY_MEM] \\
+  rw[SF DNF_ss,FOLDR_SNOC] \\
+  rpt(pairarg_tac \\ gvs[]) \\
+  first_x_assum $ match_mp_tac o MP_CANON \\
+  first_x_assum $ irule_at $ Pos hd \\
+  match_mp_tac $ GEN_ALL every_loop_inst_ok_comp \\
+  metis_tac[PAIR,FST,SND]
 QED
 
 Theorem loop_to_word_every_inst_ok_less:
   compile lprog = wprog0 ∧
-  byte_offset_ok c 0w ⇒
+  byte_offset_ok c 0w ∧
+  EVERY (λ(n,params,body). every_prog (loop_inst_ok c) body) lprog ⇒
   EVERY (λ(n,m,p). every_inst (inst_ok_less c) p) wprog0
 Proof
   strip_tac>>gs[loop_to_wordTheory.compile_def]>>
   drule_then irule loop_to_word_compile_prog_every_inst_ok_less>>
-  gs[]
+  gs[every_loop_inst_ok_comp_prog]
 QED
 
 val _ = export_theory();

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -416,6 +416,12 @@ Proof
    rewrite_tac [AND_IMP_INTRO] >> strip_tac >> rveq >>
    fs [])
   >- (
+   rename [‘eval s (Panop op es)’] >>
+   rw[eval_def] \\
+   gvs[AllCaseEqs(),DefnBase.one_line_ify NONE pan_op_def,MAP_EQ_CONS,PULL_EXISTS,
+       pan_commonPropsTheory.opt_mmap_eq_some,SF DNF_ss] \\
+   metis_tac[])
+  >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def] >>
    fs [option_case_eq, v_case_eq, word_lab_case_eq] >> rveq >>
@@ -426,6 +432,24 @@ Proof
   fs [state_rel_def, state_component_equality]
 QED
 
+(* TODO: move *)
+Theorem OPT_MMAP_NONE:
+  OPT_MMAP f xs = NONE ⇒
+  ∃x. MEM x xs ∧ f x = NONE
+Proof
+  Induct_on ‘xs’ \\ rw[PULL_EXISTS] \\
+  metis_tac[]
+QED
+
+(* TODO: move *)
+Theorem OPT_MMAP_NONE':
+  MEM x xs ∧ f x = NONE ⇒ OPT_MMAP f xs = NONE
+Proof
+  Induct_on ‘xs’ \\ rw[PULL_EXISTS]
+  THEN1 metis_tac[] \\
+  Cases_on ‘x = h’ \\ gvs[] \\
+  Cases_on ‘f h’ \\ gvs[]
+QED
 
 Theorem compile_eval_correct_none:
   ∀s e t.
@@ -512,6 +536,34 @@ Proof
    fs [] >>
    imp_res_tac compile_eval_correct >>
    fs [])
+  >- (
+   rename [‘eval s (Panop op es)’] >>
+   rw[eval_def] \\
+   PURE_TOP_CASE_TAC
+   THEN1 (gvs[AllCaseEqs(),DefnBase.one_line_ify NONE pan_op_def,MAP_EQ_CONS,PULL_EXISTS,
+              SF DNF_ss] \\
+          imp_res_tac OPT_MMAP_NONE \\
+          gvs[] \\
+          res_tac \\
+          disj1_tac \\
+          metis_tac[OPT_MMAP_NONE']) \\
+   gvs[] \\
+   strip_tac \\
+   gvs[eval_def,AllCaseEqs()]
+   THEN1 (imp_res_tac OPT_MMAP_NONE \\
+          fs[] \\
+          metis_tac[NOT_NONE_SOME,OPT_MMAP_NONE']) \\
+   qpat_x_assum ‘_ ⇒ _’ mp_tac \\ impl_keep_tac
+   THEN1 (gvs[EVERY_MEM] \\
+          rw[] \\
+          gvs[pan_commonPropsTheory.opt_mmap_eq_some,MAP_EQ_EVERY2,LIST_REL_EL_EQN,MEM_EL,PULL_EXISTS] \\
+          res_tac \\
+          drule_all_then strip_assume_tac compile_eval_correct \\
+          gvs[]) \\
+   imp_res_tac pan_commonPropsTheory.opt_mmap_length_eq \\
+   rw[DefnBase.one_line_ify NONE pan_op_def,AllCaseEqs(),MAP_EQ_CONS,PULL_EXISTS] \\
+   gvs[quantHeuristicsTheory.LIST_LENGTH_1,LENGTH_CONS] \\
+   every_case_tac \\ gvs[])
   >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def] >>

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -317,6 +317,18 @@ Proof
        TOP_CASE_TAC >> fs [v2word_def]) >>
      unabbrev_all_tac >> fs [])
   >- (
+   rename1 ‘Panop’ >>
+   rpt gen_tac >> strip_tac >>
+   gvs[compile_exp_def,AllCaseEqs(),eval_def,panLangTheory.size_of_shape_def,
+       panSemTheory.eval_def,crepSemTheory.eval_def,flatten_def,shape_of_def,
+       DefnBase.one_line_ify NONE pan_op_def,MAP_EQ_CONS,opt_mmap_eq_some,
+       cexp_heads_def,PULL_EXISTS, SF DNF_ss
+      ] >>
+   rpt $ qpat_x_assum ‘SOME _ = _’ $ assume_tac o GSYM >>
+   rpt $ first_x_assum $ drule_then $ drule_then $ drule_then drule >>
+   rpt $ disch_then $ resolve_then Any assume_tac $ GSYM PAIR >>
+   gvs[flatten_def,shape_of_def,compile_panop_def,crep_op_def])
+  >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def] >>
    fs [option_case_eq, v_case_eq, word_lab_case_eq] >> rveq >>
@@ -770,6 +782,19 @@ Proof
     qexists_tac ‘var_cexp y’ >>
     fs [] >> metis_tac []) >>
    fs [])
+  >- (rpt strip_tac >>
+      gvs[panSemTheory.eval_def,AllCaseEqs(),
+         DefnBase.one_line_ify NONE pan_op_def,
+         MAP_EQ_CONS,MEM_MAP,MEM_FLAT,compile_exp_def,
+         opt_mmap_eq_some,cexp_heads_def,PULL_EXISTS,
+         SF DNF_ss,var_cexp_def
+        ] >>
+      rpt $ first_x_assum $ resolve_then (Pat ‘_ = (_,_)’) assume_tac $ GSYM PAIR >>
+      rpt $ qpat_x_assum ‘SOME _ = _’ $ assume_tac o GSYM >>
+      rpt $ first_x_assum $ drule_then $ drule_then $ drule_then $ drule >>
+      rpt strip_tac >>
+      metis_tac[FST,MEM]
+     )
   >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def, option_case_eq, v_case_eq,
@@ -1657,6 +1682,16 @@ Proof
    impl_tac >- metis_tac [] >>
    impl_tac >- fs [] >>
    fs [EVERY_MEM])
+  >- (
+   rpt strip_tac >>
+   gvs[panSemTheory.eval_def,compile_exp_def,AllCaseEqs(),cexp_heads_def,
+       DefnBase.one_line_ify NONE pan_op_def,MAP_EQ_CONS,exps_def,
+       opt_mmap_eq_some, SF DNF_ss
+     ] >>
+   rpt $ first_x_assum $ resolve_then (Pos last) assume_tac $ GSYM PAIR >>
+   rpt $ qpat_x_assum ‘SOME _ = _’ $ assume_tac o GSYM >>
+   rpt $ first_x_assum $ drule_then $ drule_then $ drule_then drule >>
+   rw[] >> metis_tac[])
   >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def, option_case_eq, v_case_eq,

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -327,7 +327,7 @@ Proof
    rpt $ qpat_x_assum ‘SOME _ = _’ $ assume_tac o GSYM >>
    rpt $ first_x_assum $ drule_then $ drule_then $ drule_then drule >>
    rpt $ disch_then $ resolve_then Any assume_tac $ GSYM PAIR >>
-   gvs[flatten_def,shape_of_def,compile_panop_def,crep_op_def])
+   gvs[flatten_def,shape_of_def,DefnBase.one_line_ify NONE compile_panop_def,crep_op_def])
   >- (
    rpt gen_tac >> strip_tac >>
    fs [panSemTheory.eval_def] >>

--- a/pancake/semantics/crepPropsScript.sml
+++ b/pancake/semantics/crepPropsScript.sml
@@ -1265,5 +1265,40 @@ Proof
   fs []
 QED
 
+Definition exps_of_def:
+  (exps_of (Dec _ e p) = e::exps_of p) ∧
+  (exps_of (Seq p q) = exps_of p ++ exps_of q) ∧
+  (exps_of (If e p q) = e::exps_of p ++ exps_of q) ∧
+  (exps_of (While e p) = e::exps_of p) ∧
+  (exps_of (Call NONE e es) = e::es) ∧
+  (exps_of (Call (SOME (_,p,NONE)) e es) = e::es++exps_of p) ∧
+  (exps_of (Call (SOME (_,p,SOME(_,p'))) e es) = e::es++exps_of p++exps_of p') ∧
+  (exps_of (Store e1 e2) = [e1;e2]) ∧
+  (exps_of (StoreByte e1 e2) = [e1;e2]) ∧
+  (exps_of (StoreGlob _ e) = [e]) ∧
+  (exps_of (Return e) = [e]) ∧
+  (exps_of (Assign _ e) = [e]) ∧
+  (exps_of _ = [])
+End
+
+Definition every_exp_def:
+  (every_exp P (crepLang$Const w) = P(Const w)) ∧
+  (every_exp P (Var v) = P(Var v)) ∧
+  (every_exp P (Label f) = P(Label f)) ∧
+  (every_exp P (Load e) = (P(Load e) ∧ every_exp P e)) ∧
+  (every_exp P (LoadByte e) = (P(LoadByte e) ∧ every_exp P e)) ∧
+  (every_exp P (LoadGlob w) = (P(LoadGlob w))) ∧
+  (every_exp P (Op bop es) = (P(Op bop es) ∧ EVERY (every_exp P) es)) ∧
+  (every_exp P (Crepop op es) = (P(Crepop op es) ∧ EVERY (every_exp P) es)) ∧
+  (every_exp P (Cmp c e1 e2) = (P(Cmp c e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
+  (every_exp P (Shift sh e num) = (P(Shift sh e num) ∧ every_exp P e)) ∧
+  (every_exp P (BaseAddr) = P BaseAddr)
+Termination
+  wf_rel_tac `measure (exp_size ARB o SND)` >>
+  rpt strip_tac >>
+  imp_res_tac MEM_IMP_exp_size >>
+  TRY (first_x_assum (assume_tac o Q.SPEC `ARB`)) >>
+  decide_tac
+End
 
 val _ = export_theory();

--- a/pancake/semantics/crepPropsScript.sml
+++ b/pancake/semantics/crepPropsScript.sml
@@ -171,7 +171,14 @@ Proof
        MAP_EQ_EVERY2, LIST_REL_EL_EQN] >>
    rw [] >>
    fs [MEM_FLAT, MEM_MAP] >>
-   metis_tac [EL_MEM]) >>
+   metis_tac [EL_MEM])
+  >- (
+   rpt gen_tac >>
+   strip_tac >>
+   gvs [var_cexp_def, eval_def, AllCaseEqs(),opt_mmap_eq_some,SF DNF_ss,
+        DefnBase.one_line_ify NONE crep_op_def,MAP_EQ_CONS,MEM_FLAT,MEM_MAP,PULL_EXISTS] >>
+   metis_tac[]
+  ) >>
   rpt gen_tac >>
   rpt strip_tac >> fs [var_cexp_def, ETA_AX] >>
   fs [eval_def, CaseEq "option", CaseEq "word_lab"] >>
@@ -221,7 +228,16 @@ Proof
    rw[]\\
    gvs[var_cexp_def,MEM_MAP,MEM_FLAT] \\
    first_x_assum(match_mp_tac o MP_CANON) \\
-   metis_tac[]) \\
+   metis_tac[])
+  >- (
+   rpt strip_tac >>
+   gvs[eval_def,var_cexp_def,MEM_FLAT,MEM_MAP] >>
+   qmatch_goalsub_abbrev_tac ‘option_CASE a1 _ _ = option_CASE a2 _ _’ >>
+   ‘a1 = a2’ suffices_by simp[] >>
+   unabbrev_all_tac >>
+   match_mp_tac OPT_MMAP_cong >>
+   rw[] >>
+   metis_tac[]) >>
   rpt gen_tac >>
   rpt strip_tac >> fs [var_cexp_def, ETA_AX] >>
   fs [eval_def, CaseEq "option", CaseEq "word_lab"] >>
@@ -646,7 +662,6 @@ Proof
    fs [eval_def, CaseEq "option", CaseEq "word_lab"] >>
    rveq >> metis_tac [])
   >- fs [exps_def, eval_def, CaseEq "option"]
-
   >- (
    rpt gen_tac >>
    strip_tac >> fs [exps_def, ETA_AX] >>
@@ -656,7 +671,16 @@ Proof
        MAP_EQ_EVERY2, LIST_REL_EL_EQN] >>
    rw [] >>
    fs [MEM_FLAT, MEM_MAP] >>
-   metis_tac [EL_MEM]) >>
+   metis_tac [EL_MEM])
+  >- (
+   rpt gen_tac >>
+   strip_tac >>
+   gvs [exps_def, eval_def, AllCaseEqs(),opt_mmap_eq_some,SF DNF_ss,
+        MAP_EQ_CONS,MEM_FLAT,MEM_MAP,PULL_EXISTS] >>
+   first_x_assum $ irule_at $ Pos last >>
+   simp[] >>
+   gvs[MAP_EQ_EVERY2,LIST_REL_EL_EQN] >>
+   metis_tac[EL_MEM]) >>
   rpt gen_tac >>
   rpt strip_tac >> fs [exps_def, ETA_AX] >>
   fs [eval_def, CaseEq "option", CaseEq "word_lab"] >>
@@ -819,21 +843,14 @@ Proof
   TRY (
   fs [eval_def, var_cexp_def] >>
   FULL_CASE_TAC >> fs [] >> NO_TAC)
-  >- (
-   fs [var_cexp_def, ETA_AX] >>
-   fs [eval_def] >>
-   FULL_CASE_TAC >> fs [ETA_AX] >> rveq >>
-   pop_assum kall_tac >> pop_assum kall_tac >>
-   rpt (pop_assum mp_tac) >>
-   MAP_EVERY qid_spec_tac [`n`,`x`,`s`, `es`] >>
-   Induct >- rw [] >>
-   rpt gen_tac >>
-   rpt strip_tac >>
-   fs [OPT_MMAP_def] >> rveq >> fs [] >>
-   last_x_assum (qspecl_then [‘s’, ‘t’, ‘n’] mp_tac) >>
-   fs [] >>
-   impl_tac >- metis_tac [] >>
-   fs []) >>
+  >- (gvs [var_cexp_def,MEM_FLAT,MEM_MAP,eval_def,AllCaseEqs(),opt_mmap_eq_some,
+           MAP_EQ_EVERY2, LIST_REL_EL_EQN] >>
+      first_x_assum $ drule_then match_mp_tac >>
+      metis_tac[MEM_EL])
+  >- (gvs [var_cexp_def,MEM_FLAT,MEM_MAP,eval_def,AllCaseEqs(),opt_mmap_eq_some,
+           MAP_EQ_EVERY2, LIST_REL_EL_EQN] >>
+      first_x_assum $ drule_then match_mp_tac >>
+      metis_tac[MEM_EL]) >>
   fs [var_cexp_def, eval_def] >>
   every_case_tac >> fs []
 QED

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -82,6 +82,13 @@ Definition lookup_code_def:
       | _ => NONE
 End
 
+Definition crep_op_def:
+  crep_op crepLang$Div [w1;w2] = SOME(w1 / w2) ∧
+  crep_op Mul [w1;w2] = SOME(w1 * w2) ∧
+  crep_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
+  crep_op _ _ = NONE
+End
+
 Definition eval_def:
   (eval (s:('a,'ffi) crepSem$state) ((Const w):'a crepLang$exp) = SOME (Word w)) ∧
   (eval s (Var v) = FLOOKUP s.locals v) ∧
@@ -107,6 +114,13 @@ Definition eval_def:
        if (EVERY (\w. case w of (Word _) => T | _ => F) ws)
        then OPTION_MAP Word
             (word_op op (MAP (\w. case w of Word n => n) ws)) else NONE
+      | _ => NONE) /\
+  (eval s (Crepop op es) =
+    case (OPT_MMAP (eval s) es) of
+     | SOME ws =>
+       if (EVERY (\w. case w of (Word _) => T | _ => F) ws)
+       then OPTION_MAP Word
+            (crep_op op (MAP (\w. case w of Word n => n) ws)) else NONE
       | _ => NONE) /\
   (eval s (Cmp cmp e1 e2) =
     case (eval s e1, eval s e2) of

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -83,13 +83,7 @@ Definition lookup_code_def:
 End
 
 Definition crep_op_def:
-  (crep_op crepLang$Div [w1;w2] =
-   if w2 ≠ 0w then SOME(w1 / w2)
-   else NONE) ∧
-  crep_op Mul [w1;w2] = SOME(w1 * w2) ∧
-  (crep_op Mod [w1;w2] =
-   if w2 ≠ 0w then SOME(word_mod w1 w2)
-   else NONE) ∧
+  crep_op crepLang$Mul [w1:'a word;w2] = SOME(w1 * w2) ∧
   crep_op _ _ = NONE
 End
 

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -83,9 +83,13 @@ Definition lookup_code_def:
 End
 
 Definition crep_op_def:
-  crep_op crepLang$Div [w1;w2] = SOME(w1 / w2) ∧
+  (crep_op crepLang$Div [w1;w2] =
+   if w2 ≠ 0w then SOME(w1 / w2)
+   else NONE) ∧
   crep_op Mul [w1;w2] = SOME(w1 * w2) ∧
-  crep_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
+  (crep_op Mod [w1;w2] =
+   if w2 ≠ 0w then SOME(word_mod w1 w2)
+   else NONE) ∧
   crep_op _ _ = NONE
 End
 

--- a/pancake/semantics/loopPropsScript.sml
+++ b/pancake/semantics/loopPropsScript.sml
@@ -72,6 +72,12 @@ Definition cut_sets_def:
   (cut_sets l (LoadByte n m) = insert m () l) ∧
   (cut_sets l (Seq p q) = cut_sets (cut_sets l p) q) ∧
   (cut_sets l (If _ _ _ p q nl) = nl) ∧
+  (cut_sets l (Arith arith) =
+   case arith of
+     LLongDiv r1 r2 _ _ _ => insert r1 () $ insert r2 () l
+   | LLongMul r1 r2 _ _ => insert r1 () $ insert r2 () l
+   | LDiv r1 _ _ => insert r1 () l
+  ) ∧
   (cut_sets l _ = l)
 End
 

--- a/pancake/semantics/loopPropsScript.sml
+++ b/pancake/semantics/loopPropsScript.sml
@@ -84,6 +84,7 @@ End
 Definition comp_syntax_ok_def:
   (comp_syntax_ok l loopLang$Skip = T) ∧
   (comp_syntax_ok l (Assign n e) = T) ∧
+  (comp_syntax_ok l (Arith arith) = T) ∧
   (comp_syntax_ok l (LocValue n m) = T) ∧
   (comp_syntax_ok l (LoadByte n m) = T) ∧
   (comp_syntax_ok l (Seq p q) = (comp_syntax_ok l p ∧ comp_syntax_ok (cut_sets l p) q)) ∧
@@ -597,6 +598,10 @@ Proof
   rename [‘insert vn () l’] >>
   qexists_tac ‘insert vn () LN’ >>
   fs [Once insert_union, union_num_set_sym] >> NO_TAC)
+  >- (rename1 ‘Arith l’ >> Cases_on ‘l’  >> rw[] >>
+      simp[Once insert_union,union_num_set_sym] >>
+      simp[Once insert_union,SimpR “union”, union_num_set_sym] >>
+      metis_tac[union_num_set_sym,union_assoc])
   >- (
    drule comp_syn_ok_seq >>
    strip_tac >>
@@ -667,6 +672,11 @@ Proof
   TRY (
   fs [evaluate_def] >> rveq >>
   TRY every_case_tac >> fs [set_var_def, state_component_equality] >> NO_TAC)
+  >- (rename1 ‘Arith’ >>
+      gvs[comp_syntax_ok_def,evaluate_def,AllCaseEqs(),
+         DefnBase.one_line_ify NONE loop_arith_def] >>
+      simp[state_component_equality,set_var_def]) >>
+  TRY every_case_tac >> fs [set_var_def, state_component_equality]
   >- (
    drule comp_syn_ok_seq >>
    strip_tac >>
@@ -726,6 +736,13 @@ Proof
   fs [evaluate_def] >>
   every_case_tac >> fs [] >> rveq >>
   fs [set_var_def, assigned_vars_def, lookup_insert] >> NO_TAC)
+  >- (
+    rename1 ‘Arith’ >>
+    gvs[evaluate_def,assigned_vars_def,
+        DefnBase.one_line_ify NONE loop_arith_def,
+        AllCaseEqs(),set_var_def,lookup_insert
+       ]
+     )
   >- (
    drule comp_syn_ok_seq >>
    strip_tac >>

--- a/pancake/semantics/loopSemScript.sml
+++ b/pancake/semantics/loopSemScript.sml
@@ -70,6 +70,13 @@ Definition mem_load_def:
     else NONE
 End
 
+Definition loop_op_def:
+  loop_op Div [w1;w2] = SOME(w1 / w2) ∧
+  loop_op Mul [w1;w2] = SOME(w1 * w2) ∧
+  loop_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
+  loop_op _ _ = NONE
+End
+
 Definition eval_def:
   (eval ^s ((Const w):'a loopLang$exp) = SOME (Word w)) /\
   (eval s (Var v) = lookup v s.locals) /\
@@ -82,6 +89,10 @@ Definition eval_def:
      case the_words (MAP (eval s) wexps) of
      | SOME ws => (OPTION_MAP Word (word_op op ws))
      | _ => NONE) /\
+  (eval s (Loopop op es) =
+    case the_words (MAP (eval s) es) of
+     | SOME ws => OPTION_MAP Word (loop_op op ws)
+      | _ => NONE) /\
   (eval s (Shift sh wexp n) =
      case eval s wexp of
      | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)

--- a/pancake/semantics/loopSemScript.sml
+++ b/pancake/semantics/loopSemScript.sml
@@ -70,13 +70,6 @@ Definition mem_load_def:
     else NONE
 End
 
-Definition loop_op_def:
-  loop_op Div [w1;w2] = SOME(w1 / w2) ∧
-  loop_op Mul [w1;w2] = SOME(w1 * w2) ∧
-  loop_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
-  loop_op _ _ = NONE
-End
-
 Definition eval_def:
   (eval ^s ((Const w):'a loopLang$exp) = SOME (Word w)) /\
   (eval s (Var v) = lookup v s.locals) /\
@@ -89,10 +82,6 @@ Definition eval_def:
      case the_words (MAP (eval s) wexps) of
      | SOME ws => (OPTION_MAP Word (word_op op ws))
      | _ => NONE) /\
-  (eval s (Loopop op es) =
-    case the_words (MAP (eval s) es) of
-     | SOME ws => OPTION_MAP Word (loop_op op ws)
-      | _ => NONE) /\
   (eval s (Shift sh wexp n) =
      case eval s wexp of
      | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
@@ -124,6 +113,35 @@ End
 Definition set_vars_def:
   set_vars vs xs ^s =
   (s with locals := (alist_insert vs xs s.locals))
+End
+
+Definition loop_arith_def:
+  (loop_arith ^s (LDiv r1 r2 r3) =
+   case (lookup r3 s.locals, lookup r2 s.locals) of
+     (SOME (Word q), SOME(Word w2)) =>
+       if q ≠ 0w then
+         SOME(set_var r1 (Word (w2 / q)) s)
+       else NONE
+   | _  => NONE
+  ) ∧
+  (loop_arith ^s (LLongMul r1 r2 r3 r4) =
+   case (lookup r3 s.locals, lookup r4 s.locals) of
+     (SOME (Word w3), SOME(Word w4)) =>
+       (let r = w2n w3 * w2n w4 in
+          SOME (set_var r2 (Word (n2w r)) (set_var r1 (Word (n2w (r DIV dimword(:'a)))) s)))
+   | _  => NONE) ∧
+  (loop_arith ^s (LLongDiv r1 r2 r3 r4 r5) =
+   case (lookup r3 s.locals, lookup r4 s.locals, lookup r5 s.locals) of
+     (SOME (Word w3), SOME(Word w4), SOME(Word w5)) =>
+       (let n = w2n w3 * dimword (:'a) + w2n w4;
+            d = w2n w5;
+            q = n DIV d
+        in
+          if (d ≠ 0 ∧ q < dimword(:'a)) then
+            SOME (set_var r1 (Word (n2w q)) (set_var r2 (Word (n2w (n MOD d))) s))
+          else NONE)
+   | _  => NONE
+  )
 End
 
 Definition find_code_def:
@@ -184,6 +202,10 @@ Definition evaluate_def:
      case eval s exp of
      | NONE => (SOME Error, s)
      | SOME w => (NONE, set_var v w s)) /\
+  (evaluate (Arith arith,s) =
+     case loop_arith s arith of
+       NONE => (SOME Error, s)
+     | SOME s' => (NONE,s')) /\
   (evaluate (Store exp v,s) =
      case (eval s exp, lookup v s.locals) of
      | (SOME (Word adr), SOME w) =>
@@ -331,7 +353,8 @@ Proof
   \\ rpt (pairarg_tac \\ fs [])
   \\ fs [CaseEq"option",CaseEq"word_loc",mem_store_def,CaseEq"bool",CaseEq"result",
          pair_case_eq,cut_res_def]
-  \\ fs [] \\ rveq \\ fs [set_var_def,set_globals_def]
+  \\ fs[DefnBase.one_line_ify NONE loop_arith_def,CaseEq "loop_arith",
+       CaseEq "option", CaseEq "word_loc",set_var_def] \\ rveq \\ fs[]
   \\ imp_res_tac fix_clock_IMP_LESS_EQ \\ fs []
   \\ rename [‘cut_res _ xx’] \\ PairCases_on ‘xx’ \\ fs []
   \\ fs [cut_res_def]

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -1192,8 +1192,6 @@ Proof
   fs []
 QED
 
-
-
 Theorem update_locals_not_vars_eval_eq:
   ∀s e v n w.
   ~MEM n (var_exp e) /\
@@ -1258,6 +1256,13 @@ Proof
    rw [] >>
    fs [MEM_FLAT, MEM_MAP] >>
    metis_tac [EL_MEM])
+  >- (
+   rpt gen_tac >>
+   strip_tac >>
+   gvs [var_exp_def, eval_def, AllCaseEqs(),opt_mmap_eq_some,SF DNF_ss,
+        DefnBase.one_line_ify NONE pan_op_def,MAP_EQ_CONS,MEM_FLAT,MEM_MAP,PULL_EXISTS] >>
+   metis_tac[]
+  )
   >- (
     rw [] >>
     gs [var_exp_def, eval_def] >>

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -1328,4 +1328,43 @@ Proof
      metis_tac[PAIR,FST,SND])
 QED
 
+
+Definition every_exp_def:
+  (every_exp P (panLang$Const w) = P(Const w)) ∧
+  (every_exp P (Var v) = P(Var v)) ∧
+  (every_exp P (Label f) = P(Label f)) ∧
+  (every_exp P (Struct es) = (P(Struct es) ∧ EVERY (every_exp P) es)) ∧
+  (every_exp P (Field i e) = (P(Field i e) ∧ every_exp P e)) ∧
+  (every_exp P (Load sh e) = (P(Load sh e) ∧ every_exp P e)) ∧
+  (every_exp P (LoadByte e) = (P(LoadByte e) ∧ every_exp P e)) ∧
+  (every_exp P (Op bop es) = (P(Op bop es) ∧ EVERY (every_exp P) es)) ∧
+  (every_exp P (Panop op es) = (P(Panop op es) ∧ EVERY (every_exp P) es)) ∧
+  (every_exp P (Cmp c e1 e2) = (P(Cmp c e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
+  (every_exp P (Shift sh e num) = (P(Shift sh e num) ∧ every_exp P e)) ∧
+  (every_exp P BaseAddr = P BaseAddr)
+Termination
+  wf_rel_tac `measure (exp_size ARB o SND)` >>
+  rpt strip_tac >>
+  imp_res_tac MEM_IMP_exp_size >>
+  TRY (first_x_assum (assume_tac o Q.SPEC `ARB`)) >>
+  decide_tac
+End
+
+Definition exps_of_def:
+  (exps_of (Raise _ e) = [e]) ∧
+  (exps_of (Dec _ e p) = e::exps_of p) ∧
+  (exps_of (Seq p q) = exps_of p ++ exps_of q) ∧
+  (exps_of (If e p q) = e::exps_of p ++ exps_of q) ∧
+  (exps_of (While e p) = e::exps_of p) ∧
+  (exps_of (Call NONE e es) = e::es) ∧
+  (exps_of (Call (SOME (_ , (SOME (_ ,  _ , ep)))) e es) = e::es++exps_of ep) ∧
+  (exps_of (Call (SOME (_ , NONE)) e es) = e::es) ∧
+  (exps_of (Store e1 e2) = [e1;e2]) ∧
+  (exps_of (StoreByte e1 e2) = [e1;e2]) ∧
+  (exps_of (Return e) = [e]) ∧
+  (exps_of (ExtCall _ e1 e2 e3 e4) = [e1;e2;e3;e4]) ∧
+  (exps_of (Assign _ e) = [e]) ∧
+  (exps_of _ = [])
+End
+
 val _ = export_theory();

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -116,6 +116,13 @@ Termination
   fs [list_size_def, shape_size_def]
 End
 
+Definition pan_op_def:
+  pan_op Div [w1;w2] = SOME(w1 / w2) ∧
+  pan_op Mul [w1;w2] = SOME(w1 * w2) ∧
+  pan_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
+  pan_op _ _ = NONE
+End
+
 Definition eval_def:
   (eval ^s (Const w) = SOME (ValWord w)) /\
   (eval s  (Var v) = FLOOKUP s.locals v) /\
@@ -154,6 +161,13 @@ Definition eval_def:
        if (EVERY (\w. case w of (ValWord _) => T | _ => F) ws)
        then OPTION_MAP ValWord
             (word_op op (MAP (\w. case w of ValWord n => n) ws)) else NONE
+      | _ => NONE) /\
+  (eval s (Panop op es) =
+    case (OPT_MMAP (eval s) es) of
+     | SOME ws =>
+       if (EVERY (\w. case w of (ValWord _) => T | _ => F) ws)
+       then OPTION_MAP ValWord
+            (pan_op op (MAP (\w. case w of ValWord n => n) ws)) else NONE
       | _ => NONE) /\
   (eval s (Cmp cmp e1 e2) =
     case (eval s e1, eval s e2) of

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -117,13 +117,7 @@ Termination
 End
 
 Definition pan_op_def:
-  (pan_op Div [w1;w2] =
-   if w2 ≠ 0w then SOME(w1 / w2)
-   else NONE) ∧
-  pan_op Mul [w1;w2] = SOME(w1 * w2) ∧
-  (pan_op Mod [w1;w2] =
-   if w2 ≠ 0w then SOME(word_mod w1 w2)
-   else NONE) ∧
+  pan_op Mul [w1:'a word;w2] = SOME(w1 * w2) ∧
   pan_op _ _ = NONE
 End
 

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -117,9 +117,13 @@ Termination
 End
 
 Definition pan_op_def:
-  pan_op Div [w1;w2] = SOME(w1 / w2) ∧
+  (pan_op Div [w1;w2] =
+   if w2 ≠ 0w then SOME(w1 / w2)
+   else NONE) ∧
   pan_op Mul [w1;w2] = SOME(w1 * w2) ∧
-  pan_op Mod [w1;w2] = SOME(word_mod w1 w2) ∧
+  (pan_op Mod [w1;w2] =
+   if w2 ≠ 0w then SOME(word_mod w1 w2)
+   else NONE) ∧
   pan_op _ _ = NONE
 End
 


### PR DESCRIPTION
Also fixes a parser bug related to nested infix operators, and adds boolean literal parsing. This addresses half of issue #936.

Division would be nice, but I would like it to (a) target hardware division instructions on non-oddball platforms, and (b) give it consistent semantics across platforms. This is currently not possible because the way `asm` is set up, some platforms expose only signed division, and others only unsigned division. In a hypothetical future where `asm` has been extended accordingly, most of the work necessary to add division to the `pan_to_word` part of the compiler can be fished out of the commit history of this PR.