### PR TITLE
Pancake mul to exp

### DIFF
--- a/compiler/backend/proofs/word_to_wordProofScript.sml
+++ b/compiler/backend/proofs/word_to_wordProofScript.sml
@@ -833,14 +833,48 @@ Proof
      no_install_def]
 QED
 
+Theorem try_if_hoist2_no_install:
+  ! N p1 interm dummy p2 s.
+  try_if_hoist2 N p1 interm dummy p2 = SOME p3 ==>
+  no_install p1 ==> no_install p2 ==> no_install interm ==>
+  no_install p3
+Proof
+  ho_match_mp_tac word_simpTheory.try_if_hoist2_pmatch_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ REWRITE_TAC [Once word_simpTheory.try_if_hoist2_def]
+  \\ rw []
+  \\ fs [CaseEq "bool", CaseEq "wordLang$prog",
+        CaseEq "option", CaseEq "prod"]
+  \\ gvs []
+  \\ fs [no_install_def]
+  \\ irule (const_fp_no_install |> Q.GEN `r` |> SIMP_RULE std_ss [])
+  \\ gs [no_install_def, word_simpProofTheory.dest_If_thm]
+QED
+
+Theorem simp_duplicate_if_no_install:
+  !prog. no_install prog ==>
+  no_install (simp_duplicate_if prog)
+Proof
+  ho_match_mp_tac word_simpTheory.simp_duplicate_if_pmatch_ind
+  \\ rw []
+  \\ ONCE_REWRITE_TAC [word_simpTheory.simp_duplicate_if_def]
+  \\ TOP_CASE_TAC \\ fs [no_install_def]
+  \\ every_case_tac \\ fs [no_install_def]
+  \\ irule Seq_assoc_no_install
+  \\ fs [no_install_def, word_simpTheory.try_if_hoist1_def, CaseEq "option", CaseEq "prod"]
+  \\ drule try_if_hoist2_no_install
+  \\ simp [no_install_def]
+QED
+
 Theorem compile_exp_no_install:
   no_install prog ⇒
   no_install (compile_exp prog)
 Proof
   rw[word_simpTheory.compile_exp_def]>>
+  irule simp_duplicate_if_no_install>>gs[]>>
   irule const_fp_no_install>>gs[]>>
-  qexists_tac ‘simp_if (Seq_assoc Skip prog)’>>rw[]>>
-  irule simp_if_no_install>>
+  irule_at Any EQ_REFL >>
   irule Seq_assoc_no_install>>
   rw[no_install_def]
 QED
@@ -1136,14 +1170,48 @@ Proof
      no_alloc_def]
 QED
 
+Theorem try_if_hoist2_no_alloc:
+  ! N p1 interm dummy p2 s.
+  try_if_hoist2 N p1 interm dummy p2 = SOME p3 ==>
+  no_alloc p1 ==> no_alloc p2 ==> no_alloc interm ==>
+  no_alloc p3
+Proof
+  ho_match_mp_tac word_simpTheory.try_if_hoist2_pmatch_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ REWRITE_TAC [Once word_simpTheory.try_if_hoist2_def]
+  \\ rw []
+  \\ fs [CaseEq "bool", CaseEq "wordLang$prog",
+        CaseEq "option", CaseEq "prod"]
+  \\ gvs []
+  \\ fs [no_alloc_def]
+  \\ irule (const_fp_no_alloc |> Q.GEN `r` |> SIMP_RULE std_ss [])
+  \\ gs [no_alloc_def, word_simpProofTheory.dest_If_thm]
+QED
+
+Theorem simp_duplicate_if_no_alloc:
+  !prog. no_alloc prog ==>
+  no_alloc (simp_duplicate_if prog)
+Proof
+  ho_match_mp_tac word_simpTheory.simp_duplicate_if_pmatch_ind
+  \\ rw []
+  \\ ONCE_REWRITE_TAC [word_simpTheory.simp_duplicate_if_def]
+  \\ TOP_CASE_TAC \\ fs [no_alloc_def]
+  \\ every_case_tac \\ fs [no_alloc_def]
+  \\ irule Seq_assoc_no_alloc
+  \\ fs [no_alloc_def, word_simpTheory.try_if_hoist1_def, CaseEq "option", CaseEq "prod"]
+  \\ drule try_if_hoist2_no_alloc
+  \\ simp [no_alloc_def]
+QED
+
 Theorem compile_exp_no_alloc:
   no_alloc prog ⇒
   no_alloc (compile_exp prog)
 Proof
   rw[word_simpTheory.compile_exp_def]>>
