### PR TITLE
Candle parser fixes and additions

### DIFF
--- a/compiler/bootstrap/translation/caml_parserProgScript.sml
+++ b/compiler/bootstrap/translation/caml_parserProgScript.sml
@@ -140,6 +140,18 @@ val _ = update_precondition precparse_side;
 
 val r = preprocess ptree_PPattern_def |> translate;
 
+Theorem ptree_PPattern_side[local]:
+  (∀x. camlptreeconversion_ptree_ppattern_side x) ∧
+  (∀x. camlptreeconversion_ptree_ppatternlist_side x) ∧
+  (∀x y. camlptreeconversion_grabpairs_side x y)
+Proof
+  ho_match_mp_tac ptree_PPattern_ind \\ rw []
+  \\ simp [Once (fetch "-" "camlptreeconversion_ptree_ppattern_side_def")]
+  \\ rw [] \\ gs [caml_lexTheory.isInt_thm, SF SFY_ss]
+QED
+
+val _ = update_precondition ptree_PPattern_side;
+
 val r = preprocess ptree_Pattern_def |> translate;
 
 (* This takes a long time.
@@ -158,7 +170,8 @@ Theorem ptree_Expr_preconds[local]:
   (∀x. camlptreeconversion_ptree_exprlist_side x) ∧
   (∀x. camlptreeconversion_ptree_exprcommas_side x) ∧
   (∀x. camlptreeconversion_ptree_update_side x) ∧
-  (∀x. camlptreeconversion_ptree_updates_side x)
+  (∀x. camlptreeconversion_ptree_updates_side x) ∧
+  (∀x. camlptreeconversion_ptree_index_side x)
 Proof
   ho_match_mp_tac ptree_Expr_ind
   \\ strip_tac
@@ -181,7 +194,6 @@ Proof
 QED
 
 val _ = List.app (ignore o update_precondition) (CONJUNCTS ptree_Expr_preconds);
-
 
 val r = translate partition_types_def;
 

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -746,7 +746,7 @@ Definition camlPEG_def[nocompute]:
             (bindNT nLetRecBindings));
       (INL nLetBinding,
        pegf (choicel [seql [pnt nPattern; tokeq EqualT; pnt nExpr] I;
-                      seql [pnt nValueName; pnt nPatterns;
+                      seql [pnt nValueName; try (pnt nPatterns);
                             try (seql [tokeq ColonT; pnt nType] I);
                             tokeq EqualT; pnt nExpr] I])
             (bindNT nLetBinding));

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -749,7 +749,8 @@ Definition camlPEG_def[nocompute]:
             (bindNT nPatternMatches));
       (* -- Let bindings --------------------------------------------------- *)
       (INL nLetRecBinding,
-       seql [pnt nValueName; pnt nPatterns;
+       seql [pnt nValueName;
+             try (pnt nPatterns);
              try (seql [tokeq ColonT; pnt nType] I);
              tokeq EqualT; pnt nExpr]
             (bindNT nLetRecBinding));

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -266,7 +266,7 @@ Datatype:
     | nSemis | nExprItem | nExprItems | nDefItem
     (* misc *)
     | nShiftOp | nMultOp | nAddOp | nRelOp | nAndOp | nOrOp | nCatOp | nPrefixOp
-    | nAssignOp | nStart
+    | nAssignOp | nPatLiteral | nStart
     (* Declarations through CakeML pragmas *)
     | nCakeMLPragma
 End
@@ -780,8 +780,12 @@ Definition camlPEG_def[nocompute]:
                         try (seql [tokeq ColonT; pnt nType] I)] I);
              tokeq RparT]
             (bindNT nPPar));
