### PR TITLE
Faster xcf tactic

### DIFF
--- a/basis/ArrayProofScript.sml
+++ b/basis/ArrayProofScript.sml
@@ -11,6 +11,7 @@ val _ = translation_extends "ArrayProg";
 val array_st = get_ml_prog_state();
 
 fun prove_array_spec op_name =
+  rpt strip_tac \\
   xcf op_name array_st \\ TRY xpull \\
   fs [cf_aw8alloc_def, cf_aw8sub_def, cf_aw8length_def, cf_aw8update_def,
       cf_aalloc_empty_def, cf_aalloc_def, cf_asub_def, cf_alength_def, cf_aupdate_def] \\
@@ -73,79 +74,80 @@ Theorem array_fromList_spec:
     app (p:'ffi ffi_proj) ^(fetch_v "Array.fromList" array_st) [lv]
       emp (POSTv av. ARRAY av a)
 Proof
-    xcf "Array.fromList" array_st \\
-    xfun_spec `f`
-      `!ls lsv i iv a l_pre rest ar.
-        NUM i iv /\ LENGTH l_pre = i /\
-        LIST_TYPE A ls lsv /\ v_to_list lsv = SOME a /\ LENGTH ls = LENGTH rest
-      ==>
-      app p f [ar; lsv; iv]
-      (ARRAY ar (l_pre ++ rest))
-      (POSTv ret. & (ret = ar) * ARRAY ar (l_pre ++ a))` >- (
-        Induct
-          >- (rw[LIST_TYPE_def] \\
-          first_x_assum match_mp_tac \\
-          xmatch \\ xret \\
-          fs [LENGTH_NIL_SYM] \\
-          fs [semanticPrimitivesTheory.v_to_list_def] \\
-          xsimpl) \\
-        rw[LIST_TYPE_def] \\
-        fs[semanticPrimitivesTheory.v_to_list_def] \\
-        qpat_x_assum`_ = SOME _`mp_tac \\ CASE_TAC \\ rw[] \\
-        last_x_assum match_mp_tac \\
-        xmatch \\
-        Cases_on `rest` \\ fs[] \\
-        qmatch_assum_rename_tac`A h hv` \\
-        xlet `POSTv u. ARRAY ar (l_pre ++ hv::t)` >- (
-          xapp \\
-          instantiate \\
-          xsimpl ) \\
-        xlet `POSTv iv. ARRAY ar (l_pre ++ hv::t) * & NUM (LENGTH l_pre + 1) iv`
-        >- (
-          xapp \\
-          xsimpl \\
-          qexists_tac `&(LENGTH l_pre)` \\
-          fs [NUM_def, plus_def, integerTheory.INT_ADD]
-          ) \\
-        once_rewrite_tac[CONS_APPEND] \\
-        rewrite_tac[APPEND_ASSOC] \\
-        xapp \\ xsimpl ) \\
-    Cases_on `l` >>
-    fs [LIST_TYPE_def] >>
-    rfs [] >>
-    xmatch
-    >- (
-      fs [semanticPrimitivesTheory.v_to_list_def] >>
-      rw [] >>
-      xlet `POSTv uv. &UNIT_TYPE () uv`
+  rpt strip_tac \\
+  xcf "Array.fromList" array_st \\
+  xfun_spec `f`
+    `!ls lsv i iv a l_pre rest ar.
+      NUM i iv /\ LENGTH l_pre = i /\
+      LIST_TYPE A ls lsv /\ v_to_list lsv = SOME a /\ LENGTH ls = LENGTH rest
+    ==>
+    app p f [ar; lsv; iv]
+    (ARRAY ar (l_pre ++ rest))
+    (POSTv ret. & (ret = ar) * ARRAY ar (l_pre ++ a))` >- (
+      Induct
+        >- (rw[LIST_TYPE_def] \\
+        first_x_assum match_mp_tac \\
+        xmatch \\ xret \\
+        fs [LENGTH_NIL_SYM] \\
+        fs [semanticPrimitivesTheory.v_to_list_def] \\
+        xsimpl) \\
+      rw[LIST_TYPE_def] \\
+      fs[semanticPrimitivesTheory.v_to_list_def] \\
+      qpat_x_assum`_ = SOME _`mp_tac \\ CASE_TAC \\ rw[] \\
+      last_x_assum match_mp_tac \\
+      xmatch \\
+      Cases_on `rest` \\ fs[] \\
+      qmatch_assum_rename_tac`A h hv` \\
+      xlet `POSTv u. ARRAY ar (l_pre ++ hv::t)` >- (
+        xapp \\
+        instantiate \\
+        xsimpl ) \\
+      xlet `POSTv iv. ARRAY ar (l_pre ++ hv::t) * & NUM (LENGTH l_pre + 1) iv`
       >- (
-        xret >>
-        xsimpl) >>
-      xapp >>
-      simp []) >>
-    rw [] >>
-    xlet `POSTv lv. &NUM (LENGTH t + 1) lv`
-    >- (
-      xapp >>
-      xsimpl >>
-      qexists_tac `h::t` >>
-      qexists_tac `A` >>
-      simp [LIST_TYPE_def, ADD1]) >>
-    xlet `POSTv av. ARRAY av (REPLICATE (LENGTH t + 1) v2_1)`
-    >- (
-      xapp >>
-      simp []) >>
+        xapp \\
+        xsimpl \\
+        qexists_tac `&(LENGTH l_pre)` \\
+        fs [NUM_def, plus_def, integerTheory.INT_ADD]
+        ) \\
+      once_rewrite_tac[CONS_APPEND] \\
+      rewrite_tac[APPEND_ASSOC] \\
+      xapp \\ xsimpl ) \\
+  Cases_on `l` >>
+  fs [LIST_TYPE_def] >>
+  rfs [] >>
+  xmatch
+  >- (
     fs [semanticPrimitivesTheory.v_to_list_def] >>
-    every_case_tac >>
-    fs [] >>
     rw [] >>
-    first_x_assum (qspecl_then [`t`, `v2_2`, `Litv (IntLit &1)`, `x`, `[v2_1]`,
-                                `REPLICATE (LENGTH t) v2_1`] mp_tac) >>
-    simp [LENGTH_REPLICATE] >>
-    qpat_x_assum`_ = list_type_num`(assume_tac o SYM) \\ fs[GSYM ADD1] \\
-    disch_then xapp_spec >>
+    xlet `POSTv uv. &UNIT_TYPE () uv`
+    >- (
+      xret >>
+      xsimpl) >>
+    xapp >>
+    simp []) >>
+  rw [] >>
+  xlet `POSTv lv. &NUM (LENGTH t + 1) lv`
+  >- (
+    xapp >>
     xsimpl >>
-    rw [REPLICATE, GSYM ADD1]
+    qexists_tac `h::t` >>
+    qexists_tac `A` >>
+    simp [LIST_TYPE_def, ADD1]) >>
+  xlet `POSTv av. ARRAY av (REPLICATE (LENGTH t + 1) v2_1)`
+  >- (
+    xapp >>
+    simp []) >>
+  fs [semanticPrimitivesTheory.v_to_list_def] >>
+  every_case_tac >>
+  fs [] >>
+  rw [] >>
+  first_x_assum (qspecl_then [`t`, `v2_2`, `Litv (IntLit &1)`, `x`, `[v2_1]`,
+                              `REPLICATE (LENGTH t) v2_1`] mp_tac) >>
+  simp [LENGTH_REPLICATE] >>
+  qpat_x_assum`_ = list_type_num`(assume_tac o SYM) \\ fs[GSYM ADD1] \\
+  disch_then xapp_spec >>
+  xsimpl >>
+  rw [REPLICATE, GSYM ADD1]
 QED
 
 val eq_v_thm = fetch "mlbasicsProg" "eq_v_thm"
@@ -161,7 +163,8 @@ Theorem array_tabulate_spec:
     app (p:'ffi ffi_proj) ^(fetch_v "Array.tabulate" array_st) [nv; fv]
     emp (POSTv av. SEP_EXISTS vs. ARRAY av vs * cond (EVERY2 A (GENLIST f n) vs))
 Proof
-  xcf "Array.tabulate" array_st
+  rpt strip_tac
+  \\ xcf "Array.tabulate" array_st
   \\ xfun_spec `u`
       `!x xv l_pre rest av.
         NUM x xv /\ LENGTH l_pre = x /\ LENGTH l_pre + LENGTH rest = n ==>
@@ -280,26 +283,26 @@ Theorem array_copy_aux_spec:
     (POSTv uv. ARRAY srcv src *
                ARRAY dstv (bfr ++ (TAKE (max -n) (DROP n src)) ++ afr))
 Proof
-      gen_tac \\ gen_tac \\ Induct_on `max - n` >>
-      xcf_with_def "Array.copy_aux" Array_copy_aux_v_def
-      >-(xlet_auto >> (xsimpl >> xif) >>
-         instantiate >> xcon >> xsimpl >> metis_tac[TAKE_0,LENGTH_NIL]) >>
-      xlet_auto >- xsimpl >>
-      xif >> instantiate >>
-      NTAC 4 (xlet_auto >- xsimpl) >>
-      xapp >> xsimpl >>
-      cases_on`mid` >> fs[] >>
-      qexists_tac`1 + n` >> qexists_tac`t` >>
-      qexists_tac`max` >> qexists_tac`bfr ++ [EL n src]` >> fs[] >>
-      qexists_tac`afr` >> rw[]
-      >-(`LENGTH bfr <= LENGTH bfr` by fs[] >>
-         imp_res_tac LUPDATE_APPEND2 >>
-         first_x_assum (assume_tac o Q.SPECL[`EL n src`, `[h] ⧺ t ⧺ afr`]) >>
-         fs[LUPDATE_def]) >>
-     cases_on`DROP n src` >- fs[DROP_NIL] >>
-     `EL (0 + n) src = EL 0 (DROP n src)` by fs[EL_DROP] >> fs[] >>
-     `DROP 1 (DROP n src) = t'` by fs[GSYM DROP_DROP_T] >>
-     fs[DROP_DROP_T]
+  gen_tac \\ gen_tac \\ Induct_on `max - n` >>
+  rpt strip_tac \\ xcf_with_def Array_copy_aux_v_def
+  >-(xlet_auto >> (xsimpl >> xif) >>
+     instantiate >> xcon >> xsimpl >> metis_tac[TAKE_0,LENGTH_NIL]) >>
+  xlet_auto >- xsimpl >>
+  xif >> instantiate >>
+  NTAC 4 (xlet_auto >- xsimpl) >>
+  xapp >> xsimpl >>
+  cases_on`mid` >> fs[] >>
+  qexists_tac`1 + n` >> qexists_tac`t` >>
+  qexists_tac`max` >> qexists_tac`bfr ++ [EL n src]` >> fs[] >>
+  qexists_tac`afr` >> rw[]
+  >-(`LENGTH bfr <= LENGTH bfr` by fs[] >>
+     imp_res_tac LUPDATE_APPEND2 >>
+     first_x_assum (assume_tac o Q.SPECL[`EL n src`, `[h] ⧺ t ⧺ afr`]) >>
+     fs[LUPDATE_def]) >>
+ cases_on`DROP n src` >- fs[DROP_NIL] >>
+ `EL (0 + n) src = EL 0 (DROP n src)` by fs[EL_DROP] >> fs[] >>
+ `DROP 1 (DROP n src) = t'` by fs[GSYM DROP_DROP_T] >>
+ fs[DROP_DROP_T]
 QED
 
 
@@ -310,9 +313,10 @@ Theorem array_copy_spec:
       (ARRAY srcv src * ARRAY dstv (bfr ++ mid ++ afr))
     (POSTv uv. ARRAY srcv src * ARRAY dstv (bfr ++ src ++ afr))
 Proof
-    xcf "Array.copy" array_st \\
-    xlet_auto >- xsimpl >> xapp >> xsimpl >> instantiate >>
-    fs[] >> instantiate >> metis_tac[TAKE_LENGTH_ID]
+  rpt strip_tac \\
+  xcf "Array.copy" array_st \\
+  xlet_auto >- xsimpl >> xapp >> xsimpl >> instantiate >>
+  fs[] >> instantiate >> metis_tac[TAKE_LENGTH_ID]
 QED
 
 Theorem array_app_aux_spec:
@@ -330,7 +334,8 @@ Theorem array_app_aux_spec:
 Proof
   ntac 2 gen_tac >>
   completeInduct_on `LENGTH l - idx` >>
-  xcf_with_def "Array.app_aux" Array_app_aux_v_def >>
+  rpt strip_tac >>
+  xcf_with_def Array_app_aux_v_def >>
   rw [] >>
   xlet `POSTv env_v. eff l idx * ARRAY a_v l * &BOOL (idx = LENGTH l) env_v`
   >- (
@@ -400,7 +405,8 @@ Theorem array_appi_aux_spec:
 Proof
   ntac 2 gen_tac >>
   completeInduct_on `LENGTH l - idx` >>
-  xcf_with_def "Array.appi_aux" Array_appi_aux_v_def >>
+  rpt strip_tac >>
+  xcf_with_def Array_appi_aux_v_def >>
   rw [] >>
   xlet `POSTv env_v. eff l idx * ARRAY a_v l * &BOOL (idx = LENGTH l) env_v`
   >- (
@@ -478,53 +484,53 @@ Theorem array_modify_aux_spec:
     ==> app (p:'ffi ffi_proj) Array_modify_aux_v [fv; av; maxv; nv]
     (ARRAY av vs) (POSTv uv. SEP_EXISTS vs1 vs2. ARRAY av (vs1 ++ vs2) * cond(EVERY2 A (TAKE n a) vs1) * cond(EVERY2 A (MAP f (DROP n a)) vs2))
 Proof
-    gen_tac \\ gen_tac \\ Induct_on `LENGTH a - n`
-      >-(xcf_with_def "Array.modify_aux" Array_modify_aux_v_def
-      \\ rw[] \\ xlet `POSTv bool. & (BOOL (nv = maxv) bool) * ARRAY av vs`
-        >- (xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def, BOOL_def])
-      \\ xif
-        >- (xcon \\ xsimpl \\ fs[NUM_def, INT_def, BOOL_def] \\ rw[DROP_LENGTH_NIL])
-      \\ `LENGTH a = n` by DECIDE_TAC \\ fs[NUM_def, INT_def] \\ rfs[])
-    \\ xcf_with_def "Array.modify_aux" Array_modify_aux_v_def
-    \\ xlet `POSTv bool. & (BOOL (nv = maxv) bool) * ARRAY av vs`
+  gen_tac \\ gen_tac \\ Induct_on `LENGTH a - n` \\ rpt strip_tac
+    >-(xcf_with_def Array_modify_aux_v_def
+    \\ rw[] \\ xlet `POSTv bool. & (BOOL (nv = maxv) bool) * ARRAY av vs`
       >- (xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def, BOOL_def])
     \\ xif
-      >- (xcon \\ xsimpl \\ qexists_tac `vs` \\ fs[NUM_def, INT_def, BOOL_def] \\ rw[DROP_LENGTH_NIL])
-    \\ xlet `POSTv vsub. &(vsub = EL n vs)* ARRAY av vs`
-      >-(xapp \\ fs[NUM_def, INT_def] \\ imp_res_tac LIST_REL_LENGTH \\ fs[])
-    \\ xlet `POSTv res. & (A (f (EL n a)) res) * ARRAY av vs`
-        >-(xapp \\ xsimpl \\ instantiate \\ qexists_tac `(EL n a)` \\ fs[LIST_REL_EL_EQN])
-    \\ xlet `POSTv u. ARRAY av (LUPDATE res n vs)`
-      >-(xapp \\ xsimpl \\ instantiate \\ imp_res_tac LIST_REL_LENGTH \\ fs[NUM_def, INT_def] \\ rfs[])
-    \\ xlet `POSTv n1. & NUM (n + 1) n1 * ARRAY av (LUPDATE res n vs)`
-      >-(xapp \\ xsimpl \\ qexists_tac `&n` \\ fs[NUM_def, INT_def, integerTheory.INT_ADD])
-    \\ first_x_assum (qspecl_then [`LUPDATE (f (EL n a)) n a`, `n + 1`] mp_tac) \\ rw[]
-    \\ xapp \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def] \\ rw[EVERY2_LUPDATE_same]
-    \\ qexists_tac `TAKE n x`
-    \\ simp[RIGHT_EXISTS_AND_THM]
-    \\ conj_tac
-      >-(`(TAKE n (TAKE (n + 1) (LUPDATE (f (EL n a)) n a))) = (TAKE n a)` by fs[lupdate_breakdown_thm, TAKE_APPEND1, TAKE_TAKE]
-          \\ metis_tac[list_rel_take_thm])
-    \\ first_x_assum(qspec_then`ARB`kall_tac)
-    \\ qexists_tac`[EL n x] ++ x'`
-    \\ reverse conj_tac
-    >- (
-      imp_res_tac LIST_REL_LENGTH
-      \\ rfs[LENGTH_LUPDATE,LENGTH_TAKE]
-      \\ fs[LIST_EQ_REWRITE]
-      \\ qx_gen_tac`z`
-      \\ Cases_on`z<n` \\ simp[EL_APPEND1,EL_APPEND2,EL_TAKE]
-      \\ rw[] \\ `z = n` by decide_tac \\ simp[] )
-    \\ rfs[LIST_REL_EL_EQN,EL_MAP,EL_DROP,EL_LUPDATE,EL_TAKE]
-    \\ Cases \\ fs[]
-    >- ( rpt(first_x_assum(qspec_then`n`mp_tac) \\ simp[]) )
-    \\ qmatch_goalsub_rename_tac`A _ (EL z l2)`
-    \\ strip_tac
-    \\ first_x_assum(qspec_then`z`mp_tac)
-    \\ simp[]
-    \\ fs[ADD1]
-    \\ qpat_x_assum`_ = LENGTH x`(SUBST_ALL_TAC o SYM)
-    \\ fs[]
+      >- (xcon \\ xsimpl \\ fs[NUM_def, INT_def, BOOL_def] \\ rw[DROP_LENGTH_NIL])
+    \\ `LENGTH a = n` by DECIDE_TAC \\ fs[NUM_def, INT_def] \\ rfs[])
+  \\ xcf_with_def Array_modify_aux_v_def
+  \\ xlet `POSTv bool. & (BOOL (nv = maxv) bool) * ARRAY av vs`
+    >- (xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def, BOOL_def])
+  \\ xif
+    >- (xcon \\ xsimpl \\ qexists_tac `vs` \\ fs[NUM_def, INT_def, BOOL_def] \\ rw[DROP_LENGTH_NIL])
+  \\ xlet `POSTv vsub. &(vsub = EL n vs)* ARRAY av vs`
+    >-(xapp \\ fs[NUM_def, INT_def] \\ imp_res_tac LIST_REL_LENGTH \\ fs[])
+  \\ xlet `POSTv res. & (A (f (EL n a)) res) * ARRAY av vs`
+      >-(xapp \\ xsimpl \\ instantiate \\ qexists_tac `(EL n a)` \\ fs[LIST_REL_EL_EQN])
+  \\ xlet `POSTv u. ARRAY av (LUPDATE res n vs)`
+    >-(xapp \\ xsimpl \\ instantiate \\ imp_res_tac LIST_REL_LENGTH \\ fs[NUM_def, INT_def] \\ rfs[])
+  \\ xlet `POSTv n1. & NUM (n + 1) n1 * ARRAY av (LUPDATE res n vs)`
+    >-(xapp \\ xsimpl \\ qexists_tac `&n` \\ fs[NUM_def, INT_def, integerTheory.INT_ADD])
+  \\ first_x_assum (qspecl_then [`LUPDATE (f (EL n a)) n a`, `n + 1`] mp_tac) \\ rw[]
+  \\ xapp \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def] \\ rw[EVERY2_LUPDATE_same]
+  \\ qexists_tac `TAKE n x`
+  \\ simp[RIGHT_EXISTS_AND_THM]
+  \\ conj_tac
+    >-(`(TAKE n (TAKE (n + 1) (LUPDATE (f (EL n a)) n a))) = (TAKE n a)` by fs[lupdate_breakdown_thm, TAKE_APPEND1, TAKE_TAKE]
+        \\ metis_tac[list_rel_take_thm])
+  \\ first_x_assum(qspec_then`ARB`kall_tac)
+  \\ qexists_tac`[EL n x] ++ x'`
+  \\ reverse conj_tac
+  >- (
+    imp_res_tac LIST_REL_LENGTH
+    \\ rfs[LENGTH_LUPDATE,LENGTH_TAKE]
+    \\ fs[LIST_EQ_REWRITE]
+    \\ qx_gen_tac`z`
+    \\ Cases_on`z<n` \\ simp[EL_APPEND1,EL_APPEND2,EL_TAKE]
+    \\ rw[] \\ `z = n` by decide_tac \\ simp[] )
+  \\ rfs[LIST_REL_EL_EQN,EL_MAP,EL_DROP,EL_LUPDATE,EL_TAKE]
+  \\ Cases \\ fs[]
+  >- ( rpt(first_x_assum(qspec_then`n`mp_tac) \\ simp[]) )
+  \\ qmatch_goalsub_rename_tac`A _ (EL z l2)`
+  \\ strip_tac
+  \\ first_x_assum(qspec_then`z`mp_tac)
+  \\ simp[]
+  \\ fs[ADD1]
+  \\ qpat_x_assum`_ = LENGTH x`(SUBST_ALL_TAC o SYM)
+  \\ fs[]
 QED
 
 
