### PR TITLE
Speed up a very slow proof script in icing/

### DIFF
--- a/icing/cfSupportScript.sml
+++ b/icing/cfSupportScript.sml
@@ -33,1424 +33,123 @@ Definition real_spec_prog_def:
     | (st, Rval [Real r]) => r
 End
 
-(**
+(* These definitions replace several deeply nested stacks of List.hd
+ * applications in the readerN functions. Why? Because xlet_auto seems to be
+ * quadratic (or worse?) in the size of the cf term, which caused obscene
+ * running times for proofs in this theory.
+ *)
+
+Definition list2tup2_def[simp]:
+  list2tup2 (a::b::t) = (a,b)
+End
+
+Definition list2tup3_def[simp]:
+  list2tup3 (a::b::c::t) = (a,b,c)
+End
+
+Definition list2tup4_def[simp]:
+  list2tup4 (a::b::c::d::t) = (a,b,c,d)
+End
+
+Definition list2tup6_def[simp]:
+  list2tup6 (a::b::c::d::e::f::t) = (a,b,c,d,e,f)
+End
+
+Definition list2tup8_def[simp]:
+  list2tup8 (a::b::c::d::e::f::g::h::t) = (a,b,c,d,e,f,g,h)
+End
+
+Definition list2tup9_def[simp]:
+  list2tup9 (a::b::c::d::e::f::g::h::i::t) = (a,b,c,d,e,f,g,h,i)
+End
+
+Overload PAIR3_TYPE = ``\t. PAIR_TYPE t (PAIR_TYPE t t)``
+Overload PAIR4_TYPE = ``\t. PAIR_TYPE t (PAIR3_TYPE t)``
+Overload PAIR5_TYPE = ``\t. PAIR_TYPE t (PAIR4_TYPE t)``
+Overload PAIR6_TYPE = ``\t. PAIR_TYPE t (PAIR5_TYPE t)``
+Overload PAIR7_TYPE = ``\t. PAIR_TYPE t (PAIR6_TYPE t)``
+Overload PAIR8_TYPE = ``\t. PAIR_TYPE t (PAIR7_TYPE t)``
+Overload PAIR9_TYPE = ``\t. PAIR_TYPE t (PAIR8_TYPE t)``
+
+val r = translate list2tup2_def;
+val r = translate list2tup3_def;
+val r = translate list2tup4_def;
+val r = translate list2tup6_def;
+val r = translate list2tup8_def;
+val r = translate list2tup9_def;
+
+val tm = process_topdecs `
   fun reader1 u =
-  let
-  val cl = CommandLine.arguments ();
-  val cst1 = List.hd cl;
-  in (cst1) end;
-**)
-Definition reader1_def:
-  reader1 =
-    [Dletrec
-     unknown_loc
-     [("reader1","u",
-       Let (SOME "a") (Con NONE [])
-           (Let (SOME "cl")
-            (App Opapp
-             [Var (Long "CommandLine" (Short "arguments"));
-              Var (Short "a")])
-            (Let (SOME "cst1")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "cl")])
-             (Var (Short "cst1")))))]]
+    let val cl = CommandLine.arguments ();
+    in List.hd cl end;
+`;
+val _ = append_prog tm;
+Definition reader1_def: reader1 = ^tm
+End;
+
+val tm = process_topdecs `
+  fun reader2 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup2 cl end;
+`;
+val _ = append_prog tm;
+Definition reader2_def: reader2 = ^tm
 End
 
-val _ = append_prog (reader1_def |> concl |> rhs);
-
-(**
-  process_topdecs ‘fun reader2 u =
-  let
-  val cl = CommandLine.arguments ();
-  val cst1 = List.hd cl;
-  val cst2 = List.hd (List.tl cl);
-  in (cst1, cst2) end;’
-**)
-Definition reader2_def:
-  reader2 =
-  [Dletrec
-   unknown_loc
-   [("reader2","u",
-     Let (SOME "a") (Con NONE [])
-         (Let (SOME "cl")
-          (App Opapp
-           [Var (Long "CommandLine" (Short "arguments"));
-            Var (Short "a")])
-          (Let (SOME "cst1")
-           (App Opapp
-            [Var (Long "List" (Short "hd")); Var (Short "cl")])
-           (Let (SOME "b")
-            (App Opapp
-             [Var (Long "List" (Short "tl")); Var (Short "cl")])
-            (Let (SOME "cst2")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "b")])
-             (Con NONE [Var (Short "cst1"); Var (Short "cst2")]))))))]]
+val tm = process_topdecs `
+  fun reader3 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup3 cl end;
+`;
+val _ = append_prog tm;
+Definition reader3_def: reader3 = ^tm
 End
 
-val _ = append_prog (reader2_def |> concl |> rhs);
-
-(**
-   fun reader3 u =
-   let
-   val cl = CommandLine.arguments ();
-   val cst1 = List.hd cl;
-   val cst2 = List.hd (List.tl cl);
-   val cst3 = List.hd (List.tl (List.tl cl));
-   in (cst1, (cst2, cst3)) end;
-**)
-Definition reader3_def:
-  reader3 =
-  [Dletrec
-   unknown_loc
-   [("reader3","u",
-     Let (SOME "a") (Con NONE [])
-         (Let (SOME "cl")
-          (App Opapp
-           [Var (Long "CommandLine" (Short "arguments"));
-            Var (Short "a")])
-          (Let (SOME "cst1")
-           (App Opapp
-            [Var (Long "List" (Short "hd")); Var (Short "cl")])
-           (Let (SOME "b")
-            (App Opapp
-             [Var (Long "List" (Short "tl")); Var (Short "cl")])
-            (Let (SOME "cst2")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "b")])
-             (Let (SOME "c")
-              (App Opapp
-               [Var (Long "List" (Short "tl"));
-                Var (Short "cl")])
-              (Let (SOME "d")
-               (App Opapp
-                [Var (Long "List" (Short "tl"));
-                 Var (Short "c")])
-               (Let (SOME "cst3")
-                (App Opapp
-                 [Var (Long "List" (Short "hd"));
-                  Var (Short "d")])
-                (Let (SOME "e")
-                 (Con NONE
-                  [Var (Short "cst2");
-                   Var (Short "cst3")])
-                 (Con NONE
-                  [Var (Short "cst1"); Var (Short "e")]))))))))))]]
+val tm = process_topdecs `
+  fun reader4 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup4 cl end;
+`;
+val _ = append_prog tm;
+Definition reader4_def: reader4 = ^tm
 End
 
