### PR TITLE
Remove tDefine usages

### DIFF
--- a/basis/pure/mlintScript.sml
+++ b/basis/pure/mlintScript.sml
@@ -174,7 +174,7 @@ Proof
         , EVERY_EL]
 QED
 
-val fromChars_unsafe_def = tDefine "fromChars_unsafe" `
+Definition fromChars_unsafe_def:
   fromChars_unsafe 0 str = 0n ∧ (* Shouldn't happend *)
   fromChars_unsafe n str =
     if n ≤ padLen_DEC
@@ -182,11 +182,13 @@ val fromChars_unsafe_def = tDefine "fromChars_unsafe" `
     else let n'    = n - padLen_DEC;
              front = fromChars_unsafe n' str * maxSmall_DEC;
              back  = fromChars_range_unsafe n' padLen_DEC str
-         in front + back`
-(wf_rel_tac `measure FST` \\ rw [padLen_DEC_eq]);
+         in front + back
+Termination
+  wf_rel_tac `measure FST` \\ rw [padLen_DEC_eq]
+End
 val fromChars_unsafe_ind = theorem"fromChars_unsafe_ind"
 
-val fromChars_def = tDefine "fromChars" `
+Definition fromChars_def:
   fromChars 0 str = NONE ∧ (* Shouldn't happend *)
   fromChars n str =
     if n ≤ padLen_DEC
@@ -194,8 +196,10 @@ val fromChars_def = tDefine "fromChars" `
     else let n'    = n - padLen_DEC;
              front = OPTION_MAP ($* maxSmall_DEC) (fromChars n' str);
              back  = fromChars_range n' padLen_DEC str
-         in OPTION_MAP2 $+ front back`
-(wf_rel_tac `measure FST` \\ rw [padLen_DEC_eq]);
+         in OPTION_MAP2 $+ front back
+Termination
+  wf_rel_tac `measure FST` \\ rw [padLen_DEC_eq]
+End
 val fromChars_ind = theorem"fromChars_ind"
 
 Theorem fromChars_eq_unsafe:

--- a/basis/pure/mlstringScript.sml
+++ b/basis/pure/mlstringScript.sml
@@ -233,12 +233,14 @@ Proof
   rw[strcat_thm]
 QED
 
-val concatWith_aux_def = tDefine "concatWith_aux"`
+Definition concatWith_aux_def:
   (concatWith_aux s [] bool = implode []) /\
   (concatWith_aux s (h::t) T = strcat h (concatWith_aux s t F)) /\
-  (concatWith_aux s (h::t) F = strcat s (concatWith_aux s (h::t) T))`
-  (wf_rel_tac `inv_image ($< LEX $<) (\(s,l,b). (LENGTH l, if b then 0n else 1))` \\
-  rw[]);
+  (concatWith_aux s (h::t) F = strcat s (concatWith_aux s (h::t) T))
+Termination
+  wf_rel_tac `inv_image ($< LEX $<) (\(s,l,b). (LENGTH l, if b then 0n else 1))` \\
+  rw[]
+End
 
 Definition concatWith_def:
   concatWith s l = concatWith_aux s l T
@@ -296,12 +298,14 @@ Proof
   rw [translate_def, translate_aux_thm]
 QED
 
-val splitl_aux_def = tDefine"splitl_aux"`
+Definition splitl_aux_def:
   splitl_aux P s i =
     if i < strlen s ∧ P (strsub s i) then
         splitl_aux P s (i+1)
-    else (extract s 0 (SOME i), extract s i NONE)`
-(WF_REL_TAC`inv_image $< (λ(x,s,i). strlen s - i)`);
+    else (extract s 0 (SOME i), extract s i NONE)
+Termination
+  WF_REL_TAC`inv_image $< (λ(x,s,i). strlen s - i)`
+End
 
 val splitl_aux_ind = theorem"splitl_aux_ind";
 

--- a/basis/pure/mlvectorScript.sml
+++ b/basis/pure/mlvectorScript.sml
@@ -18,12 +18,14 @@ Definition tabulate_def:
   tabulate n f = Vector (GENLIST f n)
 End
 
-val toList_aux_def = tDefine "toList_aux"`
+Definition toList_aux_def:
   toList_aux vec n =
   if length(vec) <= n
     then []
-  else sub vec n::toList_aux vec (n + 1)`
-(wf_rel_tac `measure (\(vec, n). length(vec) - n)`)
+  else sub vec n::toList_aux vec (n + 1)
+Termination
+  wf_rel_tac `measure (\(vec, n). length(vec) - n)`
+End
 
 val toList_aux_ind = theorem"toList_aux_ind";
 

--- a/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -307,7 +307,7 @@ val res = translate concl_def;
 
 val _ = ml_prog_update open_local_block;
 
-val type_compare_def = tDefine "type_compare" `
+Definition type_compare_def:
   (type_compare t1 t2 =
      case (t1,t2) of
      | (Tyvar x1,Tyvar x2) => mlstring$compare x1 x2
@@ -325,10 +325,12 @@ val type_compare_def = tDefine "type_compare" `
      | (t1::ts1,t2::ts2) =>
          (case type_compare t1 t2 of
           | Equal => type_list_compare ts1 ts2
-          | other => other))`
-  (WF_REL_TAC `measure (\x. case x of
+          | other => other))
+Termination
+  WF_REL_TAC `measure (\x. case x of
                   INR (x,_) => type1_size x
-                | INL (x,_) => type_size x)`)
+                | INL (x,_) => type_size x)`
+End
 
 val type_cmp_thm = Q.prove(
   `(type_cmp = type_compare) /\

--- a/candle/overloading/monadic/holKernelScript.sml
+++ b/candle/overloading/monadic/holKernelScript.sml
@@ -230,15 +230,17 @@ val _ = Define `
         | (Tyvar v as tv) -> [tv]
 *)
 
-val _ = tDefine "tyvars" `
+Definition tyvars_def:
   tyvars x =
     dtcase x of (Tyapp _ args) => itlist union (MAP tyvars args) []
-            | (Tyvar tv) => [tv]`
- (WF_REL_TAC `measure (type_size)` THEN Induct_on `args`
+            | (Tyvar tv) => [tv]
+Termination
+  WF_REL_TAC `measure (type_size)` THEN Induct_on `args`
   THEN FULL_SIMP_TAC (srw_ss()) [type_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC
   THEN REPEAT (POP_ASSUM (MP_TAC o SPEC_ALL)) THEN REPEAT STRIP_TAC
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+End
 
 (*
   let rec type_subst i ty =
@@ -256,18 +258,20 @@ val _ = Define `
       [] => d
     | ((x,y)::l) => if y = a then x else rev_assocd a l d`;
 
-val _ = tDefine "type_subst" `
+Definition type_subst_def:
   type_subst i ty =
     dtcase ty of
       Tyapp tycon args =>
          let args' = MAP (type_subst i) args in
          if args' = args then ty else Tyapp tycon args'
-    | _ => rev_assocd ty i ty`
- (WF_REL_TAC `measure (type_size o SND)` THEN Induct_on `args`
+    | _ => rev_assocd ty i ty
+Termination
+  WF_REL_TAC `measure (type_size o SND)` THEN Induct_on `args`
   THEN FULL_SIMP_TAC (srw_ss()) [type_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC
   THEN REPEAT (POP_ASSUM (MP_TAC o SPEC_ALL)) THEN REPEAT STRIP_TAC
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+End
 
 (*
   let bool_ty = mk_type("bool",[]);;
@@ -669,7 +673,7 @@ val ZERO_LT_term_size = Q.prove(
   `!t. 0 < my_term_size t`,
   Cases THEN EVAL_TAC THEN DECIDE_TAC);
 
-val inst_aux_def = tDefine "inst_aux" `
+Definition inst_aux_def:
   (inst_aux (env:(term # term) list) tyin tm) =
     dtcase tm of
       Var n ty   => let ty' = type_subst tyin ty in
@@ -698,12 +702,14 @@ val inst_aux_def = tDefine "inst_aux" `
                             t' <- inst_aux ((Var v1 ty,Var v1 ty')::env) tyin
                                     (vsubst_aux [(Var v1 ty,y)] t) ;
                             return (Abs y' t') od)
-                    od`
-  (WF_REL_TAC `measure (\(env,tyin,tm). my_term_size tm)`
+                    od
+Termination
+  WF_REL_TAC `measure (\(env,tyin,tm). my_term_size tm)`
    THEN SIMP_TAC (srw_ss()) [my_term_size_def]
    THEN REPEAT STRIP_TAC
    THEN FULL_SIMP_TAC std_ss [my_term_size_vsubst_aux]
-   THEN DECIDE_TAC)
+   THEN DECIDE_TAC
+End
 
 val _ = Define `
   inst tyin tm = if tyin = [] then return tm else inst_aux [] tyin tm`;

--- a/candle/overloading/semantics/holModelConservativityScript.sml
+++ b/candle/overloading/semantics/holModelConservativityScript.sml
@@ -1924,8 +1924,7 @@ val one_one_conext = EVAL ``conexts_of_upd(EL 3 (mk_infinity_ctxt ARB))`` |> con
 
 (* construction of the model extension basing on the independent fragment *)
 
-val type_interpretation_ext_of_def =
-  tDefine "type_interpretation_ext_of0" `
+Definition type_interpretation_ext_of0_def:
   (type_interpretation_ext_of0
    ^mem ind upd ctxt Δ (Γ :mlstring # type -> 'U) ty =
    if ~terminating(subst_clos (dependency (upd::ctxt))) then
@@ -2070,8 +2069,9 @@ val type_interpretation_ext_of_def =
                        sigma'
                        trm0
          | NONE => One (* cannot happen *)
-  )`
-(
+  )
+Termination
+  
   wf_rel_tac `subst_clos_term_ext_rel`
   >- (
     rw[wellorderTheory.WF_IND,subst_clos_term_ext_rel_def,WF_TC_EQN] >>
@@ -2602,7 +2602,8 @@ val type_interpretation_ext_of_def =
           fs[extends_init_def]
          )
       )
-  )
+  
+End
 
 Overload type_interpretation_ext_of = ``type_interpretation_ext_of0 ^mem``
 Overload term_interpretation_ext_of = ``term_interpretation_ext_of0 ^mem``

--- a/candle/overloading/semantics/holModelConservativityScript.sml
+++ b/candle/overloading/semantics/holModelConservativityScript.sml
@@ -2071,7 +2071,7 @@ Definition type_interpretation_ext_of0_def:
          | NONE => One (* cannot happen *)
   )
 Termination
-  
+
   wf_rel_tac `subst_clos_term_ext_rel`
   >- (
     rw[wellorderTheory.WF_IND,subst_clos_term_ext_rel_def,WF_TC_EQN] >>
@@ -2602,7 +2602,7 @@ Termination
           fs[extends_init_def]
          )
       )
-  
+
 End
 
 Overload type_interpretation_ext_of = ``type_interpretation_ext_of0 ^mem``

--- a/candle/overloading/semantics/holModelConservativityScript.sml
+++ b/candle/overloading/semantics/holModelConservativityScript.sml
@@ -2608,6 +2608,7 @@ End
 Overload type_interpretation_ext_of = ``type_interpretation_ext_of0 ^mem``
 Overload term_interpretation_ext_of = ``term_interpretation_ext_of0 ^mem``
 
+val type_interpretation_ext_of_def = type_interpretation_ext_of0_def;
 val type_interpretation_ext_of_ind = fetch "-" "type_interpretation_ext_of0_ind";
 
 (* symbols from the independent fragment keeps their earlier interpretation *)

--- a/candle/overloading/semantics/holSemanticsScript.sml
+++ b/candle/overloading/semantics/holSemanticsScript.sml
@@ -75,14 +75,15 @@ Definition terms_of_frag_def:
         /\ set(allTypes t) ⊆ tys /\ welltyped t}
 End
 
-val TYPE_SUBSTf_def = tDefine "TYPE_SUBSTf" `
+Definition TYPE_SUBSTf_def:
   (TYPE_SUBSTf i (Tyvar v) = i v) ∧
   (TYPE_SUBSTf i (Tyapp v tys) =
     Tyapp v (MAP (λa. TYPE_SUBSTf i a) tys))
-  `
-  (WF_REL_TAC(`measure (type_size o SND)`) >> simp[] >>
+Termination
+  WF_REL_TAC(`measure (type_size o SND)`) >> simp[] >>
    gen_tac >> Induct >> simp[type_size_def] >> rw[] >>
-   simp[] >> res_tac >> simp[]);
+   simp[] >> res_tac >> simp[]
+End
 
 val _ = export_rewrites["TYPE_SUBSTf_def"]
 

--- a/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -262,7 +262,7 @@ val res = translate concl_def;
 
 val _ = ml_prog_update open_local_block;
 
-val type_compare_def = tDefine "type_compare" `
+Definition type_compare_def:
   (type_compare t1 t2 =
      case (t1,t2) of
      | (Tyvar x1,Tyvar x2) => mlstring$compare x1 x2
@@ -280,10 +280,12 @@ val type_compare_def = tDefine "type_compare" `
      | (t1::ts1,t2::ts2) =>
          (case type_compare t1 t2 of
           | Equal => type_list_compare ts1 ts2
-          | other => other))`
-  (WF_REL_TAC `measure (\x. case x of
+          | other => other))
+Termination
+  WF_REL_TAC `measure (\x. case x of
                   INR (x,_) => type1_size x
-                | INL (x,_) => type_size x)`)
+                | INL (x,_) => type_size x)`
+End
 
 val type_cmp_thm = Q.prove(
   `(type_cmp = type_compare) /\

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -228,15 +228,17 @@ val _ = Define `
         | (Tyvar v as tv) -> [tv]
 *)
 
-val _ = tDefine "tyvars" `
+Definition tyvars_def:
   tyvars x =
     dtcase x of (Tyapp _ args) => itlist union (MAP tyvars args) []
-            | (Tyvar tv) => [tv]`
- (WF_REL_TAC `measure (type_size)` THEN Induct_on `args`
+            | (Tyvar tv) => [tv]
+Termination
+  WF_REL_TAC `measure (type_size)` THEN Induct_on `args`
   THEN FULL_SIMP_TAC (srw_ss()) [type_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC
   THEN REPEAT (POP_ASSUM (MP_TAC o SPEC_ALL)) THEN REPEAT STRIP_TAC
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+End
 
 (*
   let rec type_subst i ty =
@@ -254,18 +256,20 @@ val _ = Define `
       [] => d
     | ((x,y)::l) => if y = a then x else rev_assocd a l d`;
 
-val _ = tDefine "type_subst" `
+Definition type_subst_def:
   type_subst i ty =
     dtcase ty of
       Tyapp tycon args =>
          let args' = MAP (type_subst i) args in
          if args' = args then ty else Tyapp tycon args'
-    | _ => rev_assocd ty i ty`
- (WF_REL_TAC `measure (type_size o SND)` THEN Induct_on `args`
+    | _ => rev_assocd ty i ty
+Termination
+  WF_REL_TAC `measure (type_size o SND)` THEN Induct_on `args`
   THEN FULL_SIMP_TAC (srw_ss()) [type_size_def]
   THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC
   THEN REPEAT (POP_ASSUM (MP_TAC o SPEC_ALL)) THEN REPEAT STRIP_TAC
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+End
 
 (*
   let bool_ty = mk_type("bool",[]);;
@@ -667,7 +671,7 @@ val ZERO_LT_term_size = Q.prove(
   `!t. 0 < my_term_size t`,
   Cases THEN EVAL_TAC THEN DECIDE_TAC);
 
-val inst_aux_def = tDefine "inst_aux" `
+Definition inst_aux_def:
   (inst_aux (env:(term # term) list) tyin tm) =
     dtcase tm of
       Var n ty   => let ty' = type_subst tyin ty in
@@ -696,12 +700,14 @@ val inst_aux_def = tDefine "inst_aux" `
                             t' <- inst_aux ((Var v1 ty,Var v1 ty')::env) tyin
                                     (vsubst_aux [(Var v1 ty,y)] t) ;
                             return (Abs y' t') od)
-                    od`
-  (WF_REL_TAC `measure (\(env,tyin,tm). my_term_size tm)`
+                    od
+Termination
+  WF_REL_TAC `measure (\(env,tyin,tm). my_term_size tm)`
    THEN SIMP_TAC (srw_ss()) [my_term_size_def]
    THEN REPEAT STRIP_TAC
    THEN FULL_SIMP_TAC std_ss [my_term_size_vsubst_aux]
-   THEN DECIDE_TAC)
+   THEN DECIDE_TAC
+End
 
 val _ = Define `
   inst tyin tm = if tyin = [] then return tm else inst_aux [] tyin tm`;

--- a/candle/standard/semantics/holSemanticsScript.sml
+++ b/candle/standard/semantics/holSemanticsScript.sml
@@ -45,11 +45,13 @@ Overload is_type_valuation = ``is_type_valuation0 ^mem``
 
 (* Semantics of types. Simply applies the valuation and assignment. *)
 
-val typesem_def = tDefine "typesem"`
+Definition typesem_def:
   (typesem δ (τ:'U tyval) (Tyvar s) = τ s) ∧
   (typesem δ τ (Tyapp name args) =
-    (δ name) (MAP (typesem δ τ) args))`
-  (type_rec_tac "SND o SND")
+    (δ name) (MAP (typesem δ τ) args))
+Termination
+  type_rec_tac "SND o SND"
+End
 
 (* A term assignment is a map from a constant name and a list of values for the
    free type variables to a value for the constant. The assignment is with

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -2816,13 +2816,14 @@ Proof
   METIS_TAC[]
 QED
 
-val variant_def = tDefine "variant" `
+Definition variant_def:
   variant avoid v =
     if EXISTS (vfree_in v) avoid then
     case v of
        Var s ty => variant avoid (Var(s ^ (strlit "'")) ty)
-    | _ => v else v`
-  (WF_REL_TAC `measure (\(avoid,v).
+    | _ => v else v
+Termination
+  WF_REL_TAC `measure (\(avoid,v).
      let n = SUM_SET (BIGUNION (set (MAP (λa. {strlen x + 1 | ∃ty. VFREE_IN (Var x ty) a}) avoid))) in
        n - (case v of Var x ty => strlen x | _ => 0))` >>
    gen_tac >> Cases >> srw_tac[][strlen_def,strcat_thm,implode_def] >>
@@ -2836,7 +2837,8 @@ val variant_def = tDefine "variant" `
      simp[Abbr`s`,pred_setTheory.EXTENSION,PULL_EXISTS,strlen_def] ) >>
    pop_assum SUBST1_TAC >>
    match_mp_tac pred_setTheory.IMAGE_FINITE >>
-   simp[])
+   simp[]
+End
 
 val variant_ind = fetch "-" "variant_ind"
 
@@ -3956,7 +3958,7 @@ QED
 
 (* a type matching algorithm, based on the implementation in HOL4 *)
 
-val tymatch_def = tDefine"tymatch"`
+Definition tymatch_def:
   (tymatch [] [] sids = SOME sids) ∧
   (tymatch [] _ _ = NONE) ∧
   (tymatch _ [] _ = NONE) ∧
@@ -3970,19 +3972,23 @@ val tymatch_def = tDefine"tymatch"`
     | SOME ty1 => if ty1=ty then tymatch ps obs sids else NONE) ∧
   (tymatch (Tyapp c1 a1::ps) (Tyapp c2 a2::obs) sids =
    if c1=c2 then tymatch (a1++ps) (a2++obs) sids else NONE) ∧
-  (tymatch _ _ _ = NONE)`
-  (WF_REL_TAC`measure (λx. type1_size (FST x) + type1_size (FST(SND x)))` >>
-   simp[type1_size_append])
+  (tymatch _ _ _ = NONE)
+Termination
+  WF_REL_TAC`measure (λx. type1_size (FST x) + type1_size (FST(SND x)))` >>
+   simp[type1_size_append]
+End
 val tymatch_ind = theorem "tymatch_ind";
 
-val arities_match_def = tDefine"arities_match"`
+Definition arities_match_def:
   (arities_match [] [] ⇔ T) ∧
   (arities_match [] _ ⇔ F) ∧
   (arities_match _ [] ⇔ F) ∧
   (arities_match (Tyapp c1 a1::xs) (Tyapp c2 a2::ys) ⇔
    ((c1 = c2) ⇒ arities_match a1 a2) ∧ arities_match xs ys) ∧
-  (arities_match (_::xs) (_::ys) ⇔ arities_match xs ys)`
-  (WF_REL_TAC`measure (λx. type1_size (FST x) + type1_size (SND x))`)
+  (arities_match (_::xs) (_::ys) ⇔ arities_match xs ys)
+Termination
+  WF_REL_TAC`measure (λx. type1_size (FST x) + type1_size (SND x))`
+End
 val arities_match_ind = theorem "arities_match_ind"
 
 Theorem arities_match_length:

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -290,11 +290,13 @@ QED
 
 (* Substitution for type variables in a type. *)
 
-val TYPE_SUBST_def = tDefine"TYPE_SUBST"`
+Definition TYPE_SUBST_def:
   (TYPE_SUBST i (Tyvar v) = REV_ASSOCD (Tyvar v) i (Tyvar v)) ∧
   (TYPE_SUBST i (Tyapp v tys) = Tyapp v (MAP (TYPE_SUBST i) tys)) ∧
-  (TYPE_SUBST i (Fun ty1 ty2) = Fun (TYPE_SUBST i ty1) (TYPE_SUBST i ty2))`
-(type_rec_tac "SND")
+  (TYPE_SUBST i (Fun ty1 ty2) = Fun (TYPE_SUBST i ty1) (TYPE_SUBST i ty2))
+Termination
+  type_rec_tac "SND"
+End
 val _ = export_rewrites["TYPE_SUBST_def"]
 Overload is_instance = ``λty0 ty. ∃i. ty = TYPE_SUBST i ty0``
 
@@ -348,7 +350,7 @@ QED
 
 (* Instantiation of type variables in terms *)
 
-val INST_CORE_def = tDefine"INST_CORE"`
+Definition INST_CORE_def:
   (INST_CORE env tyin (Var x ty) =
      let tm = Var x ty in
      let tm' = Var x (TYPE_SUBST tyin ty) in
@@ -376,8 +378,10 @@ val INST_CORE_def = tDefine"INST_CORE"`
     let ty' = TYPE_SUBST tyin ty in
     let env' = (Var x' ty,Var x' ty')::env in
     let tres = INST_CORE env' tyin t' in
-    if IS_RESULT tres then Result(Abs (Var x' ty') (RESULT tres)) else tres)`
-(WF_REL_TAC`measure (sizeof o SND o SND)` >> simp[SIZEOF_VSUBST])
+    if IS_RESULT tres then Result(Abs (Var x' ty') (RESULT tres)) else tres)
+Termination
+  WF_REL_TAC`measure (sizeof o SND o SND)` >> simp[SIZEOF_VSUBST]
+End
 
 Definition INST_def:
   INST tyin tm = RESULT(INST_CORE [] tyin tm)
@@ -385,10 +389,12 @@ End
 
 (* Type variables in a type. *)
 
-val tyvars_def = tDefine"tyvars"`
+Definition tyvars_def:
   tyvars (Tyvar v) = [v] ∧
-  tyvars (Tyapp v tys) = FOLDR (λx y. LIST_UNION (tyvars x) y) [] tys`
-(type_rec_tac "I")
+  tyvars (Tyapp v tys) = FOLDR (λx y. LIST_UNION (tyvars x) y) [] tys
+Termination
+  type_rec_tac "I"
+End
 
 (* Type variables in a term. *)
 
@@ -417,12 +423,14 @@ Overload tmsof = ``SND:sig->tmsig``
 
 (* Well-formedness of types/terms with respect to a signature *)
 
-val type_ok_def = tDefine "type_ok"`
+Definition type_ok_def:
    (type_ok tysig (Tyvar _) ⇔ T) ∧
    (type_ok tysig (Tyapp name args) ⇔
       FLOOKUP tysig name = SOME (LENGTH args) ∧
-      EVERY (type_ok tysig) args)`
-(type_rec_tac "SND")
+      EVERY (type_ok tysig) args)
+Termination
+  type_rec_tac "SND"
+End
 
 Definition term_ok_def:
   (term_ok sig (Var x ty) ⇔ type_ok (tysof sig) ty) ∧

--- a/characteristic/cfNormaliseScript.sml
+++ b/characteristic/cfNormaliseScript.sml
@@ -139,12 +139,14 @@ End
 *)
 
 (* [mk_opapp]: construct an n-ary application. *)
