### PR TITLE
pancake: add crepLang arithmetic-simplifying pass

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -245,6 +245,18 @@ val _ = translate $ spec32 comp_def;
 
 val _ = translate $ spec32 optimise_def;
 
+open crep_arithTheory;
+
+val _ = translate $ spec32 dest_const_def;
+
+val _ = translate $ spec32 dest_2exp_def;
+
+val _ = translate $ spec32 mul_const_def;
+
+val _ = translate $ spec32 simp_exp_def;
+
+val _ = translate $ spec32 simp_prog_def;
+
 open crep_to_loopTheory;
 
 val _ = translate $ spec32 prog_if_def;

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -246,6 +246,18 @@ val _ = translate $ spec64 comp_def;
 
 val _ = translate $ spec64 optimise_def;
 
+open crep_arithTheory;
+
+val _ = translate $ spec64 dest_const_def;
+
+val _ = translate $ spec64 dest_2exp_def;
+
+val _ = translate $ spec64 mul_const_def;
+
+val _ = translate $ spec64 simp_exp_def;
+
+val _ = translate $ spec64 simp_prog_def;
+
 open crep_to_loopTheory;
 
 val _ = translate $ spec64 prog_if_def;

--- a/pancake/README.md
+++ b/pancake/README.md
@@ -7,6 +7,9 @@ Crepe: instrctuons are similar to that of
 Pancake, but we flatten locals from
 struct-layout to word-layout
 
+[crep_arithScript.sml](crep_arithScript.sml):
+Simplification of arithmetic in crepLang.
+
 [crep_to_loopScript.sml](crep_to_loopScript.sml):
 Compilation from crepLang to panLang.
 

--- a/pancake/crep_arithScript.sml
+++ b/pancake/crep_arithScript.sml
@@ -1,0 +1,107 @@
+(*
+  Simplification of arithmetic in crepLang.
+*)
+open preamble crepLangTheory
+
+val _ = new_theory "crep_arith"
+
+val _ = set_grammar_ancestry
+        ["crepLang"];
+
+
+Definition dest_const_def:
+  dest_const (Const w) = SOME w /\
+  dest_const _ = NONE
+End
+
+Definition dest_2exp_def:
+  dest_2exp n w = if w = 0w then NONE
+    else if w = 1w then SOME n
+    else if word_bit 0 w then NONE
+    else dest_2exp (n + 1n) (word_lsr w 1n)
+End
+
+Triviality dest_2exp_lemma:
+  ! i w n. dest_2exp i w = SOME n ==>
+  i <= n /\ w = word_lsl 1w (n - i)
+Proof
+  ho_match_mp_tac dest_2exp_ind
+  \\ rpt gen_tac
+  \\ rpt disch_tac
+  \\ rw [Once dest_2exp_def]
+  \\ fs []
+  \\ qsuff_tac `alignment$aligned 1n w`
+  >- (
+    rw []
+    \\ fs [aligned_def]
+    \\ pop_assum (ONCE_REWRITE_TAC o single o GSYM)
+    \\ simp [align_shift]
+  )
+  >- (
+    fs [aligned_1_lsb, word_lsb_def, word_bit_def]
+  )
+QED
+
+Theorem dest_2exp_thm:
+  dest_2exp 0n w = SOME n2 ==>
+  w = word_lsl 1w n2
+Proof
+  rw [] \\ imp_res_tac dest_2exp_lemma \\ fs []
+QED
+
+Definition mul_const_def:
+  mul_const exp c = if c = 0w then Const 0w
+    else if c = 1w then exp
+    else (case dest_2exp 0n c of
+      | NONE => Crepop Mul [exp; Const c]
+      | SOME i => Shift Lsl exp i
+    )
+End
+
+Definition simp_exp_def:
+  (simp_exp (Crepop op exps) =
+    let exps = MAP simp_exp exps in
+    case (op, exps) of
+    | (Mul, [exp1; exp2]) => (
+        case (dest_const exp1, dest_const exp2) of
+        | (SOME c, _) => mul_const exp2 c
+        | (_, SOME c) => mul_const exp1 c
+        | _ => Crepop op exps
+    )
+    | _ => Crepop op exps
+  ) /\
+  simp_exp (LoadByte exp) = LoadByte (simp_exp exp) /\
+  simp_exp (Load exp) = Load (simp_exp exp) /\
+  simp_exp (Op bop exps) = Op bop (MAP simp_exp exps) /\
+  simp_exp (Cmp cmp exp1 exp2) = Cmp cmp (simp_exp exp1) (simp_exp exp2) /\
+  simp_exp (Shift s exp n) = Shift s (simp_exp exp) n /\
+  simp_exp exp = exp
+Termination
+  WF_REL_TAC `measure (exp_size (K 0))`
+End
+
+Definition simp_prog_def:
+  simp_prog (Dec v exp p) = Dec v (simp_exp exp) (simp_prog p) /\
+  simp_prog (Assign v exp) = Assign v (simp_exp exp) /\
+  simp_prog (Store exp1 exp2) = Store (simp_exp exp1) (simp_exp exp2) /\
+  simp_prog (StoreByte exp1 exp2) = StoreByte (simp_exp exp1) (simp_exp exp2) /\
+  simp_prog (StoreGlob g exp) = StoreGlob g (simp_exp exp) /\
+  simp_prog (Seq p1 p2) = Seq (simp_prog p1) (simp_prog p2) /\
+  simp_prog (If exp p1 p2) = If (simp_exp exp) (simp_prog p1) (simp_prog p2) /\
+  simp_prog (While exp p) = While (simp_exp exp) (simp_prog p) /\
+  simp_prog (Call call_type e exps) = (
+    let call_type2 = case call_type of
+      | NONE => NONE
+      | SOME (rv, rp, opt_handler) => SOME (rv, simp_prog rp, case opt_handler of
+          | NONE => NONE
+          | SOME (ix, ep) => SOME (ix, simp_prog ep)
+      ) in
+    Call call_type2 (simp_exp e) (MAP simp_exp exps)
+  ) /\
+  simp_prog (Return exp) = Return (simp_exp exp) /\
+  simp_prog (ShMem op vn exp) = ShMem op vn (simp_exp exp) /\
+  simp_prog p = p
+End
+
+val _ = export_theory();
+