-val _ = append_prog (reader3_def |> concl |> rhs);
-
-(**
-   fun reader4 u =
-   let
-   val cl = CommandLine.arguments ();
-   val cst1 = List.hd cl;
-   val cst2 = List.hd (List.tl cl);
-   val cst3 = List.hd (List.tl (List.tl cl));
-   val cst4 = List.hd (List.tl (List.tl (List.tl cl)));
-   in (cst1, (cst2, (cst3, cst4))) end;
-**)
-Definition reader4_def:
-  reader4 =
-  [Dletrec unknown_loc
-   [("reader4","u",
-     Let (SOME "a") (Con NONE [])
-         (Let (SOME "cl")
-          (App Opapp
-           [Var (Long "CommandLine" (Short "arguments"));
-            Var (Short "a")])
-          (Let (SOME "cst1")
-           (App Opapp
-            [Var (Long "List" (Short "hd")); Var (Short "cl")])
-           (Let (SOME "b")
-            (App Opapp
-             [Var (Long "List" (Short "tl")); Var (Short "cl")])
-            (Let (SOME "cst2")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "b")])
-             (Let (SOME "c")
-              (App Opapp
-               [Var (Long "List" (Short "tl"));
-                Var (Short "cl")])
-              (Let (SOME "d")
-               (App Opapp
-                [Var (Long "List" (Short "tl"));
-                 Var (Short "c")])
-               (Let (SOME "cst3")
-                (App Opapp
-                 [Var (Long "List" (Short "hd"));
-                  Var (Short "d")])
-                (Let (SOME "e")
-                 (App Opapp
-                  [Var (Long "List" (Short "tl"));
-                   Var (Short "cl")])
-                 (Let (SOME "f")
-                  (App Opapp
-                   [Var (Long "List" (Short "tl"));
-                    Var (Short "e")])
-                  (Let (SOME "g")
-                   (App Opapp
-                    [Var (Long "List" (Short "tl"));
-                     Var (Short "f")])
-                   (Let (SOME "cst4")
-                    (App Opapp
-                     [Var
-                      (Long "List" (Short "hd"));
-                      Var (Short "g")])
-                    (Let (SOME "h")
-                     (Con NONE
-                      [Var (Short "cst3");
-                       Var (Short "cst4")])
-                     (Let (SOME "i")
-                      (Con NONE
-                       [Var (Short "cst2");
-                        Var (Short "h")])
-                      (Con NONE
-                       [Var (Short "cst1");
-                        Var (Short "i")])))))))))))))))]]
+val tm = process_topdecs `
+  fun reader6 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup6 cl end;
+`;
+val _ = append_prog tm;
+Definition reader6_def: reader6 = ^tm
 End
 
-val _ = append_prog (reader4_def |> concl |> rhs);
-
-(**
-   fun reader6 u =
-   let
-   val cl = CommandLine.arguments ();
-   val cst1 = List.hd cl;
-   val cst2 = List.hd (List.tl cl);
-   val cst3 = List.hd (List.tl (List.tl cl));
-   val cst4 = List.hd (List.tl (List.tl (List.tl cl)));
-   val cst5 = List.hd (List.tl (List.tl (List.tl (List.tl cl))));
-   val cst6 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl cl)))));
-   in (cst1, (cst2, (cst3, (cst4, (cst5, cst6))))) end;
-**)
-Definition reader6_def:
-  reader6 =
-   [Dletrec unknown_loc
-    [("reader6","u",
-      Let (SOME "a") (Con NONE [])
-          (Let (SOME "cl")
-           (App Opapp
-            [Var (Long "CommandLine" (Short "arguments"));
-             Var (Short "a")])
-           (Let (SOME "cst1")
-            (App Opapp
-             [Var (Long "List" (Short "hd")); Var (Short "cl")])
-            (Let (SOME "b")
-             (App Opapp
-              [Var (Long "List" (Short "tl")); Var (Short "cl")])
-             (Let (SOME "cst2")
-              (App Opapp
-               [Var (Long "List" (Short "hd")); Var (Short "b")])
-              (Let (SOME "c")
-               (App Opapp
-                [Var (Long "List" (Short "tl"));
-                 Var (Short "cl")])
-               (Let (SOME "d")
-                (App Opapp
-                 [Var (Long "List" (Short "tl"));
-                  Var (Short "c")])
-                (Let (SOME "cst3")
-                 (App Opapp
-                  [Var (Long "List" (Short "hd"));
-                   Var (Short "d")])
-                 (Let (SOME "e")
-                  (App Opapp
-                   [Var (Long "List" (Short "tl"));
-                    Var (Short "cl")])
-                  (Let (SOME "f")
-                   (App Opapp
-                    [Var (Long "List" (Short "tl"));
-                     Var (Short "e")])
-                   (Let (SOME "g")
-                    (App Opapp
-                     [Var (Long "List" (Short "tl"));
-                      Var (Short "f")])
-                    (Let (SOME "cst4")
-                     (App Opapp
-                      [Var
-                       (Long "List" (Short "hd"));
-                       Var (Short "g")])
-                     (Let (SOME "h")
-                      (App Opapp
-                       [Var
-                        (Long "List"
-                         (Short "tl"));
-                        Var (Short "cl")])
-                      (Let (SOME "i")
-                       (App Opapp
-                        [Var
-                         (Long "List"
-                          (Short "tl"));
-                         Var (Short "h")])
-                       (Let (SOME "j")
-                        (App Opapp
-                         [Var
-                          (Long "List"
-                           (Short "tl"));
-                          Var (Short "i")])
-                        (Let (SOME "k")
-                         (App Opapp
-                          [Var
-                           (Long "List"
-                            (Short "tl"));
-                           Var (Short "j")])
-                         (Let (SOME "cst5")
-                          (App Opapp
-                           [Var
-                            (Long "List"
-                             (Short
-                              "hd"));
-                            Var
-                            (Short "k")])
-                          (Let (SOME "l")
-                           (App Opapp
-                            [Var
-                             (Long
-                              "List"
-                              (Short
-                               "tl"));
-                             Var
-                             (Short
-                              "cl")])
-                           (Let (SOME "m")
-                            (App Opapp
-                             [Var
-                              (Long
-                               "List"
-                               (Short
-                                "tl"));
-                              Var
-                              (Short
-                               "l")])
-                            (Let
-                             (SOME "n")
-                             (App
-                              Opapp
-                              [Var
-                               (Long
-                                "List"
-                                (Short
-                                 "tl"));
-                               Var
-                               (Short
-                                "m")])
-                             (Let
-                              (SOME
-                               "o")
-                              (App
-                               Opapp
-                               [Var
-                                (Long
-                                 "List"
-                                 (Short
-                                  "tl"));
-                                Var
-                                (Short
-                                 "n")])
-                              (Let
-                               (SOME
-                                "p")
-                               (App
-                                Opapp
-                                [Var
-                                 (Long
-                                  "List"
-                                  (Short
-                                   "tl"));
-                                 Var
-                                 (Short
-                                  "o")])
-                               (Let
-                                (SOME
-                                 "cst6")
-                                (App
-                                 Opapp
-                                 [Var
-                                  (Long
-                                   "List"
-                                   (Short
-                                    "hd"));
-                                  Var
-                                  (Short
-                                   "p")])
-                                (Let
-                                 (SOME
-                                  "q")
-                                 (Con
-                                  NONE
-                                  [Var
-                                   (Short
-                                    "cst5");
-                                   Var
-                                   (Short
-                                    "cst6")])
-                                 (Let
-                                  (SOME
-                                   "r")
-                                  (Con
-                                   NONE
-                                   [Var
-                                    (Short
-                                     "cst4");
-                                    Var
-                                    (Short
-                                     "q")])
-                                  (Let
-                                   (SOME
-                                    "s")
-                                   (Con
-                                    NONE
-                                    [Var
-                                     (Short
-                                      "cst3");
-                                     Var
-                                     (Short
-                                      "r")])
-                                   (Let
-                                    (SOME
-                                     "t")
-                                    (Con
-                                     NONE
-                                     [Var
-                                      (Short
-                                       "cst2");
-                                      Var
-                                      (Short
-                                       "s")])
-                                    (Con
-                                     NONE
-                                     [Var
-                                      (Short
-                                       "cst1");
-                                      Var
-                                      (Short
-                                       "t")]))))))))))))))))))))))))))))]]
+val tm = process_topdecs `
+  fun reader8 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup8 cl end;
+`;
+val _ = append_prog tm;
+Definition reader8_def: reader8 = ^tm
 End
 
