### PR TITLE
Fix Pancake error message line number reporting

### DIFF
--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -42,6 +42,7 @@ fun parse_pancake q =
   end
 
 val check_success = assert $ sumSyntax.is_inl o rhs o concl
+val check_failure = assert $ sumSyntax.is_inr o rhs o concl
 
 (** Examples can be written using quoted strings and passed to the ML
     function parse_pancake. *)
@@ -310,5 +311,44 @@ val shmem_ex = ‘
   }’;
 
 val shmem_ex_parse =  check_success $ parse_pancake shmem_ex;
+
+val comment_ex =
+ ‘/* this /* non-recursive block comment
+   */
+  // and these single-line comments
+  fun main() { //should not interfer with parsing
+    return /* nor shoud this */ 1;
+  }
+ ’
+
+val comment_ex_parse = check_success $ parse_pancake comment_ex
+
+val error_line_ex1 =
+ ‘/* this
+  nasty /* non recursive /*
+  block comment
+  */
+  // and these
+  // single-line comments
+  fun fun main() { //should not interfer with error line reporting
+    return /* nor shoud this */ 1;
+  }
+ ’
+
+val error_line_ex1_parse = check_failure $ parse_pancake error_line_ex1
+
+val error_line_ex2 =
+ ‘/* this
+  nasty /* non recursive /*
+  block comment
+  */
+  // and these
+  // single-line comments
+  fun main() { //should not interfer with error line reporting
+    return val /* nor shoud this */ 1;
+  }
+ ’
+
+val error_line_ex2_parse = check_failure $ parse_pancake error_line_ex2
 
 val _ = export_theory();

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -298,7 +298,7 @@ Definition pancake_lex_aux_def:
  (case next_token input loc of
   | NONE => []
   | SOME (token, Locs locB locE, rest) =>
-      (token, Locs locB locE) :: pancake_lex_aux rest (next_loc 1 loc))
+      (token, Locs locB locE) :: pancake_lex_aux rest locE)
 Termination
   WF_REL_TAC ‘measure (LENGTH o FST)’ >> rw[]
   >> imp_res_tac next_token_LESS

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -175,7 +175,7 @@ Definition skip_comment_def:
   skip_comment "" _ = NONE ∧
   skip_comment (x::xs) loc =
   (case x of
-   | #"\n" => SOME (xs, next_loc 1 loc)
+   | #"\n" => SOME (xs, next_line loc)
    | _ => skip_comment xs (next_loc 1 loc))
 End
 

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -186,7 +186,7 @@ Definition skip_block_comment_def:
   if x = #"*" ∧ y = #"/" then
     SOME (xs, next_loc 2 loc)
   else if x = #"\n" then
-    SOME(y::xs, next_line loc)
+    skip_block_comment (y::xs) (next_line loc)
   else
     skip_block_comment (y::xs) (next_loc 1 loc)
 End

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -266,18 +266,12 @@ Theorem next_atom_LESS:
     next_atom input l = SOME (s, l', rest) ⇒ LENGTH rest < LENGTH input
 Proof
   recInduct next_atom_ind >> rw[next_atom_def]
-  >- metis_tac[DECIDE “x < y ⇒ x < SUC y”]
-  >- metis_tac[DECIDE “x < y ⇒ x < SUC y”]
-  >- (pairarg_tac >> drule read_while_thm >> gvs[])
-  >- (pairarg_tac >> drule read_while_thm >> gvs[])
-  >- (gvs[CaseEqs ["option", "prod", "list"]]
-      >> drule_then assume_tac skip_comment_thm
-      >> sg ‘STRLEN rest < STRLEN (TL cs)’ >> rw[]
-      >> sg ‘STRLEN (TL cs) < SUC (STRLEN cs)’ >> rw[LENGTH_TL]
-      >> Cases_on ‘cs’ >> simp[])
-  >- (pairarg_tac >> drule read_while_thm >> gvs[])
-  >- (pairarg_tac >> drule read_while_thm >> gvs[])
-  >- (pairarg_tac >> drule read_while_thm >> gvs[])
+  >> res_tac >> gvs[AllCaseEqs(),pairTheory.ELIM_UNCURRY]
+  >> MAP_EVERY imp_res_tac [skip_comment_thm,skip_block_comment_thm]
+  >> gvs[]
+  >> resolve_then Any mp_tac (GSYM pairTheory.PAIR) read_while_thm
+  >> simp[LESS_EQ_IFF_LESS_SUC]
+  >> BasicProvers.PURE_FULL_CASE_TAC >> gvs[]
 QED
 
 Definition next_token_def:


### PR DESCRIPTION
This (presumed) typo caused Pancake to report incorrect line numbers in the presence of comments.