+      (INL nPatLiteral,
+       choicel [pegf (pnt nLiteral) (bindNT nPatLiteral);
+                seql [tokeq MinusT; tok isInt mktokLf]
+                     (bindNT nPatLiteral)]);
       (INL nPBase, (* ::= any / var / lit / list / '(' p ')' *)
-       pegf (choicel [pnt nLiteral; pnt nValueName; pnt nPAny; pnt nPList;
+       pegf (choicel [pnt nPatLiteral; pnt nValueName; pnt nPAny; pnt nPList;
                       pnt nPPar])
             (bindNT nPBase));
       (* -- Pat2 ----------------------------------------------------------- *)
@@ -1012,22 +1016,22 @@ val npeg0_rwts =
         “nUpdate”, “nUpdates”, “nERecUpdate”, “nERecCons”, “nLiteral”,
         “nIdent”, “nEList”, “nEConstr”, “nEBase”, “nEPrefix”, “nArrIdx”,
         “nStrIdx”, “nEIndex”, “nERecProj”, “nELazy”, “nEAssert”, “nEFunapp”,
-        “nEApp”, “nLetBinding”, “nPAny”, “nPList”, “nPPar”, “nPBase”, “nPCons”,
-        “nPAs”, “nPOps”, “nPattern”, “nPatterns”, “nLetBindings”,
-        “nLetRecBinding”, “nLetRecBindings”, “nPatternMatches”, “nPatternMatch”,
-        “nEMatch”, “nETry”, “nEFun”, “nEFunction”, “nELet”, “nELetRec”,
-        “nEWhile”, “nEFor”, “nEUnclosed”, “nENeg”, “nEShift”, “nEMult”, “nEAdd”,
-        “nECons”, “nECat”, “nERel”, “nEAnd”, “nEOr”, “nEHolInfix”, “nEProd”,
-        “nEAssign”, “nEIf”, “nESeq”, “nExpr”, “nTypeDefinition”, “nTypeDef”,
-        “nTypeDefs”, “nTVar”, “nTBase”, “nTConstr”, “nTProd”, “nTFun”, “nType”,
-        “nTypeList”, “nTypeLists”, “nTypeParams”, “nConstrDecl”, “nTypeReprs”,
-        “nTypeRepr”, “nTypeInfo”, “nConstrArgs”, “nExcDefinition”, “nTopLet”,
-        “nTopLetRec”, “nOpen”, “nSemis”, “nExprItem”, “nExprItems”,
-        “nModuleDef”, “nModTypeName”, “nModTypePath”, “nSigSpec”, “nExcType”,
-        “nValType”, “nOpenMod”, “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”,
-        “nSigItem”, “nSigItems”, “nModuleType”, “nModAscApp”, “nModAscApps”,
-        “nCakeMLPragma”, “nModuleTypeDef”, “nDefinition”, “nDefItem”,
-        “nModExpr”, “nModuleItem”
+        “nEApp”, “nLetBinding”, “nPAny”, “nPList”, “nPPar”, “nPatLiteral”,
+        “nPBase”, “nPCons”, “nPAs”, “nPOps”, “nPattern”, “nPatterns”,
+        “nLetBindings”, “nLetRecBinding”, “nLetRecBindings”, “nPatternMatches”,
+        “nPatternMatch”, “nEMatch”, “nETry”, “nEFun”, “nEFunction”, “nELet”,
+        “nELetRec”, “nEWhile”, “nEFor”, “nEUnclosed”, “nENeg”, “nEShift”,
+        “nEMult”, “nEAdd”, “nECons”, “nECat”, “nERel”, “nEAnd”, “nEOr”,
+        “nEHolInfix”, “nEProd”, “nEAssign”, “nEIf”, “nESeq”, “nExpr”,
+        “nTypeDefinition”, “nTypeDef”, “nTypeDefs”, “nTVar”, “nTBase”,
+        “nTConstr”, “nTProd”, “nTFun”, “nType”, “nTypeList”, “nTypeLists”,
+        “nTypeParams”, “nConstrDecl”, “nTypeReprs”, “nTypeRepr”, “nTypeInfo”,
+        “nConstrArgs”, “nExcDefinition”, “nTopLet”, “nTopLetRec”, “nOpen”,
+        “nSemis”, “nExprItem”, “nExprItems”, “nModuleDef”, “nModTypeName”,
+        “nModTypePath”, “nSigSpec”, “nExcType”, “nValType”, “nOpenMod”,
+        “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”, “nSigItem”, “nSigItems”,
+        “nModuleType”, “nModAscApp”, “nModAscApps”, “nCakeMLPragma”,
+        “nModuleTypeDef”, “nDefinition”, “nDefItem”, “nModExpr”, “nModuleItem”
       ];
 
 fun wfnt(t,acc) = let
@@ -1051,24 +1055,24 @@ val topo_nts =
         “nModulePath”, “nValuePath”, “nConstr”, “nTypeConstr”, “nFieldName”,
         “nLiteral”, “nIdent”, “nEList”, “nEConstr”, “nERecUpdate”, “nERecCons”,
         “nEBase”, “nEPrefix”, “nEIndex”, “nERecProj”, “nELazy”, “nEAssert”,
-        “nEFunapp”, “nEApp”, “nPAny”, “nPList”, “nPPar”, “nPBase”, “nPCons”,
-        “nPAs”, “nPOps”, “nPattern”, “nPatterns”, “nLetBinding”, “nLetBindings”,
-        “nLetRecBinding”, “nLetRecBindings”, “nPatternMatches”, “nPatternMatch”,
-        “nEMatch”, “nETry”, “nEFun”, “nEFunction”, “nELet”, “nELetRec”,
-        “nEWhile”, “nEFor”, “nEUnclosed”, “nENeg”, “nEShift”, “nEMult”, “nEAdd”,
-        “nECons”, “nECat”, “nERel”, “nEAnd”, “nEOr”, “nEHolInfix”, “nEProd”,
-        “nEAssign”, “nEIf”, “nESeq”, “nExpr”, “nTypeDefinition”, “nTVar”,
-        “nTBase”, “nTConstr”, “nTProd”, “nTFun”, “nType”, “nTypeList”,
-        “nTypeLists”, “nTypeParams”, “nTypeDef”, “nTypeDefs”, “nConstrDecl”,
-        “nTypeReprs”, “nTypeRepr”, “nTypeInfo”, “nUpdate”, “nUpdates”,
-        “nArrIdx”, “nStrIdx”, “nFieldDec”, “nFieldDecs”, “nRecord”,
-        “nConstrArgs”, “nExcDefinition”, “nTopLet”, “nTopLetRec”, “nOpen”,
-        “nSemis”, “nExprItem”, “nExprItems”, “nModuleDef”, “nModTypeName”,
-        “nModTypePath”, “nSigSpec”, “nExcType”, “nValType”, “nOpenMod”,
-        “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”, “nSigItem”, “nSigItems”,
-        “nModuleType”, “nModAscApp”, “nModAscApps”, “nCakeMLPragma”,
-        “nModuleTypeDef”, “nModExpr”, “nDefinition”, “nDefItem”, “nModuleItem”,
-        “nModuleItems”, “nStart”];
+        “nEFunapp”, “nEApp”, “nPAny”, “nPList”, “nPPar”, “nPatLiteral”,
+        “nPBase”, “nPCons”, “nPAs”, “nPOps”, “nPattern”, “nPatterns”,
+        “nLetBinding”, “nLetBindings”, “nLetRecBinding”, “nLetRecBindings”,
+        “nPatternMatches”, “nPatternMatch”, “nEMatch”, “nETry”, “nEFun”,
+        “nEFunction”, “nELet”, “nELetRec”, “nEWhile”, “nEFor”, “nEUnclosed”,
+        “nENeg”, “nEShift”, “nEMult”, “nEAdd”, “nECons”, “nECat”, “nERel”,
+        “nEAnd”, “nEOr”, “nEHolInfix”, “nEProd”, “nEAssign”, “nEIf”, “nESeq”,
+        “nExpr”, “nTypeDefinition”, “nTVar”, “nTBase”, “nTConstr”, “nTProd”,
+        “nTFun”, “nType”, “nTypeList”, “nTypeLists”, “nTypeParams”, “nTypeDef”,
+        “nTypeDefs”, “nConstrDecl”, “nTypeReprs”, “nTypeRepr”, “nTypeInfo”,
+        “nUpdate”, “nUpdates”, “nArrIdx”, “nStrIdx”, “nFieldDec”, “nFieldDecs”,
+        “nRecord”, “nConstrArgs”, “nExcDefinition”, “nTopLet”, “nTopLetRec”,
+        “nOpen”, “nSemis”, “nExprItem”, “nExprItems”, “nModuleDef”,
+        “nModTypeName”, “nModTypePath”, “nSigSpec”, “nExcType”, “nValType”,
+        “nOpenMod”, “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”, “nSigItem”,
+        “nSigItems”, “nModuleType”, “nModAscApp”, “nModAscApps”,
+        “nCakeMLPragma”, “nModuleTypeDef”, “nModExpr”, “nDefinition”,
+        “nDefItem”, “nModuleItem”, “nModuleItems”, “nStart”];
 
 val cml_wfpeg_thm = save_thm(
   "cml_wfpeg_thm",

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -988,6 +988,22 @@ Definition ptree_PPattern_def:
             return $ Pp_tannot p ty
           od
       | _ => fail (locs, «Impossible: nPPar»)
+    else if nterm = INL nPatLiteral then
+      case args of
+        [arg] =>
+          fmap Pp_lit (ptree_Literal arg) ++
+          fmap (λb. Pp_con (SOME b) []) (ptree_Bool arg)
+      | [minus; arg] =>
+          do
+            expect_tok minus MinusT;
+            lf <- destLf arg;
+            tk <- option $ destTOK lf;
+            if isInt tk then
+              return $ Pp_lit $ IntLit $ -(THE $ destInt tk)
+            else
+              fail (locs, «Impossible: nPatLiteral»)
+          od
+      | _ => fail (locs, «Impossible: nPatLiteral»)
     else if nterm = INL nPBase then
       case args of
         [arg] =>
@@ -995,9 +1011,8 @@ Definition ptree_PPattern_def:
             n <- nterm_of arg;
             if n = INL nValueName then
               fmap Pp_var (ptree_ValueName arg)
-            else if n = INL nLiteral then
-              fmap Pp_lit (ptree_Literal arg) ++
-              fmap (λb. Pp_con (SOME b) []) (ptree_Bool arg)
+            else if n = INL nPatLiteral then
+              ptree_PPattern arg
             else if n = INL nPAny ∨ n = INL nPList ∨ n = INL nPPar then
               ptree_PPattern arg
             else

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -1904,6 +1904,15 @@ Definition ptree_Expr_def:
               fail (locs, «Or-patterns are not allowed in let (rec) bindings»));
             return $ INR (nm, FLAT ps, bd)
           od
