### PR TITLE
Permit annotation comments at top-level

### DIFF
--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -440,6 +440,7 @@ val entry_fun_parse =  check_success $ parse_pancake entry_fun;
 val annot_fun =
   `
   /* this is a function with an annot-comment in it */
+  /*@ and also an annot-comment before it @*/
   fun f () {
     var x = 1;
     var y = 2;
@@ -450,6 +451,7 @@ val annot_fun =
   `
 
 val annot_fun_parse = check_success $ parse_pancake annot_fun;
+val annot_fun_tree = check_success $ parse_tree_pancake annot_fun;
 val annot_fun_lex = lex_pancake annot_fun;
 val annots = annot_fun_lex |> concl |> rhs |> listSyntax.dest_list |> fst
   |> filter (can (find_term (can (match_term ``AnnotCommentT``))))

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -133,7 +133,8 @@ Definition pancake_peg_def[nocompute]:
     tokEOF := "Failed to see expected token; saw EOF instead";
     notFAIL := "Not combinator failed";
     rules := FEMPTY |++ [
-        (INL FunListNT, seql [rpt (mknt FunNT) FLAT] (mksubtree FunListNT));
+        (INL FunListNT, seql [rpt (choicel [mknt FunNT; keep_annot]) FLAT]
+                          (mksubtree FunListNT));
         (INL FunNT, seql [try_default (keep_kw ExportK) StaticT;
                           consume_kw FunK;
                           keep_ident;

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -666,7 +666,7 @@ Definition conv_FunList_def:
   conv_FunList tree =
    case argsNT tree FunListNT of
      SOME [] => SOME []
-   | SOME fs => OPT_MMAP conv_Fun fs
+   | SOME fs => OPT_MMAP conv_Fun (FILTER (IS_NONE o dest_annot_tok) fs)
    | _ => NONE
 End
 


### PR DESCRIPTION
Permit the annotation comment token (generated by /*@ @*/ comments) to appear amongst function definitions at the top level. They are then discarded in the ptree conversion; perhaps in the future they will be kept and processed somehow.

For now, this will permit the Pancake->Viper transpiler to use regular /*@ @*/ comments prior to a function as part of
its specification.