### PR TITLE
Add pattern-matching to the record-syntax in Candle

### DIFF
--- a/candle/prover/candle_boot.ml
+++ b/candle/prover/candle_boot.ml
@@ -529,10 +529,10 @@ let () =
     let loadMsg s = print ("- Loading " ^ s ^ "\n") in
     let load_use fname =
       loadMsg fname;
-      Text_io.b_inputLinesFrom #"\n" fname in
+      Text_io.b_inputLinesFrom '\n' fname in
     let load fname =
       loadMsg fname;
-      match Text_io.b_inputLinesFrom #"\n" fname with
+      match Text_io.b_inputLinesFrom '\n' fname with
       | None -> None
       | Some lns ->
           begin

--- a/candle/prover/candle_records.ml
+++ b/candle/prover/candle_records.ml
@@ -1,0 +1,41 @@
+(* Record syntax in Candle. *)
+
+(* Records are declared as part of datatypes. It is possible to mix classic
+ * datatype constructors and record constructors freely.
+ *)
+type thing =
+  | Aa of int
+  | Bb of { integer: int; boolean: bool; a_string: string }
+;;
+
+(* Records support pattern matching. It is possible to do partial matches. *)
+let m1 t =
+  match t with
+  | Aa n -> n
+  | Bb {integer} -> integer;;
+
+(* Pattern matching on records works in the outermost pattern. Nested record
+ * patterns are not supported.
+ *)
+let Bb { a_string } = Bb { a_string = "5"; boolean = false; integer = 1 };;
+
+(* Records are constructed with this syntax: *)
+let x = Bb { a_string = "1"; boolean = false; integer = 2 };;
+let y = Aa 5;;
+
+(* Records can be updated using 'with': *)
+let z = { x with boolean = true; integer = 3; };;
+
+(* Record projection is done with a dot: *)
+let s = z.a_string;;
+
+print (s ^ "\n");;
+print (Int.toString (m1 x) ^ " " ^ Int.toString (m1 y) ^ "\n");;
+print (a_string ^ "\n");
+
+(* Limitations:
+ * - It is not possible to name the matched fields in record pattern matches
+ * - Record field names are unique: while it is possible to use the same field
+ *   name in two records, the latter definition will overwrite the formers
+ *   accessor functions.
+ *)

--- a/candle/prover/candle_records.ml
+++ b/candle/prover/candle_records.ml
@@ -31,7 +31,7 @@ let s = z.a_string;;
 
 print (s ^ "\n");;
 print (Int.toString (m1 x) ^ " " ^ Int.toString (m1 y) ^ "\n");;
-print (a_string ^ "\n");
+print (a_string ^ "\n");;
 
 (* Limitations:
  * - It is not possible to name the matched fields in record pattern matches

--- a/compiler/bootstrap/compilation/x64/64/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/64/Holmakefile
@@ -5,8 +5,8 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../.. $(CAKEMLDIR)/un
 					 ../../../../backend/$(ARCH) ../../../../backend/serialiser ../../../translation \
                                          $(CAKEMLDIR)/cv_translator
 
-all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz
-.PHONY: all
+all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz test-hello-cake test-candle-records
+.PHONY: all test-hello-cake test-candle-records
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
 DIRS = $(wildcard */)
@@ -19,12 +19,19 @@ config_enc_str.txt: *$(ARCH)BootstrapScript.sml
 cake-sexpr-32: *sexprBootstrap32Script.sml
 cake-sexpr-64: *sexprBootstrap64Script.sml
 
-cake-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile hello.cml how-to.md cake-sexpr-32 cake-sexpr-64 config_enc_str.txt candle_boot.ml repl_boot.cml
-	tar -chzf $@ --transform='s|^|cake-$(ARCH)-$(WORD_SIZE)/|' cake.S basis_ffi.c Makefile hello.cml how-to.md cake-sexpr-32 cake-sexpr-64 config_enc_str.txt candle_boot.ml repl_boot.cml
+test-hello-cake: cake-$(ARCH)-$(WORD_SIZE).tar.gz
 	make test-hello.cake   # the following lines are a basic test
 	./test-hello.cake >output
 	echo 'Hello!'>expected_output
 	diff output expected_output   # returns non-zero if files differ
+
+test-candle-records: cake-$(ARCH)-$(WORD_SIZE).tar.gz
+	make cake
+	./cake --candle < candle_records.ml | tail -n11 > candle.out
+	diff candle.out candle.expected
+
+cake-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile hello.cml how-to.md cake-sexpr-32 cake-sexpr-64 config_enc_str.txt candle_boot.ml repl_boot.cml
+	tar -chzf $@ --transform='s|^|cake-$(ARCH)-$(WORD_SIZE)/|' cake.S basis_ffi.c Makefile hello.cml how-to.md cake-sexpr-32 cake-sexpr-64 config_enc_str.txt candle_boot.ml repl_boot.cml
 
 EXTRA_CLEANS = cake.S cake-$(ARCH)-$(WORD_SIZE).tar.gz cake test-hello.cake output expected_output
 

--- a/compiler/bootstrap/compilation/x64/64/candle.expected
+++ b/compiler/bootstrap/compilation/x64/64/candle.expected
@@ -1,0 +1,11 @@
+#           val m1 = <fun>: thing -> int
+#     val a_string = "5": string
+#     val x = Bb ("1", false, 2): thing
+# val y = Aa 5: thing
+#     val z = Bb ("1", true, 3): thing
+#     val s = "1": string
+#   1
+val it = (): unit
+# 2 5
+val it = (): unit
+#       

--- a/compiler/bootstrap/compilation/x64/64/candle.expected
+++ b/compiler/bootstrap/compilation/x64/64/candle.expected
@@ -1,5 +1,3 @@
-#           val m1 = <fun>: thing -> int
-#     val a_string = "5": string
 #     val x = Bb ("1", false, 2): thing
 # val y = Aa 5: thing
 #     val z = Bb ("1", true, 3): thing
@@ -8,4 +6,6 @@
 val it = (): unit
 # 2 5
 val it = (): unit
-#       
+# 5
+val it = (): unit
+#     

--- a/compiler/bootstrap/compilation/x64/64/candle_records.ml
+++ b/compiler/bootstrap/compilation/x64/64/candle_records.ml
@@ -1,0 +1,1 @@
+../../../../../candle/prover/candle_records.ml

--- a/compiler/bootstrap/translation/caml_lexProgScript.sml
+++ b/compiler/bootstrap/translation/caml_lexProgScript.sml
@@ -157,6 +157,12 @@ QED
 
 val _ = update_precondition scan_escseq_side;
 
+val r = translate scan_float1_def;
+val r = translate scan_float2_def
+val r = translate scan_float3_def
+val r = translate scan_number_def;
+val r = translate scan_float_or_int_def;
+
 val r = translate caml_lexTheory.next_sym_def;
 
 Theorem next_sym_side[local]:

--- a/compiler/bootstrap/translation/caml_parserProgScript.sml
+++ b/compiler/bootstrap/translation/caml_parserProgScript.sml
@@ -109,7 +109,6 @@ val _ = update_precondition ptree_op_side;
 
 val r = preprocess ptree_Literal_def |> translate;
 
-
 Theorem ptree_literal_side[local]:
   ∀x. camlptreeconversion_ptree_literal_side x
 Proof
@@ -137,6 +136,8 @@ Proof
 QED
 
 val _ = update_precondition precparse_side;
+
+val r = preprocess ptree_PRecFields_def |> translate;
 
 val r = preprocess ptree_PPattern_def |> translate;
 
@@ -188,7 +189,8 @@ Proof
     \\ simp [SF CONJ_ss]
     \\ rpt strip_tac
     \\ simp [Once (fetch "-" "camlptreeconversion_ptree_expr_side_def")]
-    \\ rw [] \\ gs [caml_lexTheory.isSymbol_thm])
+    \\ simp [fetch "-" "camlptreeconversion_ptree_double_side_def"]
+    \\ rw [] \\ gs [caml_lexTheory.isSymbol_thm, caml_lexTheory.isFloat_thm])
   \\ rw []
   \\ simp [Once (fetch "-" "camlptreeconversion_ptree_expr_side_def")]
 QED

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -527,6 +527,7 @@ Definition camlPEG_def[nocompute]:
       (INL nLiteral,
        choicel [
          tok isInt    (bindNT nLiteral o mktokLf);
+         tok isFloat  (bindNT nLiteral o mktokLf);
          tok isString (bindNT nLiteral o mktokLf);
          tok isChar   (bindNT nLiteral o mktokLf);
          tok (λx. MEM x [TrueT; FalseT]) (bindNT nLiteral o mktokLf)]);

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -43,13 +43,6 @@ Definition mk_linfix_def:
     mk_linfix tgt (mkNd tgt [acc; opt; t]) rest
 End
 
-(* TODO: unused *)
-Definition mk_rinfix_def:
-  mk_rinfix tgt [] = mkNd tgt [] ∧
-  mk_rinfix tgt [t] = mkNd tgt [t] ∧
-  mk_rinfix tgt (t::opt::rest) = mkNd tgt [t; opt; mk_rinfix tgt rest]
-End
-
 Definition peg_linfix_def:
   peg_linfix tgtnt rptsym opsym =
     seq rptsym (rpt (seq opsym rptsym (++)) FLAT)
@@ -242,8 +235,8 @@ Datatype:
     | nTypeRepr | nTypeReprs | nConstrDecl | nConstrArgs | nRecord
     | nExcDefinition
     (* patterns *)