-val mk_opapp_def = tDefine "mk_opapp" `
+Definition mk_opapp_def:
   mk_opapp xs =
     if LENGTH xs < 2 then HD xs else
-      App Opapp [mk_opapp (FRONT xs); LAST xs]`
- (WF_REL_TAC `measure LENGTH`
-  \\ fs [LENGTH_FRONT] \\ Cases \\ fs []);
+      App Opapp [mk_opapp (FRONT xs); LAST xs]
+Termination
+  WF_REL_TAC `measure LENGTH`
+  \\ fs [LENGTH_FRONT] \\ Cases \\ fs []
+End
 
 val MEM_exp_size = Q.prove(
   `!args a. MEM a args ==> exp_size a <= exp6_size args`,
@@ -168,14 +170,16 @@ val dest_opapp_size = Q.prove(
   \\ fs [astTheory.exp_size_def]
   \\ res_tac \\ fs [exp6_size_lemma,astTheory.exp_size_def]);
 
-val get_name_aux_def = tDefine "get_name_aux" `
+Definition get_name_aux_def:
   get_name_aux n vs =
     let v = "t" ++ num_toString n in
-      if MEM v vs then get_name_aux (n+1) (FILTER (\x. v <> x) vs) else v`
- (WF_REL_TAC `measure (\(n,vs). LENGTH vs)`
+      if MEM v vs then get_name_aux (n+1) (FILTER (\x. v <> x) vs) else v
+Termination
+  WF_REL_TAC `measure (\(n,vs). LENGTH vs)`
   \\ rw [] \\ fs [MEM_SPLIT,FILTER_APPEND]
   \\ match_mp_tac (DECIDE ``m <= m1 /\ n <= n1 ==> m + n < m1 + (n1 + 1n)``)
-  \\ fs [LENGTH_FILTER_LEQ]);
+  \\ fs [LENGTH_FILTER_LEQ]
+End
 
 val alpha = EVAL ``GENLIST (\n. CHR (n + ORD #"a")) 26`` |> concl |> rand
 
@@ -226,7 +230,7 @@ Definition strip_annot_pat_def:
     strip_annot_pat x :: strip_annot_pat_list xs
 End
 
-val strip_annot_exp_def = tDefine"strip_annot_exp"`
+Definition strip_annot_exp_def:
   (strip_annot_exp (Raise e) =
     ast$Raise (strip_annot_exp e))
   ∧
@@ -283,15 +287,17 @@ val strip_annot_exp_def = tDefine"strip_annot_exp"`
   (strip_annot_funs [] = [])
   ∧
   (strip_annot_funs ((f,x,e)::funs) =
-    (f,x,strip_annot_exp e) :: strip_annot_funs funs)`
-  (WF_REL_TAC `inv_image $< (\x. case x of INL e => exp_size e
+    (f,x,strip_annot_exp e) :: strip_annot_funs funs)
+Termination
+  WF_REL_TAC `inv_image $< (\x. case x of INL e => exp_size e
                                  | INR (INL es) => exps_size es
                                  | INR (INR (INL pes)) => pes_size pes
                                  | INR (INR (INR funs)) => funs_size funs)` >>
-   srw_tac [ARITH_ss] [size_abbrevs, astTheory.exp_size_def]);
+   srw_tac [ARITH_ss] [size_abbrevs, astTheory.exp_size_def]
+End
 
 (*
-val norm_def = tDefine "norm" `
+Definition norm_def:
   norm (is_named: bool) (as_value: bool) (ns: string list) (Lit l) = (Lit l, ns, ([]: (string # exp) list)) /\
   norm is_named as_value ns (Var (Short name)) = (Var (Short name), name::ns, []) /\
   norm is_named as_value ns (Var long) = (Var long, ns, []) /\
@@ -396,8 +402,10 @@ val norm_def = tDefine "norm" `
      ((FST row, row_e'), ns)) /\
   protect_letrec_branch is_named ns branch =
     (let (branch_e', ns) = protect is_named ns (SND (SND branch)) in
-     ((FST branch, FST (SND branch), branch_e'), ns))`
- (...);
+     ((FST branch, FST (SND branch), branch_e'), ns))
+Termination
+  ...
+End
 (* TODO: prove the termination of [norm]. This is probably a bit tricky and
    requires refactoring the way [norm] is defined. *)
 *)

--- a/compiler/backend/ag32/ag32_memoryScript.sml
+++ b/compiler/backend/ag32/ag32_memoryScript.sml
@@ -449,7 +449,7 @@ Definition ag32_ffi_copy_code_def:
      JumpIfZero (fSnd, Imm (4w * -6w), Imm 0w, Imm 0w)]
 End
 
-val ag32_ffi_copy_def = tDefine"ag32_ffi_copy"`
+Definition ag32_ffi_copy_def:
   ag32_ffi_copy s0 =
   let s = dfn'JumpIfZero (fSnd, Reg 2w, Imm 0w, Reg 1w) s0 in
   if (s0.R 1w = 0w) then s else
@@ -459,8 +459,9 @@ val ag32_ffi_copy_def = tDefine"ag32_ffi_copy"`
   let s = dfn'Normal (fInc, 5w, Reg 5w, Imm 1w) s in
   let s0 = dfn'Normal (fDec, 1w, Reg 1w, Imm 1w) s in
   let s = dfn'JumpIfZero (fSnd, Imm (4w * -6w), Imm 0w, Imm 0w) s0 in
-  ag32_ffi_copy s`
-  (wf_rel_tac`measure (λs. w2n (s.R 1w))`
+  ag32_ffi_copy s
+Termination
+  wf_rel_tac`measure (λs. w2n (s.R 1w))`
    \\ rw[ag32Theory.dfn'JumpIfZero_def, ag32Theory.ALU_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def,
          ag32Theory.dfn'LoadConstant_def,
@@ -468,7 +469,8 @@ val ag32_ffi_copy_def = tDefine"ag32_ffi_copy"`
          ag32Theory.ri2word_def, ag32Theory.incPC_def, APPLY_UPDATE_THM]
    \\ Cases_on`s0.R 1w` \\ fs[]
    \\ Cases_on`n` \\ fs[]
-   \\ simp[ADD1, GSYM word_add_n2w]);
+   \\ simp[ADD1, GSYM word_add_n2w]
+End
 
 Theorem ag32_ffi_copy_thm:
    ∀s written.
@@ -837,15 +839,16 @@ Proof
   \\ simp[GSYM word_mul_n2w]
 QED
 
-val ag32_ffi_get_arg_length_loop1_def = tDefine"ag32_ffi_get_arg_length_loop1"`
+Definition ag32_ffi_get_arg_length_loop1_def:
   ag32_ffi_get_arg_length_loop1 s =
     if (∀n. s.MEM (s.R 5w + n2w n) ≠ 0w) then s else
     let s = dfn'LoadMEMByte (8w, Reg 5w) s in
     let s = dfn'Normal (fInc, 5w, Reg 5w, Imm 1w) s in
     let s0 = dfn'Normal (fInc, 4w, Reg 4w, Imm 1w) s in
     let s = dfn'JumpIfNotZero (fSnd, Imm (4w * -3w), Imm 0w, Reg 8w) s0 in
-    if (s0.R 8w = 0w) then s else ag32_ffi_get_arg_length_loop1 s`
-  (wf_rel_tac`measure (λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
+    if (s0.R 8w = 0w) then s else ag32_ffi_get_arg_length_loop1 s
+Termination
+  wf_rel_tac`measure (λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
    \\ rw[ag32Theory.dfn'LoadMEMByte_def,
          ag32Theory.incPC_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def, ag32Theory.ALU_def, ag32Theory.ri2word_def,
@@ -862,7 +865,8 @@ val ag32_ffi_get_arg_length_loop1_def = tDefine"ag32_ffi_get_arg_length_loop1"`
    \\ Cases_on`n'''` \\ fs[ADD1]
    \\ Cases_on`n` \\ fs[ADD1]
    \\ `¬(n'''' < n''' + 1)` by metis_tac[ADD_ASSOC,ADD_COMM]
-   \\ fs[NOT_LESS]);
+   \\ fs[NOT_LESS]
+End
 
 Theorem ag32_ffi_get_arg_length_loop1_thm:
    ag32_ffi_get_arg_length_loop1 s =
@@ -926,7 +930,7 @@ Proof
   \\ simp[FUN_EQ_THM, APPLY_UPDATE_THM, ADD1, GSYM word_add_n2w]
 QED
 
-val ag32_ffi_get_arg_length_loop_def = tDefine"ag32_ffi_get_arg_length_loop"`
+Definition ag32_ffi_get_arg_length_loop_def:
   ag32_ffi_get_arg_length_loop s0 =
   let s = dfn'JumpIfZero (fSnd, Reg 7w, Imm 0w, Reg 6w) s0 in
   if (s0.R 6w = 0w) then s else
@@ -934,8 +938,9 @@ val ag32_ffi_get_arg_length_loop_def = tDefine"ag32_ffi_get_arg_length_loop"`
   let s = ag32_ffi_get_arg_length_loop1 s in
   let s = dfn'Normal (fDec, 6w, Reg 6w, Imm 1w) s in
   let s = dfn'JumpIfZero (fSnd, Imm (4w * -7w), Imm 0w, Imm 0w) s in
-  ag32_ffi_get_arg_length_loop s`
-  (wf_rel_tac`measure (λs. w2n (s.R 6w))`
+  ag32_ffi_get_arg_length_loop s
+Termination
+  wf_rel_tac`measure (λs. w2n (s.R 6w))`
    \\ rw[ag32Theory.dfn'JumpIfZero_def, ag32Theory.ALU_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def,
          ag32Theory.dfn'LoadConstant_def,
@@ -944,13 +949,15 @@ val ag32_ffi_get_arg_length_loop_def = tDefine"ag32_ffi_get_arg_length_loop"`
          ag32_ffi_get_arg_length_loop1_thm]
    \\ CASE_TAC \\ simp[APPLY_UPDATE_THM]
    \\ Cases_on`s0.R 6w` \\ fs[]
-   \\ Cases_on`n` \\ fs[ADD1, GSYM word_add_n2w]);
+   \\ Cases_on`n` \\ fs[ADD1, GSYM word_add_n2w]
+End
 
-val get_next_mem_arg_def = tDefine"get_next_mem_arg"`
+Definition get_next_mem_arg_def:
   get_next_mem_arg (m:word32->word8) a acc =
     if m a = 0w ∨ ∀n. m (a + n2w n) ≠ 0w then (a, REVERSE acc)
-    else get_next_mem_arg m (a + 1w) (m a :: acc)`
-  (wf_rel_tac`measure(λ(m,a,acc). LEAST n. m (a + n2w n) = 0w)`
+    else get_next_mem_arg m (a + 1w) (m a :: acc)
+Termination
+  wf_rel_tac`measure(λ(m,a,acc). LEAST n. m (a + n2w n) = 0w)`
    \\ rw[]
    \\ numLib.LEAST_ELIM_TAC
    \\ Cases_on`n` \\ fs[ADD1]
@@ -966,7 +973,8 @@ val get_next_mem_arg_def = tDefine"get_next_mem_arg"`
    \\ `¬(n' < n)` by metis_tac[word_add_n2w, WORD_ADD_ASSOC]
    \\ fs[NOT_LESS]
    \\ `¬(n''' < n)` by metis_tac[word_add_n2w, WORD_ADD_ASSOC]
-   \\ fs[NOT_LESS]);
+   \\ fs[NOT_LESS]
+End
 
 val get_next_mem_arg_ind = theorem"get_next_mem_arg_ind";
 
@@ -1251,14 +1259,15 @@ Proof
   \\ simp[GSYM word_mul_n2w]
 QED
 
-val ag32_ffi_get_arg_find1_def = tDefine"ag32_ffi_get_arg_find1"`
+Definition ag32_ffi_get_arg_find1_def:
   ag32_ffi_get_arg_find1 s =
     if (∀n. s.MEM (s.R 5w + n2w n) ≠ 0w) then s else
     let s = dfn'LoadMEMByte (8w, Reg 5w) s in
     let s0 = dfn'Normal (fInc, 5w, Reg 5w, Imm 1w) s in
     let s = dfn'JumpIfNotZero (fSnd, Imm (4w * -2w), Imm 0w, Reg 8w) s0 in
-    if (s0.R 8w = 0w) then s else ag32_ffi_get_arg_find1 s`
-  (wf_rel_tac`measure (λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
+    if (s0.R 8w = 0w) then s else ag32_ffi_get_arg_find1 s
+Termination
+  wf_rel_tac`measure (λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
    \\ rw[ag32Theory.dfn'LoadMEMByte_def,
          ag32Theory.incPC_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def, ag32Theory.ALU_def, ag32Theory.ri2word_def,
@@ -1275,7 +1284,8 @@ val ag32_ffi_get_arg_find1_def = tDefine"ag32_ffi_get_arg_find1"`
    \\ Cases_on`n'''` \\ fs[ADD1]
    \\ Cases_on`n` \\ fs[ADD1]
    \\ `¬(n'''' < n''' + 1)` by metis_tac[ADD_ASSOC,ADD_COMM]
-   \\ fs[NOT_LESS]);
+   \\ fs[NOT_LESS]
+End
 
 Theorem ag32_ffi_get_arg_find1_thm:
    ag32_ffi_get_arg_find1 s =
@@ -1338,15 +1348,16 @@ Proof
   \\ simp[FUN_EQ_THM, APPLY_UPDATE_THM, ADD1, GSYM word_add_n2w]
 QED
 
-val ag32_ffi_get_arg_find_def = tDefine"ag32_ffi_get_arg_find"`
+Definition ag32_ffi_get_arg_find_def:
   ag32_ffi_get_arg_find s0 =
   let s = dfn'JumpIfZero (fSnd, Imm (4w * 6w), Imm 0w, Reg 6w) s0 in
   if (s0.R 6w = 0w) then s else
   let s = ag32_ffi_get_arg_find1 s in
   let s = dfn'Normal (fDec, 6w, Reg 6w, Imm 1w) s in
   let s = dfn'JumpIfZero (fSnd, Imm (4w * -5w), Imm 0w, Imm 0w) s in
-  ag32_ffi_get_arg_find s`
-  (wf_rel_tac`measure (λs. w2n (s.R 6w))`
+  ag32_ffi_get_arg_find s
+Termination
+  wf_rel_tac`measure (λs. w2n (s.R 6w))`
    \\ rw[ag32Theory.dfn'JumpIfZero_def, ag32Theory.ALU_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def,
          ag32Theory.dfn'LoadConstant_def,
@@ -1355,7 +1366,8 @@ val ag32_ffi_get_arg_find_def = tDefine"ag32_ffi_get_arg_find"`
          ag32_ffi_get_arg_find1_thm]
    \\ CASE_TAC \\ simp[APPLY_UPDATE_THM]
    \\ Cases_on`s0.R 6w` \\ fs[]
-   \\ Cases_on`n` \\ fs[ADD1, GSYM word_add_n2w]);
+   \\ Cases_on`n` \\ fs[ADD1, GSYM word_add_n2w]
+End
 
 Theorem ag32_ffi_get_arg_find_thm:
    (s.R 6w = n2w (index)) ∧ index ≤ cline_size ∧
@@ -1429,7 +1441,7 @@ Proof
   \\ IF_CASES_TAC \\ fs[]
 QED
 
-val ag32_ffi_get_arg_store_def = tDefine"ag32_ffi_get_arg_store"`
+Definition ag32_ffi_get_arg_store_def:
   ag32_ffi_get_arg_store s =
   if ¬(∃n. (s.MEM (s.R 5w + n2w n) = 0w) ∧ (∀i. i ≤ n ⇒ s.R 3w ≠ s.R 5w + n2w i)) then s else
   let s0 = dfn'LoadMEMByte (8w, Reg 5w) s in
@@ -1439,8 +1451,9 @@ val ag32_ffi_get_arg_store_def = tDefine"ag32_ffi_get_arg_store"`
   let s = dfn'Normal(fInc, 3w, Reg 3w, Imm 1w) s in
   let s = dfn'Normal(fInc, 5w, Reg 5w, Imm 1w) s in
   let s = dfn'JumpIfZero (fSnd, Imm (4w * -5w), Imm 0w, Imm 0w) s in
-  ag32_ffi_get_arg_store s`
-  (wf_rel_tac`measure(λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
+  ag32_ffi_get_arg_store s
+Termination
+  wf_rel_tac`measure(λs. LEAST n. (s.MEM (s.R 5w + n2w n) = 0w))`
    \\ rw[ag32Theory.dfn'LoadMEMByte_def,
          ag32Theory.incPC_def,
          ag32Theory.dfn'Normal_def, ag32Theory.norm_def, ag32Theory.ALU_def, ag32Theory.ri2word_def,
@@ -1481,7 +1494,8 @@ val ag32_ffi_get_arg_store_def = tDefine"ag32_ffi_get_arg_store"`
    \\ `¬(n' + 1 < n''''' + 1)` by metis_tac[ADD_COMM, ADD_ASSOC]
    \\ fs[NOT_LESS]
    \\ last_x_assum(qspec_then`n'''''+1`mp_tac)
-   \\ simp[]);
+   \\ simp[]
+End
 
 Theorem ag32_ffi_get_arg_store_thm:
    ((OLEAST n. s.MEM (s.R 5w + n2w n) = 0w) = SOME n) ∧

--- a/compiler/backend/bvi_tailrecScript.sml
+++ b/compiler/backend/bvi_tailrecScript.sml
@@ -488,7 +488,7 @@ QED
        branch of origin for the operation in conditionals.
 *)
 
-val scan_expr_def = tDefine "scan_expr" `
+Definition scan_expr_def:
   (scan_expr ts loc [] = []) ∧
   (scan_expr ts loc (x::y::xs) =
     let (tx, ty, r, op) = HD (scan_expr ts loc [x]) in
@@ -544,8 +544,10 @@ val scan_expr_def = tDefine "scan_expr" `
             | SOME (x, y) =>
                 [(update_context opt ts x y, opt, F, NONE)]
           else
-            [(ts, Any, F, NONE)])`
-    (WF_REL_TAC `measure (exp2_size o SND o SND)`);
+            [(ts, Any, F, NONE)])
+Termination
+  WF_REL_TAC `measure (exp2_size o SND o SND)`
+End
 
 
 Definition scan_expr_sing_def:
@@ -689,7 +691,7 @@ Theorem rewrite_eq = rewrite_def |> SRULE [scan_expr_eq];
 
 (* --- Top-level expression check --- *)
 
-val has_rec_def = tDefine "has_rec" `
+Definition has_rec_def:
   (has_rec loc [] = F) /\
   (has_rec loc (x::y::xs) =
     if has_rec loc [x] then T
@@ -702,8 +704,10 @@ val has_rec_def = tDefine "has_rec" `
   (has_rec loc [Op op xs] =
     if EXISTS (is_rec loc) xs then T
     else has_rec loc xs) /\
-  (has_rec loc [x] = F)`
-  (WF_REL_TAC `measure (exp2_size o SND)`);
+  (has_rec loc [x] = F)
+Termination
+  WF_REL_TAC `measure (exp2_size o SND)`
+End
 
 Definition has_rec1_def:
   has_rec1 loc x = has_rec loc [x]

--- a/compiler/backend/bvl_handleScript.sml
+++ b/compiler/backend/bvl_handleScript.sml
@@ -154,7 +154,7 @@ Proof
   rw[OptionalLetLet_def, OptionalLetLet_sing_def]
 QED
 
-val compile_def = tDefine "compile" `
+Definition compile_def:
   (compile l n [] = ([]:bvl$exp list,Empty,0n,T)) /\
   (compile l n (x::y::xs) =
      let (dx,lx,s1,nr1) = compile l n [x] in
@@ -197,8 +197,10 @@ val compile_def = tDefine "compile" `
        ([Tick (HD y)],lx,s1,nr1)) /\
   (compile l n [Call t dest xs] =
      let (ys,lx,s1,nr1) = compile l n xs in
-       OptionalLetLet (Call t dest ys) n lx (s1+1) l F)`
- (WF_REL_TAC `measure (bvl$exp1_size o SND o SND)`);
+       OptionalLetLet (Call t dest ys) n lx (s1+1) l F)
+Termination
+  WF_REL_TAC `measure (bvl$exp1_size o SND o SND)`
+End
 
 val compile_ind = theorem"compile_ind";
 
@@ -287,7 +289,7 @@ Proof
   >> fs[dest_Seq_def]
 QED
 
-val compile_seqs_def = tDefine "compile_seqs" `
+Definition compile_seqs_def:
   compile_seqs cut_size e acc =
     dtcase dest_Seq e of
     | NONE => (let new_e = compile_exp cut_size 0 e in
@@ -296,10 +298,12 @@ val compile_seqs_def = tDefine "compile_seqs" `
                  | SOME rest => Let [new_e] (Let [] (Let [] rest)))
     | SOME (e1,e2) =>
         compile_seqs cut_size e1
-          (SOME (compile_seqs cut_size e2 acc))`
-  ((WF_REL_TAC ` measure (\(c,e,a). exp_size e) `
+          (SOME (compile_seqs cut_size e2 acc))
+Termination
+  (WF_REL_TAC ` measure (\(c,e,a). exp_size e) `
     \\ strip_tac \\ HO_MATCH_MP_TAC (fetch "-" "dest_Seq_ind")
-    \\ fs [dest_Seq_def] \\ EVAL_TAC \\ fs []):tactic);
+    \\ fs [dest_Seq_def] \\ EVAL_TAC \\ fs []):tactic
+End
 
 Definition compile_any_def:
   compile_any split_seq cut_size arity e =

--- a/compiler/backend/bvl_jumpScript.sml
+++ b/compiler/backend/bvl_jumpScript.sml
@@ -5,7 +5,7 @@ open preamble bvlTheory;
 
 val _ = new_theory "bvl_jump";
 
-val JumpList_def = tDefine "JumpList" `
+Definition JumpList_def:
   (JumpList n xs =
      let l = LENGTH xs in
        if l = 0 then Op (Const 0) [] else
@@ -16,14 +16,16 @@ val JumpList_def = tDefine "JumpList" `
          let lt = (if n + l < 1000000 /\ n + k < 1000000
                    then Op (LessConstSmall (n+k)) [Var 0]
                    else Op Less [Op (Const (&(n+k))) []; Var 0]) in
-           If lt (JumpList n ys) (JumpList (n + k) zs))`
-  (WF_REL_TAC `measure (LENGTH o SND)` \\ REPEAT STRIP_TAC
+           If lt (JumpList n ys) (JumpList (n + k) zs))
+Termination
+  WF_REL_TAC `measure (LENGTH o SND)` \\ REPEAT STRIP_TAC
    \\ Q.ISPEC_THEN`xs`STRIP_ASSUME_TAC SPLIT_LIST \\ FULL_SIMP_TAC std_ss []
    \\ REPEAT STRIP_TAC \\ fs [rich_listTheory.TAKE_LENGTH_APPEND,
         rich_listTheory.DROP_LENGTH_APPEND]
    \\ rfs [DIV_EQ_X]  >>
    full_simp_tac std_ss [GSYM LENGTH_NIL] >>
-   decide_tac);
+   decide_tac
+End
 
 Definition Jump_def:
   Jump x xs = Let [x] (JumpList 0 xs)

--- a/compiler/backend/closLangScript.sml
+++ b/compiler/backend/closLangScript.sml
@@ -159,7 +159,7 @@ Definition pure_op_def:
 End
 
 (* pure e means e can neither raise an exception nor side-effect the state *)
-val pure_def = tDefine "pure" `
+Definition pure_def:
   (pure (Var _ _) ⇔ T)
     ∧
   (pure (If _ e1 e2 e3) ⇔ pure e1 ∧ pure e2 ∧ pure e3)
@@ -181,9 +181,11 @@ val pure_def = tDefine "pure" `
   (pure (Letrec _ _ _ _ x) ⇔ pure x)
     ∧
   (pure (Op _ opn es) ⇔ EVERY pure es ∧ pure_op opn)
-` (WF_REL_TAC `measure exp_size` >> simp[] >> rpt conj_tac >> rpt gen_tac >>
+Termination
+  WF_REL_TAC `measure exp_size` >> simp[] >> rpt conj_tac >> rpt gen_tac >>
    (Induct_on `es` ORELSE Induct_on `fns`) >> dsimp[exp_size_def] >>
-   rpt strip_tac >> res_tac >> simp[])
+   rpt strip_tac >> res_tac >> simp[]
+End
 
 (* used in proofs about closLang, BVL, BVI and dataLang *)
 Definition assign_get_code_label_def:

--- a/compiler/backend/clos_callScript.sml
+++ b/compiler/backend/clos_callScript.sml
@@ -7,7 +7,7 @@ open preamble closLangTheory db_varsTheory;
 
 val _ = new_theory "clos_call";
 
-val free_def = tDefine "free" `
+Definition free_def:
   (free [] = ([],Empty)) /\
   (free ((x:closLang$exp)::y::xs) =
      let (c1,l1) = free [x] in
@@ -55,9 +55,11 @@ val free_def = tDefine "free" `
        ([Handle t (HD c1) (HD c2)],mk_Union l1 (Shift 1 l2))) /\
   (free [Call t ticks dest xs] =
      let (c1,l1) = free xs in
-       ([Call t ticks dest c1],l1))`
- (WF_REL_TAC `measure exp3_size`
-  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC exp1_size_lemma \\ DECIDE_TAC);
+       ([Call t ticks dest c1],l1))
+Termination
+  WF_REL_TAC `measure exp3_size`
+  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC exp1_size_lemma \\ DECIDE_TAC
+End
 
 val free_ind = theorem "free_ind";
 
@@ -227,7 +229,7 @@ val exp3_size_MAP_SND = Q.prove(
   `!fns. exp3_size (MAP SND fns) <= exp1_size fns`,
   Induct \\ fs [exp_size_def,FORALL_PROD]);
 
-val calls_def = tDefine "calls" `
+Definition calls_def:
   (calls [] g = ([],g)) /\
   (calls ((x:closLang$exp)::y::xs) g =
      let (e1,g) = calls [x] g in
@@ -303,14 +305,16 @@ val calls_def = tDefine "calls" `
        else
          let (fns1,g) = calls (MAP SND fns) g in
          let (e1,g) = calls [x1] g in
-           ([Letrec t loc_opt ws (ZIP (MAP FST fns,fns1)) (HD e1)],g))`
- (WF_REL_TAC `measure (exp3_size o FST)`
+           ([Letrec t loc_opt ws (ZIP (MAP FST fns,fns1)) (HD e1)],g))
+Termination
+  WF_REL_TAC `measure (exp3_size o FST)`
   \\ REPEAT STRIP_TAC
   \\ fs [GSYM NOT_LESS]
   \\ IMP_RES_TAC EL_MEM_LEMMA
   \\ IMP_RES_TAC exp1_size_lemma
   \\ assume_tac (SPEC_ALL exp3_size_MAP_SND)
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+End
 
 Definition calls_sing_def:
   (calls_sing (Var t v) g =

--- a/compiler/backend/clos_fvsScript.sml
+++ b/compiler/backend/clos_fvsScript.sml
@@ -6,7 +6,7 @@ open preamble closLangTheory;
 val _ = new_theory "clos_fvs";
 val _ = set_grammar_ancestry ["closLang"];
 
-val remove_fvs_def = tDefine "remove_fvs" `
+Definition remove_fvs_def:
   (remove_fvs fvs [] = []) /\
   (remove_fvs fvs ((x:closLang$exp)::y::xs) =
      HD (remove_fvs fvs [x]) :: remove_fvs fvs (y::xs)) /\
@@ -41,12 +41,14 @@ val remove_fvs_def = tDefine "remove_fvs" `
      [Letrec t loc_opt vs new_fns (HD (remove_fvs (m + fvs) [x1]))]) /\
   (remove_fvs fvs [Fn t loc_opt vs num_args x1] =
     let fvs = case vs of NONE => fvs | SOME x => LENGTH x in
-    [Fn t loc_opt vs num_args (HD (remove_fvs (num_args+fvs) [x1]))])`
-  (WF_REL_TAC `measure (exp3_size o SND)`
+    [Fn t loc_opt vs num_args (HD (remove_fvs (num_args+fvs) [x1]))])
+Termination
+  WF_REL_TAC `measure (exp3_size o SND)`
    \\ simp []
    \\ rpt strip_tac
    \\ imp_res_tac exp1_size_lemma
-   \\ simp []);
+   \\ simp []
+End
 
 Definition remove_fvs_sing_def:
   (remove_fvs_sing fvs (Var t v) =

--- a/compiler/backend/clos_letopScript.sml
+++ b/compiler/backend/clos_letopScript.sml
@@ -23,7 +23,7 @@ Definition dest_op_def:
   (dest_op _ _ = NONE)
 End
 
-val let_op_def = tDefine "let_op" `
+Definition let_op_def:
   (let_op [] = []) /\
   (let_op ((x:closLang$exp)::y::xs) =
      HD (let_op [x]) :: let_op (y::xs)) /\
@@ -51,12 +51,14 @@ val let_op_def = tDefine "let_op" `
   (let_op [Letrec t loc_opt vs fns x1] =
      let new_fns = MAP (\(num_args, x). (num_args, HD (let_op [x]))) fns in
      [Letrec t loc_opt vs new_fns (HD (let_op [x1]))]) /\
-  (let_op [Fn t loc_opt vs num_args x1] = [Fn t loc_opt vs num_args (HD (let_op [x1]))])`
-  (WF_REL_TAC `measure exp3_size`
+  (let_op [Fn t loc_opt vs num_args x1] = [Fn t loc_opt vs num_args (HD (let_op [x1]))])
+Termination
+  WF_REL_TAC `measure exp3_size`
    \\ simp []
    \\ rpt strip_tac
    \\ imp_res_tac exp1_size_lemma
-   \\ simp []);
+   \\ simp []
+End
 
 val let_op_ind = theorem "let_op_ind";
 

--- a/compiler/backend/clos_mtiScript.sml
+++ b/compiler/backend/clos_mtiScript.sml
@@ -95,7 +95,7 @@ val collect_apps_more = Q.prove (
   res_tac >>
   decide_tac);
 
-val intro_multi_def = tDefine "intro_multi" `
+Definition intro_multi_def:
   (intro_multi max_app [] = []) ∧
   (intro_multi max_app (e1::e2::es) =
     HD (intro_multi max_app [e1]) :: HD (intro_multi max_app [e2]) :: intro_multi max_app es) ∧
@@ -135,8 +135,9 @@ val intro_multi_def = tDefine "intro_multi" `
   (intro_multi max_app [Letrec t NONE (SOME fvs) funs e] =
      [Letrec t NONE (SOME fvs) funs (HD (intro_multi max_app [e]))]) ∧
   (intro_multi max_app [Op t op es] =
-    [Op t op (intro_multi max_app es)])`
-  (WF_REL_TAC `measure (exp3_size o SND)` >>
+    [Op t op (intro_multi max_app es)])
+Termination
+  WF_REL_TAC `measure (exp3_size o SND)` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    imp_res_tac collect_args_size >>
    imp_res_tac collect_apps_size >>
@@ -147,7 +148,8 @@ val intro_multi_def = tDefine "intro_multi" `
                srw_tac[][exp_size_def] >>
                res_tac >>
                decide_tac) >>
-   decide_tac);
+   decide_tac
+End
 
 val intro_multi_ind = theorem "intro_multi_ind";
 

--- a/compiler/backend/clos_numberScript.sml
+++ b/compiler/backend/clos_numberScript.sml
@@ -9,7 +9,7 @@ val _ = set_grammar_ancestry ["closLang"]
 
 (* add fresh code locations *)
 
-val renumber_code_locs_def = tDefine "renumber_code_locs" `
+Definition renumber_code_locs_def:
   (renumber_code_locs_list n [] = (n,[])) /\
   (renumber_code_locs_list n (x::xs) =
      let (n,x) = renumber_code_locs n x in
@@ -51,15 +51,17 @@ val renumber_code_locs_def = tDefine "renumber_code_locs" `
        (n,Handle t x1 x2)) /\
   (renumber_code_locs n (Call t ticks dest xs) =
      let (n,xs) = renumber_code_locs_list n xs in
-       (n,Op t Add xs)) (* this case cannot occur *)`
- (WF_REL_TAC `inv_image $< (λx. case x of INL p => exp3_size (SND p) | INR p => exp_size (SND p))` >>
+       (n,Op t Add xs)) (* this case cannot occur *)
+Termination
+  WF_REL_TAC `inv_image $< (λx. case x of INL p => exp3_size (SND p) | INR p => exp_size (SND p))` >>
  rw [] >>
  TRY decide_tac >>
  Induct_on `fns` >>
  srw_tac [ARITH_ss] [exp_size_def] >>
  Cases_on `h` >>
  rw [exp_size_def] >>
- decide_tac);
+ decide_tac
+End
 
 val renumber_code_locs_ind = theorem"renumber_code_locs_ind";
 

--- a/compiler/backend/clos_ticksScript.sml
+++ b/compiler/backend/clos_ticksScript.sml
@@ -11,7 +11,7 @@ val _ = new_theory "clos_ticks";
 
 val _ = set_grammar_ancestry ["closLang"]
 
-val remove_ticks_def = tDefine "remove_ticks" `
+Definition remove_ticks_def:
   (remove_ticks [] = []) /\
   (remove_ticks ((x:closLang$exp)::y::xs) =
      HD (remove_ticks [x]) :: remove_ticks (y::xs)) /\
@@ -38,12 +38,14 @@ val remove_ticks_def = tDefine "remove_ticks" `
      let new_fns = MAP (\(num_args, x). (num_args, HD (remove_ticks [x]))) fns in
      [Letrec t loc_opt vs new_fns (HD (remove_ticks [x1]))]) /\
   (remove_ticks [Fn t loc_opt vs num_args x1] =
-     [Fn t loc_opt vs num_args (HD (remove_ticks [x1]))])`
- (WF_REL_TAC `measure exp3_size`
+     [Fn t loc_opt vs num_args (HD (remove_ticks [x1]))])
+Termination
+  WF_REL_TAC `measure exp3_size`
   \\ simp []
   \\ rpt strip_tac
   \\ imp_res_tac exp1_size_lemma
-  \\ simp []);
+  \\ simp []
+End
 
 Definition remove_ticks_sing_def:
   (remove_ticks_sing (Var t v) = (Var t v)) /\

--- a/compiler/backend/clos_to_bvlScript.sml
+++ b/compiler/backend/clos_to_bvlScript.sml
@@ -398,7 +398,7 @@ Definition init_globals_def:
       (Call 0 (SOME start_loc) []))
 End
 
-val compile_exps_def = tDefine "compile_exps" `
+Definition compile_exps_def:
   (compile_exps max_app [] aux = ([],aux)) /\
   (compile_exps max_app ((x:closLang$exp)::y::xs) aux =
      let (c1,aux1) = compile_exps max_app [x] aux in
@@ -476,8 +476,9 @@ val compile_exps_def = tDefine "compile_exps" `
        ([Handle (HD c1) (HD c2)], aux2)) /\
   (compile_exps max_app [Call t ticks dest xs] aux =
      let (c1,aux1) = compile_exps max_app xs aux in
-       ([Call ticks (SOME (dest + (num_stubs max_app))) c1],aux1))`
-  (WF_REL_TAC `measure (exp3_size o FST o SND)` >>
+       ([Call ticks (SOME (dest + (num_stubs max_app))) c1],aux1))
+Termination
+  WF_REL_TAC `measure (exp3_size o FST o SND)` >>
    srw_tac [ARITH_ss] [closLangTheory.exp_size_def] >>
    `!l. closLang$exp3_size (MAP SND l) <= exp1_size l`
             by (Induct_on `l` >>
@@ -485,7 +486,8 @@ val compile_exps_def = tDefine "compile_exps" `
                 PairCases_on `h` >>
                 full_simp_tac (srw_ss()++ARITH_ss) [closLangTheory.exp_size_def]) >>
   pop_assum (qspec_then `v7` assume_tac) >>
-  decide_tac);
+  decide_tac
+End
 
 val compile_exps_ind = theorem"compile_exps_ind";
 
@@ -700,7 +702,7 @@ Definition code_split_def:
   (code_split (z::zs) xs ys = code_split zs (z::ys) xs)
 End
 
-val code_merge_def = tDefine "code_merge" `
+Definition code_merge_def:
   code_merge xs ys =
     dtcase (xs,ys) of
     | ([],[]) => []
@@ -710,8 +712,10 @@ val code_merge_def = tDefine "code_merge" `
         if FST x1 < (FST y1):num then
           x1::code_merge xs1 ys
         else
-          y1::code_merge xs ys1`
-  (WF_REL_TAC `measure (\(xs,ys). LENGTH xs + LENGTH ys)` \\ rw []);
+          y1::code_merge xs ys1
+Termination
+  WF_REL_TAC `measure (\(xs,ys). LENGTH xs + LENGTH ys)` \\ rw []
+End
 
 Theorem code_split_NULL:
    !ts1 ts2 ts3 xs ys.
@@ -729,16 +733,18 @@ Proof
   Induct \\ fs [code_split_def] \\ rw [] \\ first_x_assum drule \\ fs []
 QED
 
-val code_sort_def = tDefine "code_sort" `
+Definition code_sort_def:
   (code_sort [] = []) /\
   (code_sort [x] = [x]) /\
   (code_sort (x::y::xs) =
      let (xs,ys) = code_split xs [x] [y] in
-       code_merge (code_sort xs) (code_sort ys))`
- (WF_REL_TAC `measure LENGTH` \\ rw []
+       code_merge (code_sort xs) (code_sort ys))
+Termination
+  WF_REL_TAC `measure LENGTH` \\ rw []
   \\ imp_res_tac code_split_LENGTH
   \\ drule code_split_NULL \\ fs [] \\ full_simp_tac std_ss [GSYM LENGTH_NIL] >>
-  decide_tac);
+  decide_tac
+End
 
 Definition chain_exps_def:
   (chain_exps i [] = [(i, 0n, Op None (Const 0) [])]) ∧

--- a/compiler/backend/exportScript.sml
+++ b/compiler/backend/exportScript.sml
@@ -6,14 +6,16 @@ open preamble mlstringTheory mlvectorTheory mlintTheory;
 
 val _ = new_theory "export";
 
-val split16_def = tDefine "split16" `
+Definition split16_def:
   (split16 f [] = Nil) /\
   (split16 f xs =
      let xs1 = TAKE 16 xs in
      let xs2 = DROP 16 xs in
-       SmartAppend (f xs1) (split16 f xs2))`
-  (WF_REL_TAC `measure (LENGTH o SND)`
-   \\ fs [listTheory.LENGTH_DROP]);
+       SmartAppend (f xs1) (split16 f xs2))
+Termination
+  WF_REL_TAC `measure (LENGTH o SND)`
+   \\ fs [listTheory.LENGTH_DROP]
+End
 
 val preamble_tm =
   ``(MAP (\n. strlit(n ++ "\n"))

--- a/compiler/backend/gc/copying_gcScript.sml
+++ b/compiler/backend/gc/copying_gcScript.sml
@@ -33,7 +33,7 @@ Definition gc_move_list_def:
        (x::xs,h2,a,n,heap,c))
 End
 
-val gc_move_loop_def = tDefine "gc_move_loop" `
+Definition gc_move_loop_def:
   (gc_move_loop (h1,[],a,n,heap,c,limit) = (h1,a,n,heap,c)) /\
   (gc_move_loop (h1,h::h2,a,n,heap,c,limit) =
      if limit < heap_length (h1 ++ h::h2) then (h1,a,n,heap,F) else
@@ -44,9 +44,11 @@ val gc_move_loop_def = tDefine "gc_move_loop" `
           let h2 = TL h2 in
           let h1 = h1 ++ [DataElement xs l d] in
             gc_move_loop (h1,h2,a,n,heap,c,limit)
-       | _ => (h1,a,n,heap,F))`
-  (WF_REL_TAC `measure (\(h1,h2,a,n,heap,c,limit). limit - heap_length h1)`
-   \\ SRW_TAC [] [heap_length_def,el_length_def,SUM_APPEND] \\ decide_tac);
+       | _ => (h1,a,n,heap,F))
+Termination
+  WF_REL_TAC `measure (\(h1,h2,a,n,heap,c,limit). limit - heap_length h1)`
+   \\ SRW_TAC [] [heap_length_def,el_length_def,SUM_APPEND] \\ decide_tac
+End
 
 Definition full_gc_def:
   full_gc (roots,heap,limit) =

--- a/compiler/backend/gc/gen_gcScript.sml
+++ b/compiler/backend/gc/gen_gcScript.sml
@@ -101,7 +101,7 @@ Proof
   \\ metis_tac [IS_PREFIX_TRANS]
 QED
 
-val gc_move_data_def = tDefine "gc_move_data"  `
+Definition gc_move_data_def:
   (gc_move_data conf state =
     case state.h2 of
     | [] => state
@@ -114,14 +114,16 @@ val gc_move_data_def = tDefine "gc_move_data"  `
          let h2 = TL state.h2 in
          let ok = state.ok /\ state.h2 <> [] /\ (HD state.h2 = h) in
            gc_move_data conf (state with <| h1 := h1; h2 := h2; ok := ok |>)
-       | _ => state with <| ok := F |>)`
-  (WF_REL_TAC `measure (\(conf,state). conf.limit - heap_length state.h1)`
+       | _ => state with <| ok := F |>)
+Termination
+  WF_REL_TAC `measure (\(conf,state). conf.limit - heap_length state.h1)`
   \\ rw [heap_length_def,el_length_def,SUM_APPEND]
   \\ imp_res_tac (GSYM gc_move_list_IMP)
   \\ fs []
-  \\ decide_tac)
+  \\ decide_tac
+End
 
-val gc_move_refs_def = tDefine "gc_move_refs" `
+Definition gc_move_refs_def:
   (* maybe more refs (r4 could have more) *)
   gc_move_refs conf state =
     case state.r2 of
@@ -132,10 +134,12 @@ val gc_move_refs_def = tDefine "gc_move_refs" `
         let (xs,state) = gc_move_list conf state xs in
         let r3 = state.r3 ++ [DataElement xs l d] in
           gc_move_refs conf (state with <| r2 := r2; r3 := r3 |>)
-      | _ => state with <| ok := F |>`
-  (WF_REL_TAC `measure (\(conf,state). heap_length state.r2)`
+      | _ => state with <| ok := F |>
+Termination
+  WF_REL_TAC `measure (\(conf,state). heap_length state.r2)`
   \\ rw [heap_length_def,el_length_def,SUM_APPEND]
-  \\ decide_tac);
+  \\ decide_tac
+End
 
 (* The main gc loop *)
 (* Runs a clock to simplify the termination argument *)

--- a/compiler/backend/gc/gen_gc_partialScript.sml
+++ b/compiler/backend/gc/gen_gc_partialScript.sml
@@ -93,7 +93,7 @@ Proof
   \\ metis_tac []
 QED
 
-val gc_move_data_def = tDefine "gc_move_data"  `
+Definition gc_move_data_def:
   (gc_move_data conf state =
     case state.h2 of
     | [] => state
@@ -106,12 +106,14 @@ val gc_move_data_def = tDefine "gc_move_data"  `
          let h2 = TL state.h2 in
          let ok = state.ok /\ state.h2 <> [] /\ (HD state.h2 = h) in
            gc_move_data conf (state with <| h1 := h1; h2 := h2; ok := ok |>)
-       | _ => state with <| ok := F |>)`
-  (WF_REL_TAC `measure (\(conf,state). conf.limit - heap_length state.h1)`
+       | _ => state with <| ok := F |>)
+Termination
+  WF_REL_TAC `measure (\(conf,state). conf.limit - heap_length state.h1)`
   \\ rw [heap_length_def,el_length_def,SUM_APPEND]
   \\ imp_res_tac (GSYM gc_move_list_IMP)
   \\ fs []
-  \\ decide_tac)
+  \\ decide_tac
+End
 
 Theorem gc_move_data_IMP:
    !conf state state1.

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -32,7 +32,7 @@ End
 (* Projection from `dataSem$v` into `bvlSem$v` that basically gets rid of
    timestamp information (note this make the function non-injective)
 *)
-Definition data_to_bvi_v_def_def:
+Definition data_to_bvi_v_def:
   data_to_bvi_v (Number i)      = bvlSem$Number i
 ∧ data_to_bvi_v (Word64 w)      = bvlSem$Word64 w
 ∧ data_to_bvi_v (CodePtr p)     = bvlSem$CodePtr p

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -32,14 +32,14 @@ End
 (* Projection from `dataSem$v` into `bvlSem$v` that basically gets rid of
    timestamp information (note this make the function non-injective)
 *)
-val data_to_bvi_v_def = tDefine"data_to_bvi_v_def"`
+Definition data_to_bvi_v_def_def:
   data_to_bvi_v (Number i)      = bvlSem$Number i
 ∧ data_to_bvi_v (Word64 w)      = bvlSem$Word64 w
 ∧ data_to_bvi_v (CodePtr p)     = bvlSem$CodePtr p
 ∧ data_to_bvi_v (RefPtr r)      = bvlSem$RefPtr r
 ∧ data_to_bvi_v (Block _ tag l) = bvlSem$Block tag (MAP data_to_bvi_v l)
-`
-(wf_rel_tac `measure v_size`
+Termination
+  wf_rel_tac `measure v_size`
 \\ `∀l. v1_size l = SUM (MAP (λx. v_size x + 1) l)`
    by (Induct >> rw [v_size_def])
 \\ rw []
@@ -49,7 +49,8 @@ val data_to_bvi_v_def = tDefine"data_to_bvi_v_def"`
 \\ rw []
 \\ ho_match_mp_tac LESS_EQ_TRANS
 \\ Q.EXISTS_TAC `v_size a + 1`
-\\ rw [])
+\\ rw []
+End
 
 (* Projection for Unit constant *)
 Theorem data_to_bvi_v_Unit:

--- a/compiler/backend/proofs/bvl_handleProofScript.sml
+++ b/compiler/backend/proofs/bvl_handleProofScript.sml
@@ -158,7 +158,7 @@ Definition let_ok_def:
   (let_ok _ = F)
 End
 
-val handle_ok_def = tDefine "handle_ok" `
+Definition handle_ok_def:
   (handle_ok [] <=> T) /\
   (handle_ok ((x:bvl$exp)::y::xs) <=>
      handle_ok [x] /\ handle_ok (y::xs)) /\
@@ -179,10 +179,12 @@ val handle_ok_def = tDefine "handle_ok" `
          EVERY isVar xs /\ bVarBound (LENGTH xs) [b] /\
          handle_ok [b] /\ handle_ok [x2]
      | _ => F) /\
-  (handle_ok [Call ticks dest xs] <=> handle_ok xs)`
-  (WF_REL_TAC `measure (exp1_size)`
+  (handle_ok [Call ticks dest xs] <=> handle_ok xs)
+Termination
+  WF_REL_TAC `measure (exp1_size)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC);
+   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC
+End
 
 val evaluate_GENLIST = save_thm("evaluate_GENLIST",
   evaluate_genlist_vars

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -31,15 +31,17 @@ val drule = old_drule
 Overload num_stubs[local] = ``bvl_num_stubs``
 Overload nss[local] = ``bvl_to_bvi_namespaces``
 
-val adjust_bv_def = tDefine "adjust_bv" `
+Definition adjust_bv_def:
   (adjust_bv b (Number i) = Number i) /\
   (adjust_bv b (Word64 w) = Word64 w) /\
   (adjust_bv b (RefPtr r) = RefPtr (b r)) /\
   (adjust_bv b (CodePtr c) = CodePtr (num_stubs + nss * c)) /\
-  (adjust_bv b (Block tag vs) = Block tag (MAP (adjust_bv b) vs))`
-  (WF_REL_TAC `measure (v_size o SND)`
+  (adjust_bv b (Block tag vs) = Block tag (MAP (adjust_bv b) vs))
+Termination
+  WF_REL_TAC `measure (v_size o SND)`
    \\ Induct_on `vs` \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [v_size_def]
-   \\ RES_TAC \\ FIRST_X_ASSUM (ASSUME_TAC o SPEC_ALL) \\ DECIDE_TAC)
+   \\ RES_TAC \\ FIRST_X_ASSUM (ASSUME_TAC o SPEC_ALL) \\ DECIDE_TAC
+End
 
 val adjust_bv_ind = theorem"adjust_bv_ind";
 
@@ -138,13 +140,15 @@ Proof
   >> rfs[]
 QED
 
-val bv_ok_def = tDefine "bv_ok" `
+Definition bv_ok_def:
   (bv_ok (refs: num |-> v ref) (RefPtr r) <=> r IN FDOM refs) /\
   (bv_ok refs (Block tag vs) <=> EVERY (bv_ok refs) vs) /\
-  (bv_ok refs _ <=> T)`
-  (WF_REL_TAC `measure (v_size o SND)`
+  (bv_ok refs _ <=> T)
+Termination
+  WF_REL_TAC `measure (v_size o SND)`
    \\ Induct_on `vs` \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [v_size_def]
-   \\ RES_TAC \\ FIRST_X_ASSUM (ASSUME_TAC o SPEC_ALL) \\ DECIDE_TAC)
+   \\ RES_TAC \\ FIRST_X_ASSUM (ASSUME_TAC o SPEC_ALL) \\ DECIDE_TAC
+End
 
 val bv_ok_ind = theorem"bv_ok_ind";
 

--- a/compiler/backend/proofs/clos_callProofScript.sml
+++ b/compiler/backend/proofs/clos_callProofScript.sml
@@ -300,7 +300,7 @@ Proof
   rw[env_rel_def,MEM_EL,PULL_EXISTS,EQ_IMP_THM,LIST_REL_EL_EQN]
 QED
 
-val v_rel_def = tDefine"v_rel"`
+Definition v_rel_def:
   (v_rel g l code (Number i) v ⇔ v = Number i) ∧
   (v_rel g l code (Word64 w) v ⇔ v = Word64 w) ∧
   (v_rel g l code (Block n vs) v ⇔
@@ -318,13 +318,15 @@ val v_rel_def = tDefine"v_rel"`
        recclosure_rel g l code loc fns1 fns2 ∧
        v = Recclosure (SOME loc) vs2 env2 fns2 i ∧ loco = SOME loc ∧
        LIST_REL (v_rel g l code) vs1 vs2 ∧
-       env_rel (v_rel g l code) env1 env2 (LENGTH fns2) fns2)`
-  (WF_REL_TAC `measure (v_size o FST o SND o SND o SND)` >> simp[v_size_def] >>
-   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[]);
+       env_rel (v_rel g l code) env1 env2 (LENGTH fns2) fns2)
+Termination
+  WF_REL_TAC `measure (v_size o FST o SND o SND o SND)` >> simp[v_size_def] >>
+   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[]
+End
 
 val v_rel_ind = theorem"v_rel_ind";
 
-val wfv_def = tDefine"wfv"`
+Definition wfv_def:
   (wfv g l code (Closure NONE _ _ _ _) ⇔ F) ∧
   (wfv g l code (Recclosure NONE _ _ _ _) ⇔ F) ∧
   (wfv g l code (Closure (SOME loc) vs env n bod) ⇔
@@ -336,9 +338,11 @@ val wfv_def = tDefine"wfv"`
     ∃fns2.
     recclosure_rel g l code loc fns fns2) ∧
   (wfv g l code (Block _ vs) ⇔ EVERY (wfv g l code) vs) ∧
-  (wfv _ _ _ _ ⇔ T)`
-  (WF_REL_TAC `measure (v_size o SND o SND o SND)` >> simp[v_size_def] >>
-   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[]);
+  (wfv _ _ _ _ ⇔ T)
+Termination
+  WF_REL_TAC `measure (v_size o SND o SND o SND)` >> simp[v_size_def] >>
+   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[]
+End
 val _ = export_rewrites["wfv_def"];
 
 val wfv_ind = theorem"wfv_ind";

--- a/compiler/backend/proofs/clos_knownProofScript.sml
+++ b/compiler/backend/proofs/clos_knownProofScript.sml
@@ -4895,13 +4895,15 @@ Proof
   \\ rw[Once mk_Ticks_def]
 QED
 
-val val_approx_every_Fn_SOME_def = tDefine"val_approx_every_Fn_SOME"`
+Definition val_approx_every_Fn_SOME_def:
   (val_approx_every_Fn_SOME (Tuple _ vs) ⇔ EVERY val_approx_every_Fn_SOME vs) ∧
   (val_approx_every_Fn_SOME (Clos _ _ b _) ⇔ every_Fn_SOME [b]) ∧
-  (val_approx_every_Fn_SOME _ ⇔ T)`
-(wf_rel_tac`measure val_approx_size`
+  (val_approx_every_Fn_SOME _ ⇔ T)
+Termination
+  wf_rel_tac`measure val_approx_size`
  \\ gen_tac \\ Induct \\ EVAL_TAC
- \\ rw[] \\ res_tac \\ rw[]);
+ \\ rw[] \\ res_tac \\ rw[]
+End
 val _ = export_rewrites["val_approx_every_Fn_SOME_def"];
 
 Theorem val_approx_every_Fn_SOME_merge:
@@ -5013,13 +5015,15 @@ Proof
   \\ imp_res_tac known_sing_EQ_E \\ fs []
 QED
 
-val val_approx_every_Fn_vs_NONE_def = tDefine"val_approx_every_Fn_vs_NONE"`
+Definition val_approx_every_Fn_vs_NONE_def:
   (val_approx_every_Fn_vs_NONE (Tuple _ vs) ⇔ EVERY val_approx_every_Fn_vs_NONE vs) ∧
   (val_approx_every_Fn_vs_NONE (Clos _ _ b _) ⇔ every_Fn_vs_NONE [b]) ∧
-  (val_approx_every_Fn_vs_NONE _ ⇔ T)`
-(wf_rel_tac`measure val_approx_size`
+  (val_approx_every_Fn_vs_NONE _ ⇔ T)
+Termination
+  wf_rel_tac`measure val_approx_size`
  \\ gen_tac \\ Induct \\ EVAL_TAC
- \\ rw[] \\ res_tac \\ rw[]);
+ \\ rw[] \\ res_tac \\ rw[]
+End
 val _ = export_rewrites["val_approx_every_Fn_vs_NONE_def"];
 
 Theorem val_approx_every_Fn_vs_NONE_merge:

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -216,14 +216,16 @@ Termination
   \\ imp_res_tac v_size_LEMMA \\ DECIDE_TAC
 End
 
-val get_refs_def = tDefine "get_refs" `
+Definition get_refs_def:
   (get_refs (Number _) = []) /\
   (get_refs (Word64 _) = []) /\
   (get_refs (CodePtr _) = []) /\
   (get_refs (RefPtr p) = [p]) /\
-  (get_refs (Block _ _ vs) = FLAT (MAP get_refs vs))`
- (WF_REL_TAC `measure (v_size)` \\ rpt strip_tac \\ Induct_on `vs`
-  \\ srw_tac [] [v_size_def] \\ res_tac \\ DECIDE_TAC);
+  (get_refs (Block _ _ vs) = FLAT (MAP get_refs vs))
+Termination
+  WF_REL_TAC `measure (v_size)` \\ rpt strip_tac \\ Induct_on `vs`
+  \\ srw_tac [] [v_size_def] \\ res_tac \\ DECIDE_TAC
+End
 
 Definition ref_edge_def:
   ref_edge refs (x:num) (y:num) =
@@ -254,11 +256,13 @@ Definition bc_ref_inv_def:
 End
 
 (* TODO: MOVE *)
-val v_all_ts_def = tDefine"v_all_ts" `
+Definition v_all_ts_def:
   v_all_ts (Block ts _ xs) = ts :: FLAT (MAP v_all_ts xs)
-∧ v_all_ts _ = []`
-  (WF_REL_TAC `measure (v_size)` \\ rpt strip_tac \\ Induct_on `xs`
-  \\ srw_tac [] [v_size_def] \\ res_tac \\ DECIDE_TAC);
+∧ v_all_ts _ = []
+Termination
+  WF_REL_TAC `measure (v_size)` \\ rpt strip_tac \\ Induct_on `xs`
+  \\ srw_tac [] [v_size_def] \\ res_tac \\ DECIDE_TAC
+End
 
 (* TODO: MOVE *)
 Definition all_ts_def:
@@ -2080,11 +2084,13 @@ Proof
   rw [GSYM all_ts_append]
 QED
 
-val v_all_vs_def = tDefine"v_all_vs"`
+Definition v_all_vs_def:
   v_all_vs (Block ts tag l :: xs) = Block ts tag l :: v_all_vs l ++ v_all_vs xs
 ∧ v_all_vs (x::xs)                = x :: v_all_vs xs
-∧ v_all_vs [] = []`
-  (WF_REL_TAC `measure (v1_size)`);
+∧ v_all_vs [] = []
+Termination
+  WF_REL_TAC `measure (v1_size)`
+End
 
 Definition all_vs_def:
   all_vs refs stack = { v | ∃(n:num) l. lookup n refs = SOME (ValueArray l) ∧ MEM v (v_all_vs l)} ∪
@@ -8620,18 +8626,20 @@ val word_cmp_loop_refl = Q.prove(
 
 val good_dimindex_def = good_dimindex_def
 
-val v_same_type_def = tDefine"v_same_type"`
+Definition v_same_type_def:
   (v_same_type (Number _) (Number _) = T) ∧
   (v_same_type (Word64 _) (Word64 _) = T) ∧
   (v_same_type (Block _ t1 l1) (Block _ t2 l2) = (t1 = t2 ∧ LENGTH l1 = LENGTH l2 ⇒ LIST_REL v_same_type l1 l2)) ∧
   (v_same_type (CodePtr _) (CodePtr _) = T) ∧
   (v_same_type (RefPtr _) (RefPtr _) = T) ∧
-  (v_same_type _ _ = F)`
-(wf_rel_tac`measure (v_size o FST)`
+  (v_same_type _ _ = F)
+Termination
+  wf_rel_tac`measure (v_size o FST)`
  \\ Induct_on`l1` \\ ntac 2 (rw[v_size_def])
  \\ Cases_on`l2` \\ fs[] \\ rw[]
  \\ res_tac \\ fs[] \\ rfs[]
- \\ first_x_assum(qspecl_then[`0`,`t1`]mp_tac) \\ rw[]);
+ \\ first_x_assum(qspecl_then[`0`,`t1`]mp_tac) \\ rw[]
+End
 val _ = export_rewrites["v_same_type_def"];
 
 val v_ind =
@@ -8892,12 +8900,14 @@ Proof
   Induct \\ rw[v_size_def]
 QED
 
-val v_depth_def = tDefine"v_depth"`
+Definition v_depth_def:
   (v_depth (Block _ _ ls) = (if NULL ls then 0 else 1) + list_max (MAP v_depth ls)) ∧
-  (v_depth _ = 0n)`
-(WF_REL_TAC`measure v_size` \\
+  (v_depth _ = 0n)
+Termination
+  WF_REL_TAC`measure v_size` \\
  ntac 2 gen_tac \\ Induct \\ rw[v_size_def] \\ rw[]
- \\ res_tac \\ rw[]);
+ \\ res_tac \\ rw[]
+End
 val _ = export_rewrites["v_depth_def"];
 
 val v_depth_ind = theorem"v_depth_ind";
@@ -9264,7 +9274,7 @@ End
    ck is an upper bound on the number of stack frames
       allocated by an equality comparison.
   *)
-val word_eq_def = tDefine "word_eq" `
+Definition word_eq_def:
   (word_eq c st dm m l ck w1 (w2:'a word) =
      if w1 = w2 then SOME (1w:'a word,l,ck) else
      if ~(word_bit 0 w1 /\ word_bit 0 w2) then SOME (0w,l,ck) else
@@ -9301,11 +9311,13 @@ val word_eq_def = tDefine "word_eq" `
                             if l = 0 then NONE else
                               word_eq_list c st dm m (l-1) ck (w-1w)
                                 (a1 + bytes_in_word) (a2 + bytes_in_word))
-       | _ => NONE)`
- (WF_REL_TAC `measure(\x. case x of
+       | _ => NONE)
+Termination
+  WF_REL_TAC `measure(\x. case x of
                           | INL (c,st,dm,m,l1,ck1,w1,w2) => l1
                           | INR (c,st,dm,m,l1,ck1,w,a1,a2) => l1)` >>
-  rw[] >> imp_res_tac fix_clock_IMP >> rw[])
+  rw[] >> imp_res_tac fix_clock_IMP >> rw[]
+End
 
 val word_eq_ind = theorem "word_eq_ind";
 
@@ -10491,7 +10503,7 @@ QED
 
 (* copy forward *)
 
-val word_copy_fwd_def = tDefine "word_copy_fwd" `
+Definition word_copy_fwd_def:
   word_copy_fwd be (n:'a word) a b (m:'a word -> 'a word_loc) dm =
     if dimword (:'a) <= 4 then NONE else
     if n <+ 4w then
@@ -10519,11 +10531,13 @@ val word_copy_fwd_def = tDefine "word_copy_fwd" `
       OPTION_BIND (mem_store_byte_aux m dm be (b+1w) w2) (\m.
       OPTION_BIND (mem_store_byte_aux m dm be (b+2w) w3) (\m.
       OPTION_BIND (mem_store_byte_aux m dm be (b+3w) w4) (\m.
-        word_copy_fwd be (n-4w) (a+4w) (b+4w) m dm))))))))`
- (WF_REL_TAC `measure (w2n o FST o SND)`
+        word_copy_fwd be (n-4w) (a+4w) (b+4w) m dm))))))))
+Termination
+  WF_REL_TAC `measure (w2n o FST o SND)`
   \\ Cases_on `n` \\ fs [] \\ rw []
   \\ fs [WORD_LO] \\ rfs [NOT_LESS]
-  \\ rewrite_tac [addressTheory.word_arith_lemma2,GSYM word_sub_def] \\ fs [])
+  \\ rewrite_tac [addressTheory.word_arith_lemma2,GSYM word_sub_def] \\ fs []
+End
 
 Definition list_copy_fwd_def:
   list_copy_fwd n xp xs yp ys =
@@ -10734,7 +10748,7 @@ QED
 
 (* copy backward *)
 
-val word_copy_bwd_def = tDefine "word_copy_bwd" `
+Definition word_copy_bwd_def:
   word_copy_bwd be (n:'a word) a b (m:'a word -> 'a word_loc) dm =
     if dimword (:'a) <= 4 then NONE else
     if n <+ 4w then
@@ -10762,11 +10776,13 @@ val word_copy_bwd_def = tDefine "word_copy_bwd" `
       OPTION_BIND (mem_store_byte_aux m dm be (b-1w) w2) (\m.
       OPTION_BIND (mem_store_byte_aux m dm be (b-2w) w3) (\m.
       OPTION_BIND (mem_store_byte_aux m dm be (b-3w) w4) (\m.
-        word_copy_bwd be (n-4w) (a-4w) (b-4w) m dm))))))))`
- (WF_REL_TAC `measure (w2n o FST o SND)`
+        word_copy_bwd be (n-4w) (a-4w) (b-4w) m dm))))))))
+Termination
+  WF_REL_TAC `measure (w2n o FST o SND)`
   \\ Cases_on `n` \\ fs [] \\ rw []
   \\ fs [WORD_LO] \\ rfs [NOT_LESS]
-  \\ rewrite_tac [addressTheory.word_arith_lemma2,GSYM word_sub_def] \\ fs [])
+  \\ rewrite_tac [addressTheory.word_arith_lemma2,GSYM word_sub_def] \\ fs []
+End
 
 Definition minus_def:
   minus m n = m - n:num

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -354,17 +354,19 @@ val flatten_exp_ok = Q.prove(`
     res_tac>>fs[]);
 
 (*All ops are 2 args. Technically, we should probably check that Sub has 2 args. However, the semantics already checks that and it will get removed later*)
-val binary_branch_exp_def = tDefine "binary_branch_exp" `
+Definition binary_branch_exp_def:
   (binary_branch_exp (Op Sub exps) = EVERY (binary_branch_exp) exps) ∧
   (binary_branch_exp (Op op xs) = (LENGTH xs = 2 ∧ EVERY (binary_branch_exp) xs)) ∧
   (binary_branch_exp (Load exp) = binary_branch_exp exp) ∧
   (binary_branch_exp (Shift shift exp nexp) = binary_branch_exp exp) ∧
-  (binary_branch_exp exp = T)`
-  (WF_REL_TAC `measure (exp_size ARB)`
+  (binary_branch_exp exp = T)
+Termination
+  WF_REL_TAC `measure (exp_size ARB)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
    \\ full_simp_tac(srw_ss())[exp_size_def]
-   \\ TRY (DECIDE_TAC));
+   \\ TRY (DECIDE_TAC)
+End
 
 (* flatten_exp syntax *)
 val flatten_exp_binary_branch_exp = Q.prove(`

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -3571,17 +3571,19 @@ Theorem wStackLoad_thm3 =
  |> Q.INST [`t`|->`set_var v1 v2 t`]
  |> PURE_REWRITE_RULE[set_var_const]
 
-val map_var_def = tDefine"map_var"`
+Definition map_var_def:
   (map_var f (Var num) = Var (f num)) ∧
   (map_var f (Load exp) = Load (map_var f exp)) ∧
   (map_var f (Op wop ls) = Op wop (MAP (map_var f) ls)) ∧
   (map_var f (Shift sh e1 e2) = Shift sh (map_var f e1) e2) ∧
   (map_var f (Const c) = Const c) ∧
-  (map_var f (Lookup v) = Lookup v)`
-(WF_REL_TAC`measure (exp_size ARB o SND)`
+  (map_var f (Lookup v) = Lookup v)
+Termination
+  WF_REL_TAC`measure (exp_size ARB o SND)`
  \\ simp[]
  \\ Induct \\ simp[] \\ rw[]
- \\ EVAL_TAC \\ simp[] \\ res_tac \\ simp[]);
+ \\ EVAL_TAC \\ simp[] \\ res_tac \\ simp[]
+End
 val _ = export_rewrites["map_var_def"];
 
 Theorem the_words_EVERY_IS_SOME_Word:

--- a/compiler/backend/reg_alloc/linear_scanScript.sml
+++ b/compiler/backend/reg_alloc/linear_scanScript.sml
@@ -506,7 +506,7 @@ Definition remove_inactive_intervals_def:
           return st
       )
 Termination
-  
+
     WF_REL_TAC `measure (\(_,st). LENGTH (st.active))` >>
     rw []
 
@@ -819,7 +819,7 @@ Definition partition_regs_def:
             od
         od
 Termination
-  
+
   WF_REL_TAC `measure (\l,rpiv,begrpiv,r. r-l)`
 
 End
@@ -844,7 +844,7 @@ Definition qsort_regs_def:
             od
         od
 Termination
-  
+
     WF_REL_TAC `measure (\l,r. r-l)`
 
 End
@@ -873,7 +873,7 @@ Definition sorted_regs_to_list_def:
           return (r::l);
         od
 Termination
-  
+
   WF_REL_TAC `measure (\n,last. last-n)`
 
 End
@@ -904,7 +904,7 @@ Definition partition_moves_def:
             od
         od
 Termination
-  
+
   WF_REL_TAC `measure (\l,piv,r. r-l)`
 
 End
@@ -928,7 +928,7 @@ Definition qsort_moves_def:
             od
         od
 Termination
-  
+
     WF_REL_TAC `measure (\l,r. r-l)`
 
 End
@@ -958,7 +958,7 @@ Definition sorted_moves_to_list_def:
           return (r::l);
         od
 Termination
-  
+
   WF_REL_TAC `measure (\n,len. len-n)`
 
 End

--- a/compiler/backend/reg_alloc/linear_scanScript.sml
+++ b/compiler/backend/reg_alloc/linear_scanScript.sml
@@ -488,7 +488,7 @@ Definition get_intervals_ct_monad_def:
       od
 End
 
-val remove_inactive_intervals_def = tDefine "remove_inactive_intervals" `
+Definition remove_inactive_intervals_def:
     remove_inactive_intervals beg st =
       case st.active of
       | [] => return st
@@ -505,10 +505,12 @@ val remove_inactive_intervals_def = tDefine "remove_inactive_intervals" `
         else
           return st
       )
-`(
+Termination
+  
     WF_REL_TAC `measure (\(_,st). LENGTH (st.active))` >>
     rw []
-);
+
+End
 
 Definition add_active_interval_def:
   (
@@ -800,7 +802,7 @@ Definition swap_regs_def:
       od
 End
 
-val partition_regs_def = tDefine "partition_regs" `
+Definition partition_regs_def:
     partition_regs l rpiv begrpiv r =
       if r <= l then
         return l
@@ -816,11 +818,13 @@ val partition_regs_def = tDefine "partition_regs" `
               partition_regs l rpiv begrpiv (r-1);
             od
         od
-` (
+Termination
+  
   WF_REL_TAC `measure (\l,rpiv,begrpiv,r. r-l)`
-);
 
-val qsort_regs_def = tDefine "qsort_regs" `
+End
+
+Definition qsort_regs_def:
     qsort_regs l r =
       if r <= l+1 then
         return ()
@@ -839,9 +843,11 @@ val qsort_regs_def = tDefine "qsort_regs" `
               qsort_regs m r;
             od
         od
-`(
+Termination
+  
     WF_REL_TAC `measure (\l,r. r-l)`
-)
+
+End
 
 Definition list_to_sorted_regs_def:
   (
@@ -856,7 +862,7 @@ Definition list_to_sorted_regs_def:
   )
 End
 
-val sorted_regs_to_list_def = tDefine "sorted_regs_to_list" `
+Definition sorted_regs_to_list_def:
     sorted_regs_to_list n last =
       if last <= n then
         return []
@@ -866,9 +872,11 @@ val sorted_regs_to_list_def = tDefine "sorted_regs_to_list" `
           l <- sorted_regs_to_list (n+1) last;
           return (r::l);
         od
-` (
+Termination
+  
   WF_REL_TAC `measure (\n,last. last-n)`
-);
+
+End
 
 Definition swap_moves_def:
     swap_moves i1 i2 =
@@ -880,7 +888,7 @@ Definition swap_moves_def:
       od
 End
 
-val partition_moves_def = tDefine "partition_moves" `
+Definition partition_moves_def:
     partition_moves l ppiv r =
       if r <= l then
         return l
@@ -895,11 +903,13 @@ val partition_moves_def = tDefine "partition_moves" `
               partition_moves l ppiv (r-1);
             od
         od
-` (
+Termination
+  
   WF_REL_TAC `measure (\l,piv,r. r-l)`
-);
 
-val qsort_moves_def = tDefine "qsort_moves" `
+End
+
+Definition qsort_moves_def:
     qsort_moves l r =
       if r <= l+1 then
         return ()
@@ -917,9 +927,11 @@ val qsort_moves_def = tDefine "qsort_moves" `
               qsort_moves m r;
             od
         od
-`(
+Termination
+  
     WF_REL_TAC `measure (\l,r. r-l)`
-)
+
+End
 
 
 Definition list_to_sorted_moves_def:
@@ -935,7 +947,7 @@ Definition list_to_sorted_moves_def:
   )
 End
 
