### PR TITLE
Pancake: concrete syntax for shared memory

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -306,6 +306,8 @@ val res = translate destTOK_def;
 
 val res = translate $ PURE_REWRITE_RULE [GSYM mlstringTheory.implode_def] conv_ident_def;
 
+val res = translate $ PURE_REWRITE_RULE [GSYM mlstringTheory.implode_def] conv_ffi_ident_def;
+
 val res = translate isNT_def;
 
 val res = translate conv_int_def;

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -309,6 +309,8 @@ val res = translate destTOK_def;
 
 val res = translate $ PURE_REWRITE_RULE [GSYM mlstringTheory.implode_def] conv_ident_def;
 
+val res = translate $ PURE_REWRITE_RULE [GSYM mlstringTheory.implode_def] conv_ffi_ident_def;
+
 val res = translate isNT_def;
 
 val res = translate conv_int_def;

--- a/compiler/bootstrap/translation/pancake_lexProgScript.sml
+++ b/compiler/bootstrap/translation/pancake_lexProgScript.sml
@@ -103,10 +103,27 @@ QED
 
 val _ = update_precondition next_atom_side;
 
+Theorem get_keyword_side[local]:
+  ∀x. get_keyword_side x
+Proof
+  simp[fetch "-" "get_keyword_side_def"]
+QED
+
+val _ = update_precondition get_keyword_side;
+
+Theorem token_of_atom_side[local]:
+  ∀x. token_of_atom_side x
+Proof
+  simp[fetch "-" "token_of_atom_side_def",get_keyword_side]
+QED
+
+val _ = update_precondition token_of_atom_side;
+
 Theorem next_token_2_side[local]:
   ∀x y. next_token_2_side x y
 Proof
-  simp [Once (fetch "-" "next_token_2_side_def"), next_atom_side]
+  simp [Once (fetch "-" "next_token_2_side_def"),
+    next_atom_side, token_of_atom_side]
 QED
 
 val _ = update_precondition next_token_2_side;

--- a/pancake/parser/README.md
+++ b/pancake/parser/README.md
@@ -2,6 +2,8 @@ The Pancake parser.
 
 [panConcreteExamplesScript.sml](panConcreteExamplesScript.sml):
 * Pancake concrete syntax examples
+* 9th May 2023: Updated with function declarations
+* March 2024: Updated with shared memory instructions
 
 [panLexerScript.sml](panLexerScript.sml):
 * The beginnings of a lexer for the Pancake language.

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -223,7 +223,7 @@ val argument_call = ‘
 
 val arg_call_tree = check_success $ parse_tree_pancake argument_call;
 