@@ -534,7 +540,8 @@ Theorem array_modify_spec:
     ==> app (p:'ffi ffi_proj) ^(fetch_v "Array.modify" array_st) [fv; av]
     (ARRAY av vs) (POSTv uv. SEP_EXISTS vs1. ARRAY av vs1 * cond(EVERY2 A (MAP f a) vs1))
 Proof
-    xcf "Array.modify" array_st
+    rpt strip_tac
+    \\ xcf "Array.modify" array_st
     \\ xlet `POSTv len. & NUM (LENGTH a) len * ARRAY av vs`
       >-(xapp \\ xsimpl \\ imp_res_tac LIST_REL_LENGTH \\ fs[INT_def, NUM_def])
     \\ xapp \\ xsimpl \\ instantiate
@@ -548,14 +555,14 @@ Theorem array_modifyi_aux_spec:
     (ARRAY av vs) (POSTv uv. SEP_EXISTS vs1 vs2. ARRAY av (vs1 ++ vs2) * cond(EVERY2 A (TAKE n a) vs1) *
       cond(EVERY2 A (MAPi (\i. f (n + i)) (DROP n a)) vs2))
 Proof
-    gen_tac \\ gen_tac \\ Induct_on `LENGTH a - n`
-      >-(xcf_with_def "Array.modifyi_aux" Array_modifyi_aux_v_def
+    gen_tac \\ gen_tac \\ Induct_on `LENGTH a - n` \\ rpt strip_tac
+      >-(xcf_with_def Array_modifyi_aux_v_def
         \\ xlet `POSTv bool. & BOOL (nv=maxv) bool * ARRAY av vs`
           >-(xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[INT_def, NUM_def, BOOL_def])
         \\ xif
           >-(xcon \\ xsimpl \\ fs[NUM_def, INT_def] \\ rw[DROP_LENGTH_NIL])
         \\ `LENGTH a = n` by DECIDE_TAC \\ fs[NUM_def, INT_def] \\ rfs[])
-    \\ xcf_with_def "Array.modifyi_aux" Array_modifyi_aux_v_def
+    \\ xcf_with_def Array_modifyi_aux_v_def
     \\ xlet `POSTv bool. & BOOL (nv=maxv) bool * ARRAY av vs`
       >-(xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[INT_def, NUM_def, BOOL_def])
     \\ xif
@@ -601,7 +608,8 @@ Theorem array_modifyi_spec:
     ==> app (p:'ffi ffi_proj) ^(fetch_v "Array.modifyi" array_st) [fv; av]
     (ARRAY av vs) (POSTv uv. SEP_EXISTS vs1. ARRAY av vs1 * cond(EVERY2 A (MAPi f a) vs1))
 Proof
-    xcf "Array.modifyi" array_st
+    rpt strip_tac
+    \\ xcf "Array.modifyi" array_st
     \\ xlet `POSTv len. & NUM (LENGTH a) len * ARRAY av vs`
       >-(xapp \\ xsimpl \\ imp_res_tac LIST_REL_LENGTH \\ fs[INT_def, NUM_def])
     \\ xapp \\ xsimpl \\ metis_tac [BETA_THM]
@@ -742,14 +750,14 @@ Theorem array_foldr_aux_spec:
       ==> app (p:'ffi ffi_proj) Array_foldr_aux_v [fv; initv; av; nv]
       (ARRAY av vs) (POSTv val. & A (FOLDR f init (TAKE n a)) val * ARRAY av vs)
 Proof
-    gen_tac \\ Induct_on `n`
-      >-(xcf_with_def "Array.foldr_aux" Array_foldr_aux_v_def
+    gen_tac \\ Induct_on `n` \\ rpt strip_tac
+      >-(xcf_with_def Array_foldr_aux_v_def
       \\ xlet `POSTv bool. SEP_EXISTS ov. & BOOL (nv = ov) bool * ARRAY av vs * & NUM 0 ov`
         >-(xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def])
       \\ xif
         >-(xvar \\ xsimpl)
       \\ fs[NUM_def, INT_def] \\ rfs[])
-    \\ xcf_with_def "Array.foldr_aux" Array_foldr_aux_v_def
+    \\ xcf_with_def Array_foldr_aux_v_def
     \\ xlet `POSTv bool. SEP_EXISTS ov. & BOOL (nv = ov) bool * ARRAY av vs * & NUM 0 ov`
       >-(xapp_spec eq_num_v_thm \\ xsimpl \\ instantiate \\ fs[NUM_def, INT_def])
     \\ xif
@@ -771,7 +779,8 @@ Theorem array_foldr_spec:
     ==> app (p:'ffi ffi_proj) ^(fetch_v "Array.foldr" array_st) [fv; initv; av]
       (ARRAY av vs) (POSTv val. & A (FOLDR f init a) val * ARRAY av vs)
 Proof
-      xcf "Array.foldr" array_st
+      rpt strip_tac
+      \\ xcf "Array.foldr" array_st
       \\ xlet `POSTv len. & NUM (LENGTH vs) len * ARRAY av vs`
         >-(xapp \\ xsimpl)
       \\ xapp \\ xsimpl \\ instantiate \\ imp_res_tac LIST_REL_LENGTH
@@ -901,7 +910,7 @@ Theorem array_updateResize_spec:
     (POSTv v. ARRAY v (update_resize arrlsv defaultv xv n))
 Proof
   rw []
-  \\ xcf_with_def "" Array_updateResize_v_def
+  \\ xcf_with_def Array_updateResize_v_def
   \\ Cases_on ‘n < LENGTH arrlsv’
   >-
    (xhandle ‘(POSTv v. ARRAY v (update_resize arrlsv defaultv xv n))’

--- a/basis/CommandLineProofScript.sml
+++ b/basis/CommandLineProofScript.sml
@@ -49,7 +49,8 @@ Theorem CommandLine_read16bit:
      (W8ARRAY av a)
      (POSTv v. W8ARRAY av a * & NUM (w2n (EL 0 a) + 256 * w2n (EL 1 a)) v)
 Proof
-  xcf_with_def "CommandLine.read16bit" CommandLine_read16bit_v_def
+  rpt strip_tac
+  \\ xcf_with_def CommandLine_read16bit_v_def
   \\ xlet_auto THEN1 xsimpl
   \\ xlet_auto THEN1 (fs [] \\ xsimpl)
   \\ xlet_auto THEN1 (fs [] \\ xsimpl)
@@ -68,7 +69,8 @@ Theorem CommandLine_write16bit:
      (W8ARRAY av a)
      (POSTv v. W8ARRAY av (n2w n::n2w (n DIV 256)::TL (TL a)))
 Proof
-  xcf_with_def "CommandLine.write16bit" CommandLine_write16bit_v_def
+  rpt strip_tac
+  \\ xcf_with_def CommandLine_write16bit_v_def
   \\ xlet_auto THEN1 xsimpl
   \\ xlet_auto THEN1 (fs [] \\ xsimpl)
   \\ xlet_auto THEN1 (fs [] \\ xsimpl)
@@ -124,12 +126,12 @@ Proof
   \\ MAP_EVERY qid_spec_tac [`events`, `a`, `cv`, `av`, `nv`, `n`]
   \\ Induct \\ rw []
   THEN1
-   (xcf_with_def "CommandLine.cloop" CommandLine_cloop_v_def
+   (xcf_with_def CommandLine_cloop_v_def
     \\ xlet_auto THEN1 xsimpl
     \\ xif \\ asm_exists_tac \\ fs []
     \\ xvar \\ fs [COMMANDLINE_def, cl_ffi_part_def, IOx_def, IO_def]
     \\ xsimpl \\ qexists_tac `events` \\ xsimpl)
-  \\ xcf_with_def "CommandLine.cloop" CommandLine_cloop_v_def
+  \\ xcf_with_def CommandLine_cloop_v_def
   \\ xlet_auto THEN1 xsimpl
   \\ xif \\ asm_exists_tac \\ fs []
   \\ rpt (xlet_auto THEN1 xsimpl)
@@ -212,7 +214,7 @@ Proof
   rw [] \\ qpat_abbrev_tac `Q = $POSTv _`
   \\ simp [COMMANDLINE_def,cl_ffi_part_def,IOx_def,IO_def]
   \\ xpull \\ qunabbrev_tac `Q`
-  \\ xcf_with_def "CommandLine.cline" CommandLine_cline_v_def
+  \\ xcf_with_def CommandLine_cline_v_def
   \\ fs [UNIT_TYPE_def] \\ rveq
   \\ xmatch
   \\ xlet_auto >- xsimpl
@@ -262,7 +264,8 @@ Theorem CommandLine_name_spec:
     (COMMANDLINE cl)
     (POSTv namev. & STRING_TYPE (HD cl) namev * COMMANDLINE cl)
 Proof
-  xcf_with_def "CommandLine.name" CommandLine_name_v_def
+  rpt strip_tac
+  \\ xcf_with_def CommandLine_name_v_def
   \\ xlet `POSTv cs. & LIST_TYPE STRING_TYPE cl cs * COMMANDLINE cl`
   >-(xapp \\ rw[] \\ fs [])
   \\ Cases_on`cl=[]` >- ( fs[COMMANDLINE_def] \\ xpull \\ fs[wfcl_def] )
@@ -295,7 +298,8 @@ Theorem CommandLine_arguments_spec:
     (POSTv argv. & LIST_TYPE STRING_TYPE
        (TL cl) argv * COMMANDLINE cl)
 Proof
-  xcf_with_def "CommandLine.arguments" CommandLine_arguments_v_def
+  rpt strip_tac
+  \\ xcf_with_def CommandLine_arguments_v_def
   \\ xlet `POSTv cs. & LIST_TYPE STRING_TYPE cl cs * COMMANDLINE cl`
   >-(xapp \\ rw[] \\ fs [])
   \\ Cases_on`cl=[]` >- ( fs[COMMANDLINE_def] \\ xpull \\ fs[wfcl_def] )

--- a/basis/DoubleProofScript.sml
+++ b/basis/DoubleProofScript.sml
@@ -67,7 +67,8 @@ Theorem double_fromWord_spec:
       (emp)
       (POSTv v. cond (v = FP_WordTree $ Fp_const w))
 Proof
-  xcf_with_def "fromWord" Double_fromWord_v_def
+  rpt strip_tac
+  \\ xcf_with_def Double_fromWord_v_def
   \\ gs[cf_fpfromword_def, local_def, emp_def] \\ rpt strip_tac
   \\ qexists_tac ‘GC’ \\ qexists_tac ‘emp’
   \\ gs[emp_def, GC_def, set_sepTheory.SEP_EXISTS, set_sepTheory.STAR_def,
@@ -99,7 +100,8 @@ Theorem double_fromString_spec:
     (DoubleIO df)
     (POSTv v. cond (v = FP_WordTree $ Fp_const $ string2Double s df) * DoubleIO df)
 Proof
-  xcf_with_def "Double.fromString" Double_fromString_v_def
+  rpt strip_tac
+  \\ xcf_with_def Double_fromString_v_def
   \\ reverse (Cases_on `doubleFuns_ok df`)
   >- (fs[DoubleIO_def] \\ xpull)
   \\ gs[string2Double_def]
@@ -213,7 +215,8 @@ Theorem double_toWord_spec:
       (emp)
       (POSTv v. cond (WORD (compress_word fp) v))
 Proof
-  xcf_with_def "toWord" Double_toWord_v_def
+  rpt strip_tac
+  \\ xcf_with_def Double_toWord_v_def
   \\ gs[cf_fptoword_def, local_def, emp_def] \\ rpt strip_tac
   \\ qexists_tac ‘GC’ \\ qexists_tac ‘emp’
   \\ gs[emp_def, GC_def, set_sepTheory.SEP_EXISTS, set_sepTheory.STAR_def,
@@ -245,7 +248,8 @@ Theorem double_toString_spec:
         (DoubleIO df)
         (POSTv v. cond (STRING_TYPE (implode (df.toString w)) v) * DoubleIO df)
 Proof
-  xcf_with_def "Double.toString" Double_toString_v_def
+  rpt strip_tac
+  \\ xcf_with_def Double_toString_v_def
   \\ reverse (Cases_on `doubleFuns_ok df`)
   >- (fs[DoubleIO_def] \\ xpull)
   \\ ntac 19 (xlet_auto >- (fs[] \\ xsimpl))

--- a/basis/HashtableProofScript.sml
+++ b/basis/HashtableProofScript.sml
@@ -81,7 +81,8 @@ Theorem hashtable_initBuckets_spec:
       (POSTv ar. SEP_EXISTS mpv. &(MAP_TYPE a b (mlmap$empty cmp) mpv) *
                                  ARRAY ar (REPLICATE n mpv))
 Proof
-  xcf_with_def "Hashtable.initBuckets" Hashtable_initBuckets_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_initBuckets_v_def
   \\ xlet `POSTv r1. & (MAP_TYPE a b (mlmap$empty cmp) r1)`
     >-(xapp
     \\ simp[])
@@ -484,7 +485,8 @@ Theorem hashtable_empty_spec:
         emp
         (POSTv htv. HASHTABLE a b hf cmp FEMPTY htv)
 Proof
-  xcf_with_def "Hashtable.empty" Hashtable_empty_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_empty_v_def
   \\ xlet_auto
     >-(xsimpl)
   \\ xlet `POSTv v. &(NUM 1 v \/ (NUM size' v /\ BOOL F bv))`
@@ -806,124 +808,125 @@ Theorem hashtable_staticInsert_spec:
         (HASHTABLE a b hf cmp h htv)
         (POSTv uv. &(UNIT_TYPE () uv) * HASHTABLE a b hf cmp (h|+(k,v)) htv)
 Proof
-xcf_with_def "Hashtable.staticInsert" Hashtable_staticInsert_v_def
-\\ fs[HASHTABLE_def, hashtable_con_stamp_def]
-\\ xpull
-\\ xmatch
-\\ fs[hashtable_inv_def]
-\\ xlet `POSTv arr. SEP_EXISTS aRef arr2 avl uRef uv uvv.
-    &(aRef = ar /\ arr2 = arr /\ avl = vlv /\ uRef = ur /\ uv = heuristic_size) *
-    REF_ARRAY ar arr vlv * REF ur uvv * & (NUM heuristic_size uvv)`
-  >-(xapp
-    \\qexists_tac `ARRAY arr vlv * REF_NUM ur heuristic_size`
-    \\qexists_tac `arr`
-    \\fs[REF_ARRAY_def, REF_NUM_def]
-    \\xsimpl)
-\\ xlet `POSTv v. SEP_EXISTS length. &(length = LENGTH vlv /\ NUM length v) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-  >-(xapp
-    \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
-    \\qexists_tac `avl`
-    \\fs[REF_ARRAY_def,REF_NUM_def]
-    \\xsimpl)
-\\ xlet `POSTv v. SEP_EXISTS hashval. &(hashval = (hf k) /\ NUM hashval v) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-  >-(xapp
-    \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-    \\qexists_tac `k`
-    \\qexists_tac `hf`
-    \\conj_tac
-     >-(qexists_tac `a`
-      \\simp[])
-    \\xsimpl)
-\\ xlet `POSTv v. SEP_EXISTS idx. &(idx = (hashval MOD length') /\ NUM idx v /\
-    idx < LENGTH avl /\ idx < LENGTH buckets /\ LENGTH buckets = LENGTH avl) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-  >-(xapp
-    \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-    \\qexists_tac `&length'`
-    \\qexists_tac `&hashval`
-    \\fs[NOT_NIL_EQ_LENGTH_NOT_0,X_MOD_Y_EQ_X,LENGTH_NIL_SYM,NUM_def, hashtable_inv_def, LIST_REL_LENGTH]
-    \\xsimpl
-    \\EVAL_TAC
-    \\fs[LIST_REL_LENGTH,NOT_NIL_EQ_LENGTH_NOT_0,LIST_REL_EL_EQN, X_MOD_Y_EQ_X])
-\\ xlet `POSTv mp. SEP_EXISTS oldMap. &(oldMap = mp /\ MAP_TYPE a b (EL idx buckets) mp) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
- >-(xapp
-    \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
-    \\qexists_tac `idx`
-    \\qexists_tac `vlv`
-    \\fs[hashtable_inv_def,NOT_NIL_EQ_LENGTH_NOT_0,LIST_REL_EL_EQN, X_MOD_Y_EQ_X,REF_ARRAY_def]
-    \\xsimpl)
-\\ xlet `POSTv retv. SEP_EXISTS newMp.
-      &(newMp = retv /\  MAP_TYPE a b (mlmap$insert (EL idx buckets)  k v) retv) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
- >-(xapp
-    \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
-    \\qexists_tac `v`
-    \\qexists_tac `k`
-    \\qexists_tac `EL idx buckets`
-    \\qexists_tac `b`
-    \\qexists_tac `a`
-    \\fs[LIST_REL_EL_EQN]
-    \\xsimpl)
-\\ xlet `POSTv unitv. SEP_EXISTS newBuckets.
-    &(UNIT_TYPE () unitv /\ newBuckets = (LUPDATE newMp idx avl)) *
-    REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
-  >-(xapp
-    \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
-    \\qexists_tac `idx`
-    \\qexists_tac `vlv`
-    \\fs[REF_ARRAY_def]
-    \\xsimpl)
-\\ xlet `POSTv b. &(BOOL (mlmap$null (EL idx buckets)) b) * REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
-  >-(xapp
-    \\qexists_tac `REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
-    \\qexists_tac `EL idx buckets`
-    \\xsimpl
-    \\qexists_tac `a`
-    \\qexists_tac `b`
-    \\fs[])
-THEN1 (xif
-THEN1 (xlet `POSTv usedv. &(NUM uv usedv) * REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
-  >-(xapp
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_staticInsert_v_def
+  \\ fs[HASHTABLE_def, hashtable_con_stamp_def]
+  \\ xpull
+  \\ xmatch
+  \\ fs[hashtable_inv_def]
+  \\ xlet `POSTv arr. SEP_EXISTS aRef arr2 avl uRef uv uvv.
+      &(aRef = ar /\ arr2 = arr /\ avl = vlv /\ uRef = ur /\ uv = heuristic_size) *
+      REF_ARRAY ar arr vlv * REF ur uvv * & (NUM heuristic_size uvv)`
+    >-(xapp
+      \\qexists_tac `ARRAY arr vlv * REF_NUM ur heuristic_size`
+      \\qexists_tac `arr`
+      \\fs[REF_ARRAY_def, REF_NUM_def]
+      \\xsimpl)
+  \\ xlet `POSTv v. SEP_EXISTS length. &(length = LENGTH vlv /\ NUM length v) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
+      \\qexists_tac `avl`
+      \\fs[REF_ARRAY_def,REF_NUM_def]
+      \\xsimpl)
+  \\ xlet `POSTv v. SEP_EXISTS hashval. &(hashval = (hf k) /\ NUM hashval v) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+      \\qexists_tac `k`
+      \\qexists_tac `hf`
+      \\conj_tac
+       >-(qexists_tac `a`
+        \\simp[])
+      \\xsimpl)
+  \\ xlet `POSTv v. SEP_EXISTS idx. &(idx = (hashval MOD length') /\ NUM idx v /\
+      idx < LENGTH avl /\ idx < LENGTH buckets /\ LENGTH buckets = LENGTH avl) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+      \\qexists_tac `&length'`
+      \\qexists_tac `&hashval`
+      \\fs[NOT_NIL_EQ_LENGTH_NOT_0,X_MOD_Y_EQ_X,LENGTH_NIL_SYM,NUM_def, hashtable_inv_def, LIST_REL_LENGTH]
+      \\xsimpl
+      \\EVAL_TAC
+      \\fs[LIST_REL_LENGTH,NOT_NIL_EQ_LENGTH_NOT_0,LIST_REL_EL_EQN, X_MOD_Y_EQ_X])
+  \\ xlet `POSTv mp. SEP_EXISTS oldMap. &(oldMap = mp /\ MAP_TYPE a b (EL idx buckets) mp) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+   >-(xapp
+      \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
+      \\qexists_tac `idx`
+      \\qexists_tac `vlv`
+      \\fs[hashtable_inv_def,NOT_NIL_EQ_LENGTH_NOT_0,LIST_REL_EL_EQN, X_MOD_Y_EQ_X,REF_ARRAY_def]
+      \\xsimpl)
+  \\ xlet `POSTv retv. SEP_EXISTS newMp.
+        &(newMp = retv /\  MAP_TYPE a b (mlmap$insert (EL idx buckets)  k v) retv) * REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+   >-(xapp
+      \\qexists_tac `REF_ARRAY aRef arr2 avl * REF_NUM uRef uv`
+      \\qexists_tac `v`
+      \\qexists_tac `k`
+      \\qexists_tac `EL idx buckets`
+      \\qexists_tac `b`
+      \\qexists_tac `a`
+      \\fs[LIST_REL_EL_EQN]
+      \\xsimpl)
+  \\ xlet `POSTv unitv. SEP_EXISTS newBuckets.
+      &(UNIT_TYPE () unitv /\ newBuckets = (LUPDATE newMp idx avl)) *
+      REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `aRef ~~> arr2 * REF_NUM uRef uv`
+      \\qexists_tac `idx`
+      \\qexists_tac `vlv`
+      \\fs[REF_ARRAY_def]
+      \\xsimpl)
+  \\ xlet `POSTv b. &(BOOL (mlmap$null (EL idx buckets)) b) * REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
+      \\qexists_tac `EL idx buckets`
+      \\xsimpl
+      \\qexists_tac `a`
+      \\qexists_tac `b`
+      \\fs[])
+  THEN1 (xif
+  THEN1 (xlet `POSTv usedv. &(NUM uv usedv) * REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
+    >-(xapp
+      \\qexists_tac `REF_ARRAY aRef arr2 newBuckets`
+      \\qexists_tac `uvv`
+      \\fs[REF_NUM_def, NUM_def, INT_def]
+      \\xsimpl)
+  \\ xlet_auto
+    >-(qexists_tac `REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
+      \\xsimpl)
+    THEN1( xapp
     \\qexists_tac `REF_ARRAY aRef arr2 newBuckets`
-    \\qexists_tac `uvv`
+    \\qexists_tac `usedv`
     \\fs[REF_NUM_def, NUM_def, INT_def]
-    \\xsimpl)
-\\ xlet_auto
-  >-(qexists_tac `REF_ARRAY aRef arr2 newBuckets * REF_NUM uRef uv`
-    \\xsimpl)
-  THEN1( xapp
-  \\qexists_tac `REF_ARRAY aRef arr2 newBuckets`
-  \\qexists_tac `usedv`
-  \\fs[REF_NUM_def, NUM_def, INT_def]
-  \\xsimpl
-  \\strip_tac
-  \\strip_tac
-  \\qexists_tac `uRef`
-  \\qexists_tac `aRef`
-  \\qexists_tac `hfv`
-  \\qexists_tac `newBuckets`
-  \\qexists_tac `arr2`
-  \\qexists_tac `cmpv`
-  \\qexists_tac `heuristic_size + 1`
-  \\xsimpl
-  \\qexists_tac `LUPDATE (mlmap$insert (EL (hf k MOD LENGTH buckets) buckets) k v) (hf k MOD LENGTH buckets) buckets`
-  \\`buckets <> []` by simp[NOT_NIL_EQ_LENGTH_NOT_0]
-  \\ imp_res_tac list_union_lupdate_insert
-  \\ simp[]
-  \\fs[every_cmp_of_insert, buckets_ok_insert, list_rel_insert, every_map_ok_insert]))
-  \\xcon
-  \\xsimpl
-  \\qexists_tac `uRef`
-  \\qexists_tac `aRef`
-  \\qexists_tac `hfv`
-  \\qexists_tac `newBuckets`
-  \\qexists_tac `arr2`
-  \\qexists_tac `cmpv`
-  \\qexists_tac `heuristic_size`
-  \\xsimpl
-  \\qexists_tac `LUPDATE (mlmap$insert (EL (hf k MOD LENGTH buckets) buckets) k v) (hf k MOD LENGTH buckets) buckets`
-  \\`buckets <> []` by simp[NOT_NIL_EQ_LENGTH_NOT_0]
-  \\ imp_res_tac list_union_lupdate_insert
-  \\ simp[]
-  \\fs[every_cmp_of_insert, buckets_ok_insert, list_rel_insert, every_map_ok_insert])
+    \\xsimpl
+    \\strip_tac
+    \\strip_tac
+    \\qexists_tac `uRef`
+    \\qexists_tac `aRef`
+    \\qexists_tac `hfv`
+    \\qexists_tac `newBuckets`
+    \\qexists_tac `arr2`
+    \\qexists_tac `cmpv`
+    \\qexists_tac `heuristic_size + 1`
+    \\xsimpl
+    \\qexists_tac `LUPDATE (mlmap$insert (EL (hf k MOD LENGTH buckets) buckets) k v) (hf k MOD LENGTH buckets) buckets`
+    \\`buckets <> []` by simp[NOT_NIL_EQ_LENGTH_NOT_0]
+    \\ imp_res_tac list_union_lupdate_insert
+    \\ simp[]
+    \\fs[every_cmp_of_insert, buckets_ok_insert, list_rel_insert, every_map_ok_insert]))
+    \\xcon
+    \\xsimpl
+    \\qexists_tac `uRef`
+    \\qexists_tac `aRef`
+    \\qexists_tac `hfv`
+    \\qexists_tac `newBuckets`
+    \\qexists_tac `arr2`
+    \\qexists_tac `cmpv`
+    \\qexists_tac `heuristic_size`
+    \\xsimpl
+    \\qexists_tac `LUPDATE (mlmap$insert (EL (hf k MOD LENGTH buckets) buckets) k v) (hf k MOD LENGTH buckets) buckets`
+    \\`buckets <> []` by simp[NOT_NIL_EQ_LENGTH_NOT_0]
+    \\ imp_res_tac list_union_lupdate_insert
+    \\ simp[]
+    \\fs[every_cmp_of_insert, buckets_ok_insert, list_rel_insert, every_map_ok_insert])
 QED
 
 Theorem list_app_pairs_spec:
@@ -935,9 +938,9 @@ Theorem list_app_pairs_spec:
   app (p:'ffi ffi_proj) List_app_v [fv; lv] (eff start)
     (POSTv v. &UNIT_TYPE () v * (eff (start + (LENGTH l))))
 Proof
- Induct_on `l` \\ rw[LIST_TYPE_def]
- >- ( xcf_with_def "List.app" List_app_v_def \\ xmatch \\ xcon \\ xsimpl )
- \\ xcf_with_def "List.app" List_app_v_def
+ Induct_on `l` \\ rw[LIST_TYPE_def] \\ rpt strip_tac
+ >- ( xcf_with_def List_app_v_def \\ xmatch \\ xcon \\ xsimpl )
+ \\ xcf_with_def List_app_v_def
  \\ xmatch
  \\ xlet`POSTv v. &UNIT_TYPE () v * eff (start+1)`
  >- (
@@ -975,7 +978,8 @@ Theorem hashtable_insertList_spec:
         (POSTv uv. &(UNIT_TYPE () uv) *
           HASHTABLE a b hf cmp (h|++l) htv)
 Proof
-  xcf_with_def "Hashtable.insertList" Hashtable_insertList_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_insertList_v_def
   \\xfun_spec `f`
    `!k v pv h' n.
       n < LENGTH l /\
@@ -1072,7 +1076,8 @@ Theorem hashtable_toAscList_spec:
           (FEMPTY |++ bsalist = h))
         * HASHTABLE a b hf cmp h htv)
 Proof
-  xcf_with_def "Hashtable.toAscList" Hashtable_toAscList_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_toAscList_v_def
   \\fs[HASHTABLE_def, hashtable_con_stamp_def]
   \\xpull
   \\fs[hashtable_inv_def]
@@ -1129,7 +1134,8 @@ Theorem hashtable_doubleCapacity_spec:
         (POSTv uv. &(UNIT_TYPE () uv) *
           HASHTABLE a b hf cmp h htv)
 Proof
-  xcf_with_def "Hashtable.doubleCapacity" Hashtable_doubleCapacity_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_doubleCapacity_v_def
   \\ fs[HASHTABLE_def, hashtable_con_stamp_def]
   \\ xpull
   \\ xmatch
@@ -1206,7 +1212,8 @@ Theorem hashtable_insert_spec:
         (POSTv uv. &(UNIT_TYPE () uv) *
           HASHTABLE a b hf cmp (h|+(k,v)) htv)
 Proof
-     xcf_with_def "Hashtable.insert" Hashtable_insert_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_insert_v_def
   \\ fs[HASHTABLE_def, hashtable_con_stamp_def]
   \\ fs[REF_ARRAY_def]
   \\ xpull
@@ -1269,7 +1276,8 @@ Theorem hashtable_lookup_spec:
         (POSTv v. &(OPTION_TYPE b (FLOOKUP h k) v) *
                     HASHTABLE a b hf cmp h htv)
 Proof
-  xcf_with_def "Hashtable.lookup" Hashtable_lookup_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_lookup_v_def
   \\ fs[HASHTABLE_def, hashtable_con_stamp_def, REF_ARRAY_def]
   \\ xpull
   \\ xmatch
@@ -1313,7 +1321,8 @@ Theorem hashtable_delete_spec:
         (HASHTABLE a b hf cmp h htv)
         (POSTv uv. &(UNIT_TYPE () uv) * HASHTABLE a b hf cmp (h \\ k) htv)
 Proof
-  xcf_with_def "Hashtable.delete" Hashtable_delete_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_delete_v_def
   \\ fs [HASHTABLE_def, hashtable_con_stamp_def, REF_ARRAY_def, hashtable_inv_def]
   \\ xpull
   \\ xmatch
@@ -1400,7 +1409,8 @@ Theorem hashtable_clear_spec:
         (HASHTABLE a b hf cmp h htv)
         (POSTv uv. &(UNIT_TYPE () uv) * HASHTABLE a b hf cmp FEMPTY htv)
 Proof
-  xcf_with_def "Hashtable.clear" Hashtable_clear_v_def
+  rpt strip_tac
+  \\ xcf_with_def Hashtable_clear_v_def
   \\ fs[HASHTABLE_def, hashtable_con_stamp_def, REF_ARRAY_def, hashtable_inv_def]
   \\ xpull
   \\ xmatch

--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -215,8 +215,9 @@ Theorem tabulate_inv_spec:
     ==>
     app (p:'ffi ffi_proj) ^(fetch_v "tabulate" st) [nv; fv] heap_inv (POSTv lv. &LIST_TYPE A ls lv * heap_inv)
 Proof
-  xcf "tabulate" st \\
-  xlet`POSTv v. &LIST_TYPE A [] v * heap_inv`
+  rpt strip_tac
+  \\ xcf "tabulate" st
+  \\ xlet`POSTv v. &LIST_TYPE A [] v * heap_inv`
   >- (xcon \\ xsimpl \\ fs[LIST_TYPE_def] )
   \\ xapp_spec tabulate_aux_inv_spec
   \\ xsimpl

--- a/basis/MarshallingProgScript.sml
+++ b/basis/MarshallingProgScript.sml
@@ -95,6 +95,7 @@ Theorem n2w2_spec:
        (W8ARRAY bl b)
        (POSTv u. &UNIT_TYPE () u * W8ARRAY bl (insert_atI (n2w2 n) off b))
 Proof
+  rpt strip_tac >>
   xcf "Marshalling.n2w2" (get_ml_prog_state()) >>
   NTAC 6 (xlet_auto >- xsimpl) >>
   xcon >> xsimpl >>
@@ -109,6 +110,7 @@ Theorem w22n_spec:
        (W8ARRAY bl b)
        (POSTv nv. &NUM (w22n [EL off b; EL (off+1) b]) nv * W8ARRAY bl b)
 Proof
+  rpt strip_tac >>
   xcf "Marshalling.w22n" (get_ml_prog_state()) >>
   NTAC 6 (xlet_auto >- xsimpl) >>
   xapp >> xsimpl  >> fs[w22n_def,NUM_def,INT_def,integerTheory.INT_ADD]

--- a/basis/RuntimeProofScript.sml
+++ b/basis/RuntimeProofScript.sml
@@ -80,7 +80,8 @@ Theorem Runtime_abort_spec:
      (RUNTIME)
      (POSTf n. λc b. RUNTIME * &(n = "exit" /\ c = [] /\ b = [1w]))
 Proof
-  xcf "Runtime.abort" st
+  rpt strip_tac
+  \\ xcf "Runtime.abort" st
   \\ fs [UNIT_TYPE_def]
   \\ xmatch
   \\ xapp

--- a/basis/TextIOProofScript.sml
+++ b/basis/TextIOProofScript.sml
@@ -909,7 +909,8 @@ Proof
   rw [] >> qpat_abbrev_tac `Q = POSTve _ _` >>
   simp [IOFS_def, fs_ffi_part_def, IOx_def, IO_def] >>
   xpull >> qunabbrev_tac `Q` >>
-  xcf_with_def "TextIO.openIn" TextIO_openIn_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_openIn_v_def >>
   fs[FILENAME_def, strlen_def, IOFS_def, IOFS_iobuff_def] >>
   REVERSE (Cases_on`consistentFS fs`) >-(xpull >> fs[wfFS_def]) >>
   xpull >> rename [`W8ARRAY _ fnm0`] >>
@@ -1019,7 +1020,8 @@ Proof
   rw [] >> qpat_abbrev_tac `Q = POSTve _ _` >>
   simp [IOFS_def, fs_ffi_part_def, IOx_def, IO_def] >>
   xpull >> qunabbrev_tac `Q` >>
-  xcf_with_def "TextIO.closeIn" TextIO_closeIn_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_closeIn_v_def >>
   fs[IOFS_def, IOFS_iobuff_def,INSTREAM_def] >> xpull >>
   rename [`W8ARRAY _ buf`] >> cases_on`buf` >> fs[LUPDATE_def] >>
   xlet_auto >- xsimpl >> fs [get_in_def] >>
@@ -1067,7 +1069,8 @@ Proof
   rw [] >> qpat_abbrev_tac `Q = POSTve _ _` >>
   simp [IOFS_def, fs_ffi_part_def, IOx_def, IO_def] >>
   xpull >> qunabbrev_tac `Q` >>
-  xcf_with_def "TextIO.closeOut" TextIO_closeOut_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_closeOut_v_def >>
   fs[IOFS_def, IOFS_iobuff_def,OUTSTREAM_def] >> xpull >>
   rename [`W8ARRAY _ buf`] >> cases_on`buf` >> fs[LUPDATE_def] >>
   xlet_auto >- xsimpl >> fs [get_out_def] >>
@@ -1173,7 +1176,8 @@ Proof
   map_every qid_spec_tac [`bc`, `h4`, `h3`, `h2`, `h1`, `fs`] >>
   NTAC 2 (FIRST_X_ASSUM MP_TAC) >> qid_spec_tac `ll` >>
   HO_MATCH_MP_TAC always_eventually_ind >>
-  xcf_with_def "TextIO.writei" TextIO_writei_v_def >> fs[FD_def]
+  rpt strip_tac >>
+  xcf_with_def TextIO_writei_v_def >> fs[FD_def]
 (* next el is <> 0 *)
   >-(sg`Lnext_pos ll = 0`
      >-(fs[Lnext_pos_def,Once Lnext_def,liveFS_def,live_numchars_def,always_thm] >>
@@ -1306,7 +1310,8 @@ Proof
   strip_tac >> `?N. n <= N` by (qexists_tac`n` >> fs[]) >>
   FIRST_X_ASSUM MP_TAC >> qid_spec_tac`n` >>
   Induct_on`N` >>
-  xcf_with_def "TextIO.write" TextIO_write_v_def
+  rpt strip_tac >>
+  xcf_with_def TextIO_write_v_def
   >>(xlet_auto >- xsimpl >> xif
          >-(TRY instantiate >> xcon >>
                 simp[IOFS_iobuff_def,IOFS_def] >> xsimpl >> qexists_tac`0` >>
@@ -1353,7 +1358,8 @@ Theorem output1_spec:
       &UNIT_TYPE () uv * SEP_EXISTS k.
       IOFS (fsupdate fs fd k (pos+1) (insert_atI [c] pos content)))
 Proof
-  xcf_with_def "TextIO.output1" TextIO_output1_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_output1_v_def >>
   fs[IOFS_def,IOFS_iobuff_def] >>
   xpull >> rename [`W8ARRAY _ bdef`] >>
   ntac 3 (xlet_auto >- xsimpl) >>
@@ -1451,7 +1457,8 @@ Proof
   `?n. strlen s <= n` by (qexists_tac`strlen s` >> fs[]) >>
   FIRST_X_ASSUM MP_TAC >> qid_spec_tac`s` >>
   Induct_on`n` >>
-  xcf_with_def "TextIO.output" TextIO_output_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_output_v_def >>
   fs[IOFS_def,IOFS_iobuff_def] >>
   xpull >> rename [`W8ARRAY _ buff`] >>
   Cases_on `buff` >> fs[] >> qmatch_goalsub_rename_tac`h1 :: t` >>
@@ -1561,7 +1568,8 @@ Theorem print_spec:
     (STDIO fs)
     (POSTv uv. &(UNIT_TYPE () uv) * STDIO (add_stdout fs s))
 Proof
-  xcf_with_def "TextIO.print" TextIO_print_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_print_v_def
   \\ reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull)
   \\ xapp_spec output_STDIO_spec
   \\ tac
@@ -1605,7 +1613,8 @@ Theorem print_err_spec:
     (STDIO fs)
     (POSTv uv. &(UNIT_TYPE () uv) * STDIO (add_stderr fs s))
 Proof
-  xcf_with_def "TextIO.print_err" TextIO_print_err_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_print_err_v_def
   \\ reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull)
   \\ xapp_spec output_stderr_spec \\ fs []
 QED
@@ -1647,7 +1656,8 @@ Theorem read_spec:
         MAP (n2w o ORD) (TAKE nr (DROP pos content))++DROP nr rest))
      (\e. &InvalidFD_exn e * &(get_file_content fs fd = NONE ∨ get_mode fs fd ≠ SOME ReadMode) * IOFS fs))
 Proof
-   xcf_with_def "TextIO.read" TextIO_read_v_def >>
+   rpt strip_tac >>
+   xcf_with_def TextIO_read_v_def >>
    fs[IOFS_def,IOFS_iobuff_def] >>
    xlet_auto >- xsimpl >>
    simp[insert_atI_def,n2w2_def] >>
@@ -1759,7 +1769,8 @@ Theorem read_into_spec:
         MAP (n2w o ORD) (TAKE nr (DROP pos content))++DROP nr rest))
      (\e. &InvalidFD_exn e * &(get_file_content fs fd = NONE ∨ get_mode fs fd ≠ SOME ReadMode) * IOFS_WO_iobuff fs))
 Proof
-   xcf_with_def "TextIO.read_into" TextIO_read_into_v_def >>
+   rpt strip_tac >>
+   xcf_with_def TextIO_read_into_v_def >>
    fs[IOFS_WO_iobuff_def] >>
    xlet_auto >- xsimpl >>
    simp[insert_atI_def,n2w2_def] >>
@@ -1867,7 +1878,8 @@ Theorem read_byte_spec:
       (\e.  &(EndOfFile_exn e /\ eof fd fs = SOME T) *
             IOFS(bumpFD fd fs 0)))
 Proof
-  xcf_with_def "TextIO.read_byte" TextIO_read_byte_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_read_byte_v_def >>
   fs[IOFS_def,IOFS_iobuff_def] >>
   xpull >> rename [`W8ARRAY _ bdef`] >>
   Cases_on `bdef` >> fs[] >> qmatch_goalsub_rename_tac`h1 :: t` >>
@@ -1924,7 +1936,8 @@ Theorem input1_spec:
         STDIO (bumpFD fd fs 0)
       | _ => &F)
 Proof
-  xcf_with_def "TextIO.input1" TextIO_input1_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_input1_v_def
   \\ xhandle`POSTve (λv. &OPTION_TYPE CHAR (SOME (EL pos content)) v *
                          STDIO (forwardFD fs fd 1) * &(eof fd fs = SOME F))
                     (λe. &EndOfFile_exn e * STDIO fs * &(eof fd fs = SOME T))`
@@ -1961,7 +1974,8 @@ Theorem input_IOFS_spec:
                                  off buf) *
        SEP_EXISTS k. IOFS (fsupdate fs fd k (MIN (len + pos) (MAX pos (LENGTH content))) content))
 Proof
-  xcf_with_def "TextIO.input" TextIO_input_v_def >>
+  rpt strip_tac >>
+  xcf_with_def TextIO_input_v_def >>
   reverse(Cases_on`pos ≤ LENGTH content`) >- (
     imp_res_tac get_file_content_eof \\ rfs[] \\
     reverse(Cases_on`wfFS fs`) >- (fs[IOFS_def] \\ xpull) \\
@@ -2201,7 +2215,8 @@ Theorem b_openStdInSetBufferSize_spec:
        (IOFS fs)
        (POSTv is. INSTREAM_BUFFERED_FD [] 0 is * IOFS fs)
 Proof
-  xcf_with_def "TextIO.b_openStdInSetBufferSize_v_def" TextIO_b_openStdInSetBufferSize_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_openStdInSetBufferSize_v_def
   \\ xlet_auto >- xsimpl
   \\ xlet_auto >- xsimpl
   \\ xlet_auto >- xsimpl
@@ -2230,7 +2245,8 @@ Theorem b_openStdIn_spec:
        (IOFS fs)
        (POSTv is. INSTREAM_BUFFERED_FD [] 0 is * IOFS fs)
 Proof
-  xcf_with_def "TextIO.b_openStdIn" TextIO_b_openStdIn_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_openStdIn_v_def
   \\ xmatch \\ fs[UNIT_TYPE_def] \\ conj_tac
   >- (xapp \\ fs[INT_NUM_EXISTS])
   \\ EVAL_TAC \\ simp[]
@@ -2265,7 +2281,8 @@ Theorem b_openInSetBufferSize_spec:
           (\e. &(BadFileName_exn e ∧ ~inFS_fname fs s)
                    * IOFS fs))
 Proof
-  xcf_with_def "TextIO.b_openInSetBufferSize_v_def" TextIO_b_openInSetBufferSize_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_openInSetBufferSize_v_def
   \\ xlet_auto >- xsimpl >- (xsimpl)
   \\ xlet_auto >- xsimpl
   \\ xlet_auto >- xsimpl
@@ -2301,7 +2318,8 @@ Theorem b_openIn_spec:
           (\e. &(BadFileName_exn e ∧ ~inFS_fname fs s)
                    * IOFS fs))
 Proof
-  xcf_with_def "TextIO.b_openIn" TextIO_b_openIn_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_openIn_v_def
   \\ xapp \\ fs[INT_NUM_EXISTS]
 QED
 
@@ -2336,7 +2354,8 @@ Theorem b_closeIn_spec:
                IOFS (fs with infds updated_by ADELKEY fd))
           (\e. &(InvalidFD_exn e /\ ¬ validFileFD fd fs.infds) * IOFS fs))
 Proof
-  xcf_with_def "TextIO.b_closeIn" TextIO_b_closeIn_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_closeIn_v_def
   \\ simp[INSTREAM_BUFFERED_FD_def] \\ xpull \\ xmatch
   \\ xapp_spec closeIn_spec \\ asm_exists_tac \\ CONV_TAC (SWAP_EXISTS_CONV)
   \\ qexists_tac `fs` \\ xsimpl
@@ -2403,7 +2422,8 @@ Theorem b_refillBuffer_with_read_spec:
                     (explode_fromI nr content pos) fd is *
                  IOFS (bumpFD fd fs nr))
 Proof
-  xcf_with_def "TextIO.b_refillBuffer_with_read" TextIO_b_refillBuffer_with_read_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_refillBuffer_with_read_v_def
   \\ fs[explode_fromI_def, take_fromI_def]
   \\ reverse(Cases_on`pos ≤ LENGTH content`)
     >-(imp_res_tac get_file_content_eof \\ rfs[]
@@ -2474,7 +2494,8 @@ Theorem b_input1_aux_spec:
         &OPTION_TYPE CHAR (SOME ((CHR o w2n) c)) chv *
         INSTREAM_BUFFERED_BL_FD_RW bcontent cs fd (r + 1) w is)
 Proof
-  xcf_with_def "TextIO.b_input1_aux" TextIO_b_input1_aux_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_input1_aux_v_def
   \\ fs[INSTREAM_BUFFERED_BL_FD_RW_def, REF_NUM_def] \\ xpull
   \\ xmatch \\ xlet_auto >- xsimpl
   \\ xlet_auto >- xsimpl
@@ -2543,7 +2564,8 @@ Theorem b_peekChar_aux_spec:
         &OPTION_TYPE CHAR (SOME ((CHR o w2n) c)) chv *
         INSTREAM_BUFFERED_BL_FD_RW bcontent bactive fd r w is)
 Proof
-  xcf_with_def "TextIO.b_peekChar_aux" TextIO_b_peekChar_aux_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_peekChar_aux_v_def
   \\ fs[INSTREAM_BUFFERED_BL_FD_RW_def, REF_NUM_def] \\ xpull
   \\ xmatch \\ xlet_auto >- xsimpl
   \\ xlet_auto >- xsimpl
@@ -2633,7 +2655,8 @@ Theorem b_input1_IOFS_spec:
                &(leftover = explode_fromI (LENGTH leftover) content (pos + 1) /\
                 (pos + LENGTH leftover + 1 <= STRLEN content)))
 Proof
-    xcf_with_def "TextIO.b_input1" TextIO_b_input1_v_def
+    rpt strip_tac
+    \\ xcf_with_def TextIO_b_input1_v_def
     \\ simp[INSTREAM_BUFFERED_FD_def, REF_NUM_def, instream_buffered_inv_def]
     \\ xpull
     \\ xmatch
@@ -2755,7 +2778,8 @@ Theorem b_peekChar_IOFS_spec:
                &(leftover = explode_fromI (LENGTH leftover) content pos /\
                 (pos + LENGTH leftover <= STRLEN content)))
 Proof
-    xcf_with_def "TextIO.b_peekChar" TextIO_b_peekChar_v_def
+    rpt strip_tac
+    \\ xcf_with_def TextIO_b_peekChar_v_def
     \\ simp[INSTREAM_BUFFERED_FD_def, REF_NUM_def, instream_buffered_inv_def]
     \\ xpull
     \\ xmatch
@@ -4978,7 +5002,8 @@ Theorem b_input_aux_w_content_spec:
                     (insert_atI (TAKE len bactive) off outcont) *
                   INSTREAM_BUFFERED_BL_FD bcontent (DROP len bactive) fd is)
 Proof
-  xcf_with_def "TextIO.b_input_aux" TextIO_b_input_aux_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_input_aux_v_def
   \\ fs[INSTREAM_BUFFERED_BL_FD_def, REF_NUM_def] \\ xpull
   \\ xmatch \\ xlet_auto >- xsimpl
   \\ fs[instream_buffered_inv_def]
@@ -5006,7 +5031,8 @@ Theorem b_input_aux_spec:
                     (insert_atI (TAKE len bactive) off outcont) *
                   INSTREAM_BUFFERED_FD (DROP len bactive) fd is)
 Proof
-  xcf_with_def "TextIO.b_input_aux" TextIO_b_input_aux_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_input_aux_v_def
   \\ fs[INSTREAM_BUFFERED_FD_def, REF_NUM_def] \\ xpull
   \\ xmatch \\ xlet_auto >- xsimpl
   \\ fs[instream_buffered_inv_def]
@@ -5043,7 +5069,8 @@ Theorem b_input_spec:
     (\e. &(IllegalArgument_exn e /\ LENGTH buf < req + off) *
           STDIO fs * W8ARRAY bufv buf * INSTREAM_BUFFERED_FD bactive fd is))
 Proof
-  xcf_with_def "TextIO.b_input" TextIO_b_input_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_input_v_def
   \\ fs[INSTREAM_BUFFERED_FD_def, REF_NUM_def]
   \\ xpull \\ xmatch
   \\ xlet_auto >- xsimpl
@@ -5366,7 +5393,8 @@ Theorem extend_array_spec:
   app (p:'ffi ffi_proj) TextIO_extend_array_v [arrv] (W8ARRAY arrv arr)
         (POSTv v. W8ARRAY v (arr ++ (REPLICATE (LENGTH arr) 0w)))
 Proof
-  xcf_with_def "TextIO.extend_array" TextIO_extend_array_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_extend_array_v_def
   \\ ntac 5 (xlet_auto >- xsimpl)
   \\ xret \\ xsimpl
   \\ simp[DROP_REPLICATE]
@@ -5382,7 +5410,7 @@ Theorem inputLine_spec:
        STDIO (lineForwardFD fs fd))
 Proof
   strip_tac \\
-  xcf_with_def "TextIO.inputLine" TextIO_inputLine_v_def \\
+  xcf_with_def TextIO_inputLine_v_def \\
   xlet_auto >- xsimpl \\
   xlet_auto >- xsimpl \\
   qpat_abbrev_tac`protect = STDIO fs` \\
@@ -5669,7 +5697,8 @@ Proof
     \\ `LENGTH content - pos = 0` by simp[]
     \\ pop_assum SUBST1_TAC
     \\ `DROP pos content = []` by fs[DROP_NIL]
-    \\ xcf_with_def "TextIO.inputLines" TextIO_inputLines_v_def
+    \\ rpt strip_tac
+    \\ xcf_with_def TextIO_inputLines_v_def
     \\ `IS_SOME (get_file_content fs fd)` by fs[IS_SOME_EXISTS]
     \\ xlet_auto >- xsimpl
     \\ rfs[std_preludeTheory.OPTION_TYPE_def,lineFD_def]
@@ -5679,7 +5708,8 @@ Proof
     \\ xsimpl
     \\ fs[LIST_TYPE_def])
   \\ qpat_x_assum`_::_ = _`(assume_tac o SYM) \\ fs[]
-  \\ xcf_with_def "TextIO.inputLines" TextIO_inputLines_v_def
+  \\ rpt strip_tac
+  \\ xcf_with_def TextIO_inputLines_v_def
   \\ `IS_SOME (get_file_content fs fd)` by fs[IS_SOME_EXISTS]
   \\ xlet_auto >- xsimpl
   \\ rfs[lineFD_def]
@@ -5735,7 +5765,8 @@ Theorem inputLinesFrom_spec:
              else NONE) sv
              * STDIO fs)
 Proof
-  xcf_with_def "TextIO.inputLinesFrom" TextIO_inputLinesFrom_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_inputLinesFrom_v_def
   \\ reverse(xhandle`POSTve
        (λv. &OPTION_TYPE (LIST_TYPE STRING_TYPE)
          (if inFS_fname fs f
@@ -5848,7 +5879,8 @@ Theorem inputAll_spec:
      &STRING_TYPE (implode (DROP pos content)) v *
      STDIO (fastForwardFD fs fd))
 Proof
-  xcf_with_def "TextIO.inputAll" TextIO_inputAll_v_def \\
+  rpt strip_tac \\
+  xcf_with_def TextIO_inputAll_v_def \\
   reverse(Cases_on`pos ≤ LENGTH content`)
   >- (
     xfun_spec `inputAll_aux`
@@ -5995,7 +6027,7 @@ Theorem print_list_spec:
      (POSTv v. &UNIT_TYPE () v * STDIO (add_stdout fs (concat ls)))
 Proof
   Induct \\ rw[LIST_TYPE_def]
-  \\ xcf_with_def "TextIO.print_list" TextIO_print_list_v_def
+  \\ xcf_with_def TextIO_print_list_v_def
   \\ (reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull))
   \\ xmatch
   >- (xcon \\ fs[STD_streams_stdout,add_stdo_nil] \\ xsimpl)
@@ -6031,7 +6063,7 @@ Proof
     by (qexists_tac`STRLEN content1 - pos` >> fs[]) >>
   FIRST_X_ASSUM MP_TAC >> qid_spec_tac`pos` >>
   Induct_on`N` >> rw[] >>
-  xcf_with_def "TextIO.copy" TextIO_copy_v_def >>
+  xcf_with_def TextIO_copy_v_def >>
   fs[STDIO_def,IOFS_def,IOFS_iobuff_def] >> xpull >>
   rename [`W8ARRAY _ bdef`] >>
   Cases_on `bdef` >> fs[] >> qmatch_goalsub_rename_tac`h1::t` >>
@@ -6817,7 +6849,7 @@ Proof
   \\ qid_spec_tac ‘i’
   \\ completeInduct_on ‘LENGTH wl - i’
   \\ rw [] \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "TextIO.find_surplus" TextIO_find_surplus_v_def
+  \\ xcf_with_def TextIO_find_surplus_v_def
   \\ xlet_auto >- xsimpl
   \\ simp [Once find_surplus_fun_def]
   \\ IF_CASES_TAC \\ gvs []
@@ -6886,7 +6918,7 @@ Theorem b_inputUntil_1_not_found:
              (INL (implode (MAP (CHR o w2n) bactive))) retv))
 Proof
   rw [] \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "TextIO.b_inputUntil_1" TextIO_b_inputUntil_1_v_def
+  \\ xcf_with_def TextIO_b_inputUntil_1_v_def
   \\ simp[INSTREAM_BUFFERED_FD_def] \\ xpull \\ xmatch
   \\ simp [REF_NUM_def] \\ xpull
   \\ xlet_auto >- xsimpl
@@ -6934,7 +6966,7 @@ Theorem b_inputUntil_1_found:
              (INR (implode (MAP (CHR o w2n) bs1 ++ [c]))) retv))
 Proof
   rw [] \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "TextIO.b_inputUntil_1" TextIO_b_inputUntil_1_v_def
+  \\ xcf_with_def TextIO_b_inputUntil_1_v_def
   \\ simp[INSTREAM_BUFFERED_FD_def] \\ xpull \\ xmatch
   \\ simp [REF_NUM_def] \\ xpull
   \\ xlet_auto >- xsimpl
@@ -7089,7 +7121,7 @@ Theorem b_refillBuffer_with_read_guard_spec_STR:
          & BOOL (NULL input) retv)
 Proof
   rw [] \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "" TextIO_b_refillBuffer_with_read_guard_v_def
+  \\ xcf_with_def TextIO_b_refillBuffer_with_read_guard_v_def
   \\ xlet_auto_spec (SOME b_refillBuffer_with_read_spec_STR)
   >-
    (qexists_tac ‘emp’ \\ qexists_tac ‘input’
@@ -7166,7 +7198,7 @@ Theorem b_inputUntil_2_spec_STR_lemma[local]:
 Proof
   gen_tac \\ completeInduct_on ‘LENGTH input’
   \\ rw [] \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "" TextIO_b_inputUntil_2_v_def
+  \\ xcf_with_def TextIO_b_inputUntil_2_v_def
   \\ xlet_auto_spec (SOME (b_inputUntil_1_spec |> Q.INST [‘non_empty’|->‘T’,‘is_empty’|->‘F’]))
   >- (rw [] \\ xsimpl \\ rw [] \\ qexists_tac ‘STDIO fs’ \\ xsimpl
       \\ qexists_tac ‘fs’ \\ xsimpl \\ rw []
@@ -7264,7 +7296,7 @@ Theorem b_inputUntil_2_spec_STR:
              (if input = "" then NONE else SOME $ gen_inputLine c input) retv)
 Proof
   strip_tac \\ gvs [PULL_FORALL]
-  \\ xcf_with_def "" TextIO_b_inputUntil_2_v_def
+  \\ xcf_with_def TextIO_b_inputUntil_2_v_def
   \\ xlet_auto_spec (SOME (b_inputUntil_1_spec
                              |> Q.INST [‘non_empty’|->‘F’,‘is_empty’|->‘F’]
                              |> REWRITE_RULE [INSTREAM_STR'_F_F]))
@@ -7407,7 +7439,8 @@ Theorem b_inputLine_spec_STR[local]:
                 STDIO (forwardFD fs fd k) *
                 INSTREAM_STR fd is (TL text) (forwardFD fs fd k))
 Proof
-  xcf_with_def "TextIO.b_inputLine" TextIO_b_inputLine_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputLine_v_def
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xapp_spec b_inputUntil_2_spec_STR
   \\ simp[LIST_TYPE_def]
@@ -7462,7 +7495,8 @@ Theorem b_inputLineTokens_spec_STR[local]:
                 STDIO (forwardFD fs fd k) *
                 INSTREAM_STR fd is (TL text) (forwardFD fs fd k))
 Proof
-  xcf_with_def "TextIO.b_inputLineTokens" TextIO_b_inputLineTokens_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputLineTokens_v_def
   \\ xlet_auto_spec (SOME b_inputLine_spec_STR)
   >- (
     qexists_tac`emp`>>
@@ -7577,7 +7611,7 @@ Theorem b_inputAllTokens_aux_spec:
 Proof
   gen_tac \\ completeInduct_on `LENGTH lines`
   \\ rpt strip_tac
-  \\ xcf_with_def "TextIO.b_inputAllTokens_aux" TextIO_b_inputAllTokens_aux_v_def
+  \\ xcf_with_def TextIO_b_inputAllTokens_aux_v_def
   \\ rveq \\ fs [PULL_FORALL]
   \\ xlet `POSTv v.
        SEP_EXISTS k.
@@ -7617,7 +7651,7 @@ Theorem b_inputAllTokens_spec:
           & LIST_TYPE (LIST_TYPE a) (MAP (MAP g o tokens f) lines) v)
 Proof
   rw []
-  \\ xcf_with_def "TextIO.b_inputAllTokens" TextIO_b_inputAllTokens_v_def
+  \\ xcf_with_def TextIO_b_inputAllTokens_v_def
   \\ xlet_auto
   THEN1 (xcon \\ xsimpl \\ fs [])
   \\ xapp_spec b_inputAllTokens_aux_spec
@@ -7648,7 +7682,8 @@ Theorem b_inputAllTokensStdIn_spec:
                    sv
       * STDIO (fastForwardFD fs 0))
 Proof
-  xcf_with_def "TextIO.b_inputAllTokensStdIn" TextIO_b_inputAllTokensStdIn_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputAllTokensStdIn_v_def
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -7705,7 +7740,8 @@ Theorem b_inputAllTokensFrom_spec:
                SOME(MAP (MAP g o tokens f) (all_lines_gen c0 fs fname))
              else NONE) sv * STDIO fs)
 Proof
-  xcf_with_def "TextIO.b_inputAllTokensFrom" TextIO_b_inputAllTokensFrom_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputAllTokensFrom_v_def
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -7823,7 +7859,7 @@ Theorem b_inputLines_aux_spec:
 Proof
   gen_tac \\ completeInduct_on `LENGTH lines`
   \\ rpt strip_tac
-  \\ xcf_with_def "TextIO.b_inputLines_aux" TextIO_b_inputLines_aux_v_def
+  \\ xcf_with_def TextIO_b_inputLines_aux_v_def
   \\ rveq \\ fs [PULL_FORALL]
   \\ xlet `POSTv v.
        SEP_EXISTS k.
@@ -7861,7 +7897,7 @@ Theorem b_inputLines_spec:
          & LIST_TYPE STRING_TYPE lines v)
 Proof
   rw []
-  \\ xcf_with_def "TextIO.b_inputLines" TextIO_b_inputLines_v_def
+  \\ xcf_with_def TextIO_b_inputLines_v_def
   \\ xlet_auto
   THEN1 (xcon \\ xsimpl \\ fs [])
   \\ xapp_spec b_inputLines_aux_spec
@@ -7904,7 +7940,8 @@ Theorem b_inputLinesFrom_spec:
              else NONE) sv
              * STDIO fs)
 Proof
-  xcf_with_def "TextIO.b_inputLinesFrom" TextIO_b_inputLinesFrom_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputLinesFrom_v_def
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -7968,7 +8005,8 @@ Theorem b_inputLinesStdIn_spec:
        & LIST_TYPE STRING_TYPE (lines_of_gen c0 (implode text)) sv
        * STDIO (fastForwardFD fs 0))
 Proof
