### PR TITLE
Improvements to the flatLang pattern compiler

### DIFF
--- a/compiler/backend/flatLangScript.sml
+++ b/compiler/backend/flatLangScript.sml
@@ -24,7 +24,7 @@ val _ = set_grammar_ancestry ["ast", "backend_common"];
 
 (* Copied from the semantics, but with AallocEmpty missing. GlobalVar ops have
  * been added, also TagLenEq and El for pattern match compilation. *)
-val _ = Datatype `
+Datatype:
  op =
   (* Operations on integers *)
     Opn opn
@@ -101,21 +101,23 @@ val _ = Datatype `
   | LenEq num
   | El num
   (* No-op step for a single value *)
-  | Id`;
+  | Id
+End
 
 Type ctor_id = ``:num``
 (* NONE represents the exception type *)
 Type type_id = ``:num option``
 Type type_group_id = ``:(num # (ctor_id # num) list) option``
 
-val _ = Datatype `
+Datatype:
   pat =
   | Pany
   | Pvar varN
   | Plit lit
   | Pcon ((ctor_id # type_group_id) option) (pat list)
   | Pas pat varN
-  | Pref pat`;
+  | Pref pat
+End
 
 Definition pat_bindings_def:
   (pat_bindings Pany already_bound = already_bound) ∧
@@ -128,7 +130,7 @@ Definition pat_bindings_def:
   (pats_bindings (p::ps) already_bound = pats_bindings ps (pat_bindings p already_bound))
 End
 
-val _ = Datatype`
+Datatype:
   exp =
     Raise tra exp
   | Handle tra exp ((pat # exp) list)
@@ -140,7 +142,8 @@ val _ = Datatype`
   | If tra exp exp exp
   | Mat tra exp ((pat # exp) list)
   | Let tra (varN option) exp exp
-  | Letrec varN ((varN # varN # exp) list) exp`;
+  | Letrec varN ((varN # varN # exp) list) exp
+End
 
 val exp_size_def = definition"exp_size_def";
 
@@ -207,7 +210,7 @@ Proof
   \\ decide_tac
 QED
 
-val _ = Datatype`
+Datatype:
  dec =
     Dlet exp
   (* The first number is the identity for the type. The sptree maps arities to
@@ -215,12 +218,46 @@ val _ = Datatype`
   | Dtype num (num spt)
   (* The first number is the identity of the exception. The second number is the
    * constructor's arity *)
-  | Dexn num num`;
+  | Dexn num num
+End
 
-val bool_id_def = Define `
-  bool_id = 0n`;
+Definition bool_id_def:
+  bool_id = 0n
+End
 
-val Bool_def = Define`
-  Bool t b = Con t (SOME (backend_common$bool_to_tag b, SOME bool_id)) []`;
+Definition Bool_def:
+  Bool t b = Con t (SOME (backend_common$bool_to_tag b, SOME bool_id)) []
+End
+
+Definition SmartIf_def:
+  SmartIf t e p q =
+    case e of
+      Con _ (SOME (tag, SOME id)) [] =>
+        if id = bool_id then
+          if tag = backend_common$true_tag then p
+          else if tag = backend_common$false_tag then q
+          else If t e p q
+        else If t e p q
+    | _ => If t e p q
+End
+
+val _ = patternMatchesLib.ENABLE_PMATCH_CASES();
+
+Theorem SmartIf_PMATCH:
+  !t e p q.
+    SmartIf t e p q =
+      case e of
+        Con _ (SOME (tag, SOME id)) [] =>
+          if id = bool_id then
+            if tag = backend_common$true_tag then p
+            else if tag = backend_common$false_tag then q
+            else If t e p q
+          else If t e p q
+      | _ => If t e p q
+Proof
+  rpt strip_tac
+  \\ CONV_TAC (RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV)
+  \\ rw [SmartIf_def]
+QED
 
 val _ = export_theory ();

--- a/compiler/backend/flat_patternScript.sml
+++ b/compiler/backend/flat_patternScript.sml
@@ -107,24 +107,36 @@ Definition decode_test_def:
 End
 
 Definition simp_guard_def:
-  simp_guard (Conj x y) = (if x = True then simp_guard y
-    else if y = True then simp_guard x
-    else if x = Not True \/ y = Not True then Not True
-    else Conj (simp_guard x) (simp_guard y)) /\
-  simp_guard (Disj x y) = (if x = True \/ y = True then True
-    else if x = Not True then simp_guard y
-    else if y = Not True then simp_guard x
-    else Disj (simp_guard  x) (simp_guard y)) /\
-  simp_guard (Not (Not x)) = simp_guard x /\
-  simp_guard (Not x) = Not (simp_guard x) /\
+  simp_guard (Conj x y) =
+    (let v = simp_guard x in
+     let w = simp_guard y in
+     if v = Not True \/ w = Not True then
+       Not True
+     else if v = True then w
+     else if w = True then v
+     else Conj v w) /\
+  simp_guard (Disj x y) =
+    (let v = simp_guard x in
+     let w = simp_guard y in
+     if v = True \/ w = True then
+       True
+     else if v = Not True then w
+     else if w = Not True then v
+     else Disj v w) /\
+  simp_guard (Not x) =
+    (let v = simp_guard x in
+     case v of
+       Not True => True
+     | Not w => w
+     | _ => Not v) /\
   simp_guard x = x
 End
 
 Definition decode_guard_def:
   decode_guard t v (Not gd) = App t Equality [decode_guard t v gd; Bool t F] /\
-  decode_guard t v (Conj gd1 gd2) = If t (decode_guard t v gd1)
+  decode_guard t v (Conj gd1 gd2) = SmartIf t (decode_guard t v gd1)
     (decode_guard t v gd2) (Bool t F) /\
-  decode_guard t v (Disj gd1 gd2) = If t (decode_guard t v gd1) (Bool t T)
+  decode_guard t v (Disj gd1 gd2) = SmartIf t (decode_guard t v gd1) (Bool t T)
     (decode_guard t v gd2) /\
   decode_guard t v True = Bool t T /\
   decode_guard t v (PosTest pos test) = decode_test t test (decode_pos t v pos)
@@ -141,7 +153,7 @@ Definition decode_dtree_def:
   let dec2 = decode_dtree t br_spt v df dt2 in
   if guard = True then dec1
   else if guard = Not True then dec2
-  else If t (decode_guard t v guard) dec1 dec2
+  else SmartIf t (decode_guard t v guard) dec1 dec2
 End
 
 Definition encode_pat_def:
@@ -165,14 +177,14 @@ Definition naive_pattern_match_def:
   naive_pattern_match t ((flatLang$Pany, _) :: mats) = naive_pattern_match t mats
   /\
   naive_pattern_match t ((Pvar _, _) :: mats) = naive_pattern_match t mats /\
-  naive_pattern_match t ((Plit l, v) :: mats) = If t
+  naive_pattern_match t ((Plit l, v) :: mats) = SmartIf t
     (App t Equality [v; Lit t l]) (naive_pattern_match t mats) (Bool t F) /\
   naive_pattern_match t ((Pcon NONE ps, v) :: mats) =
     naive_pattern_match t (MAPi (\i p. (p, App t (El i) [v])) ps ++ mats) /\
   naive_pattern_match t ((Pas p i, v) :: mats) =
     naive_pattern_match t ((p, v) :: mats) /\
   naive_pattern_match t ((Pcon (SOME stmp) ps, v) :: mats) =
-    If t (App t (TagLenEq (FST stmp) (LENGTH ps)) [v])
+    SmartIf t (App t (TagLenEq (FST stmp) (LENGTH ps)) [v])
       (naive_pattern_match t (MAPi (\i p. (p, App t (El i) [v])) ps ++ mats))
       (Bool t F)
   /\
@@ -188,7 +200,7 @@ End
 Definition naive_pattern_matches_def:
   naive_pattern_matches t v [] dflt_x = dflt_x /\
   naive_pattern_matches t v ((p, x) :: ps) dflt_x =
-  If t (naive_pattern_match t [(p, v)]) x (naive_pattern_matches t v ps dflt_x)
+  SmartIf t (naive_pattern_match t [(p, v)]) x (naive_pattern_matches t v ps dflt_x)
 End
 
 Definition compile_pats_def:
@@ -266,7 +278,7 @@ Definition compile_exp_def:
     let (i, sg1, y1) = compile_exp cfg x1 in
     let (j, sg2, y2) = compile_exp cfg x2 in
     let (k, sg3, y3) = compile_exp cfg x3 in
-    (MAX i (MAX j k), sg1 \/ sg2 \/ sg3, If t y1 y2 y3)) /\
+    (MAX i (MAX j k), sg1 \/ sg2 \/ sg3, SmartIf t y1 y2 y3)) /\
   (compile_exp cfg exp = (0, F, exp)) /\
   (compile_exps cfg [] = (0, F, [])) /\
   (compile_exps cfg (x::xs) =

--- a/compiler/backend/proofs/source_to_flatProofScript.sml
+++ b/compiler/backend/proofs/source_to_flatProofScript.sml
@@ -5649,10 +5649,11 @@ Theorem compile_flat_sub_bag:
   elist_globals (MAP dest_Dlet (FILTER is_Dlet (compile_flat cfg p))) <=
   elist_globals (MAP dest_Dlet (FILTER is_Dlet p))
 Proof
+  cheat (*
   fs [source_to_flatTheory.compile_flat_def]
   \\ metis_tac [
        flat_elimProofTheory.remove_flat_prog_sub_bag,
-       flat_patternProofTheory.compile_decs_elist_globals]
+       flat_patternProofTheory.compile_decs_elist_globals] *)
 QED
 
 Triviality compile_flat_BAG_ALL_DISTINCT = MATCH_MP
@@ -5680,6 +5681,7 @@ Theorem inc_compile_globals_BAG_ALL_DISTINCT:
   BAG_ALL_DISTINCT (elist_globals (MAP dest_Dlet (FILTER is_Dlet
     (SND (inc_compile env_id c prog)))))
 Proof
+  cheat (*
   rw []
   \\ fs [inc_compile_def, inc_compile_prog_def]
   \\ rpt (pairarg_tac \\ full_simp_tac bool_ss [UNCURRY_DEF])
@@ -5690,7 +5692,7 @@ Proof
   \\ imp_res_tac compile_decs_elist_globals
   \\ fs [LIST_TO_BAG_DISTINCT]
   \\ irule listTheory.ALL_DISTINCT_MAP_INJ
-  \\ fs [all_distinct_count_list]
+  \\ fs [all_distinct_count_list] *)
 QED
 
 Theorem SUB_BAG_IMP:
@@ -5713,6 +5715,7 @@ Theorem monotonic_globals_state_co_compile:
                 (FILTER flatProps$is_Dlet p)))))
     (state_co (\c (env_id, decs). inc_compile env_id c (f decs)) orac)
 Proof
+  cheat (*
   rw []
   \\ irule (Q.ISPEC `\c. SUC c.next.vidx` oracle_monotonic_state)
   \\ fs [FORALL_PROD]
@@ -5737,7 +5740,7 @@ Proof
   \\ rfs []
   \\ fs [Q.ISPEC `FST (FST _)` (Q.SPEC `x` EQ_SYM_EQ)]
   \\ rw [] \\ fs []
-  \\ fs [IN_LIST_TO_BAG, MEM_MAP, MEM_COUNT_LIST]
+  \\ fs [IN_LIST_TO_BAG, MEM_MAP, MEM_COUNT_LIST] *)
 QED
 
 val _ = export_theory ();

--- a/compiler/backend/proofs/source_to_flatProofScript.sml
+++ b/compiler/backend/proofs/source_to_flatProofScript.sml
@@ -5649,11 +5649,11 @@ Theorem compile_flat_sub_bag:
   elist_globals (MAP dest_Dlet (FILTER is_Dlet (compile_flat cfg p))) <=
   elist_globals (MAP dest_Dlet (FILTER is_Dlet p))
 Proof
-  cheat (*
   fs [source_to_flatTheory.compile_flat_def]
   \\ metis_tac [
        flat_elimProofTheory.remove_flat_prog_sub_bag,
-       flat_patternProofTheory.compile_decs_elist_globals] *)
+       flat_patternProofTheory.compile_decs_elist_globals,
+       SUB_BAG_TRANS]
 QED
 
 Triviality compile_flat_BAG_ALL_DISTINCT = MATCH_MP
@@ -5681,18 +5681,19 @@ Theorem inc_compile_globals_BAG_ALL_DISTINCT:
   BAG_ALL_DISTINCT (elist_globals (MAP dest_Dlet (FILTER is_Dlet
     (SND (inc_compile env_id c prog)))))
 Proof
-  cheat (*
   rw []
   \\ fs [inc_compile_def, inc_compile_prog_def]
   \\ rpt (pairarg_tac \\ full_simp_tac bool_ss [UNCURRY_DEF])
-  \\ simp_tac bool_ss [FST, SND, flat_patternProofTheory.compile_decs_elist_globals]
+  \\ simp[]
+  \\ match_mp_tac BAG_ALL_DISTINCT_SUB_BAG
+  \\ (irule_at Any) flat_patternProofTheory.compile_decs_elist_globals
   \\ rw []
   \\ fs [glob_alloc_def, op_gbag_def, store_env_id_def, FILTER_APPEND,
         elist_globals_append, env_id_tuple_def]
   \\ imp_res_tac compile_decs_elist_globals
   \\ fs [LIST_TO_BAG_DISTINCT]
   \\ irule listTheory.ALL_DISTINCT_MAP_INJ
-  \\ fs [all_distinct_count_list] *)
+  \\ fs [all_distinct_count_list]
 QED
 
 Theorem SUB_BAG_IMP:
@@ -5715,7 +5716,6 @@ Theorem monotonic_globals_state_co_compile:
                 (FILTER flatProps$is_Dlet p)))))
     (state_co (\c (env_id, decs). inc_compile env_id c (f decs)) orac)
 Proof
-  cheat (*
   rw []
   \\ irule (Q.ISPEC `\c. SUC c.next.vidx` oracle_monotonic_state)
   \\ fs [FORALL_PROD]
@@ -5726,9 +5726,10 @@ Proof
   \\ rpt (disch_tac ORELSE gen_tac)
   \\ TRY (pairarg_tac \\ fs [])
   \\ rveq \\ fs []
-  \\ simp [flat_patternProofTheory.compile_decs_elist_globals]
+  \\ simp[PULL_EXISTS,PULL_FORALL] \\ rpt strip_tac
+  \\ TRY(drule_at Any (MATCH_MP SUB_BAG_IMP (SPEC_ALL flat_patternProofTheory.compile_decs_elist_globals)) \\ strip_tac)
   \\ rpt (pairarg_tac \\ fs [])
-  \\ rveq \\ fs []
+  \\ gvs[]
   \\ imp_res_tac compile_decs_elist_globals
   \\ imp_res_tac compile_decs_num_bindings
   \\ fs []
@@ -5740,7 +5741,7 @@ Proof
   \\ rfs []
   \\ fs [Q.ISPEC `FST (FST _)` (Q.SPEC `x` EQ_SYM_EQ)]
   \\ rw [] \\ fs []
-  \\ fs [IN_LIST_TO_BAG, MEM_MAP, MEM_COUNT_LIST] *)
+  \\ fs [IN_LIST_TO_BAG, MEM_MAP, MEM_COUNT_LIST]
 QED
 
 val _ = export_theory ();

--- a/compiler/bootstrap/compilation/x64/64/README.md
+++ b/compiler/bootstrap/compilation/x64/64/README.md
@@ -6,6 +6,9 @@ inside the logic to produce the verified machine code version of the
 Implements the foreign function interface (FFI) used in the CakeML basis
 library, as a thin wrapper around the relevant system calls.
 
+[hello.cml](hello.cml):
+A simple hello world program in CakeML
+
 [proofs](proofs):
 This directory contains the end-to-end correctness theorem for the
 64-bit version of the CakeML compiler.

--- a/compiler/bootstrap/translation/to_flatProgScript.sml
+++ b/compiler/bootstrap/translation/to_flatProgScript.sml
@@ -119,6 +119,7 @@ val res = translate flat_elimTheory.remove_flat_prog_def;
 (* flat_pattern                                                              *)
 (* ------------------------------------------------------------------------- *)
 
+val _ = translate flatLangTheory.SmartIf_PMATCH
 val _ = translate pattern_compTheory.is_True_def
 val _ = translate pattern_compTheory.is_Any_def
 val _ = translate pattern_compTheory.take_until_Any_def

--- a/compiler/parsing/README.md
+++ b/compiler/parsing/README.md
@@ -33,6 +33,9 @@ Definition of the lexer: code for consuming tokens until a top-level
 semicolon is found (semicolons can be hidden in `let`-`in`-`end` blocks,
 structures, signatures, and between parentheses).
 
+[ocaml](ocaml):
+OCaml lexer and parser frontend for the Candle theorem prover.
+
 [parsingComputeLib.sml](parsingComputeLib.sml):
 compset for the lexer and parser.
 


### PR DESCRIPTION
This PR contains improvements to guard simplification in the flatLang compiler phase that removes pattern matches. Prior to this PR, this phase would create unnecessary `if true ...` and `if false ...` expressions. These conditionals would confuse the analysis of the clos_known phase.