### PR TITLE
Lift out basis_def translation from compilerXProg

### DIFF
--- a/compiler/bootstrap/translation/README.md
+++ b/compiler/bootstrap/translation/README.md
@@ -13,6 +13,9 @@ Translate the ARMv7 instruction encoder and ARMv7-specific config.
 [arm8ProgScript.sml](arm8ProgScript.sml):
 Translate the ARMv8 instruction encoder and ARMv8-specific config.
 
+[basis_defProgScript.sml](basis_defProgScript.sml):
+Translate the basis library term.
+
 [caml_lexProgScript.sml](caml_lexProgScript.sml):
 Translation of the OCaml lexer.
 

--- a/compiler/bootstrap/translation/basis_defProgScript.sml
+++ b/compiler/bootstrap/translation/basis_defProgScript.sml
@@ -1,0 +1,21 @@
+(*
+  Translate the basis library term.
+*)
+
+open preamble ml_translatorLib ml_translatorTheory;
+open sexp_parserProgTheory basis;
+
+val _ = new_theory "basis_defProg";
+
+val _ = translation_extends "sexp_parserProg";
+val _ = ml_translatorLib.use_string_type true;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "basis_defProg");
+
+val _ = print "About to translate basis (this takes some time) ";
+val res = translate basisProgTheory.basis_def;
+
+val _ = ml_translatorLib.ml_prog_update (ml_progLib.close_module NONE);
+
+val () = Feedback.set_trace "TheoryPP.include_docs" 0;
+val _ = export_theory ();

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -180,9 +180,6 @@ val _ = translate (compilerTheory.parse_sexp_input_def
 val def = spec32 (compilerTheory.compile_def);
 val res = translate def;
 
-val _ = print "About to translate basis (this takes some time) ";
-val res = translate basisProgTheory.basis_def;
-
 val res = translate (primTypesTheory.prim_tenv_def
                      |> CONV_RULE (RAND_CONV EVAL));
 

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -181,9 +181,6 @@ val _ = translate (compilerTheory.parse_sexp_input_def
 val def = spec64 (compilerTheory.compile_def);
 val res = translate def;
 
-val _ = print "About to translate basis (this takes some time) ";
-val res = translate basisProgTheory.basis_def;
-
 val res = translate (primTypesTheory.prim_tenv_def
                        |> CONV_RULE (RAND_CONV EVAL));
 

--- a/compiler/bootstrap/translation/dependency-order
+++ b/compiler/bootstrap/translation/dependency-order
@@ -24,14 +24,18 @@ reg_alloc
 infer
 explorer
 sexp_parser
+basis_def
 --- (the translation splits into two paths for 32- and 64-bit targets)
 to_word32
 to_target32
 arm7
+ag32
 compiler32
 ---
+printing
 to_word64
 to_target64
+from_pancake64
 x64
 arm8
 riscv

--- a/compiler/bootstrap/translation/printingProgScript.sml
+++ b/compiler/bootstrap/translation/printingProgScript.sml
@@ -3,13 +3,13 @@
 *)
 
 open preamble ml_translatorLib ml_translatorTheory
-     sexp_parserProgTheory std_preludeTheory printTweaksTheory
+     basis_defProgTheory std_preludeTheory printTweaksTheory
 
 val _ = set_grammar_ancestry ["infer","misc"];
 
 val _ = new_theory "printingProg"
 
-val _ = translation_extends "sexp_parserProg";
+val _ = translation_extends "basis_defProg";
 
 val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "printingProg");
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -3,14 +3,14 @@
 *)
 
 open preamble ml_translatorLib ml_translatorTheory
-     sexp_parserProgTheory std_preludeTheory
+     basis_defProgTheory std_preludeTheory
 local open backendTheory in end
 
 val _ = temp_delsimps ["NORMEQ_CONV", "lift_disj_eq", "lift_imp_disj"]
 
 val _ = new_theory "to_word32Prog"
 
-val _ = translation_extends "sexp_parserProg";
+val _ = translation_extends "basis_defProg";
 
 val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "to_word32Prog");
 val _ = ml_translatorLib.use_string_type true;


### PR DESCRIPTION
This commit moves `basis_def` translation out from compiler{32,64}ProgScript.sml, so that it is only translated once. 

Even if these theories are translated in parallel during bootstrap translation, translation of `basis_def` takes well over an hour on a fast machine, and probably consumes a lot of memory. Limiting ourselves to translating `basis_def` only once contributes towards making bootstrap translation tractable for smaller machines.