-  xcf_with_def "TextIO.b_inputLinesStdIn" TextIO_b_inputLinesStdIn_v_def
+  rpt strip_tac
+  \\ xcf_with_def TextIO_b_inputLinesStdIn_v_def
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -8034,7 +8072,8 @@ Proof
   ntac 4 strip_tac
   \\ Induct
   THEN1
-   (xcf_with_def "TextIO.fold_chars_loop" TextIO_fold_chars_loop_v_def
+   (rw []
+    \\ xcf_with_def TextIO_fold_chars_loop_v_def
     \\ xlet ‘(POSTv chv. SEP_EXISTS k.
           STDIO (forwardFD fs fd k) *
           INSTREAM_STR fd is [] (forwardFD fs fd k) *
@@ -8050,7 +8089,7 @@ Proof
     \\ fs [mllistTheory.foldl_def]
     \\ xsimpl \\ qexists_tac ‘k’ \\ xsimpl)
   \\ rw[]
-  \\ xcf_with_def "TextIO.fold_chars_loop" TextIO_fold_chars_loop_v_def
+  \\ xcf_with_def TextIO_fold_chars_loop_v_def
   \\ xlet ‘(POSTv chv. SEP_EXISTS k.
             STDIO (forwardFD fs fd k) *
             INSTREAM_STR fd is s (forwardFD fs fd k) *
@@ -8098,7 +8137,8 @@ Proof
   ntac 4 strip_tac
   \\ Induct
   THEN1
-   (xcf_with_def "TextIO.fold_lines_loop" TextIO_fold_lines_loop_v_def
+   (rw []
+    \\ xcf_with_def TextIO_fold_lines_loop_v_def
     \\ xlet ‘(POSTv chv. SEP_EXISTS k.
           STDIO (forwardFD fs fd k) *
           INSTREAM_LINES c0 fd is [] (forwardFD fs fd k) *
@@ -8115,7 +8155,7 @@ Proof
     \\ fs [mllistTheory.foldl_def]
     \\ xsimpl \\ qexists_tac ‘k’ \\ xsimpl)
   \\ rw[]
-  \\ xcf_with_def "TextIO.fold_lines_loop" TextIO_fold_lines_loop_v_def
+  \\ xcf_with_def TextIO_fold_lines_loop_v_def
   \\ xlet ‘(POSTv chv. SEP_EXISTS k.
             STDIO (forwardFD fs fd k) *
             INSTREAM_LINES c0 fd is s (forwardFD fs fd k) *
@@ -8159,7 +8199,8 @@ Theorem b_consume_rest_spec:
 Proof
   Induct
   THEN1
-   (xcf_with_def "TextIO.b_consume_rest" TextIO_b_consume_rest_v_def
+   (rw[]
+    \\ xcf_with_def TextIO_b_consume_rest_v_def
     \\ xlet ‘(POSTv chv.
           STDIO (fastForwardFD fs fd) *
           INSTREAM_STR fd is "" (fastForwardFD fs fd) *
@@ -8177,7 +8218,7 @@ Proof
     \\ xmatch \\ xvar \\ fs [INSTREAM_STR_fastForwardFD]
     \\ xsimpl)
   \\ rw[]
-  \\ xcf_with_def "TextIO.b_consume_rest" TextIO_b_consume_rest_v_def
+  \\ xcf_with_def TextIO_b_consume_rest_v_def
   \\ xlet ‘(POSTv chv. SEP_EXISTS k.
             STDIO (forwardFD fs fd k) *
             INSTREAM_STR fd is s (forwardFD fs fd k) *
@@ -8218,7 +8259,7 @@ Proof
   rpt strip_tac \\ fs []
   \\ gvs [std_preludeTheory.OPTION_TYPE_def]
   \\ rename [‘FILENAME s sv’]
-  \\ xcf_with_def "TextIO.b_open_option" TextIO_b_open_option_v_def
+  \\ xcf_with_def TextIO_b_open_option_v_def
   \\ xmatch
   \\ reverse (xhandle ‘(POSTve
             (λis.
@@ -8262,7 +8303,7 @@ Proof
   rpt strip_tac \\ fs []
   \\ gvs [std_preludeTheory.OPTION_TYPE_def]
   \\ rename [‘FILENAME s sv’]
-  \\ xcf_with_def "TextIO.b_open_option" TextIO_b_open_option_v_def
+  \\ xcf_with_def TextIO_b_open_option_v_def
   \\ xmatch
   \\ reverse (xhandle ‘
     (POSTv retv. SEP_EXISTS is f.
@@ -8318,7 +8359,7 @@ Theorem b_open_option_NONE:
 Proof
   rpt strip_tac \\ fs []
   \\ gvs [std_preludeTheory.OPTION_TYPE_def]
-  \\ xcf_with_def "TextIO.b_open_option" TextIO_b_open_option_v_def
+  \\ xcf_with_def TextIO_b_open_option_v_def
   \\ xmatch
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xlet_auto_spec (SOME b_openStdIn_spec_str)
@@ -8374,7 +8415,7 @@ Theorem foldChars_SOME:
                       retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "TextIO.foldChars" TextIO_foldChars_v_def
+  \\ xcf_with_def TextIO_foldChars_v_def
   \\ reverse (Cases_on ‘STD_streams fs’)
   THEN1 (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on ‘consistentFS fs’)
@@ -8446,7 +8487,7 @@ Theorem foldChars_NONE:
                  & (OPTION_TYPE a (SOME (foldl f x text)) retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "TextIO.foldChars" TextIO_foldChars_v_def
+  \\ xcf_with_def TextIO_foldChars_v_def
   \\ drule_all (SIMP_RULE std_ss [] b_open_option_NONE)
   \\ disch_then (assume_tac o SPEC_ALL)
   \\ xlet_auto
@@ -8499,7 +8540,7 @@ Theorem foldLines_SOME:
                       retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "TextIO.foldLines" TextIO_foldLines_v_def
+  \\ xcf_with_def TextIO_foldLines_v_def
   \\ reverse (Cases_on ‘STD_streams fs’)
   THEN1 (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on ‘consistentFS fs’)
@@ -8578,7 +8619,7 @@ Theorem foldLines_NONE:
         & (OPTION_TYPE a (SOME (foldl f x (lines_of_gen c0 (implode text)))) retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "TextIO.foldLines" TextIO_foldLines_v_def
+  \\ xcf_with_def TextIO_foldLines_v_def
   \\ drule_all (SIMP_RULE std_ss [] b_open_option_NONE)
   \\ disch_then (assume_tac o SPEC_ALL)
   \\ xlet_auto

--- a/basis/UnsafeProofScript.sml
+++ b/basis/UnsafeProofScript.sml
@@ -10,8 +10,9 @@ val _ = translation_extends "UnsafeProg";
 
 (* Unsafe.Array *)
 
-fun prove_array_spec op_name v_def =
-  xcf_with_def op_name v_def \\ TRY xpull \\
+fun prove_array_spec v_def =
+  rpt strip_tac \\
+  xcf_with_def v_def \\ TRY xpull \\
   fs [cf_aw8alloc_def, cf_aw8sub_def, cf_aw8length_def, cf_aw8update_def,
       cf_aalloc_empty_def, cf_aalloc_def, cf_asub_def, cf_alength_def, cf_aupdate_def] \\
   irule local_elim \\ reduce_tac \\
@@ -26,7 +27,7 @@ Theorem unsafe_array_sub_spec:
      app (p:'ffi ffi_proj) Unsafe_sub_v [av; nv]
        (ARRAY av a) (POSTv v. cond (v = EL n a) * ARRAY av a)
 Proof
-  prove_array_spec "Unsafe.sub" Unsafe_sub_v_def
+  prove_array_spec Unsafe_sub_v_def
 QED
 
 Theorem unsafe_array_update_spec:
@@ -37,13 +38,14 @@ Theorem unsafe_array_update_spec:
        (ARRAY av a)
        (POSTv uv. cond (UNIT_TYPE () uv) * ARRAY av (LUPDATE v n a))
 Proof
-  prove_array_spec "Unsafe.update" Unsafe_update_v_def
+  prove_array_spec Unsafe_update_v_def
 QED
 
 (* Unsafe.Word8Array *)
 
-fun prove_array_spec op_name v_def =
-  xcf_with_def op_name v_def \\ TRY xpull \\
+fun prove_array_spec v_def =
+  rpt strip_tac \\
+  xcf_with_def v_def \\ TRY xpull \\
   fs [cf_aw8alloc_def, cf_aw8sub_def, cf_aw8length_def, cf_aw8update_def,
       cf_copyaw8aw8_def, cf_aalloc_def, cf_asub_def, cf_alength_def,
       cf_aupdate_def, cf_copystraw8_def, cf_copyaw8str_def] \\
@@ -64,7 +66,7 @@ Theorem w8array_sub_spec:
      app (p:'ffi ffi_proj) Unsafe_w8sub_v [av; nv]
        (W8ARRAY av a) (POSTv v. cond (WORD (EL n a) v) * W8ARRAY av a)
 Proof
-  prove_array_spec "Unsafe.sub" Unsafe_w8sub_v_def
+  prove_array_spec Unsafe_w8sub_v_def
 QED
 
 Theorem w8array_update_spec:
@@ -75,7 +77,7 @@ Theorem w8array_update_spec:
        (W8ARRAY av a)
        (POSTv v. cond (UNIT_TYPE () v) * W8ARRAY av (LUPDATE w n a))
 Proof
-  prove_array_spec "Unsafe.update" Unsafe_w8update_v_def
+  prove_array_spec Unsafe_w8update_v_def
 QED
 
 val _ = export_theory();

--- a/basis/Word8ArrayProofScript.sml
+++ b/basis/Word8ArrayProofScript.sml
@@ -12,6 +12,7 @@ val _ = translation_extends "Word8ArrayProg";
 val basis_st = get_ml_prog_state;
 
 fun prove_array_spec op_name =
+  rpt strip_tac \\
   xcf op_name (basis_st()) \\ TRY xpull \\
   fs [cf_aw8alloc_def, cf_aw8sub_def, cf_aw8length_def, cf_aw8update_def,
       cf_copyaw8aw8_def, cf_aalloc_def, cf_asub_def, cf_alength_def,
@@ -199,7 +200,8 @@ Theorem w8array_find_aux_spec:
           cond (OPTION_TYPE (PAIR_TYPE NUM WORD8) (findi f (old ++ arr)) v))
 Proof
   Induct_on `arr`
-  \\ xcf_with_def "Word8Array.findi_aux" Word8Array_findi_aux_v_def
+  \\ rpt strip_tac
+  \\ xcf_with_def Word8Array_findi_aux_v_def
   (* Base case *)
   >- (xlet_auto
       >- (xsimpl \\ fs[NUM_def, INT_def])
@@ -262,7 +264,8 @@ Theorem w8array_find_spec:
       (POSTv v. W8ARRAY arrv arr *
           cond (OPTION_TYPE (PAIR_TYPE NUM WORD8) (findi f arr) v))
 Proof
-  xcf_with_def "Word8Array.findi" Word8Array_findi_v_def
+  rpt strip_tac
+  \\ xcf_with_def Word8Array_findi_v_def
   \\ xlet_auto >- xsimpl
   \\ xapp \\ xsimpl \\  fs[findi_def] \\ asm_exists_tac \\ fs[]
 QED

--- a/basis/basisProgScript.sml
+++ b/basis/basisProgScript.sml
@@ -55,12 +55,12 @@ Proof
   pop_assum mp_tac \\ simp[PULL_FORALL] \\ qid_spec_tac`fs` \\
   reverse (Induct_on`ls`) \\ rw[APP_LIST_TYPE_def]
   >- (
-    xcf_with_def () (fetch "-" "print_app_list_aux_v_def")
+    xcf_with_def (fetch "-" "print_app_list_aux_v_def")
     \\ xmatch \\ xcon
     \\ DEP_REWRITE_TAC[GEN_ALL add_stdo_nil]
     \\ xsimpl \\ metis_tac[STD_streams_stdout])
   >- (
-    xcf_with_def () (fetch "-" "print_app_list_aux_v_def")
+    xcf_with_def (fetch "-" "print_app_list_aux_v_def")
     \\ xmatch
     \\ xlet_auto >- xsimpl
     \\ xapp
@@ -71,7 +71,7 @@ Proof
     \\ simp[mlstringTheory.concat_thm,mlstringTheory.strcat_thm]
     \\ xsimpl
     \\ metis_tac[STD_streams_stdout])
-  \\ xcf_with_def () (fetch "-" "print_app_list_aux_v_def")
+  \\ xcf_with_def (fetch "-" "print_app_list_aux_v_def")
   \\ xmatch
   \\ xapp
   \\ simp[]
@@ -83,7 +83,7 @@ Theorem print_app_list_spec:
      (STDIO fs) (POSTv v. &UNIT_TYPE () v * STDIO (add_stdout fs (concat (append ls))))
 Proof
   rw []
-  \\ xcf_with_def () (fetch "-" "print_app_list_v_def")
+  \\ xcf_with_def (fetch "-" "print_app_list_v_def")
   \\ xlet_auto >- xsimpl
   \\ once_rewrite_tac [GSYM mlstringTheory.str_app_list_opt_thm]
   \\ xapp_spec print_app_list_aux_spec \\ fs []
@@ -97,7 +97,8 @@ Theorem print_int_spec:
    app (p:'ffi ffi_proj) ^(fetch_v "print_int" (get_ml_prog_state())) [iv]
      (STDIO fs) (POSTv v. &UNIT_TYPE () v * STDIO (add_stdout fs (toString i)))
 Proof
-  xcf"print_int"(get_ml_prog_state())
+  strip_tac
+  \\ xcf"print_int"(get_ml_prog_state())
   \\ xlet_auto >- xsimpl
   \\ xapp \\ xsimpl
 QED
@@ -110,7 +111,8 @@ Theorem print_pp_spec:
    app (p:'ffi ffi_proj) ^(fetch_v "print_pp" (get_ml_prog_state())) [lv]
      (STDIO fs) (POSTv v. &UNIT_TYPE () v * STDIO (add_stdout fs (concat (append (pp_contents pp)))))
 Proof
-  xcf "print_pp" (get_ml_prog_state())
+  rpt strip_tac
+  \\ xcf "print_pp" (get_ml_prog_state())
   \\ xlet_auto >- xsimpl
   \\ xapp
   \\ xsimpl

--- a/basis/mlbasicsProgScript.sml
+++ b/basis/mlbasicsProgScript.sml
@@ -61,6 +61,7 @@ val _ = append_prog
   (* mk_unop "ref" Opref *)]``
 
 fun prove_ref_spec op_name =
+  rpt strip_tac \\
   xcf op_name (get_ml_prog_state()) \\
   fs [cf_ref_def, cf_deref_def, cf_assign_def] \\ irule local_elim \\
   reduce_tac \\ fs [app_ref_def, app_deref_def, app_assign_def] \\

--- a/characteristic/README.md
+++ b/characteristic/README.md
@@ -94,3 +94,6 @@ Some experimental code for emulating evars support in HOL.
 
 [examples](examples):
 This directory contains examples of how the CF tactics can be used.
+
+[xcfScript.sml](xcfScript.sml):
+Definitions used to trick EVAL in xcf.sml.

--- a/characteristic/cfDivLib.sml
+++ b/characteristic/cfDivLib.sml
@@ -22,7 +22,7 @@ fun xcf_div_FFI_full name st =
     \\ conj_tac >- MATCH_ACCEPT_TAC(Q.REFL `highly_improbable_name`)
     \\ conj_tac >- EVAL_TAC
     \\ qunabbrev_tac `highly_improbable_name`
-    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV naryClosure_repack_conv)))
+    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV (REWR_CONV (GSYM cfTheory.naryClosure_def)))))
     \\ CONSEQ_CONV_TAC(
           DEPTH_CONSEQ_CONV(
             ONCE_CONSEQ_REWRITE_CONV
@@ -59,7 +59,7 @@ fun xcf_div_rule thm name st =
     \\ conj_tac >- fs []
     \\ qunabbrev_tac `highly_improbable_name`
     \\ qunabbrev_tac `another_highly_improbable_name`
-    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV naryClosure_repack_conv)))
+    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV (REWR_CONV (GSYM cfTheory.naryClosure_def)))))
     \\ CONSEQ_CONV_TAC(
           DEPTH_CONSEQ_CONV(
             ONCE_CONSEQ_REWRITE_CONV

--- a/characteristic/cfDivLib.sml
+++ b/characteristic/cfDivLib.sml
@@ -6,75 +6,92 @@ struct
 
 open cfTacticsLib cfNormaliseTheory cfDivTheory;
 
-fun xcf_div_FFI_full name st =
-  let
-    val f_def = fetch_def name st
-  in
-    rpt strip_tac
-    \\ simp[f_def]
-    \\ match_mp_tac(GEN_ALL IMP_app_POSTd)
-    (* TODO: we could look at the goal state and generate a fresh name instead*)
-    \\ qmatch_goalsub_abbrev_tac `make_stepfun_closure highly_improbable_name`
-    \\ CONV_TAC(QUANT_CONV(PATH_CONV "l" EVAL))
-    \\ qunabbrev_tac `highly_improbable_name`
-    \\ qmatch_goalsub_abbrev_tac `highly_improbable_name = _`
-    \\ qexists_tac `highly_improbable_name`
-    \\ conj_tac >- MATCH_ACCEPT_TAC(Q.REFL `highly_improbable_name`)
-    \\ conj_tac >- EVAL_TAC
-    \\ qunabbrev_tac `highly_improbable_name`
-    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV (REWR_CONV (GSYM cfTheory.naryClosure_def)))))
-    \\ CONSEQ_CONV_TAC(
-          DEPTH_CONSEQ_CONV(
-            ONCE_CONSEQ_REWRITE_CONV
-              ([],[GEN_ALL(REWRITE_RULE [AND_IMP_INTRO] app_of_cf)],[])))
-    \\ CONV_TAC(
-          STRIP_QUANT_CONV(
-            PATH_CONV "rrlr" (
-              QUANT_CONV(
-                RATOR_CONV(SIMP_CONV list_ss [])
-                          THENC PURE_REWRITE_CONV [AND_CLAUSES]
-                          THENC SIMP_CONV (srw_ss()) [cf_def,is_bound_Fun_def,astTheory.op_case_def,
-                                                      dest_opapp_def]))))
-    \\ CONV_TAC(DEPTH_CONV BETA_CONV)
-  end
+local
+  fun naryFun_repack_conv tm =
+    let
+      val (base_case, rec_case) = CONJ_PAIR (GSYM naryFun_def)
+      val Fun_pat = ``Fun _ _``
+      val conv =
+          if can (match_term Fun_pat) tm then
+            (RAND_CONV naryFun_repack_conv) THENC
+            (REWR_CONV rec_case)
+          else
+            REWR_CONV base_case
+    in conv tm
+    end
+  val naryClosure_repack_conv =
+    (RAND_CONV naryFun_repack_conv) THENC (REWR_CONV (GSYM naryClosure_def))
+in
+  fun xcf_div_FFI_full name st =
+    let
+      val f_def = fetch_def name st
+    in
+      rpt strip_tac
+      \\ simp[f_def]
+      \\ match_mp_tac(GEN_ALL IMP_app_POSTd)
+      (* TODO: we could look at the goal state and generate a fresh name instead*)
+      \\ qmatch_goalsub_abbrev_tac `make_stepfun_closure highly_improbable_name`
+      \\ CONV_TAC(QUANT_CONV(PATH_CONV "l" EVAL))
+      \\ qunabbrev_tac `highly_improbable_name`
+      \\ qmatch_goalsub_abbrev_tac `highly_improbable_name = _`
+      \\ qexists_tac `highly_improbable_name`
+      \\ conj_tac >- MATCH_ACCEPT_TAC(Q.REFL `highly_improbable_name`)
+      \\ conj_tac >- EVAL_TAC
+      \\ qunabbrev_tac `highly_improbable_name`
+      \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV naryClosure_repack_conv)))
+      \\ CONSEQ_CONV_TAC(
+            DEPTH_CONSEQ_CONV(
+              ONCE_CONSEQ_REWRITE_CONV
+                ([],[GEN_ALL(REWRITE_RULE [AND_IMP_INTRO] app_of_cf)],[])))
+      \\ CONV_TAC(
+            STRIP_QUANT_CONV(
+              PATH_CONV "rrlr" (
+                QUANT_CONV(
+                  RATOR_CONV(SIMP_CONV list_ss [])
+                            THENC PURE_REWRITE_CONV [AND_CLAUSES]
+                            THENC SIMP_CONV (srw_ss()) [cf_def,is_bound_Fun_def,astTheory.op_case_def,
+                                                        dest_opapp_def]))))
+      \\ CONV_TAC(DEPTH_CONV BETA_CONV)
+    end
 
-fun xcf_div_rule thm name st =
-  let
-    val f_def = fetch_def name st
-  in
-    rpt strip_tac
-    \\ simp[f_def]
-    \\ match_mp_tac(GEN_ALL thm)
-    (* TODO: we could look at the goal state and generate a fresh name instead*)
-    \\ qmatch_goalsub_abbrev_tac `make_stepfun_closure highly_improbable_name`
-    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "l" EVAL))
-    \\ qunabbrev_tac `highly_improbable_name`
-    \\ qmatch_goalsub_abbrev_tac `highly_improbable_name = _`
-    \\ qexists_tac `highly_improbable_name`
-    (* TODO: give an error if 'limited_parts' is not present *)
-    \\ qmatch_assum_abbrev_tac `limited_parts another_highly_improbable_name _`
-    \\ qexists_tac `another_highly_improbable_name`
-    \\ conj_tac >- MATCH_ACCEPT_TAC(Q.REFL `highly_improbable_name`)
-    \\ conj_tac >- EVAL_TAC
-    \\ conj_tac >- fs []
-    \\ qunabbrev_tac `highly_improbable_name`
-    \\ qunabbrev_tac `another_highly_improbable_name`
-    \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV (REWR_CONV (GSYM cfTheory.naryClosure_def)))))
-    \\ CONSEQ_CONV_TAC(
-          DEPTH_CONSEQ_CONV(
-            ONCE_CONSEQ_REWRITE_CONV
-              ([],[GEN_ALL(REWRITE_RULE [AND_IMP_INTRO] app_of_cf)],[])))
-    \\ CONV_TAC(
-          STRIP_QUANT_CONV(
-            PATH_CONV "rrlr" (
-              QUANT_CONV(
-                RATOR_CONV(SIMP_CONV list_ss [])
-                          THENC PURE_REWRITE_CONV [AND_CLAUSES]
-                          THENC SIMP_CONV (srw_ss()) [cf_def,is_bound_Fun_def,astTheory.op_case_def,
-                                                      dest_opapp_def]))))
-    \\ CONV_TAC(DEPTH_CONV BETA_CONV)
-  end
+  fun xcf_div_rule thm name st =
+    let
+      val f_def = fetch_def name st
+    in
+      rpt strip_tac
+      \\ simp[f_def]
+      \\ match_mp_tac(GEN_ALL thm)
+      (* TODO: we could look at the goal state and generate a fresh name instead*)
+      \\ qmatch_goalsub_abbrev_tac `make_stepfun_closure highly_improbable_name`
+      \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "l" EVAL))
+      \\ qunabbrev_tac `highly_improbable_name`
+      \\ qmatch_goalsub_abbrev_tac `highly_improbable_name = _`
+      \\ qexists_tac `highly_improbable_name`
+      (* TODO: give an error if 'limited_parts' is not present *)
+      \\ qmatch_assum_abbrev_tac `limited_parts another_highly_improbable_name _`
+      \\ qexists_tac `another_highly_improbable_name`
+      \\ conj_tac >- MATCH_ACCEPT_TAC(Q.REFL `highly_improbable_name`)
+      \\ conj_tac >- EVAL_TAC
+      \\ conj_tac >- fs []
+      \\ qunabbrev_tac `highly_improbable_name`
+      \\ qunabbrev_tac `another_highly_improbable_name`
+      \\ CONV_TAC(STRIP_QUANT_CONV(PATH_CONV "rrl" (DEPTH_CONV naryClosure_repack_conv)))
+      \\ CONSEQ_CONV_TAC(
+            DEPTH_CONSEQ_CONV(
+              ONCE_CONSEQ_REWRITE_CONV
+                ([],[GEN_ALL(REWRITE_RULE [AND_IMP_INTRO] app_of_cf)],[])))
+      \\ CONV_TAC(
+            STRIP_QUANT_CONV(
+              PATH_CONV "rrlr" (
+                QUANT_CONV(
+                  RATOR_CONV(SIMP_CONV list_ss [])
+                            THENC PURE_REWRITE_CONV [AND_CLAUSES]
+                            THENC SIMP_CONV (srw_ss()) [cf_def,is_bound_Fun_def,astTheory.op_case_def,
+                                                        dest_opapp_def]))))
+      \\ CONV_TAC(DEPTH_CONV BETA_CONV)
+    end
 