-val sorted_moves_to_list_def = tDefine "sorted_moves_to_list" `
+Definition sorted_moves_to_list_def:
     sorted_moves_to_list n len =
       if len <= n then
         return []
@@ -945,9 +957,11 @@ val sorted_moves_to_list_def = tDefine "sorted_moves_to_list" `
           l <- sorted_moves_to_list (n+1) len;
           return (r::l);
         od
-` (
+Termination
+  
   WF_REL_TAC `measure (\n,len. len-n)`
-);
+
+End
 
 Definition linear_reg_alloc_intervals_def:
     linear_reg_alloc_intervals k forced moves reglist_unsorted =

--- a/compiler/backend/reg_alloc/parmoveScript.sml
+++ b/compiler/backend/reg_alloc/parmoveScript.sml
@@ -589,11 +589,12 @@ Proof
   >> tac
 QED
 
-val pmov_def = tDefine"pmov"`
+Definition pmov_def:
   pmov s = case s of
     | ([],[],_) => s
-    | _ => pmov (fstep s)`
-  (WF_REL_TAC`measure (λ(μ,σ,τ). 2 * LENGTH μ + LENGTH σ)` >>
+    | _ => pmov (fstep s)
+Termination
+  WF_REL_TAC`measure (λ(μ,σ,τ). 2 * LENGTH μ + LENGTH σ)` >>
    rw[fstep_def] >- (
      fs[NULL_LENGTH,LENGTH_NIL,splitAtPki_def] >>
      simp[UNCURRY] >> rw[] >>
@@ -619,7 +620,8 @@ val pmov_def = tDefine"pmov"`
      rw[] >> simp[LENGTH_TAKE,ADD1] >>
      rfs[DROP_CONS_EL] >> rw[] >>
      simp[ADD1] >>
