### PR TITLE
Candle pattern parsing fixes

### DIFF
--- a/compiler/bootstrap/translation/caml_parserProgScript.sml
+++ b/compiler/bootstrap/translation/caml_parserProgScript.sml
@@ -226,6 +226,13 @@ val r = preprocess ptree_TypeDefinition_def |> translate;
 val r = preprocess ptree_ModuleType_def |> translate;
 val r = preprocess ptree_Definition_def |> translate;
 
+Theorem destresult_side[local]:
+  pegexec_destresult_side v = (?r. v = Result r)
+Proof
+  rw [fetch "-" "pegexec_destresult_side_def"]
+  \\ Cases_on `v` \\ gs []
+QED
+
 Theorem ptree_definition_side:
   (∀x. camlptreeconversion_ptree_definition_side x) ∧
   (∀x. camlptreeconversion_ptree_modexpr_side x) ∧
@@ -240,9 +247,10 @@ Proof
            parserProgTheory.peg_exec_side_def,
            parserProgTheory.coreloop_side_def]
   \\ rename [‘lexer_fun inp’]
-  \\ qspec_then ‘lexer_fun inp’ strip_assume_tac
+  \\ qspec_then ‘lexer_fun$lexer_fun inp’ strip_assume_tac
                 cmlPEGTheory.owhile_TopLevelDecs_total
   \\ fs [parserProgTheory.INTRO_FLOOKUP, SF ETA_ss]
+  \\ simp [destresult_side, cmlPEGTheory.parse_TopLevelDecs_total]
 QED
 
 val _ = List.map update_precondition (CONJUNCTS ptree_definition_side);

--- a/compiler/bootstrap/translation/caml_parserProgScript.sml
+++ b/compiler/bootstrap/translation/caml_parserProgScript.sml
@@ -40,7 +40,6 @@ fun list_mk_fun_type [ty] = ty
   | list_mk_fun_type _ = fail()
 
 val _ = add_preferred_thy "-";
-(*val _ = add_preferred_thy "termination";*)
 
 Theorem NOT_NIL_AND_LEMMA:
    (b <> [] /\ x) = if b = [] then F else x
@@ -153,7 +152,7 @@ QED
 
 val _ = update_precondition ptree_PPattern_side;
 
-val r = preprocess ptree_Pattern_def |> translate;
+val r = preprocess ptree_Pattern_PMATCH |> translate;
 
 (* This takes a long time.
  *)

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -784,7 +784,7 @@ Definition camlPEG_def[nocompute]:
             (bindNT nPRecFields));
       (INL nPCons, (* ::= constr ('{' fields '}' | p?) *)
        pegf (choicel [seql [pnt nConstr;
-                            choicel [pnt nPRecFields; try (pnt nPBase)]] I;
+                            choicel [pnt nPRecFields; try (pnt nPCons)]] I;
                       pnt nPBase])
             (bindNT nPCons));
       (INL nPAs, (* ::= p ('as' id)* *)

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -770,9 +770,9 @@ Definition camlPEG_def[nocompute]:
        choicel [pegf (pnt nLiteral) (bindNT nPatLiteral);
                 seql [tokeq MinusT; tok isInt mktokLf]
                      (bindNT nPatLiteral)]);
-      (INL nPBase, (* ::= any / var / lit / list / '(' p ')' *)
+      (INL nPBase, (* ::= any / var / lit / list / '(' p ')' / constr *)
        pegf (choicel [pnt nPatLiteral; pnt nValueName; pnt nPAny; pnt nPList;
-                      pnt nPPar])
+                      pnt nPPar; pnt nConstr])
             (bindNT nPBase));
       (* -- Pat2 ----------------------------------------------------------- *)
       (INL nPRecFields, (* '{' field (';' field)* ';'? '}' *)
@@ -784,7 +784,7 @@ Definition camlPEG_def[nocompute]:
             (bindNT nPRecFields));
       (INL nPCons, (* ::= constr ('{' fields '}' | p?) *)
        pegf (choicel [seql [pnt nConstr;
-                            choicel [pnt nPRecFields; try (pnt nPCons)]] I;
+                            choicel [pnt nPRecFields; pnt nPBase]] I;
                       pnt nPBase])
             (bindNT nPCons));
       (INL nPAs, (* ::= p ('as' id)* *)

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -797,8 +797,13 @@ Definition camlPEG_def[nocompute]:
             (bindNT nPOps));
       (INL nPattern,
        pegf (pnt nPOps) (bindNT nPattern));