-val _ = append_prog (reader6_def |> concl |> rhs);
-
-(**
-fun reader8 u =
-   let
-   val cl = CommandLine.arguments ();
-   val cst1 = List.hd cl;
-   val cst2 = List.hd (List.tl cl);
-   val cst3 = List.hd (List.tl (List.tl cl));
-   val cst4 = List.hd (List.tl (List.tl (List.tl cl)));
-   val cst5 = List.hd (List.tl (List.tl (List.tl (List.tl cl))));
-   val cst6 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl cl)))));
-   val cst7 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl cl))))));
-   val cst8 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl cl)))))));
-   in (cst1, (cst2, (cst3, (cst4, (cst5, (cst6, (cst7, cst8))))))) end;
-**)
-Definition reader8_def:
-  reader8 =
-  [Dletrec unknown_loc
-   [("reader8","u",
-     Let (SOME "a") (Con NONE [])
-         (Let (SOME "cl")
-          (App Opapp
-           [Var (Long "CommandLine" (Short "arguments"));
-            Var (Short "a")])
-          (Let (SOME "cst1")
-           (App Opapp
-            [Var (Long "List" (Short "hd")); Var (Short "cl")])
-           (Let (SOME "b")
-            (App Opapp
-             [Var (Long "List" (Short "tl")); Var (Short "cl")])
-            (Let (SOME "cst2")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "b")])
-             (Let (SOME "c")
-              (App Opapp
-               [Var (Long "List" (Short "tl"));
-                Var (Short "cl")])
-              (Let (SOME "d")
-               (App Opapp
-                [Var (Long "List" (Short "tl"));
-                 Var (Short "c")])
-               (Let (SOME "cst3")
-                (App Opapp
-                 [Var (Long "List" (Short "hd"));
-                  Var (Short "d")])
-                (Let (SOME "e")
-                 (App Opapp
-                  [Var (Long "List" (Short "tl"));
-                   Var (Short "cl")])
-                 (Let (SOME "f")
-                  (App Opapp
-                   [Var (Long "List" (Short "tl"));
-                    Var (Short "e")])
-                  (Let (SOME "g")
-                   (App Opapp
-                    [Var (Long "List" (Short "tl"));
-                     Var (Short "f")])
-                   (Let (SOME "cst4")
-                    (App Opapp
-                     [Var
-                      (Long "List" (Short "hd"));
-                      Var (Short "g")])
-                    (Let (SOME "h")
-                     (App Opapp
-                      [Var
-                       (Long "List"
-                        (Short "tl"));
-                       Var (Short "cl")])
-                     (Let (SOME "i")
-                      (App Opapp
-                       [Var
-                        (Long "List"
-                         (Short "tl"));
-                        Var (Short "h")])
-                      (Let (SOME "j")
-                       (App Opapp
-                        [Var
-                         (Long "List"
-                          (Short "tl"));
-                         Var (Short "i")])
-                       (Let (SOME "k")
-                        (App Opapp
-                         [Var
-                          (Long "List"
-                           (Short "tl"));
-                          Var (Short "j")])
-                        (Let (SOME "cst5")
-                         (App Opapp
-                          [Var
-                           (Long "List"
-                            (Short
-                             "hd"));
-                           Var
-                           (Short "k")])
-                         (Let (SOME "l")
-                          (App Opapp
-                           [Var
-                            (Long
-                             "List"
-                             (Short
-                              "tl"));
-                            Var
-                            (Short
-                             "cl")])
-                          (Let (SOME "m")
-                           (App Opapp
-                            [Var
-                             (Long
-                              "List"
-                              (Short
-                               "tl"));
-                             Var
-                             (Short
-                              "l")])
-                           (Let
-                            (SOME "n")
-                            (App
-                             Opapp
-                             [Var
-                              (Long
-                               "List"
-                               (Short
-                                "tl"));
-                              Var
-                              (Short
-                               "m")])
-                            (Let
-                             (SOME
-                              "o")
-                             (App
-                              Opapp
-                              [Var
-                               (Long
-                                "List"
-                                (Short
-                                 "tl"));
-                               Var
-                               (Short
-                                "n")])
-                             (Let
-                              (SOME
-                               "p")
-                              (App
-                               Opapp
-                               [Var
-                                (Long
-                                 "List"
-                                 (Short
-                                  "tl"));
-                                Var
-                                (Short
-                                 "o")])
-                              (Let
-                               (SOME
-                                "cst6")
-                               (App
-                                Opapp
-                                [Var
-                                 (Long
-                                  "List"
-                                  (Short
-                                   "hd"));
-                                 Var
-                                 (Short
-                                  "p")])
-                               (Let
-                                (SOME
-                                 "q")
-                                (App
-                                 Opapp
-                                 [Var
-                                  (Long
-                                   "List"
-                                   (Short
-                                    "tl"));
-                                  Var
-                                  (Short
-                                   "cl")])
-                                (Let
-                                 (SOME
-                                  "r")
-                                 (App
-                                  Opapp
-                                  [Var
-                                   (Long
-                                    "List"
-                                    (Short
-                                     "tl"));
-                                   Var
-                                   (Short
-                                    "q")])
-                                 (Let
-                                  (SOME
-                                   "s")
-                                  (App
-                                   Opapp
-                                   [Var
-                                    (Long
-                                     "List"
-                                     (Short
-                                      "tl"));
-                                    Var
-                                    (Short
-                                     "r")])
-                                  (Let
-                                   (SOME
-                                    "t")
-                                   (App
-                                    Opapp
-                                    [Var
-                                     (Long
-                                      "List"
-                                      (Short
-                                       "tl"));
-                                     Var
-                                     (Short
-                                      "s")])
-                                   (Let
-                                    (SOME
-                                     "v")
-                                    (App
-                                     Opapp
-                                     [Var
-                                      (Long
-                                       "List"
-                                       (Short
-                                        "tl"));
-                                      Var
-                                      (Short
-                                       "t")])
-                                    (Let
-                                     (SOME
-                                      "w")
-                                     (App
-                                      Opapp
-                                      [Var
-                                       (Long
-                                        "List"
-                                        (Short
-                                         "tl"));
-                                       Var
-                                       (Short
-                                        "v")])
-                                     (Let
-                                      (SOME
-                                       "cst7")
-                                      (App
-                                       Opapp
-                                       [Var
-                                        (Long
-                                         "List"
-                                         (Short
-                                          "hd"));
-                                        Var
-                                        (Short
-                                         "w")])
-                                      (Let
-                                       (SOME
-                                        "x")
-                                       (App
-                                        Opapp
-                                        [Var
-                                         (Long
-                                          "List"
-                                          (Short
-                                           "tl"));
-                                         Var
-                                         (Short
-                                          "cl")])
-                                       (Let
-                                        (SOME
-                                         "y")
-                                        (App
-                                         Opapp
-                                         [Var
-                                          (Long
-                                           "List"
-                                           (Short
-                                            "tl"));
-                                          Var
-                                          (Short
-                                           "x")])
-                                        (Let
-                                         (SOME
-                                          "z")
-                                         (App
-                                          Opapp
-                                          [Var
-                                           (Long
-                                            "List"
-                                            (Short
-                                             "tl"));
-                                           Var
-                                           (Short
-                                            "y")])
-                                         (Let
-                                          (SOME
-                                           "t0")
-                                          (App
-                                           Opapp
-                                           [Var
-                                            (Long
-                                             "List"
-                                             (Short
-                                              "tl"));
-                                            Var
-                                            (Short
-                                             "z")])
-                                          (Let
-                                           (SOME
-                                            "t1")
-                                           (App
-                                            Opapp
-                                            [Var
-                                             (Long
-                                              "List"
-                                              (Short
-                                               "tl"));
-                                             Var
-                                             (Short
-                                              "t0")])
-                                           (Let
-                                            (SOME
-                                             "t2")
-                                            (App
-                                             Opapp
-                                             [Var
-                                              (Long
-                                               "List"
-                                               (Short
-                                                "tl"));
-                                              Var
-                                              (Short
-                                               "t1")])
-                                            (Let
-                                             (SOME
-                                              "t3")
-                                             (App
-                                              Opapp
-                                              [Var
-                                               (Long
-                                                "List"
-                                                (Short
-                                                 "tl"));
-                                               Var
-                                               (Short
-                                                "t2")])
-                                             (Let
-                                              (SOME
-                                               "cst8")
-                                              (App
-                                               Opapp
-                                               [Var
-                                                (Long
-                                                 "List"
-                                                 (Short
-                                                  "hd"));
-                                                Var
-                                                (Short
-                                                 "t3")])
-                                              (Let
-                                               (SOME
-                                                "t4")
-                                               (Con
-                                                NONE
-                                                [Var
-                                                 (Short
-                                                  "cst7");
-                                                 Var
-                                                 (Short
-                                                  "cst8")])
-                                               (Let
-                                                (SOME
-                                                 "t5")
-                                                (Con
-                                                 NONE
-                                                 [Var
-                                                  (Short
-                                                   "cst6");
-                                                  Var
-                                                  (Short
-                                                   "t4")])
-                                                (Let
-                                                 (SOME
-                                                  "t6")
-                                                 (Con
-                                                  NONE
-                                                  [Var
-                                                   (Short
-                                                    "cst5");
-                                                   Var
-                                                   (Short
-                                                    "t5")])
-                                                 (Let
-                                                  (SOME
-                                                   "t7")
-                                                  (Con
-                                                   NONE
-                                                   [Var
-                                                    (Short
-                                                     "cst4");
-                                                    Var
-                                                    (Short
-                                                     "t6")])
-                                                  (Let
-                                                   (SOME
-                                                    "t8")
-                                                   (Con
-                                                    NONE
-                                                    [Var
-                                                     (Short
-                                                      "cst3");
-                                                     Var
-                                                     (Short
-                                                      "t7")])
-                                                   (Let
-                                                    (SOME
-                                                     "t9")
-                                                    (Con
-                                                     NONE
-                                                     [Var
-                                                      (Short
-                                                       "cst2");
-                                                      Var
-                                                      (Short
-                                                       "t8")])
-                                                    (Con
-                                                     NONE
-                                                     [Var
-                                                      (Short
-                                                       "cst1");
-                                                      Var
-                                                      (Short
-                                                       "t9")])))))))))))))))))))))))))))))))))))))))))))))]]
+val tm = process_topdecs `
+  fun reader9 u =
+    let val cl = CommandLine.arguments ();
+    in list2tup9 cl end;
+`;
+val _ = append_prog tm;
+Definition reader9_def: reader9 = ^tm
 End
 