-val arg_call_parse =  parse_pancake $ argument_call;
+val arg_call_parse = check_success $ parse_pancake argument_call;
 
 (** Return call example. It is not currently possible to initialise a variable
     to a value returned from a function as a variable is declared. Instead, the
@@ -241,7 +241,7 @@ val ret_call = ‘
 
 val ret_call_parse_tree = check_success $ parse_tree_pancake ret_call;
 
-val ret_call_parse =  parse_pancake $ ret_call;
+val ret_call_parse = check_success $ parse_pancake ret_call;
 
 (** Shapes and Structs. *)
 val struct_access = ‘
@@ -254,7 +254,7 @@ val struct_access = ‘
 
 val struct_access_parse_tree = check_success $ parse_tree_pancake struct_access;
 
-val struct_access_parse =  parse_pancake $ struct_access;
+val struct_access_parse = check_success $ parse_pancake struct_access;
 
 
 (* Writing ‘n’ for a shape is convenient syntax which is equivalent to ‘{1,1,...,1}’
@@ -298,5 +298,16 @@ val struct_arguments = ‘
 val struct_argument_parse_tree =  parse_tree_pancake $ struct_arguments;
 
 val struct_argument_parse =  parse_pancake $ struct_arguments;
+
+val shmem_ex = ‘
+  fun test_shmem() {
+    var v = 12;
+    !st8 v, 1000; // store byte stored in v (12) to shared memory address 1000
+    !stw v, 1004; // store word stored in v (12) to shared memory address 1004
+    !ld8 v, 1000 + 12; // load byte stored in shared memory address 1012 to v
+    !ldw v, 1000 + 12 * 2; // load word stored in shared memory address 1024 to v
+  }’;
+
+val shmem_ex_parse =  check_success $ parse_pancake shmem_ex;
 
 val _ = export_theory();

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -1,6 +1,7 @@
 (**
  * Pancake concrete syntax examples
  * 9th May 2023: Updated with function declarations
+ * March 2024: Updated with shared memory instructions
  *)
 open HolKernel Parse boolLib bossLib stringLib numLib intLib;
 open preamble panPtreeConversionTheory;

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -97,8 +97,8 @@ val ex4 = ‘
       if x >= 5 {
         break;
       } else {
-        strb y, 8; // store byte
-        #foo(x,y,k,z); // ffi function call with pointer args
+        st8 y, 8; // store byte
+        @foo(x,y,k,z); // ffi function call with pointer args
         x = x + 1;
         y = x + 1;
       }
@@ -198,8 +198,8 @@ val ex9 = ‘
    var b = 8;
    var c = @base + 16;
    var d = 1;
-   #out_morefun(a,b,c,d);
-   str @base, ic;
+   @out_morefun(a,b,c,d);
+   stw @base, ic;
    return 0;
  }’;
 

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -19,8 +19,7 @@ val _ = new_theory "panLexer";
 Datatype:
   keyword = SkipK | StoreK | StoreBK | IfK | ElseK | WhileK
   | BrK | ContK | RaiseK | RetK | TicK | VarK | WithK | HandleK
-  | LdsK | LdbK | BaseK | InK | FunK | TrueK | FalseK
-  | SharedStoreK | SharedStoreBK | SharedLdsK | SharedLdbK
+  | LdsK | LdbK | LdwK | BaseK | InK | FunK | TrueK | FalseK
 End
 
 Datatype:
@@ -110,16 +109,13 @@ Definition get_keyword_def:
   if s = "in" then (KeywordT InK) else
   if s = "with" then (KeywordT WithK) else
   if s = "handle" then (KeywordT HandleK) else
-  if s = "ldw" then (KeywordT LdsK) else
+  if s = "lds" then (KeywordT LdsK) else
+  if s = "ldw" then (KeywordT LdwK) else
   if s = "ld8" then (KeywordT LdbK) else
   if s = "@base" then (KeywordT BaseK) else
   if s = "true" then (KeywordT TrueK) else
   if s = "false" then (KeywordT FalseK) else
   if s = "fun" then (KeywordT FunK) else
-  if s = "!stw" then (KeywordT SharedStoreK) else
-  if s = "!st8" then (KeywordT SharedStoreBK) else
-  if s = "!ldw" then (KeywordT SharedLdsK) else
-  if s = "!ld8" then (KeywordT SharedLdbK) else
   if s = "" ∨ s = "@" then LexErrorT else
   if 2 <= LENGTH s ∧ EL 0 s = #"@" then ForeignIdent (DROP 1 s) else
   IdentT s
@@ -191,18 +187,6 @@ Definition num_from_dec_string_alt_def:
   num_from_dec_string_alt = s2n 10 unhex_alt
 End
 
-Definition is_shared_mem_instruction_def:
-  is_shared_mem_instruction (#"!"::cs) =
-    (("stw" ≼ cs ∨ "st8" ≼ cs ∨
-      "ldw" ≼ cs ∨ "ld8" ≼ cs) ∧
-    (LENGTH cs = 3 ∨ ¬ isAlphaNumOrWild (EL 3 cs))) ∧
-  is_shared_mem_instruction _ = F
-End
-
-Definition get_shared_mem_instruction_def:
-  get_shared_mem_instruction cs = (TAKE 4 cs, DROP 4 cs)
-End
-
 Definition next_atom_def:
   next_atom "" _ = NONE ∧
   next_atom (c::cs) loc =
@@ -224,9 +208,6 @@ Definition next_atom_def:
       (case (skip_comment (TL cs) (next_loc 2 loc)) of
        | NONE => SOME (ErrA, Locs loc (next_loc 2 loc), "")
        | SOME (rest, loc') => next_atom rest loc')
-    else if is_shared_mem_instruction (c::cs) then (* shared memory *)
-      let (n,rest) = get_shared_mem_instruction (c::cs) in
-      SOME (WordA n, Locs loc (next_loc (LENGTH n) loc), rest)
     else if isAtom_singleton c then
       SOME (SymA (STRING c []), Locs loc loc, cs)
     else if isAtom_begin_group c then
@@ -261,7 +242,6 @@ Proof
       >> sg ‘STRLEN rest < STRLEN (TL cs)’ >> rw[]
       >> sg ‘STRLEN (TL cs) < SUC (STRLEN cs)’ >> rw[LENGTH_TL]
       >> Cases_on ‘cs’ >> simp[])
-  >- gvs[get_shared_mem_instruction_def]
   >- (pairarg_tac >> drule read_while_thm >> gvs[])
   >- (pairarg_tac >> drule read_while_thm >> gvs[])
   >- (pairarg_tac >> drule read_while_thm >> gvs[])

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -270,16 +270,16 @@ Definition pancake_peg_def[nocompute]:
                                   keep_tok AsrT; keep_tok RorT]);
         (INL AddOpsNT, choicel [keep_tok PlusT; keep_tok MinusT]);
         (INL MulOpsNT, keep_tok StarT);
