### PR TITLE
Pancake annotation comments

### DIFF
--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -121,6 +121,7 @@ val r = pan_passesTheory.pan_exp_to_display_def |> spec32 |> translate;
 val r = pan_passesTheory.crep_exp_to_display_def |> spec32 |> translate;
 val r = pan_passesTheory.loop_exp_to_display_def |> spec32 |> translate;
 
+val r = pan_passesTheory.dest_annot_def |> spec32 |> translate;
 val r = pan_passesTheory.pan_seqs_def |> spec32 |> translate;
 val r = pan_passesTheory.crep_seqs_def |> spec32 |> translate;
 val r = pan_passesTheory.loop_seqs_def |> spec32 |> translate;

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -122,6 +122,7 @@ val r = pan_passesTheory.pan_exp_to_display_def |> spec64 |> translate;
 val r = pan_passesTheory.crep_exp_to_display_def |> spec64 |> translate;
 val r = pan_passesTheory.loop_exp_to_display_def |> spec64 |> translate;
 
+val r = pan_passesTheory.dest_annot_def |> spec64 |> translate;
 val r = pan_passesTheory.pan_seqs_def |> spec64 |> translate;
 val r = pan_passesTheory.crep_seqs_def |> spec64 |> translate;
 val r = pan_passesTheory.loop_seqs_def |> spec64 |> translate;

--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -694,12 +694,14 @@ val res = translate $ spec32 $ GSYM $ cj 2 conv_Exp_thm
 
 val res = translate $ spec32 $ SIMP_RULE std_ss [option_map_thm, OPTION_MAP2_thm] conv_NonRecStmt_def;
 
+val res = translate $ spec32 $ add_locs_annot_def;
+
 val res = translate butlast_def;
 
 val res = preprocess $ spec32 conv_Prog_def |> translate_no_ind;
 
 Theorem conv_Prog_ind:
-  panptreeconversion_conv_handle_ind (:'b)
+  panptreeconversion_conv_handle_ind
 Proof
   PURE_REWRITE_TAC [fetch "-" "panptreeconversion_conv_handle_ind_def"]
   \\ rpt gen_tac

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -698,12 +698,14 @@ val res = translate $ spec64 $ GSYM $ cj 2 conv_Exp_thm
 
 val res = translate $ spec64 $ SIMP_RULE std_ss [option_map_thm, OPTION_MAP2_thm] conv_NonRecStmt_def;
 
+val res = translate $ spec64 $ add_locs_annot_def;
+
 val res = translate butlast_def;
 
 val res = preprocess $ spec64 conv_Prog_def |> translate_no_ind;
 
 Theorem conv_Prog_ind:
-  panptreeconversion_conv_handle_ind (:'b)
+  panptreeconversion_conv_handle_ind
 Proof
   PURE_REWRITE_TAC [fetch "-" "panptreeconversion_conv_handle_ind_def"]
   \\ rpt gen_tac

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -75,7 +75,8 @@ Datatype:
        | Return ('a exp)
        | ShMemLoad opsize varname ('a exp)
        | ShMemStore opsize ('a exp) ('a exp)
-       | Tick;
+       | Tick
+       | Annot mlstring
 End
 
 (*

--- a/pancake/panScopeScript.sml
+++ b/pancake/panScopeScript.sml
@@ -110,7 +110,8 @@ Definition scope_check_prog_def:
   scope_check_prog ctxt (ShMemStore mop e1 e2) =
     OPTION_CHOICE (scope_check_exp ctxt e1)
                   (scope_check_exp ctxt e2) ∧
-  scope_check_prog ctxt Tick = NONE
+  scope_check_prog ctxt Tick = NONE ∧
+  scope_check_prog ctxt (Annot _) = NONE
 End
 
 Definition scope_check_funs_def:

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -153,10 +153,17 @@ Termination
   WF_REL_TAC `measure (panLang$exp_size ARB)`
 End
 
+Definition dest_annot_def:
+  dest_annot (Annot str) = SOME str /\
+  dest_annot _ = NONE
+End
+
+(* treat (Seq (Annot _) _) as a special case, and don't flatten it *)
 Definition pan_seqs_def:
   pan_seqs z =
     case z of
-    | panLang$Seq x y => Append (pan_seqs x) (pan_seqs y)
+    | panLang$Seq x y => (case dest_annot x of SOME _ => List [z]
+        | _ => Append (pan_seqs x) (pan_seqs y))
     | _ => List [z]
 End
 
@@ -166,6 +173,7 @@ Triviality MEM_append_pan_seqs:
     prog_size ARB a ≤ prog_size ARB prog1
 Proof
   Induct \\ simp [Once pan_seqs_def]
+  \\ every_case_tac
   \\ gvs [panLangTheory.prog_size_def]
   \\ rw [] \\ res_tac \\ fs []
 QED
@@ -212,7 +220,7 @@ Definition pan_prog_to_display_def:
   (pan_prog_to_display (StoreByte e1 e2) = Tuple
     [String (strlit "mem"); pan_exp_to_display e1;
      String (strlit ":="); String (strlit "byte"); pan_exp_to_display e2]) ∧
-  (pan_prog_to_display (Annot str) = Item NONE (strlit "annot" [empty_item str]) ∧
+  (pan_prog_to_display (Annot str) = Item NONE (strlit "annot") [String str]) ∧
   (pan_prog_to_display Tick = empty_item (strlit "tick")) ∧
   (pan_prog_to_display Break = empty_item (strlit "break")) ∧
   (pan_prog_to_display Continue = empty_item (strlit "continue")) ∧
@@ -221,8 +229,8 @@ Definition pan_prog_to_display_def:
   (pan_prog_to_display (Raise n e) =
      Item NONE (strlit "raise") [String n; pan_exp_to_display e]) ∧
   (pan_prog_to_display (Seq prog1 prog2) =
-    (let xs = append (Append (pan_seqs prog1) (pan_seqs prog2)) in
-       separate_lines (strlit "seq") (MAP pan_prog_to_display xs))) ∧
+     let xs = append (Append (pan_seqs prog1) (pan_seqs prog2)) in
+     separate_lines (strlit "seq") (MAP pan_prog_to_display xs)) ∧
   (pan_prog_to_display (panLang$Call ret_opt dest args) =
      case ret_opt of
      | NONE =>

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -212,6 +212,7 @@ Definition pan_prog_to_display_def:
   (pan_prog_to_display (StoreByte e1 e2) = Tuple
     [String (strlit "mem"); pan_exp_to_display e1;
      String (strlit ":="); String (strlit "byte"); pan_exp_to_display e2]) ∧
+  (pan_prog_to_display (Annot str) = Item NONE (strlit "annot" [empty_item str]) ∧
   (pan_prog_to_display Tick = empty_item (strlit "tick")) ∧
   (pan_prog_to_display Break = empty_item (strlit "break")) ∧
   (pan_prog_to_display Continue = empty_item (strlit "continue")) ∧

--- a/pancake/pan_simpScript.sml
+++ b/pancake/pan_simpScript.sml
@@ -1,5 +1,5 @@
 (*
-  Compilation from panLang to crepLang.
+  Simplification of panLang.
 *)
 
 open preamble panLangTheory
@@ -35,6 +35,7 @@ Definition seq_assoc_def:
                  name args)) /\
   (seq_assoc p (DecCall v s e es q) =
     SmartSeq p (DecCall v s e es (seq_assoc Skip q))) /\
+  (seq_assoc p (Annot _) = p) /\
   (seq_assoc p q = SmartSeq p q)
 End
 
@@ -99,6 +100,7 @@ Theorem seq_assoc_pmatch:
                        SOME (rv , (SOME (eid , ev , (seq_assoc Skip ep)))))
                   name args)
   | (DecCall v s e es q) => SmartSeq p (DecCall v s e es (seq_assoc Skip q))
+  | (Annot _) => p
   | q => SmartSeq p q
 Proof
   rpt strip_tac >>

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -297,7 +297,8 @@ Definition compile_def:
            SOME (_, r'::_) => ShMem (load_op op) r' a
          | _ => Skip)
      | _ => Skip)) ∧
-  (compile ctxt Tick = Tick)
+  (compile ctxt Tick = Tick) ∧
+  (compile _ (Annot _) = Skip)
 End
 
 Definition mk_ctxt_def:

--- a/pancake/parser/README.md
+++ b/pancake/parser/README.md
@@ -6,7 +6,7 @@ The Pancake parser.
 * March 2024: Updated with shared memory instructions
 
 [panLexerScript.sml](panLexerScript.sml):
-* The beginnings of a lexer for the Pancake language.
+* A lexer for the Pancake language.
 
 [panPEGScript.sml](panPEGScript.sml):
 * The beginnings of a PEG parser for the Pancake language.

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -423,4 +423,23 @@ val entry_fun =
 
 val entry_fun_parse =  check_success $ parse_pancake entry_fun;
 
+(* Using the annotation comment syntax. *)
+val annot_fun =
+  `
+  /* this is a function with an annot-comment in it */
+  fun f () {
+    var x = 1;
+    var y = 2;
+    /*@ good place to check y - x == 1 @*/
+    var z = x + y;
+    return z;
+  }
+  `
+
+val annot_fun_parse = check_success $ parse_pancake annot_fun;
+val annot_fun_lex = lex_pancake annot_fun;
+val annots = annot_fun_lex |> concl |> rhs |> listSyntax.dest_list |> fst
+  |> filter (can (find_term (can (match_term ``AnnotCommentT``))))
+val has_annot = assert (not o null) annots;
+
 val _ = export_theory();

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -73,6 +73,12 @@ Definition keep_ident_def:
                        | _ => F) mkleaf
 End
 
+Definition keep_annot_def:
+  keep_annot = tok (λt. case t of
+                       | AnnotCommentT _ => T
+                       | _ => F) mkleaf
+End
+
 Definition keep_ffi_ident_def:
   keep_ffi_ident = tok (λt. case t of
                        | ForeignIdent _ => T
@@ -143,6 +149,7 @@ Definition pancake_peg_def[nocompute]:
                                            FLAT]
                                (mksubtree ParamListNT));
         (INL ProgNT, rpt (choicel [mknt BlockNT;
+                                   keep_annot;
                                    seql [mknt StmtNT;
                                          consume_tok SemiT] I])
                          (mksubtree ProgNT o FLAT));