+      (* This rule is used for the patterns in let (rec) and fun, and since
+       * these allow curried pattern arguments, we must not let applications
+       * and similar be unparenthesized. This is why we accept nPBase instead
+       * of nPattern. nPBase contains single-token patterns, and patterns
+       * enclosed in [] or (). *)
       (INL nPatterns,
-       seql [pnt nPattern; try (pnt nPatterns)]
+       seql [pnt nPBase; try (pnt nPatterns)]
             (bindNT nPatterns));
       (INL nStart,
        seql [try (pnt nModuleItems)] (bindNT nStart))

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -1101,15 +1101,21 @@ Definition ptree_PPattern_def:
             n <- nterm_of arg;
             if n = INL nValueName then
               fmap Pp_var (ptree_ValueName arg)
-            else if n = INL nPatLiteral then
-              ptree_PPattern arg
-            else if n = INL nPAny ∨ n = INL nPList ∨ n = INL nPPar then
+            else if n = INL nConstr then
+              do
+                cns <- ptree_Constr arg;
+                id <- path_to_ns locs cns;
+                return $ Pp_con (SOME id) []
+              od
+            else if n = INL nPatLiteral ∨ n = INL nPAny ∨ n = INL nPList ∨
+                    n = INL nPPar then
               ptree_PPattern arg
             else
               fail (locs, «Impossible: nPBase»)
          od
       | _ => fail (locs, «Impossible: nPBase»)
-    else if nterm = INL nPCons then case args of
+    else if nterm = INL nPCons then
+      case args of
         [cn] =>
           do
             cns <- ptree_Constr cn;

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -3184,7 +3184,7 @@ Definition peg_def:
 End
 
 Overload cmlpegexec[local] =
-  ``λn t. peg_exec cmlPEG$cmlPEG (pnt n) t [] NONE [] done failed``;
+  ``λn t. peg_exec cmlPEG$cmlPEG (cmlPEG$pnt n) t [] NONE [] done failed``;
 
 Definition ptree_Definition_def:
   (ptree_Definition (Lf (_, locs)) =

--- a/compiler/parsing/ocaml/camlPtreeConversionScript.sml
+++ b/compiler/parsing/ocaml/camlPtreeConversionScript.sml
@@ -8,6 +8,9 @@ local open cmlParseTheory lexer_implTheory in end
 
 val _ = new_theory "camlPtreeConversion";
 
+val _ = set_grammar_ancestry [
+  "misc", "pegexec", "caml_lex", "camlPEG", "ast", "precparser", "sum"];
+
 (* -------------------------------------------------------------------------
  * Sum monad syntax
  * ------------------------------------------------------------------------- *)
@@ -3180,6 +3183,9 @@ Definition peg_def:
   peg (Success (_: (tokens$token # locs) list) x _) = return x
 End
 
+Overload cmlpegexec[local] =
+  ``λn t. peg_exec cmlPEG$cmlPEG (pnt n) t [] NONE [] done failed``;
+
 Definition ptree_Definition_def:
   (ptree_Definition (Lf (_, locs)) =
     fail (locs, «Expected a top-level definition non-terminal»)) ∧
@@ -3200,9 +3206,9 @@ Definition ptree_Definition_def:
               fail (locs, «The CakeML lexer failed»)
             else
               do
-                pts <- peg (destResult (cmlpegexec nTopLevelDecs toks));
+                pts <- peg (destResult (cmlpegexec gram$nTopLevelDecs toks));
                 pt <- option $ oHD pts;
-                option $ ptree_TopLevelDecs pt
+                option $ cmlPtreeConversion$ptree_TopLevelDecs pt
               od ++ fail (locs, «The CakeML parser failed»)
           od
       | _ => fail (locs, «Impossible: nCakeMLPragma»)

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1495,6 +1495,13 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
                             Pc "Append" [Pv "w"; Pv "t"]]]”)
   ;
 
+
+(* 2024-07-25: Pattern constructors applied to pattern constructors *)
+val _ = parsetest0 “nPattern” “ptree_Pattern”
+  "Some Some None"
+  (SOME $ eval “[mkpat $  Pc "Some" [Pc "Some" [Pc "None" []]]]”)
+  ;
+
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "Append (Append (v, s), Append (w, t))"
   (SOME “C "Append" [C "Append" [V "v"; V "s"];

--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -124,6 +124,15 @@ end;
 
 fun parsetest t1 t2 s = parsetest0 t1 t2 s NONE;
 
+exception ExpectedFailure;
+fun expectFailure prefix test =
+  (test (); raise ExpectedFailure)
+  handle Fail m =>
+    if String.isPrefix ("Failed " ^ prefix) m then
+      print ("OK, failed as expected, message: " ^ m ^ "\n")
+    else
+      (print "Unexpected failure!\n"; raise Fail m);
+
 (* -------------------------------------------------------------------------
  * Various identifiers
  * ------------------------------------------------------------------------- *)
@@ -209,12 +218,10 @@ val _ = parsetest0 “nStart” “ptree_Start”
           Dlet L2 (Pv "y") (V "y")]”)
   ;
 
-(* This fails, as expected:
-val _ = parsetest0 “nStart” “ptree_Start”
-  "let x = (*CML val x = x; *) 6;;"
-  NONE
-  ;
- *)
+val _ = expectFailure "REMAINING INPUT"
+      (fn () => parsetest0 “nStart” “ptree_Start”
+                           "let x = (*CML val x = x; *) 6;;"
+                           NONE);
 
 (* -------------------------------------------------------------------------
  * Types
@@ -1495,13 +1502,6 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
                             Pc "Append" [Pv "w"; Pv "t"]]]”)
   ;
 