-        (INL SharedLoadNT,seql [consume_kw SharedLdwK; keep_ident;
+        (INL SharedLoadNT,seql [consume_tok NotT; consume_kw LdwK; keep_ident;
                                 consume_tok CommaT; mknt ExpNT]
                                (mksubtree SharedLoadNT));
-        (INL SharedLoadByteNT,seql [consume_kw SharedLdbK; keep_ident;
+        (INL SharedLoadByteNT,seql [consume_tok NotT; consume_kw LdbK; keep_ident;
                                     consume_tok CommaT; mknt ExpNT]
                                    (mksubtree SharedLoadByteNT));
-        (INL SharedStoreNT,seql [consume_kw SharedStoreK; keep_ident;
+        (INL SharedStoreNT,seql [consume_tok NotT; consume_kw StoreK; keep_ident;
                                  consume_tok CommaT; mknt ExpNT]
                                 (mksubtree SharedStoreNT));
-        (INL SharedStoreByteNT,seql [consume_kw SharedStoreBK; keep_ident;
+        (INL SharedStoreByteNT,seql [consume_tok NotT; consume_kw StoreBK; keep_ident;
                                      consume_tok CommaT; mknt ExpNT]
                                     (mksubtree SharedStoreByteNT));
         ]

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -26,6 +26,8 @@ Datatype:
             | StructNT | LoadNT | LoadByteNT | LabelNT | FLabelNT
             | ShapeNT | ShapeCombNT
             | EqOpsNT | CmpOpsNT | ShiftOpsNT | AddOpsNT | MulOpsNT
+            | SharedLoadNT | SharedLoadByteNT
+            | SharedStoreNT | SharedStoreByteNT
 End
 
 Definition mknt_def:
@@ -67,6 +69,12 @@ End
 Definition keep_ident_def:
   keep_ident = tok (λt. case t of
                        | IdentT _ => T
+                       | _ => F) mkleaf
+End
+
+Definition keep_ffi_ident_def:
+  keep_ffi_ident = tok (λt. case t of
+                       | ForeignIdent _ => T
                        | _ => F) mkleaf
 End
 
@@ -136,6 +144,10 @@ Definition pancake_peg_def[nocompute]:
                               mknt CallNT;
                               mknt AssignNT; mknt StoreNT;
                               mknt StoreByteNT;
+                              mknt SharedLoadByteNT;
+                              mknt SharedLoadNT;
+                              mknt SharedStoreByteNT;
+                              mknt SharedStoreNT;
                               keep_kw BrK; keep_kw ContK;
                               mknt ExtCallNT;
                               mknt RaiseNT; mknt ReturnNT;
@@ -176,7 +188,7 @@ Definition pancake_peg_def[nocompute]:
                              consume_tok DArrowT; mknt ProgNT;
                              consume_kw HandleK]
                             (mksubtree HandleNT));
-        (INL ExtCallNT, seql [consume_tok HashT; keep_ident;
+        (INL ExtCallNT, seql [keep_ffi_ident;
                               consume_tok LParT; mknt ExpNT;
                               consume_tok CommaT; mknt ExpNT;
                               consume_tok CommaT; mknt ExpNT;
@@ -257,7 +269,20 @@ Definition pancake_peg_def[nocompute]:
         (INL ShiftOpsNT, choicel [keep_tok LslT; keep_tok LsrT;
                                   keep_tok AsrT; keep_tok RorT]);
         (INL AddOpsNT, choicel [keep_tok PlusT; keep_tok MinusT]);
-        (INL MulOpsNT, keep_tok StarT)]
+        (INL MulOpsNT, keep_tok StarT);
+        (INL SharedLoadNT,seql [consume_kw SharedLdwK; keep_ident;
+                                consume_tok CommaT; mknt ExpNT]
+                               (mksubtree SharedLoadNT));
+        (INL SharedLoadByteNT,seql [consume_kw SharedLdbK; keep_ident;
+                                    consume_tok CommaT; mknt ExpNT]
+                                   (mksubtree SharedLoadByteNT));
+        (INL SharedStoreNT,seql [consume_kw SharedStoreK; keep_ident;
+                                 consume_tok CommaT; mknt ExpNT]
+                                (mksubtree SharedStoreNT));
+        (INL SharedStoreByteNT,seql [consume_kw SharedStoreBK; keep_ident;
+                                     consume_tok CommaT; mknt ExpNT]
+                                    (mksubtree SharedStoreByteNT));
+        ]
         |>
 End
 
@@ -367,7 +392,8 @@ val wfpeg_rwts = wfpeg_cases
                                      ‘choicel (h::t)’, ‘keep_tok t’,
                                      ‘consume_tok t’, ‘keep_kw k’,
                                      ‘consume_kw k’, ‘keep_int’,
-                                     ‘keep_nat’, ‘keep_ident’,
+                                     ‘keep_nat’,‘keep_ffi_ident’,
+                                     ‘keep_ident’,
                                      ‘pegf e f’])
                    |> map (CONV_RULE
                            (RAND_CONV (SIMP_CONV (srw_ss())
@@ -375,6 +401,7 @@ val wfpeg_rwts = wfpeg_cases
                                         keep_tok_def, consume_tok_def,
                                         keep_kw_def, consume_kw_def,
                                         keep_int_def, keep_nat_def,
+                                        keep_ffi_ident_def,
                                         keep_ident_def, pegf_def])))
 
 val wfpeg_mknt = wfpeg_cases
@@ -472,6 +499,12 @@ Proof
   simp[keep_ident_def]
 QED
 
+Theorem peg0_keep_ffi_ident[simp]:
+  peg0 G keep_ffi_ident = F
+Proof
+  simp[keep_ffi_ident_def]
+QED
+
 Theorem peg0_choicel[simp]:
   (peg0 G (choicel []) = F) ∧
   (peg0 G (choicel (h::t)) ⇔
@@ -504,8 +537,11 @@ val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”
                 “RaiseNT”, “ExtCallNT”,
                 “HandleNT”, “RetNT”, “CallNT”,
                 “WhileNT”, “IfNT”, “StoreByteNT”,
-                “StoreNT”, “AssignNT”, “DecNT”,
-                “StmtNT”, “BlockNT”, “ParamListNT”, “FunNT”];
+                “StoreNT”, “AssignNT”,
+                “SharedLoadByteNT”, “SharedLoadNT”,
+                “SharedStoreByteNT”, “SharedStoreNT”, “DecNT”,
+                “StmtNT”, “BlockNT”, “ParamListNT”, “FunNT”
+                ];
 
 (*  “FunNT”, “FunListNT” *)
 
@@ -521,7 +557,7 @@ fun wfnt(t,acc) = let
                     [wfpeg_mknt, FDOM_pancake_peg, try_def,
                      seql_def, keep_tok_def, consume_tok_def,
                      keep_kw_def, consume_kw_def, keep_int_def,
-                     keep_nat_def, keep_ident_def]) THEN
+                     keep_nat_def, keep_ident_def, keep_ffi_ident_def]) THEN
           simp(wfpeg_rwts @ npeg0_rwts @ peg0_rwts @ acc))
 in
   th::acc
