### PR TITLE
Better function call syntax for Pancake

### DIFF
--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -84,8 +84,8 @@ End
 *)
 
 Overload TailCall = “Call NONE”
-Overload RetCall = “\s h. Call (SOME (SOME s , h))”
-Overload MuteCall = “\s h. Call (SOME (NONE , h))”
+Overload AssignCall = “\s h. Call (SOME (SOME s , h))”
+Overload StandAloneCall = “\s h. Call (SOME (NONE , h))”
 
 (*
 Datatype:

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -139,6 +139,7 @@ Definition exp_ids_def:
   (exp_ids (If _ p q) = exp_ids p ++ exp_ids q) ∧
   (exp_ids (While _ p) = exp_ids p) ∧
   (exp_ids (Call (SOME (_ , (SOME (e ,  _ , ep)))) _ _) = e::exp_ids ep) ∧
+  (exp_ids (DecCall _ _ _ _ p) = exp_ids p) ∧
   (exp_ids _ = [])
 End
 

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -63,7 +63,8 @@ Datatype:
        | While ('a exp) prog
        | Break
        | Continue
-       | Call ((varname # ((eid # varname # prog) option)) option) ('a exp) (('a exp) list)
+       | Call ((varname option # ((eid # varname # prog) option)) option) ('a exp) (('a exp) list)
+       | DecCall varname ('a exp) ('a exp list) prog
        | ExtCall funname ('a exp) ('a exp) ('a exp) ('a exp)
          (* FFI name, conf_ptr, conf_len, array_ptr, array_len *)
        | Raise eid ('a exp)
@@ -83,7 +84,8 @@ End
 *)
 
 Overload TailCall = “Call NONE”
-Overload RetCall = “\s h. Call (SOME (s , h))”
+Overload RetCall = “\s h. Call (SOME (SOME s , h))”
+Overload MuteCall = “\s h. Call (SOME (NONE , h))”
 
 (*
 Datatype:

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -85,7 +85,7 @@ End
 
 Overload TailCall = “Call NONE”
 Overload AssignCall = “\s h. Call (SOME (SOME s , h))”
-Overload StandAloneCall = “\s h. Call (SOME (NONE , h))”
+Overload StandAloneCall = “\h. Call (SOME (NONE , h))”
 
 (*
 Datatype:

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -64,7 +64,7 @@ Datatype:
        | Break
        | Continue
        | Call ((varname option # ((eid # varname # prog) option)) option) ('a exp) (('a exp) list)
-       | DecCall varname ('a exp) ('a exp list) prog
+       | DecCall varname shape ('a exp) ('a exp list) prog
        | ExtCall funname ('a exp) ('a exp) ('a exp) ('a exp)
          (* FFI name, conf_ptr, conf_len, array_ptr, array_len *)
        | Raise eid ('a exp)

--- a/pancake/panScopeScript.sml
+++ b/pancake/panScopeScript.sml
@@ -68,7 +68,7 @@ Definition scope_check_prog_def:
     OPTION_CHOICE
       (scope_check_exp ctxt trgt)
       (scope_check_exps ctxt args) ∧
-  scope_check_prog ctxt (RetCall rt hdl trgt args) =
+  scope_check_prog ctxt (AssignCall rt hdl trgt args) =
     OPTION_CHOICE
       (scope_check_exp ctxt trgt)
       (OPTION_CHOICE

--- a/pancake/panScopeScript.sml
+++ b/pancake/panScopeScript.sml
@@ -42,6 +42,12 @@ Definition scope_check_prog_def:
   scope_check_prog ctxt (Dec v e p) =
     OPTION_CHOICE (scope_check_exp ctxt e)
                   (scope_check_prog (ctxt with vars := v :: ctxt.vars) p) ∧
+  scope_check_prog ctxt (DecCall v s e args p) =
+    OPTION_CHOICE
+        (scope_check_exp ctxt e)
+        (OPTION_CHOICE
+         (scope_check_exps ctxt args)
+         (scope_check_prog (ctxt with vars := v :: ctxt.vars) p)) ∧
   scope_check_prog ctxt (Assign v e) =
     (if ¬MEM v ctxt.vars
         then SOME (v, ctxt.fname)
@@ -82,6 +88,17 @@ Definition scope_check_prog_def:
                if ¬MEM evar ctxt.vars
                   then SOME (evar, ctxt.fname)
                else scope_check_prog (ctxt with vars := evar :: ctxt.vars) p)) ∧
+  scope_check_prog ctxt (StandAloneCall hdl trgt args) =
+    OPTION_CHOICE
+      (scope_check_exp ctxt trgt)
+      (OPTION_CHOICE
+        (scope_check_exps ctxt args)
+        (case hdl of
+             NONE => NONE
+           | SOME (eid, evar, p) =>
+               if ¬MEM evar ctxt.vars
+                  then SOME (evar, ctxt.fname)
+               else scope_check_prog (ctxt with vars := evar :: ctxt.vars) p)) ∧
   scope_check_prog ctxt (ExtCall fname ptr1 len1 ptr2 len2) =
     scope_check_exps ctxt [ptr1;len1;ptr2;len2] ∧
   scope_check_prog ctxt (Raise eid excp) = scope_check_exp ctxt excp ∧
@@ -111,4 +128,3 @@ End
 
 
 val _ = export_theory ();
-

--- a/pancake/pan_simpScript.sml
+++ b/pancake/pan_simpScript.sml
@@ -33,6 +33,8 @@ Definition seq_assoc_def:
                    | SOME (eid , ev , ep) =>
                       SOME (rv , (SOME (eid , ev , (seq_assoc Skip ep)))))
                  name args)) /\
+  (seq_assoc p (DecCall v s e es q) =
+    SmartSeq p (DecCall v s e es (seq_assoc Skip q))) /\
   (seq_assoc p q = SmartSeq p q)
 End
 
@@ -58,6 +60,7 @@ Definition ret_to_tail_def:
                     | SOME (eid , ev , ep) =>
                         SOME (eid, ev, (ret_to_tail ep)))))
         name args) /\
+  (ret_to_tail (DecCall v s e es q) = DecCall v s e es (ret_to_tail q)) /\
   (ret_to_tail p = p)
 End
 
@@ -95,7 +98,8 @@ Theorem seq_assoc_pmatch:
                    | SOME (rv , (SOME (eid , ev , ep))) =>
                        SOME (rv , (SOME (eid , ev , (seq_assoc Skip ep)))))
                   name args)
-   | q => SmartSeq p q
+  | (DecCall v s e es q) => SmartSeq p (DecCall v s e es (seq_assoc Skip q))
+  | q => SmartSeq p q
 Proof
   rpt strip_tac >>
   CONV_TAC(RAND_CONV patternMatchesLib.PMATCH_ELIM_CONV) >>
@@ -121,6 +125,7 @@ Theorem ret_to_tail_pmatch:
                     | SOME (rv , (SOME (eid , ev , ep))) =>
                        SOME (rv , (SOME (eid , ev , (ret_to_tail ep)))))
       name args
+   | (DecCall v s e es q) => DecCall v s e es (ret_to_tail q)
    | p => p
 Proof
   rpt strip_tac >>

--- a/pancake/pan_simpScript.sml
+++ b/pancake/pan_simpScript.sml
@@ -39,7 +39,7 @@ End
 Definition seq_call_ret_def:
   seq_call_ret prog =
    dtcase prog of
-    | Seq (RetCall rv1 NONE trgt args) (Return (Var (rv2:mlstring))) =>
+    | Seq (AssignCall rv1 NONE trgt args) (Return (Var (rv2:mlstring))) =>
       if rv1 = rv2 then (TailCall trgt args) else prog
     | other => other
 End

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -247,7 +247,7 @@ Definition compile_def:
        args = FLAT (MAP FST cexps);
        vmax = ctxt.vmax;
        nvars = GENLIST (λx. vmax + SUC x) (size_of_shape s);
-       nctxt = ctxt with  <|vars := ctxt.vars |+ (v, (sh, nvars));
+       nctxt = ctxt with  <|vars := ctxt.vars |+ (v, (s, nvars));
                             vmax := ctxt.vmax + size_of_shape s|> in
      case cs of
      | [] => Skip
@@ -260,9 +260,8 @@ Definition compile_def:
                             |  SOME n => Dec n (Const 0w);
                   p' = compile nctxt p;
                   ret_decl = case ret_var s ns of
-                               NONE => p'
-                             | SOME _ =>
-                                 nested_decs nvars (load_globals 0w (LENGTH nvars)) p'
+                               NONE => nested_decs nvars (load_globals 0w (LENGTH nvars)) p'
+                             | SOME _ => p'
               in ret_dec $
                 Call (SOME ((ret_var s ns), ret_decl, NONE)) ce args
          )

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -248,23 +248,23 @@ Definition compile_def:
        vmax = ctxt.vmax;
        nvars = GENLIST (λx. vmax + SUC x) (size_of_shape s);
        nctxt = ctxt with  <|vars := ctxt.vars |+ (v, (sh, nvars));
-                            vmax := ctxt.vmax + size_of_shape sh|> in
+                            vmax := ctxt.vmax + size_of_shape s|> in
      case cs of
      | [] => Skip
      | ce::ces =>
          (case wrap_rt (SOME(s,nvars)) of
             NONE => Call (SOME (NONE, compile nctxt p, NONE)) ce args
           | SOME(sh,ns) =>
-              let ret_dec = case ret_var sh ns of
+              let ret_dec = case ret_var s ns of
                               NONE => I
                             |  SOME n => Dec n (Const 0w);
                   p' = compile nctxt p;
-                  ret_decl = case ret_var sh ns of
+                  ret_decl = case ret_var s ns of
                                NONE => p'
                              | SOME _ =>
                                  nested_decs nvars (load_globals 0w (LENGTH nvars)) p'
               in ret_dec $
-                Call (SOME ((ret_var sh ns), ret_decl, NONE)) ce args
+                Call (SOME ((ret_var s ns), ret_decl, NONE)) ce args
          )
   ) /\
   (compile ctxt (ExtCall f ptr1 len1 ptr2 len2) =

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -227,7 +227,7 @@ val arg_call_tree = check_success $ parse_tree_pancake argument_call;
 
 val arg_call_parse = check_success $ parse_pancake argument_call;
 
-(** Tail calls and returning calls
+(** Various kinds of function calls.
 
     A function call immediately underneath a return is parsed as a tail call.
     Tail calls overwrite the caller's stack frame with the callee's and
@@ -236,7 +236,7 @@ val arg_call_parse = check_success $ parse_pancake argument_call;
 val ret_call = ‘
   fun main() {
     var r = 0;
-    r = g(); // This is a returning call (but could be optimised to a tail call)
+    r = g(); // This is an assigning call (but could be optimised to a tail call)
     return r;
   }
 

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -73,9 +73,9 @@ val treeEx1 = check_success $ parse_pancake ex1;
 val ex2 = ‘
   fun main() {
     if b & (a ^ c) & d {
-      foo(1, <2, 3>);
+      return foo(1, <2, 3>);
         } else {
-      goo(4, 5, 6);
+      return goo(4, 5, 6);
     }
   }’;
 
@@ -227,18 +227,22 @@ val arg_call_tree = check_success $ parse_tree_pancake argument_call;
 
 val arg_call_parse = check_success $ parse_pancake argument_call;
 
-(** Return call example. It is not currently possible to initialise a variable
-    to a value returned from a function as a variable is declared. Instead, the
-    variable has to be declared beforehand as done below. *)
+(** Tail calls and returning calls
+
+    A function call immediately underneath a return is parsed as a tail call.
+    Tail calls overwrite the caller's stack frame with the callee's and
+    thereby prevent stack explosions.
+ **)
 val ret_call = ‘
   fun main() {
     var r = 0;
-    r = g();
+    r = g(); // This is a returning call (but could be optimised to a tail call)
     return r;
   }
 
   fun g() {
-    return 1;
+    g(); // This is a returning call
+    return g(); // This is a tail call
   }’;
 
 val ret_call_parse_tree = check_success $ parse_tree_pancake ret_call;
@@ -331,7 +335,7 @@ val error_line_ex1 =
   // and these
   // single-line comments
   fun fun main() { //should not interfer with error line reporting
-    return /* nor shoud this */ 1;
+    return /* nor should this */ 1;
   }
  ’
 
@@ -345,7 +349,7 @@ val error_line_ex2 =
   // and these
   // single-line comments
   fun main() { //should not interfer with error line reporting
-    return val /* nor shoud this */ 1;
+    return val /* nor should this */ 1;
   }
  ’
 

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -240,8 +240,14 @@ val ret_call = ‘
     return r;
   }
 
+  fun f() {
+    var 1 r = g(); // Function calls can be used to initialise variables,
+                   // but the expected shape of the return value must be declared
+    return r;
+  }
+
   fun g() {
-    g(); // This is a returning call
+    g(); // This is a stand-alone call
     return g(); // This is a tail call
   }’;
 

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -18,6 +18,7 @@ Datatype:
             | DecNT | AssignNT | StoreNT | StoreByteNT
             | IfNT | WhileNT | CallNT | RetNT | HandleNT
             | ExtCallNT | RaiseNT | ReturnNT
+            | DecCallNT
             | ArgListNT
             | ParamListNT
             | EXorNT | EAndNT | EEqNT | ECmpNT
@@ -142,6 +143,7 @@ Definition pancake_peg_def[nocompute]:
         (INL BlockNT, choicel [mknt DecNT; mknt IfNT; mknt WhileNT]);
         (INL StmtNT, choicel [keep_kw SkipK;
                               mknt CallNT;
+                              mknt DecCallNT;
                               mknt AssignNT; mknt StoreNT;
                               mknt StoreByteNT;
                               mknt SharedLoadByteNT;
@@ -180,6 +182,12 @@ Definition pancake_peg_def[nocompute]:
                            consume_tok LParT; try (mknt ArgListNT);
                            consume_tok RParT]
                           (mksubtree CallNT));
+        (INL DecCallNT, seql [consume_kw VarK; mknt ShapeNT; keep_ident; consume_tok AssignT;
+                              choicel [seql [consume_tok StarT; mknt ExpNT] I;
+                                       mknt FLabelNT];
+                              consume_tok LParT; try (mknt ArgListNT);
+                              consume_tok RParT]
+                          (mksubtree DecCallNT));
         (INL RetNT, seql [keep_ident; consume_tok AssignT;
                           try (mknt HandleNT)]
                           (mksubtree RetNT));
@@ -597,7 +605,7 @@ val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”
                 “EEqNT”, “EAndNT”, “EXorNT”,
                 “ExpNT”, “ArgListNT”, “ReturnNT”,
                 “RaiseNT”, “ExtCallNT”,
-                “HandleNT”, “RetNT”, “CallNT”,
+                “HandleNT”, “RetNT”, “DecCallNT”, “CallNT”,
                 “WhileNT”, “IfNT”, “StoreByteNT”,
                 “StoreNT”, “AssignNT”,
                 “SharedLoadByteNT”, “SharedLoadNT”,

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -18,7 +18,7 @@ Datatype:
             | DecNT | AssignNT | StoreNT | StoreByteNT
             | IfNT | WhileNT | CallNT | RetNT | HandleNT
             | ExtCallNT | RaiseNT | ReturnNT
-            | DecCallNT
+            | DecCallNT | RetCallNT
             | ArgListNT
             | ParamListNT
             | EXorNT | EAndNT | EEqNT | ECmpNT
@@ -152,7 +152,7 @@ Definition pancake_peg_def[nocompute]:
                               mknt SharedStoreNT;
                               keep_kw BrK; keep_kw ContK;
                               mknt ExtCallNT;
-                              mknt RaiseNT; mknt ReturnNT;
+                              mknt RaiseNT; mknt RetCallNT; mknt ReturnNT;
                               keep_kw TicK;
                               seql [consume_tok LCurT; mknt ProgNT; consume_tok RCurT] I
                               ]);