+  irule simp_duplicate_if_no_alloc >>
   irule const_fp_no_alloc>>gs[]>>
-  qexists_tac ‘simp_if (Seq_assoc Skip prog)’>>rw[]>>
-  irule simp_if_no_alloc>>
+  irule_at Any EQ_REFL >>
   irule Seq_assoc_no_alloc>>
   rw[no_alloc_def]
 QED
@@ -1922,14 +1990,48 @@ Proof
      no_mt_def]
 QED
 
+Theorem try_if_hoist2_no_mt:
+  ! N p1 interm dummy p2 s.
+  try_if_hoist2 N p1 interm dummy p2 = SOME p3 ==>
+  no_mt p1 ==> no_mt p2 ==> no_mt interm ==>
+  no_mt p3
+Proof
+  ho_match_mp_tac word_simpTheory.try_if_hoist2_pmatch_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ REWRITE_TAC [Once word_simpTheory.try_if_hoist2_def]
+  \\ rw []
+  \\ fs [CaseEq "bool", CaseEq "wordLang$prog",
+        CaseEq "option", CaseEq "prod"]
+  \\ gvs []
+  \\ fs [no_mt_def]
+  \\ irule (const_fp_no_mt |> Q.GEN `r` |> SIMP_RULE std_ss [])
+  \\ gs [no_mt_def, word_simpProofTheory.dest_If_thm]
+QED
+
+Theorem simp_duplicate_if_no_mt:
+  !prog. no_mt prog ==>
+  no_mt (simp_duplicate_if prog)
+Proof
+  ho_match_mp_tac word_simpTheory.simp_duplicate_if_pmatch_ind
+  \\ rw []
+  \\ ONCE_REWRITE_TAC [word_simpTheory.simp_duplicate_if_def]
+  \\ TOP_CASE_TAC \\ fs [no_mt_def]
+  \\ every_case_tac \\ fs [no_mt_def]
+  \\ irule Seq_assoc_no_mt
+  \\ fs [no_mt_def, word_simpTheory.try_if_hoist1_def, CaseEq "option", CaseEq "prod"]
+  \\ drule try_if_hoist2_no_mt
+  \\ simp [no_mt_def]
+QED
+
 Theorem compile_exp_no_mt:
   no_mt prog ==>
   no_mt (compile_exp prog)
 Proof
   rw[word_simpTheory.compile_exp_def]>>
+  irule simp_duplicate_if_no_mt >>
   irule const_fp_no_mt>>gs[]>>
-  qexists_tac ‘simp_if (Seq_assoc Skip prog)’>>rw[]>>
-  irule simp_if_no_mt>>
+  irule_at Any EQ_REFL >>
   irule Seq_assoc_no_mt>>
   rw[no_mt_def]
 QED
@@ -2327,14 +2429,48 @@ Proof
      no_share_inst_def]
 QED
 