+      | [id; colon; type; eq; bod] =>
+          do
+            expect_tok eq EqualT;
+            expect_tok colon ColonT;
+            nm <- ptree_ValueName id;
+            ty <- ptree_Type type;
+            bd <- ptree_Expr nExpr bod;
+            return $ INL (Pvar nm, Tannot bd ty)
+          od
       | [id; pats; colon; type; eq; bod] =>
           do
             expect_tok eq EqualT;

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1504,5 +1504,18 @@ val _ = parsetest0 “nStart” “ptree_Start”
                      ("g", "", App Opapp [Lit (IntLit 3); V ""])]]”)
   ;
 
+(* 2023-08-17: attach - signs to number literals in patterns.
+ *)
+
+val _ = parsetest0 “nPattern” “ptree_Pattern”
+  "-1"
+  (SOME “[Plit (IntLit (-1))]”)
+  ;
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "-1"
+  (SOME “App Opapp [Var (Long "Int" (Short "~")); Lit (IntLit 1)]”)
+  ;
+
 val _ = export_theory ();
 

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1429,5 +1429,34 @@ val _ = parsetest0 “nStart” “ptree_Start”
           Dletrec L4 [("ref","x", App Opref [V "x"])]]”)
   ;
 
+(* 2023-08-16: add support for type annotations on lets bound to a value-name
+ * without parenthesis:
+ *
+ *   let name : type = ...
+ *
+ * where previously:
+ *
+ *   let (name : type) = ...
+ *
+ * was required. (There, "(name : type)" is parsed as a pattern).
+ *)
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let x : int = 2 ;;"
+  (SOME “[Dlet L (Pv "x") (Tannot (Lit (IntLit 2)) (Atapp [] (Short "int")))]”)
+  ;
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let _ = let x : int = 2 in x;;"
+  (SOME “[Dlet L Pany
+          (Let (SOME "x") (Tannot (Lit (IntLit 2)) (Atapp [] (Short "int")))
+               (Var (Short "x")))]”)
+  ;
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let (x : int) = 2 ;;"
+  (SOME “[Dlet L (Ptannot (Pv "x") (Atapp [] (Short "int"))) (Lit (IntLit 2))]”)
+  ;
+
 val _ = export_theory ();
 

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1463,7 +1463,6 @@ val _ = parsetest0 “nStart” “ptree_Start”
  *   array-expr .( int-expr )
  *)
 