@@ -205,6 +205,12 @@ Definition pancake_peg_def[nocompute]:
                              (mksubtree ExtCallNT));
         (INL RaiseNT, seql [consume_kw RaiseK; keep_ident; mknt ExpNT]
                            (mksubtree RaiseNT));
+        (INL RetCallNT, seql [consume_kw RetK;
+                              choicel [seql [consume_tok StarT; mknt ExpNT] I;
+                                       mknt FLabelNT];
+                              consume_tok LParT; try (mknt ArgListNT);
+                              consume_tok RParT]
+                            (mksubtree RetCallNT));
         (INL ReturnNT, seql [consume_kw RetK; mknt ExpNT]
                             (mksubtree ReturnNT));
         (INL ArgListNT, seql [mknt ExpNT;
@@ -605,7 +611,7 @@ val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”
                 “EEqNT”, “EAndNT”, “EXorNT”,
                 “ExpNT”, “ArgListNT”, “ReturnNT”,
                 “RaiseNT”, “ExtCallNT”,
-                “HandleNT”, “RetNT”, “DecCallNT”, “CallNT”,
+                “HandleNT”, “RetNT”, “RetCallNT”, “DecCallNT”, “CallNT”,
                 “WhileNT”, “IfNT”, “StoreByteNT”,
                 “StoreNT”, “AssignNT”,
                 “SharedLoadByteNT”, “SharedLoadNT”,

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -174,7 +174,7 @@ Definition pancake_peg_def[nocompute]:
         (INL WhileNT, seql [consume_kw WhileK; mknt ExpNT;
                             consume_tok LCurT; mknt ProgNT;
                             consume_tok RCurT] (mksubtree WhileNT));
-        (INL CallNT, seql [try (mknt RetNT);
+        (INL CallNT, seql [try (choicel [keep_kw RetK; mknt RetNT]);
                            choicel [seql [consume_tok StarT; mknt ExpNT] I;
                                     mknt FLabelNT];
                            consume_tok LParT; try (mknt ArgListNT);

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -140,10 +140,9 @@ Definition pancake_peg_def[nocompute]:
                                    seql [mknt StmtNT;
                                          consume_tok SemiT] I])
                          (mksubtree ProgNT o FLAT));
-        (INL BlockNT, choicel [mknt DecNT; mknt IfNT; mknt WhileNT]);
+        (INL BlockNT, choicel [mknt DecCallNT; mknt DecNT; mknt IfNT; mknt WhileNT]);
         (INL StmtNT, choicel [keep_kw SkipK;
                               mknt CallNT;
-                              mknt DecCallNT;
                               mknt AssignNT; mknt StoreNT;
                               mknt StoreByteNT;
                               mknt SharedLoadByteNT;
@@ -156,6 +155,12 @@ Definition pancake_peg_def[nocompute]:
                               keep_kw TicK;
                               seql [consume_tok LCurT; mknt ProgNT; consume_tok RCurT] I
                               ]);
+        (INL DecCallNT, seql [consume_kw VarK; mknt ShapeNT; keep_ident; consume_tok AssignT;
+                              choicel [seql [consume_tok StarT; mknt ExpNT] I;
+                                       mknt FLabelNT];
+                              consume_tok LParT; try (mknt ArgListNT);
+                              consume_tok RParT;consume_tok SemiT;mknt ProgNT]
+                          (mksubtree DecCallNT));
         (INL DecNT,seql [consume_kw VarK; keep_ident;
                          consume_tok AssignT; mknt ExpNT;
                          consume_tok SemiT;mknt ProgNT]
@@ -182,12 +187,6 @@ Definition pancake_peg_def[nocompute]:
                            consume_tok LParT; try (mknt ArgListNT);
                            consume_tok RParT]
                           (mksubtree CallNT));
-        (INL DecCallNT, seql [consume_kw VarK; mknt ShapeNT; keep_ident; consume_tok AssignT;
-                              choicel [seql [consume_tok StarT; mknt ExpNT] I;
-                                       mknt FLabelNT];
-                              consume_tok LParT; try (mknt ArgListNT);
-                              consume_tok RParT]
-                          (mksubtree DecCallNT));
         (INL RetNT, seql [keep_ident; consume_tok AssignT;
                           try (mknt HandleNT)]
                           (mksubtree RetNT));
@@ -611,12 +610,12 @@ val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”
                 “EEqNT”, “EAndNT”, “EXorNT”,
                 “ExpNT”, “ArgListNT”, “ReturnNT”,
                 “RaiseNT”, “ExtCallNT”,
-                “HandleNT”, “RetNT”, “RetCallNT”, “DecCallNT”, “CallNT”,
+                “HandleNT”, “RetNT”, “RetCallNT”, “CallNT”,
                 “WhileNT”, “IfNT”, “StoreByteNT”,
                 “StoreNT”, “AssignNT”,
                 “SharedLoadByteNT”, “SharedLoadNT”,
                 “SharedStoreByteNT”, “SharedStoreNT”, “DecNT”,
-                “StmtNT”, “BlockNT”, “ParamListNT”, “FunNT”
+                “DecCallNT”, “StmtNT”, “BlockNT”, “ParamListNT”, “FunNT”
                 ];
 
 (*  “FunNT”, “FunListNT” *)

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -500,7 +500,7 @@ Definition conv_Prog_def:
             | NONE => do e' <- conv_Exp r;
                          args' <- (case ts of [] => SOME []
                                            | args::_ => conv_ArgList args);
-                         SOME $ Dec «» (Const 0w) $ RetCall «» NONE e' args'
+                         SOME $ Dec «» (Const 0w) $ AssignCall «» NONE e' args'
                       od
             | SOME(SOME r') =>
                 (case ts of

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -282,6 +282,16 @@ Proof
   fs [evaluate_def, ret_to_tail_def]
 QED
 
+Theorem ret_to_tail_DecCall:
+  ^(get_goal "panLang$DecCall")
+Proof
+  rw [] >>
+  fs [ret_to_tail_def, evaluate_def] >>
+  every_case_tac >>
+  fs [evaluate_def, ret_to_tail_def,UNCURRY_eq_pair,PULL_EXISTS] >>
+  pairarg_tac >> gvs[]
+QED
+
 Theorem ret_to_tail_Others:
   ^(get_goal "panLang$Skip") /\
   ^(get_goal "panLang$Assign") /\
@@ -305,7 +315,7 @@ Proof
   EVERY (map strip_assume_tac
          [ret_to_tail_Dec, ret_to_tail_Seq,
           ret_to_tail_If, ret_to_tail_While, ret_to_tail_Call,
-          ret_to_tail_Others]) >>
+          ret_to_tail_DecCall, ret_to_tail_Others]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED
 
@@ -755,6 +765,50 @@ Proof
   fs [state_rel_def, state_component_equality]
 QED
 
+Theorem compile_DecCall:
+  ^(get_goal "panLang$DecCall")
+Proof
+  rw [] >>
+  fs [evaluate_seq_assoc, evaluate_skip_seq] >>
+  fs [evaluate_def] >>
+  gvs[AllCaseEqs(),PULL_EXISTS] >>
+  imp_res_tac compile_eval_correct >>
+  gvs[] >>
+  irule_at (Pos hd) EQ_TRANS >>
+  first_assum $ irule_at $ Pos $ hd o tl >>
+  irule_at (Pos hd) IMP_OPT_MMAP_EQ >>
+  simp[GSYM PULL_EXISTS] >>
+  (conj_asm1_tac
+   >- (fs [pan_commonPropsTheory.opt_mmap_eq_some] >>
+       fs [MAP_EQ_EVERY2] >>
+       fs [LIST_REL_EL_EQN] >>
+       rw [] >>
+       metis_tac [compile_eval_correct])) >>
+  gvs[state_rel_def,lookup_code_def,AllCaseEqs(),PULL_EXISTS] >>
+  first_assum drule >> strip_tac >> fs[] >>
+  ‘t.clock = s.clock’ by (gvs[state_component_equality]) >>
+  gvs[] >>
+  gvs[empty_locals_def] >>
+  simp[]
+  >- gvs[state_component_equality] >>
+  qmatch_goalsub_abbrev_tac ‘compile _, tt’ >>
+  last_x_assum $ qspec_then ‘tt’ mp_tac >>
+  unabbrev_all_tac >>
+  (impl_tac >- gvs[dec_clock_def,state_component_equality]) >>
+  strip_tac >>
+  simp[] >>
+  gvs[evaluate_seq_assoc, evaluate_skip_seq,compile_def,ret_to_tail_correct] >>
+  gvs[state_component_equality,PULL_EXISTS,UNCURRY_eq_pair] >>
+  qmatch_goalsub_abbrev_tac ‘evaluate(_, tt)’ >>
+  last_x_assum $ qspec_then ‘tt’ mp_tac o CONV_RULE SWAP_FORALL_CONV >>
+  simp[Abbr ‘tt’,set_var_def] >>
+  disch_then(qspec_then ‘s1 with locals := st'.locals’ mp_tac) >>
+  simp[] >>
+  strip_tac >>
+  simp[] >>
+  qexists ‘s1 with code := t1'.code’ >>
+  simp[]
+QED
 
 Theorem compile_While:
   ^(get_goal "panLang$While")
@@ -853,7 +907,7 @@ Proof
   match_mp_tac (the_ind_thm()) >>
   EVERY (map strip_assume_tac
          [compile_Dec, compile_Seq, compile_ShMem,
-          compile_If, compile_While, compile_Call,
+          compile_If, compile_While, compile_Call, compile_DecCall
           compile_ExtCall, compile_Call,compile_Others]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -907,7 +907,7 @@ Proof
   match_mp_tac (the_ind_thm()) >>
   EVERY (map strip_assume_tac
          [compile_Dec, compile_Seq, compile_ShMem,
-          compile_If, compile_While, compile_Call, compile_DecCall
+          compile_If, compile_While, compile_Call, compile_DecCall,
           compile_ExtCall, compile_Call,compile_Others]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -4648,7 +4648,7 @@ Proof
          [compile_Skip_Break_Continue, compile_Dec, compile_ShMem,
           compile_Assign, compile_Store, compile_StoreByte, compile_Seq,
           compile_If, compile_While, compile_Call, compile_ExtCall,
-          compile_Raise, compile_Return, compile_Tick]) >>
+          compile_Raise, compile_Return, compile_Tick, compile_DecCall]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)
 QED
 

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -2041,7 +2041,6 @@ Proof
   pairarg_tac >> fs [] >> rveq >>
   first_x_assum drule_all >> strip_tac >>
   fs [] >> rveq >>
-
   cases_on ‘res’ >> fs [] >>
   cases_on ‘x’ >> fs [] >>
   TRY (cases_on ‘FLOOKUP ctxt.eids m’ >> fs [] >> cases_on ‘x’ >> fs []) >>
@@ -2980,14 +2979,6 @@ val ret_call_excp_handler_tac =
      fs []) >>
     strip_tac >> fs [])
 
