### PR TITLE
pancake: patch crep_to_loop to use static Call

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -253,6 +253,8 @@ val _ = translate $ spec32 compile_crepop_def;
 
 val _ = translate $ spec32 compile_exp_def;
 
+val _ = translate $ spec32 call_label_def;
+
 val _ = translate $ spec32 compile_def;
 
 val _ = translate $ spec32 comp_func_def;

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -254,6 +254,8 @@ val _ = translate $ spec64 compile_crepop_def;
 
 val _ = translate $ spec64 compile_exp_def;
 
+val _ = translate $ spec64 call_label_def;
+
 val _ = translate $ spec64 compile_def;
 
 val _ = translate $ spec64 comp_func_def;

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -110,6 +110,12 @@ Definition rt_var_def:
      | SOME m => m
 End
 
+Definition call_label_def:
+  call_label ctxt e = case e of
+    | Label l => (SOME (find_lab ctxt l), [])
+    | _ => (NONE, [e])
+End
+
 Definition compile_def:
   (compile _ _ (Skip:'a crepLang$prog) = (Skip:'a loopLang$prog)) /\
   (compile _ _ Break = Break) /\
@@ -169,26 +175,24 @@ Definition compile_def:
                 If NotEqual tmp (Imm 0w)
                    (Seq lp Continue) Break l]))
           l) /\
-  (compile ctxt l (Call NONE e es) =
-   let (p, les, tmp, nl) = compile_exps ctxt (ctxt.vmax + 1) l (es ++ [e]);
-       nargs = gen_temps tmp (LENGTH les) in
-   nested_seq (p ++ MAP2 Assign nargs les ++
-               [Call NONE NONE nargs NONE])) /\
-  (compile ctxt l (Call (SOME (rt, rp, hdl)) e es) =
-   let (p, les, tmp, nl) = compile_exps ctxt (ctxt.vmax + 1) l (es ++ [e]);
+  (compile ctxt l (Call call_type  e es) =
+   let (dest, indirect_dest) = call_label ctxt e;
+       (p, les, tmp, nl) = compile_exps ctxt (ctxt.vmax + 1) l (es ++ indirect_dest);
        nargs = gen_temps tmp (LENGTH les);
-       rn  = rt_var ctxt.vars rt (ctxt.vmax + 1) (ctxt.vmax + 1);
-       en  = ctxt.vmax + 1;
-       pr  = compile ctxt l rp;
-       pe  = case hdl of
-              | NONE => Raise en
-              | SOME (eid, ep) =>
-                let cpe = compile ctxt l ep in
-                  (If NotEqual en (Imm eid) (Raise en) (Seq Tick cpe) l)
+       (rt1, rt2) = case call_type of
+         | NONE => (NONE, NONE)
+         | SOME (rt, rp, hdl) =>
+           let rn = rt_var ctxt.vars rt (ctxt.vmax + 1) (ctxt.vmax + 1);
+               en  = ctxt.vmax + 1;
+               pr  = compile ctxt l rp;
+               pe  = case hdl of
+                  | NONE => Raise en
+                  | SOME (eid, ep) =>
+                    let cpe = compile ctxt l ep in
+                      (If NotEqual en (Imm eid) (Raise en) (Seq Tick cpe) l)
+           in (SOME (rn, l), SOME (en, pe, pr, l))
    in
-      nested_seq (p ++ MAP2 Assign nargs les ++
-               [Call (SOME (rn, l)) NONE nargs
-                     (SOME (en, pe, pr, l))])) /\
+      nested_seq (p ++ MAP2 Assign nargs les ++ [Call rt1 dest nargs rt2])) /\
   (compile ctxt l (ExtCall f ptr1 len1 ptr2 len2) =
     case (FLOOKUP ctxt.vars ptr1, FLOOKUP ctxt.vars len1,
           FLOOKUP ctxt.vars ptr2, FLOOKUP ctxt.vars len2) of

--- a/pancake/proofs/crep_to_loopProofScript.sml
+++ b/pancake/proofs/crep_to_loopProofScript.sml
@@ -3231,8 +3231,8 @@ Proof
       )
       >- (
         gs []
-	\\ GEN_EXISTS_TAC "ck''" `ck'`
-	\\ simp [evaluate_def, set_var_def, get_var_imm_def, asmTheory.word_cmp_def]
+        \\ GEN_EXISTS_TAC "ck''" `ck'`
+        \\ simp [evaluate_def, set_var_def, get_var_imm_def, asmTheory.word_cmp_def]
         \\ simp [cut_res_def, call_env_def]
         \\ gvs []
         \\ fs [state_rel_def, empty_locals_def, ctxt_fc_def]


### PR DESCRIPTION
Adjust the crep_to_loop compilation phase to spot the case where the target is a constant "Label X" expression, and produce a call to a known target on the loopLang side. Hopefully this should result in static calls in the final binary, rather than needless indirect calls. Frustratingly, for a simple change, quite a lot of the proof script had to be amended.

I think the tests will pass, but I haven't run them comprehensively on my machine, in particular I haven't thought about
translation.