@@ -426,7 +433,7 @@ val wfpeg_rwts = wfpeg_cases
                                      ‘consume_tok t’, ‘keep_kw k’,
                                      ‘consume_kw k’, ‘keep_int’,
                                      ‘keep_nat’,‘keep_ffi_ident’,
-                                     ‘keep_ident’,
+                                     ‘keep_ident’,‘keep_annot’,
                                      ‘pegf e f’])
                    |> map (CONV_RULE
                            (RAND_CONV (SIMP_CONV (srw_ss())
@@ -655,7 +662,7 @@ fun wfnt tm (t,acc) = let
                      seql_def, keep_tok_def, consume_tok_def,
                      keep_kw_def, consume_kw_def, keep_int_def,
                      keep_nat_def, keep_ident_def, keep_ffi_ident_def,
-                     peg_accfupds]) THEN
+                     keep_annot_def, peg_accfupds]) THEN
           simp(wfpeg_rwts @ wfpeg_rwts' @ npeg0_rwts @ npeg1_rwts @ peg0_rwts @ peg1_rwts @ acc
               ) THEN
           simp(mknt_def::wfpeg_rwts @ wfpeg_rwts' @ npeg0_rwts @ npeg1_rwts @ peg0_rwts @ peg1_rwts @ acc @
@@ -686,7 +693,8 @@ Proof
        subexprs_mknt, peg_start, peg_range, DISJ_IMP_THM,FORALL_AND_THM,
        choicel_def, seql_def, pegf_def, keep_tok_def, consume_tok_def,
        keep_kw_def, consume_kw_def, keep_int_def, keep_nat_def,
-       keep_ident_def, keep_ffi_ident_def, try_def, try_default_def] >>
+       keep_ident_def, keep_annot_def, keep_ffi_ident_def, try_def,
+       try_default_def] >>
   simp(pancake_wfpeg_thm :: wfpeg_rwts @ peg0_rwts @ npeg0_rwts)
 QED
 
@@ -697,7 +705,8 @@ Proof
        subexprs_mknt, peg_start, peg_range, DISJ_IMP_THM,FORALL_AND_THM,
        choicel_def, seql_def, pegf_def, keep_tok_def, consume_tok_def,
        keep_kw_def, consume_kw_def, keep_int_def, keep_nat_def,
