### PR TITLE
Tweak Pancake annotations

### DIFF
--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -77,7 +77,7 @@ Datatype:
        | ShMemLoad opsize varname ('a exp)
        | ShMemStore opsize ('a exp) ('a exp)
        | Tick
-       | Annot mlstring
+       | Annot mlstring mlstring
 End
 
 (*

--- a/pancake/panScopeScript.sml
+++ b/pancake/panScopeScript.sml
@@ -112,7 +112,7 @@ Definition scope_check_prog_def:
     OPTION_CHOICE (scope_check_exp ctxt e1)
                   (scope_check_exp ctxt e2) ∧
   scope_check_prog ctxt Tick = NONE ∧
-  scope_check_prog ctxt (Annot _) = NONE
+  scope_check_prog ctxt (Annot _ _) = NONE
 End
 
 Definition scope_check_funs_def:

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -157,7 +157,7 @@ Termination
 End
 
 Definition dest_annot_def:
-  dest_annot (Annot str) = SOME str /\
+  dest_annot (Annot k str) = SOME (k, str) /\
   dest_annot _ = NONE
 End
 
@@ -223,7 +223,8 @@ Definition pan_prog_to_display_def:
   (pan_prog_to_display (StoreByte e1 e2) = Tuple
     [String (strlit "mem"); pan_exp_to_display e1;
      String (strlit ":="); String (strlit "byte"); pan_exp_to_display e2]) ∧
-  (pan_prog_to_display (Annot str) = Item NONE (strlit "annot") [String str]) ∧
+  (pan_prog_to_display (Annot k str) = Item NONE (strlit "annot")
+    [String (escape_str k); String (escape_str str)]) ∧
   (pan_prog_to_display Tick = empty_item (strlit "tick")) ∧
   (pan_prog_to_display Break = empty_item (strlit "break")) ∧
   (pan_prog_to_display Continue = empty_item (strlit "continue")) ∧

--- a/pancake/pan_simpScript.sml
+++ b/pancake/pan_simpScript.sml
@@ -35,7 +35,7 @@ Definition seq_assoc_def:
                  name args)) /\
   (seq_assoc p (DecCall v s e es q) =
     SmartSeq p (DecCall v s e es (seq_assoc Skip q))) /\
-  (seq_assoc p (Annot _) = p) /\
+  (seq_assoc p (Annot _ _) = p) /\
   (seq_assoc p q = SmartSeq p q)
 End
 
@@ -100,7 +100,7 @@ Theorem seq_assoc_pmatch:
                        SOME (rv , (SOME (eid , ev , (seq_assoc Skip ep)))))
                   name args)
   | (DecCall v s e es q) => SmartSeq p (DecCall v s e es (seq_assoc Skip q))
-  | (Annot _) => p
+  | (Annot _ _) => p
   | q => SmartSeq p q
 Proof
   rpt strip_tac >>

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -299,7 +299,7 @@ Definition compile_def:
          | _ => Skip)
      | _ => Skip)) ∧
   (compile ctxt Tick = Tick) ∧
-  (compile _ (Annot _) = Skip)
+  (compile _ (Annot _ _) = Skip)
 End
 
 Definition mk_ctxt_def:

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -433,7 +433,7 @@ Definition conv_NonRecStmt_def:
     else if tokcheck leaf (kw ContK) then SOME Continue
     else if tokcheck leaf (kw TicK) then SOME Tick
     else (case dest_annot_tok leaf of
-      | SOME c => SOME (Annot (implode c))
+      | SOME c => SOME (Annot (strlit "@") (implode c))
       | NONE => NONE)
 End
 
@@ -491,11 +491,11 @@ Definition posn_string_def:
 End
 
 Definition locs_comment_def:
-  locs_comment (p1, p2) = implode ("(location " ++ posn_string p1 ++ " " ++ posn_string p2 ++ ")")
+  locs_comment (p1, p2) = implode ("(" ++ posn_string p1 ++ " " ++ posn_string p2 ++ ")")
 End
 
 Definition add_locs_annot_def:
-  add_locs_annot ptree prog = panLang$Seq (Annot (locs_comment (parsetree_locs ptree))) prog
+  add_locs_annot ptree prog = panLang$Seq (Annot (strlit "location") (locs_comment (parsetree_locs ptree))) prog
 End
 
 Definition conv_Prog_def:

--- a/pancake/proofs/pan_simpProofScript.sml
+++ b/pancake/proofs/pan_simpProofScript.sml
@@ -909,7 +909,7 @@ Theorem compile_Others:
   ^(get_goal "panLang$Continue") /\
   ^(get_goal "panLang$Raise") /\
   ^(get_goal "panLang$Return") /\
-  ^(get_goal "panLang$Annot _") /\
+  ^(get_goal "panLang$Annot") /\
   ^(get_goal "panLang$Tick")
 Proof
   rw [] >>

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -466,7 +466,7 @@ Theorem compile_Skip_Break_Continue_Annot:
   ^(get_goal "compile _ panLang$Skip") /\
   ^(get_goal "compile _ panLang$Break") /\
   ^(get_goal "compile _ panLang$Continue") /\
-  ^(get_goal "compile _ (panLang$Annot _)")
+  ^(get_goal "compile _ (panLang$Annot _ _)")
 Proof
   rpt strip_tac >>
   fs [panSemTheory.evaluate_def, evaluate_def,

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -421,7 +421,7 @@ Definition evaluate_def:
   (evaluate (Tick,s) =
     if s.clock = 0 then (SOME TimeOut,empty_locals s)
     else (NONE,dec_clock s)) /\
-  (evaluate (Annot _,s) = (NONE, s)) /\
+  (evaluate (Annot _ _,s) = (NONE, s)) /\
   (evaluate (Call caltyp trgt argexps,s) =
     case (eval s trgt, OPT_MMAP (eval s) argexps) of
      | (SOME (ValLabel fname), SOME args) =>


### PR DESCRIPTION
Adjust the Annot constructor to take two mlstring arguments rather than one.

The annotations are already being used for two different roles, and I've just thought of a third. The distinction allows the first string to identify the kind of annotation, which lets annotation consumers tell them apart without doing fiddly parsing.

Also do some string escaping in explorer output, so that user comments can't break the s-exp wellformedness by
commenting with mismatched parens.

Should be harmless, hopefully passes regression test.