### PR TITLE
Update to account for changed Dafny IR

### DIFF
--- a/compiler/dafny/dafny_astScript.sml
+++ b/compiler/dafny/dafny_astScript.sml
@@ -34,6 +34,7 @@ Datatype:
   | String
   | Bool
   | Char
+  | Native
 End
 
 Datatype:
@@ -60,6 +61,9 @@ Datatype:
   | TypeArgDecl ident (typeArgBound list) variance
 End
 
+(* From Dafny:
+ * USIZE is for whatever target considers that native arrays can be
+ * indexed with *)
 Datatype:
   newtypeRange =
   | U8 | I8
@@ -67,7 +71,8 @@ Datatype:
   | U32 | I32
   | U64 | I64
   | U128 | I128
-  | BigInt | NoRange
+  | BigInt | USIZE
+  | NoRange
 End
 
 Datatype:
@@ -263,6 +268,8 @@ Datatype:
   | MapBoundedPool expression
   (* SeqBoundedPool of includeDuplicates *)
   | SeqBoundedPool expression bool
+  (* ExactBoundedPool of *)
+  | ExactBoundedPool expression
   (* IntRange elemType lo hi up *)
   | IntRange type expression expression bool
   (* UnboundedIntRange start up *)
@@ -308,12 +315,13 @@ End
 
 Datatype:
   method =
-  (* Method isStatic hasBody outVarsAreUninitFieldsToAssign wasFunction
-            overridingPath name typeParams params body outTypes outVars *)
+  (* Method attributes isStatic hasBody outVarsAreUninitFieldsToAssign
+            wasFunction overridingPath name typeParams params body outTypes
+            outVars *)
   (* Comments from Dafny (probably Rust specific) *)
   (* outVarsAreUninitFieldsToAssign: for constructors *)
   (* wasFunction: to choose between "&self" and "&mut self" *)
-  | Method bool bool bool bool ((ident list) option) name
+  | Method (attribute list) bool bool bool bool ((ident list) option) name
            (typeArgDecl list) (formal list) (statement list)
            (type list) ((varName list) option)
 End
@@ -400,10 +408,10 @@ Definition dest_varName_def:
 End
 
 Definition dest_Method_def:
-  dest_Method (Method isStatic hasBody outVarsAreUninitFieldsToAssign
+  dest_Method (Method attributes isStatic hasBody outVarsAreUninitFieldsToAssign
                       wasFunction overridingPath nam typeParams params body
                       outTypes outVars) =
-  (isStatic, hasBody, outVarsAreUninitFieldsToAssign, wasFunction,
+  (attributes, isStatic, hasBody, outVarsAreUninitFieldsToAssign, wasFunction,
    overridingPath, nam, typeParams, params, body, outTypes, outVars)
 End
 

--- a/compiler/dafny/semantics/dafny_evaluateScript.sml
+++ b/compiler/dafny/semantics/dafny_evaluateScript.sml
@@ -15,11 +15,11 @@ Type program = “:module list”
 
 (* TODO? Move to dafny_ast *)
 Definition method_name_def:
-  method_name (Method _ _ _ _ _ nam _ _ _ _ _) = nam
+  method_name (Method _ _ _ _ _ _ nam _ _ _ _ _) = nam
 End
 
 Definition method_body_def:
-  method_body (Method _ _ _ _ _ _ _ _ body _ _) = body
+  method_body (Method _ _ _ _ _ _ _ _ _ body _ _) = body
 End
 
 Definition dest_classitem_def:
@@ -69,7 +69,7 @@ End
 
 Definition is_simple_method_def:
   is_simple_method (m: method): bool =
-  let (isStatic, hasBody,
+  let (_, isStatic, hasBody,
        outVarsAreUninitFieldsToAssign,
        wasFunction, overridingPath, _,
        typeParams, params, _, outTypes, outVars) = dest_Method m in


### PR DESCRIPTION
Dafny fork to be used: [dnezam/dafny:feat-sexpr-2](https://github.com/dnezam/dafny/tree/feat-sexpr-2)

## Expected Testing Result
```
47 out of 54 tests passed.
1 Dafny fails, 6 CakeML fails
The following test(s) failed because of Dafny:
[(PosixPath('dafny/firstSteps/4_Calls-FunctionsValues-Class+NT.dfy'),
  '(0,-1): Error: Feature not supported for this compilation target: The '
  '/runAllTests option\n')]
The following test(s) failed because of CakeML:
[(PosixPath('basic/ghost_pair.dfy'), 'cml_tuple: Cannot create 1-tuple'),
 (PosixPath('dafny/firstSteps/2_Modules.dfy'),
  'from_classlist: Unsupported item list'),
 (PosixPath('dafny/firstSteps/5_Calls-FunctionsValues-Dt.dfy'),
  'from_module: datatype unsupported'),
 (PosixPath('dafny/firstSteps/6_Calls-VariableCapture.dfy'),
  'dafny_type_of: Unsupported expression'),
 (PosixPath('dafny/firstSteps/7_Arrays.dfy'),
  'method_is_method: Type parameters are currently unsupported (in '
  'PrintArray)'),
 (PosixPath('dafny/firstSteps/7_Dt_Algebraic.dfy'),
  'from_module: datatype unsupported')]
```