-val _ = append_prog (reader8_def |> concl |> rhs);
-
-(**
-fun reader8 u =
-   let
-   val cl = CommandLine.arguments ();
-   val cst1 = List.hd cl;
-   val cst2 = List.hd (List.tl cl);
-   val cst3 = List.hd (List.tl (List.tl cl));
-   val cst4 = List.hd (List.tl (List.tl (List.tl cl)));
-   val cst5 = List.hd (List.tl (List.tl (List.tl (List.tl cl))));
-   val cst6 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl cl)))));
-   val cst7 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl cl))))));
-   val cst8 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl cl)))))));
-   val cst9 = List.hd (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl (List.tl cl))))))));
-   in (cst1, (cst2, (cst3, (cst4, (cst5, (cst6, (cst7, (cst8, cst9)))))))) end;
-**)
-Definition reader9_def:
-  reader9 =
-  [Dletrec unknown_loc
-   [("reader9","u",
-     Let (SOME "a") (Con NONE [])
-         (Let (SOME "cl")
-          (App Opapp
-           [Var (Long "CommandLine" (Short "arguments"));
-            Var (Short "a")])
-          (Let (SOME "cst1")
-           (App Opapp
-            [Var (Long "List" (Short "hd")); Var (Short "cl")])
-           (Let (SOME "b")
-            (App Opapp
-             [Var (Long "List" (Short "tl")); Var (Short "cl")])
-            (Let (SOME "cst2")
-             (App Opapp
-              [Var (Long "List" (Short "hd")); Var (Short "b")])
-             (Let (SOME "c")
-              (App Opapp
-               [Var (Long "List" (Short "tl"));
-                Var (Short "cl")])
-              (Let (SOME "d")
-               (App Opapp
-                [Var (Long "List" (Short "tl"));
-                 Var (Short "c")])
-               (Let (SOME "cst3")
-                (App Opapp
-                 [Var (Long "List" (Short "hd"));
-                  Var (Short "d")])
-                (Let (SOME "e")
-                 (App Opapp
-                  [Var (Long "List" (Short "tl"));
-                   Var (Short "cl")])
-                 (Let (SOME "f")
-                  (App Opapp
-                   [Var (Long "List" (Short "tl"));
-                    Var (Short "e")])
-                  (Let (SOME "g")
-                   (App Opapp
-                    [Var (Long "List" (Short "tl"));
-                     Var (Short "f")])
-                   (Let (SOME "cst4")
-                    (App Opapp
-                     [Var
-                      (Long "List" (Short "hd"));
-                      Var (Short "g")])
-                    (Let (SOME "h")
-                     (App Opapp
-                      [Var
-                       (Long "List"
-                        (Short "tl"));
-                       Var (Short "cl")])
-                     (Let (SOME "i")
-                      (App Opapp
-                       [Var
-                        (Long "List"
-                         (Short "tl"));
-                        Var (Short "h")])
-                      (Let (SOME "j")
-                       (App Opapp
-                        [Var
-                         (Long "List"
-                          (Short "tl"));
-                         Var (Short "i")])
-                       (Let (SOME "k")
-                        (App Opapp
-                         [Var
-                          (Long "List"
-                           (Short "tl"));
-                          Var (Short "j")])
-                        (Let (SOME "cst5")
-                         (App Opapp
-                          [Var
-                           (Long "List"
-                            (Short
-                             "hd"));
-                           Var
-                           (Short "k")])
-                         (Let (SOME "l")
-                          (App Opapp
-                           [Var
-                            (Long
-                             "List"
-                             (Short
-                              "tl"));
-                            Var
-                            (Short
-                             "cl")])
-                          (Let (SOME "m")
-                           (App Opapp
-                            [Var
-                             (Long
-                              "List"
-                              (Short
-                               "tl"));
-                             Var
-                             (Short
-                              "l")])
-                           (Let
-                            (SOME "n")
-                            (App
-                             Opapp
-                             [Var
-                              (Long
-                               "List"
-                               (Short
-                                "tl"));
-                              Var
-                              (Short
-                               "m")])
-                            (Let
-                             (SOME
-                              "o")
-                             (App
-                              Opapp
-                              [Var
-                               (Long
-                                "List"
-                                (Short
-                                 "tl"));
-                               Var
-                               (Short
-                                "n")])
-                             (Let
-                              (SOME
-                               "p")
-                              (App
-                               Opapp
-                               [Var
-                                (Long
-                                 "List"
-                                 (Short
-                                  "tl"));
-                                Var
-                                (Short
-                                 "o")])
-                              (Let
-                               (SOME
-                                "cst6")
-                               (App
-                                Opapp
-                                [Var
-                                 (Long
-                                  "List"
-                                  (Short
-                                   "hd"));
-                                 Var
-                                 (Short
-                                  "p")])
-                               (Let
-                                (SOME
-                                 "q")
-                                (App
-                                 Opapp
-                                 [Var
-                                  (Long
-                                   "List"
-                                   (Short
-                                    "tl"));
-                                  Var
-                                  (Short
-                                   "cl")])
-                                (Let
-                                 (SOME
-                                  "r")
-                                 (App
-                                  Opapp
-                                  [Var
-                                   (Long
-                                    "List"
-                                    (Short
-                                     "tl"));
-                                   Var
-                                   (Short
-                                    "q")])
-                                 (Let
-                                  (SOME
-                                   "s")
-                                  (App
-                                   Opapp
-                                   [Var
-                                    (Long
-                                     "List"
-                                     (Short
-                                      "tl"));
-                                    Var
-                                    (Short
-                                     "r")])
-                                  (Let
-                                   (SOME
-                                    "t")
-                                   (App
-                                    Opapp
-                                    [Var
-                                     (Long
-                                      "List"
-                                      (Short
-                                       "tl"));
-                                     Var
-                                     (Short
-                                      "s")])
-                                   (Let
-                                    (SOME
-                                     "v")
-                                    (App
-                                     Opapp
-                                     [Var
-                                      (Long
-                                       "List"
-                                       (Short
-                                        "tl"));
-                                      Var
-                                      (Short
-                                       "t")])
-                                    (Let
-                                     (SOME
-                                      "w")
-                                     (App
-                                      Opapp
-                                      [Var
-                                       (Long
-                                        "List"
-                                        (Short
-                                         "tl"));
-                                       Var
-                                       (Short
-                                        "v")])
-                                     (Let
-                                      (SOME
-                                       "cst7")
-                                      (App
-                                       Opapp
-                                       [Var
-                                        (Long
-                                         "List"
-                                         (Short
-                                          "hd"));
-                                        Var
-                                        (Short
-                                         "w")])
-                                      (Let
-                                       (SOME
-                                        "x")
-                                       (App
-                                        Opapp
-                                        [Var
-                                         (Long
-                                          "List"
-                                          (Short
-                                           "tl"));
-                                         Var
-                                         (Short
-                                          "cl")])
-                                       (Let
-                                        (SOME
-                                         "y")
-                                        (App
-                                         Opapp
-                                         [Var
-                                          (Long
-                                           "List"
-                                           (Short
-                                            "tl"));
-                                          Var
-                                          (Short
-                                           "x")])
-                                        (Let
-                                         (SOME
-                                          "z")
-                                         (App
-                                          Opapp
-                                          [Var
-                                           (Long
-                                            "List"
-                                            (Short
-                                             "tl"));
-                                           Var
-                                           (Short
-                                            "y")])
-                                         (Let
-                                          (SOME
-                                           "t0")
-                                          (App
-                                           Opapp
-                                           [Var
-                                            (Long
-                                             "List"
-                                             (Short
-                                              "tl"));
-                                            Var
-                                            (Short
-                                             "z")])
-                                          (Let
-                                           (SOME
-                                            "t1")
-                                           (App
-                                            Opapp
-                                            [Var
-                                             (Long
-                                              "List"
-                                              (Short
-                                               "tl"));
-                                             Var
-                                             (Short
-                                              "t0")])
-                                           (Let
-                                            (SOME
-                                             "t2")
-                                            (App
-                                             Opapp
-                                             [Var
-                                              (Long
-                                               "List"
-                                               (Short
-                                                "tl"));
-                                              Var
-                                              (Short
-                                               "t1")])
-                                            (Let
-                                             (SOME
-                                              "t3")
-                                             (App
-                                              Opapp
-                                              [Var
-                                               (Long
-                                                "List"
-                                                (Short
-                                                 "tl"));
-                                               Var
-                                               (Short
-                                                "t2")])
-                                             (Let
-                                              (SOME
-                                               "cst8")
-                                              (App
-                                               Opapp
-                                               [Var
-                                                (Long
-                                                 "List"
-                                                 (Short
-                                                  "hd"));
-                                                Var
-                                                (Short
-                                                 "t3")])
-                                              (Let
-                                               (SOME
-                                                "t4")
-                                               (App
-                                                Opapp
-                                                [Var
-                                                 (Long
-                                                  "List"
-                                                  (Short
-                                                   "tl"));
-                                                 Var
-                                                 (Short
-                                                  "cl")])
-                                               (Let
-                                                (SOME
-                                                 "t5")
-                                                (App
-                                                 Opapp
-                                                 [Var
-                                                  (Long
-                                                   "List"
-                                                   (Short
-                                                    "tl"));
-                                                  Var
-                                                  (Short
-                                                   "t4")])
-                                                (Let
-                                                 (SOME
-                                                  "t6")
-                                                 (App
-                                                  Opapp
-                                                  [Var
-                                                   (Long
-                                                    "List"
-                                                    (Short
-                                                     "tl"));
-                                                   Var
-                                                   (Short
-                                                    "t5")])
-                                                 (Let
-                                                  (SOME
-                                                   "t7")
-                                                  (App
-                                                   Opapp
-                                                   [Var
-                                                    (Long
-                                                     "List"
-                                                     (Short
-                                                      "tl"));
-                                                    Var
-                                                    (Short
-                                                     "t6")])
-                                                  (Let
-                                                   (SOME
-                                                    "t8")
-                                                   (App
-                                                    Opapp
-                                                    [Var
-                                                     (Long
-                                                      "List"
-                                                      (Short
-                                                       "tl"));
-                                                     Var
-                                                     (Short
-                                                      "t7")])
-                                                   (Let
-                                                    (SOME
-                                                     "t9")
-                                                    (App
-                                                     Opapp
-                                                     [Var
-                                                      (Long
-                                                       "List"
-                                                       (Short
-                                                        "tl"));
-                                                      Var
-                                                      (Short
-                                                       "t8")])
-                                                    (Let
-                                                     (SOME
-                                                      "t10")
-                                                     (App
-                                                      Opapp
-                                                      [Var
-                                                       (Long
-                                                        "List"
-                                                        (Short
-                                                         "tl"));
-                                                       Var
-                                                       (Short
-                                                        "t9")])
-                                                     (Let
-                                                      (SOME
-                                                       "t11")
-                                                      (App
-                                                       Opapp
-                                                       [Var
-                                                        (Long
-                                                         "List"
-                                                         (Short
-                                                          "tl"));
-                                                        Var
-                                                        (Short
-                                                         "t10")])
-                                                      (Let
-                                                       (SOME
-                                                        "cst9")
-                                                       (App
-                                                        Opapp
-                                                        [Var
-                                                         (Long
-                                                          "List"
-                                                          (Short
-                                                           "hd"));
-                                                         Var
-                                                         (Short
-                                                          "t11")])
-                                                       (Let
-                                                        (SOME
-                                                         "t12")
-                                                        (Con
-                                                         NONE
-                                                         [Var
-                                                          (Short
-                                                           "cst8");
-                                                          Var
-                                                          (Short
-                                                           "cst9")])
-                                                        (Let
-                                                         (SOME
-                                                          "t13")
-                                                         (Con
-                                                          NONE
-                                                          [Var
-                                                           (Short
-                                                            "cst7");
-                                                           Var
-                                                           (Short
-                                                            "t12")])
-                                                         (Let
-                                                          (SOME
-                                                           "t14")
-                                                          (Con
-                                                           NONE
-                                                           [Var
-                                                            (Short
-                                                             "cst6");
-                                                            Var
-                                                            (Short
-                                                             "t13")])
-                                                          (Let
-                                                           (SOME
-                                                            "t15")
-                                                           (Con
-                                                            NONE
-                                                            [Var
-                                                             (Short
-                                                              "cst5");
-                                                             Var
-                                                             (Short
-                                                              "t14")])
-                                                           (Let
-                                                            (SOME
-                                                             "t16")
-                                                            (Con
-                                                             NONE
-                                                             [Var
-                                                              (Short
-                                                               "cst4");
-                                                              Var
-                                                              (Short
-                                                               "t15")])
-                                                            (Let
-                                                             (SOME
-                                                              "t17")
-                                                             (Con
-                                                              NONE
-                                                              [Var
-                                                               (Short
-                                                                "cst3");
-                                                               Var
-                                                               (Short
-                                                                "t16")])
-                                                             (Let
-                                                              (SOME
-                                                               "t18")
-                                                              (Con
-                                                               NONE
-                                                               [Var
-                                                                (Short
-                                                                 "cst2");
-                                                                Var
-                                                                (Short
-                                                                 "t17")])
-                                                              (Con
-                                                               NONE
-                                                               [Var
-                                                                (Short
-                                                                 "cst1");
-                                                                Var
-                                                                (Short
-                                                                 "t18")])))))))))))))))))))))))))))))))))))))))))))))))))))))))]]
+val tm = process_topdecs `
+  fun printer x =
+    let val z = Word64.toInt x
+        val y = Int.toString z
+    in TextIO.print y end;
+`;
+val _ = append_prog tm;
+Definition printer_def: printer = ^tm
 End