--- a/pancake/crep_arithScript.sml
+++ b/pancake/crep_arithScript.sml
@@ -17,7 +17,7 @@ End
 Definition dest_2exp_def:
   dest_2exp n w = if w = 0w then NONE
     else if w = 1w then SOME n
-    else if word_bit 0 w then NONE
+    else if (w && 1w) <> 0w then NONE
     else dest_2exp (n + 1n) (word_lsr w 1n)
 End
 
@@ -38,7 +38,7 @@ Proof
     \\ simp [align_shift]
   )
   >- (
-    fs [aligned_1_lsb, word_lsb_def, word_bit_def]
+    simp [aligned_bitwise_and]
   )
 QED
 

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -3,7 +3,7 @@
 *)
 open preamble crepLangTheory
      loopLangTheory sptreeTheory
-     loop_liveTheory
+     loop_liveTheory crep_arithTheory
 
 val _ = new_theory "crep_to_loop"
 
@@ -250,7 +250,7 @@ Definition compile_prog_def:
    MAP2 (λn (name, params, body).
          (n,
           (GENLIST I o LENGTH) params,
-          loop_live$optimise (comp params body)))
+          loop_live$optimise (comp params (crep_arith$simp_prog body))))
    fnums prog
 End
 

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -38,8 +38,9 @@ Definition pan_to_target_all_def:
           funcs = make_funcs prog_b;
           target = c.lab_conf.asm_conf.ISA;
           comp = comp_func target funcs;
+          asimp = crep_arith$simp_prog;
           prog_b1 = MAP2 (λn (name,params,body).
-                      (n,(GENLIST I ∘ LENGTH) params, comp params body)) fnums prog_b;
+                      (n,(GENLIST I ∘ LENGTH) params, comp params (asimp body))) fnums prog_b;
           prog_c = MAP (λ(name,params,body). (name,params,loop_live$optimise body)) prog_b1;
           prog_c1 = loop_remove$comp_prog prog_c;
           prog2 = loop_to_word$compile_prog prog_c1;

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -32,15 +32,16 @@ Definition pan_to_target_all_def:
           ps = [(«initial pancake program»,Pan prog1)];
           prog_a = pan_simp$compile_prog prog1;
           ps = ps ++ [(«after pan_simp»,Pan prog_a)];
