### PR TITLE
Fix Ordering of "Chained" Field Accesses in Pancake AST

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -476,7 +476,7 @@ Definition conv_Exp_alt_def:
               OPTION_CHOICE (OPTION_CHOICE (conv_const t) (conv_var t))
                             (conv_Exp_alt t)
           | t::v4::v5 =>
-              FOLDR (λt. OPTION_MAP2 Field (conv_nat t))
+              FOLDL (λe t. OPTION_MAP2 Field (conv_nat t) e)
                     (OPTION_CHOICE (conv_var t) (conv_Exp_alt t)) (v4::v5)
         else if isNT nodeNT LabelNT then
           case args of

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -481,7 +481,7 @@ Definition conv_Exp_alt_def:
               OPTION_CHOICE (OPTION_CHOICE (conv_const t) (conv_var t))
                             (conv_Exp_alt t)
           | t::v4::v5 =>
-              FOLDR (λt. OPTION_MAP2 Field (conv_nat t))
+              FOLDL (λe t. OPTION_MAP2 Field (conv_nat t) e)
                     (OPTION_CHOICE (conv_var t) (conv_Exp_alt t)) (v4::v5)
         else if isNT nodeNT LabelNT then
           case args of

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -255,7 +255,7 @@ Definition conv_Exp_def:
       case args of
         [] => NONE
       | [t] => conv_const t ++ conv_var t ++ conv_Exp t
-      | t::ts => FOLDR (λt. lift2 Field (conv_nat t)) (conv_var t ++ conv_Exp t) ts
+      | t::ts => FOLDL (λe t. lift2 Field (conv_nat t) e) (conv_var t ++ conv_Exp t) ts
     else if isNT nodeNT LabelNT then
       case args of
         [t] => lift Label (conv_ident t)


### PR DESCRIPTION
Fixes `struct.x.y` being parsed into `Field x (Field y struct)` - now parsed as `Field y (Field x struct)` as expected