-     metis_tac[]))
+     metis_tac[])
+End
 
 val pmov_ind = theorem"pmov_ind";
 

--- a/compiler/backend/semantics/bviPropsScript.sml
+++ b/compiler/backend/semantics/bviPropsScript.sml
@@ -705,23 +705,25 @@ Proof
   metis_tac [take_drop_lem]
 QED
 
-val get_code_labels_def = tDefine"get_code_labels"
-  `(get_code_labels (Var _) = {}) ∧
-   (get_code_labels (If e1 e2 e3) = get_code_labels e1 ∪ get_code_labels e2 ∪ get_code_labels e3) ∧
-   (get_code_labels (Let es e) = BIGUNION (set (MAP get_code_labels es)) ∪ get_code_labels e) ∧
-   (get_code_labels (Raise e) = get_code_labels e) ∧
-   (get_code_labels (Tick e) = get_code_labels e) ∧
-   (get_code_labels (Call _ d es h) =
-     (case d of NONE => {} | SOME n => {n}) ∪
-     (case h of NONE => {} | SOME e => get_code_labels e) ∪
-     BIGUNION (set (MAP get_code_labels es))) ∧
-   (get_code_labels (Op op es) = closLang$assign_get_code_label op ∪ BIGUNION (set (MAP get_code_labels es)))`
-  (wf_rel_tac`measure exp_size`
-   \\ simp[bviTheory.exp_size_def]
-   \\ rpt conj_tac \\ rpt gen_tac
-   \\ Induct_on`es`
-   \\ rw[bviTheory.exp_size_def]
-   \\ simp[] \\ res_tac \\ simp[]);
+Definition get_code_labels_def:
+  (get_code_labels (Var _) = {}) ∧
+  (get_code_labels (If e1 e2 e3) = get_code_labels e1 ∪ get_code_labels e2 ∪ get_code_labels e3) ∧
+  (get_code_labels (Let es e) = BIGUNION (set (MAP get_code_labels es)) ∪ get_code_labels e) ∧
+  (get_code_labels (Raise e) = get_code_labels e) ∧
+  (get_code_labels (Tick e) = get_code_labels e) ∧
+  (get_code_labels (Call _ d es h) =
+    (case d of NONE => {} | SOME n => {n}) ∪
+    (case h of NONE => {} | SOME e => get_code_labels e) ∪
+    BIGUNION (set (MAP get_code_labels es))) ∧
+  (get_code_labels (Op op es) = closLang$assign_get_code_label op ∪ BIGUNION (set (MAP get_code_labels es)))
+Termination
+  wf_rel_tac`measure exp_size`
+  \\ simp[bviTheory.exp_size_def]
+  \\ rpt conj_tac \\ rpt gen_tac
+  \\ Induct_on`es`
+  \\ rw[bviTheory.exp_size_def]
+  \\ simp[] \\ res_tac \\ simp[]
+End
 val get_code_labels_def =
   get_code_labels_def |> SIMP_RULE (srw_ss()++ETA_ss)[] |> curry save_thm "get_code_labels_def[simp,compute,allow_rebind]"
 

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -172,7 +172,7 @@ val fix_clock_IMP = Q.prove(
    convenience of subsequent proofs, the evaluation function is
    defined to evaluate a list of bvi_exp expressions. *)
 
-val evaluate_def = tDefine "evaluate" `
+Definition evaluate_def:
   (evaluate ([],env,s) = (Rval [],s)) /\
   (evaluate (x::y::xs,env,s) =
      case fix_clock s (evaluate ([x],env,s)) of
@@ -221,14 +221,16 @@ val evaluate_def = tDefine "evaluate" `
                       | SOME x => evaluate ([x],v::env,s)
                       | NONE => (Rerr(Rraise v),s))
                 | res => res)
-     | res => res)`
-  (WF_REL_TAC `(inv_image (measure I LEX measure exp2_size)
+     | res => res)
+Termination
+  WF_REL_TAC `(inv_image (measure I LEX measure exp2_size)
                           (\(xs,env,s). (s.clock,xs)))`
   >> rpt strip_tac
   >> simp[dec_clock_def]
   >> imp_res_tac fix_clock_IMP
   >> imp_res_tac LESS_EQ_dec_clock
-  >> rw[]);
+  >> rw[]
+End
 
 val evaluate_ind = theorem"evaluate_ind";
 

--- a/compiler/backend/semantics/bvlPropsScript.sml
+++ b/compiler/backend/semantics/bvlPropsScript.sml
@@ -789,7 +789,7 @@ Proof
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[destVar_def]
 QED
 
-val bVarBound_def = tDefine "bVarBound" `
+Definition bVarBound_def:
   (bVarBound n [] <=> T) /\
   (bVarBound n ((x:bvl$exp)::y::xs) <=>
      bVarBound n [x] /\ bVarBound n (y::xs)) /\
@@ -803,12 +803,14 @@ val bVarBound_def = tDefine "bVarBound" `
   (bVarBound n [Op op xs] <=> bVarBound n xs) /\
   (bVarBound n [Handle x1 x2] <=>
      bVarBound n [x1] /\ bVarBound (n + 1) [x2]) /\
-  (bVarBound n [Call ticks dest xs] <=> bVarBound n xs)`
-  (WF_REL_TAC `measure (exp1_size o SND)`
+  (bVarBound n [Call ticks dest xs] <=> bVarBound n xs)
+Termination
+  WF_REL_TAC `measure (exp1_size o SND)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC);
+   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC
+End
 
-val bEvery_def = tDefine "bEvery" `
+Definition bEvery_def:
   (bEvery P [] <=> T) /\
   (bEvery P ((x:bvl$exp)::y::xs) <=>
      bEvery P [x] /\ bEvery P (y::xs)) /\
@@ -822,10 +824,12 @@ val bEvery_def = tDefine "bEvery" `
   (bEvery P [Op op xs] <=> P (Op op xs) /\ bEvery P xs) /\
   (bEvery P [Handle x1 x2] <=> P (Handle x1 x2) /\
      bEvery P [x1] /\ bEvery P [x2]) /\
