### PR TITLE
Remove bitmap pointer stores for Pancake

### DIFF
--- a/compiler/backend/ag32/export_ag32Script.sml
+++ b/compiler/backend/ag32/export_ag32Script.sml
@@ -7,7 +7,7 @@ val () = new_theory "export_ag32";
 
 val ag32_export_def = Define `
   ag32_export (ffi_names:string list) bytes (data:word32 list)
-      (syms: (mlstring # num # num) list) exp ret =
+      (syms: (mlstring # num # num) list) exp ret pk =
     SmartAppend
      (split16 (words_line (strlit".data_word ") word_to_string) data)
      (split16 (words_line (strlit".code_byte ") byte_to_string) bytes)`;

--- a/compiler/backend/arm7/export_arm7Script.sml
+++ b/compiler/backend/arm7/export_arm7Script.sml
@@ -53,13 +53,6 @@ val startup_def = Define `
       [strlit"     .ltorg\n";
        strlit"\n"]))))`
 
-(* val (startup_true, startup_false) =
-    (``^startup' T`` |> EVAL |> concl |> rand,
-     ``^startup' F`` |> EVAL |> concl |> rand);
-
-val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``; *)
-
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
   (ffi_asm (ffi::ffis) =

--- a/compiler/backend/arm7/export_arm7Script.sml
+++ b/compiler/backend/arm7/export_arm7Script.sml
@@ -17,42 +17,48 @@ In addition, the first address on the heap should store the address of cake_bitm
 
 Note: this set up does NOT account for restoring clobbered registers
 *)
-val startup' =
-  ``λret pk. (MAP (\n. strlit(n ++ "\n"))
-      (["/* Start up code */";
-       "";
-       "     .text";
-       "     .p2align 3";
-       "     .globl  cdecl(cml_main)";
-       "     .globl  cdecl(cml_heap)";
-       "     .globl  cdecl(cml_stack)";
-       "     .globl  cdecl(cml_stackend)";
-       "     .type   cml_main, function";
-       "cdecl(cml_main):";
-       "     ldr    r0,=cake_main            /* arg1: entry address */";
-       "     ldr    r1,=cdecl(cml_heap)      /* arg2: first address of heap */";
-       "     ldr    r1,[r1]"] ++
-       (if ~pk then
-         ["     ldr    r2,=cake_bitmaps";
-          "     str    r2,[r1]                  /* store bitmap pointer */"]
-        else []) ++
-       ["     ldr    r2,=cdecl(cml_stack)     /* arg3: first address of stack */";
-       "     ldr    r2,[r2]";
-       "     ldr    r3,=cdecl(cml_stackend)  /* arg4: first address past the stack */";
-       "     ldr    r3,[r3]"] ++
-       (if ret then
-         ["     b      cml_enter"]
-       else
-         ["     b      cake_main"]) ++
-      ["     .ltorg";
-       ""]))``
+val startup_def = Define `
+  startup ret pk =
+    SmartAppend (List
+      [strlit"\n";
+       strlit"/* Start up code */\n";
+       strlit"\n";
+       strlit"     .text\n";
+       strlit"     .p2align 3\n";
+       strlit"     .globl  cdecl(cml_main)\n";
+       strlit"     .globl  cdecl(cml_heap)\n";
+       strlit"     .globl  cdecl(cml_stack)\n";
+       strlit"     .globl  cdecl(cml_stackend)\n";
+       strlit"     .type   cml_main, function\n";
+       strlit"cdecl(cml_main):\n";
+       strlit"     ldr    r0,=cake_main            /* arg1: entry address */\n";
+       strlit"     ldr    r1,=cdecl(cml_heap)      /* arg2: first address of heap */\n";
+       strlit"     ldr    r1,[r1]\n"])
+    (SmartAppend (List
+      (if ~pk then
+        [strlit"     ldr    r2,=cake_bitmaps\n";
+         strlit"     str    r2,[r1]                  /* store bitmap pointer */\n"]
+      else []))
+    (SmartAppend (List
+      [strlit"     ldr    r2,=cdecl(cml_stack)     /* arg3: first address of stack */\n";
+       strlit"     ldr    r2,[r2]\n";
+       strlit"     ldr    r3,=cdecl(cml_stackend)  /* arg4: first address past the stack */\n";
+       strlit"     ldr    r3,[r3]\n"])
+    (SmartAppend (List
+      (if ret then
+        [strlit"     b      cml_enter\n"]
+      else
+        [strlit"     b      cake_main\n"]))
+    (List
+      [strlit"     .ltorg\n";
+       strlit"\n"]))))`
 
-val (startup_true, startup_false) =
+(* val (startup_true, startup_false) =
     (``^startup' T`` |> EVAL |> concl |> rand,
      ``^startup' F`` |> EVAL |> concl |> rand);
 
 val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``;
+  ``λret. if ret then ^startup_true else ^startup_false``; *)
 
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
@@ -176,7 +182,7 @@ val arm7_export_def = Define `
       (SmartAppend (List (data_section ".long" ret))
       (SmartAppend (split16 (words_line (strlit"\t.long ") word_to_string) data)
       (SmartAppend (List data_buffer)
-      (SmartAppend (List ((strlit"\n")::(^startup ret pk))) (^ffi_code ret))))))
+      (SmartAppend (startup ret pk) (^ffi_code ret))))))
       (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
       (SmartAppend (List code_buffer)
       (SmartAppend (emit_symbols lsyms)

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -60,7 +60,7 @@ val startup_def = Define `
     (SmartAppend (List
       (if ret then
         [strlit"     b      cml_enter\n"]
-       else
+      else
         [strlit"     b      cake_main\n"]))
     (List
       [strlit"     .ltorg\n";

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -66,13 +66,6 @@ val startup_def = Define `
       [strlit"     .ltorg\n";
        strlit"\n"]))))`
 
-(* val (startup_true, startup_false) =
-    (``^startup' T`` |> EVAL |> concl |> rand,
-     ``^startup' F`` |> EVAL |> concl |> rand);
-
-val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``; *)
-
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
   (ffi_asm (ffi::ffis) =

--- a/compiler/backend/arm8/export_arm8Script.sml
+++ b/compiler/backend/arm8/export_arm8Script.sml
@@ -17,55 +17,61 @@ In addition, the first address on the heap should store the address of cake_bitm
 
 Note: this set up does NOT account for restoring clobbered registers
 *)
-val startup' =
-  ``λret pk. (MAP (\n. strlit(n ++ "\n"))
-      (["/* Start up code */";
-       "";
-       "     .text";
-       "     .p2align 3";
-       "     .globl  cdecl(cml_main)";
-       "     .globl  cdecl(cml_heap)";
-       "     .globl  cdecl(cml_stack)";
-       "     .globl  cdecl(cml_stackend)";
-       "#ifndef __APPLE__";
-       "     .type   cml_main, function";
-       "#endif";
-       "";
-       ".macro _ldrel reg sym";
-       "#ifdef __APPLE__";
-       "adrp \\reg, \\sym@PAGE";
-       "add  \\reg, \\reg, \\sym@PAGEOFF";
-       "#else";
-       "adrp \\reg, \\sym";
-       "add  \\reg, \\reg, :lo12:\\sym";
-       "#endif";
-       ".endm";
-       "";
-       "cdecl(cml_main):";
-       "     _ldrel x0, cake_main            /* arg1: entry address */";
-       "     _ldrel x1, cdecl(cml_heap)      /* arg2: first address of heap */";
-       "     ldr    x1,[x1]"] ++
-       (if ~pk then
-         ["     _ldrel x2, cake_bitmaps";
-          "     str    x2,[x1]                  /* store bitmap pointer */"]
-        else []) ++
-       ["     _ldrel x2, cdecl(cml_stack)     /* arg3: first address of stack */";
-       "     ldr    x2,[x2]";
-       "     _ldrel x3, cdecl(cml_stackend)  /* arg4: first address past the stack */";
-       "     ldr    x3,[x3]"] ++
-       (if ret then
-         ["     b      cml_enter"]
+val startup_def = Define `
+  startup ret pk =
+    SmartAppend (List
+      [strlit"\n";
+       strlit"/* Start up code */\n";
+       strlit"\n";
+       strlit"     .text\n";
+       strlit"     .p2align 3\n";
+       strlit"     .globl  cdecl(cml_main)\n";
+       strlit"     .globl  cdecl(cml_heap)\n";
+       strlit"     .globl  cdecl(cml_stack)\n";
+       strlit"     .globl  cdecl(cml_stackend)\n";
+       strlit"#ifndef __APPLE__\n";
+       strlit"     .type   cml_main, function\n";
+       strlit"#endif\n";
+       strlit"\n";
+       strlit".macro _ldrel reg sym\n";
+       strlit"#ifdef __APPLE__\n";
+       strlit"adrp \\reg, \\sym@PAGE\n";
+       strlit"add  \\reg, \\reg, \\sym@PAGEOFF\n";
+       strlit"#else\n";
+       strlit"adrp \\reg, \\sym\n";
+       strlit"add  \\reg, \\reg, :lo12:\\sym\n";
+       strlit"#endif\n";
+       strlit".endm\n";
+       strlit"\n";
+       strlit"cdecl(cml_main):\n";
+       strlit"     _ldrel x0, cake_main            /* arg1: entry address */\n";
+       strlit"     _ldrel x1, cdecl(cml_heap)      /* arg2: first address of heap */\n";
+       strlit"     ldr    x1,[x1]\n"])
+    (SmartAppend (List
+      (if ~pk then
+        [strlit"     _ldrel x2, cake_bitmaps\n";
+         strlit"     str    x2,[x1]                  /* store bitmap pointer */\n"]
+      else []))
+    (SmartAppend (List
+      [strlit"     _ldrel x2, cdecl(cml_stack)     /* arg3: first address of stack */\n";
+       strlit"     ldr    x2,[x2]\n";
+       strlit"     _ldrel x3, cdecl(cml_stackend)  /* arg4: first address past the stack */\n";
+       strlit"     ldr    x3,[x3]\n"])
+    (SmartAppend (List
+      (if ret then
+        [strlit"     b      cml_enter\n"]
        else
-         ["     b      cake_main"]) ++
-      ["     .ltorg";
-       ""]))``
+        [strlit"     b      cake_main\n"]))
+    (List
+      [strlit"     .ltorg\n";
+       strlit"\n"]))))`
 
-val (startup_true, startup_false) =
+(* val (startup_true, startup_false) =
     (``^startup' T`` |> EVAL |> concl |> rand,
      ``^startup' F`` |> EVAL |> concl |> rand);
 
 val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``;
+  ``λret. if ret then ^startup_true else ^startup_false``; *)
 
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
@@ -200,7 +206,7 @@ val arm8_export_def = Define `
       (SmartAppend (List (data_section ".quad" ret))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List data_buffer)
-      (SmartAppend (List ((strlit"\n")::(^startup ret pk))) (^ffi_code ret))))))
+      (SmartAppend (startup ret pk) (^ffi_code ret))))))
       (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
       (SmartAppend (List code_buffer)
       (SmartAppend (emit_symbols lsyms)

--- a/compiler/backend/mips/export_mipsScript.sml
+++ b/compiler/backend/mips/export_mipsScript.sml
@@ -49,13 +49,6 @@ val startup_def = Define `
       [strlit"     nop\n";
        strlit"\n"]))))`
 
-(* val (startup_true, startup_false) =
-    (``^startup' T`` |> EVAL |> concl |> rand,
-     ``^startup' F`` |> EVAL |> concl |> rand);
-
-val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``; *)
-
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
   (ffi_asm (ffi::ffis) =

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -49,13 +49,6 @@ val startup_def = Define `
     (List
       [strlit"\n"]))))`
 
-(* val (startup_true, startup_false) =
-    (``^startup' T`` |> EVAL |> concl |> rand,
-     ``^startup' F`` |> EVAL |> concl |> rand);
-
-val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``; *)
-
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
   (ffi_asm (ffi::ffis) =

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -18,7 +18,7 @@ In addition, the first address on the heap should store the address of cake_bitm
 Note: this set up does NOT account for restoring clobbered registers
 *)
 val startup' =
-  ``λret. (MAP (\n. strlit(n ++ "\n"))
+  ``λret pk. (MAP (\n. strlit(n ++ "\n"))
       (["#### Start up code";
        "";
        "     .text";
@@ -30,10 +30,12 @@ val startup' =
        "     .type   cml_main, function";
        "cdecl(cml_main):";
        "     la      a0,cake_main           # arg1: entry address";
-       "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap";
-       "     la      t3,cake_bitmaps";
-       "     sd      t3, 0(a1)              # store bitmap pointer";
-       "     ld      a2,cdecl(cml_stack)    # arg3: first address of stack";
+       "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap"] ++
+       (if ~pk then
+         ["     la      t3,cake_bitmaps";
+          "     sd      t3, 0(a1)              # store bitmap pointer"]
+        else []) ++
+       ["     ld      a2,cdecl(cml_stack)    # arg3: first address of stack";
        "     ld      a3,cdecl(cml_stackend) # arg4: first address past the stack"] ++
        (if ret then
          ["     j       cml_enter"]
@@ -175,14 +177,14 @@ val export_funcs_def = Define `
     FOLDL export_func misc$Nil (FILTER ((flip MEM exp) o FST) lsyms)`;
 
 val riscv_export_def = Define `
-  riscv_export ffi_names bytes (data:word64 list) syms exp ret =
+  riscv_export ffi_names bytes (data:word64 list) syms exp ret pk =
     let lsyms = get_sym_labels syms in
     SmartAppend
       (SmartAppend (List preamble)
       (SmartAppend (List (data_section ".quad" ret))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List data_buffer)
-      (SmartAppend (List ((strlit"\n")::(^startup ret))) (^ffi_code ret))))))
+      (SmartAppend (List ((strlit"\n")::(^startup ret pk))) (^ffi_code ret))))))
       (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
       (SmartAppend (List code_buffer)
       (SmartAppend (emit_symbols lsyms)

--- a/compiler/backend/riscv/export_riscvScript.sml
+++ b/compiler/backend/riscv/export_riscvScript.sml
@@ -17,38 +17,44 @@ In addition, the first address on the heap should store the address of cake_bitm
 
 Note: this set up does NOT account for restoring clobbered registers
 *)
-val startup' =
-  ``λret pk. (MAP (\n. strlit(n ++ "\n"))
-      (["#### Start up code";
-       "";
-       "     .text";
-       "     .p2align 3";
-       "     .globl  cdecl(cml_main)";
-       "     .globl  cdecl(cml_heap)";
-       "     .globl  cdecl(cml_stack)";
-       "     .globl  cdecl(cml_stackend)";
-       "     .type   cml_main, function";
-       "cdecl(cml_main):";
-       "     la      a0,cake_main           # arg1: entry address";
-       "     ld      a1,cdecl(cml_heap)     # arg2: first address of heap"] ++
-       (if ~pk then
-         ["     la      t3,cake_bitmaps";
-          "     sd      t3, 0(a1)              # store bitmap pointer"]
-        else []) ++
-       ["     ld      a2,cdecl(cml_stack)    # arg3: first address of stack";
-       "     ld      a3,cdecl(cml_stackend) # arg4: first address past the stack"] ++
-       (if ret then
-         ["     j       cml_enter"]
-       else
-         ["     j       cake_main"]) ++
-      [""]))``
+val startup_def = Define `
+  startup ret pk =
+    SmartAppend (List
+      [strlit"\n";
+       strlit"#### Start up code\n";
+       strlit"\n";
+       strlit"     .text\n";
+       strlit"     .p2align 3\n";
+       strlit"     .globl  cdecl(cml_main)\n";
+       strlit"     .globl  cdecl(cml_heap)\n";
+       strlit"     .globl  cdecl(cml_stack)\n";
+       strlit"     .globl  cdecl(cml_stackend)\n";
+       strlit"     .type   cml_main, function\n";
+       strlit"cdecl(cml_main):\n";
+       strlit"     la      a0,cake_main           # arg1: entry address\n";
+       strlit"     ld      a1,cdecl(cml_heap)     # arg2: first address of heap\n"])
+    (SmartAppend (List
+      (if ~pk then
+        [strlit"     la      t3,cake_bitmaps\n";
+        strlit"     sd      t3, 0(a1)              # store bitmap pointer\n"]
+      else []))
+    (SmartAppend (List
+      [strlit"     ld      a2,cdecl(cml_stack)    # arg3: first address of stack\n";
+       strlit"     ld      a3,cdecl(cml_stackend) # arg4: first address past the stack\n"])
+    (SmartAppend (List
+      (if ret then
+        [strlit"     j       cml_enter\n"]
+      else
+        [strlit"     j       cake_main\n"]))
+    (List
+      [strlit"\n"]))))`
 
-val (startup_true, startup_false) =
+(* val (startup_true, startup_false) =
     (``^startup' T`` |> EVAL |> concl |> rand,
      ``^startup' F`` |> EVAL |> concl |> rand);
 
 val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``;
+  ``λret. if ret then ^startup_true else ^startup_false``; *)
 
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
@@ -184,7 +190,7 @@ val riscv_export_def = Define `
       (SmartAppend (List (data_section ".quad" ret))
       (SmartAppend (split16 (words_line (strlit"\t.quad ") word_to_string) data)
       (SmartAppend (List data_buffer)
-      (SmartAppend (List ((strlit"\n")::(^startup ret pk))) (^ffi_code ret))))))
+      (SmartAppend (startup ret pk) (^ffi_code ret))))))
       (SmartAppend (split16 (words_line (strlit"\t.byte ") byte_to_string) bytes)
       (SmartAppend (List code_buffer)
       (SmartAppend (emit_symbols lsyms)

--- a/compiler/backend/x64/export_x64Script.sml
+++ b/compiler/backend/x64/export_x64Script.sml
@@ -70,13 +70,6 @@ val startup_def = Define `
        strlit"     .endfunc\n";
        strlit"#endif\n"]))))`
 
-(* val (startup_true, startup_false) =
-    (``^startup' T`` |> EVAL |> concl |> rand,
-     ``^startup' F`` |> EVAL |> concl |> rand);
-
-val startup =
-  ``λret. if ret then ^startup_true else ^startup_false``; *)
-
 val ffi_asm_def = Define `
   (ffi_asm [] = Nil) /\
   (ffi_asm (ffi::ffis) =

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -244,6 +244,7 @@ val res = translate
 
 (* arm7 *)
 val res = translate arm7_configTheory.arm7_names_def;
+val res = translate export_arm7Theory.startup_def;
 val res = translate export_arm7Theory.ffi_asm_def;
 val res = translate export_arm7Theory.export_func_def;
 val res = translate export_arm7Theory.export_funcs_def;

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -238,6 +238,7 @@ val res = translate backendTheory.prim_src_config_eq;
 
 (* x64 *)
 val res = translate x64_configTheory.x64_names_def;
+val res = translate export_x64Theory.startup_def;
 val res = translate export_x64Theory.ffi_asm_def;
 val res = translate export_x64Theory.windows_ffi_asm_def;
 val res = translate export_x64Theory.export_func_def;
@@ -249,6 +250,7 @@ val res = translate
 
 (* riscv *)
 val res = translate riscv_configTheory.riscv_names_def;
+val res = translate export_riscvTheory.startup_def;
 val res = translate export_riscvTheory.ffi_asm_def;
 val res = translate export_riscvTheory.export_func_def;
 val res = translate export_riscvTheory.export_funcs_def;
@@ -259,6 +261,7 @@ val res = translate
 
 (* mips *)
 val res = translate mips_configTheory.mips_names_def;
+val res = translate export_mipsTheory.startup_def;
 val res = translate export_mipsTheory.ffi_asm_def;
 val res = translate export_mipsTheory.export_func_def;
 val res = translate export_mipsTheory.export_funcs_def;
@@ -269,6 +272,7 @@ val res = translate
 
 (* arm8 *)
 val res = translate arm8_configTheory.arm8_names_def;
+val res = translate export_arm8Theory.startup_def;
 val res = translate export_arm8Theory.ffi_asm_def;
 val res = translate export_arm8Theory.export_func_def;
 val res = translate export_arm8Theory.export_funcs_def;

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -667,7 +667,7 @@ Definition compile_64_def:
             (add_tap_output td (export
               (ffinames_to_string_list
                 $ the [] c.lab_conf.ffi_names)
-                bytes data c.symbols c.exported mainret),
+                bytes data c.symbols c.exported mainret F),
               implode "")
         | (Failure err, td) => (add_tap_output td (List []), error_to_str err))
     | INR err =>