+Theorem try_if_hoist2_no_share_inst:
+  ! N p1 interm dummy p2 s.
+  try_if_hoist2 N p1 interm dummy p2 = SOME p3 ==>
+  no_share_inst p1 ==> no_share_inst p2 ==> no_share_inst interm ==>
+  no_share_inst p3
+Proof
+  ho_match_mp_tac word_simpTheory.try_if_hoist2_pmatch_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ REWRITE_TAC [Once word_simpTheory.try_if_hoist2_def]
+  \\ rw []
+  \\ fs [CaseEq "bool", CaseEq "wordLang$prog",
+        CaseEq "option", CaseEq "prod"]
+  \\ gvs []
+  \\ fs [no_share_inst_def]
+  \\ irule (const_fp_no_share_inst |> Q.GEN `r` |> SIMP_RULE std_ss [])
+  \\ gs [no_share_inst_def, word_simpProofTheory.dest_If_thm]
+QED
+
+Theorem simp_duplicate_if_no_share_inst:
+  !prog. no_share_inst prog ==>
+  no_share_inst (simp_duplicate_if prog)
+Proof
+  ho_match_mp_tac word_simpTheory.simp_duplicate_if_pmatch_ind
+  \\ rw []
+  \\ ONCE_REWRITE_TAC [word_simpTheory.simp_duplicate_if_def]
+  \\ TOP_CASE_TAC \\ fs [no_share_inst_def]
+  \\ every_case_tac \\ fs [no_share_inst_def]
+  \\ irule Seq_assoc_no_share_inst
+  \\ fs [no_share_inst_def, word_simpTheory.try_if_hoist1_def, CaseEq "option", CaseEq "prod"]
+  \\ drule try_if_hoist2_no_share_inst
+  \\ simp [no_share_inst_def]
+QED
+
 Theorem compile_exp_no_share_inst:
   no_share_inst prog ⇒
   no_share_inst (compile_exp prog)
 Proof
   rw[word_simpTheory.compile_exp_def]>>
+  irule simp_duplicate_if_no_share_inst>>gs[]>>
   irule const_fp_no_share_inst>>gs[]>>
-  qexists_tac ‘simp_if (Seq_assoc Skip prog)’>>rw[]>>
-  irule simp_if_no_share_inst>>
+  irule_at Any EQ_REFL >>
   irule Seq_assoc_no_share_inst>>
   rw[no_share_inst_def]
 QED

--- a/compiler/backend/word_simpScript.sml
+++ b/compiler/backend/word_simpScript.sml
@@ -488,9 +488,9 @@ End
 Theorem is_simple_def[compute] = is_simple_pmatch_def
   |> CONV_RULE (DEPTH_CONV patternMatchesLib.PMATCH_ELIM_CONV)
 
-Definition try_if_hoist2_pmatch_def[nocompute]:
+Definition try_if_hoist2_def:
   try_if_hoist2 N p1 interm dummy p2 = if N = 0n then NONE
-  else case p1 of
+  else dtcase p1 of
     | wordLang$If cmp lhs rhs br1 br2 =>
       let res1 = dest_Raise_num (SND (dest_Seq (const_fp (Seq (Seq br1 interm) dummy)))) in
       if res1 = 0n then NONE
@@ -517,9 +517,6 @@ Definition try_if_hoist2_pmatch_def[nocompute]:
     | _ => NONE
 End
 
-Theorem try_if_hoist2_def[compute] = try_if_hoist2_pmatch_def
-  |> CONV_RULE (DEPTH_CONV patternMatchesLib.PMATCH_ELIM_CONV)
-
 Definition try_if_hoist1_def:
   try_if_hoist1 p1 p2 = (dtcase dest_If p2 of
   | NONE => NONE
@@ -530,8 +527,8 @@ Definition try_if_hoist1_def:
   )
 End
 
-Definition simp_duplicate_if_pmatch_def[nocompute]:
-  simp_duplicate_if p = case p of
+Definition simp_duplicate_if_def:
+  simp_duplicate_if p = dtcase p of
   | MustTerminate q => MustTerminate (simp_duplicate_if q)
   | Call ret_prog dest args handler =>
      Call (dtcase ret_prog of
@@ -552,9 +549,6 @@ Definition simp_duplicate_if_pmatch_def[nocompute]:
   )
   | _ => p
 End