-(*
-Triviality pairargI:
-  (λ(x,y). f x y) a = z ⇔ ∃a0 a1. a = (a0,a1) ∧ f a0 a1 = z
-Proof
-  rw[ELIM_UNCURRY] >> metis_tac[FST,SND,PAIR]
-QED
-*)
-
 (* TODO: move *)
 Theorem evaluate_code_invariant:
   ∀p t res st.
@@ -3893,12 +3884,103 @@ Proof
               gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
                   panLangTheory.size_of_shape_def]) >>
           PURE_TOP_CASE_TAC >> gvs[]
-          >- cheat
-          >- cheat
-          >- cheat >>
+          >- (gvs[locals_rel_def] >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’,FLOOKUP_pan_res_var_thm
+                 ]
+              >- (res_tac >> gvs[] >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos last >>
+                  resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+                  rpt strip_tac >>
+                  simp[flookup_res_var_thm] >>
+                  rw[] >>
+                  res_tac >>
+                  gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,
+                      oneline wrap_rt_def] >>
+                  gvs[ctxt_max_def] >>
+                  res_tac >> gvs[] >>
+                  drule unassigned_free_vars_evaluate_same >>
+                  simp[] >>
+                  strip_tac >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos hd >>
+                  simp[FLOOKUP_UPDATE] >>
+                  irule not_mem_context_assigned_mem_gt >>
+                  simp[ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> rw[] >>
+                  gvs[] >>
+                  rpt strip_tac >>
+                  res_tac >> gvs[] >>
+                  gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+                  metis_tac[]) >>
+              res_tac >>
+              gvs[] >>
+              match_mp_tac EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+              rpt strip_tac >>
+              simp[flookup_res_var_thm] >>
+              rw[] >>
+              res_tac >>
+              gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,FLOOKUP_UPDATE,
+                  oneline wrap_rt_def] >>
+              gvs[ctxt_max_def] >>
+              res_tac >>
+              gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
+                  panLangTheory.size_of_shape_def]
+             )
+          >- (gvs[locals_rel_def] >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’,FLOOKUP_pan_res_var_thm
+                 ]
+              >- (res_tac >> gvs[] >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos last >>
+                  resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+                  rpt strip_tac >>
+                  simp[flookup_res_var_thm] >>
+                  rw[] >>
+                  res_tac >>
+                  gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,
+                      oneline wrap_rt_def] >>
+                  gvs[ctxt_max_def] >>
+                  res_tac >> gvs[] >>
+                  drule unassigned_free_vars_evaluate_same >>
+                  simp[] >>
+                  strip_tac >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos hd >>
+                  simp[FLOOKUP_UPDATE] >>
+                  irule not_mem_context_assigned_mem_gt >>
+                  simp[ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> rw[] >>
+                  gvs[] >>
+                  rpt strip_tac >>
+                  res_tac >> gvs[] >>
+                  gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+                  metis_tac[]) >>
+              res_tac >>
+              gvs[] >>
+              match_mp_tac EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+              rpt strip_tac >>
+              simp[flookup_res_var_thm] >>
+              rw[] >>
+              res_tac >>
+              gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,FLOOKUP_UPDATE,
+                  oneline wrap_rt_def] >>
+              gvs[ctxt_max_def] >>
+              res_tac >>
+              gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
+                  panLangTheory.size_of_shape_def])
+          >- (strip_tac >> gvs[] >> gvs[globals_lookup_def]) >>
           PURE_TOP_CASE_TAC >> gvs[] >>
           gvs[Abbr ‘newctxt’] >>
-          cheat
+          strip_tac >> gvs[] >> gvs[globals_lookup_def]
          ) >>
       (* Shape size 1: Exception or FinalFFI in call *)
       simp[empty_locals_def,panSemTheory.empty_locals_def] >>
@@ -3951,20 +4033,96 @@ Proof
      ]
   >- (gvs[state_rel_def,empty_locals_def,code_rel_def,ctxt_fc_def])
   >- (PURE_FULL_CASE_TAC >> gvs[]
-      >- (Cases_on ‘size_of_shape shape = 0’ >> gvs[]
+      >- (Cases_on ‘size_of_shape(shape_of retv) = 0’ >> gvs[]
           >- (simp[nested_decs_def,load_globals_def] >>
               gvs[UNCURRY_eq_pair] >>
               qmatch_goalsub_abbrev_tac ‘evaluate (compile newctxt _, news)’ >>
               first_x_assum $ qspecl_then [‘news’,‘newctxt’] mp_tac >>
               impl_tac
-              >- (cheat) >>
+              >- (conj_asm1_tac
+                  >- gvs[state_rel_def,set_var_def,panSemTheory.set_var_def,
+                         Abbr ‘news’] >>
+                  conj_asm1_tac
+                  >- (imp_res_tac evaluate_code_invariant >>
+                      imp_res_tac crep_evaluate_code_invariant >>
+                      gvs[set_var_def, Abbr ‘newctxt’, Abbr‘news’,
+                          panSemTheory.set_var_def,
+                          dec_clock_def,
+                          panSemTheory.dec_clock_def
+                         ] >>
+                      gvs[code_rel_def]) >>
+                  conj_asm1_tac
+                  >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+                      imp_res_tac evaluate_invariants >>
+                      gvs[panSemTheory.dec_clock_def]) >>
+                  gvs[locals_rel_def] >>
+                  conj_asm1_tac
+                  >- (gvs[Abbr ‘newctxt’,no_overlap_def,FLOOKUP_UPDATE,ALL_DISTINCT_GENLIST] >>
+                      rw[] >> gvs[] >> res_tac >>
+                      gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs()]) >>
+                  conj_asm1_tac
+                  >- (gvs[Abbr ‘newctxt’,ctxt_max_def,FLOOKUP_UPDATE] >>
+                      rw[] >> gvs[] >> res_tac >>
+                      gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs()]) >>
+                  rw[] >>
+                  gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                      Abbr ‘news’] >>
+                  gvs[GSYM length_flatten_eq_size_of_shape] >>
+                  gvs[oneline wrap_rt_def,AllCaseEqs(),panLangTheory.size_of_shape_def] >>
+                  Cases_on ‘flatten retv’ >> gvs[GENLIST_CONS]
+                 ) >>
               strip_tac >>
               simp[] >>
               gvs[code_rel_def,excp_rel_def,state_rel_def,
                   Abbr ‘newctxt’,ctxt_fc_def
                  ] >>
               rw[] >> res_tac >> gvs[] >>
-              cheat) >>
+              gvs[locals_rel_def] >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,CaseEq "bool",
+                  FLOOKUP_pan_res_var_thm]
+              >- (res_tac >> gvs[] >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos last >>
+                  resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+                  rpt strip_tac >>
+                  simp[flookup_res_var_thm] >>
+                  rw[] >>
+                  res_tac >>
+                  gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,
+                      oneline wrap_rt_def] >>
+                  gvs[ctxt_max_def] >>
+                  res_tac >> gvs[] >>
+                  drule unassigned_free_vars_evaluate_same >>
+                  simp[] >>
+                  strip_tac >>
+                  unabbrev_all_tac >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos hd >>
+                  simp[FLOOKUP_UPDATE] >>
+                  irule not_mem_context_assigned_mem_gt >>
+                  simp[ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> rw[] >>
+                  gvs[] >>
+                  rpt strip_tac >>
+                  res_tac >> gvs[] >>
+                  gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+                  metis_tac[]) >>
+              res_tac >>
+              gvs[] >>
+              match_mp_tac EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+              rpt strip_tac >>
+              simp[flookup_res_var_thm] >>
+              rw[] >>
+              res_tac >>
+              gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,FLOOKUP_UPDATE,
+                  oneline wrap_rt_def] >>
+              gvs[ctxt_max_def] >>
+              res_tac >>
+              gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
+                  panLangTheory.size_of_shape_def]) >>
           ‘globals_lookup (t1 with locals := t.locals) retv = SOME (flatten retv)’
             by gvs[globals_lookup_def] >>
           drule evaluate_nested_decs_load_globals >>
@@ -3982,12 +4140,419 @@ Proof
           gvs[UNCURRY_eq_pair] >>
           qmatch_goalsub_abbrev_tac ‘evaluate (compile newctxt _, news)’ >>
           first_x_assum $ qspecl_then [‘news’,‘newctxt’] mp_tac >>
-          impl_tac >- cheat >>
+          impl_tac
+          >- (conj_asm1_tac
+              >- gvs[state_rel_def,set_var_def,panSemTheory.set_var_def,
+                     Abbr ‘news’] >>
+              conj_asm1_tac
+              >- (imp_res_tac evaluate_code_invariant >>
+                  imp_res_tac crep_evaluate_code_invariant >>
+                  gvs[set_var_def, Abbr ‘newctxt’, Abbr‘news’,
+                      panSemTheory.set_var_def,
+                      dec_clock_def,
+                      panSemTheory.dec_clock_def
+                     ] >>
+                  gvs[code_rel_def]) >>
+              conj_asm1_tac
+              >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+                  imp_res_tac evaluate_invariants >>
+                  gvs[panSemTheory.dec_clock_def]) >>
+              gvs[locals_rel_def] >>
+              conj_asm1_tac
+              >- (gvs[Abbr ‘newctxt’,no_overlap_def,FLOOKUP_UPDATE,ALL_DISTINCT_GENLIST] >>
+                  rw[] >> gvs[] >> res_tac >>
+                  gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs(),
+                      panLangTheory.size_of_shape_def] >>
+                  gvs[DISJOINT_ALT,MEM_GENLIST] >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              conj_asm1_tac
+              >- (gvs[Abbr ‘newctxt’,ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> gvs[] >> res_tac >>
+                  gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs(),MEM_GENLIST,
+                      panLangTheory.size_of_shape_def]) >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’] >>
+              gvs[GSYM length_flatten_eq_size_of_shape] >>
+              gvs[oneline wrap_rt_def,AllCaseEqs(),panLangTheory.size_of_shape_def]
+              >- (irule opt_mmap_some_eq_zip_flookup >>
+                  simp[ALL_DISTINCT_GENLIST])
+              >- (irule opt_mmap_some_eq_zip_flookup >>
+                  simp[ALL_DISTINCT_GENLIST]) >>
+              res_tac >>
+              gvs[] >>
+              dep_rewrite.DEP_ONCE_REWRITE_TAC [opt_mmap_disj_zip_flookup] >>
+              simp[distinct_lists_def] >>
+              rw[EVERY_MEM,MEM_GENLIST] >>
+              strip_tac >>
+              gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
           strip_tac >> simp[] >>