-          prog_b = pan_to_crep$compile_prog prog_a;
-          ps = ps ++ [(«after pan_to_crep»,Crep prog_b)];
+          prog_b0 = pan_to_crep$compile_prog prog_a;
+          ps = ps ++ [(«after pan_to_crep»,Crep prog_b0)];
+          prog_b = MAP (λ(n,ps,e). (n,ps,crep_arith$simp_prog e)) prog_b0;
+          ps = ps ++ [(«after crep_arith»,Crep prog_b)];
           fnums = GENLIST (λn. n + first_name) (LENGTH prog_b);
           funcs = make_funcs prog_b;
           target = c.lab_conf.asm_conf.ISA;
           comp = comp_func target funcs;
-          asimp = crep_arith$simp_prog;
           prog_b1 = MAP2 (λn (name,params,body).
-                      (n,(GENLIST I ∘ LENGTH) params, comp params (asimp body))) fnums prog_b;
+                      (n,(GENLIST I ∘ LENGTH) params, comp params body)) fnums prog_b;
           prog_c = MAP (λ(name,params,body). (name,params,loop_live$optimise body)) prog_b1;
           prog_c1 = loop_remove$comp_prog prog_c;
           prog2 = loop_to_word$compile_prog prog_c1;
@@ -58,10 +59,29 @@ Definition pan_to_target_all_def:
           (ps ++ MAP (λ(n,p). (n,Cake p)) ps1,out)
 End
 
+Triviality MAP2_MAP:
+  ∀xs ys. MAP2 g xs (MAP f ys) = MAP2 (λx y. g x (f y)) xs ys
+Proof
+  Induct \\ Cases_on ‘ys’ \\ gvs []
+QED
+
 Triviality MAP_MAP2:
   ∀xs ys. MAP f (MAP2 g xs ys) = MAP2 (λx y. f (g x y)) xs ys
 Proof
   Induct \\ Cases_on ‘ys’ \\ gvs []
+QED
+
+Triviality make_funcs_MAP:
+  ∀xs. make_funcs (MAP (λ(n,ps,e). (n,ps,f e)) xs) = crep_to_loop$make_funcs xs
+Proof
+  simp [crep_to_loopTheory.make_funcs_def]
+  \\ qspec_tac (‘first_name’,‘nn’)
+  \\ Induct_on ‘xs’ \\ gvs []
+  \\ PairCases \\ gvs [] \\ gvs [GENLIST_CONS]
+  \\ gvs [o_DEF,ADD1] \\ rw []
+  \\ pop_assum $ qspec_then ‘nn+1’ assume_tac
+  \\ gvs [GSYM ADD1,ADD_CLAUSES,AC ADD_COMM ADD_ASSOC]
+  \\ once_rewrite_tac [ADD_COMM] \\ gvs []
 QED
 
 Theorem compile_prog_eq_pan_to_target_all:
@@ -72,7 +92,8 @@ Proof
   \\ IF_CASES_TAC >- gvs []
   \\ pop_assum kall_tac
   \\ gvs [backend_passesTheory.from_word_0_thm,pan_to_wordTheory.compile_prog_def,
-          loop_to_wordTheory.compile_def,crep_to_loopTheory.compile_prog_def,MAP_MAP2]
+          loop_to_wordTheory.compile_def,crep_to_loopTheory.compile_prog_def,
+          MAP_MAP2,MAP2_MAP,make_funcs_MAP]
   \\ gvs [LAMBDA_PROD,loop_to_wordTheory.compile_def]
 QED
 

--- a/pancake/proofs/README.md
+++ b/pancake/proofs/README.md
@@ -1,5 +1,8 @@
 Proofs files for compiling Pancake.
 
+[crep_arithProofScript.sml](crep_arithProofScript.sml):
+Correctness proof for crep_arith pass
+
 [crep_to_loopProofScript.sml](crep_to_loopProofScript.sml):
 Correctness proof for ---
 