-  (bEvery P [Call ticks dest xs] <=> P (Call ticks dest xs) /\ bEvery P xs)`
-  (WF_REL_TAC `measure (exp1_size o SND)`
+  (bEvery P [Call ticks dest xs] <=> P (Call ticks dest xs) /\ bEvery P xs)
+Termination
+  WF_REL_TAC `measure (exp1_size o SND)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC
-   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC);
+   \\ SRW_TAC [] [bvlTheory.exp_size_def] \\ DECIDE_TAC
+End
 
 val _ = export_rewrites["bEvery_def","bVarBound_def"];
 

--- a/compiler/backend/semantics/bvlPropsScript.sml
+++ b/compiler/backend/semantics/bvlPropsScript.sml
@@ -847,21 +847,23 @@ Proof
   Cases_on`ls`>>simp[]
 QED
 
-val get_code_labels_def = tDefine"get_code_labels"
-  `(get_code_labels (bvl$Var _) = {}) ∧
-   (get_code_labels (If e1 e2 e3) = get_code_labels e1 ∪ get_code_labels e2 ∪ get_code_labels e3) ∧
-   (get_code_labels (Let es e) = BIGUNION (set (MAP get_code_labels es)) ∪ get_code_labels e) ∧
-   (get_code_labels (Raise e) = get_code_labels e) ∧
-   (get_code_labels (Handle e1 e2) = get_code_labels e1 ∪ get_code_labels e2) ∧
-   (get_code_labels (Tick e) = get_code_labels e) ∧
-   (get_code_labels (Call _ d es) = (case d of NONE => {} | SOME n => {n}) ∪ BIGUNION (set (MAP get_code_labels es))) ∧
-   (get_code_labels (Op op es) = closLang$assign_get_code_label op ∪ BIGUNION (set (MAP get_code_labels es)))`
-  (wf_rel_tac`measure exp_size`
-   \\ simp[bvlTheory.exp_size_def]
-   \\ rpt conj_tac \\ rpt gen_tac
-   \\ Induct_on`es`
-   \\ rw[bvlTheory.exp_size_def]
-   \\ simp[] \\ res_tac \\ simp[]);
+Definition get_code_labels_def:
+  (get_code_labels (bvl$Var _) = {}) ∧
+  (get_code_labels (If e1 e2 e3) = get_code_labels e1 ∪ get_code_labels e2 ∪ get_code_labels e3) ∧
+  (get_code_labels (Let es e) = BIGUNION (set (MAP get_code_labels es)) ∪ get_code_labels e) ∧
+  (get_code_labels (Raise e) = get_code_labels e) ∧
+  (get_code_labels (Handle e1 e2) = get_code_labels e1 ∪ get_code_labels e2) ∧
+  (get_code_labels (Tick e) = get_code_labels e) ∧
+  (get_code_labels (Call _ d es) = (case d of NONE => {} | SOME n => {n}) ∪ BIGUNION (set (MAP get_code_labels es))) ∧
+  (get_code_labels (Op op es) = closLang$assign_get_code_label op ∪ BIGUNION (set (MAP get_code_labels es)))
+Termination
+  wf_rel_tac`measure exp_size`
+  \\ simp[bvlTheory.exp_size_def]
+  \\ rpt conj_tac \\ rpt gen_tac
+  \\ Induct_on`es`
+  \\ rw[bvlTheory.exp_size_def]
+  \\ simp[] \\ res_tac \\ simp[]
+End
 val get_code_labels_def =
   get_code_labels_def |> SIMP_RULE (srw_ss()++ETA_ss)[] |> curry save_thm "get_code_labels_def[simp,compute,allow_rebind]"
 

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -74,7 +74,7 @@ Definition isClos_def:
   isClos t1 l1 = (((t1 = closure_tag) \/ (t1 = partial_app_tag)) /\ l1 <> [])
 End
 
-val do_eq_def = tDefine"do_eq"`
+Definition do_eq_def:
   (do_eq _ (CodePtr _) _ = Eq_type_error) ∧
   (do_eq _ _ (CodePtr _) = Eq_type_error) ∧
   (do_eq _ (Number n1) (Number n2) = (Eq_val (n1 = n2))) ∧
@@ -104,8 +104,10 @@ val do_eq_def = tDefine"do_eq"`
    | Eq_val T => do_eq_list refs vs1 vs2
    | Eq_val F => Eq_val F
    | bad => bad) ∧