-          cheat) >>
-      gvs[UNCURRY_eq_pair] >> cheat)
-  >- cheat
-  >- gvs[state_rel_def,empty_locals_def,code_rel_def,ctxt_fc_def]
+          conj_asm1_tac
+          >- fs[state_rel_def] >>
+          conj_asm1_tac
+          >- (imp_res_tac evaluate_code_invariant >>
+              imp_res_tac crep_evaluate_code_invariant >>
+              gvs[panSemTheory.set_var_def,dec_clock_def,Abbr ‘news’,panSemTheory.dec_clock_def]) >>
+          conj_asm1_tac
+          >- (imp_res_tac evaluate_invariants >>
+              gvs[panSemTheory.set_var_def,panSemTheory.dec_clock_def]) >>
+          gvs[locals_rel_def] >>
+          rw[FLOOKUP_pan_res_var_thm]
+          >- (res_tac >> gvs[] >>
+              simp[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              irule_at (Pos hd) flookup_res_var_distinct >>
+              conj_asm1_tac
+              >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+                  rpt strip_tac >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              rw[MAP_EQ_f] >>
+              drule unassigned_vars_evaluate_same >>
+              simp[Abbr ‘news’] >>
+              strip_tac >>
+              irule EQ_TRANS >>
+              pop_assum $ irule_at $ Pos hd >>
+              reverse conj_asm1_tac
+              >- (irule flookup_fupdate_zip_not_mem >>
+                  rw[MEM_GENLIST,length_flatten_eq_size_of_shape] >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              irule not_mem_context_assigned_mem_gt >>
+              simp[] >>
+              reverse conj_asm2_tac
+              >- (gvs[ctxt_max_def] >> res_tac >> gvs[Abbr ‘newctxt’]) >>
+              rw[Abbr ‘newctxt’,FLOOKUP_UPDATE,MEM_GENLIST] >>
+              rw[MEM_GENLIST]
+              >- (rpt strip_tac >> gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[] >>
+              strip_tac >> gvs[] >>
+              gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+              metis_tac[]) >>
+          res_tac >> gvs[Abbr ‘newctxt’,FLOOKUP_UPDATE] >>
+          simp[opt_mmap_eq_some] >>
+          irule EQ_TRANS >>
+          irule_at (Pos hd) flookup_res_var_distinct >>
+          conj_asm1_tac
+          >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+              rpt strip_tac >>
+              gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+          gvs[opt_mmap_eq_some]) >>
+      gvs[UNCURRY_eq_pair] >>
+      Cases_on ‘size_of_shape (shape_of retv) = 0’
+      >- (gvs[nested_decs_def,load_globals_def] >>
+          qmatch_goalsub_abbrev_tac ‘evaluate (compile newctxt _, news)’ >>
+          first_x_assum $ qspecl_then [‘news’,‘newctxt’] mp_tac >>
+          impl_tac
+          >- (conj_asm1_tac
+              >- gvs[state_rel_def,set_var_def,panSemTheory.set_var_def,
+                     Abbr ‘news’] >>
+              conj_asm1_tac
+              >- (imp_res_tac evaluate_code_invariant >>
+                  imp_res_tac crep_evaluate_code_invariant >>
+                  gvs[set_var_def, Abbr ‘newctxt’, Abbr‘news’,
+                      panSemTheory.set_var_def,
+                      dec_clock_def,
+                      panSemTheory.dec_clock_def
+                     ] >>
+                  gvs[code_rel_def]) >>
+              conj_asm1_tac
+              >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+                  imp_res_tac evaluate_invariants >>
+                  gvs[panSemTheory.dec_clock_def]) >>
+              gvs[locals_rel_def] >>
+              conj_asm1_tac
+              >- (gvs[Abbr ‘newctxt’,no_overlap_def,FLOOKUP_UPDATE,ALL_DISTINCT_GENLIST] >>
+                  rw[] >> gvs[] >> res_tac >>
+                  gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs()]) >>
+              conj_asm1_tac
+              >- (gvs[Abbr ‘newctxt’,ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> gvs[] >> res_tac >>
+                  gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs()]) >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’] >>
+              gvs[GSYM length_flatten_eq_size_of_shape] >>
+              gvs[oneline wrap_rt_def,AllCaseEqs(),panLangTheory.size_of_shape_def] >>
+              Cases_on ‘flatten retv’ >> gvs[GENLIST_CONS])>>
+          strip_tac >>
+          simp[] >>
+          conj_asm1_tac >- gvs[state_rel_def] >>
+          conj_asm1_tac
+              >- (imp_res_tac evaluate_code_invariant >>
+                  imp_res_tac crep_evaluate_code_invariant >>
+                  gvs[set_var_def, Abbr ‘newctxt’, Abbr‘news’,
+                      panSemTheory.set_var_def,
+                      dec_clock_def,
+                      panSemTheory.dec_clock_def
+                     ] >>
+                  gvs[code_rel_def]) >>
+          conj_asm1_tac
+              >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+                  imp_res_tac evaluate_invariants >>
+                  gvs[panSemTheory.dec_clock_def]) >>
+          PURE_TOP_CASE_TAC >> gvs[]
+          >- (gvs[locals_rel_def] >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’,FLOOKUP_pan_res_var_thm
+                 ]
+              >- (res_tac >> gvs[] >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos last >>
+                  resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+                  rpt strip_tac >>
+                  simp[flookup_res_var_thm] >>
+                  rw[] >>
+                  res_tac >>
+                  gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,
+                      oneline wrap_rt_def] >>
+                  gvs[ctxt_max_def] >>
+                  res_tac >> gvs[] >>
+                  drule unassigned_free_vars_evaluate_same >>
+                  simp[] >>
+                  strip_tac >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos hd >>
+                  simp[FLOOKUP_UPDATE] >>
+                  irule not_mem_context_assigned_mem_gt >>
+                  simp[ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> rw[] >>
+                  gvs[] >>
+                  rpt strip_tac >>
+                  res_tac >> gvs[] >>
+                  gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+                  metis_tac[]) >>
+              res_tac >>
+              gvs[] >>
+              match_mp_tac EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+              rpt strip_tac >>
+              simp[flookup_res_var_thm] >>
+              rw[] >>
+              res_tac >>
+              gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,FLOOKUP_UPDATE,
+                  oneline wrap_rt_def] >>
+              gvs[ctxt_max_def] >>
+              res_tac >>
+              gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
+                  panLangTheory.size_of_shape_def])
+          >- (gvs[locals_rel_def] >>
+              rw[] >>
+              gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+                  Abbr ‘news’,FLOOKUP_pan_res_var_thm
+                 ]
+              >- (res_tac >> gvs[] >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos last >>
+                  resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+                  rpt strip_tac >>
+                  simp[flookup_res_var_thm] >>
+                  rw[] >>
+                  res_tac >>
+                  gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,
+                      oneline wrap_rt_def] >>
+                  gvs[ctxt_max_def] >>
+                  res_tac >> gvs[] >>
+                  drule unassigned_free_vars_evaluate_same >>
+                  simp[] >>
+                  strip_tac >>
+                  match_mp_tac EQ_TRANS >>
+                  first_x_assum $ irule_at $ Pos hd >>
+                  simp[FLOOKUP_UPDATE] >>
+                  irule not_mem_context_assigned_mem_gt >>
+                  simp[ctxt_max_def,FLOOKUP_UPDATE] >>
+                  rw[] >> rw[] >>
+                  gvs[] >>
+                  rpt strip_tac >>
+                  res_tac >> gvs[] >>
+                  gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+                  metis_tac[]) >>
+              res_tac >>
+              gvs[] >>
+              match_mp_tac EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              resolve_then Any (irule_at Any) (iffRL MAP_EQ_f) $ IMP_OPT_MMAP_EQ >>
+              rpt strip_tac >>
+              simp[flookup_res_var_thm] >>
+              rw[] >>
+              res_tac >>
+              gvs[oneline ret_var_def,AllCaseEqs(),oneline oHD_def,FLOOKUP_UPDATE,
+                  oneline wrap_rt_def] >>
+              gvs[ctxt_max_def] >>
+              res_tac >>
+              gvs[SF DNF_ss,FLOOKUP_UPDATE,AllCaseEqs(),
+                  panLangTheory.size_of_shape_def]) >>
+          PURE_TOP_CASE_TAC >> gvs[Abbr ‘newctxt’]) >>
+      gvs[] >>
+      irule_at (Pos hd) EQ_TRANS >>
+      irule_at (Pos hd) evaluate_nested_decs_load_globals >>
+      simp[ALL_DISTINCT_GENLIST,PULL_EXISTS,UNCURRY_eq_pair] >>
+      gvs[globals_lookup_def] >>
+      qmatch_goalsub_abbrev_tac ‘evaluate (compile newctxt _, news)’ >>
+      first_x_assum $ qspecl_then [‘news’,‘newctxt’] mp_tac >>
+      impl_tac
+      >- (conj_asm1_tac
+          >- gvs[state_rel_def,set_var_def,panSemTheory.set_var_def,
+                 Abbr ‘news’] >>
+          conj_asm1_tac
+          >- (imp_res_tac evaluate_code_invariant >>
+              imp_res_tac crep_evaluate_code_invariant >>
+              gvs[set_var_def, Abbr ‘newctxt’, Abbr‘news’,
+                  panSemTheory.set_var_def,
+                  dec_clock_def,
+                  panSemTheory.dec_clock_def
+                 ] >>
+              gvs[code_rel_def]) >>
+          conj_asm1_tac
+          >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+              imp_res_tac evaluate_invariants >>
+              gvs[panSemTheory.dec_clock_def]) >>
+          gvs[locals_rel_def] >>
+          conj_asm1_tac
+          >- (gvs[Abbr ‘newctxt’,no_overlap_def,FLOOKUP_UPDATE,ALL_DISTINCT_GENLIST] >>
+              rw[] >> gvs[] >> res_tac >>
+              gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs(),DISJOINT_ALT,
+                  MEM_GENLIST,panLangTheory.size_of_shape_def] >>
+              gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+          conj_asm1_tac
+          >- (gvs[Abbr ‘newctxt’,ctxt_max_def,FLOOKUP_UPDATE] >>
+              rw[] >> gvs[] >> res_tac >>
+              gvs[ALL_DISTINCT_GENLIST,oneline wrap_rt_def,AllCaseEqs(),DISJOINT_ALT,
+                  MEM_GENLIST,panLangTheory.size_of_shape_def]) >>
+          rw[] >>
+          gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+              Abbr ‘news’] >>
+          simp[ALL_DISTINCT_GENLIST,length_flatten_eq_size_of_shape,
+               opt_mmap_some_eq_zip_flookup] >>
+          res_tac >>
+          gvs[] >>
+          dep_rewrite.DEP_ONCE_REWRITE_TAC[opt_mmap_disj_zip_flookup] >>
+          simp[length_flatten_eq_size_of_shape] >>
+          rw[distinct_lists_def,EVERY_MEM,PULL_EXISTS,MEM_GENLIST] >>
+          strip_tac >>
+          gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+      strip_tac >>
+      simp[] >>
+      conj_asm1_tac >- gvs[state_rel_def] >>
+      conj_asm1_tac
+      >- (imp_res_tac evaluate_code_invariant >>
+          imp_res_tac crep_evaluate_code_invariant >>
+          gvs[dec_clock_def,panSemTheory.dec_clock_def,Abbr ‘news’,panSemTheory.set_var_def]) >>
+      conj_asm1_tac
+      >- (fs[Abbr ‘newctxt’,panSemTheory.set_var_def] >>
+          imp_res_tac evaluate_invariants >>
+          gvs[panSemTheory.dec_clock_def]) >>
+      PURE_TOP_CASE_TAC >> gvs[]
+      >- (gvs[locals_rel_def] >>
+          rw[] >>
+          gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+              Abbr ‘news’,FLOOKUP_pan_res_var_thm
+             ]
+          >- (res_tac >> gvs[] >>
+              simp[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              irule_at (Pos hd) flookup_res_var_distinct >>
+              conj_asm1_tac
+              >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+                  rpt strip_tac >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              rw[MAP_EQ_f] >>
+              drule unassigned_vars_evaluate_same >>
+              simp[] >>
+              strip_tac >>
+              irule EQ_TRANS >>
+              pop_assum $ irule_at $ Pos hd >>
+              reverse conj_asm1_tac
+              >- (irule flookup_fupdate_zip_not_mem >>
+                  rw[MEM_GENLIST,length_flatten_eq_size_of_shape] >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              irule not_mem_context_assigned_mem_gt >>
+              simp[] >>
+              reverse conj_asm2_tac
+              >- (gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              rw[FLOOKUP_UPDATE,MEM_GENLIST] >>
+              rw[MEM_GENLIST]
+              >- (rpt strip_tac >> gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[] >>
+              strip_tac >> gvs[] >>
+              gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+              metis_tac[]) >>
+          res_tac >> gvs[FLOOKUP_UPDATE] >>
+          simp[opt_mmap_eq_some] >>
+          irule EQ_TRANS >>
+          irule_at (Pos hd) flookup_res_var_distinct >>
+          conj_asm1_tac
+          >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+              rpt strip_tac >>
+              gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+          gvs[opt_mmap_eq_some])
+      >- (gvs[locals_rel_def] >>
+          rw[] >>
+          gvs[panSemTheory.set_var_def,FLOOKUP_UPDATE,Abbr ‘newctxt’,CaseEq "bool",
+              Abbr ‘news’,FLOOKUP_pan_res_var_thm
+             ]
+          >- (res_tac >> gvs[] >>
+              simp[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              irule_at (Pos hd) flookup_res_var_distinct >>
+              conj_asm1_tac
+              >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+                  rpt strip_tac >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[opt_mmap_eq_some] >>
+              irule EQ_TRANS >>
+              first_x_assum $ irule_at $ Pos last >>
+              rw[MAP_EQ_f] >>
+              drule unassigned_vars_evaluate_same >>
+              simp[] >>
+              strip_tac >>
+              irule EQ_TRANS >>
+              pop_assum $ irule_at $ Pos hd >>
+              reverse conj_asm1_tac
+              >- (irule flookup_fupdate_zip_not_mem >>
+                  rw[MEM_GENLIST,length_flatten_eq_size_of_shape] >>
+                  gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              irule not_mem_context_assigned_mem_gt >>
+              simp[] >>
+              reverse conj_asm2_tac
+              >- (gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              rw[FLOOKUP_UPDATE,MEM_GENLIST] >>
+              rw[MEM_GENLIST]
+              >- (rpt strip_tac >> gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+              gvs[] >>
+              strip_tac >> gvs[] >>
+              gvs[no_overlap_def] >> res_tac >> gvs[DISJOINT_ALT] >>
+              metis_tac[]) >>
+          res_tac >> gvs[FLOOKUP_UPDATE] >>
+          simp[opt_mmap_eq_some] >>
+          irule EQ_TRANS >>
+          irule_at (Pos hd) flookup_res_var_distinct >>
+          conj_asm1_tac
+          >- (gvs[distinct_lists_def,EVERY_MEM,MEM_GENLIST,PULL_EXISTS] >>
+              rpt strip_tac >>
+              gvs[ctxt_max_def] >> res_tac >> gvs[]) >>
+          gvs[opt_mmap_eq_some]) >>
+      PURE_FULL_CASE_TAC >> gvs[Abbr ‘newctxt’,ctxt_fc_def])
+  >- (PURE_FULL_CASE_TAC >> gvs[ctxt_fc_def] >>
+      conj_asm1_tac >- gvs[state_rel_def] >>
+      conj_asm1_tac
+      >- (imp_res_tac evaluate_code_invariant >>
+          imp_res_tac crep_evaluate_code_invariant >>
+          gvs[dec_clock_def,panSemTheory.dec_clock_def]) >>
+      gvs[globals_lookup_def]) >>
+  conj_tac >- gvs[state_rel_def] >>
+  conj_asm1_tac
+  >- (imp_res_tac evaluate_code_invariant >>
+      imp_res_tac crep_evaluate_code_invariant >>
+      gvs[dec_clock_def,panSemTheory.dec_clock_def]) >>
+  imp_res_tac evaluate_invariants >>
+  gvs[panSemTheory.dec_clock_def]
 QED
 
 Theorem list_max_APPEND:

--- a/pancake/proofs/pan_to_wordProofScript.sml
+++ b/pancake/proofs/pan_to_wordProofScript.sml
@@ -1147,7 +1147,19 @@ Proof
     rpt(PURE_TOP_CASE_TAC \\ gvs[]) \\ rw[crepPropsTheory.exps_of_def,crepLangTheory.assign_ret_def] \\
     rw[every_inst_ok_less_exps_of_nested_seq,EVERY_FLAT,EVERY_MAP,load_globals_alt,MAP2_MAP,MEM_ZIP] \\
     gvs[EVERY_MEM,MEM_ZIP,PULL_EXISTS,PULL_FORALL,crepPropsTheory.exps_of_def,
+        crepPropsTheory.every_exp_def])
+  >~ [‘exp_hdl’] >-
+   (gvs[] \\
+    rpt conj_tac >-
+     (gvs[EVERY_MEM,PULL_FORALL] \\
+      metis_tac[every_inst_ok_less_pan_to_crep_compile_exp,EVERY_MEM,FST,SND,PAIR]) \\
+    simp[DefnBase.one_line_ify NONE pan_to_crepTheory.exp_hdl_def,
+         DefnBase.one_line_ify NONE pan_to_crepTheory.ret_hdl_def] \\
+    rpt(PURE_TOP_CASE_TAC \\ gvs[]) \\ rw[crepPropsTheory.exps_of_def,crepLangTheory.assign_ret_def] \\
+    rw[every_inst_ok_less_exps_of_nested_seq,EVERY_FLAT,EVERY_MAP,load_globals_alt,MAP2_MAP,MEM_ZIP] \\
+    gvs[EVERY_MEM,MEM_ZIP,PULL_EXISTS,PULL_FORALL,crepPropsTheory.exps_of_def,
         crepPropsTheory.every_exp_def]) \\
+  simp[every_inst_ok_nested_decs,crepPropsTheory.exps_of_def,every_inst_ok_nested_decs,crepPropsTheory.length_load_globals_eq_read_size,load_globals_alt] \\
   rw[EVERY_MEM,MAP2_MAP,MEM_ZIP,MEM_MAP,UNCURRY_DEF] \\
   gvs[UNCURRY_DEF,crepPropsTheory.exps_of_def,EVERY_MEM,MEM_EL,PULL_EXISTS,EL_MAP,
       crepPropsTheory.every_exp_def,DefnBase.one_line_ify NONE pan_to_crepTheory.ret_hdl_def] \\

--- a/pancake/proofs/time/time_to_panProofScript.sml
+++ b/pancake/proofs/time/time_to_panProofScript.sml
@@ -65,9 +65,9 @@ Definition build_ffi_def:
   build_ffi (:'a) be outs (seq:time_input) io =
      <| oracle    :=
         (λs f conf bytes.
-          if s = "get_time_input"
+          if s = ExtCall "get_time_input"
           then Oracle_return (next_ffi f) (time_input (:'a) be f)
-          else if MEM s outs
+          else if MEM s (MAP ExtCall outs)
           then Oracle_return f bytes
           else Oracle_final FFI_failed)
       ; ffi_state := seq
@@ -152,7 +152,9 @@ End
 
 Definition well_behaved_ffi_def:
   well_behaved_ffi ffi_name (s:(α, β) panSem$state) n (m:num) <=>
-  explode ffi_name ≠ "" ∧ n < m ∧
+  case ffi_name of
+    ExtCall
+  ffi_name ≠ ExtCall(implode "" ∧ n < m ∧
   ∃bytes.
     read_bytearray s.base_addr n
                    (mem_load_byte s.memory s.memaddrs s.be) =

--- a/pancake/semantics/crepPropsScript.sml
+++ b/pancake/semantics/crepPropsScript.sml
@@ -1280,6 +1280,36 @@ Proof
   fs []
 QED
 
+Theorem evaluate_code_invariant:
+  ∀p t res st.
+    crepSem$evaluate (p,t) = (res,st) ⇒
+    st.code = t.code
+Proof
+  recInduct crepSemTheory.evaluate_ind >> rw[]
+  >~ [‘While’]
+  >- (pop_assum mp_tac >>
+      rw[Once crepSemTheory.evaluate_def] >>
+      gvs[AllCaseEqs(),crepSemTheory.empty_locals_def,UNCURRY_eq_pair,
+          crepSemTheory.dec_clock_def])
+  >~ [‘Call’]
+  >- (pop_assum mp_tac >>
+      rw[Once crepSemTheory.evaluate_def] >>
+      rfs[AllCaseEqs(),crepSemTheory.empty_locals_def,
+          crepSemTheory.dec_clock_def] >>
+      rveq >>
+      fs[]) >>
+  gvs[crepSemTheory.evaluate_def,AllCaseEqs(),
+      oneline crepSemTheory.sh_mem_op_def,
+      oneline crepSemTheory.sh_mem_load_def,
+      oneline crepSemTheory.sh_mem_store_def,
+      crepSemTheory.set_var_def,
+      crepSemTheory.empty_locals_def,
+      UNCURRY_eq_pair,
+      crepSemTheory.dec_clock_def,
+      crepSemTheory.set_globals_def
+     ]
+QED
+
 Definition exps_of_def:
   (exps_of (Dec _ e p) = e::exps_of p) ∧
   (exps_of (Seq p q) = exps_of p ++ exps_of q) ∧

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -517,352 +517,121 @@ Theorem evaluate_add_clock_eq:
    evaluate (p,t) = (res,st) /\ res <> SOME TimeOut ==>
     evaluate (p,t with clock := t.clock + ck) = (res,st with clock := st.clock + ck)
 Proof
-  recInduct evaluate_ind >> rw [] >>
-  TRY (fs [Once evaluate_def] >> NO_TAC) >>
-  TRY (
-  rename [‘Seq’] >>
-  fs [evaluate_def] >> pairarg_tac >> fs [] >>
-  pairarg_tac >> fs [] >> rveq >>
-  fs [AllCaseEqs ()] >> rveq >> fs [] >>
-  first_x_assum (qspec_then ‘ck’ mp_tac) >>
-  fs []) >>
-  TRY (
-  rename [‘If’] >>
-  fs [evaluate_def, AllCaseEqs ()] >> rveq >>
-  fs [eval_upd_clock_eq]) >>
-  TRY (
-  rename [‘ExtCall’] >>
-  fs [evaluate_def, AllCaseEqs (), empty_locals_def] >>
-  rveq >> fs []) >>
-  TRY (
-  rename [‘While’] >>
-  qpat_x_assum ‘evaluate (While _ _,_) = _’ mp_tac >>
-  once_rewrite_tac [evaluate_def] >>
-  fs [eval_upd_clock_eq] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  pairarg_tac >> fs [] >>
-  pairarg_tac >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []
-  >- (
-   strip_tac >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   fs [dec_clock_def] >>
-   first_x_assum (qspec_then ‘ck’ mp_tac) >>
-   fs []) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [dec_clock_def] >>
-  first_x_assum (qspec_then ‘ck’ mp_tac) >>
-  fs [] >>
-  strip_tac >> strip_tac >> fs [] >> rveq >> fs []) >>
-  TRY (
-  rename [‘Call’] >>
-  qpat_x_assum ‘evaluate (Call _ _ _,_) = _’ mp_tac >>
-  once_rewrite_tac [evaluate_def] >>
-  fs [dec_clock_def, eval_upd_clock_eq] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  ‘OPT_MMAP (eval (s with clock := ck + s.clock)) argexps =
-   OPT_MMAP (eval s) argexps’ by fs [opt_mmap_eval_upd_clock_eq] >>
-  fs [] >>
-  fs [AllCaseEqs(), empty_locals_def, dec_clock_def, set_var_def] >> rveq >> fs [] >>
-  strip_tac >> fs [] >> rveq >> fs []) >>
-  TRY (
-  rename [‘Dec’] >>
-  fs [evaluate_def, eval_upd_clock_eq, AllCaseEqs () ] >>
-  pairarg_tac >> fs [] >> rveq >> fs [] >>
-  pairarg_tac >> fs [] >> rveq >> fs [] >>
-  last_x_assum (qspec_then ‘ck’ mp_tac) >>
-  fs []) >>
-  TRY (
-    rename [‘ShMem’] >>
-    Cases_on ‘op’>>
-    fs[evaluate_def, eval_upd_clock_eq]>>
-    fs[sh_mem_op_def,sh_mem_load_def,sh_mem_store_def,
-       set_var_def,empty_locals_def, AllCaseEqs ()]>>rveq>>fs[]) >>
-  fs [evaluate_def, eval_upd_clock_eq, AllCaseEqs () ,
-      set_var_def, mem_store_def,
-      dec_clock_def, empty_locals_def] >> rveq >>
-  fs [state_component_equality]
+  recInduct evaluate_ind >> rw []
+  >~ [‘While’]
+  >- (once_rewrite_tac [evaluate_def] >>
+      qpat_x_assum ‘evaluate _ = _’ mp_tac >>
+      rw[Once evaluate_def] >>
+      gvs[eval_upd_clock_eq,AllCaseEqs()] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs(),dec_clock_def]) >>
+  gvs[evaluate_def,AllCaseEqs(),eval_upd_clock_eq] >>
+  rpt(pairarg_tac >> gvs[]) >>
+  gvs[oneline sh_mem_op_def,AllCaseEqs(),
+      oneline sh_mem_load_def,
+      oneline sh_mem_store_def,
+      set_var_def,
+      empty_locals_def,
+      dec_clock_def,
+      opt_mmap_eval_upd_clock_eq
+     ]
 QED
 
 Theorem evaluate_clock_sub:
-  !p t res st ck.
+  !p t st res ck.
     evaluate (p,t) = (res,st with clock := st.clock + ck) ∧
     res <> SOME TimeOut ⇒
     evaluate (p,t with clock := t.clock - ck) = (res,st)
 Proof
-  recInduct evaluate_ind >> rw [] >>
-  TRY (
-    rename [‘Seq’] >>
-    fs [evaluate_def] >> pairarg_tac >> fs [] >>
-    pairarg_tac >> fs [] >> rveq >>
-    fs [AllCaseEqs ()] >> rveq >> fs []
-    >- (
-      first_x_assum (qspecl_then [‘s1' with clock := s1'.clock - ck’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- (
-        gs [state_component_equality] >>
-        qpat_x_assum ‘evaluate (c2,s1') = _’ assume_tac >>
-        drule evaluate_clock >>
-        strip_tac >> gs []) >>
-      gs []) >>
-    last_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-    impl_tac >- gs [] >>
-    strip_tac >> gs []) >>
-  TRY (
-    rename [‘Dec’] >>
-    fs [evaluate_def, eval_upd_clock_eq, AllCaseEqs ()]
-    >- gs [state_component_equality] >>
-    pairarg_tac >> fs [] >> rveq >> fs [] >>
-    pairarg_tac >> fs [] >> rveq >> fs [] >>
-    last_x_assum (qspecl_then [‘st'' with clock := st''.clock - ck’, ‘ck’] mp_tac) >>
-    impl_tac >- gs [state_component_equality] >>
-    gs [] >> strip_tac >>
-    rveq >> gs [state_component_equality]) >>
-  TRY (
-    rename [‘While’] >>
-    qpat_x_assum ‘evaluate (While _ _,_) = _’ mp_tac >>
-    once_rewrite_tac [evaluate_def] >>
-    gs [AllCaseEqs(), eval_upd_clock_eq] >>
-    rw [] >> gs [state_component_equality] >>
-    rw [] >> gs []
-    >- (
-      CCONTR_TAC >> gs [] >>
-      pairarg_tac >> fs [] >> rveq >> fs [] >>
-      cases_on ‘res'’ >> gs []
-      >- (
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def]) >>
-      cases_on ‘x’ >> gs [] >>
+  (* TODO: generated names *)
+  recInduct evaluate_ind >> rw []
+  >~ [‘While’]
+  >- (once_rewrite_tac [evaluate_def] >>
+      qpat_x_assum ‘evaluate _ = _’ mp_tac >>
+      rw[Once evaluate_def] >>
+      gvs[eval_upd_clock_eq,AllCaseEqs()] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs(),dec_clock_def] >>
       imp_res_tac evaluate_clock >>
-      gs [dec_clock_def]) >>
-    pairarg_tac >> fs [] >> rveq >> fs [] >>
-    pairarg_tac >> fs [] >> rveq >> fs [] >>
-    gs [] >>
-    cases_on ‘res''’ >> gs [dec_clock_def]
-    >- (
-      first_x_assum (qspecl_then [‘s1' with clock := s1'.clock - ck’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- (
-        gs [state_component_equality] >>
-        imp_res_tac evaluate_clock >>
-        gs []) >>
-      strip_tac >> rgs []) >>
-    cases_on ‘x’ >> gs [dec_clock_def] >> (
-    first_x_assum (qspecl_then [‘s1' with clock := s1'.clock - ck’, ‘ck’] mp_tac) >>
-    impl_tac
-    >- (
-      gs [state_component_equality] >>
+      gvs[] >>
+      rw[state_component_equality] >>
+      first_x_assum $ resolve_then (Pos hd) mp_tac EQ_REFL >>
+      rw[] >>
+      last_x_assum $ qspecl_then [‘s1' with clock := s1'.clock - ck’,‘ck’] mp_tac >>
+      (impl_tac >- rw[state_component_equality]) >>
+      strip_tac >>
+      gvs[])
+  >~ [‘Seq’]
+  >- (once_rewrite_tac [evaluate_def] >>
+      qpat_x_assum ‘evaluate _ = _’ mp_tac >>
+      rw[Once evaluate_def] >>
+      gvs[eval_upd_clock_eq,AllCaseEqs()] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs(),dec_clock_def] >>
       imp_res_tac evaluate_clock >>
-      gs []) >>
-    strip_tac >> gs [] >> rveq >> gs [state_component_equality])) >>
-  TRY (
-    rename [‘Call’] >>
-    qpat_x_assum ‘evaluate (Call _ _ _,_) = _’ mp_tac >>
-    once_rewrite_tac [evaluate_def] >> gs [] >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      gs [AllCaseEqs(), eval_upd_clock_eq] >>
-      strip_tac >> gs []  >> rveq >>
-      gs [state_component_equality, eval_upd_clock_eq]) >>
-    reverse TOP_CASE_TAC >> gs []
-    >- (
-      gs [AllCaseEqs(), eval_upd_clock_eq] >>
-      strip_tac >> gs []  >> rveq >>
-      gs [state_component_equality, eval_upd_clock_eq]) >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      gs [AllCaseEqs(), eval_upd_clock_eq] >>
-      strip_tac >> gs []  >> rveq >>
-      gs [state_component_equality, eval_upd_clock_eq]) >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      gs [AllCaseEqs(), eval_upd_clock_eq] >>
-      strip_tac >> gs []  >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1] >>
-      ‘st with clock := st.clock = st’ by gs [state_component_equality] >>
-      gs []) >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      gs [AllCaseEqs(), eval_upd_clock_eq] >>
-      strip_tac >> gs []  >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1] >>
-      ‘st with clock := st.clock = st’ by gs [state_component_equality] >>
-      gs []) >>
-    TOP_CASE_TAC >> gs [] >>
-    TOP_CASE_TAC >> gs [] >>
-    TOP_CASE_TAC >> gs [] >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      strip_tac >> rveq >> gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1] >>
+      gvs[] >>
+      rw[state_component_equality] >>
+      first_x_assum $ resolve_then (Pos hd) mp_tac EQ_REFL >>
+      rw[] >>
+      last_x_assum $ qspecl_then [‘s1' with clock := s1'.clock - ck’,‘ck’] mp_tac >>
+      (impl_tac >- rw[state_component_equality]) >>
+      strip_tac >>
+      gvs[])
+  >~ [‘Dec’]
+  >- (once_rewrite_tac [evaluate_def] >>
+      qpat_x_assum ‘evaluate _ = _’ mp_tac >>
+      rw[Once evaluate_def] >>
+      gvs[eval_upd_clock_eq,AllCaseEqs()] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs(),dec_clock_def] >>
       imp_res_tac evaluate_clock >>
-      gs [dec_clock_def] >>
-      first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-      impl_tac >- gs [] >>
-      strip_tac >> gs []) >>
-    TOP_CASE_TAC >> gs []
-    >- (
-      strip_tac >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-      first_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- gs [state_component_equality] >>
-      strip_tac >> gs [] >>
+      gvs[]
+      >- rw[state_component_equality] >>
+      last_x_assum $ qspecl_then [‘st'' with clock := st''.clock - ck’,‘ck’] mp_tac >>
+      (impl_tac >- gvs[state_component_equality]) >>
+      strip_tac >>
+      gvs[state_component_equality])
+  >~ [‘Call’]
+  >- (gvs[evaluate_def,AllCaseEqs(),eval_upd_clock_eq,opt_mmap_eval_upd_clock_eq1,dec_clock_def,
+         empty_locals_def,set_var_def] >>
       imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality])
-    >- (
-      strip_tac >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-      first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- gs [state_component_equality] >>
-      strip_tac >> gs [] >>
+      gvs[empty_locals_def] >>
+      TRY $ first_x_assum $ irule_at $ Pat ‘evaluate _ = _’ >>
+      gvs[state_component_equality] >>
+      TRY $ first_x_assum $ irule_at $ Pat ‘evaluate _ = _’ >>
+      rw[] >>
+      qrefine ‘_ with locals := (_:('a,'b) state).locals’ >>
+      rw[] >>
+      gvs[] >>
+      metis_tac[])
+  >~ [‘DecCall’]
+  >- (gvs[evaluate_def,AllCaseEqs(),eval_upd_clock_eq,opt_mmap_eval_upd_clock_eq1,dec_clock_def,
+         empty_locals_def,set_var_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
       imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality])
-    >- (
-      strip_tac >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-      first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- gs [state_component_equality] >>
-      strip_tac >> gs [] >>
-      imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality])
-    >- (
-      TOP_CASE_TAC >> gs []
-      >- (
-        strip_tac >> rveq >>
-        gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-        first_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- gs [state_component_equality] >>
-        strip_tac >> gs [] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      TOP_CASE_TAC >> gs []>>
-      TOP_CASE_TAC >> gs []
-      >- (
-        strip_tac >> rveq >>
-        gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-            dec_clock_def, set_var_def] >>
-        first_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- gs [state_component_equality] >>
-        strip_tac >> gs [] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      strip_tac >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-          dec_clock_def, set_var_def] >>
-      first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- gs [state_component_equality] >>
-      strip_tac >> gs [] >>
-      imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality])
-    >- (
-      TOP_CASE_TAC >> gs []
-      >- (
-        strip_tac >> rveq >>
-        gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-        first_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- gs [state_component_equality] >>
-        strip_tac >> gs [] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      TOP_CASE_TAC >> gs []>>
-      TOP_CASE_TAC >> gs []
-      >- (
-        strip_tac >> rveq >>
-        gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-            dec_clock_def, set_var_def] >>
-        first_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- gs [state_component_equality] >>
-        strip_tac >> gs [] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      TOP_CASE_TAC >> gs [] >>
-      TOP_CASE_TAC >> gs []>>
-      TOP_CASE_TAC >> gs []
-      >- (
-        TOP_CASE_TAC >> gs []
-        >- (
-          strip_tac >> rveq >>
-          gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-              dec_clock_def, set_var_def] >>
-          first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-          impl_tac
-          >- gs [state_component_equality] >>
-          strip_tac >> gs [] >>
-          imp_res_tac evaluate_clock >>
-          gs [dec_clock_def, state_component_equality]) >>
-        reverse TOP_CASE_TAC >> gs []
-        >- (
-          strip_tac >> rveq >>
-          gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-              dec_clock_def, set_var_def] >>
-          first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-          impl_tac
-          >- gs [state_component_equality] >>
-          strip_tac >> gs [] >>
-          imp_res_tac evaluate_clock >>
-          gvs [dec_clock_def, state_component_equality] >>
-          TOP_CASE_TAC >> gvs []) >>
-        strip_tac >> rveq >>
-        gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-            dec_clock_def, set_var_def] >>
-        last_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- (
-          gs [state_component_equality] >>
-          imp_res_tac evaluate_clock >>
-          gs [dec_clock_def, state_component_equality]) >>
-        strip_tac >> gs [] >>
-        first_x_assum (qspecl_then [‘st’, ‘ck’] mp_tac) >>
-        impl_tac
-        >- gs [state_component_equality] >>
-        strip_tac >> gs [] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      strip_tac >> rveq >>
-      gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def,
-          dec_clock_def, set_var_def] >>
-      last_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-      impl_tac
-      >- (
-        gs [state_component_equality] >>
-        imp_res_tac evaluate_clock >>
-        gs [dec_clock_def, state_component_equality]) >>
-      strip_tac >> gs [] >>
-      imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality]) >>
-    strip_tac >> rveq >>
-    gs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq1, empty_locals_def, dec_clock_def] >>
-    last_x_assum (qspecl_then [‘r' with clock := r'.clock - ck’, ‘ck’] mp_tac) >>
-    impl_tac
-    >- (
-      gs [state_component_equality] >>
-      imp_res_tac evaluate_clock >>
-      gs [dec_clock_def, state_component_equality]) >>
-    strip_tac >> gs [] >>
-    imp_res_tac evaluate_clock >>
-    gs [dec_clock_def, state_component_equality]) >>
-  TRY (
-    rename [‘ShMem’] >>
-    Cases_on ‘op’>>
-    fs[evaluate_def, eval_upd_clock_eq]>>
-    fs[sh_mem_op_def,sh_mem_load_def,sh_mem_store_def,
-       set_var_def,empty_locals_def, AllCaseEqs ()]>>rveq>>
-    gs [state_component_equality]) >>
-  gs [evaluate_def, AllCaseEqs ()] >> rveq >>
-  gs [eval_upd_clock_eq, state_component_equality, empty_locals_def, dec_clock_def]
+      gvs[empty_locals_def] >>
+      TRY $ first_x_assum $ irule_at $ Pat ‘evaluate _ = _’ >>
+      gvs[state_component_equality] >>
+      TRY $ first_x_assum $ irule_at $ Pat ‘evaluate _ = _’ >>
+      rw[]
+      >~ [‘UNCURRY’]
+      >- (qexists_tac ‘st' with clock := st'.clock - ck’ >>
+          simp[] >>
+          last_x_assum $ qspec_then ‘st with <|locals := st''.locals|>’ $ dep_rewrite.DEP_ONCE_REWRITE_TAC o single >>
+          simp[] >>
+          rw[state_component_equality]) >>
+      qrefine ‘_ with locals := (_:('a,'b) state).locals’ >>
+      rw[] >>
+      gvs[] >>
+      metis_tac[]) >>
+  gvs[evaluate_def,state_component_equality,AllCaseEqs(),eval_upd_clock_eq,
+      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline sh_mem_store_def, set_var_def, empty_locals_def,
+      dec_clock_def,opt_mmap_eval_upd_clock_eq1
+     ] >>
+  rpt(pairarg_tac >> gvs[]) >>
+  gvs[state_component_equality]
 QED