-
-val _ = append_prog (reader9_def |> concl |> rhs);
-
-Definition printer_def:
-  printer =
-  [Dlet unknown_loc (Pvar "printer")
-    (Fun "x"
-     (Let (SOME "z")
-      (App Opapp [
-         Var (Long "Word64" (Short "toInt"));
-         Var (Short "x")])
-      (Let (SOME "y")
-       (App Opapp [
-          Var (Long "Int" (Short "toString"));
-          Var (Short "z")])
-       (App Opapp [
-          Var (Long "TextIO" (Short "print"));
-          Var (Short "y")]))))]
-End
-
-val _ = append_prog (printer_def |> concl |> rhs);
 
 Definition intToFP_def:
   intToFP =
@@ -1502,40 +201,6 @@ Definition init_ok_def:
   init_ok (cl,fs) ⇔ wfcl cl ∧ wfFS fs ∧ STD_streams fs
 End
 
-Theorem hd_spec:
-  LIST_TYPE STRING_TYPE xs vs ∧
-  xs ≠ [] ⇒
-  app p ^(fetch_v "List.hd" st) [vs]
-  (emp) (POSTv uv. &STRING_TYPE (HD xs) uv)
-Proof
-  fs[app_def] \\ rpt strip_tac
-  \\ assume_tac (GEN_ALL (Q.ISPEC ‘STRING_TYPE’ (Q.GEN ‘a’ ListProgTheory.hd_v_thm)))
-  \\ first_x_assum (qspec_then ‘xs’ assume_tac) \\ fs[PRECONDITION_def]
-  \\ res_tac
-  \\ fs[Eq_def]
-  \\ assume_tac
-     (GEN_ALL
-      (INST_TYPE [“:'a” |-> “:mlstring list”,“:'b”|->“:mlstring”, “:'ffi” |-> “:'a”]
-       Arrow_IMP_app_basic))
-  \\ first_x_assum (qspecl_then [‘hd_v’, ‘p’, ‘HD’, ‘STRING_TYPE’] assume_tac)
-  \\ res_tac
-  \\ first_x_assum (qspecl_then [‘xs’, ‘vs’] irule)
-  \\ fs[]
-QED
-
-Theorem tl_spec:
-  LIST_TYPE STRING_TYPE xs vs ∧
-  xs ≠ [] ⇒
-  app p ^(fetch_v "List.tl" st) [vs]
-  (emp) (POSTv uv. &LIST_TYPE STRING_TYPE (TL xs) uv)
-Proof
-  fs[app_def] \\ rpt strip_tac
-  \\ assume_tac (GEN_ALL (Q.ISPEC ‘STRING_TYPE’ (Q.GEN ‘a’ ListProgTheory.tl_v_thm)))
-  \\ assume_tac (GEN_ALL (INST_TYPE [“:'a” |-> “:mlstring list”,“:'b”|->“:mlstring list”, “:'ffi” |-> “:'a”] Arrow_IMP_app_basic))
-  \\ first_x_assum (qspecl_then [‘tl_v’, ‘p’, ‘TL’, ‘LIST_TYPE STRING_TYPE’] assume_tac)
-  \\ res_tac
-QED
-
 Theorem cf_fpfromword:
   ∀ env.
   cf_fpfromword (Lit (Word64 w)) env (STDIO fs)
