### PR TITLE
Fix Pancake broken parser example

### DIFF
--- a/developers/build-sequence
+++ b/developers/build-sequence
@@ -89,6 +89,7 @@ candle/prover
 pancake
 pancake/ffi
 pancake/semantics
+pancake/parser
 pancake/proofs
 
 # examples and tests

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -174,11 +174,14 @@ val treeEx8 = check_success $ parse_pancake ex8;
 (* Multiplication
  *)
 
-val ex8_and_a_half = ‘x = a * b;
-                      x = a * b * c;
-                      x =  (a + b) * c;
-                      x = a + b * c;
-                      x = a * b + c;’;
+val ex8_and_a_half = ‘
+  fun cmps () {
+    x = a * b;
+    x = a * b * c;
+    x =  (a + b) * c;
+    x = a + b * c;
+    x = a * b + c;
+  }’;
 
 val treeEx8_and_a_half = check_success $ parse_pancake ex8_and_a_half;
 


### PR DESCRIPTION
Also add `pancake/parser` directory to build sequence to prevent similar snafus in the future.