@@ -696,7 +696,7 @@ Definition compile_pancake_64_def:
                   (List[], error_to_str err)
               | (Success (bytes, data, c)) =>
                   (export (ffinames_to_string_list $
-                    the [] c.lab_conf.ffi_names) bytes data c.symbols c.exported mainret, implode "")
+                    the [] c.lab_conf.ffi_names) bytes data c.symbols c.exported mainret T, implode "")
 End
 
 Definition full_compile_64_def:
@@ -738,7 +738,7 @@ Definition compile_32_def:
             (add_tap_output td (export
               (ffinames_to_string_list $
                 the [] c.lab_conf.ffi_names)
-                bytes data c.symbols c.exported mainret),
+                bytes data c.symbols c.exported mainret F),
               implode "")
         | (Failure err, td) => (List [], error_to_str err))
     | INR err =>
@@ -767,7 +767,7 @@ Definition compile_pancake_32_def:
                   (List[], error_to_str err)
               | (Success (bytes, data, c)) =>
                   (export (ffinames_to_string_list $
-                    the [] c.lab_conf.ffi_names) bytes data c.symbols c.exported mainret, implode "")
+                    the [] c.lab_conf.ffi_names) bytes data c.symbols c.exported mainret T, implode "")
 End
 
 Definition full_compile_32_def:

--- a/cv_translator/eval_cake_compileLib.sml
+++ b/cv_translator/eval_cake_compileLib.sml
@@ -118,7 +118,7 @@ fun eval_cake_compile_general (arch : arch_thms) (input : comp_input) = let
         Pancake compiler evaluation *)
      mk_var("cv_exp",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm,
      mk_var("cv_ret",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm,
-     mk_var("cv_pk",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm]
+     mk_var("cv_pk",cvSyntax.cv)  |-> cvSyntax.mk_cv_num numSyntax.zero_tm]
   val _ = null (free_vars export_tm) orelse failwith "failed to eval export"
   (*
     cv_repLib.cv_rep_for []

--- a/cv_translator/eval_cake_compileLib.sml
+++ b/cv_translator/eval_cake_compileLib.sml
@@ -114,10 +114,11 @@ fun eval_cake_compile_general (arch : arch_thms) (input : comp_input) = let
      get_one_subst "cv_data" data_def,
      get_one_subst "cv_bytes" code_def,
      get_one_subst "cv_syms" syms_def,
-     (* TODO: exp and ret need to be passed as arguments for in-logic
+     (* TODO: exp/ret/pk need to be passed as arguments for in-logic
         Pancake compiler evaluation *)
      mk_var("cv_exp",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm,
-     mk_var("cv_ret",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm]
+     mk_var("cv_ret",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm,
+     mk_var("cv_pk",cvSyntax.cv) |-> cvSyntax.mk_cv_num numSyntax.zero_tm]
   val _ = null (free_vars export_tm) orelse failwith "failed to eval export"
   (*
     cv_repLib.cv_rep_for []


### PR DESCRIPTION
Specifically, the store instructions under `cml_main` in the assembly template, which are not used by Pancake