-val xcf_div = xcf_div_rule IMP_app_POSTd_one_FFI_part
+  val xcf_div = xcf_div_rule IMP_app_POSTd_one_FFI_part
+end (* local *)
 
 end

--- a/characteristic/cfDivScript.sml
+++ b/characteristic/cfDivScript.sml
@@ -4174,25 +4174,25 @@ Proof
 QED
 
 Theorem repeat_POSTe:
-    !p fv xv H Q.
-      (?Hs vs j.
-         vs 0 = xv /\ H ==>> Hs 0 /\
-         (!i. i < j ==>
-            app p fv [vs i] (Hs i)
-                            (POSTv v. &(v = vs (SUC i)) * Hs (SUC i))) /\
-         app p fv [vs j] (Hs j) ($POSTe Q))
-      ==>
-      app p repeat_v [fv; xv] H ($POSTe Q)
+  !(p: 'ffi ffi_proj) fv xv H Q.
+    (?Hs vs j.
+        vs 0 = xv /\ H ==>> Hs 0 /\
+        (!i. i < j ==>
+          app p fv [vs i] (Hs i) (POSTv v. &(v = vs (SUC i)) * Hs (SUC i))) /\
+        app p fv [vs j] (Hs j) ($POSTe Q)) ==>
+          app p repeat_v [fv; xv] H ($POSTe Q)
 Proof
   rpt strip_tac
   \\ `!i. i <= j ==> app p repeat_v [fv; vs i] (Hs i) ($POSTe Q)` by (
     rpt strip_tac
     \\ Induct_on `j - i`
     THEN1 (
-      xcf "repeat" st
+      rpt strip_tac
+      \\ xcf "repeat" st
       \\ `i = j` by decide_tac \\ rveq
       \\ xlet `$POSTe Q` THEN1 xapp
       \\ xsimpl)
+    \\ rpt strip_tac
     \\ xcf "repeat" st
     \\ `i < j` by decide_tac
     \\ xlet `POSTv v. &(v = vs (SUC i)) * Hs (SUC i)`

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -22,8 +22,9 @@ val _ = monadsyntax.temp_disable_monadsyntax()
 (*------------------------------------------------------------------*)
 (* Characteristic formula for not-implemented or impossible cases *)
 
-val cf_bottom_def = Define `
-  cf_bottom = \env. local (\H Q. F)`
+Definition cf_bottom_def:
+  cf_bottom = \env. local (\H Q. F)
+End
 
 (*------------------------------------------------------------------*)
 (* Machinery for dealing with n-ary applications/functions in cf.
@@ -37,67 +38,76 @@ val cf_bottom_def = Define `
 
 (** 1) n-ary applications *)
 
-val dest_opapp_not_empty_arglist = Q.prove (
-  `!e f args. dest_opapp e = SOME (f, args) ==> args <> []`,
+Theorem dest_opapp_not_empty_arglist[local]:
+  !e f args. dest_opapp e = SOME (f, args) ==> args <> []
+Proof
   Cases \\ fs [dest_opapp_def] \\ rename1 `App op _` \\
   Cases_on `op` \\ fs [dest_opapp_def] \\ every_case_tac \\
   fs []
-)
+QED
 
 (** 2) n-ary single non-recursive functions *)
 
 (* An auxiliary definition *)
-val is_bound_Fun_def = Define `
-  is_bound_Fun (SOME _) (Fun _ _) = T /\
-  is_bound_Fun _ _ = F`
+Definition is_bound_Fun_def:
+  is_bound_Fun (SOME _: string option) (Fun _ _) = T /\
+  is_bound_Fun _ _ = F
+End
 
 (* [Fun_body]: walk down successive lambdas and return the inner
    function body *)
-val Fun_body_def = Define `
+Definition Fun_body_def:
   Fun_body (Fun _ body) =
     (case Fun_body body of
        | NONE => SOME body
        | SOME body' => SOME body') /\
-  Fun_body _ = NONE`
+  Fun_body _ = NONE
+End
 
-val Fun_body_exp_size = Q.prove (
-  `!e e'. Fun_body e = SOME e' ==> exp_size e' < exp_size e`,
+Theorem Fun_body_exp_size[local]:
+  !e e'. Fun_body e = SOME e' ==> exp_size e' < exp_size e
+Proof
   Induct \\ fs [Fun_body_def] \\ every_case_tac \\
   fs [astTheory.exp_size_def]
-)
+QED
 
-val is_bound_Fun_unfold = Q.prove (
-  `!opt e. is_bound_Fun opt e ==> (?n body. e = Fun n body)`,
+Theorem is_bound_Fun_unfold[local]:
+  !opt e. is_bound_Fun opt e ==> (?n body. e = Fun n body)
+Proof
   Cases_on `e` \\ fs [is_bound_Fun_def]
-)
+QED
 
 (* [Fun_params]: walk down successive lambdas and return the list of
    parameters *)
-val Fun_params_def = Define `
+Definition Fun_params_def:
   Fun_params (Fun n body) =
     n :: (Fun_params body) /\
   Fun_params _ =
-    []`
+    []
+End
 
-val Fun_params_Fun_body_NONE = Q.prove (
-  `!e. Fun_body e = NONE ==> Fun_params e = []`,
+Theorem Fun_params_Fun_body_NONE[local]:
+  !e. Fun_body e = NONE ==> Fun_params e = []
+Proof
   Cases \\ fs [Fun_body_def, Fun_params_def] \\ every_case_tac
-)
+QED
 
 (* [naryFun]: build the AST for a n-ary function *)
-val naryFun_def = Define `
+Definition naryFun_def:
   naryFun [] body = body /\
-  naryFun (n::ns) body = Fun n (naryFun ns body)`
+  naryFun (n::ns) body = Fun n (naryFun ns body)
+End
 
-val Fun_params_Fun_body_repack = Q.prove (
-  `!e e'.
-     Fun_body e = SOME e' ==>
-     naryFun (Fun_params e) e' = e`,
+Theorem Fun_params_Fun_body_repack[local]:
+  !e e'.
+    Fun_body e = SOME e' ==>
+    naryFun (Fun_params e) e' = e
+Proof
   Induct \\ fs [Fun_body_def, Fun_params_def] \\ every_case_tac \\
   rpt strip_tac \\ fs [Once naryFun_def] \\ TRY every_case_tac \\
   TRY (fs [Fun_params_Fun_body_NONE, Once naryFun_def] \\ NO_TAC) \\
   once_rewrite_tac [naryFun_def] \\ fs []
-)
+QED
 
 (** 3) n-ary (mutually)recursive functions *)
 
@@ -106,13 +116,14 @@ val Fun_params_Fun_body_repack = Q.prove (
     "n-ary" version of this list, that is, a list of tuples:
     (function name, parameters names, inner body)
 *)
-val letrec_pull_params_def = Define `
+Definition letrec_pull_params_def:
   letrec_pull_params [] = [] /\
   letrec_pull_params ((f, n, body)::funs) =
     (case Fun_body body of
        | NONE => (f, [n], body)
        | SOME body' => (f, n::Fun_params body, body')) ::
-    (letrec_pull_params funs)`
+    (letrec_pull_params funs)
+End
 
 Theorem letrec_pull_params_names:
    !funs P.
@@ -187,27 +198,41 @@ QED
 *)
 
 (* [naryClosure] *)
-val naryClosure_def = Define `
-  naryClosure env (n::ns) body = Closure env n (naryFun ns body)`
+Definition naryClosure_def:
+  naryClosure env (n::ns) body = Closure env n (naryFun ns body)
+End
 
 (* Properties of [naryClosure] *)
 
-val with_clock_clock = Q.prove(
-  `(s with clock := k).clock = k`,
-  EVAL_TAC);
-val with_clock_with_clock = Q.prove(
-  `((s with clock := k1) with clock := k2) = s with clock := k2`,
-  EVAL_TAC);
-val with_clock_self = Q.prove(
-  `(s with clock := s.clock) = s`,
-  fs [state_component_equality]);
-val with_clock_self_eq = Q.prove(
-  `!ck. (s with clock := ck) = s <=> ck = s.clock`,
-  fs [state_component_equality]);
+Theorem with_clock_clock[local]:
+  (s with clock := k).clock = k
+Proof
+  EVAL_TAC
+QED
 
-val evaluate_to_heap_with_clock = prove(
-  ``evaluate_to_heap (st with clock := ck) = evaluate_to_heap st``,
-  fs [evaluate_to_heap_def,FUN_EQ_THM,evaluate_ck_def]);
+Theorem with_clock_with_clock[local]:
+  ((s with clock := k1) with clock := k2) = s with clock := k2
+Proof
+  EVAL_TAC
+QED
+
+Theorem with_clock_self[local]:
+  (s with clock := s.clock) = s
+Proof
+  fs [state_component_equality]
+QED
+
+Theorem with_clock_self_eq[local]:
+  !ck. (s with clock := ck) = s <=> ck = s.clock
+Proof
+  fs [state_component_equality]
+QED
+
+Theorem evaluate_to_heap_with_clock[local]:
+  evaluate_to_heap (st with clock := ck) = evaluate_to_heap st
+Proof
+  fs [evaluate_to_heap_def,FUN_EQ_THM,evaluate_ck_def]
+QED
 
 Theorem app_one_naryClosure:
    !env n ns x xs body H Q.
@@ -264,11 +289,12 @@ Proof
 QED
 
 (* [naryRecclosure] *)
-val naryRecclosure_def = Define `
+Definition naryRecclosure_def:
   naryRecclosure env naryfuns f =
     Recclosure env
     (MAP (\ (f, ns, body). (f, HD ns, naryFun (TL ns) body)) naryfuns)
-    f`;
+    f
+End
 
 (* Properties of [naryRecclosure] *)
 
@@ -362,13 +388,15 @@ QED
 
 (* TODO: there's a version of this already defined ...*)
 (* [extend_env] *)
-val extend_env_v_def = Define `
+Definition extend_env_v_def:
   extend_env_v [] [] env_v = env_v /\
   extend_env_v (n::ns) (xv::xvs) env_v =
-    extend_env_v ns xvs (nsBind n xv env_v)`;
+    extend_env_v ns xvs (nsBind n xv env_v)
+End
 
-val extend_env_def = Define `
-  extend_env ns xvs (env:'v sem_env) = (env with v := extend_env_v ns xvs env.v)`;
+Definition extend_env_def:
+  extend_env ns xvs (env:'v sem_env) = (env with v := extend_env_v ns xvs env.v)
+End
 
 Theorem extend_env_v_rcons:
    !ns xvs n xv env_v.
@@ -392,25 +420,27 @@ Proof
 QED
 
 (* [build_rec_env_aux] *)
-val build_rec_env_aux_def = Define `
+Definition build_rec_env_aux_def:
   build_rec_env_aux funs (fs: (tvarN, tvarN # exp) alist) env add_to_env =
     FOLDR
       (\ (f,x,e) env'. nsBind f (Recclosure env funs f) env')
       add_to_env
-      fs`;
+      fs
+End
 
-val build_rec_env_zip_aux = Q.prove (
-  `!(fs: (tvarN, tvarN # exp) alist) funs env env_v.
+Theorem build_rec_env_zip_aux[local]:
+  !(fs: (tvarN, tvarN # exp) alist) funs env env_v.
     nsAppend
     (alist_to_ns
       (ZIP (MAP (\ (f,_,_). f) fs,
          MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) fs)))
       env_v =
-    FOLDR (\ (f,x,e) env'. nsBind f (Recclosure env funs f) env') env_v fs`,
+    FOLDR (\ (f,x,e) env'. nsBind f (Recclosure env funs f) env') env_v fs
+Proof
   Induct \\ rpt strip_tac THEN1 (fs []) \\
   rename1 `ftuple::fs` \\ PairCases_on `ftuple` \\ rename1 `(f,n,body)` \\
   fs [letrec_pull_params_repack]
-);
+QED
 
 Theorem build_rec_env_zip:
    !funs env env_v.
@@ -425,13 +455,15 @@ Proof
 QED
 
 (* [extend_env_rec] *)
-val extend_env_v_rec_def = Define `
+Definition extend_env_v_rec_def:
   extend_env_v_rec rec_ns rec_xvs ns xvs env_v =
-    extend_env_v ns xvs (nsAppend (alist_to_ns (ZIP (rec_ns, rec_xvs))) env_v)`;
+    extend_env_v ns xvs (nsAppend (alist_to_ns (ZIP (rec_ns, rec_xvs))) env_v)
+End
 
-val extend_env_rec_def = Define `
+Definition extend_env_rec_def:
   extend_env_rec rec_ns rec_xvs ns xvs (env:'v sem_env) =
-    env with v := extend_env_v_rec rec_ns rec_xvs ns xvs env.v`;
+    env with v := extend_env_v_rec rec_ns rec_xvs ns xvs env.v
+End
 
 Theorem extend_env_rec_build_rec_env:
    !funs env env_v.
@@ -454,12 +486,10 @@ QED
 *)
 
 val pat_bindings_def = astTheory.pat_bindings_def
-val pmatch_def = pmatch_def
-val pmatch_ind = pmatch_ind
 
 (* [pat_wildcards]: computes the number of wildcards a pattern contains. *)
 
-val pat_wildcards_def = tDefine "pat_wildcards" `
+Definition pat_wildcards_def:
   pat_wildcards Pany = 1n /\
   pat_wildcards (Pvar _) = 0n /\
   pat_wildcards (Plit _) = 0n /\
@@ -470,21 +500,23 @@ val pat_wildcards_def = tDefine "pat_wildcards" `
 
   pats_wildcards [] = 0n /\
   pats_wildcards (p::ps) =
-    (pat_wildcards p) + (pats_wildcards ps)`
-
-  (WF_REL_TAC `measure pat_size`)
+    (pat_wildcards p) + (pats_wildcards ps)
+Termination
+  WF_REL_TAC `measure pat_size`
+End
 
 (* [v_of_pat]: from a pattern and a list of instantiations for the pattern
    variables, produce a semantic value
 *)
 
-val v_of_matching_pat_aux_measure_def = Define `
+Definition v_of_matching_pat_aux_measure_def:
   v_of_matching_pat_aux_measure x =
     sum_CASE x
       (\ (_,p,_,_). pat_size p)
-      (\ (_,ps,_,_). list_size pat_size ps)`;
+      (\ (_,ps,_,_). list_size pat_size ps)
+End
 
-val v_of_pat_def = tDefine "v_of_pat" `
+Definition v_of_pat_def:
   v_of_pat envC (Pvar x) insts wildcards =
     (case insts of
          xv::rest => SOME (xv, rest, wildcards)
@@ -525,14 +557,13 @@ val v_of_pat_def = tDefine "v_of_pat" `
                 SOME (v::vs, insts_rest', wildcards_rest')
             | NONE => NONE)
        | NONE => NONE) /\
-  v_of_pat_list _ _ _ _ = NONE`
-
-  (WF_REL_TAC `measure v_of_matching_pat_aux_measure` \\
-   fs [v_of_matching_pat_aux_measure_def, list_size_def,
-       astTheory.pat_size_def] \\
-   gen_tac \\ Induct \\ fs [list_size_def, astTheory.pat_size_def]);
-
-val v_of_pat_ind = fetch "-" "v_of_pat_ind";
+  v_of_pat_list _ _ _ _ = NONE
+Termination
+  WF_REL_TAC `measure v_of_matching_pat_aux_measure` \\
+  fs [v_of_matching_pat_aux_measure_def, list_size_def,
+      astTheory.pat_size_def] \\
+  gen_tac \\ Induct \\ fs [list_size_def, astTheory.pat_size_def]
+End
 
 Theorem v_of_pat_list_length:
    !envC pats insts wildcards vs rest.
@@ -760,11 +791,12 @@ QED
    instantiations and wildcards instantiations
 *)
 
-val v_of_pat_norest_def = Define `
+Definition v_of_pat_norest_def:
   v_of_pat_norest envC pat insts wildcards =
     case v_of_pat envC pat insts wildcards of
         SOME (v, [], []) => SOME v
-      | _ => NONE`;
+      | _ => NONE
+End
 
 Theorem v_of_pat_norest_insts_length:
    !envC pat insts wildcards v.
@@ -807,9 +839,10 @@ QED
 *)
 
 (* might be wrong *)
-val pat_typechecks_def = Define `
+Definition pat_typechecks_def:
   pat_typechecks envC s pat v =
-    (pmatch envC s pat v [] <> Match_type_error)`;
+    (pmatch envC s pat v [] <> Match_type_error)
+End
 
 Definition pat_without_Pref_Pas_def:
   pat_without_Pref_Pas (Pcon _ args) = EVERY pat_without_Pref_Pas args /\
@@ -824,11 +857,12 @@ Termination
   first_assum progress \\ fs []
 End
 
-val validate_pat_def = Define `
+Definition validate_pat_def:
   validate_pat envC s pat v env =
     (pat_typechecks envC s pat v /\
      pat_without_Pref_Pas pat /\
-     ALL_DISTINCT (pat_bindings pat []))`;
+     ALL_DISTINCT (pat_bindings pat []))
+End
 
 (* Lemmas that relate [v_of_pat] and [pmatch], the pattern-matching function
    from the semantics.
@@ -983,7 +1017,7 @@ QED
 
 (* The nested ifs corresponding to a list of patterns *)
 
-val cf_cases_def = Define `
+Definition cf_cases_def:
   cf_cases v nomatch_exn [] env H Q =
     local (\H Q. H ==>> Q (Exn nomatch_exn) /\ Q =~e> POST_F) H Q /\
   cf_cases v nomatch_exn ((pat, row_cf)::rows) env H Q =
@@ -994,7 +1028,8 @@ val cf_cases_def = Define `
              row_cf (extend_env (REVERSE (pat_bindings pat [])) insts env) H Q)
         else cf_cases v nomatch_exn rows env H Q) /\
        (!s. validate_pat env.c s pat v env.v))