-    | nPAny | nPList | nPPar | nPBase | nPCons | nPAs | nPOps | nPattern
-    | nPatterns
+    | nPAny | nPList | nPPar | nPBase | nPRecFields | nPCons | nPAs | nPOps
+    | nPattern | nPatterns
     (* types *)
     | nTypeList | nTypeLists
     | nTVar | nTBase | nTConstr | nTProd | nTFun | nType
@@ -780,8 +773,16 @@ Definition camlPEG_def[nocompute]:
                       pnt nPPar])
             (bindNT nPBase));
       (* -- Pat2 ----------------------------------------------------------- *)
-      (INL nPCons, (* ::= constr p? *)
-       pegf (choicel [seql [pnt nConstr; try (pnt nPBase)] I;
+      (INL nPRecFields, (* '{' field (';' field)* ';'? '}' *)
+       seql [tokeq LbraceT;
+             pnt nFieldName;
+             rpt (seql [tokeq SemiT; pnt nFieldName] I) FLAT;
+             try (tokeq SemiT);
+             tokeq RbraceT]
+            (bindNT nPRecFields));
+      (INL nPCons, (* ::= constr ('{' fields '}' | p?) *)
+       pegf (choicel [seql [pnt nConstr;
+                            choicel [pnt nPRecFields; try (pnt nPBase)]] I;
                       pnt nPBase])
             (bindNT nPCons));
       (INL nPAs, (* ::= p ('as' id)* *)
@@ -1047,21 +1048,21 @@ val topo_nts =
         “nLiteral”, “nIdent”, “nEList”, “nEConstr”, “nERecUpdate”, “nERecCons”,
         “nEBase”, “nEPrefix”, “nEIndex”, “nERecProj”, “nELazy”, “nEAssert”,
         “nEFunapp”, “nEApp”, “nPAny”, “nPList”, “nPPar”, “nPatLiteral”,
-        “nPBase”, “nPCons”, “nPAs”, “nPOps”, “nPattern”, “nPatterns”,
-        “nLetBinding”, “nLetBindings”, “nLetRecBinding”, “nLetRecBindings”,
-        “nPatternMatches”, “nPatternMatch”, “nEMatch”, “nETry”, “nEFun”,
-        “nEFunction”, “nELet”, “nELetRec”, “nEWhile”, “nEFor”, “nEUnclosed”,
-        “nENeg”, “nEShift”, “nEMult”, “nEAdd”, “nECons”, “nECat”, “nERel”,
-        “nEAnd”, “nEOr”, “nEHolInfix”, “nEProd”, “nEAssign”, “nEIf”, “nESeq”,
-        “nExpr”, “nTypeDefinition”, “nTVar”, “nTBase”, “nTConstr”, “nTProd”,
-        “nTFun”, “nType”, “nTypeList”, “nTypeLists”, “nTypeParams”, “nTypeDef”,
-        “nTypeDefs”, “nConstrDecl”, “nTypeReprs”, “nTypeRepr”, “nTypeInfo”,
-        “nUpdate”, “nUpdates”, “nArrIdx”, “nStrIdx”, “nFieldDec”, “nFieldDecs”,
-        “nRecord”, “nConstrArgs”, “nExcDefinition”, “nTopLet”, “nTopLetRec”,
-        “nOpen”, “nSemis”, “nExprItem”, “nExprItems”, “nModuleDef”,
-        “nModTypeName”, “nModTypePath”, “nSigSpec”, “nExcType”, “nValType”,
-        “nOpenMod”, “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”, “nSigItem”,
-        “nSigItems”, “nModuleType”, “nModAscApp”, “nModAscApps”,
+        “nPBase”, “nPRecFields”, “nPCons”, “nPAs”, “nPOps”, “nPattern”,
+        “nPatterns”, “nLetBinding”, “nLetBindings”, “nLetRecBinding”,
+        “nLetRecBindings”, “nPatternMatches”, “nPatternMatch”, “nEMatch”,
+        “nETry”, “nEFun”, “nEFunction”, “nELet”, “nELetRec”, “nEWhile”, “nEFor”,
+        “nEUnclosed”, “nENeg”, “nEShift”, “nEMult”, “nEAdd”, “nECons”, “nECat”,
+        “nERel”, “nEAnd”, “nEOr”, “nEHolInfix”, “nEProd”, “nEAssign”, “nEIf”,
+        “nESeq”, “nExpr”, “nTypeDefinition”, “nTVar”, “nTBase”, “nTConstr”,
+        “nTProd”, “nTFun”, “nType”, “nTypeList”, “nTypeLists”, “nTypeParams”,
+        “nTypeDef”, “nTypeDefs”, “nConstrDecl”, “nTypeReprs”, “nTypeRepr”,
+        “nTypeInfo”, “nUpdate”, “nUpdates”, “nArrIdx”, “nStrIdx”, “nFieldDec”,
+        “nFieldDecs”, “nRecord”, “nConstrArgs”, “nExcDefinition”, “nTopLet”,
+        “nTopLetRec”, “nOpen”, “nSemis”, “nExprItem”, “nExprItems”,
+        “nModuleDef”, “nModTypeName”, “nModTypePath”, “nSigSpec”, “nExcType”,
+        “nValType”, “nOpenMod”, “nIncludeMod”, “nModTypeAsc”, “nModTypeAssign”,
+        “nSigItem”, “nSigItems”, “nModuleType”, “nModAscApp”, “nModAscApps”,
         “nCakeMLPragma”, “nModuleTypeDef”, “nModExpr”, “nDefinition”,
         “nDefItem”, “nModuleItem”, “nModuleItems”, “nStart”];
 

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -96,7 +96,7 @@ End
  * is just too annoying. Until the CakeML syntax supports the latter, we can
  * use this pre-pattern type.
  *
- * Pp_prod and Pp_as correspond to Pp_con NONE and Pp_alias and are used to
+ * Pp_prod and Pp_as correspond to Pp_con NONE and Pp_alias, and are used to
  * trick the precparser into producing n-ary tuples and suffixes (i.e. the
  * as-patterns).
  *)
@@ -106,6 +106,7 @@ Datatype:
        | Pp_var varN
        | Pp_lit lit
        | Pp_con ((modN, conN) id option) (ppat list)
+       | Pp_record ((modN, conN) id) (varN list)
        | Pp_prod (ppat list)
        | Pp_or ppat ppat
        | Pp_tannot ppat ast_t
@@ -118,6 +119,7 @@ Definition ppat_size'_def:
   ppat_size' (Pp_var a) = 1 ∧
   ppat_size' (Pp_lit a) = 1 ∧
   ppat_size' (Pp_con x xs) = (1 + list_size ppat_size' xs) ∧
+  ppat_size' (Pp_record x xs) = (1 + list_size (list_size char_size) xs) ∧
   ppat_size' (Pp_prod xs) = (1 + list_size ppat_size' xs) ∧
   ppat_size' (Pp_or x y) = (1 + ppat_size' x + ppat_size' y) ∧
   ppat_size' (Pp_tannot x y) = (1 + ppat_size' x) ∧
@@ -129,26 +131,52 @@ End
 
 (* Convert ppat patterns to CakeML patterns by distributing or-patterns at the
  * top-level (returning a list of patterns).
+ *
+ * Record patterns don't fit this very well, as there is no syntax for them. To
+ * make things simple, we only allow them at the top-level, and this function
+ * will bail out if it finds one.
  *)
 
 Definition ppat_to_pat_def:
-  ppat_to_pat Pp_any = [Pany] ∧
-  ppat_to_pat (Pp_var v) = [Pvar v] ∧
-  ppat_to_pat (Pp_lit l) = [Plit l] ∧
+  ppat_to_pat Pp_any =
+    return [Pany] ∧
+  ppat_to_pat (Pp_var v) =
+    return [Pvar v] ∧
+  ppat_to_pat (Pp_lit l) =
+    return [Plit l] ∧
   ppat_to_pat (Pp_tannot pp t) =
-    (MAP (λp. Ptannot p t) (ppat_to_pat pp)) ∧
+    fmap (MAP (λp. Ptannot p t)) (ppat_to_pat pp) ∧
   ppat_to_pat (Pp_con id pps) =
-    (MAP (λps. Pcon id ps) (list_cart_prod (MAP ppat_to_pat pps))) ∧
+    do
+      qs <- ppat_to_pats pps;
+      return (MAP (λps. Pcon id ps) (list_cart_prod qs))
+    od ∧
+  ppat_to_pat (Pp_record id fs) =
+    fail (unknown_loc, «») ∧
   ppat_to_pat (Pp_prod pps) =
-    (MAP (λps. Pcon NONE ps) (list_cart_prod (MAP ppat_to_pat pps))) ∧
+    do
+      qs <- (ppat_to_pats pps);
+      return (MAP (λps. Pcon NONE ps) (list_cart_prod qs))
+    od ∧
   ppat_to_pat (Pp_alias pp ns) =
-    (MAP (λp. FOLDL Pas p ns) (ppat_to_pat pp)) ∧
+    fmap (MAP (λp. FOLDL Pas p ns)) (ppat_to_pat pp) ∧
   ppat_to_pat (Pp_as pp n) =
-    (MAP (λp. Pas p n) (ppat_to_pat pp)) ∧
+    fmap (MAP (λp. Pas p n)) (ppat_to_pat pp) ∧
   ppat_to_pat (Pp_or p1 p2) =