-
-Theorem simp_duplicate_if_def[compute] = simp_duplicate_if_pmatch_def
-  |> CONV_RULE (DEPTH_CONV patternMatchesLib.PMATCH_ELIM_CONV)
 
 (* all of them together *)
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -368,11 +368,11 @@ val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> sp
 (* TODO: remove when pmatch is fixed *)
 val _ = translate (spec32 const_fp_loop_def)
 
-val _ = translate (spec32 is_simple_def)
-val _ = translate (spec32 dest_Raise_num_def)
-val _ = translate (spec32 try_if_hoist2_def)
+val _ = translate (spec32 is_simple_pmatch_def)
+val _ = translate (spec32 dest_Raise_num_pmatch_def)
+val _ = translate (spec32 try_if_hoist2_pmatch_def)
 val _ = translate (spec32 try_if_hoist1_def)
-val _ = translate (spec32 simp_duplicate_if_def)
+val _ = translate (spec32 simp_duplicate_if_pmatch_def)
 
 val _ = translate (spec32 compile_exp_def)
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -368,6 +368,12 @@ val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> sp
 (* TODO: remove when pmatch is fixed *)
 val _ = translate (spec32 const_fp_loop_def)
 
+val _ = translate (spec32 is_simple_def)
+val _ = translate (spec32 dest_Raise_num_def)
+val _ = translate (spec32 try_if_hoist2_def)
+val _ = translate (spec32 try_if_hoist1_def)
+val _ = translate (spec32 simp_duplicate_if_def)
+
 val _ = translate (spec32 compile_exp_def)
 
 val _ = translate (wordLangTheory.max_var_inst_def |> conv32)

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -370,9 +370,9 @@ val _ = translate (spec32 const_fp_loop_def)
 
 val _ = translate (spec32 is_simple_pmatch_def)
 val _ = translate (spec32 dest_Raise_num_pmatch_def)
-val _ = translate (spec32 try_if_hoist2_pmatch_def)
+val _ = translate (spec32 try_if_hoist2_def)
 val _ = translate (spec32 try_if_hoist1_def)
-val _ = translate (spec32 simp_duplicate_if_pmatch_def)
+val _ = translate (spec32 simp_duplicate_if_def)
 
 val _ = translate (spec32 compile_exp_def)
 

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -359,6 +359,12 @@ val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> sp
 (* TODO: remove when pmatch is fixed *)
 val _ = translate (spec64 const_fp_loop_def)
 