@@ -544,7 +580,7 @@ Proof
        subexprs_mknt, peg_start, peg_range, DISJ_IMP_THM,FORALL_AND_THM,
        choicel_def, seql_def, pegf_def, keep_tok_def, consume_tok_def,
        keep_kw_def, consume_kw_def, keep_int_def, keep_nat_def,
-       keep_ident_def, try_def] >>
+       keep_ident_def, keep_ffi_ident_def, try_def] >>
   simp(pancake_wfpeg_thm :: wfpeg_rwts @ peg0_rwts @ npeg0_rwts)
 QED
 

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -90,6 +90,13 @@ Definition conv_ident_def:
     | _ => NONE
 End
 
+Definition conv_ffi_ident_def:
+  conv_ffi_ident tree =
+    case destTOK ' (destLf tree) of
+      SOME (ForeignIdent s) => SOME (strlit s)
+    | _ => NONE
+End
+
 Definition conv_var_def:
   conv_var t = lift Var (conv_ident t)
 End
@@ -339,10 +346,26 @@ Definition conv_NonRecStmt_def:
       case args of
         [dst; src] => lift2 StoreByte (conv_Exp dst) (conv_Exp src)
       | _ => NONE
+    else if isNT nodeNT SharedLoadNT then
+      case args of
+        [v; e] => lift2 (ShMem Load) (conv_ident v) (conv_Exp e)
+      | _ => NONE
+    else if isNT nodeNT SharedLoadByteNT then
+      case args of
+        [v; e] => lift2 (ShMem Load8) (conv_ident v) (conv_Exp e)
+      | _ => NONE
+    else if isNT nodeNT SharedStoreNT then
+      case args of
+        [v; e] => lift2 (ShMem Store) (conv_ident v) (conv_Exp e)
+      | _ => NONE
+    else if isNT nodeNT SharedStoreByteNT then
+      case args of
+        [v; e] => lift2 (ShMem Store8) (conv_ident v) (conv_Exp e)
+      | _ => NONE
     else if isNT nodeNT ExtCallNT then
       case args of
         [name; ptr; clen; array; alen] =>
-          do name' <- conv_ident name;
+          do name' <- conv_ffi_ident name;
              ptr' <- conv_Exp ptr;
              clen' <- conv_Exp clen;
              array' <- conv_Exp array;


### PR DESCRIPTION
This PR introduces the concrete syntax for Pancake shared memory access.
The details of the changes are as follows:

- syntax for load/store (word/byte access) are changed to accomodate the shared memory instructions

strb  ->  st8   (for both internal/shared memory)
str     ->  stw   (for both internal/shared memory)
ldb     ->   ld8   (for both internal/shared memory)
lds     ->   lds   (for internal memory only; load shape)
               ldw  (newly added; for word access shared memory)

shared memory instructions are prefixed with '!' (so, we have !ldw, !ld8, !stw, and !st8) 

- ffi names are now prefixed with '@' instead of '#'

- the example file is updated (add a shared memory example, update existing ones for load/store changes)