-
 
 Theorem evaluate_io_events_mono:
    !exps s1 res s2.
@@ -871,64 +640,22 @@ Theorem evaluate_io_events_mono:
     s1.ffi.io_events ≼ s2.ffi.io_events
 Proof
   recInduct evaluate_ind >>
-  rw [] >>
-  TRY (
-  rename [‘Seq’] >>
-  fs [evaluate_def] >>
-  pairarg_tac >> fs [] >> rveq >>
-  every_case_tac >> fs [] >> rveq >>
-  metis_tac [IS_PREFIX_TRANS]) >>
-  TRY (
-  rename [‘ExtCall’] >>
-  fs [evaluate_def, AllCaseEqs(), empty_locals_def,
-      dec_clock_def, ffiTheory.call_FFI_def] >>
-  rveq >> fs []) >>
-  TRY (
-  rename [‘If’] >>
-  fs [evaluate_def] >>
-  every_case_tac >> fs []) >>
-  TRY (
-  rename [‘While’] >>
-  qpat_x_assum ‘evaluate (While _ _,_) = _’ mp_tac >>
-  once_rewrite_tac [evaluate_def] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [empty_locals_def]
-  >- (strip_tac >> rveq >> fs []) >>
-  pairarg_tac >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []
-  >- (
-   strip_tac >> fs [] >>
-   fs [dec_clock_def] >>
-   metis_tac [IS_PREFIX_TRANS]) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  strip_tac >> fs [] >> rveq >> fs [dec_clock_def] >>
-  metis_tac [IS_PREFIX_TRANS]) >>
-  TRY (
-  rename [‘Call’] >>
-  pop_assum mp_tac >>
-  once_rewrite_tac [evaluate_def, LET_THM] >>
-  fs [AllCaseEqs(), empty_locals_def,
-      dec_clock_def, set_var_def] >>
-  strip_tac >> fs [] >> rveq >> fs [] >>
-  metis_tac [IS_PREFIX_TRANS]) >>
-  TRY (
-  rename [‘Dec’] >>
-  fs [evaluate_def, AllCaseEqs () ] >>
-  pairarg_tac >> fs [] >> rveq >> fs []) >>
-  TRY (
-    rename [‘ShMem’] >>
-    Cases_on ‘op’>>
-    fs [evaluate_def, AllCaseEqs(),sh_mem_op_def,
-        sh_mem_store_def,sh_mem_load_def,
-        set_var_def,empty_locals_def,ffiTheory.call_FFI_def] >>
-    rveq >> fs []) >>
-  fs [evaluate_def, eval_upd_clock_eq, AllCaseEqs () ,
-      set_var_def, mem_store_def,
-      dec_clock_def, empty_locals_def] >> rveq >>
-  fs [state_component_equality]
+  rw []
+  >~ [‘While’]
+  >- (pop_assum mp_tac >>
+      simp[Once evaluate_def] >> strip_tac >>
+      gvs[AllCaseEqs(),empty_locals_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs(),dec_clock_def] >>
+      imp_res_tac IS_PREFIX_TRANS) >>
+  gvs[evaluate_def,AllCaseEqs(),
+      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline sh_mem_store_def, set_var_def, empty_locals_def,
+      dec_clock_def,opt_mmap_eval_upd_clock_eq1,
+      ffiTheory.call_FFI_def] >>
+  rpt(pairarg_tac >> gvs[]) >>
+  gvs[AllCaseEqs()] >>
+  imp_res_tac IS_PREFIX_TRANS
 QED
 
 Theorem evaluate_add_clock_io_events_mono:
@@ -936,252 +663,91 @@ Theorem evaluate_add_clock_io_events_mono:
     (SND(evaluate(exps,s))).ffi.io_events ≼
     (SND(evaluate(exps,s with clock := s.clock + extra))).ffi.io_events
 Proof
+  ‘∀exps s extra res s'.
+     evaluate(exps,s) = (res,s') ⇒
+     s'.ffi.io_events ≼ (SND(evaluate(exps,s with clock := s.clock + extra))).ffi.io_events’
+    suffices_by metis_tac [FST,SND,PAIR] >>
   recInduct evaluate_ind >>
-  rw [] >>
-  TRY (
-  rename [‘Seq’] >>
-  fs [evaluate_def] >>
-  pairarg_tac >> fs [] >> rveq >>
-  pairarg_tac >> fs [] >> rveq >>
-  every_case_tac >> fs [] >> rveq >> fs []
-  >- (
-   pop_assum mp_tac >>
-   drule evaluate_add_clock_eq >>
-   disch_then (qspec_then ‘extra’ mp_tac) >>
-   fs [] >>
-   strip_tac >>
-   strip_tac >> rveq >> fs [])
-  >- (
-   pop_assum mp_tac >>
-   pop_assum mp_tac >>
-   drule evaluate_add_clock_eq >>
-   disch_then (qspec_then ‘extra’ mp_tac) >>
-   fs [])
-  >- (
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >>
-   ‘s1.ffi.io_events ≼ s1'.ffi.io_events’ by rfs [] >>
-   cases_on ‘evaluate (c2,s1')’ >>
-   fs [] >>
-   ‘s1'.ffi.io_events ≼ r.ffi.io_events’ by
-     metis_tac [evaluate_io_events_mono] >>
-   metis_tac [IS_PREFIX_TRANS]) >>
-  first_x_assum (qspec_then ‘extra’ mp_tac) >>
-  fs []) >>
-  TRY (
-  rename [‘If’] >>
-  fs [evaluate_def, AllCaseEqs()] >> rveq >> fs [] >>
-  every_case_tac >> fs [eval_upd_clock_eq]) >>
-  TRY (
-  rename [‘While’] >>
-  once_rewrite_tac [evaluate_def] >>
-  TOP_CASE_TAC >> fs [eval_upd_clock_eq] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [empty_locals_def]
-  >- (
-   TOP_CASE_TAC >> fs [] >> rveq >>
-   fs [dec_clock_def] >>
-   pairarg_tac >> fs [] >>
-   TOP_CASE_TAC >> fs [] >>
-   TRY (cases_on ‘x’) >> fs [] >>
-   TRY (cases_on ‘evaluate (While e c,s1)’) >> fs [] >>
-   imp_res_tac evaluate_io_events_mono >> fs [] >>
-   metis_tac [IS_PREFIX_TRANS]) >>
-   pairarg_tac >> fs [] >> rveq >>
-   pairarg_tac >> fs [] >> rveq >>
-   fs [dec_clock_def] >>
-   cases_on ‘res’ >> fs []
-   >- (
-    pop_assum mp_tac >>
-    drule evaluate_add_clock_eq >>
-    fs [] >>
-    disch_then (qspec_then ‘extra’ mp_tac) >>
-    fs [] >>
-    strip_tac >> strip_tac >> rveq >> fs []) >>
-   cases_on ‘x = Continue’ >> fs []
-   >- (
-    pop_assum mp_tac >>
-    pop_assum mp_tac >>
-    drule evaluate_add_clock_eq >>
-    fs [] >>
-    disch_then (qspec_then ‘extra’ mp_tac) >>
-    fs [] >>
-    strip_tac >> strip_tac >> strip_tac >> rveq >> fs []) >>
-   cases_on ‘x = TimeOut’ >> rveq >> fs []
-   >- (
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TRY (cases_on ‘x’) >> fs [] >> rveq >> fs [] >>
-    first_x_assum (qspec_then ‘extra’ mp_tac) >>
-    fs [] >> strip_tac >>
-    cases_on ‘evaluate (While e c,s1')’ >> fs [] >>
-    drule evaluate_io_events_mono >>
-    strip_tac >>
-    metis_tac [IS_PREFIX_TRANS]) >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   drule evaluate_add_clock_eq >>
-   fs [] >>
-   disch_then (qspec_then ‘extra’ mp_tac) >>
-   fs [] >>
-   strip_tac >> strip_tac >> strip_tac >> rveq >> fs []) >>
-  TRY (
-  rename [‘Call’] >>
-  once_rewrite_tac [evaluate_def, LET_THM] >>
-  fs [eval_upd_clock_eq, opt_mmap_eval_upd_clock_eq] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs [empty_locals_def]
-  >- (
-   every_case_tac >> fs [dec_clock_def, empty_locals_def, set_var_def] >>
-   rveq >> fs [] >>
-   imp_res_tac evaluate_io_events_mono >>
-   fs [] >>
-   rename1 ‘evaluate (p,r' with locals := s.locals |+ (m'',v))’>>
-   TRY (cases_on ‘evaluate (p,r' with locals := s.locals |+ (m'',v))’) >> fs [] >>
-   imp_res_tac evaluate_io_events_mono >>
-   fs [] >> metis_tac [IS_PREFIX_TRANS]) >>
-  fs [dec_clock_def] >>
-  TOP_CASE_TAC >> fs [] >>
-  TOP_CASE_TAC >> fs []
-  >- (
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs []
-   >- (
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [set_var_def]) >>
-   every_case_tac >> fs [] >> rveq >> fs [set_var_def] >>
-   rename1 ‘evaluate (p,r'' with locals := s.locals |+ (m'',v))’>>
-   cases_on ‘evaluate (p,r'' with locals := s.locals |+ (m'',v))’ >>
-   fs [] >>
-   imp_res_tac evaluate_io_events_mono >>
-   fs [] >> metis_tac [IS_PREFIX_TRANS]) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TRY (drule evaluate_add_clock_eq >> fs [] >> NO_TAC)
-  >- (
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TRY (cases_on ‘x'’) >> fs [] >> rveq >> fs [] >>
-   TRY (
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >> fs [] >>
-   cases_on ‘evaluate (q,s with <|locals := r;
-                       clock := extra + s.clock - 1|>)’ >>
-   fs [] >> rveq >> fs [] >> NO_TAC)
-   >- (
-    every_case_tac >> fs [] >> rveq >> fs [] >>
-    first_x_assum (qspec_then ‘extra’ mp_tac) >>
-    strip_tac >> fs [set_var_def] >> rfs []) >>
-   every_case_tac >> fs [] >> rveq >> fs [] >>
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >> fs [set_var_def] >> rfs [] >>
-   rename1 ‘evaluate (p,r'' with locals := s.locals |+ (m'',v))’ >>
-   cases_on ‘evaluate (p,r'' with locals := s.locals |+ (m'',v))’ >>
-   imp_res_tac evaluate_io_events_mono >>
-   fs [] >> metis_tac [IS_PREFIX_TRANS])
-  >- (
-   TOP_CASE_TAC >> fs [] >> rveq >> fs []
-   >- (
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs []
-    >- (
-     pop_assum mp_tac >>
-     drule evaluate_add_clock_eq >> fs []) >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TRY (
-    pop_assum mp_tac >>
-    drule evaluate_add_clock_eq >> fs [] >> NO_TAC) >>
-    first_x_assum (qspec_then ‘extra’ mp_tac) >>
-    strip_tac >> fs [] >> rfs []) >>
-   TOP_CASE_TAC >> fs [set_var_def] >> rveq >> fs []>>
-   TOP_CASE_TAC >> fs [set_var_def] >> rveq >> fs []
-   >- (
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs []
-    >- (
-     pop_assum mp_tac >>
-     drule evaluate_add_clock_eq >> fs []) >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-    TRY (
-    pop_assum mp_tac >>
-    drule evaluate_add_clock_eq >> fs [] >> NO_TAC) >>
-    TOP_CASE_TAC >> fs [] >> rveq >> fs [] >> rfs [] >>
-    first_x_assum (qspec_then ‘extra’ mp_tac) >>
-    strip_tac >> fs [] >> rfs []) >>
-   drule evaluate_add_clock_eq >> fs []) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []
-  >- (
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >> fs [] >>
-   cases_on ‘evaluate (q,s with <|locals := r; clock := extra + s.clock - 1|>)’ >>
-   fs [] >>
-   TOP_CASE_TAC >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs []) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []>>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []
-  >- (
-   first_x_assum (qspec_then ‘extra’ mp_tac) >>
-   strip_tac >> fs [] >>
-   cases_on ‘evaluate (q,s with <|locals := r; clock := extra + s.clock - 1|>)’ >>
-   fs [] >>
-   TOP_CASE_TAC >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   pop_assum mp_tac >>
-   drule evaluate_add_clock_eq >> fs []) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs []
-  >- (
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> fs [] >> rveq >> fs [set_var_def] >>
-   pop_assum mp_tac >>
-   drule evaluate_add_clock_eq >> fs [] >>
-   disch_then (qspec_then ‘extra’ mp_tac) >>
-   fs [] >> strip_tac >> strip_tac >>
-   fs [] >> rveq >> fs [] >>
-   TOP_CASE_TAC >> gvs []) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  pop_assum mp_tac >>
-  drule evaluate_add_clock_eq >> fs [] >>
-  disch_then (qspec_then ‘extra’ mp_tac) >>
-  fs [] >>
-  strip_tac >>  strip_tac >> fs [] >> rveq >> fs []) >>
-  TRY (
-  rename [‘Dec’] >>
-  fs [evaluate_def] >>
-  fs [eval_upd_clock_eq] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  pairarg_tac >> fs [] >> rveq >> fs [] >>
-  pairarg_tac >> fs [] >> rveq >> fs [] >>
-  last_x_assum (qspec_then ‘extra’ mp_tac) >>
-  fs []) >>
-  TRY (
-  rename [‘ExtCall’] >>
-  fs [evaluate_def, eval_upd_clock_eq,
-      empty_locals_def] >>
-  every_case_tac >> fs []) >>
-  TRY (
-    rename [‘ShMem’] >>
-    Cases_on ‘op’>>
-    fs [evaluate_def,sh_mem_op_def,
-        sh_mem_store_def,sh_mem_load_def,eval_upd_clock_eq,
-        set_var_def,empty_locals_def,ffiTheory.call_FFI_def] >>
-    rpt (FULL_CASE_TAC>>fs[]))>>
-  fs [evaluate_def, eval_upd_clock_eq] >>
-  every_case_tac >> fs [] >>
-  fs [set_var_def, mem_store_def,
-      dec_clock_def, empty_locals_def] >> rveq >>
-  fs []
+  rw []
+  >~ [‘While’]
+  >- (simp[Once evaluate_def] >>
+      pop_assum mp_tac >>
+      simp[Once evaluate_def] >>
+      strip_tac >>
+      gvs[AllCaseEqs(),
+          eval_upd_clock_eq,
+          empty_locals_def,
+          dec_clock_def]
+      >- (IF_CASES_TAC >> gvs[] >>
+          pairarg_tac >>
+          gvs[] >>
+          rpt(PURE_TOP_CASE_TAC >> gvs[]) >>
+          metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS,
+                    Q.prove(‘(x with clock := y).ffi = x.ffi’,simp[])]) >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs()]
+      >~ [‘evaluate _ = (SOME TimeOut, _)’]
+      >- (rpt(PURE_TOP_CASE_TAC >> gvs[]) >>
+          metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS,
+                    Q.prove(‘(x with clock := y).ffi = x.ffi’,simp[])]) >>
+      qpat_x_assum ‘evaluate (_,_ with <|clock := _.clock − 1|>) = _’ assume_tac >>
+      drule_then (qspec_then ‘extra’ assume_tac) evaluate_add_clock_eq >>
+      gvs[])
+  >~ [‘Seq’]
+  >- (gvs[evaluate_def,AllCaseEqs(),
+          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline sh_mem_store_def, set_var_def, empty_locals_def,
+          dec_clock_def,opt_mmap_eval_upd_clock_eq1,
+          eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs()]
+      >- (drule_then (qspec_then ‘extra’ assume_tac) evaluate_add_clock_eq >>
+          gvs[]) >>
+      rw[] >>
+      metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS])
+  >~ [‘Call’]
+  >- (gvs[evaluate_def,AllCaseEqs(),
+          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline sh_mem_store_def, set_var_def, empty_locals_def,
+          dec_clock_def,opt_mmap_eval_upd_clock_eq1,
+          eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs()] >>
+      rw[] >>
+      rpt(IF_CASES_TAC ORELSE PURE_TOP_CASE_TAC >> gvs[]) >>
+      imp_res_tac evaluate_io_events_mono >> gvs[] >>
+      TRY(qpat_x_assum ‘evaluate (_,_ with <|locals := _; clock := _.clock − 1|>) = _’ assume_tac >>
+          drule_then (qspec_then ‘extra’ assume_tac) evaluate_add_clock_eq >>
+          gvs[]) >>
+      metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS,
+                Q.prove(‘(x with locals := y).ffi = x.ffi’,simp[])])
+  >~ [‘DecCall’]
+  >- (gvs[evaluate_def,AllCaseEqs(),
+          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline sh_mem_store_def, set_var_def, empty_locals_def,
+          dec_clock_def,opt_mmap_eval_upd_clock_eq1,
+          eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      gvs[AllCaseEqs()] >>
+      rw[] >>
+      rpt(IF_CASES_TAC ORELSE PURE_TOP_CASE_TAC >> gvs[]) >>
+      imp_res_tac evaluate_io_events_mono >> gvs[] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      TRY(qpat_x_assum ‘evaluate (_,_ with <|locals := _; clock := _.clock − 1|>) = _’ assume_tac >>
+          drule_then (qspec_then ‘extra’ assume_tac) evaluate_add_clock_eq >>
+          gvs[]) >>
+      metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS,
+                Q.prove(‘(x with locals := y).ffi = x.ffi’,simp[])]
+     ) >>
+  gvs[evaluate_def,AllCaseEqs(),
+      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline sh_mem_store_def, set_var_def, empty_locals_def,
+      dec_clock_def,opt_mmap_eval_upd_clock_eq1,
+      eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
+  rpt(pairarg_tac >> gvs[]) >>
+  rw[] >>
+  gvs[AllCaseEqs()] >>
+  metis_tac[FST,SND,PAIR,IS_PREFIX_TRANS]
 QED
 
 Theorem update_locals_not_vars_eval_eq:
@@ -1359,6 +925,7 @@ Definition exps_of_def:
   (exps_of (Call NONE e es) = e::es) ∧
   (exps_of (Call (SOME (_ , (SOME (_ ,  _ , ep)))) e es) = e::es++exps_of ep) ∧
   (exps_of (Call (SOME (_ , NONE)) e es) = e::es) ∧
+  (exps_of (DecCall _ e es p) = e::es++exps_of p) ∧
   (exps_of (Store e1 e2) = [e1;e2]) ∧
   (exps_of (StoreByte e1 e2) = [e1;e2]) ∧
   (exps_of (Return e) = [e]) ∧

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -925,7 +925,7 @@ Definition exps_of_def:
   (exps_of (Call NONE e es) = e::es) ∧
   (exps_of (Call (SOME (_ , (SOME (_ ,  _ , ep)))) e es) = e::es++exps_of ep) ∧
   (exps_of (Call (SOME (_ , NONE)) e es) = e::es) ∧
-  (exps_of (DecCall _ e es p) = e::es++exps_of p) ∧
+  (exps_of (DecCall _ _ e es p) = e::es++exps_of p) ∧
   (exps_of (Store e1 e2) = [e1;e2]) ∧
   (exps_of (StoreByte e1 e2) = [e1;e2]) ∧
   (exps_of (Return e) = [e]) ∧

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -538,7 +538,7 @@ Proof
 QED
 
 Theorem evaluate_clock_sub:
-  !p t st res ck.
+  !p t res st ck.
     evaluate (p,t) = (res,st with clock := st.clock + ck) ∧
     res <> SOME TimeOut ⇒
     evaluate (p,t with clock := t.clock - ck) = (res,st)

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -59,6 +59,14 @@ Proof
   fs [res_var_def, FLOOKUP_UPDATE, DOMSUB_FLOOKUP_NEQ]
 QED
 
+Theorem FLOOKUP_pan_res_var_thm:
+  FLOOKUP (panSem$res_var l (m,v)) n = if n = m then v else FLOOKUP l n
+Proof
+  simp[oneline panSemTheory.res_var_def] >>
+  PURE_FULL_CASE_TAC >>
+  rw[DOMSUB_FLOOKUP_THM,FLOOKUP_UPDATE]
+QED
+
 Theorem list_rel_length_shape_of_flatten:
   !vshs args.
   LIST_REL (λvsh arg. SND vsh = shape_of arg) vshs args ==>
@@ -875,7 +883,8 @@ Theorem evaluate_invariants:
   ∀p t res st.
   evaluate (p,t) = (res,st) ⇒
   st.memaddrs = t.memaddrs ∧ st.sh_memaddrs = t.sh_memaddrs ∧
-  st.be = t.be ∧ st.eshapes = t.eshapes ∧ st.base_addr = t.base_addr
+  st.be = t.be ∧ st.eshapes = t.eshapes ∧ st.base_addr = t.base_addr ∧
+  st.code = t.code
 Proof
   Ho_Rewrite.PURE_REWRITE_TAC[FORALL_AND_THM,IMP_CONJ_THM] >> rpt conj_tac >>
   recInduct evaluate_ind >>
@@ -893,7 +902,6 @@ Proof
      gvs[Once evaluate_def,AllCaseEqs(),ELIM_UNCURRY,empty_locals_def,dec_clock_def,set_var_def] >>
      metis_tac[PAIR,FST,SND])
 QED
-
 
 Definition every_exp_def:
   (every_exp P (panLang$Const w) = P(Const w)) ∧

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -440,7 +440,7 @@ Definition evaluate_def:
               | (SOME (Return retv),st) =>
                   (case caltyp of
                     | NONE      => (SOME (Return retv),empty_locals st)
-                    | SOME (NONE, _) => (NONE, st)
+                    | SOME (NONE, _) => (NONE, st with locals := s.locals)
                     | SOME (SOME rt,  _) =>
                        if is_valid_value s.locals rt retv
                        then (NONE, set_var rt retv (st with locals := s.locals))

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -474,7 +474,7 @@ Definition evaluate_def:
               | (SOME Break,st) => (SOME Error,st)
               | (SOME Continue,st) => (SOME Error,st)
               | (SOME (Return retv),st) =>
-                  if size_of_shape(shape_of retv) = size_of_shape shape then
+                  if shape_of retv = shape then
                     let (res',st') = evaluate (prog1, set_var rt retv (st with locals := s.locals)) in
                       (res',st' with locals := res_var st'.locals (rt, FLOOKUP s.locals rt))
                   else

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -461,7 +461,7 @@ Definition evaluate_def:
               | (res,st) => (res,empty_locals st))
          | _ => (SOME Error,s))
      | (_, _) => (SOME Error,s))/\
-  (evaluate (DecCall rt trgt argexps prog1,s) =
+  (evaluate (DecCall rt shape trgt argexps prog1,s) =
     case (eval s trgt, OPT_MMAP (eval s) argexps) of
      | (SOME (ValLabel fname), SOME args) =>
         (case lookup_code s.code fname args of
@@ -474,8 +474,11 @@ Definition evaluate_def:
               | (SOME Break,st) => (SOME Error,st)
               | (SOME Continue,st) => (SOME Error,st)
               | (SOME (Return retv),st) =>
-                  let (res',st') = evaluate (prog1, set_var rt retv (st with locals := s.locals)) in
-                    (res',st' with locals := res_var st'.locals (rt, FLOOKUP s.locals rt))
+                  if size_of_shape(shape_of retv) = size_of_shape shape then
+                    let (res',st') = evaluate (prog1, set_var rt retv (st with locals := s.locals)) in
+                      (res',st' with locals := res_var st'.locals (rt, FLOOKUP s.locals rt))
+                  else
+                    (SOME Error, st)
               | (res,st) => (res,empty_locals st))
            | _ => (SOME Error,s))
      | (_, _) => (SOME Error,s)) /\

--- a/pancake/time_to_panScript.sml
+++ b/pancake/time_to_panScript.sml
@@ -251,7 +251,7 @@ Definition task_controller_def:
         wait_input_time_limit;
         If (Cmp Equal (Var «sysTime») (Const (n2w (dimword (:α) - 2))))
            check_input_time (Skip:'a prog);
-        Call (SOME («taskRet», NONE)) (Var «loc»)
+        Call (SOME (SOME «taskRet», NONE)) (Var «loc»)
              [Struct (normalisedClks «sysTime» «clks» clksLength);
              Var «event»];
         Assign «clks» nClks;
@@ -317,7 +317,7 @@ Definition ta_controller_def:
   ]
   (nested_seq
    [
-     Call (SOME («retvar»,
+     Call (SOME (SOME «retvar»,
            (SOME («panic», «excpvar», (Return (Const 1w))))))
      (Label «start_controller»)
      [];


### PR DESCRIPTION
This commit revamps the function call syntax of Pancake to make it more intuitive. Previously two kinds of function calls were accepted as declarations:

```
fun f() {
  var x = 5;
  g(); // tail call
  x = g(); // assigning call (formerly and confusingly known as "returning call")
  return 0
}
```

This syntax is confusing --- the tail call will immediately return from `f()` , causing the second call to `g()` to be never evaluated, contrary to programmer intuition.

In the new style, we allow (and distinguish for purposes of compilation) four kinds of calls:

```
fun f() {
  var 1 x = g(); // declaring call
  g(); //stand-alone call
  x = g(); // assigning call
  return g(); // tail call
}
```

Declaring calls, unlike other calls, cannot have exception handlers; if `g()` above raises an exception, this would leave `x` uninitialised. Note that declaring calls need a shape annotation on the variable, because in general the shape of the return value is not statically known. (I initially tried adding this annotation on the function declaration instead, but this incorrectly assumes it is always statically known which function is being called).

Stand-alone calls have their return values ignored, but unlike tail calls, won't cause the callee to also return.

Tail calls have the `return` in front of them; hopefully that way nobody will be surprised when they return :)