-
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "!s.[c]"
   (SOME “App Opapp [App Opapp [Var (Long "String" (Short "sub"));
@@ -1480,6 +1479,29 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
                                            V "a"];
                                 V "i"]])
                 (Lit (IntLit 3))”)
+  ;
+
+(* 2023-08-17: attempt to deal with let recs/ands without explicit arguments:
+ *   let rec f = function | ...
+ * is a pattern occurring in the HOL Light code, for example.
+ *)
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let rec f : t = e ;;"
+  (SOME “[Dletrec L [("f","", App Opapp [Tannot (V "e") (Atapp [] (Short "t"));
+                                         V ""])]]”)
+  ;
+
+(* This is a bit strange: OCaml (apparently) supports mixing recursive functions
+ * with values, and its parser would generate code that binds g to 3 (as if we
+ * would've used a let) but unfortunately our hack must create functions always:
+ *)
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let rec f = e\
+  \ and g = 3;;"
+  (SOME “[Dletrec L [("f","", App Opapp [V "e"; V ""]);
+                     ("g", "", App Opapp [Lit (IntLit 3); V ""])]]”)
   ;
 
 val _ = export_theory ();

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1458,5 +1458,29 @@ val _ = parsetest0 “nStart” “ptree_Start”
   (SOME “[Dlet L (Ptannot (Pv "x") (Atapp [] (Short "int"))) (Lit (IntLit 2))]”)
   ;
 
+(* 2023-08-17: add support for OCaml's string and array index shorthands:
+ *   string-expr .[ int-expr ]
+ *   array-expr .( int-expr )
+ *)
+
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "!s.[c]"
+  (SOME “App Opapp [App Opapp [Var (Long "String" (Short "sub"));
+                               App Opapp [V "!"; V "s"]];
+                    V "c"]”)
+  ;
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "-  a.( i) + 3"
+  (SOME “vbinop (Short "+")
+                (App Opapp [Var (Long "Int" (Short "~"));
+                            App Opapp [
+                                App Opapp [Var (Long "Array" (Short "sub"));
+                                           V "a"];
+                                V "i"]])
+                (Lit (IntLit 3))”)
+  ;
+
 val _ = export_theory ();
 

--- a/compiler/parsing/ocaml/caml_lexScript.sml
+++ b/compiler/parsing/ocaml/caml_lexScript.sml
@@ -31,9 +31,9 @@ Datatype:
     | EqualT | TickT | LparT | RparT | HashT | StarT | PlusT | CommaT | MinusT
     | LessT | GreaterT | LbrackT | RbrackT | LbraceT | RbraceT | QuestionT
     | SemiT | SemisT | BarT | OrelseT | AmpT | AndalsoT | NeqT | MinusFT
-    | RarrowT | LarrowT | DotT | DotsT | EscapeT | ColonT | ColonsT | UpdateT
-    | SealT | AnyT | BtickT | TildeT | LqbraceT | RqbraceT | LqbrackT | RqbrackT
-    | RrbrackT | LlbrackT | RlbrackT
+    | RarrowT | LarrowT | DotT | DotsT | DotParenT | DotBrackT | DotBraceT
+    | EscapeT | ColonT | ColonsT | UpdateT | SealT | AnyT | BtickT | TildeT
+    | LqbraceT | RqbraceT | LqbrackT | RqbrackT | RrbrackT | LlbrackT | RlbrackT
     (* special HOL Light tokens (all infixes): *)
     | FuncompT | F_FT
     | THEN_T | THENC_T | THENL_T | THEN_TCL_T
@@ -482,6 +482,8 @@ Definition next_sym_def:
       case skip_comment (TL cs) 0 (next_loc 2 loc) of
       | NONE => SOME (ErrorS, Locs loc (next_loc 2 loc), "")
       | SOME (rest, loc') => next_sym rest loc'
+    else if c = #"." ∧ cs ≠ "" ∧ MEM (HD cs) "([{" then
+      SOME (OtherS (TAKE 2 (c::cs)), Locs loc (next_loc 2 loc), TL cs)
     else if isDelim c then
       SOME (OtherS [c], Locs loc loc, cs)
     else if isSym c then
@@ -610,6 +612,9 @@ Definition get_token_def:
     if s = "<-" then LarrowT else
     if s = "." then DotT else
     if s = ".." then DotsT else
+    if s = ".(" then DotParenT else
+    if s = ".[" then DotBrackT else
+    if s = ".{" then DotBraceT else
     if s = ".~" then EscapeT else
     if s = ":" then ColonT else
     if s = "::" then ColonsT else


### PR DESCRIPTION
This PR contributes a few (minor) additions and/or fixes to Candle's Caml parser:
* It is now possible to write `let id : ty = ...` _without_ enclosing `id : ty` in parenthesis to promote it to a pattern.
* The parser now recognizes OCaml's syntactic sugar for string and array indexing: `stringexpr .[ i ]` and `arrayexpr .( i )`. (Note that `.[` and `.(` must be written as one token with no spaces between the symbols).
* The parser expands `let rec f = b` to `let rec f x = b x` so it is possible to use `let rec` and `and` to declare functions without writing out a variable. The majority of uses in HOL Light seem to be like this:
  ```ocaml
  let rec f =
    function
    | ... -> ...
  ```
* It is finally possible to write literals with minus in patterns:
  ```ocaml
  match x with
  | -1 -> ...
  ```
As a consequence, less patching of HOL Light should be needed to run Candle.