-    ppat_to_pat p1 ++ ppat_to_pat p2
+    do
+      ps1 <- ppat_to_pat p1;
+      ps2 <- ppat_to_pat p2;
+      return (ps1 ++ ps2)
+    od ∧
+  ppat_to_pats [] = return [] ∧
+  ppat_to_pats (p::ps) =
+    do
+      p1 <- ppat_to_pat p;
+      ps1 <- ppat_to_pats ps;
+      return (p1::ps1)
+    od
 Termination
-  WF_REL_TAC ‘measure ppat_size’
+  WF_REL_TAC ‘measure sum_size ppat_size (list_size ppat_size)’
 End
 
 (* Fix some constructor applications that needs to be in CakeML's curried
@@ -445,7 +473,6 @@ Definition ptree_ValueName_def:
     else
       fail (locs, «Expected value-name non-terminal»)
 End
-
 
 Definition ptree_ConstrName_def:
   ptree_ConstrName (Lf (_, locs)) =
@@ -943,6 +970,46 @@ Definition build_list_ppat_def:
           (Pp_con (SOME (Short "[]")) [])
 End
 
+Definition ptree_FieldsList_def:
+  (ptree_FieldsList [rbrace] =
+    do
+      expect_tok rbrace RbraceT;
+      return []
+    od) ∧
+  (ptree_FieldsList [semi; rbrace] =
+    do
+      expect_tok semi SemiT;
+      expect_tok rbrace RbraceT;
+      return []
+    od) ∧
+  (ptree_FieldsList (semi::fname::fs) =
+    do
+      expect_tok semi SemiT;
+      fn <- ptree_FieldName fname;
+      fns <- ptree_FieldsList fs;
+      return (fn::fns)
+    od) ∧
+  (ptree_FieldsList [] = fail (unknown_loc, «Impossible: ptree_FieldsList»))
+End
+
+Definition ptree_PRecFields_def:
+  (ptree_PRecFields (Lf (_, locs)) =
+    fail (locs, «Expected a pattern record fields non-terminal»)) ∧
+  (ptree_PRecFields (Nd (nterm, locs) args) =
+    if nterm = INL nPRecFields then
+      case args of
+        lbrace::fname::rest =>
+          do
+            expect_tok lbrace LbraceT;
+            fn <- ptree_FieldName fname;
+            fns <- ptree_FieldsList rest;
+            return (QSORT string_lt (fn::fns))
+          od
+      | _ => fail (locs, «Impossible: nPRecFields»)
+    else
+      fail (locs, «Expected a pattern record fields non-terminal»))
+End
+
 Definition ptree_PPattern_def:
   (ptree_PPattern (Lf (_, locs)) =
     fail (locs, «Expected a pattern non-terminal»)) ∧
@@ -1026,11 +1093,17 @@ Definition ptree_PPattern_def:
             id <- path_to_ns locs cns;
             return $ Pp_con (SOME id) []
           od ++ ptree_PPattern cn
-      | [cn; pat] =>
+      | [cn; arg] =>
           do
             cns <- ptree_Constr cn;
             id <- path_to_ns locs cns;
-            p <- ptree_PPattern pat;
+            fs <- ptree_PRecFields arg;
+            return $ Pp_record id fs
+          od ++
+          do
+            cns <- ptree_Constr cn;
+            id <- path_to_ns locs cns;
+            p <- ptree_PPattern arg;
             return $ compatCurryP id p
           od
       | _ => fail (locs, «Impossible: nPCons»)
@@ -1103,8 +1176,28 @@ End
 Theorem ptree_PPattern_ind[allow_rebind] =
   SIMP_RULE (srw_ss() ++ CONJ_ss) [] ptree_PPattern_ind;
 
+(* The pattern parser functions return INL for record patterns, and INR for
+ * real patterns. Record patterns do not have a counterpart in the :pat type,
+ * so we perform some bookkeeping here.
+ *
+ * To simplify matters, we don't accept record patterns anywhere but at the
+ * top-level. The function ppat_to_pat fails if it encounters a record pattern.
+ * We convert record patterns directly in this function instead.
+ *)
+
 Definition ptree_Pattern_def:
-  ptree_Pattern p = fmap ppat_to_pat (ptree_PPattern p)
+  ptree_Pattern p =
+    do
+      pp <- ptree_PPattern p;
+      case pp of
+        Pp_record id fs => return $ [INL (id, fs)] (* record *)
+      | _ =>
+        do
+          ps <- ppat_to_pat pp;
+          return $ MAP INR ps
+        od ++
+        fail (unknown_loc, «Record patterns may only appear at the top level»)
+    od
 End
 
 Definition ptree_Patterns_def:
@@ -1160,145 +1253,10 @@ Definition build_funapp_def:
       | _ => App Opapp [a; b]) f xs
 End
 