-    ) H Q`;
+    ) H Q
+End
 
 fun NETA_CONV t = let
     val (params, body) = strip_abs t
@@ -1032,14 +1067,15 @@ QED
 (* Soundness predicate & lemmas *)
 
 (* States that a hoare triple {H} e {Q} is valid in environment [env] *)
-val htriple_valid_def = Define `
+Definition htriple_valid_def:
   htriple_valid (p:'ffi ffi_proj) e env H Q =
     !st h_i h_k.
       SPLIT (st2heap p st) (h_i, h_k) ==>
       H h_i ==>
       ?r h_f h_g heap.
         SPLIT3 heap (h_f, h_k, h_g) /\ Q r h_f /\
-        evaluate_to_heap st env e p heap r`;
+        evaluate_to_heap st env e p heap r
+End
 
 (* Not used, but interesting: app_basic as an instance of htriple_valid *)
 Theorem app_basic_iff_htriple_valid:
@@ -1062,22 +1098,23 @@ Proof
 QED
 
 (* Soundness for relation [R] *)
-val sound_def = Define `
+Definition sound_def:
   sound (p:'ffi ffi_proj) e R =
     !env H Q.
       R env H Q ==>
-      htriple_valid p e env H Q`;
+      htriple_valid p e env H Q
+End
 
-
-val star_split = Q.prove (
-  `!H1 H2 H3 H4 h1 h2 h3 h4.
-     ((H1 * H2) (h1 UNION h2) ==> (H3 * H4) (h3 UNION h4)) ==>
-     DISJOINT h1 h2 ==> H1 h1 ==> H2 h2 ==>
-     ?u v. H3 u /\ H4 v /\ SPLIT (h3 UNION h4) (u, v)`,
+Theorem star_split[local]:
+  !H1 H2 H3 H4 h1 h2 h3 h4.
+    ((H1 * H2) (h1 UNION h2) ==> (H3 * H4) (h3 UNION h4)) ==>
+    DISJOINT h1 h2 ==> H1 h1 ==> H2 h2 ==>
+    ?u v. H3 u /\ H4 v /\ SPLIT (h3 UNION h4) (u, v)
+Proof
   fs [STAR_def] \\ rpt strip_tac \\
   `SPLIT (h1 UNION h2) (h1, h2)` by SPLIT_TAC \\
   metis_tac []
-);
+QED
 
 Theorem sound_local:
    !e R. sound (p:'ffi ffi_proj) e R ==> sound (p:'ffi ffi_proj) e (\env. local (R env))
@@ -1105,30 +1142,34 @@ Proof
   rewrite_tac [sound_def]
 QED
 
-val sound_local_false = Q.prove (
-  `!e. sound (p:'ffi ffi_proj) e (\env. local (\H Q. F))`,
+Theorem sound_local_false[local]:
+  !e. sound (p:'ffi ffi_proj) e (\env. local (\H Q. F))
+Proof
   strip_tac \\ HO_MATCH_MP_TAC sound_local \\ fs [sound_false]
-);
+QED
 
 (*------------------------------------------------------------------*)
 (* Lemmas relating [app], and [htriple_valid] (usually on the
    expression composing the body of the applied function).
 *)
 
-val app_basic_of_htriple_valid = Q.prove (
-  `!clos body x env v H Q.
+Theorem app_basic_of_htriple_valid[local]:
+  !clos body x env v H Q.
     do_opapp [clos; x] = SOME (env, body) ==>
     htriple_valid (p:'ffi ffi_proj) body env H Q ==>
-    app_basic (p:'ffi ffi_proj) clos x H Q`,
+    app_basic (p:'ffi ffi_proj) clos x H Q
+Proof
   fs [app_basic_def, htriple_valid_def] \\ rpt strip_tac \\
-  first_x_assum progress \\ instantiate \\ SPLIT_TAC);
+  first_x_assum progress \\ instantiate \\ SPLIT_TAC
+QED
 
-val app_of_htriple_valid = Q.prove (
-  `!ns xvs env body H Q.
-     ns <> [] ==>
-     LENGTH ns = LENGTH xvs ==>
-     htriple_valid (p:'ffi ffi_proj) body (extend_env ns xvs env) H Q ==>
-     app (p:'ffi ffi_proj) (naryClosure env ns body) xvs H Q`,
+Theorem app_of_htriple_valid[local]:
+  !ns xvs env body H Q.
+    ns <> [] ==>
+    LENGTH ns = LENGTH xvs ==>
+    htriple_valid (p:'ffi ffi_proj) body (extend_env ns xvs env) H Q ==>
+    app (p:'ffi ffi_proj) (naryClosure env ns body) xvs H Q
+Proof
   Induct \\ rpt strip_tac \\ fs [naryClosure_def, LENGTH_CONS] \\ rw [] \\
   rename1 `extend_env (n::ns) (xv::xvs) _` \\
   Cases_on `ns` \\ fs [LENGTH_NIL, LENGTH_CONS, PULL_EXISTS] \\ rw [] \\
@@ -1139,20 +1180,22 @@ val app_of_htriple_valid = Q.prove (
   Q.REFINE_EXISTS_TAC `Val v` \\ simp [evaluate_to_heap_def] \\
   fs [POSTv_def, SEP_EXISTS, cond_def, STAR_def, PULL_EXISTS, SPLIT_emp2] \\
   fs [evaluate_ck_def, evaluate_def, st2heap_clock] \\
-  progress SPLIT3_of_SPLIT_emp3 \\ instantiate \\ fs [naryClosure_def]);
+  progress SPLIT3_of_SPLIT_emp3 \\ instantiate \\ fs [naryClosure_def]
+QED
 
-val app_rec_of_htriple_valid_aux = Q.prove (
-  `!f body params xvs funs naryfuns env H Q fvs.
-     params <> [] ==>
-     LENGTH params = LENGTH xvs ==>
-     naryfuns = letrec_pull_params funs ==>
-     ALL_DISTINCT (MAP (\ (f,_,_). f) naryfuns) ==>
-     find_recfun f naryfuns = SOME (params, body) ==>
-     htriple_valid (p:'ffi ffi_proj) body
-       (extend_env_rec (MAP (\ (f,_,_). f) naryfuns) fvs params xvs env)
-       H Q ==>
-     fvs = MAP (\ (f,_,_). naryRecclosure env naryfuns f) naryfuns ==>
-     app (p:'ffi ffi_proj) (naryRecclosure env naryfuns f) xvs H Q`,
+Theorem app_rec_of_htriple_valid_aux[local]:
+  !f body params xvs funs naryfuns env H Q fvs.
+    params <> [] ==>
+    LENGTH params = LENGTH xvs ==>
+    naryfuns = letrec_pull_params funs ==>
+    ALL_DISTINCT (MAP (\ (f,_,_). f) naryfuns) ==>
+    find_recfun f naryfuns = SOME (params, body) ==>
+    htriple_valid (p:'ffi ffi_proj) body
+      (extend_env_rec (MAP (\ (f,_,_). f) naryfuns) fvs params xvs env)
+      H Q ==>
+    fvs = MAP (\ (f,_,_). naryRecclosure env naryfuns f) naryfuns ==>
+    app (p:'ffi ffi_proj) (naryRecclosure env naryfuns f) xvs H Q
+Proof
   Cases_on `params` \\ rpt strip_tac \\ rw [] \\
   fs [LENGTH_CONS] \\ rfs [] \\ qpat_x_assum `xvs = _` (K all_tac) \\
   rename1 `extend_env_rec _ _ (n::params) (xv::xvs) _` \\
@@ -1184,25 +1227,28 @@ val app_rec_of_htriple_valid_aux = Q.prove (
   fs [naryFun_def, naryClosure_def] \\
   fs [evaluate_ck_def, evaluate_def, with_clock_self] \\
   fs [letrec_pull_params_cancel, letrec_pull_params_names] \\
-  fs [build_rec_env_zip]);
+  fs [build_rec_env_zip]
+QED
 
-val app_rec_of_htriple_valid = Q.prove (
-  `!f params body funs xvs env H Q.
-     params <> [] ==>
-     LENGTH params = LENGTH xvs ==>
-     ALL_DISTINCT (MAP (\ (f,_,_). f) funs) ==>
-     find_recfun f (letrec_pull_params funs) = SOME (params, body) ==>
-     htriple_valid (p:'ffi ffi_proj) body
-       (extend_env_rec
-          (MAP (\ (f,_,_). f) funs)
-          (MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs)
-          params xvs env)
-        H Q ==>
-     app (p:'ffi ffi_proj) (naryRecclosure env (letrec_pull_params funs) f) xvs H Q`,
+Theorem app_rec_of_htriple_valid[local]:
+  !f params body funs xvs env H Q.
+    params <> [] ==>
+    LENGTH params = LENGTH xvs ==>
+    ALL_DISTINCT (MAP (\ (f,_,_). f) funs) ==>
+    find_recfun f (letrec_pull_params funs) = SOME (params, body) ==>
+    htriple_valid (p:'ffi ffi_proj) body
+      (extend_env_rec
+         (MAP (\ (f,_,_). f) funs)
+         (MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs)
+         params xvs env)
+       H Q ==>
+    app (p:'ffi ffi_proj) (naryRecclosure env (letrec_pull_params funs) f) xvs H Q
+Proof
   rpt strip_tac \\ irule app_rec_of_htriple_valid_aux \\ rpt conj_tac
   THEN1 (fs [letrec_pull_params_names])
   THEN1 (qexists_tac `funs` \\ fs [])
-  THEN1 (instantiate \\ fs [letrec_pull_params_names]));
+  THEN1 (instantiate \\ fs [letrec_pull_params_names])
+QED
 
 (*------------------------------------------------------------------*)
 (* Lemmas used in the soundness proof of FFI *)
@@ -1213,9 +1259,11 @@ Proof
   SPLIT_TAC
 QED
 
-val SUBSET_IN = Q.prove(
-  `!s t x. s SUBSET t /\ x IN s ==> x IN t`,
-  fs [SUBSET_DEF] \\ metis_tac []);
+Theorem SUBSET_IN[local]:
+  !s t x. s SUBSET t /\ x IN s ==> x IN t
+Proof
+  fs [SUBSET_DEF] \\ metis_tac []
+QED
 
 Theorem SPLIT_FFI_SET_IMP_DISJOINT:
    SPLIT (st2heap p st) (c,{FFI_part s u ns ts}) ==>
@@ -1278,86 +1326,97 @@ QED
 (* Definition of the [cf] functions, that generates the characteristic
    formula of a cakeml expression *)
 
-val app_ref_def = Define `
+Definition app_ref_def:
   app_ref (x: v) H Q =
     ((!r. H * r ~~> x ==>> Q (Val r)) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_assign_def = Define `
+Definition app_assign_def:
   app_assign r (x: v) H Q =
     ((?x' F.
         (H ==>> F * r ~~> x') /\
         (F * r ~~> x ==>> Q (Val (Conv NONE [])))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_deref_def = Define `
+Definition app_deref_def:
   app_deref r H Q =
     ((?x F.
         (H ==>> F * r ~~> x) /\
         (H ==>> Q (Val x))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aalloc_def = Define `
+Definition app_aalloc_def:
   app_aalloc (n: int) v H Q =
     ((!a.
         n >= 0 /\
         (H * ARRAY a (REPLICATE (Num n) v) ==>> Q (Val a))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_asub_def = Define `
+Definition app_asub_def:
   app_asub a (i: int) H Q =
     ((?vs F.
         0 <= i /\ (Num i) < LENGTH vs /\
         (H ==>> F * ARRAY a vs) /\
         (H ==>> Q (Val (EL (Num i) vs)))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_alength_def = Define `
+Definition app_alength_def:
   app_alength a H Q =
     ((?vs F.
         (H ==>> F * ARRAY a vs) /\
         (H ==>> Q (Val (Litv (IntLit (& LENGTH vs)))))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aupdate_def = Define `
+Definition app_aupdate_def:
   app_aupdate a (i: int) v H Q =
     ((?vs F.
         0 <= i /\ (Num i) < LENGTH vs /\
         (H ==>> F * ARRAY a vs) /\
         (F * ARRAY a (LUPDATE v (Num i) vs) ==>> Q (Val (Conv NONE [])))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aw8alloc_def = Define `
+Definition app_aw8alloc_def:
   app_aw8alloc (n: int) w H Q =
     ((!a.
         n >= 0 /\
         (H * W8ARRAY a (REPLICATE (Num n) w) ==>> Q (Val a))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aw8sub_def = Define `
+Definition app_aw8sub_def:
   app_aw8sub a (i: int) H Q =
     ((?ws F.
         0 <= i /\ (Num i) < LENGTH ws /\
         (H ==>> F * W8ARRAY a ws) /\
         (H ==>> Q (Val (Litv (Word8 (EL (Num i) ws)))))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aw8length_def = Define `
+Definition app_aw8length_def:
   app_aw8length a H Q =
     ((?ws F.
         (H ==>> F * W8ARRAY a ws) /\
         (H ==>> Q (Val (Litv (IntLit (& LENGTH ws)))))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_aw8update_def = Define `
+Definition app_aw8update_def:
   app_aw8update a (i: int) w H Q =
     ((?ws F.
         0 <= i /\ (Num i) < LENGTH ws /\
         (H ==>> F * W8ARRAY a ws) /\
         (F * W8ARRAY a (LUPDATE w (Num i) ws) ==>> Q (Val (Conv NONE [])))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_copyaw8aw8_def = Define `
+Definition app_copyaw8aw8_def:
   app_copyaw8aw8 s so l d do' H Q =
     ((?ws wd F.
         0 <= do' /\ 0 <= so /\ 0 <= l /\
@@ -1368,9 +1427,10 @@ val app_copyaw8aw8_def = Define `
                         TAKE (Num l) (DROP (Num so) ws) ⧺
                         DROP (Num do' + Num l) wd)
             ==>> Q (Val (Conv NONE [])))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_copystraw8_def = Define `
+Definition app_copystraw8_def:
   app_copystraw8 s so l d do' H Q =
     ((?wd F.
         0 <= do' /\ 0 <= so /\ 0 <= l /\
@@ -1380,9 +1440,10 @@ val app_copystraw8_def = Define `
                         MAP (n2w o ORD) (TAKE (Num l) (DROP (Num so) s)) ⧺
                         DROP (Num do' + Num l) wd)
             ==>> Q (Val (Conv NONE [])))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_copyaw8str_def = Define `
+Definition app_copyaw8str_def:
   app_copyaw8str s so l H Q =
     ((?ws F.
         0 <= so /\ 0 <= l /\
@@ -1390,22 +1451,26 @@ val app_copyaw8str_def = Define `
         (H ==>> F * W8ARRAY s ws) /\
         (F * W8ARRAY s ws
             ==>> Q (Val (Litv (StrLit (MAP (CHR o w2n) (TAKE (Num l) (DROP (Num so) ws)))))))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_wordFromInt_W8_def = Define `
+Definition app_wordFromInt_W8_def:
   app_wordFromInt_W8 (i: int) H Q =
     (H ==>> Q (Val (Litv (Word8 (i2w i)))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_wordFromInt_W64_def = Define `
+Definition app_wordFromInt_W64_def:
   app_wordFromInt_W64 (i: int) H Q =
     (H ==>> Q (Val (Litv (Word64 (i2w i)))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_wordToInt_def = Define `
+Definition app_wordToInt_def:
   app_wordToInt w H Q =
     (H ==>> Q (Val (Litv (IntLit (& w2n w)))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
 (*
 val app_opn_def = Define `
@@ -1416,79 +1481,90 @@ val app_opn_def = Define `
       H ==>> Q (Val (Litv (IntLit (opn_lookup opn i1 i2))))
 *)
 
-val app_opn_def = Define `
+Definition app_opn_def:
   app_opn opn i1 i2 H Q =
     ((if opn = Divide \/ opn = Modulo then i2 <> 0 else T) /\
      H ==>> Q (Val (Litv (IntLit (opn_lookup opn i1 i2)))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_opb_def = Define `
+Definition app_opb_def:
   app_opb opb i1 i2 H Q =
     (H ==>> Q (Val (Boolv (opb_lookup opb i1 i2))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val app_equality_def = Define `
+Definition app_equality_def:
   app_equality v1 v2 H Q =
     (no_closures v1 /\ no_closures v2 /\
      types_match v1 v2 /\
      H ==>> Q (Val (Boolv (v1 = v2))) /\
-     Q =~v> POST_F)`
+     Q =~v> POST_F)
+End
 
-val cf_lit_def = Define `
-  cf_lit l = \env. local (\H Q.
+Definition cf_lit_def:
+  cf_lit l = \env: v sem_env. local (\H Q.
     H ==>> Q (Val (Litv l)) /\
-    Q =~v> POST_F)`
+    Q =~v> POST_F)
+End
 
-val cf_con_def = Define `
+Definition cf_con_def:
   cf_con cn args = \env. local (\H Q.
     (?argsv cv.
        do_con_check env.c cn (LENGTH args) /\
        (build_conv env.c cn argsv = SOME cv) /\
        (exp2v_list env args = SOME argsv) /\
        H ==>> Q (Val cv)) /\
-    Q =~v> POST_F)`
+    Q =~v> POST_F)
+End
 
-val cf_var_def = Define `
+Definition cf_var_def:
   cf_var name = \env. local (\H Q.
     (?v.
        nsLookup env.v name = SOME v /\
        H ==>> Q (Val v)) /\
-    Q =~v> POST_F)`
+    Q =~v> POST_F)
+End
 
-val cf_let_def = Define `
+Definition cf_let_def:
   cf_let n F1 F2 = \env. local (\H Q.
     ?Q'. (F1 env H Q' /\ Q' =~v> Q) /\
-         (!xv. F2 (env with <| v := nsOptBind n xv env.v |>) (Q' (Val xv)) Q))`
+         (!xv. F2 (env with <| v := nsOptBind n xv env.v |>) (Q' (Val xv)) Q))
+End
 
-val cf_opn_def = Define `
+Definition cf_opn_def:
   cf_opn opn x1 x2 = \env. local (\H Q.
     ?i1 i2.
       exp2v env x1 = SOME (Litv (IntLit i1)) /\
       exp2v env x2 = SOME (Litv (IntLit i2)) /\
-      app_opn opn i1 i2 H Q)`
+      app_opn opn i1 i2 H Q)
+End
 
-val cf_opb_def = Define `
+Definition cf_opb_def:
   cf_opb opb x1 x2 = \env. local (\H Q.
     ?i1 i2.
       exp2v env x1 = SOME (Litv (IntLit i1)) /\
       exp2v env x2 = SOME (Litv (IntLit i2)) /\
-      app_opb opb i1 i2 H Q)`
+      app_opb opb i1 i2 H Q)
+End
 
-val cf_equality_def = Define `
+Definition cf_equality_def:
   cf_equality x1 x2 = \env. local (\H Q.
     ?v1 v2.
       exp2v env x1 = SOME v1 /\
       exp2v env x2 = SOME v2 /\
-      app_equality v1 v2 H Q)`
+      app_equality v1 v2 H Q)
+End
 
-val cf_app_def = Define `
+Definition cf_app_def:
   cf_app (p:'ffi ffi_proj) f args = \env. local (\H Q.
     ?fv argsv.
       exp2v env f = SOME fv /\
       exp2v_list env args = SOME argsv /\
-      app (p:'ffi ffi_proj) fv argsv H Q)`
+      app (p:'ffi ffi_proj) fv argsv H Q)
+End
 
-val cf_fun_def = Define `
+Definition cf_fun_def:
   cf_fun (p:'ffi ffi_proj) f ns F1 F2 = \env. local (\H Q.
     !fv.
       curried (p:'ffi ffi_proj) (LENGTH ns) fv /\
@@ -1497,9 +1573,10 @@ val cf_fun_def = Define `
         F1 (extend_env ns xvs env) H' Q' ==>
         app (p:'ffi ffi_proj) fv xvs H' Q')
       ==>
-      F2 (env with v := nsBind f fv env.v) H Q)`
+      F2 (env with v := nsBind f fv env.v) H Q)
+End
 
-val fun_rec_aux_def = Define `
+Definition fun_rec_aux_def:
   fun_rec_aux (p:'ffi ffi_proj) fs fvs [] [] [] F2 env H Q =
     (F2 (extend_env_rec fs fvs [] [] env) H Q) /\
   fun_rec_aux (p:'ffi ffi_proj) fs fvs (ns::ns_acc) (fv::fv_acc) (Fbody::Fs) F2 env H Q =
@@ -1510,100 +1587,114 @@ val fun_rec_aux_def = Define `
         app (p:'ffi ffi_proj) fv xvs H' Q')
      ==>
      (fun_rec_aux (p:'ffi ffi_proj) fs fvs ns_acc fv_acc Fs F2 env H Q)) /\
-  fun_rec_aux _ _ _ _ _ _ _ _ _ _ = F`
+  fun_rec_aux _ _ _ _ _ _ _ _ _ _ = F
+End
 
-val cf_fun_rec_def = Define `
+Definition cf_fun_rec_def:
   cf_fun_rec (p:'ffi ffi_proj) fs_Fs F2 = \env. local (\H Q.
-    let fs = MAP (\ (f, _). f) fs_Fs in
+    let fs = MAP (\ (f: (string # string list # exp), _). f) fs_Fs in
     let Fs = MAP (\ (_, F). F) fs_Fs in
     let f_names = MAP (\ (f,_,_). f) fs in
     let f_args = MAP (\ (_,ns,_). ns) fs in
     !(fvs: v list).
       LENGTH fvs = LENGTH fs ==>
       ALL_DISTINCT f_names /\
-      fun_rec_aux (p:'ffi ffi_proj) f_names fvs f_args fvs Fs F2 env H Q)`
+      fun_rec_aux (p:'ffi ffi_proj) f_names fvs f_args fvs Fs F2 env H Q)
+End
 
-val cf_ref_def = Define `
+Definition cf_ref_def:
   cf_ref x = \env. local (\H Q.
     ?xv.
       exp2v env x = SOME xv /\
-      app_ref xv H Q)`
+      app_ref xv H Q)
+End
 
-val cf_assign_def = Define `
+Definition cf_assign_def:
   cf_assign r x = \env. local (\H Q.
     ?rv xv.
       exp2v env r = SOME rv /\
       exp2v env x = SOME xv /\
-      app_assign rv xv H Q)`
+      app_assign rv xv H Q)
+End
 
-val cf_deref_def = Define `
+Definition cf_deref_def:
   cf_deref r = \env. local (\H Q.
     ?rv.
       exp2v env r = SOME rv /\
-      app_deref rv H Q)`
+      app_deref rv H Q)
+End
 
-val cf_aalloc_def = Define `
+Definition cf_aalloc_def:
   cf_aalloc xn xv = \env. local (\H Q.
     ?n v.
       exp2v env xn = SOME (Litv (IntLit n)) /\
       exp2v env xv = SOME v /\
-      app_aalloc n v H Q)`
+      app_aalloc n v H Q)
+End
 
-val cf_aalloc_empty_def = Define `
+Definition cf_aalloc_empty_def:
   cf_aalloc_empty xu = \env. local (\H Q.
     exp2v env xu = SOME (Conv NONE []) /\
-    app_aalloc (&0) (Litv (IntLit &0)) H Q)`;
+    app_aalloc (&0) (Litv (IntLit &0)) H Q)
+End
 
-val cf_asub_def = Define `
+Definition cf_asub_def:
   cf_asub xa xi = \env. local (\H Q.
     ?a i.
       exp2v env xa = SOME a /\
       exp2v env xi = SOME (Litv (IntLit i)) /\
-      app_asub a i H Q)`
+      app_asub a i H Q)
+End
 
-val cf_alength_def = Define `
+Definition cf_alength_def:
   cf_alength xa = \env. local (\H Q.
     ?a.
       exp2v env xa = SOME a /\
-      app_alength a H Q)`
+      app_alength a H Q)
+End
 
-val cf_aupdate_def = Define `
+Definition cf_aupdate_def:
   cf_aupdate xa xi xv = \env. local (\H Q.
     ?a i v.
       exp2v env xa = SOME a /\
       exp2v env xi = SOME (Litv (IntLit i)) /\
       exp2v env xv = SOME v /\
-      app_aupdate a i v H Q)`
+      app_aupdate a i v H Q)
+End
 
-val cf_aw8alloc_def = Define `
+Definition cf_aw8alloc_def:
   cf_aw8alloc xn xw = \env. local (\H Q.
     ?n w.
       exp2v env xn = SOME (Litv (IntLit n)) /\
       exp2v env xw = SOME (Litv (Word8 w)) /\
-      app_aw8alloc n w H Q)`
+      app_aw8alloc n w H Q)
+End
 
-val cf_aw8sub_def = Define `
+Definition cf_aw8sub_def:
   cf_aw8sub xa xi = \env. local (\H Q.
     ?a i.
       exp2v env xa = SOME a /\
       exp2v env xi = SOME (Litv (IntLit i)) /\
-      app_aw8sub a i H Q)`
+      app_aw8sub a i H Q)
+End
 
-val cf_aw8length_def = Define `
+Definition cf_aw8length_def:
   cf_aw8length xa = \env. local (\H Q.
     ?a.
       exp2v env xa = SOME a /\
-      app_aw8length a H Q)`
+      app_aw8length a H Q)
+End
 
-val cf_aw8update_def = Define `
+Definition cf_aw8update_def:
   cf_aw8update xa xi xw = \env. local (\H Q.
     ?a i w.
       exp2v env xa = SOME a /\
       exp2v env xi = SOME (Litv (IntLit i)) /\
       exp2v env xw = SOME (Litv (Word8 w)) /\
-      app_aw8update a i w H Q)`
+      app_aw8update a i w H Q)
+End
 
-val cf_copyaw8aw8_def = Define `
+Definition cf_copyaw8aw8_def:
   cf_copyaw8aw8 xs xso xl xd xdo = \env. local (\H Q.
     ?s so l d do'.
       exp2v env xs = SOME s /\
@@ -1611,9 +1702,10 @@ val cf_copyaw8aw8_def = Define `
       exp2v env xl = SOME (Litv (IntLit l)) /\
       exp2v env xso = SOME (Litv (IntLit so)) /\
       exp2v env xdo = SOME (Litv (IntLit do')) /\
-      app_copyaw8aw8 s so l d do' H Q)`
+      app_copyaw8aw8 s so l d do' H Q)
+End
 
-val cf_copystraw8_def = Define `
+Definition cf_copystraw8_def:
   cf_copystraw8 xs xso xl xd xdo = \env. local (\H Q.
     ?s so l d do'.
       exp2v env xs = SOME (Litv (StrLit s)) /\
@@ -1621,61 +1713,71 @@ val cf_copystraw8_def = Define `
       exp2v env xl = SOME (Litv (IntLit l)) /\
       exp2v env xso = SOME (Litv (IntLit so)) /\
       exp2v env xdo = SOME (Litv (IntLit do')) /\
-      app_copystraw8 s so l d do' H Q)`
+      app_copystraw8 s so l d do' H Q)
+End
 
-val cf_copyaw8str_def = Define `
+Definition cf_copyaw8str_def:
   cf_copyaw8str xs xso xl = \env. local (\H Q.
     ?s so l.
       exp2v env xs = SOME s /\
       exp2v env xso = SOME (Litv (IntLit so)) /\
       exp2v env xl = SOME (Litv (IntLit l)) /\
-      app_copyaw8str s so l H Q)`
+      app_copyaw8str s so l H Q)
+End
 
-val cf_wordFromInt_W8_def = Define `
+Definition cf_wordFromInt_W8_def:
   cf_wordFromInt_W8 xi = \env. local (\H Q.
     ?i.
       exp2v env xi = SOME (Litv (IntLit i)) /\
-      app_wordFromInt_W8 i H Q)`
+      app_wordFromInt_W8 i H Q)
+End
 
-val cf_wordFromInt_W64_def = Define `
+Definition cf_wordFromInt_W64_def:
   cf_wordFromInt_W64 xi = \env. local (\H Q.
     ?i.
       exp2v env xi = SOME (Litv (IntLit i)) /\
-      app_wordFromInt_W64 i H Q)`
+      app_wordFromInt_W64 i H Q)
+End
 
-val cf_wordToInt_W8_def = Define `
+Definition cf_wordToInt_W8_def:
   cf_wordToInt_W8 xw = \env. local (\H Q.
     ?w.
       exp2v env xw = SOME (Litv (Word8 w)) /\
-      app_wordToInt w H Q)`
+      app_wordToInt w H Q)
+End
 
-val cf_wordToInt_W64_def = Define `
+Definition cf_wordToInt_W64_def:
   cf_wordToInt_W64 xw = \env. local (\H Q.
     ?w.
       exp2v env xw = SOME (Litv (Word64 w)) /\
-      app_wordToInt w H Q)`
+      app_wordToInt w H Q)
+End
 
-val app_fptoword_def = Define ‘
+Definition app_fptoword_def:
    app_fptoword fp H Q =
-   (H ==>> Q (Val (Litv (Word64 (fpSem$compress_word fp)))) ∧ Q =~v> POST_F)’;
+   (H ==>> Q (Val (Litv (Word64 (fpSem$compress_word fp)))) ∧ Q =~v> POST_F)
+End
 
-val cf_fptoword_def = Define ‘
+Definition cf_fptoword_def:
  cf_fptoword xd = λ env. local ( λ H Q.
    ∃ fp.
    exp2v env xd = SOME (FP_WordTree fp) ∧
-   app_fptoword fp H Q)’;
+   app_fptoword fp H Q)
+End
 
-val app_fpfromword_def = Define ‘
+Definition app_fpfromword_def:
  app_fpfromword w H Q =
- (H ==>> Q (Val (FP_WordTree (fpValTree$Fp_const w))) ∧ Q =~v> POST_F)’;
+ (H ==>> Q (Val (FP_WordTree (fpValTree$Fp_const w))) ∧ Q =~v> POST_F)
+End
 
-val cf_fpfromword_def = Define ‘
+Definition cf_fpfromword_def:
  cf_fpfromword xw = λ env. local (λ H Q.
    ∃ w.
    exp2v env xw = SOME (Litv (Word64 w)) ∧
-   app_fpfromword w H Q)’;
+   app_fpfromword w H Q)
+End
 
-val app_ffi_def = Define `
+Definition app_ffi_def:
   app_ffi ffi_index c a H Q =
     ((?conf ws frame s u ns events.
          MEM ffi_index ns /\
@@ -1691,16 +1793,18 @@ val app_ffi_def = Define `
              (frame * W8ARRAY a ws * one (FFI_part s u ns events) *
               cond (~MEM "" ns)) ==>> Q (FFIDiv ffi_index conf ws)
           | NONE => F)) /\
-     Q ==e> POST_F /\ Q ==d> POST_F)`
+     Q ==e> POST_F /\ Q ==d> POST_F)
+End
 
-val cf_ffi_def = Define `
+Definition cf_ffi_def:
   cf_ffi ffi_index c r = \env. local (\H Q.
     ?conf rv.
       exp2v env r = SOME rv /\
       exp2v env c = SOME conf /\
-      app_ffi ffi_index conf rv H Q)`
+      app_ffi ffi_index conf rv H Q)
+End
 
-val cf_log_def = Define `
+Definition cf_log_def:
   cf_log lop e1 cf2 = \env. local (\H Q.
     ?v b.
       exp2v env e1 = SOME v /\
@@ -1709,36 +1813,41 @@ val cf_log_def = Define `
            (And, T) => cf2 env H Q
          | (Or, F) => cf2 env H Q
          | (Or, T) => (H ==>> Q (Val v) /\ Q =~v> POST_F)
-         | (And, F) => (H ==>> Q (Val v) /\ Q =~v> POST_F)))`
+         | (And, F) => (H ==>> Q (Val v) /\ Q =~v> POST_F)))
+End
 
-val cf_if_def = Define `
+Definition cf_if_def:
   cf_if cond cf1 cf2 = \env. local (\H Q.
     ?condv b.
       exp2v env cond = SOME condv /\
       BOOL b condv /\
       (b = T ==> cf1 env H Q) /\
-      (b = F ==> cf2 env H Q))`
+      (b = F ==> cf2 env H Q))
+End
 
-val cf_match_def = Define `
+Definition cf_match_def:
   cf_match e rows = \env. local (\H Q.
     ?v.
       exp2v env e = SOME v /\
-      cf_cases v bind_exn_v rows env H Q)`
+      cf_cases v bind_exn_v rows env H Q)
+End
 
-val cf_raise_def = Define `
+Definition cf_raise_def:
   cf_raise e = \env. local (\H Q.
     ?v.
       exp2v env e = SOME v /\
       H ==>> Q (Exn v) /\
-      Q =~e> POST_F)`
+      Q =~e> POST_F)
+End
 
-val cf_handle_def = Define `
+Definition cf_handle_def:
   cf_handle Fe rows = \env. local (\H Q.
     ?Q'.
       (Fe env H Q' /\ Q' =~e> Q) /\
-      (!ev. cf_cases ev ev rows env (Q' (Exn ev)) Q))`;
+      (!ev. cf_cases ev ev rows env (Q' (Exn ev)) Q))
+End
 
-val cf_def = tDefine "cf" `
+Definition cf_def:
   cf (p:'ffi ffi_proj) (Lit l) = cf_lit l /\
   cf (p:'ffi ffi_proj) (Con opt args) = cf_con opt args /\
   cf (p:'ffi ffi_proj) (Var name) = cf_var name /\
@@ -1890,22 +1999,20 @@ val cf_def = tDefine "cf" `
   cf (p:'ffi ffi_proj) (Lannot e _) = cf p e /\
   cf (p:'ffi ffi_proj) (Tannot e _) = cf p e /\
   cf _ _ = cf_bottom
-`
-  (WF_REL_TAC `measure (exp_size o SND)` \\ rw []
-     THEN1 (
-       Cases_on `opt` \\ Cases_on `e1` \\ fs [is_bound_Fun_def] \\
-       drule Fun_body_exp_size \\ strip_tac \\ fs [astTheory.exp_size_def]
-     )
-     THEN1 (
-       Induct_on `funs` \\ fs [MEM, letrec_pull_params_def] \\ rpt strip_tac \\
-       rename1 `f::funs` \\ PairCases_on `f` \\ rename1 `(f,ns,body)::funs` \\
-       fs [letrec_pull_params_def] \\ fs [astTheory.exp_size_def] \\
-       every_case_tac \\ fs [astTheory.exp_size_def] \\
-       drule Fun_body_exp_size \\ strip_tac \\ fs [astTheory.exp_size_def]
-     )
-  )
-
-val cf_ind = fetch "-" "cf_ind"
+Termination
+  WF_REL_TAC `measure (exp_size o SND)` \\ rw []
+    THEN1 (
+      Cases_on `opt` \\ Cases_on `e1` \\ fs [is_bound_Fun_def] \\
+      drule Fun_body_exp_size \\ strip_tac \\ fs [astTheory.exp_size_def]
+    )
+    THEN1 (
+      Induct_on `funs` \\ fs [MEM, letrec_pull_params_def] \\ rpt strip_tac \\
+      rename1 `f::funs` \\ PairCases_on `f` \\ rename1 `(f,ns,body)::funs` \\
+      fs [letrec_pull_params_def] \\ fs [astTheory.exp_size_def] \\
+      every_case_tac \\ fs [astTheory.exp_size_def] \\
+      drule Fun_body_exp_size \\ strip_tac \\ fs [astTheory.exp_size_def]
+    )
+End
 
 val cf_defs = [
   cf_def,
@@ -1998,40 +2105,44 @@ fun cf_exp2v_evaluate_tac st =
     )
   ) \\ rw []
 
-val DROP_EL_CONS = Q.prove (
-  `!l n.
-    n < LENGTH l ==>
-    DROP n l = EL n l :: DROP (SUC n) l`,
+Theorem DROP_EL_CONS[local]:
+  !l n.
+   n < LENGTH l ==>
+   DROP n l = EL n l :: DROP (SUC n) l
+Proof
   Induct \\ rpt strip_tac \\ fs [] \\ every_case_tac \\ fs [] \\
   Cases_on `n` \\ fs []
-);
+QED
 
-val FST_rw = Q.prove(
-  `(\ (x,_,_). x) = FST`,
-  fs [FUN_EQ_THM,FORALL_PROD]);
+Theorem FST_rw[local]:
+  (\ (x,_,_). x) = FST
+Proof
+  fs [FUN_EQ_THM,FORALL_PROD]
+QED
 
 val _ = print "Proving cf_letrec_sound_aux\n";
-val cf_letrec_sound_aux = Q.prove (
-  `!funs e.
-     let naryfuns = letrec_pull_params funs in
-     (∀x. MEM x naryfuns ==>
-          sound (p:'ffi ffi_proj) (SND (SND x))
-            (cf (p:'ffi ffi_proj) (SND (SND x)))) ==>
-     sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e) ==>
-     !fns rest.
-       funs = rest ++ fns ==>
-       let naryrest = letrec_pull_params rest in
-       let naryfns = letrec_pull_params fns in
-       sound (p:'ffi ffi_proj) (Letrec funs e)
-         (\env H Q.
-            let fvs = MAP (\ (f,_,_). naryRecclosure env naryfuns f) naryfuns in
-            ALL_DISTINCT (MAP (\ (f,_,_). f) naryfuns) /\
-            fun_rec_aux (p:'ffi ffi_proj)
-              (MAP (\ (f,_,_). f) naryfuns) fvs
-              (MAP (\ (_,ns,_). ns) naryfns)
-              (DROP (LENGTH naryrest) fvs)
-              (MAP (\x. cf (p:'ffi ffi_proj) (SND (SND x))) naryfns)
-              (cf (p:'ffi ffi_proj) e) env H Q)`,
+Theorem cf_letrec_sound_aux[local]:
+  !funs e.
+    let naryfuns = letrec_pull_params funs in
+    (∀x. MEM x naryfuns ==>
+         sound (p:'ffi ffi_proj) (SND (SND x))
+           (cf (p:'ffi ffi_proj) (SND (SND x)))) ==>
+    sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e) ==>
+    !fns rest.
+      funs = rest ++ fns ==>
+      let naryrest = letrec_pull_params rest in
+      let naryfns = letrec_pull_params fns in
+      sound (p:'ffi ffi_proj) (Letrec funs e)
+        (\env H Q.
+           let fvs = MAP (\ (f,_,_). naryRecclosure env naryfuns f) naryfuns in
+           ALL_DISTINCT (MAP (\ (f,_,_). f) naryfuns) /\
+           fun_rec_aux (p:'ffi ffi_proj)
+             (MAP (\ (f,_,_). f) naryfuns) fvs
+             (MAP (\ (_,ns,_). ns) naryfns)
+             (DROP (LENGTH naryrest) fvs)
+             (MAP (\x. cf (p:'ffi ffi_proj) (SND (SND x))) naryfns)
+             (cf (p:'ffi ffi_proj) e) env H Q)
+Proof
   rpt gen_tac \\ rpt (CONV_TAC let_CONV) \\ rpt DISCH_TAC \\ Induct
   THEN1 (
     rpt strip_tac \\ fs [letrec_pull_params_def, DROP_LENGTH_TOO_LONG] \\
@@ -2091,7 +2202,6 @@ val cf_letrec_sound_aux = Q.prove (
     fs [LENGTH_CONS, LENGTH_NIL, PULL_EXISTS] \\
     fs [letrec_pull_params_LENGTH, letrec_pull_params_names] \\
     impl_tac
-
     THEN1 (
       sg `MEM (f, params, inner_body) (letrec_pull_params funs)`
       THEN1 (
@@ -2124,31 +2234,33 @@ val cf_letrec_sound_aux = Q.prove (
     fs [evaluate_to_heap_def, evaluate_ck_def] \\
     disch_then progress \\ instantiate \\
     rfs [evaluate_def]
-  ));
+  )
+QED
 
 val _ = print "Proving cf_letrec_sound\n";
-val cf_letrec_sound = Q.prove (
-  `!funs e.
-    (!x. MEM x (letrec_pull_params funs) ==>
-         sound (p:'ffi ffi_proj) (SND (SND x))
-           (cf (p:'ffi ffi_proj) (SND (SND x)))) ==>
-    sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e) ==>
-    sound (p:'ffi ffi_proj) (Letrec funs e)
-      (\env H Q.
-        let fvs = MAP
-          (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f)
-          funs in
-        ALL_DISTINCT (MAP (\ (f,_,_). f) funs) /\
-        fun_rec_aux (p:'ffi ffi_proj)
-          (MAP (\ (f,_,_). f) funs) fvs
-          (MAP (\ (_,ns,_). ns) (letrec_pull_params funs)) fvs
-          (MAP (\x. cf (p:'ffi ffi_proj) (SND (SND x)))
-             (letrec_pull_params funs))
-          (cf (p:'ffi ffi_proj) e) env H Q)`,
+Theorem cf_letrec_sound[local]:
+  !funs e.
+   (!x. MEM x (letrec_pull_params funs) ==>
+        sound (p:'ffi ffi_proj) (SND (SND x))
+          (cf (p:'ffi ffi_proj) (SND (SND x)))) ==>
+   sound (p:'ffi ffi_proj) e (cf (p:'ffi ffi_proj) e) ==>
+   sound (p:'ffi ffi_proj) (Letrec funs e)
+     (\env H Q.
+       let fvs = MAP
+         (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f)
+         funs in
+       ALL_DISTINCT (MAP (\ (f,_,_). f) funs) /\
+       fun_rec_aux (p:'ffi ffi_proj)
+         (MAP (\ (f,_,_). f) funs) fvs
+         (MAP (\ (_,ns,_). ns) (letrec_pull_params funs)) fvs
+         (MAP (\x. cf (p:'ffi ffi_proj) (SND (SND x)))
+            (letrec_pull_params funs))
+         (cf (p:'ffi ffi_proj) e) env H Q)
+Proof
   rpt strip_tac \\ mp_tac (Q.SPECL [`funs`, `e`] cf_letrec_sound_aux) \\
   fs [] \\ disch_then (qspecl_then [`funs`, `[]`] mp_tac) \\
   fs [letrec_pull_params_names, letrec_pull_params_def]
-);
+QED
 
 Theorem pmatch_NIL_IMP:
   (!envC refs p v env.
@@ -2165,41 +2277,41 @@ Proof
 QED
 
 val _ = print "Proving cf_cases_evaluate_match\n";
-val cf_cases_evaluate_match = Q.prove (
-  `!v env H Q nomatch_exn rows p st h_i h_k.
-    EVERY (\b. sound p (SND b) (cf p (SND b))) rows ==>
-    cf_cases v nomatch_exn (MAP (\r. (FST r, cf p (SND r))) rows) env H Q ==>
-    SPLIT (st2heap p st) (h_i, h_k) ==> H h_i ==>
-    ?r h_f h_g heap.
-      can_pmatch_all env.c st.refs (MAP FST rows) v /\
-      SPLIT3 heap (h_f, h_k, h_g) /\
-      Q r h_f /\
-      case r of
-        | Val v' => ?ck st'.
-          evaluate_match (st with clock := ck) env v rows nomatch_exn =
-          (st', Rval [v']) /\
-          st.fp_state = st'.fp_state /\
-          st'.next_type_stamp = st.next_type_stamp /\
-          st'.next_exn_stamp = st.next_exn_stamp /\
-          st2heap p st' = heap
-        | Exn e => ?ck st'.
-          evaluate_match (st with clock := ck) env v rows nomatch_exn =
-          (st', Rerr (Rraise e)) /\
-          st.fp_state = st'.fp_state /\
-          st'.next_type_stamp = st.next_type_stamp /\
-          st'.next_exn_stamp = st.next_exn_stamp /\
-          st2heap p st' = heap
-        | FFIDiv name conf bytes => ∃ck st'.
-          evaluate_match (st with clock := ck) env v rows nomatch_exn =
-          (st', Rerr (Rabort (Rffi_error (Final_event (ExtCall name) conf bytes FFI_diverged)))) /\
-          st'.next_type_stamp = st.next_type_stamp /\
-          st'.next_exn_stamp = st.next_exn_stamp /\
-          st2heap p st' = heap
-        | Div io =>
-          (∀ck. ?st'. evaluate_match (st with clock := ck) env v rows nomatch_exn =
-              (st', Rerr (Rabort Rtimeout_error))) /\
-          lprefix_lub$lprefix_lub (IMAGE (\ck. fromList (FST(evaluate_match (st with clock := ck) env v rows nomatch_exn)).ffi.io_events) UNIV) io`,
-
+Theorem cf_cases_evaluate_match[local]:
+  !v env H Q nomatch_exn rows p st h_i h_k.
+   EVERY (\b. sound p (SND b) (cf p (SND b))) rows ==>
+   cf_cases v nomatch_exn (MAP (\r. (FST r, cf p (SND r))) rows) env H Q ==>
+   SPLIT (st2heap p st) (h_i, h_k) ==> H h_i ==>
+   ?r h_f h_g heap.
+     can_pmatch_all env.c st.refs (MAP FST rows) v /\
+     SPLIT3 heap (h_f, h_k, h_g) /\
+     Q r h_f /\
+     case r of
+       | Val v' => ?ck st'.
+         evaluate_match (st with clock := ck) env v rows nomatch_exn =
+         (st', Rval [v']) /\
+         st.fp_state = st'.fp_state /\
+         st'.next_type_stamp = st.next_type_stamp /\
+         st'.next_exn_stamp = st.next_exn_stamp /\
+         st2heap p st' = heap
+       | Exn e => ?ck st'.
+         evaluate_match (st with clock := ck) env v rows nomatch_exn =
+         (st', Rerr (Rraise e)) /\
+         st.fp_state = st'.fp_state /\
+         st'.next_type_stamp = st.next_type_stamp /\
+         st'.next_exn_stamp = st.next_exn_stamp /\
+         st2heap p st' = heap
+       | FFIDiv name conf bytes => ∃ck st'.
+         evaluate_match (st with clock := ck) env v rows nomatch_exn =
+         (st', Rerr (Rabort (Rffi_error (Final_event (ExtCall name) conf bytes FFI_diverged)))) /\
+         st'.next_type_stamp = st.next_type_stamp /\
+         st'.next_exn_stamp = st.next_exn_stamp /\
+         st2heap p st' = heap
+       | Div io =>
+         (∀ck. ?st'. evaluate_match (st with clock := ck) env v rows nomatch_exn =
+             (st', Rerr (Rabort Rtimeout_error))) /\
+         lprefix_lub$lprefix_lub (IMAGE (\ck. fromList (FST(evaluate_match (st with clock := ck) env v rows nomatch_exn)).ffi.io_events) UNIV) io
+Proof
   Induct_on `rows` \\ rpt gen_tac
   \\ rpt (disch_then assume_tac)
   \\ fs [cf_cases_def,evaluatePropsTheory.can_pmatch_all_EVERY]
@@ -2214,7 +2326,6 @@ val cf_cases_evaluate_match = Q.prove (
     impl_tac THEN1 instantiate \\ strip_tac \\ instantiate \\
     rename1 `SPLIT h_i (h1', h2')` \\ qexists_tac `h2'` \\ SPLIT_TAC
   ) \\
-
   fs [local_def] \\ first_x_assum progress \\
   rename1 `(H1 * H2) h_i` \\ fs [STAR_def] \\
   rename1 `H1 h1` \\ rename1 `H2 h2` \\
@@ -2265,14 +2376,16 @@ val cf_cases_evaluate_match = Q.prove (
   >- (Cases_on ‘r’ \\ fs[] \\ instantiate)
   >- SPLIT_TAC
   \\ fs [EVERY_MEM,MEM_MAP,FORALL_PROD,PULL_EXISTS] \\ rw [] \\ res_tac \\
-  imp_res_tac (CONJUNCT1 pmatch_NIL_IMP) \\ fs []);
+  imp_res_tac (CONJUNCT1 pmatch_NIL_IMP) \\ fs []
+QED
 
 val _ = print "Proving cf_ffi_sound\n";
-val cf_ffi_sound = Q.prove (
-  `sound (p:'ffi ffi_proj) (App (FFI ffi_index) [c; r]) (\env. local (\H Q.
-     ?cv rv. exp2v env r = SOME rv /\
-          exp2v env c = SOME cv /\
-          app_ffi ffi_index cv rv H Q))`,
+Theorem cf_ffi_sound[local]:
+  sound (p:'ffi ffi_proj) (App (FFI ffi_index) [c; r]) (\env. local (\H Q.
+    ?cv rv. exp2v env r = SOME rv /\
+         exp2v env c = SOME cv /\
+         app_ffi ffi_index cv rv H Q))
+Proof
    cf_strip_sound_tac \\
    fs[app_ffi_def] \\
    Cases_on `u ffi_index conf ws s`
@@ -2481,27 +2594,30 @@ val cf_ffi_sound = Q.prove (
    \\ `x IN u2 ∪ h_k ∪ {FFI_part (p0 st.ffi.ffi_state ' ffi_index) u ns events1}
          UNION {Mem y (W8array ws)}` by SPLIT_TAC
    \\ pop_assum mp_tac
-   \\ fs [] \\ fs [ffi2heap_def] \\ rfs[]);
+   \\ fs [] \\ fs [ffi2heap_def] \\ rfs[]
+QED
 
 val _ = print "Proving evaluate_add_to_clock_lemma\n";
-val evaluate_add_to_clock_lemma = Q.prove (
-  `!extra p (s: 'ffi semanticPrimitives$state) s' r e.
-     evaluate s e p = (s', r) ==>
-     r <> Rerr (Rabort Rtimeout_error) ==>
-     evaluate (s with clock := s.clock + extra) e p =
-     (s' with clock := s'.clock + extra, r)`,
+Theorem evaluate_add_to_clock_lemma[local]:
+  !extra p (s: 'ffi semanticPrimitives$state) s' r e.
+    evaluate s e p = (s', r) ==>
+    r <> Rerr (Rabort Rtimeout_error) ==>
+    evaluate (s with clock := s.clock + extra) e p =
+    (s' with clock := s'.clock + extra, r)
+Proof
   fs [evaluatePropsTheory.evaluate_add_to_clock]
-);
+QED
 
 val _ = print "Proving evaluate_match_add_to_clock_lemma\n";
-val evaluate_match_add_to_clock_lemma = Q.prove (
-  `!extra (s: 'ffi semanticPrimitives$state) env v rows err_v s' r.
-     evaluate_match s env v rows err_v = (s', r) ==>
-     r <> Rerr (Rabort Rtimeout_error) ==>
-     evaluate_match (s with clock := s.clock + extra) env v rows err_v =
-     (s' with clock := s'.clock + extra, r)`,
+Theorem evaluate_match_add_to_clock_lemma[local]:
+  !extra (s: 'ffi semanticPrimitives$state) env v rows err_v s' r.
+    evaluate_match s env v rows err_v = (s', r) ==>
+    r <> Rerr (Rabort Rtimeout_error) ==>
+    evaluate_match (s with clock := s.clock + extra) env v rows err_v =
+    (s' with clock := s'.clock + extra, r)
+Proof
   fs [evaluatePropsTheory.evaluate_match_add_to_clock]
-);
+QED
 
 fun add_to_clock qtm th g =
   ((fn g =>
@@ -2558,17 +2674,13 @@ Theorem cf_sound:
 Proof
   recInduct cf_ind \\ rpt strip_tac \\
   rewrite_tac cf_defs \\ fs [sound_local, sound_false]
-
   THEN1 (* Lit *) cf_base_case_tac
-
   THEN1 (
     (* Con *)
     cf_base_case_tac \\ progress exp2v_list_REVERSE \\
     fs [with_clock_self_eq]
   )
-
   THEN1 (* Var *) cf_base_case_tac
-
   THEN1 (
     (* Let *)
     Cases_on `is_bound_Fun opt e1` \\ fs []
@@ -2716,7 +2828,6 @@ Proof
       `MAP (\ (f,_,_). naryRecclosure env (letrec_pull_params funs) f) funs` \\
     fs [letrec_pull_params_LENGTH] \\ res_tac \\ instantiate
   )
-
   THEN1 (
     (* App *)
     Cases_on `?ffi_index. op = FFI ffi_index` THEN1 (
@@ -3212,7 +3323,6 @@ Proof
       SPLIT_TAC
     )
   )
-
   THEN1 (
     (* Log *)
     cf_strip_sound_full_tac \\
@@ -3253,7 +3363,6 @@ Proof
       \\ cf_exp2v_evaluate_tac `st` \\ fs [do_log_def, Boolv_def]
     )
   )
-
   THEN1 (
     (* If *)
     cf_strip_sound_full_tac \\ fs [do_if_def]
@@ -3283,7 +3392,6 @@ Proof
       \\ cf_exp2v_evaluate_tac `st with clock := ck`
     )
   )
-
   THEN1 (
     (* Mat: the bulk of the proof is done in [cf_cases_evaluate_match] *)
     cf_strip_sound_full_tac
@@ -3313,7 +3421,6 @@ Proof
       \\ cf_exp2v_evaluate_tac `st with clock := ck`
     )
   )
-
   THEN1 (
     (* Raise *)
     cf_strip_sound_full_tac \\ qexists_tac `Exn v` \\ fs [] \\
@@ -3322,7 +3429,6 @@ Proof
     qexists_tac `st.clock` \\
     cf_exp2v_evaluate_tac `st with clock := st.clock` \\ fs [with_clock_self]
   )
-
   THEN1 (
     (* Handle *)
     cf_strip_sound_full_tac \\
@@ -3417,14 +3523,12 @@ Proof
       metis_tac[]
     )
   )
-
   THEN1 (
     (* Lannot *)
     cf_strip_sound_full_tac \\ fs [sound_def, htriple_valid_def] \\
     first_assum progress \\ fs [evaluate_to_heap_def, evaluate_ck_def] \\
     metis_tac[]
   )
-
   THEN1 (
     (* Tannot *)
     cf_strip_sound_full_tac \\ fs [sound_def, htriple_valid_def] \\

--- a/characteristic/cfScript.sml
+++ b/characteristic/cfScript.sml
@@ -3630,7 +3630,7 @@ Proof
 QED
 
 Theorem app_of_cf:
-   !ns env body xvs env' H Q.
+   !ns env body xvs H Q.
      ns <> [] ==>
      LENGTH xvs = LENGTH ns ==>
      cf (p:'ffi ffi_proj) body (extend_env ns xvs env) H Q ==>

--- a/characteristic/cfSyntax.sig
+++ b/characteristic/cfSyntax.sig
@@ -6,7 +6,7 @@ signature cfSyntax = sig
   val mk_cf_let   : term * term * term * term * term * term -> term
   val dest_cf_let : term -> term * term * term * term * term * term
   val is_cf_let   : term -> bool
-	      
+
   (* cf_lit lit env H Q *)
   val cf_lit_tm   : term
   val mk_cf_lit   : term * term * term * term -> term
@@ -44,4 +44,35 @@ signature cfSyntax = sig
   val mk_cf_app   : term * term * term * term * term * term -> term
   val dest_cf_app : term -> term * term * term * term * term * term
   val is_cf_app   : term -> bool
+
+  (* cf_log lop e1 e2 env H Q *)
+  val cf_log_tm : term
+  val mk_cf_log   : term * term * term * term * term * term -> term
+  val dest_cf_log : term -> term * term * term * term * term * term
+  val is_cf_log   : term -> bool
+
+  (* cf_if cond e1 e2 env H Q *)
+  val cf_if_tm : term
+  val mk_cf_if   : term * term * term * term * term * term -> term
+  val dest_cf_if : term -> term * term * term * term * term * term
+  val is_cf_if   : term -> bool
+
+  (* cf_match e branches env H Q *)
+  val cf_match_tm : term
+  val mk_cf_match   : term * term * term * term * term -> term
+  val dest_cf_match : term -> term * term * term * term * term
+  val is_cf_match   : term -> bool
+
+  (* cf_handle e branches env H Q *)
+  val cf_handle_tm : term
+  val mk_cf_handle   : term * term * term * term * term -> term
+  val dest_cf_handle : term -> term * term * term * term * term
+  val is_cf_handle   : term -> bool
+
+  (* cf_raise e env H Q *)
+  val cf_raise_tm   : term
+  val mk_cf_raise   : term * term * term * term -> term
+  val dest_cf_raise : term -> term * term * term * term
+  val is_cf_raise   : term -> bool
+
 end

--- a/characteristic/cfSyntax.sml
+++ b/characteristic/cfSyntax.sml
@@ -47,6 +47,11 @@ val (cf_var_tm, mk_cf_var, dest_cf_var, is_cf_var) = s4 "cf_var"
 val (cf_fun_tm, mk_cf_fun, dest_cf_fun, is_cf_fun) = s8 "cf_fun"
 val (cf_fun_rec_tm, mk_cf_fun_rec, dest_cf_fun_rec, is_cf_fun_rec) = s6 "cf_fun_rec"
 val (cf_app_tm, mk_cf_app, dest_cf_app, is_cf_app) = s6 "cf_app"
+val (cf_log_tm, mk_cf_log, dest_cf_log, is_cf_log) = s6 "cf_log"
+val (cf_if_tm, mk_cf_if, dest_cf_if, is_cf_if) = s6 "cf_if"
+val (cf_match_tm, mk_cf_match, dest_cf_match, is_cf_match) = s5 "cf_match"
+val (cf_handle_tm, mk_cf_handle, dest_cf_handle, is_cf_handle) = s5 "cf_handle"
+val (cf_raise_tm, mk_cf_raise, dest_cf_raise, is_cf_raise) = s4 "cf_raise"
 
 end
 

--- a/characteristic/examples/cf_examplesScript.sml
+++ b/characteristic/examples/cf_examplesScript.sml
@@ -10,7 +10,7 @@ local open basisProgTheory in end
 val _ = new_theory "cf_examples";
 val _ = translation_extends "basisProg"
 
-fun xcf' s = xcf_with_def s (DB.fetch "-" (s ^ "_v_def"))
+fun xcf' s = xcf_with_def (DB.fetch "-" (s ^ "_v_def"))
 val _ = (append_prog o process_topdecs)
   `fun example_let0 n = let val a = 3; in a end`;
 val example_let0_v_def = DB.fetch "-" "example_let0_v_def"
@@ -18,7 +18,7 @@ val example_let0_v_def = DB.fetch "-" "example_let0_v_def"
 Theorem example_let0_spec[local]:
   !nv. app (p:'ffi ffi_proj) example_let0_v [nv] emp (POSTv v. & INT 3 v)
 Proof
-  xcf' "example_let0" \\ xlet `POSTv a. & INT 3 a`
+  strip_tac \\ xcf' "example_let0" \\ xlet `POSTv a. & INT 3 a`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
 QED
@@ -29,7 +29,7 @@ val _ = (append_prog o process_topdecs)
 Theorem example_let1_spec[local]:
   !uv. app (p:'ffi ffi_proj) example_let1_v [uv] emp (POSTv v. & UNIT_TYPE () v)
 Proof
-  xcf' "example_let1" \\ xmatch \\
+  strip_tac \\ xcf' "example_let1" \\ xmatch \\
   xlet `POSTv a. & UNIT_TYPE () a`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
@@ -41,7 +41,7 @@ val _ = (append_prog o process_topdecs)
 Theorem example_let2_spec[local]:
   !uv. app (p:'ffi ffi_proj) example_let2_v [uv] emp (POSTv v. & (v = uv))
 Proof
-  xcf' "example_let2" \\ xlet `POSTv v. & (v = uv)`
+  strip_tac \\ xcf' "example_let2" \\ xlet `POSTv v. & (v = uv)`
   THEN1 (xret \\ xsimpl) \\
   xret \\ xsimpl
 QED
@@ -54,6 +54,7 @@ Theorem example_let_spec[local]:
      INT n nv ==>
      app (p:'ffi ffi_proj) example_let_v [nv] emp (POSTv v. & INT (2 * n) v)
 Proof
+  rpt strip_tac \\
   xcf' "example_let" \\
   xlet `POSTv a. & INT (n+1) a`
   THEN1 (xapp \\ fs []) \\
@@ -75,6 +76,7 @@ Theorem alloc_ref2_spec[local]:
                  & PAIR_TYPE (=) (=) (r1, r2) p *
                  REF r1 av * REF r2 bv)
 Proof
+  rpt strip_tac \\
   xcf' "alloc_ref2" \\
   xlet `POSTv r2. REF r2 bv` THEN1 (xref >> xsimpl) \\
   xlet `POSTv r1. REF r1 av * REF r2 bv` THEN1 (xref \\ xsimpl) \\
@@ -90,6 +92,7 @@ Theorem swap_spec[local]:
        (REF r1v xv * REF r2v yv)
        (POSTv v. & UNIT_TYPE () v * REF r1v yv * REF r2v xv)
 Proof
+  rpt strip_tac \\
   xcf' "swap" \\
   xlet `POSTv xv'. & (xv' = xv) * r1v ~~> xv * r2v ~~> yv`
     THEN1 (xapp \\ xsimpl) \\
@@ -109,6 +112,7 @@ Theorem example_if_spec[local]:
      app (p:'ffi ffi_proj) example_if_v [nv]
        emp (POSTv v. &(if n > 0 then INT 1 v else INT 2 v))
 Proof
+  rpt strip_tac \\
   xcf' "example_if" \\
   xlet `POSTv bv. & BOOL (n > 0) bv`
   THEN1 (xapp \\ fs []) \\
@@ -124,6 +128,7 @@ Theorem is_nil_spec[local]:
      app (p:'ffi ffi_proj) is_nil_v [lv]
        emp (POSTv bv. & BOOL (l = []) bv)
 Proof
+  rpt strip_tac \\
   xcf' "is_nil" \\ Cases_on `l` \\
   fs [LIST_TYPE_def] \\
   xmatch \\ xret \\ xsimpl
@@ -140,6 +145,7 @@ Theorem is_none_spec[local]:
      app (p:'ffi ffi_proj) is_none_v [ov]
        emp (POSTv bv. & BOOL (opt = NONE) bv)
 Proof
+  rpt strip_tac \\
   xcf' "is_none" \\ Cases_on `opt` \\
   fs [OPTION_TYPE_def] \\
   xmatch \\ xcon \\ xsimpl
@@ -154,7 +160,7 @@ Theorem example_eq_spec[local]:
      app (p:'ffi ffi_proj) example_eq_v [xv]
        emp (POSTv bv. & BOOL (x = 3) bv)
 Proof
-  xcf' "example_eq" \\ xapp \\
+  rpt strip_tac \\ xcf' "example_eq" \\ xapp \\
   (* instantiate *) qexists_tac `INT` \\ fs [] \\
   fs [EqualityType_NUM_BOOL]
 QED
@@ -168,7 +174,7 @@ Theorem example_and_spec[local]:
      app (p:'ffi ffi_proj) example_and_v [uv]
        emp (POSTv bv. & BOOL F bv)
 Proof
-  xcf' "example_and" \\ xlet `POSTv b. & BOOL T b`
+  rpt strip_tac \\ xcf' "example_and" \\ xlet `POSTv b. & BOOL T b`
   THEN1 (xret \\ xsimpl) \\
   xlog \\ xret \\ xsimpl
 QED
@@ -178,16 +184,17 @@ val example_raise = (append_prog o process_topdecs)
    fun example_raise u = raise Foo`
 
 
-val example_raise_spec = Q.prove (
-  `!uv.
-     UNIT_TYPE () uv ==>
-     app (p:'ffi ffi_proj) example_raise_v [uv]
-       emp (POSTe v. & (v = Conv (SOME (ExnStamp 8)) []))`,
-  xcf' "example_raise" \\
+Theorem example_raise_spec[local]:
+  !uv.
+    UNIT_TYPE () uv ==>
+    app (p:'ffi ffi_proj) example_raise_v [uv]
+      emp (POSTe v. & (v = Conv (SOME (ExnStamp 8)) []))
+Proof
+  rpt strip_tac \\ xcf' "example_raise" \\
   xlet `POSTv ev. & (ev = Conv (SOME (ExnStamp 8)) [])`
   THEN1 (xcon \\ xsimpl) \\
   xraise \\ xsimpl
-);
+QED
 
 val example_handle = (append_prog o process_topdecs)
   `exception Foo int
@@ -197,11 +204,13 @@ Definition Foo_exn_def:
   Foo_exn st i v = (v = Conv (SOME (ExnStamp st)) [Litv (IntLit i)])
 End
 
-val example_handle_spec = Q.prove (
-  `!uv.
-     UNIT_TYPE () uv ==>
-     app (p:'ffi ffi_proj) example_handle_v [uv]
-       emp (POSTv v. & INT 3 v)`,
+Theorem example_handle_spec[local]:
+  !uv.
+    UNIT_TYPE () uv ==>
+    app (p:'ffi ffi_proj) example_handle_v [uv]
+      emp (POSTv v. & INT 3 v)
+Proof
+  rpt strip_tac \\
   xcf' "example_handle" \\
   xhandle `POSTe v. & Foo_exn 9 3 v`
   THEN1 (
@@ -210,7 +219,7 @@ val example_handle_spec = Q.prove (
     xraise \\ xsimpl
   ) \\
   fs [Foo_exn_def] \\ xcases \\ xvar \\ xsimpl
-);
+QED
 
 val _ = (append_prog o process_topdecs)
   `exception Foo int
@@ -221,12 +230,13 @@ val _ = (append_prog o process_topdecs)
         raise (Foo (~1)))
      handle Foo i => i`
 
-val example_handle2_spec = Q.prove (
-  `!x xv.
-     INT x xv ==>
-     app (p:'ffi ffi_proj) example_handle2_v [xv]
-       emp (POSTv v. & INT (if x > 0 then 1 else (-1)) v)`,
-  xcf' "example_handle2" \\
+Theorem example_handle2_spec[local]:
+  !x xv.
+    INT x xv ==>
+    app (p:'ffi ffi_proj) example_handle2_v [xv]
+      emp (POSTv v. & INT (if x > 0 then 1 else (-1)) v)
+Proof
+  rpt strip_tac \\ xcf' "example_handle2" \\
   xhandle ‘POSTve (\v. & (x > 0 /\ INT 1 v))
                   (\e. & (x <= 0 /\ Foo_exn 10 (-1) e))’
   THEN1 (
@@ -245,21 +255,23 @@ val example_handle2_spec = Q.prove (
   )
   THEN1 xsimpl \\
   fs [Foo_exn_def] \\ xcases \\ xret \\ xsimpl \\ intLib.ARITH_TAC
-);
+QED
 
 val example_nested_apps = (append_prog o process_topdecs)
   `fun f i = ~ (~ (~ i))`;
 
-val example_nested_apps_spec = Q.prove (
-  `!x xv.
-     INT x xv ==>
-     app (p:'ffi ffi_proj) f_v [xv]
-       emp (POSTv v. & INT (~ x) v)`,
+Theorem example_nested_apps_spec[local]:
+  !x xv.
+    INT x xv ==>
+    app (p:'ffi ffi_proj) f_v [xv]
+      emp (POSTv v. & INT (~ x) v)
+Proof
+  rpt strip_tac \\
   xcf' "f" \\
   xlet `POSTv v. & INT (~ x) v` THEN1 (xapp \\ fs []) \\
   xlet `POSTv v. & INT x v` THEN1 (xapp \\ xsimpl \\ instantiate) \\
   xapp \\ fs []
-);
+QED
 
 val bytearray_fromlist = (append_prog o process_topdecs)
   `fun length l =
@@ -281,7 +293,7 @@ Theorem list_length_spec:
      app (p:'ffi ffi_proj) length_v [lv]
        emp (POSTv v. & NUM (LENGTH l) v)
 Proof
-  Induct_on `l`
+  Induct_on `l` \\ rw []
   THEN1 (
     xcf' "length" \\ fs [LIST_TYPE_def] \\
     xmatch \\ xret \\ xsimpl
@@ -296,11 +308,13 @@ Proof
   )
 QED
 
-val bytearray_fromlist_spec = Q.prove (
-  `!l lv.
-     LIST_TYPE WORD l lv ==>
-     app (p:'ffi ffi_proj) fromList_v [lv]
-       emp (POSTv av. W8ARRAY av l)`,
+Theorem bytearray_fromlist_spec[local]:
+  !l lv.
+    LIST_TYPE WORD l lv ==>
+    app (p:'ffi ffi_proj) fromList_v [lv]
+      emp (POSTv av. W8ARRAY av l)
+Proof
+  rpt strip_tac \\
   xcf' "fromList" \\
   xlet `POSTv w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
   xlet `POSTv len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
@@ -335,47 +349,53 @@ val bytearray_fromlist_spec = Q.prove (
     )
   ) \\
   xapp \\ fs [] \\ xsimpl \\ fs [LENGTH_NIL_SYM, LENGTH_REPLICATE]
-)
+QED
 
 val strcat_foo = (append_prog o process_topdecs)
   `fun strcat_foo r = r := !r ^ "foo"`
 
 val xlet_auto = cfLetAutoLib.xlet_auto
 
-val strcat_foo_spec = Q.prove (
-  `!rv sv s.
-     STRING_TYPE s sv ==>
-     app (p:'ffi ffi_proj) strcat_foo_v [rv]
-       (REF rv sv)
-       (POSTv uv. SEP_EXISTS sv'.
-            &(UNIT_TYPE () uv /\ STRING_TYPE (s ^ implode "foo") sv') *
-            REF rv sv')`,
+Theorem strcat_foo_spec[local]:
+  !rv sv s.
+    STRING_TYPE s sv ==>
+    app (p:'ffi ffi_proj) strcat_foo_v [rv]
+      (REF rv sv)
+      (POSTv uv. SEP_EXISTS sv'.
+           &(UNIT_TYPE () uv /\ STRING_TYPE (s ^ implode "foo") sv') *
+           REF rv sv')
+Proof
+  rpt strip_tac >>
   xcf' "strcat_foo" >>
   xlet_auto >- xsimpl >>
   xlet `POSTv sv'. &(STRING_TYPE (s ^ implode "foo") sv') * rv ~~> sv`
   >- (xapp >> xsimpl >> simp[mlstringTheory.implode_def] >> metis_tac[]) >>
-  rveq >> xapp >> xsimpl);
+  rveq >> xapp >> xsimpl
+QED
 
 val example_ffidiv = (append_prog o process_topdecs) `
    fun example_ffidiv b = if b then Runtime.abort () else ()`
 
-val example_ffidiv_spec = Q.prove (
-  `!b bv.
-     BOOL b bv ==>
-     app (p:'ffi ffi_proj) example_ffidiv_v [bv]
-       (RUNTIME)
-       (POST
-          (λuv. &(UNIT_TYPE () uv) * &(¬b) * RUNTIME)
-          (λev. &F)
-          (λn conf bytes. &b * &(n = "exit" /\ conf = [] /\ bytes = [1w])
-                   * RUNTIME)
-          (λio. F))`,
-  xcf' "example_ffidiv"
+Theorem example_ffidiv_spec[local]:
+  !b bv.
+    BOOL b bv ==>
+    app (p:'ffi ffi_proj) example_ffidiv_v [bv]
+      (RUNTIME)
+      (POST
+         (λuv. &(UNIT_TYPE () uv) * &(¬b) * RUNTIME)
+         (λev. &F)
+         (λn conf bytes. &b * &(n = "exit" /\ conf = [] /\ bytes = [1w])
+                  * RUNTIME)
+         (λio. F))
+Proof
+  rpt strip_tac
+  >> xcf' "example_ffidiv"
   >> xif
   >- (xlet_auto
       >- (xcon >- xsimpl)
       >> xapp >> xsimpl >> rw[] >> qexists_tac `x` >> xsimpl)
-  >> xcon >> xsimpl);
+  >> xcon >> xsimpl
+QED
 
 val example_mutrec = (append_prog o process_topdecs) `
   fun is_even n =

--- a/characteristic/examples/cf_tutorialScript.sml
+++ b/characteristic/examples/cf_tutorialScript.sml
@@ -118,7 +118,7 @@ Proof
        which turns an [app...] goal into a goal about the
        characteristic formula of the function body.
     *)
-    xcf_with_def "length" (fetch "-" "length_v_def") \\ fs [LIST_TYPE_def] \\
+    rw [] \\ xcf_with_def (fetch "-" "length_v_def") \\ fs [LIST_TYPE_def] \\
 
     (* Now, the general method is to look at the head constructor, and
        call the corresponding xtactic. Here, we have a [cf_match...]
@@ -140,7 +140,7 @@ Proof
     xsimpl
   )
   THEN1 ((** Induction *)
-    xcf_with_def "length" (fetch "-" "length_v_def") \\ fs [LIST_TYPE_def] \\
+    rw [] \\ xcf_with_def (fetch "-" "length_v_def") \\ fs [LIST_TYPE_def] \\
     rename1 `a x xv` \\ rename1 `LIST_TYPE a xs xvs` \\
     xmatch \\
 
@@ -195,7 +195,7 @@ Theorem bytearray_fromlist_spec[local]:
      app (p:'ffi ffi_proj) fromList_v [lv]
        emp (POSTv av. W8ARRAY av l)
 Proof
-  xcf_with_def "fromList" (fetch "-" "fromList_v_def") \\
+  rw [] \\ xcf_with_def (fetch "-" "fromList_v_def") \\
   xlet `POSTv w8z. & WORD (n2w 0: word8) w8z` THEN1 (xapp \\ fs []) \\
   xlet `POSTv len_v. & NUM (LENGTH l) len_v` THEN1 (xapp \\ metis_tac []) \\
   xlet `POSTv av. W8ARRAY av (REPLICATE (LENGTH l) 0w)`

--- a/characteristic/xcf.sig
+++ b/characteristic/xcf.sig
@@ -1,0 +1,11 @@
+(*
+  Implementation of the xcf and xcfs tactics.
+ *)
+signature xcf =
+sig
+  include Abbrev
+  val xcf_with_def : thm -> tactic
+  val xcf_with_defs : thm list -> tactic
+  val xcf : string -> ml_progLib.ml_prog_state -> tactic
+  val xcfs : string list -> ml_progLib.ml_prog_state -> tactic
+end (* sig *)

--- a/characteristic/xcf.sml
+++ b/characteristic/xcf.sml
@@ -1,0 +1,308 @@
+(*
+  Implementation of the xcf tactic.
+ *)
+
+structure xcf :> xcf =
+struct
+
+  open preamble;
+  open alistTheory cfAppTheory cfHeapsTheory cfTheory cfAppTheory cfHeapsTheory
+       cfTheory cfTacticsTheory cfNormaliseTheory stringTheory xcfTheory;
+  open astSyntax cfAppSyntax semanticPrimitivesSyntax stringSyntax;
+
+  fun THENCC (l, r) = ConseqConv.THEN_CONSEQ_CONV l r;
+  infix THENCC
+
+  (*
+  load "stringLib";
+  load "cfHeapsBaseSyntax";
+  load "cfSyntax";
+  *)
+
+  val ERR = mk_HOL_ERR "xcf" "xcf";
+
+  (* -----------------------------------------------------------------------
+     Terms
+   * ----------------------------------------------------------------------- *)
+
+  val naryClosure_tm =
+    prim_mk_const {Name = "naryClosure", Thy = "cf"};
+  val naryRecclosure_tm =
+    prim_mk_const {Name = "naryRecclosure", Thy = "cf"};
+  val find_recfun_tm =
+    prim_mk_const {Name = "find_recfun", Thy = "semanticPrimitives"};
+  val letrec_pull_params_tm =
+    prim_mk_const {Name = "letrec_pull_params", Thy = "cf"};
+  val local_tm =
+    prim_mk_const {Name = "local", Thy = "cfHeaps"};
+  val STOP_tm =
+    prim_mk_const {Name = "STOP", Thy = "xcf"};
+
+  (* -----------------------------------------------------------------------
+     General destructors
+   * ----------------------------------------------------------------------- *)
+
+  local
+    fun list_dest acc tm =
+      let
+        val (fx, x) = dest_comb tm
+      in
+        list_dest (x::acc) fx
+      end
+      handle HOL_ERR _ => tm::acc;
+  in
+    val list_dest_comb = list_dest [];
+  end (* local *)
+
+  local
+    fun list_dest acc tm =
+      let
+        val (v, b) = dest_forall tm
+      in
+        list_dest (v::acc) b
+      end
+      handle HOL_ERR _ => List.rev acc;
+  in
+    val list_dest_forall = list_dest [];
+  end (* local *)
+
+  (* -----------------------------------------------------------------------
+     Destructors
+   * ----------------------------------------------------------------------- *)
+
+  (*
+  val tm = ``naryClosure env vs bod``;
+  *)
+  fun dest_naryClosure tm =
+    case list_dest_comb tm of
+      [f, env, vs, bod] =>
+        if same_const f naryClosure_tm then (env, vs, bod)
+        else fail ()
+    | _ => fail ()
+  val is_naryClosure = can dest_naryClosure;
+
+  (*
+  val tm = ``naryRecclosure env naryfuns f``;
+  *)
+  fun dest_naryRecclosure tm =
+    case list_dest_comb tm of
+      [f, env, naryfuns, g] =>
+        if same_const f naryRecclosure_tm then (env, naryfuns, g)
+        else fail ()
+    | _ => fail ()
+  val is_naryRecclosure = can dest_naryRecclosure;
+
+  (* -----------------------------------------------------------------------
+     xcf_cleanup_conv
+   * ----------------------------------------------------------------------- *)
+
+  (*
+   * Reduce ``cf p ...`` terms; for example, ``cf p (Var v)`` becomes
+   * ``cf_var v``.
+   *)
+
+  val cf_cleanup_conv =
+    ONCE_REWRITE_CONV [cf_STOP_thm, ETA_THM] THENC
+    computeLib.compset_conv (listLib.list_compset ()) [
+      computeLib.Defs [
+        is_bound_Fun_def,
+        Fun_body_def,
+        dest_opapp_def,
+        cf_STOP_rewrite
+      ],
+      computeLib.Tys [
+        optionSyntax.mk_option alpha,
+        exp_ty, op_ty, v_ty, pat_ty, word_size_ty],
+      computeLib.Extenders [
+        pairLib.add_pair_compset,
+        (fn cs => computeLib.set_skip cs STOP_tm (SOME 1))
+      ]
+    ] THENC
+    REWRITE_CONV [STOP_def, ETA_THM];
+
+  (* -----------------------------------------------------------------------
+     xcf
+   * ----------------------------------------------------------------------- *)
+
+  (*
+  val tm = ``[1;2;] <> []``;
+  val tm = ``LENGTH [1;2;3] = LENGTH [a;b;c]``;
+  LIST_EVAL_CONV tm;
+  *)
+  val LIST_EVAL_CONV =
+    EQT_ELIM o computeLib.compset_conv (listLib.list_compset ()) [];
+
+  (*
+  val tm = ``app p (naryClosure env [n1;n2;] bod) [a1;a2] H Q``;
+  *)
+  fun nary_clos_app_cconv tm =
+    let
+      val (p, nc, xs, h, q) = dest_app tm
+      val (env, ns, bod) = dest_naryClosure nc
+      val th = SPECL [ns, env, bod, xs, ``TODO_REMOVE_THIS:'a``, h, q] app_of_cf
+      val th = MP_CONV LIST_EVAL_CONV th
+      val th = MP_CONV LIST_EVAL_CONV th
+    in
+      th
+    end;
+
+  (*
+  val tm = ``Fun v1 (Fun v2 (Fun v3 b))``
+  *)
+  local
+    val naryFun_tm = prim_mk_const {Name = "naryFun", Thy = "cf"};
+    fun mk_naryFun ns bod = list_mk_comb (naryFun_tm, [ns, bod]);
+    fun build acc tm =
+      case total dest_Fun tm of
+        NONE => mk_naryFun (listSyntax.mk_list (List.rev acc, string_ty)) tm
+      | SOME (n, e) => build (n::acc) e;
+    val cnv =
+      computeLib.compset_conv (listLib.list_compset()) [
+        computeLib.Defs [naryFun_def]
+        ];
+  in
+    fun nary_fun_conv tm = EQT_ELIM (cnv (mk_eq (tm, build [] tm)))
+  end (* local *)
+
+  (*
+  val tm = ``Closure env v (Fun v1 (Fun v2 (Fun v3 b)))``
+  *)
+  val nary_clos_conv =
+    RAND_CONV nary_fun_conv THENC
+    REWR_CONV (GSYM naryClosure_def);
+
+  (*
+  val tm = ``app (p: 'ffi ffi_proj) (Closure env v (Fun v1 (Fun v2 (Fun v3 b)))) [a;a1;a2;a3] H Q``;
+  *)
+  val xcf_closure_conv =
+    PATH_CONV "lllr" nary_clos_conv THENCC
+    nary_clos_app_cconv;
+
+  (*
+  val tm = ``find_recfun "f1" (letrec_pull_params [("f1","v1",Fun "v2" (Var v)); ("f2","v2",e2)])``;
+  find_recfun_conv tm
+  *)
+  val find_recfun_conv =
+    computeLib.compset_conv (listLib.list_compset ()) [
+      computeLib.Defs [
+        ALOOKUP_def, Fun_body_def, Fun_params_def, letrec_pull_params_def,
+        semanticPrimitivesPropsTheory.find_recfun_ALOOKUP
+      ],
+      computeLib.Tys [
+        optionSyntax.mk_option alpha
+      ],
+      computeLib.Extenders [
+        stringLib.add_string_compset
+      ]
+    ];
+
+  (*
+  val tm = ``ALL_DISTINCT ["f",a,b; "g",c,d; "o",e,r]``;
+  LIST_EVAL_CONV2 tm
+  *)
+  val LIST_EVAL_CONV2 =
+    computeLib.compset_conv (reduceLib.num_compset ())
+        [computeLib.Defs [
+          listTheory.ALL_DISTINCT, listTheory.MEM, listTheory.MAP
+         ],
+         computeLib.Tys [
+           listSyntax.mk_list_type alpha
+         ],
+         computeLib.Extenders [
+           stringLib.add_string_compset,
+           pairLib.add_pair_compset
+         ]
+        ];
+
+  (*
+  val tm = ``app p (naryRecclosure env (letrec_pull_params [("f1","v1",Fun "v2" (Var v)); ("f2","v2",e2)]) "f1") [v1;v2] H Q``
+  *)
+  fun nary_recclos_app_cconv tm =
+    let
+      val (p, nc, xs, h, q) = cfAppSyntax.dest_app tm
+      val (env, lpp_funs, f) = dest_naryRecclosure nc
+      val funs = rand lpp_funs
+      (* Compute find_recfun f (letrec_pull_params funs) *)
+      val fth = find_recfun_conv (boolSyntax.list_mk_icomb (find_recfun_tm, [f, lpp_funs]))
+      val (vs, bod) = (concl fth |> rhs |> optionSyntax.dest_some
+                       |> pairSyntax.dest_pair)
+                      handle HOL_ERR _ => raise ERR "frf lpp lookup failed"
+      (* Instantiate theorem: *)
+      val th = SPECL [f, vs, bod, funs, xs, env, h, q] app_rec_of_cf
+      val th = MP_CONV LIST_EVAL_CONV th
+      val th = MP_CONV LIST_EVAL_CONV th
+      val th = MP_CONV LIST_EVAL_CONV2 th
+      val th = MP th fth
+      val th = CONV_RULE (PATH_CONV "lrllrllll" LIST_EVAL_CONV2) th
+    in
+      th
+    end;
+
+  (*
+  val tm = ``app (p: 'ffi ffi_proj) (Recclosure env [("f1","v1",Fun "v2" (Var v)); ("f2","v2",e2)] "f1") [v1;v2] H Q``
+  *)
+  local
+    val cnv1 = REWR_CONV (GSYM letrec_pull_params_repack)
+    val cnv2 = REWR_CONV letrec_pull_params_repack
+  in
+    fun xcf_recclosure_conv defth =
+      PATH_CONV "lllr" cnv1 THENCC
+      nary_recclos_app_cconv THENCC
+      (* TODO(oskar.abrahamsson) Be more careful with this rewrite: *)
+      SIMP_CONV list_ss [letrec_pull_params_repack, GSYM defth]
+  end (* local *)
+
+  (*
+   * Top-level conversion for xcf.
+   *)
+  fun xcf_cconv defth tm =
+    let
+      val (ptm, defn, args, _, _) =
+        cfAppSyntax.dest_app tm handle HOL_ERR _ =>
+        raise ERR "Not an app"
+      val _ =
+        type_of ptm = cfHeapsBaseSyntax.ffi_proj_format orelse
+        raise ERR (term_to_string ptm ^ " must have type :'ffi ffi_proj")
+      val _ =
+        same_const (lhs (concl defth)) defn orelse
+        raise ERR ("theorem does not define " ^ term_to_string defn)
+      val _ =
+        listSyntax.is_list args orelse
+        raise ERR "argument list not terminated with nil"
+      val vtm = rhs (concl defth)
+      val _ =
+        semanticPrimitivesSyntax.is_Recclosure vtm orelse
+        semanticPrimitivesSyntax.is_Closure vtm orelse
+        raise ERR "rhs of theorem is not a closure or recclosure"
+    in
+      if semanticPrimitivesSyntax.is_Recclosure vtm then
+        (PATH_CONV "lllr" (REWR_CONV defth) THENCC
+         xcf_recclosure_conv defth) tm
+      else (* Closure *)
+        (PATH_CONV "lllr" (REWR_CONV defth) THENCC
+         xcf_closure_conv) tm
+    end;
+
+  (*
+   * Top-level conversion for xcfs.
+   *
+   * TODO(oskar.abrahamsson): I don't know how this is intended to work.
+   *)
+  fun xcfs_cconv defs tm = ALL_CONV tm;
+
+  fun xcf_with_def defth (g as (_, tm)) =
+    (irule (xcf_cconv defth tm) THEN
+     CONV_TAC cf_cleanup_conv) g;
+
+  fun xcf_with_defs defs (g as (_, tm)) =
+    (irule (xcfs_cconv defs tm) THEN
+     CONV_TAC cf_cleanup_conv) g;
+
+  fun xcf name st =
+    xcf_with_def (cfTacticsBaseLib.fetch_def name st);
+
+  fun xcfs names st =
+    xcf_with_defs (List.map (fn n => cfTacticsBaseLib.fetch_def n st) names);
+
+end (* struct *)
+

--- a/characteristic/xcf.sml
+++ b/characteristic/xcf.sml
@@ -103,7 +103,7 @@ struct
    *)
 
   val cf_cleanup_conv =
-    ONCE_REWRITE_CONV [cf_STOP_thm, ETA_THM] THENC
+    ONCE_REWRITE_CONV [cf_STOP_thm] THENC
     computeLib.compset_conv (listLib.list_compset ()) [
       computeLib.Defs [
         is_bound_Fun_def,
@@ -119,7 +119,8 @@ struct
         (fn cs => computeLib.set_skip cs STOP_tm (SOME 1))
       ]
     ] THENC
-    REWRITE_CONV [STOP_def, ETA_THM];
+    ONCE_REWRITE_CONV [STOP_def] THENC
+    PATH_CONV "llr" (REWRITE_CONV [ETA_THM]);
 
   (* -----------------------------------------------------------------------
      xcf

--- a/characteristic/xcf.sml
+++ b/characteristic/xcf.sml
@@ -120,7 +120,7 @@ struct
       ]
     ] THENC
     ONCE_REWRITE_CONV [STOP_def] THENC
-    PATH_CONV "llr" (REWRITE_CONV [ETA_THM]);
+    PATH_CONV "lll" (REWRITE_CONV [ETA_THM]);
 
   (* -----------------------------------------------------------------------
      xcf

--- a/characteristic/xcf.sml
+++ b/characteristic/xcf.sml
@@ -312,8 +312,7 @@ struct
      CONV_TAC cf_cleanup_conv) g;
 
   fun xcf_with_defs defs (g as (_, tm)) =
-    (rpt strip_tac THEN
-     irule (xcfs_cconv defs tm) THEN
+    (irule (xcfs_cconv defs tm) THEN
      CONV_TAC cf_cleanup_conv) g;
 
   fun xcf name st =

--- a/characteristic/xcf.sml
+++ b/characteristic/xcf.sml
@@ -139,7 +139,7 @@ struct
     let
       val (p, nc, xs, h, q) = dest_app tm
       val (env, ns, bod) = dest_naryClosure nc
-      val th = SPECL [ns, env, bod, xs, ``TODO_REMOVE_THIS:'a``, h, q] app_of_cf
+      val th = SPECL [ns, env, bod, xs, h, q] app_of_cf
       val th = MP_CONV LIST_EVAL_CONV th
       val th = MP_CONV LIST_EVAL_CONV th
     in

--- a/characteristic/xcfScript.sml
+++ b/characteristic/xcfScript.sml
@@ -1,0 +1,32 @@
+(*
+  Definitions used to trick EVAL in xcf.sml.
+ *)
+
+open preamble cfTheory;
+
+val _ = new_theory "xcf";
+
+Definition STOP_def:
+  STOP x y = y
+End
+
+Theorem cf_STOP_thm:
+  cf p x env H Q = cf p x (STOP STOP env) (STOP STOP H) (STOP STOP Q)
+Proof
+  rw [STOP_def]
+QED
+
+Theorem cf_STOP:
+  cf p x = \env H Q. cf p x (STOP STOP env) (STOP STOP H) (STOP STOP Q)
+Proof
+  rw [STOP_def, FUN_EQ_THM]
+QED
+
+Theorem cf_STOP_rewrite =
+  List.map
+    (CONV_RULE (RAND_CONV (ONCE_REWRITE_CONV [cf_STOP])) o SPEC_ALL)
+    (CONJUNCTS cf_def)
+  |> LIST_CONJ;
+
+val _ = export_theory ();
+

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -320,7 +320,7 @@ Theorem main_spec:
        * STDIO (full_compile_32 (TL cl) (get_stdin fs) fs)
        * COMMANDLINE cl)
 Proof
-  xcf_with_def "main" main_v_def
+  xcf_with_def main_v_def
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ xlet_auto
   >- (

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -530,7 +530,8 @@ Theorem main_spec:
        * STDIO (full_compile_64 (TL cl) (get_stdin fs) fs)
        * COMMANDLINE cl)
 Proof
-  xcf_with_def "main" main_v_def
+  rpt strip_tac
+  \\ xcf_with_def main_v_def
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ xlet_auto >- xsimpl
   \\ reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull)

--- a/compiler/repl/repl_moduleProgScript.sml
+++ b/compiler/repl/repl_moduleProgScript.sml
@@ -210,7 +210,8 @@ Theorem charsFrom_spec:
     (STDIO fs)
     (POSTv retv. STDIO fs * cond (LIST_TYPE CHAR content retv))
 Proof
-  xcf_with_def "Repl.charsFrom" (fetch "-" "Repl_charsFrom_v_def")
+  strip_tac
+  \\ xcf_with_def (fetch "-" "Repl_charsFrom_v_def")
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xlet ‘POSTv retv. STDIO fs *

--- a/examples/array_searchProgScript.sml
+++ b/examples/array_searchProgScript.sml
@@ -60,6 +60,7 @@ Theorem linear_search_spec:
               )
         )
 Proof
+    rpt strip_tac >>
     xcf "linear_search" (basis_st()) >>
     reverse (xfun_spec `search_aux`
         `∀ sublist sublist_vs offset offset_v .
@@ -342,6 +343,7 @@ Theorem binary_search_spec:
              )
         )
 Proof
+  rpt strip_tac >>
   xcf "binary_search" (basis_st()) >>
   reverse (xfun_spec `search_aux`
            `∀ sublist sublist_vs start finish start_v finish_v .

--- a/examples/catProgScript.sml
+++ b/examples/catProgScript.sml
@@ -235,6 +235,7 @@ Theorem cat1_spec:
           &UNIT_TYPE () u *
           STDIO (add_stdout fs (catfile_string fs fnm)))
 Proof
+  rpt strip_tac >>
   xcf "cat1" (get_ml_prog_state()) >>
   xhandle `POSTve
              (\u. SEP_EXISTS content ino. &UNIT_TYPE () u *

--- a/examples/diffProgScript.sml
+++ b/examples/diffProgScript.sml
@@ -107,7 +107,8 @@ Theorem diff'_spec:
          else add_stderr fs (notfound_string f2)
          else add_stderr fs (notfound_string f1)))
 Proof
-  xcf"diff'"(get_ml_prog_state())
+  rpt strip_tac
+  \\ xcf"diff'"(get_ml_prog_state())
   \\ xlet_auto_spec(SOME inputLinesFrom_spec)
   >- xsimpl
   \\ reverse(Cases_on `inFS_fname fs f1`) \\ fs[OPTION_TYPE_def]

--- a/examples/divScript.sml
+++ b/examples/divScript.sml
@@ -79,6 +79,7 @@ Proof
     \\ xif \\ fs[]
     \\ xlet_auto >- xsimpl
     \\ xvar \\ xsimpl \\ fs[INT_def] \\ intLib.COOPER_TAC)
+  \\ rpt strip_tac
   \\ xcf "condLoop" st
   \\ xlet_auto THEN1 xsimpl
   \\ xif \\ instantiate
@@ -228,7 +229,8 @@ Theorem put_char_spec:
     (POSTv v. &UNIT_TYPE () v *
               SIO input (SNOC (put_char_event c) events))
 Proof
-  xcf "put_char" st
+  rpt strip_tac
+  \\ xcf "put_char" st
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xlet
@@ -258,7 +260,8 @@ Theorem put_line_spec:
     (POSTv v. &UNIT_TYPE () v *
               SIO input (SNOC (put_str_event (l ++ "\n")) events))
 Proof
-  xcf "put_line" st
+  rpt strip_tac
+  \\ xcf "put_line" st
   \\ xlet_auto THEN1 xsimpl
   \\ xlet_auto THEN1 xsimpl
   \\ xlet_auto THEN1 xsimpl
@@ -290,7 +293,8 @@ Theorem get_char_spec:
                 SIO (THE (LTL input))
                     (SNOC (get_char_event (THE (LHD input))) events))
 Proof
-  xcf "get_char" st
+  rpt strip_tac
+  \\ xcf "get_char" st
   \\ qmatch_goalsub_abbrev_tac `_ * sio`
   \\ qabbrev_tac `a:word8 list = if input = [||] then
                                    [0w; 0w]

--- a/examples/divScript.sml
+++ b/examples/divScript.sml
@@ -55,7 +55,7 @@ Proof
   strip_tac \\ Cases_on `x`
   THEN1 (
     pop_assum (K ALL_TAC) \\ qid_spec_tac `n`
-    \\ Induct_on `n`
+    \\ Induct_on `n` \\ rpt strip_tac
     THEN1 (
       xcf "condLoop" st
       \\ xlet_auto THEN1 xsimpl
@@ -135,7 +135,7 @@ Theorem outerLoop_spec:
 Proof
   strip_tac \\ Cases_on `n <= 5000`
   THEN1 (
-    Induct_on `5000 - n`
+    Induct_on `5000 - n` \\ rw []
     THEN1 (
       xcf "outerLoop" st
       \\ xlet_auto THEN1 xsimpl

--- a/examples/doubleArgProgScript.sml
+++ b/examples/doubleArgProgScript.sml
@@ -24,7 +24,7 @@ Theorem double_spec:
         ⇒ app (p:'ffi ffi_proj) ^(fetch_v "double" (basis_st())) [x_v]
         emp (POSTv v. &(NUM (2 * x) v))
 Proof
-    Induct_on `x` >>
+    Induct_on `x` >> rw [] >>
     xcf "double" (basis_st())
     >- (xlet_auto
         >- xsimpl
@@ -63,6 +63,7 @@ Theorem double_tail_rec_spec:
         ⇒ app (p:'ffi ffi_proj) ^(fetch_v "double_tail_rec" (basis_st())) [x_v]
         emp (POSTv v. &(NUM (2 * x) v))
 Proof
+    rw [] >>
     xcf "double_tail_rec" (basis_st()) >>
     xlet_auto
         >- xsimpl >>
@@ -129,7 +130,7 @@ Theorem double_ref_spec:
                 (ret_ref ~~> ret_v) * &(NUM (2 * inp) ret_v))
         )
 Proof
-    Induct_on `inp` >>
+    Induct_on `inp` >> rw [] >>
     xcf "double_ref" (basis_st())
     >- (xlet_auto
         >- xsimpl
@@ -197,7 +198,7 @@ Theorem double_ref_same_spec:
             )
         )
 Proof
-    Induct_on `inp` >>
+    Induct_on `inp` >> rw [] >>
     xcf "double_ref_same" (basis_st())
     >- (
         xlet_auto

--- a/examples/filterProgScript.sml
+++ b/examples/filterProgScript.sml
@@ -795,6 +795,7 @@ Theorem forward_matching_lines_div_spec:
       (seL4_IO input [] * W8ARRAY dummyarr_loc [])
       (POSTd io. LFILTER is_emit io = LMAP (output_event_of o cut_at_null_w) (LFILTER (language o MAP (CHR o w2n) o cut_at_null_w) input))
 Proof
+  rpt strip_tac >>
   xcf "forward_matching_lines" st >>
   xlet_auto >- xsimpl >>
   xlet_auto >- xsimpl >>
@@ -1106,6 +1107,7 @@ Theorem forward_matching_lines_ffidiv_spec:
                    input))
       )
 Proof
+  rpt strip_tac >>
   xcf "forward_matching_lines" st >>
   xlet_auto >- xsimpl >>
   xlet_auto >- xsimpl >>

--- a/examples/grepProgScript.sml
+++ b/examples/grepProgScript.sml
@@ -553,7 +553,8 @@ Theorem print_matching_lines_in_file_spec:
                             (FILTER m (all_lines fs f))))
                    else add_stderr fs (notfound_string f)))
 Proof
-  xcf"print_matching_lines_in_file"(get_ml_prog_state())
+  rpt strip_tac
+  \\ xcf"print_matching_lines_in_file"(get_ml_prog_state())
   \\ reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull)
   \\ reverse(Cases_on`consistentFS fs`)
   >-(fs[STDIO_def,IOFS_def] >> xpull >> fs[wfFS_def,consistentFS_def] >> res_tac)

--- a/examples/insertSortProgScript.sml
+++ b/examples/insertSortProgScript.sml
@@ -116,6 +116,7 @@ Theorem insertsort_spec:
               PERM (ZIP (elems', elem_vs')) (ZIP (elems, elem_vs)) ∧
               SORTED (\x y. ¬(cmp y x)) elems'))
 Proof
+  rpt strip_tac >>
   xcf "insertsort" insertsort_st >>
   xfun_spec `outer_loop`
     `!elem_vs2 elems1 elems2 elem_vs1 prefix_v.

--- a/examples/lpr_checker/array/lpr_arrayFullProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayFullProgScript.sml
@@ -72,6 +72,7 @@ Theorem parse_dimacs_body_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rpt strip_tac
   \\ xcf "parse_dimacs_body_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.
@@ -193,6 +194,7 @@ Theorem parse_dimacs_toks_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rpt strip_tac
   \\ xcf "parse_dimacs_toks_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.
@@ -1673,6 +1675,7 @@ Theorem check_unsat_spec:
        STDIO (add_stdout (add_stderr fs err) out) *
        &(check_unsat_sem cl fs out))
 Proof
+  rw[]>>
   xcf"check_unsat"(get_ml_prog_state())>>
   reverse (Cases_on `STD_streams fs`) >- (fs [TextIOProofTheory.STDIO_def] \\ xpull) >>
   reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)>>

--- a/examples/lpr_checker/array/lpr_arrayPackingProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayPackingProgScript.sml
@@ -147,6 +147,7 @@ Theorem main_spec:
     (POSTv uv. &UNIT_TYPE () uv *
     COMMANDLINE cl * SEP_EXISTS err. STDIO (main_sem cl fs err))
 Proof
+  rw[]>>
   xcf"main"(get_ml_prog_state())>>
   reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)>>
   rpt xlet_autop >>

--- a/examples/lpr_checker/array/lpr_arrayParsingProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayParsingProgScript.sml
@@ -214,6 +214,7 @@ Theorem parse_one_u_spec:
             parse_one_u lines = NONE
            )))
 Proof
+  rw[]>>
   xcf "parse_one_u" (get_ml_prog_state ())>>
   Cases_on`lines`
   >- (
@@ -377,6 +378,7 @@ Theorem parse_one_c_spec:
             parse_one_c lines = NONE
            )))
 Proof
+  rw[]>>
   xcf "parse_one_c" (get_ml_prog_state ())>>
   xlet ‘(POSTv v.
    SEP_EXISTS k.
@@ -482,6 +484,7 @@ Theorem parse_one_spec:
             parse_one b lines = NONE
            )))
 Proof
+  rw[]>>
   xcf "parse_one" (get_ml_prog_state ())>>
   simp[term_char_def,parse_one_def]>>xif>>
   xapp>>metis_tac[]
@@ -738,6 +741,7 @@ Theorem check_unsat'_spec:
           b = contains_clauses_list_err fml' inds' cls
       ))
 Proof
+  rw[]>>
   xcf"check_unsat'"(get_ml_prog_state()) >>
   reverse (Cases_on `STD_streams fs`)
   >- (fs [TextIOProofTheory.STDIO_def] \\ xpull) >>

--- a/examples/lpr_checker/array/lpr_arrayProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayProgScript.sml
@@ -107,7 +107,8 @@ Theorem every_one_arr_spec:
       W8ARRAY Carrv Clist *
       &BOOL (EVERY (λi. any_el (index i) Clist w8z = w8o) ls) v)
 Proof
-  Induct>>xcf "every_one_arr" (get_ml_prog_state ())>>
+  Induct>>rw[]>>
+  xcf "every_one_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >-
     (xmatch>>xcon>>xsimpl)
@@ -138,6 +139,7 @@ Theorem delete_literals_sing_arr_spec:
       (λe. &(Fail_exn e ∧ delete_literals_sing_list Clist ls = NONE)))
 Proof
   Induct>>simp[delete_literals_sing_list_def]>>
+  rpt strip_tac>>
   xcf "delete_literals_sing_arr" (get_ml_prog_state ())
   >- (
     fs[LIST_TYPE_def]>>
@@ -226,7 +228,8 @@ Theorem is_AT_arr_aux_spec:
           (is_AT_list_aux fmlls ls c Clist) v)
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ is_AT_list_aux fmlls ls c Clist = NONE)))
 Proof
-  Induct>>xcf "is_AT_arr_aux" (get_ml_prog_state ())>>
+  Induct>>rw[]>>
+  xcf "is_AT_arr_aux" (get_ml_prog_state ())>>
   simp[is_AT_list_aux_def]
   >- (
     fs[LIST_TYPE_def]>>
@@ -310,6 +313,7 @@ Theorem set_array_spec:
           W8ARRAY Carrv (set_list Clist v c))
 Proof
   Induct>>
+  rw[]>>
   xcf "set_array" (get_ml_prog_state ())>>
   rw[set_list_def]>>
   fs[LIST_TYPE_def]
@@ -430,6 +434,7 @@ Theorem is_AT_arr_spec:
           (is_AT_list fmlls ls c Clist) v)
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ is_AT_list fmlls ls c Clist = NONE)))
 Proof
+  rw[]>>
   xcf "is_AT_arr" (get_ml_prog_state ())>>
   `WORD8 w8z w8z_v ∧ WORD8 w8o w8o_v` by
     simp[w8z_v_thm,w8o_v_thm]>>
@@ -510,7 +515,9 @@ Theorem check_RAT_arr_spec:
           ))
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ check_RAT_list fmlls Clist pp c ik i ci = NONE)))
 Proof
-  simp[check_RAT_list_def]>>  xcf "check_RAT_arr" (get_ml_prog_state ())>>
+  simp[check_RAT_list_def]>>
+  rpt strip_tac>>
+  xcf "check_RAT_arr" (get_ml_prog_state ())>>
   fs[MEMBER_INTRO]>>
   xlet_autop>>
   reverse xif
@@ -619,6 +626,7 @@ Theorem check_PR_arr_spec:
           ))
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ check_PR_list fmlls Clist w c ik i ci = NONE)))
 Proof
+  rw[]>>
   xcf "check_PR_arr" (get_ml_prog_state ())>>
   simp[check_PR_list_def]>>
   xlet_autop>>
@@ -784,6 +792,7 @@ Theorem every_check_RAT_inds_arr_spec:
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ every_check_RAT_inds_list fmlls Clist pp c ik mini ls acc = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf "every_check_RAT_inds_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def,every_check_RAT_inds_list_def]>>
   xmatch >- (
@@ -869,6 +878,7 @@ Theorem every_check_PR_inds_arr_spec:
       (λe. ARRAY fmlv fmllsv * &(Fail_exn e ∧ every_check_PR_inds_list fmlls Clist w c ik mini ls acc = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf "every_check_PR_inds_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def,every_check_PR_inds_list_def]>>
   xmatch >- (
@@ -1126,6 +1136,7 @@ Theorem resize_carr_spec:
     (POSTv carrv.
       W8ARRAY carrv (resize_Clist c Clist))
 Proof
+  rw[]>>
   xcf "resize_carr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   simp[resize_Clist_def]>>xif
@@ -1242,7 +1253,8 @@ Theorem check_earliest_arr_spec:
        ARRAY fmlv fmllsv *
        &(BOOL (check_earliest fmlls x old new is) v))
 Proof
-  Induct>>xcf "check_earliest_arr" (get_ml_prog_state ())>>
+  Induct>>rw[]>>
+  xcf "check_earliest_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def,check_earliest_def]
   >- (
     xmatch>>xcon>>

--- a/examples/lpr_checker/array/lpr_arrayRamseyProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayRamseyProgScript.sml
@@ -292,6 +292,7 @@ Theorem check_unsat_spec:
       STDIO (add_stdout (add_stderr fs err) out) *
       &(check_unsat_sem cl fs out))
 Proof
+  rw[]>>
   xcf"check_unsat"(get_ml_prog_state())>>
   reverse (Cases_on `STD_streams fs`) >- (fs [TextIOProofTheory.STDIO_def] \\ xpull) >>
   reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)>>

--- a/examples/lpr_checker/array/lpr_composeProgScript.sml
+++ b/examples/lpr_checker/array/lpr_composeProgScript.sml
@@ -220,7 +220,7 @@ Theorem line_count_of_spec:
       & (OPTION_TYPE NUM (SOME (LENGTH (lines_of (strlit proof)))) retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "line_count_of" (fetch "-" "line_count_of_v_def")
+  \\ xcf_with_def (fetch "-" "line_count_of_v_def")
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ assume_tac add_one_v
   \\ drule_at Any TextIOProofTheory.foldLines_SOME
@@ -275,7 +275,7 @@ Theorem check_compose_spec:
       & (UNIT_TYPE () retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "check_compose" (fetch "-" "check_compose_v_def")
+  \\ xcf_with_def (fetch "-" "check_compose_v_def")
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ rw []
   \\ xlet ‘(POSTv retv. STDIO fs * &OPTION_TYPE STRING_TYPE
@@ -338,7 +338,7 @@ Theorem check_compose_spec_fail:
         STDIO (add_stderr fs err))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "check_compose" (fetch "-" "check_compose_v_def")
+  \\ xcf_with_def (fetch "-" "check_compose_v_def")
   \\ reverse (Cases_on ‘STD_streams fs’)
   THEN1 (fs [STDIO_def] \\ xpull)
   \\ reverse (Cases_on ‘consistentFS fs’)

--- a/examples/md5ProgScript.sml
+++ b/examples/md5ProgScript.sml
@@ -115,7 +115,7 @@ Theorem md5_of_SOME:
                       retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "md5_of" md5_of_v_def
+  \\ xcf_with_def md5_of_v_def
   \\ assume_tac md5_update_v
   \\ assume_tac init_v
   \\ drule_all (foldChars_SOME |> GEN_ALL)
@@ -144,7 +144,7 @@ Theorem md5_of_NONE:
                  & (OPTION_TYPE STRING_TYPE (SOME (implode (md5 text))) retv))
 Proof
   rpt strip_tac
-  \\ xcf_with_def "md5_of" md5_of_v_def
+  \\ xcf_with_def md5_of_v_def
   \\ assume_tac md5_update_v
   \\ assume_tac init_v
   \\ drule_all (foldChars_NONE |> GEN_ALL)

--- a/examples/opentheory/readerProgScript.sml
+++ b/examples/opentheory/readerProgScript.sml
@@ -81,7 +81,7 @@ Theorem l2c_aux_spec:
 Proof
   Induct_on ‘linesFD fs fd’
   \\ rpt strip_tac
-  \\ xcf_with_def "l2c_aux" (fetch "-" "l2c_aux_v_def")
+  \\ xcf_with_def (fetch "-" "l2c_aux_v_def")
   \\ qpat_x_assum ‘_ = linesFD fs fd’ (assume_tac o SYM) \\ fs []
   \\ ‘IS_SOME (get_file_content fs fd)’
       by fs []
@@ -133,7 +133,7 @@ Theorem l2c_spec:
         STDIO (fastForwardFD fs fd))
 Proof
   strip_tac
-  \\ xcf_with_def "l2c" (fetch "-" "l2c_v_def")
+  \\ xcf_with_def (fetch "-" "l2c_v_def")
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ xapp
   \\ Q.LIST_EXISTS_TAC [‘emp’, ‘[]’]
@@ -175,7 +175,7 @@ Theorem l2c_from_spec:
         STDIO fs)
 Proof
   strip_tac
-  \\ xcf_with_def "l2c_from" (fetch "-" "l2c_from_v_def")
+  \\ xcf_with_def (fetch "-" "l2c_from_v_def")
   \\ ‘CARD (set (MAP FST fs.infds)) < fs.maxFD’
     by fs []
   \\ reverse (Cases_on ‘STD_streams fs’)
@@ -301,7 +301,8 @@ Theorem read_stdin_spec:
         STDIO (FST (read_stdin fs refs)) *
         HOL_STORE (FST (SND (read_stdin fs refs))))
 Proof
-  xcf_with_def "read_stdin" (fetch "-" "read_stdin_v_def")
+  strip_tac
+  \\ xcf_with_def (fetch "-" "read_stdin_v_def")
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [STDIO_def] \\ xpull)
   \\ fs [UNIT_TYPE_def, read_stdin_def]
@@ -395,7 +396,8 @@ Theorem read_file_spec:
         STDIO (FST (read_file fs refs fnm)) *
         HOL_STORE (FST (SND (read_file fs refs fnm))))
 Proof
-  xcf_with_def "read_file" (fetch "-" "read_file_v_def")
+  strip_tac
+  \\ xcf_with_def (fetch "-" "read_file_v_def")
   \\ reverse (Cases_on `STD_streams fs`)
   >- (fs [TextIOProofTheory.STDIO_def] \\ xpull)
   \\ reverse (Cases_on`consistentFS fs`)
@@ -498,7 +500,8 @@ Theorem reader_main_spec:
         &UNIT_TYPE () u *
         STDIO (FST (reader_main fs refs (TL cl))))
 Proof
-  xcf_with_def "reader_main" (fetch "-" "reader_main_v_def")
+  strip_tac
+  \\ xcf_with_def (fetch "-" "reader_main_v_def")
   \\ reverse (Cases_on ‘wfcl cl’)
   >- (simp [COMMANDLINE_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)

--- a/examples/patchProgScript.sml
+++ b/examples/patchProgScript.sml
@@ -130,7 +130,8 @@ Theorem patch'_spec:
         else add_stderr fs (notfound_string f2)
         else add_stderr fs (notfound_string f1)))
 Proof
-  xcf"patch'"(get_ml_prog_state())
+  strip_tac
+  \\ xcf"patch'"(get_ml_prog_state())
   \\ xlet_auto >- xsimpl
   \\ reverse(Cases_on `inFS_fname fs f1`) \\ fs [OPTION_TYPE_def] \\ xmatch
   >- (xlet_auto >- xsimpl

--- a/examples/pseudo_bool/array/cnfProgScript.sml
+++ b/examples/pseudo_bool/array/cnfProgScript.sml
@@ -83,6 +83,7 @@ Theorem parse_dimacs_body_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rpt strip_tac
   \\ xcf "parse_dimacs_body_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.
@@ -204,6 +205,7 @@ Theorem parse_dimacs_toks_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rw[]
   \\ xcf "parse_dimacs_toks_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.

--- a/examples/pseudo_bool/array/npbc_arrayProgScript.sml
+++ b/examples/pseudo_bool/array/npbc_arrayProgScript.sml
@@ -868,6 +868,7 @@ Theorem resize_to_fit_spec:
       )
     )
 Proof
+  rw[]>>
   xcf"resize_to_fit"(get_ml_prog_state ())>>
   rpt xlet_autop>>
   xif>>
@@ -905,6 +906,7 @@ Theorem update_assg_arr_spec:
       )
     )
 Proof
+  rw[]>>
   xcf"update_assg_arr"(get_ml_prog_state ())>>
   Cases_on`lsn`>>gvs[PAIR_TYPE_def]>>
   xmatch>>
@@ -949,6 +951,7 @@ Theorem get_rup_constraint_arr_spec:
         OPTION_TYPE constraint_TYPE
         (get_rup_constraint_list b fmlls n nc) v))
 Proof
+  rw[]>>
   xcf"get_rup_constraint_arr"(get_ml_prog_state ())>>
   xlet_autop>>
   xif>>gvs[]
@@ -1107,6 +1110,7 @@ Theorem check_rup_arr_spec:
       )
     )
 Proof
+  rw[]>>
   xcf"check_rup_arr"(get_ml_prog_state ())>>
   gvs[check_rup_list_def]>>
   rpt(pairarg_tac>>gvs[])>>
@@ -1455,6 +1459,7 @@ Theorem reindex_aux_arr_spec:
         (reindex_aux fmlls inds iacc) v))
 Proof
   Induct>>
+  rw[]>>
   xcf"reindex_aux_arr"(get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >- (
@@ -1496,6 +1501,7 @@ Theorem reindex_arr_spec:
       &(LIST_TYPE NUM
         (reindex fmlls inds) v))
 Proof
+  rw[]>>
   xcf"reindex_arr"(get_ml_prog_state ())>>
   rpt xlet_autop>>
   xapp>>
@@ -1544,6 +1550,7 @@ Theorem revalue_aux_arr_spec:
         (revalue_aux b fmlls inds vacc) v))
 Proof
   Induct>>
+  rw[]>>
   xcf"revalue_aux_arr"(get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >- (
@@ -1585,6 +1592,7 @@ Theorem revalue_arr_spec:
       &(LIST_TYPE constraint_TYPE
         (revalue b fmlls inds) v))
 Proof
+  rw[]>>
   xcf"revalue_arr"(get_ml_prog_state ())>>
   rpt xlet_autop>>
   xapp>>
@@ -1776,6 +1784,7 @@ Theorem extract_clauses_arr_spec:
           extract_clauses_list s b fmlls rsubs pfs acc = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf"extract_clauses_arr"(get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >- (
@@ -1873,6 +1882,7 @@ Theorem subst_indexes_arr_spec:
       &(LIST_TYPE (PAIR_TYPE NUM constraint_TYPE) (subst_indexes s b fmlls is) v))
 Proof
   Induct>>
+  rw[]>>
   xcf"subst_indexes_arr"(get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >- (
@@ -3125,6 +3135,7 @@ Theorem core_fmlls_arr_spec:
           (core_fmlls fmlls inds) v))
 Proof
   Induct>>
+  rw[]>>
   xcf "core_fmlls_arr" (get_ml_prog_state ())>>
   simp[core_fmlls_def]>>
   fs[LIST_TYPE_def]>>xmatch
@@ -3435,6 +3446,7 @@ Theorem core_from_inds_arr_spec:
          core_from_inds fmlls inds = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf "core_from_inds_arr" (get_ml_prog_state ())>>
   simp[core_from_inds_def]>>
   fs[LIST_TYPE_def]>>xmatch
@@ -3492,6 +3504,7 @@ Theorem all_core_arr_spec:
         (all_core_list fmlls inds iacc) v))
 Proof
   Induct>>
+  rw[]>>
   xcf"all_core_arr"(get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >- (
@@ -3830,11 +3843,12 @@ Theorem fold_update_resize_bitset_spec:
         W8ARRAY v (FOLDL (λacc (c,i). update_resize acc w8z w8o i) accls ls))
 Proof
   Induct>>
+  rw[]>>
   xcf "fold_update_resize_bitset" (get_ml_prog_state ())>>
   gvs[LIST_TYPE_def]>>xmatch
   >- (
     xvar>>xsimpl)>>
-  pairarg_tac>>fs[PAIR_TYPE_def]>>
+  Cases_on`h`>>fs[PAIR_TYPE_def]>>
   xmatch>>
   assume_tac w8o_v_thm>>
   assume_tac w8z_v_thm>>
@@ -3843,10 +3857,11 @@ Proof
   >- (
     xlet_autop>>
     xapp>>xsimpl>>
-    simp[update_resize_def])>>
+    simp[Once update_resize_def,SimpRHS]>>
+    simp[ELIM_UNCURRY])>>
   rpt xlet_autop>>
   xapp>>xsimpl>>
-  simp[update_resize_def]
+  simp[update_resize_def,ELIM_UNCURRY]
 QED
 
 val mk_vomap_arr = process_topdecs`

--- a/examples/pseudo_bool/array/npbc_arrayProgScript.sml
+++ b/examples/pseudo_bool/array/npbc_arrayProgScript.sml
@@ -316,6 +316,7 @@ Theorem delete_arr_spec:
       ARRAY fmlv fmllsv' *
       &(LIST_REL (OPTION_TYPE a) (delete_list i fmlls) fmllsv') )
 Proof
+  rw[]>>
   xcf "delete_arr" (get_ml_prog_state ())>>
   simp[delete_list_def]>>
   xlet_autop>>
@@ -406,6 +407,7 @@ Theorem rollback_arr_spec:
       ARRAY fmlv fmllsv' *
       &(LIST_REL (OPTION_TYPE a) (rollback fmlls start end) fmllsv') )
 Proof
+  rw[]>>
   xcf"rollback_arr"(get_ml_prog_state ())>>
   xlet_autop>>
   xapp>>
@@ -493,7 +495,8 @@ Proof
   rw[check_contradiction_fml_list_def]>>
   xcf"check_contradiction_fml_arr"(get_ml_prog_state ())>>
   xlet_autop>>
-  TOP_CASE_TAC>>fs[OPTION_TYPE_def]>>
+  Cases_on`lookup_core_only_list b fmlls n`>>
+  fs[OPTION_TYPE_def]>>
   xmatch
   >- (
     xcon>>

--- a/examples/pseudo_bool/array/npbc_arrayProgScript.sml
+++ b/examples/pseudo_bool/array/npbc_arrayProgScript.sml
@@ -3857,11 +3857,10 @@ Proof
   >- (
     xlet_autop>>
     xapp>>xsimpl>>
-    simp[Once update_resize_def,SimpRHS]>>
-    simp[ELIM_UNCURRY])>>
+    simp[update_resize_def])>>
   rpt xlet_autop>>
   xapp>>xsimpl>>
-  simp[update_resize_def,ELIM_UNCURRY]
+  simp[update_resize_def]
 QED
 
 val mk_vomap_arr = process_topdecs`

--- a/examples/pseudo_bool/array/npbc_fullProgScript.sml
+++ b/examples/pseudo_bool/array/npbc_fullProgScript.sml
@@ -103,7 +103,9 @@ Proof
     xlet_autop>>
     `toks = (MAP tokenize ∘ tokens blanks)` by
       metis_tac[toks_def,ETA_AX,o_DEF]>>
-    rw[parse_pbf_def]>> TOP_CASE_TAC>>
+    rw[parse_pbf_def]>>
+    qmatch_goalsub_abbrev_tac`option_CASE AAA`>>
+    Cases_on`AAA`>>
     fs[OPTION_TYPE_def]
     >- (
       xmatch >>

--- a/examples/pseudo_bool/array/npbc_parseProgScript.sml
+++ b/examples/pseudo_bool/array/npbc_parseProgScript.sml
@@ -795,6 +795,7 @@ Theorem parse_sstep_spec:
            &(Fail_exn e ∧ parse_sstep fns ss = NONE))
       )
 Proof
+  rpt strip_tac>>
   xcf "parse_sstep" (get_ml_prog_state ())>>
   Cases_on`ss`>>simp[parse_sstep_def]
   >- (
@@ -2162,6 +2163,7 @@ Theorem parse_cstep_spec:
            &(Fail_exn e ∧ parse_cstep fns ss = NONE))
       )
 Proof
+  rw[]>>
   xcf "parse_cstep" (get_ml_prog_state ())>>
   xlet`(POSTve
       (λv.
@@ -3395,6 +3397,7 @@ Theorem check_header_spec:
        INSTREAM_LINES #"\n" fd fdv lines' (forwardFD fs fd k) *
        &(OPTION_TYPE NUM res v))
 Proof
+  rw[]>>
   xcf "check_header" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   xlet ‘(POSTv v.
@@ -3484,6 +3487,7 @@ Theorem check_unsat_top_spec:
         sem_output (set fml) obj bound (set fmlt) objt output
       | INL l => T))
 Proof
+  rw[]>>
   xcf"check_unsat_top"(get_ml_prog_state()) >>
   reverse (Cases_on `STD_streams fs`)
   >- (fs [TextIOProofTheory.STDIO_def] \\ xpull) >>
@@ -3706,6 +3710,7 @@ Theorem check_unsat_top_norm_spec:
           (set (SND objft)) (FST objft) output
        | INL l => T))
 Proof
+  rw[]>>
   xcf"check_unsat_top_norm"(get_ml_prog_state()) >>
   xlet_autop>>
   `∃obj fml objt fmlt t.

--- a/examples/pseudo_bool/array/wcnfProgScript.sml
+++ b/examples/pseudo_bool/array/wcnfProgScript.sml
@@ -84,6 +84,7 @@ Theorem parse_wcnf_toks_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rw[]
   \\ xcf "parse_wcnf_toks_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.

--- a/examples/queueProgScript.sml
+++ b/examples/queueProgScript.sml
@@ -134,6 +134,7 @@ Theorem empty_queue_spec:
       app (p:'ffi ffi_proj) ^(fetch_v "empty_queue" st) [nv; errv]
           emp (POSTv qv. QUEUE A n [] qv)
 Proof
+    strip_tac \\
     xcf "empty_queue" st \\
     xs_auto_tac >> simp[QUEUE_def] >> xsimpl >>
     qexists_tac `REPLICATE n a` >>
@@ -166,6 +167,7 @@ Theorem enqueue_spec:
           (QUEUE A mx vs qv * & (A x xv ∧ LENGTH vs < mx))
           (POSTv uv. QUEUE A mx (vs ++ [x]) qv)
 Proof
+    rpt strip_tac >>
     xcf "enqueue" st >>
     xpull >> xs_auto_tac >>
     xlet ‘POSTv bv. QUEUE A mx vs qv * &(BOOL (LENGTH vs = mx) bv)’
@@ -204,6 +206,7 @@ val dequeue_spec_noexn = Q.prove(
     `!qv xv vs x. app (p:'ffi ffi_proj) ^(fetch_v "dequeue" st) [qv]
           (QUEUE A mx vs qv * &(vs ≠ []))
           (POSTv v. &(A (HD vs) v) * QUEUE A mx (TL vs) qv)`,
+    rpt strip_tac >>
     xcf "dequeue" st >> simp[QUEUE_def] >> xpull >> xs_auto_tac >>
     reverse(rw[]) >- EVAL_TAC >> xlet_auto >- xsimpl >> xif >>
     qexists_tac `F` >> simp[] >> xs_auto_tac
@@ -225,6 +228,7 @@ Theorem dequeue_spec:
        (POSTve (λv. &(vs ≠ [] ∧ A (HD vs) v) * QUEUE A mx (TL vs) qv)
                (λe. &(vs = [] ∧ EmptyQueue_exn e) * QUEUE A mx vs qv))
 Proof
+  rpt strip_tac >>
   xcf "dequeue" st >> simp[QUEUE_def] >> xpull >> xs_auto_tac >>
   reverse(rw[]) >- EVAL_TAC >> xlet_auto >- xsimpl >> xif
   >- ((* throws exception *)

--- a/examples/quicksortProgScript.sml
+++ b/examples/quicksortProgScript.sml
@@ -265,6 +265,7 @@ Theorem partition_spec:
         ARRAY arr_v (elem_vs1 ++ part1 ++ part2 ++ elem_vs3) *
         &(partition_pred cmp (LENGTH elem_vs1) p_v pivot elems2 elem_vs2 part1 part2))
 Proof
+  rpt strip_tac >>
   xcf "partition" (basis_st()) >>
   qmatch_assum_abbrev_tac `INT (&lower) lower_v` >>
   qmatch_assum_abbrev_tac `INT (&upper) upper_v` >>
@@ -1030,6 +1031,7 @@ Theorem quicksort_spec:
               (* We use "not greater than" as equivalent to "less or equal" *)
               SORTED (\x y. ¬(cmp y x)) elems'))
 Proof
+  rpt strip_tac >>
   xcf "quicksort" (basis_st()) >>
   (* The loop invariant for the main loop. Note that we have to quantify over
    * what's in the array because it changes on the recursive calls. *)

--- a/examples/sortProgScript.sml
+++ b/examples/sortProgScript.sml
@@ -346,6 +346,7 @@ Theorem sort_spec:
         &UNIT_TYPE () uv *
           STDIO (sort_sem cl fs) * COMMANDLINE cl)
 Proof
+  strip_tac >>
   xcf "sort" (get_ml_prog_state ()) >>
   xmatch >>
   qabbrev_tac `fnames = TL cl` >>

--- a/examples/stackProgScript.sml
+++ b/examples/stackProgScript.sml
@@ -61,6 +61,7 @@ Theorem empty_stack_spec':
      !uv. app (p:'ffi ffi_proj) ^(fetch_v "empty_stack" st) [uv]
           emp (POSTv qv. STACK A [] qv)
 Proof
+    strip_tac \\
     xcf "empty_stack" st \\
     xlet `POSTv v. &UNIT_TYPE () v` THEN1(xcon \\ xsimpl) \\
     xlet `POSTv av. ARRAY av []` THEN1(xapp \\ fs[]) \\
@@ -74,7 +75,9 @@ Theorem empty_stack_spec:
      !uv. app (p:'ffi ffi_proj) ^(fetch_v "empty_stack" st) [uv]
           emp (POSTv qv. STACK A [] qv)
 Proof
-    xcf "empty_stack" st >> simp[STACK_def] >> xs_auto_tac
+    strip_tac >>
+    xcf "empty_stack" st >> xs_auto_tac >> simp[STACK_def] >>
+    xs_auto_tac
 QED
 
 Theorem push_spec':
@@ -82,6 +85,7 @@ Theorem push_spec':
           (STACK A vs qv * & A x xv)
           (POSTv uv. STACK A (vs ++ [x]) qv)
 Proof
+    rpt strip_tac >>
     xcf "push" st >>
     simp[STACK_def] >>
     xpull >>
@@ -133,6 +137,7 @@ Theorem push_spec:
           (STACK A vs qv * & A x xv)
           (POSTv uv. STACK A (vs ++ [x]) qv)
 Proof
+    rpt strip_tac >>
     xcf "push" st >>
     simp[STACK_def] >>
     xpull >>
@@ -175,6 +180,7 @@ Theorem pop_spec:
    (POSTve (\v. &(not(NULL vs) /\ A (LAST vs) v) * STACK A (FRONT vs) qv)
            (\e. &(NULL vs /\ EmptyStack_exn e) * STACK A vs qv))
 Proof
+   rpt strip_tac >>
    xcf "pop" st >>
    simp[STACK_def] >>
    xpull >>

--- a/examples/vipr/viprProgScript.sml
+++ b/examples/vipr/viprProgScript.sml
@@ -154,7 +154,7 @@ Theorem main_spec_stdin:
                 COMMANDLINE cl)
 Proof
   strip_tac
-  \\ xcf_with_def () main_v_def
+  \\ xcf_with_def main_v_def
   \\ reverse $ xhandle ‘(POSTv uv. &UNIT_TYPE () uv *
                 STDIO (add_stdout (fastForwardFD fs 0) $
                          run_vipr (lines_of (implode text))) *
@@ -214,7 +214,7 @@ Theorem main_spec_file:
                 COMMANDLINE cl)
 Proof
   strip_tac
-  \\ xcf_with_def () main_v_def
+  \\ xcf_with_def main_v_def
   \\ reverse $ xhandle ‘(POSTv uv. &UNIT_TYPE () uv *
                 STDIO (add_stdout fs $
                          run_vipr (lines_of (implode text))) *

--- a/examples/xlrup_checker/array/xlrup_arrayFullProgScript.sml
+++ b/examples/xlrup_checker/array/xlrup_arrayFullProgScript.sml
@@ -91,6 +91,7 @@ Theorem parse_body_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rpt strip_tac
   \\ xcf "parse_body_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.
@@ -221,6 +222,7 @@ Theorem parse_cnf_xor_toks_arr_spec:
 Proof
   Induct
   \\ simp []
+  \\ rpt strip_tac
   \\ xcf "parse_cnf_xor_toks_arr" (get_ml_prog_state ())
   THEN1 (
     xlet ‘(POSTv v.
@@ -947,6 +949,7 @@ Theorem check_unsat_spec:
      (POSTv uv. &UNIT_TYPE () uv *
      COMMANDLINE cl * SEP_EXISTS err. STDIO (check_unsat_sem cl fs err))
 Proof
+  rw[]>>
   xcf"check_unsat"(get_ml_prog_state())>>
   reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)>>
   rpt xlet_autop >>

--- a/examples/xlrup_checker/array/xlrup_arrayProgScript.sml
+++ b/examples/xlrup_checker/array/xlrup_arrayProgScript.sml
@@ -150,7 +150,8 @@ Theorem every_one_arr_spec:
       W8ARRAY Carrv Clist *
       &BOOL (EVERY (λi. list_lookup Clist w8z (index i) = w8o) ls) v)
 Proof
-  Induct>>xcf "every_one_arr" (get_ml_prog_state ())>>
+  Induct>>rw[]>>
+  xcf "every_one_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def]
   >-
     (xmatch>>xcon>>xsimpl)
@@ -182,6 +183,7 @@ Theorem delete_literals_sing_arr_spec:
       (λe. &(Fail_exn e ∧ delete_literals_sing_list Clist ls = NONE)))
 Proof
   Induct>>simp[delete_literals_sing_list_def]>>
+  rpt strip_tac>>
   xcf "delete_literals_sing_arr" (get_ml_prog_state ())
   >- (
     fs[LIST_TYPE_def]>>
@@ -279,7 +281,9 @@ Theorem is_rup_arr_aux_spec:
       (λe. ARRAY fmlv fmllsv *
         &(Fail_exn e ∧ is_rup_list_aux fmlls ls c Clist = NONE)))
 Proof
-  Induct>>xcf "is_rup_arr_aux" (get_ml_prog_state ())>>
+  Induct>>
+  rw[]>>
+  xcf "is_rup_arr_aux" (get_ml_prog_state ())>>
   simp[is_rup_list_aux_def]
   >- (
     fs[LIST_TYPE_def]>>
@@ -371,6 +375,7 @@ Theorem set_array_spec:
           W8ARRAY Carrv (set_list Clist v c))
 Proof
   Induct>>
+  rw[]>>
   xcf "set_array" (get_ml_prog_state ())>>
   rw[set_list_def]>>
   fs[LIST_TYPE_def]
@@ -487,6 +492,7 @@ Theorem is_rup_arr_spec:
       (λe. ARRAY fmlv fmllsv *
         &(Fail_exn e ∧ is_rup_list fmlls ls c Clist = NONE)))
 Proof
+  rw[]>>
   xcf "is_rup_arr" (get_ml_prog_state ())>>
   `WORD8 w8z w8z_v ∧ WORD8 w8o w8o_v` by
     simp[w8z_v_thm,w8o_v_thm]>>
@@ -634,6 +640,7 @@ Theorem add_xors_aux_c_arr_spec:
         &(Fail_exn e ∧ add_xors_aux_c_list fmlls ls cs = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf "add_xors_aux_c_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def]>>xmatch
   >- (
@@ -720,6 +727,7 @@ Theorem get_bit_arr_spec:
     (W8ARRAY csv cs)
     (POSTv v. W8ARRAY csv cs * & BOOL (get_bit_list cs n) v)
 Proof
+  rw[]>>
   xcf "get_bit_arr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   xapp>>xsimpl>>
@@ -750,6 +758,7 @@ Theorem set_bit_arr_spec:
       &UNIT_TYPE () v *
       W8ARRAY csv (set_bit_list cs n b))
 Proof
+  rw[]>>
   xcf "set_bit_arr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   xapp>>xsimpl>>
@@ -805,6 +814,7 @@ Theorem flip_bit_arr_spec:
       &UNIT_TYPE () v *
       W8ARRAY csv (flip_bit_list cs n))
 Proof
+  rw[]>>
   xcf "flip_bit_arr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   xapp>>xsimpl>>
@@ -853,6 +863,7 @@ Theorem unit_prop_xor_arr_spec:
         &(UNIT_TYPE () v) *
         W8ARRAY csv (unit_prop_xor_list t l cs))
 Proof
+  rw[]>>
   xcf "unit_prop_xor_arr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   fs[unit_prop_xor_list_def,nabs_def,OPTION_TYPE_SPLIT]>>
@@ -926,6 +937,7 @@ Theorem unit_props_xor_arr_spec:
         &(Fail_exn e ∧ unit_props_xor_list fmlls t ls cs = NONE)))
 Proof
   Induct>>
+  rw[]>>
   xcf "unit_props_xor_arr" (get_ml_prog_state ())>>
   fs[LIST_TYPE_def]>>xmatch
   >- (
@@ -1132,6 +1144,7 @@ Theorem is_xor_arr_spec:
          ARRAY fmlv fmllsv * ARRAY cfmlv cfmllsv *
          &(Fail_exn e ∧ ¬is_xor_list def fmlls ls cfmlls cls (FST tn) s)))
 Proof
+  rw[]>>
   xcf "is_xor_arr" (get_ml_prog_state ())>>
   rw[is_xor_list_def]>>
   assume_tac w8z_v_thm>>
@@ -1266,6 +1279,7 @@ Theorem resize_carr_spec:
     (POSTv carrv.
       W8ARRAY carrv (resize_Clist c Clist))
 Proof
+  rw[]>>
   xcf "resize_carr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   simp[resize_Clist_def]>>xif
@@ -1304,6 +1318,7 @@ Theorem extend_s_arr_spec:
       W8ARRAY v cs' *
       &(extend_s_list cs n = cs'))
 Proof
+  rw[]>>
   xcf "extend_s_arr" (get_ml_prog_state ())>>
   rpt xlet_autop>>
   simp[extend_s_list_def]>>
@@ -1345,6 +1360,7 @@ Theorem conv_xor_aux_arr_spec:
       &(conv_xor_aux_list cs xs = cs'))
 Proof
   Induct>>
+  rw[]>>
   xcf "conv_xor_aux_arr" (get_ml_prog_state ())>>
   fs[conv_xor_aux_list_def,LIST_TYPE_def]>>xmatch
   >-
@@ -1388,6 +1404,7 @@ Theorem conv_rawxor_arr_spec:
     (POSTv v.
       &(STRING_TYPE (conv_rawxor_list n xs) v))
 Proof
+  rw[]>>
   xcf "conv_rawxor_arr" (get_ml_prog_state ())>>
   assume_tac w8z_v_thm>>
   xlet_autop>>
@@ -1468,6 +1485,7 @@ Theorem is_cfromx_arr_spec:
          ARRAY fmlv fmllsv *
          &(Fail_exn e ∧ ¬is_cfromx_list def fmlls ls s)))
 Proof
+  rw[]>>
   xcf "is_cfromx_arr" (get_ml_prog_state ())>>
   rw[is_cfromx_list_def]>>
   assume_tac w8z_v_thm>>
@@ -1511,7 +1529,9 @@ Theorem get_clauses_arr_spec:
       (λe. ARRAY fmlv fmllsv *
         &(Fail_exn e ∧ get_clauses_list fmlls ls = NONE)))
 Proof
-  Induct>>xcf "get_clauses_arr" (get_ml_prog_state ())>>
+  Induct>>
+  rw[]>>
+  xcf "get_clauses_arr" (get_ml_prog_state ())>>
   simp[get_clauses_list_def]
   >- (
     fs[LIST_TYPE_def]>>
@@ -1584,6 +1604,7 @@ Theorem is_xfromc_arr_spec:
          ARRAY fmlv fmllsv *
          &(Fail_exn e ∧ ¬is_xfromc_list fmlls ls rx)))
 Proof
+  rw[]>>
   xcf "is_xfromc_arr" (get_ml_prog_state ())>>
   simp[is_xfromc_list_def]>>
   xlet_autop
@@ -1621,6 +1642,7 @@ Theorem conv_xor_mv_arr_spec:
     (POSTv v.
       &(STRING_TYPE (conv_xor_mv_list n xs) v))
 Proof
+  rw[]>>
   xcf "conv_xor_mv_arr" (get_ml_prog_state ())>>
   xlet_autop>>
   xapp>>
@@ -2081,6 +2103,7 @@ Theorem contains_emp_arr_spec:
       &(BOOL (contains_emp_list cfmlls) resv) *
       ARRAY cfmlv cfmllsv)
 Proof
+  rw[]>>
   xcf "contains_emp_arr" (get_ml_prog_state ())>>
   xlet_autop>>
   xapp>>xsimpl>>
@@ -2608,6 +2631,7 @@ Theorem check_unsat'_spec:
         INL err
       ) v)
 Proof
+  rw[]>>
   xcf"check_unsat'"(get_ml_prog_state()) >>
   reverse (Cases_on `STD_streams fs`)
   >- (fs [TextIOProofTheory.STDIO_def] \\ xpull) >>

--- a/icing/cfSupportScript.sml
+++ b/icing/cfSupportScript.sml
@@ -1625,7 +1625,7 @@ Theorem intToFP_spec:
   STRING_TYPE s sv ∧
   fromString s = SOME i ∧
   0 ≤ i ⇒
-  app p ^(fetch_v "intToFP" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "intToFP" st)
   [sv]
   (STDIO fs)
   (POSTv uv. &DOUBLE (Fp_const ((n2w (Num i)):word64)) uv * STDIO fs)
@@ -1657,12 +1657,13 @@ QED
 Theorem reader1_spec:
   2 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader1" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader1" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv. &(STRING_TYPE (HD(TL cl)) uv) * STDIO fs)
 Proof
-  xcf "reader1" st
+  rpt strip_tac
+  \\ xcf "reader1" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
@@ -1678,12 +1679,13 @@ QED
 Theorem reader2_spec:
   3 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader2" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader2" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv. &(PAIR_TYPE STRING_TYPE STRING_TYPE (HD(TL cl), (HD (TL (TL cl)))) uv) * STDIO fs)
 Proof
-  xcf "reader2" st
+  rpt strip_tac
+  \\ xcf "reader2" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
@@ -1704,12 +1706,13 @@ QED
 Theorem reader3_spec:
   4 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader3" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader3" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv. &(PAIR_TYPE STRING_TYPE (PAIR_TYPE STRING_TYPE STRING_TYPE) (HD(TL cl), (HD (TL (TL cl)), HD (TL (TL (TL cl))))) uv) * STDIO fs)
 Proof
-  xcf "reader3" st
+  rpt strip_tac
+  \\ xcf "reader3" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
@@ -1736,7 +1739,7 @@ QED
 Theorem reader4_spec:
   5 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader4" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader4" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv.
@@ -1746,7 +1749,8 @@ Theorem reader4_spec:
        (HD(TL cl), (HD (TL (TL cl)), HD (TL (TL (TL cl))), HD (TL (TL (TL (TL cl))))))
        uv) * STDIO fs)
 Proof
-  xcf "reader4" st
+  rpt strip_tac
+  \\ xcf "reader4" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
@@ -1781,7 +1785,7 @@ QED
 Theorem reader6_spec:
   7 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader6" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader6" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv.
@@ -1798,7 +1802,8 @@ Theorem reader6_spec:
             HD (TL (TL (TL (TL (TL (TL cl)))))))))))
        uv) * STDIO fs)
 Proof
-  xcf "reader6" st
+  rpt strip_tac
+  \\ xcf "reader6" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
   \\ fs [quantHeuristicsTheory.LENGTH_TO_EXISTS_CONS]
@@ -1837,7 +1842,7 @@ QED
 Theorem reader8_spec:
   9 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader8" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader8" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv.
@@ -1858,7 +1863,8 @@ Theorem reader8_spec:
               HD (TL (TL (TL (TL (TL (TL (TL (TL cl)))))))))))))))
        uv) * STDIO fs)
 Proof