-  (do_eq_list _ _ _ = Eq_val F)`
-  (WF_REL_TAC `measure (\x. case x of INL (_,v1,v2) => v_size v1 | INR (_,vs1,vs2) => v1_size vs1)`);
+  (do_eq_list _ _ _ = Eq_val F)
+Termination
+  WF_REL_TAC `measure (\x. case x of INL (_,v1,v2) => v_size v1 | INR (_,vs1,vs2) => v1_size vs1)`
+End
 val _ = export_rewrites["do_eq_def"];
 
 Overload Error[local] = ``(Rerr(Rabort Rtype_error)):(bvlSem$v#('c,'ffi) bvlSem$state, bvlSem$v)result``
@@ -483,7 +485,7 @@ val fix_clock_IMP = Q.prove(
    convenience of subsequent proofs, the evaluation function is
    defined to evaluate a list of exp expressions. *)
 
-val evaluate_def = tDefine "evaluate" `
+Definition evaluate_def:
   (evaluate ([],env,^s) = (Rval [],s)) /\
   (evaluate (x::y::xs,env,s) =
      case fix_clock s (evaluate ([x],env,s)) of
@@ -529,14 +531,16 @@ val evaluate_def = tDefine "evaluate" `
           | SOME (args,exp) =>
               if s.clock < ticks + 1 then (Rerr(Rabort Rtimeout_error),s with clock := 0) else
                   evaluate ([exp],args,dec_clock (ticks + 1) s))
-     | res => res)`
- (WF_REL_TAC `(inv_image (measure I LEX measure exp1_size)
+     | res => res)
+Termination
+  WF_REL_TAC `(inv_image (measure I LEX measure exp1_size)
                          (\(xs,env,s). (s.clock,xs)))`
   \\ rpt strip_tac
   \\ simp[dec_clock_def]
   \\ imp_res_tac fix_clock_IMP
   \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ decide_tac);
+  \\ decide_tac
+End
 
 val evaluate_ind = theorem"evaluate_ind";
 

--- a/compiler/backend/semantics/closPropsScript.sml
+++ b/compiler/backend/semantics/closPropsScript.sml
@@ -111,7 +111,7 @@ Proof
   Cases_on`y`>>simp[ref_rel_def] >> srw_tac[][EQ_IMP_THM]
 QED
 
-val code_locs_def = tDefine "code_locs" `
+Definition code_locs_def:
   (code_locs [] = []) /\
   (code_locs (x::y::xs) =
      let c1 = code_locs [x] in
@@ -151,14 +151,16 @@ val code_locs_def = tDefine "code_locs" `
      let c2 = code_locs [x2] in
        c1 ++ c2) /\
   (code_locs [Call _ ticks dest xs] =
-     code_locs xs)`
-  (WF_REL_TAC `measure (exp3_size)`
+     code_locs xs)
+Termination
+  WF_REL_TAC `measure (exp3_size)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 
 Theorem code_locs_cons:
    ∀x xs. code_locs (x::xs) = code_locs [x] ++ code_locs xs
@@ -190,7 +192,7 @@ Proof
   \\ fs [code_locs_def]
 QED
 
-val contains_App_SOME_def = tDefine "contains_App_SOME" `
+Definition contains_App_SOME_def:
   (contains_App_SOME max_app [] ⇔ F) /\
   (contains_App_SOME max_app (x::y::xs) ⇔
      contains_App_SOME max_app [x] ∨
@@ -222,14 +224,16 @@ val contains_App_SOME_def = tDefine "contains_App_SOME" `
      contains_App_SOME max_app [x1] ∨
      contains_App_SOME max_app [x2]) /\
   (contains_App_SOME max_app [Call _ ticks dest xs] ⇔
-     contains_App_SOME max_app xs)`
-  (WF_REL_TAC `measure (exp3_size o SND)`
+     contains_App_SOME max_app xs)
+Termination
+  WF_REL_TAC `measure (exp3_size o SND)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 
 Theorem contains_App_SOME_EXISTS:
    ∀ls max_app. contains_App_SOME max_app ls ⇔ EXISTS (λx. contains_App_SOME max_app [x]) ls
@@ -238,7 +242,7 @@ Proof
   Cases_on`ls`>>full_simp_tac(srw_ss())[contains_App_SOME_def]
 QED
 
-val every_Fn_SOME_def = tDefine "every_Fn_SOME" `
+Definition every_Fn_SOME_def:
   (every_Fn_SOME [] ⇔ T) ∧
   (every_Fn_SOME (x::y::xs) ⇔
      every_Fn_SOME [x] ∧
@@ -271,14 +275,16 @@ val every_Fn_SOME_def = tDefine "every_Fn_SOME" `
      every_Fn_SOME [x1] ∧
      every_Fn_SOME [x2]) ∧
   (every_Fn_SOME [Call _ ticks dest xs] ⇔
-     every_Fn_SOME xs)`
-  (WF_REL_TAC `measure (exp3_size)`
+     every_Fn_SOME xs)
+Termination
+  WF_REL_TAC `measure (exp3_size)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 val _ = export_rewrites["every_Fn_SOME_def"];
 
 Theorem every_Fn_SOME_EVERY:
@@ -294,7 +300,7 @@ Proof
   once_rewrite_tac[every_Fn_SOME_EVERY] \\ rw[]
 QED
 
-val every_Fn_vs_NONE_def = tDefine "every_Fn_vs_NONE" `
+Definition every_Fn_vs_NONE_def:
   (every_Fn_vs_NONE [] ⇔ T) ∧
   (every_Fn_vs_NONE (x::y::xs) ⇔
      every_Fn_vs_NONE [x] ∧
@@ -327,14 +333,16 @@ val every_Fn_vs_NONE_def = tDefine "every_Fn_vs_NONE" `
      every_Fn_vs_NONE [x1] ∧
      every_Fn_vs_NONE [x2]) ∧
   (every_Fn_vs_NONE [Call _ ticks dest xs] ⇔
-     every_Fn_vs_NONE xs)`
-  (WF_REL_TAC `measure (exp3_size)`
+     every_Fn_vs_NONE xs)
+Termination
+  WF_REL_TAC `measure (exp3_size)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 val _ = export_rewrites["every_Fn_vs_NONE_def"];
 
 Theorem every_Fn_vs_NONE_EVERY:
@@ -357,7 +365,7 @@ Proof
   once_rewrite_tac[every_Fn_vs_NONE_EVERY] \\ rw[]
 QED
 
-val every_Fn_vs_SOME_def = tDefine "every_Fn_vs_SOME" `
+Definition every_Fn_vs_SOME_def:
   (every_Fn_vs_SOME [] ⇔ T) ∧
   (every_Fn_vs_SOME (x::y::xs) ⇔
      every_Fn_vs_SOME [x] ∧
@@ -390,14 +398,16 @@ val every_Fn_vs_SOME_def = tDefine "every_Fn_vs_SOME" `
      every_Fn_vs_SOME [x1] ∧
      every_Fn_vs_SOME [x2]) ∧
   (every_Fn_vs_SOME [Call _ ticks dest xs] ⇔
-     every_Fn_vs_SOME xs)`
-  (WF_REL_TAC `measure (exp3_size)`
+     every_Fn_vs_SOME xs)
+Termination
+  WF_REL_TAC `measure (exp3_size)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 val _ = export_rewrites["every_Fn_vs_SOME_def"];
 
 Theorem every_Fn_vs_SOME_EVERY:
@@ -1816,7 +1826,7 @@ Proof
   Cases_on `h` >> simp[]
 QED
 
-val set_globals_def = tDefine "set_globals" `
+Definition set_globals_def:
   (set_globals (Var _ _) = {||}) ∧
   (set_globals (If _ e1 e2 e3) =
     set_globals e1 ⊎ set_globals e2 ⊎ set_globals e3) ∧
@@ -1832,11 +1842,12 @@ val set_globals_def = tDefine "set_globals" `
   (set_globals (Op _ opn args) = op_gbag opn ⊎ elist_globals args) ∧
   (elist_globals [] = {||}) ∧
   (elist_globals (e::es) = set_globals e ⊎ elist_globals es)
-`
-  (WF_REL_TAC `
+Termination
+  WF_REL_TAC `
       measure (λa. case a of INL e => exp_size e | INR x => exp3_size x)` >>
    simp[] >> rpt strip_tac >>
-   imp_res_tac exp_size_MEM >> simp[])
+   imp_res_tac exp_size_MEM >> simp[]
+End
 val _ = export_rewrites ["set_globals_def"]
 
 (* {foo}sgc_free: foo is free of SetGlobal closures, meaning closures that
@@ -1851,7 +1862,7 @@ Proof
 QED
 
 (* value is setglobal-closure free *)
-val vsgc_free_def = tDefine "vsgc_free" `
+Definition vsgc_free_def:
   (vsgc_free (Closure _ VL1 VL2 _ body) ⇔
      set_globals body = {||} ∧
      EVERY vsgc_free VL1 ∧ EVERY vsgc_free VL2) ∧
@@ -1860,8 +1871,10 @@ val vsgc_free_def = tDefine "vsgc_free" `
      EVERY vsgc_free VL1 ∧ EVERY vsgc_free VL2) ∧
   (vsgc_free (Block _ VL) ⇔ EVERY vsgc_free VL) ∧
   (vsgc_free _ ⇔ T)
-` (WF_REL_TAC `measure closSem$v_size` >> simp[v_size_def] >>
-   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[])
+Termination
+  WF_REL_TAC `measure closSem$v_size` >> simp[v_size_def] >>
+   rpt strip_tac >> imp_res_tac v_size_lemma >> simp[]
+End
 
 val vsgc_free_def = save_thm(
   "vsgc_free_def[simp,allow_rebind]",
@@ -1887,7 +1900,7 @@ Definition rsgc_free_def:
 End
 val _ = export_rewrites ["rsgc_free_def"]
 
-val esgc_free_def = tDefine "esgc_free" `
+Definition esgc_free_def:
   (esgc_free (Var _ _) ⇔ T) ∧
   (esgc_free (If _ e1 e2 e3) ⇔ esgc_free e1 ∧ esgc_free e2 ∧ esgc_free e3) ∧
   (esgc_free (Let _ binds e) ⇔ EVERY esgc_free binds ∧ esgc_free e) ∧
@@ -1900,8 +1913,10 @@ val esgc_free_def = tDefine "esgc_free" `
   (esgc_free (Letrec _ _ _ binds bod) ⇔
     elist_globals (MAP SND binds) = {||} ∧ esgc_free bod) ∧
   (esgc_free (Op _ _ args) ⇔ EVERY esgc_free args)
-` (WF_REL_TAC `measure exp_size` >> simp[] >> rpt strip_tac >>
-   imp_res_tac exp_size_MEM >> simp[])
+Termination
+  WF_REL_TAC `measure exp_size` >> simp[] >> rpt strip_tac >>
+   imp_res_tac exp_size_MEM >> simp[]
+End
 val esgc_free_def = save_thm("esgc_free_def[simp,compute,allow_rebind]",
   SIMP_RULE (bool_ss ++ ETA_ss) [] esgc_free_def)
 
@@ -3310,7 +3325,7 @@ Proof
   \\ imp_res_tac do_app_SUBMAP_Rerr
 QED
 
-val obeys_max_app_def = tDefine"obeys_max_app"`
+Definition obeys_max_app_def:
   (obeys_max_app m (Var _ _) ⇔ T) ∧
   (obeys_max_app m (If _ e1 e2 e3) ⇔ obeys_max_app m e1 ∧ obeys_max_app m e2 ∧ obeys_max_app m e3) ∧
   (obeys_max_app m (Let _ es e) ⇔ EVERY (obeys_max_app m) es ∧ obeys_max_app m e) ∧
@@ -3321,20 +3336,22 @@ val obeys_max_app_def = tDefine"obeys_max_app"`
   (obeys_max_app m (App _ _ e es) ⇔ LENGTH es ≤ m ∧ obeys_max_app m e ∧ EVERY (obeys_max_app m) es) ∧
   (obeys_max_app m (Fn _ _ _ _ e) ⇔ obeys_max_app m e) ∧
   (obeys_max_app m (Letrec _ _ _ es e) ⇔ EVERY (obeys_max_app m) (MAP SND es) ∧ obeys_max_app m e) ∧
-  (obeys_max_app m (Op _ _ es) ⇔ EVERY (obeys_max_app m) es)`
-(wf_rel_tac`measure (exp_size o SND)`
+  (obeys_max_app m (Op _ _ es) ⇔ EVERY (obeys_max_app m) es)
+Termination
+  wf_rel_tac`measure (exp_size o SND)`
  \\ simp [closLangTheory.exp_size_def]
  \\ rpt conj_tac \\ rpt gen_tac
  \\ Induct_on`es`
  \\ rw [closLangTheory.exp_size_def]
- \\ simp [] \\ res_tac \\ simp []);
+ \\ simp [] \\ res_tac \\ simp []
+End
 
 val obeys_max_app_def =
   obeys_max_app_def
   |> SIMP_RULE (srw_ss()++ETA_ss)[MAP_MAP_o]
   |> curry save_thm "obeys_max_app_def[simp,compute,allow_rebind]"
 
-val no_Labels_def = tDefine"no_Labels"`
+Definition no_Labels_def:
   (no_Labels (Var _ _) ⇔ T) ∧
   (no_Labels (If _ e1 e2 e3) ⇔ no_Labels e1 ∧ no_Labels e2 ∧ no_Labels e3) ∧
   (no_Labels (Let _ es e) ⇔ EVERY no_Labels es ∧ no_Labels e) ∧
@@ -3345,20 +3362,22 @@ val no_Labels_def = tDefine"no_Labels"`
   (no_Labels (App _ _ e es) ⇔ no_Labels e ∧ EVERY no_Labels es) ∧
   (no_Labels (Fn _ _ _ _ e) ⇔ no_Labels e) ∧
   (no_Labels (Letrec _ _ _ es e) ⇔ EVERY no_Labels (MAP SND es) ∧ no_Labels e) ∧
-  (no_Labels (Op _ op es) ⇔ (∀n. op ≠ Label n) ∧ EVERY no_Labels es)`
-(wf_rel_tac`measure exp_size`
+  (no_Labels (Op _ op es) ⇔ (∀n. op ≠ Label n) ∧ EVERY no_Labels es)
+Termination
+  wf_rel_tac`measure exp_size`
  \\ simp [closLangTheory.exp_size_def]
  \\ rpt conj_tac \\ rpt gen_tac
  \\ Induct_on`es`
  \\ rw [closLangTheory.exp_size_def]
- \\ simp [] \\ res_tac \\ simp []);
+ \\ simp [] \\ res_tac \\ simp []
+End
 
 val no_Labels_def =
   no_Labels_def
   |> SIMP_RULE (srw_ss()++ETA_ss)[MAP_MAP_o]
   |> curry save_thm "no_Labels_def[simp,compute,allow_rebind]"
 
-val app_call_dests_def = tDefine "app_call_dests" `
+Definition app_call_dests_def:
   (app_call_dests opt [] = {}) /\
   (app_call_dests opt (x::y::xs) =
      let c1 = app_call_dests opt [x] in
@@ -3398,14 +3417,16 @@ val app_call_dests_def = tDefine "app_call_dests" `
        c1 ∪ c2) /\
   (app_call_dests opt [Call _ ticks dest xs] =
      if opt = SOME F then app_call_dests opt xs else
-       dest INSERT app_call_dests opt xs)`
-  (WF_REL_TAC `measure (exp3_size o SND)`
+       dest INSERT app_call_dests opt xs)
+Termination
+  WF_REL_TAC `measure (exp3_size o SND)`
    \\ REPEAT STRIP_TAC \\ TRY DECIDE_TAC >>
    Induct_on `fns` >>
    srw_tac [ARITH_ss] [closLangTheory.exp_size_def] >>
    Cases_on `h` >>
    full_simp_tac(srw_ss())[closLangTheory.exp_size_def] >>
-   decide_tac);
+   decide_tac
+End
 
 val _ = save_thm("app_call_dests_def[simp,compute,allow_rebind]",app_call_dests_def);
 
@@ -3464,7 +3485,7 @@ Proof
   \\ fs [EXTENSION] \\ rw[] \\ eq_tac \\ rw [] \\ fs []
 QED
 
-val get_code_labels_def = tDefine"get_code_labels" `
+Definition get_code_labels_def:
   (get_code_labels (Var _ _) = {}) ∧
   (get_code_labels (If _ e1 e2 e3) =
     get_code_labels e1 ∪
@@ -3494,13 +3515,15 @@ val get_code_labels_def = tDefine"get_code_labels" `
     BIGUNION (set (MAP get_code_labels (MAP SND es)))) ∧
   (get_code_labels (Op _ op es) =
     BIGUNION (set (MAP get_code_labels es)) ∪
-    closLang$assign_get_code_label op)`
-  (wf_rel_tac `measure exp_size`
+    closLang$assign_get_code_label op)
+Termination
+  wf_rel_tac `measure exp_size`
    \\ simp [closLangTheory.exp_size_def]
    \\ rpt conj_tac \\ rpt gen_tac
    \\ Induct_on`es`
    \\ rw [closLangTheory.exp_size_def]
-   \\ simp [] \\ res_tac \\ simp []);
+   \\ simp [] \\ res_tac \\ simp []
+End
 
 val get_code_labels_def =
   get_code_labels_def

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -52,7 +52,7 @@ Definition Boolv_def:
   (Boolv b = Block (if b then true_tag else false_tag) [])
 End
 
-val do_eq_def = tDefine "do_eq" `
+Definition do_eq_def:
   (do_eq x y =
      case x of
      | Number i =>
@@ -90,9 +90,11 @@ val do_eq_def = tDefine "do_eq" `
      case do_eq x y of
      | Eq_val T => do_eq_list xs ys
      | res => res) /\
-  (do_eq_list _ _ = Eq_val F)`
- (WF_REL_TAC `measure (\x. case x of INL (v,_) => v_size v
-                                   | INR (vs,_) => v1_size vs)`)
+  (do_eq_list _ _ = Eq_val F)
+Termination
+  WF_REL_TAC `measure (\x. case x of INL (v,_) => v_size v
+                                   | INR (vs,_) => v1_size vs)`
+End
 
 Definition v_to_list_def:
   (v_to_list (Block tag []) =

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -253,19 +253,23 @@ Definition space_consumed_def:
   (space_consumed s (op:closLang$op) (vs:v list) = 0:num)
 End
 
-val vb_size_def = tDefine"vb_size"`
+Definition vb_size_def:
   (vb_size (Block ts t ls) = 1 + t + SUM (MAP vb_size ls) + LENGTH ls) ∧
-  (vb_size _ = 1n)`
-(WF_REL_TAC`measure v_size` \\
+  (vb_size _ = 1n)
+Termination
+  WF_REL_TAC`measure v_size` \\
  ntac 2 gen_tac \\ Induct \\ rw[fetch "-" "v_size_def"] \\ rw[]
- \\ res_tac \\ rw[]);
+ \\ res_tac \\ rw[]
+End
 
-val vs_depth_def = tDefine"vs_depth"`
+Definition vs_depth_def:
   (vs_depth (Block ts t ls) = vs_depth_list ls) ∧
   (vs_depth _ = 0) ∧
   (vs_depth_list [] = 0) ∧
-  (vs_depth_list (x::xs) = MAX (1 + vs_depth x) (vs_depth_list xs))`
-(WF_REL_TAC`measure (λx. sum_CASE x v_size v1_size)`);
+  (vs_depth_list (x::xs) = MAX (1 + vs_depth x) (vs_depth_list xs))
+Termination
+  WF_REL_TAC`measure (λx. sum_CASE x v_size v1_size)`
+End
 
 Definition eq_code_stack_max_def:
   eq_code_stack_max n tsz =
@@ -421,7 +425,7 @@ Definition isClos_def:
   isClos t1 l1 = (((t1 = closure_tag) \/ (t1 = partial_app_tag)) /\ l1 <> [])
 End
 
-val do_eq_def = tDefine"do_eq"`
+Definition do_eq_def:
   (do_eq _ (CodePtr _) _ = Eq_type_error) ∧
   (do_eq _ _ (CodePtr _) = Eq_type_error) ∧
   (do_eq _ (Number n1) (Number n2) = (Eq_val (n1 = n2))) ∧
@@ -452,8 +456,10 @@ val do_eq_def = tDefine"do_eq"`
    | Eq_val T => do_eq_list refs vs1 vs2
    | Eq_val F => Eq_val F
    | bad => bad) ∧
-  (do_eq_list _ _ _ = Eq_val F)`
-  (WF_REL_TAC `measure (\x. case x of INL (_,v1,v2) => v_size v1 | INR (_,vs1,vs2) => v1_size vs1)`);
+  (do_eq_list _ _ _ = Eq_val F)
+Termination
+  WF_REL_TAC `measure (\x. case x of INL (_,v1,v2) => v_size v1 | INR (_,vs1,vs2) => v1_size vs1)`
+End
 val _ = export_rewrites["do_eq_def"];
 
 Overload Error[local] =

--- a/compiler/backend/semantics/flatPropsScript.sml
+++ b/compiler/backend/semantics/flatPropsScript.sml
@@ -803,7 +803,7 @@ Definition op_gbag_def:
   op_gbag _ = {||}
 End
 
-val set_globals_def = tDefine "set_globals" `
+Definition set_globals_def:
   (set_globals (Raise t e) = set_globals e) /\
   (set_globals (Handle t e pes) = set_globals e ⊎ elist_globals (MAP SND pes)) /\
   (set_globals (Con t id es) = elist_globals es) /\
@@ -817,8 +817,9 @@ val set_globals_def = tDefine "set_globals" `
     set_globals e ⊎ elist_globals (MAP (SND o SND) fs)) /\
   (set_globals _ = {||}) /\
   (elist_globals [] = {||}) /\
-  (elist_globals (e::es) = set_globals e ⊎ elist_globals es)`
- (WF_REL_TAC
+  (elist_globals (e::es) = set_globals e ⊎ elist_globals es)
+Termination
+  WF_REL_TAC
      `measure (\a. case a of INL e => exp_size e | INR es => exp6_size es)`
    \\ rw [flatLangTheory.exp_size_def]
    \\ fs [GSYM o_DEF]
@@ -826,11 +827,12 @@ val set_globals_def = tDefine "set_globals" `
     (`exp6_size (MAP (SND o SND) fs) < exp1_size fs + 1` suffices_by rw []
      \\ fs [flatLangTheory.exp_size_MAP])
    \\ `exp6_size (MAP SND pes) < exp3_size pes + 1` suffices_by rw []
-   \\ fs [flatLangTheory.exp_size_MAP]);
+   \\ fs [flatLangTheory.exp_size_MAP]
+End
 
 val _ = export_rewrites ["set_globals_def"];
 
-val esgc_free_def = tDefine "esgc_free" `
+Definition esgc_free_def:
   (esgc_free (Raise t e) <=> esgc_free e) /\
   (esgc_free (Handle t e pes) <=>
     esgc_free e /\ EVERY esgc_free (MAP SND pes)) /\
@@ -843,11 +845,13 @@ val esgc_free_def = tDefine "esgc_free" `
   (esgc_free (Let t v e1 e2) <=> esgc_free e1 /\ esgc_free e2) /\
   (esgc_free (Letrec t fs e) <=>
     esgc_free e /\ elist_globals (MAP (SND o SND) fs) = {||}) /\
-  (esgc_free _ <=> T)`
- (WF_REL_TAC `measure exp_size`
+  (esgc_free _ <=> T)
+Termination
+  WF_REL_TAC `measure exp_size`
   \\ rw []
   \\ fs [MEM_MAP] \\ rw []
-  \\ imp_res_tac flatLangTheory.exp_size_MEM \\ fs [])
+  \\ imp_res_tac flatLangTheory.exp_size_MEM \\ fs []
+End
 
 val esgc_free_def = save_thm("esgc_free_def[simp,compute,allow_rebind]",
   SIMP_RULE (bool_ss ++ ETA_ss) [] esgc_free_def)

--- a/compiler/backend/semantics/labSemScript.sml
+++ b/compiler/backend/semantics/labSemScript.sml
@@ -462,7 +462,7 @@ Definition share_mem_op_def:
   (share_mem_op Store32 r ad s = share_mem_store r ad s 4)
 End
 
-val evaluate_def = tDefine "evaluate" `
+Definition evaluate_def:
   evaluate (s:('a,'c,'ffi) labSem$state) =
     if s.clock = 0 then (TimeOut,s) else
     case asm_fetch s of
@@ -574,13 +574,15 @@ val evaluate_def = tDefine "evaluate" `
                                    clock := s.clock - 1 |>))
           | _ => (Error,s))
        | _ => (Error,s))
-    | _ => (Error,s)`
- (WF_REL_TAC `measure (\s. s.clock)`
+    | _ => (Error,s)
+Termination
+  WF_REL_TAC `measure (\s. s.clock)`
   \\ fs [inc_pc_def] \\ rw [] \\ IMP_RES_TAC asm_fetch_IMP
   \\ fs[asm_inst_consts,upd_reg_def,upd_pc_def,dec_clock_def,inc_pc_def]
   \\ Cases_on `m`
   \\ fs[share_mem_op_def,share_mem_load_def,share_mem_store_def]
-  \\ gvs[AllCaseEqs(),inc_pc_def,dec_clock_def])
+  \\ gvs[AllCaseEqs(),inc_pc_def,dec_clock_def]
+End
 
 Definition semantics_def:
   semantics s =

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -950,16 +950,18 @@ End
 
 (* stack_remove requires that all register arguments are bounded by k *)
 
-val reg_bound_exp_def = tDefine"reg_bound_exp"`
+Definition reg_bound_exp_def:
   (reg_bound_exp (Var n) k ⇔ n < k) ∧
   (reg_bound_exp (Load e) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Shift _ e _) k ⇔ reg_bound_exp e k) ∧
   (reg_bound_exp (Lookup _) _ ⇔ F) ∧
   (reg_bound_exp (Op _ es) k ⇔ EVERY (λe. reg_bound_exp e k) es) ∧
-  (reg_bound_exp _ _ ⇔ T)`
-  (WF_REL_TAC`measure ((exp_size ARB) o FST)` \\ simp[]
+  (reg_bound_exp _ _ ⇔ T)
+Termination
+  WF_REL_TAC`measure ((exp_size ARB) o FST)` \\ simp[]
    \\ Induct \\ simp[wordLangTheory.exp_size_def]
-   \\ srw_tac[][] \\ res_tac \\ simp[]);
+   \\ srw_tac[][] \\ res_tac \\ simp[]
+End
 val _ = export_rewrites["reg_bound_exp_def"];
 
 Definition reg_bound_inst_def:

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -124,7 +124,7 @@ Definition dec_clock_def:
   dec_clock (s:('a,'c,'ffi) stackSem$state) = s with clock := s.clock - 1
 End
 
-val word_exp_def = tDefine "word_exp" `
+Definition word_exp_def:
   (word_exp s (Const w) = SOME w) /\
   (word_exp s (Var v) =
      case FLOOKUP s.regs v of
@@ -146,11 +146,13 @@ val word_exp_def = tDefine "word_exp" `
   (word_exp s (Shift sh wexp n) =
      case word_exp s wexp of
      | NONE => NONE
-     | SOME w => word_sh sh w n)`
-  (WF_REL_TAC `measure (exp_size ARB o SND)`
+     | SOME w => word_sh sh w n)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC wordLangTheory.MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-   \\ DECIDE_TAC);
+   \\ DECIDE_TAC
+End
 
 Definition get_var_def:
   get_var v (s:('a,'c,'ffi) stackSem$state) = FLOOKUP s.regs v
@@ -283,7 +285,7 @@ Definition full_read_bitmap_def:
   (full_read_bitmap bitmaps _ = NONE)
 End
 
-val enc_stack_def = tDefine "enc_stack" `
+Definition enc_stack_def:
   (enc_stack bitmaps [] = NONE) /\
   (enc_stack bitmaps (w::ws) =
      if w = Word 0w then (if ws = [] then SOME [] else NONE) else
@@ -295,12 +297,14 @@ val enc_stack_def = tDefine "enc_stack" `
           | SOME (ts,ws') =>
               case enc_stack bitmaps ws' of
               | NONE => NONE
-              | SOME rs => SOME (ts ++ rs))`
- (WF_REL_TAC `measure (LENGTH o SND)` \\ REPEAT STRIP_TAC
+              | SOME rs => SOME (ts ++ rs))
+Termination
+  WF_REL_TAC `measure (LENGTH o SND)` \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC filter_bitmap_LENGTH
-  \\ fs [] \\ decide_tac)
+  \\ fs [] \\ decide_tac
+End
 
-val dec_stack_def = tDefine "dec_stack" `
+Definition dec_stack_def:
   (dec_stack bitmaps _ [] = NONE) ∧
   (dec_stack bitmaps ts (w::ws) =
     if w = Word 0w then (if ts = [] ∧ ws = [] then SOME [Word 0w] else NONE) else
@@ -312,11 +316,13 @@ val dec_stack_def = tDefine "dec_stack" `
         | SOME (hd,ts',ws') =>
            case dec_stack bitmaps ts' ws' of
            | NONE => NONE
-           | SOME rest => SOME ([w] ++ hd ++ rest))`
-  (WF_REL_TAC `measure (LENGTH o SND o SND)` \\ rw []
+           | SOME rest => SOME ([w] ++ hd ++ rest))
+Termination
+  WF_REL_TAC `measure (LENGTH o SND o SND)` \\ rw []
    \\ IMP_RES_TAC map_bitmap_LENGTH
    \\ fs [LENGTH_NIL] \\ rw []
-   \\ fs [map_bitmap_def] \\ rw [] \\ decide_tac)
+   \\ fs [map_bitmap_def] \\ rw [] \\ decide_tac
+End
 
 Definition gc_def:
   gc s =

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -190,7 +190,7 @@ Definition the_words_def:
      | _ => NONE)
 End
 
-val word_exp_def = tDefine "word_exp" `
+Definition word_exp_def:
   (word_exp ^s (Const w) = SOME (Word w)) /\
   (word_exp s (Var v) = lookup v s.locals) /\
   (word_exp s (Lookup name) = FLOOKUP s.store name) /\
@@ -205,11 +205,13 @@ val word_exp_def = tDefine "word_exp" `
   (word_exp s (Shift sh wexp n) =
      case word_exp s wexp of
      | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
-     | _ => NONE)`
-  (WF_REL_TAC `measure (exp_size ARB o SND)`
+     | _ => NONE)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-   \\ DECIDE_TAC);
+   \\ DECIDE_TAC
+End
 
 Definition get_var_def:
   get_var v ^s = sptree$lookup v s.locals

--- a/compiler/backend/stack_removeScript.sml
+++ b/compiler/backend/stack_removeScript.sml
@@ -75,45 +75,53 @@ Definition single_stack_alloc_def:
           (If Lower k (Reg (k+1)) (halt_inst 2w) Skip)
 End
 
-val stack_alloc_def = tDefine "stack_alloc" `
+Definition stack_alloc_def:
   stack_alloc jump k n =
     if n = 0 then Skip else
     if n <= max_stack_alloc then single_stack_alloc jump k n else
       Seq (single_stack_alloc jump k max_stack_alloc)
-          (stack_alloc jump k (n - max_stack_alloc))`
- (WF_REL_TAC `measure (SND o SND)` \\ fs [max_stack_alloc_def] \\ decide_tac)
+          (stack_alloc jump k (n - max_stack_alloc))
+Termination
+  WF_REL_TAC `measure (SND o SND)` \\ fs [max_stack_alloc_def] \\ decide_tac
+End
 
 Definition single_stack_free_def:
   single_stack_free k n =
     Inst (Arith (Binop Add k k (Imm (word_offset n))))
 End
 
-val stack_free_def = tDefine "stack_free" `
+Definition stack_free_def:
   stack_free k n =
     if n = 0 then Skip else
     if n <= max_stack_alloc then single_stack_free k n else
       Seq (single_stack_free k max_stack_alloc)
-          (stack_free k (n - max_stack_alloc))`
- (WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac)
+          (stack_free k (n - max_stack_alloc))
+Termination
+  WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac
+End
 
 (* upshift the stack pointer *)
-val upshift_def = tDefine"upshift"`
+Definition upshift_def:
   upshift r n =
     if n ≤ max_stack_alloc then
       (Inst (Arith (Binop Add r r (Imm (word_offset n))))):'a stackLang$prog
     else
       Seq (Inst (Arith (Binop Add r r (Imm (word_offset max_stack_alloc)))))
-      (upshift r (n-max_stack_alloc))`
-  (WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac)
+      (upshift r (n-max_stack_alloc))
+Termination
+  WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac
+End
 
-val downshift_def = tDefine"downshift"`
+Definition downshift_def:
   downshift r n =
     if n ≤ max_stack_alloc then
       (Inst (Arith (Binop Sub r r (Imm (word_offset n))))) :'a stackLang$prog
     else
       Seq (Inst (Arith (Binop Sub r r (Imm (word_offset max_stack_alloc)))))
-      (downshift r (n-max_stack_alloc))`
-  (WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac)
+      (downshift r (n-max_stack_alloc))
+Termination
+  WF_REL_TAC `measure SND` \\ fs [max_stack_alloc_def] \\ decide_tac
+End
 
 (* Shifts k up and down to store r into n*)
 Definition stack_store_def:

--- a/compiler/backend/wordLangScript.sml
+++ b/compiler/backend/wordLangScript.sml
@@ -71,16 +71,18 @@ Theorem store_consts_stub_location_eq = EVAL``store_consts_stub_location``;
 *)
 
 (* Recursors for variables *)
-val every_var_exp_def = tDefine "every_var_exp" `
+Definition every_var_exp_def:
   (every_var_exp P (Var num) = P num) ∧
   (every_var_exp P (Load exp) = every_var_exp P exp) ∧
   (every_var_exp P (Op wop ls) = EVERY (every_var_exp P) ls) ∧
   (every_var_exp P (Shift sh exp n) = every_var_exp P exp) ∧
-  (every_var_exp P expr = T)`
-(WF_REL_TAC `measure (exp_size ARB o SND)`
+  (every_var_exp P expr = T)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND)`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+End
 
 Definition every_var_imm_def:
   (every_var_imm P (Reg r) = P r) ∧
@@ -189,16 +191,18 @@ Definition every_stack_var_def:
 End
 
 (*Find the maximum variable*)
-val max_var_exp_def = tDefine "max_var_exp" `
+Definition max_var_exp_def:
   (max_var_exp (Var num) = num) ∧
   (max_var_exp (Load exp) = max_var_exp exp) ∧
   (max_var_exp (Op wop ls) = list_max (MAP (max_var_exp) ls))∧
   (max_var_exp (Shift sh exp n) = max_var_exp exp) ∧
-  (max_var_exp exp = 0:num)`
-(WF_REL_TAC `measure (exp_size ARB )`
+  (max_var_exp exp = 0:num)
+Termination
+  WF_REL_TAC `measure (exp_size ARB )`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+End
 
 Definition max_var_inst_def:
   (max_var_inst Skip = 0) ∧

--- a/compiler/backend/word_allocScript.sml
+++ b/compiler/backend/word_allocScript.sml
@@ -217,7 +217,7 @@ End
 
 (*Expressions only ever need to lookup a variable's current ssa map
   so it doesn't need the other parts *)
-val ssa_cc_trans_exp_def = tDefine "ssa_cc_trans_exp" `
+Definition ssa_cc_trans_exp_def:
   (ssa_cc_trans_exp t (Var num) =
     Var (option_lookup t num)) ∧
   (ssa_cc_trans_exp t (Load exp) = Load (ssa_cc_trans_exp t exp)) ∧
@@ -225,11 +225,13 @@ val ssa_cc_trans_exp_def = tDefine "ssa_cc_trans_exp" `
     Op wop (MAP (ssa_cc_trans_exp t) ls)) ∧
   (ssa_cc_trans_exp t (Shift sh exp nexp) =
     Shift sh (ssa_cc_trans_exp t exp) nexp) ∧
-  (ssa_cc_trans_exp t expr = expr)`
-  (WF_REL_TAC `measure (exp_size ARB o SND)`
+  (ssa_cc_trans_exp t expr = expr)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND)`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC)
+  \\ DECIDE_TAC
+End
 
 (*Attempt to pull out "renaming" moves
   This takes a current name map and updates the names of all the vars
@@ -432,16 +434,18 @@ End
 
 (*Recursively applying colours to a program*)
 
-val apply_colour_exp_def = tDefine "apply_colour_exp" `
+Definition apply_colour_exp_def:
   (apply_colour_exp f (Var num) = Var (f num)) /\
   (apply_colour_exp f (Load exp) = Load (apply_colour_exp f exp)) /\
   (apply_colour_exp f (Op wop ls) = Op wop (MAP (apply_colour_exp f) ls)) /\
   (apply_colour_exp f (Shift sh exp nexp) = Shift sh (apply_colour_exp f exp) nexp) /\
-  (apply_colour_exp f expr = expr)`
-(WF_REL_TAC `measure (exp_size ARB o SND)`
+  (apply_colour_exp f expr = expr)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND)`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+End
 
 Definition apply_colour_imm_def:
   (apply_colour_imm f (Reg n) = Reg (f n)) ∧
@@ -605,17 +609,19 @@ Definition big_union_def:
   big_union ls = FOLDR (λx y. union x y) LN ls
 End
 
-val get_live_exp_def = tDefine"get_live_exp"`
+Definition get_live_exp_def:
   (get_live_exp (Var num) = insert num () LN ) ∧
   (get_live_exp (Load exp) = get_live_exp exp) ∧
   (get_live_exp (Op wop ls) =
     big_union (MAP get_live_exp ls)) ∧
   (get_live_exp (Shift sh exp nexp) = get_live_exp exp) ∧
-  (get_live_exp expr = LN)`
-  (WF_REL_TAC `measure (exp_size ARB)`>>
+  (get_live_exp expr = LN)
+Termination
+  WF_REL_TAC `measure (exp_size ARB)`>>
   rw[]>>
   imp_res_tac MEM_IMP_exp_size>>
-  FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`) >> DECIDE_TAC)
+  FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`) >> DECIDE_TAC
+End
 
 Definition numset_list_insert_def:
   (numset_list_insert [] t = t) ∧
@@ -897,17 +903,19 @@ Definition get_delta_inst_def:
   (get_delta_inst x = Delta [] [])
 End
 
-val get_reads_exp_def = tDefine "get_reads_exp" `
+Definition get_reads_exp_def:
   (get_reads_exp (Var num) = [num]) ∧
   (get_reads_exp (Load exp) = get_reads_exp exp) ∧
   (get_reads_exp (Op wop ls) =
       FLAT (MAP get_reads_exp ls)) ∧
   (get_reads_exp (Shift sh exp nexp) = get_reads_exp exp) ∧
-  (get_reads_exp expr = [])`
-  (WF_REL_TAC `measure (exp_size ARB)`
+  (get_reads_exp expr = [])
+Termination
+  WF_REL_TAC `measure (exp_size ARB)`
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
   \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
-  \\ DECIDE_TAC)
+  \\ DECIDE_TAC
+End
 
 Definition get_clash_tree_def:
   (get_clash_tree Skip = Delta [] []) ∧

--- a/compiler/backend/word_instScript.sml
+++ b/compiler/backend/word_instScript.sml
@@ -87,7 +87,7 @@ Definition optimize_consts_def:
       | _ => Op op (Const w::nconst_ls)
 End
 
-val pull_exp_def = tDefine "pull_exp"`
+Definition pull_exp_def:
   (pull_exp (Op Sub ls) =
     let new_ls = MAP pull_exp ls in
     convert_sub new_ls) ∧
@@ -101,12 +101,14 @@ val pull_exp_def = tDefine "pull_exp"`
       optimize_consts op pull_ls) ∧
   (pull_exp (Load exp) = Load (pull_exp exp)) ∧
   (pull_exp (Shift shift exp nexp) = Shift shift (pull_exp exp) nexp) ∧
-  (pull_exp exp = exp)`
-  (WF_REL_TAC `measure (exp_size ARB)`
+  (pull_exp exp = exp)
+Termination
+  WF_REL_TAC `measure (exp_size ARB)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
    \\ fs[exp_size_def,asmTheory.binop_size_def,astTheory.shift_size_def,store_name_size_def]
-   \\ TRY (DECIDE_TAC))
+   \\ TRY (DECIDE_TAC)
+End
 
 Theorem pull_exp_pmatch:
   !(exp:'a exp).
@@ -140,19 +142,21 @@ QED
  /\
 c d
 *)
-val flatten_exp_def = tDefine "flatten_exp" `
+Definition flatten_exp_def:
   (flatten_exp (Op Sub exps) = Op Sub (MAP flatten_exp exps)) ∧
   (flatten_exp (Op op []) = op_consts op) ∧
   (flatten_exp (Op op [x]) = flatten_exp x) ∧
   (flatten_exp (Op op (x::xs)) = Op op [flatten_exp (Op op xs);flatten_exp x]) ∧
   (flatten_exp (Load exp) = Load (flatten_exp exp)) ∧
   (flatten_exp (Shift shift exp nexp) = Shift shift (flatten_exp exp) nexp) ∧
-  (flatten_exp exp = exp)`
-  (WF_REL_TAC `measure (exp_size ARB)`
+  (flatten_exp exp = exp)
+Termination
+  WF_REL_TAC `measure (exp_size ARB)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
    \\ fs[exp_size_def]
-   \\ TRY (DECIDE_TAC))
+   \\ TRY (DECIDE_TAC)
+End
 
 
   (*
@@ -208,7 +212,7 @@ QED
   in temp and the value of the whole expression must be saved in tar
 *)
 
-val inst_select_exp_def = tDefine "inst_select_exp" `
+Definition inst_select_exp_def:
   (inst_select_exp (c:'a asm_config) (tar:num) (temp:num) (Load exp) =
     dtcase exp of
     | Op Add [exp';Const w] =>
@@ -261,12 +265,14 @@ val inst_select_exp_def = tDefine "inst_select_exp" `
     else
       Inst (Const tar 0w)) ∧
   (*Make it total*)
-  (inst_select_exp _ _ _ _ = Skip)`
-  (WF_REL_TAC `measure (exp_size ARB o SND o SND o SND)`
+  (inst_select_exp _ _ _ _ = Skip)
+Termination
+  WF_REL_TAC `measure (exp_size ARB o SND o SND o SND)`
    \\ REPEAT STRIP_TAC \\ IMP_RES_TAC MEM_IMP_exp_size
    \\ TRY (FIRST_X_ASSUM (ASSUME_TAC o Q.SPEC `ARB`))
    \\ fs[exp_size_def]
-   \\ TRY (DECIDE_TAC)) ;
+   \\ TRY (DECIDE_TAC)
+End ;
 
 Theorem inst_select_exp_pmatch:
   !c tar temp exp.

--- a/compiler/backend/word_to_stackScript.sml
+++ b/compiler/backend/word_to_stackScript.sml
@@ -207,12 +207,14 @@ Definition bits_to_word_def:
   (bits_to_word (F::xs) = (bits_to_word xs << 1))
 End
 
-val word_list_def = tDefine "word_list" `
+Definition word_list_def:
   word_list (xs:bool list) d =
     if LENGTH xs <= d \/ (d = 0) then [bits_to_word xs]
-    else bits_to_word (TAKE d xs ++ [T]) :: word_list (DROP d xs) d`
- (WF_REL_TAC `measure (LENGTH o FST)`
-  \\ fs [LENGTH_DROP] \\ DECIDE_TAC)
+    else bits_to_word (TAKE d xs ++ [T]) :: word_list (DROP d xs) d
+Termination
+  WF_REL_TAC `measure (LENGTH o FST)`
+  \\ fs [LENGTH_DROP] \\ DECIDE_TAC
+End
 
 Definition write_bitmap_def:
   (write_bitmap live k f'):'a word list =

--- a/compiler/bootstrap/translation/arm8ProgScript.sml
+++ b/compiler/bootstrap/translation/arm8ProgScript.sml
@@ -234,18 +234,20 @@ val arm8_simp6 = arm8_enc6 |> SIMP_RULE (srw_ss() ++ LET_ss)
 val arm8_enc_thm = reconstruct_case ``arm8_enc i`` rand
 [arm8_simp1,arm8_simp2,arm8_simp3,arm8_simp4,arm8_simp5,arm8_simp6]
 
-val ct_curr_def = tDefine "ct_curr" `
+Definition ct_curr_def:
   ct_curr b (w:word64) =
      if
        ((1w && w) ≠ 0w ⇔ b) ∨
        if b then w = 0w else w = 0xFFFFFFFFFFFFFFFFw
      then
        0n
-     else 1 + ct_curr b (w ⋙ 1)`
-  (WF_REL_TAC`measure (w2n o SND)`
+     else 1 + ct_curr b (w ⋙ 1)
+Termination
+  WF_REL_TAC`measure (w2n o SND)`
   THEN SRW_TAC [] [wordsTheory.LSR_LESS]
   THEN Cases_on `w = 0w`
-  THEN FULL_SIMP_TAC (srw_ss()) [wordsTheory.word_0, wordsTheory.LSR_LESS]);
+  THEN FULL_SIMP_TAC (srw_ss()) [wordsTheory.word_0, wordsTheory.LSR_LESS]
+End
 
 val CountTrailing_eq = Q.prove(`
   ∀b w. CountTrailing (b,w) = ct_curr b w`,

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -650,23 +650,25 @@ val MEM_anub = prove(``
   MEM (k,v1) e1M``,
   ho_match_mp_tac anub_ind>>rw[anub_def]>>metis_tac[]);
 
-val nsSub_translate_def = tDefine "nsSub_translate"
-  `nsSub_translate path R b1 b2 ⇔
-   case b1 of (Bind e1V e1M) => case b2 of (Bind e2V e2M) =>
-     EVERY (λ(k,v1).
-       case ALOOKUP e2V k of
-         NONE => F
-       | SOME v2 => R (mk_id (REVERSE path) k) v1 v2) (anub e1V []) ∧
-     EVERY (λ(k,v1).
-       case ALOOKUP e2M k of
-         NONE => F
-       | SOME v2 => nsSub_translate (k::path) R v1 v2) (anub e1M [])`
-  (wf_rel_tac `measure (\(p,r,env,_). namespace_size (\x.0) (\x.0) (\x.0) env)`
-   >> rw[]
-   >> imp_res_tac MEM_anub >> last_x_assum kall_tac
-   >> Induct_on `e1M`
-   >> rw [namespaceTheory.namespace_size_def]
-   >> fs [namespaceTheory.namespace_size_def]);
+Definition nsSub_translate_def:
+  nsSub_translate path R b1 b2 ⇔
+  case b1 of (Bind e1V e1M) => case b2 of (Bind e2V e2M) =>
+    EVERY (λ(k,v1).
+      case ALOOKUP e2V k of
+        NONE => F
+      | SOME v2 => R (mk_id (REVERSE path) k) v1 v2) (anub e1V []) ∧
+    EVERY (λ(k,v1).
+      case ALOOKUP e2M k of
+        NONE => F
+      | SOME v2 => nsSub_translate (k::path) R v1 v2) (anub e1M [])
+Termination
+  wf_rel_tac `measure (\(p,r,env,_). namespace_size (\x.0) (\x.0) (\x.0) env)`
+  >> rw[]
+  >> imp_res_tac MEM_anub >> last_x_assum kall_tac
+  >> Induct_on `e1M`
+  >> rw [namespaceTheory.namespace_size_def]
+  >> fs [namespaceTheory.namespace_size_def]
+End
 
 val ALOOKUP_MEM_anub = prove(
   ``∀ls acc k v.

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -610,14 +610,16 @@ val generalise_list_length = Q.prove (
   srw_tac[] [] >>
   metis_tac [SND]);
 
-val gen_d_ind_def = tDefine "gen_d_ind" `
+Definition gen_d_ind_def:
   (gen_d_ind (Dmod n ds) = gen_ds_ind ds) /\
   (gen_d_ind (Dlocal lds ds) = (gen_ds_ind lds /\ gen_ds_ind ds)) /\
   (gen_d_ind _ = T) /\
   (gen_ds_ind [] = T) /\
-  (gen_ds_ind (x::xs) = (gen_d_ind x /\ gen_ds_ind xs))`
-  (WF_REL_TAC `measure (\x. case x of INL d => dec_size d
-                                    | INR ds => dec1_size ds)`)
+  (gen_ds_ind (x::xs) = (gen_d_ind x /\ gen_ds_ind xs))
+Termination
+  WF_REL_TAC `measure (\x. case x of INL d => dec_size d
+                                    | INR ds => dec1_size ds)`
+End
 
 val infer_p_wfs_dest = infer_p_wfs |> BODY_CONJUNCTS
     |> map (CONV_RULE (ONCE_DEPTH_CONV (REWR_CONV CONJ_COMM)))

--- a/compiler/bootstrap/translation/sexp_parserProgScript.sml
+++ b/compiler/bootstrap/translation/sexp_parserProgScript.sml
@@ -339,7 +339,7 @@ QED
 val _ = add_user_proved_v_thm num_to_dec_string_v_thm;
 
 (* TODO: translator failed for some reason if I just prove these as equations on print_sexp *)
-val print_sexp_alt_def = tDefine"print_sexp_alt"`
+Definition print_sexp_alt_def:
   (print_sexp_alt (SX_SYM s) = s) ∧
   (print_sexp_alt (SX_NUM n) = toString n) ∧
   (print_sexp_alt (SX_STR s) = "\"" ++ IMPLODE(escape_string s) ++ "\"") ∧
@@ -351,15 +351,17 @@ val print_sexp_alt_def = tDefine"print_sexp_alt"`
      then "'" ++ print_sexp_alt (EL 1 ls)
      else "(" ++ print_space_separated (MAP print_sexp_alt ls) ++ ")"
    | SOME lst =>
-       "(" ++ print_space_separated (MAP print_sexp_alt ls) ++ " . " ++ print_sexp_alt lst ++ ")")`
- (WF_REL_TAC`measure sexp_size` >> rw[] >> simp[simpleSexpTheory.sexp_size_def] >>
+       "(" ++ print_space_separated (MAP print_sexp_alt ls) ++ " . " ++ print_sexp_alt lst ++ ")")
+Termination
+  WF_REL_TAC`measure sexp_size` >> rw[] >> simp[simpleSexpTheory.sexp_size_def] >>
    fs[Once simpleSexpParseTheory.strip_dot_def] >>
    pairarg_tac \\ fs[] \\ rw[simpleSexpTheory.sexp_size_def] \\ fs[]
    \\ imp_res_tac simpleSexpParseTheory.strip_dot_MEM_sizelt
    \\ imp_res_tac simpleSexpParseTheory.strip_dot_last_sizeleq
    \\ fsrw_tac[boolSimps.DNF_ss][] \\ simp[]
    \\ fs[LENGTH_EQ_NUM_compute] \\ rw[] \\ fs[]
-   \\ res_tac \\ simp[]);
+   \\ res_tac \\ simp[]
+End
 
 Theorem strip_dot_EQ_NILSOME:
   strip_dot s = ([], SOME x) ⇒ s = x

--- a/compiler/inference/inferPropsScript.sml
+++ b/compiler/inference/inferPropsScript.sml
@@ -2370,15 +2370,17 @@ val t_ind = t_induction
   |> curry save_thm "t_ind";
 
 (* Rename (type_system) type identifiers with a function *)
-val ts_tid_rename_def = tDefine"ts_tid_rename"`
+Definition ts_tid_rename_def:
   (ts_tid_rename f (Tapp ts tn) = Tapp (MAP (ts_tid_rename f) ts) (f tn)) ∧
-  (ts_tid_rename f t = t)`
-  (WF_REL_TAC `measure (λ(_,y). t_size y)` >>
+  (ts_tid_rename f t = t)
+Termination
+  WF_REL_TAC `measure (λ(_,y). t_size y)` >>
   rw [] >>
   induct_on `ts` >>
   rw [t_size_def] >>
   res_tac >>
-  decide_tac);
+  decide_tac
+End
 
 val ts_tid_rename_ind = theorem"ts_tid_rename_ind";
 
@@ -2391,15 +2393,17 @@ Proof
 QED
 
 (* All type ids in a type belonging to a set *)
-val set_tids_def = tDefine "set_tids"`
+Definition set_tids_def:
   (set_tids (Tapp ts tn) = tn INSERT (BIGUNION (set (MAP set_tids ts)))) ∧
-  (set_tids _ = {})`
-  (WF_REL_TAC `measure t_size` >>
+  (set_tids _ = {})
+Termination
+  WF_REL_TAC `measure t_size` >>
   rw [] >>
   induct_on `ts` >>
   rw [t_size_def] >>
   res_tac >>
-  decide_tac)
+  decide_tac
+End
 
 val set_tids_ind = theorem"set_tids_ind";
 
@@ -2438,16 +2442,17 @@ Proof
     metis_tac[])
 QED
 
-val unconvert_t_def = tDefine "unconvert_t" `
+Definition unconvert_t_def:
 (unconvert_t (Tvar_db n) = Infer_Tvar_db n) ∧
 (unconvert_t (Tapp ts tc) = Infer_Tapp (MAP unconvert_t ts) tc) ∧
 (unconvert_t (Tvar v) = Infer_Tuvar ARB)
-`
-(wf_rel_tac `measure t_size` >>
+Termination
+  wf_rel_tac `measure t_size` >>
  rw [] >>
  induct_on `ts` >>
  rw [t_size_def] >>
- full_simp_tac (srw_ss()++ARITH_ss) []);
+ full_simp_tac (srw_ss()++ARITH_ss) []
+End
 
 val unconvert_t_ind = theorem"unconvert_t_ind"
 

--- a/compiler/inference/proofs/envRelScript.sml
+++ b/compiler/inference/proofs/envRelScript.sml
@@ -10,15 +10,17 @@ val _ = new_theory "envRel";
 
 (* ---------- Converting infer types and envs to type system ones ---------- *)
 
-val convert_t_def = tDefine "convert_t" `
+Definition convert_t_def:
 (convert_t (Infer_Tvar_db n) = Tvar_db n) ∧
-(convert_t (Infer_Tapp ts tc) = Tapp (MAP convert_t ts) tc)`
-(WF_REL_TAC `measure infer_t_size` >>
+(convert_t (Infer_Tapp ts tc) = Tapp (MAP convert_t ts) tc)
+Termination
+  WF_REL_TAC `measure infer_t_size` >>
  rw [] >>
  induct_on `ts` >>
  rw [infer_tTheory.infer_t_size_def] >>
  res_tac >>
- decide_tac);
+ decide_tac
+End
 
 Definition convert_env_def:
 convert_env s env = MAP (\(x,t). (x, convert_t (t_walkstar s t))) env

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -1270,7 +1270,7 @@ Termination
    Induct_on`ps`>>simp[pat_size_def] >>
    rw[] >> simp[] >> res_tac >>
    first_x_assum(qspec_then`cn`strip_assume_tac)>>
-   decide_tac 
+   decide_tac
 End
 
 Theorem patsexp_11[simp]:

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -580,7 +580,7 @@ Termination
 End
 
 (* translator friendly version for bootstrapping *)
-val sexppat_alt_def = tDefine"sexppat_alt"`
+Definition sexppat_alt_def:
  (sexppat_alt s =
     OPTION_MAP Pvar (odestSEXSTR s) ++
     case dstrip_sexp s of
@@ -611,10 +611,12 @@ val sexppat_alt_def = tDefine"sexppat_alt"`
        case sexppat_list d of
        | NONE => NONE
        | SOME t => SOME (h::t))
-    | _ => NONE)`
-  (wf_rel_tac`inv_image (measure sexp_size) (λx. case x of INL y => y | INR y => y)` \\ rw[] \\
+    | _ => NONE)
+Termination
+  wf_rel_tac`inv_image (measure sexp_size) (λx. case x of INL y => y | INR y => y)` \\ rw[] \\
    imp_res_tac dstrip_sexp_size \\
-   fs[LENGTH_EQ_NUM_compute]);
+   fs[LENGTH_EQ_NUM_compute]
+End
 
 val sexppat_alt_ind = theorem"sexppat_alt_ind";
 
@@ -1058,7 +1060,7 @@ Definition sexptype_def_def:
         (sexplist (sexppair odestSEXSTR (sexplist sexptype)))))
 End
 
-val sexpdec_def = tDefine"sexpdec"`
+Definition sexpdec_def:
   sexpdec s =
     do
       (nm, args) <- dstrip_sexp s;