@@ -1548,12 +213,7 @@ Proof
   \\ rpt strip_tac
   \\ qexists_tac ‘STDIO fs’ \\ qexists_tac ‘emp’
   \\ qexists_tac ‘Post’ \\ rpt conj_tac \\ unabbrev_all_tac \\ xsimpl
-   >- (
-    simp[set_sepTheory.STAR_def] \\ qexists_tac ‘h’ \\ qexists_tac ‘EMPTY’
-    \\ fs[SPLIT_def, emp_def])
-   \\ fs[DOUBLE_def, set_sepTheory.SEP_IMP_def]
-   \\ rpt strip_tac \\ fs[set_sepTheory.cond_def, set_sepTheory.STAR_def]
-   \\ unabbrev_all_tac \\ fs[SPLIT_def]
+  \\ simp [DOUBLE_def, set_sepTheory.SEP_CLAUSES]
 QED
 
 Theorem cf_fpfromword_var:
@@ -1569,12 +229,7 @@ Proof
   \\ rpt strip_tac
   \\ qexists_tac ‘STDIO fs’ \\ qexists_tac ‘emp’
   \\ qexists_tac ‘Post’ \\ rpt conj_tac \\ unabbrev_all_tac \\ xsimpl
-   >- (
-    simp[set_sepTheory.STAR_def] \\ qexists_tac ‘h’ \\ qexists_tac ‘EMPTY’
-    \\ fs[SPLIT_def, emp_def])
-   \\ fs[DOUBLE_def, set_sepTheory.SEP_IMP_def]
-   \\ rpt strip_tac \\ fs[set_sepTheory.cond_def, set_sepTheory.STAR_def]
-   \\ unabbrev_all_tac \\ fs[SPLIT_def]
+  \\ simp [DOUBLE_def, set_sepTheory.SEP_CLAUSES]
 QED
 
 Theorem fromstring_spec:
@@ -1647,10 +302,8 @@ Proof
   \\ qexists_tac ‘EMPTY’ \\ qexists_tac ‘u’
   \\ fs[WORD_def, set_sepTheory.cond_def, SPLIT_def, set_sepTheory.STAR_def]
   \\ rpt conj_tac \\ rveq \\ unabbrev_all_tac \\ xsimpl
-  >- fs[DOUBLE_def]
-  \\ rpt strip_tac \\ fs[set_sepTheory.SEP_IMP_def]
-  \\ rpt strip_tac \\ fs[]
-  \\ qexists_tac ‘s'’ \\ qexists_tac ‘EMPTY’ \\ fs[GC_def]
+  \\ simp [DOUBLE_def, set_sepTheory.SEP_CLAUSES, set_sepTheory.SEP_IMP_def]
+  \\ rpt strip_tac \\ qexists_tac ‘s'’ \\ qexists_tac ‘EMPTY’ \\ fs[GC_def]
   \\ fs[set_sepTheory.SEP_EXISTS] \\ qexists_tac ‘emp’ \\ fs[emp_def]
 QED
 
@@ -1660,20 +313,15 @@ Theorem reader1_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader1" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv. &(STRING_TYPE (HD(TL cl)) uv) * STDIO fs)
+  (POSTv uv. &(STRING_TYPE (HD (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader1" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
   \\ xlet_auto >- xsimpl
-  \\ ‘cl ≠ []’ by (Cases_on ‘cl’ \\ fs[])
-  \\ ‘TL cl ≠ []’ by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec)
-  >- (xsimpl)
-  \\ xcon \\ xsimpl
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` ListProgTheory.hd_v_thm))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute] \\ xsimpl
 QED
 
 Theorem reader2_spec:
@@ -1682,25 +330,17 @@ Theorem reader2_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader2" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv. &(PAIR_TYPE STRING_TYPE STRING_TYPE (HD(TL cl), (HD (TL (TL cl)))) uv) * STDIO fs)
+  (POSTv uv.
+    &(PAIR_TYPE STRING_TYPE STRING_TYPE (list2tup2 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader2" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
   \\ xlet_auto >- xsimpl
-  \\ ‘cl ≠ []’ by (Cases_on ‘cl’ \\ fs[])
-  \\ ‘TL cl ≠ []’ by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec)
-  >- (xsimpl)
-  \\ xlet_auto_spec (SOME tl_spec) >- (xsimpl)
-  \\ ‘TL (TL cl) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- (xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup2_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup2_side_def"]
+  \\ xsimpl
 QED
 
 Theorem reader3_spec:
@@ -1709,31 +349,16 @@ Theorem reader3_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader3" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv. &(PAIR_TYPE STRING_TYPE (PAIR_TYPE STRING_TYPE STRING_TYPE) (HD(TL cl), (HD (TL (TL cl)), HD (TL (TL (TL cl))))) uv) * STDIO fs)
+  (POSTv uv. &(PAIR3_TYPE STRING_TYPE (list2tup3 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader3" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
   \\ xlet_auto >- xsimpl
-  \\ ‘cl ≠ []’ by (Cases_on ‘cl’ \\ fs[])
-  \\ ‘TL cl ≠ []’ by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec)
-  >- (xsimpl)
-  \\ xlet_auto_spec (SOME tl_spec) >- (xsimpl)
-  \\ ‘TL (TL cl) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- (xsimpl)
-  \\ xlet_auto_spec (SOME tl_spec) >- (xsimpl)
-  \\ xlet_auto_spec (SOME tl_spec) >- (xsimpl)
-  \\ ‘TL (TL (TL cl)) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- (xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup3_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup3_side_def"]
+  \\ xsimpl
 QED
 
 Theorem reader4_spec:
@@ -1742,44 +367,16 @@ Theorem reader4_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader4" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv.
-    &(PAIR_TYPE STRING_TYPE
-      (PAIR_TYPE STRING_TYPE
-       (PAIR_TYPE STRING_TYPE STRING_TYPE))
-       (HD(TL cl), (HD (TL (TL cl)), HD (TL (TL (TL cl))), HD (TL (TL (TL (TL cl))))))
-       uv) * STDIO fs)
+  (POSTv uv. &(PAIR4_TYPE STRING_TYPE (list2tup4 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader4" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull)
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
   \\ xlet_auto >- xsimpl
-  \\ ‘cl ≠ []’ by (Cases_on ‘cl’ \\ fs[])
-  \\ ‘TL cl ≠ []’ by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec)
-  >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ ‘TL (TL cl) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ ‘TL (TL (TL cl)) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ ‘TL (TL (TL (TL cl))) ≠ []’
-     by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[]
-         \\ Cases_on ‘t’ \\ fs[] \\ Cases_on ‘t'’ \\ fs[])
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup4_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup4_side_def"]
+  \\ xsimpl
 QED
 
 Theorem reader6_spec:
@@ -1788,55 +385,16 @@ Theorem reader6_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader6" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv.
-    &(PAIR_TYPE STRING_TYPE
-      (PAIR_TYPE STRING_TYPE
-       (PAIR_TYPE STRING_TYPE
-        (PAIR_TYPE STRING_TYPE
-        (PAIR_TYPE STRING_TYPE STRING_TYPE))))
-       (HD(TL cl),
-        (HD (TL (TL cl)),
-         (HD (TL (TL (TL cl))),
-          (HD (TL (TL (TL (TL cl)))),
-           (HD (TL (TL (TL (TL (TL cl))))),
-            HD (TL (TL (TL (TL (TL (TL cl)))))))))))
-       uv) * STDIO fs)
+  (POSTv uv. &(PAIR6_TYPE STRING_TYPE (list2tup6 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader6" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ fs [quantHeuristicsTheory.LENGTH_TO_EXISTS_CONS]
-  \\ reverse(Cases_on`wfcl cl`) >- (fs[COMMANDLINE_def] \\ xpull \\ gs[])
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
   \\ xlet_auto >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup6_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup6_side_def"]
+  \\ xsimpl
 QED
 
 Theorem reader8_spec:
@@ -1845,85 +403,16 @@ Theorem reader8_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader8" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv.
-    &(PAIR_TYPE STRING_TYPE
-      (PAIR_TYPE STRING_TYPE
-       (PAIR_TYPE STRING_TYPE
-        (PAIR_TYPE STRING_TYPE
-         (PAIR_TYPE STRING_TYPE
-          (PAIR_TYPE STRING_TYPE
-           (PAIR_TYPE STRING_TYPE STRING_TYPE))))))
-       (HD(TL cl),
-        (HD (TL (TL cl)),
-         (HD (TL (TL (TL cl))),
-          (HD (TL (TL (TL (TL cl)))),
-           (HD (TL (TL (TL (TL (TL cl))))),
-            (HD (TL (TL (TL (TL (TL (TL cl)))))),
-             (HD (TL (TL (TL (TL (TL (TL (TL cl))))))),
-              HD (TL (TL (TL (TL (TL (TL (TL (TL cl)))))))))))))))
-       uv) * STDIO fs)
+  (POSTv uv. &(PAIR8_TYPE STRING_TYPE (list2tup8 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader8" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
-  \\ xlet_auto_spec (SOME CommandLine_arguments_spec) >- (xcon \\ xsimpl)
-  \\ ‘∃ e1 e2 e3 e4 e5 e6 e7 e8 e9. cl = [e1; e2; e3; e4; e5; e6; e7; e8; e9]’
-    by (Cases_on ‘cl’ \\ fs[] \\ Cases_on ‘t’ \\ fs[]
-        \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[]
-        \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[]
-        \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[]
-        \\ Cases_on ‘t'’ \\ fs[] \\ Cases_on ‘t’ \\ fs[])
-  \\ reverse(Cases_on`wfcl cl`)
-  >- (fs[COMMANDLINE_def] \\ xpull_core \\ rpt strip_tac
-      >- (rewrite_tac[Once cf_let_def] \\ simp[local_is_local])
-      \\ gs[])
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ]
-  \\ xlet_auto_spec (SOME CommandLine_arguments_spec)
-  >- (qexists_tac ‘STDIO fs’ \\ xsimpl)
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xlet_auto >- xsimpl
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup8_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup8_side_def"]
+  \\ xsimpl
 QED
 
 Theorem reader9_spec:
@@ -1932,92 +421,16 @@ Theorem reader9_spec:
   app (p: 'ffi ffi_proj) ^(fetch_v "reader9" st)
   [uv]
   (STDIO fs * COMMANDLINE cl)
-  (POSTv uv.
-    &(PAIR_TYPE STRING_TYPE
-      (PAIR_TYPE STRING_TYPE
-       (PAIR_TYPE STRING_TYPE
-        (PAIR_TYPE STRING_TYPE
-         (PAIR_TYPE STRING_TYPE
-          (PAIR_TYPE STRING_TYPE
-           (PAIR_TYPE STRING_TYPE
-            (PAIR_TYPE STRING_TYPE STRING_TYPE)))))))
-       (HD(TL cl),
-        (HD (TL (TL cl)),
-         (HD (TL (TL (TL cl))),
-          (HD (TL (TL (TL (TL cl)))),
-           (HD (TL (TL (TL (TL (TL cl))))),
-            (HD (TL (TL (TL (TL (TL (TL cl)))))),
-             (HD (TL (TL (TL (TL (TL (TL (TL cl))))))),
-              (HD (TL (TL (TL (TL (TL (TL (TL (TL cl)))))))),
-               HD (TL (TL (TL (TL (TL (TL (TL (TL (TL cl)))))))))))))))))
-       uv) * STDIO fs)
+  (POSTv uv. &(PAIR9_TYPE STRING_TYPE (list2tup9 (TL cl)) uv) * STDIO fs)
 Proof
   rpt strip_tac
   \\ xcf "reader9" st
-  \\ reverse (Cases_on`STD_streams fs`) >-(fs[STDIO_def] \\ xpull)
-  \\ xlet_auto_spec (SOME CommandLine_arguments_spec) >- (xcon \\ xsimpl)
-  \\ fs [quantHeuristicsTheory.LENGTH_TO_EXISTS_CONS]
-  \\ reverse(Cases_on`wfcl cl`)
-  >- (fs[COMMANDLINE_def] \\ xpull_core \\ rpt strip_tac
-      >- (rewrite_tac[Once cf_let_def] \\ simp[local_is_local])
-      \\ gs[])
-  \\ ‘~ NULL cl’ by fs[wfcl_def,NULL_EQ] \\ rveq
-  \\ xlet_auto_spec (SOME CommandLine_arguments_spec)
-  >- (qexists_tac ‘STDIO fs’ \\ xsimpl)
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME tl_spec) >- xsimpl
-  \\ xlet_auto_spec (SOME hd_spec) >- xsimpl
   \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xlet_auto >- (xcon \\ xsimpl)
-  \\ xcon \\ xsimpl
-  \\ fs[PAIR_TYPE_def]
+  \\ xlet_auto >- xsimpl
+  \\ xapp_spec (Q.ISPEC `STRING_TYPE` (Q.GEN `a` (fetch "-" "list2tup9_v_thm")))
+  \\ first_assum (irule_at Any)
+  \\ gvs [LENGTH_EQ_NUM_compute, fetch "-" "list2tup9_side_def"]
+  \\ xsimpl
 QED
 
 Theorem printer_spec:


### PR DESCRIPTION
This patch greatly improves the running-time of the CF proofs in `icing/cfSupportScript.sml`. 

This proof was previously a substantial (20-30 minutes) part of icing because of the abysmal performance of `xlet_auto` on goals with deeply nested lets/apps (in this case, lists of length N were converted into N-ary tuples by applying `List.tl` 1 + 2 + 3 + ... + N times).

The only dependency on this code seems to be in icing/examples. I have no idea how these things work, but as far as I can tell, running Holmake in that directory still seems to work. It isn't part of the regression test, though.