-  xcf "reader8" st
+  rpt strip_tac
+  \\ xcf "reader8" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto_spec (SOME CommandLine_arguments_spec) >- (xcon \\ xsimpl)
   \\ ‘∃ e1 e2 e3 e4 e5 e6 e7 e8 e9. cl = [e1; e2; e3; e4; e5; e6; e7; e8; e9]’
@@ -1923,7 +1929,7 @@ QED
 Theorem reader9_spec:
   10 = LENGTH cl ∧
   UNIT_TYPE () uv ⇒
-  app p ^(fetch_v "reader9" st)
+  app (p: 'ffi ffi_proj) ^(fetch_v "reader9" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
   (POSTv uv.
@@ -1946,7 +1952,8 @@ Theorem reader9_spec:
                HD (TL (TL (TL (TL (TL (TL (TL (TL (TL cl)))))))))))))))))
        uv) * STDIO fs)
 Proof
-  xcf "reader9" st
+  rpt strip_tac
+  \\ xcf "reader9" st
   \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto_spec (SOME CommandLine_arguments_spec) >- (xcon \\ xsimpl)
   \\ fs [quantHeuristicsTheory.LENGTH_TO_EXISTS_CONS]
@@ -2020,7 +2027,8 @@ Theorem printer_spec:
     (STDIO fs)
     (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stdout fs (mlint$toString (&w2n w))))
 Proof