+val _ = translate (spec64 is_simple_def)
+val _ = translate (spec64 dest_Raise_num_def)
+val _ = translate (spec64 try_if_hoist2_def)
+val _ = translate (spec64 try_if_hoist1_def)
+val _ = translate (spec64 simp_duplicate_if_def)
+
 val _ = translate (spec64 compile_exp_def)
 
 val _ = translate (wordLangTheory.max_var_inst_def |> conv64)

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -359,11 +359,11 @@ val _ = translate (asmTheory.word_cmp_def |> REWRITE_RULE[WORD_LO,WORD_LT] |> sp
 (* TODO: remove when pmatch is fixed *)
 val _ = translate (spec64 const_fp_loop_def)
 
-val _ = translate (spec64 is_simple_def)
-val _ = translate (spec64 dest_Raise_num_def)
-val _ = translate (spec64 try_if_hoist2_def)
+val _ = translate (spec64 is_simple_pmatch_def)
+val _ = translate (spec64 dest_Raise_num_pmatch_def)
+val _ = translate (spec64 try_if_hoist2_pmatch_def)
 val _ = translate (spec64 try_if_hoist1_def)
-val _ = translate (spec64 simp_duplicate_if_def)
+val _ = translate (spec64 simp_duplicate_if_pmatch_def)
 
 val _ = translate (spec64 compile_exp_def)
 

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -361,9 +361,9 @@ val _ = translate (spec64 const_fp_loop_def)
 
 val _ = translate (spec64 is_simple_pmatch_def)
 val _ = translate (spec64 dest_Raise_num_pmatch_def)
-val _ = translate (spec64 try_if_hoist2_pmatch_def)
+val _ = translate (spec64 try_if_hoist2_def)
 val _ = translate (spec64 try_if_hoist1_def)
-val _ = translate (spec64 simp_duplicate_if_pmatch_def)
+val _ = translate (spec64 simp_duplicate_if_def)
 
 val _ = translate (spec64 compile_exp_def)
 

--- a/cv_translator/backend_32_cvScript.sml
+++ b/cv_translator/backend_32_cvScript.sml
@@ -399,6 +399,12 @@ Proof
 QED
 
 val _ = word_simpTheory.const_fp_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.is_simple_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.dest_Raise_num_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.try_if_hoist2_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.rewrite_duplicate_if_max_reassoc_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.try_if_hoist1_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.simp_duplicate_if_def |> arch_spec |> cv_trans;
 val _ = word_simpTheory.compile_exp_def |> arch_spec |> cv_trans;
 
 val _ = data_to_wordTheory.real_addr_def |> arch_spec

--- a/cv_translator/backend_64_cvScript.sml
+++ b/cv_translator/backend_64_cvScript.sml
@@ -399,6 +399,12 @@ Proof
 QED
 
 val _ = word_simpTheory.const_fp_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.is_simple_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.dest_Raise_num_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.try_if_hoist2_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.rewrite_duplicate_if_max_reassoc_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.try_if_hoist1_def |> arch_spec |> cv_trans;
+val _ = word_simpTheory.simp_duplicate_if_def |> arch_spec |> cv_trans;
 val _ = word_simpTheory.compile_exp_def |> arch_spec |> cv_trans;
 
 val _ = data_to_wordTheory.real_addr_def |> arch_spec

--- a/pancake/README.md
+++ b/pancake/README.md
@@ -7,6 +7,9 @@ Crepe: instrctuons are similar to that of
 Pancake, but we flatten locals from
 struct-layout to word-layout
 
+[crep_arithScript.sml](crep_arithScript.sml):
+Simplification of arithmetic in crepLang.
+
 [crep_to_loopScript.sml](crep_to_loopScript.sml):
 Compilation from crepLang to panLang.
 

--- a/pancake/crep_arithScript.sml
+++ b/pancake/crep_arithScript.sml
@@ -1,0 +1,107 @@
+(*
+  Simplification of arithmetic in crepLang.
+*)
+open preamble crepLangTheory
+
+val _ = new_theory "crep_arith"
+
+val _ = set_grammar_ancestry
+        ["crepLang"];
+
+
+Definition dest_const_def:
+  dest_const (Const w) = SOME w /\
+  dest_const _ = NONE
+End
+
+Definition dest_2exp_def:
+  dest_2exp n w = if w = 0w then NONE
+    else if w = 1w then SOME n
+    else if word_bit 0 w then NONE
+    else dest_2exp (n + 1n) (word_lsr w 1n)
+End
+
+Triviality dest_2exp_lemma:
+  ! i w n. dest_2exp i w = SOME n ==>
+  i <= n /\ w = word_lsl 1w (n - i)
+Proof
+  ho_match_mp_tac dest_2exp_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ rw [Once dest_2exp_def]
+  \\ fs []
+  \\ qsuff_tac `alignment$aligned 1n w`
+  >- (
+    rw []
+    \\ fs [aligned_def]
+    \\ pop_assum (ONCE_REWRITE_TAC o single o GSYM)
+    \\ simp [align_shift]
+  )
+  >- (
+    fs [aligned_1_lsb, word_lsb_def, word_bit_def]
+  )
+QED
+
+Theorem dest_2exp_thm:
+  dest_2exp 0n w = SOME n2 ==>
+  w = word_lsl 1w n2
+Proof
+  rw [] \\ imp_res_tac dest_2exp_lemma \\ fs []
+QED
+
+Definition mul_const_def:
+  mul_const exp c = if c = 0w then Const 0w
+    else if c = 1w then exp
+    else (case dest_2exp 0n c of
+      | NONE => Crepop Mul [exp; Const c]
+      | SOME i => Shift Lsl exp i
+    )
+End
+
+Definition simp_exp_def:
+  (simp_exp (Crepop op exps) =
+    let exps = MAP simp_exp exps in
+    case (op, exps) of
+    | (Mul, [exp1; exp2]) => (
+        case (dest_const exp1, dest_const exp2) of
+        | (SOME c, _) => mul_const exp2 c
+        | (_, SOME c) => mul_const exp1 c
+        | _ => Crepop op exps
+    )
+    | _ => Crepop op exps
+  ) /\
+  simp_exp (LoadByte exp) = LoadByte (simp_exp exp) /\
+  simp_exp (Load exp) = Load (simp_exp exp) /\
+  simp_exp (Op bop exps) = Op bop (MAP simp_exp exps) /\
+  simp_exp (Cmp cmp exp1 exp2) = Cmp cmp (simp_exp exp1) (simp_exp exp2) /\
+  simp_exp (Shift s exp n) = Shift s (simp_exp exp) n /\
+  simp_exp exp = exp
+Termination
+  WF_REL_TAC `measure (exp_size (K 0))`
+End
+
+Definition simp_prog_def:
+  simp_prog (Dec v exp p) = Dec v (simp_exp exp) (simp_prog p) /\
+  simp_prog (Assign v exp) = Assign v (simp_exp exp) /\
+  simp_prog (Store exp1 exp2) = Store (simp_exp exp1) (simp_exp exp2) /\
+  simp_prog (StoreByte exp1 exp2) = StoreByte (simp_exp exp1) (simp_exp exp2) /\
+  simp_prog (StoreGlob g exp) = StoreGlob g (simp_exp exp) /\
+  simp_prog (Seq p1 p2) = Seq (simp_prog p1) (simp_prog p2) /\
+  simp_prog (If exp p1 p2) = If (simp_exp exp) (simp_prog p1) (simp_prog p2) /\
+  simp_prog (While exp p) = While (simp_exp exp) (simp_prog p) /\
+  simp_prog (Call call_type e exps) = (
+    let call_type2 = case call_type of
+      | NONE => NONE
+      | SOME (rv, rp, opt_handler) => SOME (rv, simp_prog rp, case opt_handler of
+          | NONE => NONE
+          | SOME (ix, ep) => SOME (ix, simp_prog ep)
+      ) in
+    Call call_type2 (simp_exp e) (MAP simp_exp exps)
+  ) /\
+  simp_prog (Return exp) = Return (simp_exp exp) /\
+  simp_prog (ShMem op vn exp) = ShMem op vn (simp_exp exp) /\
+  simp_prog p = p
+End
+
+val _ = export_theory();
+

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -3,7 +3,7 @@
 *)
 open preamble crepLangTheory
      loopLangTheory sptreeTheory
