### PR TITLE
Set module

### DIFF
--- a/basis/HashtableProgScript.sml
+++ b/basis/HashtableProgScript.sml
@@ -3,10 +3,10 @@
 *)
 open preamble
      ml_translatorLib ml_progLib basisFunctionsLib
-     MapProgTheory
+     SetProgTheory
 
 val _ = new_theory "HashtableProg"
-val _ = translation_extends "MapProg"
+val _ = translation_extends "SetProg"
 val () = ml_prog_update(open_module "Hashtable");
 
 (*Local structure:

--- a/basis/README.md
+++ b/basis/README.md
@@ -77,6 +77,10 @@ forcing a full GC to run, a function for producing debug output.
 [RuntimeProofScript.sml](RuntimeProofScript.sml):
 Proof about the exit function in the Runtime module.
 
+[SetProgScript.sml](SetProgScript.sml):
+This module contains CakeML code implementing a functional set type
+using a self-balancing binary tree.
+
 [StringProgScript.sml](StringProgScript.sml):
 Module about the built-in string tyoe.
 

--- a/basis/SetProgScript.sml
+++ b/basis/SetProgScript.sml
@@ -1,23 +1,19 @@
 (*
-  This module contains CakeML code implementing a functional map type
+  This module contains CakeML code implementing a functional set type
   using a self-balancing binary tree.
 *)
 open preamble
   ml_translatorLib ml_translatorTheory ml_progLib
-  balanced_mapTheory ArrayProgTheory basisFunctionsLib
+  balanced_mapTheory MapProgTheory basisFunctionsLib
 
-val _ = new_theory "MapProg"
+val _ = new_theory "SetProg"
 
-val _ = translation_extends "ArrayProg";
-
-val _ = (use_full_type_names := false);
-val _ = register_type ``:('a,'b) balanced_map$balanced_map``;
-val _ = (use_full_type_names := true);
+val _ = translation_extends "MapProg";
 
 val _ = ml_prog_update open_local_block;
 
 val _ = (use_full_type_names := false);
-val _ = register_type ``:('a,'b) mlmap$map``;
+val _ = register_type ``:'a mlset$mlset``;
 val _ = (use_full_type_names := true);
 
 val _ = next_ml_names := ["size", "singleton"];
@@ -25,6 +21,8 @@ val _ = translate size_def;
 val _ = translate singleton_def;
 
 (* Helpers *)
+
+val _ = translate FOLDL;
 val _ = translate ratio_def;
 val _ = translate delta_def;
 val _ = translate balanceL_def;
@@ -91,94 +89,74 @@ val _ = translate submap'_def;
 
 (* Exported functions *)
 val _ = next_ml_names :=
-  ["null", "member", "empty", "insert", "delete",
-   "union", "unionWithKey", "unionWith", "foldrWithKey",
-   "toAscList", "compare", "mapWithKey", "map", "isSubmapOfBy",
-   "isSubmapOf", "fromList", "filterWithKey", "filter", "all",
-   "exists"];
+  ["null", "member", "empty", "insert", "delete", "union", "foldrWithKey",
+   "toAscList", "compare", "isSubmapOfBy", "isSubmapOf", "fromList",
+   "filterWithKey", "all", "exists"];
 val _ = translate null_def;
 val _ = translate member_def;
 val _ = translate empty_def;
 val _ = translate insert_def;
 val _ = translate delete_def;
 val _ = translate union_def;
-val _ = translate unionWithKey_def;
-val _ = translate unionWith_def;
 val _ = translate foldrWithKey_def;
 val _ = translate toAscList_def;
 val _ = translate compare_def;
-val _ = translate mapWithKey_def;
-val _ = translate map_def;
 val _ = translate isSubmapOfBy_def;
 val _ = translate isSubmapOf_def;
 val _ = translate fromList_def;
 val _ = translate filterWithKey_def;
-val _ = translate filter_def;
 val _ = translate every_def;
 val _ = translate exists_def;
 
 val _ = ml_prog_update open_local_in_block;
 
-val _ = ml_prog_update (open_module "Map");
+val _ = ml_prog_update (open_module "Set");
 
-(* provides the Map.map name for the map type *)
+(* provides the Set.set name for the set type *)
 val _ = ml_prog_update (add_dec
-  ``Dtabbrev unknown_loc ["'a";"'b"] "map"
-             (Atapp [Atvar "'a"; Atvar "'b"] (Short "map"))`` I);
+  ``Dtabbrev unknown_loc ["'a"] "set" (Atapp [Atvar "'a"] (Short "mlset"))`` I);
 
