### PR TITLE
Rudimentary error reporting for the Pancake parser

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -678,6 +678,8 @@ val res  = translate $ spec32 conv_Fun_def;
 
 val res = translate $ spec32 conv_FunList_def;
 
+val res = translate $ spec32 panLexerTheory.dest_lexErrorT_def;
+
 val res = translate $ spec32 parse_funs_to_ast_def;
 
 val res = translate $ spec32 parse_to_ast_def;

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -680,6 +680,8 @@ val res  = translate $ spec64 conv_Fun_def;
 
 val res = translate $ spec64 conv_FunList_def;
 
+val res = translate $ spec64 panLexerTheory.dest_lexErrorT_def;
+
 val res = translate $ spec64 parse_funs_to_ast_def;
 
 val res = translate $ spec64 parse_to_ast_def;

--- a/compiler/bootstrap/translation/pancake_parseProgScript.sml
+++ b/compiler/bootstrap/translation/pancake_parseProgScript.sml
@@ -111,18 +111,36 @@ Theorem parse_side_lemma = Q.prove(`
   assume_tac PEG_wellformed \\
   drule_then strip_assume_tac pegexecTheory.peg_exec_total \\
   first_x_assum $ qspec_then `x` strip_assume_tac \\
-  FULL_SIMP_TAC std_ss [pegexecTheory.peg_exec_def,
-                        pegexecTheory.coreloop_def,
-                        CaseEq "option",
-                        pegexecTheory.evalcase_distinct,
-                        SIMP_CONV (srw_ss()) [pancake_peg_def] ``pancake_peg.start``,
-                        IS_SOME_EXISTS] \\
-  qexists_tac `Result r`\\
+  gvs [pegexecTheory.peg_exec_def,
+       pegexecTheory.coreloop_def,
+       AllCaseEqs(),
+       pegexecTheory.evalcase_distinct,
+       SIMP_CONV (srw_ss()) [pancake_peg_def] ``pancake_peg.start``,
+       IS_SOME_EXISTS]
+  >- (rename1 ‘_ = SOME (Result rr)’ \\
+      qexists_tac `Result rr`\\
+      pop_assum (REWRITE_TAC o single o GSYM) \\
+      rpt (AP_THM_TAC ORELSE AP_TERM_TAC) \\
+      rw[FUN_EQ_THM] \\
+      rpt(PURE_FULL_CASE_TAC >> gvs[FDOM_FLOOKUP]) \\
+      gvs [flookup_thm]) \\
+  assume_tac PEG_FunNT_wellformed \\
+  drule_then strip_assume_tac pegexecTheory.peg_exec_total \\
+  first_x_assum $ qspec_then `x` strip_assume_tac \\
+  gvs [pegexecTheory.peg_exec_def,
+       pegexecTheory.coreloop_def,
+       AllCaseEqs(),
+       pegexecTheory.evalcase_distinct,
+       SIMP_CONV (srw_ss()) [pancake_peg_def] ``pancake_peg.start``,
+       IS_SOME_EXISTS] \\
+  rename1 ‘_ = SOME (Result rr)’ \\
+  qexists_tac `Result rr`\\
   pop_assum (REWRITE_TAC o single o GSYM) \\
   rpt (AP_THM_TAC ORELSE AP_TERM_TAC) \\
   rw[FUN_EQ_THM] \\
   rpt(PURE_FULL_CASE_TAC >> gvs[FDOM_FLOOKUP]) \\
-  gvs [flookup_thm])
+  gvs [flookup_thm]
+  )
   |> update_precondition;
 
 val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -275,8 +275,12 @@ Definition compile_pancake_def:
   compile_pancake c input =
   let _ = empty_ffi (strlit "finished: start up") in
   case panPtreeConversion$parse_funs_to_ast input of
-  | NONE => Failure (ParseError (strlit "Failed pancake parsing"))
-  | SOME funs =>
+  | INR errs =>
+    Failure $ ParseError $ concat $
+      MAP (λ(msg,loc). concat [msg; strlit " at ";
+                               locs_to_string (implode input) (SOME loc); strlit "\n"])
+          errs
+  | INL funs =>
       let _ = empty_ffi (strlit "finished: lexing and parsing") in
       case pan_to_target$compile_prog c funs of
       | NONE => (Failure AssembleError)

--- a/pancake/parser/README.md
+++ b/pancake/parser/README.md
@@ -2,6 +2,7 @@ The Pancake parser.
 
 [panConcreteExamplesScript.sml](panConcreteExamplesScript.sml):
 * Pancake concrete syntax examples
+* 9th May 2023: Updated with function declarations
 
 [panLexerScript.sml](panLexerScript.sml):
 * The beginnings of a lexer for the Pancake language.

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -40,7 +40,7 @@ fun parse_pancake q =
     EVAL “parse_funs_to_ast ^code”
   end
 
-val check_success = assert $ optionSyntax.is_some o rhs o concl
+val check_success = assert $ sumSyntax.is_inl o rhs o concl
 
 (** Examples can be written using quoted strings and passed to the ML
     function parse_pancake. *)

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -13,6 +13,7 @@ open HolKernel Parse boolLib bossLib stringLib numLib;
 
 open arithmeticTheory stringTheory intLib listTheory locationTheory;
 open ASCIInumbersTheory ASCIInumbersLib;
+open mlstringTheory;
 
 val _ = new_theory "panLexer";
 
@@ -32,11 +33,11 @@ Datatype:
   | LBrakT | RBrakT | LCurT | RCurT
   | AssignT
   | KeywordT keyword
-  | LexErrorT
+  | LexErrorT mlstring
 End
 
 Datatype:
-  atom = NumberA int | WordA string | SymA string | ErrA
+  atom = NumberA int | WordA string | SymA string | ErrA mlstring
 End
 
 Definition isAtom_singleton_def:
@@ -53,6 +54,16 @@ End
 
 Definition isAlphaNumOrWild_def:
   isAlphaNumOrWild c ⇔ isAlphaNum c ∨ c = #"_"
+End
+
+Definition isLexErrorT_def:
+  (isLexErrorT (LexErrorT _) ⇔ T) ∧
+  (isLexErrorT _ ⇔ F)
+End
+
+Definition dest_lexErrorT_def:
+  (destLexErrorT (LexErrorT msg) = SOME msg) ∧
+  destLexErrorT _ = NONE
 End
 
 Definition get_token_def:
@@ -87,7 +98,7 @@ Definition get_token_def:
   if s = "{" then LCurT else
   if s = "}" then RCurT else
   if s = "=" then AssignT else
-  LexErrorT
+  LexErrorT $ concat [«Unrecognised symbolic token: »; implode s]
 End
 
 Definition get_keyword_def:
@@ -113,8 +124,10 @@ Definition get_keyword_def:
   if s = "true" then (KeywordT TrueK) else
   if s = "false" then (KeywordT FalseK) else
   if s = "fun" then (KeywordT FunK) else
-  if isPREFIX "@" s ∨ s = "" then LexErrorT else
-  IdentT s
+  if isPREFIX "@" s then LexErrorT $ concat [«Unrecognised keyword: »; implode s] else
+  if s = "" then LexErrorT $ «Expected keyword, found empty string»
+  else
+    IdentT s
 End
 
 Definition token_of_atom_def:
@@ -123,7 +136,7 @@ Definition token_of_atom_def:
   | NumberA i => IntT i
   | WordA s => get_keyword s
   | SymA s => get_token s
-  | ErrA => LexErrorT
+  | ErrA s => LexErrorT s
 End
 
 Definition read_while_def:
@@ -170,9 +183,8 @@ Proof
   Induct
   >> fs[skip_comment_def]
   >> rw[]
-  >> sg ‘STRLEN str < STRLEN xs’
-  >- metis_tac[]
-  >> fs[LE]
+  >> res_tac
+  >> gvs[]
 QED
 
 Definition unhex_alt_def:
@@ -202,7 +214,7 @@ Definition next_atom_def:
             rest)
     else if isPREFIX "//" (c::cs) then (* comment *)
       (case (skip_comment (TL cs) (next_loc 2 loc)) of
-       | NONE => SOME (ErrA, Locs loc (next_loc 2 loc), "")
+       | NONE => SOME (ErrA «Malformed comment», Locs loc (next_loc 2 loc), "")
        | SOME (rest, loc') => next_atom rest loc')
     else if isAtom_singleton c then
       SOME (SymA (STRING c []), Locs loc loc, cs)
@@ -213,7 +225,7 @@ Definition next_atom_def:
       let (n, rest) = read_while isAlphaNumOrWild cs [c] in
       SOME (WordA n, Locs loc (next_loc (LENGTH n) loc), rest)
     else (* input not recognised *)
-      SOME (ErrA, Locs loc loc, cs)
+      SOME (ErrA $ concat [«Unrecognised symbol: »; str c], Locs loc loc, cs)
 Termination
   WF_REL_TAC ‘measure (LENGTH o FST)’
   >> REPEAT STRIP_TAC
@@ -275,6 +287,14 @@ End
 
 Definition pancake_lex_def:
   pancake_lex input = pancake_lex_aux input init_loc
+End
+
+Definition safe_pancake_lex_def:
+  safe_pancake_lex input =
+  (let output = pancake_lex input in
+      case FILTER (isLexErrorT ∘ FST) output of
+        [] => INL output
+      | xs => INR $ MAP ((the «» ∘ destLexErrorT) ## I) xs)
 End
 
 (* Tests :

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -330,9 +330,9 @@ Definition parse_def:
     case peg_exec pancake_peg (mknt FunListNT) s [] NONE [] done failed of
     | Result (Success [] [e] _) => INL e
     | Result (Success toks _ _) =>
-        case peg_exec pancake_peg (mknt FunNT) s [] NONE [] done failed of
+        (case peg_exec pancake_peg (mknt FunNT) s [] NONE [] done failed of
           | Result (Failure loc msg) => INR [(implode msg, loc)]
-          | _ => INR []
+          | _ => INR [])
     | Result (Failure loc msg) => INR [(implode msg, loc)]
     | Looped => INR [(«PEG execution looped during parsing», unknown_loc)]
     | _ => INR [(«Unknown error during parsing», unknown_loc)]
@@ -534,6 +534,17 @@ val subexprs_mknt = Q.prove(
 
 Theorem PEG_wellformed[simp]:
   wfG pancake_peg
+Proof
+  simp[wfG_def, Gexprs_def, subexprs_def,
+       subexprs_mknt, peg_start, peg_range, DISJ_IMP_THM,FORALL_AND_THM,
+       choicel_def, seql_def, pegf_def, keep_tok_def, consume_tok_def,
+       keep_kw_def, consume_kw_def, keep_int_def, keep_nat_def,
+       keep_ident_def, try_def] >>
+  simp(pancake_wfpeg_thm :: wfpeg_rwts @ peg0_rwts @ npeg0_rwts)
+QED
+
+Theorem PEG_FunNT_wellformed:
+  wfG (pancake_peg with start := mknt FunNT)
 Proof
   simp[wfG_def, Gexprs_def, subexprs_def,
        subexprs_mknt, peg_start, peg_range, DISJ_IMP_THM,FORALL_AND_THM,

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -300,7 +300,7 @@ end
 val pancake_peg_applied' = let
   val ths = map (mk_rule_app “pancake_peg with start := mknt FunNT”) pancakeNTs
 in
-  save_thm("pancake_peg_applied", LIST_CONJ ths);
+  save_thm("pancake_peg_applied'", LIST_CONJ ths);
   ths
 end
 

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -578,8 +578,6 @@ val npeg0_rwts = List.foldl (pegnt "peg0_" “pancake_peg”) [] topo_nts
 val npeg1_rwts = List.foldl (pegnt "peg1_" “pancake_peg with start := mknt FunNT”) [] topo_nts
 
 fun wfnt tm (t,acc) = let
-  val _ = goal := ‘wfpeg ^tm (mknt ^t)’
-  val _ = ac := acc
   val th =
     Q.prove(‘wfpeg ^tm (mknt ^t)’,
           SIMP_TAC (srw_ss())

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -540,16 +540,22 @@ End
 
 Definition parse_to_ast_def:
   parse_to_ast s =
-    case parse (pancake_lex s) of
+    case parse_statement (pancake_lex s) of
       SOME e => conv_Prog e
     | _ => NONE
 End
 
 Definition parse_funs_to_ast_def:
   parse_funs_to_ast s =
-    case parse (pancake_lex s) of
-      SOME e => conv_FunList e
-    | _ => NONE
+    (case safe_pancake_lex s of
+     | INL toks =>
+        (case parse toks of
+           | INL e =>
+             (case conv_FunList e of
+              | SOME funs => INL funs
+              | NONE => INR [(«Parse tree conversion failed»,unknown_loc)])
+           | INR err => INR err)
+     | INR err => INR err)
 End
 
 val _ = export_theory();


### PR DESCRIPTION
This pull request makes it so that users can get something more informative than `### ERROR: parse error` when their Pancake program fails to compile. There's certainly room to improve the error messages further; for example, failures during parse tree conversion should be made more informative.

Closes  #937