@@ -1089,13 +1091,15 @@ val sexpdec_def = tDefine"sexpdec"`
       guard (nm = "Dlocal" ∧ LENGTH args = 2)
             (lift2 Dlocal (sexplist sexpdec (EL 0 args))
                 (sexplist sexpdec (EL 1 args)))
-    od`
-  (wf_rel_tac`measure sexp_size`
+    od
+Termination
+  wf_rel_tac`measure sexp_size`
    \\ rw[LENGTH_EQ_NUM_compute] \\ fs[]
-   \\ metis_tac[sxMEM_sizelt,dstrip_sexp_size,MEM,LESS_TRANS]);
+   \\ metis_tac[sxMEM_sizelt,dstrip_sexp_size,MEM,LESS_TRANS]
+End
 
 (* translator friendly version for bootstrapping *)
-val sexpdec_alt_def = tDefine"sexpdec_alt"`
+Definition sexpdec_alt_def:
   (sexpdec_alt s =
     case dstrip_sexp s of
     | NONE => NONE
@@ -1136,13 +1140,15 @@ val sexpdec_alt_def = tDefine"sexpdec_alt"`
          case sexpdec_list d of
          | NONE => NONE
          | SOME t => SOME (h::t))
-      | _ => NONE)`
-  (wf_rel_tac`inv_image (measure sexp_size)
+      | _ => NONE)
+Termination
+  wf_rel_tac`inv_image (measure sexp_size)
     (λx. case x of
          | INL y => y
          | INR y => y)` \\ rw[] \\
    imp_res_tac dstrip_sexp_size \\
-   fs[LENGTH_EQ_NUM_compute]);
+   fs[LENGTH_EQ_NUM_compute]
+End
 
 val sexpdec_alt_ind = theorem"sexpdec_alt_ind";
 
@@ -1210,14 +1216,16 @@ Proof
   Induct >> gen_tac >> cases_on `i2` >> fs[idsexp_def]
 QED
 
-val typesexp_def = tDefine"typesexp"`
+Definition typesexp_def:
   (typesexp (Atvar s) = listsexp [SX_SYM "Atvar"; SEXSTR s]) ∧
   (typesexp (Atfun t1 t2) = listsexp [SX_SYM "Atfun"; typesexp t1; typesexp t2]) ∧
   (typesexp (Attup ts) = listsexp [SX_SYM "Attup"; listsexp (MAP typesexp ts)]) ∧
-  (typesexp (Atapp ts tc) = listsexp [SX_SYM "Atapp"; listsexp (MAP typesexp ts); idsexp tc])`
-  (WF_REL_TAC`measure ast_t_size` >> rw[] \\
+  (typesexp (Atapp ts tc) = listsexp [SX_SYM "Atapp"; listsexp (MAP typesexp ts); idsexp tc])
+Termination
+  WF_REL_TAC`measure ast_t_size` >> rw[] \\
    Induct_on`ts` >> simp[ast_t_size_def] >>
-   rw[] >> res_tac >> simp[]);
+   rw[] >> res_tac >> simp[]
+End
 
 Theorem typesexp_11[simp]:
    ∀t1 t2. typesexp t1 = typesexp t2 ⇔ t1 = t2
@@ -1248,20 +1256,22 @@ Proof
   \\ intLib.COOPER_TAC
 QED
 
-val patsexp_def = tDefine"patsexp"`
+Definition patsexp_def:
   (patsexp Pany = listsexp [SX_SYM "Pany"]) ∧
   (patsexp (Pvar s) = SEXSTR s) ∧
   (patsexp (Plit l) = listsexp [SX_SYM "Plit"; litsexp l]) ∧
   (patsexp (Pcon cn ps) = listsexp [SX_SYM "Pcon"; optsexp (OPTION_MAP idsexp cn); listsexp (MAP patsexp ps)]) ∧
   (patsexp (Pas p i) = listsexp [SX_SYM "Pas"; patsexp p; SEXSTR i]) ∧
   (patsexp (Pref p) = listsexp [SX_SYM "Pref"; patsexp p]) ∧
-  (patsexp (Ptannot p t) = listsexp [SX_SYM "Ptannot" ; patsexp p; typesexp t])`
-  (WF_REL_TAC`measure pat_size` >>
+  (patsexp (Ptannot p t) = listsexp [SX_SYM "Ptannot" ; patsexp p; typesexp t])
+Termination
+  WF_REL_TAC`measure pat_size` >>
    simp [] >>
    Induct_on`ps`>>simp[pat_size_def] >>
    rw[] >> simp[] >> res_tac >>
    first_x_assum(qspec_then`cn`strip_assume_tac)>>
-   decide_tac );
+   decide_tac 
+End
 
 Theorem patsexp_11[simp]:
    ∀p1 p2. patsexp p1 = patsexp p2 ⇔ p1 = p2

--- a/compiler/parsing/lexer_implScript.sml
+++ b/compiler/parsing/lexer_implScript.sml
@@ -174,7 +174,7 @@ Definition num_from_hex_string_alt_def:
   num_from_hex_string_alt = s2n 16 unhex_alt
 End
 
-val next_sym_alt_def = tDefine "next_sym_alt" `
+Definition next_sym_alt_def:
   (next_sym_alt "" _ = NONE) /\
   (next_sym_alt (c::str) loc =
      if c = #"\n" then (* skip new line *)
@@ -270,12 +270,14 @@ val next_sym_alt_def = tDefine "next_sym_alt" `
                          rest)
      else if c = #"_" then SOME (OtherS "_", Locs loc loc, str)
      else (* input not recognised *)
-       SOME (ErrorS, Locs loc loc, str))`
- ( WF_REL_TAC `measure (LENGTH o FST) ` THEN REPEAT STRIP_TAC
+       SOME (ErrorS, Locs loc loc, str))
+Termination
+   WF_REL_TAC `measure (LENGTH o FST) ` THEN REPEAT STRIP_TAC
    THEN IMP_RES_TAC (GSYM read_while_thm)
    THEN IMP_RES_TAC (GSYM read_string_thm)
    THEN IMP_RES_TAC skip_comment_thm THEN Cases_on `str`
-   THEN FULL_SIMP_TAC (srw_ss()) [LENGTH] THEN DECIDE_TAC);
+   THEN FULL_SIMP_TAC (srw_ss()) [LENGTH] THEN DECIDE_TAC
+End
 
 val EVERY_isDigit_imp = Q.prove(`
   EVERY isDigit x ⇒
@@ -503,14 +505,16 @@ QED
 
 (* lex_impl_all *)
 
-val lex_impl_all_def = tDefine "lex_impl_all" `
+Definition lex_impl_all_def:
   lex_impl_all input l =
     case lex_until_toplevel_semicolon input l of
       | NONE => []
-      | SOME (t, loc, input') => t ::lex_impl_all input' loc`
-  (WF_REL_TAC `measure (LENGTH o FST)` >>
+      | SOME (t, loc, input') => t ::lex_impl_all input' loc
+Termination
+  WF_REL_TAC `measure (LENGTH o FST)` >>
    rw [] >>
-   metis_tac [lex_until_toplevel_semicolon_LESS]);
+   metis_tac [lex_until_toplevel_semicolon_LESS]
+End
 
 Definition lex_aux_tokens_def:
   lex_aux_tokens acc (d:num) input =
@@ -555,14 +559,16 @@ val lex_aux_tokens_LESS = Q.prove(
   >> FULL_SIMP_TAC (srw_ss()) [] >> RES_TAC
   >> Cases_on `q` >> Cases_on `d` >> fs[] >> res_tac >> fs[]);
 
-val lex_impl_all_tokens_def = tDefine "lex_impl_all_tokens" `
+Definition lex_impl_all_tokens_def:
   lex_impl_all_tokens input =
      case lex_until_toplevel_semicolon_tokens input of
        NONE => []
-     | SOME (t,input) => t::lex_impl_all_tokens input`
-  (WF_REL_TAC `measure LENGTH`
+     | SOME (t,input) => t::lex_impl_all_tokens input
+Termination
+  WF_REL_TAC `measure LENGTH`
    >> SIMP_TAC std_ss [lex_until_toplevel_semicolon_tokens_def]
-   >> METIS_TAC [lex_aux_tokens_LESS])
+   >> METIS_TAC [lex_aux_tokens_LESS]
+End
 
 val lex_aux_tokens_thm = Q.prove(
   `!input l acc d res1 res2.

--- a/examples/filterProgScript.sml
+++ b/examples/filterProgScript.sml
@@ -179,12 +179,14 @@ QED
 (* Auxiliary functions to deal with null termination.                        *)
 (*---------------------------------------------------------------------------*)
 
-val null_index_def = tDefine "null_index"
-  `null_index s n =
-    if n >= strlen s then NONE
-    else if strsub s n = CHR 0 then SOME n
-    else null_index s (SUC n)`
-  (wf_rel_tac `inv_image (measure (λ(a,b). SUC a - b)) (strlen ## I)`);
+Definition null_index_def:
+  null_index s n =
+   if n >= strlen s then NONE
+   else if strsub s n = CHR 0 then SOME n
+   else null_index s (SUC n)
+Termination
+  wf_rel_tac `inv_image (measure (λ(a,b). SUC a - b)) (strlen ## I)`
+End
 
 val null_index_ind = fetch "-" "null_index_ind";
 
@@ -291,12 +293,14 @@ val cut_at_null_side_lem = Q.prove(`!s. cut_at_null_side s <=> T`,
   >> imp_res_tac null_index_le_len >> fs[])
  |> update_precondition;
 
-val null_index_w_def = tDefine "null_index_w"
-  `null_index_w s n =
-    if n >= LENGTH s then NONE
-    else if EL n s = 0w then SOME n
-    else null_index_w s (SUC n)`
-  (wf_rel_tac `inv_image (measure (λ(a,b). SUC a - b)) (LENGTH ## I)`);
+Definition null_index_w_def:
+  null_index_w s n =
+   if n >= LENGTH s then NONE
+   else if EL n s = 0w then SOME n
+   else null_index_w s (SUC n)
+Termination
+  wf_rel_tac `inv_image (measure (λ(a,b). SUC a - b)) (LENGTH ## I)`
+End
 
 val null_index_w_ind = fetch "-" "null_index_w_ind";
 

--- a/examples/lpr_checker/lpr_parsingScript.sml
+++ b/examples/lpr_checker/lpr_parsingScript.sml
@@ -594,7 +594,7 @@ Proof
   metis_tac[]
 QED
 
-val parse_PR_hint_def = tDefine "parse_PR_hint" `
+Definition parse_PR_hint_def:
   parse_PR_hint id xs acc =
   if id = 0 then
     if xs = [] then SOME acc
@@ -603,10 +603,12 @@ val parse_PR_hint_def = tDefine "parse_PR_hint" `
   case parse_until_nn xs [] of
     NONE => NONE
   | SOME (n,clause,rest) =>
-      parse_PR_hint n rest ((id,clause)::acc)`
-  (WF_REL_TAC `measure (LENGTH o (FST o SND))`>>
+      parse_PR_hint n rest ((id,clause)::acc)
+Termination
+  WF_REL_TAC `measure (LENGTH o (FST o SND))`>>
   rw[]>>
-  drule parse_until_nn_length>>fs[])
+  drule parse_until_nn_length>>fs[]
+End
 
 (* LPR parser *)
 Definition parse_lprstep_def:

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -3193,12 +3193,13 @@ Proof
 QED
 
 (* computes the next position for which P holds *)
-val Lnext_def = tDefine "Lnext" `
+Definition Lnext_def:
   Lnext P ll = if eventually P ll then
                         if P ll then 0
                         else SUC(Lnext P (THE (LTL ll)))
-                     else ARB`
- (exists_tac``\(P,ll') (P',ll).
+                     else ARB
+Termination
+  exists_tac``\(P,ll') (P',ll).
     ((P = P') /\ eventually P ll /\ eventually P ll' /\
     (LTL ll = SOME ll') /\ ¬ P ll)`` >>
     reverse(rw[relationTheory.WF_DEF,eventually_thm])
@@ -3211,7 +3212,8 @@ val Lnext_def = tDefine "Lnext" `
   HO_MATCH_MP_TAC eventually_ind >> rw[]
   >-(qexists_tac`(P,ll)` >> rw[] >> pairarg_tac >> fs[] >> res_tac >> rfs[]) >>
   Cases_on`B(P,ll)` >-(metis_tac[]) >>
-  qexists_tac`(P,h:::ll)` >> fs[] >> rw[] >> pairarg_tac >> fs[]);
+  qexists_tac`(P,h:::ll)` >> fs[] >> rw[] >> pairarg_tac >> fs[]
+End
 
 Definition Lnext_pos_def:
   Lnext_pos (ll :num llist) = Lnext (λll. ∃k. LHD ll = SOME k ∧ k ≠ 0) ll

--- a/semantics/proofs/cmlPtreeConversionPropsScript.sml
+++ b/semantics/proofs/cmlPtreeConversionPropsScript.sml
@@ -53,7 +53,7 @@ Proof
 QED
 
 
-val user_expressible_type_def = tDefine "user_expressible_type" ‘
+Definition user_expressible_type_def:
   (user_expressible_type (Atvar _) ⇔ T) ∧
   (user_expressible_type (Atapp tys tycon) ⇔
      EVERY user_expressible_type tys ∧
@@ -62,13 +62,15 @@ val user_expressible_type_def = tDefine "user_expressible_type" ‘
      EVERY user_expressible_type tys ∧ 2 ≤ LENGTH tys) ∧
   (user_expressible_type (Atfun dty rty) ⇔
      user_expressible_type dty ∧ user_expressible_type rty)
-’ (WF_REL_TAC ‘measure ast$ast_t_size’ >> simp[] >> conj_tac >> rpt gen_tac >>
+Termination
+  WF_REL_TAC ‘measure ast$ast_t_size’ >> simp[] >> conj_tac >> rpt gen_tac >>
    Induct_on ‘tys’ >>
-   dsimp[astTheory.ast_t_size_def] >> rpt strip_tac >> res_tac  >> simp[]);
+   dsimp[astTheory.ast_t_size_def] >> rpt strip_tac >> res_tac  >> simp[]
+End
 val _ = augment_srw_ss [rewrites [
            SIMP_RULE (srw_ss() ++ ETA_ss) [] user_expressible_type_def]]
 
-val type_to_AST_def = tDefine "type_to_AST" ‘
+Definition type_to_AST_def:
   type_to_AST (Atvar s) (* : (token,MMLnonT,unit) parsetree *) =
     ND nType [ND nPType [ND nDType [ND nTbase [LF (TyvarT s)]]]] ∧
   (type_to_AST (Atfun dty rty) =
@@ -124,10 +126,12 @@ val type_to_AST_def = tDefine "type_to_AST" ‘
     ND nPType [ND nDType [ND nTbase [LF LparT; type_to_AST ty; LF RparT]];
                LF StarT;
                typel_to_AST_PType tys]
-’ (WF_REL_TAC
+Termination
+  WF_REL_TAC
      ‘measure (λs. case s of INL ty => ast_t_size ty
                            | INR (INL tyl) => ast_t1_size tyl
-                           | INR (INR tyl) => ast_t1_size tyl)’)
+                           | INR (INR tyl) => ast_t1_size tyl)’
+End
 
 Theorem destTyvarPT_tyname_to_AST:
    ∀i. user_expressible_tyname i ⇒ destTyvarPT (tyname_to_AST i) = NONE

--- a/semantics/proofs/namespacePropsScript.sml
+++ b/semantics/proofs/namespacePropsScript.sml
@@ -784,11 +784,12 @@ QED
 
 val _ = DefnBase.export_cong "alistSub_cong";
 
-val nsSub_compute_def = tDefine "nsSub_compute" `
+Definition nsSub_compute_def:
   nsSub_compute path R (Bind e1V e1M) (Bind e2V e2M) ⇔
     alistSub (\k v1 v2. R (mk_id (REVERSE path) k) v1 v2) e1V e2V ∧
-    alistSub (\k v1 v2. nsSub_compute (k::path) R v1 v2) e1M e2M`
- (wf_rel_tac `measure (\(p,r,env,_). namespace_size (\x.0) (\x.0) (\x.0) env)`
+    alistSub (\k v1 v2. nsSub_compute (k::path) R v1 v2) e1M e2M
+Termination
+  wf_rel_tac `measure (\(p,r,env,_). namespace_size (\x.0) (\x.0) (\x.0) env)`
  >> rw []
  >> Induct_on `e1M`
  >> rw [namespace_size_def]
@@ -796,7 +797,8 @@ val nsSub_compute_def = tDefine "nsSub_compute" `
  >> fs [ALOOKUP_def]
  >> every_case_tac
  >> fs []
- >> rw [namespace_size_def]);
+ >> rw [namespace_size_def]
+End
 
 Theorem nsLookup_FOLDR_nsLift:
    !e p k. nsLookup (FOLDR nsLift e p) (mk_id p k) = nsLookup e (Short k)

--- a/semantics/proofs/semanticPrimitivesPropsScript.sml
+++ b/semantics/proofs/semanticPrimitivesPropsScript.sml
@@ -679,7 +679,7 @@ val _ = export_rewrites["ctors_of_dec_def"]
 
 (* free vars *)
 
-val FV_def = tDefine "FV"`
+Definition FV_def:
   (FV (Raise e) = FV e) ∧
   (FV (Handle e pes) = FV e ∪ FV_pes pes) ∧
   (FV (Lit _) = {}) ∧
@@ -702,12 +702,14 @@ val FV_def = tDefine "FV"`
      (FV e DIFF (IMAGE Short (set (pat_bindings p [])))) ∪ FV_pes pes) ∧
   (FV_defs [] = {}) ∧
   (FV_defs ((_,x,e)::defs) =
-     (FV e DIFF {Short x}) ∪ FV_defs defs)`
-  (WF_REL_TAC `inv_image $< (λx. case x of
+     (FV e DIFF {Short x}) ∪ FV_defs defs)
+Termination
+  WF_REL_TAC `inv_image $< (λx. case x of
      | INL e => exp_size e
      | INR (INL es) => exp6_size es
      | INR (INR (INL pes)) => exp3_size pes
-     | INR (INR (INR (defs))) => exp1_size defs)`);
+     | INR (INR (INR (defs))) => exp1_size defs)`
+End
 val _ = export_rewrites["FV_def"]
 
 Overload SFV = ``λe. {x | Short x ∈ FV e}``

--- a/translator/ml_pmatchScript.sml
+++ b/translator/ml_pmatchScript.sml
@@ -28,7 +28,7 @@ End
   It omits some checks, which are unnecessary for the translator but needed in
   the semantics; it thereby makes the translator's automation easier.
 *)
-val Pmatch_def = tDefine"Pmatch"`
+Definition Pmatch_def:
   (Pmatch env refs [] [] = SOME env) ∧
   (Pmatch env refs (p1::p2::ps) (v1::v2::vs) =
      case Pmatch env refs [p1] [v1] of | NONE => NONE
@@ -57,8 +57,10 @@ val Pmatch_def = tDefine"Pmatch"`
    | SOME (Refv v) => Pmatch env refs [p] [v]
    | _ => NONE) ∧
   (Pmatch env refs [Ptannot p t] [v] = Pmatch env refs [p] [v]) ∧
-  (Pmatch env refs _ _ = NONE)`
-  (WF_REL_TAC`measure (pat1_size o FST o SND o SND)`)
+  (Pmatch env refs _ _ = NONE)
+Termination
+  WF_REL_TAC`measure (pat1_size o FST o SND o SND)`
+End
 
 val Pmatch_ind = theorem"Pmatch_ind"
 

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -219,12 +219,14 @@ val _ = Datatype`
             ; do_call : bool |>`
 val res = register_type``:foo``
 
-val foo_def = tDefine"foo"`
+Definition foo_def:
   foo (k:num) n =
   if n = 0 then []
   else if n ≤ 256n then [k]
-  else foo (k+1) (n-256)`
-  (WF_REL_TAC `measure SND`\\fs[])
+  else foo (k+1) (n-256)
+Termination
+  WF_REL_TAC `measure SND`\\fs[]
+End
 
 val res = translate foo_def
 
@@ -582,10 +584,12 @@ val _ = register_type ``:lit``
 
 (* step 2: translate a function that walks a char list producing datatype with strings *)
 val _ = use_string_type false;
-val chop_str_def = tDefine "chop_str" `
+Definition chop_str_def:
   chop_str [] = [] /\
-  chop_str xs = StrLit (TAKE 5 xs) :: chop_str (DROP 5 xs)`
-  (WF_REL_TAC `measure LENGTH` \\ fs [LENGTH_DROP]);
+  chop_str xs = StrLit (TAKE 5 xs) :: chop_str (DROP 5 xs)
+Termination
+  WF_REL_TAC `measure LENGTH` \\ fs [LENGTH_DROP]
+End
 val res = translate TAKE_def;
 val res = translate DROP_def;
 val res = translate chop_str_def

--- a/translator/monadic/examples/array_searchProgScript.sml
+++ b/translator/monadic/examples/array_searchProgScript.sml
@@ -74,14 +74,14 @@ Definition binary_search_aux_def:
             od
   od
 Termination
-  
+
     WF_REL_TAC `measure (λ (_, start, finish) . finish - start)` >>
     rw[] >>
     fs[NOT_GREATER_EQ, NOT_GREATER, ADD1] >>
     `start <= (finish + start) DIV 2` by fs[X_LE_DIV]
     >- DECIDE_TAC
     >- fs[DIV_LT_X]
-  
+
 End
 
 Definition binary_search_def:

--- a/translator/monadic/examples/array_searchProgScript.sml
+++ b/translator/monadic/examples/array_searchProgScript.sml
@@ -58,7 +58,7 @@ Definition linear_search_def:
 End
 
 
-val binary_search_aux_def = tDefine "binary_search_aux" `
+Definition binary_search_aux_def:
   binary_search_aux value start finish =
     do
       len <- arr_length;
@@ -73,15 +73,16 @@ val binary_search_aux_def = tDefine "binary_search_aux" `
                 binary_search_aux value (mid + 1n) finish
             od
   od
-`
-  (
+Termination
+  
     WF_REL_TAC `measure (λ (_, start, finish) . finish - start)` >>
     rw[] >>
     fs[NOT_GREATER_EQ, NOT_GREATER, ADD1] >>
     `start <= (finish + start) DIV 2` by fs[X_LE_DIV]
     >- DECIDE_TAC
     >- fs[DIV_LT_X]
-  );
+  
+End
 
 Definition binary_search_def:
   binary_search value =

--- a/translator/monadic/examples/floyd_warshallProgScript.sml
+++ b/translator/monadic/examples/floyd_warshallProgScript.sml
@@ -66,7 +66,7 @@ Definition get_weight_def:
   od
 End
 
-val st_ex_FOR_def = tDefine "st_ex_FOR" `
+Definition st_ex_FOR_def:
   st_ex_FOR (i:num) j a =
   if i >= j then
     return ()
@@ -74,8 +74,10 @@ val st_ex_FOR_def = tDefine "st_ex_FOR" `
     do
       () <- a i;
       st_ex_FOR (i+1) j a
-    od`
-  (WF_REL_TAC `measure (\(i, j:num, a).  j-i)`);
+    od
+Termination
+  WF_REL_TAC `measure (\(i, j:num, a).  j-i)`
+End
 
 Definition st_ex_FOREACH_def:
   (st_ex_FOREACH [] a = return ()) ∧

--- a/translator/monadic/examples/poly_array_sortProgScript.sml
+++ b/translator/monadic/examples/poly_array_sortProgScript.sml
@@ -438,7 +438,7 @@ val partition_helper_def = allowing_rebind (mtDefine "partition_helper" `
 (* TODO fix s5 / s6 problem - can get away with it for now,
    but probably not in general... *)
 (*
-val partition_helper_def = tDefine "partition_helper" `
+Definition partition_helper_def:
   partition_helper (cmp : 'a -> 'a -> bool) pivot lb ub s =
     if ub ≤ lb then (return ub s) else (
       monad_bind (scan_lower cmp pivot lb)
@@ -461,7 +461,9 @@ val partition_helper_def = tDefine "partition_helper" `
         )
       s1 )
     ) s