-val _ = next_ml_names := ["lookup"];
-val _ = translate mlmapTheory.lookup_def;
-val _ = next_ml_names := ["member"];
-val _ = translate mlmapTheory.member_def;
-val _ = next_ml_names := ["insert"];
-val _ = translate mlmapTheory.insert_def;
-val _ = next_ml_names := ["delete"];
-val _ = translate mlmapTheory.delete_def;
-val _ = next_ml_names := ["null"];
-val _ = translate mlmapTheory.null_def;
-val _ = next_ml_names := ["size"];
-val _ = translate mlmapTheory.size_def;
-val _ = next_ml_names := ["empty"];
-val _ = translate mlmapTheory.empty_def;
 val _ = next_ml_names := ["singleton"];
-val _ = translate mlmapTheory.singleton_def;
+val _ = translate mlsetTheory.singleton_def;
+val _ = next_ml_names := ["member"];
+val _ = translate mlsetTheory.member_def;
+val _ = next_ml_names := ["delete"];
+val _ = translate mlsetTheory.delete_def;
 val _ = next_ml_names := ["union"];
-val _ = translate mlmapTheory.union_def;
-val _ = next_ml_names := ["unionWith"];
-val _ = translate mlmapTheory.unionWith_def;
-val _ = next_ml_names := ["unionWithKey"];
-val _ = translate mlmapTheory.unionWithKey_def;
-val _ = next_ml_names := ["foldrWithKey"];
-val _ = translate mlmapTheory.foldrWithKey_def;
-val _ = next_ml_names := ["map"];
-val _ = translate mlmapTheory.map_def;
-val _ = next_ml_names := ["mapWithKey"];
-val _ = translate mlmapTheory.mapWithKey_def;
-val _ = next_ml_names := ["toAscList"];
-val _ = translate mlmapTheory.toAscList_def;
-val _ = next_ml_names := ["fromList"];
-val _ = translate mlmapTheory.fromList_def;
-val _ = next_ml_names := ["isSubmapBy"];
-val _ = translate mlmapTheory.isSubmapBy_def;
-val _ = next_ml_names := ["isSubmap"];
-val _ = translate mlmapTheory.isSubmap_def;
-val _ = next_ml_names := ["all"];
-val _ = translate mlmapTheory.all_def;
-val _ = next_ml_names := ["exists"];
-val _ = translate mlmapTheory.exists_def;
-val _ = next_ml_names := ["filterWithKey"];
-val _ = translate mlmapTheory.filterWithKey_def;
-val _ = next_ml_names := ["filter"];
-val _ = translate mlmapTheory.filter_def;
+val _ = translate mlsetTheory.union_def;
+val _ = next_ml_names := ["isSubset"];
+val _ = translate mlsetTheory.isSubset_def;
 val _ = next_ml_names := ["compare"];
-val _ = translate mlmapTheory.compare_def;
+val _ = translate mlsetTheory.compare_def;
+val _ = next_ml_names := ["all"];
+val _ = translate mlsetTheory.all_def;
+val _ = next_ml_names := ["exists"];
+val _ = translate mlsetTheory.exists_def;
+val _ = next_ml_names := ["translate"];
+val _ = translate mlsetTheory.translate_def;
+val _ = next_ml_names := ["map"];
+val _ = translate mlsetTheory.map_def;
+val _ = next_ml_names := ["filter"];
+val _ = translate mlsetTheory.filter_def;
+val _ = next_ml_names := ["fromList"];
+val _ = translate mlsetTheory.fromList_def;
+val _ = next_ml_names := ["toList"];
+val _ = translate mlsetTheory.toList_def;
+val _ = next_ml_names := ["null"];
+val _ = translate mlsetTheory.null_def;
+val _ = next_ml_names := ["size"];
+val _ = translate mlsetTheory.size_def;
+val _ = next_ml_names := ["fold"];
+val _ = translate mlsetTheory.fold_def;
+val _ = next_ml_names := ["empty"];
+val _ = translate mlsetTheory.empty_def;
+val _ = next_ml_names := ["insert"];
+val _ = translate mlsetTheory.insert_def;
 
 val _ = ml_prog_update (close_module NONE);
 