-       keep_ident_def, keep_ffi_ident_def, try_def, try_default_def] >>
+       keep_ident_def, keep_annot_def, keep_ffi_ident_def, try_def,
+       try_default_def] >>
   simp(pancake_wfpeg_thm2 :: wfpeg_rwts' @ peg1_rwts @ npeg1_rwts)
 QED
 

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -51,6 +51,12 @@ Definition tokcheck_def:
 End
 (** End copy **)
 
+Definition is_annot_tok_def:
+  is_annot_tok pt = case (OPTION_BIND (destLf pt) destTOK) of
+      SOME (AnnotCommentT _) => T
+    | _ => F
+End
+
 Definition kw_def:
   kw k = KeywordT k
 End
@@ -417,6 +423,7 @@ Definition conv_NonRecStmt_def:
     else if tokcheck leaf (kw BrK) then SOME Break
     else if tokcheck leaf (kw ContK) then SOME Continue
     else if tokcheck leaf (kw TicK) then SOME Tick
+    else if is_annot_tok leaf then SOME Skip
     else NONE
 End
 

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -476,7 +476,9 @@ Definition parsetree_locs_def:
 End
 
 Definition posn_string_def:
-  posn_string (POSN lnum cnum) = (toString lnum ++ ":" ++ toString cnum)
+  posn_string (POSN lnum cnum) = (toString lnum ++ ":" ++ toString cnum) /\
+  posn_string EOFpt = "EOF" /\
+  posn_string UNKNOWNpt = "UNKNOWN"
 End
 
 Definition locs_comment_def:

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -304,6 +304,7 @@ Theorem ret_to_tail_Others:
   ^(get_goal "panLang$ShMemLoad") /\
   ^(get_goal "panLang$ShMemStore") /\
   ^(get_goal "panLang$Return") /\
+  ^(get_goal "panLang$Annot") /\
   ^(get_goal "panLang$Tick")
 Proof
   rw [ret_to_tail_def]
@@ -908,6 +909,7 @@ Theorem compile_Others:
   ^(get_goal "panLang$Continue") /\
   ^(get_goal "panLang$Raise") /\
   ^(get_goal "panLang$Return") /\
+  ^(get_goal "panLang$Annot _") /\
   ^(get_goal "panLang$Tick")
 Proof
   rw [] >>

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -462,10 +462,11 @@ end
 
 
 
-Theorem compile_Skip_Break_Continue:
+Theorem compile_Skip_Break_Continue_Annot:
   ^(get_goal "compile _ panLang$Skip") /\
   ^(get_goal "compile _ panLang$Break") /\
-  ^(get_goal "compile _ panLang$Continue")
+  ^(get_goal "compile _ panLang$Continue") /\
+  ^(get_goal "compile _ (panLang$Annot _)")
 Proof
   rpt strip_tac >>
   fs [panSemTheory.evaluate_def, evaluate_def,
@@ -4635,7 +4636,8 @@ Theorem pc_compile_correct:
 Proof
   match_mp_tac (the_ind_thm()) >>
   EVERY (map strip_assume_tac
-         [compile_Skip_Break_Continue, compile_Dec, compile_ShMemLoad, compile_ShMemStore,
+         [compile_Skip_Break_Continue_Annot,
+          compile_Dec, compile_ShMemLoad, compile_ShMemStore,
           compile_Assign, compile_Store, compile_StoreByte, compile_Seq,
           compile_If, compile_While, compile_Call, compile_ExtCall,
           compile_Raise, compile_Return, compile_Tick, compile_DecCall]) >>

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -418,6 +418,7 @@ Definition evaluate_def:
   (evaluate (Tick,s) =
     if s.clock = 0 then (SOME TimeOut,empty_locals s)
     else (NONE,dec_clock s)) /\
+  (evaluate (Annot _,s) = (NONE, s)) /\
   (evaluate (Call caltyp trgt argexps,s) =
     case (eval s trgt, OPT_MMAP (eval s) argexps) of
      | (SOME (ValLabel fname), SOME args) =>


### PR DESCRIPTION
This adds an `Annot` constructor to Pancake's AST (which is just a skip with space to attach a string) and adjusts the parser to use `Annot` comments to tag the locations of all constructs.

It should (not well-tested yet) also pass explicit user annotation comments `/*@ ... @*/` at statement positions into the AST as `Annot` elements as well.