### PR TITLE
Pancake syntax improvements

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -478,6 +478,10 @@ Definition conv_Exp_alt_def:
             [] => NONE
           | [ts] => do es <- conv_ArgList_alt ts; SOME (Struct es) od
           | ts::v6::v7 => NONE
+        else if isNT nodeNT NotNT then
+          case args of
+            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp t)
+          | _ => NONE
         else if isNT nodeNT LoadByteNT then
           case args of
             [] => NONE
@@ -609,6 +613,8 @@ Proof
       >- (fs[]>>ntac 2 (CASE_TAC>>fs[]))>>
       IF_CASES_TAC
       >- (fs[]>>ntac 2 (CASE_TAC>>fs[]))>>
+      IF_CASES_TAC
+      >- (fs[]>>ntac 2 (CASE_TAC>>fs[]) >> metis_tac[])>>
       IF_CASES_TAC
       >- (fs[]>>ntac 6 (CASE_TAC>>fs[]))>>
       IF_CASES_TAC>>fs[]

--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -480,7 +480,7 @@ Definition conv_Exp_alt_def:
           | ts::v6::v7 => NONE
         else if isNT nodeNT NotNT then
           case args of
-            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp t)
+            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp_alt t)
           | _ => NONE
         else if isNT nodeNT LoadByteNT then
           case args of

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -482,6 +482,10 @@ Definition conv_Exp_alt_def:
             [] => NONE
           | [ts] => do es <- conv_ArgList_alt ts; SOME (Struct es) od
           | ts::v6::v7 => NONE
+        else if isNT nodeNT NotNT then
+          case args of
+            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp t)
+          | _ => NONE
         else if isNT nodeNT LoadByteNT then
           case args of
             [] => NONE
@@ -613,6 +617,8 @@ Proof
       >- (fs[]>>ntac 2 (CASE_TAC>>fs[]))>>
       IF_CASES_TAC
       >- (fs[]>>ntac 2 (CASE_TAC>>fs[]))>>
+      IF_CASES_TAC
+      >- (fs[]>>ntac 2 (CASE_TAC>>fs[]) >> metis_tac[])>>
       IF_CASES_TAC
       >- (fs[]>>ntac 6 (CASE_TAC>>fs[]))>>
       IF_CASES_TAC>>fs[]

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -484,7 +484,7 @@ Definition conv_Exp_alt_def:
           | ts::v6::v7 => NONE
         else if isNT nodeNT NotNT then
           case args of
-            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp t)
+            [t] => OPTION_MAP (λe. Cmp Equal (Const 0w) e) (conv_Exp_alt t)
           | _ => NONE
         else if isNT nodeNT LoadByteNT then
           case args of

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -53,6 +53,10 @@ Datatype:
 End
 
 Datatype:
+  opsize = Op8 | OpW
+End
+
+Datatype:
   prog = Skip
        | Dec varname ('a exp) prog
        | Assign    varname ('a exp)  (* dest, source *)
@@ -69,7 +73,8 @@ Datatype:
          (* FFI name, conf_ptr, conf_len, array_ptr, array_len *)
        | Raise eid ('a exp)
        | Return ('a exp)
-       | ShMem memop varname ('a exp)
+       | ShMemLoad opsize varname ('a exp)
+       | ShMemStore opsize ('a exp) ('a exp)
        | Tick;
 End
 
@@ -200,6 +205,16 @@ End
 Definition destruct_def:
   (destruct (Struct es) = es) /\
   (destruct _ = [])
+End
+
+Definition load_op_def:
+  load_op Op8 = Load8 ∧
+  load_op OpW = Load
+End
+
+Definition store_op_def:
+  store_op Op8 = Store8 ∧
+  store_op OpW = Store
 End
 
 val _ = export_theory();

--- a/pancake/panScopeScript.sml
+++ b/pancake/panScopeScript.sml
@@ -103,10 +103,13 @@ Definition scope_check_prog_def:
     scope_check_exps ctxt [ptr1;len1;ptr2;len2] ∧
   scope_check_prog ctxt (Raise eid excp) = scope_check_exp ctxt excp ∧
   scope_check_prog ctxt (Return rt) = scope_check_exp ctxt rt ∧
-  scope_check_prog ctxt (ShMem mop v e) =
+  scope_check_prog ctxt (ShMemLoad mop v e) =
     (if ¬MEM v ctxt.vars
         then SOME (v, ctxt.fname)
      else scope_check_exp ctxt e) ∧
+  scope_check_prog ctxt (ShMemStore mop e1 e2) =
+    OPTION_CHOICE (scope_check_exp ctxt e1)
+                  (scope_check_exp ctxt e2) ∧
   scope_check_prog ctxt Tick = NONE
 End
 

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -286,16 +286,17 @@ Definition compile_def:
   (compile ctxt (ShMemStore op r ad) =
    (case (compile_exp ctxt r,compile_exp ctxt ad) of
       ((e::_,_),(a::_, _)) =>
-        let n = FOLDR MAX 0 $ var_cexp e ++ var_cexp a
+        let n = FOLDR MAX 0 $ var_cexp e
         in
-          Dec (n+1) e $ ShMem (store_op op) (n+1) a
+          Dec (n+1) a $ ShMem (store_op op) (n+1) e
     | _ => Skip)) ∧
   (compile ctxt (ShMemLoad op r ad) =
    (case compile_exp ctxt ad of
       (a::_, _) =>
         (case FLOOKUP ctxt.vars r of
            SOME (_, r'::_) => ShMem (load_op op) r' a
-         | _ => Skip))) ∧
+         | _ => Skip)
+     | _ => Skip)) ∧
   (compile ctxt Tick = Tick)
 End
 

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -283,16 +283,21 @@ Definition compile_def:
          $ Dec (n+4) lc'
          $ crepLang$ExtCall f (n+1) (n+2) (n+3) (n+4)
      | _ => Skip) /\
-  (compile ctxt (ShMem op r ad) =
+  (compile ctxt (ShMemStore op r ad) =
+   (case (compile_exp ctxt r,compile_exp ctxt ad) of
+      ((e::_,_),(a::_, _)) =>
+        let n = FOLDR MAX 0 $ var_cexp e ++ var_cexp a
+        in
+          Dec (n+1) e $ ShMem (store_op op) (n+1) a
+    | _ => Skip)) ∧
+  (compile ctxt (ShMemLoad op r ad) =
    (case compile_exp ctxt ad of
       (a::_, _) =>
         (case FLOOKUP ctxt.vars r of
-           SOME (_, r'::_) => ShMem op r' a
-         | _ => Skip)
-    | _ => Skip)) ∧
+           SOME (_, r'::_) => ShMem (load_op op) r' a
+         | _ => Skip))) ∧
   (compile ctxt Tick = Tick)
 End
-
 
 Definition mk_ctxt_def:
   mk_ctxt vmap fs m (es:panLang$eid |-> 'a word) =

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -314,8 +314,8 @@ val struct_argument_parse =  parse_pancake $ struct_arguments;
 val shmem_ex = ‘
   fun test_shmem() {
     var v = 12;
-    !st8 v, 1000; // store byte stored in v (12) to shared memory address 1000
-    !stw v, 1004; // store word stored in v (12) to shared memory address 1004
+    !st8 1000, v; // store byte from variable v (12) to shared memory address 1000
+    !stw 1004, 1+1; // store 1+1 (aka 2) to shared memory address 1004
     !ld8 v, 1000 + 12; // load byte stored in shared memory address 1012 to v
     !ldw v, 1000 + 12 * 2; // load word stored in shared memory address 1024 to v
   }’;

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -72,7 +72,7 @@ val treeEx1 = check_success $ parse_pancake ex1;
     (‘<>’). *)
 val ex2 = ‘
   fun main() {
-    if b & (a ^ c) & d {
+    if !b & (a ^ c) & d {
       return foo(1, <2, 3>);
         } else {
       return goo(4, 5, 6);
@@ -360,5 +360,22 @@ val error_line_ex2 =
  ’
 
 val error_line_ex2_parse = check_failure $ parse_pancake error_line_ex2
+
+(** Function pointers
+
+    & can only be used to get the address of functions.
+    Function pointers can be stored in variables, in shapes, passed as arguments,
+    stored on the heap, and invoked.
+    Any other use of them---including but not limited to arithmetic and
+    shared memory operations---is considered undefined behaviour.
+ *)
+val fun_pointer_ex1 =
+  ‘fun main () {
+     var x = &main;
+     return *x(); //  this is a recursive call
+   }
+  ’
+
+val fun_pointer_ex1_parse = check_success $ parse_pancake fun_pointer_ex1;
 
 val _ = export_theory();

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -19,7 +19,7 @@ Datatype:
             | IfNT | WhileNT | CallNT | RetNT | HandleNT
             | ExtCallNT | RaiseNT | ReturnNT
             | DecCallNT | RetCallNT
-            | ArgListNT
+            | ArgListNT | NotNT
             | ParamListNT
             | EXorNT | EAndNT | EEqNT | ECmpNT
             | EShiftNT | EAddNT | EMulNT
@@ -249,6 +249,7 @@ Definition pancake_peg_def[nocompute]:
         (INL EBaseNT, seql [choicel [seql [consume_tok LParT;
                                            mknt ExpNT;
                                            consume_tok RParT] I;
+                                     mknt NotNT;
                                      keep_kw TrueK; keep_kw FalseK;
                                      keep_int; keep_ident; mknt LabelNT;
                                      mknt StructNT; mknt LoadNT;
@@ -257,7 +258,9 @@ Definition pancake_peg_def[nocompute]:
                             rpt (seql [consume_tok DotT; keep_nat] I)
                                 FLAT]
                            (mksubtree EBaseNT));
-        (INL LabelNT, seql [consume_tok NotT; keep_ident]
+        (INL NotNT, seql [consume_tok NotT; mknt EBaseNT]
+                           (mksubtree NotNT));
+        (INL LabelNT, seql [consume_tok AndT; keep_ident]
                            (mksubtree LabelNT));
         (INL FLabelNT, seql [keep_ident]
                             (mksubtree FLabelNT));
@@ -604,7 +607,7 @@ end
 
 val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”,
                 “EqOpsNT”, “ShapeNT”,
-                “ShapeCombNT”, “LabelNT”, “FLabelNT”, “LoadByteNT”,
+                “ShapeCombNT”, “NotNT”, “LabelNT”, “FLabelNT”, “LoadByteNT”,
                 “LoadNT”, “StructNT”,
                 “EBaseNT”, “EMulNT”, “EAddNT”, “EShiftNT”, “ECmpNT”,
                 “EEqNT”, “EAndNT”, “EXorNT”,

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -289,10 +289,10 @@ Definition pancake_peg_def[nocompute]:
         (INL SharedLoadByteNT,seql [consume_tok NotT; consume_kw LdbK; keep_ident;
                                     consume_tok CommaT; mknt ExpNT]
                                    (mksubtree SharedLoadByteNT));
-        (INL SharedStoreNT,seql [consume_tok NotT; consume_kw StoreK; keep_ident;
+        (INL SharedStoreNT,seql [consume_tok NotT; consume_kw StoreK; mknt ExpNT;
                                  consume_tok CommaT; mknt ExpNT]
                                 (mksubtree SharedStoreNT));
-        (INL SharedStoreByteNT,seql [consume_tok NotT; consume_kw StoreBK; keep_ident;
+        (INL SharedStoreByteNT,seql [consume_tok NotT; consume_kw StoreBK; mknt ExpNT;
                                      consume_tok CommaT; mknt ExpNT]
                                     (mksubtree SharedStoreByteNT));
         ]

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -348,19 +348,19 @@ Definition conv_NonRecStmt_def:
       | _ => NONE
     else if isNT nodeNT SharedLoadNT then
       case args of
-        [v; e] => lift2 (ShMem Load) (conv_ident v) (conv_Exp e)
+        [v; e] => lift2 (ShMemLoad OpW) (conv_ident v) (conv_Exp e)
       | _ => NONE
     else if isNT nodeNT SharedLoadByteNT then
       case args of
-        [v; e] => lift2 (ShMem Load8) (conv_ident v) (conv_Exp e)
+        [v; e] => lift2 (ShMemLoad Op8) (conv_ident v) (conv_Exp e)
       | _ => NONE
     else if isNT nodeNT SharedStoreNT then
       case args of
-        [v; e] => lift2 (ShMem Store) (conv_ident v) (conv_Exp e)
+        [v; e] => lift2 (ShMemStore OpW) (conv_Exp v) (conv_Exp e)
       | _ => NONE
     else if isNT nodeNT SharedStoreByteNT then
       case args of
-        [v; e] => lift2 (ShMem Store8) (conv_ident v) (conv_Exp e)
+        [v; e] => lift2 (ShMemStore Op8) (conv_Exp v) (conv_Exp e)
       | _ => NONE
     else if isNT nodeNT ExtCallNT then
       case args of

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -260,6 +260,10 @@ Definition conv_Exp_def:
                    SOME $ Struct es
                 od
       | _ => NONE
+    else if isNT nodeNT NotNT then
+      case args of
+        [t] => lift (Cmp Equal (Const 0w)) (conv_Exp t)
+      | _ => NONE
     else if isNT nodeNT LoadByteNT then
       case args of
         [t] => lift LoadByte (conv_Exp t)

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -301,7 +301,8 @@ Theorem ret_to_tail_Others:
   ^(get_goal "panLang$Continue") /\
   ^(get_goal "panLang$ExtCall") /\
   ^(get_goal "panLang$Raise") /\
-  ^(get_goal "panLang$ShMem") /\
+  ^(get_goal "panLang$ShMemLoad") /\
+  ^(get_goal "panLang$ShMemStore") /\
   ^(get_goal "panLang$Return") /\
   ^(get_goal "panLang$Tick")
 Proof
@@ -862,14 +863,32 @@ Proof
   strip_tac >> fs []
 QED
 
-Theorem compile_ShMem:
-  ^(get_goal "panLang$ShMem")
+Theorem compile_ShMemLoad:
+  ^(get_goal "panLang$ShMemLoad")
 Proof
   rw [] >>
   fs [evaluate_seq_assoc, evaluate_skip_seq] >>
   Cases_on ‘op’>>
   fs [evaluate_def] >> rveq >>
-  fs [sh_mem_op_def,sh_mem_load_def,sh_mem_store_def,
+  fs [nb_op_def,sh_mem_load_def,sh_mem_store_def,
+      set_var_def,empty_locals_def] >>
+  last_x_assum mp_tac >>
+  rpt (TOP_CASE_TAC >> fs []) >>
+  MAP_EVERY imp_res_tac [compile_eval_correct,compile_eval_correct_none] >> gvs[] >>
+  rfs [state_rel_def, state_component_equality,
+       empty_locals_def, dec_clock_def] >> rveq >> fs [] >>
+  rveq >> fs [] >> rveq >> rfs [] >>
+  strip_tac >> fs []
+QED
+
+Theorem compile_ShMemStore:
+  ^(get_goal "panLang$ShMemStore")
+Proof
+  rw [] >>
+  fs [evaluate_seq_assoc, evaluate_skip_seq] >>
+  Cases_on ‘op’>>
+  fs [evaluate_def] >> rveq >>
+  fs [nb_op_def,sh_mem_load_def,sh_mem_store_def,
       set_var_def,empty_locals_def] >>
   last_x_assum mp_tac >>
   rpt (TOP_CASE_TAC >> fs []) >>
@@ -906,7 +925,7 @@ Theorem compile_correct:
 Proof
   match_mp_tac (the_ind_thm()) >>
   EVERY (map strip_assume_tac
-         [compile_Dec, compile_Seq, compile_ShMem,
+         [compile_Dec, compile_Seq, compile_ShMemLoad, compile_ShMemStore,
           compile_If, compile_While, compile_Call, compile_DecCall,
           compile_ExtCall, compile_Call,compile_Others]) >>
   asm_rewrite_tac [] >> rw [] >> rpt (pop_assum kall_tac)

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -535,7 +535,7 @@ Proof
       gvs[AllCaseEqs(),dec_clock_def]) >>
   gvs[evaluate_def,AllCaseEqs(),eval_upd_clock_eq] >>
   rpt(pairarg_tac >> gvs[]) >>
-  gvs[oneline sh_mem_op_def,AllCaseEqs(),
+  gvs[oneline nb_op_def,AllCaseEqs(),
       oneline sh_mem_load_def,
       oneline sh_mem_store_def,
       set_var_def,
@@ -633,7 +633,7 @@ Proof
       gvs[] >>
       metis_tac[]) >>
   gvs[evaluate_def,state_component_equality,AllCaseEqs(),eval_upd_clock_eq,
-      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline nb_op_def,oneline sh_mem_load_def,
       oneline sh_mem_store_def, set_var_def, empty_locals_def,
       dec_clock_def,opt_mmap_eval_upd_clock_eq1
      ] >>
@@ -657,7 +657,7 @@ Proof
       gvs[AllCaseEqs(),dec_clock_def] >>
       imp_res_tac IS_PREFIX_TRANS) >>
   gvs[evaluate_def,AllCaseEqs(),
-      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline nb_op_def,oneline sh_mem_load_def,
       oneline sh_mem_store_def, set_var_def, empty_locals_def,
       dec_clock_def,opt_mmap_eval_upd_clock_eq1,
       ffiTheory.call_FFI_def] >>
@@ -703,7 +703,7 @@ Proof
       gvs[])
   >~ [‘Seq’]
   >- (gvs[evaluate_def,AllCaseEqs(),
-          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline nb_op_def,oneline sh_mem_load_def,
           oneline sh_mem_store_def, set_var_def, empty_locals_def,
           dec_clock_def,opt_mmap_eval_upd_clock_eq1,
           eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
@@ -715,7 +715,7 @@ Proof
       metis_tac[FST,SND,PAIR,evaluate_io_events_mono,IS_PREFIX_TRANS])
   >~ [‘Call’]
   >- (gvs[evaluate_def,AllCaseEqs(),
-          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline nb_op_def,oneline sh_mem_load_def,
           oneline sh_mem_store_def, set_var_def, empty_locals_def,
           dec_clock_def,opt_mmap_eval_upd_clock_eq1,
           eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
@@ -731,7 +731,7 @@ Proof
                 Q.prove(‘(x with locals := y).ffi = x.ffi’,simp[])])
   >~ [‘DecCall’]
   >- (gvs[evaluate_def,AllCaseEqs(),
-          oneline sh_mem_op_def,oneline sh_mem_load_def,
+          oneline nb_op_def,oneline sh_mem_load_def,
           oneline sh_mem_store_def, set_var_def, empty_locals_def,
           dec_clock_def,opt_mmap_eval_upd_clock_eq1,
           eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
@@ -748,7 +748,7 @@ Proof
                 Q.prove(‘(x with locals := y).ffi = x.ffi’,simp[])]
      ) >>
   gvs[evaluate_def,AllCaseEqs(),
-      oneline sh_mem_op_def,oneline sh_mem_load_def,
+      oneline nb_op_def,oneline sh_mem_load_def,
       oneline sh_mem_store_def, set_var_def, empty_locals_def,
       dec_clock_def,opt_mmap_eval_upd_clock_eq1,
       eval_upd_clock_eq,ffiTheory.call_FFI_def] >>
@@ -893,10 +893,16 @@ Proof
      >- (qpat_x_assum ‘evaluate _ = _’ (strip_assume_tac o ONCE_REWRITE_RULE[evaluate_def]) >>
          gvs[AllCaseEqs(),empty_locals_def,ELIM_UNCURRY,dec_clock_def] >>
          metis_tac[PAIR,FST,SND])
-     >~[‘ShMem’]
+     >~[‘ShMemLoad’]
      >- (Cases_on ‘op’>>
          gvs[Once evaluate_def,AllCaseEqs(),ELIM_UNCURRY,empty_locals_def,
-             dec_clock_def,set_var_def,sh_mem_op_def,sh_mem_store_def,
+             dec_clock_def,set_var_def,nb_op_def,sh_mem_store_def,
+             sh_mem_load_def] >>
+         metis_tac[PAIR,FST,SND])
+     >~[‘ShMemStore’]
+     >- (Cases_on ‘op’>>
+         gvs[Once evaluate_def,AllCaseEqs(),ELIM_UNCURRY,empty_locals_def,
+             dec_clock_def,set_var_def,nb_op_def,sh_mem_store_def,
              sh_mem_load_def] >>
          metis_tac[PAIR,FST,SND])>>
      gvs[Once evaluate_def,AllCaseEqs(),ELIM_UNCURRY,empty_locals_def,dec_clock_def,set_var_def] >>
@@ -939,7 +945,8 @@ Definition exps_of_def:
   (exps_of (Return e) = [e]) ∧
   (exps_of (ExtCall _ e1 e2 e3 e4) = [e1;e2;e3;e4]) ∧
   (exps_of (Assign _ e) = [e]) ∧
-  (exps_of (ShMem _ _ e) = [e]) ∧
+  (exps_of (ShMemLoad _ _ e) = [e]) ∧
+  (exps_of (ShMemStore _ e1 e2) = [e1;e2]) ∧
   (exps_of _ = [])
 End
 


### PR DESCRIPTION
This PR:

- Changes the argument order of shared memory stores so that it coincides with that of local memory stores. The destination address now comes first.
- Allows both the destination address and the payload of a shared memory store to be arbitrary expressions; previously, the data had to be stored in a local variable.
- Makes `!` in expressions denote boolean negation; this was previously used to denote function pointers, which is now `&` instead.