### PR TITLE
Add constructor names to record functions

### DIFF
--- a/candle/prover/candle_records.ml
+++ b/candle/prover/candle_records.ml
@@ -23,19 +23,32 @@ let Bb { a_string } = Bb { a_string = "5"; boolean = false; integer = 1 };;
 let x = Bb { a_string = "1"; boolean = false; integer = 2 };;
 let y = Aa 5;;
 
-(* Records can be updated using 'with': *)
-let z = { x with boolean = true; integer = 3; };;
+(* Records can be updated using 'with'. This updates the record 'x': *)
+let z = Bb { x with boolean = true; integer = 3; };;
 
-(* Record projection is done with a dot: *)
-let s = z.a_string;;
+(* Record projection is done with dots, using the name of the constructor and
+ * the name of the field: *)
+let s = z.Bb.a_string;;
 
 print (s ^ "\n");;
 print (Int.toString (m1 x) ^ " " ^ Int.toString (m1 y) ^ "\n");;
 print (a_string ^ "\n");;
 
+module Mod = struct
+  type blob = Cc of { cc: bool };;
+  let x = Cc { cc = true };;
+end;;
+
+(* It's possible to use records with qualified constructors:
+ * - Mod.x is to access the value x,
+ * - Mod.Cc is for the record constructor in Cc in Mod, and
+ * - cc is the field in the record Cc: *)
+print "cc=";;
+print (if Mod.x.Mod.Cc.cc then "true\n" else "false\n");;
+
 (* Limitations:
  * - It is not possible to name the matched fields in record pattern matches
- * - Record field names are unique: while it is possible to use the same field
- *   name in two records, the latter definition will overwrite the formers
- *   accessor functions.
+ * - Record constructors are present in all record-related syntax. This is
+ *   because records are implemented as a syntax extension in the Candle parser,
+ *   and the parser does not know what names belong to what records.
  *)

--- a/compiler/bootstrap/compilation/x64/64/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/64/Holmakefile
@@ -27,7 +27,7 @@ test-hello-cake: cake-$(ARCH)-$(WORD_SIZE).tar.gz
 
 test-candle-records: cake-$(ARCH)-$(WORD_SIZE).tar.gz
 	make cake
-	./cake --candle < candle_records.ml | tail -n11 > candle.out
+	./cake --candle < candle_records.ml | tail -n29 > candle.out
 	diff candle.out candle.expected
 
 cake-$(ARCH)-$(WORD_SIZE).tar.gz: cake.S basis_ffi.c Makefile hello.cml how-to.md cake-sexpr-32 cake-sexpr-64 config_enc_str.txt candle_boot.ml repl_boot.cml

--- a/compiler/bootstrap/compilation/x64/64/candle.expected
+++ b/compiler/bootstrap/compilation/x64/64/candle.expected
@@ -1,3 +1,13 @@
+#             val pp_thing = <fun>: thing -> pp_data
+val {record_constructor(Bb)(a_string)(boolean)(integer)} = <fun>: string -> bool -> int -> thing
+val {record_projection(Bb.a_string)} = <fun>: thing -> string
+val {record_projection(Bb.boolean)} = <fun>: thing -> bool
+val {record_projection(Bb.integer)} = <fun>: thing -> int
+val {record_update(Bb.a_string)} = <fun>: thing -> string -> thing
+val {record_update(Bb.boolean)} = <fun>: thing -> bool -> thing
+val {record_update(Bb.integer)} = <fun>: thing -> int -> thing
+#           val m1 = <fun>: thing -> int
+#     val a_string = "5": string
 #     val x = Bb ("1", false, 2): thing
 # val y = Aa 5: thing
 #     val z = Bb ("1", true, 3): thing
@@ -7,5 +17,13 @@ val it = (): unit
 # 2 5
 val it = (): unit
 # 5