-
-(* 2024-07-25: Pattern constructors applied to pattern constructors *)
-val _ = parsetest0 “nPattern” “ptree_Pattern”
-  "Some Some None"
-  (SOME $ eval “[mkpat $  Pc "Some" [Pc "Some" [Pc "None" []]]]”)
-  ;
-
 val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "Append (Append (v, s), Append (w, t))"
   (SOME “C "Append" [C "Append" [V "v"; V "s"];
@@ -1513,7 +1513,6 @@ val _ = parsetest0 “nPattern” “ptree_Pattern”
   (SOME $ eval “[mkpat $ Pcon NONE [Pc "Var" [Pany; Pany];
                                     Pc "Comb" [Pany; Pany]]]”)
   ;
-
 
 val _ = parsetest0 “nStart” “ptree_Start”
   "let x = 2 ;; (*CML val x = 5; print \"z\"; fun ref x = Ref x; *)"
@@ -1625,6 +1624,50 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   "Double.(-)"
   (SOME “Var (Long "Double" (Short "-"))”)
   ;
+
+(* 2024-07-25: Pattern constructors applied to pattern constructors *)
+val _ = parsetest0 “nPattern” “ptree_Pattern”
+  "Some (Some None)"
+  (SOME $ eval “[mkpat $  Pc "Some" [Pc "Some" [Pc "None" []]]]”)
+  ;
+
+(* 2024-07-27: Parse patterns in function lets properly: require parenthesis
+ * around anything below nPBase.
+ *)
+
+(* Application of the constructor Some to the variable x: *)
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let f (Some x) = y"
+  (SOME $ eval
+   “[Dlet L (Pv "f") (Fun "" (Mat (V"") [(Pc "Some" [Pv "x"], V "y")]))]”)
+  ;
+
+(* A function with two arguments: the first pattern-matching on the constructor
+ * Some (with no arguments), and the second, a variable: *)
+val _ = parsetest0 “nStart” “ptree_Start”
+  "let f Some x = y"
+  (SOME $ eval
+   “[Dlet L (Pv "f") (Fun "" (Mat (V"") [(Pc "Some" [], Fun "x" (V "y"))]))]”)
+  ;
+
+(* This should fail: we require parenthesis around ambiguous patterns here: *)
+val _ = expectFailure "FAILED" (fn () =>
+  parsetest0 “nExpr” “ptree_Expr nExpr”
+  "fun x,y -> z"
+  NONE);
+
+
+(* This should fail: we require parenthesis around ambiguous patterns here: *)
+val _ = expectFailure "REMAINING INPUT" (fn () =>
+  parsetest0 “nStart” “ptree_Start”
+  "let f x,y = z"
+  NONE);
+
+(* This is OK though: *)
+val _ =
+  parsetest0 “nStart” “ptree_Start”
+  "let x,y = z"
+  NONE;
 
 val _ = export_theory ();
 


### PR DESCRIPTION
Fixes to the pattern parts of the Candle parser PEG:
- function argument patterns must now be properly parenthesized: `let f Some n` is not pattern matching on `Some` properly, `let f (Some n)` is.
- constructors can now be nested without parenthesis where applicable: `match x with | Some None -> ...`

Closes #1027. Closes #1020.