-(* this is here so that the type name is accessible without the full name *)
 val _ = ml_prog_update (add_dec
-  ``Dtabbrev unknown_loc ["'a";"'b"] "map"
-             (Atapp [Atvar "'a"; Atvar "'b"] (Short "map"))`` I);
+  ``Dtabbrev unknown_loc ["'a"] "set" (Atapp [Atvar "'a"] (Short "mlset"))`` I);
 
 val _ = ml_prog_update close_local_block;
 

--- a/basis/SetProgScript.sml
+++ b/basis/SetProgScript.sml
@@ -5,6 +5,7 @@
 open preamble
   ml_translatorLib ml_translatorTheory ml_progLib
   balanced_mapTheory MapProgTheory basisFunctionsLib
+local open mlsetTheory in end
 
 val _ = new_theory "SetProg"
 
@@ -159,5 +160,11 @@ val _ = ml_prog_update (add_dec
   ``Dtabbrev unknown_loc ["'a"] "set" (Atapp [Atvar "'a"] (Short "mlset"))`` I);
 
 val _ = ml_prog_update close_local_block;
+
+(* Remove all overloads introduced by loading mlset: *)
+val _ = List.app (fn nm => remove_ovl_mapping nm {Name = nm, Thy = "mlset"})
+                 ["singleton","member","delete","union","isSubset","compare",
+                  "all", "exists", "translate", "map", "filter", "fromList",
+                  "toList", "null", "size", "fold", "empty", "insert"];
 
 val _ = export_theory ();