--- a/pancake/proofs/crep_arithProofScript.sml
+++ b/pancake/proofs/crep_arithProofScript.sml
@@ -1,0 +1,150 @@
+(*
+  Correctness proof for crep_arith pass
+*)
+
+open preamble
+     crepSemTheory crepPropsTheory crep_arithTheory
+
+val _ = new_theory "crep_arithProof";
+
+Theorem dest_const_thm:
+  dest_const exp = SOME v ==> exp = Const v
+Proof
+  Cases_on `exp` \\ fs [dest_const_def]
+QED
+
+Theorem eval_mul_const:
+  eval s exp = SOME (Word w) ==>
+  eval s (mul_const exp c) = SOME (Word (w * c))
+Proof
+  simp [mul_const_def]
+  \\ every_case_tac
+  \\ fs [eval_def, crep_op_def]
+  \\ imp_res_tac dest_2exp_thm
+  \\ simp [wordLangTheory.word_sh_def, wordsTheory.WORD_MUL_LSL]
+  \\ CCONTR_TAC \\ fs []
+QED
+
+Triviality OPT_MMAP_EQ_SOME_MONO:
+  OPT_MMAP f xs = SOME y ==>
+  (! x z. MEM x xs ==> f x = SOME z ==> g x = SOME z) ==>
+  OPT_MMAP g xs = SOME y
+Proof
+  rw []
+  \\ irule EQ_TRANS
+  \\ irule_at Any OPT_MMAP_CONG
+  \\ simp []
+  \\ qexists_tac `f`
+  \\ rw []
+  \\ imp_res_tac pan_commonPropsTheory.opt_mmap_mem_func
+  \\ res_tac
+  \\ fs []
+QED
+
+Overload mapc[local] = ``\f s. s with code := FMAP_MAP2 f s.code``
+
+Triviality simp_exp_correct1:
+  ! s exp v.
+  crepSem$eval s exp <> NONE ==>
+  eval (mapc f s) (simp_exp exp) = eval s exp
+Proof
+  ho_match_mp_tac (name_ind_cases [] eval_ind)
+  \\ rw []
+  \\ fs [simp_exp_def]
+  \\ imp_res_tac (IS_SOME_EXISTS |> REWRITE_RULE [IS_SOME_EQ_NOT_NONE])
+  \\ fs [eval_def, CaseEq "option", CaseEq "word_lab"]
+  \\ fs [FLOOKUP_FMAP_MAP2, mem_load_def]
+  >~ [`Case (Op _ _)`]
+  >- (
+    qpat_x_assum `word_op _ _ = SOME _` (irule_at Any)
+    \\ simp [OPT_MMAP_MAP_o]
+    \\ drule_then irule OPT_MMAP_EQ_SOME_MONO
+    \\ rw []
+  )
+  >~ [`Case (Crepop _ _)`]
+  >- (
+    drule OPT_MMAP_EQ_SOME_MONO
+    \\ disch_then (qspec_then `eval (mapc f s) o simp_exp` mp_tac)
+    \\ impl_tac \\ rw []
+    \\ every_case_tac \\ gs [eval_def, MAP_EQ_CONS]
+    \\ gvs [DISJ_IMP_THM, FORALL_AND_THM, OPT_MMAP_MAP_o, combinTheory.o_DEF]
+    \\ every_case_tac \\ fs []
+    \\ imp_res_tac dest_const_thm
+    \\ irule EQ_TRANS \\ irule_at Any eval_mul_const
+    \\ Cases_on `op` \\ fs [crep_op_def, eval_def]
+  )
+QED
+
+Theorem simp_exp_correct:
+  crepSem$eval s exp = SOME v ==>
+  eval (mapc f s) (simp_exp exp) = SOME v
+Proof
+  rw [simp_exp_correct1]
+QED
+
+Overload mapcs[local] = ``mapc (\(s,n,p). (n, simp_prog p))``
+
+Triviality lookup_code:
+  lookup_code (FMAP_MAP2 (\(s,n,p). (n, simp_prog p)) c) fname args len =
+  OPTION_MAP (simp_prog ## I) (lookup_code c fname args len)
+Proof
+  simp [lookup_code_def, FLOOKUP_FMAP_MAP2]
+  \\ Cases_on `FLOOKUP c fname` \\ fs []
+  \\ pairarg_tac \\ fs []
+  \\ rw []
+QED
+
+Triviality sh_mem_op_code:
+  sh_mem_op op p addr (mapc f s) =
+    (I ## mapc f) (sh_mem_op op p addr s)
+Proof
+  Cases_on `op` \\ fs [sh_mem_op_def, sh_mem_load_def, sh_mem_store_def]
+  \\ every_case_tac \\ fs [set_var_def, empty_locals_def]
+QED
+
+Triviality ind_thm = crepSemTheory.evaluate_ind
+    |> Q.SPEC `UNCURRY Q`
+    |> REWRITE_RULE [UNCURRY_DEF]
+    |> Q.GEN `Q`
+
+
+Theorem simp_prog_correct:
+  ! p s r s'.
+  crepSem$evaluate (p, s) = (r, s') ==>
+  r <> SOME Error ==>
+  evaluate (simp_prog p, mapcs s) = (r, mapcs s')
+Proof
+  ho_match_mp_tac (name_ind_cases [] ind_thm)
+  \\ rw [simp_prog_def]
+  >~ [`Case (While _ _)`]
+  >~ [`Case (Call _ _ _)`]
+  >- (
+    fs [evaluate_def, UNCURRY_eq_pair, CaseEq "option", CaseEq "word_lab", CaseEq "prod"]
+    \\ imp_res_tac simp_exp_correct
+    \\ simp [OPT_MMAP_MAP_o]
+    \\ drule_then (irule_at Any) OPT_MMAP_EQ_SOME_MONO
+    \\ simp [simp_exp_correct, lookup_code]
+    \\ fs [AllCaseEqs ()]
+    \\ gvs [empty_locals_def, dec_clock_def]
+    \\ TRY (rename [`Case (Call (SOME (_, _, handler)) _ _ )`] \\ Cases_on `handler`)
+    \\ simp []
+    \\ simp [PAIR_FST_SND_EQ]
+  )
+  >- (
+    qpat_x_assum `evaluate _ = _` mp_tac
+    \\ ONCE_REWRITE_TAC [evaluate_def]
+    \\ strip_tac
+    \\ fs [CaseEq "bool", CaseEq "prod", CaseEq "option", dec_clock_def] \\ gs []
+    \\ drule_then (irule_at Any) simp_exp_correct
+    \\ fs [AllCaseEqs (), UNCURRY_eq_pair] \\ gvs []
+    \\ simp [empty_locals_def]
+  )
+  \\ fs [evaluate_def, AllCaseEqs (), UNCURRY_eq_pair]
+  \\ imp_res_tac simp_exp_correct
+  \\ gvs [set_globals_def, empty_locals_def, dec_clock_def]
+  \\ res_tac
+  \\ rw [] \\ fs []
+  \\ fs [sh_mem_op_code]
+QED
+
+val _ = export_theory();

--- a/pancake/proofs/pan_to_wordProofScript.sml
+++ b/pancake/proofs/pan_to_wordProofScript.sml
@@ -1,5 +1,5 @@
 (*
-  Correctness proof for --
+  Correctness proof for combined pan_to_word compilation.
 *)
 
 open preamble pan_to_wordTheory
@@ -523,7 +523,6 @@ Proof
   fs [] >>
   pop_assum kall_tac >>
   qmatch_goalsub_abbrev_tac ‘_ = semantics lst _’ >>
-
   (* loop_to_word pass *)
   qmatch_asmsub_abbrev_tac ‘_ = SOME ([],cprog)’ >>
   drule pan_simpProofTheory.first_compile_prog_all_distinct >>
@@ -618,112 +617,40 @@ Proof
         fs []) >>
      fs [pan_to_wordTheory.compile_prog_def] >>
      fs [loop_to_wordTheory.compile_def] >>
-     drule mem_prog_mem_compile_prog >> fs []) >>
-    drule pan_commonPropsTheory.lookup_some_el >>
-    strip_tac >>
-    drule EL_MEM >>
-    strip_tac >>
-    rfs []
-    >- (drule loop_removeProofTheory.comp_prog_no_loops >> fs []) >>
-    drule loop_removeProofTheory.compile_prog_distinct_params >>
-    impl_tac
+     drule mem_prog_mem_compile_prog >> fs []
+    )
     >- (
-      ho_match_mp_tac crep_to_loopProofTheory.compile_prog_distinct_params >>
+      drule pan_commonPropsTheory.lookup_some_el >> rw [] >>
+      imp_res_tac EL_MEM >>
+      gs [] >>
+      drule loop_removeProofTheory.comp_prog_no_loops >> fs []
+    )
+    >- (
+      drule pan_commonPropsTheory.lookup_some_el >> rw [] >>
+      imp_res_tac EL_MEM >>
+      gs [] >>
+      drule_then irule loop_removeProofTheory.compile_prog_distinct_params >>
+      irule crep_to_loopProofTheory.compile_prog_distinct_params >>
       fs [Abbr ‘ccode’] >>
       ho_match_mp_tac pan_to_crepProofTheory.compile_prog_distinct_params >>
       fs [Abbr ‘pcode’] >>
       ho_match_mp_tac pan_simpProofTheory.compile_prog_distinct_params >>
-      fs [distinct_params_def]) >>
-    fs []) >>
+      fs [distinct_params_def])
+  ) >>
   drule fstate_rel_imp_semantics >>