-`
+Termination
+  ...
+End
 *)
 
 Theorem partition_helper_index:
@@ -713,7 +715,7 @@ Definition array_get_aux_def:
       return (elem :: rest)
     od
 Termination
-  
+
   WF_REL_TAC `measure (λ (length, n) . length - n)`
 
 End

--- a/translator/monadic/examples/poly_array_sortProgScript.sml
+++ b/translator/monadic/examples/poly_array_sortProgScript.sml
@@ -705,17 +705,18 @@ Proof
   metis_tac[]
 QED
 
-val array_get_aux_def = tDefine "array_get_aux" `
+Definition array_get_aux_def:
   array_get_aux length n =
     if n ≥ length then return [] else do
       rest <- array_get_aux length (n + 1);
       elem <- arr_sub n;
       return (elem :: rest)
     od
-`
-(
+Termination
+  
   WF_REL_TAC `measure (λ (length, n) . length - n)`
-)
+
+End
 
 Definition array_get_def:
   array_get () = do

--- a/translator/okasaki-examples/BinomialHeapScript.sml
+++ b/translator/okasaki-examples/BinomialHeapScript.sml
@@ -22,28 +22,32 @@ Type heap = ``:'a tree list``
 
 val tree_size_def = fetch "-" "tree_size_def";
 
-val heap_to_bag_def = tDefine "heap_to_bag" `
+Definition heap_to_bag_def:
 (heap_to_bag [] = {||}) ∧
 (heap_to_bag (h::hs) =
   BAG_UNION (tree_to_bag h) (heap_to_bag hs)) ∧
 
 (tree_to_bag (Node _ x hs) =
-  BAG_INSERT x (heap_to_bag hs))`
-(wf_rel_tac `measure (\x. case x of INL x => tree1_size (\x.0) x
+  BAG_INSERT x (heap_to_bag hs))
+Termination
+  wf_rel_tac `measure (\x. case x of INL x => tree1_size (\x.0) x
                                   | INR x => tree_size (\x.0) x)` >>
- rw [tree_size_def]);
+ rw [tree_size_def]
+End
 
-val is_heap_ordered_def = tDefine "is_heap_ordered" `
+Definition is_heap_ordered_def:
 (is_heap_ordered get_key leq [] <=> T) ∧
 (is_heap_ordered get_key leq (t::ts) <=>
   is_heap_ordered_tree get_key leq t ∧ is_heap_ordered get_key leq ts) ∧
 
 (is_heap_ordered_tree get_key leq (Node _ x hs) <=>
   is_heap_ordered get_key leq hs ∧
-  BAG_EVERY (\y. leq (get_key x) (get_key y)) (heap_to_bag hs))`
-(wf_rel_tac `measure (\x. case x of INL (_,_,x) => tree1_size (\x.0) x
+  BAG_EVERY (\y. leq (get_key x) (get_key y)) (heap_to_bag hs))
+Termination
+  wf_rel_tac `measure (\x. case x of INL (_,_,x) => tree1_size (\x.0) x
                                   | INR (_,_,x) => tree_size (\x.0) x)` >>
- rw [tree_size_def]);
+ rw [tree_size_def]
+End
 
 val empty_def = mlDefine `
 empty = []`;
@@ -327,13 +331,15 @@ QED
 
 (* Verify size and shape invariants *)
 
-val heap_size_def = tDefine "heap_size" `
+Definition heap_size_def:
 (heap_size [] = 0) ∧
 (heap_size (t::ts) = heap_tree_size t + heap_size ts) ∧
-(heap_tree_size (Node _ _ trees) = (1:num) + heap_size trees)`
-(wf_rel_tac `measure (\x. case x of INR y => tree_size (\x.0) y
+(heap_tree_size (Node _ _ trees) = (1:num) + heap_size trees)
+Termination
+  wf_rel_tac `measure (\x. case x of INR y => tree_size (\x.0) y
                                   | INL z => tree1_size (\x.0) z)` >>
- rw []);
+ rw []
+End
 
 Definition is_binomial_tree_def:
 (is_binomial_tree (Node r x []) <=> (r = 0)) ∧

--- a/translator/okasaki-examples/BottomUpMergeSortScript.sml
+++ b/translator/okasaki-examples/BottomUpMergeSortScript.sml
@@ -17,7 +17,7 @@ val _ = translation_extends "ListProg";
 
 Type sortable = ``:num # 'a list list``
 
-val sortable_inv_def = tDefine "sortable_inv" `
+Definition sortable_inv_def:
 (sortable_inv leq (n,[]) m = (n = 0)) ∧
 (sortable_inv leq (n,xs::xss) m =
   if (n = 0) then
@@ -27,11 +27,13 @@ val sortable_inv_def = tDefine "sortable_inv" `
   else
     (LENGTH xs = m) ∧
     SORTED leq xs ∧
-    sortable_inv leq (n DIV 2, xss) (m * 2))`
-(wf_rel_tac `measure (\(x,(y,z),s). y)` >>
+    sortable_inv leq (n DIV 2, xss) (m * 2))
+Termination
+  wf_rel_tac `measure (\(x,(y,z),s). y)` >>
  rw [] >>
  Cases_on `n = 0` >>
- full_simp_tac (srw_ss()++ARITH_ss) []);
+ full_simp_tac (srw_ss()++ARITH_ss) []
+End
 
 val sortable_inv_ind = fetch "-" "sortable_inv_ind"
 
@@ -58,16 +60,18 @@ empty = (0, [])`;
 val sptree_size = Parse.hide"size"
 val _ = Parse.hide"seg"
 
-val add_seg_def = tDefine "add_seg" `
+Definition add_seg_def:
 add_seg leq seg segs size =
   if size MOD 2 = 0 then
     seg::segs
   else
-    add_seg leq (mrg leq seg (HD segs)) (TL segs) (size DIV 2)`
-(wf_rel_tac `measure (\(x,y,z,s). s)` >>
+    add_seg leq (mrg leq seg (HD segs)) (TL segs) (size DIV 2)
+Termination
+  wf_rel_tac `measure (\(x,y,z,s). s)` >>
  rw [] >>
  Cases_on `size = 0` >>
- full_simp_tac (srw_ss()++ARITH_ss) []);
+ full_simp_tac (srw_ss()++ARITH_ss) []
+End
 
 val add_seg_ind = fetch "-" "add_seg_ind"
 

--- a/translator/okasaki-examples/PairingHeapScript.sml
+++ b/translator/okasaki-examples/PairingHeapScript.sml
@@ -27,17 +27,19 @@ Definition heap_to_bag_def:
   BAG_UNION (heap_to_bag h) (heaps_to_bag hs))
 End
 
-val is_heap_ordered_def = tDefine "is_heap_ordered" `
+Definition is_heap_ordered_def:
 (is_heap_ordered get_key leq Empty <=> T) ∧
 (is_heap_ordered get_key leq (Tree x hs) <=>
   EVERY (is_heap_ordered get_key leq) hs ∧
-  BAG_EVERY (\y. leq (get_key x) (get_key y)) (heaps_to_bag hs))`
-(wf_rel_tac `measure (\(_,_,h). (heap_size (\x.1) h))` >>
+  BAG_EVERY (\y. leq (get_key x) (get_key y)) (heaps_to_bag hs))
+Termination
+  wf_rel_tac `measure (\(_,_,h). (heap_size (\x.1) h))` >>
 rw [] >>
 induct_on `hs` >>
 rw [fetch "-" "heap_size_def"] >>
 fs [] >>
-decide_tac);
+decide_tac
+End
 
 val empty_def = mlDefine `
 empty = Empty`;

--- a/translator/okasaki-examples/SplayHeapScript.sml
+++ b/translator/okasaki-examples/SplayHeapScript.sml
@@ -87,17 +87,19 @@ insert get_key leq x t =
   let (a, b) = partition get_key leq x t in
     Tree a x b`;
 
-val merge_def = tDefine "merge" `
+Definition merge_def:
 (merge get_key leq Empty h2 = h2) ∧
 (merge get_key leq (Tree a x b) h2 =
   let (ta, tb) = partition get_key leq x h2 in
-    Tree (merge get_key leq ta a) x (merge get_key leq tb b))`
-(WF_REL_TAC `measure (\(_,x,y,z).  heap_size (\_.1) y + heap_size (\_.1) z)` >>
+    Tree (merge get_key leq ta a) x (merge get_key leq tb b))
+Termination
+  WF_REL_TAC `measure (\(_,x,y,z).  heap_size (\_.1) y + heap_size (\_.1) z)` >>
  rw [] >>
  imp_res_tac partition_size >>
  pop_assum (MP_TAC o Q.SPEC `(λ_.1)`) >>
  pop_assum (MP_TAC o Q.SPEC `(λ_.1)`) >>
- full_simp_tac (srw_ss() ++ ARITH_ss) [partition_size]);
+ full_simp_tac (srw_ss() ++ ARITH_ss) [partition_size]
+End
 
 val _ = translate merge_def
 

--- a/translator/okasaki-examples/benchmarkScript.sml
+++ b/translator/okasaki-examples/benchmarkScript.sml
@@ -139,17 +139,19 @@ insert get_key leq x t =
   let (a, b) = partition get_key leq x t in
     Tree a x b`;
 
-val merge_def = tDefine "merge" `
+Definition merge_def:
 (merge get_key leq Empty h2 = h2) ∧
 (merge get_key leq (Tree a x b) h2 =
   let (ta, tb) = partition get_key leq x h2 in
-    Tree (merge get_key leq ta a) x (merge get_key leq tb b))`
-(WF_REL_TAC `measure (\(_,x,y,z).  heap_size (\_.1) y + heap_size (\_.1) z)` >>
+    Tree (merge get_key leq ta a) x (merge get_key leq tb b))
+Termination
+  WF_REL_TAC `measure (\(_,x,y,z).  heap_size (\_.1) y + heap_size (\_.1) z)` >>
  rw [] >>
  imp_res_tac partition_size >>
  pop_assum (MP_TAC o Q.SPEC `(λ_.1)`) >>
  pop_assum (MP_TAC o Q.SPEC `(λ_.1)`) >>
- full_simp_tac (srw_ss() ++ ARITH_ss) [partition_size]);
+ full_simp_tac (srw_ss() ++ ARITH_ss) [partition_size]
+End
 
 val _ = translate merge_def
 

--- a/translator/other-examples/auxiliary/copying_gcScript.sml
+++ b/translator/other-examples/auxiliary/copying_gcScript.sml
@@ -50,18 +50,20 @@ Definition rel_gc_step_def:
       (i,j,m)
 End
 
-val rel_gc_loop_def = tDefine "rel_gc_loop" `
+Definition rel_gc_loop_def:
   rel_gc_loop z (i,j,m,b,e,b2,e2) =
     if i = j then (i,m) else
     if ~(i < j /\ j <= e) then (i,m) else
       let (i,j,m) = rel_gc_step z (i,j,m,b,e,b2,e2) in
       let (i,m) = rel_gc_loop z (i,j,m,b,e,b2,e2) in
-        (i,m)`
- (WF_REL_TAC `measure (\(z,i,j,m,b,e,b2,e2). e - i)`
+        (i,m)
+Termination
+  WF_REL_TAC `measure (\(z,i,j,m,b,e,b2,e2). e - i)`
   THEN SIMP_TAC std_ss [rel_gc_step_def,LET_DEF]
   THEN CONV_TAC (DEPTH_CONV (PairRules.PBETA_CONV))
   THEN ONCE_REWRITE_TAC [EQ_SYM_EQ]
-  THEN SIMP_TAC std_ss [] THEN REPEAT STRIP_TAC THEN DECIDE_TAC);
+  THEN SIMP_TAC std_ss [] THEN REPEAT STRIP_TAC THEN DECIDE_TAC
+End
 
 Definition RANGE_def:
   RANGE(i:num,j) k = i <= k /\ k < j

--- a/translator/other-examples/auxiliary/regexpMatchScript.sml
+++ b/translator/other-examples/auxiliary/regexpMatchScript.sml
@@ -652,21 +652,20 @@ val match_seq_find_lemma = Q.prove
 (* out the intermediate parts of the match sequence.                         *)
 (*---------------------------------------------------------------------------*)
 
-val NS_DEF =
- tDefine
-  "NS"
-  `NS ms =
-     case split (\x. ?r l w. x = (Repeat r::l, w, SOME (Repeat r::l))) ms [] of
-         NONE => ms
-      |  SOME (l1, (bad_r, bad_w, bad_s), z) =>
-           let opt = split (\x. ?s. x = (bad_r, bad_w, s)) l1 []
-           in if opt = NONE then []
-              else
-                let (x1, (rl, w1, s1), y) = THE opt in
-                if (?ra L. (rl = Repeat ra::L) /\ (FST(HD z) = L))
-                  then NS (x1 ++ [(rl,w1,s1)] ++ change_stop_on_prefix z s1)
-                  else NS (x1 ++ [(rl,w1,s1)] ++ z)`
-(WF_REL_TAC `measure LENGTH`
+Definition NS_def:
+  NS ms =
+    case split (\x. ?r l w. x = (Repeat r::l, w, SOME (Repeat r::l))) ms [] of
+        NONE => ms
+     |  SOME (l1, (bad_r, bad_w, bad_s), z) =>
+          let opt = split (\x. ?s. x = (bad_r, bad_w, s)) l1 []
+          in if opt = NONE then []
+             else
+               let (x1, (rl, w1, s1), y) = THE opt in
+               if (?ra L. (rl = Repeat ra::L) /\ (FST(HD z) = L))
+                 then NS (x1 ++ [(rl,w1,s1)] ++ change_stop_on_prefix z s1)
+               else NS (x1 ++ [(rl,w1,s1)] ++ z)
+Termination
+  WF_REL_TAC `measure LENGTH`
   THEN RW_TAC list_ss [LENGTH_CSP]
   THEN IMP_RES_TAC split_thm THEN FULL_SIMP_TAC list_ss []
   THEN RW_TAC list_ss []
@@ -675,7 +674,8 @@ val NS_DEF =
   THEN FULL_SIMP_TAC list_ss []
   THEN Cases_on `x` THEN Cases_on `r`
   THEN IMP_RES_TAC split_thm THEN FULL_SIMP_TAC list_ss []
-  THEN RW_TAC list_ss []);
+  THEN RW_TAC list_ss []
+End
 
 val NS_IND = fetch "-" "NS_ind";
 
@@ -747,7 +747,7 @@ val match_seq_surg_thm = Q.prove
 val NS_match_thm = Q.prove
 (`!ms. match_seq ms ==> match_seq (NS ms)`,
  recInduct NS_IND THEN RW_TAC list_ss []
-   THEN ONCE_REWRITE_TAC [NS_DEF] THEN CASE_TAC THENL
+   THEN ONCE_REWRITE_TAC [NS_def] THEN CASE_TAC THENL
    [METIS_TAC [],
     REPEAT CASE_TAC
      THEN RW_TAC list_ss [match_seq_def, LET_THM]
@@ -767,7 +767,7 @@ val NS_match_thm = Q.prove
 val NS_is_normal_thm = Q.prove
 (`!ms r w t. ~MEM (Repeat r::t, w, SOME (Repeat r::t)) (NS ms)`,
  recInduct NS_IND THEN RW_TAC list_ss []
-   THEN ONCE_REWRITE_TAC [NS_DEF]
+   THEN ONCE_REWRITE_TAC [NS_def]
    THEN CASE_TAC THENL
    [IMP_RES_TAC split_thm4
       THEN FULL_SIMP_TAC list_ss [] THEN RW_TAC list_ss []
@@ -802,7 +802,7 @@ val  NS_HD_THM = Q.prove
               match_seq t ==>
              ?t''. (NS t = (r, w, NONE)::t'')`,
  recInduct NS_IND THEN RW_TAC list_ss []
-   THEN ONCE_REWRITE_TAC [NS_DEF]
+   THEN ONCE_REWRITE_TAC [NS_def]
    THEN REPEAT CASE_TAC
    THEN REPEAT (POP_ASSUM MP_TAC)
    THEN RENAME_FREES_TAC [("q","l1"), ("r''","l2"),

--- a/translator/other-examples/auxiliary/slr_parser_genScript.sml
+++ b/translator/other-examples/auxiliary/slr_parser_genScript.sml
@@ -17,10 +17,12 @@ Definition pop_def:
   (pop (h::t) n = if (n = 0) then (h::t) else pop t (n-1))
 End
 
-val take1_def = tDefine "take1" `
+Definition take1_def:
   (take1 0 [] = []) /\
-  (take1 n (x::xs) = (if n=0 then [] else x::take1 (n - 1) xs))`
-  (WF_REL_TAC (`measure (\(n,l).LENGTH l)`) THEN SRW_TAC [] []);
+  (take1 n (x::xs) = (if n=0 then [] else x::take1 (n - 1) xs))
+Termination
+  WF_REL_TAC (`measure (\(n,l).LENGTH l)`) THEN SRW_TAC [] []
+End
 
 Definition take_def:
   (take n l = if (LENGTH l >= n) then SOME (take1 n l)
@@ -99,14 +101,16 @@ Definition findItemInRules_def:
   (findItemInRules _ _ = F)
 End
 
-val itemEqRuleList_defn = tDefine "itemEqRuleList" `
+Definition itemEqRuleList_def:
   (itemEqRuleList [] [] = T) /\
   (itemEqRuleList [] _ = T) /\
   (itemEqRuleList _ [] = F) /\
   (itemEqRuleList l1 l2 =
      if ~(LENGTH l1 = LENGTH l2) then F else
-       if (findItemInRules (HD l1) l2) then itemEqRuleList (TL l1) l2 else F)`
-  (WF_REL_TAC (`measure (\(l1,l2).LENGTH l1)`) THEN SRW_TAC [] [])
+       if (findItemInRules (HD l1) l2) then itemEqRuleList (TL l1) l2 else F)
+Termination
+  WF_REL_TAC (`measure (\(l1,l2).LENGTH l1)`) THEN SRW_TAC [] []
+End
 
 Definition getState_def:
    getState (sg,red) (itl:item list) sym =


### PR DESCRIPTION
A quick grep (`grep -rP 'tDefine' --include "*Script.sml"`) reveals that the only instance of `tDefine` remaining is in `cv_translator/backend_cvScript.sml`, which is `val def = tDefine name [ANTIQUOTE tm] tac` within a function.