--- a/basis/SetProgScript.sml
+++ b/basis/SetProgScript.sml
@@ -162,9 +162,9 @@ val _ = ml_prog_update (add_dec
 val _ = ml_prog_update close_local_block;
 
 (* Remove all overloads introduced by loading mlset: *)
-val _ = List.app (fn nm => remove_ovl_mapping nm {Name = nm, Thy = "mlset"})
-                 ["singleton","member","delete","union","isSubset","compare",
-                  "all", "exists", "translate", "map", "filter", "fromList",
-                  "toList", "null", "size", "fold", "empty", "insert"];
+val _ = List.app (fn tm => let val {Name, Thy,...} = dest_thy_const tm
+                           in remove_ovl_mapping Name {Name = Name, Thy = Thy}
+                           end)
+                 (constants "mlset");
 
 val _ = export_theory ();

--- a/basis/dependency-order
+++ b/basis/dependency-order
@@ -23,6 +23,7 @@ Word8
 Word8Array
 Array
 Map
+Set
 Hashtable
 CommandLine
 Double

--- a/basis/pure/README.md
+++ b/basis/pure/README.md
@@ -31,6 +31,11 @@ Types and pure functions for pretty printing
 [mlratScript.sml](mlratScript.sml):
 Pure functions for the Rat module.
 
+[mlsetScript.sml](mlsetScript.sml):
+Pure functions for the Set module.
+This file defines a wrapper around the balanced_map type. See
+$HOLDIR/examples/balanced_bst/osetScript.sml.
+
 [mlstringLib.sml](mlstringLib.sml):
 More ML functions for manipulating HOL terms involving mlstrings.
 

--- a/basis/pure/mlmapScript.sml
+++ b/basis/pure/mlmapScript.sml
@@ -102,6 +102,19 @@ Definition exists_def:
   exists f (Map cmp t) = balanced_map$exists f t
 End
 
+Definition member_def:
+  member k (Map cmp t) = balanced_map$member cmp k t
+End
+
+Definition singleton_def:
+  singleton cmp k v = Map cmp (balanced_map$singleton k v)
+End
+
+Definition compare_def:
+  compare vcmp (Map cmp m1) (Map _ m2) =
+    balanced_map$compare cmp vcmp m1 m2
+End
+
 (* definitions for proofs *)
 
 Definition map_ok_def:

--- a/basis/pure/mlmapScript.sml
+++ b/basis/pure/mlmapScript.sml
@@ -111,7 +111,7 @@ Definition singleton_def:
 End
 
 Definition compare_def:
-  compare vcmp (Map cmp m1) (Map _ m2) =
+  compare vcmp (Map cmp m1: ('a, 'b) map) (Map _ m2: ('a, 'b) map) =
     balanced_map$compare cmp vcmp m1 m2
 End
 

--- a/basis/pure/mlsetScript.sml
+++ b/basis/pure/mlsetScript.sml
@@ -1,0 +1,92 @@
+(*
+  Pure functions for the Set module.
+  This file defines a wrapper around the balanced_map type.
+*)
+open preamble balanced_mapTheory;
+
+val _ = set_grammar_ancestry ["balanced_map"];
+val _ = new_theory "mlset";
+
+(* The type :set would collide with :pred_set$set *)
+Datatype:
+  mlset = Set ('a -> 'a -> ordering) (('a,unit) balanced_map)
+End
+
+Definition empty_def:
+  empty cmp = Set cmp balanced_map$empty
+End
+
+Definition singleton_def:
+  singleton cmp x = Set cmp (balanced_map$singleton x ())
+End
+
+Definition member_def:
+  member x (Set cmp s) = balanced_map$member cmp x s
+End
+
+Definition insert_def:
+  insert x (Set cmp s) = Set cmp (balanced_map$insert cmp x () s)
+End
+
+Definition delete_def:
+  delete x (Set cmp s) = Set cmp (balanced_map$delete cmp x s)
+End
+
+Definition union_def:
+  union (Set cmp s) (Set _ t) = Set cmp (balanced_map$union cmp s t)
+End
+
+Definition isSubset_def:
+  isSubset (Set cmp s) (Set _ t) = balanced_map$isSubmapOf cmp s t
+End
+
+Definition compare_def:
+  compare (Set cmp s) (Set _ t) = balanced_map$compare cmp (\x y. Equal) s t
+End
+
+Definition all_def:
+  all f (Set cmp s) = balanced_map$every (\k _. f k) s
+End
+
+Definition exists_def:
+  exists f (Set cmp s) = balanced_map$exists (\k _. f k) s
+End
+
+Definition translate_def:
+  translate f cmp (Set _ s) =
+    Set cmp (balanced_map$foldrWithKey
+              (\k _ t. balanced_map$insert cmp (f k) () t)
+              balanced_map$empty s)
+End
+
+Definition map_def:
+  map f (Set cmp s) = translate f cmp (Set cmp s)
+End
+
+Definition filter_def:
+  filter f (Set cmp s) = Set cmp (balanced_map$filterWithKey (\k (). f k) s)
+End
+
+Definition fromList_def:
+  fromList cmp xs =
+    Set cmp (FOLDL (\t k. balanced_map$insert cmp k () t)
+                   balanced_map$empty xs)
+End
+
+Definition null_def:
+  null (Set cmp s) = balanced_map$null s
+End
+
+Definition size_def:
+  size (Set cmp s) = balanced_map$size s
+End
+
+Definition toList_def:
+  toList (Set cmp s) = balanced_map$foldrWithKey (\k _ xs. k::xs) [] s
+End
+
+Definition fold_def:
+  fold f e (Set cmp s) = balanced_map$foldrWithKey (\k _ t. f k t) e s
+End
+
+val _ = export_theory ();

--- a/basis/types.txt
+++ b/basis/types.txt
@@ -242,11 +242,13 @@ Array.collate: ('a -> 'b -> ordering) -> 'a Array.array -> 'b Array.array -> ord
 Array.lookup: 'a Array.array -> 'a -> int -> 'a
 Array.updateResize: 'a Array.array -> 'a -> int -> 'a -> 'a Array.array
 Map.lookup: ('a, 'b) map -> 'a -> 'b option
+Map.member: 'a -> ('a, 'b) map -> bool
 Map.insert: ('a, 'b) map -> 'a -> 'b -> ('a, 'b) map
 Map.delete: ('a, 'b) map -> 'a -> ('a, 'b) map
 Map.null: ('a, 'b) map -> bool
 Map.size: ('a, 'b) map -> int
 Map.empty: ('a -> 'a -> ordering) -> ('a, 'b) map
+Map.singleton: ('a -> 'a -> ordering) -> 'a -> 'b -> ('a, 'b) map
 Map.union: ('a, 'b) map -> ('a, 'b) map -> ('a, 'b) map
 Map.unionWith: ('a -> 'a -> 'a) -> ('b, 'a) map -> ('b, 'a) map -> ('b, 'a) map
 Map.unionWithKey: ('a -> 'b -> 'b -> 'b) -> ('a, 'b) map -> ('a, 'b) map -> ('a, 'b) map
@@ -261,6 +263,25 @@ Map.all: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.exists: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.filterWithKey: ('a -> 'b -> bool) -> ('a, 'b) map -> ('a, 'b) map
 Map.filter: ('a -> bool) -> ('b, 'a) map -> ('b, 'a) map
+Map.compare: ('a -> 'b -> ordering) -> ('c, 'a) map -> ('c, 'b) map -> ordering
+Set.singleton: ('a -> 'a -> ordering) -> 'a -> 'a set
+Set.member: 'a -> 'a set -> bool
+Set.delete: 'a -> 'a set -> 'a set
+Set.union: 'a set -> 'a set -> 'a set
+Set.isSubset: 'a set -> 'a set -> bool
+Set.compare: 'a set -> 'a set -> ordering
+Set.all: ('a -> bool) -> 'a set -> bool
+Set.exists: ('a -> bool) -> 'a set -> bool
+Set.translate: ('a -> 'b) -> ('b -> 'b -> ordering) -> 'a set -> 'b set
+Set.map: ('a -> 'a) -> 'a set -> 'a set
+Set.filter: ('a -> bool) -> 'a set -> 'a set
+Set.fromList: ('a -> 'a -> ordering) -> 'a list -> 'a set
+Set.toList: 'a set -> 'a list
+Set.null: 'a set -> bool
+Set.size: 'a set -> int
+Set.fold: ('a -> 'b -> 'b) -> 'b -> 'a set -> 'b
+Set.empty: ('a -> 'a -> ordering) -> 'a set
+Set.insert: 'a -> 'a set -> 'a set
 Hashtable.delete: ('a, 'b) Hashtable.hashtable -> 'a -> unit
 Hashtable.lookup: ('a, 'b) Hashtable.hashtable -> 'a -> 'b option
 Hashtable.toAscList: ('a, 'b) Hashtable.hashtable -> ('a * 'b) list

--- a/basis/types.txt
+++ b/basis/types.txt
@@ -263,7 +263,7 @@ Map.all: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.exists: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.filterWithKey: ('a -> 'b -> bool) -> ('a, 'b) map -> ('a, 'b) map
 Map.filter: ('a -> bool) -> ('b, 'a) map -> ('b, 'a) map
-Map.compare: ('a -> 'b -> ordering) -> ('c, 'a) map -> ('c, 'b) map -> ordering
+Map.compare: ('a -> 'a -> ordering) -> ('b, 'a) map -> ('b, 'a) map -> ordering
 Set.singleton: ('a -> 'a -> ordering) -> 'a -> 'a set
 Set.member: 'a -> 'a set -> bool
 Set.delete: 'a -> 'a set -> 'a set

--- a/basis/types.txt
+++ b/basis/types.txt
@@ -263,7 +263,7 @@ Map.all: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.exists: ('a -> 'b -> bool) -> ('a, 'b) map -> bool
 Map.filterWithKey: ('a -> 'b -> bool) -> ('a, 'b) map -> ('a, 'b) map
 Map.filter: ('a -> bool) -> ('b, 'a) map -> ('b, 'a) map
-Map.compare: ('a -> 'a -> ordering) -> ('b, 'a) map -> ('b, 'a) map -> ordering
+Map.compare: ('a -> 'b -> ordering) -> ('c, 'a) map -> ('c, 'b) map -> ordering
 Set.singleton: ('a -> 'a -> ordering) -> 'a -> 'a set
 Set.member: 'a -> 'a set -> bool
 Set.delete: 'a -> 'a set -> 'a set

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -1707,8 +1707,8 @@ QED
 (* pair definition *)
 
 Definition PAIR_TYPE_def:
-    PAIR_TYPE b c (x_2:'b,x_1:'c) v <=>
-    ?v1_1 v1_2. v = Conv NONE [v1_1; v1_2] /\ b x_2 v1_1 /\ c x_1 v1_2
+    PAIR_TYPE a b (x_2:'a,x_1:'b) v <=>
+    ?v1_1 v1_2. v = Conv NONE [v1_1; v1_2] /\ a x_2 v1_1 /\ b x_1 v1_2
 End
 
 val PAIR_TYPE_SIMP = Q.prove(


### PR DESCRIPTION
This PR adds a new Set module to basis, based on the same balanced map as Map.map, but specialized to unit values. It is translated in a separate theory (SetProg) to avoid clashes with translator theorem names for values with identical (unqualified) names within the theory.

Also adds some more operations to the Map module (member, compare, singleton)