-  disch_then (qspecl_then [‘lc+first_name’,
-     ‘loop_live$optimise (comp_func c (make_funcs ccode) [] cprog)’] mp_tac) >>
-  impl_tac
-  >- (
-   fs [Abbr ‘lst’, loop_state_def,
+  disch_then irule >>
+  fs [Abbr ‘lst’, loop_state_def,
        Abbr ‘ccode’, Abbr ‘pcode’,
        pan_to_wordTheory.compile_prog_def] >>
-   fs [lookup_fromAList] >>
-   fs [Abbr ‘cprog’] >>
-   match_mp_tac ALOOKUP_ALL_DISTINCT_MEM >>
-   conj_tac
-   >- fs [crep_to_loopProofTheory.first_compile_prog_all_distinct] >>
-   fs [crep_to_loopTheory.compile_prog_def] >>
-   qmatch_goalsub_abbrev_tac ‘MEM ff _’ >>
-   pop_assum mp_tac >>
-   qpat_x_assum ‘lc < _’ mp_tac >>
-   qpat_x_assum ‘EL lc pan_code = _’ mp_tac >>
-   qpat_x_assum ‘FLOOKUP _ _ = SOME _’ mp_tac >>
-   qpat_x_assum ‘ALOOKUP _ _ = SOME _’ mp_tac >>
-   qpat_x_assum ‘ALOOKUP _ _ = SOME _’ mp_tac >>
-   qpat_x_assum ‘ALOOKUP _ _ = SOME _’ mp_tac >>
-   rpt (pop_assum kall_tac) >>
-   rpt strip_tac >>
-   qmatch_asmsub_abbrev_tac
-   ‘ALOOKUP (_ (_ pan_code)) start = SOME ([],cprog)’ >>
-   ‘lc < LENGTH (pan_to_crep$compile_prog (pan_simp$compile_prog pan_code))’ by
-     fs [pan_to_crepTheory.compile_prog_def, pan_simpTheory.compile_prog_def] >>
-   fs [MEM_EL] >>
-   qexists_tac ‘lc’ >>
-   rfs [] >>
-   qmatch_goalsub_abbrev_tac ‘_ = EL lc (MAP2 gg xs ys)’ >>
-   ‘EL lc (MAP2 gg xs ys) = gg (EL lc xs) (EL lc ys)’ by (
-     ho_match_mp_tac EL_MAP2 >>
-     fs [Abbr ‘xs’, Abbr ‘ys’]) >>
-   fs [Abbr ‘gg’, Abbr ‘xs’, Abbr ‘ys’] >>
-   pop_assum kall_tac >>
-   qmatch_goalsub_abbrev_tac ‘_ = hs x’ >>
-   cases_on ‘x’ >> fs [] >>
-   cases_on ‘r’ >> fs [] >>
-   fs [Abbr ‘hs’, Abbr ‘ff’] >>
-   conj_asm1_tac
-   >- (
-    fs [pan_to_crepTheory.compile_prog_def] >>
-    pop_assum mp_tac >>
-    qmatch_goalsub_abbrev_tac ‘EL n (MAP ff xs)’ >>
-    ‘EL n (MAP ff xs) = ff (EL n xs)’ by (
-      match_mp_tac EL_MAP >>
-      fs [Abbr ‘ff’, Abbr ‘xs’]) >>
-    fs [Abbr ‘ff’, Abbr ‘xs’] >>
-    pop_assum kall_tac >>
-    strip_tac >>
-    cases_on ‘EL n (pan_simp$compile_prog pan_code)’ >>
-    fs [] >>
-    cases_on ‘r’ >> fs [] >>
-    unabbrev_all_tac >>
-    fs [] >>  rveq >> fs [] >>
-    pop_assum mp_tac >>
-    fs [pan_simpTheory.compile_prog_def] >>
-    qmatch_goalsub_abbrev_tac ‘EL n (MAP ff xs)’ >>
-    ‘EL n (MAP ff xs) = ff (EL n xs)’ by (
-      match_mp_tac EL_MAP >>
-      fs [Abbr ‘ff’, Abbr ‘xs’]) >>
-    fs [Abbr ‘ff’, Abbr ‘xs’] >> rveq >> gs [] >>
-    fs [pan_to_crepTheory.crep_vars_def, panLangTheory.size_of_shape_def]) >>
-   cases_on ‘q'’ >> fs [GENLIST] >>
-   qsuff_tac ‘cprog = r'’
-   >- fs [] >>
-   fs [Abbr ‘cprog’] >>
-   pop_assum kall_tac >>
-   fs [pan_to_crepTheory.compile_prog_def] >>
-   pop_assum mp_tac >>
-   qmatch_goalsub_abbrev_tac ‘EL n (MAP ff xs)’ >>
-   ‘EL n (MAP ff xs) = ff (EL n xs)’ by (
-     match_mp_tac EL_MAP >>
-     fs [Abbr ‘ff’, Abbr ‘xs’]) >>
-   fs [Abbr ‘ff’, Abbr ‘xs’] >>
-   strip_tac >>
-   cases_on ‘EL n (pan_simp$compile_prog pan_code)’ >>
-   fs [] >>
-   cases_on ‘r’ >> fs [] >> rveq >> gs [] >>
-   pop_assum mp_tac >>
-   fs [pan_simpTheory.compile_prog_def] >>
-   qmatch_goalsub_abbrev_tac ‘EL n (MAP ff xs)’ >>
-   ‘EL n (MAP ff xs) = ff (EL n xs)’ by (
-     match_mp_tac EL_MAP >>
-     fs [Abbr ‘ff’, Abbr ‘xs’]) >>
-   fs [Abbr ‘ff’, Abbr ‘xs’]) >>
-  fs []
+  fs [lookup_fromAList] >>
+  irule_at Any ALOOKUP_ALL_DISTINCT_MEM >>
+  irule_at Any crep_to_loopProofTheory.first_compile_prog_all_distinct >>
+  fs [crep_to_loopTheory.compile_prog_def] >>
+  simp [MAP2_MAP, MEM_MAP, EXISTS_PROD] >>
+  csimp [MEM_ZIP, EL_GENLIST] >>
+  fs [pan_to_crepTheory.compile_prog_def, pan_simpTheory.compile_prog_def] >>
+  simp [EL_MAP] >>
+  simp [pan_to_crepTheory.crep_vars_def, panLangTheory.size_of_shape_def]
 QED
 
 (*** no_install/no_alloc/no_mt lemmas ***)
@@ -959,6 +886,38 @@ Proof
   rw[crep_to_loopTheory.comp_func_def,crep_to_loopTheory.make_funcs_def] \\
   match_mp_tac every_inst_ok_less_crep_to_loop_compile \\
   rw[crep_to_loopTheory.mk_ctxt_def]
+QED
+
+Theorem every_inst_ok_arith_simp_exp:
+  ! exp.
+  every_exp (λx. ∀op es. x = Crepop op es ⇒ LENGTH es = 2) exp ==>
+  every_exp (λx. ∀op es. x = Crepop op es ⇒ LENGTH es = 2) (simp_exp exp)
+Proof
+  ho_match_mp_tac crep_arithTheory.simp_exp_ind
+  \\ simp [crep_arithTheory.simp_exp_def, crepPropsTheory.every_exp_def]
+  \\ rw [crep_arithTheory.mul_const_def]
+  \\ every_case_tac \\ fs []
+  \\ gvs [listTheory.MAP_EQ_CONS]
+  \\ fs [crepPropsTheory.every_exp_def]
+  \\ simp [EVERY_MAP]
+  \\ fs [EVERY_MEM]
+QED
+
+Theorem every_inst_ok_arith_simp_prog:
+  ! prog.
+  EVERY (every_exp (λx. ∀op es. x = Crepop op es ⇒ LENGTH es = 2))
+          (exps_of prog) ==>
+  EVERY (every_exp (λx. ∀op es. x = Crepop op es ⇒ LENGTH es = 2))
+          (exps_of (simp_prog prog))
+Proof
+  ho_match_mp_tac crep_arithTheory.simp_prog_ind
+  \\ simp [crep_arithTheory.simp_prog_def, crepPropsTheory.exps_of_def]
+  \\ simp [every_inst_ok_arith_simp_exp]
+  \\ rw []
+  \\ every_case_tac \\ fs []
+  \\ fs [crepPropsTheory.exps_of_def, every_inst_ok_arith_simp_exp]
+  \\ fs [EVERY_MAP]
+  \\ fs [EVERY_MEM, every_inst_ok_arith_simp_exp]
 QED
 
 Theorem every_inst_ok_nested_decs:
@@ -1228,6 +1187,22 @@ Proof
       every_inst_ok_less_seq_assoc]
 QED
 