-     loop_liveTheory
+     loop_liveTheory crep_arithTheory
 
 val _ = new_theory "crep_to_loop"
 
@@ -250,7 +250,7 @@ Definition compile_prog_def:
    MAP2 (λn (name, params, body).
          (n,
           (GENLIST I o LENGTH) params,
-          loop_live$optimise (comp params body)))
+          loop_live$optimise (comp params (crep_arith$simp_prog body))))
    fnums prog
 End
 

--- a/pancake/proofs/README.md
+++ b/pancake/proofs/README.md
@@ -1,5 +1,8 @@
 Proofs files for compiling Pancake.
 
+[crep_arithProofScript.sml](crep_arithProofScript.sml):
+Correctness proof for crep_arith pass
+
 [crep_to_loopProofScript.sml](crep_to_loopProofScript.sml):
 Correctness proof for ---
 

--- a/pancake/proofs/crep_arithProofScript.sml
+++ b/pancake/proofs/crep_arithProofScript.sml
@@ -1,0 +1,150 @@
+(*
+  Correctness proof for crep_arith pass
+*)
+
+open preamble
+     crepSemTheory crepPropsTheory crep_arithTheory
+
+val _ = new_theory "crep_arithProof";
+
+Theorem dest_const_thm:
+  dest_const exp = SOME v ==> exp = Const v
+Proof
+  Cases_on `exp` \\ fs [dest_const_def]
+QED
+
+Theorem eval_mul_const:
+  eval s exp = SOME (Word w) ==>
+  eval s (mul_const exp c) = SOME (Word (w * c))
+Proof
+  simp [mul_const_def]
+  \\ every_case_tac
+  \\ fs [eval_def, crep_op_def]
+  \\ imp_res_tac dest_2exp_thm
+  \\ simp [wordLangTheory.word_sh_def, wordsTheory.WORD_MUL_LSL]
+  \\ CCONTR_TAC \\ fs []
+QED
+
+Triviality OPT_MMAP_EQ_SOME_MONO:
+  OPT_MMAP f xs = SOME y ==>
+  (! x z. MEM x xs ==> f x = SOME z ==> g x = SOME z) ==>
+  OPT_MMAP g xs = SOME y
+Proof
+  rw []
+  \\ irule EQ_TRANS
+  \\ irule_at Any OPT_MMAP_CONG
+  \\ simp []
+  \\ qexists_tac `f`
+  \\ rw []
+  \\ imp_res_tac pan_commonPropsTheory.opt_mmap_mem_func
+  \\ res_tac
+  \\ fs []
+QED
+
+Overload mapc[local] = ``\f s. s with code := FMAP_MAP2 f s.code``
+
+Triviality simp_exp_correct1:
+  ! s exp v.
+  crepSem$eval s exp <> NONE ==>
+  eval (mapc f s) (simp_exp exp) = eval s exp
+Proof
+  ho_match_mp_tac (name_ind_cases [] eval_ind)
+  \\ rw []
+  \\ fs [simp_exp_def]
+  \\ imp_res_tac (IS_SOME_EXISTS |> REWRITE_RULE [IS_SOME_EQ_NOT_NONE])
+  \\ fs [eval_def, CaseEq "option", CaseEq "word_lab"]
+  \\ fs [FLOOKUP_FMAP_MAP2, mem_load_def]
+  >~ [`Case (Op _ _)`]
+  >- (
+    qpat_x_assum `word_op _ _ = SOME _` (irule_at Any)
+    \\ simp [OPT_MMAP_MAP_o]
+    \\ drule_then irule OPT_MMAP_EQ_SOME_MONO
+    \\ rw []
+  )
+  >~ [`Case (Crepop _ _)`]
+  >- (
+    drule OPT_MMAP_EQ_SOME_MONO
+    \\ disch_then (qspec_then `eval (mapc f s) o simp_exp` mp_tac)
+    \\ impl_tac \\ rw []
+    \\ every_case_tac \\ gs [eval_def, MAP_EQ_CONS]
+    \\ gvs [DISJ_IMP_THM, FORALL_AND_THM, OPT_MMAP_MAP_o, combinTheory.o_DEF]
+    \\ every_case_tac \\ fs []
+    \\ imp_res_tac dest_const_thm
+    \\ irule EQ_TRANS \\ irule_at Any eval_mul_const
+    \\ Cases_on `op` \\ fs [crep_op_def, eval_def]
+  )
+QED
+
+Theorem simp_exp_correct:
+  crepSem$eval s exp = SOME v ==>
+  eval (mapc f s) (simp_exp exp) = SOME v
+Proof
+  rw [simp_exp_correct1]
+QED
+
+Overload mapcs[local] = ``mapc (\(s,n,p). (n, simp_prog p))``
+
+Triviality lookup_code:
+  lookup_code (FMAP_MAP2 (\(s,n,p). (n, simp_prog p)) c) fname args len =
+  OPTION_MAP (simp_prog ## I) (lookup_code c fname args len)
+Proof
+  simp [lookup_code_def, FLOOKUP_FMAP_MAP2]
+  \\ Cases_on `FLOOKUP c fname` \\ fs []
+  \\ pairarg_tac \\ fs []
+  \\ rw []
+QED
+
+Triviality sh_mem_op_code:
+  sh_mem_op op p addr (mapc f s) =
+    (I ## mapc f) (sh_mem_op op p addr s)
+Proof
+  Cases_on `op` \\ fs [sh_mem_op_def, sh_mem_load_def, sh_mem_store_def]
+  \\ every_case_tac \\ fs [set_var_def, empty_locals_def]
+QED
+
+Triviality ind_thm = crepSemTheory.evaluate_ind
+    |> Q.SPEC `UNCURRY Q`
+    |> REWRITE_RULE [UNCURRY_DEF]
+    |> Q.GEN `Q`
+
+
+Theorem simp_prog_correct:
+  ! p s r s'.
+  crepSem$evaluate (p, s) = (r, s') ==>
+  r <> SOME Error ==>
+  evaluate (simp_prog p, mapcs s) = (r, mapcs s')
+Proof
+  ho_match_mp_tac (name_ind_cases [] ind_thm)
+  \\ rw [simp_prog_def]
+  >~ [`Case (While _ _)`]
+  >~ [`Case (Call _ _ _)`]
+  >- (
+    fs [evaluate_def, UNCURRY_eq_pair, CaseEq "option", CaseEq "word_lab", CaseEq "prod"]
+    \\ imp_res_tac simp_exp_correct
+    \\ simp [OPT_MMAP_MAP_o]
+    \\ drule_then (irule_at Any) OPT_MMAP_EQ_SOME_MONO
+    \\ simp [simp_exp_correct, lookup_code]
+    \\ fs [AllCaseEqs ()]
+    \\ gvs [empty_locals_def, dec_clock_def]
+    \\ TRY (rename [`Case (Call (SOME (_, _, handler)) _ _ )`] \\ Cases_on `handler`)
+    \\ simp []
+    \\ simp [PAIR_FST_SND_EQ]
+  )
+  >- (
+    qpat_x_assum `evaluate _ = _` mp_tac
+    \\ ONCE_REWRITE_TAC [evaluate_def]
+    \\ strip_tac
+    \\ fs [CaseEq "bool", CaseEq "prod", CaseEq "option", dec_clock_def] \\ gs []
+    \\ drule_then (irule_at Any) simp_exp_correct
+    \\ fs [AllCaseEqs (), UNCURRY_eq_pair] \\ gvs []
+    \\ simp [empty_locals_def]
+  )
+  \\ fs [evaluate_def, AllCaseEqs (), UNCURRY_eq_pair]
+  \\ imp_res_tac simp_exp_correct
+  \\ gvs [set_globals_def, empty_locals_def, dec_clock_def]
+  \\ res_tac
+  \\ rw [] \\ fs []
+  \\ fs [sh_mem_op_code]
+QED
+
+val _ = export_theory();


### PR DESCRIPTION
    pancake: add a crepLang arithmetic-simplifying pass
    
    For the moment, this is focused on doing rewrites of the form
    (x * 8) ==> (x << 3).
    
    Along the way, experiment with rearranging the standard proof that relates
    evaluate (clocked) semantics to total semantics, to try to reduce the need
    to copy-paste the same logic into every phase.