+val it = (): unit
+#         val Mod.pp_blob = <fun>: blob -> pp_data
+val Mod.{record_constructor(Cc)(cc)} = <fun>: bool -> blob
+val Mod.{record_projection(Cc.cc)} = <fun>: blob -> bool
+val Mod.{record_update(Cc.cc)} = <fun>: blob -> bool -> blob
+val Mod.x = Cc true: blob
+#     cc=val it = (): unit
+# true
 val it = (): unit
 #     

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -540,16 +540,17 @@ Definition camlPEG_def[nocompute]:
        seql [pnt nUpdate; try (seql [tokeq SemiT; pnt nUpdates] I)]
             (bindNT nUpdates));
       (INL nERecUpdate,
-       seql [tokeq LbraceT; pnt nExpr; tokeq WithT; pnt nUpdates;
+       seql [pnt nConstr; tokeq LbraceT; pnt nExpr; tokeq WithT; pnt nUpdates;
              try (tokeq SemiT); tokeq RbraceT]
             (bindNT nERecUpdate));
       (INL nEBase,
        choicel [
          pegf (pnt nLiteral) (bindNT nEBase);
          pegf (pnt nValuePath) (bindNT nEBase);
+         (* N.B. nERecUpdate goes before nConstr, because they coincide *)
+         pegf (pnt nERecUpdate) (bindNT nEBase);
          pegf (pnt nConstr) (bindNT nEBase);
          pegf (pnt nEList) (bindNT nEBase);
-         pegf (pnt nERecUpdate) (bindNT nEBase);
          seql [tokeq LparT; tokeq RparT] (bindNT nEBase); (* unit *)
          seql [tokeq BeginT; tokeq EndT] (bindNT nEBase); (* unit *)
          seql [tokeq LparT; pnt nExpr;
@@ -576,7 +577,7 @@ Definition camlPEG_def[nocompute]:
       (* -- Expr14.5 ------------------------------------------------------- *)
       (INL nERecProj,
        seql [pnt nEIndex;
-             try (seql [tokeq DotT; pnt nFieldName] I)]
+             try (seql [tokeq DotT; pnt nConstr; tokeq DotT; pnt nFieldName] I)]
             (bindNT nERecProj));
       (* -- Expr14 --------------------------------------------------------- *)
       (INL nEAssert,

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -461,27 +461,39 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
 (* record projection and update *)
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
-  "x.foo"
-  (SOME $ eval “App Opapp [V (mk_record_proj_name "foo"); V "x"]”)
+  "x.Cons.foo"
+  (SOME $ eval “App Opapp [V (mk_record_proj_name "foo" "Cons");
+                           V "x"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
-  "{x with foo = bar}"
+  "Foo {x with foo = bar}"
   (SOME $ eval “App Opapp [App Opapp [
-                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”)
+                        V (mk_record_update_name "foo" "Foo"); V "x"];
+                        V "bar"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
-  "{x with foo = bar;}"
+  "Foo {x with foo = bar;}"
   (SOME $ eval “App Opapp [App Opapp [
-                        V (mk_record_update_name "foo"); V "x"]; V "bar"]”)
+                        V (mk_record_update_name "foo" "Foo"); V "x"];
+                        V "bar"]”)
   ;
 
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
-  "{x with foo = bar; baz = quux;}"
-  (SOME $ eval “App Opapp [App Opapp [V (mk_record_update_name "baz");
-           App Opapp [App Opapp [V (mk_record_update_name "foo");
+  "Foo {x with foo = bar; baz = quux;}"
+  (SOME $ eval “App Opapp [App Opapp [V (mk_record_update_name "baz" "Foo");
+           App Opapp [App Opapp [V (mk_record_update_name "foo" "Foo");
              V "x"]; V "bar"]]; V "quux"]”)
+  ;
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "Bar.Foo {x with foo = bar; baz = quux;}"
+  (SOME $ eval “App Opapp [App Opapp [
+                  Var (Long "Bar" (Short (mk_record_update_name "baz" "Foo")));
+                  App Opapp [App Opapp [
+                    Var (Long "Bar" (Short (mk_record_update_name "foo" "Foo")));
+                    V "x"]; V "bar"]]; V "quux"]”)
   ;
 
 (* construction *)
@@ -499,6 +511,11 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   NONE
   ;
 
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "Bar.Foo { f2 = 2; f1 = 1; f3 = 3;}"
+  NONE
+  ;
+
 (* declaration *)
 
 val _ = parsetest0 “nStart” “ptree_Start”
@@ -512,16 +529,16 @@ val _ = parsetest0 “nStart” “ptree_Start”
       [Dtype L [([],"rec1",[("Foo",[Attup [Atapp [] (Short "bool"); Atapp [] (Short "int")]])])];
        Dlet L1 (Pv (mk_record_constr_name "Foo" ["bar";"foo"]))
           (Fun "bar" (Fun "foo" (C "Foo" [Con NONE [V "bar"; V "foo"]])));
-        Dlet L2 (Pv (mk_record_proj_name "bar"))
+        Dlet L2 (Pv (mk_record_proj_name "bar" "Foo"))
           (Fun "" (Mat (V "") [(Pc "Foo" [Pcon NONE [Pv "bar"; Pv "foo"]],V "bar")]));
-        Dlet L3 (Pv (mk_record_proj_name "foo"))
+        Dlet L3 (Pv (mk_record_proj_name "foo" "Foo"))
           (Fun "" (Mat (V "") [(Pc "Foo" [Pcon NONE [Pv "bar"; Pv "foo"]],V "foo")]));
-        Dlet L4 (Pv (mk_record_update_name "bar"))
+        Dlet L4 (Pv (mk_record_update_name "bar" "Foo"))
           (Fun ""
              (Mat (V "")
                 [(Pc "Foo" [Pcon NONE [Pv "bar"; Pv "foo"]],
                   Fun "bar" (C "Foo" [Con NONE [V "bar"; V "foo"]]))]));
-        Dlet L5 (Pv (mk_record_update_name "foo"))
+        Dlet L5 (Pv (mk_record_update_name "foo" "Foo"))
           (Fun ""
              (Mat (V "")
                 [(Pc "Foo" [Pcon NONE [Pv "bar"; Pv "foo"]],
@@ -546,6 +563,12 @@ val _ = parsetest0 “nStart” “ptree_Start”
 val _ = parsetest0 “nStart” “ptree_Start”
   "match y with\
   \  Foo {z} -> f z;;"
+  NONE
+  ;
+
+val _ = parsetest0 “nStart” “ptree_Start”
+  "match y with\
+  \  Bar.Foo {z} -> f z;;"
   NONE
   ;
 


### PR DESCRIPTION
This PR makes it possible to use the same field names accross different record types. To support this, the syntax has changed a bit. Now the constructor must appear in all record syntax:
```ocaml
(* record update *)
Cons { x with f1 = e1; f2 = e2; ...; fN = eN }
(* record projection *)
x.Cons.f1
```