+Theorem every_inst_ok_less_crep_to_loop_compile_prog:
+  EVERY (λ(name,params,body). EVERY (every_exp (λx. ∀op es. x = Crepop op es ⇒ LENGTH es = 2)) (exps_of body)) crep_code ⇒
+  EVERY (λ(name,params,body). every_prog (loop_inst_ok c) body)
+    (crep_to_loop$compile_prog c.ISA crep_code)
+Proof
+  simp [crep_to_loopTheory.compile_prog_def]
+  \\ simp [MAP2_MAP, EVERY_MAP]
+  \\ simp [ELIM_UNCURRY, every_zip_snd]
+  \\ rw [EVERY_MEM]
+  \\ irule every_inst_ok_less_optimise
+  \\ irule every_inst_ok_less_comp_func
+  \\ irule every_inst_ok_arith_simp_prog
+  \\ fs [EVERY_MEM]
+  \\ res_tac
+QED
+
 Theorem every_inst_ok_less_pan_simp_compile_prog:
   EVERY (λ(name,params,body). EVERY (every_exp (λx. ∀op es. x = Panop op es ⇒ LENGTH es = 2)) (exps_of body)) pan_code ⇒
   EVERY (λ(name,params,body). EVERY (every_exp (λx. ∀op es. x = Panop op es ⇒ LENGTH es = 2)) (exps_of body)) (pan_simp$compile_prog pan_code)
