### PR TITLE
Make the double type distinct from word64

### DIFF
--- a/basis/DoubleProgScript.sml
+++ b/basis/DoubleProgScript.sml
@@ -20,7 +20,7 @@ val _ = ml_prog_update (open_module "Double");
 val () = generate_sigs := true;
 
 val _ = ml_prog_update (add_dec
-  ``Dtabbrev unknown_loc [] "double" (Atapp [] (Short "word64"))`` I);
+  ``Dtabbrev unknown_loc [] "double" (Atapp [] (Short "double"))`` I);
 
 val _ = ml_prog_update open_local_block;
 
@@ -143,6 +143,16 @@ fun monop s b = “[Dlet unknown_loc (Pvar ^s)
 val _ = append_prog $ monop “"abs"” “FP_Abs”;
 val _ = append_prog $ monop “"sqrt"” “FP_Sqrt”;
 val _ = append_prog $ monop “"~"” “FP_Neg”;
+
+(* Pretty-printer *)
+
+val pp_double_tm = “
+  [Dlet unknown_loc
+     (Pvar "pp_double")
+     (Fun "x" (App Opapp [
+        Var (Long "PrettyPrinter" (Short "token"));
+        App Opapp [Var (Short "toString"); Var (Short "x")]]))]”;
+val _ = append_prog pp_double_tm;
 
 val _ = ml_prog_update (close_module NONE);
 

--- a/basis/types.txt
+++ b/basis/types.txt
@@ -288,6 +288,7 @@ Double.=: Double.double -> Double.double -> bool
 Double.abs: Double.double -> Double.double
 Double.sqrt: Double.double -> Double.double
 Double.~: Double.double -> Double.double
+Double.pp_double: Double.double -> PrettyPrinter.pp_data
 Marshalling.n2w2: int -> byte_array -> int -> unit
 Marshalling.w22n: byte_array -> int -> int
 TextIO.stdIn: TextIO.instream

--- a/semantics/primTypesScript.sml
+++ b/semantics/primTypesScript.sml
@@ -62,6 +62,7 @@ Definition prim_tenv_def:
               [("array",["'a"],Tapp [Tvar "'a"] Tarray_num);
                ("bool",[],Tapp [] Tbool_num);
                ("char",[],Tapp [] Tchar_num);
+               ("double",[],Tapp [] Tdouble_num);
                ("exn",[],Tapp [] Texn_num);
                ("int",[],Tapp [] Tint_num);
                (* Tfn is ->, specially handled *)

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -37,6 +37,6 @@ cake: cake.S basis_ffi.c
 
 basis-types-output: cake
 	echo "" | ./cake --types 2> $@
-	diff $@ $(CAKEMLDIR)/basis/types.txt
+	diff --context $(CAKEMLDIR)/basis/types.txt $@
 
 EXTRA_CLEANS = cake.S cake-sexpr-$(ARCH)-$(WORD_SIZE) cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz how-to.output how-to.cake how-to.cml extract_code.cake cake basis-types-output


### PR DESCRIPTION
This PR makes the `double` type distinct from word64, by adding it to prim_types, and removing the type abbreviation in the Double module. It also adds a pretty-printer for doubles to the REPL.

Closes #1021.