-(* Turns a curried lambda with patterns, e.g. “fun a [3;4] c -> e”
- * into a sequence of lambdas, possibly with pattern matches:
- * “fun a -> fun fresh -> match fresh with [3;4] -> fun c -> e”.
+(* Functions for records.
+ * TODO Make it so that the names include the constructor function, so that we
+ *      can have the same record field name defined for different record types.
  *)
-
-Definition build_fun_lam_def:
-  build_fun_lam body pats =
-      FOLDR (λp b. case p of
-                     Pvar x => Fun x b
-                   | _ => Fun "" (Mat (Var (Short "")) [p, b]))
-            body pats
-End
-
-(*
- * build_letrec is given a list of entries consisting of:
- * - a function name
- * - a list of patterns
- * - a body expression.
- *
- * A letrec in the CakeML AST is made from a function name, a variable name, and
- * a body expression. If there is no pattern in the list given to build_letrec,
- * then we use the empty variable name ("") and apply the body expression to
- * this variable (like eta expansion). This enables us to write things like:
- *   let rec f = function ... -> ...
- * or
- *   let rec f x y = ...
- *   and g = ...
- *
- * As a consequence, the parser will turn this:
- *   let rec f x = ...
- *   and y = 5
- * into this:
- *   let rec f x = ...
- *   and y x = 5 x
- * which is different from what OCaml generates (it correctly binds the value 5
- * to y with a let).
- *
- * Patterns are turned into variables using pattern match expressions:
- * - If the first pattern is not a variable, invent a variable name and
- *   match on it using the first pattern.
- * - If the first pattern is a variable, create a lambda.
- *)
-
-Definition build_letrec_def:
-  build_letrec =
-    MAP (λ(f,ps,x).
-           case ps of
-             [] =>
-               (f, "", App Opapp [x; Var (Short "")])
-           | Pvar v::ps =>
-               (f, v, build_fun_lam x ps)
-           | p::ps =>
-               (f, "", Mat (Var (Short "")) [(p, build_fun_lam x ps)]))
-End
-
-(* Builds a sequence of lets out of a list of let bindings.
- *)
-
-Definition build_lets_def:
-  build_lets binds body =
-    FOLDR (λbind rest.
-             case bind of
-               INL (Pvar v,x) =>
-                 Let (SOME v) x rest
-             | INL (Pany,x) =>
-                 Let NONE x rest
-             | INL (p,x) =>
-                 Mat x [p, rest]
-             | INR (f, ps, bd) =>
-                 Let (SOME f) (build_fun_lam bd ps) rest)
-          binds body
-End
-
-(* TODO
- * With these functions it's not possible to mix value definitions
- * and recursive function definitions.
- *
- * NOTE
- * I think this means that the parser won't accept
- *
- *   let rec f x = something
- *   and y = 5;;
- *
- * which is a bit annoying but it hardly matters.
- *)
-
-(* Builds a pattern match expression that allocates a closure each time a guard
- * expression is encountered. N.B. this expects a call with pattern rows in
- * reverse order.
- *)
-
-Definition SmartMat_def:
-  SmartMat (Var x) [Pany, y] = y ∧
-  SmartMat x ps = Mat x ps
-End
-
-Definition build_pmatch_def:
-  build_pmatch mvar match_fn acc [] =
-    match_fn (Var (Short mvar)) acc ∧
-  build_pmatch mvar match_fn acc ((pat,exp,NONE)::ps) =
-    build_pmatch mvar match_fn ((pat,exp)::acc) ps ∧
-  build_pmatch mvar match_fn acc ((pat,exp,SOME guard)::ps) =
-    let mexp = match_fn (Var (Short mvar)) acc in
-    let clos = Let (SOME " p") (Fun " u" mexp) in
-    let call = App Opapp [Var (Short " p"); Con NONE []] in
-    let mat = match_fn (Var (Short mvar))
-                       [(pat,If guard exp call); (Pany,call)] in
-      build_pmatch mvar match_fn [Pany,clos mat] ps
-End
-
-Definition build_match_def:
-  build_match x rows =
-    if EXISTS (λ(p,x,g). case g of SOME _ => T | _ => F) rows then
-      Let (SOME "") x (build_pmatch "" SmartMat [] (REVERSE rows))
-    else
-      Mat x (MAP (λ(p,x,g). (p,x)) rows)
-End
-
-Definition build_handle_def:
-  build_handle x rows =
-    if EXISTS (λ(p,x,g). case g of SOME _ => T | _ => F) rows then
-      let exn = Var (Short "") in
-      (Handle exn [
-        Pany,build_pmatch "" SmartMat [] ((Pany,Raise exn,NONE)::REVERSE rows)])
-    else
-      Handle x (MAP (λ(p,x,g). (p,x)) rows)
-End
-
-Definition build_function_def:
-  build_function rows =
-    Fun ""  (build_pmatch "" SmartMat [] (REVERSE rows))
-End
-
-(* Flatten the row-alternatives in a pattern-match.
- *)
-
-Definition flatten_pmatch_def:
-  flatten_pmatch pss = FLAT (MAP (λ(ps,x,w). MAP (λp. (p,x,w)) ps) pss)
-End
 
 Definition mk_record_update_name_def:
   mk_record_update_name field = "{record_update(" ++ field ++ ")}"
@@ -1343,6 +1301,202 @@ Definition build_record_cons_def:
         id <- build_record_cons_id names path;
         return $ build_funapp (Var id) exprs
       od
+End
+
+(* Pattern match on a record: first pattern match on the constructor (with
+ * a wildcard for the pattern that would otherwise contain the argument tuple)
+ * and then generate a let-binding for each field name matched on. Example:
+ *
+ *   type a = Foo of { a: int; b: bool; c: string };;
+ *   match x with
+ *   | Foo { a, b } -> f a b
+ *
+ * becomes
+ *
+ *   type a = Foo of int * bool * string;;
+ *   match x with
+ *   | Foo _ -> let a = <build_record_proj(Foo,a)>(x) in
+ *              let b = <build_record_proj(Foo,a)>(x) in
+ *                f a b
+ *)
+
+Definition mk_record_match_aux_def:
+  mk_record_match_aux recv constr body [] = body /\
+  mk_record_match_aux recv constr body (f::fs) =
+    Let (SOME f) (build_record_proj f (Var (Short recv)))
+                 (mk_record_match_aux recv constr body fs)
+End
+
+Definition mk_record_match_def:
+  mk_record_match constr fs recv body =
+    Mat (Var (Short recv))
+        [Pcon (SOME constr) [Pany], mk_record_match_aux recv constr body fs]
+End
+
+(* Turns a curried lambda with patterns, e.g. “fun a [3;4] c -> e”
+ * into a sequence of lambdas, possibly with pattern matches:
+ * “fun a -> fun fresh -> match fresh with [3;4] -> fun c -> e”.
+ *)
+
+Definition build_fun_lam_def:
+  build_fun_lam body pats =
+      FOLDR (λp b. case p of
+                     INL (c, fs) => Fun "" (mk_record_match c fs "" b)
+                   | INR (Pvar x) => Fun x b
+                   | INR p => Fun "" (Mat (Var (Short "")) [p, b]))
+            body pats
+End
+
+(*
+ * build_letrec is given a list of entries consisting of:
+ * - a function name
+ * - a list of patterns
+ * - a body expression.
+ *
+ * A letrec in the CakeML AST is made from a function name, a variable name, and
+ * a body expression. If there is no pattern in the list given to build_letrec,
+ * then we use the empty variable name ("") and apply the body expression to
+ * this variable (like eta expansion). This enables us to write things like:
+ *   let rec f = function ... -> ...
+ * or
+ *   let rec f x y = ...
+ *   and g = ...
+ *
+ * As a consequence, the parser will turn this:
+ *   let rec f x = ...
+ *   and y = 5
+ * into this:
+ *   let rec f x = ...
+ *   and y x = 5 x
+ * which is different from what OCaml generates (it correctly binds the value 5
+ * to y with a let).
+ *
+ * Patterns are turned into variables using pattern match expressions:
+ * - If the first pattern is not a variable, invent a variable name and
+ *   match on it using the first pattern.
+ * - If the first pattern is a variable, create a lambda.
+ *)
+
+Definition build_letrec_def:
+  build_letrec =
+    MAP (λ(f,ps,x).
+           case ps of
+             [] =>
+               (f, "", App Opapp [x; Var (Short "")])
+           | INL (c, fs) ::ps =>
+               (f, "", mk_record_match c fs "" (build_fun_lam x ps))
+           | INR (Pvar v)::ps =>
+               (f, v, build_fun_lam x ps)
+           | INR p::ps =>
+               (f, "", Mat (Var (Short "")) [(p, build_fun_lam x ps)]))
+End
+
+(* Builds a sequence of lets out of a list of let bindings.
+ *
+ * N.B. The sum type determines whether we're building a regular let (INL), or
+ * a let rec (INR).
+ *)
+
+Definition build_lets_def:
+  build_lets binds body =
+    FOLDR (λbind rest.
+             case bind of
+               INL (INL (c, fs), x) =>
+                 Let (SOME " r") x (mk_record_match c fs " r" rest)
+             | INL (INR (Pvar v), x) =>
+                 Let (SOME v) x rest
+             | INL (INR Pany, x) =>
+                 Let NONE x rest
+             | INL (INR p, x) =>
+                 Mat x [p, rest]
+             | INR (f, ps, bd) =>
+                 Let (SOME f) (build_fun_lam bd ps) rest)
+          binds body
+End
+
+(* TODO
+ * With these functions it's not possible to mix value definitions
+ * and recursive function definitions.
+ *
+ * NOTE
+ * I think this means that the parser won't accept
+ *
+ *   let rec f x = something
+ *   and y = 5;;
+ *
+ * which is a bit annoying but it hardly matters.
+ *)
+
+(* Build pattern match rows from lists of patterns that contain record matches.
+ *)
+
+Definition build_match_row_def:
+  build_match_row mvar (INL (c, fs), x) =
+     (Pcon (SOME c) [Pany], mk_record_match c fs mvar x) ∧
+  build_match_row y (INR p, x) =
+     (p, x)
+End
+
+(* I don't remember what was smart about this? *)
+
+Definition SmartMat_def:
+  SmartMat mvar [INR Pany, y] = y ∧
+  SmartMat mvar rows =
+    Mat (Var (Short mvar)) (MAP (build_match_row mvar) rows)
+End
+
+(* Builds a pattern match expression that allocates a closure each time a guard
+ * expression is encountered. N.B. this expects a call with pattern rows in
+ * reverse order.
+ *)
+
+Definition build_pmatch_def:
+  build_pmatch mvar acc [] =
+    SmartMat mvar acc ∧
+  build_pmatch mvar acc ((pat,exp,NONE)::ps) =
+    build_pmatch mvar ((pat,exp)::acc) ps ∧
+  build_pmatch mvar acc ((pat,exp,SOME guard)::ps) =
+    let mexp = SmartMat mvar acc in
+    let clos = Let (SOME " p") (Fun " u" mexp) in
+    let call = App Opapp [Var (Short " p"); Con NONE []] in
+    let mat = SmartMat mvar [(pat,If guard exp call); (INR Pany,call)] in
+      build_pmatch mvar [INR Pany,clos mat] ps
+End
+
+Definition build_match_def:
+  build_match x rows =
+    let mvar = " m" in
+    Let (SOME mvar) x
+      (if EXISTS (λ(p,x,g). case g of SOME _ => T | _ => F) rows then
+         build_pmatch mvar [] (REVERSE rows)
+       else
+         (Mat (Var (Short mvar))
+              (MAP (λ(p,x,g). build_match_row mvar (p,x)) rows)))
+End
+
+Definition build_handle_def:
+  build_handle x rows =
+    if EXISTS (λ(p,x,g). case g of SOME _ => T | _ => F) rows then
+      let exn = Var (Short "") in
+      (Handle exn [
+        Pany,build_pmatch "" [] ((INR Pany,Raise exn,NONE)::REVERSE rows)])
+    else
+      let mvar = " e" in
+      Let (SOME mvar) x
+          (Handle (Var (Short mvar))
+                  (MAP (λ(p,x,g). build_match_row mvar (p,x)) rows))
+End
+
+Definition build_function_def:
+  build_function rows =
+    Fun ""  (build_pmatch "" [] (REVERSE rows))
+End
+
+(* Flatten the row-alternatives in a pattern-match.
+ *)
+
+Definition flatten_pmatch_def:
+  flatten_pmatch pss = FLAT (MAP (λ(ps,x,w). MAP (λp. (p,x,w)) ps) pss)
 End
 
 Definition ptree_Expr_def:
@@ -1967,7 +2121,7 @@ Definition ptree_Expr_def:
             nm <- ptree_ValueName id;
             ty <- ptree_Type type;
             bd <- ptree_Expr nExpr bod;
-            return $ INL (Pvar nm, Tannot bd ty)
+            return $ INL (INR (Pvar nm), Tannot bd ty)
           od
       | [id; pats; colon; type; eq; bod] =>
           do
@@ -2530,6 +2684,9 @@ End
 
 (* Builds the constructor, projection, and update functions for a record
  * datatype constructor.
+ *
+ * TODO It would be possible to build a pretty-printing function for the
+ *      datatype, too.
  *)
 
 Definition build_rec_funs_def:
@@ -2671,7 +2828,13 @@ Definition build_dlet_def:
   build_dlet locs binds =
     MAP (λbind.
            case bind of
-             INL (p, x) =>
+             INL (INL (c, fs), x) =>
+               let v = " c" in
+               Dlocal
+                 [Dlet locs (Pvar v) x]
+                 (MAP (λf. Dlet locs (Pvar f)
+                                     (build_record_proj f (Var (Short v)))) fs)
+           | INL (INR p, x) =>
                Dlet locs p x
            | INR (f,ps,bd) =>
                Dlet locs (Pvar f) (build_fun_lam bd ps))
@@ -3194,16 +3357,35 @@ End
 val _ = patternMatchesLib.ENABLE_PMATCH_CASES ();
 
 Theorem SmartMat_PMATCH:
-  ∀v ps.
-    SmartMat v ps =
-      case v, ps of
-        Var x, [Pany, y] => y
-      | _, _ => Mat v ps
+  ∀mvar rows.
+    SmartMat mvar rows =
+      case rows of
+        [INR Pany, y] => y
+      | _ => Mat (Var (Short mvar)) (MAP (build_match_row mvar) rows)
 Proof
   CONV_TAC (DEPTH_CONV patternMatchesLib.PMATCH_ELIM_CONV)
-  \\ Cases_on ‘v’ \\ Cases_on ‘ps’ \\ simp [SmartMat_def]
+  \\ Cases_on ‘rows’ \\ simp [SmartMat_def]
   \\ rename [‘(h::t)’]
   \\ PairCases_on ‘h’ \\ rpt CASE_TAC \\ simp [SmartMat_def]
+QED
+
+Theorem ptree_Pattern_PMATCH:
+  ∀p.
+    ptree_Pattern p =
+      do
+        pp <- ptree_PPattern p;
+        case pp of
+          Pp_record id fs => return $ [INL (id, fs)] (* record *)
+        | _ =>
+          do
+            ps <- ppat_to_pat pp;
+            return $ MAP INR ps
+          od ++
+          fail (unknown_loc, «Record patterns may only appear at the top level»)
+      od
+Proof
+  CONV_TAC (DEPTH_CONV patternMatchesLib.PMATCH_ELIM_CONV)
+  \\ gen_tac \\ simp [ptree_Pattern_def]
 QED
 
 val _ = export_theory ();

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -1491,15 +1491,15 @@ End
 
 Definition build_handle_def:
   build_handle x rows =
-    if EXISTS (λ(p,x,g). case g of SOME _ => T | _ => F) rows then
-      let exn = Var (Short "") in
-      (Handle exn [
-        Pany,build_pmatch "" [] ((INR Pany,Raise exn,NONE)::REVERSE rows)])
-    else
-      let mvar = " e" in
-      Let (SOME mvar) x
-          (Handle (Var (Short mvar))
-                  (MAP (λ(p,x,g). build_match_row mvar (p,x)) rows))
+    (* Save the handled exception in a variable by first matching with Handle
+     * on a single variable, and then applying Mat to the variable. Reraise the
+     * exception in case of no match.
+     *
+     * This trickery is used to support pattern guards and fake records.
+     *)
+    let mvar = " e" in
+    let rows' = (INR Pany, Raise (Var (Short mvar)), NONE)::REVERSE rows in
+    Handle x [Pvar mvar, build_pmatch mvar [] rows']
 End
 
 Definition build_function_def:

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -1023,7 +1023,7 @@ Definition ptree_PRecFields_def:
             expect_tok lbrace LbraceT;
             fn <- ptree_FieldName fname;
             fns <- ptree_FieldsList rest;
-            return (QSORT string_lt (fn::fns))
+            return (fn::fns)
           od
       | _ => fail (locs, «Impossible: nPRecFields»)
     else

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1106,15 +1106,33 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   (SOME “App Opapp [Var (Long "Int" (Short "~")); Lit (IntLit 3)]”)
   ;
 
-(* TODO: floating point literals not handled; not sure how to handle.
- *       call Double.fromString on them? *)
+(* 2024-06-07: floating point literals *)
 
-(*
+Definition mkfloat_def:
+  mkfloat s = App Opapp [Var (Long "Double" (Short "fromString"));
+                         Lit (StrLit s)]
+End
+
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "-. 3.0"
-  (SOME “App Opapp [Var (Long "Double" (Short "~")); Lit (IntLit 3)]”)
+  (SOME $ eval “App Opapp [Var (Long "Double" (Short "~"));
+                           mkfloat "3.0"]”)
   ;
- *)
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "3_000e+37"
+  (SOME $ eval “mkfloat "3000e+37"”)
+  ;
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "1E-77"
+  (SOME $ eval “mkfloat "1E-77"”)
+  ;
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "3.14151E+0_0__0"
+  (SOME $ eval “mkfloat "3.14151E+000"”)
+  ;
 
 (* if without the else *)
 

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -279,52 +279,61 @@ val _ = tytest0 "('a,'b) d"
  * Patterns
  * ------------------------------------------------------------------------- *)
 
+Definition mkpat_def:
+  mkpat p = INR p : (modN, varN) id # string list + pat
+End
+
+val eval = rconc o EVAL;
+
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Cc a as i, Dd b as j" (* = ((Cc a as i), Dd b) as j *)
-  (SOME “[Pas (Pcon NONE [Pas (Pc "Cc" [Pv "a"]) "i"; Pc "Dd" [Pv "b"]]) "j"]”)
+  (SOME $ eval “[mkpat $ Pas (Pcon NONE [Pas (Pc "Cc" [Pv "a"]) "i";
+                                         Pc "Dd" [Pv "b"]]) "j"]” )
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "(x) as i :: j" (* = (x as i) :: j *)
-  (SOME “[Pc "::" [Pas (Pv "x") "i"; Pv "j"]]”)
+  (SOME $ eval “[mkpat $ Pc "::" [Pas (Pv "x") "i"; Pv "j"]]”)
   ;
 
 (* , is below :: in prec. but we can raise it by wrapping it with 'as i' *)
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x,y as i :: j"
-  (SOME “[Pc "::" [Pas (Pcon NONE [Pv "x"; Pv "y"]) "i"; Pv "j"]]”)
+  (SOME $ eval “[mkpat $ Pc "::" [Pas (Pcon NONE [Pv "x"; Pv "y"]) "i";
+                                  Pv "j"]]”)
   ;
 
 (* can nest 'as' arbitrarily deep (though its a pretty useless feature) *)
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x as i as j as k"
-  (SOME “[Pas (Pas (Pas (Pv "x") "i") "j") "k"]”)
+  (SOME $ eval “[mkpat $ Pas (Pas (Pas (Pv "x") "i") "j") "k"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x as i as j as k :: j"
-  (SOME “[Pc "::" [Pas (Pas (Pas (Pv "x") "i") "j") "k"; Pv "j"]]”)
+  (SOME $ eval “[mkpat $ Pc "::" [Pas (Pas (Pas (Pv "x") "i") "j") "k";
+                                  Pv "j"]]”)
   ;
 
 (* as needs to bind anything to its left *)
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x as i :: y as j"
-  (SOME “[Pas (Pc "::" [Pas (Pv "x") "i"; Pv "y"]) "j"]”)
+  (SOME $ eval “[mkpat $ Pas (Pc "::" [Pas (Pv "x") "i"; Pv "y"]) "j"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x as i :: y as j :: z as k"
-  (SOME “[Pas (Pc "::" [
+  (SOME $ eval “[mkpat $ Pas (Pc "::" [
                  Pas (Pc "::" [Pas (Pv "x") "i"; Pv "y"]) "j"; Pv "z"])
               "k"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x,y as i :: y as j :: z as k"
-  (SOME “[Pas (Pc "::" [
+  (SOME $ eval “[mkpat $ Pas (Pc "::" [
                  Pas (Pc "::" [Pas (Pcon NONE [Pv "x"; Pv "y"]) "i";
                                Pv "y"]) "j";
                  Pv "z"]) "k"]”)
@@ -332,46 +341,47 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "a, b | c, d"
-  (SOME “[Pcon NONE [Pv "a"; Pv "b"];
-          Pcon NONE [Pv "c"; Pv "d"]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pv "a"; Pv "b"];
+                 mkpat $ Pcon NONE [Pv "c"; Pv "d"]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Comb (a,b) as c, d"
-  (SOME “[Pcon NONE [Pas (Pc "Comb" [Pv "a"; Pv "b"]) "c"; Pv "d"]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pas (Pc "Comb" [Pv "a"; Pv "b"]) "c";
+                 Pv "d"]]”)
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "false::[]"
-  (SOME “[Pc "::" [Pc "False" []; Pc "[]" []]]”)
+  (SOME $ eval “[mkpat $ Pc "::" [Pc "False" []; Pc "[]" []]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x as y"
-  (SOME “[Pas (Pvar "x") "y"]”)
+  (SOME $ eval “[mkpat $ Pas (Pvar "x") "y"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "x | y"
-  (SOME “[Pvar "x"; Pvar "y"]”)
+  (SOME $ eval “[mkpat $ Pvar "x"; mkpat $ Pvar "y"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Some x | y"
-  (SOME “[Pc "Some" [Pvar "x"]; Pvar "y"]”)
+  (SOME $ eval “[mkpat $ Pc "Some" [Pvar "x"]; mkpat $ Pvar "y"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "y,z,x"
-  (SOME “[Pcon NONE [Pvar "y"; Pvar "z"; Pvar "x"]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pvar "y"; Pvar "z"; Pvar "x"]]”)
   ;
 
 (* Make sure or-patterns distribute OK *)
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Some (x | Inl (y | z))"
-  (SOME “[Pc "Some" [Pv "x"];
-          Pc "Some" [Pc "Inl" [Pv "y"]];
-          Pc "Some" [Pc "Inl" [Pv "z"]]]”)
+  (SOME $ eval “[mkpat $ Pc "Some" [Pv "x"];
+                 mkpat $ Pc "Some" [Pc "Inl" [Pv "y"]];
+                 mkpat $ Pc "Some" [Pc "Inl" [Pv "z"]]]”)
   ;
 
 (* Make sure the precedence parser can handle commas correctly
@@ -380,32 +390,32 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "(y,z),x"
-  (SOME “[Pcon NONE [Pcon NONE [Pvar "y"; Pvar "z"]; Pvar "x"]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pcon NONE [Pvar "y"; Pvar "z"]; Pvar "x"]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "y,(z,x)"
-  (SOME “[Pcon NONE [Pv "y"; Pcon NONE [Pvar "z"; Pvar "x"]]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pv "y"; Pcon NONE [Pvar "z"; Pvar "x"]]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "(x: int)"
-  (SOME “[Ptannot (Pvar "x") (Atapp [] (Short "int"))]”)
+  (SOME $ eval “[mkpat $ Ptannot (Pvar "x") (Atapp [] (Short "int"))]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Aa (Bb (Cc x))"
-  (SOME “[Pc "Aa" [Pc "Bb" [Pc "Cc" [Pvar "x"]]]]”)
+  (SOME $ eval “[mkpat $ Pc "Aa" [Pc "Bb" [Pc "Cc" [Pvar "x"]]]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "a :: 1"
-  (SOME “[Pc "::" [Pvar "a"; Plit (IntLit 1)]]”)
+  (SOME $ eval “[mkpat $ Pc "::" [Pvar "a"; Plit (IntLit 1)]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "[a,b ; c]"
-  (SOME “[Pc "::" [Pcon NONE [Pvar "a"; Pvar "b"];
+  (SOME $ eval “[mkpat $ Pc "::" [Pcon NONE [Pvar "a"; Pvar "b"];
                    Pc "::" [Pvar "c"; Pc "[]" []]]]”)
   ;
 
@@ -423,8 +433,9 @@ val _ = parsetest0 “nPattern” “ptree_PPattern”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "a,b :: c, d | zs as i"
-  (SOME (“[Pas (Pcon NONE [Pv "a"; Pc "::" [Pv "b"; Pv "c"]; Pv "d"]) "i";
-           Pas (Pv "zs") "i"]”))
+  (SOME $ eval “[mkpat $ Pas (Pcon NONE [Pv "a"; Pc "::" [Pv "b"; Pv "c"];
+                                   Pv "d"]) "i";
+                 mkpat $ Pas (Pv "zs") "i"]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_PPattern”
@@ -440,7 +451,7 @@ val _ = parsetest0 “nPattern” “ptree_PPattern”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Cn(x,(y as z))"
-  (SOME “[Pc "Cn" [Pcon NONE [Pv "x"; Pas (Pv "y") "z"]]]”)
+  (SOME $ eval “[mkpat $ Pc "Cn" [Pcon NONE [Pv "x"; Pas (Pv "y") "z"]]]”)
   ;
 
 (* -------------------------------------------------------------------------
@@ -451,36 +462,36 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "x.foo"
-  (SOME (rconc $ EVAL “App Opapp [V (mk_record_proj_name "foo"); V "x"]”))
+  (SOME $ eval “App Opapp [V (mk_record_proj_name "foo"); V "x"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "{x with foo = bar}"
-  (SOME (rconc $ EVAL “App Opapp [App Opapp [
-                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”))
+  (SOME $ eval “App Opapp [App Opapp [
+                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "{x with foo = bar;}"
-  (SOME (rconc $ EVAL “App Opapp [App Opapp [
-                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”))
+  (SOME $ eval “App Opapp [App Opapp [
+                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "{x with foo = bar; baz = quux;}"
-  (SOME (rconc $ EVAL “App Opapp [App Opapp [V (mk_record_update_name "baz");
+  (SOME $ eval “App Opapp [App Opapp [V (mk_record_update_name "baz");
            App Opapp [App Opapp [V (mk_record_update_name "foo");
-             V "x"]; V "bar"]]; V "quux"]”))
+             V "x"]; V "bar"]]; V "quux"]”)
   ;
 
 (* construction *)
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "Foo { foo = 5; bar = true }"
-  (SOME (rconc $ EVAL
+  (SOME $ eval
     “App Opapp [App Opapp [V (mk_record_constr_name "Foo" ["bar";"foo"]);
                            (C "True" [])];
-                    Lit (IntLit 5)]”))
+                    Lit (IntLit 5)]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -497,7 +508,7 @@ val _ = parsetest0 “nStart” “ptree_Start”
 
 val _ = parsetest0 “nStart” “ptree_Start”
   "type rec1 = Foo of {foo: int; bar: bool};;"
-  (SOME (rconc $ EVAL “
+  (SOME $ eval “
       [Dtype L [([],"rec1",[("Foo",[Attup [Atapp [] (Short "bool"); Atapp [] (Short "int")]])])];
        Dlet L1 (Pv (mk_record_constr_name "Foo" ["bar";"foo"]))
           (Fun "bar" (Fun "foo" (C "Foo" [Con NONE [V "bar"; V "foo"]])));
@@ -514,7 +525,28 @@ val _ = parsetest0 “nStart” “ptree_Start”
           (Fun ""
              (Mat (V "")
                 [(Pc "Foo" [Pcon NONE [Pv "bar"; Pv "foo"]],
-                  Fun "foo" (C "Foo" [Con NONE [V "bar"; V "foo"]]))]))]”))
+                  Fun "foo" (C "Foo" [Con NONE [V "bar"; V "foo"]]))]))]”)
+  ;
+
+(* 2024-06-06: pattern matching *)
+
+Definition mkrec_def:
+  mkrec x = INL x : (modN, varN) id # string list + pat
+End
+
+val _ = parsetest0 “nPattern” “ptree_Pattern”
+  "Foo {b; a}"
+  (SOME $ eval “[mkrec (Short "Foo", ["a"; "b"])]”)
+  ;
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let f d (Foo {c; a}) b = z;;"
+  NONE;
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "match y with\
+  \  Foo {z} -> f z;;"
+  NONE
   ;
 
 (* -------------------------------------------------------------------------
@@ -533,7 +565,9 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "0 + match x with y -> z"
-  (SOME (“vbinop (Short "+") (Lit (IntLit 0)) (Mat (V "x") [(Pv "y", V "z")])”))
+  (SOME (“vbinop (Short "+") (Lit (IntLit 0))
+                 (Let (SOME " m") (V "x")
+                   (Mat (V " m") [(Pv "y", V "z")]))”))
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -554,18 +588,22 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "a, match x with y -> z, w"
-  (SOME “Con NONE [V "a"; Mat (V "x") [(Pv "y", Con NONE [V "z"; V "w"])]]”)
+  (SOME “Con NONE [V "a";
+                   Let (SOME " m") (V "x")
+                       (Mat (V " m") [(Pv "y", Con NONE [V "z"; V "w"])])]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "match x with y -> z, w"
-  (SOME “Mat (V "x") [(Pv "y", Con NONE [V "z"; V "w"])]”)
+  (SOME “Let (SOME " m") (V "x")
+             (Mat (V " m") [(Pv "y", Con NONE [V "z"; V "w"])])”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "match !myref () with a -> b"
-  (SOME “Mat (App Opapp [App Opapp [V "!"; V "myref"]; Con NONE []])
-             ([(Pv "a", V "b")])”)
+  (SOME “Let (SOME " m")
+             (App Opapp [App Opapp [V "!"; V "myref"]; Con NONE []])
+             (Mat (V " m") ([(Pv "a", V "b")]))”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -674,9 +712,10 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   \ | a -> f; c \
   \ | b -> q; w"
   (SOME “
-    Mat (V "x")
-        [(Pv "a", Let NONE (V "f") (V "c"));
-         (Pv "b", Let NONE (V "q") (V "w"))]”)
+    Let (SOME " m") (V "x")
+      (Mat (V " m")
+          [(Pv "a", Let NONE (V "f") (V "c"));
+           (Pv "b", Let NONE (V "q") (V "w"))])”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -920,20 +959,22 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   " match x with\
   \ | [] -> 3\
   \ | [e;_] -> e"
-  (SOME “Mat (Var (Short "x"))
-             [(Pc "[]" [], Lit (IntLit 3));
-              (Pc "::" [Pvar "e"; Pc "::" [Pany; Pc "[]" []]],
-                       V "e")]”)
+  (SOME “Let (SOME " m") (V "x")
+             (Mat (V " m")
+                  [(Pc "[]" [], Lit (IntLit 3));
+                   (Pc "::" [Pvar "e"; Pc "::" [Pany; Pc "[]" []]],
+                            V "e")])”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   " match x with\
   \ | Some 3 | Some 4 -> e\
   \ | _ -> d"
-  (SOME “Mat (V "x")
-             [(Pc "Some" [Plit (IntLit 3)], V "e");
-              (Pc "Some" [Plit (IntLit 4)], V "e");
-              (Pany, V "d")]”)
+  (SOME “Let (SOME " m") (V "x")
+             (Mat (V " m")
+                  [(Pc "Some" [Plit (IntLit 3)], V "e");
+                   (Pc "Some" [Plit (IntLit 4)], V "e");
+                   (Pany, V "d")])”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -941,11 +982,12 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   \ | [] -> 3\
   \ | [] :: _ -> 1\
   \ | (h::t) :: rest -> 2"
-  (SOME “Mat (V "x")
-             [(Pc "[]" [], Lit (IntLit 3));
-              (Pc "::" [Pc "[]" []; Pany], Lit (IntLit 1));
-              (Pc "::" [Pc "::" [Pvar "h"; Pvar "t"]; Pvar "rest"],
-               Lit (IntLit 2))]”)
+  (SOME “Let (SOME " m") (V "x")
+             (Mat (V " m")
+                  [(Pc "[]" [], Lit (IntLit 3));
+                   (Pc "::" [Pc "[]" []; Pany], Lit (IntLit 1));
+                   (Pc "::" [Pc "::" [Pvar "h"; Pvar "t"]; Pvar "rest"],
+                    Lit (IntLit 2))])”)
   ;
 
 (* pattern match with guard;
@@ -961,11 +1003,10 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   \| [] -> z \n\
   \| _ -> w"
   (SOME “
-    Let (SOME "") (V "x")
-      (Let (SOME " p") (Fun " u" (Mat (V "") [(Pc "[]" [],V "z");
-                                              (Pany,V "w");
-                                             ]))
-       (Mat (V "")
+    Let (SOME " m") (V "x")
+      (Let (SOME " p") (Fun " u" (Mat (V " m") [(Pc "[]" [],V "z");
+                                                (Pany,V "w")]))
+       (Mat (V " m")
           [(Pc "::" [Pv "h"; Pv "t"],
             If (V "P") (V "z") (App Opapp [V " p"; Con NONE []]));
            (Pany,App Opapp [V " p"; Con NONE []])]))”);
@@ -978,26 +1019,27 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   \| r3 when x3 -> y3\n\
   \| r4 -> y4\n"
   (SOME “
-    Let (SOME "") (V "x")
+    Let (SOME " m") (V "x")
       (Let (SOME " p")
-        (Fun " u" (Mat (V "") [
+        (Fun " u" (Mat (V " m") [
                     (Pv "r2", V "y2");
                     (Pany, Let (SOME " p")
-                             (Fun " u" (Mat (V "") [(Pv "r4",V "y4")]))
-                             (Mat (V "") [
+                             (Fun " u" (Mat (V " m") [(Pv "r4",V "y4")]))
+                             (Mat (V " m") [
                                (Pv "r3", If (V "x3") (V "y3")
                                          (App Opapp [V " p"; Con NONE []]));
                                (Pany,App Opapp [V " p"; Con NONE []])]))]))
-        (Mat (V "") [
+        (Mat (V " m") [
           (Pv "r1",If (V "x1") (V "y1") (App Opapp [V " p"; Con NONE []]));
           (Pany,App Opapp [V " p"; Con NONE []])]))”);
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   " try f x with Ea _ -> g x\
   \            | Eb -> h"
-  (SOME “Handle (App Opapp [V "f"; V "x"])
-                [(Pc "Ea" [Pany], App Opapp [V "g"; V "x"]);
-                 (Pc "Eb" [], V "h")]”)
+  (SOME “Let (SOME " e") (App Opapp [V "f"; V "x"])
+             (Handle (V " e")
+                     [(Pc "Ea" [Pany], App Opapp [V "g"; V "x"]);
+                      (Pc "Eb" [], V "h")])”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -1400,13 +1442,13 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Comb (Var (v, s), Const (w, t))"
-  (SOME “[Pc "Comb" [Pc "Var" [Pv "v"; Pv "s"]; Pc "Const" [Pv "w"; Pv "t"]]]”)
+  (SOME $ eval “[mkpat $ Pc "Comb" [Pc "Var" [Pv "v"; Pv "s"]; Pc "Const" [Pv "w"; Pv "t"]]]”)
   ;
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Append (Append (v, s), Append (w, t))"
-  (SOME “[Pc "Append" [Pc "Append" [Pv "v"; Pv "s"];
-                       Pc "Append" [Pv "w"; Pv "t"]]]”)
+  (SOME $ eval “[mkpat $  Pc "Append" [Pc "Append" [Pv "v"; Pv "s"];
+                            Pc "Append" [Pv "w"; Pv "t"]]]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
@@ -1417,7 +1459,8 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Var _, Comb _"
-  (SOME “[Pcon NONE [Pc "Var" [Pany; Pany]; Pc "Comb" [Pany; Pany]]]”)
+  (SOME $ eval “[mkpat $ Pcon NONE [Pc "Var" [Pany; Pany];
+                                    Pc "Comb" [Pany; Pany]]]”)
   ;
 
 
@@ -1509,7 +1552,7 @@ val _ = parsetest0 “nStart” “ptree_Start”
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "-1"
-  (SOME “[Plit (IntLit (-1))]”)
+  (SOME $ eval “[mkpat $ Plit (IntLit (-1))]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -536,7 +536,7 @@ End
 
 val _ = parsetest0 “nPattern” “ptree_Pattern”
   "Foo {b; a}"
-  (SOME $ eval “[mkrec (Short "Foo", ["a"; "b"])]”)
+  (SOME $ eval “[mkrec (Short "Foo", ["b"; "a"])]”)
   ;
 
 val _ = parsetest0 “nStart” “ptree_Start”
@@ -1036,22 +1036,25 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   " try f x with Ea _ -> g x\
   \            | Eb -> h"
-  (SOME “Let (SOME " e") (App Opapp [V "f"; V "x"])
-             (Handle (V " e")
-                     [(Pc "Ea" [Pany], App Opapp [V "g"; V "x"]);
-                      (Pc "Eb" [], V "h")])”)
+  (SOME “Handle (App Opapp [V "f"; V "x"])
+           [(Pv " e", Mat (V " e")
+               [(Pc "Ea" [Pany],App Opapp [V "g"; V "x"]);
+                (Pc "Eb" [],V "h");
+                (Pany, Raise (V " e"))])]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "try f ()\n\
   \with Bar when P -> X"
   (SOME “
-    Handle (V"") [
-      (Pany, Let (SOME " p") (Fun " u" (Raise (V"")))
-                 (Mat (V"")
-                      [(Pc "Bar" [],
-                        If (V "P") (V "X") (App Opapp [V " p"; Con NONE []]));
-                       (Pany, App Opapp [V " p"; Con NONE []])]))]”)
+    Handle (App Opapp [V "f"; Con NONE []])
+     [(Pv " e",
+       Let (SOME " p") (Fun " u" (Raise (V " e")))
+           (Mat (V " e")
+                [(Pc "Bar" [],
+                  If (V "P") (V "X")
+                     (App Opapp [V " p"; Con NONE []]));
+                 (Pany, App Opapp [V " p"; Con NONE []])]))]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”

--- a/compiler/parsing/ocaml/caml_lexScript.sml
+++ b/compiler/parsing/ocaml/caml_lexScript.sml
@@ -8,6 +8,8 @@ val _ = set_grammar_ancestry [ "misc", "location", "lexer_impl", "lexer_fun" ];
 
 val _ = new_theory "caml_lex";
 
+val _ = numLib.prefer_num ();
+
 (* -------------------------------------------------------------------------
  * Tokens
  * ------------------------------------------------------------------------- *)
@@ -37,6 +39,7 @@ Datatype:
     | PragmaT string
     (* literals and identifiers: *)
     | IntT int
+    | FloatT string
     | CharT char
     | StringT string
     | IdentT string
@@ -58,6 +61,22 @@ Theorem isInt_thm:
   isInt x ⇔ ∃y. x = IntT y
 Proof
   Cases_on ‘x’ \\ rw [isInt_def]
+QED
+
+Definition isFloat_def:
+  isFloat (FloatT s) = T ∧
+  isFloat _ = F
+End
+
+Definition destFloat_def[simp]:
+  destFloat (FloatT s) = SOME s ∧
+  destFloat _ = NONE
+End
+
+Theorem isFloat_thm:
+  isFloat x ⇔ ∃y. x = FloatT y
+Proof
+  Cases_on ‘x’ \\ rw [isFloat_def]
 QED
 
 Definition isChar_def:
@@ -147,6 +166,7 @@ QED
 Datatype:
   symbol
     = NumberS int
+    | FloatS string
     | StringS string
     | CharS char
     | OtherS string
@@ -389,6 +409,76 @@ Definition scan_number_def:
               rest)
 End
 
+(* FLOATS
+ *
+ *   float-lit ::= [0-9] [0-9_]* ("." [0-9_]* )? ([eE] [+-]? [0-9_]* )?
+ *
+ *)
+
+(* [0-9] [0-9_]* *)
+Definition scan_float1_def:
+  scan_float1 cs =
+    if cs = "" ∨ ¬isDigit (HD cs) then NONE else
+      let (cs', rest) = take_while (λc. c = #"_" ∨ isDigit c) cs in
+      let n = FILTER ($≠ #"_") cs' in
+        SOME (n, LENGTH cs', rest)
+End
+
+(* "." [0-9_]* *)
+Definition scan_float2_def:
+  scan_float2 cs =
+    if cs = "" ∨ HD cs ≠ #"." then NONE else
+      let (cs', rest) = take_while (λc. c = #"_" ∨ isDigit c) (TL cs) in
+      let n = FILTER ($≠ #"_") cs' in
+        SOME (#"." :: n, LENGTH cs' + 1, rest)
+End
+
+(* [eE] [+-]? *)
+Definition scan_float3_def:
+  scan_float3 cs =
+    case cs of
+      x :: y :: rest =>
+        if ¬MEM x "eE" then NONE
+        else if MEM y "+-" then
+          if rest = "" ∨ ¬isDigit (HD rest) then NONE else
+            let (cs', rest') = take_while (λc. c = #"_" ∨ isDigit c) rest in
+            let n = FILTER ($≠ #"_") cs' in
+              SOME (x::y::n, 2 + LENGTH cs', rest')
+        else if ¬isDigit y then NONE
+        else
+          let (cs', rest') = take_while (λc. c = #"_" ∨ isDigit c) rest in
+          let n = FILTER ($≠ #"_") cs' in
+            SOME (x::y::n, 2 + LENGTH cs', rest')
+    | _ => NONE
+End
+
+(* At least one of scan_float2 or scan_float3 must succeed. If they fail,
+ * try to scan an integer instead.
+ *)
+Definition scan_float_or_int_def:
+  scan_float_or_int cs loc =
+    case scan_float1 cs of
+      NONE => SOME (ErrorS, Locs loc loc, cs)
+    | SOME (s1, n1, cs1) =>
+        case scan_float2 cs1 of
+          NONE =>
+            (* try scan_float3 *)
+            (case scan_float3 cs1 of
+              NONE => scan_number isDigit (λs. &dec2num s) 0 cs loc
+            | SOME (s2, n2, cs2) => SOME (FloatS (s1 ++ s2),
+                                          Locs loc (next_loc (n1 + n2) loc),
+                                          cs2))
+        | SOME (s2, n2, cs2) =>
+            (case scan_float3 cs2 of
+              NONE => SOME (FloatS (s1 ++ s2),
+                            Locs loc (next_loc (n1 + n2) loc),
+                            cs2)
+            | SOME (s3, n3, cs3) =>
+                SOME (FloatS (s1 ++ s2 ++ s3),
+                      Locs loc (next_loc (n1 + n2 + n3) loc),
+                      cs3))
+End
+
 Definition scan_pragma_def:
   scan_pragma (level: num) (n: num) cs loc =
   case cs of
@@ -429,6 +519,17 @@ Proof
   \\ gvs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL, CaseEq "bool"]
 QED
 
+Theorem scan_float_or_int_thm:
+  scan_float_or_int cs loc = SOME (sym, locs, ds) ⇒ LENGTH ds ≤ LENGTH cs
+Proof
+  simp [scan_float_or_int_def, scan_float1_def, scan_float2_def,
+        scan_float3_def, CaseEqs ["prod", "string", "option", "bool"],
+        IS_SOME_EXISTS]
+  \\ rw [] \\ gvs [UNCURRY_eq_pair, NOT_NIL_EQ_LENGTH_NOT_0]
+  \\ imp_res_tac take_while_thm \\ gs [LENGTH_TL]
+  \\ imp_res_tac scan_number_thm \\ gs []
+QED
+
 Definition isSym_def:
   isSym c ⇔ MEM c "#$&*+-/=>@^|~!?%<:.;"
 End
@@ -453,9 +554,9 @@ Definition next_sym_def:
         else if HD cs = #"b" ∨ HD cs = #"B" then
           scan_number isBinDigit (λs. &bin2num s) 2 (TL cs) loc
         else
-          scan_number isDigit (λs. &dec2num s) 0 (c::cs) loc
+          scan_float_or_int (c::cs) loc
       else
-        scan_number isDigit (λs. &dec2num s) 0 (c::cs) loc
+        scan_float_or_int (c::cs) loc
     else if c = #"\"" then
       scan_strlit [] cs (next_loc 1 loc)
     else if c = #"'" then
@@ -515,6 +616,27 @@ Proof
   \\ CASE_TAC \\ gs [] \\ rw [] \\ gs []
 QED
 
+Theorem scan_float2_thm[local]:
+  scan_float2 cs = SOME (s, n, ds) ⇒
+    0 < n ∧
+    LENGTH cs = n + LENGTH ds
+Proof
+  rw [scan_float2_def, UNCURRY_eq_pair] \\ gs []
+  \\ drule_then assume_tac take_while_thm
+  \\ gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL]
+QED
+
+Theorem scan_float3_thm[local]:
+  scan_float3 cs = SOME (s, n, ds) ⇒
+    0 < n ∧
+    LENGTH cs = n + LENGTH ds
+Proof
+  rw [scan_float3_def, UNCURRY_eq_pair] \\ gs []
+  \\ gvs [CaseEqs ["string", "bool", "option"], UNCURRY_eq_pair]
+  \\ drule_then assume_tac take_while_thm
+  \\ gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL]
+QED
+
 Theorem next_sym_thm:
   ∀cs loc sym locs ds.
     next_sym cs loc = SOME (sym, locs, ds) ⇒
@@ -525,26 +647,37 @@ Proof
   \\ pop_assum mp_tac
   \\ rw [Once next_sym_def] \\ gs []
   \\ map_every imp_res_tac [
+    scan_float_or_int_thm,
     scan_number_thm,
-    scan_strlit_thm,
-    scan_pragma_thm,
-    scan_charlit_thm ] \\ gs []
-  \\ gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL]
-  \\ imp_res_tac skip_comment_thm \\ gs []
-  \\ imp_res_tac take_while_thm \\ gs []
-  \\ gs [take_while_def, Once scan_number_def, isAlphaNum_def]
-  \\ gvs [CaseEqs ["option", "prod", "bool"]]
-  \\ rpt (pairarg_tac \\ gvs [])
-  \\ gvs [CaseEqs ["option", "prod", "bool"]]
-  \\ imp_res_tac take_while_lemma \\ gs []
-  \\ gs [GSYM take_while_def]
-  \\ imp_res_tac take_while_thm
-  \\ gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL]
-  \\ imp_res_tac scan_charlit_thm \\ gs []
-  \\ imp_res_tac scan_pragma_thm \\ gs []
+    scan_strlit_thm] \\ gs []
+  \\ gs [CaseEqs ["option", "prod", "bool"], UNCURRY_eq_pair]
+  \\ imp_res_tac scan_charlit_thm
+  (* Various scan_number calls: *)
+  \\ TRY (gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL] \\ NO_TAC)
+  (* Two identical scan_float goals: *)
+  \\ TRY (
+    qpat_x_assum ‘scan_float_or_int _ _ = _’ mp_tac
+    \\ simp [scan_float_or_int_def]
+    \\ CASE_TAC \\ gs []
+    \\ gvs [scan_float1_def, UNCURRY_eq_pair]
+    \\ rw [CaseEqs ["option", "prod"]] \\ gs []
+    \\ gvs [scan_number_def, UNCURRY_eq_pair, CaseEq "bool"]
+    \\ map_every imp_res_tac [
+        scan_float2_thm,
+        scan_float3_thm,
+        take_while_thm]
+    \\ gs [NOT_NIL_EQ_LENGTH_NOT_0, LENGTH_TL]
+    \\ gs [take_while_def]
+    \\ drule_at (Pos (el 3)) take_while_lemma \\ gs [])
+  \\ map_every imp_res_tac [
+      scan_pragma_thm,
+      skip_comment_thm] \\ gs []
   \\ Cases_on ‘cs’ \\ gs []
-  \\ imp_res_tac skip_comment_thm \\ gs []
-  \\ Cases_on ‘c’ \\ gs []
+  \\ Cases_on ‘ds’ \\ gs []
+  \\ imp_res_tac take_while_thm \\ gvs []
+  \\ gs [take_while_def, isAlphaNum_def]
+  \\ imp_res_tac take_while_lemma \\ gvs []
+  \\ gs [take_while_aux_def]
 QED
 
 (*
@@ -572,6 +705,12 @@ EVAL “next_sym "(= bar)" loc”
 EVAL “next_sym "=<! bar" loc”
 
 EVAL “next_sym "*" loc”
+
+EVAL “next_sym "123.456e+33" loc”
+EVAL “next_sym "123.456E33" loc”
+EVAL “next_sym "123." loc”
+EVAL “next_sym "0.3e" loc”
+
  *)
 
 Definition get_token_def:
@@ -696,6 +835,7 @@ Definition sym2token_def:
   sym2token s =
     case s of
       NumberS i => IntT i
+    | FloatS s => FloatT s
     | StringS s => StringT s
     | CharS c => CharT c
     | ErrorS => LexErrorT
@@ -777,6 +917,26 @@ Theorem destInt_PMATCH:
   ∀x. destInt x =
         case x of
           IntT i => SOME i
+        | _ => NONE
+Proof
+  CONV_TAC (DEPTH_CONV PMCONV)
+  \\ Cases \\ rw []
+QED
+
+Theorem isFloat_PMATCH:
+  ∀x. isFloat x =
+        case x of
+          FloatT i => T
+        | _ => F
+Proof
+  CONV_TAC (DEPTH_CONV PMCONV)
+  \\ Cases \\ rw [isFloat_def]
+QED
+
+Theorem destFloat_PMATCH:
+  ∀x. destFloat x =
+        case x of
+          FloatT i => SOME i
         | _ => NONE
 Proof
   CONV_TAC (DEPTH_CONV PMCONV)

--- a/compiler/parsing/ocaml/caml_lexScript.sml
+++ b/compiler/parsing/ocaml/caml_lexScript.sml
@@ -8,11 +8,6 @@ val _ = set_grammar_ancestry [ "misc", "location", "lexer_impl", "lexer_fun" ];
 
 val _ = new_theory "caml_lex";
 
-
-(* TODO
- * - Location spans might be wrong just about everywhere
- *)
-
 (* -------------------------------------------------------------------------
  * Tokens
  * ------------------------------------------------------------------------- *)


### PR DESCRIPTION
This PR adds pattern matching to Candle's record syntax, as well as some minor improvements or fixes.

Summary:
- Adds record pattern matching syntax.
- Fixes a syntax error in candle_boot.ml, preventing Candle from loading HOL Light.
- Adds support for floating point literals to the parser. This works by parsing the strings as-is and calling Double.fromString on the result.
- Adds an example of how the record syntax works, as well as a small test at the end of the bootstrap which tests the syntax.