@@ -1251,28 +1226,10 @@ Proof
   gs[pan_to_wordTheory.compile_prog_def]>>strip_tac>>
   drule_then irule loop_to_word_every_inst_ok_less>>gs[]>>
   last_x_assum kall_tac>>
-  simp[crep_to_loopTheory.compile_prog_def,EVERY_MEM]>>
-  dep_rewrite.DEP_ONCE_REWRITE_TAC [MAP2_ZIP]>>simp[]>>
-  rw[MEM_MAP,MEM_ZIP]>>
-  rpt(pairarg_tac>>gvs[])>>
-  match_mp_tac every_inst_ok_less_optimise>>
-  match_mp_tac every_inst_ok_less_comp_func>>
-  rw[EVERY_MEM,MEM_EL]>>
-  drule_at (Pos last) $ MP_CANON $ SIMP_RULE std_ss [MEM_EL,EVERY_MEM,PULL_EXISTS,PULL_FORALL] every_inst_ok_less_pan_to_crep_compile_prog>>
-  simp[] >>
-  disch_then $ match_mp_tac o MP_CANON>>
-  rw[] >>
-  pairarg_tac>>
-  rw[]>>
-  drule_at (Pos last) $ MP_CANON $ SIMP_RULE std_ss [MEM_EL,EVERY_MEM,PULL_EXISTS,PULL_FORALL] every_inst_ok_less_pan_simp_compile_prog>>
-  simp[]>>
-  disch_then $ match_mp_tac o MP_CANON>>
-  rw[]>>
-  pairarg_tac >>
-  rw[]>>
-  gvs[EVERY_MEM,MEM_EL,PULL_EXISTS]>>
-  first_x_assum dxrule>>
-  simp[]
+  irule every_inst_ok_less_crep_to_loop_compile_prog>>
+  irule every_inst_ok_less_pan_to_crep_compile_prog>>
+  irule every_inst_ok_less_pan_simp_compile_prog>>
+  simp []
 QED
 
 val _ = export_theory();


### PR DESCRIPTION
For the moment, this is focused on doing rewrites of the form (x * 8) ==> (x << 3).

Along the way, experiment with rearranging the standard proof that relates evaluate (clocked) semantics to total semantics, to try to reduce the need to copy-paste the same logic into every phase.