-  xcf "printer" st
+  rpt strip_tac
+  \\ xcf "printer" st
   \\ xlet_auto
   >- (xsimpl)
   \\ xlet_auto

--- a/icing/examples/exampleLib.sml
+++ b/icing/examples/exampleLib.sml
@@ -1138,7 +1138,7 @@ end;
         \\ first_x_assum $ mp_then Any assume_tac
                          $ SIMP_RULE std_ss [is_Double_def] (INST_TYPE [“:'ffi”|->“:'a”] theAST_spec)
         \\ gs[DOUBLE_def]
-        \\ xcf "main" st
+        \\ rpt strip_tac \\ xcf "main" st
         (* let for unit value *)
         \\ xlet_auto >- (xcon \\ xsimpl)
         \\ ‘^(numSyntax.term_of_int (numArgs+1)) = LENGTH cl’ by (rveq \\ fs[])

--- a/tutorial/wordcountProgScript.sml
+++ b/tutorial/wordcountProgScript.sml
@@ -42,7 +42,8 @@ Theorem inputLinesFromAny_spec:
                            | SOME f => all_lines fs f)
        else NONE) sv * STDIO (if IS_SOME fo then fs else fastForwardFD fs 0))
 Proof
-  xcf"inputLinesFromAny"(get_ml_prog_state())
+  rpt strip_tac
+  \\ xcf"inputLinesFromAny"(get_ml_prog_state())
   \\ reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ xpull )
   \\ reverse(Cases_on`∃ll. wfFS (fs with numchars := ll)`) >- (fs[STDIO_def,IOFS_def] \\ xpull)
   \\ Cases_on`fo` \\ fs[OPTION_TYPE_def]


### PR DESCRIPTION
This PR contributes a slightly improved version of the `xcf` tactic:
* The main upside with the new tactic is that it runs much faster.
* The new implementation moves the `xcf` tactic into a separate file called `xcf.sml`.
The new tactic only works on `app` goals: it doesn't automatically strip_tac, so some updates to proofs were needed.

Thanks to @tanyongkiam for help with repairing proofs and testing the new tactic.