### PR TITLE
Remove val foo = Q.prove(..) automatically

### DIFF
--- a/basis/ArrayProofScript.sml
+++ b/basis/ArrayProofScript.sml
@@ -153,9 +153,11 @@ QED
 val eq_v_thm = fetch "mlbasicsProg" "eq_v_thm"
 val eq_num_v_thm = MATCH_MP (DISCH_ALL eq_v_thm) (EqualityType_NUM_BOOL |> CONJUNCT1)
 
-val num_eq_thm = Q.prove(
-  `!n nv x xv. NUM n nv /\ NUM x xv ==> (n = x <=> nv = xv)`,
-  metis_tac[EqualityType_NUM_BOOL, EqualityType_def]);
+Triviality num_eq_thm:
+  !n nv x xv. NUM n nv /\ NUM x xv ==> (n = x <=> nv = xv)
+Proof
+  metis_tac[EqualityType_NUM_BOOL, EqualityType_def]
+QED
 
 Theorem array_tabulate_spec:
    !n nv f fv (A: 'a -> v -> bool).
@@ -251,8 +253,9 @@ val res = max_print_depth := 100
 *)
 
 
-val less_than_length_thm = Q.prove (
-  `!xs n. (n < LENGTH xs) ==> (?ys z zs. (xs = ys ++ z::zs) /\ (LENGTH ys = n))`,
+Triviality less_than_length_thm:
+  !xs n. (n < LENGTH xs) ==> (?ys z zs. (xs = ys ++ z::zs) /\ (LENGTH ys = n))
+Proof
   rw[] \\
   qexists_tac`TAKE n xs` \\
   rw[] \\
@@ -260,18 +263,19 @@ val less_than_length_thm = Q.prove (
   qexists_tac`TL (DROP n xs)` \\
   Cases_on`DROP n xs` \\ fs[] \\
   metis_tac[TAKE_DROP,APPEND_ASSOC,CONS_APPEND]
-);
+QED
 
 
-val lupdate_breakdown_thm = Q.prove(
-  `!l val n. n < LENGTH l
-    ==> LUPDATE val n l = TAKE n l ++ [val] ++ DROP (n + 1) l`,
-    rw[] \\ drule less_than_length_thm
+Triviality lupdate_breakdown_thm:
+  !l val n. n < LENGTH l
+    ==> LUPDATE val n l = TAKE n l ++ [val] ++ DROP (n + 1) l
+Proof
+  rw[] \\ drule less_than_length_thm
     \\ rw[] \\ simp_tac std_ss [TAKE_LENGTH_APPEND, GSYM APPEND_ASSOC, GSYM CONS_APPEND]
     \\simp_tac std_ss [DROP_APPEND2]
     \\ simp_tac std_ss [GSYM CONS_APPEND]
     \\ EVAL_TAC \\ rw[lupdate_append2]
-);
+QED
 
 Theorem array_copy_aux_spec:
    !src n srcv dstv di div nv max maxv bfr mid afr.
@@ -462,16 +466,18 @@ Proof
   rw [NUM_def]
 QED
 
-val list_rel_take_thm = Q.prove(
-  `!A xs ys n.
-      LIST_REL A xs ys ==> LIST_REL A (TAKE n xs) (TAKE n ys)`,
-    Induct_on `xs` \\ Induct_on `ys` \\ rw[LIST_REL_def, TAKE_def]
-);
+Triviality list_rel_take_thm:
+  !A xs ys n.
+      LIST_REL A xs ys ==> LIST_REL A (TAKE n xs) (TAKE n ys)
+Proof
+  Induct_on `xs` \\ Induct_on `ys` \\ rw[LIST_REL_def, TAKE_def]
+QED
 
-val drop_pre_length_thm = Q.prove(
-  `!l. l <> [] ==> (DROP (LENGTH l - 1) l) = [(EL (LENGTH l - 1) l)]`,
+Triviality drop_pre_length_thm:
+  !l. l <> [] ==> (DROP (LENGTH l - 1) l) = [(EL (LENGTH l - 1) l)]
+Proof
   rw[] \\ Induct_on `l` \\ rw[DROP, LENGTH, DROP_EL_CONS, DROP_LENGTH_NIL]
-);
+QED
 
 (*
 Definition ARRAY_TYPE_def:

--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -431,11 +431,13 @@ Definition AUPDATE_def:
 End
 val AUPDATE_eval = translate AUPDATE_def;
 
-val FMAP_EQ_ALIST_UPDATE = Q.prove(
-  `FMAP_EQ_ALIST f l ==> FMAP_EQ_ALIST (FUPDATE f (x,y)) (AUPDATE l (x,y))`,
+Triviality FMAP_EQ_ALIST_UPDATE:
+  FMAP_EQ_ALIST f l ==> FMAP_EQ_ALIST (FUPDATE f (x,y)) (AUPDATE l (x,y))
+Proof
   SIMP_TAC (srw_ss()) [FMAP_EQ_ALIST_def,AUPDATE_def,ALOOKUP_def,FUN_EQ_THM,
     finite_mapTheory.FLOOKUP_DEF,finite_mapTheory.FAPPLY_FUPDATE_THM]
-  THEN METIS_TAC []);
+  THEN METIS_TAC []
+QED
 
 val Eval_FUPDATE = Q.prove(
   `!v. ((LIST_TYPE (PAIR_TYPE a b) -->
@@ -473,22 +475,28 @@ val _ = next_ml_names := ["every","every"];
 val _ = translate AEVERY_AUX_def;
 val AEVERY_eval = translate AEVERY_def;
 
-val AEVERY_AUX_THM = Q.prove(
-  `!l aux P. AEVERY_AUX aux P l <=>
-              !x y. (ALOOKUP l x = SOME y) /\ ~(MEM x aux) ==> P (x,y)`,
+Triviality AEVERY_AUX_THM:
+  !l aux P. AEVERY_AUX aux P l <=>
+              !x y. (ALOOKUP l x = SOME y) /\ ~(MEM x aux) ==> P (x,y)
+Proof
   Induct
   THEN FULL_SIMP_TAC std_ss [ALOOKUP_def,AEVERY_AUX_def,FORALL_PROD,
     MEM,GSYM MEMBER_INTRO] THEN REPEAT STRIP_TAC
-  THEN SRW_TAC [] [] THEN METIS_TAC [SOME_11]);
+  THEN SRW_TAC [] [] THEN METIS_TAC [SOME_11]
+QED
 
-val AEVERY_THM = Q.prove(
-  `AEVERY P l <=> !x y. (ALOOKUP l x = SOME y) ==> P (x,y)`,
-  SIMP_TAC (srw_ss()) [AEVERY_def,AEVERY_AUX_THM]);
+Triviality AEVERY_THM:
+  AEVERY P l <=> !x y. (ALOOKUP l x = SOME y) ==> P (x,y)
+Proof
+  SIMP_TAC (srw_ss()) [AEVERY_def,AEVERY_AUX_THM]
+QED
 
-val AEVERY_EQ_FEVERY = Q.prove(
-  `FMAP_EQ_ALIST f l ==> (AEVERY P l <=> FEVERY P f)`,
+Triviality AEVERY_EQ_FEVERY:
+  FMAP_EQ_ALIST f l ==> (AEVERY P l <=> FEVERY P f)
+Proof
   FULL_SIMP_TAC std_ss [FMAP_EQ_ALIST_def,FEVERY_DEF,AEVERY_THM]
-  THEN FULL_SIMP_TAC std_ss [FLOOKUP_DEF]);
+  THEN FULL_SIMP_TAC std_ss [FLOOKUP_DEF]
+QED
 
 val Eval_FEVERY = Q.prove(
   `!v. (((PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool) --> BOOL) -->
@@ -509,16 +517,20 @@ Definition AMAP_def:
 End
 val AMAP_eval = translate AMAP_def;
 
-val ALOOKUP_AMAP = Q.prove(
-  `!l. ALOOKUP (AMAP f l) a =
-        case ALOOKUP l a of NONE => NONE | SOME x => SOME (f x)`,
+Triviality ALOOKUP_AMAP:
+  !l. ALOOKUP (AMAP f l) a =
+        case ALOOKUP l a of NONE => NONE | SOME x => SOME (f x)
+Proof
   Induct THEN SIMP_TAC std_ss [AMAP_def,ALOOKUP_def,FORALL_PROD]
-  THEN SRW_TAC [] []);
+  THEN SRW_TAC [] []
+QED
 
-val FMAP_EQ_ALIST_o_f = Q.prove(
-  `FMAP_EQ_ALIST m l ==> FMAP_EQ_ALIST (x o_f m) (AMAP x l)`,
+Triviality FMAP_EQ_ALIST_o_f:
+  FMAP_EQ_ALIST m l ==> FMAP_EQ_ALIST (x o_f m) (AMAP x l)
+Proof
   SIMP_TAC std_ss [FMAP_EQ_ALIST_def,FUN_EQ_THM,FLOOKUP_DEF,
-    o_f_DEF,ALOOKUP_AMAP] THEN REPEAT STRIP_TAC THEN SRW_TAC [] []);
+    o_f_DEF,ALOOKUP_AMAP] THEN REPEAT STRIP_TAC THEN SRW_TAC [] []
+QED
 
 val Eval_o_f = Q.prove(
   `!v. (((b --> c) --> LIST_TYPE (PAIR_TYPE (a:'a->v->bool) (b:'b->v->bool)) -->
@@ -567,17 +579,21 @@ Definition ADEL_def:
 End
 val ADEL_eval = translate ADEL_def;
 
-val ALOOKUP_ADEL = Q.prove(
-  `!l a x. ALOOKUP (ADEL l a) x = if x = a then NONE else ALOOKUP l x`,
+Triviality ALOOKUP_ADEL:
+  !l a x. ALOOKUP (ADEL l a) x = if x = a then NONE else ALOOKUP l x
+Proof
   Induct THEN SRW_TAC [] [ALOOKUP_def,ADEL_def] THEN Cases_on `h`
-  THEN SRW_TAC [] [ALOOKUP_def,ADEL_def]);
+  THEN SRW_TAC [] [ALOOKUP_def,ADEL_def]
+QED
 
-val FMAP_EQ_ALIST_ADEL = Q.prove(
-  `!x l. FMAP_EQ_ALIST x l ==>
-          FMAP_EQ_ALIST (x \\ a) (ADEL l a)`,
+Triviality FMAP_EQ_ALIST_ADEL:
+  !x l. FMAP_EQ_ALIST x l ==>
+          FMAP_EQ_ALIST (x \\ a) (ADEL l a)
+Proof
   FULL_SIMP_TAC std_ss [FMAP_EQ_ALIST_def,ALOOKUP_def,fmap_domsub,FUN_EQ_THM]
   THEN REPEAT STRIP_TAC THEN SRW_TAC [] [ALOOKUP_ADEL,FLOOKUP_DEF,DRESTRICT_DEF]
-  THEN FULL_SIMP_TAC std_ss []);
+  THEN FULL_SIMP_TAC std_ss []
+QED
 
 val Eval_fmap_domsub = Q.prove(
   `!v. ((LIST_TYPE (PAIR_TYPE a b) --> a -->

--- a/basis/RatProgScript.sml
+++ b/basis/RatProgScript.sml
@@ -52,10 +52,11 @@ val _ = add_type_inv ``REAL_TYPE`` ``:rational``;
 
 (* transfer *)
 
-val RAT_RAT = Q.prove(
-  `(!r1. real_of_rat (f1 r1) = f2 (real_of_rat r1)) ==>
+Triviality RAT_RAT:
+  (!r1. real_of_rat (f1 r1) = f2 (real_of_rat r1)) ==>
    !v. (RAT_TYPE --> RAT_TYPE) f1 v ==>
-       (REAL_TYPE --> REAL_TYPE) f2 v`,
+       (REAL_TYPE --> REAL_TYPE) f2 v
+Proof
   strip_tac
   \\ SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,REAL_TYPE_def,PULL_EXISTS,
                           FORALL_PROD] \\ rw []
@@ -64,12 +65,14 @@ val RAT_RAT = Q.prove(
                      mp_then.mp_then (mp_then.Pos hd)
                                     (qspec_then ‘R’ strip_assume_tac))
   \\ fs [] \\ asm_exists_tac \\ fs []
-  \\ fs [] \\ asm_exists_tac \\ fs []);
+  \\ fs [] \\ asm_exists_tac \\ fs []
+QED
 
-val RAT_RAT_RAT = Q.prove(
-  `(!r1 r2. real_of_rat (f1 r1 r2) = f2 (real_of_rat r1) (real_of_rat r2)) ==>
+Triviality RAT_RAT_RAT:
+  (!r1 r2. real_of_rat (f1 r1 r2) = f2 (real_of_rat r1) (real_of_rat r2)) ==>
    !v. (RAT_TYPE --> RAT_TYPE --> RAT_TYPE) f1 v ==>
-       (REAL_TYPE --> REAL_TYPE --> REAL_TYPE) f2 v`,
+       (REAL_TYPE --> REAL_TYPE --> REAL_TYPE) f2 v
+Proof
   strip_tac
   \\ SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,REAL_TYPE_def,PULL_EXISTS,
                           FORALL_PROD] \\ rw []
@@ -81,12 +84,14 @@ val RAT_RAT_RAT = Q.prove(
   \\ rw [] \\ first_x_assum drule
   \\ qmatch_goalsub_rename_tac `(empty_state with refs := refs2)`
   \\ disch_then (qspec_then `refs2` mp_tac)
-  \\ strip_tac \\ rpt (asm_exists_tac \\ fs []));
+  \\ strip_tac \\ rpt (asm_exists_tac \\ fs [])
+QED
 
-val RAT_RAT_BOOL = Q.prove(
-  `(!r1 r2. f1 r1 r2 <=> f2 (real_of_rat r1) (real_of_rat r2)) ==>
+Triviality RAT_RAT_BOOL:
+  (!r1 r2. f1 r1 r2 <=> f2 (real_of_rat r1) (real_of_rat r2)) ==>
    !v. (RAT_TYPE --> RAT_TYPE --> BOOL) f1 v ==>
-       (REAL_TYPE --> REAL_TYPE --> BOOL) f2 v`,
+       (REAL_TYPE --> REAL_TYPE --> BOOL) f2 v
+Proof
   strip_tac
   \\ SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,REAL_TYPE_def,PULL_EXISTS,
                           FORALL_PROD] \\ rw []
@@ -98,23 +103,28 @@ val RAT_RAT_BOOL = Q.prove(
   \\ rw [] \\ first_x_assum drule
   \\ qmatch_goalsub_rename_tac `(empty_state with refs := refs2)`
   \\ disch_then (qspec_then `refs2` mp_tac)
-  \\ strip_tac \\ rpt (asm_exists_tac \\ fs []));
+  \\ strip_tac \\ rpt (asm_exists_tac \\ fs [])
+QED
 
-val RAT_BOOL = Q.prove(
-  `(!r1. (f1 r1) = f2 (real_of_rat r1)) ==>
+Triviality RAT_BOOL:
+  (!r1. (f1 r1) = f2 (real_of_rat r1)) ==>
    !v. (RAT_TYPE --> BOOL) f1 v ==>
-       (REAL_TYPE --> BOOL) f2 v`,
+       (REAL_TYPE --> BOOL) f2 v
+Proof
   strip_tac
   \\ SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,REAL_TYPE_def,PULL_EXISTS,
-                          FORALL_PROD] \\ rw []);
+                          FORALL_PROD] \\ rw []
+QED
 
-val RAT_INT = Q.prove(
-  `(!r1. (f1 r1) = f2 (real_of_rat r1)) ==>
+Triviality RAT_INT:
+  (!r1. (f1 r1) = f2 (real_of_rat r1)) ==>
    !v. (RAT_TYPE --> INT) f1 v ==>
-       (REAL_TYPE --> INT) f2 v`,
+       (REAL_TYPE --> INT) f2 v
+Proof
   strip_tac
   \\ SIMP_TAC (srw_ss()) [Arrow_def,AppReturns_def,REAL_TYPE_def,PULL_EXISTS,
-                          FORALL_PROD] \\ rw []);
+                          FORALL_PROD] \\ rw []
+QED
 
 
 (* -- *)
@@ -362,8 +372,9 @@ Proof
          arithmeticTheory.NOT_ZERO_LT_ZERO])
 QED
 
-val INT_NEG_DIV_FACTOR = Q.prove(
-  ‘0 < (x:num) ==> (-&(x * y):int / &x = -&y)’,
+Triviality INT_NEG_DIV_FACTOR:
+  0 < (x:num) ==> (-&(x * y):int / &x = -&y)
+Proof
   strip_tac >> qspec_then ‘&x’ mp_tac integerTheory.INT_DIVISION >>
   simp[] >> disch_then (qspec_then ‘-&(x * y)’ strip_assume_tac) >>
   map_every qabbrev_tac [`D:int = -&(x * y)`, `q = D / &x`, `r = D % &x`] >>
@@ -388,7 +399,8 @@ val INT_NEG_DIV_FACTOR = Q.prove(
   >- (rename [‘q + &y = 0’] >> disch_then kall_tac >>
       ‘q + &y + -&y = -&y’ by metis_tac [integerTheory.INT_ADD_LID] >>
       metis_tac[integerTheory.INT_ADD_ASSOC, integerTheory.INT_ADD_RID,
-                integerTheory.INT_ADD_RINV]))
+                integerTheory.INT_ADD_RINV])
+QED
 
 val PAIR_TYPE_IMP_RAT_TYPE = prove(
   ``r = rat_of_int m / & n /\ n <> 0 ==>
@@ -424,9 +436,11 @@ End
 val _ = next_ml_names := ["+"];
 val pair_add_v_thm = translate pair_add_def;
 
-val abs_rat_ONTO = Q.prove(
-  ‘!r. ?f. abs_rat f = r’,
-  gen_tac >> qexists_tac ‘rep_rat r’ >> simp[rat_type_thm]);
+Triviality abs_rat_ONTO:
+  !r. ?f. abs_rat f = r
+Proof
+  gen_tac >> qexists_tac ‘rep_rat r’ >> simp[rat_type_thm]
+QED
 
 val Eval_RAT_ADD = Q.prove(
   `!v.

--- a/basis/StringProgScript.sml
+++ b/basis/StringProgScript.sml
@@ -51,9 +51,11 @@ val _ = next_ml_names := ["translate"];
 val result = translate translate_def;
 val translate_side_def = definition"translate_side_def";
 
-val translate_aux_side_thm = Q.prove (
-  `!f s n len. n + len = strlen s ==> translate_aux_side f s n len`,
-  Induct_on `len` \\ rw[Once translate_aux_side_def]);
+Triviality translate_aux_side_thm:
+  !f s n len. n + len = strlen s ==> translate_aux_side f s n len
+Proof
+  Induct_on `len` \\ rw[Once translate_aux_side_def]
+QED
 
 val translate_side_thm = Q.prove (
   `!f s. translate_side f s`,
@@ -78,11 +80,13 @@ val _ = next_ml_names := ["tokens"];
 val result = translate tokens_alt;
 val tokens_side_def = definition"tokens_side_def";
 
-val tokens_alt_aux_side_thm = Q.prove (
-  `!f s i j k. i ≤ j ∧ j ≤ k ∧ k ≤ strlen s ⇒ tokens_alt_aux_side f s i j k`,
+Triviality tokens_alt_aux_side_thm:
+  !f s i j k. i ≤ j ∧ j ≤ k ∧ k ≤ strlen s ⇒ tokens_alt_aux_side f s i j k
+Proof
   ho_match_mp_tac tokens_alt_aux_ind>>
   rw[]>>
-  rw [Once tokens_alt_aux_side_def]);
+  rw [Once tokens_alt_aux_side_def]
+QED
 
 val tokens_side_thm = Q.prove (
   `!f s. tokens_side f s`,
@@ -99,11 +103,13 @@ val _ = next_ml_names := ["fields"];
 val result = translate fields_alt;
 val fields_side_def = definition"fields_side_def";
 
-val fields_alt_aux_side_thm = Q.prove (
-  `!f s i j k. i ≤ j ∧ j ≤ k ∧ k ≤ strlen s ⇒ fields_alt_aux_side f s i j k`,
+Triviality fields_alt_aux_side_thm:
+  !f s i j k. i ≤ j ∧ j ≤ k ∧ k ≤ strlen s ⇒ fields_alt_aux_side f s i j k
+Proof
   ho_match_mp_tac fields_alt_aux_ind>>
   rw[]>>
-  rw [Once fields_alt_aux_side_def]);
+  rw [Once fields_alt_aux_side_def]
+QED
 
 val fields_side_thm = Q.prove (
   `!f s. fields_side f s`,
@@ -117,22 +123,26 @@ val result = translate isStringThere_aux_def;
 val isStringThere_aux_side_def = theorem"isstringthere_aux_side_def";
 val _ = ml_prog_update open_local_in_block;
 
-val isStringThere_aux_side_thm = Q.prove (
-  `!s1 s2 s1i s2i len.
+Triviality isStringThere_aux_side_thm:
+  !s1 s2 s1i s2i len.
      s1i + len ≤ strlen s1 ∧ s2i + len <= strlen s2 ==>
-     isstringthere_aux_side s1 s2 s1i s2i len`,
-  Induct_on `len` \\ rw [Once isStringThere_aux_side_def]);
+     isstringthere_aux_side s1 s2 s1i s2i len
+Proof
+  Induct_on `len` \\ rw [Once isStringThere_aux_side_def]
+QED
 
 val _ = next_ml_names := ["isSubstring"];
 val result = translate isSubstring_aux_def;
 val isSubstring_aux_side_def = theorem"issubstring_aux_side_def";
-val isSubstring_aux_side_thm = Q.prove (
-  `!s1 s2 lens1 n len.
+Triviality isSubstring_aux_side_thm:
+  !s1 s2 lens1 n len.
     (lens1 = strlen s1) ∧ n + len + lens1 ≤ strlen s2 + 1 ==>
-    issubstring_aux_side s1 s2 lens1 n len`,
+    issubstring_aux_side s1 s2 lens1 n len
+Proof
   Induct_on `len` >>
   rw [Once isSubstring_aux_side_def] >>
-  irule isStringThere_aux_side_thm >> simp[]);
+  irule isStringThere_aux_side_thm >> simp[]
+QED
 
 val _ = next_ml_names := ["isSubstring"];
 val result = translate isSubstring_def;
@@ -164,12 +174,14 @@ val _ = next_ml_names := ["compare"];
 val result = translate compare_def;
 val compare_side_def = definition"compare_1_side_def";
 
-val compare_aux_side_thm = Q.prove (
-  `!s1 s2 ord n len. (n + len =
+Triviality compare_aux_side_thm:
+  !s1 s2 ord n len. (n + len =
     if strlen s1 < strlen s2
       then strlen s1
-    else strlen s2) ==> compare_aux_side s1 s2 ord n len`,
-  Induct_on `len` \\ rw [Once compare_aux_side_def]);
+    else strlen s2) ==> compare_aux_side s1 s2 ord n len
+Proof
+  Induct_on `len` \\ rw [Once compare_aux_side_def]
+QED
 
 val compare_side_thm = Q.prove (
   `!s1 s2. compare_1_side s1 s2`,
@@ -193,12 +205,14 @@ val _ = next_ml_names := ["collate"];
 val result = translate collate_def;
 val collate_side_def = definition"collate_1_side_def";
 
-val collate_aux_side_thm = Q.prove (
-  `!f s1 s2 ord n len. (n + len =
+Triviality collate_aux_side_thm:
+  !f s1 s2 ord n len. (n + len =
     if strlen s1 < strlen s2
       then strlen s1
-    else strlen s2) ==> collate_aux_side f s1 s2 ord n len`,
-  Induct_on `len` \\ rw [Once collate_aux_side_def]);
+    else strlen s2) ==> collate_aux_side f s1 s2 ord n len
+Proof
+  Induct_on `len` \\ rw [Once collate_aux_side_def]
+QED
 
 val collate_side_thm = Q.prove (
   `!f s1 s2. collate_1_side f s1 s2`,

--- a/basis/VectorProgScript.sml
+++ b/basis/VectorProgScript.sml
@@ -58,9 +58,11 @@ val _ = next_ml_names := ["foldli"];
 val result = translate foldli_def;
 val foldli_side_def = definition"foldli_1_side_def";
 
-val foldli_aux_side_thm = Q.prove(
-  `!f e vec n len. n + len = length vec ==> foldli_aux_side f e vec n len`,
-  Induct_on`len` \\ rw[Once foldli_aux_side_def]);
+Triviality foldli_aux_side_thm:
+  !f e vec n len. n + len = length vec ==> foldli_aux_side f e vec n len
+Proof
+  Induct_on`len` \\ rw[Once foldli_aux_side_def]
+QED
 
 val foldli_side_thm = Q.prove(
   `foldli_1_side f e vec`,
@@ -75,9 +77,11 @@ val _ = next_ml_names := ["foldl"];
 val result = translate foldl_def;
 val foldl_side_def = definition"foldl_1_side_def";
 
-val foldl_aux_side_thm = Q.prove(
-  `!f e vec n len. n + len = length vec ==> foldl_aux_side f e vec n len`,
-  Induct_on `len` \\ rw [Once foldl_aux_side_def]);
+Triviality foldl_aux_side_thm:
+  !f e vec n len. n + len = length vec ==> foldl_aux_side f e vec n len
+Proof
+  Induct_on `len` \\ rw [Once foldl_aux_side_def]
+QED
 
 val foldl_side_thm = Q.prove(
   `!f e vec. foldl_1_side f e vec`,
@@ -92,9 +96,11 @@ val _ = next_ml_names := ["foldri"];
 val result = translate foldri_def;
 val foldri_side_def = definition"foldri_1_side_def";
 
-val foldri_aux_side_thm = Q.prove(
-  `!f e vec len. len <= length vec ==> foldri_aux_side f e vec len`,
-  Induct_on `len` \\ rw [Once foldri_aux_side_def]);
+Triviality foldri_aux_side_thm:
+  !f e vec len. len <= length vec ==> foldri_aux_side f e vec len
+Proof
+  Induct_on `len` \\ rw [Once foldri_aux_side_def]
+QED
 
 val foldri_side_thm = Q.prove(
   `!f e vec. foldri_1_side f e vec`,
@@ -109,9 +115,11 @@ val _ = next_ml_names := ["foldr"];
 val result = translate foldr_def;
 val foldr_side_def = definition"foldr_1_side_def";
 
-val foldr_aux_side_thm = Q.prove(
-  `!f e vec len. len <= length vec ==> foldr_aux_side f e vec len`,
-  Induct_on `len` \\ rw[Once foldr_aux_side_def]);
+Triviality foldr_aux_side_thm:
+  !f e vec len. len <= length vec ==> foldr_aux_side f e vec len
+Proof
+  Induct_on `len` \\ rw[Once foldr_aux_side_def]
+QED
 
 val foldr_side_thm = Q.prove(
   `!f e vec. foldr_1_side f e vec`,
@@ -126,9 +134,11 @@ val _ = next_ml_names := ["findi"];
 val result = translate findi_def;
 val findi_side_def = definition"findi_side_def"
 
-val findi_aux_side_thm = Q.prove (
-  `!f vec n len. n + len = length vec ==> findi_aux_side f vec n len`,
-  Induct_on `len` \\ rw [Once findi_aux_side_def]);
+Triviality findi_aux_side_thm:
+  !f vec n len. n + len = length vec ==> findi_aux_side f vec n len
+Proof
+  Induct_on `len` \\ rw [Once findi_aux_side_def]
+QED
 
 val findi_side_thm = Q.prove (
   `!f vec. findi_side f vec`,
@@ -143,9 +153,11 @@ val _ = next_ml_names := ["find"];
 val result = translate find_def;
 val find_side_def = definition"find_1_side_def"
 
-val find_aux_side_thm = Q.prove (
-  `!f vec n len. n + len = length vec ==> find_aux_side f vec n len`,
-  Induct_on `len` \\ rw [Once find_aux_side_def]);
+Triviality find_aux_side_thm:
+  !f vec n len. n + len = length vec ==> find_aux_side f vec n len
+Proof
+  Induct_on `len` \\ rw [Once find_aux_side_def]
+QED
 
 val find_side_thm = Q.prove (
   `!f vec. find_1_side f vec`,
@@ -160,9 +172,11 @@ val _ = next_ml_names := ["exists"];
 val result = translate exists_def;
 val exists_side_def = definition"exists_1_side_def";
 
-val exists_aux_side_thm = Q.prove (
-  `!f vec n len. n + len = length vec ==> exists_aux_side f vec n len`,
-  Induct_on `len` \\ rw [Once exists_aux_side_def]);
+Triviality exists_aux_side_thm:
+  !f vec n len. n + len = length vec ==> exists_aux_side f vec n len
+Proof
+  Induct_on `len` \\ rw [Once exists_aux_side_def]
+QED
 
 val exists_side_thm = Q.prove (
   `!f vec. exists_1_side f vec`,
@@ -177,9 +191,11 @@ val _ = next_ml_names := ["all"];
 val result = translate all_def;
 val all_side_def = definition"all_1_side_def";
 
-val all_aux_side_thm = Q.prove (
-  `!f vec n len. n + len = length vec ==> all_aux_side f vec n len`,
-  Induct_on `len` \\ rw[Once all_aux_side_def]);
+Triviality all_aux_side_thm:
+  !f vec n len. n + len = length vec ==> all_aux_side f vec n len
+Proof
+  Induct_on `len` \\ rw[Once all_aux_side_def]
+QED
 
 val all_side_thm = Q.prove (
   `!f vec. all_1_side f vec`,
@@ -194,13 +210,15 @@ val _ = next_ml_names := ["collate"];
 val result = translate collate_def;
 val collate_side_def = definition"collate_1_side_def";
 
-val collate_aux_side_thm = Q.prove (
-  `!f vec1 vec2 n ord len. n + len =
+Triviality collate_aux_side_thm:
+  !f vec1 vec2 n ord len. n + len =
     (if length vec1 < length vec2
       then length vec1
     else length vec2) ==>
-        collate_aux_side f vec1 vec2 n ord len`,
-  Induct_on `len` \\ rw[Once collate_aux_side_def]);
+        collate_aux_side f vec1 vec2 n ord len
+Proof
+  Induct_on `len` \\ rw[Once collate_aux_side_def]
+QED
 
 val collate_side_thm = Q.prove (
   `!f vec1 vec2. collate_1_side f vec1 vec2`,

--- a/basis/fsFFIPropsScript.sml
+++ b/basis/fsFFIPropsScript.sml
@@ -1303,10 +1303,13 @@ Proof
  fs[STD_streams_def]
 QED
 
-val lemma = Q.prove(
-  `UStream (strlit "stdin") ≠ UStream (strlit "stdout") ∧
+Triviality lemma:
+  UStream (strlit "stdin") ≠ UStream (strlit "stdout") ∧
    UStream (strlit "stdin") ≠ UStream (strlit "stderr") ∧
-   UStream (strlit "stdout") ≠ UStream (strlit "stderr")`,rw[]);
+   UStream (strlit "stdout") ≠ UStream (strlit "stderr")
+Proof
+  rw[]
+QED
 
 Theorem STD_streams_forwardFD:
    fd ≠ 1 ∧ fd ≠ 2 ⇒

--- a/basis/pure/mlratScript.sml
+++ b/basis/pure/mlratScript.sml
@@ -143,10 +143,12 @@ Proof
        realTheory.real_sub]
 QED
 
-val inv_div = Q.prove(
-  ‘x ≠ 0r ∧ y ≠ 0 ⇒ (inv (x / y) = y / x)’,
+Triviality inv_div:
+  x ≠ 0r ∧ y ≠ 0 ⇒ (inv (x / y) = y / x)
+Proof
   simp[realTheory.real_div, realTheory.REAL_INV_MUL, realTheory.REAL_INV_EQ_0,
-       realTheory.REAL_INV_INV, realTheory.REAL_MUL_COMM]);
+       realTheory.REAL_INV_INV, realTheory.REAL_MUL_COMM]
+QED
 
 Theorem real_of_int_eq_num[simp]:
    ((real_of_int i = &n) <=> (i = &n)) /\

--- a/basis/pure/mlstringScript.sml
+++ b/basis/pure/mlstringScript.sml
@@ -248,13 +248,14 @@ Definition concatWith_def:
   concatWith s l = concatWith_aux s l T
 End
 
-val concatWith_CONCAT_WITH_aux = Q.prove (
-  `!s l fl. (CONCAT_WITH_aux s l fl = REVERSE fl ++ explode (concatWith (implode s) (MAP implode l)))`,
+Triviality concatWith_CONCAT_WITH_aux:
+  !s l fl. (CONCAT_WITH_aux s l fl = REVERSE fl ++ explode (concatWith (implode s) (MAP implode l)))
+Proof
   ho_match_mp_tac CONCAT_WITH_aux_ind
   \\ rw[CONCAT_WITH_aux_def, concatWith_def, implode_def, concatWith_aux_def, strcat_thm]
   >-(Induct_on `l` \\ rw[MAP, implode_def, concatWith_aux_def, strcat_thm]
   \\ Cases_on `l` \\ rw[concatWith_aux_def, explode_implode, strcat_thm, implode_def])
-);
+QED
 
 Theorem concatWith_CONCAT_WITH:
    !s l. CONCAT_WITH s l = explode (concatWith (implode s) (MAP implode l))
@@ -287,12 +288,13 @@ Definition translate_def:
   translate f s = implode (translate_aux f s 0 (strlen s))
 End
 
-val translate_aux_thm = Q.prove (
-  `!f s n len. (n + len = strlen s) ==> (translate_aux f s n len = MAP f (DROP n (explode s)))`,
+Triviality translate_aux_thm:
+  !f s n len. (n + len = strlen s) ==> (translate_aux f s n len = MAP f (DROP n (explode s)))
+Proof
   Cases_on `s` \\ Induct_on `len` \\ rw [translate_aux_def, strlen_def, explode_def] \\
   rw [DROP_LENGTH_NIL] \\
   rw [strsub_def, DROP_EL_CONS]
-);
+QED
 
 Theorem translate_thm:
    !f s. translate f s = implode (MAP f (explode s))
@@ -385,13 +387,14 @@ Definition tokens_def:
 End
 
 
-val tokens_aux_filter = Q.prove (
-  `!f s ss n len. (n + len = strlen s) ==> (concat (tokens_aux f s ss n len) =
-      implode (REVERSE ss++FILTER ($~ o f) (DROP n (explode s))))`,
+Triviality tokens_aux_filter:
+  !f s ss n len. (n + len = strlen s) ==> (concat (tokens_aux f s ss n len) =
+      implode (REVERSE ss++FILTER ($~ o f) (DROP n (explode s))))
+Proof
   Cases_on `s` \\ Induct_on `len` \\
   rw [strlen_def, tokens_aux_def, concat_cons, DROP_LENGTH_NIL, strcat_thm, implode_def] \\
   Cases_on `ss` \\ rw [tokens_aux_def, DROP_EL_CONS, concat_cons, strcat_thm, implode_def]
-);
+QED
 
 Theorem tokens_filter:
    !f s. concat (tokens f s) = implode (FILTER ($~ o f) (explode s))
@@ -630,13 +633,14 @@ End
 
 
 
-val fields_aux_filter = Q.prove (
-  `!f s ss n len. (n + len = strlen s) ==> (concat (fields_aux f s ss n len) =
-      implode (REVERSE ss++FILTER ($~ o f) (DROP n (explode s))))`,
+Triviality fields_aux_filter:
+  !f s ss n len. (n + len = strlen s) ==> (concat (fields_aux f s ss n len) =
+      implode (REVERSE ss++FILTER ($~ o f) (DROP n (explode s))))
+Proof
   Cases_on `s` \\ Induct_on `len` \\ rw [strlen_def, fields_aux_def, concat_cons,
     implode_def, explode_thm, DROP_LENGTH_NIL, strcat_thm] \\
   rw [DROP_EL_CONS]
-);
+QED
 
 Theorem fields_filter:
    !f s. concat (fields f s) = implode (FILTER ($~ o f) (explode s))
@@ -644,12 +648,13 @@ Proof
   rw [fields_def, fields_aux_filter]
 QED
 
-val fields_aux_length = Q.prove (
-  `!f s ss n len. (n + len = strlen s) ==>
-    (LENGTH (fields_aux f s ss n len) = LENGTH (FILTER f (DROP n (explode s))) + 1)`,
+Triviality fields_aux_length:
+  !f s ss n len. (n + len = strlen s) ==>
+    (LENGTH (fields_aux f s ss n len) = LENGTH (FILTER f (DROP n (explode s))) + 1)
+Proof
   Cases_on `s` \\ Induct_on `len` \\
   rw [strlen_def, fields_aux_def, explode_thm, DROP_LENGTH_NIL, ADD1, DROP_EL_CONS]
-);
+QED
 
 
 Theorem fields_length:
@@ -913,8 +918,8 @@ Overload ">=" = ``λx y. mlstring_ge x y``
 val flip_ord_def = ternaryComparisonsTheory.invert_comparison_def
 Overload flip_ord = ``invert_comparison``
 
-val compare_aux_spec = Q.prove (
-  `!s1 s2 ord_in start len.
+Triviality compare_aux_spec:
+  !s1 s2 ord_in start len.
     len + start ≤ strlen s1 ∧ len + start ≤ strlen s2 ⇒
     (compare_aux s1 s2 ord_in start len =
       if TAKE len (DROP start (explode s1)) = TAKE len (DROP start (explode s2)) then
@@ -922,7 +927,8 @@ val compare_aux_spec = Q.prove (
       else if string_lt (TAKE len (DROP start (explode s1))) (TAKE len (DROP start (explode s2))) then
         LESS
       else
-        GREATER)`,
+        GREATER)
+Proof
   Induct_on `len` >>
   rw [] >>
   ONCE_REWRITE_TAC [compare_aux_def] >>
@@ -935,20 +941,24 @@ val compare_aux_spec = Q.prove (
   fs [string_lt_def] >>
   simp [] >>
   rw [] >>
-  fs [char_lt_def, CHAR_EQ_THM]);
+  fs [char_lt_def, CHAR_EQ_THM]
+QED
 
-val compare_aux_refl = Q.prove (
-  `!s1 s2 start len.
+Triviality compare_aux_refl:
+  !s1 s2 start len.
     start + len ≤ strlen s1 ∧ start + len ≤ strlen s2
     ⇒
     ((compare_aux s1 s2 EQUAL start len = EQUAL)
      ⇔
-     (TAKE len (DROP start (explode s1)) = TAKE len (DROP start (explode s2))))`,
-  rw [compare_aux_spec]);
+     (TAKE len (DROP start (explode s1)) = TAKE len (DROP start (explode s2))))
+Proof
+  rw [compare_aux_spec]
+QED
 
-val compare_aux_equal = Q.prove (
-  `!s1 s2 ord_in start len.
-    (compare_aux s1 s2 ord_in start len = EQUAL) ⇒ (ord_in = EQUAL)`,
+Triviality compare_aux_equal:
+  !s1 s2 ord_in start len.
+    (compare_aux s1 s2 ord_in start len = EQUAL) ⇒ (ord_in = EQUAL)
+Proof
   Induct_on `len` >>
   rw []
   >- fs [Once compare_aux_def] >>
@@ -956,13 +966,15 @@ val compare_aux_equal = Q.prove (
   ONCE_REWRITE_TAC [compare_aux_def] >>
   simp_tac (std_ss++ARITH_ss) [] >>
   rw [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val compare_aux_sym = Q.prove (
-  `!s1 s2 ord_in start len ord_out.
+Triviality compare_aux_sym:
+  !s1 s2 ord_in start len ord_out.
     (compare_aux s1 s2 ord_in start len = ord_out)
     ⇔
-    (compare_aux s2 s1 (flip_ord ord_in) start len = flip_ord ord_out)`,
+    (compare_aux s2 s1 (flip_ord ord_in) start len = flip_ord ord_out)
+Proof
   Induct_on `len` >>
   rw [] >>
   ONCE_REWRITE_TAC [compare_aux_def] >>
@@ -985,38 +997,47 @@ val compare_aux_sym = Q.prove (
     simp [flip_ord_def]) >>
   ASM_REWRITE_TAC [] >>
   simp_tac (std_ss++ARITH_ss) [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val string_lt_take_mono = Q.prove (
-  `!s1 s2 x.
-    s1 < s2 ⇒ TAKE x s1 < TAKE x s2 ∨ (TAKE x s1 = TAKE x s2)`,
+Triviality string_lt_take_mono:
+  !s1 s2 x.
+    s1 < s2 ⇒ TAKE x s1 < TAKE x s2 ∨ (TAKE x s1 = TAKE x s2)
+Proof
   ho_match_mp_tac string_lt_ind >>
   rw [string_lt_def] >>
   Cases_on `x` >>
   fs [string_lt_def] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val string_lt_remove_take = Q.prove (
-  `!s1 s2 x. TAKE x s1 < TAKE x s2 ⇒ s1 < s2`,
+Triviality string_lt_remove_take:
+  !s1 s2 x. TAKE x s1 < TAKE x s2 ⇒ s1 < s2
+Proof
   ho_match_mp_tac string_lt_ind >>
   rw [string_lt_def] >>
   Cases_on `x` >>
   fs [string_lt_def] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val string_prefix_le = Q.prove (
-  `!s1 s2. s1 ≼ s2 ⇒ s1 ≤ s2`,
+Triviality string_prefix_le:
+  !s1 s2. s1 ≼ s2 ⇒ s1 ≤ s2
+Proof
   ho_match_mp_tac string_lt_ind >>
   rw [string_lt_def, string_le_def, isPREFIX_STRCAT] >>
   Cases_on `s3` >>
-  fs []);
+  fs []
+QED
 
-val take_prefix = Q.prove (
-  `!l s. TAKE l s ≼ s`,
+Triviality take_prefix:
+  !l s. TAKE l s ≼ s
+Proof
   Induct_on `s` >>
   rw [] >>
   Cases_on `l` >>
-  fs []);
+  fs []
+QED
 
 Theorem mlstring_lt_inv_image:
    mlstring_lt = inv_image string_lt explode
@@ -1165,11 +1186,13 @@ Proof
   \\ imp_res_tac string_lt_total \\ fs []
 QED
 
-val transitive_mlstring_lt = Q.prove(
-  `transitive mlstring_lt`,
+Triviality transitive_mlstring_lt:
+  transitive mlstring_lt
+Proof
   simp[mlstring_lt_inv_image] >>
   match_mp_tac transitive_inv_image >>
-  metis_tac[transitive_def,string_lt_trans])
+  metis_tac[transitive_def,string_lt_trans]
+QED
 
 Theorem strlit_le_strlit:
    strlit s1 ≤ strlit s2 <=> s1 <= s2
@@ -1178,18 +1201,22 @@ Proof
   \\ fs [string_le_def,mlstring_lt_inv_image]
 QED
 
-val irreflexive_mlstring_lt = Q.prove(
-  `irreflexive mlstring_lt`,
+Triviality irreflexive_mlstring_lt:
+  irreflexive mlstring_lt
+Proof
   simp[mlstring_lt_inv_image] >>
   match_mp_tac irreflexive_inv_image >>
-  simp[irreflexive_def,string_lt_nonrefl])
+  simp[irreflexive_def,string_lt_nonrefl]
+QED
 
-val trichotomous_mlstring_lt = Q.prove(
-  `trichotomous mlstring_lt`,
+Triviality trichotomous_mlstring_lt:
+  trichotomous mlstring_lt
+Proof
   simp[mlstring_lt_inv_image] >>
   match_mp_tac trichotomous_inv_image >>
   reverse conj_tac >- metis_tac[explode_BIJ,BIJ_DEF] >>
-  metis_tac[trichotomous,string_lt_cases])
+  metis_tac[trichotomous,string_lt_cases]
+QED
 
 Theorem StrongLinearOrder_mlstring_lt:
    StrongLinearOrder mlstring_lt

--- a/basis/pure/mlvectorScript.sml
+++ b/basis/pure/mlvectorScript.sml
@@ -33,8 +33,9 @@ Definition toList_def:
   toList vec = toList_aux vec 0
 End
 
-val toList_aux_thm = Q.prove (
-  `!vec n. toList_aux vec n = case vec of Vector vs => DROP n vs`,
+Triviality toList_aux_thm:
+  !vec n. toList_aux vec n = case vec of Vector vs => DROP n vs
+Proof
   ho_match_mp_tac toList_aux_ind \\
   rw [] \\
   ONCE_REWRITE_TAC [toList_aux_def] \\
@@ -43,7 +44,7 @@ val toList_aux_thm = Q.prove (
   fs [] \\
   Cases_on `vec` \\
   fs [sub_def, length_def, DROP_EL_CONS]
-);
+QED
 
 Theorem toList_thm:
    !ls. toList (Vector ls) = ls
@@ -102,8 +103,9 @@ Definition mapi_def:
 End
 
 
-val less_than_length_thm = Q.prove (
-  `!xs n. (n < LENGTH xs) ==> (?ys z zs. (xs = ys ++ z::zs) /\ (LENGTH ys = n))`,
+Triviality less_than_length_thm:
+  !xs n. (n < LENGTH xs) ==> (?ys z zs. (xs = ys ++ z::zs) /\ (LENGTH ys = n))
+Proof
   rw[] \\
   qexists_tac`TAKE n xs` \\
   rw[] \\
@@ -111,7 +113,7 @@ val less_than_length_thm = Q.prove (
   qexists_tac`TL (DROP n xs)` \\
   Cases_on`DROP n xs` \\ fs[] \\
   metis_tac[TAKE_DROP,APPEND_ASSOC,CONS_APPEND]
-);
+QED
 
 Definition foldli_aux_def:
   (foldli_aux f e vec n 0 = e) /\
@@ -122,14 +124,15 @@ Definition foldli_def:
   foldli f e vec = foldli_aux f e vec 0 (length vec)
 End
 
-val foldli_aux_thm = Q.prove (
-  `!f e vec n len. (n + len = length vec) ==>
-    (foldli_aux f e vec n len = mllist$foldli_aux f e n (DROP n (toList vec)))`,
+Triviality foldli_aux_thm:
+  !f e vec n len. (n + len = length vec) ==>
+    (foldli_aux f e vec n len = mllist$foldli_aux f e n (DROP n (toList vec)))
+Proof
   Cases_on `vec` \\ Induct_on `len` \\
   rw [foldli_aux_def, toList_thm, length_def, sub_def]
   >-(rw [DROP_LENGTH_TOO_LONG, mllistTheory.foldli_aux_def])
   \\ rw [DROP_EL_CONS, mllistTheory.foldli_aux_def, ADD1]
-);
+QED
 
 Theorem foldli_thm:
    !f e vec. foldli f e vec = mllist$foldli f e (toList vec)
@@ -146,9 +149,10 @@ Definition foldl_def:
   foldl f e vec = foldl_aux f e vec 0 (length vec)
 End
 
-val foldl_aux_thm = Q.prove (
-  `!f e vec x len. (x + len = length vec) ==>
-    (foldl_aux f e vec x len = FOLDL f e (DROP x (toList vec)))`,
+Triviality foldl_aux_thm:
+  !f e vec x len. (x + len = length vec) ==>
+    (foldl_aux f e vec x len = FOLDL f e (DROP x (toList vec)))
+Proof
   Induct_on `len` \\ Cases_on `vec` \\
   rw [foldl_aux_def, DROP_LENGTH_TOO_LONG, length_def, toList_thm] \\
   rw [length_def, sub_def, toList_thm] \\
@@ -159,7 +163,7 @@ val foldl_aux_thm = Q.prove (
   `LENGTH ys + 1 = LENGTH (ys ++ [z])` by (fs [] \\ NO_TAC) \\ ASM_REWRITE_TAC [DROP_LENGTH_APPEND]\\
   simp_tac std_ss [GSYM APPEND_ASSOC, APPEND, EL_LENGTH_APPEND, NULL, HD,
         FOLDL,  DROP_LENGTH_APPEND]
-);
+QED
 
 Theorem foldl_thm:
    !f e vec. foldl f e vec = FOLDL f e (toList vec)
@@ -179,13 +183,14 @@ Definition foldri_def:
 End
 
 
-val foldri_aux_thm = Q.prove (
-  `!f e vec len. len <= length vec ==>
-    (foldri_aux f e vec len = FOLDRi f e (TAKE len (toList vec)))`,
+Triviality foldri_aux_thm:
+  !f e vec len. len <= length vec ==>
+    (foldri_aux f e vec len = FOLDRi f e (TAKE len (toList vec)))
+Proof
   Induct_on `len` \\ rw[foldri_aux_def] \\
   Cases_on `vec` \\ fs[length_def, toList_thm, sub_def] \\
   rw [ADD1, TAKE_SUM, TAKE1_DROP, FOLDRi_APPEND]
-);
+QED
 
 Theorem foldri_thm:
    !f e vec. foldri f e vec = FOLDRi f e (toList vec)
@@ -205,13 +210,14 @@ Definition foldr_def:
   foldr f e vec = foldr_aux f e vec (length vec)
 End
 
-val foldr_aux_thm = Q.prove (
-  `!f e vec len. len <= length vec ==>
-    (foldr_aux f e vec len = FOLDR f e (TAKE len (toList vec)))`,
+Triviality foldr_aux_thm:
+  !f e vec len. len <= length vec ==>
+    (foldr_aux f e vec len = FOLDR f e (TAKE len (toList vec)))
+Proof
   Induct_on `len` \\ rw[foldr_aux_def] \\
   Cases_on `vec` \\ fs[length_def, toList_thm, sub_def] \\
   rw [ADD1, TAKE_SUM, TAKE1_DROP, FOLDR_APPEND]
-);
+QED
 
 Theorem foldr_thm:
    !f e vec. foldr f e vec = FOLDR f e (toList vec)
@@ -247,14 +253,15 @@ Definition find_def:
   find f vec = find_aux f vec 0 (length vec)
 End
 
-val find_aux_thm = Q.prove (
-  `!f vec n len. (n + len = length vec) ==> (find_aux f vec n len = FIND f (DROP n (toList vec)))`,
+Triviality find_aux_thm:
+  !f vec n len. (n + len = length vec) ==> (find_aux f vec n len = FIND f (DROP n (toList vec)))
+Proof
   Induct_on `len` \\ Cases_on `vec` \\ rw [find_aux_def, sub_def, length_def,
   toList_thm, FIND_def, INDEX_FIND_def] \\
   rw[DROP_LENGTH_NIL, INDEX_FIND_def] THEN1
   (qexists_tac`(0, EL n l)` \\ rw [DROP_EL_CONS, INDEX_FIND_def]) \\
   rw [DROP_EL_CONS, INDEX_FIND_def, index_find_thm]
-);
+QED
 
 Theorem find_thm:
    !f vec. find f vec = FIND f (toList vec)

--- a/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -176,9 +176,11 @@ val res = translate check_tm_tm_def;
 (*
 val res = translate mlstringTheory.explode_aux_def;
 val res = translate mlstringTheory.explode_def;
-val explode_aux_side_thm = Q.prove(
-  `∀s n m. n + m = strlen s ==> explode_aux_side s n m `,
-  Induct_on`m` \\ rw[Once (theorem"explode_aux_side_def")]);
+Triviality explode_aux_side_thm:
+  ∀s n m. n + m = strlen s ==> explode_aux_side s n m
+Proof
+  Induct_on`m` \\ rw[Once (theorem"explode_aux_side_def")]
+QED
 val explode_side_thm = Q.prove(
   `explode_side x`,
   rw[definition"explode_side_def",explode_aux_side_thm])
@@ -386,15 +388,17 @@ Definition term_compare_def:
          | Greater => Greater
 End
 
-val term_cmp_thm = Q.prove(
-  `term_cmp = term_compare`,
+Triviality term_cmp_thm:
+  term_cmp = term_compare
+Proof
   fs [FUN_EQ_THM]
   \\ HO_MATCH_MP_TAC (fetch "-" "term_compare_ind")
   \\ REPEAT STRIP_TAC \\ fs []
   \\ ONCE_REWRITE_TAC [holSyntaxExtraTheory.term_cmp_thm]
   \\ ONCE_REWRITE_TAC [term_compare_def]
   \\ REPEAT BasicProvers.CASE_TAC
-  \\ fs [comparisonTheory.pair_cmp_def])
+  \\ fs [comparisonTheory.pair_cmp_def]
+QED
 
 val _ = add_preferred_thy "-";
 val _ = save_thm("term_cmp_ind",

--- a/candle/overloading/monadic/holKernelPmatchScript.sml
+++ b/candle/overloading/monadic/holKernelPmatchScript.sml
@@ -25,9 +25,11 @@ val _ = hide "state";
 Type M = ``: hol_refs -> ('a, hol_exn) exc # hol_refs``
 
 (* TODO: stolen from deepMatchesLib.sml; should be exported? *)
-val PAIR_EQ_COLLAPSE = Q.prove (
-`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
-Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
+Triviality PAIR_EQ_COLLAPSE:
+  (((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))
+Proof
+  Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[]
+QED
 
 val pabs_elim_ss =
     simpLib.conv_ss

--- a/candle/overloading/monadic/holKernelProofScript.sml
+++ b/candle/overloading/monadic/holKernelProofScript.sml
@@ -33,9 +33,11 @@ QED
 
 val REPLICATE_GENLIST = rich_listTheory.REPLICATE_GENLIST
 
-val REPLICATE_11 = Q.prove(
-  `!m n x. (REPLICATE n x = REPLICATE m x) = (m = n)`,
-  Induct \\ Cases \\ SRW_TAC [] [rich_listTheory.REPLICATE]);
+Triviality REPLICATE_11:
+  !m n x. (REPLICATE n x = REPLICATE m x) = (m = n)
+Proof
+  Induct \\ Cases \\ SRW_TAC [] [rich_listTheory.REPLICATE]
+QED
 
 Overload impossible_term = ``holSyntax$Comb (Var (strlit "x") Bool) (Var (strlit "x") Bool)``
 
@@ -83,62 +85,78 @@ End
 (* impossible term lemmas                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val term_ok_impossible_term = Q.prove(
-  `~(term_ok defs impossible_term)`,
-  simp[term_ok_def])
+Triviality term_ok_impossible_term:
+  ~(term_ok defs impossible_term)
+Proof
+  simp[term_ok_def]
+QED
 
-val impossible_term_thm = Q.prove(
-  `TERM defs tm ==> tm <> impossible_term`,
+Triviality impossible_term_thm:
+  TERM defs tm ==> tm <> impossible_term
+Proof
   SIMP_TAC std_ss [TERM_def] \\ REPEAT STRIP_TAC
-  \\ FULL_SIMP_TAC (srw_ss()) [term_ok_impossible_term])
+  \\ FULL_SIMP_TAC (srw_ss()) [term_ok_impossible_term]
+QED
 
-val Abs_Var = Q.prove(
-  `TERM defs (Abs v tm) ==> ?s ty. v = Var s ty`,
-  simp[TERM_def,term_ok_def] >> rw[])
+Triviality Abs_Var:
+  TERM defs (Abs v tm) ==> ?s ty. v = Var s ty
+Proof
+  simp[TERM_def,term_ok_def] >> rw[]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* invariant lemmas                                                          *)
 (* ------------------------------------------------------------------------- *)
 
-val CONTEXT_ALL_DISTINCT = Q.prove(
-  `CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
-                   ALL_DISTINCT (MAP FST (const_list defs))`,
+Triviality CONTEXT_ALL_DISTINCT:
+  CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
+                   ALL_DISTINCT (MAP FST (const_list defs))
+Proof
   rw[CONTEXT_def] >>
-  METIS_TAC[extends_ALL_DISTINCT,init_ALL_DISTINCT])
+  METIS_TAC[extends_ALL_DISTINCT,init_ALL_DISTINCT]
+QED
 
-val STATE_ALL_DISTINCT = Q.prove(
-  `STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
-                   ALL_DISTINCT (MAP FST s.the_term_constants)`,
+Triviality STATE_ALL_DISTINCT:
+  STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
+                   ALL_DISTINCT (MAP FST s.the_term_constants)
+Proof
   rw[STATE_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`X = const_list Y`(assume_tac o SYM) >> fs[] >>
-  fs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
+  fs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX]
+QED
 
-val TYPE_Tyapp = Q.prove(
-  `MEM (tyop,LENGTH args) r.the_type_constants /\
+Triviality TYPE_Tyapp:
+  MEM (tyop,LENGTH args) r.the_type_constants /\
     STATE defs r /\ EVERY (TYPE defs) args ==>
-    TYPE defs (Tyapp tyop args)`,
+    TYPE defs (Tyapp tyop args)
+Proof
   rw[EVERY_MEM,TYPE_def] >>
   imp_res_tac STATE_ALL_DISTINCT >>
   rw[type_ok_def,EVERY_MAP,EVERY_MEM] >>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
-  rfs[STATE_def])
+  rfs[STATE_def]
+QED
 
-val CONTEXT_std_sig = Q.prove(
-  `CONTEXT defs ⇒ is_std_sig (sigof defs)`,
+Triviality CONTEXT_std_sig:
+  CONTEXT defs ⇒ is_std_sig (sigof defs)
+Proof
   rw[CONTEXT_def] >>
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
-  imp_res_tac theory_ok_sig >> fs[is_std_sig_def])
+  imp_res_tac theory_ok_sig >> fs[is_std_sig_def]
+QED
 
-val CONTEXT_fun = Q.prove(
-  `CONTEXT defs ⇒
-      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)`,
+Triviality CONTEXT_fun:
+  CONTEXT defs ⇒
+      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)
+Proof
   rw[] >> imp_res_tac CONTEXT_ALL_DISTINCT >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
   EQ_TAC >> rw[] >> res_tac >> fs[] >>
-  imp_res_tac ALOOKUP_MEM)
+  imp_res_tac ALOOKUP_MEM
+QED
 
 Theorem TYPE:
   (STATE defs state ==> TYPE defs (Tyvar v)) /\
@@ -160,38 +178,50 @@ Proof
   rw[TERM_def,TYPE_def] >> fs[term_ok_def]
 QED
 
-val TYPE_Fun = Q.prove(
-  `CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
-    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])`,
+Triviality TYPE_Fun:
+  CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
+    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])
+Proof
   rw[TYPE_def,type_ok_def] >>
   imp_res_tac CONTEXT_fun >>
-  METIS_TAC[ALOOKUP_ALL_DISTINCT_MEM,CONTEXT_ALL_DISTINCT]);
+  METIS_TAC[ALOOKUP_ALL_DISTINCT_MEM,CONTEXT_ALL_DISTINCT]
+QED
 
-val TERM_Var_SIMP = Q.prove(
-  `(TERM defs (Var n ty) = TYPE defs ty)`,
-  rw[TERM_def,TYPE_def,term_ok_def]);
+Triviality TERM_Var_SIMP:
+  (TERM defs (Var n ty) = TYPE defs ty)
+Proof
+  rw[TERM_def,TYPE_def,term_ok_def]
+QED
 
-val TERM_Var = Q.prove(
-  `TYPE defs ty ==> TERM defs (Var n ty)`,
-  METIS_TAC [TERM_Var_SIMP]);
+Triviality TERM_Var:
+  TYPE defs ty ==> TERM defs (Var n ty)
+Proof
+  METIS_TAC [TERM_Var_SIMP]
+QED
 
-val IMP_TERM_Abs = Q.prove(
-  `TERM defs (Var str ty) /\ TERM defs bod ==>
-    TERM defs (Abs (Var str ty) bod)`,
-  fs[TERM_def,term_ok_def]);
+Triviality IMP_TERM_Abs:
+  TERM defs (Var str ty) /\ TERM defs bod ==>
+    TERM defs (Abs (Var str ty) bod)
+Proof
+  fs[TERM_def,term_ok_def]
+QED
 
-val IMP_TERM_Comb = Q.prove(
-  `TERM defs f /\
+Triviality IMP_TERM_Comb:
+  TERM defs f /\
     TERM defs a /\
     (typeof a = ty1) /\
     (typeof f = Fun ty1 ty2) ==>
-    TERM defs (Comb f a)`,
+    TERM defs (Comb f a)
+Proof
   rw[TERM_def,term_ok_def] >>
-  METIS_TAC[term_ok_welltyped])
+  METIS_TAC[term_ok_welltyped]
+QED
 
-val TERM_Abs = Q.prove(
-  `TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm`,
-  rw[TERM_def,term_ok_def,TYPE_def]);
+Triviality TERM_Abs:
+  TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm
+Proof
+  rw[TERM_def,term_ok_def,TYPE_def]
+QED
 
 val INST_CORE_LEMMA =
   INST_CORE_HAS_TYPE |> Q.SPECL [`holSyntax$sizeof tm`,`tm`,`[]`,`tyin`]
@@ -237,25 +267,32 @@ val type_IND = type_induction
   |> UNDISCH_ALL |> CONJUNCT1 |> DISCH_ALL
   |> Q.GEN`P`
 
-val type_subst_EMPTY = Q.prove(
-  `!ty. type_subst [] ty = ty`,
+Triviality type_subst_EMPTY:
+  !ty. type_subst [] ty = ty
+Proof
   HO_MATCH_MP_TAC type_IND
   \\ REPEAT STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once type_subst_def]
   \\ SIMP_TAC std_ss [rev_assocd_thm,REV_ASSOCD,LET_DEF]
   \\ sg `MAP (\a. type_subst [] a) l = l` \\ FULL_SIMP_TAC std_ss []
-  \\ Induct_on `l` \\ FULL_SIMP_TAC std_ss [MAP,EVERY_DEF]);
+  \\ Induct_on `l` \\ FULL_SIMP_TAC std_ss [MAP,EVERY_DEF]
+QED
 
-val MAP_EQ_2 = Q.prove(
-  `(MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)`,
-  Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[])
+Triviality MAP_EQ_2:
+  (MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)
+Proof
+  Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[]
+QED
 
-val sequent_has_type_bool = Q.prove(
-  `(d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)`,
-  strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM])
+Triviality sequent_has_type_bool:
+  (d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)
+Proof
+  strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM]
+QED
 
-val THM_term_ok_bool = Q.prove(
-  `THM defs (Sequent asl p) ⇒
-    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)`,
+Triviality THM_term_ok_bool:
+  THM defs (Sequent asl p) ⇒
+    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)
+Proof
   REPEAT STRIP_TAC
   \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [THM_def]
@@ -264,7 +301,8 @@ val THM_term_ok_bool = Q.prove(
   \\ FULL_SIMP_TAC std_ss [TERM_def,EVERY_MEM,MEM_MAP,PULL_EXISTS,MEM]
   \\ NTAC 2 STRIP_TAC
   \\ FULL_SIMP_TAC std_ss []
-  \\ METIS_TAC [WELLTYPED_LEMMA])
+  \\ METIS_TAC [WELLTYPED_LEMMA]
+QED
 
 (* TODO move *)
 Theorem ALOOKUP_ALL_DISTINCT_MEM_EXISTS:
@@ -313,12 +351,14 @@ QED
 (* ------------------------------------------------------------------------- *)
 (* Verification of type functions                                            *)
 (* ------------------------------------------------------------------------- *)
-val can_thm = Q.prove(
-  `can f x s = case f x s of (M_success _,s) => (M_success T,s) |
-                              (_,s) => (M_success F,s)`,
+Triviality can_thm:
+  can f x s = case f x s of (M_success _,s) => (M_success T,s) |
+                              (_,s) => (M_success F,s)
+Proof
   SIMP_TAC std_ss [can_def,st_ex_ignore_bind_def,otherwise_def]
   \\ Cases_on `f x s` \\ Cases_on `q`
-  \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]);
+  \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
+QED
 
 Theorem assoc_thm:
   !xs y z s s'.
@@ -332,14 +372,16 @@ Proof
   \\ METIS_TAC []
 QED
 
-val get_type_arity_thm = Q.prove(
-  `!name s z s'.
+Triviality get_type_arity_thm:
+  !name s z s'.
       (get_type_arity name s = (z,s')) ==> (s' = s) /\
       (!i. (z = M_success i) ==> MEM (name,i) s.the_type_constants) /\
-      (!e. (z = M_failure e) ==> !i. ~MEM (name,i) s.the_type_constants)`,
+      (!e. (z = M_failure e) ==> !i. ~MEM (name,i) s.the_type_constants)
+Proof
   SIMP_TAC (srw_ss()) [get_type_arity_def,st_ex_bind_def,
     get_the_type_constants_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC assoc_thm);
+  \\ IMP_RES_TAC assoc_thm
+QED
 
 Theorem mk_vartype_thm:
    !name s.
@@ -400,8 +442,9 @@ Proof
   Cases \\ SIMP_TAC (srw_ss()) [is_vartype_def]
 QED
 
-val tyvars_thm = Q.prove(
-  `!ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)`,
+Triviality tyvars_thm:
+  !ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)
+Proof
   HO_MATCH_MP_TAC holKernelTheory.tyvars_ind \\ REPEAT STRIP_TAC
   \\ Cases_on `ty` \\ FULL_SIMP_TAC (srw_ss()) [type_11,type_distinct]
   \\ SIMP_TAC (srw_ss()) [Once holKernelTheory.tyvars_def,
@@ -409,7 +452,8 @@ val tyvars_thm = Q.prove(
   \\ FULL_SIMP_TAC std_ss [rich_listTheory.FOLDR_MAP]
   \\ Induct_on `l`
   \\ SIMP_TAC (srw_ss()) [Once itlist_def,FOLDR,MEM_union,MEM_LIST_UNION]
-  \\ METIS_TAC []);
+  \\ METIS_TAC []
+QED
 
 Theorem type_subst:
    !i ty.
@@ -448,14 +492,16 @@ QED
 
 Overload aty[local] = ``(Tyvar (strlit "A")):type``
 
-val get_const_type_thm = Q.prove(
-  `!name s z s'.
+Triviality get_const_type_thm:
+  !name s z s'.
       (get_const_type name s = (z,s')) ==> (s' = s) /\
       (!i. (z = M_success i) ==> MEM (name,i) s.the_term_constants) /\
-      (!e. (z = M_failure e) ==> !i. ~(MEM (name,i) s.the_term_constants))`,
+      (!e. (z = M_failure e) ==> !i. ~(MEM (name,i) s.the_term_constants))
+Proof
   SIMP_TAC (srw_ss()) [get_const_type_def,st_ex_bind_def,
     get_the_term_constants_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC assoc_thm);
+  \\ IMP_RES_TAC assoc_thm
+QED
 
 Definition term_type_def:
   term_type tm =
@@ -560,20 +606,23 @@ Proof
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_bind_def]
 QED
 
-val alphavars_thm = Q.prove(
-  `!env.
+Triviality alphavars_thm:
+  !env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))`,
+      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [Once alphavars_def,ALPHAVARS_def]
   \\ Cases \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ METIS_TAC []);
+  \\ METIS_TAC []
+QED
 
-val raconv_thm = Q.prove(
-  `!tm1 tm2 env.
+Triviality raconv_thm:
+  !tm1 tm2 env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (raconv env tm1 tm2 = RACONV env (tm1, tm2))`,
+      (raconv env tm1 tm2 = RACONV env (tm1, tm2))
+Proof
   Induct THEN1
    (Cases_on `tm2` >> simp[Once raconv_def, Once RACONV] >> rw[] >>
     IMP_RES_TAC alphavars_thm)
@@ -599,7 +648,8 @@ val raconv_thm = Q.prove(
   \\ FULL_SIMP_TAC std_ss [EVERY_DEF]
   \\ impl_tac
   THEN1 (REPEAT STRIP_TAC \\ MATCH_MP_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [])
-  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [])
+  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
+QED
 
 Theorem aconv_thm:
    !tm1 tm2 env.
@@ -727,17 +777,22 @@ Proof
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
 QED
 
-val type_subst_bool = Q.prove(
-  `type_subst i Bool = Bool`,
-  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF]);
+Triviality type_subst_bool:
+  type_subst i Bool = Bool
+Proof
+  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF]
+QED
 
-val type_subst_fun = Q.prove(
-  `type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)`,
-  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []);
+Triviality type_subst_fun:
+  type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)
+Proof
+  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []
+QED
 
-val TERM_Const = Q.prove(
-  `STATE defs r /\ MEM (name,a) r.the_term_constants ==>
-    TERM defs (Const name a)`,
+Triviality TERM_Const:
+  STATE defs r /\ MEM (name,a) r.the_term_constants ==>
+    TERM defs (Const name a)
+Proof
   rw[STATE_def,TERM_def,term_ok_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`_ = const_list _`(ASSUME_TAC o SYM) >>
@@ -751,11 +806,13 @@ val TERM_Const = Q.prove(
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
   fs[theory_ok_def] >> first_x_assum MATCH_MP_TAC >>
   MATCH_MP_TAC ALOOKUP_IN_FRANGE >>
-  simp[ALOOKUP_MAP] >> METIS_TAC[])
+  simp[ALOOKUP_MAP] >> METIS_TAC[]
+QED
 
-val TERM_Const_type_subst = Q.prove(
-  `EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
-    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))`,
+Triviality TERM_Const_type_subst:
+  EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
+    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))
+Proof
   REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
   \\ IMP_RES_TAC type_subst
   \\ FULL_SIMP_TAC std_ss [type_subst,TERM_def,TYPE_def] >>
@@ -765,7 +822,8 @@ val TERM_Const_type_subst = Q.prove(
     rfs[EVERY_MAP,EVERY_MEM,FORALL_PROD] >>
     METIS_TAC[] ) >>
   simp[TYPE_SUBST_compose] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
 Theorem mk_const_thm:
    !name theta s z s'.
@@ -785,9 +843,10 @@ Proof
   \\ IMP_RES_TAC TERM_Const
 QED
 
-val get_const_type_Equal = Q.prove(
-  `STATE defs s ==>
-    (get_const_type (strlit "=") s = (M_success (Fun aty (Fun aty Bool)),s))`,
+Triviality get_const_type_Equal:
+  STATE defs s ==>
+    (get_const_type (strlit "=") s = (M_success (Fun aty (Fun aty Bool)),s))
+Proof
   SIMP_TAC std_ss [STATE_def]
   \\ Cases_on `get_const_type (strlit "=") s`
   \\ IMP_RES_TAC get_const_type_thm \\ REPEAT STRIP_TAC >>
@@ -799,25 +858,30 @@ val get_const_type_Equal = Q.prove(
   fs[MEM_MAP,EXISTS_PROD] >>
   reverse(Cases_on`q`)>>fs[]>-METIS_TAC[]>>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
-  rfs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
+  rfs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX]
+QED
 
-val mk_const_eq = Q.prove(
-  `STATE defs s ==>
+Triviality mk_const_eq:
+  STATE defs s ==>
     (mk_const ((strlit "="),[]) s =
-     (M_success (Const (strlit "=") (Fun aty (Fun aty Bool))),s))`,
+     (M_success (Const (strlit "=") (Fun aty (Fun aty Bool))),s))
+Proof
   SIMP_TAC std_ss [mk_const_def,st_ex_bind_def,try_def,otherwise_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC get_const_type_Equal
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ EVAL_TAC);
+  \\ EVAL_TAC
+QED
 
-val mk_eq_lemma = Q.prove(
-  `inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
+Triviality mk_eq_lemma:
+  inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
     ex_return
         (Const (strlit "=")
-           (Fun (term_type x) (Fun (term_type x) Bool))) s`,
+           (Fun (term_type x) (Fun (term_type x) Bool))) s
+Proof
   NTAC 10 (SIMP_TAC (srw_ss()) [Once inst_def, Once inst_aux_def, Once LET_DEF])
   \\ NTAC 50 (SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF, Once mk_vartype_def,
-       Once rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []);
+       Once rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []
+QED
 
 Theorem mk_eq_thm:
   (mk_eq(x,y)s = (res,s')) ==>
@@ -875,42 +939,53 @@ Proof
          st_ex_bind_def,dest_type_def]
 QED
 
-val TERM_Eq_x = Q.prove(
-  `STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
-    (Fun (typeof x) (Fun (typeof x) Bool) = ty)`,
+Triviality TERM_Eq_x:
+  STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
+    (Fun (typeof x) (Fun (typeof x) Bool) = ty)
+Proof
   rw[TERM_def,STATE_def] >>
   fs[term_ok_def] >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >> rw[] >>
-  fs[TYPE_SUBST_def])
+  fs[TYPE_SUBST_def]
+QED
 
-val TERM_Comb = Q.prove(
-  `CONTEXT defs ⇒
+Triviality TERM_Comb:
+  CONTEXT defs ⇒
     (TERM defs (Comb f a) <=>
      TERM defs f /\ TERM defs a /\
-     ?ty. term_type f = Fun (term_type a) ty)`,
+     ?ty. term_type f = Fun (term_type a) ty)
+Proof
   REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC term_type
   \\ FULL_SIMP_TAC std_ss [TERM_def,WELLTYPED_CLAUSES,term_ok_def]
-  \\ METIS_TAC[term_ok_welltyped])
+  \\ METIS_TAC[term_ok_welltyped]
+QED
 
-val MAP_EQ_2_SYM = Q.prove(
-  `([x;y] = MAP f l) ⇔ (MAP f l = [x;y])`,METIS_TAC[])
+Triviality MAP_EQ_2_SYM:
+  ([x;y] = MAP f l) ⇔ (MAP f l = [x;y])
+Proof
+  METIS_TAC[]
+QED
 
-val Equal_type = Q.prove(
-  `STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)`,
+Triviality Equal_type:
+  STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)
+Proof
   rw[STATE_def,TERM_def] >>
   imp_res_tac CONTEXT_std_sig >>
-  fs[is_std_sig_def,term_ok_def])
+  fs[is_std_sig_def,term_ok_def]
+QED
 
-val Equal_type_IMP = Q.prove(
-  `STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
-    (typeof ll = a')`,
+Triviality Equal_type_IMP:
+  STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
+    (typeof ll = a')
+Proof
   simp[TERM_Comb] >> strip_tac >>
   imp_res_tac TERM_Eq_x >>
   fs[Once term_type_def] >>
-  rw[] >> imp_res_tac term_type >> simp[])
+  rw[] >> imp_res_tac term_type >> simp[]
+QED
 
 Theorem dest_eq_thm:
   (dest_eq tm s = (res, s')) /\
@@ -928,26 +1003,31 @@ Proof
   \\ IMP_RES_TAC TERM_Eq_x
 QED
 
-val VFREE_IN_IMP = Q.prove(
-  `!y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
+Triviality VFREE_IN_IMP:
+  !y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
         VFREE_IN (Var name ty) y ==>
-        vfree_in (Var name ty) y`,
-  METIS_TAC [vfree_in_thm]);
+        vfree_in (Var name ty) y
+Proof
+  METIS_TAC [vfree_in_thm]
+QED
 
-val SELECT_LEMMA = Q.prove(
-  `(@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)`,
+Triviality SELECT_LEMMA:
+  (@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)
+Proof
   Q.ABBREV_TAC `p = (@f. !s s'. f (s',s) <=> s <> t)`
   \\ sg `?f. !s s'. f (s',s) <=> s <> t`
   THEN1 (Q.EXISTS_TAC `(\(z,y). y <> t)` \\ FULL_SIMP_TAC std_ss [])
   \\ `!s s'. p (s',s) <=> s <> t` by METIS_TAC []
-  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
+  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]
+QED
 
-val SELECT_LEMMA2 = Q.prove(
-  `(@f.
+Triviality SELECT_LEMMA2:
+  (@f.
        !s s''.
          f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm') =
-    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')`,
+    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')
+Proof
   Q.ABBREV_TAC `p = (@f. !s s''. f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm')`
   \\ sg `?f. !s s''. f (s'',s) <=>
@@ -956,20 +1036,26 @@ val SELECT_LEMMA2 = Q.prove(
                 VFREE_IN s tm')` \\ FULL_SIMP_TAC std_ss [])
   \\ `!s s''. p (s'',s) <=> VFREE_IN (Var s' ty) s'' /\
                             VFREE_IN s tm'` by METIS_TAC []
-  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
+  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]
+QED
 
-val is_var_thm = Q.prove(
-  `!x. is_var x = ?v ty. x = Var v ty`,
-  Cases \\ FULL_SIMP_TAC (srw_ss()) [is_var_def]);
+Triviality is_var_thm:
+  !x. is_var x = ?v ty. x = Var v ty
+Proof
+  Cases \\ FULL_SIMP_TAC (srw_ss()) [is_var_def]
+QED
 
-val VSUBST_EMPTY = Q.prove(
-  `(!tm. holSyntax$VSUBST [] tm = tm)`,
+Triviality VSUBST_EMPTY:
+  (!tm. holSyntax$VSUBST [] tm = tm)
+Proof
   Induct
-  \\ FULL_SIMP_TAC (srw_ss()) [VSUBST_def,REV_ASSOCD,EVERY_DEF,FILTER,LET_THM]);
+  \\ FULL_SIMP_TAC (srw_ss()) [VSUBST_def,REV_ASSOCD,EVERY_DEF,FILTER,LET_THM]
+QED
 
-val VFREE_IN_TYPE = Q.prove(
-  `!x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
-        ?ty. (oty = ty) /\ TYPE defs ty`,
+Triviality VFREE_IN_TYPE:
+  !x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
+        ?ty. (oty = ty) /\ TYPE defs ty
+Proof
   Induct
   THEN1 (SIMP_TAC std_ss [VFREE_IN_def,term_11] \\ METIS_TAC [TERM])
   THEN1 (SRW_TAC [] [VFREE_IN_def,term_11,term_distinct])
@@ -978,11 +1064,13 @@ val VFREE_IN_TYPE = Q.prove(
   \\ SIMP_TAC std_ss [VFREE_IN_def,term_11] \\ STRIP_TAC
   \\ IMP_RES_TAC Abs_Var \\ FULL_SIMP_TAC std_ss [] \\ POP_ASSUM (K ALL_TAC)
   \\ IMP_RES_TAC TERM
-  \\ FULL_SIMP_TAC std_ss [VFREE_IN_def] \\ METIS_TAC []);
+  \\ FULL_SIMP_TAC std_ss [VFREE_IN_def] \\ METIS_TAC []
+QED
 
-val VFREE_IN_IMP_MEM = Q.prove(
-  `VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
-    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1`,
+Triviality VFREE_IN_IMP_MEM:
+  VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
+    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1
+Proof
   Induct_on `h0` THEN1 (Q.SPEC_TAC (`oty`,`oty`)
     \\ FULL_SIMP_TAC (srw_ss()) [VFREE_IN_def,term_11,Once frees_def]
     \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [])
@@ -995,19 +1083,23 @@ val VFREE_IN_IMP_MEM = Q.prove(
   \\ SIMP_TAC (srw_ss()) [Once frees_def,MEM_union,VFREE_IN_def]
   \\ SIMP_TAC (srw_ss()) [subtract_def,MEM_FILTER]
   \\ IMP_RES_TAC VFREE_IN_TYPE \\ FULL_SIMP_TAC std_ss []
-  \\ fs[])
+  \\ fs[]
+QED
 
-val term_type_Var = Q.prove(
-  `term_type (Var v ty) = ty`,
-  SIMP_TAC (srw_ss()) [Once term_type_def]);
+Triviality term_type_Var:
+  term_type (Var v ty) = ty
+Proof
+  SIMP_TAC (srw_ss()) [Once term_type_def]
+QED
 
-val vsubst_aux_thm = Q.prove(
-  `!t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
+Triviality vsubst_aux_thm:
+  !t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
                      (term_type t1 = term_type t2) /\ is_var t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (vsubst_aux theta tm = t) ==>
     TERM defs t /\
-    (t = VSUBST theta tm)`,
+    (t = VSUBST theta tm)
+Proof
   SIMP_TAC std_ss [] \\ Induct THEN1
    (NTAC 4 STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def]
     \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def,VSUBST_def]
@@ -1136,27 +1228,33 @@ val vsubst_aux_thm = Q.prove(
       METIS_TAC[vfree_in_thm,TERM] ) >>
   qunabbrev_tac`theta1` >>
   Q.PAT_ABBREV_TAC`vv = holSyntax$VARIANT A B Z` >>
-  simp[])
+  simp[]
+QED
 
-val forall_thm = Q.prove(
-  `!f s xs. (forall f xs s = (res,s')) ==>
+Triviality forall_thm:
+  !f s xs. (forall f xs s = (res,s')) ==>
     (!x. ?r. f x s = (r,s)) ==>
-    (s' = s) /\ ((res = M_success T) ==> EVERY (\x. FST (f x s) = M_success T) xs)`,
+    (s' = s) /\ ((res = M_success T) ==> EVERY (\x. FST (f x s) = M_success T) xs)
+Proof
   STRIP_TAC \\ STRIP_TAC
   \\ Induct \\ ASM_SIMP_TAC (srw_ss()) [Once forall_def,st_ex_return_def,st_ex_bind_def]
   \\ STRIP_TAC \\ Cases_on `f h s` \\ SIMP_TAC std_ss [Once EQ_SYM_EQ]
   \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] \\ STRIP_TAC \\ STRIP_TAC
   \\ `r = s` by METIS_TAC [PAIR,PAIR_EQ] \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `a` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC [FST,PAIR]);
+  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC [FST,PAIR]
+QED
 
-val assoc_state = Q.prove(
-  `!xs x. ?r. assoc x xs s = (r,s)`,
+Triviality assoc_state:
+  !xs x. ?r. assoc x xs s = (r,s)
+Proof
   Induct \\ ONCE_REWRITE_TAC [assoc_def] \\ TRY Cases
-  \\ FULL_SIMP_TAC (srw_ss()) [raise_Fail_def,st_ex_return_def] \\ SRW_TAC [] []);
+  \\ FULL_SIMP_TAC (srw_ss()) [raise_Fail_def,st_ex_return_def] \\ SRW_TAC [] []
+QED
 
-val type_of_state = Q.prove(
-  `!tm. ?r. type_of tm s = (r,s)`,
+Triviality type_of_state:
+  !tm. ?r. type_of tm s = (r,s)
+Proof
   HO_MATCH_MP_TAC type_of_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [Once type_of_def] \\ Cases_on `tm`
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def,raise_Fail_def,st_ex_bind_def]
@@ -1175,7 +1273,8 @@ val type_of_state = Q.prove(
   \\ STRIP_ASSUME_TAC (assoc_state |> ISPEC ``s.the_type_constants``
         |> ISPEC ``strlit"fun"``) \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `r` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ SRW_TAC [] []);
+  \\ SRW_TAC [] []
+QED
 
 Theorem variant_thm:
   !tms tm. EVERY (TERM defs) tms ∧ TERM defs tm ∧ STATE defs s ⇒
@@ -1464,12 +1563,13 @@ Proof
   BasicProvers.CASE_TAC >> fs[]
 QED
 
-val inst_lemma = Q.prove(
-  `EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
+Triviality inst_lemma:
+  EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (inst theta tm s = (res, s')) ==>
     (s' = s) /\ !t. (res = M_success t) ==>
-    (t = INST theta (tm))`,
+    (t = INST theta (tm))
+Proof
   SIMP_TAC std_ss [INST_def,inst_def] \\ Cases_on `theta = []`
   \\ ASM_SIMP_TAC std_ss [MAP,EVERY_DEF,st_ex_return_def] THEN1
    (Q.SPEC_TAC (`res`,`res`) \\ SIMP_TAC (srw_ss()) []
@@ -1491,7 +1591,8 @@ val inst_lemma = Q.prove(
        [`(MAP (\(t1,t2). (hol_ty t1,hol_ty t2)) theta)`,`[]`])
   \\ FULL_SIMP_TAC std_ss [MEM,REV_ASSOCD] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [MAP,RESULT_def,result_distinct,result_11]
-  \\ Cases_on `res` \\ FULL_SIMP_TAC (srw_ss()) [])
+  \\ Cases_on `res` \\ FULL_SIMP_TAC (srw_ss()) []
+QED
 
 Theorem inst_thm:
    EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
@@ -1524,10 +1625,11 @@ Proof
   \\ METIS_TAC []
 QED
 
-val freesin_IMP = Q.prove(
-  `!rhs vars.
+Triviality freesin_IMP:
+  !rhs vars.
        freesin vars rhs /\ TERM defs rhs /\ VFREE_IN (Var x ty) (rhs) ==>
-       MEM (Var x ty) vars`,
+       MEM (Var x ty) vars
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [Once freesin_def]
   THEN1 (REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
          \\ FULL_SIMP_TAC std_ss [CLOSED_def,VFREE_IN_def])
@@ -1538,7 +1640,8 @@ val freesin_IMP = Q.prove(
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `(Var s ty'::vars)`)
   \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [MEM]
-  \\ FULL_SIMP_TAC (srw_ss()) [term_11]);
+  \\ FULL_SIMP_TAC (srw_ss()) [term_11]
+QED
 
 Theorem ALL_DISTINCT_union:
   !xs. ALL_DISTINCT (holSyntaxExtra$union xs ys) = ALL_DISTINCT ys
@@ -1713,28 +1816,32 @@ Proof
   match_mp_tac proveHyp >> rw[]
 QED
 
-val map_type_of = Q.prove(
-  `∀ls s r s'.
+Triviality map_type_of:
+  ∀ls s r s'.
       EVERY (TERM defs) ls ∧ STATE defs s ∧
       (map type_of ls s = (M_success r,s')) ⇒
       (s' = s) ∧
-      (r = MAP term_type ls)`,
+      (r = MAP term_type ls)
+Proof
   Induct >> simp[Once map_def] >- (
     simp[st_ex_return_def] ) >>
   rw[st_ex_bind_def] >>
   every_case_tac >> fs[st_ex_return_def] >> rw[] >>
   imp_res_tac type_of_thm >> fs[] >> rw[] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
-val map_type_of_state = Q.prove(
-  `∀ls s r s'.
+Triviality map_type_of_state:
+  ∀ls s r s'.
       (map type_of ls s = (r,s')) ⇒
-      (s' = s)`,
+      (s' = s)
+Proof
   Induct >> simp[Once map_def] >- (
     simp[st_ex_return_def] ) >>
   rw[st_ex_bind_def] >>
   every_case_tac >> fs[st_ex_return_def] >> rw[] >>
-  METIS_TAC[type_of_state,PAIR,FST,SND])
+  METIS_TAC[type_of_state,PAIR,FST,SND]
+QED
 
 Theorem hypset_ok_list_to_hypset[simp]:
    ∀ls a. hypset_ok a ⇒ hypset_ok (list_to_hypset ls a)
@@ -2016,12 +2123,13 @@ Proof
   simp[]
 QED
 
-val image_lemma = Q.prove(
-  `∀f l s g defs res s'.
+Triviality image_lemma:
+  ∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ((f x s = (M_success (g x),s)))) l ⇒
-      (s' = s) ∧ (res = M_success (term_image g l))`,
+      (s' = s) ∧ (res = M_success (term_image g l))
+Proof
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[st_ex_return_def,Once term_image_def] ) >>
   simp[st_ex_bind_def] >> rpt gen_tac >>
@@ -2033,7 +2141,8 @@ val image_lemma = Q.prove(
   BasicProvers.CASE_TAC >>
   simp[st_ex_return_def] >> strip_tac >>
   rpt BasicProvers.VAR_EQ_TAC >>
-  simp[] >> res_tac >> fs[])
+  simp[] >> res_tac >> fs[]
+QED
 
 Theorem INST_TYPE_thm:
    EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
@@ -2069,13 +2178,14 @@ Proof
   METIS_TAC[]
 QED
 
-val image_lemma = Q.prove(
-  `∀f l s g defs res s'.
+Triviality image_lemma:
+  ∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ∃r s'. ((f x s = (r,s))) ∧
                             (∀t. (r = M_success t) ⇒ (t = g x))) l ⇒
-      (s' = s) ∧ ∀ts. (res = M_success ts) ⇒ (ts = term_image g l)`,
+      (s' = s) ∧ ∀ts. (res = M_success ts) ⇒ (ts = term_image g l)
+Proof
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[st_ex_return_def,Once term_image_def] ) >>
   simp[st_ex_bind_def] >> rpt gen_tac >>
@@ -2088,7 +2198,8 @@ val image_lemma = Q.prove(
   BasicProvers.CASE_TAC >>
   simp[st_ex_return_def] >> strip_tac >>
   rpt BasicProvers.VAR_EQ_TAC >>
-  simp[] >> res_tac >> fs[])
+  simp[] >> res_tac >> fs[]
+QED
 
 Theorem INST_thm:
   (INST theta th1 s = (res, s')) /\
@@ -2188,27 +2299,32 @@ Definition STRCAT_SHADOW_def[nocompute]:
   STRCAT_SHADOW = STRCAT
 End
 
-val first_dup_thm = Q.prove(
-  `∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)`,
+Triviality first_dup_thm:
+  ∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)
+Proof
   Induct >> simp[Once first_dup_def] >>
   rpt gen_tac >>
   BasicProvers.CASE_TAC >>
   strip_tac >> res_tac >>
-  fs[MEM] >> METIS_TAC[])
+  fs[MEM] >> METIS_TAC[]
+QED
 
-val first_dup_SOME = Q.prove(
-  `∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)`,
+Triviality first_dup_SOME:
+  ∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)
+Proof
   Induct >> simp[Once first_dup_def] >>
   rw[] >> fs[ALL_DISTINCT_APPEND] >>
   res_tac >> rw[] >> fs[ALL_DISTINCT] >> fs[] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
-val add_constants_thm = Q.prove(
-  `∀ls s res s'. (add_constants ls s = (res,s')) ⇒
+Triviality add_constants_thm:
+  ∀ls s res s'. (add_constants ls s = (res,s')) ⇒
       (∀u. (res = M_success u) ∧ ALL_DISTINCT (MAP FST s.the_term_constants) ⇒
            ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants) ∧
            (s' = s with the_term_constants := ls++s.the_term_constants)) ∧
-      (∀msg. (res = M_failure msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))`,
+      (∀msg. (res = M_failure msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))
+Proof
   simp_tac std_ss [add_constants_def,GSYM STRCAT_SHADOW_def] >>
   simp[st_ex_bind_def,get_the_term_constants_def] >>
   rpt gen_tac >>
@@ -2220,7 +2336,8 @@ val add_constants_thm = Q.prove(
   Cases_on`res`>>
   fs[set_the_term_constants_def] >>
   rpt BasicProvers.VAR_EQ_TAC >> simp[] >>
-  simp[ALL_DISTINCT_APPEND])
+  simp[ALL_DISTINCT_APPEND]
+QED
 
 Theorem check_overloads_thm:
   ∀ls s res s'. (check_overloads ls s = (res,s')) ⇒

--- a/candle/overloading/monadic/holKernelScript.sml
+++ b/candle/overloading/monadic/holKernelScript.sml
@@ -576,22 +576,28 @@ End
   this a non-failing function to make it pure.
 *)
 
-val EXISTS_IMP = Q.prove(
-  `!xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x`,
-  Induct THEN SIMP_TAC (srw_ss()) [EXISTS_DEF] THEN METIS_TAC []);
+Triviality EXISTS_IMP:
+  !xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x
+Proof
+  Induct THEN SIMP_TAC (srw_ss()) [EXISTS_DEF] THEN METIS_TAC []
+QED
 
-val MEM_subtract = Q.prove(
-  `!y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)`,
-  FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER] THEN METIS_TAC []);
+Triviality MEM_subtract:
+  !y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)
+Proof
+  FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER] THEN METIS_TAC []
+QED
 
-val vfree_in_IMP = Q.prove(
-  `!(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)`,
+Triviality vfree_in_IMP:
+  !(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)
+Proof
   HO_MATCH_MP_TAC (SIMP_RULE std_ss [] (vfree_in_ind))
   THEN REPEAT STRIP_TAC THEN Cases_on `x` THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [vfree_in_def,frees_def]
   THEN FULL_SIMP_TAC (srw_ss()) []
   THEN FULL_SIMP_TAC (srw_ss()) [MEM_union,MEM_subtract]
-  THEN REPEAT STRIP_TAC THEN RES_TAC THEN ASM_SIMP_TAC std_ss []);
+  THEN REPEAT STRIP_TAC THEN RES_TAC THEN ASM_SIMP_TAC std_ss []
+QED
 
 (*
   let vsubst =
@@ -678,21 +684,25 @@ Definition my_term_size_def:
   (my_term_size (Abs s1 s2) = 1 + my_term_size s1 + my_term_size s2)
 End
 
-val my_term_size_variant = Q.prove(
-  `!avoid t. my_term_size (variant avoid t) = my_term_size t`,
+Triviality my_term_size_variant:
+  !avoid t. my_term_size (variant avoid t) = my_term_size t
+Proof
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
-  THEN FULL_SIMP_TAC std_ss [my_term_size_def]);
+  THEN FULL_SIMP_TAC std_ss [my_term_size_def]
+QED
 
-val is_var_variant = Q.prove(
-  `!avoid t. is_var (variant avoid t) = is_var t`,
+Triviality is_var_variant:
+  !avoid t. is_var (variant avoid t) = is_var t
+Proof
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
-  THEN FULL_SIMP_TAC (srw_ss()) [my_term_size_def,fetch "-" "is_var_def"]);
+  THEN FULL_SIMP_TAC (srw_ss()) [my_term_size_def,fetch "-" "is_var_def"]
+QED
 
 val my_term_size_vsubst_aux = Q.prove(
   `!t xs. EVERY (\x. is_var (FST x)) xs ==>
@@ -716,9 +726,11 @@ val my_term_size_vsubst_aux = Q.prove(
   |> Q.SPECL [`t`,`[(Var v ty,x)]`]
   |> SIMP_RULE (srw_ss()) [EVERY_DEF,fetch "-" "is_var_def"]
 
-val ZERO_LT_term_size = Q.prove(
-  `!t. 0 < my_term_size t`,
-  Cases THEN EVAL_TAC THEN DECIDE_TAC);
+Triviality ZERO_LT_term_size:
+  !t. 0 < my_term_size t
+Proof
+  Cases THEN EVAL_TAC THEN DECIDE_TAC
+QED
 
 Definition inst_aux_def:
   (inst_aux (env:(term # term) list) tyin tm) =

--- a/candle/overloading/semantics/holBoolScript.sml
+++ b/candle/overloading/semantics/holBoolScript.sml
@@ -296,11 +296,13 @@ Proof
 QED
 
 (* TODO: move *)
-val builtins_std_assignment = Q.prove(
-  `is_std_type_assignment(ext_type_frag_builtins δ)`,
+Triviality builtins_std_assignment:
+  is_std_type_assignment(ext_type_frag_builtins δ)
+Proof
   rw[is_std_type_assignment_def]
   >> CONV_TAC(RATOR_CONV(PURE_ONCE_REWRITE_CONV [ext_type_frag_builtins_def]))
-  >> rw[]);
+  >> rw[]
+QED
 
 (* TODO: move *)
 Theorem is_std_interpretation_total_fragment:

--- a/candle/overloading/semantics/holSemanticsExtraScript.sml
+++ b/candle/overloading/semantics/holSemanticsExtraScript.sml
@@ -17,15 +17,17 @@ val mem = ``mem:'U->'U->bool``
 fun drule0 th =
   first_assum(mp_tac o MATCH_MP (ONCE_REWRITE_RULE[GSYM AND_IMP_INTRO] th))
 
-val consts_of_term_RACONV = Q.prove(
-  `!env tt.
+Triviality consts_of_term_RACONV:
+  !env tt.
      RACONV env tt /\ welltyped(FST tt) /\ welltyped(SND tt)
      /\ (!x y. MEM (x,y) env ==> ?n ty n' ty'. x = Var n ty /\ y = Var n' ty')
-     ==> consts_of_term (FST tt) = consts_of_term (SND tt)`,
+     ==> consts_of_term (FST tt) = consts_of_term (SND tt)
+Proof
   simp[GSYM AND_IMP_INTRO]
   >> ho_match_mp_tac RACONV_strongind >> rpt strip_tac
   >> fs[consts_of_term_def,DISJ_IMP_THM]
-  >> fs[DISJ_IMP_THM]);
+  >> fs[DISJ_IMP_THM]
+QED
 
 Theorem consts_of_term_ACONV:
   ACONV a1 a2 /\ welltyped a1 /\ welltyped a2 ==> consts_of_term a1 = consts_of_term a2
@@ -33,16 +35,18 @@ Proof
   rw[ACONV_def] >> drule consts_of_term_RACONV >> simp[]
 QED
 
-val allTypes_RACONV = Q.prove(
-  `!env tt.
+Triviality allTypes_RACONV:
+  !env tt.
      RACONV env tt /\ welltyped(FST tt) /\ welltyped(SND tt)
      /\ (!x y. MEM (x,y) env ==> ?n ty n'. x = Var n ty /\ y = Var n' ty)
-     ==> allTypes (FST tt) = allTypes (SND tt)`,
+     ==> allTypes (FST tt) = allTypes (SND tt)
+Proof
   simp[GSYM AND_IMP_INTRO]
   >> ho_match_mp_tac RACONV_strongind >> rpt strip_tac
   >> fs[allTypes_def]
   >- (imp_res_tac ALPHAVARS_MEM >> fs[] >> first_x_assum drule >> simp[])
-  >- fs[DISJ_IMP_THM]);
+  >- fs[DISJ_IMP_THM]
+QED
 
 Theorem allTypes_ACONV:
   !t1 t2.
@@ -162,17 +166,21 @@ Proof
   >> metis_tac[]
 QED
 
-val typeof_VSUBST = Q.prove(
-  `!l a. EVERY (\(x,y). typeof x = typeof y) l /\ welltyped a
-    ==> typeof (VSUBST l a) = typeof a`,
+Triviality typeof_VSUBST:
+  !l a. EVERY (\(x,y). typeof x = typeof y) l /\ welltyped a
+    ==> typeof (VSUBST l a) = typeof a
+Proof
   Induct_on `a` >> rw[VSUBST_def]
   >- (rw[REV_ASSOCD_ALOOKUP] >> EVERY_CASE_TAC >> fs[] >> imp_res_tac ALOOKUP_MEM
       >> fs[EVERY_MEM,MEM_MAP] >> first_x_assum drule >> pairarg_tac >> fs[]
       >> rveq >> fs[])
   >> fs[dest_var_def]
-  >> first_x_assum match_mp_tac >> fs[EVERY_FILTER_IMP])
+  >> first_x_assum match_mp_tac >> fs[EVERY_FILTER_IMP]
+QED
 
-val TYPE_SUBST_tyvars = Q.prove(`!sigma ty. tyvars ty = [] ==> TYPE_SUBST sigma ty = ty`,
+Triviality TYPE_SUBST_tyvars:
+  !sigma ty. tyvars ty = [] ==> TYPE_SUBST sigma ty = ty
+Proof
   ho_match_mp_tac TYPE_SUBST_ind >> rpt strip_tac
   >> fs[tyvars_def]
   >> match_mp_tac LIST_EQ >> rw[]
@@ -188,11 +196,13 @@ val TYPE_SUBST_tyvars = Q.prove(`!sigma ty. tyvars ty = [] ==> TYPE_SUBST sigma 
   >> disch_then(mp_tac o CONV_RULE(RESORT_FORALL_CONV List.rev))
   >> disch_then(mp_tac o CONV_RULE(SWAP_FORALL_CONV))
   >> disch_then(qspec_then `[]` mp_tac)
-  >> simp[] >> metis_tac[list_CASES,EL_MAP]);
+  >> simp[] >> metis_tac[list_CASES,EL_MAP]
+QED
 
-val TYPE_SUBST_2 = Q.prove(
-  `!sigma ty. EVERY (λty. tyvars ty = []) (MAP FST sigma)
-    ==> TYPE_SUBST sigma (TYPE_SUBST sigma ty) = TYPE_SUBST sigma ty`,
+Triviality TYPE_SUBST_2:
+  !sigma ty. EVERY (λty. tyvars ty = []) (MAP FST sigma)
+    ==> TYPE_SUBST sigma (TYPE_SUBST sigma ty) = TYPE_SUBST sigma ty
+Proof
   ho_match_mp_tac TYPE_SUBST_ind >> rpt strip_tac
   >- (fs[TYPE_SUBST_def] >> fs[REV_ASSOCD_ALOOKUP]
       >> PURE_TOP_CASE_TAC >> fs[]
@@ -205,7 +215,8 @@ val TYPE_SUBST_2 = Q.prove(
       >> Q.REFINE_EXISTS_TAC `(_,_)` >> simp[] >> metis_tac[])
   >> fs[TYPE_SUBST_def] >> match_mp_tac LIST_EQ
   >> rw[EL_MAP] >> drule EL_MEM
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
 Theorem fresh_vsubst:
   !t x ty tm. ~VFREE_IN (Var x ty) t ==> VSUBST [(tm,Var x ty)] t = t
@@ -228,15 +239,17 @@ Proof
       >> HINT_EXISTS_TAC >> simp[])
 QED
 
-val VSUBST_id_lemma = Q.prove(
-  `!tm ilist v. welltyped tm ==> VSUBST (ilist ++ [(Var x ty,Var x ty)]) tm = VSUBST ilist tm`,
+Triviality VSUBST_id_lemma:
+  !tm ilist v. welltyped tm ==> VSUBST (ilist ++ [(Var x ty,Var x ty)]) tm = VSUBST ilist tm
+Proof
   Induct >> rpt strip_tac
   >> fs[VSUBST_def,REV_ASSOCD_ALOOKUP]
   >- (rpt(PURE_TOP_CASE_TAC >> fs[]) >> fs[ALOOKUP_APPEND] >> rveq)
   >> Cases_on `Var x ty = Var n ty'`
   >> fs[FILTER_APPEND]
   >> PURE_ONCE_REWRITE_TAC [CONS_APPEND] >> PURE_ONCE_REWRITE_TAC [APPEND_ASSOC]
-  >> fs[]);
+  >> fs[]
+QED
 
 Theorem RACONV_TRANS_matchable:
   !env env2 env3 t1 t2 t3. RACONV env2 (t1,t2) /\ RACONV env3 (t2,t3) /\
@@ -467,15 +480,17 @@ Proof
   >> metis_tac[term_ok_def]
 QED
 
-val TYPE_SUBSTf_lemma = Q.prove(
-  `!ty sigma sigma'. (!tv. MEM tv (tyvars ty) ==> REV_ASSOCD (Tyvar tv) sigma' (Tyvar tv) = sigma tv) ==>
-  TYPE_SUBSTf sigma ty = TYPE_SUBST sigma' ty`,
+Triviality TYPE_SUBSTf_lemma:
+  !ty sigma sigma'. (!tv. MEM tv (tyvars ty) ==> REV_ASSOCD (Tyvar tv) sigma' (Tyvar tv) = sigma tv) ==>
+  TYPE_SUBSTf sigma ty = TYPE_SUBST sigma' ty
+Proof
   ho_match_mp_tac type_ind >> rpt strip_tac
   >- fs[tyvars_def]
   >> fs[tyvars_def,MEM_FOLDR_LIST_UNION,PULL_EXISTS]
   >> rw[MAP_EQ_f]
   >> fs[EVERY_MEM] >> rpt(first_x_assum drule) >> rpt strip_tac
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
 Theorem TYPE_SUBSTf_TYPE_SUBST:
   !ty sigma. ?sigma'. TYPE_SUBSTf sigma ty = TYPE_SUBST sigma' ty

--- a/candle/overloading/semantics/holSemanticsScript.sml
+++ b/candle/overloading/semantics/holSemanticsScript.sml
@@ -121,11 +121,12 @@ Proof
   >> simp[Once builtin_closure_cases]
 QED
 
-val allTypes_no_tyvars_and_ok = Q.prove(
-  `!ty. (∀x. x ∈ q ⇒ tyvars x = [] /\ type_ok (tysof sig) x)
+Triviality allTypes_no_tyvars_and_ok:
+  !ty. (∀x. x ∈ q ⇒ tyvars x = [] /\ type_ok (tysof sig) x)
         /\ (∀x. MEM x (allTypes' ty) ⇒ x ∈ q)
         /\ is_std_sig sig
-        ==> tyvars ty = [] /\ type_ok (tysof sig) ty`,
+        ==> tyvars ty = [] /\ type_ok (tysof sig) ty
+Proof
   ho_match_mp_tac type_ind >> rpt strip_tac
   >> fs[allTypes'_defn]
   >- (BasicProvers.PURE_FULL_CASE_TAC >- fs[tyvars_def]
@@ -143,29 +144,36 @@ val allTypes_no_tyvars_and_ok = Q.prove(
   >> BasicProvers.PURE_FULL_CASE_TAC
   >- (fs[listTheory.LENGTH_EQ_NUM_compute,is_std_sig_def,type_ok_def]
       \\ fs[])
-  \\ fs[type_ok_def]);
+  \\ fs[type_ok_def]
+QED
 
-val allTypes_no_tyvars2 = Q.prove(
-  `!tm ty1 ty2. tm has_type ty1 /\
+Triviality allTypes_no_tyvars2:
+  !tm ty1 ty2. tm has_type ty1 /\
            MEM ty2 (allTypes' ty1)
-           ==> MEM ty2 (allTypes tm)`,
+           ==> MEM ty2 (allTypes tm)
+Proof
   simp[GSYM AND_IMP_INTRO,GSYM PULL_FORALL]
   >> ho_match_mp_tac has_type_strongind
-  >> rw[allTypes_def,allTypes'_defn] >> fs[]);
+  >> rw[allTypes_def,allTypes'_defn] >> fs[]
+QED
 
-val builtin_closure_tyvars = Q.prove(
-  `∀q x. x ∈ builtin_closure q /\ (∀x. x ∈ q ⇒ tyvars x = []) ==> tyvars x = []`,
+Triviality builtin_closure_tyvars:
+  ∀q x. x ∈ builtin_closure q /\ (∀x. x ∈ q ⇒ tyvars x = []) ==> tyvars x = []
+Proof
   simp [IN_DEF,GSYM AND_IMP_INTRO]
   >> ho_match_mp_tac builtin_closure_ind
-  >> rw[tyvars_def]);
+  >> rw[tyvars_def]
+QED
 
-val builtin_closure_type_ok = Q.prove(
-  `∀q x. x ∈ builtin_closure q /\ (∀x. x ∈ q ⇒ type_ok (tysof sig) x)
+Triviality builtin_closure_type_ok:
+  ∀q x. x ∈ builtin_closure q /\ (∀x. x ∈ q ⇒ type_ok (tysof sig) x)
    /\ is_std_sig sig
-   ==> type_ok (tysof sig) x`,
+   ==> type_ok (tysof sig) x
+Proof
   simp [IN_DEF,GSYM AND_IMP_INTRO]
   >> ho_match_mp_tac builtin_closure_ind
-  >> rw[is_std_sig_def,type_ok_def]);
+  >> rw[is_std_sig_def,type_ok_def]
+QED
 
 Theorem builtin_closure_allTypes:
   !ty q. (∀x. MEM x (allTypes' ty) ⇒ x ∈ q) ==> ty ∈ builtin_closure q
@@ -231,8 +239,9 @@ Proof
     >> metis_tac[builtin_closure_rules,boolTheory.IN_DEF])
 QED
 
-val allTypes'_builtin_closure = Q.prove(
-  `!q ty x. ty ∈ builtin_closure q /\ q ⊆ nonbuiltin_types /\ MEM x (allTypes' ty) ⇒ x ∈ q`,
+Triviality allTypes'_builtin_closure:
+  !q ty x. ty ∈ builtin_closure q /\ q ⊆ nonbuiltin_types /\ MEM x (allTypes' ty) ⇒ x ∈ q
+Proof
   simp[boolTheory.IN_DEF,GSYM AND_IMP_INTRO,GSYM PULL_FORALL]
   >> ho_match_mp_tac builtin_closure_ind
   >> rpt strip_tac
@@ -241,46 +250,57 @@ val allTypes'_builtin_closure = Q.prove(
       >> fs[is_builtin_type_def,is_builtin_name_def]
       >> fs[allTypes'_defn])
   >- fs[allTypes'_defn]
-  >- (fs[allTypes'_defn,boolTheory.IN_DEF] >> rpt(first_x_assum drule >> strip_tac)));
+  >- (fs[allTypes'_defn,boolTheory.IN_DEF] >> rpt(first_x_assum drule >> strip_tac))
+QED
 
-val consts_of_free_const = Q.prove(
-  `!tm x v. x ∈ consts_of_term v /\ VFREE_IN v tm
-            ==> v = Const (FST x) (SND x)`,
+Triviality consts_of_free_const:
+  !tm x v. x ∈ consts_of_term v /\ VFREE_IN v tm
+            ==> v = Const (FST x) (SND x)
+Proof
   Induct >> rpt strip_tac
   >> fs[consts_of_term_def,VFREE_IN_def]
   >> rpt(BasicProvers.VAR_EQ_TAC)
-  >> fs[consts_of_term_def]);
+  >> fs[consts_of_term_def]
+QED
 
-val VFREEs_IN_consts = Q.prove(
-  `!tm s ty. VFREE_IN (Const s ty) tm
-            ==> (s,ty) ∈ consts_of_term tm`,
+Triviality VFREEs_IN_consts:
+  !tm s ty. VFREE_IN (Const s ty) tm
+            ==> (s,ty) ∈ consts_of_term tm
+Proof
   Induct >> rpt strip_tac
   >> fs[consts_of_term_def,VFREE_IN_def]
   >> rpt(BasicProvers.VAR_EQ_TAC)
-  >> fs[consts_of_term_def]);
+  >> fs[consts_of_term_def]
+QED
 
-val var_type_in_types = Q.prove(
-  `!tm ty v. VFREE_IN v tm /\ MEM ty (allTypes v)
-            ==> MEM ty (allTypes tm)`,
+Triviality var_type_in_types:
+  !tm ty v. VFREE_IN v tm /\ MEM ty (allTypes v)
+            ==> MEM ty (allTypes tm)
+Proof
   Induct >> rpt strip_tac
   >> fs[VFREE_IN_def,allTypes_def]
   >> rpt(BasicProvers.VAR_EQ_TAC)
   >> fs[allTypes_def]
-  >> rpt(qpat_x_assum `!x. _` imp_res_tac) >> fs[]);
+  >> rpt(qpat_x_assum `!x. _` imp_res_tac) >> fs[]
+QED
 
-val VFREE_type = Q.prove(
-  `!tm v. VFREE_IN v tm ==> v has_type typeof v`,
+Triviality VFREE_type:
+  !tm v. VFREE_IN v tm ==> v has_type typeof v
+Proof
   Induct >> rpt strip_tac
   >> fs[VFREE_IN_def]
   >> rpt(BasicProvers.VAR_EQ_TAC)
-  >> fs[typeof_def,has_type_rules]);
+  >> fs[typeof_def,has_type_rules]
+QED
 
-val RTC_lifts_invariants_inv = Q.prove(
-  `(∀x y. P x ∧ R y x ⇒ P y) ⇒ ∀x y. P x ∧ R^* y x ⇒ P y`,
+Triviality RTC_lifts_invariants_inv:
+  (∀x y. P x ∧ R y x ⇒ P y) ⇒ ∀x y. P x ∧ R^* y x ⇒ P y
+Proof
   rpt strip_tac
   >> Q.ISPECL_THEN [`inv R`,`P`] assume_tac (GEN_ALL relationTheory.RTC_lifts_invariants)
   >> fs[relationTheory.inv_DEF,relationTheory.inv_MOVES_OUT]
-  >> metis_tac[])
+  >> metis_tac[]
+QED
 
 Theorem terms_of_frag_combE:
   !f a b sig. is_sig_fragment sig f /\ Comb a b ∈ terms_of_frag f ==>
@@ -380,23 +400,28 @@ Proof
 QED
 
 (* TODO: unify these two lemmas *)
-val consts_of_term_REV_ASSOCD = Q.prove(
-  `!x t ilist d. x ∈ consts_of_term (REV_ASSOCD t ilist d)
-   ==> x ∈ consts_of_term d \/ EXISTS ($IN x) (MAP (consts_of_term o FST) ilist)`,
+Triviality consts_of_term_REV_ASSOCD:
+  !x t ilist d. x ∈ consts_of_term (REV_ASSOCD t ilist d)
+   ==> x ∈ consts_of_term d \/ EXISTS ($IN x) (MAP (consts_of_term o FST) ilist)
+Proof
   Induct_on `ilist`
   >> rw[holSyntaxLibTheory.REV_ASSOCD_def]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val allTypes_REV_ASSOCD = Q.prove(
-  `!x t ilist d. MEM x (allTypes (REV_ASSOCD t ilist d))
-   ==> MEM x (allTypes d) \/ EXISTS ($MEM x) (MAP (allTypes o FST) ilist)`,
+Triviality allTypes_REV_ASSOCD:
+  !x t ilist d. MEM x (allTypes (REV_ASSOCD t ilist d))
+   ==> MEM x (allTypes d) \/ EXISTS ($MEM x) (MAP (allTypes o FST) ilist)
+Proof
   Induct_on `ilist`
   >> rw[holSyntaxLibTheory.REV_ASSOCD_def]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val consts_of_term_VSUBST = Q.prove(
-  `!x n ty tm1 ilist. x ∈ consts_of_term (VSUBST ilist tm1)
-   ==> x ∈ consts_of_term tm1 \/ EXISTS ($IN x) (MAP (consts_of_term o FST) ilist)`,
+Triviality consts_of_term_VSUBST:
+  !x n ty tm1 ilist. x ∈ consts_of_term (VSUBST ilist tm1)
+   ==> x ∈ consts_of_term tm1 \/ EXISTS ($IN x) (MAP (consts_of_term o FST) ilist)
+Proof
   Induct_on `tm1`
   >> rw[VSUBST_def]
   >- (imp_res_tac consts_of_term_REV_ASSOCD >> simp[])
@@ -412,12 +437,14 @@ val consts_of_term_VSUBST = Q.prove(
       >> strip_tac >> fs[consts_of_term_def]
       >> disj2_tac
       >> fs[listTheory.EXISTS_MEM,listTheory.MEM_MAP,listTheory.MEM_FILTER]
-      >> metis_tac[]));
+      >> metis_tac[])
+QED
 
-val allTypes_VSUBST = Q.prove(
-  `!x tm1 ilist. MEM x (allTypes (VSUBST ilist tm1))
+Triviality allTypes_VSUBST:
+  !x tm1 ilist. MEM x (allTypes (VSUBST ilist tm1))
                       /\ welltyped tm1
-                      ==> MEM x (allTypes tm1) \/ EXISTS ($MEM x) (MAP (allTypes o FST) ilist)`,
+                      ==> MEM x (allTypes tm1) \/ EXISTS ($MEM x) (MAP (allTypes o FST) ilist)
+Proof
   Induct_on `tm1`
   >> rw[VSUBST_def]
   >- (imp_res_tac allTypes_REV_ASSOCD >> simp[])
@@ -429,7 +456,8 @@ val allTypes_VSUBST = Q.prove(
   >- (fs[allTypes_def]
       >> first_x_assum drule >> strip_tac >> fs[allTypes_def]
       >> fs[listTheory.EXISTS_MEM,listTheory.MEM_MAP,listTheory.MEM_FILTER]
-      >> metis_tac[]));
+      >> metis_tac[])
+QED
 
 (* 8(1) *)
 Theorem types_of_frag_ground:
@@ -937,11 +965,13 @@ Definition fleq_def:
     /\ (!ty. ty ∈ tyfrag1 ==> δ1 ty = δ2 ty))
 End
 
-val builtin_closure_mono_lemma = Q.prove(
-  `!tys1 ty. builtin_closure tys1 ty ==> !tys2. tys1 ⊆ tys2 ==> builtin_closure tys2 ty`,
+Triviality builtin_closure_mono_lemma:
+  !tys1 ty. builtin_closure tys1 ty ==> !tys2. tys1 ⊆ tys2 ==> builtin_closure tys2 ty
+Proof
   ho_match_mp_tac builtin_closure_ind
   >> rpt strip_tac
-  >> metis_tac[builtin_closure_rules,pred_setTheory.SUBSET_DEF,boolTheory.IN_DEF]);
+  >> metis_tac[builtin_closure_rules,pred_setTheory.SUBSET_DEF,boolTheory.IN_DEF]
+QED
 
 Theorem builtin_closure_mono:
   !tys1 tys2. tys1 ⊆ tys2 ==> builtin_closure tys1 ⊆ builtin_closure tys2
@@ -952,12 +982,14 @@ QED
 (* Lemma 9 from Kunčar and Popescu's ITP2015 paper *)
 
 (* 9(1) *)
-val fleq_types_le = Q.prove(
-  `!frag1 i1 frag2 i2. fleq (frag1,i1) (frag2,i2)
-   ==> types_of_frag frag1 ⊆ types_of_frag frag2`,
+Triviality fleq_types_le:
+  !frag1 i1 frag2 i2. fleq (frag1,i1) (frag2,i2)
+   ==> types_of_frag frag1 ⊆ types_of_frag frag2
+Proof
   rpt Cases
   >> rw[fleq_def,types_of_frag_def]
-  >> imp_res_tac builtin_closure_mono);
+  >> imp_res_tac builtin_closure_mono
+QED
 
 (* 9(2) *)
 Theorem fleq_terms_le:

--- a/candle/overloading/syntax/holAxiomsSyntaxScript.sml
+++ b/candle/overloading/syntax/holAxiomsSyntaxScript.sml
@@ -82,10 +82,12 @@ Definition mk_infinity_ctxt_def:
     ctxt
 End
 
-val tyvar_inst_exists = Q.prove(
-  `∃i. ty = REV_ASSOCD (Tyvar a) i b`,
+Triviality tyvar_inst_exists:
+  ∃i. ty = REV_ASSOCD (Tyvar a) i b
+Proof
   qexists_tac`[(ty,Tyvar a)]` >>
-  rw[REV_ASSOCD])
+  rw[REV_ASSOCD]
+QED
 
 Theorem infinity_extends:
    ∀ctxt. theory_ok (thyof ctxt) ∧

--- a/candle/overloading/syntax/holSyntaxScript.sml
+++ b/candle/overloading/syntax/holSyntaxScript.sml
@@ -718,9 +718,11 @@ Definition is_builtin_type_def:
        (m = strlit "bool" /\ LENGTH ty = 0)))
 End
 
-val type1_size_append = Q.prove(
-  `∀l1 l2. type1_size (l1 ++ l2) = type1_size l1 + type1_size l2`,
-  Induct >> simp[fetch "-" "type_size_def"]);
+Triviality type1_size_append:
+  ∀l1 l2. type1_size (l1 ++ l2) = type1_size l1 + type1_size l2
+Proof
+  Induct >> simp[fetch "-" "type_size_def"]
+QED
 
 (* allTypes(\sigma) -- the smallest set of non-built-in types that can produce
  * \sigma by combinations of built-in types.

--- a/candle/set-theory/jrhSetScript.sml
+++ b/candle/set-theory/jrhSetScript.sml
@@ -8,9 +8,11 @@ val _ = numLib.temp_prefer_num()
 
 val _ = new_theory"jrhSet"
 
-val ind_model_exists = Q.prove(
-  `∃x. (@s:num->bool. s ≠ {} ∧ FINITE s) x`,
-    metis_tac[IN_DEF, MEMBER_NOT_EMPTY, IN_SING, FINITE_DEF])
+Triviality ind_model_exists:
+  ∃x. (@s:num->bool. s ≠ {} ∧ FINITE s) x
+Proof
+  metis_tac[IN_DEF, MEMBER_NOT_EMPTY, IN_SING, FINITE_DEF]
+QED
 
 val ind_model_ty =
   new_type_definition ("ind_model",ind_model_exists)
@@ -21,9 +23,11 @@ val mk_ind_onto   = prove_abs_fn_onto    ind_model_bij
 val dest_ind_11   = prove_rep_fn_one_one ind_model_bij
 val dest_ind_onto = prove_rep_fn_onto    ind_model_bij
 
-val inacc_exists = Q.prove(
-  `∃x:num. UNIV x`,
-  metis_tac[IN_UNIV,IN_DEF])
+Triviality inacc_exists:
+  ∃x:num. UNIV x
+Proof
+  metis_tac[IN_UNIV,IN_DEF]
+QED
 
 val inacc_ty =
   new_type_definition ("I",inacc_exists)
@@ -40,14 +44,16 @@ Proof
   metis_tac[INFINITE_Unum]
 QED
 
-val lemma = Q.prove(
-  `∀s. s ≺ 𝕌(:I) ⇔ FINITE s`,
+Triviality lemma:
+  ∀s. s ≺ 𝕌(:I) ⇔ FINITE s
+Proof
   rw[FINITE_CARD_LT] >>
   match_mp_tac CARDEQ_CARDLEQ >>
   simp[cardeq_REFL] >>
   match_mp_tac cardleq_ANTISYM >>
   simp[cardleq_def,INJ_DEF] >>
-  metis_tac[inacc_bij,dest_I_11,mk_I_11,IN_UNIV,IN_DEF])
+  metis_tac[inacc_bij,dest_I_11,mk_I_11,IN_UNIV,IN_DEF]
+QED
 
 Theorem I_AXIOM:
    𝕌(:ind_model) ≺ 𝕌(:I) ∧
@@ -94,14 +100,16 @@ Proof
   qexists_tac`{}`>>simp[]
 QED
 
-val I_PAIR_EXISTS = Q.prove(
-  `∃f:I#I->I. !x y. (f x = f y) ==> (x = y)`,
+Triviality I_PAIR_EXISTS:
+  ∃f:I#I->I. !x y. (f x = f y) ==> (x = y)
+Proof
   qsuff_tac `𝕌(:I#I) ≼ 𝕌(:I)` >-
     simp[cardleq_def,INJ_DEF] >>
   match_mp_tac CARDEQ_SUBSET_CARDLEQ >>
   qsuff_tac`𝕌(:I#I) = 𝕌(:I) × 𝕌(:I)` >-
     metis_tac[cardeq_TRANS,SET_SQUARED_CARDEQ_SET,I_INFINITE] >>
-  simp[EXTENSION])
+  simp[EXTENSION]
+QED
 
 val INJ_LEMMA = METIS_PROVE[]``(!x y. (f x = f y) ==> (x = y)) <=> (!x y. (f x = f y) <=> (x = y))``
 
@@ -117,30 +125,36 @@ Proof
   HINT_EXISTS_TAC >> simp[UNIV_BOOL]
 QED
 
-val I_BOOL_EXISTS = Q.prove(
-  `∃f:bool->I. !x y. (f x = f y) ==> (x = y)`,
+Triviality I_BOOL_EXISTS:
+  ∃f:bool->I. !x y. (f x = f y) ==> (x = y)
+Proof
   `𝕌(:bool) ≼ 𝕌(:I)` by metis_tac[CARD_BOOL_LT_I,cardlt_lenoteq] >>
-  fs[cardleq_def,INJ_DEF] >> metis_tac[])
+  fs[cardleq_def,INJ_DEF] >> metis_tac[]
+QED
 
 val I_BOOL_def =
   new_specification("I_BOOL_def",["I_BOOL"],
     REWRITE_RULE[INJ_LEMMA] I_BOOL_EXISTS)
 
-val I_IND_EXISTS = Q.prove(
-  `∃f:ind_model->I. !x y. (f x = f y) ==> (x = y)`,
+Triviality I_IND_EXISTS:
+  ∃f:ind_model->I. !x y. (f x = f y) ==> (x = y)
+Proof
   `𝕌(:ind_model) ≼ 𝕌(:I)` by metis_tac[I_AXIOM,cardlt_lenoteq] >>
-  fs[cardleq_def,INJ_DEF] >> metis_tac[])
+  fs[cardleq_def,INJ_DEF] >> metis_tac[]
+QED
 
 val I_IND_def =
   new_specification("I_IND_def",["I_IND"],
     REWRITE_RULE[INJ_LEMMA] I_IND_EXISTS)
 
-val I_SET_EXISTS = Q.prove(
-  `∀s:I->bool. s ≺ 𝕌(:I) ⇒ ∃f:(I->bool)->I. !x y. x ⊆ s ∧ y ⊆ s ∧ (f x = f y) ==> (x = y)`,
+Triviality I_SET_EXISTS:
+  ∀s:I->bool. s ≺ 𝕌(:I) ⇒ ∃f:(I->bool)->I. !x y. x ⊆ s ∧ y ⊆ s ∧ (f x = f y) ==> (x = y)
+Proof
   gen_tac >> disch_then(strip_assume_tac o MATCH_MP(CONJUNCT2 I_AXIOM)) >>
   fs[cardlt_lenoteq] >>
   fs[cardleq_def,INJ_DEF,IN_POW] >>
-  metis_tac[])
+  metis_tac[]
+QED
 
 val I_SET_def =
   new_specification("I_SET_def",["I_SET"],
@@ -200,10 +214,12 @@ Definition universe_def:
   universe = {(t,x) | x ∈ setlevel t}
 End
 
-val v_exists = Q.prove(
-  `∃a. a ∈ universe`,
+Triviality v_exists:
+  ∃a. a ∈ universe
+Proof
   qexists_tac`Ur_bool,I_BOOL T` >>
-  rw[universe_def,setlevel_def])
+  rw[universe_def,setlevel_def]
+QED
 
 val v_ty =
   new_type_definition ("V",SIMP_RULE std_ss [IN_DEF]v_exists)
@@ -214,9 +230,11 @@ val mk_V_onto   = prove_abs_fn_onto    v_bij
 val dest_V_11   = prove_rep_fn_one_one v_bij
 val dest_V_onto = prove_rep_fn_onto    v_bij
 
-val universe_IN = Q.prove(
-  `universe x ⇔ x ∈ universe`,
-  rw[IN_DEF])
+Triviality universe_IN:
+  universe x ⇔ x ∈ universe
+Proof
+  rw[IN_DEF]
+QED
 
 Theorem V_bij:
    ∀l e. e ∈ setlevel l ⇔ dest_V(mk_V(l,e)) = (l,e)
@@ -319,19 +337,22 @@ Proof
   metis_tac[I_SET_SETLEVEL]
 QED
 
-val EMPTY_EXISTS = Q.prove(
-  `∀l. ∃s. level s = l ∧ ∀x. ¬(x <: s)`,
+Triviality EMPTY_EXISTS:
+  ∀l. ∃s. level s = l ∧ ∀x. ¬(x <: s)
+Proof
   Induct >> TRY (
     qexists_tac`mk_V(Powerset l,I_SET(setlevel l){})` >>
     simp[inset_def,MK_V_CLAUSES,MK_V_SET] >> NO_TAC ) >>
-  metis_tac[LEVEL_SET_EXISTS,MEMBERS_ISASET,isaset_def,theorem"setlevel_distinct"])
+  metis_tac[LEVEL_SET_EXISTS,MEMBERS_ISASET,isaset_def,theorem"setlevel_distinct"]
+QED
 
 val emptyset_def =
   new_specification("emptyset_def",["emptyset"],
     SIMP_RULE std_ss [SKOLEM_THM] EMPTY_EXISTS)
 
-val COMPREHENSION_EXISTS = Q.prove(
-  `∀s p. ∃t. level t = level s ∧ ∀x. x <: t ⇔ x <: s ∧ p x`,
+Triviality COMPREHENSION_EXISTS:
+  ∀s p. ∃t. level t = level s ∧ ∀x. x <: t ⇔ x <: s ∧ p x
+Proof
   rpt gen_tac >>
   reverse(Cases_on`isaset s`) >- metis_tac[MEMBERS_ISASET] >>
   fs[isaset_def] >>
@@ -344,7 +365,8 @@ val COMPREHENSION_EXISTS = Q.prove(
     fs[SUBSET_DEF,Abbr`v`] ) >>
   simp[MK_V_SET,inset_def] >>
   fs[Abbr`v`] >>
-  metis_tac[SET,MK_V_SET])
+  metis_tac[SET,MK_V_SET]
+QED
 
 val _ = Parse.add_infix("suchthat",9,Parse.LEFT)
 
@@ -381,8 +403,9 @@ Proof
   metis_tac[SET_DECOMP]
 QED
 
-val POWERSET_EXISTS = Q.prove(
-  `∀s. ∃t. level t = Powerset(level s) ∧ ∀x. x <: t ⇔ x <=: s`,
+Triviality POWERSET_EXISTS:
+  ∀s. ∃t. level t = Powerset(level s) ∧ ∀x. x <: t ⇔ x <=: s
+Proof
   gen_tac >> Cases_on`isaset s` >- (
     fs[isaset_def] >>
     qspec_then`Powerset l`(Q.X_CHOOSE_THEN`t`strip_assume_tac)
@@ -392,7 +415,8 @@ val POWERSET_EXISTS = Q.prove(
     metis_tac[ELEMENT_IN_LEVEL] ) >>
   fs[subset_def] >>
   metis_tac[MEMBERS_ISASET,SETLEVEL_EXISTS
-           ,ELEMENT_IN_LEVEL,isaset_def])
+           ,ELEMENT_IN_LEVEL,isaset_def]
+QED
 
 val powerset_def =
   new_specification("powerset_def",["powerset"],
@@ -447,10 +471,11 @@ Proof
   rw[fst_def,snd_def] >> metis_tac[PAIR_INJ]
 QED
 
-val CARTESIAN_EXISTS = Q.prove(
-  `∀s t. ∃u. level u = Powerset(Cartprod (droplevel(level s))
+Triviality CARTESIAN_EXISTS:
+  ∀s t. ∃u. level u = Powerset(Cartprod (droplevel(level s))
                                           (droplevel(level t))) ∧
-              ∀z. z <: u ⇔ ∃x y. (z = pair x y) ∧ x <: s ∧ y <: t`,
+              ∀z. z <: u ⇔ ∃x y. (z = pair x y) ∧ x <: s ∧ y <: t
+Proof
   rpt gen_tac >>
   reverse(Cases_on`isaset s`) >- (
     metis_tac[EMPTY_EXISTS,MEMBERS_ISASET] ) >>
@@ -467,7 +492,8 @@ val CARTESIAN_EXISTS = Q.prove(
   simp[Abbr`Q`,suchthat_def] >>
   simp[Abbr`R`]>>
   fs[inset_def] >>
-  metis_tac[ELEMENT_IN_LEVEL,LEVEL_PAIR])
+  metis_tac[ELEMENT_IN_LEVEL,LEVEL_PAIR]
+QED
 
 val PRODUCT_def =
   new_specification("PRODUCT_def",["product"],
@@ -525,9 +551,11 @@ Definition boolset_def:
   boolset = mk_V(Powerset Ur_bool,I_SET (setlevel Ur_bool) (setlevel Ur_bool))
 End
 
-val setlevel_bool = Q.prove(
-  `∀b. I_BOOL b ∈ setlevel Ur_bool`,
-  simp[setlevel_def,I_BOOL_def])
+Triviality setlevel_bool:
+  ∀b. I_BOOL b ∈ setlevel Ur_bool
+Proof
+  simp[setlevel_def,I_BOOL_def]
+QED
 
 Theorem IN_BOOL:
    ∀x. x <: boolset ⇔ x = true ∨ x = false
@@ -577,21 +605,29 @@ val ch_def =
     Q.prove(`∃ch. ∀s. (∃x. x <: s) ⇒ ch s <: s`,
       simp[GSYM SKOLEM_THM] >> metis_tac[]))
 
-val IN_POWERSET = Q.prove
- (`!x s. x <: powerset s <=> x <=: s`,
-  metis_tac[powerset_def]);;
+Triviality IN_POWERSET:
+  !x s. x <: powerset s <=> x <=: s
+Proof
+  metis_tac[powerset_def]
+QED;
 
-val IN_PRODUCT = Q.prove
- (`!z s t. z <: product s t <=> ?x y. (z = pair x y) /\ x <: s /\ y <: t`,
-  metis_tac[PRODUCT_def]);;
+Triviality IN_PRODUCT:
+  !z s t. z <: product s t <=> ?x y. (z = pair x y) /\ x <: s /\ y <: t
+Proof
+  metis_tac[PRODUCT_def]
+QED;
 
-val IN_COMPREHENSION = Q.prove
- (`!p s x. x <: (s suchthat p) <=> x <: s /\ p x`,
-  metis_tac[suchthat_def]);;
+Triviality IN_COMPREHENSION:
+  !p s x. x <: (s suchthat p) <=> x <: s /\ p x
+Proof
+  metis_tac[suchthat_def]
+QED;
 
-val PRODUCT_INHABITED = Q.prove
- (`(?x. x <: s) /\ (?y. y <: t) ==> ?z. z <: product s t`,
-  metis_tac[IN_PRODUCT]);;
+Triviality PRODUCT_INHABITED:
+  (?x. x <: s) /\ (?y. y <: t) ==> ?z. z <: product s t
+Proof
+  metis_tac[IN_PRODUCT]
+QED;
 
 Definition funspace_def:
   funspace s t = (powerset(product s t) suchthat

--- a/candle/set-theory/setModelScript.sml
+++ b/candle/set-theory/setModelScript.sml
@@ -223,14 +223,16 @@ Proof
   metis_tac[V_bij]
 QED
 
-val V_choice_exists = Q.prove(
-  `∃ch. is_choice V_mem ch`,
+Triviality V_choice_exists:
+  ∃ch. is_choice V_mem ch
+Proof
   simp[is_choice_def,GSYM SKOLEM_THM] >>
   rw[] >> simp[V_mem_def] >>
   qspecl_then[`dest_V x`]mp_tac
     (List.nth(CONJUNCTS V_mem_rep_def,6)) >>
   simp[V_bij] >>
-  metis_tac[V_bij] )
+  metis_tac[V_bij]
+QED
 
 val V_choice_def =
   new_specification("V_choice_def",["V_choice"],V_choice_exists)

--- a/candle/set-theory/zfc/setModelScript.sml
+++ b/candle/set-theory/zfc/setModelScript.sml
@@ -416,14 +416,16 @@ Proof
   metis_tac[V_bij]
 QED
 
-val V_choice_exists = Q.prove(
-  `∃ch. is_choice V_mem ch`,
+Triviality V_choice_exists:
+  ∃ch. is_choice V_mem ch
+Proof
   simp[is_choice_def,GSYM SKOLEM_THM] >>
   rw[] >> simp[V_mem_def] >>
   qspecl_then[`dest_V x`]mp_tac
     (List.nth(CONJUNCTS V_mem_rep_def,8)) >>
   simp[V_bij] >>
-  metis_tac[V_bij] )
+  metis_tac[V_bij]
+QED
 
 val V_choice_def =
   new_specification("V_choice_def",["V_choice"],V_choice_exists)

--- a/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -131,9 +131,11 @@ val res = translate check_tm_tm_def;
 (*
 val res = translate mlstringTheory.explode_aux_def;
 val res = translate mlstringTheory.explode_def;
-val explode_aux_side_thm = Q.prove(
-  `∀s n m. n + m = strlen s ==> explode_aux_side s n m `,
-  Induct_on`m` \\ rw[Once (theorem"explode_aux_side_def")]);
+Triviality explode_aux_side_thm:
+  ∀s n m. n + m = strlen s ==> explode_aux_side s n m
+Proof
+  Induct_on`m` \\ rw[Once (theorem"explode_aux_side_def")]
+QED
 val explode_side_thm = Q.prove(
   `explode_side x`,
   rw[definition"explode_side_def",explode_aux_side_thm])
@@ -341,15 +343,17 @@ Definition term_compare_def:
          | Greater => Greater
 End
 
-val term_cmp_thm = Q.prove(
-  `term_cmp = term_compare`,
+Triviality term_cmp_thm:
+  term_cmp = term_compare
+Proof
   fs [FUN_EQ_THM]
   \\ HO_MATCH_MP_TAC (fetch "-" "term_compare_ind")
   \\ REPEAT STRIP_TAC \\ fs []
   \\ ONCE_REWRITE_TAC [holSyntaxExtraTheory.term_cmp_thm]
   \\ ONCE_REWRITE_TAC [term_compare_def]
   \\ REPEAT BasicProvers.CASE_TAC
-  \\ fs [comparisonTheory.pair_cmp_def])
+  \\ fs [comparisonTheory.pair_cmp_def]
+QED
 
 val _ = add_preferred_thy "-";
 val _ = save_thm("term_cmp_ind",

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -25,9 +25,11 @@ val _ = hide "state";
 Type M = ``: hol_refs -> ('a, hol_exn) exc # hol_refs``
 
 (* TODO: stolen from deepMatchesLib.sml; should be exported? *)
-val PAIR_EQ_COLLAPSE = Q.prove (
-`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
-Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
+Triviality PAIR_EQ_COLLAPSE:
+  (((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))
+Proof
+  Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[]
+QED
 
 val pabs_elim_ss =
     simpLib.conv_ss

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -33,9 +33,11 @@ QED
 
 val REPLICATE_GENLIST = rich_listTheory.REPLICATE_GENLIST
 
-val REPLICATE_11 = Q.prove(
-  `!m n x. (REPLICATE n x = REPLICATE m x) = (m = n)`,
-  Induct \\ Cases \\ SRW_TAC [] [rich_listTheory.REPLICATE]);
+Triviality REPLICATE_11:
+  !m n x. (REPLICATE n x = REPLICATE m x) = (m = n)
+Proof
+  Induct \\ Cases \\ SRW_TAC [] [rich_listTheory.REPLICATE]
+QED
 
 Overload impossible_term = ``holSyntax$Comb (Var (strlit "x") Bool) (Var (strlit "x") Bool)``
 
@@ -83,62 +85,78 @@ End
 (* impossible term lemmas                                                    *)
 (* ------------------------------------------------------------------------- *)
 
-val term_ok_impossible_term = Q.prove(
-  `~(term_ok defs impossible_term)`,
-  simp[term_ok_def])
+Triviality term_ok_impossible_term:
+  ~(term_ok defs impossible_term)
+Proof
+  simp[term_ok_def]
+QED
 
-val impossible_term_thm = Q.prove(
-  `TERM defs tm ==> tm <> impossible_term`,
+Triviality impossible_term_thm:
+  TERM defs tm ==> tm <> impossible_term
+Proof
   SIMP_TAC std_ss [TERM_def] \\ REPEAT STRIP_TAC
-  \\ FULL_SIMP_TAC (srw_ss()) [term_ok_impossible_term])
+  \\ FULL_SIMP_TAC (srw_ss()) [term_ok_impossible_term]
+QED
 
-val Abs_Var = Q.prove(
-  `TERM defs (Abs v tm) ==> ?s ty. v = Var s ty`,
-  simp[TERM_def,term_ok_def] >> rw[])
+Triviality Abs_Var:
+  TERM defs (Abs v tm) ==> ?s ty. v = Var s ty
+Proof
+  simp[TERM_def,term_ok_def] >> rw[]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* invariant lemmas                                                          *)
 (* ------------------------------------------------------------------------- *)
 
-val CONTEXT_ALL_DISTINCT = Q.prove(
-  `CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
-                   ALL_DISTINCT (MAP FST (const_list defs))`,
+Triviality CONTEXT_ALL_DISTINCT:
+  CONTEXT defs ⇒ ALL_DISTINCT (MAP FST (type_list defs)) ∧
+                   ALL_DISTINCT (MAP FST (const_list defs))
+Proof
   rw[CONTEXT_def] >>
-  METIS_TAC[extends_ALL_DISTINCT,init_ALL_DISTINCT])
+  METIS_TAC[extends_ALL_DISTINCT,init_ALL_DISTINCT]
+QED
 
-val STATE_ALL_DISTINCT = Q.prove(
-  `STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
-                   ALL_DISTINCT (MAP FST s.the_term_constants)`,
+Triviality STATE_ALL_DISTINCT:
+  STATE defs s ⇒ ALL_DISTINCT (MAP FST s.the_type_constants) ∧
+                   ALL_DISTINCT (MAP FST s.the_term_constants)
+Proof
   rw[STATE_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`X = const_list Y`(assume_tac o SYM) >> fs[] >>
-  fs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
+  fs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX]
+QED
 
-val TYPE_Tyapp = Q.prove(
-  `MEM (tyop,LENGTH args) r.the_type_constants /\
+Triviality TYPE_Tyapp:
+  MEM (tyop,LENGTH args) r.the_type_constants /\
     STATE defs r /\ EVERY (TYPE defs) args ==>
-    TYPE defs (Tyapp tyop args)`,
+    TYPE defs (Tyapp tyop args)
+Proof
   rw[EVERY_MEM,TYPE_def] >>
   imp_res_tac STATE_ALL_DISTINCT >>
   rw[type_ok_def,EVERY_MAP,EVERY_MEM] >>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
-  rfs[STATE_def])
+  rfs[STATE_def]
+QED
 
-val CONTEXT_std_sig = Q.prove(
-  `CONTEXT defs ⇒ is_std_sig (sigof defs)`,
+Triviality CONTEXT_std_sig:
+  CONTEXT defs ⇒ is_std_sig (sigof defs)
+Proof
   rw[CONTEXT_def] >>
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
-  imp_res_tac theory_ok_sig >> fs[is_std_sig_def])
+  imp_res_tac theory_ok_sig >> fs[is_std_sig_def]
+QED
 
-val CONTEXT_fun = Q.prove(
-  `CONTEXT defs ⇒
-      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)`,
+Triviality CONTEXT_fun:
+  CONTEXT defs ⇒
+      ∀a. MEM (strlit"fun",a) (type_list defs) ⇔ (a = 2)
+Proof
   rw[] >> imp_res_tac CONTEXT_ALL_DISTINCT >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
   EQ_TAC >> rw[] >> res_tac >> fs[] >>
-  imp_res_tac ALOOKUP_MEM)
+  imp_res_tac ALOOKUP_MEM
+QED
 
 Theorem TYPE:
   (STATE defs state ==> TYPE defs (Tyvar v)) /\
@@ -160,38 +178,50 @@ Proof
   rw[TERM_def,TYPE_def] >> fs[term_ok_def]
 QED
 
-val TYPE_Fun = Q.prove(
-  `CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
-    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])`,
+Triviality TYPE_Fun:
+  CONTEXT defs ∧ TYPE defs ty1 /\ TYPE defs ty2 ==>
+    TYPE defs (Tyapp (strlit "fun") [ty1;ty2])
+Proof
   rw[TYPE_def,type_ok_def] >>
   imp_res_tac CONTEXT_fun >>
-  METIS_TAC[ALOOKUP_ALL_DISTINCT_MEM,CONTEXT_ALL_DISTINCT]);
+  METIS_TAC[ALOOKUP_ALL_DISTINCT_MEM,CONTEXT_ALL_DISTINCT]
+QED
 
-val TERM_Var_SIMP = Q.prove(
-  `(TERM defs (Var n ty) = TYPE defs ty)`,
-  rw[TERM_def,TYPE_def,term_ok_def]);
+Triviality TERM_Var_SIMP:
+  (TERM defs (Var n ty) = TYPE defs ty)
+Proof
+  rw[TERM_def,TYPE_def,term_ok_def]
+QED
 
-val TERM_Var = Q.prove(
-  `TYPE defs ty ==> TERM defs (Var n ty)`,
-  METIS_TAC [TERM_Var_SIMP]);
+Triviality TERM_Var:
+  TYPE defs ty ==> TERM defs (Var n ty)
+Proof
+  METIS_TAC [TERM_Var_SIMP]
+QED
 
-val IMP_TERM_Abs = Q.prove(
-  `TERM defs (Var str ty) /\ TERM defs bod ==>
-    TERM defs (Abs (Var str ty) bod)`,
-  fs[TERM_def,term_ok_def]);
+Triviality IMP_TERM_Abs:
+  TERM defs (Var str ty) /\ TERM defs bod ==>
+    TERM defs (Abs (Var str ty) bod)
+Proof
+  fs[TERM_def,term_ok_def]
+QED
 
-val IMP_TERM_Comb = Q.prove(
-  `TERM defs f /\
+Triviality IMP_TERM_Comb:
+  TERM defs f /\
     TERM defs a /\
     (typeof a = ty1) /\
     (typeof f = Fun ty1 ty2) ==>
-    TERM defs (Comb f a)`,
+    TERM defs (Comb f a)
+Proof
   rw[TERM_def,term_ok_def] >>
-  METIS_TAC[term_ok_welltyped])
+  METIS_TAC[term_ok_welltyped]
+QED
 
-val TERM_Abs = Q.prove(
-  `TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm`,
-  rw[TERM_def,term_ok_def,TYPE_def]);
+Triviality TERM_Abs:
+  TERM defs (Abs (Var v ty) tm) <=> TYPE defs ty /\ TERM defs tm
+Proof
+  rw[TERM_def,term_ok_def,TYPE_def]
+QED
 
 val INST_CORE_LEMMA =
   INST_CORE_HAS_TYPE |> Q.SPECL [`holSyntax$sizeof tm`,`tm`,`[]`,`tyin`]
@@ -237,25 +267,32 @@ val type_IND = type_induction
   |> UNDISCH_ALL |> CONJUNCT1 |> DISCH_ALL
   |> Q.GEN`P`
 
-val type_subst_EMPTY = Q.prove(
-  `!ty. type_subst [] ty = ty`,
+Triviality type_subst_EMPTY:
+  !ty. type_subst [] ty = ty
+Proof
   HO_MATCH_MP_TAC type_IND
   \\ REPEAT STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once type_subst_def]
   \\ SIMP_TAC std_ss [rev_assocd_thm,REV_ASSOCD,LET_DEF]
   \\ sg `MAP (\a. type_subst [] a) l = l` \\ FULL_SIMP_TAC std_ss []
-  \\ Induct_on `l` \\ FULL_SIMP_TAC std_ss [MAP,EVERY_DEF]);
+  \\ Induct_on `l` \\ FULL_SIMP_TAC std_ss [MAP,EVERY_DEF]
+QED
 
-val MAP_EQ_2 = Q.prove(
-  `(MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)`,
-  Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[])
+Triviality MAP_EQ_2:
+  (MAP f l = [x;y]) ⇔ ∃x0 y0. (l = [x0;y0]) ∧ (x = f x0) ∧ (y = f y0)
+Proof
+  Cases_on`l`>>simp[]>>Cases_on`t`>>simp[]>>METIS_TAC[]
+QED
 
-val sequent_has_type_bool = Q.prove(
-  `(d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)`,
-  strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM])
+Triviality sequent_has_type_bool:
+  (d,h) |- c ⇒ EVERY (λt. t has_type Bool) (c::h)
+Proof
+  strip_tac >> imp_res_tac proves_term_ok >> fs[EVERY_MEM]
+QED
 
-val THM_term_ok_bool = Q.prove(
-  `THM defs (Sequent asl p) ⇒
-    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)`,
+Triviality THM_term_ok_bool:
+  THM defs (Sequent asl p) ⇒
+    EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (p::asl)
+Proof
   REPEAT STRIP_TAC
   \\ IMP_RES_TAC THM
   \\ FULL_SIMP_TAC std_ss [THM_def]
@@ -264,7 +301,8 @@ val THM_term_ok_bool = Q.prove(
   \\ FULL_SIMP_TAC std_ss [TERM_def,EVERY_MEM,MEM_MAP,PULL_EXISTS,MEM]
   \\ NTAC 2 STRIP_TAC
   \\ FULL_SIMP_TAC std_ss []
-  \\ METIS_TAC [WELLTYPED_LEMMA])
+  \\ METIS_TAC [WELLTYPED_LEMMA]
+QED
 
 (* TODO move *)
 Theorem ALOOKUP_ALL_DISTINCT_MEM_EXISTS:
@@ -313,12 +351,14 @@ QED
 (* ------------------------------------------------------------------------- *)
 (* Verification of type functions                                            *)
 (* ------------------------------------------------------------------------- *)
-val can_thm = Q.prove(
-  `can f x s = case f x s of (M_success _,s) => (M_success T,s) |
-                              (_,s) => (M_success F,s)`,
+Triviality can_thm:
+  can f x s = case f x s of (M_success _,s) => (M_success T,s) |
+                              (_,s) => (M_success F,s)
+Proof
   SIMP_TAC std_ss [can_def,st_ex_ignore_bind_def,otherwise_def]
   \\ Cases_on `f x s` \\ Cases_on `q`
-  \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]);
+  \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
+QED
 
 Theorem assoc_thm:
   !xs y z s s'.
@@ -332,14 +372,16 @@ Proof
   \\ METIS_TAC []
 QED
 
-val get_type_arity_thm = Q.prove(
-  `!name s z s'.
+Triviality get_type_arity_thm:
+  !name s z s'.
       (get_type_arity name s = (z,s')) ==> (s' = s) /\
       (!i. (z = M_success i) ==> MEM (name,i) s.the_type_constants) /\
-      (!e. (z = M_failure e) ==> !i. ~MEM (name,i) s.the_type_constants)`,
+      (!e. (z = M_failure e) ==> !i. ~MEM (name,i) s.the_type_constants)
+Proof
   SIMP_TAC (srw_ss()) [get_type_arity_def,st_ex_bind_def,
     get_the_type_constants_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC assoc_thm);
+  \\ IMP_RES_TAC assoc_thm
+QED
 
 Theorem mk_vartype_thm:
    !name s.
@@ -400,8 +442,9 @@ Proof
   Cases \\ SIMP_TAC (srw_ss()) [is_vartype_def]
 QED
 
-val tyvars_thm = Q.prove(
-  `!ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)`,
+Triviality tyvars_thm:
+  !ty s. MEM s (holKernel$tyvars ty) = MEM s (holSyntax$tyvars ty)
+Proof
   HO_MATCH_MP_TAC holKernelTheory.tyvars_ind \\ REPEAT STRIP_TAC
   \\ Cases_on `ty` \\ FULL_SIMP_TAC (srw_ss()) [type_11,type_distinct]
   \\ SIMP_TAC (srw_ss()) [Once holKernelTheory.tyvars_def,
@@ -409,7 +452,8 @@ val tyvars_thm = Q.prove(
   \\ FULL_SIMP_TAC std_ss [rich_listTheory.FOLDR_MAP]
   \\ Induct_on `l`
   \\ SIMP_TAC (srw_ss()) [Once itlist_def,FOLDR,MEM_union,MEM_LIST_UNION]
-  \\ METIS_TAC []);
+  \\ METIS_TAC []
+QED
 
 Theorem type_subst:
    !i ty.
@@ -448,14 +492,16 @@ QED
 
 Overload aty[local] = ``(Tyvar (strlit "A")):type``
 
-val get_const_type_thm = Q.prove(
-  `!name s z s'.
+Triviality get_const_type_thm:
+  !name s z s'.
       (get_const_type name s = (z,s')) ==> (s' = s) /\
       (!i. (z = M_success i) ==> MEM (name,i) s.the_term_constants) /\
-      (!e. (z = M_failure e) ==> !i. ~(MEM (name,i) s.the_term_constants))`,
+      (!e. (z = M_failure e) ==> !i. ~(MEM (name,i) s.the_term_constants))
+Proof
   SIMP_TAC (srw_ss()) [get_const_type_def,st_ex_bind_def,
     get_the_term_constants_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC assoc_thm);
+  \\ IMP_RES_TAC assoc_thm
+QED
 
 Definition term_type_def:
   term_type tm =
@@ -560,20 +606,23 @@ Proof
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_bind_def]
 QED
 
-val alphavars_thm = Q.prove(
-  `!env.
+Triviality alphavars_thm:
+  !env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))`,
+      (alphavars env tm1 tm2 = ALPHAVARS env (tm1, tm2))
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [Once alphavars_def,ALPHAVARS_def]
   \\ Cases \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ METIS_TAC []);
+  \\ METIS_TAC []
+QED
 
-val raconv_thm = Q.prove(
-  `!tm1 tm2 env.
+Triviality raconv_thm:
+  !tm1 tm2 env.
       STATE defs s /\ TERM defs tm1 /\ TERM defs tm2 /\
       EVERY (\(v1,v2). TERM defs v1 /\ TERM defs v2) env ==>
-      (raconv env tm1 tm2 = RACONV env (tm1, tm2))`,
+      (raconv env tm1 tm2 = RACONV env (tm1, tm2))
+Proof
   Induct THEN1
    (Cases_on `tm2` >> simp[Once raconv_def, Once RACONV] >> rw[] >>
     IMP_RES_TAC alphavars_thm)
@@ -599,7 +648,8 @@ val raconv_thm = Q.prove(
   \\ FULL_SIMP_TAC std_ss [EVERY_DEF]
   \\ impl_tac
   THEN1 (REPEAT STRIP_TAC \\ MATCH_MP_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [])
-  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [])
+  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
+QED
 
 Theorem aconv_thm:
    !tm1 tm2 env.
@@ -727,17 +777,22 @@ Proof
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
 QED
 
-val type_subst_bool = Q.prove(
-  `type_subst i Bool = Bool`,
-  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF]);
+Triviality type_subst_bool:
+  type_subst i Bool = Bool
+Proof
+  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF]
+QED
 
-val type_subst_fun = Q.prove(
-  `type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)`,
-  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []);
+Triviality type_subst_fun:
+  type_subst i (Fun ty1 ty2) = Fun (type_subst i ty1) (type_subst i ty2)
+Proof
+  SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF] \\ SRW_TAC [] []
+QED
 
-val TERM_Const = Q.prove(
-  `STATE defs r /\ MEM (name,a) r.the_term_constants ==>
-    TERM defs (Const name a)`,
+Triviality TERM_Const:
+  STATE defs r /\ MEM (name,a) r.the_term_constants ==>
+    TERM defs (Const name a)
+Proof
   rw[STATE_def,TERM_def,term_ok_def] >>
   imp_res_tac CONTEXT_ALL_DISTINCT >>
   qpat_x_assum`_ = const_list _`(ASSUME_TAC o SYM) >>
@@ -751,11 +806,13 @@ val TERM_Const = Q.prove(
   imp_res_tac extends_theory_ok >> fs[init_theory_ok] >>
   fs[theory_ok_def] >> first_x_assum MATCH_MP_TAC >>
   MATCH_MP_TAC ALOOKUP_IN_FRANGE >>
-  simp[ALOOKUP_MAP] >> METIS_TAC[])
+  simp[ALOOKUP_MAP] >> METIS_TAC[]
+QED
 
-val TERM_Const_type_subst = Q.prove(
-  `EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
-    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))`,
+Triviality TERM_Const_type_subst:
+  EVERY (\(x,y). TYPE defs x /\ TYPE defs y) theta /\
+    TERM defs (Const name a) ==> TERM defs (Const name (type_subst theta a))
+Proof
   REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
   \\ IMP_RES_TAC type_subst
   \\ FULL_SIMP_TAC std_ss [type_subst,TERM_def,TYPE_def] >>
@@ -765,7 +822,8 @@ val TERM_Const_type_subst = Q.prove(
     rfs[EVERY_MAP,EVERY_MEM,FORALL_PROD] >>
     METIS_TAC[] ) >>
   simp[TYPE_SUBST_compose] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
 Theorem mk_const_thm:
    !name theta s z s'.
@@ -785,9 +843,10 @@ Proof
   \\ IMP_RES_TAC TERM_Const
 QED
 
-val get_const_type_Equal = Q.prove(
-  `STATE defs s ==>
-    (get_const_type (strlit "=") s = (M_success (Fun aty (Fun aty Bool)),s))`,
+Triviality get_const_type_Equal:
+  STATE defs s ==>
+    (get_const_type (strlit "=") s = (M_success (Fun aty (Fun aty Bool)),s))
+Proof
   SIMP_TAC std_ss [STATE_def]
   \\ Cases_on `get_const_type (strlit "=") s`
   \\ IMP_RES_TAC get_const_type_thm \\ REPEAT STRIP_TAC >>
@@ -799,25 +858,30 @@ val get_const_type_Equal = Q.prove(
   fs[MEM_MAP,EXISTS_PROD] >>
   reverse(Cases_on`q`)>>fs[]>-METIS_TAC[]>>
   imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
-  rfs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX])
+  rfs[MAP_MAP_o,combinTheory.o_DEF,UNCURRY,ETA_AX]
+QED
 
-val mk_const_eq = Q.prove(
-  `STATE defs s ==>
+Triviality mk_const_eq:
+  STATE defs s ==>
     (mk_const ((strlit "="),[]) s =
-     (M_success (Const (strlit "=") (Fun aty (Fun aty Bool))),s))`,
+     (M_success (Const (strlit "=") (Fun aty (Fun aty Bool))),s))
+Proof
   SIMP_TAC std_ss [mk_const_def,st_ex_bind_def,try_def,otherwise_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC get_const_type_Equal
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ EVAL_TAC);
+  \\ EVAL_TAC
+QED
 
-val mk_eq_lemma = Q.prove(
-  `inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
+Triviality mk_eq_lemma:
+  inst [(term_type x,aty)] (Const (strlit "=") (Fun aty (Fun aty Bool))) s =
     ex_return
         (Const (strlit "=")
-           (Fun (term_type x) (Fun (term_type x) Bool))) s`,
+           (Fun (term_type x) (Fun (term_type x) Bool))) s
+Proof
   NTAC 10 (SIMP_TAC (srw_ss()) [Once inst_def, Once inst_aux_def, Once LET_DEF])
   \\ NTAC 50 (SIMP_TAC (srw_ss()) [Once type_subst_def,LET_DEF, Once mk_vartype_def,
-       Once rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []);
+       Once rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []
+QED
 
 Theorem mk_eq_thm:
   (mk_eq(x,y)s = (res,s')) ==>
@@ -875,42 +939,53 @@ Proof
          st_ex_bind_def,dest_type_def]
 QED
 
-val TERM_Eq_x = Q.prove(
-  `STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
-    (Fun (typeof x) (Fun (typeof x) Bool) = ty)`,
+Triviality TERM_Eq_x:
+  STATE defs s /\ TERM defs (Comb (Const (strlit "=") ty) x) ==>
+    (Fun (typeof x) (Fun (typeof x) Bool) = ty)
+Proof
   rw[TERM_def,STATE_def] >>
   fs[term_ok_def] >>
   imp_res_tac CONTEXT_std_sig >>
   fs[is_std_sig_def] >> rw[] >>
-  fs[TYPE_SUBST_def])
+  fs[TYPE_SUBST_def]
+QED
 
-val TERM_Comb = Q.prove(
-  `CONTEXT defs ⇒
+Triviality TERM_Comb:
+  CONTEXT defs ⇒
     (TERM defs (Comb f a) <=>
      TERM defs f /\ TERM defs a /\
-     ?ty. term_type f = Fun (term_type a) ty)`,
+     ?ty. term_type f = Fun (term_type a) ty)
+Proof
   REPEAT STRIP_TAC \\ EQ_TAC \\ REPEAT STRIP_TAC
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC term_type
   \\ FULL_SIMP_TAC std_ss [TERM_def,WELLTYPED_CLAUSES,term_ok_def]
-  \\ METIS_TAC[term_ok_welltyped])
+  \\ METIS_TAC[term_ok_welltyped]
+QED
 
-val MAP_EQ_2_SYM = Q.prove(
-  `([x;y] = MAP f l) ⇔ (MAP f l = [x;y])`,METIS_TAC[])
+Triviality MAP_EQ_2_SYM:
+  ([x;y] = MAP f l) ⇔ (MAP f l = [x;y])
+Proof
+  METIS_TAC[]
+QED
 
-val Equal_type = Q.prove(
-  `STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)`,
+Triviality Equal_type:
+  STATE defs s ∧ TERM defs (Const (strlit "=") ty) ==> ?a. ty = Fun a (Fun a Bool)
+Proof
   rw[STATE_def,TERM_def] >>
   imp_res_tac CONTEXT_std_sig >>
-  fs[is_std_sig_def,term_ok_def])
+  fs[is_std_sig_def,term_ok_def]
+QED
 
-val Equal_type_IMP = Q.prove(
-  `STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
-    (typeof ll = a')`,
+Triviality Equal_type_IMP:
+  STATE defs s ∧ TERM defs (Comb (Const (strlit "=") (Fun a' (Fun a' Bool))) ll) ==>
+    (typeof ll = a')
+Proof
   simp[TERM_Comb] >> strip_tac >>
   imp_res_tac TERM_Eq_x >>
   fs[Once term_type_def] >>
-  rw[] >> imp_res_tac term_type >> simp[])
+  rw[] >> imp_res_tac term_type >> simp[]
+QED
 
 Theorem dest_eq_thm:
   (dest_eq tm s = (res, s')) /\
@@ -928,26 +1003,31 @@ Proof
   \\ IMP_RES_TAC TERM_Eq_x
 QED
 
-val VFREE_IN_IMP = Q.prove(
-  `!y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
+Triviality VFREE_IN_IMP:
+  !y. TERM defs y /\ TYPE defs ty /\ STATE defs s /\
         VFREE_IN (Var name ty) y ==>
-        vfree_in (Var name ty) y`,
-  METIS_TAC [vfree_in_thm]);
+        vfree_in (Var name ty) y
+Proof
+  METIS_TAC [vfree_in_thm]
+QED
 
-val SELECT_LEMMA = Q.prove(
-  `(@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)`,
+Triviality SELECT_LEMMA:
+  (@f. !s s'. f (s',s) <=> s <> t) = (\(z,y). y <> t)
+Proof
   Q.ABBREV_TAC `p = (@f. !s s'. f (s',s) <=> s <> t)`
   \\ sg `?f. !s s'. f (s',s) <=> s <> t`
   THEN1 (Q.EXISTS_TAC `(\(z,y). y <> t)` \\ FULL_SIMP_TAC std_ss [])
   \\ `!s s'. p (s',s) <=> s <> t` by METIS_TAC []
-  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
+  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]
+QED
 
-val SELECT_LEMMA2 = Q.prove(
-  `(@f.
+Triviality SELECT_LEMMA2:
+  (@f.
        !s s''.
          f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm') =
-    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')`,
+    (\(x,y). VFREE_IN (Var s' ty) x /\ VFREE_IN y tm')
+Proof
   Q.ABBREV_TAC `p = (@f. !s s''. f (s'',s) <=>
          VFREE_IN (Var s' ty) s'' /\ VFREE_IN s tm')`
   \\ sg `?f. !s s''. f (s'',s) <=>
@@ -956,20 +1036,26 @@ val SELECT_LEMMA2 = Q.prove(
                 VFREE_IN s tm')` \\ FULL_SIMP_TAC std_ss [])
   \\ `!s s''. p (s'',s) <=> VFREE_IN (Var s' ty) s'' /\
                             VFREE_IN s tm'` by METIS_TAC []
-  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]);
+  \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,FORALL_PROD]
+QED
 
-val is_var_thm = Q.prove(
-  `!x. is_var x = ?v ty. x = Var v ty`,
-  Cases \\ FULL_SIMP_TAC (srw_ss()) [is_var_def]);
+Triviality is_var_thm:
+  !x. is_var x = ?v ty. x = Var v ty
+Proof
+  Cases \\ FULL_SIMP_TAC (srw_ss()) [is_var_def]
+QED
 
-val VSUBST_EMPTY = Q.prove(
-  `(!tm. holSyntax$VSUBST [] tm = tm)`,
+Triviality VSUBST_EMPTY:
+  (!tm. holSyntax$VSUBST [] tm = tm)
+Proof
   Induct
-  \\ FULL_SIMP_TAC (srw_ss()) [VSUBST_def,REV_ASSOCD,EVERY_DEF,FILTER,LET_THM]);
+  \\ FULL_SIMP_TAC (srw_ss()) [VSUBST_def,REV_ASSOCD,EVERY_DEF,FILTER,LET_THM]
+QED
 
-val VFREE_IN_TYPE = Q.prove(
-  `!x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
-        ?ty. (oty = ty) /\ TYPE defs ty`,
+Triviality VFREE_IN_TYPE:
+  !x. VFREE_IN (Var name oty) x /\ TERM defs x ==>
+        ?ty. (oty = ty) /\ TYPE defs ty
+Proof
   Induct
   THEN1 (SIMP_TAC std_ss [VFREE_IN_def,term_11] \\ METIS_TAC [TERM])
   THEN1 (SRW_TAC [] [VFREE_IN_def,term_11,term_distinct])
@@ -978,11 +1064,13 @@ val VFREE_IN_TYPE = Q.prove(
   \\ SIMP_TAC std_ss [VFREE_IN_def,term_11] \\ STRIP_TAC
   \\ IMP_RES_TAC Abs_Var \\ FULL_SIMP_TAC std_ss [] \\ POP_ASSUM (K ALL_TAC)
   \\ IMP_RES_TAC TERM
-  \\ FULL_SIMP_TAC std_ss [VFREE_IN_def] \\ METIS_TAC []);
+  \\ FULL_SIMP_TAC std_ss [VFREE_IN_def] \\ METIS_TAC []
+QED
 
-val VFREE_IN_IMP_MEM = Q.prove(
-  `VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
-    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1`,
+Triviality VFREE_IN_IMP_MEM:
+  VFREE_IN (Var name oty) h0 /\ TERM defs h0 /\ STATE defs s ==>
+    ?ty1. MEM (Var name ty1) (frees h0) /\ (oty = ty1) /\ TYPE defs ty1
+Proof
   Induct_on `h0` THEN1 (Q.SPEC_TAC (`oty`,`oty`)
     \\ FULL_SIMP_TAC (srw_ss()) [VFREE_IN_def,term_11,Once frees_def]
     \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [])
@@ -995,19 +1083,23 @@ val VFREE_IN_IMP_MEM = Q.prove(
   \\ SIMP_TAC (srw_ss()) [Once frees_def,MEM_union,VFREE_IN_def]
   \\ SIMP_TAC (srw_ss()) [subtract_def,MEM_FILTER]
   \\ IMP_RES_TAC VFREE_IN_TYPE \\ FULL_SIMP_TAC std_ss []
-  \\ fs[])
+  \\ fs[]
+QED
 
-val term_type_Var = Q.prove(
-  `term_type (Var v ty) = ty`,
-  SIMP_TAC (srw_ss()) [Once term_type_def]);
+Triviality term_type_Var:
+  term_type (Var v ty) = ty
+Proof
+  SIMP_TAC (srw_ss()) [Once term_type_def]
+QED
 
-val vsubst_aux_thm = Q.prove(
-  `!t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
+Triviality vsubst_aux_thm:
+  !t tm theta. EVERY (\(t1,t2). TERM defs t1 /\ TERM defs t2 /\
                      (term_type t1 = term_type t2) /\ is_var t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (vsubst_aux theta tm = t) ==>
     TERM defs t /\
-    (t = VSUBST theta tm)`,
+    (t = VSUBST theta tm)
+Proof
   SIMP_TAC std_ss [] \\ Induct THEN1
    (NTAC 4 STRIP_TAC \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def]
     \\ SIMP_TAC (srw_ss()) [Once vsubst_aux_def,VSUBST_def]
@@ -1136,27 +1228,33 @@ val vsubst_aux_thm = Q.prove(
       METIS_TAC[vfree_in_thm,TERM] ) >>
   qunabbrev_tac`theta1` >>
   Q.PAT_ABBREV_TAC`vv = holSyntax$VARIANT A B Z` >>
-  simp[])
+  simp[]
+QED
 
-val forall_thm = Q.prove(
-  `!f s (xs:(term # term) list). (forall f xs s = (res,s')) ==>
+Triviality forall_thm:
+  !f s (xs:(term # term) list). (forall f xs s = (res,s')) ==>
     (!x. ?r. f x s = (r,s)) ==>
-    (s' = s) /\ ((res = M_success T) ==> EVERY (\x. FST (f x s) = M_success T) xs)`,
+    (s' = s) /\ ((res = M_success T) ==> EVERY (\x. FST (f x s) = M_success T) xs)
+Proof
   STRIP_TAC \\ STRIP_TAC
   \\ Induct \\ ASM_SIMP_TAC (srw_ss()) [Once forall_def,st_ex_return_def,st_ex_bind_def]
   \\ STRIP_TAC \\ Cases_on `f h s` \\ SIMP_TAC std_ss [Once EQ_SYM_EQ]
   \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] \\ STRIP_TAC \\ STRIP_TAC
   \\ `r = s` by METIS_TAC [PAIR,PAIR_EQ] \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `a` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC [FST,PAIR]);
+  \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] \\ METIS_TAC [FST,PAIR]
+QED
 
-val assoc_state = Q.prove(
-  `!xs x. ?r. assoc x xs s = (r,s)`,
+Triviality assoc_state:
+  !xs x. ?r. assoc x xs s = (r,s)
+Proof
   Induct \\ ONCE_REWRITE_TAC [assoc_def] \\ TRY Cases
-  \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def,st_ex_return_def] \\ SRW_TAC [] []);
+  \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def,st_ex_return_def] \\ SRW_TAC [] []
+QED
 
-val type_of_state = Q.prove(
-  `!tm. ?r. type_of tm s = (r,s)`,
+Triviality type_of_state:
+  !tm. ?r. type_of tm s = (r,s)
+Proof
   HO_MATCH_MP_TAC type_of_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [Once type_of_def] \\ Cases_on `tm`
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def,raise_Failure_def,st_ex_bind_def]
@@ -1175,7 +1273,8 @@ val type_of_state = Q.prove(
   \\ STRIP_ASSUME_TAC (assoc_state |> ISPEC ``s.the_type_constants``
         |> ISPEC ``strlit"fun"``) \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `r` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ SRW_TAC [] []);
+  \\ SRW_TAC [] []
+QED
 
 Theorem variant_thm:
   !tms tm. EVERY (TERM defs) tms ∧ TERM defs tm ∧ STATE defs s ⇒
@@ -1464,12 +1563,13 @@ Proof
   BasicProvers.CASE_TAC >> fs[]
 QED
 
-val inst_lemma = Q.prove(
-  `EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
+Triviality inst_lemma:
+  EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
     TERM defs tm /\ STATE defs s /\
     (inst theta tm s = (res, s')) ==>
     (s' = s) /\ !t. (res = M_success t) ==>
-    (t = INST theta (tm))`,
+    (t = INST theta (tm))
+Proof
   SIMP_TAC std_ss [INST_def,inst_def] \\ Cases_on `theta = []`
   \\ ASM_SIMP_TAC std_ss [MAP,EVERY_DEF,st_ex_return_def] THEN1
    (Q.SPEC_TAC (`res`,`res`) \\ SIMP_TAC (srw_ss()) []
@@ -1491,7 +1591,8 @@ val inst_lemma = Q.prove(
        [`(MAP (\(t1,t2). (hol_ty t1,hol_ty t2)) theta)`,`[]`])
   \\ FULL_SIMP_TAC std_ss [MEM,REV_ASSOCD] \\ REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [MAP,RESULT_def,result_distinct,result_11]
-  \\ Cases_on `res` \\ FULL_SIMP_TAC (srw_ss()) [])
+  \\ Cases_on `res` \\ FULL_SIMP_TAC (srw_ss()) []
+QED
 
 Theorem inst_thm:
    EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
@@ -1524,10 +1625,11 @@ Proof
   \\ METIS_TAC []
 QED
 
-val freesin_IMP = Q.prove(
-  `!rhs vars.
+Triviality freesin_IMP:
+  !rhs vars.
        freesin vars rhs /\ TERM defs rhs /\ VFREE_IN (Var x ty) (rhs) ==>
-       MEM (Var x ty) vars`,
+       MEM (Var x ty) vars
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [Once freesin_def]
   THEN1 (REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
          \\ FULL_SIMP_TAC std_ss [CLOSED_def,VFREE_IN_def])
@@ -1538,29 +1640,37 @@ val freesin_IMP = Q.prove(
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `(Var s ty'::vars)`)
   \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [MEM]
-  \\ FULL_SIMP_TAC (srw_ss()) [term_11]);
+  \\ FULL_SIMP_TAC (srw_ss()) [term_11]
+QED
 
-val ALL_DISTINCT_union = Q.prove(
-  `!xs. ALL_DISTINCT (holSyntaxExtra$union xs ys) = ALL_DISTINCT ys`,
+Triviality ALL_DISTINCT_union:
+  !xs. ALL_DISTINCT (holSyntaxExtra$union xs ys) = ALL_DISTINCT ys
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [union_def,Once itlist_def,insert_def]
-  \\ SRW_TAC [] [] \\ FULL_SIMP_TAC std_ss [union_def]);
+  \\ SRW_TAC [] [] \\ FULL_SIMP_TAC std_ss [union_def]
+QED
 
-val ALL_DISTINCT_tyvars_ALT = Q.prove(
-  `!h. ALL_DISTINCT (tyvars (h:type))`,
+Triviality ALL_DISTINCT_tyvars_ALT:
+  !h. ALL_DISTINCT (tyvars (h:type))
+Proof
   HO_MATCH_MP_TAC type_IND \\ REPEAT STRIP_TAC
   \\ SIMP_TAC (srw_ss()) [Once holKernelTheory.tyvars_def]
   \\ Induct_on `l` \\ SIMP_TAC (srw_ss()) [Once itlist_def,MAP]
-  \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_union]);
+  \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_union]
+QED
 
-val ALL_DISTINCT_type_vars_in_term = Q.prove(
-  `!P. ALL_DISTINCT (type_vars_in_term P)`,
+Triviality ALL_DISTINCT_type_vars_in_term:
+  !P. ALL_DISTINCT (type_vars_in_term P)
+Proof
   Induct \\ SIMP_TAC (srw_ss()) [Once type_vars_in_term_def]
   \\ FULL_SIMP_TAC std_ss [tyvars_ALL_DISTINCT,ALL_DISTINCT_union]
-  \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_tyvars_ALT]);
+  \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT_tyvars_ALT]
+QED
 
-val MEM_type_vars_in_term = Q.prove(
-  `!rhs v. TERM defs rhs ==>
-            (MEM v (type_vars_in_term rhs) = MEM v (tvars rhs))`,
+Triviality MEM_type_vars_in_term:
+  !rhs v. TERM defs rhs ==>
+            (MEM v (type_vars_in_term rhs) = MEM v (tvars rhs))
+Proof
   Induct
   \\ SIMP_TAC (srw_ss()) [Once type_vars_in_term_def,tvars_def,tyvars_thm]
   THEN1 (FULL_SIMP_TAC std_ss [MEM_union,MEM_LIST_UNION] \\ REPEAT STRIP_TAC
@@ -1569,11 +1679,13 @@ val MEM_type_vars_in_term = Q.prove(
   \\ FULL_SIMP_TAC std_ss [] \\ POP_ASSUM (K ALL_TAC)
   \\ IMP_RES_TAC TERM \\ FULL_SIMP_TAC std_ss [MEM_union,
        tvars_def,MEM_LIST_UNION]
-  \\ IMP_RES_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [pred_setTheory.IN_UNION]);
+  \\ IMP_RES_TAC TERM_Var \\ FULL_SIMP_TAC std_ss [pred_setTheory.IN_UNION]
+QED
 
-val QSORT_type_vars_in_term = Q.prove(
-  `TERM defs P ==>
-    (QSORT $<= (MAP explode (type_vars_in_term P)) = STRING_SORT (MAP explode (tvars P)))`,
+Triviality QSORT_type_vars_in_term:
+  TERM defs P ==>
+    (QSORT $<= (MAP explode (type_vars_in_term P)) = STRING_SORT (MAP explode (tvars P)))
+Proof
   REPEAT STRIP_TAC \\
   MATCH_MP_TAC (MP_CANON sortingTheory.SORTED_PERM_EQ) \\
   qexists_tac`$<=` >>
@@ -1595,7 +1707,8 @@ val QSORT_type_vars_in_term = Q.prove(
              ,ALL_DISTINCT_type_vars_in_term
              ,ALL_DISTINCT_MAP_explode] ) >>
   simp[ALL_DISTINCT_STRING_SORT] >>
-  METIS_TAC[sortingTheory.QSORT_MEM,MEM_type_vars_in_term,MEM_MAP])
+  METIS_TAC[sortingTheory.QSORT_MEM,MEM_type_vars_in_term,MEM_MAP]
+QED
 
 (* ------------------------------------------------------------------------- *)
 (* Verification of thm functions                                             *)
@@ -1705,28 +1818,32 @@ Proof
   match_mp_tac proveHyp >> rw[]
 QED
 
-val map_type_of = Q.prove(
-  `∀ls s r s'.
+Triviality map_type_of:
+  ∀ls s r s'.
       EVERY (TERM defs) ls ∧ STATE defs s ∧
       (map type_of ls s = (M_success r,s')) ⇒
       (s' = s) ∧
-      (r = MAP term_type ls)`,
+      (r = MAP term_type ls)
+Proof
   Induct >> simp[Once map_def] >- (
     simp[st_ex_return_def] ) >>
   rw[st_ex_bind_def] >>
   every_case_tac >> fs[st_ex_return_def] >> rw[] >>
   imp_res_tac type_of_thm >> fs[] >> rw[] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
-val map_type_of_state = Q.prove(
-  `∀ls s r s'.
+Triviality map_type_of_state:
+  ∀ls s r s'.
       (map type_of ls s = (r,s')) ⇒
-      (s' = s)`,
+      (s' = s)
+Proof
   Induct >> simp[Once map_def] >- (
     simp[st_ex_return_def] ) >>
   rw[st_ex_bind_def] >>
   every_case_tac >> fs[st_ex_return_def] >> rw[] >>
-  METIS_TAC[type_of_state,PAIR,FST,SND])
+  METIS_TAC[type_of_state,PAIR,FST,SND]
+QED
 
 Theorem hypset_ok_list_to_hypset[simp]:
    ∀ls a. hypset_ok a ⇒ hypset_ok (list_to_hypset ls a)
@@ -2008,12 +2125,13 @@ Proof
   simp[]
 QED
 
-val image_lemma = Q.prove(
-  `∀f l s g defs res s'.
+Triviality image_lemma:
+  ∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ((f x s = (M_success (g x),s)))) l ⇒
-      (s' = s) ∧ (res = M_success (term_image g l))`,
+      (s' = s) ∧ (res = M_success (term_image g l))
+Proof
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[st_ex_return_def,Once term_image_def] ) >>
   simp[st_ex_bind_def] >> rpt gen_tac >>
@@ -2025,7 +2143,8 @@ val image_lemma = Q.prove(
   BasicProvers.CASE_TAC >>
   simp[st_ex_return_def] >> strip_tac >>
   rpt BasicProvers.VAR_EQ_TAC >>
-  simp[] >> res_tac >> fs[])
+  simp[] >> res_tac >> fs[]
+QED
 
 Theorem INST_TYPE_thm:
    EVERY (\(t1,t2). TYPE defs t1 /\ TYPE defs t2) theta /\
@@ -2061,13 +2180,14 @@ Proof
   METIS_TAC[]
 QED
 
-val image_lemma = Q.prove(
-  `∀f l s g defs res s'.
+Triviality image_lemma:
+  ∀f l s g defs res s'.
       (image f l s = (res,s')) ∧ STATE defs s ⇒
       EVERY (λx. ∀s. STATE defs s ⇒
                      ∃r s'. ((f x s = (r,s))) ∧
                             (∀t. (r = M_success t) ⇒ (t = g x))) l ⇒
-      (s' = s) ∧ ∀ts. (res = M_success ts) ⇒ (ts = term_image g l)`,
+      (s' = s) ∧ ∀ts. (res = M_success ts) ⇒ (ts = term_image g l)
+Proof
   gen_tac >> Induct >> simp[Once image_def] >- (
     simp[st_ex_return_def,Once term_image_def] ) >>
   simp[st_ex_bind_def] >> rpt gen_tac >>
@@ -2080,7 +2200,8 @@ val image_lemma = Q.prove(
   BasicProvers.CASE_TAC >>
   simp[st_ex_return_def] >> strip_tac >>
   rpt BasicProvers.VAR_EQ_TAC >>
-  simp[] >> res_tac >> fs[])
+  simp[] >> res_tac >> fs[]
+QED
 
 Theorem INST_thm:
   (INST theta th1 s = (res, s')) /\
@@ -2180,27 +2301,32 @@ Definition STRCAT_SHADOW_def[nocompute]:
   STRCAT_SHADOW = STRCAT
 End
 
-val first_dup_thm = Q.prove(
-  `∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)`,
+Triviality first_dup_thm:
+  ∀ls acc. (first_dup ls acc = NONE) ⇒ ALL_DISTINCT ls ∧ (∀x. MEM x ls ⇒ ¬MEM x acc)
+Proof
   Induct >> simp[Once first_dup_def] >>
   rpt gen_tac >>
   BasicProvers.CASE_TAC >>
   strip_tac >> res_tac >>
-  fs[MEM] >> METIS_TAC[])
+  fs[MEM] >> METIS_TAC[]
+QED
 
-val first_dup_SOME = Q.prove(
-  `∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)`,
+Triviality first_dup_SOME:
+  ∀ls acc. (first_dup ls acc = SOME x) ⇒ ¬ALL_DISTINCT (ls++acc)
+Proof
   Induct >> simp[Once first_dup_def] >>
   rw[] >> fs[ALL_DISTINCT_APPEND] >>
   res_tac >> rw[] >> fs[ALL_DISTINCT] >> fs[] >>
-  METIS_TAC[])
+  METIS_TAC[]
+QED
 
-val add_constants_thm = Q.prove(
-  `∀ls s res s'. (add_constants ls s = (res,s')) ⇒
+Triviality add_constants_thm:
+  ∀ls s res s'. (add_constants ls s = (res,s')) ⇒
       (∀u. (res = M_success u) ∧ ALL_DISTINCT (MAP FST s.the_term_constants) ⇒
            ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants) ∧
            (s' = s with the_term_constants := ls++s.the_term_constants)) ∧
-      (∀msg. (res = M_failure msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))`,
+      (∀msg. (res = M_failure msg) ⇒ (s' = s) ∧ (¬ALL_DISTINCT (MAP FST ls ++ MAP FST s.the_term_constants)))
+Proof
   simp_tac std_ss [add_constants_def,GSYM STRCAT_SHADOW_def] >>
   simp[st_ex_bind_def,get_the_term_constants_def] >>
   rpt gen_tac >>
@@ -2212,7 +2338,8 @@ val add_constants_thm = Q.prove(
   Cases_on`res`>>
   fs[set_the_term_constants_def] >>
   rpt BasicProvers.VAR_EQ_TAC >> simp[] >>
-  simp[ALL_DISTINCT_APPEND])
+  simp[ALL_DISTINCT_APPEND]
+QED
 
 (* TODO move *)
 Theorem tyvars_EQ_thm:

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -574,22 +574,28 @@ End
   this a non-failing function to make it pure.
 *)
 
-val EXISTS_IMP = Q.prove(
-  `!xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x`,
-  Induct THEN SIMP_TAC (srw_ss()) [EXISTS_DEF] THEN METIS_TAC []);
+Triviality EXISTS_IMP:
+  !xs p. EXISTS p xs ==> ?x. MEM x xs /\ p x
+Proof
+  Induct THEN SIMP_TAC (srw_ss()) [EXISTS_DEF] THEN METIS_TAC []
+QED
 
-val MEM_subtract = Q.prove(
-  `!y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)`,
-  FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER] THEN METIS_TAC []);
+Triviality MEM_subtract:
+  !y z x. MEM x (subtract y z) = (MEM x y /\ ~MEM x z)
+Proof
+  FULL_SIMP_TAC std_ss [subtract_def,MEM_FILTER] THEN METIS_TAC []
+QED
 
-val vfree_in_IMP = Q.prove(
-  `!(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)`,
+Triviality vfree_in_IMP:
+  !(t:term) x v. vfree_in (Var v ty) x ==> MEM (Var v ty) (frees x)
+Proof
   HO_MATCH_MP_TAC (SIMP_RULE std_ss [] (vfree_in_ind))
   THEN REPEAT STRIP_TAC THEN Cases_on `x` THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [vfree_in_def,frees_def]
   THEN FULL_SIMP_TAC (srw_ss()) []
   THEN FULL_SIMP_TAC (srw_ss()) [MEM_union,MEM_subtract]
-  THEN REPEAT STRIP_TAC THEN RES_TAC THEN ASM_SIMP_TAC std_ss []);
+  THEN REPEAT STRIP_TAC THEN RES_TAC THEN ASM_SIMP_TAC std_ss []
+QED
 
 (*
   let vsubst =
@@ -676,21 +682,25 @@ Definition my_term_size_def:
   (my_term_size (Abs s1 s2) = 1 + my_term_size s1 + my_term_size s2)
 End
 
-val my_term_size_variant = Q.prove(
-  `!avoid t. my_term_size (variant avoid t) = my_term_size t`,
+Triviality my_term_size_variant:
+  !avoid t. my_term_size (variant avoid t) = my_term_size t
+Proof
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
-  THEN FULL_SIMP_TAC std_ss [my_term_size_def]);
+  THEN FULL_SIMP_TAC std_ss [my_term_size_def]
+QED
 
-val is_var_variant = Q.prove(
-  `!avoid t. is_var (variant avoid t) = is_var t`,
+Triviality is_var_variant:
+  !avoid t. is_var (variant avoid t) = is_var t
+Proof
   HO_MATCH_MP_TAC (variant_ind) THEN REPEAT STRIP_TAC
   THEN ONCE_REWRITE_TAC [variant_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) []
   THEN SRW_TAC [] [] THEN RES_TAC
-  THEN FULL_SIMP_TAC (srw_ss()) [my_term_size_def,fetch "-" "is_var_def"]);
+  THEN FULL_SIMP_TAC (srw_ss()) [my_term_size_def,fetch "-" "is_var_def"]
+QED
 
 val my_term_size_vsubst_aux = Q.prove(
   `!t xs. EVERY (\x. is_var (FST x)) xs ==>
@@ -714,9 +724,11 @@ val my_term_size_vsubst_aux = Q.prove(
   |> Q.SPECL [`t`,`[(Var v ty,x)]`]
   |> SIMP_RULE (srw_ss()) [EVERY_DEF,fetch "-" "is_var_def"]
 
-val ZERO_LT_term_size = Q.prove(
-  `!t. 0 < my_term_size t`,
-  Cases THEN EVAL_TAC THEN DECIDE_TAC);
+Triviality ZERO_LT_term_size:
+  !t. 0 < my_term_size t
+Proof
+  Cases THEN EVAL_TAC THEN DECIDE_TAC
+QED
 
 Definition inst_aux_def:
   (inst_aux (env:(term # term) list) tyin tm) =

--- a/candle/standard/syntax/holAxiomsSyntaxScript.sml
+++ b/candle/standard/syntax/holAxiomsSyntaxScript.sml
@@ -82,10 +82,12 @@ Definition mk_infinity_ctxt_def:
     ctxt
 End
 
-val tyvar_inst_exists = Q.prove(
-  `∃i. ty = REV_ASSOCD (Tyvar a) i b`,
+Triviality tyvar_inst_exists:
+  ∃i. ty = REV_ASSOCD (Tyvar a) i b
+Proof
   qexists_tac`[(ty,Tyvar a)]` >>
-  rw[REV_ASSOCD])
+  rw[REV_ASSOCD]
+QED
 
 Theorem infinity_extends:
    ∀ctxt. theory_ok (thyof ctxt) ∧

--- a/candle/standard/syntax/holConservativeScript.sml
+++ b/candle/standard/syntax/holConservativeScript.sml
@@ -9,18 +9,21 @@ val _ = new_theory "holConservative";
 
 (* Theorems that should probably be proved elsewhere (perhaps some already are) *)
 
-val CLOSED_INST = Q.prove (
-`!tm tysubst. CLOSED tm ∧ welltyped tm ⇒ CLOSED (INST tysubst tm)`,
+Triviality CLOSED_INST:
+  !tm tysubst. CLOSED tm ∧ welltyped tm ⇒ CLOSED (INST tysubst tm)
+Proof
   rw[INST_def] >>
   qspecl_then[`sizeof tm`,`tm`,`[]`,`tysubst`]mp_tac INST_CORE_HAS_TYPE >>
   simp[REV_ASSOCD] >> strip_tac >> simp[] >>
-  fs[CLOSED_def]);
+  fs[CLOSED_def]
+QED
 
-val type_ok_subst = Q.prove (
-`!tys i ty.
+Triviality type_ok_subst:
+  !tys i ty.
   type_ok tys (TYPE_SUBST i ty)
   ⇒
-  ?i'. EVERY (type_ok tys) (MAP FST i') ∧ TYPE_SUBST i' ty = TYPE_SUBST i ty`,
+  ?i'. EVERY (type_ok tys) (MAP FST i') ∧ TYPE_SUBST i' ty = TYPE_SUBST i ty
+Proof
   rpt strip_tac >>
   imp_res_tac type_ok_TYPE_SUBST_imp >>
   qexists_tac`MAP (λx. (TYPE_SUBST i (Tyvar x), Tyvar x)) (tyvars ty)` >>
@@ -28,7 +31,8 @@ val type_ok_subst = Q.prove (
   simp[TYPE_SUBST_tyvars] >>
   rpt(pop_assum kall_tac) >>
   qspec_tac(`tyvars ty`,`ls`) >>
-  Induct >> simp[REV_ASSOCD] >> rw[]);
+  Induct >> simp[REV_ASSOCD] >> rw[]
+QED
 
 Theorem term_image_term_union:
  !f h1 h2.
@@ -52,13 +56,14 @@ Proof
   ...
 QED
 
-val term_image_term_remove = Q.prove (
-`!x f tm tms.
+Triviality term_image_term_remove:
+  !x f tm tms.
   (!t1 t2. ACONV t1 t2 ⇒ ACONV (f t1) (f t2)) ∧
   hypset_ok tms ∧
   MEM x (term_remove (f tm) (term_image f tms)) ⇒
-  ?x'. MEM x' (term_image f (term_remove tm tms)) ∧ ACONV x x'`,
- rw [] >>
+  ?x'. MEM x' (term_image f (term_remove tm tms)) ∧ ACONV x x'
+Proof
+  rw [] >>
  imp_res_tac hypset_ok_term_image >>
  imp_res_tac MEM_term_remove_imp >>
  imp_res_tac MEM_term_image_imp >>
@@ -69,7 +74,8 @@ val term_image_term_remove = Q.prove (
      imp_res_tac MEM_term_image >>
      `hypset_ok (term_remove tm tms)` by metis_tac [hypset_ok_term_remove] >>
      fs [])
- >- metis_tac [MEM_term_remove]);
+ >- metis_tac [MEM_term_remove]
+QED
 
 (* End of theorems for elsewhere *)
 
@@ -98,13 +104,14 @@ Definition upd_to_subst_def:
 (upd_to_subst _ = [])
 End
 
-val updates_to_subst = Q.prove (
-`!upd ctxt.
+Triviality updates_to_subst:
+  !upd ctxt.
   upd updates ctxt
   ⇒
   const_subst_ok (upd_to_subst upd) ∧
-  ALOOKUP (upd_to_subst upd) (strlit "=") = NONE`,
- rw [updates_cases] >>
+  ALOOKUP (upd_to_subst upd) (strlit "=") = NONE
+Proof
+  rw [updates_cases] >>
  rw [upd_to_subst_def, const_subst_ok_def] >>
  imp_res_tac proves_theory_ok >>
  imp_res_tac theory_ok_sig
@@ -123,11 +130,13 @@ val updates_to_subst = Q.prove (
      imp_res_tac ALOOKUP_MEM >>
      res_tac >>
      fs [MEM_MAP] >>
-     metis_tac [pair_CASES, FST, SND]));
+     metis_tac [pair_CASES, FST, SND])
+QED
 
-val typeof_remove_const = Q.prove (
-`!tm thy s. const_subst_ok s ⇒ typeof (remove_const thy s tm) = typeof tm`,
- Induct_on `tm` >>
+Triviality typeof_remove_const:
+  !tm thy s. const_subst_ok s ⇒ typeof (remove_const thy s tm) = typeof tm
+Proof
+  Induct_on `tm` >>
  rw [remove_const_def] >>
  every_case_tac >>
  rw [] >>
@@ -143,16 +152,20 @@ val typeof_remove_const = Q.prove (
  Cases_on `?tysubst. TYPE_SUBST tysubst (typeof x) = t` >>
  fs [some_def] >>
  rw [] >>
- metis_tac [SELECT_THM]);
+ metis_tac [SELECT_THM]
+QED
 
-val remove_const_eq = Q.prove (
-`const_subst_ok s ∧ ALOOKUP s (strlit "=") = NONE ⇒
-  remove_const thy s (tm1 === tm2) = remove_const thy s tm1 === remove_const thy s tm2`,
- rw [equation_def, remove_const_def, typeof_remove_const]);
+Triviality remove_const_eq:
+  const_subst_ok s ∧ ALOOKUP s (strlit "=") = NONE ⇒
+  remove_const thy s (tm1 === tm2) = remove_const thy s tm1 === remove_const thy s tm2
+Proof
+  rw [equation_def, remove_const_def, typeof_remove_const]
+QED
 
-val has_type_remove_const = Q.prove (
-`!tm ty. tm has_type ty ⇒ !s. const_subst_ok s ⇒ remove_const thy s tm has_type ty`,
- ho_match_mp_tac has_type_ind >>
+Triviality has_type_remove_const:
+  !tm ty. tm has_type ty ⇒ !s. const_subst_ok s ⇒ remove_const thy s tm has_type ty
+Proof
+  ho_match_mp_tac has_type_ind >>
  rw [remove_const_def]
  >- rw [Once has_type_cases]
  >- (every_case_tac >>
@@ -171,11 +184,13 @@ val has_type_remove_const = Q.prove (
          rw [] >>
          metis_tac [SELECT_THM]))
  >- metis_tac [has_type_cases]
- >- rw [Once has_type_cases]);
+ >- rw [Once has_type_cases]
+QED
 
-val vfree_in_remove_const = Q.prove (
-`const_subst_ok s ∧ VFREE_IN (Var x ty) (remove_const thy s tm) ⇒ VFREE_IN (Var x ty) tm`,
- Induct_on `tm` >>
+Triviality vfree_in_remove_const:
+  const_subst_ok s ∧ VFREE_IN (Var x ty) (remove_const thy s tm) ⇒ VFREE_IN (Var x ty) tm
+Proof
+  Induct_on `tm` >>
  rw [VFREE_IN_def, remove_const_def] >>
  rw [VFREE_IN_def] >>
  every_case_tac >>
@@ -189,10 +204,11 @@ val vfree_in_remove_const = Q.prove (
            fs []) >>
  fs[const_subst_ok_def,EVERY_MEM] >>
  imp_res_tac ALOOKUP_MEM >> res_tac >> fs[] >>
- metis_tac [CLOSED_INST, CLOSED_def]);
+ metis_tac [CLOSED_INST, CLOSED_def]
+QED
 
-val type_ok_remove_upd = Q.prove (
-`!sig ty.
+Triviality type_ok_remove_upd:
+  !sig ty.
   type_ok sig ty
   ⇒
   !ctxt upd.
@@ -200,8 +216,9 @@ val type_ok_remove_upd = Q.prove (
     (!name pred v2 v3. upd ≠ TypeDefn name pred v2 v3) ∧
     sig = alist_to_fmap (types_of_upd upd) ⊌ tysof ctxt
     ⇒
-    type_ok (tysof ctxt) ty`,
- ho_match_mp_tac type_ok_ind >>
+    type_ok (tysof ctxt) ty
+Proof
+  ho_match_mp_tac type_ok_ind >>
  rw [type_ok_def]
  >- (Cases_on `upd` >>
      fs [FLOOKUP_UPDATE, FLOOKUP_FUNION] >>
@@ -209,16 +226,18 @@ val type_ok_remove_upd = Q.prove (
      fs []) >>
  fs [EVERY_MEM] >>
  rw [] >>
- metis_tac []);
+ metis_tac []
+QED
 
-val term_ok_remove_upd = Q.prove (
-`!upd ctxt tm thy.
+Triviality term_ok_remove_upd:
+  !upd ctxt tm thy.
   term_ok (alist_to_fmap (types_of_upd upd) ⊌ tysof ctxt, alist_to_fmap (consts_of_upd upd) ⊌ tmsof ctxt) tm ∧
   upd updates ctxt ∧
   (?consts p. upd = ConstSpec consts p)
   ⇒
-  term_ok (sigof ctxt) (remove_const (tysof ctxt) (upd_to_subst upd) tm)`,
- Induct_on `tm` >>
+  term_ok (sigof ctxt) (remove_const (tysof ctxt) (upd_to_subst upd) tm)
+Proof
+  Induct_on `tm` >>
  rw [term_ok_def, remove_const_def] >>
  rw [upd_to_subst_def]
  >- metis_tac [type_ok_remove_upd, update_distinct]
@@ -284,28 +303,34 @@ val term_ok_remove_upd = Q.prove (
  >- (imp_res_tac updates_to_subst >>
      fs [upd_to_subst_def] >>
      rw [typeof_remove_const])
- >- metis_tac [type_ok_remove_upd, update_distinct]);
+ >- metis_tac [type_ok_remove_upd, update_distinct]
+QED
 
-val theory_ok_remove_upd = Q.prove (
-`!sig ty.
+Triviality theory_ok_remove_upd:
+  !sig ty.
   (?consts p. upd = ConstSpec consts p) ∧
   upd updates ctxt
   ⇒
-  theory_ok (thyof ctxt)`,
- rw [updates_cases] >>
+  theory_ok (thyof ctxt)
+Proof
+  rw [updates_cases] >>
  imp_res_tac proves_theory_ok >>
- fs []);
+ fs []
+QED
 
-val remove_const_inst = Q.prove (
-`!tys consts tyin tm.
-  remove_const tys consts (INST tyin tm) = INST tyin (remove_const tys consts tm)`,
- Induct_on `tm` >>
+Triviality remove_const_inst:
+  !tys consts tyin tm.
+  remove_const tys consts (INST tyin tm) = INST tyin (remove_const tys consts tm)
+Proof
+  Induct_on `tm` >>
  rw [remove_const_def] >>
- ...);
+ ...
+QED
 
-val RACONV_REFL2 = Q.prove (
-`!tms tm. EVERY (\(x,y). (x ≠ y) ⇒ ~VFREE_IN x tm ∧ ~VFREE_IN y tm) tms ⇒ RACONV tms (tm,tm)`,
- Induct_on `tm` >>
+Triviality RACONV_REFL2:
+  !tms tm. EVERY (\(x,y). (x ≠ y) ⇒ ~VFREE_IN x tm ∧ ~VFREE_IN y tm) tms ⇒ RACONV tms (tm,tm)
+Proof
+  Induct_on `tm` >>
  rw [] >>
  rw [Once RACONV_cases]
  >- (pop_assum mp_tac >>
@@ -321,13 +346,15 @@ val RACONV_REFL2 = Q.prove (
      metis_tac [])
  >- (fs [EVERY_MEM, LAMBDA_PROD, FORALL_PROD] >>
      metis_tac [])
- >- ...);
+ >- ...
+QED
 
-val remove_const_raconv = Q.prove (
-`!tms tm. RACONV tms tm ⇒
+Triviality remove_const_raconv:
+  !tms tm. RACONV tms tm ⇒
   const_subst_ok consts ⇒
-  RACONV tms (remove_const tys consts (FST tm), remove_const tys consts (SND tm))`,
- ho_match_mp_tac RACONV_ind >>
+  RACONV tms (remove_const tys consts (FST tm), remove_const tys consts (SND tm))
+Proof
+  ho_match_mp_tac RACONV_ind >>
  rw [remove_const_def]
  >- rw [Once RACONV_cases]
  >- (Cases_on `ALOOKUP consts x` >>
@@ -348,42 +375,52 @@ val remove_const_raconv = Q.prove (
      `(?x y. p_1 = Var x y) ∧ (?x y. p_2 = Var x y)` by ... >>
      metis_tac [])
  >- rw [Once RACONV_cases]
- >- rw [Once RACONV_cases]);
+ >- rw [Once RACONV_cases]
+QED
 
-val remove_const_aconv = Q.prove (
-`!tm1 tm2. const_subst_ok consts ∧ ACONV tm1 tm2 ⇒ ACONV (remove_const tys consts tm1) (remove_const tys consts tm2)`,
- rw [ACONV_def] >>
+Triviality remove_const_aconv:
+  !tm1 tm2. const_subst_ok consts ∧ ACONV tm1 tm2 ⇒ ACONV (remove_const tys consts tm1) (remove_const tys consts tm2)
+Proof
+  rw [ACONV_def] >>
  imp_res_tac remove_const_raconv >>
- fs []);
+ fs []
+QED
 
-val remove_const_vsubst = Q.prove (
-`!tys consts tm.
+Triviality remove_const_vsubst:
+  !tys consts tm.
   remove_const tys consts (VSUBST ilist tm) =
-  VSUBST (MAP (λ(x,y). (remove_const tys consts x, y)) ilist) (remove_const tys consts tm)`,
- ...);
+  VSUBST (MAP (λ(x,y). (remove_const tys consts x, y)) ilist) (remove_const tys consts tm)
+Proof
+  ...
+QED
 
-val welltyped_remove_const = Q.prove (
-`!tys consts tm.
-  const_subst_ok consts ∧ welltyped tm ⇒ welltyped (remove_const tys consts tm)`,
- rw [WELLTYPED] >>
+Triviality welltyped_remove_const:
+  !tys consts tm.
+  const_subst_ok consts ∧ welltyped tm ⇒ welltyped (remove_const tys consts tm)
+Proof
+  rw [WELLTYPED] >>
  imp_res_tac has_type_remove_const >>
- rw [typeof_remove_const]);
+ rw [typeof_remove_const]
+QED
 
-val use_const_spec = Q.prove (
-`!ctxt consts p.
+Triviality use_const_spec:
+  !ctxt consts p.
   (thyof ctxt,MAP (λ(s,t). Var s (typeof t) === t) consts) |- p
   ⇒
   (thyof ctxt,[]) |-
-  remove_const (tysof ctxt) consts (VSUBST (MAP (λ(s,t). (Const s (typeof t),Var s (typeof t))) consts) p)`,
- ...);
+  remove_const (tysof ctxt) consts (VSUBST (MAP (λ(s,t). (Const s (typeof t),Var s (typeof t))) consts) p)
+Proof
+  ...
+QED
 
-val remove_const_old_axiom = Q.prove (
-`!ctxt consts tm.
+Triviality remove_const_old_axiom:
+  !ctxt consts tm.
   term_ok (sigof ctxt) tm ∧
   (∀s. MEM s (MAP FST consts) ⇒ ¬MEM s (MAP FST (const_list ctxt)))
   ⇒
-  remove_const (tysof ctxt) consts tm = tm`,
- Induct_on `tm` >>
+  remove_const (tysof ctxt) consts tm = tm
+Proof
+  Induct_on `tm` >>
  rw [remove_const_def] >>
  every_case_tac >>
  fs [] >>
@@ -392,16 +429,19 @@ val remove_const_old_axiom = Q.prove (
  res_tac >>
  fs [FORALL_PROD] >>
  imp_res_tac ALOOKUP_MEM >>
- metis_tac []);
+ metis_tac []
+QED
 
-val proves_hypset_ok = Q.prove (
-`!thy h c. (thy,h) |- c ⇒ hypset_ok h`,
- rw [] >>
+Triviality proves_hypset_ok:
+  !thy h c. (thy,h) |- c ⇒ hypset_ok h
+Proof
+  rw [] >>
  imp_res_tac proves_term_ok >>
- fs []);
+ fs []
+QED
 
-val update_conservative = Q.prove (
-`!lhs tm.
+Triviality update_conservative:
+  !lhs tm.
   lhs |- tm
   ⇒
   !ctxt tms upd.
@@ -409,8 +449,9 @@ val update_conservative = Q.prove (
     upd updates ctxt ∧
     (?consts p. upd = ConstSpec consts p)
     ⇒
-    (thyof ctxt,term_image (remove_const (tysof (upd::ctxt)) (upd_to_subst upd)) tms) |- remove_const (tysof (upd::ctxt)) (upd_to_subst upd) tm`,
- ho_match_mp_tac proves_strongind >>
+    (thyof ctxt,term_image (remove_const (tysof (upd::ctxt)) (upd_to_subst upd)) tms) |- remove_const (tysof (upd::ctxt)) (upd_to_subst upd) tm
+Proof
+  ho_match_mp_tac proves_strongind >>
  rw [] >>
  imp_res_tac proves_hypset_ok >>
  imp_res_tac updates_to_subst >>
@@ -574,7 +615,8 @@ val update_conservative = Q.prove (
          fs [theory_ok_def] >>
          res_tac >>
          rw [term_image_def] >>
-         metis_tac [remove_const_old_axiom])));
+         metis_tac [remove_const_old_axiom]))
+QED
 
 *)
 

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -380,16 +380,19 @@ Proof
   rw[term_cmp_def,TO_of_LinearOrder]
 QED
 
-val irreflexive_type_lt = Q.prove(
-  `irreflexive type_lt`,
+Triviality irreflexive_type_lt:
+  irreflexive type_lt
+Proof
   mp_tac StrongLinearOrder_mlstring_lt >>
   simp[StrongLinearOrder,StrongOrder,irreflexive_def] >>
   strip_tac >> ho_match_mp_tac type_ind >>
   simp[type_lt_thm,LEX_DEF] >>
-  Induct >> simp[])
+  Induct >> simp[]
+QED
 
-val trichotomous_type_lt = Q.prove(
-  `trichotomous type_lt`,
+Triviality trichotomous_type_lt:
+  trichotomous type_lt
+Proof
   mp_tac StrongLinearOrder_mlstring_lt >>
   simp[StrongLinearOrder,trichotomous] >> strip_tac >>
   ho_match_mp_tac type_ind >>
@@ -403,10 +406,12 @@ val trichotomous_type_lt = Q.prove(
   Induct_on`l` >>
   Cases_on`l2`>>simp[]>>
   rw[] >> fs[] >>
-  metis_tac[])
+  metis_tac[]
+QED
 
-val transitive_type_lt = Q.prove(
-  `∀x y. type_lt x y ⇒ ∀z. type_lt y z ⇒ type_lt x z`,
+Triviality transitive_type_lt:
+  ∀x y. type_lt x y ⇒ ∀z. type_lt y z ⇒ type_lt x z
+Proof
   ho_match_mp_tac type_lt_strongind >>
   rpt conj_tac >> rpt gen_tac >> simp[PULL_FORALL] >>
   Cases_on`z` >> simp[type_lt_thm,LEX_DEF_THM] >-
@@ -468,7 +473,8 @@ val transitive_type_lt = Q.prove(
   fs[LIST_EQ_REWRITE,rich_listTheory.EL_TAKE] >>
   rfs[LIST_EQ_REWRITE,rich_listTheory.EL_TAKE] >>
   `LENGTH args1 ≤ LENGTH l` by DECIDE_TAC >> simp[] >>
-  simp[rich_listTheory.EL_TAKE])
+  simp[rich_listTheory.EL_TAKE]
+QED
 
 Theorem StrongLinearOrder_type_lt:
    StrongLinearOrder type_lt
@@ -485,31 +491,37 @@ Proof
   ACCEPT_TAC StrongLinearOrder_type_lt
 QED
 
-val irreflexive_term_lt = Q.prove(
-  `irreflexive term_lt`,
+Triviality irreflexive_term_lt:
+  irreflexive term_lt
+Proof
   mp_tac StrongLinearOrder_mlstring_lt >>
   mp_tac StrongLinearOrder_type_lt >>
   simp[StrongLinearOrder,StrongOrder,irreflexive_def] >>
   ntac 2 strip_tac >> ho_match_mp_tac term_induction >>
-  simp[term_lt_thm,LEX_DEF])
+  simp[term_lt_thm,LEX_DEF]
+QED
 
-val trichotomous_term_lt = Q.prove(
-  `trichotomous term_lt`,
+Triviality trichotomous_term_lt:
+  trichotomous term_lt
+Proof
   mp_tac StrongLinearOrder_mlstring_lt >>
   mp_tac StrongLinearOrder_type_lt >>
   simp[StrongLinearOrder,trichotomous] >> ntac 2 strip_tac >>
   ho_match_mp_tac term_induction >>
   rpt conj_tac >> rpt gen_tac >> TRY(strip_tac) >>
   Cases_on`b` >> simp[term_lt_thm,LEX_DEF_THM] >>
-  metis_tac[])
+  metis_tac[]
+QED
 
-val transitive_term_lt = Q.prove(
-  `∀x y. term_lt x y ⇒ ∀z. term_lt y z ⇒ term_lt x z`,
+Triviality transitive_term_lt:
+  ∀x y. term_lt x y ⇒ ∀z. term_lt y z ⇒ term_lt x z
+Proof
   ho_match_mp_tac term_lt_strongind >>
   rpt conj_tac >> rpt gen_tac >> simp[PULL_FORALL] >>
   Cases_on`z` >> simp[term_lt_thm,LEX_DEF_THM] >>
   metis_tac[StrongLinearOrder_mlstring_lt,StrongLinearOrder_type_lt,StrongLinearOrder,
-            StrongOrder,transitive_def])
+            StrongOrder,transitive_def]
+QED
 
 Theorem StrongLinearOrder_term_lt:
    StrongLinearOrder term_lt
@@ -526,15 +538,19 @@ Proof
   ACCEPT_TAC StrongLinearOrder_term_lt
 QED
 
-val StrongLinearOrder_irreflexive = Q.prove(
-  `StrongLinearOrder R ⇒ irreflexive R`,
-  rw[StrongLinearOrder,StrongOrder])
+Triviality StrongLinearOrder_irreflexive:
+  StrongLinearOrder R ⇒ irreflexive R
+Proof
+  rw[StrongLinearOrder,StrongOrder]
+QED
 
 val irreflexive_mlstring_lt = MATCH_MP StrongLinearOrder_irreflexive StrongLinearOrder_mlstring_lt
 
-val LLEX_irreflexive = Q.prove(
-  `∀R. irreflexive R ⇒ irreflexive (LLEX R)`,
-  rw[irreflexive_def] >> Induct_on`x`>>rw[])
+Triviality LLEX_irreflexive:
+  ∀R. irreflexive R ⇒ irreflexive (LLEX R)
+Proof
+  rw[irreflexive_def] >> Induct_on`x`>>rw[]
+QED
 
 val irreflexive_LLEX_type_lt = MATCH_MP LLEX_irreflexive (irreflexive_type_lt)
 
@@ -675,19 +691,23 @@ QED
 
 (* alpha ordering *)
 
-val ALPHAVARS_ordav = Q.prove(
-  `∀env tp. ALPHAVARS env tp ⇒ ordav env (FST tp) (SND tp) = EQUAL`,
+Triviality ALPHAVARS_ordav:
+  ∀env tp. ALPHAVARS env tp ⇒ ordav env (FST tp) (SND tp) = EQUAL
+Proof
   Induct >> rw[ALPHAVARS_def,ordav_def] >>
   Cases_on`h`>>rw[ordav_def] >> fs[] >>
   rfs[term_cmp_def,TO_of_LinearOrder] >>
-  ntac 2 (pop_assum mp_tac) >> rw[])
+  ntac 2 (pop_assum mp_tac) >> rw[]
+QED
 
-val ordav_ALPHAVARS = Q.prove(
-  `∀env t1 t2. ordav env t1 t2 = EQUAL ⇒ ALPHAVARS env (t1,t2)`,
+Triviality ordav_ALPHAVARS:
+  ∀env t1 t2. ordav env t1 t2 = EQUAL ⇒ ALPHAVARS env (t1,t2)
+Proof
   ho_match_mp_tac ordav_ind >>
   rw[ALPHAVARS_def,ordav_def] >>
   fs[term_cmp_def,TO_of_LinearOrder] >>
-  rpt(pop_assum mp_tac) >> rw[])
+  rpt(pop_assum mp_tac) >> rw[]
+QED
 
 Theorem ALPHAVARS_eq_ordav:
    ∀env t1 t2. ALPHAVARS env (t1,t2) ⇔ ordav env t1 t2 = EQUAL
@@ -695,14 +715,17 @@ Proof
   metis_tac[ALPHAVARS_ordav,ordav_ALPHAVARS,pair_CASES,FST,SND]
 QED
 
-val RACONV_orda = Q.prove(
-  `∀env tp. RACONV env tp ⇒ orda env (FST tp) (SND tp) = EQUAL`,
+Triviality RACONV_orda:
+  ∀env tp. RACONV env tp ⇒ orda env (FST tp) (SND tp) = EQUAL
+Proof
   ho_match_mp_tac RACONV_ind >> rw[ALPHAVARS_eq_ordav]
   >- rw[orda_def] >- rw[orda_def] >- rw[Once orda_def] >>
-  rw[Once orda_def])
+  rw[Once orda_def]
+QED
 
-val orda_RACONV = Q.prove(
-  `∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)`,
+Triviality orda_RACONV:
+  ∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)
+Proof
   ho_match_mp_tac orda_ind >> rw[] >>
   reverse(Cases_on`t1 ≠ t2 ∨ env ≠ []`) >- (
     fs[RACONV_REFL] ) >>
@@ -719,7 +742,8 @@ val orda_RACONV = Q.prove(
     rw[term_cmp_def,TO_of_LinearOrder] >>
     NO_TAC) >> fs[] >>
   qhdtm_x_assum`type_cmp`mp_tac >>
-  rw[type_cmp_def,TO_of_LinearOrder])
+  rw[type_cmp_def,TO_of_LinearOrder]
+QED
 
 Theorem RACONV_eq_orda:
    ∀env t1 t2. RACONV env (t1,t2) ⇔ orda env t1 t2 = EQUAL
@@ -776,22 +800,25 @@ Proof
   simp[]
 QED
 
-val orda_thm = Q.prove(
-  `∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))`,
+Triviality orda_thm:
+  ∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))
+Proof
   rpt gen_tac >>
   CONV_TAC(LAND_CONV(REWR_CONV orda_def)) >>
   reverse IF_CASES_TAC >- rw[] >> rw[] >>
   BasicProvers.CASE_TAC >> rw[ordav_def] >>
-  fs[GSYM RACONV_eq_orda,RACONV_REFL])
+  fs[GSYM RACONV_eq_orda,RACONV_REFL]
+QED
 
-val ordav_lx_trans = Q.prove(
-  `∀t1 t2 t3 env1 env2.
+Triviality ordav_lx_trans:
+  ∀t1 t2 t3 env1 env2.
     ordav env1 t1 t2 ≠ GREATER ∧
     ordav env2 t2 t3 ≠ GREATER ∧
     MAP SND env1 = MAP FST env2
     ⇒ ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 ≠ GREATER ∧
       (ordav env1 t1 t2 = LESS ∨ ordav env2 t2 t3 = LESS ⇒
-       ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)`,
+       ordav (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)
+Proof
   mp_tac TotOrd_term_cmp >> simp[TotOrd] >> strip_tac >>
   ntac 3 gen_tac >> Induct >> simp[ordav_def] >- (
     metis_tac[cpn_nchotomy,cpn_distinct] ) >>
@@ -799,21 +826,25 @@ val ordav_lx_trans = Q.prove(
   Cases >> simp[] >>
   Cases_on`h` >>
   rw[ordav_def] >>
-  metis_tac[cpn_nchotomy,cpn_distinct] )
+  metis_tac[cpn_nchotomy,cpn_distinct]
+QED
 
-val undo_zip_map_fst = Q.prove(
-  `p::ZIP(MAP FST l1,MAP SND l2) =
-    ZIP (MAP FST ((FST p,v2)::l1), MAP SND ((v2,SND p)::l2))`,
-  Cases_on`p`>>rw[])
+Triviality undo_zip_map_fst:
+  p::ZIP(MAP FST l1,MAP SND l2) =
+    ZIP (MAP FST ((FST p,v2)::l1), MAP SND ((v2,SND p)::l2))
+Proof
+  Cases_on`p`>>rw[]
+QED
 
-val orda_lx_trans = Q.prove(
-  `∀env1 t1 t2 env2 t3.
+Triviality orda_lx_trans:
+  ∀env1 t1 t2 env2 t3.
     orda env1 t1 t2 ≠ GREATER ∧
     orda env2 t2 t3 ≠ GREATER ∧
     MAP SND env1 = MAP FST env2
     ⇒ orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 ≠ GREATER ∧
       (orda env1 t1 t2 = LESS ∨ orda env2 t2 t3 = LESS ⇒
-       orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)`,
+       orda (ZIP (MAP FST env1, MAP SND env2)) t1 t3 = LESS)
+Proof
   completeInduct_on`term_size t1 + term_size t2 + term_size t3` >>
   rpt gen_tac >> strip_tac >>
   BasicProvers.VAR_EQ_TAC >>
@@ -906,7 +937,8 @@ val orda_lx_trans = Q.prove(
         (fn g as (asl,w) => (Cases_on`^(lhs w)`>>fs[]) g) >>
         NO_TAC)
       [`t1`,`t2`,`t3`,`t4`,`t5`,`t6`]))) >>
-  metis_tac[cpn_nchotomy,cpn_distinct])
+  metis_tac[cpn_nchotomy,cpn_distinct]
+QED
 
 Theorem transitive_alpha_lt:
    transitive alpha_lt
@@ -1100,10 +1132,12 @@ Proof
   metis_tac[MEM,ACONV_REFL,ACONV_SYM,hypset_ok_cons]
 QED
 
-val term_union_sing_lt = Q.prove(
-  `∀ys x. EVERY (λy. alpha_lt x y) ys ⇒ (term_union [x] ys = x::ys)`,
+Triviality term_union_sing_lt:
+  ∀ys x. EVERY (λy. alpha_lt x y) ys ⇒ (term_union [x] ys = x::ys)
+Proof
   Induct >> simp[term_union_thm] >> rw[] >> fs[] >>
-  fs[alpha_lt_def])
+  fs[alpha_lt_def]
+QED
 
 Theorem term_union_insert:
    ∀ys x zs.
@@ -3140,23 +3174,26 @@ val rws = [
   rich_listTheory.EL_DROP,
   rich_listTheory.EL_CONS]
 
-val proves_concl_ACONV = Q.prove(
-  `∀thyh c c'. thyh |- c ∧ ACONV c c' ∧ welltyped c' ⇒ thyh |- c'`,
+Triviality proves_concl_ACONV:
+  ∀thyh c c'. thyh |- c ∧ ACONV c c' ∧ welltyped c' ⇒ thyh |- c'
+Proof
   rw[] >>
   qspecl_then[`c'`,`FST thyh`]mp_tac refl_equation >>
   imp_res_tac proves_theory_ok >>
   imp_res_tac proves_term_ok >> fs[] >>
   imp_res_tac term_ok_aconv >> pop_assum kall_tac >> simp[] >>
   Cases_on`thyh`>>fs[]>>
-  metis_tac[eqMp_equation,term_union_thm,ACONV_SYM] )
+  metis_tac[eqMp_equation,term_union_thm,ACONV_SYM]
+QED
 
-val proves_ACONV_lemma = Q.prove(
-  `∀thy c h' h1 h.
+Triviality proves_ACONV_lemma:
+  ∀thy c h' h1 h.
     (thy,h1++h) |- c ∧
     hypset_ok (h1++h') ∧
     EVERY (λx. EXISTS (ACONV x) h') h ∧
     EVERY (λx. term_ok (sigof thy) x ∧ x has_type Bool) h'
-    ⇒ (thy,h1++h') |- c`,
+    ⇒ (thy,h1++h') |- c
+Proof
   ntac 2 gen_tac >> Induct >> rw[] >> rw[] >>
   imp_res_tac proves_term_ok >> fs[hypset_ok_cons] >>
   Cases_on`EXISTS (ACONV h) h''` >- (
@@ -3234,7 +3271,8 @@ val proves_ACONV_lemma = Q.prove(
     qpat_x_assum`EVERY P1 X`kall_tac >>
     fs[EVERY_MEM,EXISTS_MEM] >>
     metis_tac[ACONV_SYM] ) >>
-  metis_tac[rich_listTheory.CONS_APPEND,APPEND_ASSOC])
+  metis_tac[rich_listTheory.CONS_APPEND,APPEND_ASSOC]
+QED
 
 Theorem proves_ACONV:
    ∀thy h' c' h c.
@@ -3730,15 +3768,16 @@ QED
 
 (* proofs still work in extended contexts *)
 
-val update_extension = Q.prove (
-    `!lhs tm.
+Triviality update_extension:
+  !lhs tm.
       lhs |- tm
       ⇒
       !ctxt tms upd.
         lhs = (thyof ctxt,tms) ∧
         upd updates ctxt
         ⇒
-        (thyof (upd::ctxt),tms) |- tm`,
+        (thyof (upd::ctxt),tms) |- tm
+Proof
   ho_match_mp_tac proves_ind >>
   rw []
   >- (rw [Once proves_cases] >>
@@ -3856,7 +3895,8 @@ val update_extension = Q.prove (
       >- (imp_res_tac updates_theory_ok >>
           fs [])
       >- (Cases_on `ctxt` >>
-          fs [])));
+          fs []))
+QED
 
 Theorem updates_proves:
    ∀upd ctxt.  upd updates ctxt ⇒
@@ -3906,15 +3946,19 @@ Proof
   ho_match_mp_tac term_induction >> rw[] >> rw[]
 QED
 
-val Var_subterm_types_in = Q.prove(
-  `∀t x ty. Var x ty subterm t ⇒ ty ∈ types_in t`,
+Triviality Var_subterm_types_in:
+  ∀t x ty. Var x ty subterm t ⇒ ty ∈ types_in t
+Proof
   ho_match_mp_tac term_induction >> rw[subterm_Comb,subterm_Abs] >>
-  metis_tac[])
+  metis_tac[]
+QED
 
-val Const_subterm_types_in = Q.prove(
-  `∀t x ty. Const x ty subterm t ⇒ ty ∈ types_in t`,
+Triviality Const_subterm_types_in:
+  ∀t x ty. Const x ty subterm t ⇒ ty ∈ types_in t
+Proof
   ho_match_mp_tac term_induction >> rw[subterm_Comb,subterm_Abs] >>
-  metis_tac[])
+  metis_tac[]
+QED
 
 Theorem subterm_typeof_types_in:
    ∀t1 t2 name args. (Tyapp name args) subtype (typeof t1) ∧ t1 subterm t2 ∧ welltyped t2 ∧ name ≠ (strlit"fun") ⇒

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -266,9 +266,11 @@ Proof
   simp[GSYM MEMBER_NOT_EMPTY] >> rw[] >> metis_tac[]
 QED
 
-val LEAST_EXISTS = Q.prove(
-  `(∃n:num. P n) ⇒ ∃k. P k ∧ ∀m. m < k ⇒ ¬(P m)`,
-  metis_tac[whileTheory.LEAST_EXISTS])
+Triviality LEAST_EXISTS:
+  (∃n:num. P n) ⇒ ∃k. P k ∧ ∀m. m < k ⇒ ¬(P m)
+Proof
+  metis_tac[whileTheory.LEAST_EXISTS]
+QED
 
 val VARIANT_PRIMES_def = new_specification
   ("VARIANT_PRIMES_def"

--- a/candle/syntax-lib/holSyntaxLibScript.sml
+++ b/candle/syntax-lib/holSyntaxLibScript.sml
@@ -210,8 +210,9 @@ Definition INORDER_INSERT_def:
    (APPEND [x] (FILTER (λy. string_lt x y) xs))
 End
 
-val LENGTH_INORDER_INSERT = Q.prove(
-  `!xs. ALL_DISTINCT (x::xs) ==> (LENGTH (INORDER_INSERT x xs) = SUC (LENGTH xs))`,
+Triviality LENGTH_INORDER_INSERT:
+  !xs. ALL_DISTINCT (x::xs) ==> (LENGTH (INORDER_INSERT x xs) = SUC (LENGTH xs))
+Proof
   FULL_SIMP_TAC std_ss [INORDER_INSERT_def,LENGTH_APPEND,LENGTH]
   \\ FULL_SIMP_TAC std_ss [ALL_DISTINCT] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [DECIDE ``1 + n = SUC n``]
@@ -221,20 +222,25 @@ val LENGTH_INORDER_INSERT = Q.prove(
   \\ Q.MATCH_ASSUM_RENAME_TAC `MEM y xs`
   \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `x = y` \\ FULL_SIMP_TAC std_ss []
-  \\ METIS_TAC [stringTheory.string_lt_cases,stringTheory.string_lt_antisym]);
+  \\ METIS_TAC [stringTheory.string_lt_cases,stringTheory.string_lt_antisym]
+QED
 
-val ALL_DISTINCT_INORDER_INSERT = Q.prove(
-  `!xs h. ALL_DISTINCT xs ==> ALL_DISTINCT (INORDER_INSERT h xs)`,
+Triviality ALL_DISTINCT_INORDER_INSERT:
+  !xs h. ALL_DISTINCT xs ==> ALL_DISTINCT (INORDER_INSERT h xs)
+Proof
   FULL_SIMP_TAC (srw_ss()) [ALL_DISTINCT,INORDER_INSERT_def,
     ALL_DISTINCT_APPEND,MEM_FILTER] \\ REPEAT STRIP_TAC
   \\ TRY (MATCH_MP_TAC FILTER_ALL_DISTINCT)
   \\ FULL_SIMP_TAC (srw_ss()) [stringTheory.string_lt_nonrefl]
-  \\ METIS_TAC [stringTheory.string_lt_antisym]);
+  \\ METIS_TAC [stringTheory.string_lt_antisym]
+QED
 
-val ALL_DISTINCT_FOLDR_INORDER_INSERT = Q.prove(
-  `!xs. ALL_DISTINCT (FOLDR INORDER_INSERT [] xs)`,
+Triviality ALL_DISTINCT_FOLDR_INORDER_INSERT:
+  !xs. ALL_DISTINCT (FOLDR INORDER_INSERT [] xs)
+Proof
   Induct \\ SIMP_TAC std_ss [ALL_DISTINCT,FOLDR] \\ REPEAT STRIP_TAC
-  \\ MATCH_MP_TAC ALL_DISTINCT_INORDER_INSERT \\ FULL_SIMP_TAC std_ss []);
+  \\ MATCH_MP_TAC ALL_DISTINCT_INORDER_INSERT \\ FULL_SIMP_TAC std_ss []
+QED
 
 Theorem MEM_FOLDR_INORDER_INSERT:
    !xs x. MEM x (FOLDR INORDER_INSERT [] xs) = MEM x xs

--- a/characteristic/cfAppScript.sml
+++ b/characteristic/cfAppScript.sml
@@ -61,8 +61,9 @@ Definition app_basic_def:
         Q r h_f /\ evaluate_to_heap st env exp p heap r
 End
 
-val app_basic_local = Q.prove (
-  `!f x. is_local (app_basic p f x)`,
+Triviality app_basic_local:
+  !f x. is_local (app_basic p f x)
+Proof
   simp [is_local_def] \\ rpt strip_tac \\
   irule EQ_EXT \\ qx_gen_tac `H` \\ irule EQ_EXT \\ qx_gen_tac `Q` \\
   eq_tac \\ fs [local_elim] \\
@@ -83,7 +84,7 @@ val app_basic_local = Q.prove (
   disch_then (assume_tac o REWRITE_RULE [STAR_def]) \\ fs [] \\
   instantiate \\ rename1 `GC h_g'` \\ qexists_tac `h_g' UNION h_g` \\
   SPLIT_TAC
-);
+QED
 
 (* [app]: n-ary application *)
 Definition app_def:
@@ -390,30 +391,37 @@ Proof
   \\ simp[]
 QED
 
-val forall_cases = Q.prove(
-  `(!x. P x) <=> (!x1 x2. P (Mem x1 x2)) /\
+Triviality forall_cases:
+  (!x. P x) <=> (!x1 x2. P (Mem x1 x2)) /\
                   (P FFI_split) /\
                   (!x3 x4 x2 x1. P (FFI_part x1 x2 x3 x4)) /\
-                  (!x1. P (FFI_full x1))`,
-  EQ_TAC \\ rw [] \\ Cases_on `x` \\ fs []);
+                  (!x1. P (FFI_full x1))
+Proof
+  EQ_TAC \\ rw [] \\ Cases_on `x` \\ fs []
+QED
 
-val SPLIT_UNION_IMP_SUBSET = Q.prove(
-  `SPLIT x (y UNION y1,y2) ==> y1 SUBSET x`,
-  SPLIT_TAC);
+Triviality SPLIT_UNION_IMP_SUBSET:
+  SPLIT x (y UNION y1,y2) ==> y1 SUBSET x
+Proof
+  SPLIT_TAC
+QED
 
-val FILTER_ffi_has_index_in_EQ_NIL = Q.prove(
-  `~(MEM n xs) /\ EVERY (ffi_has_index_in xs) ys ==>
-    FILTER (ffi_has_index_in [n]) ys = []`,
+Triviality FILTER_ffi_has_index_in_EQ_NIL:
+  ~(MEM n xs) /\ EVERY (ffi_has_index_in xs) ys ==>
+    FILTER (ffi_has_index_in [n]) ys = []
+Proof
   Induct_on `ys` \\ fs [] \\ rw [] \\ fs []
   \\ Cases_on `h` \\ Cases_on `f`
   \\ fs [ffi_has_index_in_def] \\ rw []
-  \\ CCONTR_TAC \\ fs [] \\ fs [ffi_has_index_in_def]);
+  \\ CCONTR_TAC \\ fs [] \\ fs [ffi_has_index_in_def]
+QED
 
-val FILTER_ffi_has_index_in_MEM = Q.prove(
-  `!ys zs xs x.
+Triviality FILTER_ffi_has_index_in_MEM:
+  !ys zs xs x.
       MEM x xs /\
       FILTER (ffi_has_index_in xs) ys = FILTER (ffi_has_index_in xs) zs ==>
-      FILTER (ffi_has_index_in [x]) ys = FILTER (ffi_has_index_in [x]) zs`,
+      FILTER (ffi_has_index_in [x]) ys = FILTER (ffi_has_index_in [x]) zs
+Proof
   once_rewrite_tac [EQ_SYM_EQ] \\ Induct \\ fs [] THEN1
    (fs [listTheory.FILTER_EQ_NIL] \\ fs [EVERY_MEM] \\ rw []
     \\ res_tac \\ Cases_on `x'` \\ Cases_on `f`
@@ -439,15 +447,17 @@ val FILTER_ffi_has_index_in_MEM = Q.prove(
   \\ fs [FILTER_APPEND]
   \\ fs [GSYM FILTER_APPEND]
   \\ first_x_assum match_mp_tac \\ fs [] \\ asm_exists_tac \\ fs []
-  \\ fs [FILTER_APPEND]);
+  \\ fs [FILTER_APPEND]
+QED
 
-val LENGTH_FILTER_EQ_IMP_EMPTY = Q.prove(
-  `!xs l.
+Triviality LENGTH_FILTER_EQ_IMP_EMPTY:
+  !xs l.
       (!io_ev. MEM io_ev l ==>
         ?s bs bs'. io_ev = IO_event (ExtCall s) bs bs') /\
       (∀n. LENGTH (FILTER (ffi_has_index_in [n]) (xs ++ l)) =
            LENGTH (FILTER (ffi_has_index_in [n]) xs)) ==>
-      l = []`,
+      l = []
+Proof
   Induct THEN1
    (rw[] \\ Cases_on `l` \\ fs []
     \\ Cases_on `h` \\ Cases_on `f`
@@ -462,38 +472,47 @@ val LENGTH_FILTER_EQ_IMP_EMPTY = Q.prove(
   \\ rw[]
   \\ pop_assum $ qspec_then `n` assume_tac
   \\ Cases_on `ffi_has_index_in [n] h`
-  \\ fs[LENGTH]);
+  \\ fs[LENGTH]
+QED
 
-val IN_DISJOINT_LEMMA1 = Q.prove(
-  `!s. x IN h_g /\ DISJOINT s h_g ==> ~(x IN s)`,
-  SPLIT_TAC);
+Triviality IN_DISJOINT_LEMMA1:
+  !s. x IN h_g /\ DISJOINT s h_g ==> ~(x IN s)
+Proof
+  SPLIT_TAC
+QED
 
-val FFI_part_EXISTS = Q.prove(
-  `parts_ok s1 (p0,p1) /\ parts_ok s2 (p0,p1) /\
+Triviality FFI_part_EXISTS:
+  parts_ok s1 (p0,p1) /\ parts_ok s2 (p0,p1) /\
     FFI_part x1 x2 x3 x4 ∈ ffi2heap (p0,p1) s1 ==>
-    ?y1 y2 y4. FFI_part y1 y2 x3 y4 ∈ ffi2heap (p0,p1) s2`,
+    ?y1 y2 y4. FFI_part y1 y2 x3 y4 ∈ ffi2heap (p0,p1) s2
+Proof
   strip_tac \\ rfs [ffi2heap_def] \\ asm_exists_tac \\ fs []
-  \\ fs [parts_ok_def] \\ metis_tac []);
+  \\ fs [parts_ok_def] \\ metis_tac []
+QED
 
-val ALL_DISTINCT_FLAT_MEM_IMP = Q.prove(
-  `!p1 x x2 y2.
+Triviality ALL_DISTINCT_FLAT_MEM_IMP:
+  !p1 x x2 y2.
       ALL_DISTINCT (FLAT (MAP FST p1)) /\ x <> [] /\
-      MEM (x,x2) p1 /\ MEM (x,y2) p1 ==> x2 = y2`,
+      MEM (x,x2) p1 /\ MEM (x,y2) p1 ==> x2 = y2
+Proof
   Induct \\ fs [] \\ Cases \\ fs [ALL_DISTINCT_APPEND]
   \\ rw [] \\ res_tac \\ rveq
   \\ Cases_on `MEM (q,r) p1` \\ fs [] \\ res_tac
   \\ fs [MEM_FLAT,MEM_MAP,FORALL_PROD]
   \\ Cases_on `q` \\ fs []
-  \\ metis_tac [MEM]);
+  \\ metis_tac [MEM]
+QED
 
-val FFI_part_11 = Q.prove(
-  `parts_ok s1 (p0,p1) /\ parts_ok s2 (p0,p1) /\
+Triviality FFI_part_11:
+  parts_ok s1 (p0,p1) /\ parts_ok s2 (p0,p1) /\
     FFI_part x1 x2 x3 x4 ∈ ffi2heap (p0,p1) s1 /\
     FFI_part y1 y2 x3 y4 ∈ ffi2heap (p0,p1) s1 ==>
-    x1 = y1 /\ x2 = y2 /\ x4 = y4`,
+    x1 = y1 /\ x2 = y2 /\ x4 = y4
+Proof
   strip_tac \\ rfs [ffi2heap_def]
   \\ Cases_on `x3` \\ fs [] \\ fs [parts_ok_def]
-  \\ imp_res_tac ALL_DISTINCT_FLAT_MEM_IMP \\ fs []);
+  \\ imp_res_tac ALL_DISTINCT_FLAT_MEM_IMP \\ fs []
+QED
 
 Theorem SPLIT_st2heap_ffi:
    SPLIT (st2heap p st') (st2heap p st, h_g) ⇒

--- a/characteristic/cfDivScript.sml
+++ b/characteristic/cfDivScript.sml
@@ -349,8 +349,8 @@ Definition mk_tailrec_closure_def:
     od) /\ mk_tailrec_closure _ = NONE
 End
 
-val mk_single_app_F_unchanged_gen = Q.prove(
-  `(!fname allow_fname e e'. mk_single_app fname allow_fname e = SOME e'
+Triviality mk_single_app_F_unchanged_gen:
+  (!fname allow_fname e e'. mk_single_app fname allow_fname e = SOME e'
                /\ allow_fname = F ==> e = e') /\
    (!fname allow_fname es es'. mk_single_apps fname allow_fname es = SOME es'
                /\ allow_fname = F ==> es = es') /\
@@ -358,13 +358,14 @@ val mk_single_app_F_unchanged_gen = Q.prove(
                 /\ allow_fname = F ==> pes = pes') /\
    (!fname allow_fname recfuns recfuns'. mk_single_appr fname allow_fname recfuns = SOME recfuns'
                 /\ allow_fname = F ==> recfuns = recfuns')
-  `,
+Proof
   ho_match_mp_tac mk_single_app_ind >>
   rw[mk_single_app_def] >> fs[] >>
   every_case_tac >> fs[] >> rfs[] >>
   first_x_assum drule >> simp[] >>
   imp_res_tac dest_opapp_eq_single_IMP >>
-  fs[]);
+  fs[]
+QED
 
 val mk_single_app_F_unchanged = save_thm("mk_single_app_F_unchanged",
   SIMP_RULE std_ss [] mk_single_app_F_unchanged_gen);
@@ -431,16 +432,17 @@ Proof
     fs[quantHeuristicsTheory.LIST_LENGTH_1]
 QED
 
-val build_conv_check_IMP_nsLookup = Q.prove(
-  `!env const v consname stamp n.
+Triviality build_conv_check_IMP_nsLookup:
+  !env const v consname stamp n.
   (∀v. build_conv env (SOME const) [v] =
    SOME (Conv (SOME stamp) [v])) /\
   do_con_check env (SOME const) n
   ==> nsLookup env const = SOME(n,stamp)
-  `,
+Proof
   rw[semanticPrimitivesTheory.build_conv_def,semanticPrimitivesTheory.do_con_check_def,
      namespaceTheory.nsLookup_def] >>
-  every_case_tac >> fs[]);
+  every_case_tac >> fs[]
+QED
 
 Theorem evaluate_IMP_inl:
     do_con_check env.c (SOME (Short "Inl")) 1 = T /\
@@ -495,8 +497,8 @@ Proof
   \\ rw [] \\ fs [] \\ res_tac \\ fs []
 QED
 
-val mk_single_app_NONE_evaluate = Q.prove(
-  `(!^st env es es'. mk_single_apps NONE T es = SOME es'
+Triviality mk_single_app_NONE_evaluate:
+  (!^st env es es'. mk_single_apps NONE T es = SOME es'
     /\ do_con_check env.c (SOME (Short "Inr")) 1 = T
     /\ (!v. build_conv env.c (SOME (Short "Inr")) [v] =
            SOME(Conv (SOME (TypeStamp "Inr" 4)) [v]))
@@ -512,7 +514,7 @@ val mk_single_app_NONE_evaluate = Q.prove(
         = case evaluate_match st env v pes err_v of
            (st',res) => (st', mk_inr_res res)
    )
-   `,
+Proof
   ho_match_mp_tac evaluate_ind >> rpt strip_tac >> PURE_TOP_CASE_TAC
   (* Nil *)
   >- (fs[mk_single_app_def] >> rveq >> fs[evaluate_def,mk_inr_res_def])
@@ -644,20 +646,22 @@ val mk_single_app_NONE_evaluate = Q.prove(
         (fs[] >> rveq >> fs[mk_inr_res_def]) >>
       fs[] >> rveq >> fs[mk_inr_res_def, fp_translate_def] >>
       TOP_CASE_TAC >> gs[] >> rveq >> fs[mk_inr_res_def])
-  );
+QED
 
-val mk_single_app_NONE_evaluate_single = Q.prove(
-  `(!^st env e e'. mk_single_app NONE T e = SOME e'
+Triviality mk_single_app_NONE_evaluate_single:
+  (!^st env e e'. mk_single_app NONE T e = SOME e'
     /\ do_con_check env.c (SOME (Short "Inr")) 1
     /\ (!v. build_conv env.c (SOME (Short "Inr")) [v] =
            SOME(Conv (SOME (TypeStamp "Inr" 4)) [v]))
     ==> evaluate st env [e']
         = case evaluate st env [e] of
            (st',res) => (st', mk_inr_res res)
-   )`,
+   )
+Proof
   rpt strip_tac >>
   match_mp_tac(CONJUNCT1 mk_single_app_NONE_evaluate) >>
-  simp[mk_single_app_def]);
+  simp[mk_single_app_def]
+QED
 
 Definition partially_evaluates_to_def:
 partially_evaluates_to fv env st [] = T /\
@@ -696,8 +700,8 @@ partially_evaluates_to_match fv mv err_v env st (pr1,pr2) =
    | (st',rerr) => evaluate_match st env mv pr2 err_v = (st',rerr)
 End
 
-val mk_single_app_evaluate = Q.prove(
-  `(!^st env es es' fname fv. mk_single_apps (SOME fname) T es = SOME es'
+Triviality mk_single_app_evaluate:
+  (!^st env es es' fname fv. mk_single_apps (SOME fname) T es = SOME es'
     /\ do_con_check env.c (SOME (Short "Inr")) 1 = T
     /\ (!v. build_conv env.c (SOME (Short "Inr")) [v] =
            SOME(Conv (SOME (TypeStamp "Inr" 4)) [v]))
@@ -717,7 +721,7 @@ val mk_single_app_evaluate = Q.prove(
     /\ nsLookup env.v (Short fname) = SOME fv
     ==> partially_evaluates_to_match fv v err_v env st (pes',pes)
    )
-   `,
+Proof
   ho_match_mp_tac evaluate_ind >> rpt strip_tac
   (* Nil *)
   >- (fs[mk_single_app_def] >> rveq >> fs[partially_evaluates_to_def])
@@ -967,7 +971,7 @@ val mk_single_app_evaluate = Q.prove(
       Cases_on `result` >> fs[mk_inr_res_def] >> rveq >> fs[dest_inr_v_def] >>
       imp_res_tac evaluatePropsTheory.evaluate_length >>
       fs[quantHeuristicsTheory.LIST_LENGTH_1] >> fs[dest_inr_v_def])
-    );
+QED
 
 Theorem mk_single_app_evaluate_single:
   !^st env e e' fname fv. mk_single_app (SOME fname) T e = SOME e'
@@ -986,8 +990,8 @@ Proof
   rpt(disch_then drule) >> simp[]
 QED
 
-val evaluate_tailrec_ind_lemma = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname st' res.
+Triviality evaluate_tailrec_ind_lemma:
+  !ck fbody gbody env env' ^st farg x v fname st' res.
    mk_single_app (SOME fname) T fbody = SOME gbody /\
    do_con_check env.c (SOME (Short "Inr")) 1 /\
    (∀v.
@@ -1027,7 +1031,8 @@ val evaluate_tailrec_ind_lemma = Q.prove(
        evaluate_ck ck ^st
          (env with
           v := nsBind farg v (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st' with clock := ck',res)`,
+         [fbody] = (st' with clock := ck',res)
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   pop_assum mp_tac >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -1139,10 +1144,10 @@ val evaluate_tailrec_ind_lemma = Q.prove(
         rveq) >>
       rpt strip_tac >>
       fs[semanticPrimitivesTheory.state_component_equality])
-  );
+QED
 
-val evaluate_tailrec_lemma = Q.prove(
- `!ck fbody gbody env ^st farg x fname st' res.
+Triviality evaluate_tailrec_lemma:
+  !ck fbody gbody env ^st farg x fname st' res.
    mk_single_app (SOME fname) T fbody = SOME gbody /\
    do_con_check env.c (SOME (Short "Inr")) 1 /\
    (∀v.
@@ -1170,7 +1175,8 @@ val evaluate_tailrec_lemma = Q.prove(
     ∃ck'.evaluate_ck ck ^st
          (env with
           v := nsBind farg x (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st' with clock := ck',res)`,
+         [fbody] = (st' with clock := ck',res)
+Proof
   rpt strip_tac >>
   fs[evaluate_ck_def] >>
   pop_assum mp_tac >>
@@ -1190,10 +1196,11 @@ val evaluate_tailrec_lemma = Q.prove(
   drule evaluatePropsTheory.evaluate_add_to_clock >>
   simp[] >>
   disch_then(qspec_then `2` mp_tac) >>
-  simp[semanticPrimitivesTheory.state_component_equality]);
+  simp[semanticPrimitivesTheory.state_component_equality]
+QED
 
-val mk_single_app_unroll_lemma = Q.prove(
-  `!fname fbody gbody ^st st' ck1 env farg ck2 x v.
+Triviality mk_single_app_unroll_lemma:
+  !fname fbody gbody ^st st' ck1 env farg ck2 x v.
     mk_single_app (SOME fname) T fbody = SOME gbody /\
     evaluate (^st with clock := ck1)
                (env with
@@ -1223,7 +1230,8 @@ val mk_single_app_unroll_lemma = Q.prove(
                  v :=
              nsBind farg v
                     (nsBind fname (Recclosure env [(fname,farg,fbody)] fname) env.v))
-            [fbody]`,
+            [fbody]
+Proof
   rpt strip_tac >>
   drule mk_single_app_evaluate_single >>
   disch_then(qspecl_then [`st with clock := ck1 + ck2 + 1`,
@@ -1236,10 +1244,11 @@ val mk_single_app_unroll_lemma = Q.prove(
   simp[dest_inr_v_def,dest_inl_v_def,evaluateTheory.dec_clock_def,do_opapp_def,
        Once find_recfun_def] >>
   rpt strip_tac >>
-  simp[] >> fs[build_rec_env_def]);
+  simp[] >> fs[build_rec_env_def]
+QED
 
-val evaluate_tailrec_diverge_lemma = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname.
+Triviality evaluate_tailrec_diverge_lemma:
+  !ck fbody gbody env env' ^st farg x v fname.
    mk_single_app (SOME fname) T fbody = SOME gbody /\
    do_con_check env.c (SOME (Short "Inr")) 1 /\
    (∀v.
@@ -1278,7 +1287,8 @@ val evaluate_tailrec_diverge_lemma = Q.prove(
        evaluate_ck ck ^st
          (env with
           v := nsBind farg v (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st',Rerr(Rabort(Rtimeout_error)))`,
+         [fbody] = (st',Rerr(Rabort(Rtimeout_error)))
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   pop_assum mp_tac >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -1404,10 +1414,10 @@ val evaluate_tailrec_diverge_lemma = Q.prove(
         disch_then(qspecl_then [`aenv`,`aenv'`,`ast`,`farg`,`argx`,`argv`] mp_tac) >>
         simp[] >> simp[build_rec_env_def])
     )
-  );
+QED
 
-val evaluate_tailrec_div_ind_lemma = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname st' res.
+Triviality evaluate_tailrec_div_ind_lemma:
+  !ck fbody gbody env env' ^st farg x v fname st' res.
    mk_single_app (SOME fname) T fbody = SOME gbody /\
    do_con_check env.c (SOME (Short "Inr")) 1 /\
    (∀v.
@@ -1447,7 +1457,8 @@ val evaluate_tailrec_div_ind_lemma = Q.prove(
        evaluate_ck ck' ^st
          (env with
           v := nsBind farg v (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st',Rerr(Rabort(Rtimeout_error)))`,
+         [fbody] = (st',Rerr(Rabort(Rtimeout_error)))
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   pop_assum mp_tac >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -1545,10 +1556,10 @@ val evaluate_tailrec_div_ind_lemma = Q.prove(
       disch_then match_mp_tac >>
       simp[] >>
       asm_exists_tac >> first_x_assum ACCEPT_TAC)
-  );
+QED
 
-val evaluate_tailrec_div_ind_lemma2 = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname st' res.
+Triviality evaluate_tailrec_div_ind_lemma2:
+  !ck fbody gbody env env' ^st farg x v fname st' res.
    mk_single_app (SOME fname) T fbody = SOME gbody /\
    do_con_check env.c (SOME (Short "Inr")) 1 /\
    (∀v.
@@ -1586,7 +1597,8 @@ val evaluate_tailrec_div_ind_lemma2 = Q.prove(
                                 (Recclosure env [(fname,farg,fbody)] fname)
                                 env.v) farg gbody) env.v))
                 env')))
-     [^tailrec_body] = (st',Rerr(Rabort(Rtimeout_error)))`,
+     [^tailrec_body] = (st',Rerr(Rabort(Rtimeout_error)))
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   Q.REFINE_EXISTS_TAC `ck' + 1` >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -1653,24 +1665,25 @@ val evaluate_tailrec_div_ind_lemma2 = Q.prove(
       fs[evaluateTheory.dec_clock_def] >>
       HINT_EXISTS_TAC >> simp[] >>
       imp_res_tac evaluate_clock >> fs[])
-  );
+QED
 
-val lprefix_mono_lprefix = Q.prove(
- `!f i k.
+Triviality lprefix_mono_lprefix:
+  !f i k.
  (!i. LPREFIX (f i) (f(i + 1)))
  ==> LPREFIX (f i) (f(i + (k:num)))
- `,
- rw[] >> Induct_on `k` >> fs[] >>
+Proof
+  rw[] >> Induct_on `k` >> fs[] >>
  first_x_assum(qspec_then `i + k` assume_tac) >>
  fs[ADD1] >>
- metis_tac[LPREFIX_TRANS]);
+ metis_tac[LPREFIX_TRANS]
+QED
 
-val gify = Q.prove(
- `!g n.
+Triviality gify:
+  !g n.
  (!i. g i < g (i +1))
  ==> ?k (i:num). g i = (n:num) + k
- `,
- rpt strip_tac >>
+Proof
+  rpt strip_tac >>
  `n <= g n`
    by(Induct_on `n` >> simp[] >>
       qpat_x_assum `!i. _ < _` (qspec_then `n` mp_tac) >>
@@ -1678,7 +1691,8 @@ val gify = Q.prove(
       fs[LESS_EQ,LESS_EQ_EXISTS,ADD1] >>
       metis_tac[ADD_ASSOC]) >>
  fs[LESS_EQ_EXISTS] >>
- metis_tac[ADD_SYM]);
+ metis_tac[ADD_SYM]
+QED
 
 Theorem lprefix_lub_unskip:
   (!i. LPREFIX (f i) (f(i + 1))) /\
@@ -1874,21 +1888,22 @@ Proof
   \\ qexists_tac `ck-ck0` \\ fs []
 QED
 
-val lprefix_mono_lprefix = Q.prove(
-  `!f i k.
+Triviality lprefix_mono_lprefix:
+  !f i k.
   (!i. LPREFIX (f i) (f(i + 1)))
   ==> LPREFIX (f i) (f(i + (k:num)))
-  `,
+Proof
   rw[] >> Induct_on `k` >> fs[] >>
   first_x_assum(qspec_then `i + k` assume_tac) >>
   fs[ADD1] >>
-  metis_tac[LPREFIX_TRANS]);
+  metis_tac[LPREFIX_TRANS]
+QED
 
-val gify = Q.prove(
-  `!g n.
+Triviality gify:
+  !g n.
   (!i. g i < g (i +1))
   ==> ?k (i:num). g i = (n:num) + k
-  `,
+Proof
   rpt strip_tac >>
   `n <= g n`
     by(Induct_on `n` >> simp[] >>
@@ -1897,7 +1912,8 @@ val gify = Q.prove(
        fs[LESS_EQ,LESS_EQ_EXISTS,ADD1] >>
        metis_tac[ADD_ASSOC]) >>
   fs[LESS_EQ_EXISTS] >>
-  metis_tac[ADD_SYM]);
+  metis_tac[ADD_SYM]
+QED
 
 Theorem lprefix_lub_skip:
    (!i. LPREFIX (f i) (f(i + 1))) /\
@@ -2506,8 +2522,8 @@ Definition make_repeat_closure_def:
     od) /\ make_repeat_closure _ = NONE
 End
 
-val make_single_app_F_unchanged_gen = Q.prove(
-  `(!fname allow_fname e e'. make_single_app fname allow_fname e = SOME e'
+Triviality make_single_app_F_unchanged_gen:
+  (!fname allow_fname e e'. make_single_app fname allow_fname e = SOME e'
                /\ allow_fname = F ==> e = e') /\
    (!fname es es'. make_single_apps fname es = SOME es'
                ==> es = es') /\
@@ -2515,13 +2531,14 @@ val make_single_app_F_unchanged_gen = Q.prove(
                /\ allow_fname = F ==> pes = pes') /\
    (!fname recfuns recfuns'. make_single_appr fname recfuns = SOME recfuns'
                ==> recfuns = recfuns')
-  `,
+Proof
   ho_match_mp_tac make_single_app_ind >>
   rw[make_single_app_def] >> fs[] >>
   every_case_tac >> fs[] >> rfs[] >>
   first_x_assum drule >> simp[] >>
   imp_res_tac dest_opapp_eq_single_IMP >>
-  fs[]);
+  fs[]
+QED
 
 val make_single_app_F_unchanged = save_thm("make_single_app_F_unchanged",
   SIMP_RULE std_ss [] make_single_app_F_unchanged_gen);
@@ -2987,8 +3004,8 @@ QED
 val make_single_app_SOME_evaluate_exp =
   make_single_app_SOME_evaluate |> CONJUNCT1 |> SIMP_RULE std_ss [];
 
-val make_single_app_unroll_lemma = Q.prove(
-  `!fname fbody gbody ^st st' ck1 env farg ck2 x v.
+Triviality make_single_app_unroll_lemma:
+  !fname fbody gbody ^st st' ck1 env farg ck2 x v.
     make_single_app (SOME fname) T fbody = SOME gbody /\
     evaluate (^st with clock := ck1)
                (env with
@@ -3010,7 +3027,8 @@ val make_single_app_unroll_lemma = Q.prove(
                  v :=
              nsBind farg v
                     (nsBind fname (Recclosure env [(fname,farg,fbody)] fname) env.v))
-            [fbody]`,
+            [fbody]
+Proof
   rpt strip_tac >>
   drule make_single_app_SOME_evaluate_exp >>
   disch_then(qspecl_then [`st with clock := ck1 + ck2 + 1`,
@@ -3022,10 +3040,11 @@ val make_single_app_unroll_lemma = Q.prove(
   simp[evaluateTheory.dec_clock_def,do_opapp_def,
        Once find_recfun_def] >>
   rpt strip_tac >>
-  simp[] >> fs[build_rec_env_def]);
+  simp[] >> fs[build_rec_env_def]
+QED
 
-val evaluate_repeat_diverge_lemma = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname.
+Triviality evaluate_repeat_diverge_lemma:
+  !ck fbody gbody env env' ^st farg x v fname.
    make_single_app (SOME fname) T fbody = SOME gbody /\
    fname <> farg /\
    (!ck. ?st'. evaluate_ck ck ^st
@@ -3056,7 +3075,8 @@ val evaluate_repeat_diverge_lemma = Q.prove(
        evaluate_ck ck ^st
          (env with
           v := nsBind farg v (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st',Rerr(Rabort Rtimeout_error))`,
+         [fbody] = (st',Rerr(Rabort Rtimeout_error))
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   pop_assum mp_tac >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -3168,10 +3188,11 @@ val evaluate_repeat_diverge_lemma = Q.prove(
    impl_tac >- metis_tac[ADD_SYM,ADD_ASSOC] >>
    disch_then drule >>
    disch_then(qspecl_then [`aenv`,`aenv'`,`ast`,`farg`,`argx`,`argv`] mp_tac) >>
-   simp[] >> simp[build_rec_env_def]);
+   simp[] >> simp[build_rec_env_def]
+QED
 
-val evaluate_repeat_div_ind_lemma = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname st' res.
+Triviality evaluate_repeat_div_ind_lemma:
+  !ck fbody gbody env env' ^st farg x v fname st' res.
    make_single_app (SOME fname) T fbody = SOME gbody /\
    fname <> farg /\
    ck > 0 /\
@@ -3203,7 +3224,8 @@ val evaluate_repeat_div_ind_lemma = Q.prove(
        evaluate_ck ck' ^st
          (env with
           v := nsBind farg v (build_rec_env [(fname,farg,fbody)] env env.v))
-         [fbody] = (st',Rerr(Rabort Rtimeout_error))`,
+         [fbody] = (st',Rerr(Rabort Rtimeout_error))
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   pop_assum mp_tac >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -3279,10 +3301,11 @@ val evaluate_repeat_div_ind_lemma = Q.prove(
   simp[build_rec_env_def] >>
   disch_then match_mp_tac >>
   simp[] >>
-  asm_exists_tac >> first_x_assum ACCEPT_TAC);
+  asm_exists_tac >> first_x_assum ACCEPT_TAC
+QED
 
-val evaluate_repeat_div_ind_lemma2 = Q.prove(
-  `!ck fbody gbody env env' ^st farg x v fname st' res.
+Triviality evaluate_repeat_div_ind_lemma2:
+  !ck fbody gbody env env' ^st farg x v fname st' res.
    make_single_app (SOME fname) T fbody = SOME gbody /\
    fname <> farg /\
    evaluate_ck ck ^st
@@ -3313,7 +3336,8 @@ val evaluate_repeat_div_ind_lemma2 = Q.prove(
                                 env.v) farg gbody) env.v))
                 env')))
      [^repeat_body] = (st',Rerr(Rabort res2)) /\
-     (res2 <> Rtimeout_error ==> res2 = Rtype_error)`,
+     (res2 <> Rtimeout_error ==> res2 = Rtype_error)
+Proof
   ho_match_mp_tac COMPLETE_INDUCTION >> rw[evaluate_ck_def] >>
   Q.REFINE_EXISTS_TAC `ck' + 1` >>
   ntac 5 (simp[Once evaluate_def]) >>
@@ -3367,7 +3391,8 @@ val evaluate_repeat_div_ind_lemma2 = Q.prove(
   first_x_assum(match_mp_tac o MP_CANON) >>
   fs[evaluateTheory.dec_clock_def,build_rec_env_def] >>
   HINT_EXISTS_TAC >> simp[] >>
-  imp_res_tac evaluate_clock >> fs[]);
+  imp_res_tac evaluate_clock >> fs[]
+QED
 
 Theorem make_repeat_closure_sound_basic:
    !fv env .
@@ -4383,11 +4408,12 @@ Proof
  simp[LNTH_LUNFOLD,FUNPOW]
 QED
 
-val every_LGENLIST = Q.prove(`
+Triviality every_LGENLIST:
   every P (LGENLIST f NONE)
   = !x. P(f x)
-  `,
-  rw[every_LNTH,LNTH_LGENLIST,EQ_IMP_THM]);
+Proof
+  rw[every_LNTH,LNTH_LGENLIST,EQ_IMP_THM]
+QED
 
 Theorem LFLATTEN_LAPPEND_fromList:
   !l1 ll2.
@@ -4468,13 +4494,17 @@ Proof
   \\ fs[o_DEF]
 QED
 
-val list_length_eq = Q.prove(
-   `l1 = l2 ==> LENGTH l1 = LENGTH l2`,
-   simp[])
+Triviality list_length_eq:
+  l1 = l2 ==> LENGTH l1 = LENGTH l2
+Proof
+  simp[]
+QED
 
-val list_length_eq2 = Q.prove(
-   `l1 = l2 ==> LENGTH(FLAT(MAP FST l1)) = LENGTH(FLAT(MAP FST l2))`,
-   simp[])
+Triviality list_length_eq2:
+  l1 = l2 ==> LENGTH(FLAT(MAP FST l1)) = LENGTH(FLAT(MAP FST l2))
+Proof
+  simp[]
+QED
 
 Theorem MEM_FLAT_MAP_FST_SING:
   MEM (FLAT (MAP FST r),u) r

--- a/characteristic/cfLetAutoScript.sml
+++ b/characteristic/cfLetAutoScript.sml
@@ -104,26 +104,34 @@ metis_tac[]
 QED *)
 
 (* The following lemmas aim to prove that a valid heap can not have one pointer pointing to two different values *)
-val PTR_MEM_LEM = Q.prove(`!s l xv H. (l ~~>> xv * H) s ==> Mem l xv IN s`,
-rw[STAR_def, SPLIT_def, cell_def, one_def] >> fs[]);
+Triviality PTR_MEM_LEM:
+  !s l xv H. (l ~~>> xv * H) s ==> Mem l xv IN s
+Proof
+  rw[STAR_def, SPLIT_def, cell_def, one_def] >> fs[]
+QED
 
 (* Intermediate lemma to reason on subsets of heaps *)
-val HEAP_SUBSET_GC = Q.prove(`!s s' H. s SUBSET s' ==> H s ==> (H * GC) s'`,
-rw[STAR_def] >>
+Triviality HEAP_SUBSET_GC:
+  !s s' H. s SUBSET s' ==> H s ==> (H * GC) s'
+Proof
+  rw[STAR_def] >>
 instantiate >>
 fs[SPLIT_EQ, GC_def, SEP_EXISTS] >>
 qexists_tac `\x. T` >>
-rw[]);
+rw[]
+QED
 
 (* UNIQUE_PTRS property for a heap converted from a state *)
-val UNIQUE_PTRS_HFS = Q.prove(
-`!s. HEAP_FROM_STATE s ==> !l xv xv' H H'. (l ~~>> xv * H) s /\ (l ~~>> xv' * H') s ==> xv' = xv`,
-rw[HEAP_FROM_STATE_def] >>
+Triviality UNIQUE_PTRS_HFS:
+  !s. HEAP_FROM_STATE s ==> !l xv xv' H H'. (l ~~>> xv * H) s /\ (l ~~>> xv' * H') s ==> xv' = xv
+Proof
+  rw[HEAP_FROM_STATE_def] >>
 fs[st2heap_def] >>
 IMP_RES_TAC PTR_MEM_LEM >>
 fs[UNION_DEF]
 >-(IMP_RES_TAC store2heap_IN_unique_key)>>
-IMP_RES_TAC Mem_NOT_IN_ffi2heap);
+IMP_RES_TAC Mem_NOT_IN_ffi2heap
+QED
 
 Theorem UNIQUE_PTRS:
  !s. VALID_HEAP s ==> !l xv xv' H H'. (l ~~>> xv * H) s /\ (l ~~>> xv' * H') s ==> xv' = xv
@@ -197,11 +205,12 @@ prove_hprop_inj_tac UNIQUE_W8ARRAYS
 QED
 
 (* A valid heap must have proper ffi partitions *)
-val NON_OVERLAP_FFI_PART_HFS = Q.prove(
-`!s. HEAP_FROM_STATE s ==>
+Triviality NON_OVERLAP_FFI_PART_HFS:
+  !s. HEAP_FROM_STATE s ==>
 !s1 u1 ns1 ts1 s2 u2 ns2 ts2. FFI_part s1 u1 ns1 ts1 IN s /\ FFI_part s2 u2 ns2 ts2 IN s /\ (?p. MEM p ns1 /\ MEM p ns2) ==>
-s2 = s1 /\ u2 = u1 /\ ns2 = ns1 /\ ts2 = ts1`,
-rpt (FIRST[GEN_TAC, DISCH_TAC]) >>
+s2 = s1 /\ u2 = u1 /\ ns2 = ns1 /\ ts2 = ts1
+Proof
+  rpt (FIRST[GEN_TAC, DISCH_TAC]) >>
 fs[HEAP_FROM_STATE_def, st2heap_def, UNION_DEF] >>
 `FFI_part s1 u1 ns1 ts1 ∈ ffi2heap f st.ffi` by (rw[] >> fs[FFI_part_NOT_IN_store2heap]) >>
 `FFI_part s2 u2 ns2 ts2 ∈ ffi2heap f st.ffi` by (rw[] >> fs[FFI_part_NOT_IN_store2heap]) >>
@@ -243,7 +252,8 @@ Cases_on `parts_ok st.ffi (proj, parts)`
     (* u2 = u1 *)
     IMP_RES_TAC ALL_DISTINCT_FLAT_FST_IMP
 ) >>
-fs[]);
+fs[]
+QED
 
 Theorem NON_OVERLAP_FFI_PART:
  !s. VALID_HEAP s ==>
@@ -259,9 +269,11 @@ rw[]
 QED
 
 (* A minor lemma *)
-val FFI_PORT_IN_HEAP_LEM = Q.prove(
-`!s u ns events H h. (one (FFI_part s u ns events) * H) h ==> FFI_part s u ns events IN h`,
-rw[one_def, STAR_def, SPLIT_def, IN_DEF, UNION_DEF] >> rw[]);
+Triviality FFI_PORT_IN_HEAP_LEM:
+  !s u ns events H h. (one (FFI_part s u ns events) * H) h ==> FFI_part s u ns events IN h
+Proof
+  rw[one_def, STAR_def, SPLIT_def, IN_DEF, UNION_DEF] >> rw[]
+QED
 
 (* Another important theorem *)
 Theorem FRAME_UNIQUE_IO:
@@ -295,22 +307,26 @@ Proof
 Induct >-(strip_tac >> rw[]) >> rw[]
 QED
 
-val REPLICATE_APPEND_RIGHT = Q.prove(
-`a++b = REPLICATE n x ==> b = REPLICATE (LENGTH b) x`,
-strip_tac >>
+Triviality REPLICATE_APPEND_RIGHT:
+  a++b = REPLICATE n x ==> b = REPLICATE (LENGTH b) x
+Proof
+  strip_tac >>
 `b = DROP (LENGTH a) (a++b)` by simp[GSYM DROP_LENGTH_APPEND] >>
 `b = DROP (LENGTH a) (REPLICATE n x)` by POP_ASSUM (fn thm => metis_tac[thm]) >>
 `b = REPLICATE (n - (LENGTH a)) x` by POP_ASSUM (fn thm => metis_tac[thm, DROP_REPLICATE]) >>
-fs[LENGTH_REPLICATE]);
+fs[LENGTH_REPLICATE]
+QED
 
-val REPLICATE_APPEND_LEFT = Q.prove(
-`a++b = REPLICATE n x ==> a = REPLICATE (LENGTH a) x`,
-strip_tac >> `b = REPLICATE (LENGTH b) x` by metis_tac[REPLICATE_APPEND_RIGHT] >>
+Triviality REPLICATE_APPEND_LEFT:
+  a++b = REPLICATE n x ==> a = REPLICATE (LENGTH a) x
+Proof
+  strip_tac >> `b = REPLICATE (LENGTH b) x` by metis_tac[REPLICATE_APPEND_RIGHT] >>
 `LENGTH b <= n` by metis_tac[APPEND_LENGTH_INEQ, LENGTH_REPLICATE] >>
 `REPLICATE n x = REPLICATE (n-(LENGTH b)) x ++ REPLICATE (LENGTH b) x` by simp[REPLICATE_APPEND] >>
 POP_ASSUM (fn x => fs[x]) >> POP_ASSUM (fn x => ALL_TAC) >>
 `a ++ REPLICATE (LENGTH b) x = REPLICATE (n − LENGTH b) x ++ REPLICATE (LENGTH b) x` by metis_tac[] >>
-fs[LENGTH_REPLICATE]);
+fs[LENGTH_REPLICATE]
+QED
 
 Theorem REPLICATE_APPEND_DECOMPOSE:
  a ++ b = REPLICATE n x <=>
@@ -328,20 +344,24 @@ Proof
 `n+1 = SUC n` by rw[] >> rw[REPLICATE]
 QED
 
-val LIST_REL_DECOMPOSE_RIGHT_recip = Q.prove(
-`!R. LIST_REL R (a ++ b) x ==> LIST_REL R a (TAKE (LENGTH a) x) /\ LIST_REL R b (DROP (LENGTH a) x)`,
-strip_tac >> strip_tac >>
+Triviality LIST_REL_DECOMPOSE_RIGHT_recip:
+  !R. LIST_REL R (a ++ b) x ==> LIST_REL R a (TAKE (LENGTH a) x) /\ LIST_REL R b (DROP (LENGTH a) x)
+Proof
+  strip_tac >> strip_tac >>
 `x = TAKE (LENGTH a) x ++ DROP (LENGTH a) x` by rw[TAKE_DROP] >>
 `LENGTH (a ++ b) = LENGTH x` by (MATCH_MP_TAC LIST_REL_LENGTH >> rw[]) >>
 POP_ASSUM (fn x => CONV_RULE (SIMP_CONV list_ss []) x |> ASSUME_TAC) >>
 `LENGTH a <= LENGTH x` by bossLib.DECIDE_TAC >>
-metis_tac[LENGTH_TAKE, LIST_REL_APPEND_IMP]);
+metis_tac[LENGTH_TAKE, LIST_REL_APPEND_IMP]
+QED
 
-val LIST_REL_DECOMPOSE_RIGHT_imp = Q.prove(
-`!R. LIST_REL R a (TAKE (LENGTH a) x) /\ LIST_REL R b (DROP (LENGTH a) x) ==> LIST_REL R (a ++ b) x`,
-rpt strip_tac >>
+Triviality LIST_REL_DECOMPOSE_RIGHT_imp:
+  !R. LIST_REL R a (TAKE (LENGTH a) x) /\ LIST_REL R b (DROP (LENGTH a) x) ==> LIST_REL R (a ++ b) x
+Proof
+  rpt strip_tac >>
 `x = TAKE (LENGTH a) x ++ DROP (LENGTH a) x` by rw[TAKE_DROP] >>
-metis_tac[rich_listTheory.EVERY2_APPEND_suff]);
+metis_tac[rich_listTheory.EVERY2_APPEND_suff]
+QED
 
 Theorem LIST_REL_DECOMPOSE_RIGHT:
  !R. LIST_REL R (a ++ b) x <=> LIST_REL R a (TAKE (LENGTH a) x) /\ LIST_REL R b (DROP (LENGTH a) x)
@@ -349,20 +369,24 @@ Proof
 strip_tac >> metis_tac[LIST_REL_DECOMPOSE_RIGHT_recip, LIST_REL_DECOMPOSE_RIGHT_imp]
 QED
 
-val LIST_REL_DECOMPOSE_LEFT_recip = Q.prove(
-`!R. LIST_REL R x (a ++ b) ==> LIST_REL R (TAKE (LENGTH a) x) a /\ LIST_REL R (DROP (LENGTH a) x) b`,
-strip_tac >> strip_tac >>
+Triviality LIST_REL_DECOMPOSE_LEFT_recip:
+  !R. LIST_REL R x (a ++ b) ==> LIST_REL R (TAKE (LENGTH a) x) a /\ LIST_REL R (DROP (LENGTH a) x) b
+Proof
+  strip_tac >> strip_tac >>
 `x = TAKE (LENGTH a) x ++ DROP (LENGTH a) x` by rw[TAKE_DROP] >>
 `LENGTH x = LENGTH (a ++ b)` by (MATCH_MP_TAC LIST_REL_LENGTH >> rw[]) >>
 POP_ASSUM (fn x => CONV_RULE (SIMP_CONV list_ss []) x |> ASSUME_TAC) >>
 `LENGTH a <= LENGTH x` by bossLib.DECIDE_TAC >>
-metis_tac[LENGTH_TAKE, LIST_REL_APPEND_IMP]);
+metis_tac[LENGTH_TAKE, LIST_REL_APPEND_IMP]
+QED
 
-val LIST_REL_DECOMPOSE_LEFT_imp = Q.prove(
-`!R. LIST_REL R (TAKE (LENGTH a) x) a /\ LIST_REL R (DROP (LENGTH a) x) b ==> LIST_REL R x (a ++ b)`,
-rpt strip_tac >>
+Triviality LIST_REL_DECOMPOSE_LEFT_imp:
+  !R. LIST_REL R (TAKE (LENGTH a) x) a /\ LIST_REL R (DROP (LENGTH a) x) b ==> LIST_REL R x (a ++ b)
+Proof
+  rpt strip_tac >>
 `x = TAKE (LENGTH a) x ++ DROP (LENGTH a) x` by rw[TAKE_DROP] >>
-metis_tac[rich_listTheory.EVERY2_APPEND_suff]);
+metis_tac[rich_listTheory.EVERY2_APPEND_suff]
+QED
 
 Theorem LIST_REL_DECOMPOSE_LEFT:
  !R. LIST_REL R x (a ++ b) <=> LIST_REL R (TAKE (LENGTH a) x) a /\ LIST_REL R (DROP (LENGTH a) x) b
@@ -419,8 +443,11 @@ Definition InjectiveRel_def:
 InjectiveRel A = !x1 y1 x2 y2. A x1 y1 /\ A x2 y2 ==> (x1 = x2 <=> y1 = y2)
 End
 
-val EQTYPE_INJECTIVEREL = Q.prove(`EqualityType A ==> InjectiveRel A`,
-rw[InjectiveRel_def, EqualityType_def]);
+Triviality EQTYPE_INJECTIVEREL:
+  EqualityType A ==> InjectiveRel A
+Proof
+  rw[InjectiveRel_def, EqualityType_def]
+QED
 
 Theorem LIST_REL_INJECTIVE_REL:
  !A. InjectiveRel A ==> InjectiveRel (LIST_REL A)
@@ -474,19 +501,22 @@ fs[PAIR_TYPE_def, types_match_def, semanticPrimitivesTheory.ctor_same_type_def] 
 metis_tac[]
 QED
 
-val LIST_TYPE_no_closure = Q.prove(
-`!A x xv. EqualityType A ==> LIST_TYPE A x xv ==> no_closures xv`,
-Induct_on `x`
+Triviality LIST_TYPE_no_closure:
+  !A x xv. EqualityType A ==> LIST_TYPE A x xv ==> no_closures xv
+Proof
+  Induct_on `x`
 >-(fs[LIST_TYPE_def, no_closures_def]) >>
 rw[LIST_TYPE_def] >>
 rw[no_closures_def]
 >-(metis_tac[EqualityType_def]) >>
-last_assum IMP_RES_TAC);
+last_assum IMP_RES_TAC
+QED
 
-val LIST_TYPE_inj = Q.prove(
-`!A x1 x2 v1 v2. EqualityType A ==> LIST_TYPE A x1 v1 ==> LIST_TYPE A x2 v2 ==>
-(v1 = v2 <=> x1 = x2)`,
-Induct_on `x1`
+Triviality LIST_TYPE_inj:
+  !A x1 x2 v1 v2. EqualityType A ==> LIST_TYPE A x1 v1 ==> LIST_TYPE A x2 v2 ==>
+(v1 = v2 <=> x1 = x2)
+Proof
+  Induct_on `x1`
 >-(
     Cases_on `x2` >>
     rw[LIST_TYPE_def, EqualityType_def]
@@ -496,13 +526,15 @@ rw[LIST_TYPE_def] >>
 last_x_assum IMP_RES_TAC >>
 rw[] >>
 fs[EqualityType_def] >>
-metis_tac[]);
+metis_tac[]
+QED
 
 val types_match_tac = rpt (CHANGED_TAC (rw[LIST_TYPE_def, types_match_def, semanticPrimitivesTheory.ctor_same_type_def]));
-val LIST_TYPE_types_match = Q.prove(
-`!A x1 x2 v1 v2. EqualityType A ==> LIST_TYPE A x1 v1 ==> LIST_TYPE A x2 v2 ==>
-types_match v1 v2`,
-Induct_on `x1`
+Triviality LIST_TYPE_types_match:
+  !A x1 x2 v1 v2. EqualityType A ==> LIST_TYPE A x1 v1 ==> LIST_TYPE A x2 v2 ==>
+types_match v1 v2
+Proof
+  Induct_on `x1`
 >-(
     Cases_on `x2` >>
     types_match_tac >>
@@ -512,7 +544,8 @@ Cases_on `x2`
 >-(types_match_tac >> EVAL_TAC)>>
 types_match_tac
 >-(metis_tac[EqualityType_def])>>
-last_assum IMP_RES_TAC);
+last_assum IMP_RES_TAC
+QED
 
 Theorem EqualityType_LIST_TYPE:
  EqualityType A ==> EqualityType (LIST_TYPE A)
@@ -549,7 +582,11 @@ QED
 
 (* Some rules used to simplify arithmetic equations (not happy with that: write a conversion instead? *)
 
-val NUM_EQ_lem = Q.prove(`!(a1:num) (a2:num) (b:num). b <= a1 ==> b <= a2 ==> (a1 = a2 <=> a1 - b = a2 - b)`, rw[]);
+Triviality NUM_EQ_lem:
+  !(a1:num) (a2:num) (b:num). b <= a1 ==> b <= a2 ==> (a1 = a2 <=> a1 - b = a2 - b)
+Proof
+  rw[]
+QED
 
 Theorem NUM_EQ_SIMP1:
  a1 + (NUMERAL n1)*b = a2 + (NUMERAL n2)*b <=>

--- a/characteristic/cfMainScript.sml
+++ b/characteristic/cfMainScript.sml
@@ -65,10 +65,11 @@ Proof
   \\ asm_exists_tac \\ fs []
 QED
 
-val prog_to_semantics_prog = Q.prove(
-  `!init_env inp prog st c r env2 s2.
+Triviality prog_to_semantics_prog:
+  !init_env inp prog st c r env2 s2.
      Decls init_env inp prog env2 s2 ==>
-     (semantics_prog inp init_env prog (Terminate Success s2.ffi.io_events))`,
+     (semantics_prog inp init_env prog (Terminate Success s2.ffi.io_events))
+Proof
   rw[ml_progTheory.Decls_def]
   \\ fs[semanticsTheory.semantics_prog_def,PULL_EXISTS]
   \\ fs[semanticsTheory.evaluate_prog_with_clock_def]
@@ -80,27 +81,33 @@ val prog_to_semantics_prog = Q.prove(
   \\ qpat_x_assum `_ = (_,Rval _)` assume_tac
   \\ drule evaluate_decs_add_to_clock
   \\ disch_then (qspec_then `k` mp_tac)
-  \\ rpt strip_tac \\ fs []);
+  \\ rpt strip_tac \\ fs []
+QED
 
-val clock_eq_lemma = Q.prove(
-  `!c. st with clock := a = st2 with clock := b ==>
-    st with clock := c = st2 with clock := c`,
-  simp[state_component_equality]);
+Triviality clock_eq_lemma:
+  !c. st with clock := a = st2 with clock := b ==>
+    st with clock := c = st2 with clock := c
+Proof
+  simp[state_component_equality]
+QED
 
-val state_eq_semantics_prog = Q.prove(
-  `st with clock := a = st2 with clock := b ==>
-   semantics_prog st env prog r = semantics_prog st2 env prog r`,
+Triviality state_eq_semantics_prog:
+  st with clock := a = st2 with clock := b ==>
+   semantics_prog st env prog r = semantics_prog st2 env prog r
+Proof
   strip_tac \\ Cases_on `r`
   \\ simp[semanticsTheory.semantics_prog_def,semanticsTheory.evaluate_prog_with_clock_def]
   \\ imp_res_tac clock_eq_lemma
-  \\ fs[]);
+  \\ fs[]
+QED
 
-val prog_APPEND_semantics_prog = Q.prove(
-  `!prog1 init_env prog2 st1 c outcome events env2 st2.
+Triviality prog_APPEND_semantics_prog:
+  !prog1 init_env prog2 st1 c outcome events env2 st2.
   Decls init_env st1 prog1 env2 st2
   /\ semantics_prog st2 (merge_env env2 init_env) prog2 (Terminate outcome events)
   ==>
-  semantics_prog st1 init_env (prog1++prog2) (Terminate outcome events)`,
+  semantics_prog st1 init_env (prog1++prog2) (Terminate outcome events)
+Proof
   Induct_on `prog1` \\ rw[]
   >- (fs[ml_progTheory.Decls_def] \\ rveq \\ fs[ml_progTheory.merge_env_def]
       \\ metis_tac[state_eq_semantics_prog])
@@ -120,15 +127,18 @@ val prog_APPEND_semantics_prog = Q.prove(
   \\ rpt(dxrule evaluate_decs_add_to_clock) \\ simp[]
   \\ rpt strip_tac
   \\ fs[combine_dec_result_def] \\ rveq
-  \\ fs[extend_dec_env_def,ml_progTheory.merge_env_def]);
+  \\ fs[extend_dec_env_def,ml_progTheory.merge_env_def]
+QED
 
-val prog_SNOC_semantics_prog = Q.prove(
-  `!prog1 init_env decl st1 c outcome events env2 st2.
+Triviality prog_SNOC_semantics_prog:
+  !prog1 init_env decl st1 c outcome events env2 st2.
   Decls init_env st1 prog1 env2 st2
   /\ semantics_prog st2 (merge_env env2 init_env) [decl] (Terminate outcome events)
   ==>
-  semantics_prog st1 init_env (SNOC decl prog1) (Terminate outcome events)`,
-  simp[SNOC_APPEND] \\ MATCH_ACCEPT_TAC prog_APPEND_semantics_prog);
+  semantics_prog st1 init_env (SNOC decl prog1) (Terminate outcome events)
+Proof
+  simp[SNOC_APPEND] \\ MATCH_ACCEPT_TAC prog_APPEND_semantics_prog
+QED
 
 Definition FFI_part_hprop_def:
   FFI_part_hprop Q =

--- a/characteristic/cfNormaliseScript.sml
+++ b/characteristic/cfNormaliseScript.sml
@@ -148,27 +148,35 @@ Termination
   \\ fs [LENGTH_FRONT] \\ Cases \\ fs []
 End
 
-val MEM_exp_size = Q.prove(
-  `!args a. MEM a args ==> exp_size a <= exp6_size args`,
-  Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []);
-
-val MEM_exp1_size = Q.prove(
-  `!rs. MEM (v,a,e') rs ==> exp_size e' < exp1_size rs`,
+Triviality MEM_exp_size:
+  !args a. MEM a args ==> exp_size a <= exp6_size args
+Proof
   Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []
-  \\ fs [astTheory.exp_size_def]);
+QED
 
-val exp6_size_lemma = Q.prove(
-  `!xs ys. exp6_size (xs ++ ys) = exp6_size xs + exp6_size ys`,
-  Induct \\ fs [astTheory.exp_size_def]);
+Triviality MEM_exp1_size:
+  !rs. MEM (v,a,e') rs ==> exp_size e' < exp1_size rs
+Proof
+  Induct \\ fs [astTheory.exp_size_def] \\ rw [] \\ res_tac \\ fs []
+  \\ fs [astTheory.exp_size_def]
+QED
 
-val dest_opapp_size = Q.prove(
-  `!xs p_1 p_2.
+Triviality exp6_size_lemma:
+  !xs ys. exp6_size (xs ++ ys) = exp6_size xs + exp6_size ys
+Proof
+  Induct \\ fs [astTheory.exp_size_def]
+QED
+
+Triviality dest_opapp_size:
+  !xs p_1 p_2.
       dest_opapp xs = SOME (p_1,p_2) ==>
-      exp_size p_1 + exp6_size p_2 < exp_size xs`,
+      exp_size p_1 + exp6_size p_2 < exp_size xs
+Proof
   recInduct (theorem "dest_opapp_ind") \\ fs [dest_opapp_def]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ fs [astTheory.exp_size_def]
-  \\ res_tac \\ fs [exp6_size_lemma,astTheory.exp_size_def]);
+  \\ res_tac \\ fs [exp6_size_lemma,astTheory.exp_size_def]
+QED
 
 Definition get_name_aux_def:
   get_name_aux n vs =
@@ -414,9 +422,11 @@ Definition full_normalise_def:
   full_normalise ns e = FST (protect T ns (strip_annot_exp e))
 End
 
-val MEM_v_size = Q.prove(
-  `!xs. MEM a xs ==> v_size a < v7_size xs`,
-  Induct  \\ fs [v_size_def] \\ rw [] \\ res_tac \\ fs []);
+Triviality MEM_v_size:
+  !xs. MEM a xs ==> v_size a < v7_size xs
+Proof
+  Induct  \\ fs [v_size_def] \\ rw [] \\ res_tac \\ fs []
+QED
 
 Definition norm_exp_rel_def:
   norm_exp_rel ns e1 e2 <=> (e1 = e2) \/

--- a/compiler/backend/ag32/proofs/ag32_ffi_codeProofScript.sml
+++ b/compiler/backend/ag32/proofs/ag32_ffi_codeProofScript.sml
@@ -407,11 +407,13 @@ fun rnwc_next n =
         ag32Theory.dfn'LoadConstant_def])) >> strip_tac
     end
 
-val ltNumeral = Q.prove(
-  ‘(x < NUMERAL (BIT2 n) ⇔ x < NUMERAL (BIT1 n) \/ x = NUMERAL (BIT1 n)) /\
+Triviality ltNumeral:
+  (x < NUMERAL (BIT2 n) ⇔ x < NUMERAL (BIT1 n) \/ x = NUMERAL (BIT1 n)) /\
    (x < NUMERAL (BIT1 n) ⇔
-      x < PRE (NUMERAL (BIT1 n)) \/ x = PRE (NUMERAL (BIT1 n)))’,
-  REWRITE_TAC[BIT1, BIT2, NUMERAL_DEF] >> simp[])
+      x < PRE (NUMERAL (BIT1 n)) \/ x = PRE (NUMERAL (BIT1 n)))
+Proof
+  REWRITE_TAC[BIT1, BIT2, NUMERAL_DEF] >> simp[]
+QED
 
 fun instn0 th i =
     first_assum (qspec_then [QUOTE (Int.toString i)]
@@ -428,11 +430,13 @@ fun instn0 th i =
 
 val instn = instn0 ag32_ffi_read_num_written_code_def
 
-val sub_common = Q.prove(
-  ‘u <= v ⇒ ((x:word32) + (n2w u) = y + (n2w v) ⇔ x = y + n2w (v - u))’,
+Triviality sub_common:
+  u <= v ⇒ ((x:word32) + (n2w u) = y + (n2w v) ⇔ x = y + n2w (v - u))
+Proof
   strip_tac >> drule LESS_EQ_ADD_EXISTS >> rw[] >> simp[] >>
   REWRITE_TAC [GSYM word_add_n2w] >>
-  REWRITE_TAC [WORD_ADD_ASSOC, addressTheory.WORD_EQ_ADD_CANCEL]);
+  REWRITE_TAC [WORD_ADD_ASSOC, addressTheory.WORD_EQ_ADD_CANCEL]
+QED
 
 fun glAbbr i =
   TRY (qpat_x_assum [QUOTE ("Abbrev (s" ^ Int.toString i ^ " = _)")]
@@ -2331,25 +2335,31 @@ val codedefs = [ag32_ffi_read_code_def, ag32_ffi_read_set_id_code_def,
                 ag32_ffi_read_num_written_code_def,
                 ag32_ffi_read_load_lengths_code_def]
 
-val bytes_in_memory_update = Q.prove(
-  ‘∀bs a. k ∉ md ∧ bytes_in_memory a bs mf md ⇒
-          bytes_in_memory a bs ((k =+ v) mf) md’,
+Triviality bytes_in_memory_update:
+  ∀bs a. k ∉ md ∧ bytes_in_memory a bs mf md ⇒
+          bytes_in_memory a bs ((k =+ v) mf) md
+Proof
   Induct >> simp[bytes_in_memory_def] >>
-  metis_tac[combinTheory.UPDATE_APPLY]);
+  metis_tac[combinTheory.UPDATE_APPLY]
+QED
 
-val bytes_in_memory_prefix = Q.prove(
-  ‘∀bs sfx a. bytes_in_memory a (bs ++ sfx) mf md ⇒
-              bytes_in_memory a bs mf md’,
-  Induct >> simp[bytes_in_memory_def] >> metis_tac[]);
+Triviality bytes_in_memory_prefix:
+  ∀bs sfx a. bytes_in_memory a (bs ++ sfx) mf md ⇒
+              bytes_in_memory a bs mf md
+Proof
+  Induct >> simp[bytes_in_memory_def] >> metis_tac[]
+QED
 
-val asm_write_bytearray_avoiding = Q.prove(
-  ‘∀a bs.
-     x ∉ {a + n2w i | i < LENGTH bs } ⇒ asm_write_bytearray a bs f x = f x’,
+Triviality asm_write_bytearray_avoiding:
+  ∀a bs.
+     x ∉ {a + n2w i | i < LENGTH bs } ⇒ asm_write_bytearray a bs f x = f x
+Proof
   simp[] >> Induct_on ‘bs’ >> simp[asm_write_bytearray_def] >>
   simp[combinTheory.UPDATE_def] >> rw[]
   >- (first_x_assum (qspec_then ‘0’ mp_tac) >> simp[]) >>
   first_x_assum (qspec_then ‘SUC j’ (mp_tac o Q.GEN ‘j’)) >> simp[] >>
-  strip_tac >> first_x_assum irule >> fs[GSYM word_add_n2w, ADD1]);
+  strip_tac >> first_x_assum irule >> fs[GSYM word_add_n2w, ADD1]
+QED
 
 fun glAbbrs i = EVERY (List.tabulate(i, fn j => glAbbr (i - j)))
 
@@ -2360,17 +2370,23 @@ Proof
   map_every (fn q => Q.ISPEC_THEN q mp_tac w2n_lt) [‘b1’, ‘b2’] >> simp[]
 QED
 
-val ltSUC = Q.prove(
-  ‘x < SUC y ⇔ x = 0 ∨ ∃x0. x = SUC x0 ∧ x0 < y’,
-  Cases_on ‘x’ >> simp[]);
+Triviality ltSUC:
+  x < SUC y ⇔ x = 0 ∨ ∃x0. x = SUC x0 ∧ x0 < y
+Proof
+  Cases_on ‘x’ >> simp[]
+QED
 
-val n2w_o_SUC = Q.prove(
-  ‘n2w o SUC = word_add 1w o n2w’,
-  simp[FUN_EQ_THM, ADD1, word_add_n2w]);
+Triviality n2w_o_SUC:
+  n2w o SUC = word_add 1w o n2w
+Proof
+  simp[FUN_EQ_THM, ADD1, word_add_n2w]
+QED
 
-val word_add_o = Q.prove(
-  ‘word_add m o (word_add n o f) = word_add (m + n) o f’,
-  simp[FUN_EQ_THM]);
+Triviality word_add_o:
+  word_add m o (word_add n o f) = word_add (m + n) o f
+Proof
+  simp[FUN_EQ_THM]
+QED
 
 
 
@@ -2384,13 +2400,15 @@ Proof
        GSYM word_add_n2w, CONJ_ASSOC, n2w_o_SUC, word_add_o]
 QED
 
-val WORD_ADD_CANCEL_LBARE = Q.prove(
-  ‘y ≤ x ⇒ (n2w x = n2w y + z ⇔ z = n2w (x - y))’,
+Triviality WORD_ADD_CANCEL_LBARE:
+  y ≤ x ⇒ (n2w x = n2w y + z ⇔ z = n2w (x - y))
+Proof
   strip_tac >> eq_tac
   >- (disch_then (mp_tac o AP_TERM “(+) (- (n2w y) : α word)” ) >>
       simp_tac bool_ss [WORD_ADD_ASSOC, WORD_ADD_LINV] >> simp[] >>
       simp[WORD_LITERAL_ADD]) >>
-  simp[word_add_n2w]);
+  simp[word_add_n2w]
+QED
 
 val lbare' = CONV_RULE (PATH_CONV "rlr" (REWR_CONV EQ_SYM_EQ THENC
                                          LAND_CONV (REWR_CONV WORD_ADD_COMM)))
@@ -2824,16 +2842,20 @@ val instn = instn0 (LIST_CONJ [ag32_ffi_get_arg_count_code_def,
                                ag32_ffi_get_arg_count_main_code_def,
                                ag32_ffi_return_code_def])
 
-val ag32_ffi_return_LET = Q.prove(
-  ‘ag32_ffi_return (LET f v) = LET (ag32_ffi_return o f) v’,
-  simp[]);
+Triviality ag32_ffi_return_LET:
+  ag32_ffi_return (LET f v) = LET (ag32_ffi_return o f) v
+Proof
+  simp[]
+QED
 
 val ag32_ffi_get_arg_count_entrypoint_thm =
     EVAL “ag32_ffi_get_arg_count_entrypoint”
 
-val div_lemma = Q.prove(
-  ‘0 < c ⇒ (c * x + y) DIV c = x + y DIV c ∧ (c * x) DIV c = x’,
-  metis_tac[ADD_DIV_ADD_DIV, MULT_COMM, MULT_DIV]);
+Triviality div_lemma:
+  0 < c ⇒ (c * x + y) DIV c = x + y DIV c ∧ (c * x) DIV c = x
+Proof
+  metis_tac[ADD_DIV_ADD_DIV, MULT_COMM, MULT_DIV]
+QED
 
 val gmw = gmw0 (fn i =>
                    simp0[ffi_code_start_offset_thm] >>
@@ -3563,11 +3585,13 @@ Proof
   \\ simp[]
 QED
 
-val ag32_ffi_get_arg_setup_decomp_thm' = Q.prove(
-  ‘ag32_ffi_get_arg_setup_decomp (s,md) = (ag32_ffi_get_arg_setup s, md)’,
+Triviality ag32_ffi_get_arg_setup_decomp_thm':
+  ag32_ffi_get_arg_setup_decomp (s,md) = (ag32_ffi_get_arg_setup s, md)
+Proof
   Cases_on ‘ag32_ffi_get_arg_setup_decomp (s,md)’ >> simp[] >>
   mp_tac ag32_ffi_get_arg_setup_decomp_thm >> simp[] >>
-  fs[ag32_ffi_get_arg_setup_decomp_def]);
+  fs[ag32_ffi_get_arg_setup_decomp_def]
+QED
 
 val ag32_ffi_get_arg_setup_decomp_pre' =
     let

--- a/compiler/backend/ag32/proofs/ag32_memoryProofScript.sml
+++ b/compiler/backend/ag32/proofs/ag32_memoryProofScript.sml
@@ -286,15 +286,17 @@ Proof
   \\ rw[]
 QED
 
-val get_byte_repl = Q.prove(`
+Triviality get_byte_repl:
   n+m < dimword(:32) ∧
   (m MOD 4 = 0n) ==>
   (get_byte ((n2w (n + m)):word32) w F =
-  get_byte (n2w n) w F)`,
+  get_byte (n2w n) w F)
+Proof
   EVAL_TAC>>
   fs[]>>rw[]>>
   ntac 2 AP_TERM_TAC>>
-  intLib.ARITH_TAC);
+  intLib.ARITH_TAC
+QED
 
 (* -- *)
 
@@ -392,9 +394,11 @@ Proof
   simp[Abbr`codel`]
 QED
 
-val lem = Q.prove(`
-  (m MOD 4 = 0) ∧ n < m ⇒ n DIV 4 < m DIV 4`,
-  intLib.ARITH_TAC);
+Triviality lem:
+  (m MOD 4 = 0) ∧ n < m ⇒ n DIV 4 < m DIV 4
+Proof
+  intLib.ARITH_TAC
+QED
 
 Theorem init_memory_startup:
    ∀code data ffis n.
@@ -939,8 +943,8 @@ val mem_ok_tac =
      addressTheory.ALIGNED_n2w,
      bitTheory.BITS_ZERO3 ]
 
-val bounded_bits = Q.prove(`
-   ll < 4294967296 ⇒
+Triviality bounded_bits:
+  ll < 4294967296 ⇒
    ((BIT 0 (ll MOD 256) ⇔ BIT 0 ll) ∧ (BIT 1 (ll MOD 256) ⇔ BIT 1 ll) ∧
    (BIT 2 (ll MOD 256) ⇔ BIT 2 ll) ∧ (BIT 3 (ll MOD 256) ⇔ BIT 3 ll) ∧
    (BIT 4 (ll MOD 256) ⇔ BIT 4 ll) ∧ (BIT 5 (ll MOD 256) ⇔ BIT 5 ll) ∧
@@ -968,7 +972,8 @@ val bounded_bits = Q.prove(`
    (BIT 4 (BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256) ⇔ BIT 28 ll) ∧
    (BIT 5 (BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256) ⇔ BIT 29 ll) ∧
    (BIT 6 (BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256) ⇔ BIT 30 ll) ∧
-   (BIT 7 (BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256) ⇔ BIT 31 ll))`,
+   (BIT 7 (BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256) ⇔ BIT 31 ll))
+Proof
   strip_tac>>
   CONJ_TAC>- (
     `BITS 7 0 (ll MOD 256) = BITS 7 0 ll` by
@@ -987,7 +992,8 @@ val bounded_bits = Q.prove(`
   `BITS 31 8 (BITS 31 8 (BITS 31 8 ll)) MOD 256 = BITS 31 24 ll` by
     (simp[bitTheory.BITS_THM]>>
     intLib.ARITH_TAC)>>
-  simp[bitTheory.BIT_OF_BITS_THM]);
+  simp[bitTheory.BIT_OF_BITS_THM]
+QED
 
 val mem_word_tac =
     rw[word_of_bytes_def,
@@ -1006,12 +1012,14 @@ val mem_word_tac =
     blastLib.BBLAST_TAC>>
     simp[bounded_bits]
 
-val ag32_const_enc = Q.prove(`
+Triviality ag32_const_enc:
   (∃a b c d.
   ag32_enc (Inst (Const r w)) = [a;b;c;d]) ∨
-  ∃a b c d e f g h. ag32_enc (Inst (Const r w)) = [a;b;c;d;e;f;g;h]`,
+  ∃a b c d e f g h. ag32_enc (Inst (Const r w)) = [a;b;c;d;e;f;g;h]
+Proof
   rpt (EVAL_TAC>>
-  rw[]));
+  rw[])
+QED
 
 fun LENGTH_ag32_enc_cases_tac
   (g as (asl,w))
@@ -1028,9 +1036,11 @@ fun LENGTH_ag32_enc_cases_tac
     \\ simp[]
   end g
 
-val FLAT_CONS = Q.prove(`
-  FLAT (h::t) = h ++ FLAT t`,
-  fs[]);
+Triviality FLAT_CONS:
+  FLAT (h::t) = h ++ FLAT t
+Proof
+  fs[]
+QED
 
 val startup_asm_code_eq =
   startup_asm_code_def |> SPEC_ALL

--- a/compiler/backend/bvi_to_dataScript.sml
+++ b/compiler/backend/bvi_to_dataScript.sml
@@ -208,12 +208,14 @@ Proof
   \\ gvs [compile_def]
 QED
 
-val compile_LESS_EQ_lemma = Q.prove(
-  `!n env tail live xs.
-      n <= SND (SND (compile n env tail live xs))`,
+Triviality compile_LESS_EQ_lemma:
+  !n env tail live xs.
+      n <= SND (SND (compile n env tail live xs))
+Proof
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
-  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);
+  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC
+QED
 
 Theorem compile_LESS_EQ:
    !n env tail live xs c vs new_var.
@@ -223,12 +225,14 @@ Proof
   \\ FULL_SIMP_TAC std_ss []
 QED
 
-val compile_LENGTH_lemma = Q.prove(
-  `!n env tail live xs.
-      (LENGTH (FST (SND (compile n env tail live xs))) = LENGTH xs)`,
+Triviality compile_LENGTH_lemma:
+  !n env tail live xs.
+      (LENGTH (FST (SND (compile n env tail live xs))) = LENGTH xs)
+Proof
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
-  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] []);
+  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] []
+QED
 
 Theorem compile_LENGTH:
    !n env tail live xs c vs new_var.

--- a/compiler/backend/bvl_to_bviScript.sml
+++ b/compiler/backend/bvl_to_bviScript.sml
@@ -450,11 +450,13 @@ Proof
   \\ gvs [compile_exps_def,compile_exps_sing_def,SmartAppend_Nil]
 QED
 
-val compile_exps_LENGTH_lemma = Q.prove(
-  `!n xs. (LENGTH (FST (compile_exps n xs)) = LENGTH xs)`,
+Triviality compile_exps_LENGTH_lemma:
+  !n xs. (LENGTH (FST (compile_exps n xs)) = LENGTH xs)
+Proof
   HO_MATCH_MP_TAC compile_exps_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_exps_def] \\ SRW_TAC [] []
-  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC);
+  \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] \\ DECIDE_TAC
+QED
 
 Theorem compile_exps_LENGTH:
    (compile_exps n xs = (ys,aux,n1)) ==> (LENGTH ys = LENGTH xs)

--- a/compiler/backend/clos_callScript.sml
+++ b/compiler/backend/clos_callScript.sml
@@ -197,9 +197,11 @@ Proof
   simp[closed_def, free_sing_eq] >> pairarg_tac >> gvs[]
 QED
 
-val EL_MEM_LEMMA = Q.prove(
-  `!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs`,
-  Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []);
+Triviality EL_MEM_LEMMA:
+  !xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs
+Proof
+  Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []
+QED
 
 Definition insert_each_def:
   (insert_each p 0 g = g) /\
@@ -225,9 +227,11 @@ Definition calls_list_def:
           calls_list t (i+1) (loc+2n) xs)
 End
 
-val exp3_size_MAP_SND = Q.prove(
-  `!fns. exp3_size (MAP SND fns) <= exp1_size fns`,
-  Induct \\ fs [exp_size_def,FORALL_PROD]);
+Triviality exp3_size_MAP_SND:
+  !fns. exp3_size (MAP SND fns) <= exp1_size fns
+Proof
+  Induct \\ fs [exp_size_def,FORALL_PROD]
+QED
 
 Definition calls_def:
   (calls [] g = ([],g)) /\

--- a/compiler/backend/clos_knownScript.sml
+++ b/compiler/backend/clos_knownScript.sml
@@ -430,9 +430,11 @@ Proof
   >> fs[known_op_def]
 QED
 
-val EL_MEM_LEMMA = Q.prove(
-  `!xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs`,
-  Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []);
+Triviality EL_MEM_LEMMA:
+  !xs i x. i < LENGTH xs /\ (x = EL i xs) ==> MEM x xs
+Proof
+  Induct \\ fs [] \\ REPEAT STRIP_TAC \\ Cases_on `i` \\ fs []
+QED
 
 Definition clos_approx_def:
   clos_approx max_size loc num_args body =

--- a/compiler/backend/clos_mtiScript.sml
+++ b/compiler/backend/clos_mtiScript.sml
@@ -31,16 +31,18 @@ Proof
    decide_tac
 QED
 
-val collect_args_more = Q.prove (
-  `!max_app num_args e num_args' e'.
+Triviality collect_args_more:
+  !max_app num_args e num_args' e'.
     (num_args', e') = collect_args max_app num_args e
     ⇒
-    num_args ≤ num_args'`,
+    num_args ≤ num_args'
+Proof
   ho_match_mp_tac collect_args_ind >>
   srw_tac[][collect_args_def] >>
   srw_tac[][] >>
   res_tac >>
-  decide_tac);
+  decide_tac
+QED
 
 Theorem collect_args_zero:
    !max_app num_args e e'.
@@ -65,10 +67,12 @@ End
 
 val collect_apps_ind = theorem "collect_apps_ind";
 
-val exp3_size_append = Q.prove (
-`!es1 es2. exp3_size (es1 ++ es2) = exp3_size es1 + exp3_size es2`,
- Induct_on `es1` >>
- simp [exp_size_def]);
+Triviality exp3_size_append:
+  !es1 es2. exp3_size (es1 ++ es2) = exp3_size es1 + exp3_size es2
+Proof
+  Induct_on `es1` >>
+ simp [exp_size_def]
+QED
 
 Theorem collect_apps_size:
    !max_app args e args' e'.
@@ -84,16 +88,18 @@ Proof
    decide_tac
 QED
 
-val collect_apps_more = Q.prove (
-  `!max_app args e args' e'.
+Triviality collect_apps_more:
+  !max_app args e args' e'.
     (args', e') = collect_apps max_app args e
     ⇒
-    LENGTH args ≤ LENGTH args'`,
+    LENGTH args ≤ LENGTH args'
+Proof
   ho_match_mp_tac collect_apps_ind >>
   srw_tac[][collect_apps_def] >>
   srw_tac[][] >>
   res_tac >>
-  decide_tac);
+  decide_tac
+QED
 
 Definition intro_multi_def:
   (intro_multi max_app [] = []) ∧

--- a/compiler/backend/clos_to_bvlScript.sml
+++ b/compiler/backend/clos_to_bvlScript.sml
@@ -605,17 +605,21 @@ End
 
 Theorem compile_prog_eq = compile_prog_def |> SRULE [compile_exp_sing_eq];
 
-val pair_lem1 = Q.prove (
-  `!f x. (\(a,b). f a b) x = f (FST x) (SND x)`,
+Triviality pair_lem1:
+  !f x. (\(a,b). f a b) x = f (FST x) (SND x)
+Proof
   rw [] >>
   PairCases_on `x` >>
-  fs []);
+  fs []
+QED
 
-val pair_lem2 = Q.prove (
-  `!x y z. (x,y) = z ⇔ x = FST z ∧ y = SND z`,
+Triviality pair_lem2:
+  !x y z. (x,y) = z ⇔ x = FST z ∧ y = SND z
+Proof
   rw [] >>
   PairCases_on `z` >>
-  rw []);
+  rw []
+QED
 
 Theorem compile_exps_acc:
    !max_app xs aux.

--- a/compiler/backend/db_varsScript.sml
+++ b/compiler/backend/db_varsScript.sml
@@ -127,10 +127,12 @@ Proof
   \\ fs [lookup_db_to_set]
 QED
 
-val has_var_FOLDL_Union = Q.prove(
-  `!vs n s. has_var n (FOLDL (\s1 v. Union (Var v) s1) s vs) <=>
-             MEM n vs \/ has_var n s`,
-  Induct \\ fs [] \\ rw [] \\ fs [] \\ eq_tac \\ rw [] \\ fs []);
+Triviality has_var_FOLDL_Union:
+  !vs n s. has_var n (FOLDL (\s1 v. Union (Var v) s1) s vs) <=>
+             MEM n vs \/ has_var n s
+Proof
+  Induct \\ fs [] \\ rw [] \\ fs [] \\ eq_tac \\ rw [] \\ fs []
+QED
 
 Theorem MEM_vars_from_list:
    !vs n. has_var n (vars_from_list vs) <=> MEM n vs

--- a/compiler/backend/gc/copying_gcScript.sml
+++ b/compiler/backend/gc/copying_gcScript.sml
@@ -91,29 +91,35 @@ End
 
 (* Invariant maintained *)
 
-val DRESTRICT_heap_map = Q.prove(
-  `!heap k. n < k ==> (DRESTRICT (heap_map k heap) (COMPL {n}) = heap_map k heap)`,
+Triviality DRESTRICT_heap_map:
+  !heap k. n < k ==> (DRESTRICT (heap_map k heap) (COMPL {n}) = heap_map k heap)
+Proof
   simp_tac (srw_ss()) [GSYM fmap_EQ_THM,DRESTRICT_DEF,EXTENSION] \\ rpt strip_tac
   \\ Cases_on `x IN FDOM (heap_map k heap)` \\ full_simp_tac std_ss []
   \\ rpt (pop_assum mp_tac)  \\ Q.SPEC_TAC (`k`,`k`) \\ Q.SPEC_TAC (`heap`,`heap`)
   \\ Induct \\ full_simp_tac (srw_ss()) [heap_map_def]
   \\ Cases \\ full_simp_tac (srw_ss()) [heap_map_def]
   \\ rpt strip_tac \\ full_simp_tac std_ss []
-  \\ metis_tac [DECIDE ``n<k ==> n < k + m:num``,DECIDE ``n<k ==> n < k + m+1:num``]);
+  \\ metis_tac [DECIDE ``n<k ==> n < k + m:num``,DECIDE ``n<k ==> n < k + m+1:num``]
+QED
 
-val IN_FRANGE = Q.prove(
-  `!heap n. MEM (ForwardPointer ptr d l) heap ==> ptr IN FRANGE (heap_map n heap)`,
+Triviality IN_FRANGE:
+  !heap n. MEM (ForwardPointer ptr d l) heap ==> ptr IN FRANGE (heap_map n heap)
+Proof
   Induct \\ full_simp_tac std_ss [MEM] \\ rpt strip_tac
   \\ Cases_on `h` \\ full_simp_tac (srw_ss()) [heap_map_def,FRANGE_FUPDATE]
-  \\ `n < n + n0 + 1` by decide_tac \\ full_simp_tac std_ss [DRESTRICT_heap_map]);
+  \\ `n < n + n0 + 1` by decide_tac \\ full_simp_tac std_ss [DRESTRICT_heap_map]
+QED
 
-val heap_addresses_SNOC = Q.prove(
-  `!xs n x.
+Triviality heap_addresses_SNOC:
+  !xs n x.
       heap_addresses n (xs ++ [x]) =
-      heap_addresses n xs UNION {heap_length xs + n}`,
+      heap_addresses n xs UNION {heap_length xs + n}
+Proof
   Induct \\ full_simp_tac (srw_ss()) [heap_addresses_def,APPEND,heap_length_def]
   \\ full_simp_tac (srw_ss()) [EXTENSION] \\ rpt strip_tac
-  \\ full_simp_tac std_ss [AC ADD_COMM ADD_ASSOC,DISJ_ASSOC]);
+  \\ full_simp_tac std_ss [AC ADD_COMM ADD_ASSOC,DISJ_ASSOC]
+QED
 
 val NOT_IN_heap_addresses = Q.prove(
   `!xs n. ~(n + heap_length xs IN heap_addresses n xs)`,
@@ -123,8 +129,8 @@ val NOT_IN_heap_addresses = Q.prove(
   THEN1 (Cases_on `h` \\ EVAL_TAC \\ decide_tac) \\ metis_tac [])
   |> Q.SPECL [`xs`,`0`] |> SIMP_RULE std_ss [];
 
-val gc_move_thm = Q.prove(
-  `gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 roots0 /\
+Triviality gc_move_thm:
+  gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 roots0 /\
     (!ptr u. (x = Pointer ptr u) ==> isSomeDataOrForward (heap_lookup ptr heap) /\
                                      reachable_addresses roots0 heap0 ptr) ==>
     ?x3 h23 a3 n3 heap3 c3.
@@ -133,7 +139,8 @@ val gc_move_thm = Q.prove(
       (!ptr. isSomeDataOrForward (heap_lookup ptr heap) =
              isSomeDataOrForward (heap_lookup ptr heap3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0 roots0`,
+      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0 roots0
+Proof
   Cases_on `x` \\ simp_tac (srw_ss()) [gc_move_def,ADDR_APPLY_def]
   \\ simp_tac std_ss [Once isSomeDataOrForward_def] \\ rpt strip_tac
   \\ full_simp_tac (srw_ss()) [isSomeForwardPointer_def] THEN1
@@ -202,10 +209,11 @@ val gc_move_thm = Q.prove(
   \\ SRW_TAC [] [] \\ full_simp_tac std_ss []
   \\ res_tac \\ fs []
   \\ match_mp_tac ADDR_MAP_EQ
-  \\ full_simp_tac std_ss [FAPPLY_FUPDATE_THM] \\ metis_tac []);
+  \\ full_simp_tac std_ss [FAPPLY_FUPDATE_THM] \\ metis_tac []
+QED
 
-val gc_move_list_thm = Q.prove(
-  `!xs h2 a n heap c.
+Triviality gc_move_list_thm:
+  !xs h2 a n heap c.
     gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 roots0 /\
     (!ptr u. MEM (Pointer ptr u) (xs:'a heap_address list) ==>
              isSomeDataOrForward (heap_lookup ptr heap) /\
@@ -216,7 +224,8 @@ val gc_move_list_thm = Q.prove(
       (!ptr. isSomeDataOrForward (heap_lookup ptr heap) =
              isSomeDataOrForward (heap_lookup ptr heap3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0 roots0`,
+      gc_inv (h1,h23,a3,n3,heap3,c3,limit) heap0 roots0
+Proof
   Induct THEN1 (full_simp_tac std_ss [gc_move_list_def,ADDR_MAP_def,MEM,SUBMAP_REFL])
   \\ full_simp_tac std_ss [MEM,gc_move_list_def,LET_DEF] \\ rpt strip_tac
   \\ Q.ABBREV_TAC `x = h` \\ pop_assum (K all_tac)
@@ -230,7 +239,8 @@ val gc_move_list_thm = Q.prove(
   \\ strip_tac THEN1
    (Cases_on `x` \\ full_simp_tac (srw_ss()) [ADDR_APPLY_def,ADDR_MAP_def]
     \\ full_simp_tac std_ss [heap_map1_def,SUBMAP_DEF])
-  \\ full_simp_tac std_ss [SUBMAP_DEF] \\ metis_tac []);
+  \\ full_simp_tac std_ss [SUBMAP_DEF] \\ metis_tac []
+QED
 
 val APPEND_NIL_LEMMA = METIS_PROVE [APPEND_NIL] ``?xs1. xs = xs ++ xs1:'a list``
 
@@ -260,21 +270,24 @@ Proof
   \\ full_simp_tac std_ss [APPEND_ASSOC]
 QED
 
-val gc_move_list_APPEND_lemma = Q.prove(
-  `!ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
+Triviality gc_move_list_APPEND_lemma:
+  !ys xs a n heap c limit ys3 xs3 a3 n3 heap3 c3.
       (gc_move_list (ys,xs,a,n,heap,c,limit) = (ys3,xs3,a3,n3,heap3,c3)) ==>
-      (?xs1. xs3 = xs ++ xs1)`,
+      (?xs1. xs3 = xs ++ xs1)
+Proof
   once_rewrite_tac [gc_move_list_ALT] \\ full_simp_tac std_ss [LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ full_simp_tac std_ss [APPEND_ASSOC] \\ metis_tac []);
+  \\ full_simp_tac std_ss [APPEND_ASSOC] \\ metis_tac []
+QED
 
-val gc_move_loop_thm = Q.prove(
-  `!h1 h2 a n heap c.
+Triviality gc_move_loop_thm:
+  !h1 h2 a n heap c.
       gc_inv (h1,h2,a,n,heap:('a,'b) heap_element list,c,limit) heap0 roots0 ==>
       ?h13 a3 n3 heap3 c3.
         (gc_move_loop (h1,h2,a,n,heap,c,limit) = (h13,a3,n3,heap3,c3)) /\
       ((heap_map 0 heap) SUBMAP (heap_map 0 heap3)) /\
-      gc_inv (h13,[],a3,n3,heap3,c3,limit) heap0 roots0`,
+      gc_inv (h13,[],a3,n3,heap3,c3,limit) heap0 roots0
+Proof
   completeInduct_on `limit - heap_length h1` \\ rpt strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `h2`
   \\ full_simp_tac std_ss [gc_move_loop_def,SUBMAP_REFL]
@@ -345,16 +358,19 @@ val gc_move_loop_thm = Q.prove(
   \\ `0 < l+1` by decide_tac \\ full_simp_tac std_ss []
   \\ Cases_on `j < heap_length h1 + (l + 1)` \\ full_simp_tac (srw_ss()) []
   \\ full_simp_tac std_ss [heap_length_APPEND]
-  \\ full_simp_tac (srw_ss()) [heap_length_def,el_length_def]);
+  \\ full_simp_tac (srw_ss()) [heap_length_def,el_length_def]
+QED
 
-val gc_inv_init = Q.prove(
-  `gc_inv ([],[],0,limit,heap,T,limit) heap roots = heap_ok heap limit`,
+Triviality gc_inv_init:
+  gc_inv ([],[],0,limit,heap,T,limit) heap roots = heap_ok heap limit
+Proof
   full_simp_tac std_ss [gc_inv_def] \\ Cases_on `heap_ok heap limit`
   \\ full_simp_tac (srw_ss()) [heap_addresses_def,heap_length_def]
   \\ full_simp_tac std_ss [heap_ok_def]
   \\ imp_res_tac FILTER_LEMMA \\ full_simp_tac std_ss [heap_length_def]
   \\ full_simp_tac (srw_ss()) [heaps_similar_REFL,heap_map_EMPTY,FLOOKUP_DEF]
-  \\ full_simp_tac (srw_ss()) [BIJ_DEF,INJ_DEF,SURJ_DEF]);
+  \\ full_simp_tac (srw_ss()) [BIJ_DEF,INJ_DEF,SURJ_DEF]
+QED
 
 Theorem full_gc_thm:
    roots_ok roots heap /\ heap_ok (heap:('a,'b) heap_element list) limit ==>

--- a/compiler/backend/gc/gen_gc_partialScript.sml
+++ b/compiler/backend/gc/gen_gc_partialScript.sml
@@ -891,11 +891,12 @@ val MAP_to_gen_heap_address_11 = prove(
   Induct \\ Cases_on `y` \\ fs []
   \\ rw [] \\ fs [] \\ metis_tac [to_gen_heap_address_11]);
 
-val gc_forward_ptr_data_pres = Q.prove(
-   `!x a ptr d ok x' ok'.
+Triviality gc_forward_ptr_data_pres:
+  !x a ptr d ok x' ok'.
    (gc_forward_ptr a x ptr d ok = (x',ok'))
    ==> (MEM (DataElement xs l dd) x
-        = (MEM (DataElement xs l dd) x' \/ (heap_lookup a x = SOME(DataElement xs l dd))))`,
+        = (MEM (DataElement xs l dd) x' \/ (heap_lookup a x = SOME(DataElement xs l dd))))
+Proof
   Induct
   >> rw[gc_forward_ptr_def] >> rpt strip_tac
   >> fs[heap_lookup_def]
@@ -903,39 +904,46 @@ val gc_forward_ptr_data_pres = Q.prove(
   >> pairarg_tac
   >> fs[]
   >> qpat_x_assum `_::_ = _` (assume_tac o GSYM)
-  >> fs[] >> metis_tac[]);
+  >> fs[] >> metis_tac[]
+QED
 
-val gc_move_data_pres = Q.prove(
-  `(gc_move conf state x = (x1,state1))
+Triviality gc_move_data_pres:
+  (gc_move conf state x = (x1,state1))
    ==> (MEM (DataElement xs l dd) (state1.heap++state1.h2)
-        = MEM (DataElement xs l dd) (state.heap++state.h2))`,
+        = MEM (DataElement xs l dd) (state.heap++state.h2))
+Proof
   Cases_on `x` >> rw[gc_move_def] >> rpt strip_tac
   >> fs[] >> every_case_tac >> fs[] >> TRY(pairarg_tac >> fs[]) >>
   qpat_x_assum `_ = (y:('a,'b) gc_state)` (assume_tac o GSYM) >> fs[]
-  >> drule gc_forward_ptr_data_pres >> strip_tac >> fs[] >> metis_tac[]);
+  >> drule gc_forward_ptr_data_pres >> strip_tac >> fs[] >> metis_tac[]
+QED
 
-val gc_move_list_data_pres = Q.prove(
-  `!x conf state x1 state1 xs l dd.
+Triviality gc_move_list_data_pres:
+  !x conf state x1 state1 xs l dd.
    (gc_move_list conf state x = (x1,state1))
    ==> (MEM (DataElement xs l dd) (state1.heap++state1.h2)
-        = MEM (DataElement xs l dd) (state.heap++state.h2))`,
+        = MEM (DataElement xs l dd) (state.heap++state.h2))
+Proof
   Induct_on `x` >> rw[gc_move_list_def] >> fs[]
   >> pairarg_tac >> fs[] >> pairarg_tac >> fs[]
   >> qpat_x_assum `_ = (y:('a,'b) gc_state)` (assume_tac o GSYM)
   >> fs[] >> drule gc_move_data_pres >> strip_tac >> fs[]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val gc_move_ref_list_data_pres = Q.prove(
-  `!x conf state x1 state1 xs l dd.
+Triviality gc_move_ref_list_data_pres:
+  !x conf state x1 state1 xs l dd.
    (gc_move_ref_list conf state x = (x1,state1))
    ==> (MEM (DataElement xs l dd) (state1.heap++state1.h2)
-        = MEM (DataElement xs l dd) (state.heap++state.h2))`,
+        = MEM (DataElement xs l dd) (state.heap++state.h2))
+Proof
   Induct_on `x` >> rw[gc_move_ref_list_def] >> fs[]
   >> Induct_on `h` >> rw[gc_move_ref_list_def] >> rpt strip_tac
   >> fs[]
   >> pairarg_tac >> fs[] >> pairarg_tac >> fs[]
   >> fs[] >> drule gc_move_list_data_pres >> strip_tac >> fs[]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
 val gc_move_data_simulation = prove(
   ``!conf state heap0 state' ptr1' state1'.
@@ -1069,8 +1077,9 @@ val gc_move_data_h2 = prove(
   \\ every_case_tac \\ fs []
   \\ rpt (pairarg_tac \\ fs []) \\ rveq \\ fs []);
 
-val gc_move_ref_list_heap_length = Q.prove(
-  `!h x state state'. (gc_move_ref_list conf state h = (x,state')) ==> (heap_length state.heap = heap_length state'.heap)`,
+Triviality gc_move_ref_list_heap_length:
+  !h x state state'. (gc_move_ref_list conf state h = (x,state')) ==> (heap_length state.heap = heap_length state'.heap)
+Proof
   Induct_on `h`
   >> rpt strip_tac
   >> first_x_assum (assume_tac o GSYM)
@@ -1079,10 +1088,14 @@ val gc_move_ref_list_heap_length = Q.prove(
   >> fs[gc_move_ref_list_def]
   >> pairarg_tac >> fs[]
   >> pairarg_tac >> fs[]
-  >> metis_tac[gc_move_list_heap_length]);
+  >> metis_tac[gc_move_list_heap_length]
+QED
 
-val gc_move_data_r1 = Q.prove(`(gc_move_data conf state).r1 = state.r1`,
-  metis_tac[gc_move_data_IMP]);
+Triviality gc_move_data_r1:
+  (gc_move_data conf state).r1 = state.r1
+Proof
+  metis_tac[gc_move_data_IMP]
+QED
 
 val partial_gc_simulation = prove(
   ``!conf roots heap0 roots1 state1 heap0_old heap0_current heap0_refs

--- a/compiler/backend/proofs/bvi_letProofScript.sml
+++ b/compiler/backend/proofs/bvi_letProofScript.sml
@@ -26,28 +26,32 @@ Proof
   \\ imp_res_tac (METIS_PROVE [] ``x=y ==> LENGTH x = LENGTH y``) \\ fs []
 QED
 
-val env_rel_LLOOKUP_NONE = Q.prove(
-  `!ax env env2 n d.
+Triviality env_rel_LLOOKUP_NONE:
+  !ax env env2 n d.
       env_rel ax d env env2 /\
       LLOOKUP ax n = NONE /\
       n < LENGTH env ==>
       n+d < LENGTH env2 /\
-      EL (n+d) env2 = EL n env`,
+      EL (n+d) env2 = EL n env
+Proof
   Induct THEN1 (fs [env_rel_def,LLOOKUP_def,EL_DROP])
   \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ rw [] \\ Cases_on `n` \\ fs []
-  \\ res_tac \\ fs [LLOOKUP_def] \\ rfs [] \\ fs[ADD_CLAUSES]);
+  \\ res_tac \\ fs [LLOOKUP_def] \\ rfs [] \\ fs[ADD_CLAUSES]
+QED
 
-val env_rel_LOOKUP_SOME = Q.prove(
-  `!env env2 ax x n d.
+Triviality env_rel_LOOKUP_SOME:
+  !env env2 ax x n d.
       env_rel ax d env env2 /\
       LLOOKUP ax n = SOME x ==>
-      v_rel x (EL n env) (EL n env2) (DROP n env) (DROP n env2)`,
+      v_rel x (EL n env) (EL n env2) (DROP n env) (DROP n env2)
+Proof
   Induct \\ Cases_on `env2` \\ Cases_on `ax` \\ fs [env_rel_def,LLOOKUP_def]
   \\ rw [] \\ fs [env_rel_def] \\ res_tac \\ fs []
   \\ Cases_on `n` \\ fs [env_rel_def]
   \\ first_x_assum match_mp_tac
-  \\ Cases_on `h'` \\ fs [env_rel_def]);
+  \\ Cases_on `h'` \\ fs [env_rel_def]
+QED
 
 Theorem evaluate_delete_var_Rerr_SING:
    !x s r e env2.
@@ -60,11 +64,12 @@ Proof
   \\ CCONTR_TAC \\ fs [] \\ rw []
 QED
 
-val evaluate_delete_var_Rerr = Q.prove(
-  `!xs s r e env2.
+Triviality evaluate_delete_var_Rerr:
+  !xs s r e env2.
       evaluate (xs,env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate (MAP delete_var xs,env2,s) = (Rerr e,r)`,
+      evaluate (MAP delete_var xs,env2,s) = (Rerr e,r)
+Proof
   Induct \\ fs [] \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ TRY (drule evaluate_delete_var_Rerr_SING \\ fs [])
@@ -72,14 +77,16 @@ val evaluate_delete_var_Rerr = Q.prove(
   \\ Cases_on `h` \\ fs [delete_var_def]
   \\ rw [] \\ fs [] \\ fs [evaluate_def,do_app_def,do_app_aux_def] \\ rw []
   \\ every_case_tac \\ fs [] \\ rw [] \\ fs [] \\ rw []
-  \\ pop_assum mp_tac \\ EVAL_TAC);
+  \\ pop_assum mp_tac \\ EVAL_TAC
+QED
 
-val evaluate_delete_var_Rval = Q.prove(
-  `!xs env2 s a r ax env d.
+Triviality evaluate_delete_var_Rval:
+  !xs env2 s a r ax env d.
       evaluate (xs,env2,s:('c,'ffi) bviSem$state) = (Rval a,r) /\
       env_rel ax d env env2 ==>
       ?b. evaluate (MAP delete_var xs,env2,s) = (Rval b,r) /\
-          env_rel (extract_list xs ++ ax) d (a ++ env) (b ++ env2)`,
+          env_rel (extract_list xs ++ ax) d (a ++ env) (b ++ env2)
+Proof
   Induct \\ fs [env_rel_def,extract_list_def]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ Cases_on `evaluate ([h],env2,s)` \\ fs []
@@ -99,7 +106,8 @@ val evaluate_delete_var_Rval = Q.prove(
   \\ res_tac \\ fs [] \\ rw []
   \\ `extract h xs = 0` by (Cases_on `h` \\ fs [extract_def]) \\ fs []
   \\ imp_res_tac evaluate_SING_IMP \\ rw [] \\ fs []
-  \\ fs [v_rel_def,env_rel_def,LLOOKUP_def]);
+  \\ fs [v_rel_def,env_rel_def,LLOOKUP_def]
+QED
 
 Theorem evaluate_SNOC_Rval:
    evaluate (SNOC x y,env,s) = (Rval a,r) ==>

--- a/compiler/backend/proofs/bvi_tailrecProofScript.sml
+++ b/compiler/backend/proofs/bvi_tailrecProofScript.sml
@@ -291,24 +291,27 @@ Definition code_rel_def:
             lookup n c2 = SOME (arity + 1, exp_opt))
 End
 
-val code_rel_find_code_SOME = Q.prove (
-  `∀c1 c2 (args: v list) a exp.
+Triviality code_rel_find_code_SOME:
+  ∀c1 c2 (args: v list) a exp.
      code_rel c1 c2 ∧
      find_code (SOME n) args c1 = SOME (a, exp) ⇒
-       find_code (SOME n) args c2 ≠ NONE`,
+       find_code (SOME n) args c2 ≠ NONE
+Proof
   rw [find_code_def, code_rel_def]
   \\ pop_assum mp_tac
   \\ rpt (PURE_TOP_CASE_TAC \\ fs [])
   \\ first_x_assum drule
   \\ fs [compile_exp_def]
   \\ CASE_TAC \\ fs [] \\ rw []
-  \\ pairarg_tac \\ fs []);
+  \\ pairarg_tac \\ fs []
+QED
 
-val code_rel_find_code_NONE = Q.prove (
-  `∀c1 c2 (args: v list) a exp.
+Triviality code_rel_find_code_NONE:
+  ∀c1 c2 (args: v list) a exp.
      code_rel c1 c2 ∧
      find_code NONE args c1 = SOME (a, exp) ⇒
-       find_code NONE args c2 ≠ NONE`,
+       find_code NONE args c2 ≠ NONE
+Proof
   rw [find_code_def, code_rel_def]
   \\ pop_assum mp_tac
   \\ rpt (PURE_TOP_CASE_TAC \\ fs []) \\ rw []
@@ -320,7 +323,8 @@ val code_rel_find_code_NONE = Q.prove (
   \\ first_x_assum drule
   \\ fs [compile_exp_def]
   \\ CASE_TAC \\ fs [] \\ rw []
-  \\ pairarg_tac \\ fs []);
+  \\ pairarg_tac \\ fs []
+QED
 
 Theorem code_rel_domain:
    ∀c1 c2.
@@ -416,13 +420,15 @@ Proof
   \\ Cases_on `h`  \\ fs [] \\ Cases_on `h'` \\ simp [decide_ty_def]
 QED
 
-val ty_rel_APPEND = Q.prove (
-  `∀env ts ws vs.
-     ty_rel env ts ∧ ty_rel vs ws ⇒ ty_rel (vs ++ env) (ws ++ ts)`,
+Triviality ty_rel_APPEND:
+  ∀env ts ws vs.
+     ty_rel env ts ∧ ty_rel vs ws ⇒ ty_rel (vs ++ env) (ws ++ ts)
+Proof
   rw []
   \\ sg `LENGTH ws = LENGTH vs`
   >- (fs [ty_rel_def, LIST_REL_EL_EQN])
-  \\ fs [ty_rel_def, LIST_REL_APPEND_EQ]);
+  \\ fs [ty_rel_def, LIST_REL_APPEND_EQ]
+QED
 
 Theorem LAST1_thm:
    !xs. LAST1 xs = NONE <=> xs = []
@@ -687,23 +693,29 @@ Definition free_names_def:
   free_names n (name: num) ⇔ ∀k. n + bvl_to_bvi_namespaces*k ≠ name
 End
 
-val more_free_names = Q.prove (
-  `free_names n name ⇒ free_names (n + bvl_to_bvi_namespaces) name`,
+Triviality more_free_names:
+  free_names n name ⇒ free_names (n + bvl_to_bvi_namespaces) name
+Proof
   fs [free_names_def] \\ rpt strip_tac
   \\ first_x_assum (qspec_then `k + 1` mp_tac) \\ strip_tac
-  \\ rw []);
+  \\ rw []
+QED
 
-val is_free_name = Q.prove (
-  `free_names n name ⇒ n ≠ name`,
+Triviality is_free_name:
+  free_names n name ⇒ n ≠ name
+Proof
   fs [free_names_def] \\ strip_tac
-  \\ first_x_assum (qspec_then `0` mp_tac) \\ strip_tac \\ rw []);
+  \\ first_x_assum (qspec_then `0` mp_tac) \\ strip_tac \\ rw []
+QED
 
-val compile_exp_next_addr = Q.prove (
-  `compile_exp loc next args exp = NONE ⇒
-     compile_exp loc (next + bvl_to_bvi_namespaces) args exp = NONE`,
+Triviality compile_exp_next_addr:
+  compile_exp loc next args exp = NONE ⇒
+     compile_exp loc (next + bvl_to_bvi_namespaces) args exp = NONE
+Proof
   fs [compile_exp_def]
   \\ every_case_tac
-  \\ pairarg_tac \\ fs []);
+  \\ pairarg_tac \\ fs []
+QED
 
 Theorem compile_prog_untouched:
    ∀next prog prog2 loc exp arity.
@@ -740,14 +752,16 @@ Proof
   \\ rw [fromAList_def, lookup_insert, is_free_name]
 QED
 
-val EVERY_free_names_SUCSUC = Q.prove (
-  `∀xs.
+Triviality EVERY_free_names_SUCSUC:
+  ∀xs.
      EVERY (free_names n o FST) xs ⇒
-       EVERY (free_names (n + bvl_to_bvi_namespaces) o FST) xs`,
+       EVERY (free_names (n + bvl_to_bvi_namespaces) o FST) xs
+Proof
   Induct
   \\ strip_tac \\ fs []
   \\ strip_tac
-  \\ imp_res_tac more_free_names);
+  \\ imp_res_tac more_free_names
+QED
 
 Theorem compile_prog_touched:
    ∀next prog prog2 loc exp arity.
@@ -802,24 +816,30 @@ Proof
   \\ fs[backend_commonTheory.bvl_to_bvi_namespaces_def]
 QED
 
-val check_exp_NONE_compile_exp = Q.prove (
-  `check_exp loc arity exp = NONE ⇒ compile_exp loc next arity exp = NONE`,
-  fs [compile_exp_def]);
+Triviality check_exp_NONE_compile_exp:
+  check_exp loc arity exp = NONE ⇒ compile_exp loc next arity exp = NONE
+Proof
+  fs [compile_exp_def]
+QED
 
-val check_exp_SOME_compile_exp = Q.prove (
-  `check_exp loc arity exp = SOME p ⇒
-     ∃q. compile_exp loc next arity exp = SOME q`,
+Triviality check_exp_SOME_compile_exp:
+  check_exp loc arity exp = SOME p ⇒
+     ∃q. compile_exp loc next arity exp = SOME q
+Proof
   fs [compile_exp_def, check_exp_def]
   \\ rw [] \\ rw []
-  \\ pairarg_tac \\ fs []);
+  \\ pairarg_tac \\ fs []
+QED
 
-val EVERY_free_names_thm = Q.prove (
-  `EVERY (free_names next o FST) prog ∧
+Triviality EVERY_free_names_thm:
+  EVERY (free_names next o FST) prog ∧
    lookup loc (fromAList prog) = SOME x ⇒
-     free_names next loc`,
+     free_names next loc
+Proof
   rw [lookup_fromAList, EVERY_MEM]
   \\ imp_res_tac ALOOKUP_MEM
-  \\ first_x_assum (qspec_then `(loc, x)` mp_tac) \\ rw []);
+  \\ first_x_assum (qspec_then `(loc, x)` mp_tac) \\ rw []
+QED
 
 Theorem compile_prog_code_rel:
    compile_prog next prog = (next1, prog2) ∧
@@ -884,14 +904,14 @@ Proof
   \\ qexists_tac`k'' + 1` \\ simp[]
 QED
 
-val compile_prog_intro = Q.prove (
-  `∀xs n ys n1 name.
+Triviality compile_prog_intro:
+  ∀xs n ys n1 name.
     ¬MEM name (MAP FST xs) ∧
     free_names n name ∧
     compile_prog n xs = (n1, ys) ⇒
       ¬MEM name (MAP FST ys) ∧
       free_names n1 name
-      `,
+Proof
   Induct
   >- fs [compile_prog_def]
   \\ gen_tac
@@ -905,7 +925,8 @@ val compile_prog_intro = Q.prove (
     \\ metis_tac [])
   \\ PURE_CASE_TAC \\ fs []
   \\ rpt strip_tac \\ rveq \\ fs []
-  \\ metis_tac [is_free_name,more_free_names]);
+  \\ metis_tac [is_free_name,more_free_names]
+QED
 
 Theorem compile_prog_ALL_DISTINCT:
    compile_prog n xs = (n1,ys) /\ ALL_DISTINCT (MAP FST xs) /\

--- a/compiler/backend/proofs/bvi_to_dataProofScript.sml
+++ b/compiler/backend/proofs/bvi_to_dataProofScript.sml
@@ -89,13 +89,14 @@ End
 val find_code_def = bvlSemTheory.find_code_def;
 val _ = temp_bring_to_front_overload"find_code"{Name="find_code",Thy="bvlSem"};
 
-val find_code_lemma = Q.prove(
-  `state_rel r t2 ∧
+Triviality find_code_lemma:
+  state_rel r t2 ∧
     find_code dest (MAP data_to_bvi_v a) r.code = SOME (args,exp)
     ⇒ ∃args' ss.
        args = MAP data_to_bvi_v args' ∧
        dataSem$find_code dest a t2.code t2.stack_frame_sizes =
-         SOME (args',compile_exp (LENGTH args') exp,ss)`,
+         SOME (args',compile_exp (LENGTH args') exp,ss)
+Proof
   reverse (Cases_on `dest`) \\ SIMP_TAC std_ss [find_code_def,dataSemTheory.find_code_def]
   \\ FULL_SIMP_TAC (srw_ss()) [state_rel_def,code_rel_def]
   \\ REPEAT STRIP_TAC THEN1
@@ -111,7 +112,8 @@ val find_code_lemma = Q.prove(
      by (qpat_x_assum `FRONT _ = _` (assume_tac o GSYM) \\ rveq
         \\ Cases_on `a` \\ fs [])
   \\ `?t1 t2. a = SNOC t1 t2` by METIS_TAC [SNOC_CASES]
-  \\ FULL_SIMP_TAC std_ss [FRONT_SNOC,LENGTH_SNOC,ADD1,MAP_SNOC]);
+  \\ FULL_SIMP_TAC std_ss [FRONT_SNOC,LENGTH_SNOC,ADD1,MAP_SNOC]
+QED
 
 Theorem optimise_correct:
    !c s. FST (evaluate (c,s)) <> SOME (Rerr(Rabort Rtype_error)) /\
@@ -131,10 +133,11 @@ Proof
   \\ rfs [] \\ MAP_EVERY qexists_tac [`safe'`,`peak'`,`smx`,`ls`] \\ rw [state_component_equality]
 QED
 
-val compile_RANGE_lemma = Q.prove(
-  `!n env tail live xs.
+Triviality compile_RANGE_lemma:
+  !n env tail live xs.
       EVERY (\v. v < (SND (SND (compile n env tail live xs))))
-        (FST (SND (compile n env tail live xs)))`,
+        (FST (SND (compile n env tail live xs)))
+Proof
   HO_MATCH_MP_TAC compile_ind \\ REPEAT STRIP_TAC
   \\ SIMP_TAC std_ss [compile_def] \\ SRW_TAC [] []
   \\ FULL_SIMP_TAC (srw_ss()) []
@@ -143,11 +146,14 @@ val compile_RANGE_lemma = Q.prove(
   \\ rw[]
   \\ RES_TAC
   \\ IMP_RES_TAC compile_LESS_EQ
-  \\ TRY (Cases_on `tail`) \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC);
+  \\ TRY (Cases_on `tail`) \\ full_simp_tac(srw_ss())[] \\ DECIDE_TAC
+QED
 
-val compile_RANGE = Q.prove(
-  `(compile n env tail live xs = (ys,vs,k)) ==> EVERY (\v.  v < k) vs`,
-  REPEAT STRIP_TAC \\ MP_TAC (compile_RANGE_lemma |> SPEC_ALL) \\ full_simp_tac(srw_ss())[]);
+Triviality compile_RANGE:
+  (compile n env tail live xs = (ys,vs,k)) ==> EVERY (\v.  v < k) vs
+Proof
+  REPEAT STRIP_TAC \\ MP_TAC (compile_RANGE_lemma |> SPEC_ALL) \\ full_simp_tac(srw_ss())[]
+QED
 
 Overload res_list = ``map_result (λv. [v]) I``
 Overload isException = ``λx. ∃v. x = Rerr(Rraise v)``
@@ -157,9 +163,11 @@ val stack_case_eq_thm = prove_case_eq_thm { nchotomy = stack_nchotomy, case_def 
 
 val RW = REWRITE_RULE;
 
-val compile_part_thm = Q.prove(
-  `compile_part = λ(x,y). (x, (λ(a,b). (a, compile_exp a b)) y)`,
-  simp[FUN_EQ_THM,FORALL_PROD,compile_part_def])
+Triviality compile_part_thm:
+  compile_part = λ(x,y). (x, (λ(a,b). (a, compile_exp a b)) y)
+Proof
+  simp[FUN_EQ_THM,FORALL_PROD,compile_part_def]
+QED
 
 (* Projection for results, injective upto `dataSem$v` *)
 Definition data_to_bvi_result_def:
@@ -1893,9 +1901,11 @@ Proof
   \\ fs [state_rel_def]
 QED
 
-val state_rel_dec_clock = Q.prove(
-  `state_rel s1 t1 ⇒ state_rel (dec_clock 1 s1) (dec_clock t1)`,
-  srw_tac[][state_rel_def,bviSemTheory.dec_clock_def,dataSemTheory.dec_clock_def])
+Triviality state_rel_dec_clock:
+  state_rel s1 t1 ⇒ state_rel (dec_clock 1 s1) (dec_clock t1)
+Proof
+  srw_tac[][state_rel_def,bviSemTheory.dec_clock_def,dataSemTheory.dec_clock_def]
+QED
 
 Theorem compile_part_evaluate:
    evaluate ([Call 0 (SOME start) [] NONE],[],s1) = (res,s2) ∧

--- a/compiler/backend/proofs/bvl_constProofScript.sml
+++ b/compiler/backend/proofs/bvl_constProofScript.sml
@@ -31,25 +31,29 @@ Proof
   \\ Cases \\ fs [env_rel_def]
 QED
 
-val env_rel_LLOOKUP_NONE = Q.prove(
-  `!ax env env2 n.
+Triviality env_rel_LLOOKUP_NONE:
+  !ax env env2 n.
       env_rel (:'c) (:'ffi) ax env env2 /\
       (LLOOKUP ax n = NONE \/ LLOOKUP ax n = SOME NONE) ==>
-      EL n env2 = EL n env`,
+      EL n env2 = EL n env
+Proof
   Induct \\ Cases_on `env` \\ Cases_on `env2` \\ fs [env_rel_def]
   \\ Cases \\ fs [env_rel_def,LLOOKUP_def]
-  \\ rw [] \\ fs [] \\ Cases_on `n` \\ fs [EL]);
+  \\ rw [] \\ fs [] \\ Cases_on `n` \\ fs [EL]
+QED
 
-val env_rel_LOOKUP_SOME = Q.prove(
-  `!env env2 ax x n.
+Triviality env_rel_LOOKUP_SOME:
+  !env env2 ax x n.
       env_rel (:'c) (:'ffi) ax env env2 /\
       LLOOKUP ax n = SOME (SOME x) ==>
-      v_rel (:'c) (:'ffi) x (EL n env) (EL n env2) (DROP n env) (DROP n env2)`,
+      v_rel (:'c) (:'ffi) x (EL n env) (EL n env2) (DROP n env) (DROP n env2)
+Proof
   Induct \\ Cases_on `env2` \\ Cases_on `ax` \\ fs [env_rel_def,LLOOKUP_def]
   \\ rw [] \\ fs [env_rel_def] \\ res_tac \\ fs []
   \\ Cases_on `n` \\ fs [env_rel_def]
   \\ first_x_assum match_mp_tac
-  \\ Cases_on `h'` \\ fs [env_rel_def]);
+  \\ Cases_on `h'` \\ fs [env_rel_def]
+QED
 
 Theorem evaluate_delete_var_Rerr_SING:
    !x s r e env2.
@@ -62,11 +66,12 @@ Proof
   \\ CCONTR_TAC \\ fs [] \\ rw []
 QED
 
-val evaluate_delete_var_Rerr = Q.prove(
-  `!xs s r e env2.
+Triviality evaluate_delete_var_Rerr:
+  !xs s r e env2.
       evaluate (xs,env2,s) = (Rerr e,r) /\
       e <> Rabort Rtype_error ==>
-      evaluate (MAP bvl_const$delete_var xs,env2,s) = (Rerr e,r)`,
+      evaluate (MAP bvl_const$delete_var xs,env2,s) = (Rerr e,r)
+Proof
   Induct \\ fs [] \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ every_case_tac \\ fs [] \\ rw []
   \\ TRY (drule evaluate_delete_var_Rerr_SING \\ fs [])
@@ -74,14 +79,16 @@ val evaluate_delete_var_Rerr = Q.prove(
   \\ Cases_on `h` \\ fs [delete_var_def]
   \\ rw [] \\ fs []
   \\ fs [evaluate_def,do_app_def] \\ rw []
-  \\ every_case_tac \\ fs [] \\ rw []);
+  \\ every_case_tac \\ fs [] \\ rw []
+QED
 
-val evaluate_delete_var_Rval = Q.prove(
-  `!xs env2 s a r ax env.
+Triviality evaluate_delete_var_Rval:
+  !xs env2 s a r ax env.
       evaluate (xs,env2,s:('c,'ffi) bvlSem$state) = (Rval a,r) /\
       env_rel (:'c) (:'ffi) ax env env2 ==>
       ?b. evaluate (MAP delete_var xs,env2,s) = (Rval b,r) /\
-          env_rel (:'c) (:'ffi) (extract_list xs ++ ax) (a ++ env) (b ++ env2)`,
+          env_rel (:'c) (:'ffi) (extract_list xs ++ ax) (a ++ env) (b ++ env2)
+Proof
   Induct \\ fs [env_rel_def,extract_list_def]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ rw [] \\ Cases_on `evaluate ([h],env2,s)` \\ fs []
@@ -105,7 +112,8 @@ val evaluate_delete_var_Rval = Q.prove(
   \\ Cases_on `opp` \\ fs [extract_def] \\ rw []
   \\ every_case_tac \\ fs []
   \\ fs [v_rel_def,NULL_EQ,evaluate_def,do_app_def]
-  \\ every_case_tac \\ fs []);
+  \\ every_case_tac \\ fs []
+QED
 
 Theorem evaluate_EQ_NIL:
    bvlSem$evaluate (xs,env,s) = (Rval [],t) <=> xs = [] /\ s = t

--- a/compiler/backend/proofs/bvl_handleProofScript.sml
+++ b/compiler/backend/proofs/bvl_handleProofScript.sml
@@ -307,16 +307,19 @@ Proof
   fs [LIST_RELi_EL_EQN,env_rel_def]
 QED
 
-val opt_lemma = Q.prove(
-  `x = y <=> (x = SOME () <=> y = SOME ())`,
-  Cases_on `x` \\ Cases_on `y` \\ fs []);
+Triviality opt_lemma:
+  x = y <=> (x = SOME () <=> y = SOME ())
+Proof
+  Cases_on `x` \\ Cases_on `y` \\ fs []
+QED
 
-val OptionalLetLet_IMP = Q.prove(
-  `(ys,l,s',nr') = OptionalLetLet y (LENGTH env) lx s1 limit nr /\
+Triviality OptionalLetLet_IMP:
+  (ys,l,s',nr') = OptionalLetLet y (LENGTH env) lx s1 limit nr /\
     (∀env2 extra.
       env_rel l env env2 ⇒ evaluate ([y],env2 ++ extra,s) = res) /\
     env_rel l env env1 /\ b ==>
-    evaluate (ys,env1 ++ extra,s) = res /\ b`,
+    evaluate (ys,env1 ++ extra,s) = res /\ b
+Proof
   rw [OptionalLetLet_def,evaluate_def]
   \\ drule evaluate_LetLet \\ fs []
   \\ fs [GSYM db_varsTheory.vars_flatten_def,GSYM db_varsTheory.vars_to_list_def]
@@ -324,7 +327,8 @@ val OptionalLetLet_IMP = Q.prove(
   \\ fs [spt_eq_thm,db_varsTheory.wf_db_to_set]
   \\ rw [] \\ once_rewrite_tac [opt_lemma]
   \\ rewrite_tac [GSYM db_varsTheory.lookup_db_to_set]
-  \\ fs []);
+  \\ fs []
+QED
 
 Theorem OptionalLetLet_limit:
    (ys,l,s',nr') = OptionalLetLet e (LENGTH env) lx s1 limit nr /\

--- a/compiler/backend/proofs/bvl_inlineProofScript.sml
+++ b/compiler/backend/proofs/bvl_inlineProofScript.sml
@@ -1597,8 +1597,8 @@ Definition let_op_cc_def:
      (λcfg prog. cc cfg (MAP (I ## let_opt q4 l4) prog))
 End
 
-val let_evaluate_Call = Q.prove(
-  `evaluate ([Call 0 (SOME start) []], [],
+Triviality let_evaluate_Call:
+  evaluate ([Call 0 (SOME start) []], [],
              initial_state ffi0 prog co (let_op_cc q4 l4 cc) k) = (r, s) /\
    r <> Rerr (Rabort Rtype_error) ⇒
    ∃(s2:('c,'ffi) bvlSem$state).
@@ -1607,7 +1607,8 @@ val let_evaluate_Call = Q.prove(
         initial_state ffi0 (map (let_opt q4 l4) prog)
           ((I ## MAP (I ## let_opt q4 l4)) o co)
           cc k) = (r, s2) ∧
-     s2.ffi = s.ffi /\ s.clock = s2.clock`,
+     s2.ffi = s.ffi /\ s.clock = s2.clock
+Proof
   strip_tac \\ fs [let_op_cc_def]
   \\ imp_res_tac evaluate_let_op
   \\ fs [let_op_def]
@@ -1615,7 +1616,8 @@ val let_evaluate_Call = Q.prove(
   \\ first_x_assum (qspecl_then [`t4`,`q4`,`l4`] mp_tac)
   \\ impl_tac \\ rw [] \\ fs []
   \\ fs [let_state_rel_def]
-  \\ unabbrev_all_tac \\ fs [initial_state_def]);
+  \\ unabbrev_all_tac \\ fs [initial_state_def]
+QED
 
 val semantics_let_op = prove(
   ``semantics ffi prog co (let_op_cc q4 l4 cc) start <> Fail ==>

--- a/compiler/backend/proofs/bvl_jumpProofScript.sml
+++ b/compiler/backend/proofs/bvl_jumpProofScript.sml
@@ -5,11 +5,12 @@ open preamble bvl_jumpTheory bvlSemTheory bvlPropsTheory;
 
 val _ = new_theory"bvl_jumpProof";
 
-val evaluate_JumpList = Q.prove(
-  `!n xs k.
+Triviality evaluate_JumpList:
+  !n xs k.
       k < LENGTH xs ==>
       (evaluate ([JumpList n xs],Number (&(n+k))::env,s) =
-       evaluate ([EL k xs],Number (&(n+k))::env,s))`,
+       evaluate ([EL k xs],Number (&(n+k))::env,s))
+Proof
   recInduct JumpList_ind \\ REPEAT STRIP_TAC \\ fs[]
   \\ SIMP_TAC std_ss [Once JumpList_def,LET_DEF]
   \\ fs [LENGTH_NIL]
@@ -27,7 +28,8 @@ val evaluate_JumpList = Q.prove(
   \\ `k - LENGTH ys < LENGTH zs` by DECIDE_TAC \\ RES_TAC
   \\ `n + LENGTH ys + (k - LENGTH ys) = n + k` by DECIDE_TAC
   \\ fs[] \\ fs[NOT_LESS]
-  \\ IMP_RES_TAC EL_APPEND2 \\ fs [EL_APPEND2]);
+  \\ IMP_RES_TAC EL_APPEND2 \\ fs [EL_APPEND2]
+QED
 
 Theorem evaluate_Jump:
    (evaluate ([x],env,s) = (Rval [Number (&n)],t)) /\

--- a/compiler/backend/proofs/bvl_to_bviProofScript.sml
+++ b/compiler/backend/proofs/bvl_to_bviProofScript.sml
@@ -64,12 +64,14 @@ Definition aux_code_installed_def:
      aux_code_installed rest t)
 End
 
-val aux_code_installed_APPEND = Q.prove(
-  `!xs ys.
+Triviality aux_code_installed_APPEND:
+  !xs ys.
       aux_code_installed (xs++ys) code ==>
       aux_code_installed xs code /\
-      aux_code_installed ys code`,
-  Induct \\ fs[APPEND,aux_code_installed_def,FORALL_PROD] \\ METIS_TAC []);
+      aux_code_installed ys code
+Proof
+  Induct \\ fs[APPEND,aux_code_installed_def,FORALL_PROD] \\ METIS_TAC []
+QED
 
 Theorem aux_code_installed_subspt:
    !x c1 c2. aux_code_installed x c1 /\ subspt c1 c2 ==>
@@ -152,11 +154,13 @@ End
 
 val bv_ok_ind = theorem"bv_ok_ind";
 
-val bv_ok_SUBSET_IMP = Q.prove(
-  `!refs x refs2.
-      bv_ok refs x /\ FDOM refs SUBSET FDOM refs2 ==> bv_ok refs2 x`,
+Triviality bv_ok_SUBSET_IMP:
+  !refs x refs2.
+      bv_ok refs x /\ FDOM refs SUBSET FDOM refs2 ==> bv_ok refs2 x
+Proof
   HO_MATCH_MP_TAC bv_ok_ind \\ full_simp_tac(srw_ss())[bv_ok_def]
-  \\ full_simp_tac(srw_ss())[SUBSET_DEF,EVERY_MEM]);
+  \\ full_simp_tac(srw_ss())[SUBSET_DEF,EVERY_MEM]
+QED
 
 Theorem bv_ok_Unit[simp]:
    bv_ok refs Unit
@@ -170,14 +174,16 @@ Proof
   EVAL_TAC
 QED
 
-val bv_ok_IMP_adjust_bv_eq = Q.prove(
-  `!b2 a1 b3.
+Triviality bv_ok_IMP_adjust_bv_eq:
+  !b2 a1 b3.
       bv_ok refs a1 /\
       (!a. a IN FDOM refs ==> b2 a = b3 a) ==>
-      (adjust_bv b2 a1 = adjust_bv b3 a1)`,
+      (adjust_bv b2 a1 = adjust_bv b3 a1)
+Proof
   HO_MATCH_MP_TAC adjust_bv_ind
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[adjust_bv_def,bv_ok_def]
-  \\ full_simp_tac(srw_ss())[MAP_EQ_f,EVERY_MEM]);
+  \\ full_simp_tac(srw_ss())[MAP_EQ_f,EVERY_MEM]
+QED
 
 Definition state_ok_def:
   state_ok (s:('c,'ffi) bvlSem$state) <=>
@@ -189,26 +195,32 @@ End
 
 (* evaluate preserves state_ok *)
 
-val evaluate_ok_lemma = Q.prove(
-  `(state_ok (dec_clock n s) = state_ok s) /\
-    ((dec_clock n s).refs = s.refs)`,
-  full_simp_tac(srw_ss())[state_ok_def,bvlSemTheory.dec_clock_def]);
+Triviality evaluate_ok_lemma:
+  (state_ok (dec_clock n s) = state_ok s) /\
+    ((dec_clock n s).refs = s.refs)
+Proof
+  full_simp_tac(srw_ss())[state_ok_def,bvlSemTheory.dec_clock_def]
+QED
 
-val evaluate_IMP_bv_ok = Q.prove(
-  `(bvlSem$evaluate (xs,env,s) = (res,t)) ==>
+Triviality evaluate_IMP_bv_ok:
+  (bvlSem$evaluate (xs,env,s) = (res,t)) ==>
     (bv_ok s.refs a1 ==> bv_ok t.refs a1) /\
-    (EVERY (bv_ok s.refs) as ==> EVERY (bv_ok t.refs) as)`,
+    (EVERY (bv_ok s.refs) as ==> EVERY (bv_ok t.refs) as)
+Proof
   REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[EVERY_MEM]
   \\ REPEAT STRIP_TAC \\ RES_TAC
-  \\ IMP_RES_TAC evaluate_refs_SUBSET \\ IMP_RES_TAC bv_ok_SUBSET_IMP);
+  \\ IMP_RES_TAC evaluate_refs_SUBSET \\ IMP_RES_TAC bv_ok_SUBSET_IMP
+QED
 
-val v_to_list_ok = Q.prove(
-  `∀v x. v_to_list v = SOME x ∧
+Triviality v_to_list_ok:
+  ∀v x. v_to_list v = SOME x ∧
          bv_ok refs v ⇒
-         EVERY (bv_ok refs) x`,
+         EVERY (bv_ok refs) x
+Proof
   ho_match_mp_tac v_to_list_ind >>
   simp[v_to_list_def,bv_ok_def] >> srw_tac[][] >>
-  every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][]);
+  every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][]
+QED
 
 Theorem list_to_v_ok:
    !xs. EVERY (bv_ok refs) xs ==> bv_ok refs (list_to_v xs)
@@ -568,10 +580,11 @@ val evaluate_MAP_Var2 = Q.prove(
   \\ full_simp_tac(srw_ss())[rich_listTheory.EL_APPEND1]) |> SPEC_ALL
   |> INST_TYPE[beta|->``:'ffi``,alpha|->``:'c``];
 
-val bEval_bVarBound = Q.prove(
-  `!xs vs s env.
+Triviality bEval_bVarBound:
+  !xs vs s env.
       bVarBound (LENGTH vs) xs ==>
-      (bvlSem$evaluate (xs,vs ++ env,s) = evaluate (xs,vs,s))`,
+      (bvlSem$evaluate (xs,vs ++ env,s) = evaluate (xs,vs,s))
+Proof
   recInduct bvlSemTheory.evaluate_ind \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def,bVarBound_def]
   \\ TRY (BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[ADD1] \\ NO_TAC)
@@ -580,7 +593,8 @@ val bEval_bVarBound = Q.prove(
   THEN1 (BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
          \\ FIRST_X_ASSUM MATCH_MP_TAC
          \\ IMP_RES_TAC bvlPropsTheory.evaluate_IMP_LENGTH
-         \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]));
+         \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC])
+QED
 
 val iEval_def = bviSemTheory.evaluate_def;
 
@@ -947,12 +961,14 @@ QED
 val bEval_def = bvlSemTheory.evaluate_def;
 val iEval_append = bviPropsTheory.evaluate_APPEND;
 
-val compile_exps_Var_list = Q.prove(
-  `!l n. EVERY isVar l ==> (∃aux. compile_exps n l = (MAP (Var o destVar) l ,aux,n) ∧ append aux = [])`,
+Triviality compile_exps_Var_list:
+  !l n. EVERY isVar l ==> (∃aux. compile_exps n l = (MAP (Var o destVar) l ,aux,n) ∧ append aux = [])
+Proof
   Induct \\ fs[compile_exps_def] \\ Cases \\ rw[isVar_def] \\ fs[]
   \\ Cases_on`l` \\ fs[compile_exps_def,destVar_def]
   \\ qmatch_goalsub_rename_tac`compile_exps a`
-  \\ first_x_assum(qspec_then`a`strip_assume_tac) \\ fs[]);
+  \\ first_x_assum(qspec_then`a`strip_assume_tac) \\ fs[]
+QED
 
 Theorem compile_int_thm[local]:
   ∀i env s. evaluate ([compile_int i],env,s) = (Rval [Number i],s)
@@ -1164,14 +1180,16 @@ Proof
   \\ FIRST_X_ASSUM MATCH_MP_TAC \\ full_simp_tac(srw_ss())[ADD1]
 QED
 
-val v_to_list_adjust = Q.prove(
-  `∀x. v_to_list (adjust_bv f x) = OPTION_MAP (MAP (adjust_bv f)) (v_to_list x)`,
+Triviality v_to_list_adjust:
+  ∀x. v_to_list (adjust_bv f x) = OPTION_MAP (MAP (adjust_bv f)) (v_to_list x)
+Proof
   ho_match_mp_tac v_to_list_ind >>
   simp[v_to_list_def,adjust_bv_def] >> srw_tac[][] >>
-  Cases_on`v_to_list x`>>full_simp_tac(srw_ss())[]);
+  Cases_on`v_to_list x`>>full_simp_tac(srw_ss())[]
+QED
 
-val do_eq_adjust_lemma = Q.prove(
-  `(!refs x1 x2 b.
+Triviality do_eq_adjust_lemma:
+  (!refs x1 x2 b.
               refs = r.refs /\
               do_eq refs x1 x2 = Eq_val b /\ state_rel b2 r t2 /\
               bv_ok r.refs x1 /\ bv_ok r.refs x2 ==>
@@ -1180,7 +1198,8 @@ val do_eq_adjust_lemma = Q.prove(
               refs = r.refs /\
               do_eq_list refs x1 x2 = Eq_val b /\ state_rel b2 r t2 /\
               EVERY (bv_ok r.refs) x1 /\ EVERY (bv_ok r.refs) x2 ==>
-              do_eq_list t2.refs (MAP (adjust_bv b2) x1) (MAP (adjust_bv b2) x2) = Eq_val b)`,
+              do_eq_list t2.refs (MAP (adjust_bv b2) x1) (MAP (adjust_bv b2) x2) = Eq_val b)
+Proof
   ho_match_mp_tac do_eq_ind \\ rw [] \\ fs [adjust_bv_def]
   THEN1 (
     fs[bv_ok_def]
@@ -1197,13 +1216,16 @@ val do_eq_adjust_lemma = Q.prove(
   \\ fs [bv_ok_def] \\ rfs []
   \\ rpt (pop_assum mp_tac)
   \\ CONV_TAC (DEPTH_CONV ETA_CONV)
-  \\ rw [] \\ every_case_tac \\ fs []);
+  \\ rw [] \\ every_case_tac \\ fs []
+QED
 
-val do_eq_adjust = Q.prove(
-  `do_eq r.refs x1 x2 = Eq_val b /\ state_rel b2 r t2 /\
+Triviality do_eq_adjust:
+  do_eq r.refs x1 x2 = Eq_val b /\ state_rel b2 r t2 /\
    bv_ok r.refs x1 /\ bv_ok r.refs x2 ==>
-   do_eq t2.refs (adjust_bv b2 x1) (adjust_bv b2 x2) = Eq_val b`,
-  metis_tac [do_eq_adjust_lemma]);
+   do_eq t2.refs (adjust_bv b2 x1) (adjust_bv b2 x2) = Eq_val b
+Proof
+  metis_tac [do_eq_adjust_lemma]
+QED
 
 Theorem list_to_v_adjust:
    !xs.
@@ -1546,16 +1568,18 @@ Proof
   \\ fs [MEM_EL] \\ asm_exists_tac \\ fs []
 QED
 
-val do_app_Ref = Q.prove(
-  `do_app Ref vs s =
+Triviality do_app_Ref:
+  do_app Ref vs s =
      Rval
       (RefPtr (LEAST ptr. ptr ∉ FDOM s.refs),
        bvl_to_bvi
         (bvi_to_bvl s with
          refs :=
-           s.refs |+ ((LEAST ptr. ptr ∉ FDOM s.refs),ValueArray vs)) s)`,
+           s.refs |+ ((LEAST ptr. ptr ∉ FDOM s.refs),ValueArray vs)) s)
+Proof
   fs [iEvalOp_def,do_app_aux_def,bEvalOp_def,LET_THM]
-  \\ every_case_tac \\ fs []);
+  \\ every_case_tac \\ fs []
+QED
 
 Theorem state_rel_add_bytearray:
    state_rel b2 s5 (t2:('c,'ffi) bviSem$state) ∧
@@ -1735,14 +1759,15 @@ Proof
   impl_keep_tac >- EVAL_TAC \\ simp[]
 QED
 
-val compile_list_imp = Q.prove(
-  `∀n prog code n' name arity exp.
+Triviality compile_list_imp:
+  ∀n prog code n' name arity exp.
      compile_list n prog = (code,n') ∧
      ALOOKUP prog name = SOME (arity,exp) ⇒
      ∃n0 c aux n1.
      compile_exps n0 [exp] = ([c],aux,n1) ∧
      ALOOKUP (append code) (nss * name + num_stubs) = SOME (arity,bvi_let$compile_exp c) ∧
-     IS_SUBLIST (append code) (append aux)`,
+     IS_SUBLIST (append code) (append aux)
+Proof
   Induct_on`prog` >> simp[] >>
   qx_gen_tac`p`>>PairCases_on`p`>>
   simp[compile_list_def] >>
@@ -1775,7 +1800,8 @@ val compile_list_imp = Q.prove(
     `in_ns 0 (b * nss + 1)` by METIS_TAC[] \\
     fs[]) >>
   full_simp_tac(srw_ss())[IS_SUBLIST_APPEND] >>
-  metis_tac [APPEND,APPEND_ASSOC]);
+  metis_tac [APPEND,APPEND_ASSOC]
+QED
 
 val nss_lemma = prove(
   ``n * nss <> k * nss + 1``,
@@ -3625,13 +3651,15 @@ Proof
   Cases_on`e`>>simp[] >> METIS_TAC[]
 QED
 
-val evaluate_REPLICATE_0 = Q.prove(
-  `!n. evaluate (REPLICATE n (Op (Const 0) []),env,s) =
-          (Rval (REPLICATE n (Number 0)),s)`,
+Triviality evaluate_REPLICATE_0:
+  !n. evaluate (REPLICATE n (Op (Const 0) []),env,s) =
+          (Rval (REPLICATE n (Number 0)),s)
+Proof
   Induct \\ fs [evaluate_def,REPLICATE]
   \\ once_rewrite_tac [evaluate_CONS]
   \\ fs [evaluate_def,REPLICATE,do_app_def,do_app_aux_def]
-  \\ fs [EVAL ``small_enough_int 0``]);
+  \\ fs [EVAL ``small_enough_int 0``]
+QED
 
 Theorem bvi_stubs_evaluate:
    ∀kk start ffi0 code k.

--- a/compiler/backend/proofs/clos_annotateProofScript.sml
+++ b/compiler/backend/proofs/clos_annotateProofScript.sml
@@ -179,10 +179,11 @@ QED
 
 val env_ok_def = v_rel_cases |> CONJUNCT2
 
-val env_ok_EXTEND = Q.prove(
-  `EVERY2 v_rel env1 env2 /\ (l1 = LENGTH env1) /\
+Triviality env_ok_EXTEND:
+  EVERY2 v_rel env1 env2 /\ (l1 = LENGTH env1) /\
     (l1 <= n ==> env_ok m l i env1' env2' (n - l1)) ==>
-    env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n`,
+    env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n
+Proof
   SRW_TAC [] [] \\ SIMP_TAC std_ss [env_ok_def]
   \\ Cases_on `n < LENGTH env1` \\ full_simp_tac(srw_ss())[] THEN1
    (DISJ2_TAC \\ DISJ1_TAC \\ REPEAT STRIP_TAC
@@ -204,7 +205,8 @@ val env_ok_EXTEND = Q.prove(
   \\ `LENGTH env2 <= l + LENGTH env2 + v` by DECIDE_TAC
   \\ full_simp_tac(srw_ss())[rich_listTheory.EL_APPEND2]
   \\ `l + LENGTH env2 + v - LENGTH env2 = l + v` by DECIDE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+QED
 
 val env_ok_cons = env_ok_EXTEND
   |> Q.INST [`env1`|->`[v1]`,`env2`|->`[v2]`] |> Q.GEN `l1`
@@ -223,15 +225,17 @@ val env_ok_append = env_ok_EXTEND
   |> GSYM |> Q.INST [`l`|->`0`]
   |> SIMP_RULE (srw_ss()) []
 
-val env_ok_EXTEND_IGNORE = Q.prove(
-  `(LENGTH env2 = LENGTH env1) /\ LENGTH env1 <= n /\ l1 = LENGTH env1 /\
+Triviality env_ok_EXTEND_IGNORE:
+  (LENGTH env2 = LENGTH env1) /\ LENGTH env1 <= n /\ l1 = LENGTH env1 /\
    env_ok m l i env1' env2' (n - l1) ==>
-   env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n`,
+   env_ok m (l + l1) i (env1 ++ env1') (env2 ++ env2') n
+Proof
   SRW_TAC [] [] \\ SIMP_TAC std_ss [env_ok_def] \\ fs []
   \\ Cases_on `n < LENGTH env1` \\ fs []
   \\ full_simp_tac(srw_ss())[NOT_LESS]
   \\ full_simp_tac(srw_ss())[env_ok_def]
-  \\ fs [rich_listTheory.EL_APPEND2]);
+  \\ fs [rich_listTheory.EL_APPEND2]
+QED
 
 Definition state_rel_def:
   state_rel (s:('c,'ffi) closSem$state) (t:('c,'ffi) closSem$state) <=>
@@ -298,14 +302,15 @@ Proof
   \\ rw [] \\ fs [v_rel_simp, list_to_v_def]
 QED
 
-val v_to_list = Q.prove(
-  `!h h'.
+Triviality v_to_list:
+  !h h'.
       v_rel h h' ==>
       (v_to_list h = NONE /\
        v_to_list h' = NONE) \/
       ?x x'. (v_to_list h = SOME x) /\
              (v_to_list h' = SOME x') /\
-             EVERY2 v_rel x x'`,
+             EVERY2 v_rel x x'
+Proof
   HO_MATCH_MP_TAC v_to_list_ind
   \\ full_simp_tac(srw_ss())[v_rel_simp]
   \\ full_simp_tac(srw_ss())[v_to_list_def]
@@ -314,7 +319,8 @@ val v_to_list = Q.prove(
   \\ Cases_on `v_to_list h'` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `v_to_list y'` \\ full_simp_tac(srw_ss())[]
   \\ CCONTR_TAC \\ RES_TAC \\ full_simp_tac(srw_ss())[]
-  \\ RES_TAC \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ fs[]);
+  \\ RES_TAC \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ fs[]
+QED
 
 val do_app_lemma = prove(
   ``state_rel s t ∧ LIST_REL v_rel xs ys ⇒
@@ -341,16 +347,18 @@ val do_app_lemma = prove(
   \\ rfs [] \\ fs [FAPPLY_FUPDATE_THM] \\ rveq
   \\ fs [ref_rel_def] \\ rw []);
 
-val do_app_thm = Q.prove(
-  `state_rel s1 t1 /\ EVERY2 v_rel xs ys /\
+Triviality do_app_thm:
+  state_rel s1 t1 /\ EVERY2 v_rel xs ys /\
    (do_app op xs s1 = Rval (v,s2)) ==>
    ?w t2. (do_app op ys t1 = Rval (w,t2)) /\
-          v_rel v w /\ state_rel s2 t2`,
+          v_rel v w /\ state_rel s2 t2
+Proof
   rpt strip_tac
   \\ drule (GEN_ALL do_app_lemma)
   \\ disch_then drule
   \\ disch_then (qspec_then `op` mp_tac) \\ fs []
-  \\ rpt strip_tac \\ fs []);
+  \\ rpt strip_tac \\ fs []
+QED
 
 val v_rel_Number = prove(
   ``(v_rel x (Number i) <=> (x = Number i)) /\
@@ -360,11 +368,12 @@ val v_rel_Number = prove(
     (v_rel (Word64 w) x <=> (x = Word64 w))``,
   once_rewrite_tac [v_rel_cases] \\ fs []);
 
-val do_app_err_thm = Q.prove(
-  `state_rel s1 t1 /\ EVERY2 v_rel xs ys /\
+Triviality do_app_err_thm:
+  state_rel s1 t1 /\ EVERY2 v_rel xs ys /\
    do_app op xs s1 = Rerr err /\ (err <> Rabort Rtype_error) ==>
      ?w. do_app op ys t1 = Rerr w /\
-          exc_rel v_rel err w`,
+          exc_rel v_rel err w
+Proof
   srw_tac[][] >>
   imp_res_tac do_app_err >> fsrw_tac[][] >>
   Cases_on `?i. op = EqualConst i`
@@ -378,7 +387,8 @@ val do_app_err_thm = Q.prove(
          \\ rveq >> fs[] >> fs[v_rel_simp])
   \\ rpt(PURE_FULL_CASE_TAC \\ fs[])
   \\ fs[state_rel_def] \\ first_x_assum drule \\ strip_tac \\ fs[]
-  \\ rveq \\ rfs[]);
+  \\ rveq \\ rfs[]
+QED
 
 Theorem v_to_bytes:
    v_rel x y ==> (v_to_bytes x) = (v_to_bytes y)
@@ -457,18 +467,21 @@ QED
 
 (* compiler correctness *)
 
-val lookup_EL_shifted_env = Q.prove(
-  `!y n k. n < LENGTH y /\ ALL_DISTINCT y ==>
-            (lookup (EL n y) (shifted_env k y) = SOME (k + n))`,
+Triviality lookup_EL_shifted_env:
+  !y n k. n < LENGTH y /\ ALL_DISTINCT y ==>
+            (lookup (EL n y) (shifted_env k y) = SOME (k + n))
+Proof
   Induct \\ full_simp_tac(srw_ss())[] \\ Cases_on `n` \\ full_simp_tac(srw_ss())[shifted_env_def,lookup_insert]
   \\ SRW_TAC [] [ADD1,AC ADD_COMM ADD_ASSOC]
-  \\ full_simp_tac(srw_ss())[MEM_EL] \\ METIS_TAC []);
+  \\ full_simp_tac(srw_ss())[MEM_EL] \\ METIS_TAC []
+QED
 
-val env_ok_shifted_env = Q.prove(
-  `env_ok m l i env env2 k /\ MEM k live /\ ALL_DISTINCT live /\
+Triviality env_ok_shifted_env:
+  env_ok m l i env env2 k /\ MEM k live /\ ALL_DISTINCT live /\
     (lookup_vars (MAP (get_var m l i) (FILTER (\n. n < m + l) live)) env2 =
       SOME x) ==>
-    env_ok (m + l) 0 (shifted_env 0 (FILTER (\n. n < m + l) live)) env x k`,
+    env_ok (m + l) 0 (shifted_env 0 (FILTER (\n. n < m + l) live)) env x k
+Proof
   REPEAT STRIP_TAC
   \\ Q.ABBREV_TAC `y = FILTER (\n. n < m + l) live`
   \\ `ALL_DISTINCT y` by
@@ -492,20 +505,23 @@ val env_ok_shifted_env = Q.prove(
   \\ full_simp_tac(srw_ss())[env_ok_def] \\ DISJ2_TAC
   \\ TRY (`k < l + m` by DECIDE_TAC) \\ full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[lookup_EL_shifted_env]
-  \\ IMP_RES_TAC lookup_vars_SOME \\ full_simp_tac(srw_ss())[]);
+  \\ IMP_RES_TAC lookup_vars_SOME \\ full_simp_tac(srw_ss())[]
+QED
 
-val EL_shift_alt_free = Q.prove(
-  `!fns index.
+Triviality EL_shift_alt_free:
+  !fns index.
      index < LENGTH fns ==>
      ([EL index (shift (FST (alt_free fns)) l m i)] =
-      (shift (FST (alt_free [EL index fns])) l m i))`,
+      (shift (FST (alt_free [EL index fns])) l m i))
+Proof
   Induct \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [alt_free_CONS]
   \\ SIMP_TAC std_ss [Once shift_CONS]
   \\ Cases_on `index` \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[LET_DEF,alt_free_def]
   \\ REPEAT (AP_TERM_TAC ORELSE AP_THM_TAC)
-  \\ full_simp_tac(srw_ss())[SING_HD,LENGTH_FST_alt_free]);
+  \\ full_simp_tac(srw_ss())[SING_HD,LENGTH_FST_alt_free]
+QED
 
 val FOLDR_mk_Union = prove(
   ``!ys aux l.
@@ -562,8 +578,8 @@ val code_tac =
           EVERY_MAP,EVERY_GENLIST,shift_seq_def]
     \\ fs[every_Fn_vs_NONE_EVERY_MAP,o_DEF];
 
-val shift_correct = Q.prove(
-  `(!xs env (s1:('c,'ffi) closSem$state) env' t1 res s2 m l i.
+Triviality shift_correct:
+  (!xs env (s1:('c,'ffi) closSem$state) env' t1 res s2 m l i.
      (evaluate (xs,env,s1) = (res,s2)) /\ res <> Rerr (Rabort Rtype_error) /\
      (LENGTH env = m + l) /\
      alt_fv_set xs SUBSET env_ok m l i env env' /\
@@ -585,7 +601,8 @@ val shift_correct = Q.prove(
      ?res' s2'.
        (evaluate_app loc_opt f' args' s1' = (res',s2')) /\
        result_rel (LIST_REL v_rel) v_rel res res' /\
-       state_rel s2 s2')`,
+       state_rel s2 s2')
+Proof
   HO_MATCH_MP_TAC (evaluate_ind |> Q.SPEC `λ(x1,x2,x3). P0 x1 x2 x3` |> Q.GEN `P0`
                              |> SIMP_RULE std_ss [FORALL_PROD])
   \\ REPEAT STRIP_TAC
@@ -1218,11 +1235,14 @@ val shift_correct = Q.prove(
     \\ code_tac \\ full_simp_tac(srw_ss())[dec_clock_def]
     \\ MATCH_MP_TAC EVERY2_DROP
     \\ MATCH_MP_TAC rich_listTheory.EVERY2_APPEND_suff
-    \\ full_simp_tac(srw_ss())[]));
+    \\ full_simp_tac(srw_ss())[])
+QED
 
-val env_set_default = Q.prove(
-  `x SUBSET env_ok 0 0 LN [] env'`,
-  full_simp_tac(srw_ss())[SUBSET_DEF,IN_DEF,env_ok_def]);
+Triviality env_set_default:
+  x SUBSET env_ok 0 0 LN [] env'
+Proof
+  full_simp_tac(srw_ss())[SUBSET_DEF,IN_DEF,env_ok_def]
+QED
 
 val annotate_correct = save_thm("annotate_correct",
   shift_correct |> CONJUNCT1
@@ -1295,14 +1315,16 @@ QED
 
 val IF_MAP_EQ = MAP_EQ_f |> SPEC_ALL |> EQ_IMP_RULE |> snd;
 
-val shift_code_locs = Q.prove(
-  `!xs env s1 env'. code_locs (shift xs env s1 env') = code_locs xs`,
+Triviality shift_code_locs:
+  !xs env s1 env'. code_locs (shift xs env s1 env') = code_locs xs
+Proof
   ho_match_mp_tac shift_ind
   \\ simp[shift_def,code_locs_def,shift_LENGTH_LEMMA]
   \\ srw_tac[][code_locs_append]
   \\ full_simp_tac(srw_ss())[MAP_MAP_o,o_DEF]
   \\ ONCE_REWRITE_TAC [code_locs_map]
-  \\ AP_TERM_TAC \\ MATCH_MP_TAC IF_MAP_EQ \\ full_simp_tac(srw_ss())[FORALL_PROD]);
+  \\ AP_TERM_TAC \\ MATCH_MP_TAC IF_MAP_EQ \\ full_simp_tac(srw_ss())[FORALL_PROD]
+QED
 
 Theorem code_locs_const_0[simp]:
    code_locs [clos_annotate$const_0 t] = []
@@ -1310,8 +1332,9 @@ Proof
 EVAL_TAC
 QED
 
-val alt_free_code_locs = Q.prove(
-  `!xs. set (code_locs (FST (alt_free xs))) ⊆ set (code_locs xs)`,
+Triviality alt_free_code_locs:
+  !xs. set (code_locs (FST (alt_free xs))) ⊆ set (code_locs xs)
+Proof
   ho_match_mp_tac alt_free_ind
   \\ simp[alt_free_def,code_locs_def,UNCURRY] >> rw[]
   \\ Cases_on `alt_free [x]` \\ full_simp_tac(srw_ss())[code_locs_append,HD_FST_alt_free]
@@ -1321,10 +1344,12 @@ val alt_free_code_locs = Q.prove(
   \\ fs[MAP_MAP_o,o_DEF,SUBSET_DEF,code_locs_def,GSYM MAP_K_REPLICATE]
   \\ ONCE_REWRITE_TAC [code_locs_map]
   \\ simp[MEM_FLAT,MEM_GENLIST,MEM_MAP,PULL_EXISTS,UNCURRY,HD_FST_alt_free]
-  \\ metis_tac[HD_FST_alt_free,FST,PAIR]);
+  \\ metis_tac[HD_FST_alt_free,FST,PAIR]
+QED
 
-val alt_free_code_locs_distinct = Q.prove(
-  `∀xs. ALL_DISTINCT (code_locs xs) ⇒ ALL_DISTINCT (code_locs (FST (alt_free xs)))`,
+Triviality alt_free_code_locs_distinct:
+  ∀xs. ALL_DISTINCT (code_locs xs) ⇒ ALL_DISTINCT (code_locs (FST (alt_free xs)))
+Proof
   recInduct alt_free_ind
   \\ rw[alt_free_def,code_locs_def]
   \\ rpt(pairarg_tac \\ fs[])
@@ -1347,7 +1372,8 @@ val alt_free_code_locs_distinct = Q.prove(
     \\ fs[ALL_DISTINCT_FLAT,EL_MAP]
     \\ fs[MEM_FLAT,MEM_MAP,PULL_EXISTS,EXISTS_PROD] \\ rw[]
     \\ metis_tac[SUBSET_DEF,alt_free_code_locs,FST] )
-  \\ metis_tac[SUBSET_DEF,alt_free_code_locs,FST,alt_free_SING,HD]);
+  \\ metis_tac[SUBSET_DEF,alt_free_code_locs,FST,alt_free_SING,HD]
+QED
 
 Theorem annotate_code_locs:
    !n ls. set (code_locs (annotate n ls)) ⊆ set (code_locs ls) ∧

--- a/compiler/backend/proofs/clos_callProofScript.sml
+++ b/compiler/backend/proofs/clos_callProofScript.sml
@@ -29,10 +29,12 @@ val _ = temp_bring_to_front_overload"wf"{Name="wf",Thy="sptree"};
 
 val PUSH_EXISTS_IMP = SPEC_ALL RIGHT_EXISTS_IMP_THM;
 
-val v_size_lemma = Q.prove(
-  `MEM (v:closSem$v) vl ⇒ v_size v < v1_size vl`,
+Triviality v_size_lemma:
+  MEM (v:closSem$v) vl ⇒ v_size v < v1_size vl
+Proof
   Induct_on `vl` >> dsimp[v_size_def] >> rpt strip_tac >>
-  res_tac >> simp[]);
+  res_tac >> simp[]
+QED
 
 Theorem code_locs_GENLIST_Var[simp]:
    ∀n t i. code_locs (GENLIST_Var t i n) = []
@@ -74,10 +76,12 @@ Definition every_refv_def:
 End
 val _ = export_rewrites["every_refv_def"];
 
-val IMP_EXISTS_IFF = Q.prove(
-  `!xs. (!x. MEM x xs ==> (P x <=> Q x)) ==>
-         (EXISTS P xs <=> EXISTS Q xs)`,
-  Induct \\ fs []);
+Triviality IMP_EXISTS_IFF:
+  !xs. (!x. MEM x xs ==> (P x <=> Q x)) ==>
+         (EXISTS P xs <=> EXISTS Q xs)
+Proof
+  Induct \\ fs []
+QED
 
 (* -- *)
 
@@ -1113,10 +1117,11 @@ Proof
   \\ metis_tac[SND_insert_each, SND, FST_insert_each_same, FST]
 QED
 
-val calls_acc_0 = Q.prove(
-  `!xs tmp x r.
+Triviality calls_acc_0:
+  !xs tmp x r.
      x ++ r = SND tmp ⇒
-     calls xs tmp = (I ## I ## (combin$C (++) r)) (calls xs (FST tmp, x))`,
+     calls xs tmp = (I ## I ## (combin$C (++) r)) (calls xs (FST tmp, x))
+Proof
   recInduct calls_ind
   \\ rw[calls_def]
   \\ rpt(pairarg_tac \\ fs[])
@@ -1190,7 +1195,8 @@ val calls_acc_0 = Q.prove(
     \\ strip_tac \\ rveq \\ fs[]
     \\ pairmaparg_tac \\ fs[]
     \\ `q'' = q` by metis_tac[FST_code_list, FST]
-    \\ fs[] ));
+    \\ fs[] )
+QED
 
 Theorem calls_acc:
    !xs d old res d1 aux.
@@ -4289,30 +4295,36 @@ Proof
   )
 QED
 
-val code_locs_calls_list = Q.prove(`
-  ∀ls n tr i. code_locs (MAP SND (calls_list tr i n ls)) = []`,
+Triviality code_locs_calls_list:
+  ∀ls n tr i. code_locs (MAP SND (calls_list tr i n ls)) = []
+Proof
   Induct>>fs[calls_list_def,FORALL_PROD,Once code_locs_cons]>>
-  rw[Once code_locs_def])
+  rw[Once code_locs_def]
+QED
 
-val code_locs_code_list_MEM = Q.prove(`
+Triviality code_locs_code_list_MEM:
   ∀ls n rest x.
   MEM x (code_locs (MAP (SND o SND) (SND (code_list n ls rest)))) ⇔
-  MEM x (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))`,
+  MEM x (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))
+Proof
   Induct>>fs[code_list_def,FORALL_PROD,Once code_locs_cons,code_locs_append]>>
   rw[]>>EVAL_TAC>>
   rw[EQ_IMP_THM]>>
-  fs[Once code_locs_cons,code_locs_def])
+  fs[Once code_locs_cons,code_locs_def]
+QED
 
-val code_locs_code_list_ALL_DISTINCT = Q.prove(`
+Triviality code_locs_code_list_ALL_DISTINCT:
   ∀ls n rest.
   ALL_DISTINCT (code_locs (MAP (SND o SND) (SND (code_list n ls rest)))) ⇔
-  ALL_DISTINCT (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))`,
+  ALL_DISTINCT (code_locs (MAP (SND o SND) (SND rest)++MAP SND ls))
+Proof
   Induct>>fs[code_list_def,FORALL_PROD,Once code_locs_cons,code_locs_append]>>
   rw[]>>EVAL_TAC>>
   fs[ALL_DISTINCT_APPEND]>>
   rw[EQ_IMP_THM]>>
   fs[Once code_locs_cons,ALL_DISTINCT_APPEND,code_locs_def]>>
-  metis_tac[])
+  metis_tac[]
+QED
 
 (* All code_locs come from the original code,
    and therefore, are all even

--- a/compiler/backend/proofs/clos_knownProofScript.sml
+++ b/compiler/backend/proofs/clos_knownProofScript.sml
@@ -875,8 +875,8 @@ QED
 val say = say0 "evaluate_changed_globals_0";
 
 (* Evaluate  *)
-val evaluate_changed_globals_0 = Q.prove(
-  `(!es env (s0:('c,'ffi) closSem$state) res s.
+Triviality evaluate_changed_globals_0:
+  (!es env (s0:('c,'ffi) closSem$state) res s.
       evaluate (es, env, s0) = (res, s) /\
       ssgc_free s0 /\ EVERY esgc_free es /\
       EVERY vsgc_free env ==>
@@ -893,7 +893,8 @@ val evaluate_changed_globals_0 = Q.prove(
         ?n.
           s.compile_oracle = shift_seq n s0.compile_oracle /\
           mglobals_extend s0.globals
-            (SET_OF_BAG (elist_globals (FLAT (first_n_exps s0.compile_oracle n)))) s.globals)`,
+            (SET_OF_BAG (elist_globals (FLAT (first_n_exps s0.compile_oracle n)))) s.globals)
+Proof
   ho_match_mp_tac (evaluate_ind |> Q.SPEC `\(x1,x2,x3). P0 x1 x2 x3`
                    |> Q.GEN `P0` |> SIMP_RULE std_ss [FORALL_PROD])
   \\ rpt conj_tac \\ rpt (gen_tac ORELSE disch_then strip_assume_tac)
@@ -1150,7 +1151,8 @@ val evaluate_changed_globals_0 = Q.prove(
            \\ `g3 = g1 ∪ g2` suffices_by metis_tac [mglobals_extend_trans]
            \\ fs [elist_globals_append, SET_OF_BAG_UNION]
            \\ metis_tac [UNION_ASSOC, UNION_COMM])
-    \\ qexists_tac `n` \\ fs []));
+    \\ qexists_tac `n` \\ fs [])
+QED
 
 val evaluate_changed_globals = save_thm(
    "evaluate_changed_globals",
@@ -1422,14 +1424,16 @@ Proof
   simp[o_DEF,ADD1]
 QED
 
-val letrec_case_eq = Q.prove(`
+Triviality letrec_case_eq:
   !limit loc fns.
   (case loc of
     NONE => REPLICATE (LENGTH fns) Other
   | SOME n => clos_gen_noinline n 0 fns) =
   GENLIST (case loc of NONE => K Other |
-                       SOME n => λi. ClosNoInline (n + 2*i) (FST (EL i fns))) (LENGTH fns)`,
-  Cases_on`loc`>>fs[clos_gen_noinline_eq,REPLICATE_GENLIST])
+                       SOME n => λi. ClosNoInline (n + 2*i) (FST (EL i fns))) (LENGTH fns)
+Proof
+  Cases_on`loc`>>fs[clos_gen_noinline_eq,REPLICATE_GENLIST]
+QED
 
 Definition every_var_def:
   (every_var P Empty = T) /\
@@ -2745,13 +2749,14 @@ Proof
   \\ metis_tac [OPTREL_SOME]
 QED
 
-val do_app_lemma = Q.prove(
-  `!c g s t xs ys opp. state_rel c g s t /\ LIST_REL (v_rel c g) xs ys ==>
+Triviality do_app_lemma:
+  !c g s t xs ys opp. state_rel c g s t /\ LIST_REL (v_rel c g) xs ys ==>
     case do_app opp xs s of
       | Rerr err1 => ?err2. do_app opp ys t = Rerr err2 /\
                             exc_rel (v_rel c g) err1 err2
       | Rval (x, s1) => ?y t1. v_rel c g x y /\ state_rel c g s1 t1 /\
-                               do_app opp ys t = Rval (y, t1)`,
+                               do_app opp ys t = Rval (y, t1)
+Proof
   rpt gen_tac
   \\ match_mp_tac simple_val_rel_do_app
   \\ conj_tac THEN1 (fs [simple_val_rel_def] \\ rw []
@@ -2763,7 +2768,8 @@ val do_app_lemma = Q.prove(
   \\ rfs []
   \\ TRY (first_x_assum drule \\ fs [ref_rel_cases])
   \\ fs [FAPPLY_FUPDATE_THM]
-  \\ rw [] \\ fs [ref_rel_cases]);
+  \\ rw [] \\ fs [ref_rel_cases]
+QED
 
 Theorem evaluate_app_exact_rw:
    args <> [] /\ num_args = LENGTH args

--- a/compiler/backend/proofs/clos_mtiProofScript.sml
+++ b/compiler/backend/proofs/clos_mtiProofScript.sml
@@ -1252,20 +1252,24 @@ Proof
   rpt strip_tac >> metis_tac[set_globals_empty_esgc_free]
 QED
 
-val every_Fn_vs_NONE_collect_apps = Q.prove(
-  `∀max_app es e x y. collect_apps max_app es e = (x,y) ⇒
+Triviality every_Fn_vs_NONE_collect_apps:
+  ∀max_app es e x y. collect_apps max_app es e = (x,y) ⇒
   (every_Fn_vs_NONE x ∧ every_Fn_vs_NONE [y] ⇔
-   every_Fn_vs_NONE es ∧ every_Fn_vs_NONE [e])`,
+   every_Fn_vs_NONE es ∧ every_Fn_vs_NONE [e])
+Proof
   ho_match_mp_tac collect_apps_ind >>
   srw_tac[][collect_apps_def] >> full_simp_tac(srw_ss())[] >>
   ONCE_REWRITE_TAC[every_Fn_vs_NONE_EVERY] >>
-  srw_tac[][] >> metis_tac[]);
+  srw_tac[][] >> metis_tac[]
+QED
 
-val every_Fn_vs_NONE_collect_args = Q.prove(
-  `∀max_app es e x y. collect_args max_app es e = (x,y) ⇒
-    (every_Fn_vs_NONE [y] ⇔ every_Fn_vs_NONE [e])`,
+Triviality every_Fn_vs_NONE_collect_args:
+  ∀max_app es e x y. collect_args max_app es e = (x,y) ⇒
+    (every_Fn_vs_NONE [y] ⇔ every_Fn_vs_NONE [e])
+Proof
   ho_match_mp_tac collect_args_ind >>
-  srw_tac[][collect_args_def] >> full_simp_tac(srw_ss())[]);
+  srw_tac[][collect_args_def] >> full_simp_tac(srw_ss())[]
+QED
 
 Theorem every_Fn_vs_NONE_intro_multi[simp]:
    ∀max_app es. every_Fn_vs_NONE (intro_multi max_app es) = every_Fn_vs_NONE es
@@ -1303,9 +1307,11 @@ Proof
   Cases_on`do_mti` \\ rw[clos_mtiTheory.compile_def, clos_mtiTheory.intro_multi_length]
 QED
 
-val EVERY_HD = Q.prove(
-  `EVERY P l ∧ l ≠ [] ⇒ P (HD l)`,
-  Cases_on `l` >> simp[]);
+Triviality EVERY_HD:
+  EVERY P l ∧ l ≠ [] ⇒ P (HD l)
+Proof
+  Cases_on `l` >> simp[]
+QED
 
 Theorem collect_apps_preserves_set_globals:
    ∀max_app es e es' e'.

--- a/compiler/backend/proofs/clos_numberProofScript.sml
+++ b/compiler/backend/proofs/clos_numberProofScript.sml
@@ -150,16 +150,18 @@ Proof
   \\ qexists_tac `$<` \\ simp [relationTheory.irreflexive_def]
 QED
 
-val renumber_code_locs_list_els = Q.prove(
-  `∀ls ls' n n'. renumber_code_locs_list n ls = (n',ls') ⇒
+Triviality renumber_code_locs_list_els:
+  ∀ls ls' n n'. renumber_code_locs_list n ls = (n',ls') ⇒
       ∀x. x < LENGTH ls ⇒
-        ∃m. EL x ls' = SND (renumber_code_locs m (EL x ls))`,
+        ∃m. EL x ls' = SND (renumber_code_locs m (EL x ls))
+Proof
   Induct >> simp[renumber_code_locs_def] >>
   simp[UNCURRY] >> srw_tac[][] >>
   Cases_on`x`>>full_simp_tac(srw_ss())[] >- METIS_TAC[] >>
   first_x_assum (MATCH_MP_TAC o MP_CANON) >>
   simp[] >>
-  METIS_TAC[pair_CASES,SND])
+  METIS_TAC[pair_CASES,SND]
+QED
 
 (* value relation *)
 
@@ -201,31 +203,43 @@ Definition state_rel_def:
     s.code = FEMPTY ∧ t.code = FEMPTY
 End
 
-val state_rel_max_app = Q.prove (
-  `!s t. state_rel s t ⇒ s.max_app = t.max_app`,
-   srw_tac[][state_rel_def]);
+Triviality state_rel_max_app:
+  !s t. state_rel s t ⇒ s.max_app = t.max_app
+Proof
+  srw_tac[][state_rel_def]
+QED
 
-val state_rel_with_clock = Q.prove (
-  `!s t. state_rel s t ⇒ state_rel (s with clock := x) (t with clock := x)`,
-   srw_tac[][state_rel_def] \\ rfs[]);
+Triviality state_rel_with_clock:
+  !s t. state_rel s t ⇒ state_rel (s with clock := x) (t with clock := x)
+Proof
+  srw_tac[][state_rel_def] \\ rfs[]
+QED
 
-val state_rel_clock = Q.prove(
-  `state_rel s t ⇒ s.clock = t.clock`,
-  rw[state_rel_def]);
+Triviality state_rel_clock:
+  state_rel s t ⇒ s.clock = t.clock
+Proof
+  rw[state_rel_def]
+QED
 
-val state_rel_globals = Q.prove(
-  `state_rel s t ⇒
-    LIST_REL (OPTREL (v_rel s.max_app)) s.globals t.globals`,
-  srw_tac[][state_rel_def])
+Triviality state_rel_globals:
+  state_rel s t ⇒
+    LIST_REL (OPTREL (v_rel s.max_app)) s.globals t.globals
+Proof
+  srw_tac[][state_rel_def]
+QED
 
-val state_rel_refs = Q.prove(
-  `state_rel s t ⇒
-    fmap_rel (ref_rel (v_rel t.max_app)) s.refs t.refs`,
-  srw_tac[][state_rel_def])
+Triviality state_rel_refs:
+  state_rel s t ⇒
+    fmap_rel (ref_rel (v_rel t.max_app)) s.refs t.refs
+Proof
+  srw_tac[][state_rel_def]
+QED
 
-val state_rel_code = Q.prove(
-  `state_rel s t ⇒ s.code = FEMPTY ∧ t.code = FEMPTY`,
-  rw[state_rel_def]);
+Triviality state_rel_code:
+  state_rel s t ⇒ s.code = FEMPTY ∧ t.code = FEMPTY
+Proof
+  rw[state_rel_def]
+QED
 
 val v_rel_simp = let
   val f = SIMP_CONV (srw_ss()) [Once v_rel_cases]
@@ -262,13 +276,14 @@ QED
 
 (* semantic functions respect relation *)
 
-val dest_closure_v_rel_none = Q.prove (
-  `!f args f' args'.
+Triviality dest_closure_v_rel_none:
+  !f args f' args'.
     v_rel max_app f f' ∧
     LIST_REL (v_rel max_app) args args' ∧
     dest_closure max_app NONE f args = NONE
     ⇒
-    dest_closure max_app NONE f' args' = NONE`,
+    dest_closure max_app NONE f' args' = NONE
+Proof
   srw_tac[][] >>
   imp_res_tac EVERY2_LENGTH >>
   full_simp_tac(srw_ss())[dest_closure_def, v_rel_cases] >>
@@ -293,17 +308,19 @@ val dest_closure_v_rel_none = Q.prove (
   `LENGTH (MAP FST es) = LENGTH r'` by metis_tac [LENGTH_MAP] >>
   full_simp_tac(srw_ss())[EL_ZIP, EL_MAP] >>
   srw_tac[][] >>
-  rev_full_simp_tac(srw_ss())[]);
+  rev_full_simp_tac(srw_ss())[]
+QED
 
-val dest_closure_v_rel_partial = Q.prove (
-  `!c f args f' args'.
+Triviality dest_closure_v_rel_partial:
+  !c f args f' args'.
     v_rel max_app f f' ∧
     LIST_REL (v_rel max_app) args args' ∧
     dest_closure max_app NONE f args = SOME (Partial_app c)
     ⇒
     ?c'.
       dest_closure max_app NONE f' args' = SOME (Partial_app c') ∧
-      v_rel max_app c c'`,
+      v_rel max_app c c'
+Proof
   srw_tac[][] >>
   imp_res_tac EVERY2_LENGTH >>
   full_simp_tac(srw_ss())[dest_closure_def, v_rel_cases] >>
@@ -330,10 +347,11 @@ val dest_closure_v_rel_partial = Q.prove (
   full_simp_tac(srw_ss())[EL_ZIP, EL_MAP] >>
   srw_tac[][] >>
   rev_full_simp_tac(srw_ss())[] >>
-  metis_tac [SND, EVERY2_APPEND]);
+  metis_tac [SND, EVERY2_APPEND]
+QED
 
-val dest_closure_v_rel_full = Q.prove (
-  `!c f args f' args' args1 args2.
+Triviality dest_closure_v_rel_full:
+  !c f args f' args' args1 args2.
     v_rel max_app f f' ∧
     LIST_REL (v_rel max_app) args args' ∧
     dest_closure max_app NONE f args = SOME (Full_app exp args1 args2)
@@ -342,7 +360,8 @@ val dest_closure_v_rel_full = Q.prove (
       dest_closure max_app NONE f' args' = SOME (Full_app (SND (renumber_code_locs n exp)) args1' args2') ∧
       LIST_REL (v_rel max_app) args1 args1' ∧
       LIST_REL (v_rel max_app) args2 args2' ∧
-      ~contains_App_SOME max_app [exp]`,
+      ~contains_App_SOME max_app [exp]
+Proof
   srw_tac[][] >>
   imp_res_tac EVERY2_LENGTH >>
   full_simp_tac(srw_ss())[dest_closure_def, v_rel_cases] >>
@@ -390,24 +409,31 @@ val dest_closure_v_rel_full = Q.prove (
   simp [DROP_REVERSE, TAKE_REVERSE] >>
   `q' - LENGTH argenv' ≤ LENGTH args` by decide_tac >>
   srw_tac[][] >>
-  metis_tac [EVERY2_APPEND, list_rel_lastn, LENGTH_LASTN, LENGTH_GENLIST, EVERY2_LENGTH, list_rel_butlastn]);
+  metis_tac [EVERY2_APPEND, list_rel_lastn, LENGTH_LASTN, LENGTH_GENLIST, EVERY2_LENGTH, list_rel_butlastn]
+QED
 
-val helper = Q.prove (
-  `SND ((λ(n',x'). (n',[x'])) x) = [SND x]`,
-  Cases_on `x` >> full_simp_tac(srw_ss())[]);
+Triviality helper:
+  SND ((λ(n',x'). (n',[x'])) x) = [SND x]
+Proof
+  Cases_on `x` >> full_simp_tac(srw_ss())[]
+QED
 
-val v_rel_Boolv_mono = Q.prove(
-  `(x ⇔ y) ⇒ (v_rel max_app (Boolv x) (Boolv y))`,
-  Cases_on`x`>>simp[Boolv_def,v_rel_simp])
+Triviality v_rel_Boolv_mono:
+  (x ⇔ y) ⇒ (v_rel max_app (Boolv x) (Boolv y))
+Proof
+  Cases_on`x`>>simp[Boolv_def,v_rel_simp]
+QED
 
-val v_to_list = Q.prove(
-  `∀x y. v_rel max_app x y ⇒
-          OPTREL (LIST_REL (v_rel max_app)) (v_to_list x) (v_to_list y)`,
+Triviality v_to_list:
+  ∀x y. v_rel max_app x y ⇒
+          OPTREL (LIST_REL (v_rel max_app)) (v_to_list x) (v_to_list y)
+Proof
   ho_match_mp_tac v_to_list_ind >>
   simp[v_rel_simp,v_to_list_def,PULL_EXISTS] >>
   srw_tac[][] >> TRY(srw_tac[][optionTheory.OPTREL_def]>>NO_TAC) >>
   first_x_assum(fn th => first_x_assum(STRIP_ASSUME_TAC o MATCH_MP th)) >>
-  full_simp_tac(srw_ss())[optionTheory.OPTREL_def])
+  full_simp_tac(srw_ss())[optionTheory.OPTREL_def]
+QED
 
 Theorem simple_val_rel:
   simple_val_rel (v_rel max_app_n)
@@ -466,15 +492,16 @@ Proof
   \\ rw [] \\ fs [v_rel_simp, list_to_v_def]
 QED
 
-val do_app = Q.prove(
-  `state_rel s1 s2 ∧
+Triviality do_app:
+  state_rel s1 s2 ∧
     LIST_REL (v_rel s1.max_app) x1 x2 ⇒
     (∀err.
       do_app op x1 s1 = (Rerr err) ⇒
       do_app op x2 s2 = (Rerr err)) ∧
     (∀v1 w1. do_app op x1 s1 = Rval(v1,w1) ⇒
              ∃v2 w2. do_app op x2 s2 = Rval(v2,w2) ∧
-                     v_rel s1.max_app v1 v2 ∧ state_rel w1 w2)`,
+                     v_rel s1.max_app v1 v2 ∧ state_rel w1 w2)
+Proof
   rpt strip_tac
   \\ drule (GEN_ALL do_app_lemma)
   \\ disch_then drule
@@ -484,15 +511,20 @@ val do_app = Q.prove(
   \\ qpat_x_assum `_ = Rerr (Rraise _)` mp_tac
   \\ simp [do_app_cases_err]
   \\ strip_tac \\ fs []
-  \\ every_case_tac \\ fs[]);
+  \\ every_case_tac \\ fs[]
+QED
 
-val v_to_bytes = Q.prove(
-  `v_rel m v w ⇒ v_to_bytes v = v_to_bytes w`,
-  metis_tac [simple_val_rel, simple_val_rel_v_to_bytes]);
+Triviality v_to_bytes:
+  v_rel m v w ⇒ v_to_bytes v = v_to_bytes w
+Proof
+  metis_tac [simple_val_rel, simple_val_rel_v_to_bytes]
+QED
 
-val v_to_words = Q.prove(
-  `v_rel m v w ⇒ v_to_words v = v_to_words w`,
-  metis_tac [simple_val_rel, simple_val_rel_v_to_words]);
+Triviality v_to_words:
+  v_rel m v w ⇒ v_to_words v = v_to_words w
+Proof
+  metis_tac [simple_val_rel, simple_val_rel_v_to_words]
+QED
 
 fun DFOCUS_PAT pat thm = let
     fun UN Ps thm = let
@@ -510,8 +542,8 @@ Proof
   \\ pairarg_tac \\ rw[] \\ rw[]
 QED
 
-val do_install = Q.prove(
-  `state_rel s1 s2 ∧
+Triviality do_install:
+  state_rel s1 s2 ∧
    LIST_REL (v_rel s1.max_app) x1 x2 ⇒
    (∀err t. do_install x1 s1 = (Rerr (Rabort Rtimeout_error),t) ⇒
             ?t'. do_install x2 s2 = (Rerr (Rabort Rtimeout_error),t') /\
@@ -520,7 +552,8 @@ val do_install = Q.prove(
      ∃e2 t2. do_install x2 s2 = (Rval e2,t2) ∧
              ¬contains_App_SOME t1.max_app (e1) ∧ t1.max_app = s1.max_app ∧
              e2 = SND (compile_inc (FST(FST(s1.compile_oracle 0))) e1) ∧
-             state_rel t1 t2)`,
+             state_rel t1 t2)
+Proof
   strip_tac
   \\ `∃res. do_install x1 s1 = res` by fs[]
   \\ fs[do_install_def,case_eq_thms] \\ rveq \\ fs[]
@@ -557,7 +590,7 @@ val do_install = Q.prove(
   \\ fs[state_rel_def,state_co_def,ignore_table_def]
   \\ fs[FUPDATE_LIST_THM]
   \\ metis_tac[FUPDATE_LIST_THM,FST,SND,DECIDE``(n+1n)+1 = n+2``,LENGTH_NIL]
-);
+QED
 
 (* compiler correctness *)
 

--- a/compiler/backend/proofs/clos_to_bvlProofScript.sml
+++ b/compiler/backend/proofs/clos_to_bvlProofScript.sml
@@ -43,10 +43,11 @@ val _ = temp_bring_to_front_overload"compile_exps"{Name="compile_exps",Thy="clos
 
 val EVERY2_GENLIST = LIST_REL_GENLIST |> EQ_IMP_RULE |> snd |> Q.GEN`l`
 
-val EVERY_ZIP_GENLIST = Q.prove(
-  `!xs.
+Triviality EVERY_ZIP_GENLIST:
+  !xs.
       (!i. i < LENGTH xs ==> P (EL i xs,f i)) ==>
-      EVERY P (ZIP (xs,GENLIST f (LENGTH xs)))`,
+      EVERY P (ZIP (xs,GENLIST f (LENGTH xs)))
+Proof
   HO_MATCH_MP_TAC SNOC_INDUCT \\ full_simp_tac(srw_ss())[GENLIST] \\ REPEAT STRIP_TAC
   \\ full_simp_tac(srw_ss())[ZIP_SNOC,EVERY_SNOC] \\ REPEAT STRIP_TAC
   THEN1
@@ -54,153 +55,193 @@ val EVERY_ZIP_GENLIST = Q.prove(
     \\ IMP_RES_TAC EL_SNOC \\ full_simp_tac(srw_ss())[]
     \\ `i < SUC (LENGTH xs)` by DECIDE_TAC \\ RES_TAC \\ METIS_TAC [])
   \\ `LENGTH xs < SUC (LENGTH xs)` by DECIDE_TAC \\ RES_TAC
-  \\ full_simp_tac(srw_ss())[SNOC_APPEND,EL_LENGTH_APPEND]);
+  \\ full_simp_tac(srw_ss())[SNOC_APPEND,EL_LENGTH_APPEND]
+QED
 
-val IS_SUBLIST_MEM = Q.prove(`
+Triviality IS_SUBLIST_MEM:
   ∀ls ls' x.
   MEM x ls ∧ IS_SUBLIST ls' ls ⇒
-  MEM x ls'`,
+  MEM x ls'
+Proof
   Induct>>Induct_on`ls'`>>rw[IS_SUBLIST]>>
-  metis_tac[MEM,IS_PREFIX_IS_SUBLIST])
+  metis_tac[MEM,IS_PREFIX_IS_SUBLIST]
+QED
 
-val IS_SUBLIST_APPEND1 = Q.prove(`
+Triviality IS_SUBLIST_APPEND1:
   ∀A B C.
   IS_SUBLIST A C ⇒
-  IS_SUBLIST (A++B) C`,
+  IS_SUBLIST (A++B) C
+Proof
   rw[]>>match_mp_tac (snd(EQ_IMP_RULE (SPEC_ALL IS_SUBLIST_APPEND)))>>
   fs[IS_SUBLIST_APPEND]>>
-  metis_tac[APPEND_ASSOC])
+  metis_tac[APPEND_ASSOC]
+QED
 
-val IS_SUBLIST_APPEND2 = Q.prove(`
+Triviality IS_SUBLIST_APPEND2:
   ∀A B C.
   IS_SUBLIST B C ⇒
-  IS_SUBLIST (A++B) C`,
-  Induct_on`A`>>Induct_on`B`>>Induct_on`C`>>fs[IS_SUBLIST])
+  IS_SUBLIST (A++B) C
+Proof
+  Induct_on`A`>>Induct_on`B`>>Induct_on`C`>>fs[IS_SUBLIST]
+QED
 
-val IS_SUBLIST_REFL = Q.prove(`
+Triviality IS_SUBLIST_REFL:
   ∀ls.
-  IS_SUBLIST ls ls`,
-  Induct>>fs[IS_SUBLIST])
+  IS_SUBLIST ls ls
+Proof
+  Induct>>fs[IS_SUBLIST]
+QED
 
-val map2_snoc = Q.prove (
-  `!l1 l2 f x y.
+Triviality map2_snoc:
+  !l1 l2 f x y.
     LENGTH l1 = LENGTH l2 ⇒
-    MAP2 f (SNOC x l1) (SNOC y l2) = MAP2 f l1 l2 ++ [f x y]`,
+    MAP2 f (SNOC x l1) (SNOC y l2) = MAP2 f l1 l2 ++ [f x y]
+Proof
   Induct_on `l1` >>
   srw_tac[][] >>
   `l2 = [] ∨ ?h l2'. l2 = h::l2'` by (Cases_on `l2` >> srw_tac[][]) >>
   Cases_on `l2` >>
   full_simp_tac(srw_ss())[] >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
-val el_map2 = Q.prove (
-  `!x f l1 l2.
+Triviality el_map2:
+  !x f l1 l2.
     LENGTH l1 = LENGTH l2 ∧ x < LENGTH l1
     ⇒
-    EL x (MAP2 f l1 l2) = f (EL x l1) (EL x l2)`,
+    EL x (MAP2 f l1 l2) = f (EL x l1) (EL x l2)
+Proof
   Induct_on `x` >>
   srw_tac[][] >>
   Cases_on `l2` >>
   full_simp_tac(srw_ss())[] >>
   Cases_on `l1` >>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
-val length_take2 = Q.prove (
-  `!x l. ¬(x ≤ LENGTH l) ⇒ LENGTH (TAKE x l) = LENGTH l`,
+Triviality length_take2:
+  !x l. ¬(x ≤ LENGTH l) ⇒ LENGTH (TAKE x l) = LENGTH l
+Proof
   Induct_on `l` >>
   srw_tac[][TAKE_def] >>
   Cases_on `x` >>
   full_simp_tac(srw_ss())[] >>
   first_x_assum match_mp_tac >>
-  decide_tac);
+  decide_tac
+QED
 
-val el_take_append = Q.prove (
-  `!n l x l2. n ≤ LENGTH l ⇒ EL n (TAKE n l ++ [x] ++ l2) = x`,
+Triviality el_take_append:
+  !n l x l2. n ≤ LENGTH l ⇒ EL n (TAKE n l ++ [x] ++ l2) = x
+Proof
   Induct_on `l` >>
   srw_tac[][] >>
   ONCE_REWRITE_TAC [GSYM APPEND_ASSOC]>>
-  fs[EL_APPEND2,LENGTH_TAKE])
+  fs[EL_APPEND2,LENGTH_TAKE]
+QED
 
-val el_append2 = Q.prove (
-  `∀l x. EL (LENGTH l) (l++[x]) = x`,
-  Induct_on `l` >> srw_tac[][]);
+Triviality el_append2:
+  ∀l x. EL (LENGTH l) (l++[x]) = x
+Proof
+  Induct_on `l` >> srw_tac[][]
+QED
 
-val el_append2_lemma = Q.prove (
-  `!n args.
+Triviality el_append2_lemma:
+  !n args.
     n+1 = LENGTH args
     ⇒
-    EL (SUC n) (args ++ [x]) = x`,
+    EL (SUC n) (args ++ [x]) = x
+Proof
   Induct_on `args` >> srw_tac[][] >>
-  full_simp_tac (srw_ss()++ARITH_ss) [ADD1, el_append2]);
+  full_simp_tac (srw_ss()++ARITH_ss) [ADD1, el_append2]
+QED
 
-val hd_append = Q.prove (
-  `!l1 l2. 0 < LENGTH l1 ⇒ HD (l1 ++ l2) = HD l1`,
-  Cases_on `l1` >> srw_tac[][]);
+Triviality hd_append:
+  !l1 l2. 0 < LENGTH l1 ⇒ HD (l1 ++ l2) = HD l1
+Proof
+  Cases_on `l1` >> srw_tac[][]
+QED
 
-val tl_append = Q.prove (
-  `!l1 l2. 0 < LENGTH l1 ⇒ TL (l1 ++ l2) = TL l1 ++ l2`,
-  Cases_on `l1` >> srw_tac[][]);
+Triviality tl_append:
+  !l1 l2. 0 < LENGTH l1 ⇒ TL (l1 ++ l2) = TL l1 ++ l2
+Proof
+  Cases_on `l1` >> srw_tac[][]
+QED
 
-val twod_table_lemma = Q.prove (
-  `!x y z.
+Triviality twod_table_lemma:
+  !x y z.
     z ≤ y ⇒
     GENLIST (λt. f ((t + x * y) DIV y) ((t + x * y) MOD y)) z
     =
-    GENLIST (λt. f x t) z`,
+    GENLIST (λt. f x t) z
+Proof
   Induct_on `z` >>
   srw_tac[][GENLIST] >>
   `z < y ∧ z ≤ y` by decide_tac >>
   full_simp_tac(srw_ss())[] >>
   `z+x*y = x*y+z` by decide_tac >>
-  rw_tac std_ss [MOD_MULT, DIV_MULT, LESS_DIV_EQ_ZERO]);
+  rw_tac std_ss [MOD_MULT, DIV_MULT, LESS_DIV_EQ_ZERO]
+QED
 
-val twod_table = Q.prove (
-  `!f x y.
+Triviality twod_table:
+  !f x y.
     0 < y ⇒
     FLAT (GENLIST (\m. GENLIST (\n. f m n) y) x) =
-    GENLIST (\n. f (n DIV y) (n MOD y)) (x * y)`,
+    GENLIST (\n. f (n DIV y) (n MOD y)) (x * y)
+Proof
   Induct_on `x` >>
   srw_tac[][GENLIST] >>
   `(x+1) * y = y + x * y` by decide_tac >>
-  full_simp_tac(srw_ss())[ADD1, GENLIST_APPEND, twod_table_lemma]);
+  full_simp_tac(srw_ss())[ADD1, GENLIST_APPEND, twod_table_lemma]
+QED
 
-val less_rectangle = Q.prove (
-  `!(x:num) y m n. m < x ∧ n < y ⇒ x * n +m < x * y`,
+Triviality less_rectangle:
+  !(x:num) y m n. m < x ∧ n < y ⇒ x * n +m < x * y
+Proof
   REPEAT STRIP_TAC
   \\ `SUC n <= y` by full_simp_tac(srw_ss())[LESS_EQ]
   \\ `x * (SUC n) <= x * y` by full_simp_tac(srw_ss())[]
   \\ FULL_SIMP_TAC bool_ss [MULT_CLAUSES]
-  \\ DECIDE_TAC);
+  \\ DECIDE_TAC
+QED
 
-val less_rectangle2 = Q.prove (
-  `!(x:num) y m n. m < x ∧ n < y ⇒ m + n * x< x * y`,
-  metis_tac [less_rectangle, ADD_COMM, MULT_COMM]);
+Triviality less_rectangle2:
+  !(x:num) y m n. m < x ∧ n < y ⇒ m + n * x< x * y
+Proof
+  metis_tac [less_rectangle, ADD_COMM, MULT_COMM]
+QED
 
 val ARITH_TAC = intLib.ARITH_TAC;
 
-val sum_genlist_triangle_help = Q.prove (
-  `!x. SUM (GENLIST (\y. y) (x+1)) = x * (x + 1) DIV 2`,
+Triviality sum_genlist_triangle_help:
+  !x. SUM (GENLIST (\y. y) (x+1)) = x * (x + 1) DIV 2
+Proof
   Induct >>
   fs [GENLIST, SUM_SNOC, GSYM ADD1] >>
   simp [ADD1] >>
-  ARITH_TAC);
+  ARITH_TAC
+QED
 
-val sum_genlist_triangle = Q.prove (
-  `!x. SUM (GENLIST (\y. y) x) = x * (x - 1) DIV 2`,
+Triviality sum_genlist_triangle:
+  !x. SUM (GENLIST (\y. y) x) = x * (x - 1) DIV 2
+Proof
   rw [] >>
   mp_tac (Q.SPEC `x-1` sum_genlist_triangle_help) >>
   Cases_on `x = 0` >>
-  simp []);
+  simp []
+QED
 
-val triangle_table_size = Q.prove (
-  `!max f. LENGTH (FLAT (GENLIST (\x. (GENLIST (\y. f x y) x)) max)) =
-    max * (max -1) DIV 2`,
-  rw [LENGTH_FLAT, MAP_GENLIST, combinTheory.o_DEF, sum_genlist_triangle]);
+Triviality triangle_table_size:
+  !max f. LENGTH (FLAT (GENLIST (\x. (GENLIST (\y. f x y) x)) max)) =
+    max * (max -1) DIV 2
+Proof
+  rw [LENGTH_FLAT, MAP_GENLIST, combinTheory.o_DEF, sum_genlist_triangle]
+QED
 
-val tri_lemma = Q.prove (
-  `!tot max_app.
+Triviality tri_lemma:
+  !tot max_app.
     tot < max_app ⇒
-    tot + tot * (tot − 1) DIV 2 < max_app + (max_app − 1) * (max_app − 2) DIV 2`,
+    tot + tot * (tot − 1) DIV 2 < max_app + (max_app − 1) * (max_app − 2) DIV 2
+Proof
   Induct_on `max_app` >>
   rw [ADD1] >>
   `tot = max_app ∨ tot < max_app` by decide_tac >>
@@ -212,13 +253,15 @@ val tri_lemma = Q.prove (
   rpt (pop_assum kall_tac) >>
   Induct_on `max_app` >>
   rw [ADD1] >>
-  ARITH_TAC);
+  ARITH_TAC
+QED
 
-val triangle_div_lemma = Q.prove (
-  `!max_app n tot.
+Triviality triangle_div_lemma:
+  !max_app n tot.
     tot < max_app ∧ n < tot
     ⇒
-    n + tot * (tot − 1) DIV 2 < max_app * (max_app − 1) DIV 2`,
+    n + tot * (tot − 1) DIV 2 < max_app * (max_app − 1) DIV 2
+Proof
   rw [] >>
   `(tot - 1) + (tot * (tot − 1) DIV 2) < max_app * (max_app − 1) DIV 2`
   suffices_by decide_tac >>
@@ -234,10 +277,11 @@ val triangle_div_lemma = Q.prove (
   fs [ADD1] >>
   Cases_on `n'` >>
   fs [ADD1] >>
-  ARITH_TAC);
+  ARITH_TAC
+QED
 
-val triangle_el = Q.prove (
-  `!n tot max_app stuff f g.
+Triviality triangle_el:
+  !n tot max_app stuff f g.
     n < tot ∧ tot < max_app
     ⇒
     EL (n + tot * (tot − 1) DIV 2)
@@ -248,7 +292,8 @@ val triangle_el = Q.prove (
                  (λprev. f tot prev) tot)
             max_app) ++
        stuff) =
-    f tot n`,
+    f tot n
+Proof
   Induct_on `max_app` >>
   rw [GENLIST, FLAT_SNOC] >>
   `tot = max_app ∨ tot < max_app` by decide_tac >>
@@ -256,10 +301,11 @@ val triangle_el = Q.prove (
   >- simp [triangle_table_size, EL_APPEND_EQN] >>
   res_tac >>
   fs [] >>
-  metis_tac [APPEND_ASSOC]);
+  metis_tac [APPEND_ASSOC]
+QED
 
-val triangle_el_no_suff = Q.prove (
-  `!n tot max_app f g.
+Triviality triangle_el_no_suff:
+  !n tot max_app f g.
     n < tot ∧ tot < max_app
     ⇒
     EL (n + tot * (tot − 1) DIV 2)
@@ -269,35 +315,45 @@ val triangle_el_no_suff = Q.prove (
                GENLIST
                  (λprev. f tot prev) tot)
             max_app)) =
-    f tot n`,
-  metis_tac [triangle_el, APPEND_NIL]);
+    f tot n
+Proof
+  metis_tac [triangle_el, APPEND_NIL]
+QED
 
-val if_expand = Q.prove (
-  `!w x y z. (if x then y else z) = w ⇔ x ∧ y = w ∨ ~x ∧ z = w`,
-  metis_tac []);
+Triviality if_expand:
+  !w x y z. (if x then y else z) = w ⇔ x ∧ y = w ∨ ~x ∧ z = w
+Proof
+  metis_tac []
+QED
 
-val take_drop_lemma = Q.prove (
-  `!rem_args arg_list.
+Triviality take_drop_lemma:
+  !rem_args arg_list.
    LENGTH arg_list > rem_args
    ⇒
    TAKE (rem_args + 1) (DROP (LENGTH arg_list − (rem_args + 1)) (arg_list ++ stuff)) =
-   DROP (LENGTH arg_list − (rem_args + 1)) arg_list`,
+   DROP (LENGTH arg_list − (rem_args + 1)) arg_list
+Proof
   Induct_on `arg_list` >>fs[ADD1]>>rw[]>>
-  Cases_on`rem_args = LENGTH arg_list`>>fs[TAKE_LENGTH_APPEND])
+  Cases_on`rem_args = LENGTH arg_list`>>fs[TAKE_LENGTH_APPEND]
+QED
 
-val ETA2_THM = Q.prove (
-  `(\x y. f a b c x y) = f a b c`,
-  srw_tac[][FUN_EQ_THM]);
+Triviality ETA2_THM:
+  (\x y. f a b c x y) = f a b c
+Proof
+  srw_tac[][FUN_EQ_THM]
+QED
 
-val p_genlist = Q.prove (
-  `EL k exps_ps = ((n',e),p) ∧
+Triviality p_genlist:
+  EL k exps_ps = ((n',e),p) ∧
    MAP SND exps_ps = GENLIST (λn. loc + (num_stubs max_app) + 2*n) (LENGTH exps_ps) ∧
    k < LENGTH exps_ps
    ⇒
-   p = EL k (GENLIST (λn. loc + (num_stubs max_app) + 2*n) (LENGTH exps_ps))`,
+   p = EL k (GENLIST (λn. loc + (num_stubs max_app) + 2*n) (LENGTH exps_ps))
+Proof
   srw_tac[][] >>
   `EL k (MAP SND exps_ps) = EL k (GENLIST (λn. loc + (num_stubs max_app) + 2*n) (LENGTH exps_ps))` by metis_tac [] >>
-  rev_full_simp_tac(srw_ss())[EL_MAP]);
+  rev_full_simp_tac(srw_ss())[EL_MAP]
+QED
 
 Theorem list_CASE_same:
    list_CASE ls (P []) (λx y. P (x::y)) = P ls
@@ -309,13 +365,14 @@ QED
 
 (* correctness of partial/over application *)
 
-val evaluate_genlist_prev_args = Q.prove (
-  `!prev_args z x tag arg_list st.
+Triviality evaluate_genlist_prev_args:
+  !prev_args z x tag arg_list st.
     evaluate (REVERSE (GENLIST (λprev_arg. Op El [Op (Const (&(prev_arg + LENGTH z))) []; Var (LENGTH x)]) (LENGTH prev_args)),
            x++(Block tag (z++prev_args))::arg_list,
            st)
     =
-    (Rval (REVERSE prev_args),st)`,
+    (Rval (REVERSE prev_args),st)
+Proof
   Induct_on `prev_args` >>
   srw_tac[][evaluate_def, GENLIST_CONS] >>
   srw_tac[][evaluate_APPEND, evaluate_def, do_app_def] >>
@@ -328,26 +385,30 @@ val evaluate_genlist_prev_args = Q.prove (
   `x ++ Block tag (z ++ [h] ++ prev_args)::arg_list = x ++ [Block tag (z ++ [h] ++ prev_args)] ++ arg_list`
           by metis_tac [APPEND, APPEND_ASSOC] >>
   srw_tac[][el_append3] >>
-  decide_tac);
+  decide_tac
+QED
 
-val evaluate_genlist_prev_args1_simpl = Q.prove (
-  `!prev_args x y tag p n cl a st.
+Triviality evaluate_genlist_prev_args1_simpl:
+  !prev_args x y tag p n cl a st.
     evaluate (REVERSE (GENLIST (λprev_arg. Op El [Op (Const (&(prev_arg + 3))) []; Var 3]) (LENGTH prev_args)),
            [x;y;a; Block tag (p::n::cl::prev_args)],
            st)
     =
-    (Rval (REVERSE prev_args),st)`,
+    (Rval (REVERSE prev_args),st)
+Proof
   srw_tac[][] >>
   (Q.SPECL_THEN [`prev_args`, `[p;n;cl]`, `[x;y;a]`]assume_tac evaluate_genlist_prev_args) >>
-  full_simp_tac (srw_ss()++ARITH_ss) [ADD1]);
+  full_simp_tac (srw_ss()++ARITH_ss) [ADD1]
+QED
 
-val evaluate_genlist_prev_args_no_rev = Q.prove (
-  `!prev_args z x tag arg_list st.
+Triviality evaluate_genlist_prev_args_no_rev:
+  !prev_args z x tag arg_list st.
     evaluate (GENLIST (λprev_arg. Op El [Op (Const (&(prev_arg + LENGTH z))) []; Var (LENGTH x)]) (LENGTH prev_args),
            x++(Block tag (z++prev_args))::arg_list,
            st)
     =
-    (Rval prev_args,st)`,
+    (Rval prev_args,st)
+Proof
   Induct_on `prev_args` >>
   srw_tac[][evaluate_def, GENLIST_CONS] >>
   srw_tac[][Once evaluate_CONS, evaluate_def, do_app_def] >>
@@ -360,15 +421,17 @@ val evaluate_genlist_prev_args_no_rev = Q.prove (
   `x ++ Block tag (z ++ [h] ++ prev_args)::arg_list = x ++ [Block tag (z ++ [h] ++ prev_args)] ++ arg_list`
           by metis_tac [APPEND, APPEND_ASSOC] >>
   srw_tac[][el_append3] >>
-  decide_tac);
+  decide_tac
+QED
 
-val evaluate_genlist_prev_args_no_rev = Q.prove (
-  `!prev_args z x tag arg_list st.
+Triviality evaluate_genlist_prev_args_no_rev:
+  !prev_args z x tag arg_list st.
     evaluate (GENLIST (λprev_arg. Op El [Op (Const (&(prev_arg + LENGTH z))) []; Var (LENGTH x)]) (LENGTH prev_args),
            x++(Block tag (z++prev_args))::arg_list,
            st)
     =
-    (Rval prev_args,st)`,
+    (Rval prev_args,st)
+Proof
   Induct_on `prev_args` >>
   srw_tac[][evaluate_def, GENLIST_CONS] >>
   srw_tac[][Once evaluate_CONS, evaluate_def, do_app_def] >>
@@ -381,20 +444,23 @@ val evaluate_genlist_prev_args_no_rev = Q.prove (
   `x ++ Block tag (z ++ [h] ++ prev_args)::arg_list = x ++ [Block tag (z ++ [h] ++ prev_args)] ++ arg_list`
           by metis_tac [APPEND, APPEND_ASSOC] >>
   srw_tac[][el_append3] >>
-  decide_tac);
+  decide_tac
+QED
 
-val evaluate_genlist_prev_args1_no_rev = Q.prove (
-  `!prev_args x tag p n cl args st.
+Triviality evaluate_genlist_prev_args1_no_rev:
+  !prev_args x tag p n cl args st.
     evaluate (GENLIST (λprev_arg. Op El [Op (Const (&(prev_arg + 3))) []; Var (LENGTH args + 1)]) (LENGTH prev_args),
            x::(args++[Block tag (p::n::cl::prev_args)]),
            st)
     =
-    (Rval prev_args,st)`,
+    (Rval prev_args,st)
+Proof
   metis_tac [evaluate_genlist_prev_args_no_rev, APPEND, LENGTH, DECIDE ``SUC (SUC (SUC 0)) = 3``,
-             DECIDE ``(SUC 0) = 1``, DECIDE ``SUC (SUC 0) = 2``, ADD1]);
+             DECIDE ``(SUC 0) = 1``, DECIDE ``SUC (SUC 0) = 2``, ADD1]
+QED
 
-val evaluate_partial_app_fn_location_code = Q.prove (
-  `!max_app n total_args st args tag ptr x fvs.
+Triviality evaluate_partial_app_fn_location_code:
+  !max_app n total_args st args tag ptr x fvs.
      partial_app_fn_location max_app total_args n ∈ domain st.code ∧
      n < total_args ∧ total_args < max_app ⇒
      evaluate
@@ -404,11 +470,13 @@ val evaluate_partial_app_fn_location_code = Q.prove (
         (x::(args++[Block tag (ptr::Number(&total_args)::fvs)])),
         st)
      =
-     (Rval [Number (&(total_args * (total_args - 1) DIV 2 + n))], st)`,
+     (Rval [Number (&(total_args * (total_args - 1) DIV 2 + n))], st)
+Proof
   rw [partial_app_fn_location_code_def, evaluate_def, do_app_def, EL_CONS,
       el_append2, PRE_SUB1, partial_app_fn_location_def] >>
   rw [integerTheory.INT_ADD, integerTheory.INT_MUL, integerTheory.INT_DIV,
-      integerTheory.INT_SUB]);
+      integerTheory.INT_SUB]
+QED
 
 Definition global_table_def:
   global_table max_app =
@@ -417,8 +485,8 @@ Definition global_table_def:
         (\prev. CodePtr (partial_app_fn_location max_app tot prev)) tot) max_app))
 End
 
-val evaluate_generic_app1 = Q.prove (
-  `!n args st total_args l fvs cl.
+Triviality evaluate_generic_app1:
+  !n args st total_args l fvs cl.
     partial_app_fn_location max_app total_args n ∈ domain st.code ∧
     n < total_args ∧
     total_args < max_app ∧
@@ -434,7 +502,8 @@ val evaluate_generic_app1 = Q.prove (
                                       Number (&(total_args - (n + 1))) ::
                                       cl::
                                       args)],
-         dec_clock n st)`,
+         dec_clock n st)
+Proof
   srw_tac[][generate_generic_app_def] >>
   srw_tac[][evaluate_def, do_app_def] >>
   full_simp_tac (srw_ss() ++ ARITH_ss) [el_append2] >>
@@ -452,10 +521,11 @@ val evaluate_generic_app1 = Q.prove (
         triangle_div_lemma] >>
   srw_tac[][evaluate_def, do_app_def, int_arithTheory.INT_NUM_SUB, el_append2, TAKE_LENGTH_APPEND] >>
   CCONTR_TAC >>
-  intLib.ARITH_TAC);
+  intLib.ARITH_TAC
+QED
 
-val evaluate_generic_app2 = Q.prove (
-  `!n args st rem_args prev_args l clo cl.
+Triviality evaluate_generic_app2:
+  !n args st rem_args prev_args l clo cl.
     partial_app_fn_location max_app (rem_args + LENGTH prev_args) (n + LENGTH prev_args) ∈ domain st.code ∧
     n < rem_args ∧
     n + 1 = LENGTH args ∧
@@ -473,7 +543,8 @@ val evaluate_generic_app2 = Q.prove (
                                       clo ::
                                       args ++
                                       prev_args)],
-         dec_clock n st)`,
+         dec_clock n st)
+Proof
   srw_tac[][generate_generic_app_def, mk_const_def] >>
   srw_tac[][evaluate_def, do_app_def] >>
   full_simp_tac (srw_ss() ++ ARITH_ss) [] >>
@@ -514,7 +585,8 @@ val evaluate_generic_app2 = Q.prove (
     `n + LENGTH prev_args < rem_args + LENGTH prev_args` by decide_tac >>
     `rem_args + LENGTH prev_args < max_app` by decide_tac >>
     REWRITE_TAC [ADD_ASSOC] >>
-    simp [triangle_div_lemma]));
+    simp [triangle_div_lemma])
+QED
 
 Inductive unpack_closure:
   (total_args ≥ 0
@@ -656,26 +728,28 @@ Proof
   full_simp_tac(srw_ss())[]
 QED
 
-val mk_cl_lem = Q.prove (
-  `l < LENGTH env
+Triviality mk_cl_lem:
+  l < LENGTH env
    ⇒
    evaluate (GENLIST (λn. Var (n + 3)) l, a::b::c::env, st) =
-   evaluate (GENLIST (λn. Var (n + 1)) l, a::env, st)`,
+   evaluate (GENLIST (λn. Var (n + 1)) l, a::env, st)
+Proof
   srw_tac[][] >>
   `l + 3 ≤ LENGTH (a::b::c::env)` by srw_tac [ARITH_ss] [ADD1] >>
   `l + 1 ≤ LENGTH (a::env)` by srw_tac [ARITH_ss] [ADD1] >>
   imp_res_tac evaluate_genlist_vars >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
-val evaluate_mk_cl_simpl = Q.prove (
-  `evaluate ([mk_cl_call (Var 0) (GENLIST (λn. Var (n + 3)) (LENGTH args' − (n + 1)))],
+Triviality evaluate_mk_cl_simpl:
+  evaluate ([mk_cl_call (Var 0) (GENLIST (λn. Var (n + 3)) (LENGTH args' − (n + 1)))],
                                v::a::b::(args' ++ [Block tag (CodePtr p::Number (&n)::xs)]),
                                st')
    =
    evaluate ([mk_cl_call (Var 0) (GENLIST (λn. Var (n + 1)) (LENGTH args' − (n + 1)))],
                                v::(args' ++ [Block tag (CodePtr p::Number (&n)::xs)]),
-                               st')`,
-
+                               st')
+Proof
   srw_tac[][mk_cl_call_def, evaluate_def, do_app_def] >>
   reverse (Cases_on `v`) >>
   srw_tac[][] >>
@@ -687,10 +761,11 @@ val evaluate_mk_cl_simpl = Q.prove (
   full_simp_tac (srw_ss()++ARITH_ss) [evaluate_def, do_app_def] >>
   `LENGTH args' - (n + 1) < LENGTH (args' ++ [Block tag (CodePtr p::Number (&n)::xs)])`
               by srw_tac [ARITH_ss] [] >>
-  srw_tac [ARITH_ss] [mk_cl_lem]);
+  srw_tac [ARITH_ss] [mk_cl_lem]
+QED
 
-val evaluate_mk_cl_call = Q.prove (
-  `!cl env s tag p n args args' exp exp2 xs.
+Triviality evaluate_mk_cl_call:
+  !cl env s tag p n args args' exp exp2 xs.
     evaluate ([cl],env,s) = (Rval [Block tag (CodePtr p::Number &n::xs)], s) ∧
     evaluate (args,env,s) = (Rval args', s) ∧
     lookup p s.code = SOME (n+2, exp) ∧
@@ -721,7 +796,8 @@ val evaluate_mk_cl_call = Q.prove (
                               st') of
                     | (Rval v,s2) => (Rval [HD v],s2)
                     | x => x)
-            | x => x`,
+            | x => x
+Proof
   srw_tac[][Once mk_cl_call_def, evaluate_def, do_app_def, do_eq_def, generic_app_fn_location_def] >>
   full_simp_tac(srw_ss())[ADD1] >>
   Cases_on `n = &(LENGTH args − 1)` >>
@@ -736,10 +812,11 @@ val evaluate_mk_cl_call = Q.prove (
   imp_res_tac evaluate_generic_app_full >>
   srw_tac[][] >>
   full_simp_tac (srw_ss()++ARITH_ss) [dec_clock_def] >>
-  simp [evaluate_mk_cl_simpl]);
+  simp [evaluate_mk_cl_simpl]
+QED
 
-val evaluate_partial_app_fn = Q.prove (
-  `!num_args args' num_args' prev_args tag num tag' l l' fvs exp code.
+Triviality evaluate_partial_app_fn:
+  !num_args args' num_args' prev_args tag num tag' l l' fvs exp code.
     lookup l code = SOME (LENGTH args' + LENGTH prev_args + 1,exp) /\
     LENGTH prev_args ≠ 0 ∧
     LENGTH prev_args < num_args ∧
@@ -754,7 +831,8 @@ val evaluate_partial_app_fn = Q.prove (
      else
        evaluate ([exp],
               DROP (LENGTH args' + LENGTH prev_args − num_args) args'++prev_args++[Block tag' (CodePtr l::num_args'::fvs)],
-              dec_clock 1 (st with code := code))`,
+              dec_clock 1 (st with code := code))
+Proof
   srw_tac[][evaluate_def, generate_partial_app_closure_fn_def, mk_const_def, do_app_def] >>
   `LENGTH prev_args <> 0` by simp[] >>
   full_simp_tac (srw_ss()++ARITH_ss) [el_append2, evaluate_APPEND] >>
@@ -770,7 +848,8 @@ val evaluate_partial_app_fn = Q.prove (
   srw_tac[][evaluate_genlist_prev_args1_no_rev, Abbr `cl`, evaluate_def, do_app_def, find_code_def] >>
   full_simp_tac (srw_ss()++ARITH_ss) [ADD1,EL_LENGTH_APPEND] >>
   srw_tac[][evaluate_genlist_prev_args1_no_rev, evaluate_def, do_app_def, find_code_def] >>
-  srw_tac[][FRONT_APPEND, TAKE_LENGTH_APPEND, bvlSemTheory.state_component_equality] >> fs[]);
+  srw_tac[][FRONT_APPEND, TAKE_LENGTH_APPEND, bvlSemTheory.state_component_equality] >> fs[]
+QED
 
 (* -- *)
 
@@ -839,13 +918,15 @@ Definition add_args_def:
   (add_args _ _ = NONE)
 End
 
-val add_args_append = Q.prove (
-  `add_args cl arg_env = SOME func
+Triviality add_args_append:
+  add_args cl arg_env = SOME func
    ⇒
-   add_args cl (args ++ arg_env) = add_args func args`,
+   add_args cl (args ++ arg_env) = add_args func args
+Proof
   Cases_on `cl` >>
   srw_tac[][add_args_def] >>
-  srw_tac[][add_args_def]);
+  srw_tac[][add_args_def]
+QED
 
 Definition get_num_args_def:
   (get_num_args (Closure loc_opt args env num_args exp : closSem$v) =
@@ -890,23 +971,27 @@ Inductive v_rel:
                                Number (&(num_args - 1 - LENGTH arg_env)) :: cl' :: ys)))
 End
 
-val cl_rel_F = Q.prove (
-  `~cl_rel max_app f refs code (env,ys) (Number i) cl ∧
+Triviality cl_rel_F:
+  ~cl_rel max_app f refs code (env,ys) (Number i) cl ∧
    ~cl_rel max_app f refs code (env,ys) (Word64 w) cl ∧
    ~cl_rel max_app f refs code (env,ys) (RefPtr p) cl ∧
    ~cl_rel max_app f refs code (env,ys) (Block tag xs) cl ∧
-   ~cl_rel max_app f refs code (env,ys) (ByteVector bs) cl`,
-  srw_tac[][cl_rel_cases]);
+   ~cl_rel max_app f refs code (env,ys) (ByteVector bs) cl
+Proof
+  srw_tac[][cl_rel_cases]
+QED
 
-val add_args_F = Q.prove (
-  `!cl args p i tag xs.
+Triviality add_args_F:
+  !cl args p i tag xs.
    add_args cl args ≠ SOME (RefPtr p) ∧
    add_args cl args ≠ SOME (Number i) ∧
    add_args cl args ≠ SOME (Word64 w) ∧
    add_args cl args ≠ SOME (Block tag xs) ∧
-   add_args cl args ≠ SOME (ByteVector bs)`,
+   add_args cl args ≠ SOME (ByteVector bs)
+Proof
   Cases_on `cl` >>
-  srw_tac[][add_args_def]);
+  srw_tac[][add_args_def]
+QED
 
 Theorem v_rel_Unit[simp]:
    (v_rel max_app f refs code Unit y ⇔ (y = Unit)) ∧
@@ -955,33 +1040,41 @@ Definition env_rel_def:
      v_rel max_app f refs code x y /\ env_rel max_app f refs code xs ys)
 End
 
-val env_rel_APPEND = Q.prove(
-  `!xs1 xs2.
+Triviality env_rel_APPEND:
+  !xs1 xs2.
       EVERY2 (v_rel max_app f1 refs code) xs1 xs2 /\
       env_rel max_app f1 refs code ys1 ys2 ==>
-      env_rel max_app f1 refs code (xs1 ++ ys1) (xs2 ++ ys2)`,
-  Induct \\ Cases_on `xs2` \\ full_simp_tac(srw_ss())[env_rel_def]);
+      env_rel max_app f1 refs code (xs1 ++ ys1) (xs2 ++ ys2)
+Proof
+  Induct \\ Cases_on `xs2` \\ full_simp_tac(srw_ss())[env_rel_def]
+QED
 
-val list_rel_IMP_env_rel = Q.prove(
-  `!xs ys.
+Triviality list_rel_IMP_env_rel:
+  !xs ys.
       LIST_REL (v_rel max_app f refs code) xs ys ==>
-      env_rel max_app f refs code xs (ys ++ ts)`,
+      env_rel max_app f refs code xs (ys ++ ts)
+Proof
   Induct \\ Cases_on `ys` \\ full_simp_tac(srw_ss())[env_rel_def]
-  \\ Cases_on `ts` \\ full_simp_tac(srw_ss())[env_rel_def]);
+  \\ Cases_on `ts` \\ full_simp_tac(srw_ss())[env_rel_def]
+QED
 
-val env_rel_IMP_LENGTH = Q.prove(
-  `!env1 env2.
+Triviality env_rel_IMP_LENGTH:
+  !env1 env2.
       env_rel max_app f refs code env1 env2 ==>
-      LENGTH env1 <= LENGTH env2`,
-  Induct \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]);
+      LENGTH env1 <= LENGTH env2
+Proof
+  Induct \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]
+QED
 
-val LESS_LENGTH_env_rel_IMP = Q.prove(
-  `!env env2 n.
+Triviality LESS_LENGTH_env_rel_IMP:
+  !env env2 n.
       n < LENGTH env /\ env_rel max_app f refs code env env2 ==>
-      n < LENGTH env2 /\ v_rel max_app f refs code (EL n env) (EL n env2)`,
+      n < LENGTH env2 /\ v_rel max_app f refs code (EL n env) (EL n env2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[LENGTH] \\ REPEAT STRIP_TAC
   \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]
-  \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]);
+  \\ Cases_on `n` \\ full_simp_tac(srw_ss())[]
+QED
 
 val env_rel_IMP_EL =
   LESS_LENGTH_env_rel_IMP |> SPEC_ALL |> UNDISCH
@@ -1074,11 +1167,13 @@ Definition state_rel_def:
         code_installed aux2 t.code)
 End
 
-val state_rel_globals = Q.prove(
-  `state_rel f s t ⇒
+Triviality state_rel_globals:
+  state_rel f s t ⇒
     get_global 0 t.globals = SOME (SOME (global_table s.max_app)) ∧
-    LIST_REL (OPTREL (v_rel s.max_app f t.refs t.code)) s.globals (DROP num_added_globals t.globals)`,
-  srw_tac[][state_rel_def]);
+    LIST_REL (OPTREL (v_rel s.max_app f t.refs t.code)) s.globals (DROP num_added_globals t.globals)
+Proof
+  srw_tac[][state_rel_def]
+QED
 
 Theorem state_rel_clock[simp]:
    (!f s t. state_rel f s (t with clock := x) = state_rel f s t) ∧
@@ -1098,10 +1193,11 @@ Proof
   \\ res_tac \\ fs[] \\ rw[]
 QED
 
-val cl_rel_SUBMAP = Q.prove (
-  `cl_rel max_app f1 refs1 code (env,ys) x y ∧
+Triviality cl_rel_SUBMAP:
+  cl_rel max_app f1 refs1 code (env,ys) x y ∧
    f1 ⊆ f2 /\ FDIFF refs1 f1 SUBMAP FDIFF refs2 f2 ==>
-   cl_rel max_app f2 refs2 code (env,ys) x y`,
+   cl_rel max_app f2 refs2 code (env,ys) x y
+Proof
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
@@ -1109,7 +1205,8 @@ val cl_rel_SUBMAP = Q.prove (
   \\ rev_full_simp_tac(srw_ss())[]
   \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[] \\ STRIP_TAC
   \\ full_simp_tac(srw_ss())[FDIFF_def,SUBMAP_DEF,DRESTRICT_DEF,FLOOKUP_DEF]
-  \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `r`) \\ full_simp_tac(srw_ss())[]);
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `r`) \\ full_simp_tac(srw_ss())[]
+QED
 
 val v_rel_SUBMAP = Q.prove(
   `!x y. v_rel max_app f1 refs1 code x y ==>
@@ -1139,9 +1236,10 @@ val env_rel_SUBMAP = Q.prove(
   Induct \\ Cases_on `env2` \\ full_simp_tac(srw_ss())[env_rel_def]
   \\ REPEAT STRIP_TAC \\ IMP_RES_TAC v_rel_SUBMAP) |> GEN_ALL;
 
-val cl_rel_NEW_REF = Q.prove (
-  `!x y. cl_rel max_app f1 refs1 code (env,ys) x y ==> ~(r IN FDOM refs1) ==>
-         cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y`,
+Triviality cl_rel_NEW_REF:
+  !x y. cl_rel max_app f1 refs1 code (env,ys) x y ==> ~(r IN FDOM refs1) ==>
+         cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y
+Proof
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
@@ -1149,7 +1247,8 @@ val cl_rel_NEW_REF = Q.prove (
   \\ rev_full_simp_tac(srw_ss())[]
   \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[FDIFF_def,SUBMAP_DEF,DRESTRICT_DEF,FLOOKUP_DEF]
-  \\ full_simp_tac(srw_ss())[FAPPLY_FUPDATE_THM] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
+  \\ full_simp_tac(srw_ss())[FAPPLY_FUPDATE_THM] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
+QED
 
 val v_rel_NEW_REF = Q.prove(
   `!x y. v_rel max_app f1 refs1 code x y ==> ~(r IN FDOM refs1) ==>
@@ -1168,10 +1267,11 @@ val v_rel_NEW_REF = Q.prove(
          metis_tac [] ))
   |> SPEC_ALL |> MP_CANON;
 
-val cl_rel_UPDATE_REF = Q.prove(
-  `!x y. cl_rel max_app f1 refs1 code (env,ys) x y ==>
+Triviality cl_rel_UPDATE_REF:
+  !x y. cl_rel max_app f1 refs1 code (env,ys) x y ==>
           (r IN f1) ==>
-          cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y`,
+          cl_rel max_app f1 (refs1 |+ (r,t)) code (env,ys) x y
+Proof
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
@@ -1180,7 +1280,8 @@ val cl_rel_UPDATE_REF = Q.prove(
   \\ CONV_TAC (DEPTH_CONV ETA_CONV) \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[FDIFF_def,SUBMAP_DEF,DRESTRICT_DEF,FLOOKUP_DEF]
   \\ full_simp_tac(srw_ss())[FAPPLY_FUPDATE_THM] \\ SRW_TAC [] []
-  \\ full_simp_tac(srw_ss())[FRANGE_DEF] \\ METIS_TAC []);
+  \\ full_simp_tac(srw_ss())[FRANGE_DEF] \\ METIS_TAC []
+QED
 
 val v_rel_UPDATE_REF = Q.prove(
   `!x y. v_rel max_app f1 refs1 code x y ==>
@@ -1200,33 +1301,41 @@ val v_rel_UPDATE_REF = Q.prove(
          metis_tac [] ))
   |> SPEC_ALL |> MP_CANON;
 
-val OPTREL_v_rel_NEW_REF = Q.prove(
-  `OPTREL (v_rel max_app f1 refs1 code) x y /\ ~(r IN FDOM refs1) ==>
-    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y`,
-  Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_NEW_REF]);
+Triviality OPTREL_v_rel_NEW_REF:
+  OPTREL (v_rel max_app f1 refs1 code) x y /\ ~(r IN FDOM refs1) ==>
+    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y
+Proof
+  Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_NEW_REF]
+QED
 
-val OPTREL_v_rel_UPDATE_REF = Q.prove(
-  `OPTREL (v_rel max_app f1 refs1 code) x y /\ r IN FRANGE f1 ==>
-    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y`,
-  Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_UPDATE_REF]);
+Triviality OPTREL_v_rel_UPDATE_REF:
+  OPTREL (v_rel max_app f1 refs1 code) x y /\ r IN FRANGE f1 ==>
+    OPTREL (v_rel max_app f1 (refs1 |+ (r,t)) code) x y
+Proof
+  Cases_on `x` \\ Cases_on `y` \\ full_simp_tac(srw_ss())[OPTREL_def,v_rel_UPDATE_REF]
+QED
 
-val env_rel_NEW_REF = Q.prove(
-  `!x y.
+Triviality env_rel_NEW_REF:
+  !x y.
       env_rel max_app f1 refs1 code x y /\ ~(r IN FDOM refs1) ==>
-      env_rel max_app f1 (refs1 |+ (r,t)) code x y`,
+      env_rel max_app f1 (refs1 |+ (r,t)) code x y
+Proof
   Induct \\ Cases_on `y` \\ full_simp_tac(srw_ss())[env_rel_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC v_rel_NEW_REF \\ full_simp_tac(srw_ss())[]);
+  \\ IMP_RES_TAC v_rel_NEW_REF \\ full_simp_tac(srw_ss())[]
+QED
 
-val cl_rel_NEW_F = Q.prove(
-  `!x y.
+Triviality cl_rel_NEW_F:
+  !x y.
       cl_rel max_app f2 t2.refs t2.code (env,ys) x y ==>
       ~(qq IN FDOM t2.refs) ==>
-      cl_rel max_app (qq INSERT f2) t2.refs t2.code (env,ys) x y`,
+      cl_rel max_app (qq INSERT f2) t2.refs t2.code (env,ys) x y
+Proof
   srw_tac[][cl_rel_cases]
   >- metis_tac []
   >- metis_tac []
   \\ DISJ2_TAC \\ Q.LIST_EXISTS_TAC [`exps_ps`,`r`] \\ full_simp_tac(srw_ss())[]
-  \\ strip_tac >> full_simp_tac(srw_ss())[FLOOKUP_DEF])
+  \\ strip_tac >> full_simp_tac(srw_ss())[FLOOKUP_DEF]
+QED
 
 val v_rel_NEW_F = Q.prove(
   `!x y.
@@ -1341,17 +1450,19 @@ QED
 
 (* semantic functions respect relation *)
 
-val v_to_list = Q.prove(
-  `∀v l v'.
+Triviality v_to_list:
+  ∀v l v'.
    v_to_list v = SOME l ∧
    v_rel max_app f r c v v'
    ⇒
    ∃l'. v_to_list v' = SOME l' ∧
-        LIST_REL (v_rel max_app f r c) l l'`,
+        LIST_REL (v_rel max_app f r c) l l'
+Proof
   ho_match_mp_tac closSemTheory.v_to_list_ind >>
   srw_tac[][v_rel_SIMP,closSemTheory.v_to_list_def,bvlSemTheory.v_to_list_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][] >>
-  srw_tac[][bvlSemTheory.v_to_list_def] >> res_tac >> srw_tac[][]);
+  srw_tac[][bvlSemTheory.v_to_list_def] >> res_tac >> srw_tac[][]
+QED
 
 Theorem not_isClos[simp]:
    ~isClos (if n < ^(closure_tag_def |> concl |> rand) then n else (n + 2)) ys
@@ -1359,8 +1470,8 @@ Proof
   EVAL_TAC \\ rw []
 QED
 
-val do_eq = Q.prove(
-  `INJ ($' f) (FDOM f) (FRANGE f) ∧
+Triviality do_eq:
+  INJ ($' f) (FDOM f) (FRANGE f) ∧
    (∀x y bs. FLOOKUP f x = SOME y ⇒ FLOOKUP r y ≠ SOME (ByteArray T bs)) ⇒
     (∀x y x1 y1.
            v_rel max_app f r c x x1 ∧
@@ -1369,8 +1480,9 @@ val do_eq = Q.prove(
     (∀x y x1 y1.
            LIST_REL (v_rel max_app f r c) x x1 ∧
            LIST_REL (v_rel max_app f r c) y y1 ⇒
-           do_eq_list x y = do_eq_list r x1 y1)`,
-   strip_tac >>
+           do_eq_list x y = do_eq_list r x1 y1)
+Proof
+  strip_tac >>
    HO_MATCH_MP_TAC closSemTheory.do_eq_ind >>
    srw_tac[][]
    >- (srw_tac[][closSemTheory.do_eq_def] >>
@@ -1394,13 +1506,15 @@ val do_eq = Q.prove(
       qpat_x_assum `X = do_eq _ y'' y'''` (mp_tac o GSYM) >>
       srw_tac[][])
   >- full_simp_tac(srw_ss())[closSemTheory.do_eq_def]
-  >- full_simp_tac(srw_ss())[closSemTheory.do_eq_def]);
+  >- full_simp_tac(srw_ss())[closSemTheory.do_eq_def]
+QED
 
 val r = mk_var("r",``:num |-> 'a ref``);
 
-val do_eq_sym = Q.prove(
-  `(∀^r x y. do_eq r x y = do_eq r y x) ∧
-   (∀^r x y. do_eq_list r x y = do_eq_list r y x)`,
+Triviality do_eq_sym:
+  (∀^r x y. do_eq r x y = do_eq r y x) ∧
+   (∀^r x y. do_eq_list r x y = do_eq_list r y x)
+Proof
   ho_match_mp_tac do_eq_ind >> simp[] >>
   conj_tac >- ( ntac 2 gen_tac >> Cases >> srw_tac[][] ) >>
   conj_tac >- METIS_TAC[] >>
@@ -1410,7 +1524,8 @@ val do_eq_sym = Q.prove(
     rpt gen_tac >> strip_tac >>
     IF_CASES_TAC >> full_simp_tac(srw_ss())[] >>
     srw_tac[][] >> full_simp_tac(srw_ss())[] ) >>
-  srw_tac[][] >> every_case_tac >> fs[]);
+  srw_tac[][] >> every_case_tac >> fs[]
+QED
 
 Theorem do_eq_list_T_every:
    ∀vs1 vs2. do_eq_list r vs1 vs2 = Eq_val T ⇔ LIST_REL (λv1 v2. do_eq r v1 v2 = Eq_val T) vs1 vs2
@@ -1686,14 +1801,15 @@ val clos_do_app_case_eqs = closSemTheory.do_app_def |> concl
   |> Redblackset.listItems
   |> map (TypeBasePure.case_eq_of o Option.valOf o TypeBase.fetch);
 
-val do_app_err = Q.prove(
-  `do_app op xs s1 = Rerr err ∧
+Triviality do_app_err:
+  do_app op xs s1 = Rerr err ∧
    err ≠ Rabort Rtype_error ∧
    state_rel f s1 t1 ∧
    LIST_REL (v_rel s1.max_app f t1.refs t1.code) xs ys
    ⇒
    ∃e. do_app (compile_op op) ys t1 = Rerr e ∧
-       exc_rel (v_rel s1.max_app f t1.refs t1.code) err e`,
+       exc_rel (v_rel s1.max_app f t1.refs t1.code) err e
+Proof
   Cases_on `?i. op = EqualConst i` THEN1
     (srw_tac[][closSemTheory.do_app_def] \\ fs [] \\ every_case_tac \\ fs []) >>
   Cases_on `?tag. op = ConsExtend tag`
@@ -1720,7 +1836,8 @@ val do_app_err = Q.prove(
   \\ spose_not_then strip_assume_tac \\ fs[]
   \\ rpt (pop_assum mp_tac)
   \\ rpt (PURE_CASE_TAC \\ fs []) \\ fs []
-  \\ TRY(rpt strip_tac \\ fs[v_rel_cases] \\ fs[state_rel_def] \\ NO_TAC));
+  \\ TRY(rpt strip_tac \\ fs[v_rel_cases] \\ fs[state_rel_def] \\ NO_TAC)
+QED
 
 (* correctness of implemented primitives *)
 
@@ -1730,29 +1847,35 @@ Definition eq_res_def:
 End
 val _ = export_rewrites["eq_res_def"];
 
-val eq_res_not_timeout = Q.prove(
-  `eq_res x ≠ Rerr (Rabort Rtimeout_error)`,
-  Cases_on`x`>>simp[])
+Triviality eq_res_not_timeout:
+  eq_res x ≠ Rerr (Rabort Rtimeout_error)
+Proof
+  Cases_on`x`>>simp[]
+QED
 
-val evaluate_check_closure = Q.prove(
-  `n < LENGTH env ∧
+Triviality evaluate_check_closure:
+  n < LENGTH env ∧
    EL n env = bvlSem$Block t vs
    ⇒
    evaluate ([check_closure n e],env,s) =
    if t = closure_tag ∨ t = partial_app_tag then
      (eq_res (Eq_val T),s)
    else
-     evaluate ([e],env,s)`,
+     evaluate ([e],env,s)
+Proof
   srw_tac[][check_closure_def,bvlSemTheory.evaluate_def,bvlSemTheory.do_app_def] >>
-  full_simp_tac(srw_ss())[])
+  full_simp_tac(srw_ss())[]
+QED
 
 val s = ``s:('c,'ffi) bvlSem$state``
 
 (* compiler correctness *)
 
-val EXISTS_NOT_IN_refs = Q.prove(
-  `?x. ~(x IN FDOM (t1:('c,'ffi) bvlSem$state).refs)`,
-  METIS_TAC [NUM_NOT_IN_FDOM])
+Triviality EXISTS_NOT_IN_refs:
+  ?x. ~(x IN FDOM (t1:('c,'ffi) bvlSem$state).refs)
+Proof
+  METIS_TAC [NUM_NOT_IN_FDOM]
+QED
 
 val lookup_vars_IMP2 = Q.prove(
   `!vs env xs env2.
@@ -1769,26 +1892,30 @@ val lookup_vars_IMP2 = Q.prove(
   \\ RES_TAC \\ IMP_RES_TAC LESS_LENGTH_env_rel_IMP \\ full_simp_tac(srw_ss())[])
   |> INST_TYPE[alpha|->``:'c``,beta|->``:'ffi``];
 
-val lookup_vars_IMP = Q.prove(
-  `!vs env xs env2.
+Triviality lookup_vars_IMP:
+  !vs env xs env2.
       (lookup_vars vs env = SOME xs) /\
       env_rel max_app f refs code env env2 ==>
       ?ys. (evaluate (MAP Var vs,env2,t1) = (Rval ys,t1:('c, 'ffi) bvlSem$state)) /\
            EVERY2 (v_rel max_app f refs code) xs ys /\
-           (LENGTH vs = LENGTH xs)`,
+           (LENGTH vs = LENGTH xs)
+Proof
   (* TODO: metis_tac is not VALID here *)
-    PROVE_TAC[lookup_vars_IMP2]);
+    PROVE_TAC[lookup_vars_IMP2]
+QED
 
-val compile_exps_IMP_code_installed = Q.prove(
-  `(compile_exps max_app xs aux = (c,aux1)) /\
+Triviality compile_exps_IMP_code_installed:
+  (compile_exps max_app xs aux = (c,aux1)) /\
     code_installed aux1 code ==>
-    code_installed aux code`,
+    code_installed aux code
+Proof
   REPEAT STRIP_TAC
   \\ MP_TAC (SPEC_ALL compile_exps_acc) \\ full_simp_tac(srw_ss())[LET_DEF]
-  \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[code_installed_def]);
+  \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[code_installed_def]
+QED
 
-val compile_exps_LIST_IMP_compile_exps_EL = Q.prove(
-  `!exps aux1 c7 aux7 i n8 n4 aux5 num_args e.
+Triviality compile_exps_LIST_IMP_compile_exps_EL:
+  !exps aux1 c7 aux7 i n8 n4 aux5 num_args e.
       EL i exps = (num_args, e) ∧
       (compile_exps max_app (MAP SND exps) aux1 = (c7,aux7)) /\ i < LENGTH exps /\
       (build_aux n8 (MAP2 (code_for_recc_case k) (MAP FST exps) c7) aux7 = (n4,aux5)) /\
@@ -1796,7 +1923,8 @@ val compile_exps_LIST_IMP_compile_exps_EL = Q.prove(
       ?aux c aux1'.
         compile_exps max_app [e] aux = ([c],aux1') /\
         lookup (n8 + 2*i) t1.code = SOME (num_args + 1,SND (code_for_recc_case k num_args c)) /\
-        code_installed aux1' t1.code`,
+        code_installed aux1' t1.code
+Proof
   HO_MATCH_MP_TAC SNOC_INDUCT \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ Cases_on `i = LENGTH exps` \\ full_simp_tac(srw_ss())[] THEN1
    (full_simp_tac(srw_ss())[SNOC_APPEND,EL_LENGTH_APPEND]
@@ -1847,7 +1975,8 @@ val compile_exps_LIST_IMP_compile_exps_EL = Q.prove(
   \\ POP_ASSUM MP_TAC
   \\ ONCE_REWRITE_TAC [build_aux_MOVE]
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
-  \\ full_simp_tac(srw_ss())[code_installed_def]);
+  \\ full_simp_tac(srw_ss())[code_installed_def]
+QED
 
 Theorem compile_exps_EL:
    ∀ls aux l2 aux2 n. compile_exps ma ls aux = (l2, aux2) ∧
@@ -1877,8 +2006,8 @@ Proof
   \\ metis_tac[APPEND_ASSOC]
 QED
 
-val evaluate_recc_Lets = Q.prove(
-  `!(ll:(num#'a) list) n7 rr env' (t1:('c,'ffi) bvlSem$state) ys c8 (x:(num#'a)) (x':(num#'a)) ck.
+Triviality evaluate_recc_Lets:
+  !(ll:(num#'a) list) n7 rr env' (t1:('c,'ffi) bvlSem$state) ys c8 (x:(num#'a)) (x':(num#'a)) ck.
      EVERY (\n. n7 + ns + 2* n IN domain t1.code) (GENLIST I (LENGTH ll)) ==>
      (evaluate
        ([recc_Lets (n7 + ns) (REVERSE (MAP FST ll)) (LENGTH ll) (HD c8)],
@@ -1894,7 +2023,8 @@ val evaluate_recc_Lets = Q.prove(
         t1 with <| refs := t1.refs |+ (rr,
                ValueArray
                (MAP2 (\n args. Block closure_tag [CodePtr (n7 + ns + 2* n); Number &(args-1); RefPtr rr])
-                  (GENLIST I (LENGTH ll + 1)) (MAP FST ll ++ [FST x']) ++ ys)); clock := ck |>))`,
+                  (GENLIST I (LENGTH ll + 1)) (MAP FST ll ++ [FST x']) ++ ys)); clock := ck |>))
+Proof
   recInduct SNOC_INDUCT \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
   \\ ONCE_REWRITE_TAC [recc_Lets_def] \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ full_simp_tac(srw_ss())[bvlSemTheory.evaluate_def,recc_Let_def,bvlSemTheory.do_app_def]
@@ -1924,44 +2054,51 @@ val evaluate_recc_Lets = Q.prove(
   simp [SNOC_APPEND, APPEND_ASSOC]
   \\ FULL_SIMP_TAC std_ss [DECIDE ``SUC n + 1 = SUC (n+1)``,GENLIST]
   \\ FULL_SIMP_TAC std_ss [ADD1,SNOC_APPEND]
-  \\ SIMP_TAC std_ss [GSYM APPEND_ASSOC,APPEND]);
+  \\ SIMP_TAC std_ss [GSYM APPEND_ASSOC,APPEND]
+QED
 
-val evaluate_app_helper = Q.prove (
-  `(!x. r ≠ Rval x) ∧ evaluate (c8,env,s) = (r,s')
+Triviality evaluate_app_helper:
+  (!x. r ≠ Rval x) ∧ evaluate (c8,env,s) = (r,s')
     ⇒
     evaluate
            ([case loc of
               NONE => Let (c8++[c7]) (mk_cl_call (Var (LENGTH c8)) (GENLIST Var (LENGTH c8)))
-            | SOME loc => Call (LENGTH c8 - 1) (SOME (loc + num_stubs max_app)) (c8++[c7])],env,s) = (r, s')`,
+            | SOME loc => Call (LENGTH c8 - 1) (SOME (loc + num_stubs max_app)) (c8++[c7])],env,s) = (r, s')
+Proof
   srw_tac[][] >>
   Cases_on `loc` >>
   srw_tac[][bvlSemTheory.evaluate_def, bvlPropsTheory.evaluate_APPEND] >>
   Cases_on `r` >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
-val evaluate_app_helper2 = Q.prove (
-  `(!x. r ≠ Rval x) ∧ evaluate (c8,env,s) = (Rval x, s') ∧ evaluate ([c7],env,s') = (r,s'')
+Triviality evaluate_app_helper2:
+  (!x. r ≠ Rval x) ∧ evaluate (c8,env,s) = (Rval x, s') ∧ evaluate ([c7],env,s') = (r,s'')
     ⇒
     evaluate ([case loc of
               NONE => Let (c8++[c7]) (mk_cl_call (Var (LENGTH c8)) (GENLIST Var (LENGTH c8)))
-            | SOME loc => Call (LENGTH c8 - 1) (SOME (loc + num_stubs max_app)) (c8++[c7])],env,s) = (r, s'')`,
+            | SOME loc => Call (LENGTH c8 - 1) (SOME (loc + num_stubs max_app)) (c8++[c7])],env,s) = (r, s'')
+Proof
   srw_tac[][] >>
   Cases_on `loc` >>
   srw_tac[][bvlSemTheory.evaluate_def, bvlPropsTheory.evaluate_APPEND] >>
   Cases_on `r` >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
-val evaluate_simple_genlist_vars = Q.prove (
-  `!env1 env2 s.
+Triviality evaluate_simple_genlist_vars:
+  !env1 env2 s.
     0 < LENGTH env1
     ⇒
-    evaluate (GENLIST Var (LENGTH env1), env1++env2, s) = (Rval env1, s)`,
+    evaluate (GENLIST Var (LENGTH env1), env1++env2, s) = (Rval env1, s)
+Proof
   srw_tac[][] >>
   qspecl_then [`0`, `env1++env2`, `LENGTH env1`, `s`] assume_tac evaluate_genlist_vars >>
   rev_full_simp_tac(srw_ss())[] >>
   rpt (pop_assum mp_tac) >>
   srw_tac [ARITH_ss] [TAKE_LENGTH_APPEND] >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Definition num_remaining_args_def:
   (num_remaining_args (Closure loc_opt args env num_args exp : closSem$v) =
@@ -1971,14 +2108,15 @@ Definition num_remaining_args_def:
   (num_remaining_args _ = NONE)
 End
 
-val dest_closure_part_app = Q.prove (
-  `!loc_opt func args c f1 t1.
+Triviality dest_closure_part_app:
+  !loc_opt func args c f1 t1.
     LENGTH args ≠ 0 ∧
     dest_closure max_app loc_opt func args = SOME (Partial_app c)
     ⇒
     loc_opt = NONE ∧
     SOME c = add_args func args ∧
-    ?n. num_remaining_args func = SOME n ∧ LENGTH args < n ∧ LENGTH args ≤ max_app`,
+    ?n. num_remaining_args func = SOME n ∧ LENGTH args < n ∧ LENGTH args ≤ max_app
+Proof
   srw_tac[][dest_closure_def] >>
   BasicProvers.EVERY_CASE_TAC >>
   full_simp_tac(srw_ss())[add_args_def, LET_THM, num_remaining_args_def] >>
@@ -1988,7 +2126,8 @@ val dest_closure_part_app = Q.prove (
   full_simp_tac(srw_ss())[] >>
   Cases_on `loc_opt` >>
   full_simp_tac(srw_ss())[check_loc_def] >>
-  decide_tac);
+  decide_tac
+QED
 
 Definition get_loc_def:
   (get_loc (Closure (SOME loc) args env num_args exp) = SOME loc) ∧
@@ -2008,8 +2147,8 @@ Definition get_cl_env_def:
   (get_cl_env _ = NONE)
 End
 
-val dest_closure_full_app = Q.prove (
-  `!loc_opt func args c f1 t1 exp args1 args2.
+Triviality dest_closure_full_app:
+  !loc_opt func args c f1 t1 exp args1 args2.
     dest_closure max_app loc_opt func args = SOME (Full_app exp args1 args2)
     ⇒
     ?rem_args loc num_args old_args cl_env.
@@ -2022,7 +2161,8 @@ val dest_closure_full_app = Q.prove (
       rem_args ≤ num_args ∧
       num_args ≤ LENGTH old_args + LENGTH args ∧
       LENGTH args2 = LENGTH args - rem_args ∧
-      check_loc max_app loc_opt loc num_args (LENGTH args) (num_args - rem_args)`,
+      check_loc max_app loc_opt loc num_args (LENGTH args) (num_args - rem_args)
+Proof
   srw_tac[][dest_closure_def] >>
   BasicProvers.EVERY_CASE_TAC >>
   full_simp_tac(srw_ss())[] >>
@@ -2035,17 +2175,19 @@ val dest_closure_full_app = Q.prove (
   TRY (Cases_on `o'`) >>
   full_simp_tac(srw_ss())[get_loc_def] >>
   simp [] >>
-  decide_tac);
+  decide_tac
+QED
 
-val v_rel_num_rem_args = Q.prove (
-  `!f refs code v1 v2 n.
+Triviality v_rel_num_rem_args:
+  !f refs code v1 v2 n.
     v_rel max_app f refs code v1 v2 ∧
     num_remaining_args v1 = SOME n
     ⇒
     ?tag ptr rest exp.
       v2 = Block tag (CodePtr ptr::Number (&n-1)::rest) ∧
       n ≠ 0 ∧
-      lookup ptr code = SOME (n+1, exp)`,
+      lookup ptr code = SOME (n+1, exp)
+Proof
   srw_tac[][v_rel_cases] >>
   full_simp_tac(srw_ss())[num_remaining_args_def]
   >- (full_simp_tac(srw_ss())[cl_rel_cases] >>
@@ -2066,7 +2208,8 @@ val v_rel_num_rem_args = Q.prove (
       full_simp_tac(srw_ss())[get_num_args_def, add_args_def] >>
       srw_tac[][] >>
       full_simp_tac(srw_ss())[num_remaining_args_def, int_arithTheory.INT_NUM_SUB] >>
-      intLib.ARITH_TAC));
+      intLib.ARITH_TAC)
+QED
 
 val unpack_closure_thm = Q.prove (
   `v_rel max_app f1 t1.refs t1.code func (Block tag (ptr::Number (&n-1)::rest)) ∧
@@ -2101,10 +2244,11 @@ val unpack_closure_thm = Q.prove (
   srw_tac[][EL_MAP] >>
   decide_tac) |> INST_TYPE[alpha|->``:'ffi``];
 
-val cl_rel_get_num_args = Q.prove (
-  `cl_rel max_app f1 refs code (env,ys) func (Block tag (p::Number (&(total_args) - 1)::fvs))
+Triviality cl_rel_get_num_args:
+  cl_rel max_app f1 refs code (env,ys) func (Block tag (p::Number (&(total_args) - 1)::fvs))
    ⇒
-   get_num_args func = SOME total_args`,
+   get_num_args func = SOME total_args
+Proof
   srw_tac[][cl_rel_cases] >>
   full_simp_tac(srw_ss())[get_num_args_def, int_arithTheory.INT_NUM_SUB, EL_MAP, closure_code_installed_def, EVERY_EL] >>
   `?n e p. EL k exps_ps = ((n,e),p)` by metis_tac [pair_CASES] >>
@@ -2114,21 +2258,26 @@ val cl_rel_get_num_args = Q.prove (
   res_tac >>
   srw_tac[][] >>
   full_simp_tac(srw_ss())[] >>
-  ARITH_TAC);
+  ARITH_TAC
+QED
 
-val arith_helper_lem = Q.prove (
-  `LENGTH args' ≠ 0 ⇒ x − 1 − (LENGTH args' − 1) = x − LENGTH args'`,
-  decide_tac);
+Triviality arith_helper_lem:
+  LENGTH args' ≠ 0 ⇒ x − 1 − (LENGTH args' − 1) = x − LENGTH args'
+Proof
+  decide_tac
+QED
 
-val arith_helper_lem3 = Q.prove (
-  `LENGTH args' < total_args + 1 − LENGTH prev_args ∧
+Triviality arith_helper_lem3:
+  LENGTH args' < total_args + 1 − LENGTH prev_args ∧
    LENGTH args' ≠ 0 ∧
    total_args − LENGTH prev_args + 1 = num_args − LENGTH prev_args
    ⇒
    total_args − (LENGTH args' + LENGTH prev_args − 1) = total_args + 1 − (LENGTH args' + LENGTH prev_args) ∧
    LENGTH args' + LENGTH prev_args < total_args + 1 ∧
-   num_args = total_args+1`,
-  simp_tac(std_ss++ARITH_ss)[int_arithTheory.INT_NUM_SUB]);
+   num_args = total_args+1
+Proof
+  simp_tac(std_ss++ARITH_ss)[int_arithTheory.INT_NUM_SUB]
+QED
 
 val closure_tag_neq_1 = EVAL``closure_tag = 1``|>EQF_ELIM
 
@@ -2140,8 +2289,8 @@ val bEval_SING = bvlPropsTheory.evaluate_SING;
 val bEval_APPEND = bvlPropsTheory.evaluate_APPEND;
 val bEvalOp_def = bvlSemTheory.do_app_def;
 
-val evaluate_mk_cl_call_spec = Q.prove (
-  `!s env tag p n args exp xs.
+Triviality evaluate_mk_cl_call_spec:
+  !s env tag p n args exp xs.
     lookup p s.code = SOME (n+2, exp) ∧
     lookup (generic_app_fn_location (LENGTH args - 1)) s.code =
       SOME (LENGTH args + 1, generate_generic_app max_app (LENGTH args - 1)) ∧
@@ -2170,7 +2319,8 @@ val evaluate_mk_cl_call_spec = Q.prove (
                               st') of
                     | (Rval v,s2) => (Rval [HD v],s2)
                     | x => x)
-            | x => x`,
+            | x => x
+Proof
   rpt strip_tac >>
   `evaluate ([Var (LENGTH args)], args ++ [Block tag (CodePtr p::Number (&n)::xs)] ++ env,s) =
    (Rval [Block tag (CodePtr p::Number (&n)::xs)], s)`
@@ -2184,13 +2334,15 @@ val evaluate_mk_cl_call_spec = Q.prove (
   rpt (pop_assum (fn th => first_assum (strip_assume_tac o MATCH_MP th))) >>
   rev_full_simp_tac(srw_ss())[] >>
   first_x_assum match_mp_tac >>
-  Cases_on`LENGTH args` \\ fs[GENLIST_CONS]);
+  Cases_on`LENGTH args` \\ fs[GENLIST_CONS]
+QED
 
-val cl_rel_get_loc = Q.prove (
-  `cl_rel max_app f1 refs code (env,fvs) func (Block tag (CodePtr p::n::ys))
+Triviality cl_rel_get_loc:
+  cl_rel max_app f1 refs code (env,fvs) func (Block tag (CodePtr p::n::ys))
    ⇒
    num_stubs max_app ≤ p ∧
-   get_loc func = SOME (p-(num_stubs max_app))`,
+   get_loc func = SOME (p-(num_stubs max_app))
+Proof
   srw_tac[][cl_rel_cases] >>
   full_simp_tac(srw_ss())[get_loc_def, closure_code_installed_def, EVERY_EL] >>
   `?n e p. EL k exps_ps = ((n,e),p)` by metis_tac [pair_CASES] >>
@@ -2203,7 +2355,8 @@ val cl_rel_get_loc = Q.prove (
   srw_tac[][] >>
   `p = EL k (GENLIST (λn. loc + num_stubs max_app + 2*n) (LENGTH exps_ps))` by metis_tac [p_genlist] >>
   srw_tac[][] >>
-  ARITH_TAC);
+  ARITH_TAC
+QED
 
 (* Differs from check_loc and dest_closure by not checking that max_app *)
 Definition check_loc'_def:
@@ -2242,28 +2395,32 @@ Definition dest_closure'_def:
     | _ => NONE
 End
 
-val dest_cl_imp_dest_cl' = Q.prove (
-  `dest_closure max_app l f a = SOME x ⇒ dest_closure' l f a = SOME x`,
+Triviality dest_cl_imp_dest_cl':
+  dest_closure max_app l f a = SOME x ⇒ dest_closure' l f a = SOME x
+Proof
   srw_tac[][dest_closure_def, dest_closure'_def] >>
   BasicProvers.EVERY_CASE_TAC >>
   full_simp_tac(srw_ss())[] >>
   Cases_on `l` >>
   full_simp_tac(srw_ss())[check_loc_def, check_loc'_def, LET_THM] >>
   Cases_on `EL n l1` >>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
-val cl_rel_run_lemma1 = Q.prove (
-  `num_args ≤ LENGTH args'
+Triviality cl_rel_run_lemma1:
+  num_args ≤ LENGTH args'
    ⇒
    evaluate (GENLIST Var num_args, DROP (LENGTH args' - num_args) args' ++ stuff, t1) =
-   (Rval (DROP (LENGTH args' - num_args) args'), t1)`,
+   (Rval (DROP (LENGTH args' - num_args) args'), t1)
+Proof
   srw_tac[][] >>
   assume_tac (Q.SPECL [`0`, `DROP (LENGTH args' - num_args) args'++stuff`, `num_args`, `t1`] evaluate_genlist_vars) >>
   rev_full_simp_tac(srw_ss())[] >>
   rpt (pop_assum mp_tac) >>
   srw_tac [ARITH_ss] [ETA_THM] >>
   `LENGTH (DROP (LENGTH args' - num_args) args') = num_args` by srw_tac [ARITH_ss] [] >>
-  metis_tac [TAKE_LENGTH_APPEND]);
+  metis_tac [TAKE_LENGTH_APPEND]
+QED
 
 val cl_rel_run_lemma2 = Q.prove (
   `num_args ≤ LENGTH args'
@@ -2278,14 +2435,16 @@ val cl_rel_run_lemma2 = Q.prove (
   `LENGTH (DROP (LENGTH args' - num_args) args'++[f]) = num_args+1` by srw_tac [ARITH_ss] [] >>
   metis_tac [TAKE_LENGTH_APPEND]) |> Q.INST [`stuff`|-> `[]`] |> SIMP_RULE (srw_ss()) [];
 
-val cl_rel_run_lemma3 = Q.prove (
-  `LIST_REL R args args' ⇒
-   LIST_REL R (DROP (LENGTH args' − n) args) (DROP (LENGTH args' − n) args')`,
+Triviality cl_rel_run_lemma3:
+  LIST_REL R args args' ⇒
+   LIST_REL R (DROP (LENGTH args' − n) args) (DROP (LENGTH args' − n) args')
+Proof
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN] >>
   srw_tac[][] >>
   `n' + (LENGTH args' − n) < LENGTH args` by decide_tac >>
   `n' + (LENGTH args' − n) < LENGTH args'` by metis_tac [] >>
-  srw_tac[][EL_DROP]);
+  srw_tac[][EL_DROP]
+QED
 
 val bEval_free_let_Block = Q.prove (
   `!ys zs.
@@ -2324,8 +2483,8 @@ val cl_rel_run_tac =
   srw_tac[][] >>
   metis_tac [list_rel_IMP_env_rel, APPEND_ASSOC, LASTN_LENGTH_ID, env_rel_APPEND, LIST_REL_def, cl_rel_run_lemma3];
 
-val genlist_el = Q.prove (
-  `!skip st r xs args p n env ys.
+Triviality genlist_el:
+  !skip st r xs args p n env ys.
     FLOOKUP st.refs r = SOME (ValueArray (ys++xs)) ∧
     skip = LENGTH ys
     ⇒
@@ -2333,7 +2492,8 @@ val genlist_el = Q.prove (
            RefPtr r:: (args ++ Block closure_tag [CodePtr p; Number (&n); RefPtr r]::env),
            st)
     =
-    (Rval xs, st)`,
+    (Rval xs, st)
+Proof
   Induct_on `xs` >>
   srw_tac[][evaluate_def, GENLIST_CONS] >>
   srw_tac[][Once evaluate_CONS, evaluate_def, do_app_def, combinTheory.o_DEF] >>
@@ -2342,10 +2502,11 @@ val genlist_el = Q.prove (
   simp [ADD1] >>
   srw_tac[][] >>
   full_simp_tac(srw_ss())[ADD1] >>
-  srw_tac[][EL_LENGTH_APPEND]);
+  srw_tac[][EL_LENGTH_APPEND]
+QED
 
-val evaluate_code_for_recc_case = Q.prove (
-  `!st r xs args c p n env.
+Triviality evaluate_code_for_recc_case:
+  !st r xs args c p n env.
     FLOOKUP st.refs r = SOME (ValueArray xs)
     ⇒
     evaluate ([SND (code_for_recc_case (LENGTH xs) (LENGTH args) c)],
@@ -2353,7 +2514,8 @@ val evaluate_code_for_recc_case = Q.prove (
               st) =
     evaluate ([c],
               args ++ xs ++ [RefPtr r] ++ args ++ Block closure_tag [CodePtr p; Number (&n); RefPtr r]::env,
-              st)`,
+              st)
+Proof
   simp [code_for_recc_case_def, evaluate_def, do_app_def] >>
   simp [evaluate_APPEND, EL_LENGTH_APPEND] >>
   rpt strip_tac >>
@@ -2363,10 +2525,11 @@ val evaluate_code_for_recc_case = Q.prove (
   full_simp_tac(srw_ss())[] >>
   mp_tac (Q.SPEC `0` genlist_el) >>
   simp [LENGTH_NIL_SYM] >>
-  srw_tac[][TAKE_LENGTH_APPEND]);
+  srw_tac[][TAKE_LENGTH_APPEND]
+QED
 
-val cl_rel_run = Q.prove (
-  `!loc f1 refs code args args' env env' ptr body new_env func func' rest n fvs.
+Triviality cl_rel_run:
+  !loc f1 refs code args args' env env' ptr body new_env func func' rest n fvs.
     func' = Block closure_tag (CodePtr ptr::Number (&n)::env') ∧
     dest_closure' loc func args = SOME (Full_app body new_env rest) ∧
     v_rel max_app f1 refs code func func' ∧
@@ -2379,7 +2542,8 @@ val cl_rel_run = Q.prove (
       compile_exps max_app [body] aux1 = ([body'],aux2) ∧ code_installed aux2 code ∧
       env_rel max_app f1 refs code new_env new_env' ∧
       !t1. evaluate ([exp'], DROP (LENGTH args' - (n + 1)) args'++[func'], t1 with <| refs := refs; code := code |>) =
-           evaluate ([body'], new_env', t1 with <| refs := refs; code := code |>)`,
+           evaluate ([body'], new_env', t1 with <| refs := refs; code := code |>)
+Proof
   srw_tac[][cl_rel_cases, dest_closure'_def] >>
   full_simp_tac(srw_ss())[int_arithTheory.INT_NUM_SUB, closure_code_installed_def] >>
   rev_full_simp_tac(srw_ss())[] >>
@@ -2452,28 +2616,32 @@ val cl_rel_run = Q.prove (
       imp_res_tac EVERY2_LENGTH >>
       `LENGTH args' − (LENGTH args' − (n + 1)) = n'` by ARITH_TAC >>
       full_simp_tac(srw_ss())[] >>
-      srw_tac[][Once ADD_COMM]));
+      srw_tac[][Once ADD_COMM])
+QED
 
-val cl_rel_dest = Q.prove (
-  `!f refs code cl cl' fvs fvs'.
+Triviality cl_rel_dest:
+  !f refs code cl cl' fvs fvs'.
     cl_rel max_app f refs code (fvs,fvs') cl cl'
     ⇒
     get_old_args cl = SOME [] ∧
     ?l num_args fvs.
-      cl' = Block closure_tag (CodePtr l::Number (&num_args)::fvs)`,
+      cl' = Block closure_tag (CodePtr l::Number (&num_args)::fvs)
+Proof
   srw_tac[][cl_rel_cases] >>
   srw_tac[][get_old_args_def, EL_MAP] >>
   `?n e p. EL k exps_ps = ((n,e),p)` by metis_tac [pair_CASES] >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
-val dest_closure_full_of_part = Q.prove (
-  `dest_closure max_app loc func args = SOME (Full_app body newenv rest) ∧
+Triviality dest_closure_full_of_part:
+  dest_closure max_app loc func args = SOME (Full_app body newenv rest) ∧
    LENGTH arg_env ≠ 0 ∧
    add_args cl arg_env = SOME func ∧
    get_num_args cl = SOME num_args ∧
    LENGTH arg_env < num_args
    ⇒
-   dest_closure' loc cl (args++arg_env) = SOME (Full_app body newenv rest)`,
+   dest_closure' loc cl (args++arg_env) = SOME (Full_app body newenv rest)
+Proof
   srw_tac[][dest_closure_def, dest_closure'_def] >>
   BasicProvers.EVERY_CASE_TAC >>
   full_simp_tac(srw_ss())[add_args_def, check_loc_def, check_loc'_def, get_num_args_def] >>
@@ -2498,7 +2666,8 @@ val dest_closure_full_of_part = Q.prove (
           srw_tac [ARITH_ss] [])
       >- (`LENGTH (REVERSE arg_env) ≤ num_args' - LENGTH l` by (srw_tac [ARITH_ss] []) >>
           srw_tac[][DROP_APPEND2] >>
-          srw_tac [ARITH_ss] [])));
+          srw_tac [ARITH_ss] []))
+QED
 
 val v_rel_run = Q.prove (
   `!f1 refs code args args' env' ptr body newenv func func' rest tag n loc.
@@ -2599,13 +2768,14 @@ val v_rel_run = Q.prove (
   full_simp_tac(srw_ss())[DROP_APPEND1] >>
   srw_tac[][dec_clock_def]) |> INST_TYPE[alpha|->``:'c``,beta|->``:'ffi``];
 
-val list_rel_app = Q.prove (
-  `!R args args' l0 c l func rem_args.
+Triviality list_rel_app:
+  !R args args' l0 c l func rem_args.
     dest_closure max_app NONE func args = SOME (Full_app c l l0) ∧
     num_remaining_args func = SOME rem_args ∧
     LIST_REL R args args'
     ⇒
-    LIST_REL R l0 (TAKE (LENGTH args' − rem_args) args')`,
+    LIST_REL R l0 (TAKE (LENGTH args' − rem_args) args')
+Proof
   srw_tac[][dest_closure_def, LET_THM] >>
   BasicProvers.EVERY_CASE_TAC >>
   full_simp_tac(srw_ss())[] >>
@@ -2616,7 +2786,8 @@ val list_rel_app = Q.prove (
   full_simp_tac(srw_ss())[] >>
   srw_tac[][] >>
   full_simp_tac(srw_ss())[LIST_REL_EL_EQN, check_loc_def, num_remaining_args_def] >>
-  srw_tac [ARITH_ss] [EL_TAKE, EL_REVERSE, EL_DROP, PRE_SUB1]);
+  srw_tac [ARITH_ss] [EL_TAKE, EL_REVERSE, EL_DROP, PRE_SUB1]
+QED
 
 val mk_call_simp2 = Q.prove(
   `!n args stuff stuff' v t.
@@ -2644,20 +2815,22 @@ val mk_call_simp2 = Q.prove(
   srw_tac [ARITH_ss] [TAKE_APPEND1, TAKE_TAKE, EL_CONS])
   |> INST_TYPE[alpha|->``:'c``,beta|->``:'ffi``];
 
-val no_partial_args = Q.prove (
-  `num_remaining_args func = SOME x ∧
+Triviality no_partial_args:
+  num_remaining_args func = SOME x ∧
    get_num_args func = SOME x ∧
    x ≠ 0 ∧
    add_args cl arg_env = SOME func
    ⇒
-   arg_env = []`,
+   arg_env = []
+Proof
   Cases_on `cl` >>
   srw_tac[][add_args_def] >>
   full_simp_tac(srw_ss())[get_num_args_def, num_remaining_args_def] >>
   srw_tac[][] >>
   Cases_on `arg_env` >>
   full_simp_tac(srw_ss())[] >>
-  decide_tac);
+  decide_tac
+QED
 
 val s1 = ``s1:('c,'ffi) closSem$state``;
 
@@ -5178,10 +5351,11 @@ QED
 
 (* more correctness properties *)
 
-val build_aux_thm = Q.prove(
-  `∀c n aux n7 aux7.
+Triviality build_aux_thm:
+  ∀c n aux n7 aux7.
     build_aux n c aux = (n7,aux7++aux) ⇒
-    (MAP FST aux7) = (REVERSE (GENLIST ($+ n o $* 2) (LENGTH c)))`,
+    (MAP FST aux7) = (REVERSE (GENLIST ($+ n o $* 2) (LENGTH c)))
+Proof
   Induct >> simp[build_aux_def] >> srw_tac[][] >>
   qmatch_assum_abbrev_tac`build_aux nn kk auxx = Z` >>
   qspecl_then[`kk`,`nn`,`auxx`]strip_assume_tac build_aux_acc >>
@@ -5189,7 +5363,8 @@ val build_aux_thm = Q.prove(
   full_simp_tac std_ss [Once (CONS_APPEND)] >>
   full_simp_tac std_ss [Once (GSYM APPEND_ASSOC)] >> res_tac >>
   srw_tac[][GENLIST,REVERSE_APPEND,REVERSE_GENLIST,PRE_SUB1] >>
-  simp[LIST_EQ_REWRITE])
+  simp[LIST_EQ_REWRITE]
+QED
 
 Theorem MEM_build_aux_imp_SND_MEM:
    ∀n ls acc m aux x.
@@ -5202,16 +5377,20 @@ Proof
   \\ first_x_assum drule \\ rw[] \\ fs[]
 QED
 
-val lemma = Q.prove(`
+Triviality lemma:
   compile_exps max_app xs aux = (c,aux1) ⇒
-  LENGTH c = LENGTH xs ∧ ∃ys. aux1 = ys ++ aux`,
+  LENGTH c = LENGTH xs ∧ ∃ys. aux1 = ys ++ aux
+Proof
   mp_tac (SPEC_ALL compile_exps_acc) \\ rw[] \\
-  pairarg_tac \\ fs[] \\ rw[]);
+  pairarg_tac \\ fs[] \\ rw[]
+QED
 
-val lemma2 = Q.prove(`
+Triviality lemma2:
   build_aux n k aux = (a,b) ⇒
-  ∃z. b = z ++ aux`,
-  mp_tac (SPEC_ALL build_aux_acc) \\ rw[] \\ fs[]);
+  ∃z. b = z ++ aux
+Proof
+  mp_tac (SPEC_ALL build_aux_acc) \\ rw[] \\ fs[]
+QED
 
 Theorem compile_exps_code_locs:
    ∀max_app xs aux ys aux2.
@@ -5386,11 +5565,13 @@ Proof
 QED
 
 (*
-val even_stubs3 = Q.prove (
-  `!max_app. EVEN (num_stubs max_app + 3)`,
+Triviality even_stubs3:
+  !max_app. EVEN (num_stubs max_app + 3)
+Proof
   Induct_on `max_app` >>
   rw [num_stubs_def, EVEN_ADD, EVEN, GSYM EVEN_MOD2] >>
-  metis_tac []);
+  metis_tac []
+QED
   *)
 
 Overload code_loc' = ``λe. code_locs [e]``
@@ -5599,22 +5780,25 @@ Proof
 QED
 
 (* actually, this can be made even stronger *)
-val code_installed_fromAList_strong = Q.prove(`
+Triviality code_installed_fromAList_strong:
   ∀ls ls'.
   ALL_DISTINCT(MAP FST ls) ∧
   IS_SUBLIST ls ls' ⇒
-  code_installed ls' (fromAList ls)`,
+  code_installed ls' (fromAList ls)
+Proof
   srw_tac[][code_installed_def,EVERY_MEM,FORALL_PROD,lookup_fromAList] >>
-  metis_tac[ALOOKUP_ALL_DISTINCT_MEM,IS_SUBLIST_MEM])
+  metis_tac[ALOOKUP_ALL_DISTINCT_MEM,IS_SUBLIST_MEM]
+QED
 
 (*
-val compile_prog_stubs = Q.prove(`
+Triviality compile_prog_stubs:
   ∀ls ls' n m e new_e aux.
   MEM (n,m,e) ls ∧
   compile_prog max_app ls = ls' ∧
   compile_exps max_app [e] [] = (new_e,aux) ⇒
   MEM (n+(num_stubs max_app),m,HD new_e) ls' ∧
-  IS_SUBLIST ls' aux`,
+  IS_SUBLIST ls' aux
+Proof
   Induct>>fs[FORALL_PROD,compile_prog_def]>>
   rw[]>>rpt(pairarg_tac>>fs[])>>
   imp_res_tac compile_exps_SING>>fs[]>>rveq>>fs[]>>
@@ -5622,23 +5806,26 @@ val compile_prog_stubs = Q.prove(`
   Cases_on`aux`>>
   rfs[IS_SUBLIST]>>
   DISJ2_TAC>>
-  metis_tac[IS_SUBLIST_APPEND2]);
+  metis_tac[IS_SUBLIST_APPEND2]
+QED
 *)
 
-val evaluate_init1 = Q.prove(`
+Triviality evaluate_init1:
   ∀mapp2 mapp1 tot st.
   (∀n. n < mapp2 ⇒
   partial_app_fn_location mapp1 tot n ∈ domain st.code) ⇒
   bvlSem$evaluate (REVERSE
   (GENLIST (λprev. Op (Label (partial_app_fn_location mapp1 tot prev))[]) mapp2) ,[Unit],st) =
   (Rval (REVERSE
-  (GENLIST (λprev. CodePtr (partial_app_fn_location mapp1 tot prev)) mapp2)),st)`,
+  (GENLIST (λprev. CodePtr (partial_app_fn_location mapp1 tot prev)) mapp2)),st)
+Proof
   Induct>>fs[bvlSemTheory.evaluate_def]>>
   rw[]>>simp[GENLIST,REVERSE_SNOC]>>
   ONCE_REWRITE_TAC[CONS_APPEND]>>
-  simp[bvlPropsTheory.evaluate_APPEND,bvlSemTheory.evaluate_def,do_app_def])
+  simp[bvlPropsTheory.evaluate_APPEND,bvlSemTheory.evaluate_def,do_app_def]
+QED
 
-val evaluate_init = Q.prove(`
+Triviality evaluate_init:
   ∀mapp2 mapp1 st.
   (∀m n. m < mapp2 ∧ n < m ⇒
   partial_app_fn_location mapp1 m n ∈ domain st.code) ⇒
@@ -5647,14 +5834,16 @@ val evaluate_init = Q.prove(`
   (λprev. Op (Label (partial_app_fn_location mapp1 tot prev))[]) tot) mapp2)) ,[Unit],st) =
     (Rval (REVERSE
     (FLAT (GENLIST (λtot. GENLIST
-    (λprev. CodePtr (partial_app_fn_location mapp1 tot prev)) tot) mapp2))),st)`,
+    (λprev. CodePtr (partial_app_fn_location mapp1 tot prev)) tot) mapp2))),st)
+Proof
   Induct>>fs[bvlSemTheory.evaluate_def]>>
   simp[GENLIST,FLAT_SNOC]>>
   simp[REVERSE_APPEND,bvlPropsTheory.evaluate_APPEND]>>
   rw[]>>
   `∀n. n < mapp2 ⇒ partial_app_fn_location mapp1 mapp2 n ∈ domain st.code` by fs[] >>
   drule evaluate_init1>>
-  simp[]);
+  simp[]
+QED
 
 val FST_EQ_LEMMA = prove(
   ``FST x = y <=> ?y1. x = (y,y1)``,
@@ -6655,9 +6844,11 @@ Proof
     miscTheory.ALL_DISTINCT_alist_to_fmap_REVERSE]
 QED
 
-val obvious_arith_comm = Q.prove (
-  `((a : num) = b + a) = (b = 0)`,
-  Cases_on `b` \\ fs []);
+Triviality obvious_arith_comm:
+  ((a : num) = b + a) = (b = 0)
+Proof
+  Cases_on `b` \\ fs []
+QED
 
 Theorem SND_SND_known_compile_inc:
   SND (SND (clos_known$compile_inc conf app es)) = SND es
@@ -7424,8 +7615,11 @@ Proof
   Cases_on `TL exps` \\ rw [can_extract_def] \\ fs []
 QED
 
-val show_SUBSET = Q.prove (`(!x. x IN s ==> x IN t) ==> s SUBSET t`,
-    fs [SUBSET_DEF]);
+Triviality show_SUBSET:
+  (!x. x IN s ==> x IN t) ==> s SUBSET t
+Proof
+  fs [SUBSET_DEF]
+QED
 
 Theorem trivia_1:
   COUNT_LIST 1 = [0] /\ MAX 1 (SUC x) = SUC x /\
@@ -8113,13 +8307,14 @@ Proof
 QED
 
 (* TODO: move *)
-val ALOOKUP_lemma = Q.prove(
-  `∀l1 l2 n k v.
+Triviality ALOOKUP_lemma:
+  ∀l1 l2 n k v.
     (EL n l1 = (k,v)) ∧
     ALL_DISTINCT (MAP FST l1) ∧
     n < LENGTH l1 ∧ LENGTH l2 = LENGTH l1
     ⇒
-  ALOOKUP (MAP2 (λ(loc,args,_) exp. (loc + (m:num),args,exp)) l1 l2) (k + m) = SOME (FST v, EL n l2)`,
+  ALOOKUP (MAP2 (λ(loc,args,_) exp. (loc + (m:num),args,exp)) l1 l2) (k + m) = SOME (FST v, EL n l2)
+Proof
   Induct \\ rw[]
   \\ Cases_on`l2` \\ fs[]
   \\ pairarg_tac \\ fs[]
@@ -8131,7 +8326,8 @@ val ALOOKUP_lemma = Q.prove(
       fs[MEM_MAP, PULL_EXISTS, Once EXISTS_PROD, MEM_EL]
       \\ metis_tac[] )
     \\ rw[] )
-  \\ Cases_on`n` \\ fs[]);
+  \\ Cases_on`n` \\ fs[]
+QED
 
 Theorem ALOOKUP_compile_common:
    compile_common c es = (c', prog) ∧

--- a/compiler/backend/proofs/data_liveProofScript.sml
+++ b/compiler/backend/proofs/data_liveProofScript.sml
@@ -10,9 +10,11 @@ val _ = new_theory"data_liveProof";
 val _ = temp_bring_to_front_overload"get_vars"{Name="get_vars",Thy="dataSem"};
 val _ = temp_bring_to_front_overload"cut_env"{Name="cut_env",Thy="dataSem"};
 
-val SPLIT_PAIR = Q.prove(
-  `!x y z. (x = (y,z)) <=> (y = FST x) /\ (z = SND x)`,
-  Cases \\ SRW_TAC [] [] \\ METIS_TAC []);
+Triviality SPLIT_PAIR:
+  !x y z. (x = (y,z)) <=> (y = FST x) /\ (z = SND x)
+Proof
+  Cases \\ SRW_TAC [] [] \\ METIS_TAC []
+QED
 
 Definition state_rel_def:
   state_rel (s1:('a,'ffi) dataSem$state) (t1:('a,'ffi) dataSem$state) (live:num_set) <=>
@@ -27,23 +29,27 @@ Definition state_rel_def:
     (!x. x IN domain live ==> (lookup x s1.locals = lookup x t1.locals))
 End
 
-val state_rel_ID = Q.prove(
-  `!s live. state_rel s s live`,
-  fs [state_rel_def]);
+Triviality state_rel_ID:
+  !s live. state_rel s s live
+Proof
+  fs [state_rel_def]
+QED
 
-val jump_exc_IMP_state_rel = Q.prove(
-  `!s1 t1 s2 t2.
+Triviality jump_exc_IMP_state_rel:
+  !s1 t1 s2 t2.
       (jump_exc s1 = SOME s2) /\ (jump_exc t1 = SOME t2) /\
       state_rel s1 t1 LN /\ (LENGTH s2.stack = LENGTH t2.stack) ==>
       state_rel (s2 with handler := s1.handler)
-                (t2 with handler := t1.handler) LN`,
+                (t2 with handler := t1.handler) LN
+Proof
   REPEAT STRIP_TAC
   \\ FULL_SIMP_TAC std_ss [jump_exc_def]
   \\ every_case_tac >> fs[]
-  \\ SRW_TAC [] [] \\ fs [state_rel_def]);
+  \\ SRW_TAC [] [] \\ fs [state_rel_def]
+QED
 
-val state_rel_IMP_do_app_aux = Q.prove(
-  `(do_app_aux op args s1 = Rval (v,s2)) /\
+Triviality state_rel_IMP_do_app_aux:
+  (do_app_aux op args s1 = Rval (v,s2)) /\
     state_rel s1 t1 anything ==>
     (s1.handler = s2.handler) /\ (s1.stack = s2.stack) /\
     (∃safe peak smx lss.
@@ -55,16 +61,18 @@ val state_rel_IMP_do_app_aux = Q.prove(
                             handler := t1.handler ;
                             safe_for_space := safe ;
                             peak_heap_length := peak ;
-                            |>))`,
+                            |>))
+Proof
   STRIP_TAC
   \\ Cases_on `op` \\ TRY (rename [‘EqualConst cc’] \\ Cases_on ‘cc’)
   \\ fs [do_app_aux_def,do_space_def,with_fresh_ts_def,state_rel_def,check_lim_def]
   \\ fs [state_rel_def,consume_space_def,case_eq_thms,do_install_def,UNCURRY]
   \\ ASM_SIMP_TAC (srw_ss()) [dataSemTheory.state_component_equality]
-  \\ SRW_TAC [] [] \\ fs[]);
+  \\ SRW_TAC [] [] \\ fs[]
+QED
 
-val state_rel_IMP_do_app = Q.prove(
-  `(do_app op args s1 = Rval (v,s2)) /\
+Triviality state_rel_IMP_do_app:
+  (do_app op args s1 = Rval (v,s2)) /\
     state_rel s1 t1 anything ==>
     (s1.handler = s2.handler) /\ (s1.stack = s2.stack) /\
     (∃safe peak smx lss. do_app op args t1 = Rval (v,s2 with <| locals := t1.locals ;
@@ -73,7 +81,8 @@ val state_rel_IMP_do_app = Q.prove(
                                                    stack_max := smx ;
                                                    handler := t1.handler ;
                                                    safe_for_space := safe ;
-                                                   peak_heap_length := peak|>))`,
+                                                   peak_heap_length := peak|>))
+Proof
   STRIP_TAC
   \\ IMP_RES_TAC do_app_const
   \\ fs [do_app_def, do_space_def, do_install_def
@@ -86,21 +95,25 @@ val state_rel_IMP_do_app = Q.prove(
  \\ `state_rel s1' t1' anything` by (UNABBREV_ALL_TAC \\ fs [state_rel_def])
  \\ drule_then (qspecl_then [`t1'`,`anything`] mp_tac) state_rel_IMP_do_app_aux
  \\ fs [state_rel_def] \\ rfs [] \\ rveq
- \\ fs [Abbr `t1'`]);
+ \\ fs [Abbr `t1'`]
+QED
 
-val state_rel_IMP_do_app_aux_err = Q.prove(
-  `(do_app_aux op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
-    (do_app_aux op args t1 = Rerr e)`,
+Triviality state_rel_IMP_do_app_aux_err:
+  (do_app_aux op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
+    (do_app_aux op args t1 = Rerr e)
+Proof
   STRIP_TAC
   \\ Cases_on `op` \\ TRY (rename [‘EqualConst cc’] \\ Cases_on ‘cc’)
   \\ fs [do_app_aux_def,do_space_def,with_fresh_ts_def]
   \\ fs [state_rel_def,consume_space_def,case_eq_thms,do_install_def,UNCURRY]
   \\ ASM_SIMP_TAC (srw_ss()) [dataSemTheory.state_component_equality]
-  \\ SRW_TAC [] [] \\ fs[]);
+  \\ SRW_TAC [] [] \\ fs[]
+QED
 
-val state_rel_IMP_do_app_err = Q.prove(
-  `(do_app op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
-    (do_app op args t1 = Rerr e)`,
+Triviality state_rel_IMP_do_app_err:
+  (do_app op args s1 = Rerr e) /\ state_rel s1 t1 anything ==>
+    (do_app op args t1 = Rerr e)
+Proof
   STRIP_TAC
   \\ fs [do_app_def,do_space_def]
   \\ fs [state_rel_def,consume_space_def,case_eq_thms,do_install_def,UNCURRY]
@@ -110,43 +123,49 @@ val state_rel_IMP_do_app_err = Q.prove(
   \\ `state_rel s1' t1' anything` by (UNABBREV_ALL_TAC \\ fs [state_rel_def])
   \\ drule_then (qspecl_then [`t1'`,`anything`] mp_tac) state_rel_IMP_do_app_aux_err
   \\ fs [state_rel_def] \\ rfs []
-);
+QED
 
-val state_rel_IMP_get_vars = Q.prove(
-  `!args s1 t1 t xs.
+Triviality state_rel_IMP_get_vars:
+  !args s1 t1 t xs.
       state_rel s1 t1 (list_insert args t) /\
       (get_vars args s1.locals = SOME xs) ==>
-      (get_vars args t1.locals = SOME xs)`,
+      (get_vars args t1.locals = SOME xs)
+Proof
   Induct \\ fs [get_vars_def] \\ REPEAT STRIP_TAC
   \\ `state_rel s1 t1 (list_insert args t) /\
       (get_var h s1.locals = get_var h t1.locals)` by
    (fs [state_rel_def,list_insert_def,domain_list_insert,get_var_def]
     \\ METIS_TAC []) \\ fs []
   \\ every_case_tac >> fs[]
-  \\ RES_TAC \\ fs [] \\ SRW_TAC [] []);
+  \\ RES_TAC \\ fs [] \\ SRW_TAC [] []
+QED
 
-val is_pure_do_app_Rerr_IMP = Q.prove(
-  `is_pure op /\ do_app op xs s = Rerr e ==>
-    Rabort Rtype_error = e`,
+Triviality is_pure_do_app_Rerr_IMP:
+  is_pure op /\ do_app op xs s = Rerr e ==>
+    Rabort Rtype_error = e
+Proof
   Cases_on `op` \\ TRY (rename [‘EqualConst cc’] \\ Cases_on ‘cc’)
   \\ fs [is_pure_def,do_app_def,do_app_aux_def]
   \\ simp[do_space_def,data_spaceTheory.op_space_req_def,
-          case_eq_thms,do_install_def,UNCURRY] \\ rw[]);
+          case_eq_thms,do_install_def,UNCURRY] \\ rw[]
+QED
 
-val is_pure_do_app_Rval_IMP = Q.prove(
-  `is_pure op /\ do_app op x s = Rval (q,r)
+Triviality is_pure_do_app_Rval_IMP:
+  is_pure op /\ do_app op x s = Rval (q,r)
    ⇒  ∃safe smax. r = s with <| safe_for_space := safe;
-                                stack_max := smax |>`,
+                                stack_max := smax |>
+Proof
   Cases_on `op` \\ TRY (rename [‘EqualConst cc’] \\ Cases_on ‘cc’)
   \\ fs [is_pure_def,do_app_def,do_app_aux_def]
   \\ simp[do_space_def,dataLangTheory.op_space_reset_def,data_spaceTheory.op_space_req_def,
           consume_space_def,do_install_def,UNCURRY,case_eq_thms]
   \\ rw[] \\ fs [state_component_equality,is_pure_def
                 ,data_spaceTheory.op_space_req_def,allowed_op_def
-                ,do_stack_def]);
+                ,do_stack_def]
+QED
 
-val evaluate_compile = Q.prove(
-  `!c s1 res s2 l2 t1 l1 d.
+Triviality evaluate_compile:
+  !c s1 res s2 l2 t1 l1 d.
       (evaluate (c,s1) = (res,s2)) /\ state_rel s1 t1 l1 /\
       (compile c l2 = (d,l1)) /\ (res <> SOME (Rerr (Rabort Rtype_error))) /\
       (!s3. (jump_exc s1 = SOME s3) ==>
@@ -154,7 +173,8 @@ val evaluate_compile = Q.prove(
                  (t3.handler = s3.handler) /\
                  (LENGTH t3.stack = LENGTH s3.stack)) ==>
       ?t2. (evaluate (d,t1) = (res,t2)) /\
-           state_rel s2 t2 (case res of NONE => l2 | _ => LN)`,
+           state_rel s2 t2 (case res of NONE => l2 | _ => LN)
+Proof
   ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ recInduct evaluate_ind \\ REPEAT STRIP_TAC
   THEN1 (* Skip *)
@@ -653,7 +673,8 @@ val evaluate_compile = Q.prove(
   \\ SRW_TAC [] [] \\ fs []
   \\ Cases_on `LASTN (t1.handler + 1) t1.stack` \\ fs []
   \\ Cases_on `h` \\ fs []
-  \\ SRW_TAC [] [] \\ fs []);
+  \\ SRW_TAC [] [] \\ fs []
+QED
 
 Theorem compile_correct:
    !c s. FST (evaluate (c,s)) <> SOME (Rerr(Rabort Rtype_error)) /\

--- a/compiler/backend/proofs/data_simpProofScript.sml
+++ b/compiler/backend/proofs/data_simpProofScript.sml
@@ -7,17 +7,22 @@ val _ = new_theory"data_simpProof";
 
 val _ = set_grammar_ancestry ["data_simp", "dataSem", "dataProps"];
 
-val evaluate_Seq_Skip = Q.prove(
-  `!c s. evaluate (Seq c Skip,s) = evaluate (c,s)`,
+Triviality evaluate_Seq_Skip:
+  !c s. evaluate (Seq c Skip,s) = evaluate (c,s)
+Proof
   fs [evaluate_def,LET_DEF] \\ REPEAT STRIP_TAC
-  \\ Cases_on `evaluate (c,s)` \\ fs [] \\ SRW_TAC [] []);
+  \\ Cases_on `evaluate (c,s)` \\ fs [] \\ SRW_TAC [] []
+QED
 
-val evaluate_pSeq = Q.prove(
-  `evaluate (pSeq c1 c2, s) = evaluate (Seq c1 c2, s)`,
-  SRW_TAC [] [pSeq_def] \\ fs [evaluate_Seq_Skip]);
+Triviality evaluate_pSeq:
+  evaluate (pSeq c1 c2, s) = evaluate (Seq c1 c2, s)
+Proof
+  SRW_TAC [] [pSeq_def] \\ fs [evaluate_Seq_Skip]
+QED
 
-val evaluate_simp = Q.prove(
-  `!c1 s c2. evaluate (simp c1 c2,s) = evaluate (Seq c1 c2,s)`,
+Triviality evaluate_simp:
+  !c1 s c2. evaluate (simp c1 c2,s) = evaluate (Seq c1 c2,s)
+Proof
   recInduct evaluate_ind \\ reverse (REPEAT STRIP_TAC) THEN1
    (Cases_on `handler` \\ fs [simp_def,evaluate_pSeq]
     \\ Cases_on `x` \\ fs [simp_def,evaluate_pSeq]
@@ -33,7 +38,8 @@ val evaluate_simp = Q.prove(
   \\ Cases_on `evaluate (c2,set_var n a r)` \\ fs []
   \\ rw[] >> every_case_tac \\ fs [evaluate_def] \\ fs []
   \\ CONV_TAC (DEPTH_CONV (PairRules.PBETA_CONV))
-  \\ every_case_tac >> fs[evaluate_def]);
+  \\ every_case_tac >> fs[evaluate_def]
+QED
 
 Theorem simp_correct:
    !c s. evaluate (simp c Skip,s) = evaluate (c,s)

--- a/compiler/backend/proofs/data_spaceProofScript.sml
+++ b/compiler/backend/proofs/data_spaceProofScript.sml
@@ -14,13 +14,17 @@ val _ = temp_bring_to_front_overload"lookup"{Name="lookup",Thy="sptree"};
 val _ = temp_bring_to_front_overload"insert"{Name="insert",Thy="sptree"};
 val _ = temp_bring_to_front_overload"wf"{Name="wf",Thy="sptree"};
 
-val IMP_sptree_eq = Q.prove(
-  `wf x /\ wf y /\ (!a. lookup a x = lookup a y) ==> (x = y)`,
-  METIS_TAC [spt_eq_thm]);
+Triviality IMP_sptree_eq:
+  wf x /\ wf y /\ (!a. lookup a x = lookup a y) ==> (x = y)
+Proof
+  METIS_TAC [spt_eq_thm]
+QED
 
-val mk_wf_inter = Q.prove(
-  `!t1 t2. inter t1 t2 = mk_wf (inter t1 t2)`,
-  full_simp_tac(srw_ss())[]);
+Triviality mk_wf_inter:
+  !t1 t2. inter t1 t2 = mk_wf (inter t1 t2)
+Proof
+  full_simp_tac(srw_ss())[]
+QED
 
 Theorem get_vars_IMP_LENGTH:
    !xs s l. get_vars xs s = SOME l ==> (LENGTH l = LENGTH xs)
@@ -43,8 +47,8 @@ Proof
   rw [do_stack_def,stack_consumed_def]
 QED
 
-val evaluate_compile = Q.prove(
-  `!c s res s2 vars l.
+Triviality evaluate_compile:
+  !c s res s2 vars l.
      res <> SOME (Rerr(Rabort Rtype_error)) /\ (evaluate (c,s) = (res,s2)) /\
      locals_ok s.locals l ==>
      ?w safe peak smx.
@@ -56,7 +60,8 @@ val evaluate_compile = Q.prove(
                             else s2 with <| safe_for_space := safe;
                                             peak_heap_length := peak;
                                             stack_max := smx |>)) /\
-         locals_ok s2.locals w`,
+         locals_ok s2.locals w
+Proof
   SIMP_TAC std_ss [compile_def]
   \\ recInduct evaluate_ind \\ REPEAT STRIP_TAC
   \\ fs[evaluate_def,space_def,pMakeSpace_def]
@@ -487,7 +492,8 @@ val evaluate_compile = Q.prove(
                                       , `s2.safe_for_space`
                                       , `s2.peak_heap_length`
                                       , `s2.stack_max`]
-    \\ rw [locals_ok_refl,with_same_locals,state_component_equality]));
+    \\ rw [locals_ok_refl,with_same_locals,state_component_equality])
+QED
 
 Theorem compile_correct:
    !c s.

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -795,15 +795,17 @@ Proof
   \\ fs [] \\ every_case_tac \\ fs [] \\ rw[] \\ fs []
 QED
 
-val state_rel_ext_with_clock = Q.prove(
-  `state_rel_ext a b c s1 s2 ==>
-    state_rel_ext a b c (s1 with clock := k) (s2 with clock := k)`,
+Triviality state_rel_ext_with_clock:
+  state_rel_ext a b c s1 s2 ==>
+    state_rel_ext a b c (s1 with clock := k) (s2 with clock := k)
+Proof
   full_simp_tac(srw_ss())[state_rel_ext_def] \\ srw_tac[][]
   \\ old_drule state_rel_with_clock
   \\ strip_tac \\ asm_exists_tac \\ full_simp_tac(srw_ss())[]
   \\ qexists_tac `l` \\ full_simp_tac(srw_ss())[]
   \\ fs [wordSemTheory.state_component_equality]
-  \\ metis_tac []);
+  \\ metis_tac []
+QED
 
 (* observational semantics preservation *)
 
@@ -1448,38 +1450,46 @@ Proof
 QED
 
 (* TODO: goes away on inlineenc branch *)
-val extract_labels_WordOp64_on_32 = Q.prove(`
-  extract_labels (WordOp64_on_32 f) = []`,
+Triviality extract_labels_WordOp64_on_32:
+  extract_labels (WordOp64_on_32 f) = []
+Proof
   simp[WordOp64_on_32_def]>>Cases_on`f`>>simp[]>>
-  EVAL_TAC);
+  EVAL_TAC
+QED
 
-val extract_labels_WordShift64_on_32 = Q.prove(`
-  extract_labels (WordShift64_on_32 f g) = []`,
+Triviality extract_labels_WordShift64_on_32:
+  extract_labels (WordShift64_on_32 f g) = []
+Proof
   simp[WordShift64_on_32_def]>>
   Cases_on`f`>>simp[]>>
-  IF_CASES_TAC>>EVAL_TAC);
+  IF_CASES_TAC>>EVAL_TAC
+QED
 
-val extract_labels_assignWordOp = Q.prove(`
+Triviality extract_labels_assignWordOp:
   assign a b c d (WordOp e f) g h = (i,j) ⇒
-  extract_labels i = [] ∧ c ≤ j`,
+  extract_labels i = [] ∧ c ≤ j
+Proof
   simp[assign_def]>>
   Cases_on`dimindex(:'a) = 64`>> simp[]
   >- (every_case_tac>>rw[]>> EVAL_TAC)
   >>
     every_case_tac>>rw[]>>
     simp[extract_labels_def,list_Seq_def,extract_labels_WordOp64_on_32]>>
-    EVAL_TAC);
+    EVAL_TAC
+QED
 
-val extract_labels_assignWordShift = Q.prove(`
+Triviality extract_labels_assignWordShift:
   assign a b c d (WordShift e f k) g h = (i,j) ⇒
-  extract_labels i = [] ∧ c ≤ j`,
+  extract_labels i = [] ∧ c ≤ j
+Proof
   simp[assign_def]>>
   Cases_on`dimindex(:'a) >= 64`>> simp[]
   >- (every_case_tac>>rw[]>> EVAL_TAC)
   >>
     every_case_tac>>rw[]>>
     simp[extract_labels_def,list_Seq_def,extract_labels_WordShift64_on_32]>>
-    EVAL_TAC);
+    EVAL_TAC
+QED
 
 Theorem data_to_word_lab_pres_lem:
   ∀c n l p.
@@ -1525,9 +1535,11 @@ Proof
        SilentFFI_def,list_Seq_def])
 QED
 
-val labels_rel_emp = Q.prove(`
-  labels_rel [] ls ⇒ ls = [] `,
-  fs[word_simpProofTheory.labels_rel_def]);
+Triviality labels_rel_emp:
+  labels_rel [] ls ⇒ ls = []
+Proof
+  fs[word_simpProofTheory.labels_rel_def]
+QED
 
 Theorem stub_labels:
     EVERY (λ(n,m,p).
@@ -1602,15 +1614,19 @@ Proof
   disch_then(qspec_then`n` assume_tac)>>rfs[]
 QED
 
-val StoreEach_no_inst = Q.prove(`
+Triviality StoreEach_no_inst:
   ∀a ls off.
-  every_inst (inst_ok_less ac) (StoreEach a ls off)`,
-  Induct_on`ls`>>rw[StoreEach_def,every_inst_def]);
+  every_inst (inst_ok_less ac) (StoreEach a ls off)
+Proof
+  Induct_on`ls`>>rw[StoreEach_def,every_inst_def]
+QED
 
-val MemEqList_no_inst = Q.prove(`
+Triviality MemEqList_no_inst:
   ∀a x.
-  every_inst (inst_ok_less ac) (MemEqList a x)`,
-  Induct_on `x` \\ fs [MemEqList_def,every_inst_def]);
+  every_inst (inst_ok_less ac) (MemEqList a x)
+Proof
+  Induct_on `x` \\ fs [MemEqList_def,every_inst_def]
+QED
 
 Theorem StoreAnyConsts_no_inst[local]:
   ∀r1 r2 r3 ws w. every_inst (inst_ok_less ac) (StoreAnyConsts r1 r2 r3 ws w)
@@ -1666,7 +1682,7 @@ Proof
   IF_CASES_TAC >> EVAL_TAC >> fs []
 QED
 
-val bounds_lem = Q.prove(`
+Triviality bounds_lem:
   (dimindex(:'a) = 32 ∨ dimindex(:'a) = 64) ∧
   (w:'a word = -3w ∨
   w = -2w ∨
@@ -1680,14 +1696,16 @@ val bounds_lem = Q.prove(`
   w = 6w ∨
   w = 7w)
   ⇒
-  -8w ≤ w ∧ w ≤ 8w`,
+  -8w ≤ w ∧ w ≤ 8w
+Proof
   rw[]>>
   EVAL_TAC>>
   simp[dimword_def]>>
   EVAL_TAC>>
   simp[dimword_def]>>
   EVAL_TAC>>
-  simp[numeral_bitTheory.iSUC,numeralTheory.numeral_evenodd,ODD]);
+  simp[numeral_bitTheory.iSUC,numeralTheory.numeral_evenodd,ODD]
+QED
 
 Theorem data_to_word_compile_conventions:
     good_dimindex(:'a) ==>
@@ -1797,94 +1815,114 @@ in
 (* TODO: most of the following lemmas ought to be moved *)
 
 (* remove_must_terminate*)
-val word_get_code_labels_remove_must_terminate = Q.prove(`
+Triviality word_get_code_labels_remove_must_terminate:
   ∀ps.
   word_get_code_labels (remove_must_terminate ps) =
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   ho_match_mp_tac remove_must_terminate_ind>>rw[]>>
   fs[remove_must_terminate_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val word_good_handlers_remove_must_terminate = Q.prove(`
+Triviality word_good_handlers_remove_must_terminate:
   ∀ps.
   word_good_handlers n (remove_must_terminate ps) ⇔
-  word_good_handlers n ps`,
+  word_good_handlers n ps
+Proof
   ho_match_mp_tac remove_must_terminate_ind>>rw[]>>
   fs[remove_must_terminate_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
 (* word_alloc *)
 
-val word_get_code_labels_apply_colour = Q.prove(`
+Triviality word_get_code_labels_apply_colour:
   ∀col ps.
   word_get_code_labels (apply_colour col ps) =
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   ho_match_mp_tac apply_colour_ind>>rw[]>>
   fs[apply_colour_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val word_good_handlers_apply_colour = Q.prove(`
+Triviality word_good_handlers_apply_colour:
   ∀col ps.
   word_good_handlers n (apply_colour col ps) ⇔
-  word_good_handlers n ps`,
+  word_good_handlers n ps
+Proof
   ho_match_mp_tac apply_colour_ind>>rw[]>>
   fs[apply_colour_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val word_get_code_labels_word_alloc = Q.prove(`
+Triviality word_get_code_labels_word_alloc:
   word_get_code_labels (word_alloc fc c alg k prog col_opt) =
-  word_get_code_labels prog`,
+  word_get_code_labels prog
+Proof
   fs[word_alloc_def,oracle_colour_ok_def]>>
   EVERY_CASE_TAC>>fs[]>>
   TRY(pairarg_tac)>>fs[]>>
   EVERY_CASE_TAC>>fs[]>>
-  metis_tac[word_get_code_labels_apply_colour])
+  metis_tac[word_get_code_labels_apply_colour]
+QED
 
-val word_good_handlers_word_alloc = Q.prove(`
+Triviality word_good_handlers_word_alloc:
   word_good_handlers n (word_alloc fc c alg k prog col_opt) ⇔
-  word_good_handlers n prog`,
+  word_good_handlers n prog
+Proof
   fs[word_alloc_def,oracle_colour_ok_def]>>
   EVERY_CASE_TAC>>fs[]>>
   TRY(pairarg_tac)>>fs[]>>
   EVERY_CASE_TAC>>fs[]>>
-  metis_tac[word_good_handlers_apply_colour]);
+  metis_tac[word_good_handlers_apply_colour]
+QED
 
 (* three to two *)
-val word_get_code_labels_three_to_two_reg = Q.prove(`
+Triviality word_get_code_labels_three_to_two_reg:
   ∀ps.
   word_get_code_labels (three_to_two_reg ps) =
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   ho_match_mp_tac three_to_two_reg_ind>>rw[]>>
   fs[three_to_two_reg_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val word_good_handlers_three_to_two_reg = Q.prove(`
+Triviality word_good_handlers_three_to_two_reg:
   ∀ps.
   word_good_handlers n (three_to_two_reg ps) ⇔
-  word_good_handlers n ps`,
+  word_good_handlers n ps
+Proof
   ho_match_mp_tac three_to_two_reg_ind>>rw[]>>
   fs[three_to_two_reg_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
 (* remove_dead *)
-val word_get_code_labels_remove_dead = Q.prove(`
+Triviality word_get_code_labels_remove_dead:
   ∀ps live.
   word_get_code_labels (FST (remove_dead ps live)) ⊆
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   ho_match_mp_tac remove_dead_ind>>rw[]>>
   fs[remove_dead_def]>>
   every_case_tac>>fs[]>>
   rpt(pairarg_tac>>fs[])>>rw[]>>
-  fs[SUBSET_DEF]);
+  fs[SUBSET_DEF]
+QED
 
-val word_good_handlers_remove_dead = Q.prove(`
+Triviality word_good_handlers_remove_dead:
   ∀ps live.
   word_good_handlers n ps ⇒
-  word_good_handlers n (FST (remove_dead ps live))`,
+  word_good_handlers n (FST (remove_dead ps live))
+Proof
   ho_match_mp_tac remove_dead_ind>>rw[]>>
   fs[remove_dead_def]>>
   every_case_tac>>fs[]>>
-  rpt(pairarg_tac>>fs[])>>rw[]);
+  rpt(pairarg_tac>>fs[])>>rw[]
+QED
 
 (* ssa *)
 
@@ -1948,10 +1986,11 @@ Proof
     \\ fs[])
 QED
 
-val word_get_code_labels_full_ssa_cc_trans = Q.prove(`
+Triviality word_get_code_labels_full_ssa_cc_trans:
   ∀m p.
   word_get_code_labels (full_ssa_cc_trans m p) =
-  word_get_code_labels p`,
+  word_get_code_labels p
+Proof
   simp[full_ssa_cc_trans_def]
   \\ rpt gen_tac
   \\ pairarg_tac \\ fs[]
@@ -1960,7 +1999,8 @@ val word_get_code_labels_full_ssa_cc_trans = Q.prove(`
   \\ pairarg_tac \\ fs[]
   \\ rveq \\ fs[]
   \\ old_drule word_get_code_labels_ssa_cc_trans
-  \\ rw[]);
+  \\ rw[]
+QED
 
 Theorem word_good_handlers_fake_moves:
    ∀a b c d e f g h i.
@@ -2022,10 +2062,11 @@ Proof
     \\ fs[])
 QED
 
-val word_good_handlers_full_ssa_cc_trans = Q.prove(`
+Triviality word_good_handlers_full_ssa_cc_trans:
   ∀m p.
   word_good_handlers n (full_ssa_cc_trans m p) ⇔
-  word_good_handlers n p`,
+  word_good_handlers n p
+Proof
   simp[full_ssa_cc_trans_def]
   \\ rpt gen_tac
   \\ pairarg_tac \\ fs[]
@@ -2034,73 +2075,90 @@ val word_good_handlers_full_ssa_cc_trans = Q.prove(`
   \\ pairarg_tac \\ fs[]
   \\ rveq \\ fs[]
   \\ old_drule word_good_handlers_ssa_cc_trans
-  \\ rw[]);
+  \\ rw[]
+QED
 
 (* inst *)
-val word_get_code_labels_inst_select_exp = Q.prove(`
+Triviality word_get_code_labels_inst_select_exp:
   ∀a b c exp.
-  word_get_code_labels (inst_select_exp a b c exp) = {}`,
+  word_get_code_labels (inst_select_exp a b c exp) = {}
+Proof
   ho_match_mp_tac inst_select_exp_ind>>rw[]>>
   fs[inst_select_exp_def]>>
-  every_case_tac>>fs[inst_select_exp_def]);
+  every_case_tac>>fs[inst_select_exp_def]
+QED
 
-val word_get_code_labels_inst_select = Q.prove(`
+Triviality word_get_code_labels_inst_select:
   ∀ac v ps.
   word_get_code_labels (inst_select ac v ps) =
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   ho_match_mp_tac inst_select_ind>>rw[]>>
   fs[inst_select_def]>>
-  every_case_tac>>fs[word_get_code_labels_inst_select_exp]);
+  every_case_tac>>fs[word_get_code_labels_inst_select_exp]
+QED
 
-val word_good_handlers_inst_select_exp = Q.prove(`
+Triviality word_good_handlers_inst_select_exp:
   ∀a b c exp.
-  word_good_handlers n (inst_select_exp a b c exp)`,
+  word_good_handlers n (inst_select_exp a b c exp)
+Proof
   ho_match_mp_tac inst_select_exp_ind>>rw[]>>
   fs[inst_select_exp_def]>>
-  every_case_tac>>fs[inst_select_exp_def]);
+  every_case_tac>>fs[inst_select_exp_def]
+QED
 
-val word_good_handlers_inst_select = Q.prove(`
+Triviality word_good_handlers_inst_select:
   ∀ac v ps.
   word_good_handlers n (inst_select ac v ps) ⇔
-  word_good_handlers n ps`,
+  word_good_handlers n ps
+Proof
   ho_match_mp_tac inst_select_ind>>rw[]>>
   fs[inst_select_def]>>
-  every_case_tac>>fs[word_good_handlers_inst_select_exp]);
+  every_case_tac>>fs[word_good_handlers_inst_select_exp]
+QED
 
 (* simp *)
-val word_get_code_labels_const_fp_loop = Q.prove(`
+Triviality word_get_code_labels_const_fp_loop:
   ∀p l.
-  word_get_code_labels (FST (const_fp_loop p l)) ⊆ word_get_code_labels p`,
+  word_get_code_labels (FST (const_fp_loop p l)) ⊆ word_get_code_labels p
+Proof
   ho_match_mp_tac const_fp_loop_ind \\ rw []
   \\ fs [const_fp_loop_def]
   \\ every_case_tac\\ fs[]
   \\ rpt (pairarg_tac \\ fs[])
-  \\ fs[SUBSET_DEF] \\ metis_tac[]);
+  \\ fs[SUBSET_DEF] \\ metis_tac[]
+QED
 
-val word_good_handlers_const_fp_loop = Q.prove(`
+Triviality word_good_handlers_const_fp_loop:
   ∀p l.
   word_good_handlers n p ⇒
-  word_good_handlers n (FST (const_fp_loop p l))`,
+  word_good_handlers n (FST (const_fp_loop p l))
+Proof
   ho_match_mp_tac const_fp_loop_ind \\ rw []
   \\ fs [const_fp_loop_def]
   \\ every_case_tac\\ fs[]
-  \\ rpt (pairarg_tac \\ fs[]));
+  \\ rpt (pairarg_tac \\ fs[])
+QED
 
-val word_get_code_labels_Seq_assoc = Q.prove(`
+Triviality word_get_code_labels_Seq_assoc:
   ∀p1 p2.
-  word_get_code_labels (Seq_assoc p1 p2) = word_get_code_labels p1 ∪ word_get_code_labels p2`,
+  word_get_code_labels (Seq_assoc p1 p2) = word_get_code_labels p1 ∪ word_get_code_labels p2
+Proof
   ho_match_mp_tac Seq_assoc_ind>>rw[]>>
   fs[Seq_assoc_def,SmartSeq_def]>>rw[]>>
   fs[UNION_ASSOC]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val word_good_handlers_Seq_assoc = Q.prove(`
+Triviality word_good_handlers_Seq_assoc:
   ∀p1 p2.
   word_good_handlers n (Seq_assoc p1 p2) ⇔
-  word_good_handlers n p1 ∧ word_good_handlers n p2`,
+  word_good_handlers n p1 ∧ word_good_handlers n p2
+Proof
   ho_match_mp_tac Seq_assoc_ind>>rw[]>>
   fs[Seq_assoc_def,SmartSeq_def]>>rw[]>>
-  every_case_tac>>fs[]>>metis_tac[]);
+  every_case_tac>>fs[]>>metis_tac[]
+QED
 
 Triviality word_good_handlers_try_if_hoist2:
   ! N p1 interm dummy p2 s.
@@ -2187,26 +2245,29 @@ Proof
   \\ metis_tac []
 QED
 
-val word_get_code_labels_word_simp = Q.prove(`
+Triviality word_get_code_labels_word_simp:
   ∀ps.
   word_get_code_labels (word_simp$compile_exp ps) ⊆
-  word_get_code_labels ps`,
+  word_get_code_labels ps
+Proof
   rw [compile_exp_def]>>
   irule SUBSET_TRANS >> irule_at Any word_get_code_labels_simp_duplicate_if >>
   simp [const_fp_def] >>
   irule SUBSET_TRANS >> irule_at Any word_get_code_labels_const_fp_loop >>
   simp [word_get_code_labels_Seq_assoc]
-);
+QED
 
-val word_good_handlers_word_simp = Q.prove(`
+Triviality word_good_handlers_word_simp:
   ∀ps.
   word_good_handlers n ps ⇒
-  word_good_handlers n (word_simp$compile_exp ps)`,
+  word_good_handlers n (word_simp$compile_exp ps)
+Proof
   rw[compile_exp_def]>>
   irule word_good_handlers_simp_duplicate_if >>
   simp [const_fp_def] >>
   match_mp_tac word_good_handlers_const_fp_loop>>
-  fs[word_good_handlers_Seq_assoc]);
+  fs[word_good_handlers_Seq_assoc]
+QED
 
 Theorem word_good_handlers_word_to_word_incr_helper:
   ∀oracles.
@@ -2314,15 +2375,19 @@ Proof
   rveq>>fs[]
 QED;
 
-val word_get_code_labels_StoreEach = Q.prove(`
+Triviality word_get_code_labels_StoreEach:
   ∀ls off.
-  word_get_code_labels (StoreEach v ls off) = {}`,
-  Induct>>fs[StoreEach_def]);
+  word_get_code_labels (StoreEach v ls off) = {}
+Proof
+  Induct>>fs[StoreEach_def]
+QED
 
-val word_get_code_labels_MemEqList = Q.prove(`
+Triviality word_get_code_labels_MemEqList:
   ∀x b.
-  word_get_code_labels (MemEqList b x) = {}`,
-  Induct>>fs[MemEqList_def]);
+  word_get_code_labels (MemEqList b x) = {}
+Proof
+  Induct>>fs[MemEqList_def]
+QED
 
 Triviality part_to_words_isWord:
   ∀h c m i w ws.
@@ -2447,15 +2512,19 @@ Proof
     EVAL_TAC>>rw[]>>fs[]
 QED
 
-val word_good_handlers_StoreEach = Q.prove(`
+Triviality word_good_handlers_StoreEach:
   ∀ls off.
-  word_good_handlers secn (StoreEach v ls off)`,
-  Induct>>fs[StoreEach_def]);
+  word_good_handlers secn (StoreEach v ls off)
+Proof
+  Induct>>fs[StoreEach_def]
+QED
 
-val word_good_handlers_MemEqList = Q.prove(`
+Triviality word_good_handlers_MemEqList:
   ∀x b.
-  word_good_handlers secn (MemEqList b x)`,
-  Induct>>fs[MemEqList_def]);
+  word_good_handlers secn (MemEqList b x)
+Proof
+  Induct>>fs[MemEqList_def]
+QED
 
 Theorem word_good_handlers_StoreAnyConsts[local]:
   ∀r1 r2 r3 ws w. word_good_handlers secn (StoreAnyConsts r1 r2 r3 ws w)
@@ -2478,9 +2547,10 @@ Proof
   rw[]>>EVAL_TAC)
 QED
 
-val data_to_word_comp_good_handlers = Q.prove(`
+Triviality data_to_word_comp_good_handlers:
   ∀c secn l p.
-  word_good_handlers secn ((FST (comp c secn l p)):'a wordLang$prog)`,
+  word_good_handlers secn ((FST (comp c secn l p)):'a wordLang$prog)
+Proof
   ho_match_mp_tac comp_ind>>
   rw[]>>Cases_on`p`>>fs[]>>
   simp[Once comp_def]>>
@@ -2493,14 +2563,17 @@ val data_to_word_comp_good_handlers = Q.prove(`
   >-
     fs[word_good_handlers_assign]
   >>
-    EVAL_TAC>>rw[]>>fs[]);
+    EVAL_TAC>>rw[]>>fs[]
+QED
 
-val stubs_labels = Q.prove(`
+Triviality stubs_labels:
   BIGUNION (set (MAP (λ(n,m,pp). word_get_code_labels pp)  (stubs (:'a) dc)))
-  ⊆ set (MAP FST (stubs (:'a) dc))`,
+  ⊆ set (MAP FST (stubs (:'a) dc))
+Proof
   rpt(EVAL_TAC>>
   IF_CASES_TAC>>
-  simp[]));
+  simp[])
+QED
 
 Theorem data_to_word_good_code_labels:
   (data_to_word$compile data_conf word_conf asm_conf prog) = (xx,prog') ∧

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -2323,7 +2323,7 @@ Proof
   EVAL_TAC>>rw[]
 QED
 
-val word_exp_set = Q.prove(`
+Triviality word_exp_set:
   (word_exp s (Op Add [Var n; Const c]) =
   case get_var n s of
     SOME (Word w) => SOME (Word (w+c))
@@ -2331,28 +2331,36 @@ val word_exp_set = Q.prove(`
   (word_exp s (Op Sub [Var n; Const c]) =
   case get_var n s of
     SOME (Word w) => SOME (Word (w-c))
-  | _ => NONE)`,
+  | _ => NONE)
+Proof
   EVAL_TAC>>rw[]>>
   every_case_tac>>rw[]>>
-  fs[]);
+  fs[]
+QED
 
-val good_dimindex_w2w_byte = Q.prove(`
+Triviality good_dimindex_w2w_byte:
   good_dimindex (:'a) ⇒
-  w2w (w2w (w:word8):'a word) = w`,
+  w2w (w2w (w:word8):'a word) = w
+Proof
   rw[good_dimindex_def]>>
   simp[w2w_w2w]>>
-  match_mp_tac WORD_ALL_BITS>>fs[]);
+  match_mp_tac WORD_ALL_BITS>>fs[]
+QED
 
-val set_var_consts = Q.prove(`
+Triviality set_var_consts:
   (set_var r v s).memory = s.memory ∧
   (set_var r v s).mdomain = s.mdomain ∧
   (set_var r v s).be = s.be ∧
-  (set_var r v s).code = s.code`,
-  fs[wordSemTheory.set_var_def]);
+  (set_var r v s).code = s.code
+Proof
+  fs[wordSemTheory.set_var_def]
+QED
 
-val get_var_consts = Q.prove(`
-  get_var r (s with memory:=m) = get_var r s`,
-  EVAL_TAC>>rw[]);
+Triviality get_var_consts:
+  get_var r (s with memory:=m) = get_var r s
+Proof
+  EVAL_TAC>>rw[]
+QED
 
 Theorem CopyByteAdd_thm:
    !be n a1 a2 m dm ret_val l1 l2 (s:('a,'c,'ffi) wordSem$state) m1.

--- a/compiler/backend/proofs/data_to_word_gcProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_gcProofScript.sml
@@ -5968,11 +5968,12 @@ Proof
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[isWord_def]
 QED
 
-val word_gc_move_roots_IMP_FILTER0 = Q.prove(
-  `!ws i pa old m dm ws2 i2 pa2 m2 c2 c.
+Triviality word_gc_move_roots_IMP_FILTER0:
+  !ws i pa old m dm ws2 i2 pa2 m2 c2 c.
       word_gc_move_roots c (ws,i,pa,old,m,dm) = (ws2,i2,pa2,m2,c2) ==>
       word_gc_move_roots c (FILTER isWord ws,i,pa,old,m,dm) =
-                           (FILTER isWord ws2,i2,pa2,m2,c2)`,
+                           (FILTER isWord ws2,i2,pa2,m2,c2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def]
   \\ Cases \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_gc_move_roots_def]
@@ -5983,14 +5984,16 @@ val word_gc_move_roots_IMP_FILTER0 = Q.prove(
     \\ res_tac \\ fs [])
   \\ fs [isWord_def,word_gc_move_def,LET_DEF]
   \\ rpt (pairarg_tac \\ fs []) \\ fs [] \\ rveq
-  \\ res_tac \\ fs [isWord_def]);
+  \\ res_tac \\ fs [isWord_def]
+QED
 
-val word_gen_gc_move_roots_IMP_FILTER0 = Q.prove(
-  `!ws i pa ib pb old m dm ws2 i2 pa2 ib2 pb2 m2 c2 c.
+Triviality word_gen_gc_move_roots_IMP_FILTER0:
+  !ws i pa ib pb old m dm ws2 i2 pa2 ib2 pb2 m2 c2 c.
       word_gen_gc_move_roots c (ws,i,pa,ib,pb,old,m,dm) =
          (ws2,i2,pa2,ib2,pb2,m2,c2) ==>
       word_gen_gc_move_roots c (FILTER isWord ws,i,pa,ib,pb,old,m,dm) =
-                               (FILTER isWord ws2,i2,pa2,ib2,pb2,m2,c2)`,
+                               (FILTER isWord ws2,i2,pa2,ib2,pb2,m2,c2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[word_gen_gc_move_roots_def]
   \\ Cases \\ full_simp_tac(srw_ss())[]
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_gen_gc_move_roots_def]
@@ -6001,7 +6004,8 @@ val word_gen_gc_move_roots_IMP_FILTER0 = Q.prove(
     \\ res_tac \\ fs [])
   \\ fs [isWord_def,word_gen_gc_move_def,LET_DEF]
   \\ rpt (pairarg_tac \\ fs []) \\ fs [] \\ rveq
-  \\ res_tac \\ fs [isWord_def]);
+  \\ res_tac \\ fs [isWord_def]
+QED
 
 Theorem word_gen_gc_partial_move_roots_IMP_FILTER:
    !ws i pa ib pb old m dm ws2 i2 pa2 ib2 pb2 m2 c2 c.

--- a/compiler/backend/proofs/data_to_word_memoryProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_memoryProofScript.sml
@@ -171,10 +171,12 @@ Proof
   Cases \\ rw[Word64Rep_def]
 QED
 
-val v_size_LEMMA = Q.prove(
-  `!vs v. MEM v vs ==> v_size v <= v1_size vs`,
+Triviality v_size_LEMMA:
+  !vs v. MEM v vs ==> v_size v <= v1_size vs
+Proof
   Induct \\ full_simp_tac (srw_ss()) [v_size_def]
-  \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss [] \\ DECIDE_TAC);
+  \\ rpt strip_tac \\ res_tac \\ full_simp_tac std_ss [] \\ DECIDE_TAC
+QED
 
 (*
   code pointers (i.e. Locs) will end in ...0
@@ -433,9 +435,11 @@ val EVERY2_EQ_EL = LIST_REL_EL_EQN
 val EVERY2_IMP_EL = METIS_PROVE[EVERY2_EQ_EL]
   ``!xs ys P. EVERY2 P xs ys ==> !n. n < LENGTH ys ==> P (EL n xs) (EL n ys)``
 
-val EVERY2_MAP_FST_SND = Q.prove(
-  `!xs. EVERY2 P (MAP FST xs) (MAP SND xs) = EVERY (\(x,y). P x y) xs`,
-  Induct \\ srw_tac [] [LIST_REL_def] \\ Cases_on `h` \\ srw_tac [] []);
+Triviality EVERY2_MAP_FST_SND:
+  !xs. EVERY2 P (MAP FST xs) (MAP SND xs) = EVERY (\(x,y). P x y) xs
+Proof
+  Induct \\ srw_tac [] [LIST_REL_def] \\ Cases_on `h` \\ srw_tac [] []
+QED
 
 Theorem fapply_fupdate_update:
    $' (f |+ p) = (FST p =+ SND p) ($' f)
@@ -444,19 +448,23 @@ Proof
   simp[FUN_EQ_THM,FAPPLY_FUPDATE_THM,APPLY_UPDATE_THM] >> rw[]
 QED
 
-val heap_lookup_APPEND1 = Q.prove(
-  `∀h1 z h2.
+Triviality heap_lookup_APPEND1:
+  ∀h1 z h2.
     heap_length h1 ≤ z ⇒
-    (heap_lookup z (h1 ++ h2) = heap_lookup (z - heap_length h1) h2)`,
+    (heap_lookup z (h1 ++ h2) = heap_lookup (z - heap_length h1) h2)
+Proof
   Induct >>fs[heap_lookup_def,heap_length_def] >> rw[] >> simp[]
-  >> fsrw_tac[ARITH_ss][] >> Cases_on`h`>>fs[el_length_def])
+  >> fsrw_tac[ARITH_ss][] >> Cases_on`h`>>fs[el_length_def]
+QED
 
-val heap_lookup_APPEND2 = Q.prove(
-  `∀h1 z h2.
+Triviality heap_lookup_APPEND2:
+  ∀h1 z h2.
     z < heap_length h1 ⇒
-    (heap_lookup z (h1 ++ h2) = heap_lookup z h1)`,
+    (heap_lookup z (h1 ++ h2) = heap_lookup z h1)
+Proof
   Induct >> fs[heap_lookup_def,heap_length_def] >> rw[] >>
-  simp[])
+  simp[]
+QED
 
 Theorem heap_lookup_APPEND:
    heap_lookup a (h1 ++ h2) =
@@ -470,30 +478,37 @@ QED
 
 (* Prove refinement is maintained past GC calls *)
 
-val LENGTH_ADDR_MAP = Q.prove(
-  `!xs f. LENGTH (ADDR_MAP f xs) = LENGTH xs`,
-  Induct \\ TRY (Cases_on `h`) \\ srw_tac [] [ADDR_MAP_def]);
+Triviality LENGTH_ADDR_MAP:
+  !xs f. LENGTH (ADDR_MAP f xs) = LENGTH xs
+Proof
+  Induct \\ TRY (Cases_on `h`) \\ srw_tac [] [ADDR_MAP_def]
+QED
 
-val MEM_IMP_v_size = Q.prove(
-  `!l a. MEM a l ==> v_size a < 1 + v1_size l`,
+Triviality MEM_IMP_v_size:
+  !l a. MEM a l ==> v_size a < 1 + v1_size l
+Proof
   Induct \\ full_simp_tac std_ss [MEM,v_size_def]
-  \\ rpt strip_tac \\ full_simp_tac std_ss [] \\ res_tac \\ DECIDE_TAC);
+  \\ rpt strip_tac \\ full_simp_tac std_ss [] \\ res_tac \\ DECIDE_TAC
+QED
 
-val EL_ADDR_MAP = Q.prove(
-  `!xs n f.
-      n < LENGTH xs ==> (EL n (ADDR_MAP f xs) = ADDR_APPLY f (EL n xs))`,
+Triviality EL_ADDR_MAP:
+  !xs n f.
+      n < LENGTH xs ==> (EL n (ADDR_MAP f xs) = ADDR_APPLY f (EL n xs))
+Proof
   Induct \\ full_simp_tac (srw_ss()) [] \\ Cases_on `n` \\ Cases_on `h`
-  \\ full_simp_tac (srw_ss()) [ADDR_MAP_def,ADDR_APPLY_def]);
+  \\ full_simp_tac (srw_ss()) [ADDR_MAP_def,ADDR_APPLY_def]
+QED
 
 val _ = augment_srw_ss [rewrites [LIST_REL_def]];
 
-val v_inv_related = Q.prove(
-  `!w x f tf.
+Triviality v_inv_related:
+  !w x f tf.
         gc_shared$gc_related g heap1 (heap2:'a ml_heap) /\
       (!ptr u. (x = Pointer ptr u) ==> ptr IN FDOM g) /\
       v_inv conf w (x,f,tf,heap1) ==>
       v_inv conf w (ADDR_APPLY (FAPPLY g) x,g f_o_f f,g f_o_f tf,heap2) /\
-      EVERY (\n. f ' n IN FDOM g) (get_refs w)`,
+      EVERY (\n. f ' n IN FDOM g) (get_refs w)
+Proof
   completeInduct_on `v_size w` \\ NTAC 6 strip_tac
   \\ fs[PULL_FORALL] \\ Cases_on `w` THEN1
    (fs[v_inv_def,get_refs_def,EVERY_DEF]
@@ -548,19 +563,23 @@ val v_inv_related = Q.prove(
   THEN1
     (full_simp_tac (srw_ss()) [v_inv_def,ADDR_APPLY_def]
      \\ sg `n IN FDOM (g f_o_f f)` \\ asm_simp_tac std_ss []
-     \\ full_simp_tac (srw_ss()) [f_o_f_DEF,get_refs_def]));
+     \\ full_simp_tac (srw_ss()) [f_o_f_DEF,get_refs_def])
+QED
 
-val EVERY2_ADDR_MAP = Q.prove(
-  `!zs l. EVERY2 P (ADDR_MAP g zs) l <=>
-           EVERY2 (\x y. P (ADDR_APPLY g x) y) zs l`,
+Triviality EVERY2_ADDR_MAP:
+  !zs l. EVERY2 P (ADDR_MAP g zs) l <=>
+           EVERY2 (\x y. P (ADDR_APPLY g x) y) zs l
+Proof
   Induct \\ Cases_on `l`
   \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def] \\ Cases
-  \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def,ADDR_APPLY_def]);
+  \\ full_simp_tac std_ss [LIST_REL_def,ADDR_MAP_def,ADDR_APPLY_def]
+QED
 
-val bc_ref_inv_related = Q.prove(
-  `gc_shared$gc_related g heap1 heap2 /\
+Triviality bc_ref_inv_related:
+  gc_shared$gc_related g heap1 heap2 /\
     bc_ref_inv conf n refs (f,tf,heap1,be) /\ (f ' n) IN FDOM g ==>
-    bc_ref_inv conf n refs (g f_o_f f,g f_o_f tf,heap2,be)`,
+    bc_ref_inv conf n refs (g f_o_f f,g f_o_f tf,heap2,be)
+Proof
   full_simp_tac std_ss [bc_ref_inv_def] \\ strip_tac \\ full_simp_tac std_ss []
   \\ MP_TAC v_inv_related \\ asm_simp_tac std_ss []
   \\ full_simp_tac (srw_ss()) [f_o_f_DEF,gc_related_def,RefBlock_def] \\ res_tac
@@ -574,13 +593,15 @@ val bc_ref_inv_related = Q.prove(
   \\ rpt strip_tac \\ qpat_x_assum `EVERY2 qqq zs l` MP_TAC
   \\ match_mp_tac EVERY2_IMP_EVERY2 \\ simp_tac std_ss [] \\ rpt strip_tac
   \\ Cases_on `x'` \\ full_simp_tac (srw_ss()) [ADDR_APPLY_def]
-  \\ res_tac \\ fs [ADDR_APPLY_def]);
+  \\ res_tac \\ fs [ADDR_APPLY_def]
+QED
 
-val RTC_lemma = Q.prove(
-  `!r n. RTC (ref_edge refs) r n ==>
+Triviality RTC_lemma:
+  !r n. RTC (ref_edge refs) r n ==>
           (!m. RTC (ref_edge refs) r m ==> bc_ref_inv conf m refs (f,tf,heap,be)) /\
           gc_shared$gc_related g heap heap2 /\
-          f ' r IN FDOM g ==> f ' n IN FDOM g`,
+          f ' r IN FDOM g ==> f ' n IN FDOM g
+Proof
   ho_match_mp_tac RTC_INDUCT \\ full_simp_tac std_ss [] \\ rpt strip_tac
   \\ full_simp_tac std_ss []
   \\ qpat_x_assum `bb ==> bbb` match_mp_tac \\ full_simp_tac std_ss []
@@ -606,14 +627,16 @@ val RTC_lemma = Q.prove(
   \\ res_tac \\ CCONTR_TAC \\ full_simp_tac std_ss []
   \\ srw_tac [] [] \\ POP_ASSUM MP_TAC \\ simp_tac std_ss []
   \\ imp_res_tac MEM_EVERY2_IMP \\ fs []
-  \\ fs [] \\ metis_tac []);
+  \\ fs [] \\ metis_tac []
+QED
 
-val reachable_refs_lemma = Q.prove(
-  `gc_related g heap heap2 /\
+Triviality reachable_refs_lemma:
+  gc_related g heap heap2 /\
     EVERY2 (\v x. v_inv conf v (x,f,tf,heap)) stack roots /\
     (!n. reachable_refs stack refs n ==> bc_ref_inv conf n refs (f,tf,heap,be)) /\
     (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM g) ==>
-    (!n. reachable_refs stack refs n ==> n IN FDOM f /\ (f ' n) IN FDOM g)`,
+    (!n. reachable_refs stack refs n ==> n IN FDOM f /\ (f ' n) IN FDOM g)
+Proof
   NTAC 3 strip_tac \\ full_simp_tac std_ss [reachable_refs_def,PULL_EXISTS]
   \\ `?xs1 xs2. stack = xs1 ++ x::xs2` by metis_tac [MEM_SPLIT]
   \\ full_simp_tac std_ss [] \\ imp_res_tac LIST_REL_SPLIT1
@@ -626,13 +649,15 @@ val reachable_refs_lemma = Q.prove(
   \\ full_simp_tac std_ss []
   \\ `bc_ref_inv conf r refs (f,tf,heap,be)` by metis_tac [RTC_REFL]
   \\ `(!m. RTC (ref_edge refs) r m ==>
-           bc_ref_inv conf m refs (f,tf,heap,be))` by metis_tac [] \\ imp_res_tac RTC_lemma);
+           bc_ref_inv conf m refs (f,tf,heap,be))` by metis_tac [] \\ imp_res_tac RTC_lemma
+QED
 
-val bc_stack_ref_inv_related = Q.prove(
-  `gc_related g heap1 heap2 /\
+Triviality bc_stack_ref_inv_related:
+  gc_related g heap1 heap2 /\
     bc_stack_ref_inv conf ts stack refs (roots,heap1,be) /\
     (!ptr u. MEM (Pointer ptr u) roots ==> ptr IN FDOM g) ==>
-    bc_stack_ref_inv conf ts stack refs (ADDR_MAP (FAPPLY g) roots,heap2,be)`,
+    bc_stack_ref_inv conf ts stack refs (ADDR_MAP (FAPPLY g) roots,heap2,be)
+Proof
   rpt strip_tac \\ full_simp_tac std_ss [bc_stack_ref_inv_def]
   \\ qexists_tac `g f_o_f f`
   \\ qexists_tac `g f_o_f tf`
@@ -651,7 +676,8 @@ val bc_stack_ref_inv_related = Q.prove(
     \\ imp_res_tac v_inv_related \\ imp_res_tac EL_ADDR_MAP
     \\ full_simp_tac std_ss [])
   \\ match_mp_tac bc_ref_inv_related \\ full_simp_tac std_ss []
-  \\ metis_tac [reachable_refs_lemma]);
+  \\ metis_tac [reachable_refs_lemma]
+QED
 
 Theorem data_up_to_APPEND[simp]:
    data_up_to (heap_length xs) (xs ++ ys) <=> EVERY isDataElement xs
@@ -789,33 +815,40 @@ Definition make_gc_conf_def:
         : (tag # 'a) gen_gc$gen_gc_conf
 End
 
-val gc_move_data_refs_split = Q.prove(`
+Triviality gc_move_data_refs_split:
   (gen_gc$gc_move cc s x = (x1,s1)) /\ (!t r. (cc.isRef (t,r) <=> t = RefTag))
    /\ EVERY isDataElement s.h2 /\(EVERY (λx. ¬isRef x)) s.h2 /\ EVERY isRef s.r4 ==>
    EVERY isDataElement s1.h2 /\
-   (EVERY (λx. ¬isRef x)) s1.h2 /\ EVERY isRef s1.r4`,
+   (EVERY (λx. ¬isRef x)) s1.h2 /\ EVERY isRef s1.r4
+Proof
   Cases_on `x` >> fs[gen_gcTheory.gc_move_def]
   >> rpt strip_tac >> rveq >> fs[]
   >> every_case_tac >> rveq >> fs[]
   >> TRY pairarg_tac >> fs[]
   >> qpat_x_assum `_ = s1` (assume_tac o GSYM) >> fs[isDataElement_def]
-  >> Cases_on `b` >> fs[isRef_def] >> metis_tac[]);
+  >> Cases_on `b` >> fs[isRef_def] >> metis_tac[]
+QED
 
-val gc_move_list_data_refs_split = Q.prove(`!x x1 s s1.
+Triviality gc_move_list_data_refs_split:
+  !x x1 s s1.
   (gen_gc$gc_move_list cc s x = (x1,s1)) /\ (!t r. (cc.isRef (t,r) <=> t = RefTag))
    /\ EVERY isDataElement s.h2 /\(EVERY (λx. ¬isRef x)) s.h2 /\ EVERY isRef s.r4 ==>
-   EVERY isDataElement s1.h2 /\(EVERY (λx. ¬isRef x)) s1.h2 /\ EVERY isRef s1.r4`,
+   EVERY isDataElement s1.h2 /\(EVERY (λx. ¬isRef x)) s1.h2 /\ EVERY isRef s1.r4
+Proof
   Induct >> fs[gen_gcTheory.gc_move_list_def]
   >> rpt strip_tac >> rpt(pairarg_tac >> fs[])
-  >> drule gc_move_data_refs_split >> metis_tac[]);
+  >> drule gc_move_data_refs_split >> metis_tac[]
+QED
 
-val gc_move_refs_data_refs_split = Q.prove(`!cc s s1.
+Triviality gc_move_refs_data_refs_split:
+  !cc s s1.
   (gen_gc$gc_move_refs cc s = s1) /\ (!t r. (cc.isRef (t,r) <=> t = RefTag))
    /\ EVERY isDataElement (s.h1++s.h2) /\ (EVERY (λx. ¬isRef x)) (s.h1++s.h2) /\
    EVERY isRef (s.r1 ++ s.r2 ++ s.r3 ++ s.r4) ==>
    EVERY isDataElement (s1.h1++s1.h2) /\
    (EVERY (λx. ¬isRef x)) (s1.h1++s1.h2) /\
-   EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)`,
+   EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)
+Proof
   recInduct (fetch "gen_gc" "gc_move_refs_ind")
   >> rpt strip_tac
   >> qpat_x_assum `gc_move_refs _ _ = _` mp_tac
@@ -826,16 +859,19 @@ val gc_move_refs_data_refs_split = Q.prove(`!cc s s1.
   >> drule gen_gcTheory.gc_move_list_IMP >> strip_tac >> fs[]
   >> drule gc_move_list_data_refs_split >> fs[] >> strip_tac
   >> first_x_assum drule >> fs[]
-  >> Cases_on `b` >> fs[isRef_def]);
+  >> Cases_on `b` >> fs[isRef_def]
+QED
 
-val gc_move_data_data_refs_split = Q.prove(`!cc s s1.
+Triviality gc_move_data_data_refs_split:
+  !cc s s1.
   (gen_gc$gc_move_data cc s = s1) /\ (!t r. (cc.isRef (t,r) <=> t = RefTag))
    /\ (EVERY (λx. ¬isRef x)) (s.h1++s.h2) /\
    EVERY isDataElement (s.h1++s.h2) /\
    EVERY isRef (s.r1 ++ s.r2 ++ s.r3 ++ s.r4) ==>
    EVERY isDataElement (s1.h1++s1.h2) /\
    (EVERY (λx. ¬isRef x)) (s1.h1++s1.h2) /\
-   EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)`,
+   EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)
+Proof
   recInduct (fetch "gen_gc" "gc_move_data_ind")
   >> rpt strip_tac >> qpat_x_assum `gc_move_data _ _ = _` mp_tac
   >> simp[Once gen_gcTheory.gc_move_data_def]
@@ -845,9 +881,11 @@ val gc_move_data_data_refs_split = Q.prove(`!cc s s1.
   >> drule gc_move_list_data_refs_split >> fs[] >> strip_tac
   >> first_x_assum drule >> fs[]
   >> Cases_on `b` >> fs[isRef_def]
-  >> Cases_on `state''.h2` >> fs[] >> rfs[isDataElement_def]);
+  >> Cases_on `state''.h2` >> fs[] >> rfs[isDataElement_def]
+QED
 
-val gc_move_loop_data_refs_split = Q.prove(`!clock cc s s1.
+Triviality gc_move_loop_data_refs_split:
+  !clock cc s s1.
   (gen_gc$gc_move_loop cc s clock = s1) /\
   (!t r. (cc.isRef (t,r) <=> t = RefTag)) /\
   EVERY isDataElement (s.h1++s.h2) /\
@@ -855,7 +893,8 @@ val gc_move_loop_data_refs_split = Q.prove(`!clock cc s s1.
   EVERY isRef (s.r1 ++ s.r2 ++ s.r3 ++ s.r4) ==>
   EVERY isDataElement (s1.h1++s1.h2) /\
   (EVERY (λx. ¬isRef x)) (s1.h1++s1.h2) /\
-  EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)`,
+  EVERY isRef (s1.r1 ++ s1.r2 ++ s1.r3 ++ s1.r4)
+Proof
   Induct >> rpt strip_tac >> qpat_x_assum `gc_move_loop _ _ _ = _` mp_tac
   >> PURE_ONCE_REWRITE_TAC [gen_gcTheory.gc_move_loop_def]
   >> every_case_tac >> fs[]
@@ -868,14 +907,17 @@ val gc_move_loop_data_refs_split = Q.prove(`!clock cc s s1.
   >> drule gc_move_refs_data_refs_split >> drule gc_move_data_data_refs_split
   >> fs[] >> rpt strip_tac
   >> qpat_x_assum `_ = s1` (assume_tac o GSYM) >> fs[]
-  >> rpt strip_tac >> fs[]);
+  >> rpt strip_tac >> fs[]
+QED
 
-val gen_gc_data_refs_split = Q.prove(`!cc roots heap.
+Triviality gen_gc_data_refs_split:
+  !cc roots heap.
   (gen_gc cc (roots,heap) = (roots1,s)) /\
   (!t r. (cc.isRef (t,r) <=> t = RefTag)) ==>
   (EVERY (λx. ¬isRef x)) (s.h1 ++ s.h2) /\
   EVERY isDataElement (s.h1 ++ s.h2) /\
-  EVERY isRef (s.r1 ++ s.r2 ++ s.r3 ++ s.r4)`,
+  EVERY isRef (s.r1 ++ s.r2 ++ s.r3 ++ s.r4)
+Proof
   rpt strip_tac >> fs[gen_gcTheory.gen_gc_def]
   >> rpt (pairarg_tac >> fs[])
   >> drule gc_move_list_data_refs_split >> fs[empty_state_def]
@@ -883,7 +925,8 @@ val gen_gc_data_refs_split = Q.prove(`!cc roots heap.
   >> drule gen_gcTheory.gc_move_list_IMP
   >> fs[] >> disch_then (assume_tac o GSYM) >> fs[]
   >> drule gc_move_loop_data_refs_split
-  >> fs []);
+  >> fs []
+QED
 
 Theorem heap_expand_not_isRef:
   EVERY (λx. ¬isRef x) (heap_expand n)
@@ -1319,30 +1362,36 @@ Definition heap_store_rel_def:
            (heap_lookup ptr heap2 = heap_lookup ptr heap))
 End
 
-val isSomeDataElement_heap_lookup_lemma1 = Q.prove(
-  `isSomeDataElement (heap_lookup n (Unused k :: xs)) <=>
-    k < n /\ isSomeDataElement (heap_lookup (n-(k+1)) xs)`,
+Triviality isSomeDataElement_heap_lookup_lemma1:
+  isSomeDataElement (heap_lookup n (Unused k :: xs)) <=>
+    k < n /\ isSomeDataElement (heap_lookup (n-(k+1)) xs)
+Proof
   srw_tac [] [heap_lookup_def,isSomeDataElement_def,el_length_def,NOT_LESS]
   THEN1 (DISJ1_TAC \\ DECIDE_TAC)
-  \\ `k < n` by DECIDE_TAC \\ full_simp_tac std_ss []);
+  \\ `k < n` by DECIDE_TAC \\ full_simp_tac std_ss []
+QED
 
-val isSomeDataElement_heap_lookup_lemma2 = Q.prove(
-  `isSomeDataElement (heap_lookup n (heap_expand k ++ xs)) <=>
-    k <= n /\ isSomeDataElement (heap_lookup (n-k) xs)`,
+Triviality isSomeDataElement_heap_lookup_lemma2:
+  isSomeDataElement (heap_lookup n (heap_expand k ++ xs)) <=>
+    k <= n /\ isSomeDataElement (heap_lookup (n-k) xs)
+Proof
   srw_tac [] [heap_expand_def,isSomeDataElement_heap_lookup_lemma1]
   \\ imp_res_tac (DECIDE ``sp <> 0 ==> (sp - 1 + 1 = sp:num)``)
   \\ full_simp_tac std_ss []
   \\ Cases_on `isSomeDataElement (heap_lookup (n - k) xs)`
-  \\ full_simp_tac std_ss [] \\ DECIDE_TAC);
+  \\ full_simp_tac std_ss [] \\ DECIDE_TAC
+QED
 
-val isSomeDataElement_heap_lookup_lemma3 = Q.prove(
-  `n <> 0 ==>
+Triviality isSomeDataElement_heap_lookup_lemma3:
+  n <> 0 ==>
     (isSomeDataElement (heap_lookup n (x::xs)) <=>
-     el_length x <= n /\ isSomeDataElement (heap_lookup (n - el_length x) xs))`,
+     el_length x <= n /\ isSomeDataElement (heap_lookup (n - el_length x) xs))
+Proof
   srw_tac [] [heap_expand_def,heap_lookup_def,isSomeDataElement_def]
   \\ Cases_on`n < el_length x` THEN srw_tac[][]
   THEN1 (DISJ1_TAC \\ DECIDE_TAC)
-  \\ `el_length x <= n` by DECIDE_TAC \\ full_simp_tac std_ss []);
+  \\ `el_length x <= n` by DECIDE_TAC \\ full_simp_tac std_ss []
+QED
 
 Theorem IMP_heap_store_unused[local]:
   unused_space_inv a sp (heap:('a,'b) heap_element list) /\
@@ -1465,8 +1514,8 @@ Proof
   \\ full_simp_tac std_ss [] \\ fs[]
 QED
 
-val IMP_heap_store_unused_alt = Q.prove(
-  `unused_space_inv a sp (heap:('a,'b) heap_element list) /\
+Triviality IMP_heap_store_unused_alt:
+  unused_space_inv a sp (heap:('a,'b) heap_element list) /\
     el_length x <= sp ==>
     ?heap2. (heap_store_unused_alt a sp x heap = (heap2,T)) /\
             (isDataElement x ==>
@@ -1483,7 +1532,8 @@ val IMP_heap_store_unused_alt = Q.prove(
             (isDataElement x ==>
              ({a | isSomeDataElement (heap_lookup a heap2)} =
                a INSERT {a | isSomeDataElement (heap_lookup a heap)})) /\
-            heap_store_rel heap heap2`,
+            heap_store_rel heap heap2
+Proof
   rpt strip_tac \\ asm_simp_tac std_ss [heap_store_unused_alt_def,heap_store_rel_def]
   \\ `sp <> 0` by (Cases_on `x` \\ full_simp_tac std_ss [el_length_def] \\ DECIDE_TAC)
   \\ full_simp_tac std_ss [unused_space_inv_def]
@@ -1560,21 +1610,25 @@ val IMP_heap_store_unused_alt = Q.prove(
   \\ fs [el_length_def]
   \\ imp_res_tac LESS_EQUAL_ANTISYM \\ fs []
   \\ rveq \\ fs []
-  \\ rfs [GSYM SUB_PLUS]);
+  \\ rfs [GSYM SUB_PLUS]
+QED
 
-val heap_store_rel_lemma = Q.prove(
-  `heap_store_rel h1 h2 /\ (heap_lookup n h1 = SOME (DataElement ys l d)) ==>
-    (heap_lookup n h2 = SOME (DataElement ys l d))`,
-  simp_tac std_ss [heap_store_rel_def,isSomeDataElement_def] \\ metis_tac []);
+Triviality heap_store_rel_lemma:
+  heap_store_rel h1 h2 /\ (heap_lookup n h1 = SOME (DataElement ys l d)) ==>
+    (heap_lookup n h2 = SOME (DataElement ys l d))
+Proof
+  simp_tac std_ss [heap_store_rel_def,isSomeDataElement_def] \\ metis_tac []
+QED
 
 (* cons *)
 
-val v_inv_SUBMAP = Q.prove(
-  `!w x.
+Triviality v_inv_SUBMAP:
+  !w x.
       f SUBMAP f1 /\ tf SUBMAP tf1 /\
       heap_store_rel heap heap1 /\
       v_inv conf w (x,f,tf,heap) ==>
-      v_inv conf w (x,f1,tf1,heap1) `,
+      v_inv conf w (x,f1,tf1,heap1)
+Proof
   completeInduct_on `v_size w` \\ NTAC 3 strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `w` THEN1
    (full_simp_tac std_ss [v_inv_def,Bignum_def] \\ srw_tac [] []
@@ -1601,7 +1655,8 @@ val v_inv_SUBMAP = Q.prove(
      (full_simp_tac std_ss [v_size_def]
       \\ imp_res_tac MEM_IMP_v_size \\ DECIDE_TAC) \\ res_tac)
   THEN1 (full_simp_tac std_ss [v_inv_def] \\ metis_tac [])
-  THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF] \\ rw []));
+  THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF] \\ rw [])
+QED
 
 Theorem heap_store_rel_v_inv:
   !w x.
@@ -1752,11 +1807,13 @@ Proof
   Induct \\ rw [list_to_BlockReps_def] \\ CASE_TAC \\ fs []
 QED
 
-val list_to_BlockReps_data_up_to_lem = Q.prove (
-  `xs <> [] /\
+Triviality list_to_BlockReps_data_up_to_lem:
+  xs <> [] /\
    h1 = list_to_BlockReps conf x len xs ==>
-   data_up_to (heap_length h1) (h1 ++ h2)`,
-  rw [data_up_to_def, list_to_BlockReps_isDataElement]);
+   data_up_to (heap_length h1) (h1 ++ h2)
+Proof
+  rw [data_up_to_def, list_to_BlockReps_isDataElement]
+QED
 
 val list_to_BlockReps_data_up_to = save_thm (
   "list_to_BlockReps_data_up_to",
@@ -1802,8 +1859,8 @@ Proof
   \\ Cases_on `t` \\ fs [list_to_BlockReps_def]
 QED
 
-val list_to_BlockReps_Pointer_lem = Q.prove (
-  `!xs len ys l d ptr u.
+Triviality list_to_BlockReps_Pointer_lem:
+  !xs len ys l d ptr u.
      let allocd = list_to_BlockReps conf x len xs in
        xs <> [] /\
        MEM (DataElement ys l d) allocd /\
@@ -1813,7 +1870,8 @@ val list_to_BlockReps_Pointer_lem = Q.prove (
          (ptr < len + heap_length allocd /\
           ptr > len /\
           isSomeDataElement
-            (heap_lookup (ptr - len) allocd))`,
+            (heap_lookup (ptr - len) allocd))
+Proof
   fs [LET_THM]
   \\ Induct \\ rw []
   \\ imp_res_tac list_to_BlockReps_MEM
@@ -1830,7 +1888,8 @@ val list_to_BlockReps_Pointer_lem = Q.prove (
   \\ CASE_TAC \\ fs [el_length_def, heap_lookup_def]
   \\ rw [isSomeDataElement_def]
   \\ fs [list_to_BlockReps_def, BlockRep_def]
-  \\ CASE_TAC \\ fs [el_length_def, isSomeDataElement_def, heap_lookup_def]);
+  \\ CASE_TAC \\ fs [el_length_def, isSomeDataElement_def, heap_lookup_def]
+QED
 
 val list_to_BlockReps_Pointer = save_thm ("list_to_BlockReps_Pointer",
   list_to_BlockReps_Pointer_lem
@@ -2733,17 +2792,20 @@ QED
 
 (* update ref *)
 
-val ref_edge_ValueArray = Q.prove(
-  `ref_edge (insert ptr (ValueArray xs) refs) x y =
-    if x = ptr then MEM y (get_refs (Block 0 ARB xs)) else ref_edge refs x y`,
+Triviality ref_edge_ValueArray:
+  ref_edge (insert ptr (ValueArray xs) refs) x y =
+    if x = ptr then MEM y (get_refs (Block 0 ARB xs)) else ref_edge refs x y
+Proof
   simp_tac std_ss [FUN_EQ_THM,ref_edge_def] \\ rpt strip_tac
   \\ full_simp_tac (srw_ss()) [FLOOKUP_DEF,FAPPLY_FUPDATE_THM]
   \\ Cases_on `x = ptr` \\ full_simp_tac (srw_ss()) []
-  \\ rw [lookup_insert]);
+  \\ rw [lookup_insert]
+QED
 
-val reachable_refs_UPDATE = Q.prove(
-  `reachable_refs (xs ++ RefPtr ptr::stack) (insert ptr (ValueArray xs) refs) n ==>
-    reachable_refs (xs ++ RefPtr ptr::stack) refs n`,
+Triviality reachable_refs_UPDATE:
+  reachable_refs (xs ++ RefPtr ptr::stack) (insert ptr (ValueArray xs) refs) n ==>
+    reachable_refs (xs ++ RefPtr ptr::stack) refs n
+Proof
   full_simp_tac std_ss [reachable_refs_def] \\ rpt strip_tac
   \\ Cases_on `?m. MEM m (get_refs (Block 0 ARB xs)) /\
         RTC (ref_edge refs) m n` THEN1
@@ -2761,12 +2823,14 @@ val reachable_refs_UPDATE = Q.prove(
   \\ qexists_tac `z` \\ full_simp_tac std_ss []
   \\ full_simp_tac std_ss [ref_edge_ValueArray]
   \\ reverse (Cases_on `r = ptr`)
-  \\ full_simp_tac std_ss [] \\ res_tac);
+  \\ full_simp_tac std_ss [] \\ res_tac
+QED
 
-val reachable_refs_UPDATE1 = Q.prove(
-  `reachable_refs (xs ++ RefPtr ptr::stack) (insert ptr (ValueArray xs1) refs) n ==>
+Triviality reachable_refs_UPDATE1:
+  reachable_refs (xs ++ RefPtr ptr::stack) (insert ptr (ValueArray xs1) refs) n ==>
     (!v. MEM v xs1 ==> ~MEM v xs ==> ?xs2. (lookup ptr refs = SOME (ValueArray xs2)) /\ MEM v xs2) ==>
-    reachable_refs (xs ++ RefPtr ptr::stack) refs n`,
+    reachable_refs (xs ++ RefPtr ptr::stack) refs n
+Proof
   full_simp_tac std_ss [reachable_refs_def] \\ rpt strip_tac
   \\ pop_assum mp_tac \\ last_x_assum mp_tac \\ last_x_assum mp_tac
   \\ map_every qid_spec_tac[`stack`,`xs`,`x`]
@@ -2801,7 +2865,8 @@ val reachable_refs_UPDATE1 = Q.prove(
   simp[get_refs_def] >>
   strip_tac >- metis_tac[] >- metis_tac[] >>
   BasicProvers.VAR_EQ_TAC >> fs[get_refs_def] >>
-  rw[] >> metis_tac[RTC_CASES1]);
+  rw[] >> metis_tac[RTC_CASES1]
+QED
 
 Definition isRefBlock_def:
   isRefBlock x = ?p. x = RefBlock p
@@ -2828,15 +2893,16 @@ Proof
   \\ full_simp_tac std_ss [LET_DEF]
 QED
 
-val heap_lookup_RefBlock_lemma = Q.prove(
-  `(heap_lookup n (ha ++ RefBlock y::hb) = SOME x) =
+Triviality heap_lookup_RefBlock_lemma:
+  (heap_lookup n (ha ++ RefBlock y::hb) = SOME x) =
       if n < heap_length ha then
         (heap_lookup n ha = SOME x)
       else if n = heap_length ha then
         (x = RefBlock y)
       else if heap_length ha + (LENGTH y + 1) <= n then
         (heap_lookup (n - heap_length ha - (LENGTH y + 1)) hb = SOME x)
-      else F`,
+      else F
+Proof
   Cases_on `n < heap_length ha` \\ full_simp_tac std_ss [LESS_IMP_heap_lookup]
   \\ full_simp_tac std_ss [NOT_LESS_IMP_heap_lookup]
   \\ full_simp_tac std_ss [heap_lookup_def]
@@ -2847,10 +2913,11 @@ val heap_lookup_RefBlock_lemma = Q.prove(
        by (full_simp_tac std_ss [el_length_def,RefBlock_def] >> decide_tac)
   \\ full_simp_tac std_ss [] \\ srw_tac [] []
   \\ full_simp_tac std_ss [el_length_def,RefBlock_def,NOT_LESS]
-  \\ DISJ1_TAC \\ DECIDE_TAC);
+  \\ DISJ1_TAC \\ DECIDE_TAC
+QED
 
-val heap_store_RefBlock = Q.prove(
-  `(LENGTH y = LENGTH h) /\
+Triviality heap_store_RefBlock:
+  (LENGTH y = LENGTH h) /\
     (heap_lookup n heap = SOME (RefBlock y)) ==>
     ?heap2. (heap_store n [RefBlock h] heap = (heap2,T)) /\
             RefBlock_inv heap heap2 /\
@@ -2863,7 +2930,8 @@ val heap_store_RefBlock = Q.prove(
             (!a. isSomeDataElement (heap_lookup a heap2) =
                  isSomeDataElement (heap_lookup a heap)) /\
             !m x. m <> n /\ (heap_lookup m heap = SOME x) ==>
-                  (heap_lookup m heap2 = SOME x)`,
+                  (heap_lookup m heap2 = SOME x)
+Proof
   rpt strip_tac \\ imp_res_tac heap_lookup_SPLIT
   \\ full_simp_tac std_ss [heap_store_RefBlock_thm]
   \\ strip_tac THEN1
@@ -2881,20 +2949,24 @@ val heap_store_RefBlock = Q.prove(
    (full_simp_tac std_ss [isSomeDataElement_def,heap_lookup_RefBlock_lemma]
     \\ full_simp_tac std_ss [RefBlock_def] \\ metis_tac [])
   \\ full_simp_tac std_ss [isSomeDataElement_def,heap_lookup_RefBlock_lemma]
-  \\ metis_tac []);
+  \\ metis_tac []
+QED
 
-val NOT_isRefBlock = Q.prove(
-  `~(isRefBlock (Bignum x)) /\
+Triviality NOT_isRefBlock:
+  ~(isRefBlock (Bignum x)) /\
     ~(isRefBlock (Word64Rep a w)) /\
-    ~(isRefBlock (DataElement xs (LENGTH xs) (BlockTag n,[])))`,
+    ~(isRefBlock (DataElement xs (LENGTH xs) (BlockTag n,[])))
+Proof
   simp_tac (srw_ss()) [isRefBlock_def,RefBlock_def,Bignum_def]
   \\ Cases_on`a` \\ rw[]
   \\ TRY pairarg_tac \\ fs[]
-  \\ EVAL_TAC \\ rw[]);
+  \\ EVAL_TAC \\ rw[]
+QED
 
-val v_inv_Ref = Q.prove(
-  `RefBlock_inv heap heap2 ==>
-    !x h f tf. (v_inv conf x (h,f,tf,heap2) = v_inv conf x (h,f,tf,heap))`,
+Triviality v_inv_Ref:
+  RefBlock_inv heap heap2 ==>
+    !x h f tf. (v_inv conf x (h,f,tf,heap2) = v_inv conf x (h,f,tf,heap))
+Proof
   strip_tac \\ completeInduct_on `v_size x` \\ NTAC 3 strip_tac
   \\ full_simp_tac std_ss [PULL_FORALL] \\ Cases_on `x` THEN1
    (full_simp_tac std_ss [v_inv_def] \\ srw_tac [] []
@@ -2939,7 +3011,8 @@ val v_inv_Ref = Q.prove(
         \\ imp_res_tac MEM_IMP_v_size \\ DECIDE_TAC) \\ res_tac
       \\ full_simp_tac std_ss []))
   THEN1 (full_simp_tac std_ss [v_inv_def])
-  THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF]));
+  THEN1 (full_simp_tac (srw_ss()) [v_inv_def,SUBMAP_DEF])
+QED
 
 val heap_lookup_heap_split = prove(
   ``!heap a b h1 h2 x.
@@ -3313,20 +3386,25 @@ Proof
   Induct \\ fs [write_bytes_def]
 QED
 
-val LIST_REL_IMP_LIST_REL = Q.prove(
-  `!xs ys.
+Triviality LIST_REL_IMP_LIST_REL:
+  !xs ys.
       (!x y. MEM x xs ==> P x y ==> Q x y) ==>
-      LIST_REL P xs ys ==> LIST_REL Q xs ys`,
-  Induct \\ fs [PULL_EXISTS]);
+      LIST_REL P xs ys ==> LIST_REL Q xs ys
+Proof
+  Induct \\ fs [PULL_EXISTS]
+QED
 
-val v_size_LESS_EQ = Q.prove(
-  `!l x. MEM x l ==> v_size x <= v1_size l`,
-  Induct \\ fs [v_size_def] \\ rw [] \\ fs [] \\ res_tac \\ fs []);
+Triviality v_size_LESS_EQ:
+  !l x. MEM x l ==> v_size x <= v1_size l
+Proof
+  Induct \\ fs [v_size_def] \\ rw [] \\ fs [] \\ res_tac \\ fs []
+QED
 
-val v_inv_IMP = Q.prove(
-  `∀y x f tf ha.
+Triviality v_inv_IMP:
+  ∀y x f tf ha.
       v_inv conf y (x,f,tf,ha ++ [Bytes be fl xs ws] ++ hb) ⇒
-      v_inv conf y (x,f,tf,ha ++ [Bytes be fl ys ws] ++ hb)`,
+      v_inv conf y (x,f,tf,ha ++ [Bytes be fl ys ws] ++ hb)
+Proof
   completeInduct_on `v_size y` \\ rw [] \\ fs [PULL_FORALL]
   \\ Cases_on `y` \\ fs [v_inv_def] \\ rw [] \\ fs []
   THEN1
@@ -3346,7 +3424,8 @@ val v_inv_IMP = Q.prove(
     \\ fs [v_size_def] \\ imp_res_tac v_size_LESS_EQ \\ fs [])
   \\ fs [Bytes_def,heap_lookup_APPEND,heap_lookup_def,BlockRep_def,
          heap_length_APPEND,heap_length_def,SUM_APPEND,el_length_def]
-  \\ rw [] \\ fs []);
+  \\ rw [] \\ fs []
+QED
 
 val gen_state_ok_update_byte = prove(
   ``gen_state_ok a k (ha ++ [Bytes be fl xs ws] ++ hb) gens ==>
@@ -5348,9 +5427,11 @@ Proof
   \\ fs [GSYM word_add_n2w,AC CONJ_COMM CONJ_ASSOC,PULL_EXISTS]
 QED
 
-val minus_lemma = Q.prove(
-  `-1w * (bytes_in_word * w) = bytes_in_word * -w`,
-  fs []);
+Triviality minus_lemma:
+  -1w * (bytes_in_word * w) = bytes_in_word * -w
+Proof
+  fs []
+QED
 
 Theorem n2w_lsr_eq_0:
    n DIV 2 ** k = 0 /\ n < dimword (:'a) ==> n2w n >>> k = 0w:'a word
@@ -5358,20 +5439,26 @@ Proof
   rw [] \\ simp_tac std_ss [GSYM w2n_11,w2n_lsr] \\ fs []
 QED
 
-val LESS_EXO_SUB = Q.prove(
-  `n < 2 ** (k - m) ==> n < 2n ** k`,
+Triviality LESS_EXO_SUB:
+  n < 2 ** (k - m) ==> n < 2n ** k
+Proof
   rw [] \\ match_mp_tac LESS_LESS_EQ_TRANS
-  \\ asm_exists_tac \\ fs []);
+  \\ asm_exists_tac \\ fs []
+QED
 
-val LESS_EXO_SUB_ALT = Q.prove(
-  `m <= k ==> n < 2 ** (k - m) ==> n * 2 ** m < 2n ** k`,
+Triviality LESS_EXO_SUB_ALT:
+  m <= k ==> n < 2 ** (k - m) ==> n * 2 ** m < 2n ** k
+Proof
   rw [] \\ match_mp_tac LESS_LESS_EQ_TRANS
   \\ qexists_tac `2 ** (k - m) * 2 ** m`
-  \\ fs [GSYM EXP_ADD]);
+  \\ fs [GSYM EXP_ADD]
+QED
 
-val less_pow_dimindex_sub_imp = Q.prove(
-  `n < 2 ** (dimindex (:'a) - k) ==> n < dimword (:'a)`,
-  fs [dimword_def] \\ metis_tac [LESS_EXO_SUB]);
+Triviality less_pow_dimindex_sub_imp:
+  n < 2 ** (dimindex (:'a) - k) ==> n < dimword (:'a)
+Proof
+  fs [dimword_def] \\ metis_tac [LESS_EXO_SUB]
+QED
 
 Theorem encode_header_NEQ_0:
    encode_header c n k = SOME w ==> w <> 0w
@@ -5382,11 +5469,12 @@ Proof
   \\ qexists_tac `0` \\ fs [] \\ EVAL_TAC
 QED
 
-val encode_header_IMP = Q.prove(
-  `encode_header c tag len = SOME (hd:'a word) /\
+Triviality encode_header_IMP:
+  encode_header c tag len = SOME (hd:'a word) /\
     c.len_size + 5 < dimindex (:'a) /\ good_dimindex (:'a) ==>
     len < 2 ** (dimindex (:'a) - 4) /\
-    decode_length c hd = n2w len`,
+    decode_length c hd = n2w len
+Proof
   fs [encode_header_def] \\ rw [make_header_def] \\ fs [decode_length_def]
   \\ `3w >>> (dimindex (:α) − c.len_size) = 0w:'a word` by
       (match_mp_tac n2w_lsr_eq_0
@@ -5412,7 +5500,8 @@ val encode_header_IMP = Q.prove(
   \\ imp_res_tac less_pow_dimindex_sub_imp \\ fs []
   \\ `dimword (:'a) = 2 ** c.len_size * 2 ** (dimindex (:α) − c.len_size)`
         suffices_by fs []
-  \\ fs [GSYM EXP_ADD,dimword_def]);
+  \\ fs [GSYM EXP_ADD,dimword_def]
+QED
 
 Theorem word_list_exists_thm:
    (word_list_exists a 0 = emp) /\
@@ -5533,9 +5622,11 @@ Proof
   \\ metis_tac [word_el_IMP_word_list_exists]
 QED
 
-val EVERY2_f_EQ = Q.prove(
-  `!rs ws f. EVERY2 (\v w. f v = w) rs ws <=> MAP f rs = ws`,
-  Induct \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []);
+Triviality EVERY2_f_EQ:
+  !rs ws f. EVERY2 (\v w. f v = w) rs ws <=> MAP f rs = ws
+Proof
+  Induct \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []
+QED
 
 Theorem word_heap_heap_expand:
    word_heap a (heap_expand n) conf = word_list_exists a n
@@ -5545,9 +5636,11 @@ Proof
          SEP_EXISTS_THM,cond_STAR,word_list_def,word_el_def,SEP_CLAUSES]
 QED
 
-val get_lowerbits_or_1 = Q.prove(
-  `get_lowerbits c v = (get_lowerbits c v || 1w)`,
-  Cases_on `v` \\ fs [get_lowerbits_def]);
+Triviality get_lowerbits_or_1:
+  get_lowerbits c v = (get_lowerbits c v || 1w)
+Proof
+  Cases_on `v` \\ fs [get_lowerbits_def]
+QED
 
 Theorem memory_rel_Word64_alt:
    memory_rel c be ts refs sp st m dm (vs ++ vars) ∧ good_dimindex (:'a) ∧
@@ -5632,8 +5725,8 @@ val memory_rel_WordOp64_alt =
   |> CONV_RULE(LAND_CONV(SIMP_CONV(srw_ss())[]))
   |> curry save_thm "memory_rel_WordOp64_alt"
 
-val IMP_memory_rel_bignum_alt = Q.prove(
-  `memory_rel c be ts refs sp st m dm (vs ++ vars) ∧
+Triviality IMP_memory_rel_bignum_alt:
+  memory_rel c be ts refs sp st m dm (vs ++ vars) ∧
    good_dimindex (:α) ∧ ¬small_int (:α) i ∧
    (Bignum i :α ml_el) = DataElement [] (LENGTH ws) (NumTag sign,MAP Word ws) ∧
    LENGTH ws < sp ∧
@@ -5645,7 +5738,8 @@ val IMP_memory_rel_bignum_alt = Q.prove(
      (store_list next (MAP Word (hd::ws)) m dm = SOME m1 ∧
       memory_rel c be ts refs (sp - (LENGTH ws + 1))
         (st |+ (NextFree,Word (next + bytes_in_word * n2w (LENGTH ws + 1))))
-        m1 dm ((Number i,make_ptr c (next - curr) (0w:α word) (LENGTH ws))::vars))`,
+        m1 dm ((Number i,make_ptr c (next - curr) (0w:α word) (LENGTH ws))::vars))
+Proof
   rw[memory_rel_def,word_ml_inv_def,PULL_EXISTS]
   \\ imp_res_tac EVERY2_SWAP
   \\ imp_res_tac EVERY2_APPEND_IMP_APPEND
@@ -5711,7 +5805,8 @@ val IMP_memory_rel_bignum_alt = Q.prove(
      \\ simp[AC STAR_ASSOC STAR_COMM])
   \\ simp[word_addr_def,make_ptr_def,get_addr_def,
           get_lowerbits_def,bytes_in_word_mul_eq_shift]
-  \\ imp_res_tac EVERY2_SWAP \\ fs[]);
+  \\ imp_res_tac EVERY2_SWAP \\ fs[]
+QED
 
 val IMP_memory_rel_bignum_alt = save_thm("IMP_memory_rel_bignum_alt",
   IMP_memory_rel_bignum_alt |> Q.INST [`vs`|->`[]`] |> SIMP_RULE std_ss [APPEND]);
@@ -6061,9 +6156,10 @@ val ADD_DIV_EQ = save_thm("ADD_DIV_EQ",LIST_CONJ
   [GSYM ADD_DIV_ADD_DIV,
    ONCE_REWRITE_RULE [ADD_COMM] (GSYM ADD_DIV_ADD_DIV)])
 
-val set_byte_word_of_byte = Q.prove(
-  `good_dimindex (:'a) ==>
-    set_byte a w (word_of_byte ((w2w w):'a word)) be = word_of_byte (w2w w)`,
+Triviality set_byte_word_of_byte:
+  good_dimindex (:'a) ==>
+    set_byte a w (word_of_byte ((w2w w):'a word)) be = word_of_byte (w2w w)
+Proof
   fs [set_byte_def,good_dimindex_def] \\ rw [] \\ fs []
   \\ fs [word_of_byte_def]
   \\ `?k. byte_index a be = 8 * k /\ k < (dimindex (:'a) DIV 8)` by
@@ -6073,7 +6169,8 @@ val set_byte_word_of_byte = Q.prove(
                               n = 4 \/ n = 5 \/ n = 6 \/ n = 7n``]
   \\ rveq \\ fs []
   \\ fs [fcpTheory.CART_EQ,word_or_def,word_lsl_def,fcpTheory.FCP_BETA,
-        word_slice_alt_def,w2w] \\ rw [] \\ EQ_TAC \\ rw [] \\ fs []);
+        word_slice_alt_def,w2w] \\ rw [] \\ EQ_TAC \\ rw [] \\ fs []
+QED
 
 Theorem w2w_word_of_byte_w2w:
    good_dimindex(:'a) ==>
@@ -6083,18 +6180,20 @@ Proof
   \\ srw_tac[wordsLib.WORD_BIT_EQ_ss][]
 QED
 
-val write_bytes_REPLICATE = Q.prove(
-  `!n m.
+Triviality write_bytes_REPLICATE:
+  !n m.
       good_dimindex (:'a) ==>
       write_bytes (REPLICATE m w) (REPLICATE n (word_of_byte (w2w w))) be =
-      REPLICATE n (word_of_byte ((w2w w):'a word))`,
+      REPLICATE n (word_of_byte ((w2w w):'a word))
+Proof
   Induct \\ fs [write_bytes_def,REPLICATE,DROP_REPLICATE] \\ rw []
   \\ qspec_tac (`m`,`m`)
   \\ qspec_tac (`0w:'a word`,`a`)
   \\ qspec_tac (`dimindex (:α) DIV 8`,`n`)
   \\ Induct
   \\ simp [Once bytes_to_word_def,REPLICATE] \\ Cases_on `m`
-  \\ fs [REPLICATE,set_byte_word_of_byte]);
+  \\ fs [REPLICATE,set_byte_word_of_byte]
+QED
 
 Theorem IMP_EXP_LESS:
    m <= l ==> 2n ** m <= 2 ** l
@@ -6102,10 +6201,11 @@ Proof
   simp [Once LESS_EQ_EXISTS] \\ rw []
 QED
 
-val shift_shift_lemma = Q.prove(
-  `l = k + shift (:'a) /\ t < k /\ n DIV i < 2 ** t /\ l = dimindex (:'a) /\
+Triviality shift_shift_lemma:
+  l = k + shift (:'a) /\ t < k /\ n DIV i < 2 ** t /\ l = dimindex (:'a) /\
     i = 2 ** shift (:'a) /\ n < dimword (:'a) ==>
-    n2w n << (k - t) >>> (l - t) = (n2w (n DIV i)):'a word`,
+    n2w n << (k - t) >>> (l - t) = (n2w (n DIV i)):'a word
+Proof
   rw [] \\ `k + shift (:α) − t = (k - t) + shift (:'a)` by decide_tac
   \\ pop_assum (fn th => rewrite_tac [th,GSYM LSR_ADD])
   \\ qsuff_tac `w2n ((n2w n):'a word) * 2 ** (k - t) < dimword (:'a)`
@@ -6122,7 +6222,8 @@ val shift_shift_lemma = Q.prove(
   \\ fs [LESS_EQ_EXISTS] \\ rw []
   \\ fs [dimword_def,EXP_ADD]
   \\ simp_tac bool_ss [Once MULT_COMM]
-  \\ rewrite_tac [LT_MULT_LCANCEL,GSYM MULT_ASSOC] \\ fs []);
+  \\ rewrite_tac [LT_MULT_LCANCEL,GSYM MULT_ASSOC] \\ fs []
+QED
 
 Theorem write_bytes_APPEND:
    !xs ys vals be.
@@ -6952,9 +7053,10 @@ Proof
   \\ strip_tac \\ fs []
 QED
 
-val make_header_tag_mask = Q.prove(
-  `k < 2 ** (dimindex (:α) − (c.len_size + 2)) ==>
-    (tag_mask c && make_header c ((n2w k):'a word) n) = n2w (4 * k)`,
+Triviality make_header_tag_mask:
+  k < 2 ** (dimindex (:α) − (c.len_size + 2)) ==>
+    (tag_mask c && make_header c ((n2w k):'a word) n) = n2w (4 * k)
+Proof
   srw_tac [wordsLib.WORD_MUL_LSL_ss, boolSimps.LET_ss]
        [tag_mask_def, make_header_def, GSYM wordsTheory.word_mul_n2w]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index]
@@ -6970,13 +7072,16 @@ val make_header_tag_mask = Q.prove(
   \\ fs []
   \\ `i - (q + 2) <= i - 2` by decide_tac
   \\ metis_tac [bitTheory.NOT_BIT_GT_TWOEXP, bitTheory.TWOEXP_MONO2,
-                arithmeticTheory.LESS_LESS_EQ_TRANS]);
+                arithmeticTheory.LESS_LESS_EQ_TRANS]
+QED
 
-val make_header_and_2 = Q.prove(
-  `(2w && make_header c w n) = 2w`,
+Triviality make_header_and_2:
+  (2w && make_header c w n) = 2w
+Proof
   fs [make_header_def]
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [word_index]
-  \\ Cases_on `i=1` \\ fs []);
+  \\ Cases_on `i=1` \\ fs []
+QED
 
 Theorem encode_header_tag_mask:
    encode_header c (4 * tag) n = SOME (w:'a word) /\ good_dimindex (:'a) ==>
@@ -7005,13 +7110,17 @@ Proof
   \\ imp_res_tac encode_header_tag_mask \\ fs []
 QED
 
-val LESS_DIV_16_IMP = Q.prove(
-  `n < k DIV 16 ==> 16 * n + 2 < k:num`,
-  fs [X_LT_DIV]);
+Triviality LESS_DIV_16_IMP:
+  n < k DIV 16 ==> 16 * n + 2 < k:num
+Proof
+  fs [X_LT_DIV]
+QED
 
-val MULT_BIT0 = Q.prove(
-  `BIT 0 (m * n) <=> BIT 0 m /\ BIT 0 n`,
-  fs [bitTheory.BIT0_ODD,ODD_MULT]);
+Triviality MULT_BIT0:
+  BIT 0 (m * n) <=> BIT 0 m /\ BIT 0 n
+Proof
+  fs [bitTheory.BIT0_ODD,ODD_MULT]
+QED
 
 Theorem memory_rel_test_nil_eq:
    memory_rel c be ts refs sp st m dm ((Block ts' tag l,w:'a word_loc)::rest) /\
@@ -7035,10 +7144,12 @@ Proof
   \\ CCONTR_TAC \\ fs [] \\ rw [] \\ rfs [LENGTH_NIL,PULL_EXISTS]
 QED
 
-val not_bit_lt_2exp = Q.prove(
-  `!p x n. n < 2 ** (p + 1) ==> ~BIT (p + (x + 1)) n`,
+Triviality not_bit_lt_2exp:
+  !p x n. n < 2 ** (p + 1) ==> ~BIT (p + (x + 1)) n
+Proof
   metis_tac [DECIDE ``p + 1 <= p + (x + 1n)``, bitTheory.TWOEXP_MONO2,
-     arithmeticTheory.LESS_LESS_EQ_TRANS, bitTheory.NOT_BIT_GT_TWOEXP])
+     arithmeticTheory.LESS_LESS_EQ_TRANS, bitTheory.NOT_BIT_GT_TWOEXP]
+QED
 
 val not_bit_lt_2 = not_bit_lt_2exp |> Q.SPEC `0` |> SIMP_RULE (srw_ss()) []
 
@@ -7180,14 +7291,16 @@ Proof
   \\ rfs [good_dimindex_def]
 QED
 
-val MOD_MULT_MOD_LEMMA = Q.prove(
-  `k MOD n = 0 /\ x MOD n = t /\ 0 < k /\ 0 < n /\ n <= k ==>
-    x MOD k MOD n = t`,
+Triviality MOD_MULT_MOD_LEMMA:
+  k MOD n = 0 /\ x MOD n = t /\ 0 < k /\ 0 < n /\ n <= k ==>
+    x MOD k MOD n = t
+Proof
   rw [] \\ drule DIVISION
   \\ disch_then (qspec_then `k` mp_tac) \\ strip_tac
   \\ qpat_x_assum `_ = _` (fn th => once_rewrite_tac [th])
   \\ fs [] \\ Cases_on `0 < k DIV n` \\ fs [MOD_MULT_MOD]
-  \\ fs [DIV_EQ_X] \\ rfs [DIV_EQ_X]);
+  \\ fs [DIV_EQ_X] \\ rfs [DIV_EQ_X]
+QED
 
 Theorem w2n_add_byte_align_lemma:
    good_dimindex (:'a) ==>
@@ -8070,9 +8183,10 @@ Proof
   \\ Cases_on `i1` \\ fs [GSYM WORD_NOT_LESS,word_msb_neg]
 QED
 
-val memory_rel_RefPtr_EQ_lemma = Q.prove(
-  `n * 2 ** k < dimword (:'a) /\ m * 2 ** k < dimword (:'a) /\ 0 < k /\
-    (n2w n << k || 1w) = (n2w m << k || 1w:'a word) ==> n = m`,
+Triviality memory_rel_RefPtr_EQ_lemma:
+  n * 2 ** k < dimword (:'a) /\ m * 2 ** k < dimword (:'a) /\ 0 < k /\
+    (n2w n << k || 1w) = (n2w m << k || 1w:'a word) ==> n = m
+Proof
   `!n a b. 0n < n ==> (a * n = b * n) = (a = b)`
   by (Cases \\ simp [])
   \\ rw []
@@ -8084,7 +8198,7 @@ val memory_rel_RefPtr_EQ_lemma = Q.prove(
       \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index])
   \\ fs [addressTheory.word_LSL_n2w]
   \\ rfs []
-  )
+QED
 
 Theorem memory_rel_RefPtr_EQ:
    memory_rel c be ts refs sp st m dm
@@ -8159,10 +8273,11 @@ val lt8 =
   DECIDE ``(n < 8n) = (n = 0 \/ n = 1 \/ n = 2 \/ n = 3 \/
                        n = 4 \/ n = 5 \/ n = 6 \/ n = 7)``
 
-val Smallnum_test = Q.prove(
-  `((Smallnum i && -1w ≪ (dimindex (:'a) − 2)) = 0w:'a word) /\
+Triviality Smallnum_test:
+  ((Smallnum i && -1w ≪ (dimindex (:'a) − 2)) = 0w:'a word) /\
     good_dimindex (:'a) /\ small_int (:'a) i ==>
-    ~(i < 0) /\ i < 2 ** (dimindex (:'a) - 4)`,
+    ~(i < 0) /\ i < 2 ** (dimindex (:'a) - 4)
+Proof
   Tactical.REVERSE (Cases_on `i`)
   \\ srw_tac [wordsLib.WORD_MUL_LSL_ss]
       [Smallnum_def, small_int_def, good_dimindex_def,
@@ -8228,7 +8343,7 @@ val Smallnum_test = Q.prove(
       \\ simp [bitTheory.BIT_COMP_THM3
                |> Q.SPECL [`60`, `59`, `0`] |> numLib.REDUCE_RULE |> GSYM,
                bitTheory.BITSLT_THM2 |> Q.SPEC `59` |> numLib.REDUCE_RULE])
-  )
+QED
 
 val small_int_w2i_i2w = prove(
   ``small_int (:α) i /\ good_dimindex (:'a) ==>
@@ -8290,9 +8405,11 @@ Proof
   \\ intLib.COOPER_TAC
 QED
 
-val exists_num = Q.prove(
-  `~(i < 0i) <=> ?n. i = &n`,
-  Cases_on `i` \\ fs []);
+Triviality exists_num:
+  ~(i < 0i) <=> ?n. i = &n
+Proof
+  Cases_on `i` \\ fs []
+QED
 
 Theorem small_int_w2n[simp]:
    good_dimindex (:'a) ==> small_int (:'a) (& (w2n (w:word8)))
@@ -11049,7 +11166,7 @@ Definition list_copy_alias_def:
     else list_copy_bwd_alias n (xp+n-1) (yp+n-1) ys
 End
 
-val list_copy_fwd_eq = Q.prove(`
+Triviality list_copy_fwd_eq:
   ∀n xp xs yp ys.
   xp + n <= LENGTH xs ∧
   yp + n <= LENGTH ys ⇒
@@ -11057,7 +11174,8 @@ val list_copy_fwd_eq = Q.prove(`
     SOME
       (TAKE yp ys ++
       TAKE n (DROP xp xs) ++
-      DROP (n+yp) ys)`,
+      DROP (n+yp) ys)
+Proof
   ho_match_mp_tac (fetch "-""list_copy_fwd_ind")>>rw[]>>
   simp[Once list_copy_fwd_def]>>
   rpt(IF_CASES_TAC)>>fs[]>>
@@ -11066,9 +11184,10 @@ val list_copy_fwd_eq = Q.prove(`
   simp[EL_TAKE,EL_DROP])>>
   simp[EL_LUPDATE]>>
   rw[]>>
-  Cases_on`x=yp`>>fs[]);
+  Cases_on`x=yp`>>fs[]
+QED
 
-val list_copy_bwd_eq = Q.prove(`
+Triviality list_copy_bwd_eq:
   ∀n xp xs yp ys.
   n ≤ xp+1 ∧ xp < LENGTH xs ∧
   n ≤ yp+1 ∧ yp < LENGTH ys ⇒
@@ -11076,7 +11195,8 @@ val list_copy_bwd_eq = Q.prove(`
     SOME
       (TAKE (yp+1-n) ys ++
       TAKE n (DROP (xp+1-n) xs) ++
-      DROP (yp+1) ys)`,
+      DROP (yp+1) ys)
+Proof
   ho_match_mp_tac (fetch "-""list_copy_bwd_ind")>>rw[]>>
   simp[Once list_copy_bwd_def]>>
   fs[minus_def]>>
@@ -11108,7 +11228,8 @@ val list_copy_bwd_eq = Q.prove(`
   >>
   rw[LIST_EQ_REWRITE,EL_LUPDATE,EL_APPEND_EQN]>>
   rpt(IF_CASES_TAC>>
-  simp[EL_TAKE,EL_DROP]));
+  simp[EL_TAKE,EL_DROP])
+QED
 
 Theorem list_copy_thm:
    !xs ys xp yp n ys1.
@@ -11132,7 +11253,7 @@ QED
 
 (* see more interesting theorem below *)
 
-val list_copy_fwd_alias_eq = Q.prove(`
+Triviality list_copy_fwd_alias_eq:
   ∀n xp yp ys.
   yp ≤ xp ∧
   xp + n <= LENGTH ys ∧
@@ -11141,7 +11262,8 @@ val list_copy_fwd_alias_eq = Q.prove(`
     SOME
       (TAKE yp ys ++
       TAKE n (DROP xp ys) ++
-      DROP (n+yp) ys)`,
+      DROP (n+yp) ys)
+Proof
   ho_match_mp_tac (fetch "-""list_copy_fwd_alias_ind")>>rw[]>>
   simp[Once list_copy_fwd_alias_def]>>
   rpt(IF_CASES_TAC)>>fs[]>>
@@ -11150,9 +11272,10 @@ val list_copy_fwd_alias_eq = Q.prove(`
   simp[EL_TAKE,EL_DROP])>>
   simp[EL_LUPDATE]>>
   rw[]>>
-  Cases_on`x=yp`>>fs[]);
+  Cases_on`x=yp`>>fs[]
+QED
 
-val list_copy_bwd_alias_eq = Q.prove(`
+Triviality list_copy_bwd_alias_eq:
   ∀n xp yp ys.
   xp <= yp ∧
   n ≤ xp +1 ∧ xp < LENGTH ys ∧
@@ -11161,7 +11284,8 @@ val list_copy_bwd_alias_eq = Q.prove(`
     SOME
       (TAKE (yp+1-n) ys ++
       TAKE n (DROP (xp+1-n) ys) ++
-      DROP (yp+1) ys)`,
+      DROP (yp+1) ys)
+Proof
   ho_match_mp_tac (fetch "-""list_copy_bwd_alias_ind")>>rw[]>>
   simp[Once list_copy_bwd_alias_def]>>
   fs[minus_def]>>
@@ -11193,7 +11317,8 @@ val list_copy_bwd_alias_eq = Q.prove(`
   >>
   rw[LIST_EQ_REWRITE,EL_LUPDATE,EL_APPEND_EQN]>>
   rpt(IF_CASES_TAC>>
-  simp[EL_TAKE,EL_DROP]));
+  simp[EL_TAKE,EL_DROP])
+QED
 
 Theorem list_copy_alias_thm:
    !ys xp yp n ys1.

--- a/compiler/backend/proofs/flat_elimProofScript.sml
+++ b/compiler/backend/proofs/flat_elimProofScript.sml
@@ -1609,22 +1609,28 @@ val flat_remove_semantics = save_thm ("flat_remove_semantics",
 
 (* syntactic results *)
 
-val elist_globals_filter = Q.prove (
-  `elist_globals (MAP dest_Dlet (FILTER is_Dlet ds)) = {||}
+Triviality elist_globals_filter:
+  elist_globals (MAP dest_Dlet (FILTER is_Dlet ds)) = {||}
    ==>
-   elist_globals (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds))) = {||}`,
-  Induct_on `ds` \\ rw [] \\ fs [SUB_BAG_UNION]);
+   elist_globals (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds))) = {||}
+Proof
+  Induct_on `ds` \\ rw [] \\ fs [SUB_BAG_UNION]
+QED
 
-val esgc_free_filter = Q.prove (
-  `EVERY esgc_free (MAP dest_Dlet (FILTER is_Dlet ds))
+Triviality esgc_free_filter:
+  EVERY esgc_free (MAP dest_Dlet (FILTER is_Dlet ds))
    ==>
-   EVERY esgc_free (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds)))`,
-  Induct_on `ds` \\ rw []);
+   EVERY esgc_free (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds)))
+Proof
+  Induct_on `ds` \\ rw []
+QED
 
-val elist_globals_filter_SUB_BAG = Q.prove (
-  `elist_globals (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds))) <=
-   elist_globals (MAP dest_Dlet (FILTER is_Dlet ds))`,
-  Induct_on `ds` \\ rw [] \\ fs [SUB_BAG_UNION]);
+Triviality elist_globals_filter_SUB_BAG:
+  elist_globals (MAP dest_Dlet (FILTER is_Dlet (FILTER P ds))) <=
+   elist_globals (MAP dest_Dlet (FILTER is_Dlet ds))
+Proof
+  Induct_on `ds` \\ rw [] \\ fs [SUB_BAG_UNION]
+QED
 
 Theorem remove_flat_prog_elist_globals_eq_empty:
    elist_globals (MAP dest_Dlet (FILTER is_Dlet ds)) = {||}

--- a/compiler/backend/proofs/lab_filterProofScript.sml
+++ b/compiler/backend/proofs/lab_filterProofScript.sml
@@ -32,9 +32,11 @@ Definition all_skips_def:
     asm_fetch_aux (pc+i) code = SOME(Asm (Asmi(Inst Skip)) x y)
 End
 
-val is_Label_not_skip = Q.prove(`
-  is_Label y ⇒ not_skip y`,
-  Cases_on`y`>>full_simp_tac(srw_ss())[is_Label_def,not_skip_def])
+Triviality is_Label_not_skip:
+  is_Label y ⇒ not_skip y
+Proof
+  Cases_on`y`>>full_simp_tac(srw_ss())[is_Label_def,not_skip_def]
+QED
 
 (*
 Proof plan:
@@ -118,10 +120,11 @@ Proof
 QED
 (*For any adjusted fetch, the original fetch is either equal or is a skip
 This is probably the wrong direction*)
-val asm_fetch_not_skip_adjust_pc = Q.prove(
-  `∀pc code inst.
+Triviality asm_fetch_not_skip_adjust_pc:
+  ∀pc code inst.
   (∀x y.asm_fetch_aux pc code ≠ SOME (Asm (Asmi(Inst Skip)) x y)) ⇒
-  asm_fetch_aux pc code = asm_fetch_aux (adjust_pc pc code) (filter_skip code)`,
+  asm_fetch_aux pc code = asm_fetch_aux (adjust_pc pc code) (filter_skip code)
+Proof
   ho_match_mp_tac asm_fetch_aux_ind>>srw_tac[][]
   >-
     simp[asm_fetch_aux_def,filter_skip_def]
@@ -150,22 +153,26 @@ val asm_fetch_not_skip_adjust_pc = Q.prove(
     full_simp_tac(srw_ss())[Once asm_fetch_aux_def]>>
     simp[Once adjust_pc_def,SimpRHS]>>
     IF_CASES_TAC>>full_simp_tac(srw_ss())[filter_skip_def]>>
-    simp[asm_fetch_aux_def]);
+    simp[asm_fetch_aux_def]
+QED
 
-val state_rw = Q.prove(`
+Triviality state_rw:
   s with clock := s.clock = s ∧
   s with pc := s.pc = s ∧
-  s with <|pc := s.pc; clock:= s.clock+k'|> = s with clock:=s.clock+k'`,
-  full_simp_tac(srw_ss())[state_component_equality])
+  s with <|pc := s.pc; clock:= s.clock+k'|> = s with clock:=s.clock+k'
+Proof
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (* 2) all_skips allow swapping pc for clock*)
-val all_skips_evaluate = Q.prove(`
+Triviality all_skips_evaluate:
   ∀k s.
   all_skips s.pc s.code k ∧
   ¬s.failed ⇒
   ∀k'.
   evaluate (s with clock:= s.clock +k' + k) =
-  evaluate (s with <|pc := s.pc +k; clock:= s.clock +k'|>)`,
+  evaluate (s with <|pc := s.pc +k; clock:= s.clock +k'|>)
+Proof
   Induct>>full_simp_tac(srw_ss())[all_skips_def]
   >-
     metis_tac[state_rw]
@@ -184,7 +191,8 @@ val all_skips_evaluate = Q.prove(`
       (srw_tac[][]>>first_x_assum(qspec_then`i+1` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
       metis_tac[arithmeticTheory.ADD_COMM,ADD_ASSOC])>>
     srw_tac[][]>>first_x_assum(qspec_then`0` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
-    metis_tac[arithmeticTheory.ADD_COMM,ADD_ASSOC])
+    metis_tac[arithmeticTheory.ADD_COMM,ADD_ASSOC]
+QED
 
 Definition state_rel_def:
   state_rel (s1:('a,'c,'ffi) labSem$state) t1 ⇔
@@ -198,10 +206,11 @@ Definition state_rel_def:
     ¬t1.failed
 End
 
-val adjust_pc_all_skips = Q.prove(`
+Triviality adjust_pc_all_skips:
   ∀k pc code.
   all_skips pc code k ⇒
-  adjust_pc pc code +1 = adjust_pc (pc+k+1) code`,
+  adjust_pc pc code +1 = adjust_pc (pc+k+1) code
+Proof
   Induct>>full_simp_tac(srw_ss())[all_skips_def]>>simp[]>>
   ho_match_mp_tac asm_fetch_aux_ind
   >>
@@ -235,22 +244,26 @@ val adjust_pc_all_skips = Q.prove(`
     `!i. i+(pc-1) = i+pc -1` by DECIDE_TAC>>
     full_simp_tac(srw_ss())[]>>
     first_assum match_mp_tac>>full_simp_tac(srw_ss())[]>>
-    full_simp_tac(srw_ss())[]);
+    full_simp_tac(srw_ss())[]
+QED
 
-val asm_fetch_aux_eq2 = Q.prove(
-`asm_fetch_aux (adjust_pc pc code) (filter_skip code) = x ⇒
+Triviality asm_fetch_aux_eq2:
+  asm_fetch_aux (adjust_pc pc code) (filter_skip code) = x ⇒
   ∃k.
   asm_fetch_aux (pc+k) code = x ∧
-  all_skips pc code k`,
-  metis_tac[asm_fetch_aux_eq]);
+  all_skips pc code k
+Proof
+  metis_tac[asm_fetch_aux_eq]
+QED
 
 val all_skips_evaluate_0 = all_skips_evaluate |>SIMP_RULE std_ss [PULL_FORALL]|>(Q.SPECL[`k`,`s`,`0`])|>GEN_ALL|>SIMP_RULE std_ss[]
 
-val all_skips_evaluate_rw = Q.prove(`
+Triviality all_skips_evaluate_rw:
   all_skips s.pc s.code k ∧ ¬s.failed ∧
   s.clock = clk + k ∧
   t = s with <| pc:= s.pc +k ; clock := clk |> ⇒
-  evaluate s = evaluate t`,
+  evaluate s = evaluate t
+Proof
   srw_tac[][]>>
   qabbrev_tac`s' = s with clock := clk`>>
   `s = s' with clock := s'.clock +k` by
@@ -259,12 +272,14 @@ val all_skips_evaluate_rw = Q.prove(`
    s' with <| pc := s'.pc +k ; clock := s'.clock|>` by full_simp_tac(srw_ss())[state_component_equality]>>
    ntac 2 (pop_assum SUBST_ALL_TAC)>>
    match_mp_tac all_skips_evaluate_0>>
-   full_simp_tac(srw_ss())[state_component_equality])
+   full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (*For all initial code there is some all_skips*)
-val all_skips_initial_adjust = Q.prove(`
+Triviality all_skips_initial_adjust:
   ∀code.
-  ∃k. all_skips 0 code k ∧ adjust_pc k code = 0`,
+  ∃k. all_skips 0 code k ∧ adjust_pc k code = 0
+Proof
   Induct>>full_simp_tac(srw_ss())[all_skips_def]
   >-
     (qexists_tac`0`>>full_simp_tac(srw_ss())[adjust_pc_def,asm_fetch_aux_def])
@@ -286,13 +301,15 @@ val all_skips_initial_adjust = Q.prove(`
         `i-1 < k'` by DECIDE_TAC>>
         metis_tac[])
       >> (qexists_tac`0`>>full_simp_tac(srw_ss())[]))
-    >> (qexists_tac`0`>>full_simp_tac(srw_ss())[]));
+    >> (qexists_tac`0`>>full_simp_tac(srw_ss())[])
+QED
 
 (*May need strengthening*)
-val loc_to_pc_eq_NONE = Q.prove(`
+Triviality loc_to_pc_eq_NONE:
   ∀n1 n2 code.
   loc_to_pc n1 n2 (filter_skip code) = NONE ⇒
-  loc_to_pc n1 n2 code = NONE`,
+  loc_to_pc n1 n2 code = NONE
+Proof
   ho_match_mp_tac loc_to_pc_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[filter_skip_def]>>
   full_simp_tac(srw_ss())[Once loc_to_pc_def]>>IF_CASES_TAC>>full_simp_tac(srw_ss())[]>>
@@ -305,14 +322,16 @@ val loc_to_pc_eq_NONE = Q.prove(`
     IF_CASES_TAC>>full_simp_tac(srw_ss())[]>>
     simp[Once loc_to_pc_def]>>
     EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>NO_TAC)>>
-  full_simp_tac(srw_ss())[not_skip_def])
+  full_simp_tac(srw_ss())[not_skip_def]
+QED
 
-val loc_to_pc_eq_SOME = Q.prove(`
+Triviality loc_to_pc_eq_SOME:
   ∀n1 n2 code pc.
   loc_to_pc n1 n2 (filter_skip code) = SOME pc ⇒
   ∃pc'.
   loc_to_pc n1 n2 code = SOME pc' ∧
-  adjust_pc pc' code = pc`,
+  adjust_pc pc' code = pc
+Proof
   ho_match_mp_tac loc_to_pc_ind>>srw_tac[][]
   >-
     (full_simp_tac(srw_ss())[filter_skip_def,adjust_pc_def]>>
@@ -374,20 +393,24 @@ val loc_to_pc_eq_SOME = Q.prove(`
           DECIDE_TAC)>>
         srw_tac[][]>>
         simp[Once loc_to_pc_def]>>
-        simp[Once adjust_pc_def])));
+        simp[Once adjust_pc_def]))
+QED
 
-val next_label_filter_skip = Q.prove(`
+Triviality next_label_filter_skip:
   ∀code.
-  next_label code = next_label (filter_skip code)`,
+  next_label code = next_label (filter_skip code)
+Proof
   ho_match_mp_tac next_label_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[next_label_def,filter_skip_def,not_skip_def]>>
-  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[next_label_def])
+  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[next_label_def]
+QED
 
-val all_skips_get_lab_after = Q.prove(`
+Triviality all_skips_get_lab_after:
   ∀code k.
   all_skips 0 code k ⇒
   get_lab_after k code =
-  get_lab_after 0 (filter_skip code)`,
+  get_lab_after 0 (filter_skip code)
+Proof
   Induct>>full_simp_tac(srw_ss())[get_lab_after_def,filter_skip_def]>>
   Induct>>Induct_on`l`>>srw_tac[][]>>full_simp_tac(srw_ss())[filter_skip_def,get_lab_after_def]
   >-
@@ -422,12 +445,14 @@ val all_skips_get_lab_after = Q.prove(`
     full_simp_tac(srw_ss())[all_skips_def,asm_fetch_aux_def]>>srw_tac[][]>>
     `i+1 < k` by DECIDE_TAC>>
     res_tac>>
-    full_simp_tac(srw_ss())[]);
+    full_simp_tac(srw_ss())[]
+QED
 
-val get_lab_after_adjust = Q.prove(`
+Triviality get_lab_after_adjust:
   ∀pc code k.
   all_skips pc code k ⇒
-  get_lab_after (pc+k) code = get_lab_after (adjust_pc pc code) (filter_skip code)`,
+  get_lab_after (pc+k) code = get_lab_after (adjust_pc pc code) (filter_skip code)
+Proof
   ho_match_mp_tac get_lab_after_ind>>
   srw_tac[][]
   >-
@@ -474,12 +499,14 @@ val get_lab_after_adjust = Q.prove(`
       full_simp_tac(srw_ss())[]>>
       first_assum match_mp_tac>>
       `∀x. pc + x -1 = pc -1 +x` by DECIDE_TAC>>
-      full_simp_tac(srw_ss())[all_skips_def,asm_fetch_aux_def]);
+      full_simp_tac(srw_ss())[all_skips_def,asm_fetch_aux_def]
+QED
 
-val loc_to_pc_adjust_pc_append = Q.prove(`
+Triviality loc_to_pc_adjust_pc_append:
   ∀n1 n2 code pc ls.
   loc_to_pc n1 n2 code = SOME pc ==>
-  adjust_pc pc code = adjust_pc pc (code++ls)`,
+  adjust_pc pc code = adjust_pc pc (code++ls)
+Proof
   ho_match_mp_tac loc_to_pc_ind>>rw[]>>
   pop_assum mp_tac>>
   simp[Once loc_to_pc_def]>>
@@ -506,7 +533,8 @@ val loc_to_pc_adjust_pc_append = Q.prove(`
   fs[]>>
   simp[Once adjust_pc_def]>>
   simp[Once adjust_pc_def,SimpRHS]>>
-  IF_CASES_TAC>>rw[]>>simp[])
+  IF_CASES_TAC>>rw[]>>simp[]
+QED
 
 val same_inst_tac =
   full_simp_tac(srw_ss())[asm_fetch_def,state_rel_def,state_component_equality]>>
@@ -984,8 +1012,9 @@ Proof
       same_inst_tac
 QED
 
-val state_rel_IMP_sem_EQ_sem = Q.prove(
-  `!s t. state_rel s t ==> semantics s = semantics t`,
+Triviality state_rel_IMP_sem_EQ_sem:
+  !s t. state_rel s t ==> semantics s = semantics t
+Proof
   srw_tac[][labSemTheory.semantics_def] >- (
     DEEP_INTRO_TAC some_intro >>
     full_simp_tac(srw_ss())[FST_EQ_EQUIV] >>
@@ -1095,7 +1124,8 @@ val state_rel_IMP_sem_EQ_sem = Q.prove(
       simp[] >> strip_tac >>
       full_simp_tac(srw_ss())[IS_PREFIX_APPEND] >> full_simp_tac(srw_ss())[] >>
       qexists_tac`k+k'`>>simp[EL_APPEND1] ) >>
-    metis_tac[build_lprefix_lub_thm,unique_lprefix_lub,lprefix_lub_new_chain]));
+    metis_tac[build_lprefix_lub_thm,unique_lprefix_lub,lprefix_lub_new_chain])
+QED
 
 Theorem filter_skip_semantics:
    !s t. (t.pc = 0) ∧ ¬t.failed /\

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -18,14 +18,16 @@ val _ = set_trace "BasicProvers.var_eq_old" 1
 
 fun say0 pfx s g = (print (pfx ^ ": " ^ s ^ "\n"); ALL_TAC g)
 
-val evaluate_ignore_clocks = Q.prove(
-  `evaluate mc_conf ffi k ms = (r1,ms1,st1) /\ r1 <> TimeOut /\
+Triviality evaluate_ignore_clocks:
+  evaluate mc_conf ffi k ms = (r1,ms1,st1) /\ r1 <> TimeOut /\
     evaluate mc_conf ffi k' ms = (r2,ms2,st2) /\ r2 <> TimeOut ==>
-    (r1,ms1,st1) = (r2,ms2,st2)`,
+    (r1,ms1,st1) = (r2,ms2,st2)
+Proof
   srw_tac[][] \\ imp_res_tac evaluate_add_clock \\ full_simp_tac(srw_ss())[]
   \\ pop_assum (qspec_then `k'` mp_tac)
   \\ pop_assum (qspec_then `k` mp_tac)
-  \\ full_simp_tac(srw_ss())[AC ADD_ASSOC ADD_COMM])
+  \\ full_simp_tac(srw_ss())[AC ADD_ASSOC ADD_COMM]
+QED
 
 Definition sec_loc_to_pc_def:
   (sec_loc_to_pc n2 xs =
@@ -102,14 +104,16 @@ Definition enc_with_nop_def:
           bytes = init ++ FLAT (REPLICATE n step)
 End
 
-val enc_with_nop_thm = Q.prove(
-  `enc_with_nop enc (b:'a asm) bytes =
-      ?n. bytes = enc b ++ FLAT (REPLICATE n (enc (asm$Inst Skip)))`,
+Triviality enc_with_nop_thm:
+  enc_with_nop enc (b:'a asm) bytes =
+      ?n. bytes = enc b ++ FLAT (REPLICATE n (enc (asm$Inst Skip)))
+Proof
   fs [enc_with_nop_def,LENGTH_NIL]
   \\ IF_CASES_TAC \\ fs [FLAT_REPLICATE_NIL]
   \\ EQ_TAC \\ rw [] THEN1 metis_tac []
   \\ fs [LENGTH_APPEND,LENGTH_FLAT,map_replicate,SUM_REPLICATE]
-  \\ full_simp_tac (std_ss++ARITH_ss) [GSYM LENGTH_NIL,MULT_DIV]);
+  \\ full_simp_tac (std_ss++ARITH_ss) [GSYM LENGTH_NIL,MULT_DIV]
+QED
 
 Definition asm_step_nop_def:
   asm_step_nop bytes c s1 i s2 <=>
@@ -128,14 +132,18 @@ val evaluate_nop_step =
     |> SIMP_RULE (srw_ss()) [asm_def,inst_def,asm_ok_def,inst_ok_def,
          Once upd_pc_def,GSYM CONJ_ASSOC]
 
-val shift_interfer_0 = Q.prove(
-  `shift_interfer 0 = I`,
+Triviality shift_interfer_0:
+  shift_interfer 0 = I
+Proof
   full_simp_tac(srw_ss())[shift_interfer_def,FUN_EQ_THM,shift_seq_def,
-      machine_config_component_equality]);
+      machine_config_component_equality]
+QED
 
-val upd_pc_with_pc = Q.prove(
-  `upd_pc s1.pc s1 = s1:'a asm_state`,
-  full_simp_tac(srw_ss())[asm_state_component_equality,upd_pc_def]);
+Triviality upd_pc_with_pc:
+  upd_pc s1.pc s1 = s1:'a asm_state
+Proof
+  full_simp_tac(srw_ss())[asm_state_component_equality,upd_pc_def]
+QED
 
 Theorem shift_interfer_twice[simp]:
    shift_interfer l' (shift_interfer l c) =
@@ -144,8 +152,8 @@ Proof
   full_simp_tac(srw_ss())[shift_interfer_def,shift_seq_def,AC ADD_COMM ADD_ASSOC]
 QED
 
-val evaluate_nop_steps = Q.prove(
-  `!n s1 ms1 c.
+Triviality evaluate_nop_steps:
+  !n s1 ms1 c.
       encoder_correct c.target /\
       c.prog_addresses = s1.mem_domain /\
       ffi_entry_pcs_disjoint c s1
@@ -166,7 +174,8 @@ val evaluate_nop_steps = Q.prove(
             (upd_pc
               (s1.pc +
                n2w (n * LENGTH (c.target.config.encode (Inst Skip)))) s1)
-            ms2`,
+            ms2
+Proof
   Induct \\ full_simp_tac(srw_ss())[] THEN1
    (rpt strip_tac \\ Q.LIST_EXISTS_TAC [`0`,`ms1`]
     \\ full_simp_tac(srw_ss())[shift_interfer_0,upd_pc_with_pc])
@@ -216,7 +225,8 @@ val evaluate_nop_steps = Q.prove(
   \\ first_x_assum (mp_tac o Q.SPEC `k`)
   \\ first_x_assum (mp_tac o Q.SPEC `k+l'`)
   \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]
-  \\ gvs [word_add_n2w]);
+  \\ gvs [word_add_n2w]
+QED
 
 Theorem ffi_entry_pcs_disjoint_LENGTH_shorter:
 !l1 l2.
@@ -342,11 +352,13 @@ Definition lab_lookup_def:
     | SOME f => lookup k2 f
 End
 
-val lab_lookup_IMP = Q.prove(
-  `(lab_lookup l1 l2 labs = SOME x) ==>
-    (find_pos (Lab l1 l2) labs = x)`,
+Triviality lab_lookup_IMP:
+  (lab_lookup l1 l2 labs = SOME x) ==>
+    (find_pos (Lab l1 l2) labs = x)
+Proof
   full_simp_tac(srw_ss())[lab_lookup_def,find_pos_def,lookup_any_def]
-  \\ BasicProvers.EVERY_CASE_TAC);
+  \\ BasicProvers.EVERY_CASE_TAC
+QED
 
 Definition labs_domain_def:
   labs_domain labs = { (n1, n2) | lab_lookup n1 n2 labs ≠ NONE }
@@ -426,9 +438,11 @@ Proof
   match_mp_tac EVERY2_refl >> simp[]
 QED
 
-val line_similar_trans = Q.prove(
-  `line_similar x y /\ line_similar y z ==> line_similar x z`,
-  Cases_on `x` \\ Cases_on `y` \\ Cases_on `z` \\ fs[line_similar_def]);
+Triviality line_similar_trans:
+  line_similar x y /\ line_similar y z ==> line_similar x z
+Proof
+  Cases_on `x` \\ Cases_on `y` \\ Cases_on `z` \\ fs[line_similar_def]
+QED
 
 Theorem code_similar_trans:
    !c1 c2 c3. code_similar c1 c2 /\ code_similar c2 c3 ==> code_similar c1 c3
@@ -628,16 +642,18 @@ Proof
   Induct_on`lines` \\ rw[sec_pos_val_def]
 QED
 
-val pos_val_thm0 = Q.prove(
-  `∀i pos acc.
+Triviality pos_val_thm0:
+  ∀i pos acc.
     pos_val i pos acc =
       case acc of [] => pos
       | Section k s :: ss =>
         case sec_pos_val i pos s of NONE =>
         pos_val (i - LENGTH (FILTER ($~ o is_Label) s)) (pos + SUM (MAP line_length s)) ss
-        | SOME x => x`,
+        | SOME x => x
+Proof
   ho_match_mp_tac pos_val_ind
-  \\ rw[pos_val_def,sec_pos_val_def,ADD1]);
+  \\ rw[pos_val_def,sec_pos_val_def,ADD1]
+QED
 
 Theorem pos_val_thm:
    (pos_val i pos [] = pos) ∧
@@ -945,8 +961,8 @@ Proof
 QED
 
 (* bytes_in_memory lemmas *)
-val prog_to_bytes_lemma = Q.prove(
-  `!code2 code1 pc i pos.
+Triviality prog_to_bytes_lemma:
+  !code2 code1 pc i pos.
       code_similar code1 code2 /\
       all_enc_ok (mc_conf:('a,'state,'b) machine_config).target.config
         labs ffi_names pos code2 /\
@@ -956,7 +972,8 @@ val prog_to_bytes_lemma = Q.prove(
         (LENGTH bs + pos = pos_val pc pos code2) /\
         (LENGTH bs + pos + LENGTH (line_bytes j) = pos_val (pc+1) pos code2) /\
         line_similar i j /\
-        line_ok mc_conf.target.config labs ffi_names (pos_val pc pos code2) j`,
+        line_ok mc_conf.target.config labs ffi_names (pos_val pc pos code2) j
+Proof
   HO_MATCH_MP_TAC asm_code_length_ind \\ REPEAT STRIP_TAC
   THEN1 (Cases_on `code1` \\ full_simp_tac(srw_ss())[code_similar_def,asm_fetch_aux_def])
   THEN1
@@ -996,18 +1013,21 @@ val prog_to_bytes_lemma = Q.prove(
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[]
   \\ Q.LIST_EXISTS_TAC [`line_bytes x2 ++ bs`,
         `j`,`bs2`] \\ full_simp_tac(srw_ss())[] \\ `pc - 1 + 1 = pc` by decide_tac
-  \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC])
+  \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]
+QED
 
 val prog_to_bytes_lemma = prog_to_bytes_lemma
   |> Q.SPECL [`code2`,`code1`,`pc`,`i`,`0`]
   |> SIMP_RULE std_ss [];
 
-val bytes_in_mem_APPEND = Q.prove(
-  `!xs ys a m md md1.
+Triviality bytes_in_mem_APPEND:
+  !xs ys a m md md1.
       bytes_in_mem a (xs ++ ys) m md md1 <=>
       bytes_in_mem a xs m md md1 /\
-      bytes_in_mem (a + n2w (LENGTH xs)) ys m md md1`,
-  Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def,ADD1,GSYM word_add_n2w,CONJ_ASSOC]);
+      bytes_in_mem (a + n2w (LENGTH xs)) ys m md md1
+Proof
+  Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def,ADD1,GSYM word_add_n2w,CONJ_ASSOC]
+QED
 
 Theorem bytes_in_mem_UPDATE:
    ∀ls a m md md2 w1 w2.
@@ -1028,8 +1048,8 @@ QED
 
 val s1 = ``s1:('a,'a lab_to_target$config,'ffi) labSem$state``;
 
-val IMP_bytes_in_memory = Q.prove(
-  `code_similar code1 code2 /\
+Triviality IMP_bytes_in_memory:
+  code_similar code1 code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     (asm_fetch_aux pc code1 = SOME i) /\
     bytes_in_mem p (prog_to_bytes code2) m (dm:'a word set) dm1 ==>
@@ -1038,20 +1058,23 @@ val IMP_bytes_in_memory = Q.prove(
       line_ok (mc_conf:('a,'state,'b) machine_config).target.config
         labs ffi_names (pos_val pc 0 code2) j /\
       (pos_val (pc+1) 0 code2 = pos_val pc 0 code2 + LENGTH (line_bytes j)) /\
-      line_similar i j`,
+      line_similar i j
+Proof
   rpt strip_tac
   \\ mp_tac prog_to_bytes_lemma \\ fs[] \\ rpt strip_tac
   \\ fs[bytes_in_mem_APPEND]
-  \\ Q.EXISTS_TAC `j` \\ fs[] \\ decide_tac);
+  \\ Q.EXISTS_TAC `j` \\ fs[] \\ decide_tac
+QED
 
-val IMP_bytes_in_memory_JumpReg = Q.prove(
-  `code_similar s1.code code2 /\
+Triviality IMP_bytes_in_memory_JumpReg:
+  code_similar s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (Asm (Asmi (JumpReg r1)) l n)) ==>
     bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
       (mc_conf.target.config.encode (JumpReg r1)) t1.mem t1.mem_domain /\
-    asm_ok (JumpReg r1) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+    asm_ok (JumpReg r1) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1061,7 +1084,8 @@ val IMP_bytes_in_memory_JumpReg = Q.prove(
   \\ fs[line_ok_def,enc_with_nop_thm] \\ srw_tac[][] \\ fs[]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
 fun get_thms ty = { case_def = TypeBase.case_def_of ty, nchotomy = TypeBase.nchotomy_of ty }
 val lab_thms = get_thms ``:lab``
@@ -1071,8 +1095,8 @@ val bool_case_eq_thms = map (fn th =>
   let val v = th |> concl |> lhs |> rhs
   in th |> GEN v |> Q.ISPEC`T` |> SIMP_RULE bool_ss [] end) case_eq_thms0
 
-val IMP_bytes_in_memory_Jump = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Jump:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (Jump jtarget) l bytes n)) ==>
@@ -1082,7 +1106,8 @@ val IMP_bytes_in_memory_Jump = Q.prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1095,10 +1120,11 @@ val IMP_bytes_in_memory_Jump = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
-val IMP_bytes_in_memory_JumpCmp = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_JumpCmp:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)) ==>
@@ -1108,7 +1134,8 @@ val IMP_bytes_in_memory_JumpCmp = Q.prove(
       (enc = mc_conf.target.config.encode (JumpCmp cmp rr ri tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1121,10 +1148,11 @@ val IMP_bytes_in_memory_JumpCmp = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
-val IMP_bytes_in_memory_JumpCmp_1 = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_JumpCmp_1:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)) ==>
@@ -1135,7 +1163,8 @@ val IMP_bytes_in_memory_JumpCmp_1 = Q.prove(
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (JumpCmp cmp rr ri tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1148,24 +1177,27 @@ val IMP_bytes_in_memory_JumpCmp_1 = Q.prove(
   \\ Q.EXISTS_TAC `l'` \\ fs[enc_with_nop_thm,PULL_EXISTS,line_length_def]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[line_bytes_def]
   \\ rveq \\ fs[lab_inst_def]
-  \\ metis_tac[]);
+  \\ metis_tac[]
+QED
 
-val IMP_bytes_in_memory_Call = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Call:
+  code_similar ^s1.code code2 /\
     all_enc_ok
       (mc_conf: ('a,'state,'b) machine_config).target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem
       (t1:'a asm_state).mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (Call ww) l bytes n)) ==>
-    F`,
+    F
+Proof
   rpt strip_tac
   \\ full_simp_tac(srw_ss())[asm_fetch_def,LET_DEF]
   \\ imp_res_tac IMP_bytes_in_memory
   \\ Cases_on `j` \\ full_simp_tac(srw_ss())[line_similar_def] \\ srw_tac[][]
-  \\ full_simp_tac(srw_ss())[line_ok_def] \\ rev_full_simp_tac(srw_ss())[]);
+  \\ full_simp_tac(srw_ss())[line_ok_def] \\ rev_full_simp_tac(srw_ss())[]
+QED
 
-val IMP_bytes_in_memory_LocValue = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_LocValue:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (LocValue reg (Lab l1 l2)) l bytes n)) ==>
@@ -1176,7 +1208,8 @@ val IMP_bytes_in_memory_LocValue = Q.prove(
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (Loc reg tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Loc reg tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1189,10 +1222,11 @@ val IMP_bytes_in_memory_LocValue = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND] \\ srw_tac[][] \\ metis_tac[]);
+         bytes_in_memory_APPEND] \\ srw_tac[][] \\ metis_tac[]
+QED
 
-val IMP_bytes_in_memory_Inst = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Inst:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (Asm (Asmi(Inst i)) bytes len)) ==>
@@ -1203,7 +1237,8 @@ val IMP_bytes_in_memory_Inst = Q.prove(
       bytes_in_mem ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain s1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (Inst i) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Inst i) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1216,10 +1251,11 @@ val IMP_bytes_in_memory_Inst = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND] \\ srw_tac[][]);
+         bytes_in_memory_APPEND] \\ srw_tac[][]
+QED
 
-val IMP_bytes_in_memory_Cbw = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Cbw:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (Asm (Cbw r1 r2) bytes len)) ==>
@@ -1230,7 +1266,8 @@ val IMP_bytes_in_memory_Cbw = Q.prove(
       bytes_in_mem ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         bytes t1.mem t1.mem_domain s1.mem_domain /\
       (pos_val (s1.pc+1) 0 code2 = pos_val s1.pc 0 code2 + LENGTH bytes) /\
-      asm_ok (Inst (Mem Store8 r2 (Addr r1 0w))) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Inst (Mem Store8 r2 (Addr r1 0w))) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1243,10 +1280,11 @@ val IMP_bytes_in_memory_Cbw = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND] \\ srw_tac[][]);
+         bytes_in_memory_APPEND] \\ srw_tac[][]
+QED
 
-val IMP_bytes_in_memory_CallFFI = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_CallFFI:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm (CallFFI name) l bytes n)) ==>
@@ -1255,7 +1293,8 @@ val IMP_bytes_in_memory_CallFFI = Q.prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1266,10 +1305,11 @@ val IMP_bytes_in_memory_CallFFI = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
-val IMP_bytes_in_memory_Halt = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Halt:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm Halt l bytes n)) ==>
@@ -1278,7 +1318,8 @@ val IMP_bytes_in_memory_Halt = Q.prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def,LET_DEF]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1289,10 +1330,11 @@ val IMP_bytes_in_memory_Halt = Q.prove(
   \\ fs[LET_DEF,lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
-val IMP_bytes_in_memory_Install = Q.prove(
-  `code_similar ^s1.code code2 /\
+Triviality IMP_bytes_in_memory_Install:
+  code_similar ^s1.code code2 /\
     all_enc_ok mc_conf.target.config labs ffi_names 0 code2 /\
     bytes_in_mem p (prog_to_bytes code2) t1.mem t1.mem_domain s1.mem_domain /\
     (asm_fetch s1 = SOME (LabAsm Install c l n)) ==>
@@ -1301,7 +1343,8 @@ val IMP_bytes_in_memory_Install = Q.prove(
       (enc = mc_conf.target.config.encode (Jump tt)) /\
       bytes_in_memory ((p:'a word) + n2w (pos_val s1.pc 0 code2))
         enc t1.mem t1.mem_domain /\
-      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config`,
+      asm_ok (Jump tt) (mc_conf: ('a,'state,'b) machine_config).target.config
+Proof
   fs[asm_fetch_def]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`) \\ strip_tac
   \\ Q.SPEC_TAC (`s1.code`,`code1`) \\ strip_tac \\ strip_tac
@@ -1312,7 +1355,8 @@ val IMP_bytes_in_memory_Install = Q.prove(
   \\ fs[lab_inst_def,get_label_def] \\ srw_tac[][]
   \\ imp_res_tac bytes_in_mem_IMP \\ fs[]
   \\ fs[asm_fetch_aux_def,prog_to_bytes_def,LET_DEF,line_bytes_def,
-         bytes_in_memory_APPEND]);
+         bytes_in_memory_APPEND]
+QED
 
 Theorem all_enc_ok_asm_fetch_aux_IMP_line_ok:
   !pc n code2.
@@ -1420,22 +1464,25 @@ Proof
   \\ gvs[line_length_def,enc_with_nop_thm,FLAT_REPLICATE_NIL]
 QED
 
-val bytes_in_mem_IMP_memory = Q.prove(
-  `!xs a.
+Triviality bytes_in_mem_IMP_memory:
+  !xs a.
       (!a. ~(a IN dm1) ==> m a = m1 a) ==>
       bytes_in_mem a xs m dm dm1 ==>
-      bytes_in_memory a xs m1 dm`,
-  Induct \\ full_simp_tac(srw_ss())[bytes_in_memory_def,bytes_in_mem_def]);
+      bytes_in_memory a xs m1 dm
+Proof
+  Induct \\ full_simp_tac(srw_ss())[bytes_in_memory_def,bytes_in_mem_def]
+QED
 
 (* read/write bytearrays for FFI *)
 
-val read_bytearray_state_rel = Q.prove(
-  `!n a x.
+Triviality read_bytearray_state_rel:
+  !n a x.
       state_rel (mc_conf,code2,labs,p) s1 t1 ms1 /\
       (read_bytearray a n (mem_load_byte_aux s1.mem s1.mem_domain s1.be) = SOME x) ==>
       (read_bytearray a n
         (\a. if a IN mc_conf.prog_addresses then SOME (t1.mem a) else NONE) =
-       SOME x)`,
+       SOME x)
+Proof
   Induct
   \\ full_simp_tac(srw_ss())[read_bytearray_def]
   \\ rpt strip_tac
@@ -1445,11 +1492,13 @@ val read_bytearray_state_rel = Q.prove(
   \\ Cases_on `s1.mem (byte_align a)` \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ FIRST_X_ASSUM (Q.SPEC_THEN `a` mp_tac) \\ full_simp_tac(srw_ss())[]
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[word_loc_val_def]
-  \\ rev_full_simp_tac(srw_ss())[word_loc_val_byte_def,word_loc_val_def]);
+  \\ rev_full_simp_tac(srw_ss())[word_loc_val_byte_def,word_loc_val_def]
+QED
 
-val IMP_has_io_name = Q.prove(
-  `(asm_fetch s1 = SOME (LabAsm (CallFFI index) l bytes n)) ==>
-    has_io_name index s1.code`,
+Triviality IMP_has_io_name:
+  (asm_fetch s1 = SOME (LabAsm (CallFFI index) l bytes n)) ==>
+    has_io_name index s1.code
+Proof
   full_simp_tac(srw_ss())[asm_fetch_def]
   \\ Q.SPEC_TAC (`s1.pc`,`pc`)
   \\ Q.SPEC_TAC (`s1.code`,`code`)
@@ -1457,21 +1506,25 @@ val IMP_has_io_name = Q.prove(
   \\ full_simp_tac(srw_ss())[asm_fetch_aux_def,has_io_name_def] \\ res_tac
   \\ Cases_on `is_Label y` \\ full_simp_tac(srw_ss())[]
   THEN1 (Cases_on `y` \\ full_simp_tac(srw_ss())[is_Label_def] \\ res_tac)
-  \\ Cases_on `pc = 0` \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[]);
+  \\ Cases_on `pc = 0` \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[]
+QED
 
-val bytes_in_mem_asm_write_bytearray_lemma = Q.prove(
-  `!xs p.
+Triviality bytes_in_mem_asm_write_bytearray_lemma:
+  !xs p.
       (!a. ~(a IN k) ==> (m1 a = m2 a)) ==>
       bytes_in_mem p xs m1 d k ==>
-      bytes_in_mem p xs m2 d k`,
-  Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def]);
+      bytes_in_mem p xs m2 d k
+Proof
+  Induct \\ full_simp_tac(srw_ss())[bytes_in_mem_def]
+QED
 
-val bytes_in_mem_asm_write_bytearray = Q.prove(
-  `(∀a. byte_align a ∈ s1.mem_domain ⇒ a ∈ s1.mem_domain) ∧
+Triviality bytes_in_mem_asm_write_bytearray:
+  (∀a. byte_align a ∈ s1.mem_domain ⇒ a ∈ s1.mem_domain) ∧
     (read_bytearray c1 (LENGTH new_bytes) (mem_load_byte_aux s1.mem s1.mem_domain s1.be) = SOME x) ==>
     bytes_in_mem p xs t1.mem t1.mem_domain s1.mem_domain ==>
     bytes_in_mem p xs
-      (asm_write_bytearray c1 new_bytes t1.mem) t1.mem_domain s1.mem_domain`,
+      (asm_write_bytearray c1 new_bytes t1.mem) t1.mem_domain s1.mem_domain
+Proof
   STRIP_TAC \\ match_mp_tac bytes_in_mem_asm_write_bytearray_lemma
   \\ POP_ASSUM MP_TAC
   \\ Q.SPEC_TAC (`c1`,`a`)
@@ -1488,20 +1541,23 @@ val bytes_in_mem_asm_write_bytearray = Q.prove(
   \\ full_simp_tac(srw_ss())[mem_load_byte_aux_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ srw_tac[][combinTheory.APPLY_UPDATE_THM]
-  \\ full_simp_tac(srw_ss())[] \\ res_tac);
+  \\ full_simp_tac(srw_ss())[] \\ res_tac
+QED
 
-val write_bytearray_NOT_Loc = Q.prove(
-  `!xs c1 s1 a c.
+Triviality write_bytearray_NOT_Loc:
+  !xs c1 s1 a c.
       (s1.mem a = Word c) ==>
-      (write_bytearray c1 xs s1.mem s1.mem_domain s1.be) a <> Loc n n0`,
+      (write_bytearray c1 xs s1.mem s1.mem_domain s1.be) a <> Loc n n0
+Proof
   Induct \\ full_simp_tac(srw_ss())[write_bytearray_def,mem_store_byte_aux_def]
   \\ rpt strip_tac \\ res_tac
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[labSemTheory.upd_mem_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]
-  \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[]);
+  \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[]
+QED
 
-val CallFFI_bytearray_lemma = Q.prove(
-  `byte_align (a:'a word) IN s1.mem_domain /\ good_dimindex (:'a) /\
+Triviality CallFFI_bytearray_lemma:
+  byte_align (a:'a word) IN s1.mem_domain /\ good_dimindex (:'a) /\
     a IN t1.mem_domain /\
     a IN s1.mem_domain /\
     (s1.be = mc_conf.target.config.big_endian) /\
@@ -1510,7 +1566,8 @@ val CallFFI_bytearray_lemma = Q.prove(
        SOME (t1.mem a)) ==>
     (word_loc_val_byte p labs (write_bytearray c1 new_bytes s1.mem s1.mem_domain s1.be) a
        mc_conf.target.config.big_endian =
-     SOME (asm_write_bytearray c1 new_bytes t1.mem a))`,
+     SOME (asm_write_bytearray c1 new_bytes t1.mem a))
+Proof
   Q.SPEC_TAC (`s1`,`s1`) \\ Q.SPEC_TAC (`t1`,`t1`) \\ Q.SPEC_TAC (`c1`,`c1`)
   \\ Q.SPEC_TAC (`x`,`x`) \\ Q.SPEC_TAC (`new_bytes`,`xs`) \\ Induct
   \\ full_simp_tac(srw_ss())[asm_write_bytearray_def,write_bytearray_def,read_bytearray_def]
@@ -1533,28 +1590,33 @@ val CallFFI_bytearray_lemma = Q.prove(
   \\ full_simp_tac(srw_ss())[labSemTheory.upd_mem_def,word_loc_val_byte_def,APPLY_UPDATE_THM]
   \\ Cases_on `a = c1` \\ full_simp_tac(srw_ss())[word_loc_val_def,good_dimindex_get_byte_set_byte]
   \\ Cases_on `byte_align c1 = byte_align a` \\ full_simp_tac(srw_ss())[word_loc_val_def]
-  \\ full_simp_tac(srw_ss())[get_byte_set_byte_diff]);
+  \\ full_simp_tac(srw_ss())[get_byte_set_byte_diff]
+QED
 
 (* inst correct *)
 
-val MULT_ADD_LESS_MULT = Q.prove(
-  `!m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num`,
+Triviality MULT_ADD_LESS_MULT:
+  !m n k l j. m < l /\ n < k /\ j <= k ==> m * j + n < l * k:num
+Proof
   rpt strip_tac
   \\ `SUC m <= l` by asm_rewrite_tac [GSYM LESS_EQ]
   \\ `m * k + k <= l * k` by asm_simp_tac bool_ss [LE_MULT_RCANCEL,GSYM MULT]
   \\ `m * j <= m * k` by asm_simp_tac bool_ss [LE_MULT_LCANCEL]
-  \\ decide_tac);
+  \\ decide_tac
+QED
 
-val aligned_IMP_ADD_LESS_dimword = Q.prove(
-  `aligned k (x:'a word) /\ k <= dimindex (:'a) ==>
-    w2n x + (2 ** k - 1) < dimword (:'a)`,
+Triviality aligned_IMP_ADD_LESS_dimword:
+  aligned k (x:'a word) /\ k <= dimindex (:'a) ==>
+    w2n x + (2 ** k - 1) < dimword (:'a)
+Proof
   Cases_on `x` \\ fs [aligned_w2n,dimword_def] \\ rw []
   \\ full_simp_tac std_ss [ONCE_REWRITE_RULE [ADD_COMM]LESS_EQ_EXISTS]
   \\ pop_assum (fn th => full_simp_tac std_ss [th])
   \\ full_simp_tac std_ss [MOD_EQ_0_DIVISOR]
   \\ var_eq_tac
   \\ full_simp_tac std_ss [EXP_ADD]
-  \\ match_mp_tac MULT_ADD_LESS_MULT \\ fs []);
+  \\ match_mp_tac MULT_ADD_LESS_MULT \\ fs []
+QED
 
 Theorem aligned_2_imp:
    aligned 2 (x:'a word) /\ dimindex (:'a) = 32 ==>
@@ -1610,16 +1672,18 @@ Proof
     metis_tac[aligned_3_imp]
 QED
 
-val dimword_eq_32_imp_or_bytes = Q.prove(
-  `dimindex (:'a) = 32 ==>
+Triviality dimword_eq_32_imp_or_bytes:
+  dimindex (:'a) = 32 ==>
     (w2w ((w2w (x:'a word)):word8) ||
      w2w ((w2w (x ⋙ 8)):word8) ≪ 8 ||
      w2w ((w2w (x ⋙ 16)):word8) ≪ 16 ||
-     w2w ((w2w (x ⋙ 24)):word8) ≪ 24) = x`,
-  srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [])
+     w2w ((w2w (x ⋙ 24)):word8) ≪ 24) = x
+Proof
+  srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] []
+QED
 
-val dimword_eq_64_imp_or_bytes = Q.prove(
-  `dimindex (:'a) = 64 ==>
+Triviality dimword_eq_64_imp_or_bytes:
+  dimindex (:'a) = 64 ==>
     (w2w ((w2w (x:'a word)):word8) ||
      w2w ((w2w (x ⋙ 8)):word8) ≪ 8 ||
      w2w ((w2w (x ⋙ 16)):word8) ≪ 16 ||
@@ -1627,35 +1691,42 @@ val dimword_eq_64_imp_or_bytes = Q.prove(
      w2w ((w2w (x ⋙ 32)):word8) ≪ 32 ||
      w2w ((w2w (x ⋙ 40)):word8) ≪ 40 ||
      w2w ((w2w (x ⋙ 48)):word8) ≪ 48 ||
-     w2w ((w2w (x ⋙ 56)):word8) ≪ 56) = x`,
-  srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] [])
+     w2w ((w2w (x ⋙ 56)):word8) ≪ 56) = x
+Proof
+  srw_tac [wordsLib.WORD_BIT_EQ_ss, boolSimps.CONJ_ss] []
+QED
 
-val byte_align_32_eq = Q.prove(`
+Triviality byte_align_32_eq:
   dimindex (:'a) = 32 ⇒
-  byte_align (a:'a word) +n2w (w2n a MOD 4) = a`,
+  byte_align (a:'a word) +n2w (w2n a MOD 4) = a
+Proof
   Cases_on`a`>>
   rw[alignmentTheory.byte_align_def]>>
   fs[alignmentTheory.align_w2n,word_add_n2w]>>rfs[dimword_def]>>
   Q.SPEC_THEN `4n` mp_tac DIVISION>>
   fs[]>>disch_then (Q.SPEC_THEN`n` assume_tac)>>
-  simp[])
+  simp[]
+QED
 
-val byte_align_64_eq = Q.prove(`
+Triviality byte_align_64_eq:
   dimindex (:'a) = 64 ⇒
-  byte_align (a:'a word) +n2w (w2n a MOD 8) = a`,
+  byte_align (a:'a word) +n2w (w2n a MOD 8) = a
+Proof
   Cases_on`a`>>
   rw[alignmentTheory.byte_align_def]>>
   fs[alignmentTheory.align_w2n,word_add_n2w]>>rfs[dimword_def]>>
   Q.SPEC_THEN `8n` mp_tac DIVISION>>
   fs[]>>disch_then (Q.SPEC_THEN`n` assume_tac)>>
-  simp[])
+  simp[]
+QED
 
-val byte_align_32_IMP = Q.prove(`
+Triviality byte_align_32_IMP:
   dimindex(:'a) = 32 ⇒
   (byte_align a = a ⇒ w2n a MOD 4 = 0) ∧
   (byte_align a + (1w:'a word) = a ⇒ w2n a MOD 4 = 1) ∧
   (byte_align a + (2w:'a word) = a ⇒ w2n a MOD 4 = 2) ∧
-  (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 4 = 3)`,
+  (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 4 = 3)
+Proof
   rw[]>>imp_res_tac byte_align_32_eq>>fs[]>>
   qpat_x_assum`_=a` mp_tac>>
   qabbrev_tac`ba = byte_align a`>>
@@ -1666,36 +1737,43 @@ val byte_align_32_IMP = Q.prove(`
   Q.ISPECL_THEN[`32n`,`w2n a MOD 4`] assume_tac bitTheory.MOD_ZERO_GT>>
   fs[]>>
   Q.ISPECL_THEN [`w2n a`,`4n`] assume_tac MOD_LESS>>
-  DECIDE_TAC);
+  DECIDE_TAC
+QED
 
-val MOD4_CASES = Q.prove(`
-  ∀n. n MOD 4 = 0 ∨ n MOD 4 = 1 ∨ n MOD 4 = 2 ∨ n MOD 4 = 3`,
+Triviality MOD4_CASES:
+  ∀n. n MOD 4 = 0 ∨ n MOD 4 = 1 ∨ n MOD 4 = 2 ∨ n MOD 4 = 3
+Proof
   rw[]>>`n MOD 4 < 4` by fs []
   \\ IMP_RES_TAC (DECIDE
        ``n < 4 ==> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num)``)
-  \\ fs [])
+  \\ fs []
+QED
 
-val byte_align_32_CASES = Q.prove(`
+Triviality byte_align_32_CASES:
   dimindex(:'a) = 32 ⇒
   byte_align a + (3w:'a word) = a ∨
   byte_align a + (2w:'a word) = a ∨
   byte_align a + (1w:'a word) = a ∨
-  byte_align a = a`,
+  byte_align a = a
+Proof
   rw[]>>imp_res_tac byte_align_32_eq>>
   pop_assum(qspec_then`a` assume_tac)>>
   Q.SPEC_THEN `w2n a` mp_tac MOD4_CASES>>rw[]>>
-  fs[])
+  fs[]
+QED
 
-val MOD8_CASES = Q.prove(`
+Triviality MOD8_CASES:
   ∀n. n MOD 8 = 0 ∨ n MOD 8 = 1 ∨ n MOD 8 = 2 ∨ n MOD 8 = 3 ∨
-      n MOD 8 = 4 ∨ n MOD 8 = 5 ∨ n MOD 8 = 6 ∨ n MOD 8 = 7`,
+      n MOD 8 = 4 ∨ n MOD 8 = 5 ∨ n MOD 8 = 6 ∨ n MOD 8 = 7
+Proof
   rw[]>>`n MOD 8 < 8` by fs []
   \\ IMP_RES_TAC (DECIDE
        ``n < 8 ==> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num) \/
                    (n = 4) \/ (n = 5) \/ (n = 6) \/ (n = 7)``)
-  \\ fs [])
+  \\ fs []
+QED
 
-val byte_align_64_CASES = Q.prove(`
+Triviality byte_align_64_CASES:
   dimindex(:'a) = 64 ⇒
   byte_align a + (7w:'a word) = a ∨
   byte_align a + (6w:'a word) = a ∨
@@ -1704,13 +1782,15 @@ val byte_align_64_CASES = Q.prove(`
   byte_align a + (3w:'a word) = a ∨
   byte_align a + (2w:'a word) = a ∨
   byte_align a + (1w:'a word) = a ∨
-  byte_align a = a`,
+  byte_align a = a
+Proof
   rw[]>>imp_res_tac byte_align_64_eq>>
   pop_assum(qspec_then`a` assume_tac)>>
   Q.SPEC_THEN `w2n a` mp_tac MOD8_CASES>>rw[]>>
-  fs[])
+  fs[]
+QED
 
-val byte_align_64_IMP = Q.prove(`
+Triviality byte_align_64_IMP:
   dimindex(:'a) = 64 ⇒
   (byte_align a + (7w:'a word) = a ⇒ w2n a MOD 8 = 7) ∧
   (byte_align a + (6w:'a word) = a ⇒ w2n a MOD 8 = 6) ∧
@@ -1719,7 +1799,8 @@ val byte_align_64_IMP = Q.prove(`
   (byte_align a + (3w:'a word) = a ⇒ w2n a MOD 8 = 3) ∧
   (byte_align a + (2w:'a word) = a ⇒ w2n a MOD 8 = 2) ∧
   (byte_align a + (1w:'a word) = a ⇒ w2n a MOD 8 = 1) ∧
-  (byte_align a = a ⇒ w2n a MOD 8 = 0)`,
+  (byte_align a = a ⇒ w2n a MOD 8 = 0)
+Proof
   rw[]>>imp_res_tac byte_align_64_eq>>fs[]>>
   qpat_x_assum`_=a` mp_tac>>
   qabbrev_tac`ba = byte_align a`>>
@@ -1730,12 +1811,14 @@ val byte_align_64_IMP = Q.prove(`
   Q.ISPECL_THEN[`64n`,`w2n a MOD 8`] assume_tac bitTheory.MOD_ZERO_GT>>
   fs[]>>
   Q.ISPECL_THEN [`w2n a`,`8n`] assume_tac MOD_LESS>>
-  DECIDE_TAC)
+  DECIDE_TAC
+QED
 
-val arith_upd_lemma = Q.prove(
-  `(∀r. word_loc_val p labs (read_reg r s1) = SOME (t1.regs r)) ∧ ¬(arith_upd a s1).failed ⇒
+Triviality arith_upd_lemma:
+  (∀r. word_loc_val p labs (read_reg r s1) = SOME (t1.regs r)) ∧ ¬(arith_upd a s1).failed ⇒
    ∀r. word_loc_val p labs (read_reg r (arith_upd a s1)) =
-       SOME ((arith_upd a t1).regs r)`,
+       SOME ((arith_upd a t1).regs r)
+Proof
   Cases_on`a`>>srw_tac[][arith_upd_def]>- (
     every_case_tac >> full_simp_tac(srw_ss())[] >>
     EVAL_TAC >> srw_tac[][] >>
@@ -1773,7 +1856,8 @@ val arith_upd_lemma = Q.prove(
     \\ every_case_tac \\ fs[]
     \\ EVAL_TAC \\ rw[] \\ EVAL_TAC \\ fs[]
     \\ fs[read_reg_def]
-    \\ fs[labSemTheory.assert_def]));
+    \\ fs[labSemTheory.assert_def])
+QED
 
 (* The lab and asm versions should be in their individual props *)
 Theorem arith_upd_fp_regs[simp]:
@@ -1786,14 +1870,15 @@ Proof
   fs[]
 QED
 
-val fp_upd_lemma = Q.prove(`
+Triviality fp_upd_lemma:
   (∀r. word_loc_val p labs (read_reg r s1) = SOME (t1.regs r)) ∧
   (!r. s1.fp_regs r = t1.fp_regs r) /\
    ¬(fp_upd f s1).failed ⇒
   (∀r. (fp_upd f s1).fp_regs r = (fp_upd f t1).fp_regs r) ∧
   ∀r.
     word_loc_val p labs (read_reg r (fp_upd f s1)) =
-    SOME ((fp_upd f t1).regs r)`,
+    SOME ((fp_upd f t1).regs r)
+Proof
   strip_tac>>Cases_on`f`>>fs[fp_upd_def,read_fp_reg_def,labSemTheory.read_fp_reg_def,upd_reg_def,labSemTheory.upd_reg_def]>>
   TRY(rw[]>>EVAL_TAC>>rw[]>>EVAL_TAC>>NO_TAC)
   >-
@@ -1812,7 +1897,8 @@ val fp_upd_lemma = Q.prove(`
   >>
     TOP_CASE_TAC>>rfs[]>>fs[labSemTheory.assert_def]>>
     IF_CASES_TAC>>fs[]>>
-    rw[]>>EVAL_TAC>>rw[]);
+    rw[]>>EVAL_TAC>>rw[]
+QED
 
 Theorem Inst_share_mem_pc_update_helper:
   share_mem_state_rel mc_conf s1 t1 ms1 /\
@@ -2248,22 +2334,26 @@ QED
 
 (* compile correct *)
 
-val line_length_MOD_0 = Q.prove(
-  `encoder_correct mc_conf.target /\
+Triviality line_length_MOD_0:
+  encoder_correct mc_conf.target /\
     (~EVEN p ==> (mc_conf.target.config.code_alignment = 0)) /\
     line_ok mc_conf.target.config labs ffi_names p h ==>
-    (line_length h MOD 2 ** mc_conf.target.config.code_alignment = 0)`,
+    (line_length h MOD 2 ** mc_conf.target.config.code_alignment = 0)
+Proof
   Cases_on `h` \\ TRY (Cases_on `a`) \\ full_simp_tac(srw_ss())[line_ok_def,line_length_def]
   \\ srw_tac[][]
   \\ full_simp_tac(srw_ss())[encoder_correct_def,target_ok_def,enc_ok_def]
   \\ fs(bool_case_eq_thms)
   \\ full_simp_tac(srw_ss())[LET_DEF,enc_with_nop_thm] \\ srw_tac[][LENGTH_FLAT,LENGTH_REPLICATE]
   \\ qpat_x_assum `2 ** nn = xx:num` (ASSUME_TAC o GSYM) \\ full_simp_tac(srw_ss())[]
-  \\ full_simp_tac(srw_ss())[LET_DEF,map_replicate,SUM_REPLICATE]);
+  \\ full_simp_tac(srw_ss())[LET_DEF,map_replicate,SUM_REPLICATE]
+QED
 
-val pos_val_MOD_0_lemma = Q.prove(
-  `(0 MOD 2 ** mc_conf.target.config.code_alignment = 0)`,
-  full_simp_tac(srw_ss())[]);
+Triviality pos_val_MOD_0_lemma:
+  (0 MOD 2 ** mc_conf.target.config.code_alignment = 0)
+Proof
+  full_simp_tac(srw_ss())[]
+QED
 
 val pos_val_MOD_0 = Q.prove(
   `!x pos code2.
@@ -2315,10 +2405,11 @@ Proof
   simp[]
 QED
 
-val word_cmp_lemma = Q.prove(
-  `state_rel (mc_conf,code2,labs,p) s1 t1 ms1 /\
+Triviality word_cmp_lemma:
+  state_rel (mc_conf,code2,labs,p) s1 t1 ms1 /\
     (word_cmp cmp (read_reg rr s1) (reg_imm ri s1) = SOME x) ==>
-    (x = word_cmp cmp (read_reg rr t1) (reg_imm ri t1))`,
+    (x = word_cmp cmp (read_reg rr t1) (reg_imm ri t1))
+Proof
   Cases_on `ri` \\ full_simp_tac(srw_ss())[labSemTheory.reg_imm_def,asmSemTheory.reg_imm_def]
   \\ full_simp_tac(srw_ss())[asmSemTheory.read_reg_def]
   \\ Cases_on `s1.regs rr` \\ full_simp_tac(srw_ss())[]
@@ -2334,13 +2425,15 @@ val word_cmp_lemma = Q.prove(
   \\ rpt (qpat_x_assum `1w = xxx` (fn th => full_simp_tac(srw_ss())[GSYM th]))
   \\ rpt (qpat_x_assum `p + n2w xxx = t1.regs rr` (fn th => full_simp_tac(srw_ss())[GSYM th]))
   \\ res_tac \\ full_simp_tac(srw_ss())[]
-  \\ metis_tac[EVEN_add_AND]);
+  \\ metis_tac[EVEN_add_AND]
+QED
 
-val list_add_if_fresh_simp = Q.prove(`
+Triviality list_add_if_fresh_simp:
   !n s. list_add_if_fresh s l =
     if find_index s l n = NONE then
       APPEND l [s]
-    else l`,
+    else l
+Proof
   Induct_on `l`
   >- fs [list_add_if_fresh_def, find_index_def]
   >-
@@ -2349,7 +2442,8 @@ val list_add_if_fresh_simp = Q.prove(`
      >> FIRST_X_ASSUM (fn thm => ASSUME_TAC(Q.SPEC `s` thm))
      >> fs [list_add_if_fresh_def, find_index_def]
      >> every_case_tac
-     >> fs [list_add_if_fresh_def, find_index_def]))
+     >> fs [list_add_if_fresh_def, find_index_def])
+QED
 
 Theorem list_add_if_fresh_thm:
    list_add_if_fresh s l =
@@ -2361,9 +2455,10 @@ QED
 
 val list_add_if_fresh_simp = Q.SPECL [`n`,`s`] list_add_if_fresh_simp
 
-val find_index_append = Q.prove(`
+Triviality find_index_append:
   !n. find_index s (l++l') n =
-  (case find_index s l n of NONE => find_index s l' (n + LENGTH l) | SOME i => SOME i)`,
+  (case find_index s l n of NONE => find_index s l' (n + LENGTH l) | SOME i => SOME i)
+Proof
   Induct_on `l`
   >- fs [find_index_def]
   >-
@@ -2371,11 +2466,13 @@ val find_index_append = Q.prove(`
    >> FIRST_X_ASSUM (fn thm => ASSUME_TAC(Q.SPEC `n+1` thm))
    >> fs [find_index_def]
    >> every_case_tac
-   >> fs [find_index_def,ADD1]))
+   >> fs [find_index_def,ADD1])
+QED
 
-val has_io_name_find_index = Q.prove(`
+Triviality has_io_name_find_index:
   !l s. has_io_name s l
-  ==> ?y. find_index (ExtCall s) (find_ffi_names l) 0 = SOME y`,
+  ==> ?y. find_index (ExtCall s) (find_ffi_names l) 0 = SOME y
+Proof
   ho_match_mp_tac find_ffi_names_ind
   >> rpt strip_tac
   >> fs[has_io_name_def,find_index_def, find_ffi_names_def,Q.INST [`n`|->`0`] list_add_if_fresh_simp,find_index_append]
@@ -2385,20 +2482,25 @@ val has_io_name_find_index = Q.prove(`
   >> fs[has_io_name_def,find_index_def, find_ffi_names_def,Q.INST [`n`|->`0`] list_add_if_fresh_simp,find_index_append]
   >- metis_tac [NOT_NONE_SOME]
   >- (Cases_on `find_index (ExtCall s) (find_ffi_names (Section k xs::rest)) 0`
-      >> metis_tac [NOT_NONE_SOME]))
+      >> metis_tac [NOT_NONE_SOME])
+QED
 
-val find_index_in_range = Q.prove(`
-  !n. find_index s l n = SOME x ==> x < n + LENGTH l /\ x >= n`,
+Triviality find_index_in_range:
+  !n. find_index s l n = SOME x ==> x < n + LENGTH l /\ x >= n
+Proof
   Induct_on `l`
   >> fs [find_index_def]
   >> rpt strip_tac
   >> every_case_tac
   >> FIRST_X_ASSUM (fn thm => TRY(ASSUME_TAC(Q.SPEC `n+1` thm)))
-  >> rfs [find_index_def])
+  >> rfs [find_index_def]
+QED
 
-val find_index_in_range0 = Q.prove(`
-  find_index s l 0 = SOME x ==> x < LENGTH l /\ x >= 0`,
-  ASSUME_TAC (Q.SPEC `0` find_index_in_range) >> rfs [])
+Triviality find_index_in_range0:
+  find_index s l 0 = SOME x ==> x < LENGTH l /\ x >= 0
+Proof
+  ASSUME_TAC (Q.SPEC `0` find_index_in_range) >> rfs []
+QED
 
 Theorem EL_get_ffi_index_MEM:
    MEM s ls ⇒ EL (get_ffi_index ls s) ls = s
@@ -2473,14 +2575,16 @@ End
 
 val enc_lines_again_simp_ind = theorem"enc_lines_again_simp_ind";
 
-val enc_lines_again_simp_EQ = Q.prove(`
+Triviality enc_lines_again_simp_EQ:
   ∀labs ffis pos enc ls acc b.
   let (ls',flag) = enc_lines_again_simp labs ffis pos enc ls in
-  enc_lines_again labs ffis pos enc ls (acc,b) = (REVERSE acc ++ ls',sec_length ls' pos,b ∧ flag)`,
+  enc_lines_again labs ffis pos enc ls (acc,b) = (REVERSE acc ++ ls',sec_length ls' pos,b ∧ flag)
+Proof
   ho_match_mp_tac enc_lines_again_simp_ind >>
   fs[enc_lines_again_simp_def,enc_lines_again_def]>>rw[sec_length_def]>>
   rpt(pairarg_tac>>fs[])>>
-  rw[EQ_IMP_THM,sec_length_def])
+  rw[EQ_IMP_THM,sec_length_def]
+QED
 
 Theorem enc_lines_again_simp_len:
    ∀labs ffis pos enc lines res.
@@ -2595,12 +2699,14 @@ QED
 
 (* code_similar preservation *)
 
-val line_similar_add_nop = Q.prove(`
+Triviality line_similar_add_nop:
   ∀ls ls' h.
   LIST_REL line_similar ls ls' ⇒
-  LIST_REL line_similar ls (add_nop h ls')`,
+  LIST_REL line_similar ls (add_nop h ls')
+Proof
   Induct_on`ls`>>rw[add_nop_def]>>
-  Cases_on`y`>>Cases_on`h`>>fs[add_nop_def,line_similar_def]);
+  Cases_on`y`>>Cases_on`h`>>fs[add_nop_def,line_similar_def]
+QED
 
 Theorem line_similar_pad_section:
    ∀nop l2 aux l1.
@@ -2648,12 +2754,14 @@ Proof
   simp[]
 QED
 
-val LIST_REL_enc_line = Q.prove(`
+Triviality LIST_REL_enc_line:
   ∀ls ls'.
   LIST_REL line_similar ls ls' ⇔
-  LIST_REL line_similar (MAP (enc_line enc len) ls) ls'` ,
+  LIST_REL line_similar (MAP (enc_line enc len) ls) ls'
+Proof
   Induct>>rw[]>>Cases_on`h`>>rw[enc_line_def,EQ_IMP_THM]>>Cases_on`y`>>
-  fs[line_similar_def])
+  fs[line_similar_def]
+QED
 
 Theorem code_similar_enc_sec_list[simp]:
    ∀code1 code2 n.
@@ -2669,18 +2777,20 @@ Proof
    metis_tac[LIST_REL_enc_line]
 QED
 
-val enc_lines_again_IMP_similar = Q.prove(`
+Triviality enc_lines_again_IMP_similar:
   ∀labs ffis pos enc lines acc ok lines' ok' curr.
   enc_lines_again labs ffis pos enc lines (acc,ok) = (lines',ok') ⇒
   LIST_REL line_similar curr (REVERSE acc) ⇒
-  LIST_REL line_similar (curr++lines) lines'`,
+  LIST_REL line_similar (curr++lines) lines'
+Proof
   Induct_on`lines`>>fs[enc_lines_again_def]>>rw[]>>
   fs[AND_IMP_INTRO]>>
   `curr ++ h ::lines = SNOC h curr ++ lines` by fs[]>>
   pop_assum SUBST1_TAC>>
   first_assum match_mp_tac>>
   Cases_on`h`>>fs[enc_lines_again_def]>>EVERY_CASE_TAC>>
-  asm_exists_tac>>fs[SNOC_APPEND,line_similar_def])
+  asm_exists_tac>>fs[SNOC_APPEND,line_similar_def]
+QED
 
 Theorem enc_secs_again_IMP_similar:
    ∀pos labs ffis enc code code1 ok.
@@ -2701,15 +2811,17 @@ val lines_upd_lab_len_AUX = Q.prove(
   \\ Cases \\ simp_tac std_ss [lines_upd_lab_len_def,LET_DEF]
   \\ pop_assum (fn th => once_rewrite_tac [GSYM th]) \\ fs []) |> GSYM
 
-val line_similar_lines_upd_lab_len = Q.prove(
-  `!l aux pos l1.
+Triviality line_similar_lines_upd_lab_len:
+  !l aux pos l1.
       LIST_REL line_similar (FST (lines_upd_lab_len pos l [])) l1 =
-      LIST_REL line_similar l l1`,
+      LIST_REL line_similar l l1
+Proof
   Induct \\ fs [lines_upd_lab_len_def]
   \\ Cases \\ fs [lines_upd_lab_len_def]
   \\ once_rewrite_tac [lines_upd_lab_len_AUX]
   \\ fs [] \\ rw [] \\ eq_tac \\ rw []
-  \\ Cases_on `y` \\ fs [line_similar_def]);
+  \\ Cases_on `y` \\ fs [line_similar_def]
+QED
 
 Theorem code_similar_upd_lab_len:
    !code pos code1.
@@ -2813,14 +2925,16 @@ Proof
   \\ strip_tac \\ res_tac \\ fs[]
 QED
 
-val enc_lines_again_sec_labels_ok = Q.prove(`
+Triviality enc_lines_again_sec_labels_ok:
   ∀labs ffis pos enc lines acc ok res ok' k.
     enc_lines_again labs ffis pos enc lines (acc,ok) = (res,ok') ∧
     EVERY (sec_label_ok k) acc ∧
     EVERY (sec_label_ok k) lines ⇒
-    EVERY (sec_label_ok k) res`,
+    EVERY (sec_label_ok k) res
+Proof
   recInduct enc_lines_again_ind \\ rw[enc_lines_again_def]
-  \\ rw[EVERY_REVERSE]);
+  \\ rw[EVERY_REVERSE]
+QED
 
 Theorem enc_secs_again_sec_labels_ok:
    ∀pos ffis labs enc ls res ok k.
@@ -2834,14 +2948,16 @@ Proof
   \\ asm_exists_tac \\ fs[]
 QED
 
-val lines_upd_lab_len_sec_label_ok = Q.prove(
-  `∀pos lines acc k.
+Triviality lines_upd_lab_len_sec_label_ok:
+  ∀pos lines acc k.
      EVERY (sec_label_ok k) lines ∧
      EVERY (sec_label_ok k) acc ⇒
-     EVERY (sec_label_ok k) (FST (lines_upd_lab_len pos lines acc))`,
+     EVERY (sec_label_ok k) (FST (lines_upd_lab_len pos lines acc))
+Proof
   recInduct lines_upd_lab_len_ind
   \\ rw[lines_upd_lab_len_def]
-  \\ rw[EVERY_REVERSE]);
+  \\ rw[EVERY_REVERSE]
+QED
 
 Theorem upd_lab_len_sec_labels_ok:
    ∀n ls. EVERY sec_labels_ok ls ⇒ EVERY sec_labels_ok (upd_lab_len n ls)
@@ -2853,23 +2969,27 @@ Proof
   \\ rw[]
 QED
 
-val add_nop_sec_label_ok = Q.prove(
-  `∀nop aux.
+Triviality add_nop_sec_label_ok:
+  ∀nop aux.
     EVERY (sec_label_ok k) aux ⇒
-    EVERY (sec_label_ok k) (add_nop nop aux)`,
+    EVERY (sec_label_ok k) (add_nop nop aux)
+Proof
   recInduct add_nop_ind
-  \\ rw[add_nop_def]);
+  \\ rw[add_nop_def]
+QED
 
-val pad_section_sec_label_ok = Q.prove(
-  `∀nop xs acc k.
+Triviality pad_section_sec_label_ok:
+  ∀nop xs acc k.
     EVERY (sec_label_ok k) xs ∧
     EVERY (sec_label_ok k) acc ⇒
-    EVERY (sec_label_ok k) (pad_section nop xs acc)`,
+    EVERY (sec_label_ok k) (pad_section nop xs acc)
+Proof
   recInduct pad_section_ind
   \\ rw[pad_section_def]
   \\ rw[EVERY_REVERSE] \\ fs[]
   \\ first_x_assum match_mp_tac
-  \\ metis_tac[add_nop_sec_label_ok]);
+  \\ metis_tac[add_nop_sec_label_ok]
+QED
 
 Theorem pad_code_sec_labels_ok:
    ∀nop code.
@@ -3239,10 +3359,12 @@ End
 
 (* label_zero preservation *)
 
-val EVERY_label_zero_add_nop = Q.prove(
-  `!xs. EVERY label_zero (add_nop nop xs) = EVERY label_zero xs`,
+Triviality EVERY_label_zero_add_nop:
+  !xs. EVERY label_zero (add_nop nop xs) = EVERY label_zero xs
+Proof
   Induct \\ fs [add_nop_def,EVERY_REVERSE]
-  \\ Cases \\ fs [add_nop_def,EVERY_REVERSE]);
+  \\ Cases \\ fs [add_nop_def,EVERY_REVERSE]
+QED
 
 Theorem EVERY_label_zero_pad_section[simp]:
    ∀nop xs aux.
@@ -4297,37 +4419,45 @@ val _ = export_rewrites["sec_labs_exist_def"];
 Overload all_labs_exist = ``λlabs code. EVERY (sec_labs_exist labs) code``
 
 (* Remove tail recursion from zero_labs_acc_exist *)
-val zero_labs_acc_of_eq_zero_labs_of = Q.prove(`
+Triviality zero_labs_acc_of_eq_zero_labs_of:
   domain (zero_labs_acc_of l acc) =
-  IMAGE FST (restrict_zero (labs_of l)) ∪ domain acc`,
+  IMAGE FST (restrict_zero (labs_of l)) ∪ domain acc
+Proof
   Cases_on`l`>> (TRY (Cases_on`l'`))>>
   simp[backendPropsTheory.restrict_zero_def]>>
   rw[]>>
-  simp[EXTENSION]);
+  simp[EXTENSION]
+QED
 
-val line_get_zero_labs_acc_eq_line_get_zero_labels = Q.prove(`
+Triviality line_get_zero_labs_acc_eq_line_get_zero_labels:
   domain (line_get_zero_labs_acc l acc) =
-  IMAGE FST (restrict_zero (line_get_labels l)) ∪ domain acc`,
+  IMAGE FST (restrict_zero (line_get_labels l)) ∪ domain acc
+Proof
   Cases_on`l`>>fs[line_get_zero_labs_acc_def,line_get_labels_def]>>
   simp[backendPropsTheory.restrict_zero_def]>>
-  fs[zero_labs_acc_of_eq_zero_labs_of,backendPropsTheory.restrict_zero_def]);
+  fs[zero_labs_acc_of_eq_zero_labs_of,backendPropsTheory.restrict_zero_def]
+QED
 
-val sec_get_zero_labs_acc_eq_sec_get_zero_labels = Q.prove(`
+Triviality sec_get_zero_labs_acc_eq_sec_get_zero_labels:
   domain (sec_get_zero_labs_acc sec acc) =
-  IMAGE FST (restrict_zero (sec_get_labels sec)) ∪ domain acc`,
+  IMAGE FST (restrict_zero (sec_get_labels sec)) ∪ domain acc
+Proof
   Cases_on`sec`>>Induct_on`l`>>
   fs[sec_get_zero_labs_acc_def,sec_get_labels_def]>>
   simp[line_get_zero_labs_acc_eq_line_get_zero_labels]>>
   simp[EXTENSION,backendPropsTheory.restrict_zero_def]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val get_zero_labs_acc_eq_get_zero_labels = Q.prove(`
+Triviality get_zero_labs_acc_eq_get_zero_labels:
   domain (FOLDR sec_get_zero_labs_acc acc code) =
-  IMAGE FST (restrict_zero (get_labels code)) ∪ domain acc`,
+  IMAGE FST (restrict_zero (get_labels code)) ∪ domain acc
+Proof
   Induct_on`code`>>fs[get_labels_def]>>
   simp[sec_get_zero_labs_acc_eq_sec_get_zero_labels]>>
   simp[EXTENSION,backendPropsTheory.restrict_zero_def]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Theorem zero_labs_acc_exist_eq:
   zero_labs_acc_exist labs code ⇔
@@ -4590,22 +4720,25 @@ Proof
   \\ asm_exists_tac \\ fs[]
 QED
 
-val all_enc_ok_split = Q.prove(`
+Triviality all_enc_ok_split:
   ∀c labs ffis pos k lines xs.
   all_enc_ok c labs ffis pos (Section k lines::xs) ⇒
   all_enc_ok c labs ffis pos [Section k lines] ∧
-  all_enc_ok c labs ffis (pos + sec_length lines 0) xs`,
+  all_enc_ok c labs ffis (pos + sec_length lines 0) xs
+Proof
   Induct_on`lines`>>rw[all_enc_ok_def,sec_length_def,all_enc_ok_def]>>
   Cases_on`h`>>TRY(Cases_on`a`)>>
   fs[sec_length_def,sec_length_add,line_length_def,line_ok_def]>>rveq>>
   fs(bool_case_eq_thms) \\ imp_res_tac lab_lookup_IMP \\ rw[] >>
   rfs[]>>
-  metis_tac[ADD_ASSOC])
+  metis_tac[ADD_ASSOC]
+QED
 
-val all_enc_ok_even = Q.prove(`
+Triviality all_enc_ok_even:
   ∀lines pos.
   all_enc_ok c labs ffis pos [Section k lines] ⇒
-  EVEN (sec_length lines pos)`,
+  EVEN (sec_length lines pos)
+Proof
   Induct>>fs[all_enc_ok_def,sec_length_def]>>Cases>>
   TRY(Cases_on`a`)>>
   rw[]>>fs[line_ok_def,line_length_def,sec_length_add,sec_length_def]>>
@@ -4613,15 +4746,17 @@ val all_enc_ok_even = Q.prove(`
   `n + sec_length lines pos = sec_length lines (n + pos)` by
     metis_tac[sec_length_add,ADD_COMM]>>
   fs[]>>
-  fs(bool_case_eq_thms) \\ imp_res_tac lab_lookup_IMP \\ rw[]);
+  fs(bool_case_eq_thms) \\ imp_res_tac lab_lookup_IMP \\ rw[]
+QED
 
-val all_enc_ok_lab_lookup_even = Q.prove(
-  `∀c labs ffis pos sec_list l1 l2 acc x.
+Triviality all_enc_ok_lab_lookup_even:
+  ∀c labs ffis pos sec_list l1 l2 acc x.
       all_enc_ok c labs ffis pos sec_list ∧
       lab_lookup l1 l2 (compute_labels_alt pos sec_list acc) = SOME x ∧
       (∀x. lab_lookup l1 l2 acc = SOME x ==> EVEN x) ∧
       EVEN pos ⇒
-      EVEN x`,
+      EVEN x
+Proof
   Induct_on`sec_list`>>
   fs[all_enc_ok_def,compute_labels_alt_def]>>
   Cases \\ fs[compute_labels_alt_def] \\
@@ -4641,7 +4776,8 @@ val all_enc_ok_lab_lookup_even = Q.prove(
   \\ fs[all_enc_ok_cons]
   \\ match_mp_tac lines_ok_section_lab_lookup_even
   \\ asm_exists_tac \\ fs[]
-  \\ qexists_tac`[]` \\ simp[]);
+  \\ qexists_tac`[]` \\ simp[]
+QED
 
 Theorem line_ok_pre_light_imp_line_ok:
    ∀c labs ffis pos line.
@@ -5083,66 +5219,82 @@ Proof
   \\ simp[]
 QED
 
-val enc_lines_again_all_enc_ok_pre = Q.prove(`
+Triviality enc_lines_again_all_enc_ok_pre:
   ∀labs ffis pos enc lines acc ok res ok' c.
   enc_lines_again labs ffis pos enc lines (acc,ok) = (res,ok') ∧
   EVERY (line_ok_pre c) lines ∧ EVERY (line_ok_pre c) acc ⇒
-  EVERY (line_ok_pre c) res`,
+  EVERY (line_ok_pre c) res
+Proof
   recInduct enc_lines_again_ind>>rw[enc_lines_again_def]>>
-  rw[EVERY_REVERSE]>>fs[line_ok_pre_def])
+  rw[EVERY_REVERSE]>>fs[line_ok_pre_def]
+QED
 
-val enc_secs_again_all_enc_ok_pre = Q.prove(`
+Triviality enc_secs_again_all_enc_ok_pre:
   ∀pos labs ffis enc ls res ok c.
   enc_secs_again pos labs ffis enc ls = (res,ok) ∧ all_enc_ok_pre c ls ⇒
-  all_enc_ok_pre c res`,
+  all_enc_ok_pre c res
+Proof
   ho_match_mp_tac enc_secs_again_ind>>rw[enc_secs_again_def]>>
   rw[]>>
   rpt (pairarg_tac>>fs[])>>
   rw[]>>
-  match_mp_tac enc_lines_again_all_enc_ok_pre>>asm_exists_tac>>fs[])
+  match_mp_tac enc_lines_again_all_enc_ok_pre>>asm_exists_tac>>fs[]
+QED
 
-val line_ok_pre_add_nop = Q.prove(`
+Triviality line_ok_pre_add_nop:
   EVERY (line_ok_pre c) xs ⇒
-  EVERY (line_ok_pre c) (add_nop nop xs)`,
-  Induct_on`xs`>>EVAL_TAC>>Cases>>fs[]>>rw[]>>EVAL_TAC>>fs[line_ok_pre_def])
+  EVERY (line_ok_pre c) (add_nop nop xs)
+Proof
+  Induct_on`xs`>>EVAL_TAC>>Cases>>fs[]>>rw[]>>EVAL_TAC>>fs[line_ok_pre_def]
+QED
 
-val line_ok_pre_pad_section = Q.prove(`
+Triviality line_ok_pre_pad_section:
   ∀nop xs acc c.
   EVERY (line_ok_pre c) xs ∧ EVERY (line_ok_pre c) acc ⇒
-  EVERY (line_ok_pre c) (pad_section nop xs acc)`,
+  EVERY (line_ok_pre c) (pad_section nop xs acc)
+Proof
   ho_match_mp_tac pad_section_ind>>rw[pad_section_def]>>
   fs[EVERY_REVERSE]>>
   first_x_assum match_mp_tac>>fs[line_ok_pre_def]>>
-  metis_tac[line_ok_pre_add_nop])
+  metis_tac[line_ok_pre_add_nop]
+QED
 
-val all_enc_ok_pre_pad_code = Q.prove(`
+Triviality all_enc_ok_pre_pad_code:
   ∀nop code c.
   all_enc_ok_pre c code ⇒
-  all_enc_ok_pre c (pad_code nop code)`,
+  all_enc_ok_pre c (pad_code nop code)
+Proof
   ho_match_mp_tac pad_code_ind>>rw[]>>EVAL_TAC>>rw[]>>
   rfs[]>>
-  match_mp_tac line_ok_pre_pad_section>>fs[])
+  match_mp_tac line_ok_pre_pad_section>>fs[]
+QED
 
-val all_enc_ok_pre_lines_upd_lab_len = Q.prove(`
+Triviality all_enc_ok_pre_lines_upd_lab_len:
   ∀n lines acc.
   EVERY (line_ok_pre c) lines ∧
   EVERY (line_ok_pre c) acc ⇒
-  EVERY (line_ok_pre c) (FST (lines_upd_lab_len n lines acc))`,
+  EVERY (line_ok_pre c) (FST (lines_upd_lab_len n lines acc))
+Proof
   ho_match_mp_tac lines_upd_lab_len_ind>>rw[lines_upd_lab_len_def]>>
-  fs[EVERY_REVERSE,line_ok_pre_def])
+  fs[EVERY_REVERSE,line_ok_pre_def]
+QED
 
-val all_enc_ok_pre_upd_lab_len = Q.prove(`
+Triviality all_enc_ok_pre_upd_lab_len:
   ∀n code.
   all_enc_ok_pre c code ⇒
-  all_enc_ok_pre c (upd_lab_len n code)`,
+  all_enc_ok_pre c (upd_lab_len n code)
+Proof
   ho_match_mp_tac upd_lab_len_ind>>rw[]>> EVAL_TAC>>fs[]>>
   pairarg_tac \\ fs[] \\
   qspecl_then[`n`,`lines`,`[]`]mp_tac all_enc_ok_pre_lines_upd_lab_len
-  \\ rw[])
+  \\ rw[]
+QED
 
-val EXP_IMP_ZERO_LT = Q.prove(
-  `(2n ** y = x) ⇒ 0 < x`,
-  metis_tac[bitTheory.TWOEXP_NOT_ZERO,NOT_ZERO_LT_ZERO]);
+Triviality EXP_IMP_ZERO_LT:
+  (2n ** y = x) ⇒ 0 < x
+Proof
+  metis_tac[bitTheory.TWOEXP_NOT_ZERO,NOT_ZERO_LT_ZERO]
+QED
 
 Theorem line_ok_alignment:
    ∀c labs ffis pos line.
@@ -5182,8 +5334,8 @@ Proof
   \\ metis_tac[line_ok_alignment,ODD_EVEN]
 QED
 
-val remove_labels_loop_thm = Q.prove(
-  `∀n c init_pos init_labs ffis code code2 labs.
+Triviality remove_labels_loop_thm:
+  ∀n c init_pos init_labs ffis code code2 labs.
     remove_labels_loop n c init_pos init_labs ffis code = SOME (code2,labs) ∧
     EVERY sec_ends_with_label code ∧
     EVERY sec_labels_ok code ∧
@@ -5210,7 +5362,8 @@ val remove_labels_loop_thm = Q.prove(
                lab_lookup l1 l2 labs = SOME x) /\
     !l1 l2 x2.
       loc_to_pc l1 l2 code = SOME x2 ==>
-      lab_lookup l1 l2 labs = SOME (pos_val x2 init_pos code2)`,
+      lab_lookup l1 l2 labs = SOME (pos_val x2 init_pos code2)
+Proof
   HO_MATCH_MP_TAC remove_labels_loop_ind  >> rpt gen_tac >> strip_tac
   >> simp[Once remove_labels_loop_def]
   >> rpt gen_tac
@@ -5387,7 +5540,8 @@ val remove_labels_loop_thm = Q.prove(
   \\ match_mp_tac code_similar_pad_code
   \\ imp_res_tac enc_secs_again_IMP_similar
   \\ fs [code_similar_upd_lab_len,Abbr`code2`]
-  \\ metis_tac [code_similar_trans]);
+  \\ metis_tac [code_similar_trans]
+QED
 
 Theorem loc_to_pc_enc_sec_list[simp]:
    ∀l1 l2 code.
@@ -5417,13 +5571,15 @@ Proof
   >> BasicProvers.TOP_CASE_TAC >> full_simp_tac(srw_ss())[])
 QED
 
-val all_enc_ok_pre_enc_sec_list = Q.prove(`
+Triviality all_enc_ok_pre_enc_sec_list:
   ∀code enc c.
   all_enc_ok_pre c code ⇒
-  all_enc_ok_pre c (enc_sec_list enc code)`,
+  all_enc_ok_pre c (enc_sec_list enc code)
+Proof
   fs[enc_sec_list_def]>>Induct>>fs[]>>
   Cases>>fs[enc_sec_def]>>rw[]>>
-  Induct_on`l`>>fs[]>>Cases>>fs[enc_line_def,line_ok_pre_def])
+  Induct_on`l`>>fs[]>>Cases>>fs[enc_line_def,line_ok_pre_def]
+QED
 
 Theorem remove_labels_thm:
    remove_labels clock conf init_pos init_labs ffi_names code = SOME (code2,labs) /\
@@ -5583,11 +5739,12 @@ Proof
   Induct>>rw[lines_ok_def]>> metis_tac[line_ok_line_byte_length]
 QED
 
-val all_enc_ok_prog_to_bytes_EVEN = Q.prove(`
+Triviality all_enc_ok_prog_to_bytes_EVEN:
   ∀code n c labs ffi pos.
    EVEN pos ∧
    all_enc_ok c labs ffi pos code ⇒
-   EVEN (LENGTH (prog_to_bytes code))`,
+   EVEN (LENGTH (prog_to_bytes code))
+Proof
   fs[prog_to_bytes_MAP]>>
   Induct>>fs[]>>Cases>>
   fs[all_enc_ok_cons]>>rw[EVEN_ADD]>>
@@ -5596,9 +5753,10 @@ val all_enc_ok_prog_to_bytes_EVEN = Q.prove(`
   `MAP line_length l = MAP LENGTH (MAP line_bytes l)` by
     metis_tac[lines_ok_MAP_line_byte_length]>>
   pop_assum SUBST_ALL_TAC >>simp[]>>
-  metis_tac[EVEN_ADD]);
+  metis_tac[EVEN_ADD]
+QED
 
-val loc_to_pc_append = Q.prove(`
+Triviality loc_to_pc_append:
   ∀l1 l2 c1 c2 conf labs ffis pos.
   EVERY sec_labels_ok (c1++c2) ⇒
   loc_to_pc l1 l2 (c1++c2) =
@@ -5607,7 +5765,8 @@ val loc_to_pc_append = Q.prove(`
   | NONE =>
     case loc_to_pc l1 l2 c2 of
       SOME x => SOME (x + SUM (MAP (len_no_lab o Section_lines) c1))
-    | NONE => NONE`,
+    | NONE => NONE
+Proof
   Induct_on`c1`
   >-
     (fs[loc_to_pc_thm]>>
@@ -5616,7 +5775,8 @@ val loc_to_pc_append = Q.prove(`
   simp[Once loc_to_pc_thm,SimpLHS]>>
   simp[Once loc_to_pc_thm,SimpRHS]>>
   rw[]>>
-  rpt(TOP_CASE_TAC>>fs[]));
+  rpt(TOP_CASE_TAC>>fs[])
+QED
 
 Theorem all_enc_ok_append:
    ∀conf labs ffi n c1 c2.
@@ -5778,18 +5938,20 @@ Proof
     res_tac>>fs[]
 QED
 
-val find_ffi_names_append = Q.prove(`
+Triviality find_ffi_names_append:
   ∀l1 l2.
   find_ffi_names (l1++l2) =
   (find_ffi_names l2) ++
-  FILTER (λn. ¬ MEM n (find_ffi_names l2)) (find_ffi_names l1) `,
+  FILTER (λn. ¬ MEM n (find_ffi_names l2)) (find_ffi_names l1)
+Proof
   ho_match_mp_tac find_ffi_names_ind>>rw[find_ffi_names_def]>>
   fs[FILTER_EQ_ID]>>
   TOP_CASE_TAC>>fs[]>>
   TOP_CASE_TAC>>fs[]>>
   fs[list_add_if_fresh_thm]>>rw[]>>
   fs[MEM_FILTER,FILTER_APPEND]>>
-  fs[]);
+  fs[]
+QED
 
 Theorem all_enc_ok_aligned_pos_val:
   !(mc_conf : ('a, 'b, 'c) machine_config) labs code2 pc ffi_names.
@@ -8916,8 +9078,8 @@ Proof
 QED
 
 (* This is set up for the very first compile call *)
-val IMP_state_rel_make_init = Q.prove(
-  `good_code mc_conf.target.config LN (code: 'a sec list) ∧
+Triviality IMP_state_rel_make_init:
+  good_code mc_conf.target.config LN (code: 'a sec list) ∧
    mc_conf_ok mc_conf ∧
    (no_share_mem_inst code ==>
      compiler_oracle_ok coracle labs (LENGTH (prog_to_bytes code2)) mc_conf.target.config mc_conf.ffi_names) ∧
@@ -8946,7 +9108,8 @@ val IMP_state_rel_make_init = Q.prove(
    state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,
        mc_conf.target.get_pc ms)
      (make_init mc_conf (ffi:'ffi ffi_state) io_regs cc_regs t m dm sdm ms code
-      compile_lab (mc_conf.target.get_pc ms+n2w(LENGTH(prog_to_bytes code2))) cbspace coracle) t ms`,
+      compile_lab (mc_conf.target.get_pc ms+n2w(LENGTH(prog_to_bytes code2))) cbspace coracle) t ms
+Proof
   rw[] \\ drule $ GEN_ALL remove_labels_thm
   \\ impl_tac >- (
     fs[good_code_def,mc_conf_ok_def]
@@ -9166,7 +9329,7 @@ val IMP_state_rel_make_init = Q.prove(
     \\ metis_tac[MEM_APPEND,TAKE_DROP]
   )
   \\ drule_then (drule_then irule) $ GEN_ALL code_similar_IMP_both_no_install_or_no_share_mem
-);
+QED
 
 Theorem make_init_simp[simp]:
     (make_init a b d e f g h i j k l m n p).ffi = b ∧
@@ -9215,12 +9378,14 @@ Proof
   \\ fs [lab_filterTheory.not_skip_def,find_ffi_names_def]
 QED
 
-val all_enc_ok_pre_filter_skip = Q.prove(`
+Triviality all_enc_ok_pre_filter_skip:
   ∀code c.
   all_enc_ok_pre c code ⇒
-  all_enc_ok_pre c (filter_skip code)`,
+  all_enc_ok_pre c (filter_skip code)
+Proof
   Induct>>TRY(Cases)>>fs[lab_filterTheory.filter_skip_def]>>rw[]>>
-  Induct_on`l`>>fs[]>>rw[])
+  Induct_on`l`>>fs[]>>rw[]
+QED
 
 Theorem MAP_Section_num_filter_skip[simp]:
    ∀code. MAP Section_num (filter_skip code) = MAP Section_num code

--- a/compiler/backend/proofs/source_to_flatProofScript.sml
+++ b/compiler/backend/proofs/source_to_flatProofScript.sml
@@ -21,10 +21,12 @@ val grammar_ancestry =
    "backend_common","misc","backendProps", "source_evalProof"];
 val _ = set_grammar_ancestry grammar_ancestry;
 
-val compile_exps_length = Q.prove (
-  `LENGTH (compile_exps t m es) = LENGTH es`,
+Triviality compile_exps_length:
+  LENGTH (compile_exps t m es) = LENGTH es
+Proof
   induct_on `es` >>
-  rw [compile_exp_def]);
+  rw [compile_exp_def]
+QED
 
 Theorem mapi_map:
    !f g l. MAPi f (MAP g l) = MAPi (\i x. f i (g x)) l
@@ -33,24 +35,30 @@ Proof
   rw [combinTheory.o_DEF]
 QED
 
-val fst_lem = Q.prove (
-  `(λ(p1,p1',p2). p1) = FST`,
+Triviality fst_lem:
+  (λ(p1,p1',p2). p1) = FST
+Proof
   rw [FUN_EQ_THM] >>
   pairarg_tac >>
-  rw []);
+  rw []
+QED
 
-val funion_submap = Q.prove (
-  `FUNION x y SUBMAP z ∧ DISJOINT (FDOM x) (FDOM y) ⇒ y SUBMAP z`,
+Triviality funion_submap:
+  FUNION x y SUBMAP z ∧ DISJOINT (FDOM x) (FDOM y) ⇒ y SUBMAP z
+Proof
   rw [SUBMAP_DEF, DISJOINT_DEF, EXTENSION, FUNION_DEF] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val flookup_funion_submap = Q.prove (
-  `(x ⊌ y) SUBMAP z ∧
+Triviality flookup_funion_submap:
+  (x ⊌ y) SUBMAP z ∧
    FLOOKUP (x ⊌ y) k = SOME v
    ⇒
-   FLOOKUP z k = SOME v`,
+   FLOOKUP z k = SOME v
+Proof
   rw [SUBMAP_DEF, FLOOKUP_DEF] >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Theorem FILTER_MAPi_ID:
    ∀ls f. FILTER P (MAPi f ls) = MAPi f ls ⇔
@@ -83,20 +91,24 @@ Definition bind_locals_def:
     nsBindList (MAP2 (\t x. (x, Local t x)) ts locals) comp_map
 End
 
-val nsAppend_bind_locals = Q.prove(`
+Triviality nsAppend_bind_locals:
   ∀funs.
   nsAppend (alist_to_ns (MAP (λx. (x,Local t x)) (MAP FST funs))) (bind_locals ts locals comp_map) =
-  bind_locals (REPLICATE (LENGTH funs) t ++ ts) (MAP FST funs ++ locals) comp_map`,
-  Induct_on`funs`>>fs[FORALL_PROD,bind_locals_def,namespaceTheory.nsBindList_def]);
+  bind_locals (REPLICATE (LENGTH funs) t ++ ts) (MAP FST funs ++ locals) comp_map
+Proof
+  Induct_on`funs`>>fs[FORALL_PROD,bind_locals_def,namespaceTheory.nsBindList_def]
+QED
 
-val nsBindList_pat_tups_bind_locals = Q.prove(`
+Triviality nsBindList_pat_tups_bind_locals:
   ∀ls.
   ∃tss.
   nsBindList (pat_tups t ls) (bind_locals ts locals comp_map) =
   bind_locals (tss ++ ts) (ls ++ locals) comp_map ∧
-  LENGTH tss = LENGTH ls`,
+  LENGTH tss = LENGTH ls
+Proof
   Induct>>rw[pat_tups_def,namespaceTheory.nsBindList_def,bind_locals_def]>>
-  qexists_tac`(t § (LENGTH ls + 1))::tss`>>simp[]);
+  qexists_tac`(t § (LENGTH ls + 1))::tss`>>simp[]
+QED
 
 Datatype:
   global_env =
@@ -365,27 +377,30 @@ Proof
   \\ simp [PULL_EXISTS, FORALL_PROD]
 QED
 
-val env_rel_dom = Q.prove (
-  `!genv env env'.
+Triviality env_rel_dom:
+  !genv env env'.
     env_rel genv env env'
     ⇒
-    ?l. env = alist_to_ns l ∧ MAP FST l = MAP FST env'`,
+    ?l. env = alist_to_ns l ∧ MAP FST l = MAP FST env'
+Proof
   induct_on `env'` >>
   simp [Once v_rel_cases] >>
   rw [] >>
   first_x_assum drule >>
   rw [] >>
   rw_tac list_ss [GSYM alist_to_ns_cons] >>
-  prove_tac [MAP, FST]);
+  prove_tac [MAP, FST]
+QED
 
-val env_rel_lookup = Q.prove (
-  `!genv env x v env'.
+Triviality env_rel_lookup:
+  !genv env x v env'.
     ALOOKUP env x = SOME v ∧
     env_rel genv (alist_to_ns env) env'
     ⇒
     ?v'.
       v_rel genv v v' ∧
-      ALOOKUP env' x = SOME v'`,
+      ALOOKUP env' x = SOME v'
+Proof
   induct_on `env'` >>
   simp [] >>
   simp [Once v_rel_cases] >>
@@ -397,14 +412,16 @@ val env_rel_lookup = Q.prove (
   TRY (PairCases_on `h`) >>
   fs [alist_to_ns_cons] >>
   rw [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val env_rel_append = Q.prove (
-  `!genv env1 env2 env1' env2'.
+Triviality env_rel_append:
+  !genv env1 env2 env1' env2'.
     env_rel genv env1 env1' ∧
     env_rel genv env2 env2'
     ⇒
-    env_rel genv (nsAppend env1 env2) (env1'++env2')`,
+    env_rel genv (nsAppend env1 env2) (env1'++env2')
+Proof
   induct_on `env1'` >>
   rw []
   >- (
@@ -414,7 +431,8 @@ val env_rel_append = Q.prove (
   simp [Once v_rel_cases] >>
   rw [] >>
   rw [] >>
-  simp [Once v_rel_cases]);
+  simp [Once v_rel_cases]
+QED
 
 Triviality env_rel_one:
   env_rel genv (nsBind a b nsEmpty) xs <=>
@@ -431,10 +449,11 @@ Theorem env_rel_bind_one = env_rel_append
   |> GEN_ALL
   |> SIMP_RULE (srw_ss ()) [env_rel_one]
 
-val env_rel_el = Q.prove (
-  `!genv env env_i1.
+Triviality env_rel_el:
+  !genv env env_i1.
     env_rel genv (alist_to_ns env) env_i1 ⇔
-    LENGTH env = LENGTH env_i1 ∧ !n. n < LENGTH env ⇒ (FST (EL n env) = FST (EL n env_i1)) ∧ v_rel genv (SND (EL n env)) (SND (EL n env_i1))`,
+    LENGTH env = LENGTH env_i1 ∧ !n. n < LENGTH env ⇒ (FST (EL n env) = FST (EL n env_i1)) ∧ v_rel genv (SND (EL n env)) (SND (EL n env_i1))
+Proof
   induct_on `env` >>
   srw_tac[][v_rel_eqns] >>
   PairCases_on `h` >>
@@ -454,7 +473,8 @@ val env_rel_el = Q.prove (
       qexists_tac `SND h` >>
       srw_tac[][] >>
       FIRST_X_ASSUM (qspecl_then [`SUC n`] mp_tac) >>
-      srw_tac[][]));
+      srw_tac[][])
+QED
 
 Definition subglobals_def:
   subglobals g1 g2 ⇔
@@ -462,20 +482,25 @@ Definition subglobals_def:
     !n. n < LENGTH g1 ∧ IS_SOME (EL n g1) ⇒ EL n g1 = EL n g2
 End
 
-val subglobals_refl = Q.prove (
-  `!g. subglobals g g`,
-  rw [subglobals_def]);
+Triviality subglobals_refl:
+  !g. subglobals g g
+Proof
+  rw [subglobals_def]
+QED
 
-val subglobals_trans = Q.prove (
-  `!g1 g2 g3. subglobals g1 g2 ∧ subglobals g2 g3 ⇒ subglobals g1 g3`,
+Triviality subglobals_trans:
+  !g1 g2 g3. subglobals g1 g2 ∧ subglobals g2 g3 ⇒ subglobals g1 g3
+Proof
   rw [subglobals_def] >>
   res_tac >>
-  fs []);
+  fs []
+QED
 
-val subglobals_refl_append = Q.prove (
-  `!g1 g2 g3.
+Triviality subglobals_refl_append:
+  !g1 g2 g3.
     subglobals (g1 ++ g2) (g1 ++ g3) = subglobals g2 g3 ∧
-    (LENGTH g2 = LENGTH g3 ⇒ subglobals (g2 ++ g1) (g3 ++ g1) = subglobals g2 g3)`,
+    (LENGTH g2 = LENGTH g3 ⇒ subglobals (g2 ++ g1) (g3 ++ g1) = subglobals g2 g3)
+Proof
   rw [subglobals_def] >>
   eq_tac >>
   rw []
@@ -493,10 +518,11 @@ val subglobals_refl_append = Q.prove (
     Cases_on `n < LENGTH g3` >>
     fs [EL_APPEND_EQN] >>
     rfs [] >>
-    fs []));
+    fs [])
+QED
 
-val v_rel_weakening = Q.prove (
-  `(!genv v v'.
+Triviality v_rel_weakening:
+  (!genv v v'.
     v_rel genv v v'
     ⇒
     !genv'. genv.c = genv'.c ∧ genv.tys = genv'.tys ∧
@@ -510,7 +536,8 @@ val v_rel_weakening = Q.prove (
     global_env_inv genv comp_map shadowers env
     ⇒
     !genv'. genv.c = genv'.c ∧ genv.tys = genv'.tys ∧
-        subglobals genv.v genv'.v ⇒ global_env_inv genv' comp_map shadowers env)`,
+        subglobals genv.v genv'.v ⇒ global_env_inv genv' comp_map shadowers env)
+Proof
   ho_match_mp_tac v_rel_ind >>
   srw_tac[][v_rel_eqns, subglobals_def] >> fs[]
   >- fs [LIST_REL_EL_EQN]
@@ -540,7 +567,8 @@ val v_rel_weakening = Q.prove (
     rveq >> fs [] >>
     rveq >> fs [] >>
     rfs []
-  ));
+  )
+QED
 
 Triviality v_rel_weakening2:
    (!genv v v'.
@@ -580,14 +608,16 @@ Proof
   )
 QED
 
-val drestrict_lem = Q.prove (
-  `f1 SUBMAP f2 ⇒ DRESTRICT f2 (COMPL (FDOM f1)) ⊌ f1 = f2`,
+Triviality drestrict_lem:
+  f1 SUBMAP f2 ⇒ DRESTRICT f2 (COMPL (FDOM f1)) ⊌ f1 = f2
+Proof
   rw [FLOOKUP_EXT, FUN_EQ_THM, FLOOKUP_FUNION] >>
   every_case_tac >>
   fs [FLOOKUP_DRESTRICT, SUBMAP_DEF] >>
   fs [FLOOKUP_DEF] >>
   rw [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Theorem v_rel_weak:
    !genv v v' genv'.
@@ -656,8 +686,8 @@ Inductive result_rel:
     result_rel f genv (Rerr (Rabort a)) (Rerr (Rabort a)))
 End
 
-val result_rel_eqns = Q.prove (
-  `(!genv v r.
+Triviality result_rel_eqns:
+  (!genv v r.
     result_rel f genv (Rval v) r ⇔
       ?v'. f genv v v' ∧ r = Rval v') ∧
    (!genv v r.
@@ -665,9 +695,11 @@ val result_rel_eqns = Q.prove (
       ?v'. v_rel genv v v' ∧ r = Rerr (Rraise v')) ∧
    (!genv v r a.
     result_rel f genv (Rerr (Rabort a)) r ⇔
-      r = Rerr (Rabort a))`,
+      r = Rerr (Rabort a))
+Proof
   srw_tac[][result_rel_cases] >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Inductive sv_rel:
   (!genv v v'.
@@ -682,16 +714,18 @@ Inductive sv_rel:
     sv_rel genv (Varray vs) (Varray vs'))
 End
 
-val sv_rel_weak = Q.prove (
-  `!genv sv sv' genv'.
+Triviality sv_rel_weak:
+  !genv sv sv' genv'.
    sv_rel genv sv sv' ∧
    genv.c ⊑ genv'.c ∧
    genv.tys ⊑ genv'.tys ∧
    subglobals genv.v genv'.v
    ⇒
-   sv_rel genv' sv sv'`,
+   sv_rel genv' sv sv'
+Proof
   srw_tac[][sv_rel_cases] >>
-  metis_tac [v_rel_weak, LIST_REL_EL_EQN]);
+  metis_tac [v_rel_weak, LIST_REL_EL_EQN]
+QED
 
 Inductive s_rel:
   (!genv s s'.
@@ -718,20 +752,22 @@ Inductive env_all_rel:
       locals)
 End
 
-val env_all_rel_weak = Q.prove (
-  `!genv map locals env env' genv'.
+Triviality env_all_rel_weak:
+  !genv map locals env env' genv'.
    env_all_rel genv map env env' locals ∧
    genv.c ⊑ genv'.c ∧
    genv.tys ⊑ genv'.tys ∧
    subglobals genv.v genv'.v
    ⇒
-   env_all_rel genv' map env env' locals`,
+   env_all_rel genv' map env env' locals
+Proof
   rw [env_all_rel_cases] >>
   imp_res_tac env_rel_weak >>
   imp_res_tac global_env_inv_weak >>
   MAP_EVERY qexists_tac [`alist_to_ns l`, `env''`, `env'''`] >>
   rw [] >>
-  metis_tac [SUBMAP_FDOM_SUBSET, SUBSET_TRANS]);
+  metis_tac [SUBMAP_FDOM_SUBSET, SUBSET_TRANS]
+QED
 
 Definition match_result_rel_def:
   (match_result_rel genv env' (Match env) (Match env_i1) =
@@ -751,8 +787,8 @@ QED
 
 (* semantic functions respect relation *)
 
-val do_eq = Q.prove (
-  `!genv. genv_c_ok genv.c ⇒
+Triviality do_eq:
+  !genv. genv_c_ok genv.c ⇒
    (!v1 v2 r v1_i1 v2_i1.
     do_eq v1 v2 = r ∧
     v_rel genv v1 v1_i1 ∧
@@ -764,7 +800,8 @@ val do_eq = Q.prove (
     LIST_REL (v_rel genv) vs1 vs1_i1 ∧
     LIST_REL (v_rel genv) vs2 vs2_i1
     ⇒
-    do_eq_list vs1_i1 vs2_i1 = r)`,
+    do_eq_list vs1_i1 vs2_i1 = r)
+Proof
   ntac 2 strip_tac >>
   ho_match_mp_tac semanticPrimitivesTheory.do_eq_ind >>
   rpt strip_tac >>
@@ -799,7 +836,7 @@ val do_eq = Q.prove (
   gs[lit_same_type_def] >>
   metis_tac [SOME_11, genv_c_ok_def
     |> SIMP_RULE (srw_ss()) [semanticPrimitivesTheory.ctor_same_type_def]]
-  );
+QED
 
 Theorem genv_lookup_nil:
   genv_c_ok genv_c ==>
@@ -821,13 +858,14 @@ Proof
   \\ metis_tac []
 QED
 
-val v_to_char_list = Q.prove (
-  `!genv. genv_c_ok genv.c ⇒
+Triviality v_to_char_list:
+  !genv. genv_c_ok genv.c ⇒
    !v1 v2 vs1.
     v_rel genv v1 v2 ∧
     v_to_char_list v1 = SOME vs1
     ⇒
-    v_to_char_list v2 = SOME vs1`,
+    v_to_char_list v2 = SOME vs1
+Proof
   ntac 2 strip_tac >>
   ho_match_mp_tac semanticPrimitivesTheory.v_to_char_list_ind >>
   srw_tac[][semanticPrimitivesTheory.v_to_char_list_def] >>
@@ -836,17 +874,19 @@ val v_to_char_list = Q.prove (
   imp_res_tac genv_lookup_nil >>
   imp_res_tac genv_lookup_cons >>
   fs [] >>
-  rw [flatSemTheory.v_to_char_list_def]);
+  rw [flatSemTheory.v_to_char_list_def]
+QED
 
-val v_to_list = Q.prove (
-  `!genv. genv_c_ok genv.c ⇒
+Triviality v_to_list:
+  !genv. genv_c_ok genv.c ⇒
    !v1 v2 vs1.
     v_rel genv v1 v2 ∧
     v_to_list v1 = SOME vs1
     ⇒
     ?vs2.
       v_to_list v2 = SOME vs2 ∧
-      LIST_REL (v_rel genv) vs1 vs2`,
+      LIST_REL (v_rel genv) vs1 vs2
+Proof
   ntac 2 strip_tac >>
   ho_match_mp_tac semanticPrimitivesTheory.v_to_list_ind >>
   srw_tac[][semanticPrimitivesTheory.v_to_list_def] >>
@@ -858,27 +898,31 @@ val v_to_list = Q.prove (
   fs [] >>
   rw [flatSemTheory.v_to_list_def] >>
   res_tac >>
-  fs []);
+  fs []
+QED
 
-val vs_to_string = Q.prove(
-  `∀v1 v2 s.
+Triviality vs_to_string:
+  ∀v1 v2 s.
     LIST_REL (v_rel genv) v1 v2 ⇒
     vs_to_string v1 = SOME s ⇒
-    vs_to_string v2 = SOME s`,
+    vs_to_string v2 = SOME s
+Proof
   ho_match_mp_tac semanticPrimitivesTheory.vs_to_string_ind
   \\ rw[semanticPrimitivesTheory.vs_to_string_def,vs_to_string_def]
   \\ fs[v_rel_eqns]
   \\ pop_assum mp_tac
   \\ TOP_CASE_TAC \\ strip_tac \\ rveq \\ fs[]
-  \\ rw[vs_to_string_def]);
+  \\ rw[vs_to_string_def]
+QED
 
-val v_rel_lems = Q.prove (
-  `!genv. genv_c_ok genv.c ⇒
+Triviality v_rel_lems:
+  !genv. genv_c_ok genv.c ⇒
     (!b. v_rel genv (Boolv b) (Boolv b)) ∧
     v_rel genv div_exn_v div_exn_v ∧
     v_rel genv chr_exn_v chr_exn_v ∧
     v_rel genv bind_exn_v bind_exn_v ∧
-    v_rel genv sub_exn_v subscript_exn_v`,
+    v_rel genv sub_exn_v subscript_exn_v
+Proof
   rw [semanticPrimitivesTheory.div_exn_v_def, flatSemTheory.div_exn_v_def,
       semanticPrimitivesTheory.chr_exn_v_def, flatSemTheory.chr_exn_v_def,
       semanticPrimitivesTheory.bind_exn_v_def, flatSemTheory.bind_exn_v_def,
@@ -886,7 +930,8 @@ val v_rel_lems = Q.prove (
       v_rel_eqns, genv_c_ok_def, has_exns_def, has_bools_def,
       semanticPrimitivesTheory.Boolv_def, flatSemTheory.Boolv_def] >>
   every_case_tac >>
-  simp [v_rel_eqns]);
+  simp [v_rel_eqns]
+QED
 
 Theorem list_to_v_v_rel:
    !xs ys.
@@ -1340,21 +1385,23 @@ val do_app = time Q.prove (
       srw_tac[][semanticPrimitivesPropsTheory.do_app_cases, flatSemTheory.do_app_def]
   ));
 
-val find_recfun = Q.prove (
-  `!x funs e comp_map y t.
+Triviality find_recfun:
+  !x funs e comp_map y t.
     find_recfun x funs = SOME (y,e)
     ⇒
     find_recfun x (compile_funs t comp_map funs) =
-      SOME (y, compile_exp (x::t) (comp_map with v := nsBind y (Local None y) comp_map.v) e)`,
-   induct_on `funs` >>
+      SOME (y, compile_exp (x::t) (comp_map with v := nsBind y (Local None y) comp_map.v) e)
+Proof
+  induct_on `funs` >>
    srw_tac[][Once find_recfun_def, compile_exp_def] >>
    PairCases_on `h` >>
    full_simp_tac(srw_ss())[] >>
    every_case_tac >>
-   full_simp_tac(srw_ss())[Once find_recfun_def, compile_exp_def]);
+   full_simp_tac(srw_ss())[Once find_recfun_def, compile_exp_def]
+QED
 
-val do_app_rec_help = Q.prove (
-  `!genv comp_map env_v_local env_v_local' env_v_top funs t.
+Triviality do_app_rec_help:
+  !genv comp_map env_v_local env_v_local' env_v_top funs t.
     env_rel genv env_v_local env_v_local'.v ∧
     global_env_inv genv comp_map (set (MAP FST env_v_local'.v)) env' ∧
     LENGTH ts = LENGTH funs' + LENGTH env_v_local'.v
@@ -1381,7 +1428,8 @@ val do_app_rec_help = Q.prove (
              (comp_map with v :=
                (FOLDR (λ(x,v) e. nsBind x v e) comp_map.v
                 (MAP2 (λt x. (x,Local t x)) ts
-                   (MAP FST funs' ++ MAP FST env_v_local'.v)))) funs))`,
+                   (MAP FST funs' ++ MAP FST env_v_local'.v)))) funs))
+Proof
   induct_on `funs`
   >- srw_tac[][v_rel_eqns, compile_exp_def] >>
   rw [] >>
@@ -1390,24 +1438,28 @@ val do_app_rec_help = Q.prove (
   simp [Once v_rel_cases] >>
   MAP_EVERY qexists_tac [`comp_map`, `env'`, `env_v_local`, `t`,`ts`] >>
   simp[compile_exp_def,bind_locals_def]>>
-  simp_tac (std_ss) [GSYM APPEND, namespaceTheory.nsBindList_def]);
+  simp_tac (std_ss) [GSYM APPEND, namespaceTheory.nsBindList_def]
+QED
 
-val global_env_inv_add_locals = Q.prove (
-  `!genv comp_map locals1 locals2 env.
+Triviality global_env_inv_add_locals:
+  !genv comp_map locals1 locals2 env.
     global_env_inv genv comp_map locals1 env
     ⇒
-    global_env_inv genv comp_map (locals2 ∪ locals1) env`,
+    global_env_inv genv comp_map (locals2 ∪ locals1) env
+Proof
   srw_tac[][v_rel_global_eqn] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val global_env_inv_extend2 = Q.prove (
-  `!genv comp_map env new_vars env' locals env_c.
+Triviality global_env_inv_extend2:
+  !genv comp_map env new_vars env' locals env_c.
     set (MAP (Short o FST) new_vars) = nsDom env' ∧
     global_env_inv genv comp_map locals env ∧
     global_env_inv genv (comp_map with v := alist_to_ns new_vars) locals <| v := env'; c := env_c |>
     ⇒
     global_env_inv genv (comp_map with v := nsBindList new_vars comp_map.v) locals
-        (env with v := nsAppend env' env.v)`,
+        (env with v := nsAppend env' env.v)
+Proof
   rw [v_rel_global_eqn, GSYM nsAppend_to_nsBindList] >>
   fs [nsLookup_nsAppend_some, nsLookup_alist_to_ns_none, nsLookup_alist_to_ns_some] >>
   res_tac >>
@@ -1430,35 +1482,41 @@ val global_env_inv_extend2 = Q.prove (
     fs [namespaceTheory.id_to_mods_def] >>
     Cases_on `p1` >>
     fs [] >>
-    rw []));
+    rw [])
+QED
 
-val lookup_build_rec_env_lem = Q.prove (
-  `!x cl_env funs' funs.
+Triviality lookup_build_rec_env_lem:
+  !x cl_env funs' funs.
     ALOOKUP (MAP (λ(fn,n,e). (fn,Recclosure cl_env funs' fn)) funs) x = SOME v
     ⇒
-    v = semanticPrimitives$Recclosure cl_env funs' x`,
+    v = semanticPrimitives$Recclosure cl_env funs' x
+Proof
   induct_on `funs` >>
   srw_tac[][] >>
   PairCases_on `h` >>
   full_simp_tac(srw_ss())[] >>
   every_case_tac >>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
-val sem_env_eq_lemma = Q.prove (
-  `!(env:'a sem_env) x. (env with v := x) = <| v := x; c := env.c |>`,
+Triviality sem_env_eq_lemma:
+  !(env:'a sem_env) x. (env with v := x) = <| v := x; c := env.c |>
+Proof
   rw [] >>
-  rw [sem_env_component_equality]);
+  rw [sem_env_component_equality]
+QED
 
-val do_opapp = Q.prove (
-  `!genv vs vs_i1 env e.
+Triviality do_opapp:
+  !genv vs vs_i1 env e.
     semanticPrimitives$do_opapp vs = SOME (env, e) ∧
     LIST_REL (v_rel genv) vs vs_i1
     ⇒
      ∃comp_map env_i1 locals t1 ts.
        env_all_rel genv comp_map env env_i1 locals ∧
        LENGTH ts = LENGTH locals ∧
-       flatSem$do_opapp vs_i1 = SOME (env_i1, compile_exp t1 (comp_map with v := bind_locals ts locals comp_map.v) e)`,
-   srw_tac[][do_opapp_cases, flatSemTheory.do_opapp_def] >>
+       flatSem$do_opapp vs_i1 = SOME (env_i1, compile_exp t1 (comp_map with v := bind_locals ts locals comp_map.v) e)
+Proof
+  srw_tac[][do_opapp_cases, flatSemTheory.do_opapp_def] >>
    full_simp_tac(srw_ss())[LIST_REL_CONS1] >>
    srw_tac[][]
    >- (
@@ -1565,7 +1623,8 @@ val do_opapp = Q.prove (
          qexists_tac `nsEmpty` >>
          rw [namespaceTheory.nsSing_def, namespaceTheory.nsEmpty_def,
              namespaceTheory.nsBind_def] >>
-         simp [Once v_rel_cases, namespaceTheory.nsEmpty_def]))));
+         simp [Once v_rel_cases, namespaceTheory.nsEmpty_def])))
+QED
 
 Theorem pat_bindings_compile_pat[simp]:
  !comp_map (p:ast$pat) vars. pat_bindings (compile_pat comp_map p) vars = pat_bindings p vars
@@ -1577,17 +1636,21 @@ Proof
   fs [pat_bindings_def,astTheory.pat_bindings_def, PULL_FORALL]
 QED
 
-val eta2 = Q.prove (
-  `!f x. (\y. f x y) = f x`,
-  metis_tac []);
+Triviality eta2:
+  !f x. (\y. f x y) = f x
+Proof
+  metis_tac []
+QED
 
-val ctor_same_type_refl = Q.prove (
-  `ctor_same_type x x`,
+Triviality ctor_same_type_refl:
+  ctor_same_type x x
+Proof
   Cases_on `x` >>
   rw [ctor_same_type_def] >>
   rename [`SOME x`] >>
   Cases_on `x` >>
-  rw [ctor_same_type_def]);
+  rw [ctor_same_type_def]
+QED
 
 Triviality ctor_same_type_SND:
   ctor_same_type (SOME x) (SOME y) = (SND x = SND y)
@@ -1752,19 +1815,24 @@ QED
 
 (* compiler correctness *)
 
-val opt_bind_lem = Q.prove (
-  `opt_bind NONE = \x y.y`,
-  rw [FUN_EQ_THM, libTheory.opt_bind_def]);
+Triviality opt_bind_lem:
+  opt_bind NONE = \x y.y
+Proof
+  rw [FUN_EQ_THM, libTheory.opt_bind_def]
+QED
 
-val env_updated_lem = Q.prove (
-  `env with v updated_by (λy. y) = (env : 'a flatSem$environment)`,
-  rw [environment_component_equality]);
+Triviality env_updated_lem:
+  env with v updated_by (λy. y) = (env : 'a flatSem$environment)
+Proof
+  rw [environment_component_equality]
+QED
 
-val evaluate_foldr_let_err = Q.prove (
-  `!env s s' exps e x.
+Triviality evaluate_foldr_let_err:
+  !env s s' exps e x.
     flatSem$evaluate env s exps = (s', Rerr x)
     ⇒
-    evaluate env s [FOLDR (Let t NONE) e exps] = (s', Rerr x)`,
+    evaluate env s [FOLDR (Let t NONE) e exps] = (s', Rerr x)
+Proof
   Induct_on `exps` >>
   rw [evaluate_def] >>
   fs [Once evaluate_cons] >>
@@ -1775,7 +1843,8 @@ val evaluate_foldr_let_err = Q.prove (
   disch_then (qspec_then `e` mp_tac) >>
   rw [] >>
   every_case_tac >>
-  fs [opt_bind_lem, env_updated_lem]);
+  fs [opt_bind_lem, env_updated_lem]
+QED
 
 Theorem v_rel_FP_BoolTree:
   v_rel genv (FP_BoolTree fp) v ==>
@@ -1793,15 +1862,17 @@ Definition env_domain_eq_def:
     nsDomMod var_map.c = nsDomMod env.c
 End
 
-val env_domain_eq_append = Q.prove (
-  `env_domain_eq env1 env1' ∧
+Triviality env_domain_eq_append:
+  env_domain_eq env1 env1' ∧
    env_domain_eq env2 env2'
    ⇒
-   env_domain_eq (extend_env env1 env2) (extend_dec_env env1' env2')`,
+   env_domain_eq (extend_env env1 env2) (extend_dec_env env1' env2')
+Proof
   rw [env_domain_eq_def, extend_env_def, extend_dec_env_def,nsLookupMod_nsAppend_some,
       nsLookup_nsAppend_some, nsLookup_nsDom, namespaceTheory.nsDomMod_def,
       EXTENSION, GSPECIFICATION, EXISTS_PROD] >>
-  metis_tac [option_nchotomy, NOT_SOME_NONE, pair_CASES]);
+  metis_tac [option_nchotomy, NOT_SOME_NONE, pair_CASES]
+QED
 
 Theorem v_rel_do_fpoptimise:
   ∀ vs vsF genv annot.
@@ -1833,13 +1904,14 @@ Proof
    fs[fpSemTheory.compress_bool_def])
 QED
 
-val global_env_inv_append = Q.prove (
-  `!genv var_map1 var_map2 env1 env2.
+Triviality global_env_inv_append:
+  !genv var_map1 var_map2 env1 env2.
     env_domain_eq var_map1 env1 ∧
     global_env_inv genv var_map1 {} env1 ∧
     global_env_inv genv var_map2 {} env2
     ⇒
-    global_env_inv genv (extend_env var_map1 var_map2) {} (extend_dec_env env1 env2)`,
+    global_env_inv genv (extend_env var_map1 var_map2) {} (extend_dec_env env1 env2)
+Proof
   rw [env_domain_eq_def, v_rel_global_eqn, nsLookup_nsAppend_some,
     extend_env_def, extend_dec_env_def] >>
   first_x_assum drule >>
@@ -1860,7 +1932,8 @@ val global_env_inv_append = Q.prove (
     ) >>
     fs [EXTENSION, namespacePropsTheory.nsLookup_nsDom] >>
     metis_tac [NOT_SOME_NONE, option_nchotomy]
-  ));
+  )
+QED
 
 val result_rel_imp = hd (RES_CANON result_rel_cases);
 
@@ -2483,8 +2556,8 @@ Proof
   \\ metis_tac []
 QED
 
-val evaluate_make_varls = Q.prove (
-  `!n t idx vars g g' s env vals len.
+Triviality evaluate_make_varls:
+  !n t idx vars g g' s env vals len.
     s.globals = g ++ REPLICATE len NONE ++ g' ∧
     LENGTH g = idx ∧
     LENGTH vals = LENGTH vars ∧
@@ -2492,7 +2565,8 @@ val evaluate_make_varls = Q.prove (
     (!n. n < LENGTH vals ⇒ ALOOKUP env.v (EL n vars) = SOME (EL n vals))
     ⇒
     flatSem$evaluate env s [make_varls n t idx vars] =
-    (s with globals := g ++ MAP SOME vals ++ g', Rval [flatSem$Conv NONE []])`,
+    (s with globals := g ++ MAP SOME vals ++ g', Rval [flatSem$Conv NONE []])
+Proof
   ho_match_mp_tac make_varls_ind >>
   rw [make_varls_def, evaluate_def]
   >- fs [state_component_equality]
@@ -2550,7 +2624,8 @@ val evaluate_make_varls = Q.prove (
     first_x_assum (qspec_then `n+1` mp_tac) >>
     simp [GSYM ADD1]) >>
   first_x_assum (qspec_then `0` mp_tac) >>
-  rw [state_component_equality]);
+  rw [state_component_equality]
+QED
 
 Theorem EL_APPEND_IF:
   EL i (xs ++ ys) = if i < LENGTH xs then EL i xs else EL (i - LENGTH xs) ys
@@ -2584,14 +2659,15 @@ Proof
   \\ fs [EL_MAP]
 QED
 
-val ALOOKUP_alloc_defs_EL = Q.prove (
-  `!funs l n m.
+Triviality ALOOKUP_alloc_defs_EL:
+  !funs l n m.
     ALL_DISTINCT (MAP (λ(x,y,z). x) funs) ∧
     n < LENGTH funs
     ⇒
     ∃tt.
     ALOOKUP (alloc_defs m l (MAP FST (REVERSE funs))) (EL n (MAP FST funs)) =
-      SOME (Glob tt (l + LENGTH funs − (n + 1)))`,
+      SOME (Glob tt (l + LENGTH funs − (n + 1)))
+Proof
   gen_tac >>
   Induct_on `LENGTH funs` >>
   rw [] >>
@@ -2624,16 +2700,18 @@ val ALOOKUP_alloc_defs_EL = Q.prove (
     first_x_assum (qspec_then `REVERSE t` mp_tac) >>
     simp [] >>
     fs [ALL_DISTINCT_APPEND, ALL_DISTINCT_REVERSE, MAP_REVERSE]>>
-    disch_then(qspec_then`l+1` assume_tac)>>fs[]));
+    disch_then(qspec_then`l+1` assume_tac)>>fs[])
+QED
 
-val ALOOKUP_alloc_defs = Q.prove (
-  `!env x v l tt.
+Triviality ALOOKUP_alloc_defs:
+  !env x v l tt.
     ALOOKUP (REVERSE env) x = SOME v
     ⇒
     ∃n t.
       ALOOKUP (alloc_defs tt l (MAP FST (REVERSE env))) x = SOME (Glob t (l + n)) ∧
       n < LENGTH (MAP FST env) ∧
-      EL n (REVERSE (MAP SOME (MAP SND env))) = SOME v`,
+      EL n (REVERSE (MAP SOME (MAP SND env))) = SOME v
+Proof
   Induct_on `env` >>
   rw [ALOOKUP_APPEND, alloc_defs_append] >>
   every_case_tac >>
@@ -2660,10 +2738,11 @@ val ALOOKUP_alloc_defs = Q.prove (
   >- (
     first_x_assum drule >>
     disch_then (qspecl_then [`l`,`tt`] mp_tac) >>
-    rw [EL_APPEND_EQN]));
+    rw [EL_APPEND_EQN])
+QED
 
-val global_env_inv_extend = Q.prove (
-  `!pat_env genv pat_env' tt g1 g2.
+Triviality global_env_inv_extend:
+  !pat_env genv pat_env' tt g1 g2.
     env_rel genv (alist_to_ns pat_env) pat_env' ∧
     genv.v = g1 ⧺ MAP SOME (REVERSE (MAP SND pat_env')) ⧺ g2 ∧
     ALL_DISTINCT (MAP FST pat_env)
@@ -2672,7 +2751,8 @@ val global_env_inv_extend = Q.prove (
       <|c := nsEmpty;
         v := alist_to_ns (alloc_defs tt (LENGTH g1) (REVERSE (MAP FST pat_env')))|>
       ∅
-      <|v := alist_to_ns pat_env; c := nsEmpty|>`,
+      <|v := alist_to_ns pat_env; c := nsEmpty|>
+Proof
   rw [v_rel_global_eqn, extend_dec_env_def, extend_env_def,
       nsLookup_nsAppend_some, nsLookup_alist_to_ns_some] >>
   rfs [Once (GSYM alookup_distinct_reverse)] >>
@@ -2691,7 +2771,8 @@ val global_env_inv_extend = Q.prove (
   rw [] >>
   fs [EL_REPLICATE] >>
   rfs [EL_REVERSE, EL_MAP] >>
-  rw []);
+  rw []
+QED
 
 Theorem LIST_REL_sv_rel_weak:
   LIST_REL (sv_rel genv) vs vs' ∧
@@ -3513,31 +3594,37 @@ Proof
   )
 QED
 
-val nsAppend_foldl' = Q.prove (
-  `!l ns ns'.
+Triviality nsAppend_foldl':
+  !l ns ns'.
    nsAppend (FOLDL (λns (l,cids). nsAppend l ns) ns' l) ns
    =
-   FOLDL (λns (l,cids). nsAppend l ns) (nsAppend ns' ns) l`,
+   FOLDL (λns (l,cids). nsAppend l ns) (nsAppend ns' ns) l
+Proof
   Induct_on `l` >>
   rw [] >>
   PairCases_on `h` >>
-  rw []);
+  rw []
+QED
 
-val nsAppend_foldl = Q.prove (
-  `!l ns.
+Triviality nsAppend_foldl:
+  !l ns.
    FOLDL (λns (l,cids). nsAppend l ns) ns l
    =
-   nsAppend (FOLDL (λns (l,cids). nsAppend l ns) nsEmpty l) ns`,
-  metis_tac [nsAppend_foldl', nsAppend_nsEmpty]);
+   nsAppend (FOLDL (λns (l,cids). nsAppend l ns) nsEmpty l) ns
+Proof
+  metis_tac [nsAppend_foldl', nsAppend_nsEmpty]
+QED
 
-val build_tdefs_no_mod = Q.prove (
-  `!idx tdefs. nsDomMod (build_tdefs idx tdefs) = {[]}`,
+Triviality build_tdefs_no_mod:
+  !idx tdefs. nsDomMod (build_tdefs idx tdefs) = {[]}
+Proof
   Induct_on `tdefs` >>
   rw [build_tdefs_def] >>
   PairCases_on `h` >>
   rw [build_tdefs_def] >>
   pop_assum (qspec_then `idx+1` mp_tac) >>
-  rw [nsDomMod_nsAppend_flat]);
+  rw [nsDomMod_nsAppend_flat]
+QED
 
 val extend_env_v_empty =
 ``extend_env <| c := c; v := nsEmpty |> <| c := c'; v := nsEmpty |>``
@@ -5263,9 +5350,11 @@ Proof
   \\ rveq \\ fs []
 QED
 
-val SND_eq = Q.prove(
-  `SND x = y ⇔ ∃a. x = (a,y)`,
-  Cases_on`x`\\rw[]);
+Triviality SND_eq:
+  SND x = y ⇔ ∃a. x = (a,y)
+Proof
+  Cases_on`x`\\rw[]
+QED
 
 Theorem compile_prog_semantics:
   precondition1 interp g s1 env1 conf eval_conf prog ⇒
@@ -5569,8 +5658,11 @@ Proof
   \\ irule flat_patternProofTheory.compile_decs_no_Mat
 QED
 
-val mem_size_lemma = Q.prove ( `list_size sz xs < N ==> (MEM x xs ⇒ sz x < N)`,
-  Induct_on `xs` \\ rw [list_size_def] \\ fs []);
+Triviality mem_size_lemma:
+  list_size sz xs < N ==> (MEM x xs ⇒ sz x < N)
+Proof
+  Induct_on `xs` \\ rw [list_size_def] \\ fs []
+QED
 
 Definition num_bindings_def:
    (num_bindings (Dlet _ p _) = LENGTH (pat_bindings p [])) ∧

--- a/compiler/backend/proofs/stack_allocProofScript.sml
+++ b/compiler/backend/proofs/stack_allocProofScript.sml
@@ -65,16 +65,20 @@ QED
 
 (* ---- *)
 
-val get_var_imm_case = Q.prove(
-  `get_var_imm ri s =
+Triviality get_var_imm_case:
+  get_var_imm ri s =
     case ri of
     | Reg n => get_var n s
-    | Imm w => SOME (Word w)`,
-  Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def]);
+    | Imm w => SOME (Word w)
+Proof
+  Cases_on `ri` \\ full_simp_tac(srw_ss())[get_var_imm_def]
+QED
 
-val prog_comp_lemma = Q.prove(
-  `prog_comp = \(n,p). (n,FST (comp n (next_lab p 2) p))`,
-  full_simp_tac(srw_ss())[FUN_EQ_THM,FORALL_PROD,prog_comp_def]);
+Triviality prog_comp_lemma:
+  prog_comp = \(n,p). (n,FST (comp n (next_lab p 2) p))
+Proof
+  full_simp_tac(srw_ss())[FUN_EQ_THM,FORALL_PROD,prog_comp_def]
+QED
 
 Theorem FST_prog_comp[simp]:
    FST (prog_comp pp) = FST pp
@@ -95,14 +99,15 @@ Proof
   \\ metis_tac []
 QED
 
-val map_bitmap_APPEND = Q.prove(
-  `!x q stack p0 p1.
+Triviality map_bitmap_APPEND:
+  !x q stack p0 p1.
       filter_bitmap x stack = SOME (p0,p1) /\
       LENGTH q = LENGTH p0 ==>
       map_bitmap x (q ++ q') stack =
       case map_bitmap x q stack of
       | NONE => NONE
-      | SOME (hd,ts,ws) => SOME (hd,ts++q',ws)`,
+      | SOME (hd,ts,ws) => SOME (hd,ts++q',ws)
+Proof
   Induct \\ full_simp_tac(srw_ss())[map_bitmap_def]
   \\ reverse (Cases \\ Cases_on `stack`)
   \\ full_simp_tac(srw_ss())[map_bitmap_def,filter_bitmap_def]
@@ -110,7 +115,8 @@ val map_bitmap_APPEND = Q.prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ Cases \\ full_simp_tac(srw_ss())[map_bitmap_def]
-  \\ every_case_tac \\ full_simp_tac(srw_ss())[]);
+  \\ every_case_tac \\ full_simp_tac(srw_ss())[]
+QED
 
 Theorem filter_bitmap_map_bitmap:
    !x t q xs xs1 z ys ys1.
@@ -160,9 +166,11 @@ Proof
   \\ full_simp_tac(srw_ss())[ADD1] \\ srw_tac[][]
 QED
 
-val word_lsr_dimindex = Q.prove(
-  `(w:'a word) >>> dimindex (:'a) = 0w`,
-  full_simp_tac(srw_ss())[]);
+Triviality word_lsr_dimindex:
+  (w:'a word) >>> dimindex (:'a) = 0w
+Proof
+  full_simp_tac(srw_ss())[]
+QED
 
 Theorem bit_length_LESS_EQ_dimindex:
    bit_length (w:'a word) <= dimindex (:'a)
@@ -183,33 +191,39 @@ Proof
   \\ simp []
 QED
 
-val word_msb_IMP_bit_length = Q.prove(
-  `!h. word_msb (h:'a word) ==> (bit_length h = dimindex (:'a))`,
+Triviality word_msb_IMP_bit_length:
+  !h. word_msb (h:'a word) ==> (bit_length h = dimindex (:'a))
+Proof
   srw_tac[][] \\ imp_res_tac shift_to_zero_word_msb \\ CCONTR_TAC
   \\ imp_res_tac (DECIDE ``n<>m ==> n < m \/ m < n:num``)
   \\ qspec_then `h` mp_tac bit_length_thm
   \\ strip_tac \\ res_tac \\ full_simp_tac(srw_ss())[word_lsr_dimindex]
-  \\ decide_tac);
+  \\ decide_tac
+QED
 
-val get_bits_intro = Q.prove(
-  `word_msb (h:'a word) ==>
-    GENLIST (\i. h ' i) (dimindex (:'a) - 1) = get_bits h`,
-  full_simp_tac(srw_ss())[get_bits_def,word_msb_IMP_bit_length]);
+Triviality get_bits_intro:
+  word_msb (h:'a word) ==>
+    GENLIST (\i. h ' i) (dimindex (:'a) - 1) = get_bits h
+Proof
+  full_simp_tac(srw_ss())[get_bits_def,word_msb_IMP_bit_length]
+QED
 
-val filter_bitmap_APPEND = Q.prove(
-  `!xs stack ys.
+Triviality filter_bitmap_APPEND:
+  !xs stack ys.
       filter_bitmap (xs ++ ys) stack =
       case filter_bitmap xs stack of
       | NONE => NONE
       | SOME (zs,rs) =>
         case filter_bitmap ys rs of
         | NONE => NONE
-        | SOME (zs2,rs) => SOME (zs ++ zs2,rs)`,
+        | SOME (zs2,rs) => SOME (zs ++ zs2,rs)
+Proof
   Induct \\ Cases_on `stack` \\ full_simp_tac(srw_ss())[filter_bitmap_def]
   THEN1 (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   THEN1 (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
   \\ Cases \\ full_simp_tac(srw_ss())[filter_bitmap_def] \\ srw_tac[][]
-  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
+  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[])
+QED
 
 Theorem bit_length_minus_1:
    w <> 0w ==> bit_length w − 1 = bit_length (w >>> 1)
@@ -237,15 +251,17 @@ Proof
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [wordsTheory.word_index]
 QED
 
-val split_num_forall_to_10 = Q.prove(
-  `($! P) <=> P 0 /\ P 1 /\ P 2 /\ P 3 /\ P 4 /\ P 5 /\
-               P 6 /\ P 7 /\ P 8 /\ P 9 /\ !x. 9 < x ==> P (x:num)`,
+Triviality split_num_forall_to_10:
+  ($! P) <=> P 0 /\ P 1 /\ P 2 /\ P 3 /\ P 4 /\ P 5 /\
+               P 6 /\ P 7 /\ P 8 /\ P 9 /\ !x. 9 < x ==> P (x:num)
+Proof
   full_simp_tac(srw_ss())[GSYM (RAND_CONV ETA_CONV ``!x. P x``)]
   \\ eq_tac \\ srw_tac[][]
   \\ Cases_on `x` \\ full_simp_tac(srw_ss())[]
   \\ ntac 5 (Cases_on `n` \\ full_simp_tac(srw_ss())[] \\ Cases_on `n'` \\ full_simp_tac(srw_ss())[])
   \\ full_simp_tac(srw_ss())[ADD1,GSYM ADD_ASSOC]
-  \\ pop_assum match_mp_tac \\ decide_tac);
+  \\ pop_assum match_mp_tac \\ decide_tac
+QED
 
 val nine_less = DECIDE
   ``9 < n ==> n <> 0 /\ n <> 1 /\ n <> 2 /\ n <> 3 /\ n <> 4 /\
@@ -271,28 +287,38 @@ Proof
   srw_tac [wordsLib.WORD_BIT_EQ_ss] [] \\ eq_tac \\ rw []
 QED
 
-val is_fwd_ptr_iff = Q.prove(
-  `!w. is_fwd_ptr w <=> ?v. w = Word v /\ (v && 3w) = 0w`,
-  Cases \\ full_simp_tac(srw_ss())[wordSemTheory.is_fwd_ptr_def]);
+Triviality is_fwd_ptr_iff:
+  !w. is_fwd_ptr w <=> ?v. w = Word v /\ (v && 3w) = 0w
+Proof
+  Cases \\ full_simp_tac(srw_ss())[wordSemTheory.is_fwd_ptr_def]
+QED
 
-val isWord_thm = Q.prove(
-  `!w. isWord w = ?v. w = Word v`,
-  Cases \\ full_simp_tac(srw_ss())[wordSemTheory.isWord_def]);
+Triviality isWord_thm:
+  !w. isWord w = ?v. w = Word v
+Proof
+  Cases \\ full_simp_tac(srw_ss())[wordSemTheory.isWord_def]
+QED
 
-val lower_2w_eq = Q.prove(
-  `!w:'a word. good_dimindex (:'a) ==> (w <+ 2w <=> w = 0w \/ w = 1w)`,
+Triviality lower_2w_eq:
+  !w:'a word. good_dimindex (:'a) ==> (w <+ 2w <=> w = 0w \/ w = 1w)
+Proof
   Cases \\ fs [good_dimindex_def,WORD_LO,dimword_def]
-  \\ rw [] \\ rw []);
+  \\ rw [] \\ rw []
+QED
 
-val EL_LENGTH_ADD_LEMMA = Q.prove(
-  `EL (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) = x`,
+Triviality EL_LENGTH_ADD_LEMMA:
+  EL (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) = x
+Proof
   mp_tac (EL_LENGTH_APPEND |> Q.SPECL [`[x] ++ st1`,`init++old`])
-  \\ fs []);
+  \\ fs []
+QED
 
-val LUPDATE_LENGTH_ADD_LEMMA = Q.prove(
-  `LUPDATE w (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) =
-       init ++ old ++ [w] ++ st1`,
-  mp_tac (LUPDATE_LENGTH |> Q.SPECL [`init++old`]) \\ fs []);
+Triviality LUPDATE_LENGTH_ADD_LEMMA:
+  LUPDATE w (LENGTH init + LENGTH old) (init ++ old ++ [x] ++ st1) =
+       init ++ old ++ [w] ++ st1
+Proof
+  mp_tac (LUPDATE_LENGTH |> Q.SPECL [`init++old`]) \\ fs []
+QED
 
 Theorem word_msb_IFF_lsr_EQ_0:
    word_msb h <=> (h >>> (dimindex (:'a) - 1) <> 0w:'a word)
@@ -320,9 +346,11 @@ Proof
   \\ every_case_tac \\ fs []
 QED
 
-val EL_LENGTH_ADD_LEMMA = Q.prove(
-  `!n xs y ys. LENGTH xs = n ==> EL n (xs ++ y::ys) = y`,
-  fs [EL_LENGTH_APPEND]);
+Triviality EL_LENGTH_ADD_LEMMA:
+  !n xs y ys. LENGTH xs = n ==> EL n (xs ++ y::ys) = y
+Proof
+  fs [EL_LENGTH_APPEND]
+QED
 
 Theorem bytes_in_word_word_shift_n2w:
    good_dimindex (:α) ∧ (dimindex(:'a) DIV 8) * n < dimword (:α) ⇒
@@ -354,8 +382,8 @@ fun abbrev_under_exists tm tac =
   (fn state => (`?^(tm). ^(hd (fst (hd (fst (tac state)))))` by
         (fs [markerTheory.Abbrev_def] \\ NO_TAC)) state)
 
-val memcpy_code_thm = Q.prove(
-  `!n a b m dm b1 m1 (s:('a,'c,'b)stackSem$state).
+Triviality memcpy_code_thm:
+  !n a b m dm b1 m1 (s:('a,'c,'b)stackSem$state).
       memcpy ((n2w n):'a word) a b m dm = (b1:'a word,m1,T) /\
       n < dimword (:'a) /\
       s.memory = m /\ s.mdomain = dm /\
@@ -369,7 +397,8 @@ val memcpy_code_thm = Q.prove(
                           regs := s.regs |++ [(0,Word 0w);
                                               (1,r1);
                                               (2,Word (a + n2w n * bytes_in_word));
-                                              (3,Word b1)] |>)`,
+                                              (3,Word b1)] |>)
+Proof
   Induct THEN1
    (simp [Once memcpy_def]
     \\ srw_tac[][]
@@ -404,7 +433,8 @@ val memcpy_code_thm = Q.prove(
   \\ full_simp_tac(srw_ss())[FUPDATE_LIST,GSYM fmap_EQ,FLOOKUP_DEF,EXTENSION,
          FUN_EQ_THM,FAPPLY_FUPDATE_THM]
   \\ once_rewrite_tac [split_num_forall_to_10] \\ full_simp_tac(srw_ss())[nine_less]
-  \\ full_simp_tac(srw_ss())[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB])
+  \\ full_simp_tac(srw_ss())[GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
+QED
 
 Theorem memcpy_code_thm:
    !w a b m dm b1 m1 (s:('a,'c,'b)stackSem$state).
@@ -443,8 +473,8 @@ val word_gc_fun_lemma =
   |> SIMP_RULE std_ss [Once LET_THM]
   |> SIMP_RULE std_ss [Once LET_THM,word_gc_move_roots_def]
 
-val word_gc_fun_thm = Q.prove(
-  `conf.gc_kind = Simple ==>
+Triviality word_gc_fun_thm:
+  conf.gc_kind = Simple ==>
    word_gc_fun conf (roots,m,dm,s) =
       let (w1,i1:'a word,pa1,m1,c1) =
             word_gc_move conf
@@ -473,11 +503,13 @@ val word_gc_fun_thm = Q.prove(
              (Globals,w1);
              (GlobReal,glob_real conf (theWord (s ' OtherHeap)) w1)]
       in
-        if word_gc_fun_assum conf s /\ c2 then SOME (ws2,m1,s1) else NONE`,
+        if word_gc_fun_assum conf s /\ c2 then SOME (ws2,m1,s1) else NONE
+Proof
   full_simp_tac(srw_ss())[word_gc_fun_lemma,LET_THM]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[])
-  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]);
+  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
+QED
 
 val gc_lemma = gc_def
   |> SPEC_ALL
@@ -514,8 +546,8 @@ Proof
   Cases_on `c` \\ fs [] \\ rw [] \\ imp_res_tac word_gc_move_loop_F \\ fs []
 QED
 
-val gc_thm = Q.prove(
-  `s.gc_fun = word_gc_fun conf /\ conf.gc_kind = Simple ==>
+Triviality gc_thm:
+  s.gc_fun = word_gc_fun conf /\ conf.gc_kind = Simple ==>
    gc (s:('a,'c,'b)stackSem$state) =
    if LENGTH s.stack < s.stack_space then NONE else
      let unused = TAKE s.stack_space s.stack in
@@ -551,7 +583,8 @@ val gc_thm = Q.prove(
             (GlobReal,glob_real conf (theWord (s.store ' OtherHeap)) w1)] in
        if word_gc_fun_assum conf s.store /\ c2 then SOME (s with
                        <|stack := unused ++ stack; store := s1;
-                         regs := FEMPTY; memory := m1|>) else NONE`,
+                         regs := FEMPTY; memory := m1|>) else NONE
+Proof
   strip_tac \\ drule gc_lemma
   \\ disch_then (fn th => full_simp_tac(srw_ss())[th])
   \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
@@ -569,7 +602,8 @@ val gc_thm = Q.prove(
     \\ imp_res_tac word_gc_move_loop_F \\ full_simp_tac(srw_ss())[]
     \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[])
   \\ full_simp_tac(srw_ss())[] \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
-  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]);
+  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
+QED
 
 Definition word_gc_move_bitmaps_def:
   word_gc_move_bitmaps conf (w,stack,bitmaps,i1,pa1,curr,m,dm) =
@@ -587,12 +621,13 @@ Definition word_gc_move_bitmaps_def:
               SOME (hd,ws,i2,pa2,m2,c2)
 End
 
-val word_gc_move_roots_APPEND = Q.prove(
-  `!xs ys i1 pa1 m.
+Triviality word_gc_move_roots_APPEND:
+  !xs ys i1 pa1 m.
       word_gc_move_roots conf (xs++ys,i1,pa1,curr,m,dm) =
         let (ws1,i1,pa1,m1,c1) = word_gc_move_roots conf (xs,i1,pa1,curr,m,dm) in
         let (ws2,i2,pa2,m2,c2) = word_gc_move_roots conf (ys,i1,pa1,curr,m1,dm) in
-          (ws1++ws2,i2,pa2,m2,c1 /\ c2)`,
+          (ws1++ws2,i2,pa2,m2,c1 /\ c2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[word_gc_move_roots_def,LET_THM]
   \\ srw_tac[][] \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ fs[]
@@ -600,7 +635,8 @@ val word_gc_move_roots_APPEND = Q.prove(
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
   \\ rveq \\ fs[]
-  \\ EQ_TAC \\ fs[] \\ rw[]);
+  \\ EQ_TAC \\ fs[] \\ rw[]
+QED
 
 Theorem word_gc_move_roots_IMP_LENGTH:
    !xs r0 r1 curr r2 dm ys i2 pa2 m2 c conf.
@@ -612,8 +648,8 @@ Proof
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[] \\ res_tac
 QED
 
-val word_gc_move_roots_bitmaps = Q.prove(
-  `!stack i1 pa1 m stack2 i2 pa2 m2.
+Triviality word_gc_move_roots_bitmaps:
+  !stack i1 pa1 m stack2 i2 pa2 m2.
       (word_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,curr,m,dm) =
         (stack2,i2,pa2,m2,T)) ==>
       word_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,curr,m,dm) =
@@ -626,7 +662,8 @@ val word_gc_move_roots_bitmaps = Q.prove(
           | SOME (new,stack,i2,pa2,m2,c2) =>
               let (stack,i,pa,m,c3) =
                 word_gc_move_roots_bitmaps conf (stack,bitmaps,i2,pa2,curr,m2,dm) in
-                  (w::new++stack,i,pa,m,c2 /\ c3)`,
+                  (w::new++stack,i,pa,m,c2 /\ c3)
+Proof
   Cases THEN1 (full_simp_tac(srw_ss())[word_gc_move_roots_bitmaps_def,
                  enc_stack_def])
   \\ rpt strip_tac \\ pop_assum mp_tac \\ full_simp_tac(srw_ss())[]
@@ -658,7 +695,8 @@ val word_gc_move_roots_bitmaps = Q.prove(
   \\ imp_res_tac word_gc_move_roots_IMP_LENGTH \\ full_simp_tac(srw_ss())[]
   \\ drule filter_bitmap_map_bitmap
   \\ disch_then drule \\ full_simp_tac(srw_ss())[]
-  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]);
+  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
+QED
 
 Definition word_gc_move_bitmap_def:
   word_gc_move_bitmap conf (w,stack,i1,pa1,curr,m,dm) =
@@ -700,8 +738,8 @@ val word_gc_move_bitmaps_Loc =
   ``word_gc_move_bitmaps conf (Loc l1 l2,stack,bitmaps,i1,pa1,curr,m,dm)``
   |> SIMP_CONV std_ss [word_gc_move_bitmaps_def,full_read_bitmap_def];
 
-val word_gc_move_bitmaps_unroll = Q.prove(
-  `word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) = SOME x /\
+Triviality word_gc_move_bitmaps_unroll:
+  word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) = SOME x /\
     LENGTH bitmaps < dimword (:'a) - 1 /\ good_dimindex (:'a) ==>
     word_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,curr,m,dm) =
     case DROP (w2n (w - 1w:'a word)) bitmaps of
@@ -714,7 +752,8 @@ val word_gc_move_bitmaps_unroll = Q.prove(
             case word_gc_move_bitmaps conf (Word (w+1w),ws,bitmaps,i2,pa2,curr,m2,dm) of
             | NONE => NONE
             | SOME (hd3,ws3,i3,pa3,m3,c3) =>
-                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)`,
+                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)
+Proof
   full_simp_tac(srw_ss())[word_gc_move_bitmaps_def,full_read_bitmap_def]
   \\ Cases_on `w = 0w` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `DROP (w2n (w + -1w)) bitmaps`
@@ -773,10 +812,11 @@ val word_gc_move_bitmaps_unroll = Q.prove(
   \\ once_rewrite_tac [EQ_SYM_EQ] \\ disch_then drule
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]);
+  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]
+QED
 
-val word_gc_move_bitmap_unroll = Q.prove(
-  `word_gc_move_bitmap conf (w,stack,i1,pa1,curr,m,dm) =
+Triviality word_gc_move_bitmap_unroll:
+  word_gc_move_bitmap conf (w,stack,i1,pa1,curr,m,dm) =
     if w = 0w:'a word then SOME ([],stack,i1,pa1,m,T) else
     if w = 1w then SOME ([],stack,i1,pa1,m,T) else
       case stack of
@@ -790,7 +830,8 @@ val word_gc_move_bitmap_unroll = Q.prove(
           let (x1,i1,pa1,m1,c1) = word_gc_move conf (x,i1,pa1,curr,m,dm) in
           case word_gc_move_bitmap conf (w >>> 1,xs,i1,pa1,curr,m1,dm) of
           | NONE => NONE
-          | SOME (new,stack,i1,pa1,m,c) => SOME (x1::new,stack,i1,pa1,m,c1 /\ c)`,
+          | SOME (new,stack,i1,pa1,m,c) => SOME (x1::new,stack,i1,pa1,m,c1 /\ c)
+Proof
   simp [word_and_one_eq_0_iff]
   \\ simp [Once word_gc_move_bitmap_def,get_bits_def]
   \\ IF_CASES_TAC
@@ -823,7 +864,8 @@ val word_gc_move_bitmap_unroll = Q.prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[word_gc_move_roots_def,LET_THM]
   \\ ntac 3 (pairarg_tac \\ full_simp_tac(srw_ss())[]) \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[map_bitmap_def]
-  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
+  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[])
+QED
 
 Theorem word_gc_move_code_thm:
    word_gc_move conf (w,i,pa,old,m,dm) = (w1,i1,pa1,m1,T) /\
@@ -1000,8 +1042,8 @@ Proof
   \\ full_simp_tac(srw_ss())[nine_less]
 QED
 
-val word_gc_move_loop_code_thm = Q.prove(
-  `!k pb1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'c,'b)stackSem$state).
+Triviality word_gc_move_loop_code_thm:
+  !k pb1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'c,'b)stackSem$state).
       word_gc_move_loop k conf (pb1,i1,pa1,old1,m1,dm1,c1) = (i2,pa2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
       2 < dimindex (:'a) /\ conf.len_size <> 0 /\
@@ -1029,7 +1071,8 @@ val word_gc_move_loop_code_thm = Q.prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,Word pa2)] |>)`,
+                                              (8,Word pa2)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gc_move_loop _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gc_move_loop_def]
@@ -1112,7 +1155,8 @@ val word_gc_move_loop_code_thm = Q.prove(
   \\ full_simp_tac(srw_ss())[FUPDATE_LIST,GSYM fmap_EQ,FLOOKUP_DEF,EXTENSION,
          FUN_EQ_THM,FAPPLY_FUPDATE_THM]
   \\ once_rewrite_tac [split_num_forall_to_10]
-  \\ full_simp_tac(srw_ss())[nine_less]);
+  \\ full_simp_tac(srw_ss())[nine_less]
+QED
 
 Theorem word_gc_move_bitmap_code_thm:
    !w stack (s:('a,'c,'b)stackSem$state) i pa curr m dm new stack1 a1 i1 pa1 m1 old.
@@ -1679,8 +1723,8 @@ val word_gc_fun_lemma =
   |> SIMP_RULE std_ss [Once LET_THM]
   |> SIMP_RULE std_ss [Once LET_THM,word_gen_gc_move_roots_def]
 
-val word_gc_fun_thm = Q.prove(
-  `conf.gc_kind = ^kind ==>
+Triviality word_gc_fun_thm:
+  conf.gc_kind = ^kind ==>
    word_gc_fun conf (roots,m,dm,s) =
      if ¬word_gc_fun_assum conf s then NONE else
      if word_gen_gc_can_do_partial gen_sizes s then
@@ -1768,7 +1812,8 @@ val word_gc_fun_thm = Q.prove(
        in
          if word_gc_fun_assum conf s /\ c1 /\ c2 /\ c3
          then SOME (ws2,m3,s1)
-         else NONE)`,
+         else NONE)
+Proof
   strip_tac
   \\ drule word_gc_fun_lemma
   \\ disch_then (fn th => rewrite_tac [th])
@@ -1779,7 +1824,8 @@ val word_gc_fun_thm = Q.prove(
          \\ fs [word_gc_fun_assum_def,isWord_thm,theWord_def])
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
-  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]);
+  \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
+QED
 
 val gc_lemma = gc_def
   |> SPEC_ALL
@@ -1828,8 +1874,8 @@ val word_gen_gc_partial_move_ref_list_ok = prove(
   \\ asm_rewrite_tac [] \\ simp_tac std_ss []
   \\ strip_tac \\ res_tac);
 
-val gc_thm = Q.prove(
-  `s.gc_fun = word_gc_fun conf /\ conf.gc_kind = ^kind ==>
+Triviality gc_thm:
+  s.gc_fun = word_gc_fun conf /\ conf.gc_kind = ^kind ==>
    gc (s:('a,'c,'b)stackSem$state) =
    if LENGTH s.stack < s.stack_space then NONE else
      if ¬word_gc_fun_assum conf s.store then NONE else
@@ -1912,7 +1958,8 @@ val gc_thm = Q.prove(
        in
          if word_gc_fun_assum conf s.store /\ c1 /\ c2 /\ c3 then SOME (s with
               <| stack := unused ++ ws2; store := s1;
-                 regs := FEMPTY; memory := m3|>) else NONE)`,
+                 regs := FEMPTY; memory := m3|>) else NONE)
+Proof
   strip_tac \\ drule gc_lemma \\ fs []
   \\ disch_then (fn th => full_simp_tac(srw_ss())[th])
   \\ IF_CASES_TAC \\ full_simp_tac(srw_ss())[]
@@ -1939,7 +1986,8 @@ val gc_thm = Q.prove(
   \\ fs [UNDISCH word_gc_fun_thm]
   \\ rpt (pairarg_tac \\ full_simp_tac(srw_ss())[])
   \\ rpt (CASE_TAC \\ fs []) \\ rveq \\ fs []
-  \\ every_case_tac \\ fs [] \\ rveq);
+  \\ every_case_tac \\ fs [] \\ rveq
+QED
 
 Definition word_gen_gc_move_bitmaps_def:
   word_gen_gc_move_bitmaps conf (w,stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) =
@@ -1973,37 +2021,41 @@ Definition word_gen_gc_partial_move_bitmaps_def:
               SOME (hd,ws,i2,pa2,m2,c2)
 End
 
-val word_gen_gc_move_roots_APPEND = Q.prove(
-  `!xs ys i1 pa1 ib1 pb1 m.
+Triviality word_gen_gc_move_roots_APPEND:
+  !xs ys i1 pa1 ib1 pb1 m.
       word_gen_gc_move_roots conf (xs++ys,i1,pa1,ib1,pb1,curr,m,dm) =
         let (ws1,i1,pa1,ib1,pb1,m1,c1) =
           word_gen_gc_move_roots conf (xs,i1,pa1,ib1,pb1,curr,m,dm) in
         let (ws2,i2,pa2,ib2,pb2,m2,c2) =
           word_gen_gc_move_roots conf (ys,i1,pa1,ib1,pb1,curr,m1,dm) in
-            (ws1++ws2,i2,pa2,ib2,pb2,m2,c1 /\ c2)`,
+            (ws1++ws2,i2,pa2,ib2,pb2,m2,c1 /\ c2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[word_gen_gc_move_roots_def,LET_THM]
   \\ srw_tac[][] \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
-  \\ rveq \\ fs[] \\ EQ_TAC \\ fs[] \\ rw[]);
+  \\ rveq \\ fs[] \\ EQ_TAC \\ fs[] \\ rw[]
+QED
 
-val word_gen_gc_partial_move_roots_APPEND = Q.prove(
-  `!xs ys i1 pa1 ib1 pb1 m.
+Triviality word_gen_gc_partial_move_roots_APPEND:
+  !xs ys i1 pa1 ib1 pb1 m.
       word_gen_gc_partial_move_roots conf (xs++ys,i1,pa1,curr,m,dm,gs,rs) =
         let (ws1,i1,pa1,m1,c1) =
           word_gen_gc_partial_move_roots conf (xs,i1,pa1,curr,m,dm,gs,rs) in
         let (ws2,i2,pa2,m2,c2) =
           word_gen_gc_partial_move_roots conf (ys,i1,pa1,curr,m1,dm,gs,rs) in
-            (ws1++ws2,i2,pa2,m2,c1 /\ c2)`,
+            (ws1++ws2,i2,pa2,m2,c1 /\ c2)
+Proof
   Induct \\ full_simp_tac(srw_ss())[word_gen_gc_partial_move_roots_def,LET_THM]
   \\ srw_tac[][] \\ pairarg_tac \\ full_simp_tac(srw_ss())[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
   \\ pairarg_tac \\ fs[]
-  \\ rveq \\ fs[] \\ EQ_TAC \\ fs[] \\ rw[]);
+  \\ rveq \\ fs[] \\ EQ_TAC \\ fs[] \\ rw[]
+QED
 
 Theorem word_gen_gc_move_roots_IMP_LENGTH:
    !xs r0 r1 r3 r4 curr r2 dm ys i2 pa2 m2 c conf ib2 pb2.
@@ -2029,8 +2081,8 @@ Proof
   \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[] \\ res_tac
 QED
 
-val word_gen_gc_move_roots_bitmaps = Q.prove(
-  `!stack i1 pa1 m stack2 i2 pa2 m2.
+Triviality word_gen_gc_move_roots_bitmaps:
+  !stack i1 pa1 m stack2 i2 pa2 m2.
       (word_gen_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) =
         (stack2,i2,pa2,ib2,pb2,m2,T)) ==>
       word_gen_gc_move_roots_bitmaps conf (stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) =
@@ -2044,7 +2096,8 @@ val word_gen_gc_move_roots_bitmaps = Q.prove(
               let (stack,i,pa,ib1,pb1,m,c3) =
                 word_gen_gc_move_roots_bitmaps conf
                   (stack,bitmaps,i2,pa2,ib2,pb2,curr,m2,dm) in
-                    (w::new++stack,i,pa,ib1,pb1,m,c2 /\ c3)`,
+                    (w::new++stack,i,pa,ib1,pb1,m,c2 /\ c3)
+Proof
   Cases THEN1 (full_simp_tac(srw_ss())[word_gen_gc_move_roots_bitmaps_def,
                  enc_stack_def])
   \\ rpt strip_tac \\ pop_assum mp_tac \\ full_simp_tac(srw_ss())[]
@@ -2078,10 +2131,11 @@ val word_gen_gc_move_roots_bitmaps = Q.prove(
   \\ imp_res_tac word_gen_gc_move_roots_IMP_LENGTH \\ full_simp_tac(srw_ss())[]
   \\ drule filter_bitmap_map_bitmap
   \\ disch_then drule \\ full_simp_tac(srw_ss())[]
-  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]);
+  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
+QED
 
-val word_gen_gc_partial_move_roots_bitmaps = Q.prove(
-  `!stack i1 pa1 m stack2 i2 pa2 m2.
+Triviality word_gen_gc_partial_move_roots_bitmaps:
+  !stack i1 pa1 m stack2 i2 pa2 m2.
       (word_gen_gc_partial_move_roots_bitmaps conf
         (stack,bitmaps,i1,pa1,curr,m,dm,gs,rs) =
           (stack2,i2,pa2,m2,T)) ==>
@@ -2097,7 +2151,8 @@ val word_gen_gc_partial_move_roots_bitmaps = Q.prove(
               let (stack,i,pa,m,c3) =
                 word_gen_gc_partial_move_roots_bitmaps conf
                   (stack,bitmaps,i2,pa2,curr,m2,dm,gs,rs) in
-                    (w::new++stack,i,pa,m,c2 /\ c3)`,
+                    (w::new++stack,i,pa,m,c2 /\ c3)
+Proof
   Cases THEN1 (full_simp_tac(srw_ss())[word_gen_gc_partial_move_roots_bitmaps_def,
                  enc_stack_def])
   \\ rpt strip_tac \\ pop_assum mp_tac \\ full_simp_tac(srw_ss())[]
@@ -2131,7 +2186,8 @@ val word_gen_gc_partial_move_roots_bitmaps = Q.prove(
   \\ imp_res_tac word_gen_gc_partial_move_roots_IMP_LENGTH \\ full_simp_tac(srw_ss())[]
   \\ drule filter_bitmap_map_bitmap
   \\ disch_then drule \\ full_simp_tac(srw_ss())[]
-  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]);
+  \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
+QED
 
 Definition word_gen_gc_move_bitmap_def:
   word_gen_gc_move_bitmap conf (w,stack,i1,pa1,ib1,pb1,curr,m,dm) =
@@ -2191,8 +2247,8 @@ val word_gen_gc_partial_move_bitmaps_Loc =
   ``word_gen_gc_partial_move_bitmaps conf (Loc l1 l2,stack,bitmaps,i1,pa1,curr,m,dm,gs,rs)``
   |> SIMP_CONV std_ss [word_gen_gc_partial_move_bitmaps_def,full_read_bitmap_def];
 
-val word_gen_gc_move_bitmaps_unroll = Q.prove(
-  `word_gen_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) = SOME x /\
+Triviality word_gen_gc_move_bitmaps_unroll:
+  word_gen_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) = SOME x /\
     LENGTH bitmaps < dimword (:'a) - 1 /\ good_dimindex (:'a) ==>
     word_gen_gc_move_bitmaps conf (Word w,stack,bitmaps,i1,pa1,ib1,pb1,curr,m,dm) =
     case DROP (w2n (w - 1w:'a word)) bitmaps of
@@ -2205,7 +2261,8 @@ val word_gen_gc_move_bitmaps_unroll = Q.prove(
             case word_gen_gc_move_bitmaps conf (Word (w+1w),ws,bitmaps,i2,pa2,ib2,pb2,curr,m2,dm) of
             | NONE => NONE
             | SOME (hd3,ws3,i3,pa3,ib3,pb3,m3,c3) =>
-                SOME (hd++hd3,ws3,i3,pa3,ib3,pb3,m3,c2 /\ c3)`,
+                SOME (hd++hd3,ws3,i3,pa3,ib3,pb3,m3,c2 /\ c3)
+Proof
   full_simp_tac(srw_ss())[word_gen_gc_move_bitmaps_def,full_read_bitmap_def]
   \\ Cases_on `w = 0w` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `DROP (w2n (w + -1w)) bitmaps`
@@ -2264,10 +2321,11 @@ val word_gen_gc_move_bitmaps_unroll = Q.prove(
   \\ once_rewrite_tac [EQ_SYM_EQ] \\ disch_then drule
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]);
+  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]
+QED
 
-val word_gen_gc_partial_move_bitmaps_unroll = Q.prove(
-  `word_gen_gc_partial_move_bitmaps conf
+Triviality word_gen_gc_partial_move_bitmaps_unroll:
+  word_gen_gc_partial_move_bitmaps conf
       (Word w,stack,bitmaps,i1,pa1,curr,m,dm,gs,rs) = SOME x /\
     LENGTH bitmaps < dimword (:'a) - 1 /\ good_dimindex (:'a) ==>
     word_gen_gc_partial_move_bitmaps conf
@@ -2283,7 +2341,8 @@ val word_gen_gc_partial_move_bitmaps_unroll = Q.prove(
                    (Word (w+1w),ws,bitmaps,i2,pa2,curr,m2,dm,gs,rs) of
             | NONE => NONE
             | SOME (hd3,ws3,i3,pa3,m3,c3) =>
-                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)`,
+                SOME (hd++hd3,ws3,i3,pa3,m3,c2 /\ c3)
+Proof
   full_simp_tac(srw_ss())[word_gen_gc_partial_move_bitmaps_def,full_read_bitmap_def]
   \\ Cases_on `w = 0w` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `DROP (w2n (w + -1w)) bitmaps`
@@ -2342,10 +2401,11 @@ val word_gen_gc_partial_move_bitmaps_unroll = Q.prove(
   \\ once_rewrite_tac [EQ_SYM_EQ] \\ disch_then drule
   \\ strip_tac \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]);
+  \\ PairCases_on `x` \\ full_simp_tac(srw_ss())[]
+QED
 
-val word_gen_gc_move_bitmap_unroll = Q.prove(
-  `word_gen_gc_move_bitmap conf (w,stack,i1,pa1,ib1,pb1,curr,m,dm) =
+Triviality word_gen_gc_move_bitmap_unroll:
+  word_gen_gc_move_bitmap conf (w,stack,i1,pa1,ib1,pb1,curr,m,dm) =
     if w = 0w:'a word then SOME ([],stack,i1,pa1,ib1,pb1,m,T) else
     if w = 1w then SOME ([],stack,i1,pa1,ib1,pb1,m,T) else
       case stack of
@@ -2362,7 +2422,8 @@ val word_gen_gc_move_bitmap_unroll = Q.prove(
           case word_gen_gc_move_bitmap conf (w >>> 1,xs,i1,pa1,ib1,pb1,curr,m1,dm) of
           | NONE => NONE
           | SOME (new,stack,i1,pa1,ib1,pb1,m,c) =>
-              SOME (x1::new,stack,i1,pa1,ib1,pb1,m,c1 /\ c)`,
+              SOME (x1::new,stack,i1,pa1,ib1,pb1,m,c1 /\ c)
+Proof
   simp [word_and_one_eq_0_iff]
   \\ simp [Once word_gen_gc_move_bitmap_def,get_bits_def]
   \\ IF_CASES_TAC
@@ -2395,10 +2456,11 @@ val word_gen_gc_move_bitmap_unroll = Q.prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[word_gen_gc_move_roots_def,LET_THM]
   \\ ntac 3 (pairarg_tac \\ full_simp_tac(srw_ss())[]) \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[map_bitmap_def]
-  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
+  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[])
+QED
 
-val word_gen_gc_partial_move_bitmap_unroll = Q.prove(
-  `word_gen_gc_partial_move_bitmap conf (w,stack,i1,pa1,curr,m,dm,gs,rs) =
+Triviality word_gen_gc_partial_move_bitmap_unroll:
+  word_gen_gc_partial_move_bitmap conf (w,stack,i1,pa1,curr,m,dm,gs,rs) =
     if w = 0w:'a word then SOME ([],stack,i1,pa1,m,T) else
     if w = 1w then SOME ([],stack,i1,pa1,m,T) else
       case stack of
@@ -2417,7 +2479,8 @@ val word_gen_gc_partial_move_bitmap_unroll = Q.prove(
                  (w >>> 1,xs,i1,pa1,curr,m1,dm,gs,rs) of
           | NONE => NONE
           | SOME (new,stack,i1,pa1,m,c) =>
-              SOME (x1::new,stack,i1,pa1,m,c1 /\ c)`,
+              SOME (x1::new,stack,i1,pa1,m,c1 /\ c)
+Proof
   simp [word_and_one_eq_0_iff]
   \\ simp [Once word_gen_gc_partial_move_bitmap_def,get_bits_def]
   \\ IF_CASES_TAC
@@ -2450,7 +2513,8 @@ val word_gen_gc_partial_move_bitmap_unroll = Q.prove(
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[word_gen_gc_partial_move_roots_def,LET_THM]
   \\ ntac 3 (pairarg_tac \\ full_simp_tac(srw_ss())[]) \\ rpt var_eq_tac \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[map_bitmap_def]
-  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[]));
+  \\ rpt (CASE_TAC \\ full_simp_tac(srw_ss())[])
+QED
 
 Theorem word_gen_gc_move_code_thm:
    word_gen_gc_move conf (w,i,pa,ib,pb,old,m,dm) = (w1,i1,pa1,ib1,pb1,m1,T) /\
@@ -3825,8 +3889,8 @@ Proof
   \\ full_simp_tac(srw_ss())[nine_less]
 QED
 
-val word_gen_gc_partial_move_ref_list_code_thm = Q.prove(
-  `!k r2a1 r1a1 r2a2 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
+Triviality word_gen_gc_partial_move_ref_list_code_thm:
+  !k r2a1 r1a1 r2a2 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
       word_gen_gc_partial_move_ref_list k conf (r1a1,i1,pa1,old1,m1,dm1,T,gs,rs,r2a1) =
         (i2,pa2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -3859,7 +3923,8 @@ val word_gen_gc_partial_move_ref_list_code_thm = Q.prove(
                                               (6,r6);
                                               (7,r7);
                                               (8,r8);
-                                              (9,r9)] |>)`,
+                                              (9,r9)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gen_gc_partial_move_ref_list _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gen_gc_partial_move_ref_list_def]
@@ -3914,10 +3979,11 @@ val word_gen_gc_partial_move_ref_list_code_thm = Q.prove(
   \\ full_simp_tac(srw_ss())[FUPDATE_LIST,GSYM fmap_EQ,FLOOKUP_DEF,EXTENSION,
          FUN_EQ_THM,FAPPLY_FUPDATE_THM]
   \\ once_rewrite_tac [split_num_forall_to_10]
-  \\ full_simp_tac(srw_ss())[nine_less]);
+  \\ full_simp_tac(srw_ss())[nine_less]
+QED
 
-val word_gen_gc_move_data_code_thm = Q.prove(
-  `!k ha1 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
+Triviality word_gen_gc_move_data_code_thm:
+  !k ha1 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
       word_gen_gc_move_data conf k (ha1,i1,pa1,ib1,pb1,old1,m1,dm1) =
         (i2,pa2,ib2,pb2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -3954,7 +4020,8 @@ val word_gen_gc_move_data_code_thm = Q.prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,Word pa2)] |>)`,
+                                              (8,Word pa2)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gen_gc_move_data _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gen_gc_move_data_def]
@@ -4044,10 +4111,11 @@ val word_gen_gc_move_data_code_thm = Q.prove(
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less]
   \\ qexists_tac `t0'` \\ qexists_tac `t1'`
-  \\ rw [] \\ eq_tac \\ rw[] \\ fs []);
+  \\ rw [] \\ eq_tac \\ rw[] \\ fs []
+QED
 
-val word_gen_gc_partial_move_data_code_thm = Q.prove(
-  `!k ha1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'c,'b)stackSem$state).
+Triviality word_gen_gc_partial_move_data_code_thm:
+  !k ha1 i1 pa1 old1 m1 dm1 c1 i2 pa2 m2 (s:('a,'c,'b)stackSem$state).
       word_gen_gc_partial_move_data conf k (ha1,i1,pa1,old1,m1,dm1,gs,rs) =
         (i2,pa2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -4078,7 +4146,8 @@ val word_gen_gc_partial_move_data_code_thm = Q.prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,Word pa2)] |>)`,
+                                              (8,Word pa2)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gen_gc_partial_move_data _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gen_gc_partial_move_data_def]
@@ -4161,10 +4230,11 @@ val word_gen_gc_partial_move_data_code_thm = Q.prove(
   \\ full_simp_tac(srw_ss())[FUPDATE_LIST,GSYM fmap_EQ,FLOOKUP_DEF,EXTENSION,
          FUN_EQ_THM,FAPPLY_FUPDATE_THM]
   \\ once_rewrite_tac [split_num_forall_to_10]
-  \\ full_simp_tac(srw_ss())[nine_less]);
+  \\ full_simp_tac(srw_ss())[nine_less]
+QED
 
-val word_gen_gc_move_refs_code_thm = Q.prove(
-  `!k r2a1 r1a1 r2a2 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
+Triviality word_gen_gc_move_refs_code_thm:
+  !k r2a1 r1a1 r2a2 i1 pa1 ib1 pb1 old1 m1 dm1 c1 i2 pa2 ib2 pb2 m2 (s:('a,'c,'b)stackSem$state).
       word_gen_gc_move_refs conf k (r2a1,r1a1,i1,pa1,ib1,pb1,old1,m1,dm1) =
         (r2a2,i2,pa2,ib2,pb2,m2,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -4202,7 +4272,8 @@ val word_gen_gc_move_refs_code_thm = Q.prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,Word r2a2)] |>)`,
+                                              (8,Word r2a2)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gen_gc_move_refs _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gen_gc_move_refs_def]
@@ -4263,10 +4334,11 @@ val word_gen_gc_move_refs_code_thm = Q.prove(
   \\ once_rewrite_tac [split_num_forall_to_10]
   \\ full_simp_tac(srw_ss())[nine_less]
   \\ qexists_tac `t0'` \\ qexists_tac `t1'`
-  \\ rw [] \\ eq_tac \\ rw[] \\ fs []);
+  \\ rw [] \\ eq_tac \\ rw[] \\ fs []
+QED
 
-val word_gen_gc_move_loop_code_thm = Q.prove(
-  `!k pax i pa ib pb pbx old m dm i1 pa1 ib1 pb1 m1 tt (s:('a,'c,'b)stackSem$state).
+Triviality word_gen_gc_move_loop_code_thm:
+  !k pax i pa ib pb pbx old m dm i1 pa1 ib1 pb1 m1 tt (s:('a,'c,'b)stackSem$state).
       word_gen_gc_move_loop conf k (pax,i,pa,ib,pb,pbx,old,m,dm) =
           (i1,pa1,ib1,pb1,m1,T) /\
       shift_length conf < dimindex (:'a) /\ word_shift (:'a) < dimindex (:'a) /\
@@ -4308,7 +4380,8 @@ val word_gen_gc_move_loop_code_thm = Q.prove(
                                               (5,r5);
                                               (6,r6);
                                               (7,r7);
-                                              (8,r8)] |>)`,
+                                              (8,r8)] |>)
+Proof
   strip_tac \\ completeInduct_on `k` \\ rpt strip_tac
   \\ qpat_x_assum `word_gen_gc_move_loop _ _ _ = _` mp_tac
   \\ once_rewrite_tac [word_gen_gc_move_loop_def]
@@ -4450,7 +4523,8 @@ val word_gen_gc_move_loop_code_thm = Q.prove(
   \\ qexists_tac `t4`
   \\ qexists_tac `t5`
   \\ qexists_tac `t6`
-  \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []);
+  \\ fs [] \\ rw [] \\ eq_tac \\ rw [] \\ fs []
+QED
 
 val word_sub_0_eq = prove(
   ``((-1w * w + v = 0w) <=> w = v) /\
@@ -5015,8 +5089,8 @@ Proof
   THEN1 metis_tac [alloc_correct_lemma_Generational]
 QED
 
-val alloc_correct = Q.prove(
-  `alloc w (s:('a,'c,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
+Triviality alloc_correct:
+  alloc w (s:('a,'c,'b)stackSem$state) = (r,t) /\ r <> SOME Error /\
     s.gc_fun = word_gc_fun c /\
     LENGTH s.bitmaps < dimword (:'a) - 1 /\
     LENGTH s.stack * (dimindex (:'a) DIV 8) < dimword (:'a) /\
@@ -5032,7 +5106,8 @@ val alloc_correct = Q.prove(
           t with
            <| use_store := T; use_stack := T; use_alloc := F;
               use_alloc := F; code := fromAList (compile c (toAList s.code));
-              regs := l2; gc_fun := anything|>) /\ t.regs SUBMAP l2`,
+              regs := l2; gc_fun := anything|>) /\ t.regs SUBMAP l2
+Proof
   `find_code (INL gc_stub_location) (l \\ 0) (fromAList (compile c (toAList s.code))) =
       SOME (Seq (word_gc_code c) (Return 0 0))` by
      simp[find_code_def,lookup_fromAList,compile_def,ALOOKUP_APPEND,stubs_def]
@@ -5041,14 +5116,17 @@ val alloc_correct = Q.prove(
   \\ disch_then (qspecl_then [`c`,`l |+ (0,Loc n' m)`] mp_tac)
   \\ fs [FLOOKUP_UPDATE] \\ strip_tac
   \\ qexists_tac `ck+1` \\ fs []
-  \\ Cases_on `r` \\ fs [state_component_equality]);
+  \\ Cases_on `r` \\ fs [state_component_equality]
+QED
 
-val find_code_IMP_lookup = Q.prove(
-  `find_code dest regs (s:'a num_map) = SOME x ==>
+Triviality find_code_IMP_lookup:
+  find_code dest regs (s:'a num_map) = SOME x ==>
     ?k. sptree$lookup k s = SOME x /\
-        (find_code dest regs = ((lookup k):'a num_map -> 'a option))`,
+        (find_code dest regs = ((lookup k):'a num_map -> 'a option))
+Proof
   Cases_on `dest` \\ full_simp_tac(srw_ss())[find_code_def,FUN_EQ_THM]
-  \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ metis_tac []);
+  \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ metis_tac []
+QED
 
 Theorem alloc_length_stack:
    alloc c s = (r,t) /\ s.gc_fun = word_gc_fun conf /\
@@ -5110,20 +5188,24 @@ Proof
   \\ rw [] \\ metis_tac [get_labels_comp,SUBSET_DEF]
 QED
 
-val SUBMAP_DOMSUB_both = Q.prove(`
+Triviality SUBMAP_DOMSUB_both:
   A SUBMAP B ⇒
-  A \\ c SUBMAP B \\ c`,
+  A \\ c SUBMAP B \\ c
+Proof
   rw[GSYM SUBMAP_DOMSUB_gen]>>
-  metis_tac[SUBMAP_TRANS,SUBMAP_DOMSUB]);
+  metis_tac[SUBMAP_TRANS,SUBMAP_DOMSUB]
+QED
 
-val SUBMAP_FUPDATE_both = Q.prove(`
+Triviality SUBMAP_FUPDATE_both:
   A SUBMAP B ⇒
-  A |+ (n,v) SUBMAP B |+ (n,v)`,
+  A |+ (n,v) SUBMAP B |+ (n,v)
+Proof
   rw[]>>match_mp_tac SUBMAP_mono_FUPDATE >>
-  fs[SUBMAP_DOMSUB_both]);
+  fs[SUBMAP_DOMSUB_both]
+QED
 
 (* This proof is very slow! *)
-val inst_correct = Q.prove(`
+Triviality inst_correct:
   inst (i:'a inst) (s:('a,'c,'b) stackSem$state) = SOME t ∧
   LENGTH s.stack * (dimindex (:α) DIV 8) < dimword (:α) ∧
   LENGTH s.data_buffer.buffer + (LENGTH s.bitmaps + s.data_buffer.space_left) < dimword (:'a) - 1 ∧
@@ -5143,7 +5225,8 @@ val inst_correct = Q.prove(`
           code := fromAList (compile c (toAList t.code))|>) ∧
     t.regs SUBMAP regs1 ∧
     LENGTH t.stack * (dimindex (:α) DIV 8) < dimword (:α) ∧
-    LENGTH t.data_buffer.buffer + (LENGTH t.bitmaps + t.data_buffer.space_left) < dimword (:'a) - 1`,
+    LENGTH t.data_buffer.buffer + (LENGTH t.bitmaps + t.data_buffer.space_left) < dimword (:'a) - 1
+Proof
   Cases_on`i`>>fs[inst_def]
   >-
     (rw[]>>rfs[state_component_equality])
@@ -5174,7 +5257,8 @@ val inst_correct = Q.prove(`
     every_case_tac>>
     imp_res_tac FLOOKUP_SUBMAP>>fs[]>>
     fs[set_var_def,state_component_equality]>>
-    metis_tac[SUBMAP_FUPDATE_both]));
+    metis_tac[SUBMAP_FUPDATE_both])
+QED
 
 Theorem ALOOKUP_prog_comp:
   ∀xs a y.

--- a/compiler/backend/proofs/stack_namesProofScript.sml
+++ b/compiler/backend/proofs/stack_namesProofScript.sml
@@ -170,9 +170,11 @@ Proof
   Cases_on ‘op’>>rw[sh_mem_op_def]
 QED
 
-val prog_comp_eta = Q.prove(
-  `prog_comp f = λ(x,y). (x,comp f y)`,
-  rw[prog_comp_def,FUN_EQ_THM,FORALL_PROD])
+Triviality prog_comp_eta:
+  prog_comp f = λ(x,y). (x,comp f y)
+Proof
+  rw[prog_comp_def,FUN_EQ_THM,FORALL_PROD]
+QED
 
 Theorem find_code_rename_state[simp]:
    BIJ (find_name f) UNIV UNIV ⇒
@@ -256,23 +258,29 @@ Proof
   rw[rename_state_def,domain_fromAList,toAList_domain,EXTENSION]
 QED
 
-val comp_STOP_While = Q.prove(
-  `comp f (STOP (While cmp r1 ri c1)) =
-    STOP (While cmp (find_name f r1) (ri_find_name f ri) (comp f c1))`,
-  simp [Once comp_def] \\ fs [STOP_def]);
+Triviality comp_STOP_While:
+  comp f (STOP (While cmp r1 ri c1)) =
+    STOP (While cmp (find_name f r1) (ri_find_name f ri) (comp f c1))
+Proof
+  simp [Once comp_def] \\ fs [STOP_def]
+QED
 
-val get_labels_comp = Q.prove(
-  `!f p. get_labels (comp f p) = get_labels p`,
+Triviality get_labels_comp:
+  !f p. get_labels (comp f p) = get_labels p
+Proof
   HO_MATCH_MP_TAC stack_namesTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [comp_def] \\ fs []
-  \\ every_case_tac \\ fs [get_labels_def]);
+  \\ every_case_tac \\ fs [get_labels_def]
+QED
 
-val loc_check_rename_state = Q.prove(
-  `loc_check (rename_state c f s).code (l1,l2) =
-    loc_check s.code (l1,l2)`,
+Triviality loc_check_rename_state:
+  loc_check (rename_state c f s).code (l1,l2) =
+    loc_check s.code (l1,l2)
+Proof
   fs [loc_check_def,rename_state_def,lookup_fromAList,compile_def,prog_comp_def]
   \\ simp[lookup_fromAList,compile_def,prog_comp_eta,ALOOKUP_MAP,ALOOKUP_toAList]
-  \\ fs [PULL_EXISTS,get_labels_comp]);
+  \\ fs [PULL_EXISTS,get_labels_comp]
+QED
 
 Theorem comp_correct[local]:
   ∀p s r t.
@@ -528,13 +536,15 @@ Proof
   srw_tac[QUANT_INST_ss[pair_default_qp]][]
 QED
 
-val compile_semantics_alt = Q.prove(
-  `!s t.
+Triviality compile_semantics_alt:
+  !s t.
       BIJ (find_name f) UNIV UNIV /\ (rename_state t.compile f s = t) /\
       s.compile = (λc. t.compile c o (compile f)) /\
       ~s.use_alloc /\ ~s.use_store /\ ~s.use_stack ==>
-      semantics start t = semantics start s`,
-  metis_tac [compile_semantics]);
+      semantics start t = semantics start s
+Proof
+  metis_tac [compile_semantics]
+QED
 
 Definition make_init_def:
   make_init f code oracle (s:('a,'c,'ffi) stackSem$state) =
@@ -577,25 +587,30 @@ Proof
   BasicProvers.EVERY_CASE_TAC>>fs[extract_labels_def]
 QED
 
-val names_ok_imp = Q.prove(`
+Triviality names_ok_imp:
   names_ok f c.reg_count c.avoid_regs ⇒
   ∀n. reg_name n c ⇒
-  reg_ok (find_name f n) c`,
-  fs[names_ok_def,EVERY_GENLIST,reg_name_def,asmTheory.reg_ok_def])
+  reg_ok (find_name f n) c
+Proof
+  fs[names_ok_def,EVERY_GENLIST,reg_name_def,asmTheory.reg_ok_def]
+QED
 
-val names_ok_imp2 = Q.prove(`
+Triviality names_ok_imp2:
   names_ok f c.reg_count c.avoid_regs ∧
   n ≠ n' ∧
   reg_name n c ∧ reg_name n' c ⇒
-  find_name f n ≠ find_name f n'`,
+  find_name f n ≠ find_name f n'
+Proof
   rw[names_ok_def]>>fs[ALL_DISTINCT_GENLIST,reg_name_def]>>
-  metis_tac[])
+  metis_tac[]
+QED
 
-val stack_names_comp_stack_asm_ok = Q.prove(`
+Triviality stack_names_comp_stack_asm_ok:
   ∀f p.
   stack_asm_name c p ∧ names_ok f c.reg_count c.avoid_regs ∧
   fixed_names f c ⇒
-  stack_asm_ok c (stack_names$comp f p)`,
+  stack_asm_ok c (stack_names$comp f p)
+Proof
   ho_match_mp_tac comp_ind>>
   Cases_on`p`>>rw[]>>
   simp[Once comp_def]>>fs[stack_asm_ok_def,stack_asm_name_def]
@@ -625,7 +640,8 @@ val stack_names_comp_stack_asm_ok = Q.prove(`
   >- metis_tac[names_ok_imp,asmTheory.reg_ok_def]
   >- (CASE_TAC>>gs[stack_asm_ok_def]>>
       metis_tac[names_ok_imp,asmTheory.reg_ok_def,addr_ok_def,addr_name_def])
-  >- metis_tac[names_ok_imp,asmTheory.reg_ok_def]);
+  >- metis_tac[names_ok_imp,asmTheory.reg_ok_def]
+QED
 
 Theorem stack_names_stack_asm_ok:
     EVERY (λ(n,p). stack_asm_name c p) prog ∧

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -200,21 +200,27 @@ Definition state_rel_def:
     | _ => F
 End
 
-val state_rel_get_var = Q.prove(
-  `state_rel jump off k s t /\ n < k ==> (get_var n s = get_var n t)`,
-  full_simp_tac(srw_ss())[state_rel_def,get_var_def]);
+Triviality state_rel_get_var:
+  state_rel jump off k s t /\ n < k ==> (get_var n s = get_var n t)
+Proof
+  full_simp_tac(srw_ss())[state_rel_def,get_var_def]
+QED
 
-val state_rel_IMP = Q.prove(
-  `state_rel jump off k s t1 ==>
-    state_rel jump off k (dec_clock s) (dec_clock t1)`,
+Triviality state_rel_IMP:
+  state_rel jump off k s t1 ==>
+    state_rel jump off k (dec_clock s) (dec_clock t1)
+Proof
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
-  \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
+  \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[]
+QED
 
-val state_rel_with_clock = Q.prove(
-  `state_rel jump off k s t1 ==>
-    state_rel jump off k (s with clock := c) (t1 with clock := c)`,
+Triviality state_rel_with_clock:
+  state_rel jump off k s t1 ==>
+    state_rel jump off k (s with clock := c) (t1 with clock := c)
+Proof
   srw_tac[][] \\ full_simp_tac(srw_ss())[state_rel_def,dec_clock_def,empty_env_def] \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[]
-  \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[])
+  \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[]
+QED
 
 Theorem state_rel_const:
    state_rel jump off k s t ⇒
@@ -227,27 +233,31 @@ Proof
   fs[state_rel_def]
 QED
 
-val find_code_lemma = Q.prove(
-  `state_rel jump off k s t1 /\
+Triviality find_code_lemma:
+  state_rel jump off k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest s.regs s.code = SOME x ==>
-    find_code dest t1.regs t1.code = SOME (comp jump off k x) /\ reg_bound x k`,
+    find_code dest t1.regs t1.code = SOME (comp jump off k x) /\ reg_bound x k
+Proof
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
+  \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac
+QED
 
-val find_code_lemma2 = Q.prove(
-  `state_rel jump off k s t1 /\
+Triviality find_code_lemma2:
+  state_rel jump off k s t1 /\
     (case dest of INL v2 => T | INR i => i < k) /\
     find_code dest (s.regs \\ x1) s.code = SOME x ==>
-    find_code dest (t1.regs \\ x1) t1.code = SOME (comp jump off k x) /\ reg_bound x k`,
+    find_code dest (t1.regs \\ x1) t1.code = SOME (comp jump off k x) /\ reg_bound x k
+Proof
   CASE_TAC \\ full_simp_tac(srw_ss())[find_code_def,state_rel_def,code_rel_def]
   \\ strip_tac \\ res_tac
   \\ fs[DOMSUB_FLOOKUP_THM]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac
-  \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac);
+  \\ CASE_TAC \\ full_simp_tac(srw_ss())[] \\ res_tac
+QED
 
 Theorem state_rel_set_var[simp]:
    state_rel jump off k s t1 /\ v < k ==>
@@ -258,68 +268,83 @@ Proof
   metis_tac[]
 QED
 
-val word_store_CurrHeap = Q.prove(
-  `word_store base (s.store |+ (CurrHeap,x)) = word_store base s.store`,
-  full_simp_tac(srw_ss())[word_store_def,store_list_def,FLOOKUP_UPDATE]);
+Triviality word_store_CurrHeap:
+  word_store base (s.store |+ (CurrHeap,x)) = word_store base s.store
+Proof
+  full_simp_tac(srw_ss())[word_store_def,store_list_def,FLOOKUP_UPDATE]
+QED
 
-val memory_fun2set_IMP_read = Q.prove(
-  `(memory m d * p) (fun2set (m1,d1)) /\ a IN d ==>
-    a IN d1 /\ m1 a = m a`,
+Triviality memory_fun2set_IMP_read:
+  (memory m d * p) (fun2set (m1,d1)) /\ a IN d ==>
+    a IN d1 /\ m1 a = m a
+Proof
   simp [Once STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
-  \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS]);
+  \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS]
+QED
 
-val state_rel_read = Q.prove(
-  `state_rel jump off k s t /\ a IN s.mdomain ==>
-    a IN t.mdomain /\ (t.memory a = s.memory a)`,
+Triviality state_rel_read:
+  state_rel jump off k s t /\ a IN s.mdomain ==>
+    a IN t.mdomain /\ (t.memory a = s.memory a)
+Proof
   full_simp_tac(srw_ss())[state_rel_def] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ strip_tac
-  \\ full_simp_tac(srw_ss())[GSYM STAR_ASSOC] \\ metis_tac [memory_fun2set_IMP_read]);
+  \\ full_simp_tac(srw_ss())[GSYM STAR_ASSOC] \\ metis_tac [memory_fun2set_IMP_read]
+QED
 
-val mem_load_byte_aux_IMP = Q.prove(
-  `state_rel jump off k s t /\
+Triviality mem_load_byte_aux_IMP:
+  state_rel jump off k s t /\
     mem_load_byte_aux s.memory s.mdomain s.be a = SOME x ==>
-    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x`,
+    mem_load_byte_aux t.memory t.mdomain t.be a = SOME x
+Proof
   full_simp_tac(srw_ss())[wordSemTheory.mem_load_byte_aux_def] \\ srw_tac[][]
   \\ `s.be = t.be` by full_simp_tac(srw_ss())[state_rel_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
   \\ imp_res_tac state_rel_read
-  \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
+  \\ full_simp_tac(srw_ss())[] \\ rev_full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+QED
 
-val read_bytearray_IMP_read_bytearray = Q.prove(
-  `!n a k s t x.
+Triviality read_bytearray_IMP_read_bytearray:
+  !n a k s t x.
       state_rel jump off k s t /\
       read_bytearray a n (mem_load_byte_aux s.memory s.mdomain s.be) = SOME x ==>
-      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x`,
+      read_bytearray a n (mem_load_byte_aux t.memory t.mdomain t.be) = SOME x
+Proof
   Induct \\ full_simp_tac(srw_ss())[read_bytearray_def]
   \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ res_tac \\ srw_tac[][]
-  \\ imp_res_tac mem_load_byte_aux_IMP \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
+  \\ imp_res_tac mem_load_byte_aux_IMP \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+QED
 
-val write_bytearray_IGNORE_non_aligned = Q.prove(
-  `!new_bytes a.
+Triviality write_bytearray_IGNORE_non_aligned:
+  !new_bytes a.
       (!x. b <> byte_align x) ==>
-      write_bytearray a new_bytes m d be b = m b`,
+      write_bytearray a new_bytes m d be b = m b
+Proof
   Induct \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[wordSemTheory.mem_store_byte_aux_def]
-  \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]);
+  \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM]
+QED
 
-val write_bytearray_IGNORE = Q.prove(
-  `!new_bytes a x xx.
+Triviality write_bytearray_IGNORE:
+  !new_bytes a x xx.
       d1 SUBSET d /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME x /\ xx ∉ d1 ==>
-      write_bytearray a new_bytes m d be xx = m xx`,
+      write_bytearray a new_bytes m d be xx = m xx
+Proof
   Induct_on `new_bytes`
   \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def,read_bytearray_def]
   \\ full_simp_tac(srw_ss())[wordSemTheory.mem_load_byte_aux_def]
   \\ full_simp_tac(srw_ss())[wordSemTheory.mem_store_byte_aux_def]
   \\ rpt gen_tac \\ every_case_tac
   \\ srw_tac[][] \\ res_tac \\ full_simp_tac(srw_ss())[]
-  \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
+  \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+QED
 
-val write_bytearray_EQ = Q.prove(
-  `!new_bytes a m1 m y x.
+Triviality write_bytearray_EQ:
+  !new_bytes a m1 m y x.
       d1 SUBSET d /\ (!a. a IN d1 ==> m1 a = m a /\ a IN d) /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME y /\ m1 x = m x ==>
       write_bytearray a new_bytes m1 d1 be x =
-      write_bytearray a new_bytes m d be x`,
+      write_bytearray a new_bytes m d be x
+Proof
   Induct_on `new_bytes`
   \\ full_simp_tac(srw_ss())[wordSemTheory.write_bytearray_def,read_bytearray_def]
   \\ rpt gen_tac \\ ntac 2 BasicProvers.TOP_CASE_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
@@ -333,14 +358,16 @@ val write_bytearray_EQ = Q.prove(
   \\ `write_bytearray (a + 1w) new_bytes m1 d1 be (byte_align a) =
       write_bytearray (a + 1w) new_bytes m d be (byte_align a)` by
     (first_x_assum match_mp_tac \\ full_simp_tac(srw_ss())[] \\ res_tac \\ full_simp_tac(srw_ss())[])
-  \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][]);
+  \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][]
+QED
 
-val write_bytearray_lemma = Q.prove(
-  `!new_bytes a m1 d1 be x p m d.
+Triviality write_bytearray_lemma:
+  !new_bytes a m1 d1 be x p m d.
       (memory m1 d1 * p) (fun2set (m,d)) /\
       read_bytearray a (LENGTH new_bytes) (mem_load_byte_aux m1 d1 be) = SOME x ==>
       (memory (write_bytearray a new_bytes m1 d1 be) d1 * p)
-        (fun2set (write_bytearray a new_bytes m d be,d))`,
+        (fun2set (write_bytearray a new_bytes m d be,d))
+Proof
   simp [STAR_def,set_sepTheory.SPLIT_EQ,memory_def]
   \\ full_simp_tac(srw_ss())[fun2set_def,SUBSET_DEF,PULL_EXISTS] \\ srw_tac[][]
   \\ `d1 SUBSET d` by full_simp_tac(srw_ss())[SUBSET_DEF]
@@ -354,7 +381,8 @@ val write_bytearray_lemma = Q.prove(
   \\ rename1 `xx IN d`
   \\ Cases_on `xx IN d1` \\ res_tac \\ full_simp_tac(srw_ss())[]
   \\ imp_res_tac write_bytearray_IGNORE \\ full_simp_tac(srw_ss())[]
-  \\ imp_res_tac write_bytearray_EQ \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[] \\ metis_tac []);
+  \\ imp_res_tac write_bytearray_EQ \\ rev_full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[] \\ metis_tac []
+QED
 
 Theorem state_rel_get_var_k:
    state_rel jump off k s t ⇒
@@ -686,16 +714,20 @@ Proof
   \\ simp[]
 QED
 
-val state_rel_get_fp_var = Q.prove(`
+Triviality state_rel_get_fp_var:
   state_rel jump off k s t ⇒
-  get_fp_var n s = get_fp_var n t`,
-  fs[state_rel_def,get_fp_var_def]);
+  get_fp_var n s = get_fp_var n t
+Proof
+  fs[state_rel_def,get_fp_var_def]
+QED
 
-val state_rel_set_fp_var = Q.prove(`
+Triviality state_rel_set_fp_var:
   state_rel jump off k s t ⇒
-  state_rel jump off k (set_fp_var n v s) (set_fp_var n v t)`,
+  state_rel jump off k (set_fp_var n v s) (set_fp_var n v t)
+Proof
   rw[state_rel_def,set_fp_var_def]>>rfs[]>>
-  res_tac >> fs[]);
+  res_tac >> fs[]
+QED
 
 Theorem state_rel_inst:
    state_rel jump off k s t ∧
@@ -841,30 +873,38 @@ Proof
       good_dimindex_def]
 QED
 
-val get_labels_stack_free = Q.prove(
-  `!k n. get_labels (stack_free k n) = {}`,
+Triviality get_labels_stack_free:
+  !k n. get_labels (stack_free k n) = {}
+Proof
   recInduct stack_free_ind \\ rw []
   \\ once_rewrite_tac [stack_free_def] \\ rw []
-  \\ fs [get_labels_def,single_stack_free_def]);
+  \\ fs [get_labels_def,single_stack_free_def]
+QED
 
-val get_labels_stack_alloc = Q.prove(
-  `!jump k n. get_labels (stack_alloc jump k n) = {}`,
+Triviality get_labels_stack_alloc:
+  !jump k n. get_labels (stack_alloc jump k n) = {}
+Proof
   recInduct stack_alloc_ind \\ rw []
   \\ once_rewrite_tac [stack_alloc_def] \\ rw []
   \\ fs [get_labels_def,single_stack_alloc_def]
-  \\ IF_CASES_TAC \\ fs[get_labels_def,halt_inst_def]);
+  \\ IF_CASES_TAC \\ fs[get_labels_def,halt_inst_def]
+QED
 
-val get_labels_upshift = Q.prove(
-  `!n n0. get_labels (upshift n n0) = {}`,
+Triviality get_labels_upshift:
+  !n n0. get_labels (upshift n n0) = {}
+Proof
   recInduct upshift_ind \\ rw []
   \\ once_rewrite_tac [upshift_def] \\ rw []
-  \\ fs [get_labels_def]);
+  \\ fs [get_labels_def]
+QED
 
-val get_labels_downshift = Q.prove(
-  `!n n0. get_labels (downshift n n0) = {}`,
+Triviality get_labels_downshift:
+  !n n0. get_labels (downshift n n0) = {}
+Proof
   recInduct downshift_ind \\ rw []
   \\ once_rewrite_tac [downshift_def] \\ rw []
-  \\ fs [get_labels_def]);
+  \\ fs [get_labels_def]
+QED
 
 Theorem get_labels_comp:
    !jump off k e. get_labels (comp jump off k e) = get_labels e
@@ -954,10 +994,11 @@ Proof
   \\ qexists_tac`ck+ck'`\\simp[]
 QED
 
-val evaluate_upshift = Q.prove(`
+Triviality evaluate_upshift:
   ∀r n st w.
   FLOOKUP st.regs r = SOME (Word w) ⇒
-  evaluate(upshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w + word_offset n)))`,
+  evaluate(upshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w + word_offset n)))
+Proof
   ho_match_mp_tac upshift_ind>>rw[]>>
   simp[Once upshift_def]>>IF_CASES_TAC>>
   simp[evaluate_def,inst_def,assign_def,word_exp_def,wordLangTheory.word_op_def,set_var_def]>>
@@ -968,12 +1009,14 @@ val evaluate_upshift = Q.prove(`
   simp[state_component_equality,FUPD11_SAME_KEY_AND_BASE,word_offset_def]>>
   FULL_SIMP_TAC std_ss [Once (GSYM WORD_ADD_ASSOC),word_add_n2w]>>
   FULL_SIMP_TAC std_ss [GSYM RIGHT_ADD_DISTRIB]>>
-  simp[]);
+  simp[]
+QED
 
-val evaluate_downshift = Q.prove(`
+Triviality evaluate_downshift:
   ∀r n st w.
   FLOOKUP st.regs r = SOME (Word w) ⇒
-  evaluate(downshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w - word_offset n)))`,
+  evaluate(downshift r n,st) = (NONE, st with regs := st.regs |+ (r,Word (w - word_offset n)))
+Proof
   ho_match_mp_tac downshift_ind>>rw[]>>
   simp[Once downshift_def]>>IF_CASES_TAC>>
   simp[evaluate_def,inst_def,assign_def,word_exp_def,wordLangTheory.word_op_def,set_var_def]>>
@@ -987,7 +1030,8 @@ val evaluate_downshift = Q.prove(`
   FULL_SIMP_TAC std_ss [GSYM WORD_LEFT_ADD_DISTRIB]>>
   FULL_SIMP_TAC std_ss [Once (GSYM WORD_ADD_ASSOC),word_add_n2w]>>
   FULL_SIMP_TAC std_ss [GSYM RIGHT_ADD_DISTRIB]>>
-  simp[]);
+  simp[]
+QED
 
 val name_cases = prove(
   ``!name. name <> CurrHeap ==> MEM name store_list``,
@@ -999,7 +1043,7 @@ val name_cases = prove(
   \\ pop_assum mp_tac \\ rpt (pop_assum kall_tac) \\ decide_tac);
 
 (* Significantly faster than SEP_R_TAC *)
-val mem_load_lemma = Q.prove(`
+Triviality mem_load_lemma:
   MEM name store_list ∧
   FLOOKUP (s:('a,'c,'b)stackSem$state).store name = SOME x ∧
   (memory s.memory s.mdomain *
@@ -1013,7 +1057,8 @@ val mem_load_lemma = Q.prove(`
            n2w (LENGTH s.data_buffer.buffer + LENGTH s.bitmaps))
           s.data_buffer.space_left * word_store c s.store *
         word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) stackSem$state).mdomain)) ⇒
-  mem_load (c+store_offset name) t1 = SOME x`,
+  mem_load (c+store_offset name) t1 = SOME x
+Proof
   strip_tac >>
   drule fun2set_STAR_IMP>>
   pop_assum kall_tac >> strip_tac >> pop_assum kall_tac >>
@@ -1037,10 +1082,11 @@ val mem_load_lemma = Q.prove(`
   qpat_x_assum`Abbrev (Q ⇔ _)` kall_tac>>
   fs[Abbr`R`]>>
   pop_assum mp_tac)>>
-  fs[store_list_def]);
+  fs[store_list_def]
+QED
 
 (* basically the same thing, but without the read assumption *)
-val mem_load_lemma2 = Q.prove(`
+Triviality mem_load_lemma2:
   MEM name store_list ∧
   (memory s.memory s.mdomain *
         word_list
@@ -1053,7 +1099,8 @@ val mem_load_lemma2 = Q.prove(`
            n2w (LENGTH s.data_buffer.buffer + LENGTH s.bitmaps))
           s.data_buffer.space_left * word_store c s.store *
         word_list c s.stack) (fun2set (t1.memory,(t1:('a,'c,'b) stackSem$state).mdomain)) ⇒
-  c+store_offset name ∈ t1.mdomain`,
+  c+store_offset name ∈ t1.mdomain
+Proof
   strip_tac >>
   drule fun2set_STAR_IMP>>
   pop_assum kall_tac >> strip_tac >> pop_assum kall_tac >>
@@ -1073,16 +1120,19 @@ val mem_load_lemma2 = Q.prove(`
   qpat_x_assum`Abbrev (Q ⇔ _)` kall_tac>>
   fs[Abbr`R`]>>
   pop_assum mp_tac)>>
-  fs[store_list_def]);
+  fs[store_list_def]
+QED
 
-val assoc_lem = Q.prove(`
+Triviality assoc_lem:
   (A:(('a -> bool) -> bool) * B) * C =
-  (B * C) * A`,
-  metis_tac[STAR_ASSOC,STAR_COMM])
+  (B * C) * A
+Proof
+  metis_tac[STAR_ASSOC,STAR_COMM]
+QED
 
 val write_fun2set2 = write_fun2set |> SIMP_RULE std_ss [GSYM STAR_COMM]
 
-val store_write_lemma = Q.prove(`
+Triviality store_write_lemma:
   MEM name store_list ∧
   (memory s.memory s.mdomain *
         word_list
@@ -1104,7 +1154,8 @@ val store_write_lemma = Q.prove(`
          bytes_in_word *
          n2w (LENGTH s.data_buffer.buffer + LENGTH s.bitmaps))
         s.data_buffer.space_left * word_store c (s.store |+ (name,x)) *
-      word_list c s.stack) (fun2set ((c + store_offset name =+ x) m,d))`,
+      word_list c s.stack) (fun2set ((c + store_offset name =+ x) m,d))
+Proof
   strip_tac>>
   pop_assum mp_tac>>
   qmatch_goalsub_abbrev_tac`A * B * C`>>
@@ -1145,7 +1196,8 @@ val store_write_lemma = Q.prove(`
     qmatch_asmsub_abbrev_tac`(_* one(_,vv)) _`>>
     qexists_tac`vv`>>
     first_x_assum ACCEPT_TAC))>>
-  fs[store_list_def]);
+  fs[store_list_def]
+QED
 
 Theorem prog_comp_eta:
    prog_comp = \jump off k (n,p). (n,comp jump off k p)
@@ -2621,13 +2673,17 @@ val halt_tac =
   tac \\ fs [good_dimindex_def]
   \\ rw [] \\ fs [dimword_def]
 
-val MOD_EQ_IMP_MULT = Q.prove(
-  `!n d. n MOD d = 0 /\ d <> 0 ==> ?k. n = d * k`,
-  rw [] \\ fs [MOD_EQ_0_DIVISOR] \\ metis_tac []);
+Triviality MOD_EQ_IMP_MULT:
+  !n d. n MOD d = 0 /\ d <> 0 ==> ?k. n = d * k
+Proof
+  rw [] \\ fs [MOD_EQ_0_DIVISOR] \\ metis_tac []
+QED
 
-val star_move_lemma = Q.prove(
-  `p0 * p1 * p1' * p2 * p3 * p4 = p2 * (p1 * p1' * STAR p3 (p4 * p0))`,
-  fs [AC STAR_COMM STAR_ASSOC]);
+Triviality star_move_lemma:
+  p0 * p1 * p1' * p2 * p3 * p4 = p2 * (p1 * p1' * STAR p3 (p4 * p0))
+Proof
+  fs [AC STAR_COMM STAR_ASSOC]
+QED
 
 Definition read_mem_def:
   (read_mem a m 0 = []) /\
@@ -2646,9 +2702,10 @@ Proof
   Induct \\ fs [read_mem_def]
 QED
 
-val IN_addresses = Q.prove(
-  `!n a x. x IN addresses a n <=>
-            ?i. i < n /\ x = a + n2w i * bytes_in_word`,
+Triviality IN_addresses:
+  !n a x. x IN addresses a n <=>
+            ?i. i < n /\ x = a + n2w i * bytes_in_word
+Proof
   Induct \\ fs [addresses_def]
   \\ rw [] \\ eq_tac \\ rw []
   THEN1 (qexists_tac `0` \\ fs [])
@@ -2656,7 +2713,8 @@ val IN_addresses = Q.prove(
          \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB])
   \\ Cases_on `i` \\ fs []
   \\ fs [ADD1,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
-  \\ metis_tac []);
+  \\ metis_tac []
+QED
 
 Theorem addresses_thm:
    !n a. addresses a n = { a + n2w i * bytes_in_word | i < n }
@@ -2664,10 +2722,11 @@ Proof
   rw[EXTENSION, IN_addresses] \\ metis_tac[]
 QED
 
-val memory_addresses = Q.prove(
-  `!n (a:'a word) (m:'a word -> 'a word_loc).
+Triviality memory_addresses:
+  !n (a:'a word) (m:'a word -> 'a word_loc).
       n * (dimindex (:'a) DIV 8) < dimword (:'a) /\ good_dimindex (:'a) ==>
-      memory m (addresses a n) = word_list a (read_mem a m n)`,
+      memory m (addresses a n) = word_list a (read_mem a m n)
+Proof
   once_rewrite_tac [EQ_SYM_EQ]
   \\ Induct \\ fs [addresses_def,read_mem_def,word_list_def]
   THEN1 (fs [memory_def,FUN_EQ_THM,fun2set_def,emp_def])
@@ -2689,15 +2748,20 @@ val memory_addresses = Q.prove(
   \\ sg `i * (dimindex (:α) DIV 8) + dimindex (:α) DIV 8 < dimword (:α)`
   \\ fs[]
   \\ fs [good_dimindex_def,dimword_def]
-  \\ fs [good_dimindex_def,dimword_def]);
+  \\ fs [good_dimindex_def,dimword_def]
+QED
 
-val MOD_LESS_EQ_MOD_IMP = Q.prove(
-  `m MOD k <= n /\ m < k ==> m <= n`,
-  rw [] \\ fs [])
+Triviality MOD_LESS_EQ_MOD_IMP:
+  m MOD k <= n /\ m < k ==> m <= n
+Proof
+  rw [] \\ fs []
+QED
 
-val MAP_mem_val_MAP_INL = Q.prove(
-  `!ws f. MAP (mem_val f) (MAP INL ws) = MAP Word ws`,
-  Induct \\ fs [mem_val_def]);
+Triviality MAP_mem_val_MAP_INL:
+  !ws f. MAP (mem_val f) (MAP INL ws) = MAP Word ws
+Proof
+  Induct \\ fs [mem_val_def]
+QED
 
 Theorem word_list_EQ_rev:
    !xs a. word_list a xs =
@@ -2709,24 +2773,30 @@ Proof
   \\ fs [AC STAR_COMM STAR_ASSOC]
 QED
 
-val word_list_and_rev_join_lemma = Q.prove(
-  `(b = a + n2w (LENGTH xs + LENGTH ys) * bytes_in_word) /\
+Triviality word_list_and_rev_join_lemma:
+  (b = a + n2w (LENGTH xs + LENGTH ys) * bytes_in_word) /\
     (p * word_list a (xs ++ REVERSE ys) * q) ss /\ b1 ==>
-    (p * word_list a xs * word_list_rev b ys * q) ss /\ b1`,
+    (p * word_list a xs * word_list_rev b ys * q) ss /\ b1
+Proof
   fs [word_list_APPEND,WORD_LEFT_ADD_DISTRIB]
   \\ fs [word_list_EQ_rev] \\ rw []
-  \\ fs [AC STAR_COMM STAR_ASSOC,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]);
+  \\ fs [AC STAR_COMM STAR_ASSOC,GSYM word_add_n2w,WORD_LEFT_ADD_DISTRIB]
+QED
 
-val word_list_IMP_read_mem = Q.prove(
-  `!xs a p.
+Triviality word_list_IMP_read_mem:
+  !xs a p.
       (p * word_list a xs) (fun2set (m,dm)) ==>
-      read_mem a m (LENGTH xs) = xs`,
+      read_mem a m (LENGTH xs) = xs
+Proof
   Induct \\ fs [read_mem_def,word_list_def,STAR_ASSOC]
-  \\ rw [] \\ res_tac \\ SEP_R_TAC);
+  \\ rw [] \\ res_tac \\ SEP_R_TAC
+QED
 
-val INSERT_DELETE_EQ_DELETE = Q.prove(
-  `(x INSERT s) DELETE x = s DELETE x`,
-  fs [EXTENSION] \\ metis_tac []);
+Triviality INSERT_DELETE_EQ_DELETE:
+  (x INSERT s) DELETE x = s DELETE x
+Proof
+  fs [EXTENSION] \\ metis_tac []
+QED
 
 Theorem word_list_exists_addresses:
    !n a. (dimindex(:'a) DIV 8) * n < dimword (:'a) /\
@@ -2775,10 +2845,12 @@ Definition init_reduce_def:
                                (CurrHeap::store_list)) |>
 End
 
-val init_reduce_stack_space = Q.prove(
-  `(init_reduce gen_gc jump off k code bitmaps data_sp coracle s8).stack_space <=
-    LENGTH (init_reduce gen_gc jump off k code bitmaps data_sp coracle s8).stack`,
-  fs [init_reduce_def,LENGTH_read_mem]);
+Triviality init_reduce_stack_space:
+  (init_reduce gen_gc jump off k code bitmaps data_sp coracle s8).stack_space <=
+    LENGTH (init_reduce gen_gc jump off k code bitmaps data_sp coracle s8).stack
+Proof
+  fs [init_reduce_def,LENGTH_read_mem]
+QED
 
 Definition stack_heap_limit_ok_def:
   stack_heap_limit_ok t (stack_lim, heap_lim) <=>
@@ -2857,14 +2929,16 @@ Definition init_code_pre_def:
         (fun2set (s.memory,s.mdomain))
 End
 
-val byte_aligned_bytes_in_word_MULT = Q.prove(
-  `good_dimindex (:'a) ==>
-    byte_aligned (bytes_in_word * w:'a word)`,
+Triviality byte_aligned_bytes_in_word_MULT:
+  good_dimindex (:'a) ==>
+    byte_aligned (bytes_in_word * w:'a word)
+Proof
   fs [good_dimindex_def] \\ rw []
   \\ fs [alignmentTheory.byte_aligned_def,bytes_in_word_def]
   \\ qspecl_then [`2`,`w`] mp_tac alignmentTheory.aligned_mul_shift_1
   \\ qspecl_then [`3`,`w`] mp_tac alignmentTheory.aligned_mul_shift_1
-  \\ fs [WORD_MUL_LSL]);
+  \\ fs [WORD_MUL_LSL]
+QED
 
 (* The extra b equality makes this work better with SEP_NEQ_TAC *)
 Theorem word_list_wrap:
@@ -2889,18 +2963,22 @@ Proof
   metis_tac[]
 QED
 
-val sub_rewrite = Q.prove(`
+Triviality sub_rewrite:
   ptr <= ptr' ⇒
-  -1w * n2w ptr + n2w ptr' = n2w (ptr'-ptr)`,
+  -1w * n2w ptr + n2w ptr' = n2w (ptr'-ptr)
+Proof
   rw[]>>simp[Once WORD_SUB_INTRO]>>
-  simp[WORD_LITERAL_ADD]);
+  simp[WORD_LITERAL_ADD]
+QED
 
-val div_rewrite = Q.prove(`
+Triviality div_rewrite:
   n <= x ∧ 1 < n
   ⇒
-  x DIV n ≠ 0`,
+  x DIV n ≠ 0
+Proof
   rw[]>>
-  fs[DIV_EQ_0]);
+  fs[DIV_EQ_0]
+QED
 
 Theorem push_if:
    (if b then f x else f y) = f (if b then x else y) /\
@@ -3727,14 +3805,16 @@ Proof
   \\ Cases \\ fs [clock_neutral_def,store_list_code_def,list_Seq_def]
 QED
 
-val evaluate_init_code_clock = Q.prove(
-  `evaluate (init_code gen_gc max_heap k,s) = (res,t) ==>
+Triviality evaluate_init_code_clock:
+  evaluate (init_code gen_gc max_heap k,s) = (res,t) ==>
     evaluate (init_code gen_gc max_heap k,s with clock := c) =
-      (res,t with clock := c)`,
+      (res,t with clock := c)
+Proof
   srw_tac[][] \\ match_mp_tac evaluate_clock_neutral \\ fs []
   \\ fs [clock_neutral_def,init_code_def] \\ rw []
   \\ fs [clock_neutral_def,init_code_def,halt_inst_def,
-         list_Seq_def,init_memory_def,clock_neutral_store_list_code]);
+         list_Seq_def,init_memory_def,clock_neutral_store_list_code]
+QED
 
 Theorem evaluate_init_code_ffi:
    evaluate (init_code gen_gc max_heap k,(s:('a,'c,'ffi) stackSem$state)) = (res,t) ==>
@@ -3828,10 +3908,11 @@ Proof
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ metis_tac []
 QED
 
-val IMP_code_rel = Q.prove(
-  `EVERY (\(n,p). reg_bound p k /\ num_stubs ≤ n+1) code1 /\
+Triviality IMP_code_rel:
+  EVERY (\(n,p). reg_bound p k /\ num_stubs ≤ n+1) code1 /\
    code2 = fromAList (compile jump off gen_gc max_heap k start code1) ==>
-   code_rel jump off k (fromAList code1) code2`,
+   code_rel jump off k (fromAList code1) code2
+Proof
   rw[]>>
   fs[code_rel_def,lookup_fromAList]>>
   CONJ_TAC>- (
@@ -3843,7 +3924,8 @@ val IMP_code_rel = Q.prove(
     \\ pop_assum mp_tac \\ EVAL_TAC)>>
   simp[domain_fromAList,compile_def,init_stubs_def,prog_comp_eta,MAP_MAP_o,UNCURRY,o_DEF,ETA_AX]>>
   simp[EXTENSION]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Definition make_init_any_def:
   make_init_any gen_gc max_heap bitmaps data_sp coracle jump off k code s =

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -127,11 +127,12 @@ Proof
   res_tac >> fsrw_tac[ARITH_ss][ADD1]
 QED
 
-val code_installed_get_labels_IMP = Q.prove(
-  `!top e n q pc.
+Triviality code_installed_get_labels_IMP:
+  !top e n q pc.
       code_installed pc (append (FST (flatten top e n q))) c /\
       (l1,l2) ∈ get_labels e ==>
-      ?v. loc_to_pc l1 l2 c = SOME v`,
+      ?v. loc_to_pc l1 l2 c = SOME v
+Proof
   recInduct flatten_ind \\ rw []
   \\ ntac 2 (pop_assum mp_tac)
   \\ once_rewrite_tac [flatten_def]
@@ -153,24 +154,29 @@ val code_installed_get_labels_IMP = Q.prove(
   \\ fs [get_labels_def]
   \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []
   \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []
-  \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []);
+  \\ imp_res_tac code_installed_append_imp \\ res_tac \\ fs []
+QED
 
 (* TODO: these may already be proved in lab_filter or lab_to_target,
          they ought to move into labProps
 *)
-val asm_fetch_aux_SOME_append = Q.prove(`
+Triviality asm_fetch_aux_SOME_append:
   ∀pc code l code2.
   asm_fetch_aux pc code = SOME l ⇒
-  asm_fetch_aux pc (code++code2) = SOME l`,
-  ho_match_mp_tac asm_fetch_aux_ind>>simp[asm_fetch_aux_def]>>rw[]);
+  asm_fetch_aux pc (code++code2) = SOME l
+Proof
+  ho_match_mp_tac asm_fetch_aux_ind>>simp[asm_fetch_aux_def]>>rw[]
+QED
 
-val asm_fetch_aux_SOME_isPREFIX = Q.prove(`
+Triviality asm_fetch_aux_SOME_isPREFIX:
   ∀pc code l code2.
   asm_fetch_aux pc code = SOME l /\
   code ≼ code2 ==>
-  asm_fetch_aux pc code2 = SOME l`,
+  asm_fetch_aux pc code2 = SOME l
+Proof
   rw[]>>fs[IS_PREFIX_APPEND]>>
-  metis_tac[asm_fetch_aux_SOME_append]);
+  metis_tac[asm_fetch_aux_SOME_append]
+QED
 
 Theorem loc_to_pc_APPEND:
     ∀n m code pc code2.
@@ -227,11 +233,13 @@ Proof
   rw[]>>fs[IS_PREFIX_APPEND]>>metis_tac[loc_to_pc_APPEND]
 QED
 
-val MAP_prog_to_section_FST = Q.prove(`
+Triviality MAP_prog_to_section_FST:
   MAP (λs. case s of Section n v => n) (MAP prog_to_section prog) =
-  MAP FST prog`,
+  MAP FST prog
+Proof
   match_mp_tac LIST_EQ>>rw[EL_MAP]>>Cases_on`EL x prog`>>fs[prog_to_section_def]>>
-  pairarg_tac>>fs[]);
+  pairarg_tac>>fs[]
+QED
 
 Theorem MAP_prog_to_section_Section_num:
     MAP Section_num (MAP prog_to_section prog) =
@@ -414,20 +422,22 @@ Proof
   \\ rw [] \\ res_tac \\ fs [asm_fetch_aux_add]
 QED
 
-val code_installed_prog_to_section_lemma = Q.prove(
-  `!prog4 n prog3.
+Triviality code_installed_prog_to_section_lemma:
+  !prog4 n prog3.
       ALOOKUP prog4 n = SOME prog3 ==>
       ?pc.
         code_installed' pc (append (FST (flatten T prog3 n (next_lab prog3 2))))
           (MAP prog_to_section prog4) /\
-        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc`,
+        loc_to_pc n 0 (MAP prog_to_section prog4) = SOME pc
+Proof
   Induct_on `prog4` \\ fs [] \\ Cases \\ fs [ALOOKUP_def] \\ rw []
   THEN1
    (fs [stack_to_labTheory.prog_to_section_def] \\ pairarg_tac \\ fs []
     \\ once_rewrite_tac [labSemTheory.loc_to_pc_def]
     \\ fs [code_installed'_simp])
   \\ res_tac \\ fs [stack_to_labTheory.prog_to_section_def] \\ pairarg_tac
-  \\ fs [loc_to_pc_skip_section,code_installed_cons]);
+  \\ fs [loc_to_pc_skip_section,code_installed_cons]
+QED
 
 val extract_labels_def = labPropsTheory.extract_labels_def
 val extract_labels_append = labPropsTheory.extract_labels_append
@@ -2944,10 +2954,11 @@ Definition memory_assumption_def:
        (fun2set (t.mem,t.mem_domain))
 End
 
-val halt_assum_lemma = Q.prove(
-  `halt_assum (:'ffi#'c)
+Triviality halt_assum_lemma:
+  halt_assum (:'ffi#'c)
      (fromAList (stack_names$compile f
-       (compile jump off gen max_heap k l code)))`,
+       (compile jump off gen max_heap k l code)))
+Proof
   fs [halt_assum_def] \\ rw []
   \\ fs [stackSemTheory.evaluate_def,
          stackSemTheory.find_code_def]
@@ -2960,22 +2971,27 @@ val halt_assum_lemma = Q.prove(
          EVAL ``stack_names$comp f (halt_inst 0w)``]
   \\ first_x_assum(qspec_then`1`mp_tac) \\ simp[]
   \\ fs [stackSemTheory.evaluate_def,EVAL ``inst (Const n 0w) (dec_clock s)``,
-         get_var_def,FLOOKUP_UPDATE]);
+         get_var_def,FLOOKUP_UPDATE]
+QED
 
-val FLOOKUP_regs = Q.prove(
-  `!regs n v f s.
+Triviality FLOOKUP_regs:
+  !regs n v f s.
       FLOOKUP (FEMPTY |++ MAP (λr. (r,read_reg r s)) regs) n = SOME v ==>
-      read_reg n s = v`,
+      read_reg n s = v
+Proof
   recInduct SNOC_INDUCT \\ fs [FUPDATE_LIST,FOLDL_SNOC,MAP_SNOC]
-  \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs []);
+  \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs []
+QED
 
 (*
-val FLOOKUP_fp_regs = Q.prove(
-  `!regs n v f s.
+Triviality FLOOKUP_fp_regs:
+  !regs n v f s.
       FLOOKUP (FEMPTY |++ MAP (λr. (r,read_fp_reg r s)) regs) n = SOME v ==>
-      s.fp_regs n = v`,
+      s.fp_regs n = v
+Proof
   recInduct SNOC_INDUCT \\ fs [FUPDATE_LIST,FOLDL_SNOC,MAP_SNOC]
-  \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs [read_fp_reg_def]);*)
+  \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs [read_fp_reg_def]
+QED*)
 
 Theorem state_rel_make_init:
    state_rel (make_init code coracle regs save_regs s) (s:('a,'c,'ffi) labSem$state) <=>
@@ -3010,18 +3026,20 @@ Proof
   \\ metis_tac [FLOOKUP_regs]
 QED
 
-val MAP_FST_compile_compile = Q.prove(
-  `MAP FST (compile jump off gen max_heap k InitGlobals_location
+Triviality MAP_FST_compile_compile:
+  MAP FST (compile jump off gen max_heap k InitGlobals_location
               (stack_alloc$compile c
                  (stack_rawcall$compile code))) =
-    0::1::2::gc_stub_location::MAP FST code`,
+    0::1::2::gc_stub_location::MAP FST code
+Proof
   fs [stack_removeTheory.compile_def,stack_removeTheory.init_stubs_def,
       stack_allocTheory.compile_def,stack_rawcallTheory.compile_def,
       stack_allocTheory.stubs_def,stack_removeTheory.prog_comp_def]
   \\ rename [`comp_top ii`]
   \\ Induct_on `code` \\ fs []
   \\ fs [stack_removeTheory.prog_comp_def,FORALL_PROD,
-         stack_allocTheory.prog_comp_def]);
+         stack_allocTheory.prog_comp_def]
+QED
 
 val sextract_labels_def = stackPropsTheory.extract_labels_def
 
@@ -3086,17 +3104,21 @@ Proof
 QED
 *)
 
-val MAP_prog_to_section_FST = Q.prove(`
+Triviality MAP_prog_to_section_FST:
   MAP (λs. case s of Section n v => n) (MAP prog_to_section prog) =
-  MAP FST prog`,
+  MAP FST prog
+Proof
   match_mp_tac LIST_EQ>>rw[EL_MAP]>>Cases_on`EL x prog`>>fs[prog_to_section_def]>>
-  pairarg_tac>>fs[]);
+  pairarg_tac>>fs[]
+QED
 
-val extract_label_store_list_code = Q.prove(`
+Triviality extract_label_store_list_code:
   ∀a t ls.
-  extract_labels (store_list_code a t ls) = []`,
+  extract_labels (store_list_code a t ls) = []
+Proof
   ho_match_mp_tac stack_removeTheory.store_list_code_ind>>
-  EVAL_TAC>>fs[]);
+  EVAL_TAC>>fs[]
+QED
 
 Theorem stack_to_lab_compile_lab_pres:
     EVERY (λn. n ≠ 0 ∧ n ≠ 1 ∧ n ≠ 2 ∧ n ≠ gc_stub_location) (MAP FST prog) ∧
@@ -3437,12 +3459,13 @@ QED
 
 val stack_asm_ok_def = stackPropsTheory.stack_asm_ok_def
 
-val flatten_line_ok_pre = Q.prove(`
+Triviality flatten_line_ok_pre:
   ∀t p n m ls a b c.
   byte_offset_ok c 0w /\
   stack_asm_ok c p ∧
   flatten t p n m = (ls,a,b) ⇒
-  EVERY (line_ok_pre c) (append ls)`,
+  EVERY (line_ok_pre c) (append ls)
+Proof
   ho_match_mp_tac flatten_ind>>Cases_on`p`>>rw[]>>
   pop_assum mp_tac>>simp[Once flatten_def]>>rw[]>>fs[]
   >-
@@ -3467,7 +3490,8 @@ val flatten_line_ok_pre = Q.prove(`
     pop_assum mp_tac>>EVAL_TAC>>
     pop_assum mp_tac>>EVAL_TAC>>
     fs[]>>
-    Cases_on ‘a’>>EVAL_TAC>>rw[]);
+    Cases_on ‘a’>>EVAL_TAC>>rw[]
+QED
 
 Theorem compile_all_enc_ok_pre:
     byte_offset_ok c 0w ∧
@@ -3749,15 +3773,17 @@ Proof
   \\ metis_tac[]
 QED
 
-val prog_to_section_preserves_MAP_FST = Q.prove(`
-    ∀p.
+Triviality prog_to_section_preserves_MAP_FST:
+  ∀p.
     IMAGE (λn. n,0) (set (MAP FST p)) ⊆
-    get_code_labels (MAP prog_to_section p)`,
-    Induct>>
+    get_code_labels (MAP prog_to_section p)
+Proof
+  Induct>>
     fs[labPropsTheory.get_code_labels_cons,FORALL_PROD,stack_to_labTheory.prog_to_section_def]>>
     rw[]>> rpt(pairarg_tac>>fs[])>>
     simp[labPropsTheory.get_code_labels_cons, labPropsTheory.sec_get_code_labels_def]>>
-    fs[SUBSET_DEF]);
+    fs[SUBSET_DEF]
+QED
 
 Theorem prog_to_section_labels:
     prog_to_section (n,p) = pp ⇒
@@ -3886,12 +3912,14 @@ QED
     (I think the latter may be sufficient)
  *)
 (* stack_names *)
-val get_code_labels_comp = Q.prove(
-  `!f p. complex_get_code_labels (stack_names$comp f p) = complex_get_code_labels p`,
+Triviality get_code_labels_comp:
+  !f p. complex_get_code_labels (stack_names$comp f p) = complex_get_code_labels p
+Proof
   HO_MATCH_MP_TAC stack_namesTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_namesTheory.comp_def] \\ fs [get_code_labels_def]
   \\ every_case_tac \\ fs [] \\
-  fs[stack_namesTheory.dest_find_name_def]);
+  fs[stack_namesTheory.dest_find_name_def]
+QED
 
 Theorem stack_names_get_code_labels:
     LIST_REL (λcp p. complex_get_code_labels cp = complex_get_code_labels p)
@@ -3904,8 +3932,9 @@ Proof
 QED
 
 (* stack_remove *)
-val get_code_labels_comp = Q.prove(
-  `!a b c p. get_code_labels (comp a b c p) SUBSET (stack_err_lab,0) INSERT get_code_labels p`,
+Triviality get_code_labels_comp:
+  !a b c p. get_code_labels (comp a b c p) SUBSET (stack_err_lab,0) INSERT get_code_labels p
+Proof
   HO_MATCH_MP_TAC stack_removeTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_removeTheory.comp_def]
   \\ rw[] \\ fs [get_code_labels_def,stackLangTheory.list_Seq_def,
@@ -3944,32 +3973,41 @@ val get_code_labels_comp = Q.prove(
     completeInduct_on`n0`>>simp[Once stack_removeTheory.upshift_def,Once stack_removeTheory.downshift_def]>>
     rw[]>>fs[get_code_labels_def]>>
     first_x_assum(qspec_then`n0-max_stack_alloc` mp_tac)>>
-    fs[stack_removeTheory.max_stack_alloc_def]));
+    fs[stack_removeTheory.max_stack_alloc_def])
+QED
 
-val init_stubs_labels = Q.prove(`
-  EVERY (λp. get_code_labels p SUBSET (set [(1n,0n);(start,0n)])) (MAP SND (init_stubs ggc mh k start))`,
-  rpt(EVAL_TAC>>rw[]>>fs[]));
+Triviality init_stubs_labels:
+  EVERY (λp. get_code_labels p SUBSET (set [(1n,0n);(start,0n)])) (MAP SND (init_stubs ggc mh k start))
+Proof
+  rpt(EVAL_TAC>>rw[]>>fs[])
+QED
 
 (* ---- stack_names  ----*)
-val stack_names_get_code_labels_comp = Q.prove(
-  `!f p. get_code_labels (stack_names$comp f p) = get_code_labels p`,
+Triviality stack_names_get_code_labels_comp:
+  !f p. get_code_labels (stack_names$comp f p) = get_code_labels p
+Proof
   HO_MATCH_MP_TAC stack_namesTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_namesTheory.comp_def] \\ fs [get_code_labels_def]
   \\ every_case_tac \\ fs [] \\
-  fs[stack_namesTheory.dest_find_name_def]);
+  fs[stack_namesTheory.dest_find_name_def]
+QED
 
-val stack_names_stack_get_handler_labels_comp = Q.prove(`
+Triviality stack_names_stack_get_handler_labels_comp:
   !f p n.
   stack_get_handler_labels n (stack_names$comp f p) =
-  stack_get_handler_labels n p`,
+  stack_get_handler_labels n p
+Proof
   HO_MATCH_MP_TAC stack_namesTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_namesTheory.comp_def] \\ fs [stack_get_handler_labels_def]
   \\ every_case_tac \\ fs [] \\
-  fs[stack_namesTheory.dest_find_name_def]);
+  fs[stack_namesTheory.dest_find_name_def]
+QED
 
-val UNCURRY_PAIR_ETA = Q.prove(`
-  UNCURRY f = λ(p1,p2). f p1 p2`,
-  fs[FUN_EQ_THM]);
+Triviality UNCURRY_PAIR_ETA:
+  UNCURRY f = λ(p1,p2). f p1 p2
+Proof
+  fs[FUN_EQ_THM]
+QED
 
 (* TODO: Exported for now -- maybe using in backendProof *)
 Theorem stack_names_stack_good_code_labels:
@@ -3984,9 +4022,10 @@ Proof
 QED;
 
 (* ---- stack_remove ---- *)
-val stack_remove_get_code_labels_comp = Q.prove(
-  `!a b c p.
-  get_code_labels (comp a b c p) SUBSET (stack_err_lab,0) INSERT get_code_labels p`,
+Triviality stack_remove_get_code_labels_comp:
+  !a b c p.
+  get_code_labels (comp a b c p) SUBSET (stack_err_lab,0) INSERT get_code_labels p
+Proof
   HO_MATCH_MP_TAC stack_removeTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_removeTheory.comp_def]
   \\ rw[] \\ fs [get_code_labels_def,stackLangTheory.list_Seq_def,
@@ -4025,12 +4064,14 @@ val stack_remove_get_code_labels_comp = Q.prove(
     completeInduct_on`n0`>>simp[Once stack_removeTheory.upshift_def,Once stack_removeTheory.downshift_def]>>
     rw[]>>fs[get_code_labels_def]>>
     first_x_assum(qspec_then`n0-max_stack_alloc` mp_tac)>>
-    fs[stack_removeTheory.max_stack_alloc_def]));
+    fs[stack_removeTheory.max_stack_alloc_def])
+QED
 
-val stack_remove_stack_get_handler_labels_comp = Q.prove(
-  `!a b c p m.
+Triviality stack_remove_stack_get_handler_labels_comp:
+  !a b c p m.
   stack_get_handler_labels m (comp a b c p) =
-  stack_get_handler_labels m p`,
+  stack_get_handler_labels m p
+Proof
   HO_MATCH_MP_TAC stack_removeTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_removeTheory.comp_def]
   \\ rw[] \\ fs [stack_get_handler_labels_def,stackLangTheory.list_Seq_def,
@@ -4064,11 +4105,14 @@ val stack_remove_stack_get_handler_labels_comp = Q.prove(
     completeInduct_on`n0`>>simp[Once stack_removeTheory.upshift_def,Once stack_removeTheory.downshift_def]>>
     rw[]>>fs[stack_get_handler_labels_def]>>
     first_x_assum(qspec_then`n0-max_stack_alloc` mp_tac)>>
-    fs[stack_removeTheory.max_stack_alloc_def]));
+    fs[stack_removeTheory.max_stack_alloc_def])
+QED
 
-val stack_remove_init_code_labels = Q.prove(`
-  x ∈ get_code_labels (init_code ggc mh sp) ⇒ x = (1n,0n)`,
-  rpt(EVAL_TAC>>rw[]>>fs[]));
+Triviality stack_remove_init_code_labels:
+  x ∈ get_code_labels (init_code ggc mh sp) ⇒ x = (1n,0n)
+Proof
+  rpt(EVAL_TAC>>rw[]>>fs[])
+QED
 
 Theorem stack_remove_stack_good_code_labels:
   ∀prog.
@@ -4121,32 +4165,38 @@ Proof
 QED;
 
 (* --- stack_alloc ---- *)
-val stack_alloc_get_code_labels_comp = Q.prove(`
+Triviality stack_alloc_get_code_labels_comp:
   !n m p pp mm.
-  get_code_labels (FST (comp n m p)) ⊆ (gc_stub_location,0) INSERT get_code_labels p`,
+  get_code_labels (FST (comp n m p)) ⊆ (gc_stub_location,0) INSERT get_code_labels p
+Proof
   HO_MATCH_MP_TAC stack_allocTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_allocTheory.comp_def]
   \\ rw[] \\ fs [stack_get_handler_labels_def,stackLangTheory.list_Seq_def]
   \\ every_case_tac \\ fs []
   \\ rpt(pairarg_tac \\ fs[])
-  \\ fs[SUBSET_DEF]>>metis_tac[]);
+  \\ fs[SUBSET_DEF]>>metis_tac[]
+QED
 
-val stack_alloc_stack_get_handler_labels_comp = Q.prove(`
+Triviality stack_alloc_stack_get_handler_labels_comp:
   !n m p pp mm.
-  stack_get_handler_labels i (FST (comp n m p)) = stack_get_handler_labels i p`,
+  stack_get_handler_labels i (FST (comp n m p)) = stack_get_handler_labels i p
+Proof
   HO_MATCH_MP_TAC stack_allocTheory.comp_ind \\ rw []
   \\ Cases_on `p` \\ once_rewrite_tac [stack_allocTheory.comp_def]
   \\ rw[] \\ fs [stack_get_handler_labels_def,stackLangTheory.list_Seq_def]
   \\ every_case_tac \\ fs []
   \\ rpt(pairarg_tac \\ fs[stack_get_handler_labels_def])
-  \\ fs[stack_get_handler_labels_def]);
+  \\ fs[stack_get_handler_labels_def]
+QED
 
-val stack_alloc_init_code_labels = Q.prove(`
-  get_code_labels (word_gc_code c) = {}`,
+Triviality stack_alloc_init_code_labels:
+  get_code_labels (word_gc_code c) = {}
+Proof
   simp[stack_allocTheory.word_gc_code_def]>>
   EVAL_TAC>>
   EVERY_CASE_TAC>>fs[]>>
-  rpt(EVAL_TAC>>rw[]>>fs[]));
+  rpt(EVAL_TAC>>rw[]>>fs[])
+QED
 
 Theorem stack_alloc_stack_good_code_labels:
   ∀prog c.

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -26,45 +26,55 @@ Proof
   srw_tac[][SUBSET_DEF]
 QED
 
-val INJ_UNION = Q.prove(
-`!f A B.
+Triviality INJ_UNION:
+  !f A B.
   INJ f (A ∪ B) UNIV ⇒
   INJ f A UNIV ∧
-  INJ f B UNIV`,
+  INJ f B UNIV
+Proof
   srw_tac[][]>>
-  metis_tac[INJ_SUBSET,SUBSET_DEF,SUBSET_UNION]);
+  metis_tac[INJ_SUBSET,SUBSET_DEF,SUBSET_UNION]
+QED
 
-val INJ_less = Q.prove(`
+Triviality INJ_less:
   INJ f s' UNIV ∧ s ⊆ s'
   ⇒
-  INJ f s UNIV`,
-  metis_tac[INJ_DEF,SUBSET_DEF])
+  INJ f s UNIV
+Proof
+  metis_tac[INJ_DEF,SUBSET_DEF]
+QED
 
 (* TODO: can we have a global for this *)
 Definition hide_def:
   hide x = x
 End
 
-val INJ_IMP_IMAGE_DIFF = Q.prove(`
+Triviality INJ_IMP_IMAGE_DIFF:
   INJ f (s ∪ t) UNIV ⇒
-  IMAGE f (s DIFF t) = (IMAGE f s) DIFF (IMAGE f t)`,
+  IMAGE f (s DIFF t) = (IMAGE f s) DIFF (IMAGE f t)
+Proof
   rw[EXTENSION,EQ_IMP_THM]>> TRY (metis_tac[])>>
   fs[INJ_DEF]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val INJ_IMP_IMAGE_DIFF_single = Q.prove(`
+Triviality INJ_IMP_IMAGE_DIFF_single:
   INJ f (s ∪ {n}) UNIV ⇒
-  (IMAGE f s) DIFF {f n} = IMAGE f (s DIFF {n})`,
+  (IMAGE f s) DIFF {f n} = IMAGE f (s DIFF {n})
+Proof
   rw[]>>
   `{f n} = IMAGE f {n}` by fs[]>>
-  fs[INJ_IMP_IMAGE_DIFF]);
+  fs[INJ_IMP_IMAGE_DIFF]
+QED
 
-val INJ_ALL_DISTINCT_MAP = Q.prove(`
+Triviality INJ_ALL_DISTINCT_MAP:
   ∀ls.
   ALL_DISTINCT (MAP f ls) ⇒
-  INJ f (set ls) UNIV`,
+  INJ f (set ls) UNIV
+Proof
   Induct>>full_simp_tac(srw_ss())[INJ_DEF]>>srw_tac[][]>>
-  metis_tac[MEM_MAP]);
+  metis_tac[MEM_MAP]
+QED
 
 (* word_alloc proofs
   1. correctness theorem about colouring_ok
@@ -162,30 +172,35 @@ Proof
   metis_tac[INSERT_UNION_EQ,UNION_COMM]
 QED
 
-val strong_locals_rel_get_var = Q.prove(`
+Triviality strong_locals_rel_get_var:
   strong_locals_rel f live st.locals cst.locals ∧
   n ∈ live ∧
   get_var n st = SOME x
   ⇒
-  get_var (f n) cst = SOME x`,
-  full_simp_tac(srw_ss())[get_var_def,strong_locals_rel_def]);
+  get_var (f n) cst = SOME x
+Proof
+  full_simp_tac(srw_ss())[get_var_def,strong_locals_rel_def]
+QED
 
-val strong_locals_rel_get_var_imm = Q.prove(`
+Triviality strong_locals_rel_get_var_imm:
   strong_locals_rel f live st.locals cst.locals ∧
   (case n of Reg n => n ∈ live | _ => T) ∧
   get_var_imm n st = SOME x
   ⇒
-  get_var_imm (apply_colour_imm f n) cst = SOME x`,
+  get_var_imm (apply_colour_imm f n) cst = SOME x
+Proof
   Cases_on`n`>>full_simp_tac(srw_ss())[get_var_imm_def]>>
-  metis_tac[strong_locals_rel_get_var]);
+  metis_tac[strong_locals_rel_get_var]
+QED
 
-val strong_locals_rel_get_vars = Q.prove(`
+Triviality strong_locals_rel_get_vars:
   ∀ls y f live st cst.
   strong_locals_rel f live st.locals cst.locals ∧
   (∀x. MEM x ls ⇒ x ∈ live) ∧
   get_vars ls st = SOME y
   ⇒
-  get_vars (MAP f ls) cst = SOME y`,
+  get_vars (MAP f ls) cst = SOME y
+Proof
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>srw_tac[][]>>
   Cases_on`get_var h st`>>full_simp_tac(srw_ss())[]>>
   `h ∈ live` by full_simp_tac(srw_ss())[]>>
@@ -194,25 +209,30 @@ val strong_locals_rel_get_vars = Q.prove(`
   res_tac>>
   pop_assum(qspec_then`live` mp_tac)>>impl_tac
   >-metis_tac[]>>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
-val domain_big_union_subset = Q.prove(`
+Triviality domain_big_union_subset:
   !ls a.
   MEM a ls ⇒
   domain (get_live_exp a) ⊆
-  domain (big_union (MAP get_live_exp ls))`,
+  domain (big_union (MAP get_live_exp ls))
+Proof
   Induct>>rw[]>>fs[big_union_def,domain_union,SUBSET_UNION,SUBSET_DEF]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 val size_tac= (full_simp_tac(srw_ss())[prog_size_def]>>DECIDE_TAC);
 
-val apply_nummap_key_domain = Q.prove(`
+Triviality apply_nummap_key_domain:
   ∀f names.
   domain (apply_nummap_key f names) =
-  IMAGE f (domain names)`,
+  IMAGE f (domain names)
+Proof
   full_simp_tac(srw_ss())[domain_def,domain_fromAList]>>
   full_simp_tac(srw_ss())[MEM_MAP,MAP_MAP_o,EXTENSION,EXISTS_PROD]>>
-  metis_tac[MEM_toAList,domain_lookup]);
+  metis_tac[MEM_toAList,domain_lookup]
+QED
 
 Theorem cut_env_lemma:
     ∀names sloc tloc x f.
@@ -248,30 +268,36 @@ Proof
     full_simp_tac(srw_ss())[domain_inter,SUBSET_INTER_ABSORPTION,INTER_COMM]
 QED
 
-val LENGTH_list_rerrange = Q.prove(`
-  LENGTH (list_rearrange mover xs) = LENGTH xs`,
+Triviality LENGTH_list_rerrange:
+  LENGTH (list_rearrange mover xs) = LENGTH xs
+Proof
   full_simp_tac(srw_ss())[list_rearrange_def]>>
-  IF_CASES_TAC>>full_simp_tac(srw_ss())[])
+  IF_CASES_TAC>>full_simp_tac(srw_ss())[]
+QED
 
 (*For any 2 lists that are permutations of each other,
   We can give a list_rearranger that permutes one to the other*)
-val list_rearrange_perm = Q.prove(`
+Triviality list_rearrange_perm:
   PERM xs ys
   ⇒
-  ∃perm. list_rearrange perm xs = ys`,
+  ∃perm. list_rearrange perm xs = ys
+Proof
   srw_tac[][]>>
   imp_res_tac PERM_BIJ>>full_simp_tac(srw_ss())[list_rearrange_def]>>
   qexists_tac`f`>>
   IF_CASES_TAC>>
-  full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF]>>metis_tac[])
+  full_simp_tac(srw_ss())[BIJ_DEF,INJ_DEF]>>metis_tac[]
+QED
 
-val GENLIST_MAP = Q.prove(
-  `!k. (!i. i < LENGTH l ==> m i < LENGTH l) /\ k <= LENGTH l ==>
+Triviality GENLIST_MAP:
+  !k. (!i. i < LENGTH l ==> m i < LENGTH l) /\ k <= LENGTH l ==>
         GENLIST (\i. EL (m i) (MAP f l)) k =
-        MAP f (GENLIST (\i. EL (m i) l) k)`,
+        MAP f (GENLIST (\i. EL (m i) l) k)
+Proof
   Induct \\ full_simp_tac(srw_ss())[GENLIST] \\ REPEAT STRIP_TAC
   \\ `k < LENGTH l /\ k <= LENGTH l` by DECIDE_TAC
-  \\ full_simp_tac(srw_ss())[EL_MAP]);
+  \\ full_simp_tac(srw_ss())[EL_MAP]
+QED
 
 Theorem list_rearrange_MAP:
    !l f m. list_rearrange m (MAP f l) = MAP f (list_rearrange m l)
@@ -290,7 +316,7 @@ val ALL_DISTINCT_FST = ALL_DISTINCT_MAP |> Q.ISPEC `FST`
    given by the IH)
 *)
 
-val env_to_list_perm = Q.prove(`
+Triviality env_to_list_perm:
   ∀tperm.
   domain y = IMAGE f (domain x) ∧
   INJ f (domain x) UNIV ∧
@@ -300,7 +326,8 @@ val env_to_list_perm = Q.prove(`
   ∃perm'.
     let(l',permute') = env_to_list x perm' in
       permute' = tperm ∧ (*Just change the first permute*)
-      MAP (λx,y.f x,y) l' = l`,
+      MAP (λx,y.f x,y) l' = l
+Proof
   srw_tac[][]>>
   full_simp_tac(srw_ss())[env_to_list_def,LET_THM,strong_locals_rel_def]>>
   qabbrev_tac `xls = QSORT key_val_compare (toAList x)`>>
@@ -358,7 +385,8 @@ val env_to_list_perm = Q.prove(`
   imp_res_tac PERM_TRANS>>
   imp_res_tac list_rearrange_perm>>
   qexists_tac`λn. if n = 0:num then perm' else tperm (n-1)`>>
-  full_simp_tac(srw_ss())[FUN_EQ_THM]);
+  full_simp_tac(srw_ss())[FUN_EQ_THM]
+QED
 
 (*Proves s_val_eq and some extra conditions on the resulting lists*)
 Theorem push_env_s_val_eq:
@@ -488,24 +516,28 @@ QED
 
 val lookup_alist_insert = sptreeTheory.lookup_alist_insert |> INST_TYPE [alpha|->``:'a word_loc``]
 
-val strong_locals_rel_subset = Q.prove(`
+Triviality strong_locals_rel_subset:
   s ⊆ s' ∧
   strong_locals_rel f s' stl cstl
   ⇒
-  strong_locals_rel f s stl cstl`,
+  strong_locals_rel f s stl cstl
+Proof
   srw_tac[][strong_locals_rel_def]>>
-  metis_tac[SUBSET_DEF]);
+  metis_tac[SUBSET_DEF]
+QED
 
-val env_to_list_keys = Q.prove(`
+Triviality env_to_list_keys:
   let (l,permute) = env_to_list x perm in
-  set (MAP FST l) = domain x`,
+  set (MAP FST l) = domain x
+Proof
   full_simp_tac(srw_ss())[LET_THM,env_to_list_def,EXTENSION,MEM_MAP,EXISTS_PROD]>>
   srw_tac[][EQ_IMP_THM]
   >-
     (imp_res_tac mem_list_rearrange>>
     full_simp_tac(srw_ss())[QSORT_MEM,MEM_toAList,domain_lookup])
   >>
-    full_simp_tac(srw_ss())[mem_list_rearrange,QSORT_MEM,MEM_toAList,domain_lookup]);
+    full_simp_tac(srw_ss())[mem_list_rearrange,QSORT_MEM,MEM_toAList,domain_lookup]
+QED
 
 Theorem list_rearrange_keys:
     list_rearrange perm (ls:('a,'b) alist) = e ⇒
@@ -550,13 +582,14 @@ Proof
 QED
 *)
 
-val apply_colour_exp_lemma = Q.prove(
-  `∀st w cst f res.
+Triviality apply_colour_exp_lemma:
+  ∀st w cst f res.
     word_exp st w = SOME res ∧
     word_state_eq_rel st cst ∧
     strong_locals_rel f (domain (get_live_exp w)) st.locals cst.locals
     ⇒
-    word_exp cst (apply_colour_exp f w) = SOME res`,
+    word_exp cst (apply_colour_exp f w) = SOME res
+Proof
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,apply_colour_exp_def,strong_locals_rel_def,get_live_exp_def,word_state_eq_rel_def]
   >-
@@ -581,7 +614,8 @@ val apply_colour_exp_lemma = Q.prove(
     fs[])
   >>
     qpat_x_assum`A=SOME res`mp_tac>>TOP_CASE_TAC>>rw[]>>
-    fs[]);
+    fs[]
+QED
 
 Theorem get_fp_var_perm[simp]:
    get_fp_var r (st with permute:= p) = get_fp_var r st
@@ -619,16 +653,20 @@ val setup_tac = Cases_on`word_exp st expr`>>full_simp_tac(srw_ss())[]>>
       imp_res_tac apply_colour_exp_lemma>>
       pop_assum(qspecl_then[`f`,`cst`]mp_tac)>>unabbrev_all_tac;
 
-val LASTN_LENGTH2 = Q.prove(`
-  LASTN (LENGTH xs +1) (x::xs) = x::xs`,
+Triviality LASTN_LENGTH2:
+  LASTN (LENGTH xs +1) (x::xs) = x::xs
+Proof
   `LENGTH (x::xs) = LENGTH xs +1` by simp[]>>
-  metis_tac[LASTN_LENGTH_ID]);
+  metis_tac[LASTN_LENGTH_ID]
+QED
 
-val toAList_not_empty = Q.prove(`
+Triviality toAList_not_empty:
   domain t ≠ {} ⇒
-  toAList t ≠ []`,
+  toAList t ≠ []
+Proof
   CCONTR_TAC>>full_simp_tac(srw_ss())[GSYM MEMBER_NOT_EMPTY]>>
-  full_simp_tac(srw_ss())[GSYM toAList_domain]);
+  full_simp_tac(srw_ss())[GSYM toAList_domain]
+QED
 
 (*liveness theorem*)
 Theorem evaluate_apply_colour:
@@ -1539,10 +1577,11 @@ Definition colouring_ok_alt_def:
 End
 
 (*hd element is just get_live*)
-val get_clash_sets_hd = Q.prove(
-`∀prog live hd ls.
+Triviality get_clash_sets_hd:
+  ∀prog live hd ls.
   get_clash_sets prog live = (hd,ls) ⇒
-  get_live prog live = hd`,
+  get_live prog live = hd
+Proof
   Induct>>srw_tac[][get_clash_sets_def]>>full_simp_tac(srw_ss())[LET_THM]
   >-
     full_simp_tac(srw_ss())[get_live_def]
@@ -1558,7 +1597,8 @@ val get_clash_sets_hd = Q.prove(
   >>
     Cases_on`get_clash_sets prog live`>>
     Cases_on`get_clash_sets prog' live`>>
-    full_simp_tac(srw_ss())[get_live_def,LET_THM]>>metis_tac[]);
+    full_simp_tac(srw_ss())[get_live_def,LET_THM]>>metis_tac[]
+QED
 
 (*The liveset passed in at the back is always satisfied*)
 Theorem get_clash_sets_tl[local]:
@@ -1640,15 +1680,17 @@ val fs1 = full_simp_tac(srw_ss())[LET_THM, get_clash_sets_def,
   get_live_inst_def, every_name_def, toAList_domain];
 *)
 
-val every_var_exp_get_live_exp = Q.prove(`
+Triviality every_var_exp_get_live_exp:
   ∀exp.
-  every_var_exp (λx. x ∈ domain (get_live_exp exp)) exp`,
+  every_var_exp (λx. x ∈ domain (get_live_exp exp)) exp
+Proof
   ho_match_mp_tac get_live_exp_ind>>
   srw_tac[][]>>full_simp_tac(srw_ss())[get_live_exp_def,every_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>srw_tac[][]>>res_tac>>
   match_mp_tac every_var_exp_mono>>
   HINT_EXISTS_TAC>>full_simp_tac(srw_ss())[]>>
-  metis_tac[SUBSET_DEF,domain_big_union_subset]);
+  metis_tac[SUBSET_DEF,domain_big_union_subset]
+QED
 
 (*
 (*Every variable is in some clash set*)
@@ -1860,25 +1902,29 @@ Proof
     fs[domain_lookup]
 QED
 
-val wf_insert_swap = Q.prove(`
+Triviality wf_insert_swap:
   wf (t:num_set) ⇒
   insert (a:num) () (insert c () t) =
-  insert (c:num) () (insert a () t)`,
+  insert (c:num) () (insert a () t)
+Proof
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[wf_insert,lookup_insert]>>
-  rw[]);
+  rw[]
+QED
 
 (*TODO: This is true without wf*)
-val numset_list_insert_swap = Q.prove(`
+Triviality numset_list_insert_swap:
   ∀ls h live.
   wf live ⇒
   wf (numset_list_insert ls live) ∧
   numset_list_insert ls (insert h () live) =
-  insert h () (numset_list_insert ls live)`,
+  insert h () (numset_list_insert ls live)
+Proof
   Induct>>fs[numset_list_insert_def]>>rw[]>>
   res_tac>>
-  fs[wf_insert,wf_insert_swap]);
+  fs[wf_insert,wf_insert_swap]
+QED
 
 Theorem check_partial_col_INJ:
    ∀ls f live flive live' flive'.
@@ -1933,18 +1979,23 @@ Proof
     fs[]
 QED
 
-val domain_insert_eq_union = Q.prove(`
-  domain (insert num () live) = domain (union (insert num () LN) live)`,
+Triviality domain_insert_eq_union:
+  domain (insert num () live) = domain (union (insert num () LN) live)
+Proof
   fs[domain_union,domain_insert,UNION_COMM,EXTENSION]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val domain_numset_list_insert_eq_union = Q.prove(`
-  domain (numset_list_insert ls live) = domain (union (numset_list_insert ls LN) live)`,
-  fs[domain_union,domain_numset_list_insert,UNION_COMM]);
+Triviality domain_numset_list_insert_eq_union:
+  domain (numset_list_insert ls live) = domain (union (numset_list_insert ls LN) live)
+Proof
+  fs[domain_union,domain_numset_list_insert,UNION_COMM]
+QED
 
-val get_reads_exp_get_live_exp = Q.prove(`
+Triviality get_reads_exp_get_live_exp:
   ∀exp.
-  set(get_reads_exp exp) = domain (get_live_exp exp)`,
+  set(get_reads_exp exp) = domain (get_live_exp exp)
+Proof
   ho_match_mp_tac get_reads_exp_ind>>
   fs[get_reads_exp_def,get_live_exp_def]>>
   rw[EXTENSION]>>
@@ -1960,21 +2011,25 @@ val get_reads_exp_get_live_exp = Q.prove(`
     (qexists_tac`get_reads_exp h`>>simp[]>>
     metis_tac[])>>
   fs[]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val lookup_numset_list_insert = Q.prove(`
+Triviality lookup_numset_list_insert:
   ∀ls n t.
   lookup n (numset_list_insert ls t) =
-  if MEM n ls then SOME () else lookup n t`,
+  if MEM n ls then SOME () else lookup n t
+Proof
   Induct>>fs[numset_list_insert_def,lookup_insert]>>rw[]>>
-  fs[]);
+  fs[]
+QED
 
-val numset_list_insert_eq_UNION = Q.prove(`
+Triviality numset_list_insert_eq_UNION:
   ∀t t' ls.
   wf t ∧ wf t' ∧
   domain t' = set ls ⇒
   numset_list_insert ls t =
-  union t' t`,
+  union t' t
+Proof
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[numset_list_insert_swap,wf_union,EXTENSION]>>rw[]>>
@@ -1987,39 +2042,48 @@ val numset_list_insert_eq_UNION = Q.prove(`
   `n ∉ domain t'` by fs[]>>
   `lookup n t' = NONE` by
     metis_tac[domain_lookup,option_CASES]>>
-  fs[lookup_union,domain_lookup]);
+  fs[lookup_union,domain_lookup]
+QED
 
-val wf_delete_swap = Q.prove(`
+Triviality wf_delete_swap:
   wf t ⇒
   delete a (delete c t) =
-  delete c (delete a t)`,
+  delete c (delete a t)
+Proof
   rw[]>>
   dep_rewrite.DEP_REWRITE_TAC[spt_eq_thm]>>
   fs[wf_delete,lookup_delete]>>
-  rw[]);
+  rw[]
+QED
 
-val numset_list_delete_swap = Q.prove(`
+Triviality numset_list_delete_swap:
   ∀ls h live.
   wf live ⇒
   wf (numset_list_delete ls live) ∧
   numset_list_delete ls (delete h live) =
-  delete h (numset_list_delete ls live)`,
+  delete h (numset_list_delete ls live)
+Proof
   Induct>>fs[numset_list_delete_def]>>rw[]>>
   res_tac>>
-  fs[wf_delete,wf_delete_swap]);
+  fs[wf_delete,wf_delete_swap]
+QED
 
-val wf_numset_list_delete_eq = Q.prove(`
+Triviality wf_numset_list_delete_eq:
   ∀ls t live.
   wf t ⇒
-  FOLDR delete t ls = numset_list_delete ls t`,
-  Induct>>fs[numset_list_delete_def,numset_list_delete_swap]);
+  FOLDR delete t ls = numset_list_delete ls t
+Proof
+  Induct>>fs[numset_list_delete_def,numset_list_delete_swap]
+QED
 
-val wf_get_live_exp = Q.prove(`
-  ∀exp. wf(get_live_exp exp)`,
+Triviality wf_get_live_exp:
+  ∀exp. wf(get_live_exp exp)
+Proof
   ho_match_mp_tac get_live_exp_ind>>fs[get_live_exp_def,wf_insert,wf_def]>>
   rw[]>>
   fs[big_union_def]>>
-  Induct_on`ls`>>rw[wf_def,wf_union]);
+  Induct_on`ls`>>rw[wf_def,wf_union]
+QED
 
 val start_tac =
   FULL_CASE_TAC>>fs[]>>Cases_on`x`>>
@@ -2479,25 +2543,31 @@ val check_colouring_ok_alt_INJ = Q.prove(`
   imp_res_tac INJ_ALL_DISTINCT_MAP>>
   full_simp_tac(srw_ss())[set_toAList_keys])
 *)
-val get_forced_tail_split = Q.prove(`
+Triviality get_forced_tail_split:
   ∀c p ls ls'.
   get_forced c p (ls++ls') =
-  get_forced c p ls ++ ls'`,
+  get_forced c p ls ++ ls'
+Proof
   ho_match_mp_tac get_forced_ind>>rw[get_forced_def]>>
-  EVERY_CASE_TAC>>fs[])
+  EVERY_CASE_TAC>>fs[]
+QED
 
-val EVERY_get_forced = Q.prove(`
+Triviality EVERY_get_forced:
   EVERY P (get_forced c p ls) ⇔
-  EVERY P (get_forced c p []) ∧ EVERY P ls`,
+  EVERY P (get_forced c p []) ∧ EVERY P ls
+Proof
   Q.SPECL_THEN [`c`,`p`,`[]`,`ls`] assume_tac get_forced_tail_split>>
-  fs[])
+  fs[]
+QED
 
-val get_forced_pairwise_distinct = Q.prove(`
+Triviality get_forced_pairwise_distinct:
   ∀c prog ls.
   EVERY (λx,y. x ≠ y) ls ⇒
-  EVERY (λx,y. x ≠ y) (get_forced c prog ls)`,
+  EVERY (λx,y. x ≠ y) (get_forced c prog ls)
+Proof
   ho_match_mp_tac get_forced_ind>>rw[get_forced_def]>>
-  EVERY_CASE_TAC>>fs[])
+  EVERY_CASE_TAC>>fs[]
+QED
 
 val get_forced_in_get_clash_tree = Q.prove(`
   ∀prog c.
@@ -2530,12 +2600,14 @@ val get_forced_in_get_clash_tree = Q.prove(`
       (simp[Once EVERY_get_forced]>>
       fs[EVERY_MEM,FORALL_PROD]>>metis_tac[])))|>SIMP_RULE (srw_ss()) [LET_THM];
 
-val total_colour_rw = Q.prove(`
-  total_colour col = (\x. 2 * x) o (sp_default col)`,
+Triviality total_colour_rw:
+  total_colour col = (\x. 2 * x) o (sp_default col)
+Proof
   rw[FUN_EQ_THM]>>fs[total_colour_def,sp_default_def,lookup_any_def]>>
   TOP_CASE_TAC>>simp[]>>
   IF_CASES_TAC>>simp[]>>
-  metis_tac[is_phy_var_def,EVEN_MOD2,EVEN_EXISTS,TWOxDIV2]);
+  metis_tac[is_phy_var_def,EVEN_MOD2,EVEN_EXISTS,TWOxDIV2]
+QED
 
 Theorem select_reg_alloc_correct:
       !alg spillcosts k heu_moves tree forced.
@@ -2651,35 +2723,42 @@ val apply_colour_exp_I = Q.prove(`
   fs[MAP_EQ_ID]) |> SIMP_RULE std_ss[];
 
 (* Dead code removal *)
-val strong_locals_rel_I_word_exp = Q.prove(`
-   word_exp st exp = SOME res ∧
+Triviality strong_locals_rel_I_word_exp:
+  word_exp st exp = SOME res ∧
    strong_locals_rel I (domain (union (get_live_exp exp) live)) st.locals t ⇒
-   word_exp (st with locals := t) exp = SOME res`,
-   rw[]>>drule apply_colour_exp_lemma>>
+   word_exp (st with locals := t) exp = SOME res
+Proof
+  rw[]>>drule apply_colour_exp_lemma>>
    disch_then (qspecl_then [`st with locals:= t`,`I`] mp_tac)>>
    rfs[word_state_eq_rel_def,apply_colour_exp_I]>>
    impl_tac>>fs[]>>
-   fs[strong_locals_rel_def,domain_union]);
+   fs[strong_locals_rel_def,domain_union]
+QED
 
-val strong_locals_rel_insert_notin = Q.prove(`
+Triviality strong_locals_rel_insert_notin:
   strong_locals_rel f live s t ∧
   n ∉ live ⇒
-  strong_locals_rel f live (insert n v s) t`,
+  strong_locals_rel f live (insert n v s) t
+Proof
   rw[strong_locals_rel_def,lookup_insert]>>
-  Cases_on`n'=n`>>fs[]);
+  Cases_on`n'=n`>>fs[]
+QED
 
-val strong_locals_rel_I_get_var = Q.prove(`
+Triviality strong_locals_rel_I_get_var:
   get_var x st = SOME v ∧
   strong_locals_rel I (x INSERT live) st.locals t ⇒
-  get_var x (st with locals:=t) = SOME v`,
-  fs[strong_locals_rel_def,get_var_def]);
+  get_var x (st with locals:=t) = SOME v
+Proof
+  fs[strong_locals_rel_def,get_var_def]
+QED
 
-val strong_locals_rel_I_get_vars = Q.prove(`
+Triviality strong_locals_rel_I_get_vars:
   ∀ls live st t vs.
   (∀x. MEM x ls ⇒ x ∈ live) ∧
   strong_locals_rel I live st.locals t ∧
   get_vars ls st = SOME vs ⇒
-  get_vars ls (st with locals:=t) = SOME vs`,
+  get_vars ls (st with locals:=t) = SOME vs
+Proof
   Induct>>rw[get_vars_def]>>
   pop_assum mp_tac>>ntac 2 TOP_CASE_TAC>>
   strip_tac>>
@@ -2689,19 +2768,22 @@ val strong_locals_rel_I_get_vars = Q.prove(`
   `!x. MEM x ls ⇒ x ∈ live` by fs[]>>
   first_assum drule>>
   strip_tac >> res_tac>>
-  fs[]);
+  fs[]
+QED
 
-val strong_locals_rel_I_cut_env = Q.prove(`
+Triviality strong_locals_rel_I_cut_env:
   strong_locals_rel I (domain cutset) st.locals t ∧
   cut_env cutset st.locals = SOME x ⇒
-  cut_env cutset t = SOME x`,
+  cut_env cutset t = SOME x
+Proof
   fs[cut_env_def,strong_locals_rel_def,SUBSET_DEF]>>rw[]
   >-
     metis_tac[domain_lookup]
   >>
     simp[inter_def,lookup_inter]>>rw[]>>
     EVERY_CASE_TAC>>fs[domain_lookup]>>
-    res_tac>>fs[]);
+    res_tac>>fs[]
+QED
 
 val rm_tac =
     EVERY_CASE_TAC>>fs[]>>
@@ -2713,25 +2795,31 @@ val rm_tac =
       imp_res_tac strong_locals_rel_I_word_exp>>
       fs[state_component_equality,strong_locals_rel_def,lookup_insert,domain_union]>>rw[]
 
-val get_vars_eq = Q.prove(
-  `(set ls) SUBSET domain st.locals ==> ?z. get_vars ls st = SOME z /\
-                                             z = MAP (\x. THE (lookup x st.locals)) ls`,
+Triviality get_vars_eq:
+  (set ls) SUBSET domain st.locals ==> ?z. get_vars ls st = SOME z /\
+                                             z = MAP (\x. THE (lookup x st.locals)) ls
+Proof
   Induct_on`ls`>>full_simp_tac(srw_ss())[get_vars_def,get_var_def]>>srw_tac[][]>>
-  full_simp_tac(srw_ss())[domain_lookup]);
+  full_simp_tac(srw_ss())[domain_lookup]
+QED
 
-val get_vars_exists = Q.prove(`
+Triviality get_vars_exists:
   ∀ls.
   (∃z. get_vars ls st = SOME z) ⇔
-  set ls ⊆ domain st.locals`,
+  set ls ⊆ domain st.locals
+Proof
   Induct>>fs[get_vars_def,get_var_def]>>rw[]>>
-  EVERY_CASE_TAC>>fs[domain_lookup]);
+  EVERY_CASE_TAC>>fs[domain_lookup]
+QED
 
-val strong_locals_rel_I_insert_insert = Q.prove(`
+Triviality strong_locals_rel_I_insert_insert:
   strong_locals_rel I (live DELETE p) A B ∧
   v = v' ⇒
-  strong_locals_rel I live (insert p v A) (insert p v' B)`,
+  strong_locals_rel I live (insert p v A) (insert p v' B)
+Proof
   rw[strong_locals_rel_def,lookup_insert]>>
-  IF_CASES_TAC>>fs[]);
+  IF_CASES_TAC>>fs[]
+QED
 
 Theorem evaluate_remove_dead:
   ∀prog live prog' livein st t res rst.
@@ -3203,13 +3291,14 @@ Definition ssa_map_ok_def:
     (∀z. z ≠ x ⇒ lookup z ssa ≠ SOME y))
 End
 
-val list_next_var_rename_lemma_1 = Q.prove(`
+Triviality list_next_var_rename_lemma_1:
   ∀ls ssa na ls' ssa' na'.
   list_next_var_rename ls ssa na = (ls',ssa',na') ⇒
   let len = LENGTH ls in
   ALL_DISTINCT ls' ∧
   ls' = (MAP (λx. 4*x+na) (COUNT_LIST len)) ∧
-  na' = na + 4* len`,
+  na' = na + 4* len
+Proof
   Induct>>
   full_simp_tac(srw_ss())[list_next_var_rename_def,LET_THM,next_var_rename_def,COUNT_LIST_def]>>
   ntac 7 strip_tac>>
@@ -3231,54 +3320,62 @@ val list_next_var_rename_lemma_1 = Q.prove(`
     full_simp_tac(srw_ss())[MAP_EQ_f]>>srw_tac[][]>>
     DECIDE_TAC)
   >>
-    DECIDE_TAC);
+    DECIDE_TAC
+QED
 
-val list_next_var_rename_lemma_2 = Q.prove(`
+Triviality list_next_var_rename_lemma_2:
   ∀ls ssa na.
   ALL_DISTINCT ls ⇒
   let (ls',ssa',na') = list_next_var_rename ls ssa na in
   ls' = MAP (λx. THE(lookup x ssa')) ls ∧
   domain ssa' = domain ssa ∪ set ls ∧
   (∀x. ¬MEM x ls ⇒ lookup x ssa' = lookup x ssa) ∧
-  (∀x. MEM x ls ⇒ ∃y. lookup x ssa' = SOME y)`,
+  (∀x. MEM x ls ⇒ ∃y. lookup x ssa' = SOME y)
+Proof
   Induct>>full_simp_tac(srw_ss())[list_next_var_rename_def,LET_THM,next_var_rename_def]>>
   srw_tac[][]>>
   first_x_assum(qspecl_then[`insert h na ssa`,`na+4`] assume_tac)>>
   rev_full_simp_tac(srw_ss())[]>>
   Cases_on`list_next_var_rename ls (insert h na ssa) (na+4)`>>Cases_on`r`>>
   full_simp_tac(srw_ss())[lookup_insert,EXTENSION]>>srw_tac[][]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 val exists_tac = qexists_tac`cst.permute`>>
     full_simp_tac(srw_ss())[evaluate_def,LET_THM,word_state_eq_rel_def
       ,ssa_cc_trans_def];
 
-val ssa_locals_rel_get_var = Q.prove(`
+Triviality ssa_locals_rel_get_var:
   ssa_locals_rel na ssa st.locals cst.locals ∧
   get_var n st = SOME x
   ⇒
-  get_var (option_lookup ssa n) cst = SOME x`,
+  get_var (option_lookup ssa n) cst = SOME x
+Proof
   full_simp_tac(srw_ss())[get_var_def,ssa_locals_rel_def,strong_locals_rel_def,option_lookup_def]>>
   srw_tac[][]>>
   FULL_CASE_TAC>>full_simp_tac(srw_ss())[domain_lookup]>>
-  first_x_assum(qspecl_then[`n`,`x`] assume_tac)>>rev_full_simp_tac(srw_ss())[]);
+  first_x_assum(qspecl_then[`n`,`x`] assume_tac)>>rev_full_simp_tac(srw_ss())[]
+QED
 
-val ssa_locals_rel_get_vars = Q.prove(`
+Triviality ssa_locals_rel_get_vars:
   ∀ls y na ssa st cst.
   ssa_locals_rel na ssa st.locals cst.locals ∧
   get_vars ls st = SOME y
   ⇒
-  get_vars (MAP (option_lookup ssa) ls) cst = SOME y`,
+  get_vars (MAP (option_lookup ssa) ls) cst = SOME y
+Proof
   Induct>>full_simp_tac(srw_ss())[get_vars_def]>>srw_tac[][]>>
   Cases_on`get_var h st`>>full_simp_tac(srw_ss())[]>>
   imp_res_tac ssa_locals_rel_get_var>>full_simp_tac(srw_ss())[]>>
   Cases_on`get_vars ls st`>>full_simp_tac(srw_ss())[]>>
-  res_tac>>full_simp_tac(srw_ss())[]);
+  res_tac>>full_simp_tac(srw_ss())[]
+QED
 
-val ssa_map_ok_extend = Q.prove(`
+Triviality ssa_map_ok_extend:
   ssa_map_ok na ssa ∧
   ¬is_phy_var na ⇒
-  ssa_map_ok (na+4) (insert h na ssa)`,
+  ssa_map_ok (na+4) (insert h na ssa)
+Proof
   full_simp_tac(srw_ss())[ssa_map_ok_def]>>
   srw_tac[][]>>full_simp_tac(srw_ss())[lookup_insert]>>
   Cases_on`x=h`>>full_simp_tac(srw_ss())[]>>
@@ -3288,9 +3385,10 @@ val ssa_map_ok_extend = Q.prove(`
     (SPOSE_NOT_THEN assume_tac>>res_tac>>
     DECIDE_TAC)
   >>
-    Cases_on`z=h`>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
+    Cases_on`z=h`>>full_simp_tac(srw_ss())[]>>DECIDE_TAC
+QED
 
-val merge_moves_frame = Q.prove(`
+Triviality merge_moves_frame:
   ∀ls na ssaL ssaR.
   is_alloc_var na
   ⇒
@@ -3298,7 +3396,8 @@ val merge_moves_frame = Q.prove(`
   is_alloc_var na' ∧
   na ≤ na' ∧
   (ssa_map_ok na ssaL ⇒ ssa_map_ok na' ssaL') ∧
-  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')`,
+  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3317,14 +3416,16 @@ val merge_moves_frame = Q.prove(`
   CONJ_TAC>-
     DECIDE_TAC)
   >>
-  metis_tac[ssa_map_ok_extend,convention_partitions]);
+  metis_tac[ssa_map_ok_extend,convention_partitions]
+QED
 
-val merge_moves_fst = Q.prove(`
+Triviality merge_moves_fst:
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   na ≤ na' ∧
   EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveL) ∧
-  EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveR) `,
+  EVERY (λx. x < na' ∧ x ≥ na) (MAP FST moveR)
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>>srw_tac[][]>>
   full_simp_tac(srw_ss())[EVERY_MAP]>>
   first_x_assum(qspecl_then[`na`,`ssaL`,`ssaR`]assume_tac)>>
@@ -3334,16 +3435,18 @@ val merge_moves_fst = Q.prove(`
   qpat_x_assum`A = moveR` (sym_sub_tac)>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>srw_tac[][]>>
   res_tac>>
-  DECIDE_TAC);
+  DECIDE_TAC
+QED
 
 (*Characterize result of merge_moves*)
-val merge_moves_frame2 = Q.prove(`
+Triviality merge_moves_frame2:
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   domain ssaL' = domain ssaL ∧
   domain ssaR' = domain ssaR ∧
   ∀x. MEM x ls ∧ x ∈ domain (inter ssaL ssaR) ⇒
-    lookup x ssaL' = lookup x ssaR'`,
+    lookup x ssaL' = lookup x ssaR'
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3365,15 +3468,17 @@ val merge_moves_frame2 = Q.prove(`
     rev_full_simp_tac(srw_ss())[])
   >>
     full_simp_tac(srw_ss())[EXTENSION]>>srw_tac[][]>>
-    metis_tac[domain_lookup,lookup_insert]);
+    metis_tac[domain_lookup,lookup_insert]
+QED
 
 (*Another frame proof about unchanged lookups*)
-val merge_moves_frame3 = Q.prove(`
+Triviality merge_moves_frame3:
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = merge_moves ls ssaL ssaR na in
   ∀x. ¬MEM x ls ∨ x ∉ domain (inter ssaL ssaR) ⇒
     lookup x ssaL' = lookup x ssaL ∧
-    lookup x ssaR' = lookup x ssaR`,
+    lookup x ssaR' = lookup x ssaR
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])>>
   rpt strip_tac>>
@@ -3389,25 +3494,28 @@ val merge_moves_frame3 = Q.prove(`
   rev_full_simp_tac(srw_ss())[LET_THM]>>
   `h ∈ domain r3 ∧ h ∈ domain r2` by full_simp_tac(srw_ss())[domain_lookup]>>
   full_simp_tac(srw_ss())[domain_inter]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 (*Don't know a neat way to prove this for both sides at once neatly,
 Also, the cases are basically copy pasted... *)
 
-val mov_eval_head = Q.prove(`
+Triviality mov_eval_head:
   evaluate(Move p moves,st) = (NONE,rst) ∧
   y ∈ domain st.locals ∧
   ¬MEM y (MAP FST moves) ∧
   ¬MEM x (MAP FST moves)
   ⇒
-  evaluate(Move p ((x,y)::moves),st) = (NONE, rst with locals:=insert x (THE (lookup y st.locals)) rst.locals)`,
+  evaluate(Move p ((x,y)::moves),st) = (NONE, rst with locals:=insert x (THE (lookup y st.locals)) rst.locals)
+Proof
   full_simp_tac(srw_ss())[evaluate_def,get_vars_def,get_var_def,domain_lookup]>>
   EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>
   strip_tac>>
   full_simp_tac(srw_ss())[set_vars_def,alist_insert_def]>>
-  qpat_x_assum `A=rst` (sym_sub_tac)>>full_simp_tac(srw_ss())[]);
+  qpat_x_assum `A=rst` (sym_sub_tac)>>full_simp_tac(srw_ss())[]
+QED
 
-val merge_moves_correctL = Q.prove(`
+Triviality merge_moves_correctL:
   ∀ls na ssaL ssaR stL cstL pri.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3421,7 +3529,8 @@ val merge_moves_correctL = Q.prove(`
     (∀x y. (x < na ∧ lookup x cstL.locals = SOME y)
     ⇒  lookup x rcstL.locals = SOME y) ∧
     ssa_locals_rel na' ssaL' stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)`,
+    word_state_eq_rel cstL rcstL)
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3480,9 +3589,10 @@ val merge_moves_correctL = Q.prove(`
     >-
       (res_tac>>DECIDE_TAC))
   >>
-      full_simp_tac(srw_ss())[word_state_eq_rel_def]);
+      full_simp_tac(srw_ss())[word_state_eq_rel_def]
+QED
 
-val merge_moves_correctR = Q.prove(`
+Triviality merge_moves_correctR:
   ∀ls na ssaL ssaR stR cstR pri.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3496,7 +3606,8 @@ val merge_moves_correctR = Q.prove(`
     (∀x y. (x < na ∧ lookup x cstR.locals = SOME y)
     ⇒  lookup x rcstR.locals = SOME y) ∧
     ssa_locals_rel na' ssaR' stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)`,
+    word_state_eq_rel cstR rcstR)
+Proof
   Induct>>full_simp_tac(srw_ss())[merge_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3555,9 +3666,10 @@ val merge_moves_correctR = Q.prove(`
     >-
       (res_tac>>DECIDE_TAC))
   >>
-      full_simp_tac(srw_ss())[word_state_eq_rel_def]);
+      full_simp_tac(srw_ss())[word_state_eq_rel_def]
+QED
 
-val fake_moves_frame = Q.prove(`
+Triviality fake_moves_frame:
   ∀ls na ssaL ssaR.
   is_alloc_var na
   ⇒
@@ -3565,7 +3677,8 @@ val fake_moves_frame = Q.prove(`
   is_alloc_var na' ∧
   na ≤ na' ∧
   (ssa_map_ok na ssaL ⇒ ssa_map_ok na' ssaL') ∧
-  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')`,
+  (ssa_map_ok na ssaR ⇒ ssa_map_ok na' ssaR')
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3584,14 +3697,16 @@ val fake_moves_frame = Q.prove(`
   CONJ_TAC>-
     DECIDE_TAC)
   >>
-  metis_tac[ssa_map_ok_extend,convention_partitions]);
+  metis_tac[ssa_map_ok_extend,convention_partitions]
+QED
 
-val fake_moves_frame2 = Q.prove(`
+Triviality fake_moves_frame2:
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = fake_moves ls ssaL ssaR na in
   domain ssaL' = domain ssaL ∪ (set ls ∩ (domain ssaR ∪ domain ssaL)) ∧
   domain ssaR' = domain ssaR ∪ (set ls ∩ (domain ssaR ∪ domain ssaL)) ∧
-  ∀x. MEM x ls ∧ x ∉ domain(inter ssaL ssaR) ⇒ lookup x ssaL' = lookup x ssaR'`,
+  ∀x. MEM x ls ∧ x ∉ domain(inter ssaL ssaR) ⇒ lookup x ssaL' = lookup x ssaR'
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3602,14 +3717,16 @@ val fake_moves_frame2 = Q.prove(`
   Cases_on`fake_moves ls ssaL ssaR na`>>PairCases_on`r`>>rev_full_simp_tac(srw_ss())[]>>
   EVERY_CASE_TAC>>
   full_simp_tac(srw_ss())[EXTENSION,domain_inter]>>srw_tac[][]>>
-  metis_tac[domain_lookup,lookup_insert]);
+  metis_tac[domain_lookup,lookup_insert]
+QED
 
-val fake_moves_frame3 = Q.prove(`
+Triviality fake_moves_frame3:
   ∀ls na ssaL ssaR.
   let(moveL,moveR,na',ssaL',ssaR') = fake_moves ls ssaL ssaR na in
   ∀x. ¬ MEM x ls ∨ x ∈ domain(inter ssaL ssaR) ⇒
     lookup x ssaL' = lookup x ssaL ∧
-    lookup x ssaR' = lookup x ssaR`,
+    lookup x ssaR' = lookup x ssaR
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>full_simp_tac(srw_ss())[])
   >>
@@ -3626,9 +3743,10 @@ val fake_moves_frame3 = Q.prove(`
   IF_CASES_TAC>>full_simp_tac(srw_ss())[]>>
   `h ∈ domain r2` by full_simp_tac(srw_ss())[domain_lookup]>>
   res_tac>>
-  full_simp_tac(srw_ss())[lookup_NONE_domain]);
+  full_simp_tac(srw_ss())[lookup_NONE_domain]
+QED
 
-val fake_moves_correctL = Q.prove(`
+Triviality fake_moves_correctL:
   ∀ls na ssaL ssaR stL cstL.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3642,7 +3760,8 @@ val fake_moves_correctL = Q.prove(`
     (∀x y. (x < na ∧ lookup x cstL.locals = SOME y)
     ⇒  lookup x rcstL.locals = SOME y) ∧
     ssa_locals_rel na' ssaL' stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)`,
+    word_state_eq_rel cstL rcstL)
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
     (srw_tac[][]>>
     full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3719,9 +3838,10 @@ val fake_moves_correctL = Q.prove(`
       (res_tac>>
       DECIDE_TAC)
     >>
-      full_simp_tac(srw_ss())[word_state_eq_rel_def]));
+      full_simp_tac(srw_ss())[word_state_eq_rel_def])
+QED
 
-val fake_moves_correctR = Q.prove(`
+Triviality fake_moves_correctR:
   ∀ls na ssaL ssaR stR cstR.
   is_alloc_var na ∧
   ALL_DISTINCT ls ∧
@@ -3735,7 +3855,8 @@ val fake_moves_correctR = Q.prove(`
     (∀x y. (x < na ∧ lookup x cstR.locals = SOME y)
     ⇒  lookup x rcstR.locals = SOME y) ∧
     ssa_locals_rel na' ssaR' stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)`,
+    word_state_eq_rel cstR rcstR)
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>-
   (srw_tac[][]>>
   full_simp_tac(srw_ss())[evaluate_def,word_state_eq_rel_def,get_vars_def,set_vars_def,alist_insert_def]>>
@@ -3812,44 +3933,53 @@ val fake_moves_correctR = Q.prove(`
       (res_tac>>
       DECIDE_TAC)
     >>
-      full_simp_tac(srw_ss())[word_state_eq_rel_def]));
+      full_simp_tac(srw_ss())[word_state_eq_rel_def])
+QED
 
 (*Swapping lemma that allows us to swap in ssaL for ssaR
   after we are done fixing them*)
-val ssa_eq_rel_swap = Q.prove(`
+Triviality ssa_eq_rel_swap:
   ssa_locals_rel na ssaR st.locals cst.locals ∧
   domain ssaL = domain ssaR ∧
   (∀x. lookup x ssaL = lookup x ssaR) ⇒
-  ssa_locals_rel na ssaL st.locals cst.locals`,
-  srw_tac[][ssa_locals_rel_def]);
+  ssa_locals_rel na ssaL st.locals cst.locals
+Proof
+  srw_tac[][ssa_locals_rel_def]
+QED
 
-val ssa_locals_rel_more = Q.prove(`
+Triviality ssa_locals_rel_more:
   ssa_locals_rel na ssa stlocs cstlocs ∧ na ≤ na' ⇒
-  ssa_locals_rel na' ssa stlocs cstlocs`,
+  ssa_locals_rel na' ssa stlocs cstlocs
+Proof
   srw_tac[][ssa_locals_rel_def]>>full_simp_tac(srw_ss())[]
   >- metis_tac[]>>
   res_tac>>full_simp_tac(srw_ss())[]>>
-  DECIDE_TAC);
+  DECIDE_TAC
+QED
 
-val ssa_map_ok_more = Q.prove(`
+Triviality ssa_map_ok_more:
   ssa_map_ok na ssa ∧ na ≤ na' ⇒
-  ssa_map_ok na' ssa`,
+  ssa_map_ok na' ssa
+Proof
   full_simp_tac(srw_ss())[ssa_map_ok_def]>>srw_tac[][]
   >-
     metis_tac[]>>
-  res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
+  res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC
+QED
 
-val get_var_ignore = Q.prove(`
+Triviality get_var_ignore:
   ∀ls a.
   get_var x cst = SOME y ∧
   ¬MEM x ls ∧
   LENGTH ls = LENGTH a ⇒
-  get_var x (set_vars ls a cst) = SOME y`,
+  get_var x (set_vars ls a cst) = SOME y
+Proof
   Induct>>full_simp_tac(srw_ss())[get_var_def,set_vars_def,alist_insert_def]>>
   srw_tac[][]>>
-  Cases_on`a`>>full_simp_tac(srw_ss())[alist_insert_def,lookup_insert]);
+  Cases_on`a`>>full_simp_tac(srw_ss())[alist_insert_def,lookup_insert]
+QED
 
-val fix_inconsistencies_correctL = Q.prove(`
+Triviality fix_inconsistencies_correctL:
   ∀na ssaL ssaR.
   is_alloc_var na ∧
   ssa_map_ok na ssaL
@@ -3860,7 +3990,8 @@ val fix_inconsistencies_correctL = Q.prove(`
   let (resL,rcstL) = evaluate(moveL,cstL) in
     resL = NONE ∧
     ssa_locals_rel na' ssaU stL.locals rcstL.locals ∧
-    word_state_eq_rel cstL rcstL)`,
+    word_state_eq_rel cstL rcstL)
+Proof
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   Q.ISPECL_THEN [`var_union`,`na`,`ssaL`,`ssaR`,`stL`,`cstL`,`1`] mp_tac
       merge_moves_correctL>>
@@ -3879,9 +4010,10 @@ val fix_inconsistencies_correctL = Q.prove(`
   simp[Once evaluate_def]>>
   full_simp_tac(srw_ss())[]>>
   rpt VAR_EQ_TAC>>full_simp_tac(srw_ss())[]>>
-  srw_tac[][]>>full_simp_tac(srw_ss())[word_state_eq_rel_def]);
+  srw_tac[][]>>full_simp_tac(srw_ss())[word_state_eq_rel_def]
+QED
 
-val fix_inconsistencies_correctR = Q.prove(`
+Triviality fix_inconsistencies_correctR:
   ∀na ssaL ssaR.
   is_alloc_var na ∧
   ssa_map_ok na ssaR
@@ -3892,7 +4024,8 @@ val fix_inconsistencies_correctR = Q.prove(`
   let (resR,rcstR) = evaluate(moveR,cstR) in
     resR = NONE ∧
     ssa_locals_rel na' ssaU stR.locals rcstR.locals ∧
-    word_state_eq_rel cstR rcstR)`,
+    word_state_eq_rel cstR rcstR)
+Proof
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   Q.ISPECL_THEN [`var_union`,`na`,`ssaL`,`ssaR`,`stR`,`cstR`,`1`] mp_tac
       merge_moves_correctR>>
@@ -3933,7 +4066,8 @@ val fix_inconsistencies_correctR = Q.prove(`
     metis_tac[lookup_NONE_domain])
   >>
     full_simp_tac(srw_ss())[domain_inter]>>
-    metis_tac[]);
+    metis_tac[]
+QED
 
 fun use_ALOOKUP_ALL_DISTINCT_MEM (g as (asl,w)) =
   let
@@ -3944,7 +4078,7 @@ fun use_ALOOKUP_ALL_DISTINCT_MEM (g as (asl,w)) =
     mp_tac(ISPECL [al,k] (Q.GENL[`al`,`k`,`v`] ALOOKUP_ALL_DISTINCT_MEM))
   end g;
 
-val list_next_var_rename_move_preserve = Q.prove(`
+Triviality list_next_var_rename_move_preserve:
   ∀st ssa na ls cst.
   ssa_locals_rel na ssa st.locals cst.locals ∧
   set ls ⊆ domain st.locals ∧
@@ -3958,7 +4092,8 @@ val list_next_var_rename_move_preserve = Q.prove(`
     ssa_locals_rel na' ssa' st.locals rcst.locals ∧
     word_state_eq_rel st rcst ∧
     (¬is_phy_var na ⇒ ∀w. is_phy_var w ⇒ lookup w rcst.locals = lookup w cst.locals) ∧
-    (∀x y. lookup x st.locals = SOME y ⇒ lookup (THE (lookup x ssa)) rcst.locals = SOME y)`,
+    (∀x y. lookup x st.locals = SOME y ⇒ lookup (THE (lookup x ssa)) rcst.locals = SOME y)
+Proof
   full_simp_tac(srw_ss())[list_next_var_rename_move_def,ssa_locals_rel_def]>>
   srw_tac[][]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -4059,12 +4194,14 @@ val list_next_var_rename_move_preserve = Q.prove(`
       res_tac>>fs[])>>
     fs[]>>
     ntac 3 (last_x_assum kall_tac)>>
-    rfs[]);
+    rfs[]
+QED
 
-val get_vars_list_insert_eq_gen= Q.prove(
-`!ls x locs a b. (LENGTH ls = LENGTH x /\ ALL_DISTINCT ls /\
+Triviality get_vars_list_insert_eq_gen:
+  !ls x locs a b. (LENGTH ls = LENGTH x /\ ALL_DISTINCT ls /\
                   LENGTH a = LENGTH b /\ !e. MEM e ls ==> ~MEM e a)
-  ==> get_vars ls (st with locals := alist_insert (a++ls) (b++x) locs) = SOME x`,
+  ==> get_vars ls (st with locals := alist_insert (a++ls) (b++x) locs) = SOME x
+Proof
   ho_match_mp_tac alist_insert_ind>>
   srw_tac[][]>- (full_simp_tac(srw_ss())[get_vars_def])>>
   full_simp_tac(srw_ss())[get_vars_def,get_var_def,lookup_alist_insert]>>
@@ -4078,53 +4215,61 @@ val get_vars_list_insert_eq_gen= Q.prove(
   first_x_assum(qspecl_then [`a++[ls]`,`b++[x]`] assume_tac)>>
   `LENGTH (a++[ls]) = LENGTH (b++[x])` by full_simp_tac(srw_ss())[]>> rev_full_simp_tac(srw_ss())[]>>
   `a++[ls]++ls' = a++ls::ls' /\ b++[x]++x' = b++x::x'` by full_simp_tac(srw_ss())[]>>
-  ntac 2 (pop_assum SUBST_ALL_TAC)>> full_simp_tac(srw_ss())[]);
+  ntac 2 (pop_assum SUBST_ALL_TAC)>> full_simp_tac(srw_ss())[]
+QED
 
-val get_vars_set_vars_eq = Q.prove(`
+Triviality get_vars_set_vars_eq:
   ∀ls x.
   ALL_DISTINCT ls ∧ LENGTH x = LENGTH ls ⇒
-  get_vars ls (set_vars ls x cst) = SOME x`,
+  get_vars ls (set_vars ls x cst) = SOME x
+Proof
   full_simp_tac(srw_ss())[get_vars_def,set_vars_def]>>srw_tac[][]>>
   Q.ISPECL_THEN [`cst`,`ls`,`x`,`cst.locals`,`[]:num list`
     ,`[]:'a word_loc list`] mp_tac (GEN_ALL get_vars_list_insert_eq_gen)>>
-  impl_tac>>full_simp_tac(srw_ss())[]);
+  impl_tac>>full_simp_tac(srw_ss())[]
+QED
 
-val ssa_locals_rel_ignore_set_var = Q.prove(`
+Triviality ssa_locals_rel_ignore_set_var:
   ssa_map_ok na ssa ∧
   ssa_locals_rel na ssa st.locals cst.locals ∧
   is_phy_var v
   ⇒
-  ssa_locals_rel na ssa st.locals (set_var v a cst).locals`,
+  ssa_locals_rel na ssa st.locals (set_var v a cst).locals
+Proof
   srw_tac[][ssa_locals_rel_def,ssa_map_ok_def,set_var_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>-
     metis_tac[]
   >>
   res_tac>>
   full_simp_tac(srw_ss())[domain_lookup]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val ssa_locals_rel_ignore_insert = Q.prove(`
+Triviality ssa_locals_rel_ignore_insert:
   ssa_map_ok na ssa ∧
   ssa_locals_rel na ssa stloc cstloc ∧
   is_phy_var v
   ⇒
-  ssa_locals_rel na ssa stloc (insert v a cstloc)`,
+  ssa_locals_rel na ssa stloc (insert v a cstloc)
+Proof
   srw_tac[][ssa_locals_rel_def,ssa_map_ok_def,set_var_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>-
     metis_tac[]
   >>
   res_tac>>
   full_simp_tac(srw_ss())[domain_lookup]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 
-val ssa_locals_rel_ignore_list_insert = Q.prove(`
+Triviality ssa_locals_rel_ignore_list_insert:
   ssa_map_ok na ssa ∧
   ssa_locals_rel na ssa st.locals cst.locals ∧
   EVERY is_phy_var ls ∧
   LENGTH ls = LENGTH x
   ⇒
-  ssa_locals_rel na ssa st.locals (alist_insert ls x cst.locals)`,
+  ssa_locals_rel na ssa st.locals (alist_insert ls x cst.locals)
+Proof
   srw_tac[][ssa_locals_rel_def,ssa_map_ok_def]>>
   full_simp_tac(srw_ss())[domain_alist_insert,lookup_alist_insert]>-
     metis_tac[]
@@ -4135,13 +4280,15 @@ val ssa_locals_rel_ignore_list_insert = Q.prove(`
   `ALOOKUP (ZIP(ls,x)) v = NONE` by
     (srw_tac[][ALOOKUP_FAILS,MEM_ZIP]>>
     metis_tac[EVERY_EL])>>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
-val ssa_locals_rel_set_var = Q.prove(`
+Triviality ssa_locals_rel_set_var:
   ssa_locals_rel na ssa st.locals cst.locals ∧
   ssa_map_ok na ssa ∧
   n < na ⇒
-  ssa_locals_rel (na+4) (insert n na ssa) (insert n w st.locals) (insert na w cst.locals)`,
+  ssa_locals_rel (na+4) (insert n na ssa) (insert n w st.locals) (insert na w cst.locals)
+Proof
   srw_tac[][ssa_locals_rel_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>>Cases_on`x=n`>>full_simp_tac(srw_ss())[]
   >-
@@ -4161,13 +4308,15 @@ val ssa_locals_rel_set_var = Q.prove(`
     DECIDE_TAC
   >>
     (*Finally, this illustrates need for <na assumption on st.locals*)
-    full_simp_tac(srw_ss())[ssa_map_ok_def]>>res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
+    full_simp_tac(srw_ss())[ssa_map_ok_def]>>res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC
+QED
 
-val ssa_locals_rel_insert = Q.prove(`
+Triviality ssa_locals_rel_insert:
   ssa_locals_rel na ssa stloc cstloc ∧
   ssa_map_ok na ssa ∧
   n < na ⇒
-  ssa_locals_rel (na+4) (insert n na ssa) (insert n w stloc) (insert na w cstloc)`,
+  ssa_locals_rel (na+4) (insert n na ssa) (insert n w stloc) (insert na w cstloc)
+Proof
   srw_tac[][ssa_locals_rel_def]>>
   full_simp_tac(srw_ss())[lookup_insert]>>Cases_on`x=n`>>full_simp_tac(srw_ss())[]
   >-
@@ -4187,41 +4336,50 @@ val ssa_locals_rel_insert = Q.prove(`
     DECIDE_TAC
   >>
     (*Finally, this illustrates need for <na assumption on st.locals*)
-    full_simp_tac(srw_ss())[ssa_map_ok_def]>>res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC);
+    full_simp_tac(srw_ss())[ssa_map_ok_def]>>res_tac>>full_simp_tac(srw_ss())[]>>DECIDE_TAC
+QED
 
-val is_alloc_var_add = Q.prove(`
-  is_alloc_var na ⇒ is_alloc_var (na+4)`,
+Triviality is_alloc_var_add:
+  is_alloc_var na ⇒ is_alloc_var (na+4)
+Proof
   full_simp_tac(srw_ss())[is_alloc_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`4`] assume_tac)>>
-    rev_full_simp_tac(srw_ss())[]));
+    rev_full_simp_tac(srw_ss())[])
+QED
 
-val is_stack_var_add= Q.prove(`
-  is_stack_var na ⇒ is_stack_var (na+4)`,
+Triviality is_stack_var_add:
+  is_stack_var na ⇒ is_stack_var (na+4)
+Proof
   full_simp_tac(srw_ss())[is_stack_var_def]>>
   (qspec_then `4` assume_tac arithmeticTheory.MOD_PLUS>>full_simp_tac(srw_ss())[]>>
     pop_assum (qspecl_then [`na`,`4`] assume_tac)>>
-    rev_full_simp_tac(srw_ss())[]));
+    rev_full_simp_tac(srw_ss())[])
+QED
 
-val is_alloc_var_flip = Q.prove(`
-  is_alloc_var na ⇒ is_stack_var (na+2)`,
+Triviality is_alloc_var_flip:
+  is_alloc_var na ⇒ is_stack_var (na+2)
+Proof
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
   ‘0 < 4:num’ by fs [] >>
   drule arithmeticTheory.MOD_PLUS >>
   disch_then $ qspecl_then [`na`,`2`] assume_tac >>
   full_simp_tac std_ss [EVAL “2 MOD 4”] >>
-  strip_tac >> fs []);
+  strip_tac >> fs []
+QED
 
-val is_stack_var_flip = Q.prove(`
-  is_stack_var na ⇒ is_alloc_var (na+2)`,
+Triviality is_stack_var_flip:
+  is_stack_var na ⇒ is_alloc_var (na+2)
+Proof
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
   ‘0 < 4:num’ by fs [] >>
   drule arithmeticTheory.MOD_PLUS >>
   disch_then $ qspecl_then [`na`,`2`] assume_tac >>
   full_simp_tac std_ss [EVAL “2 MOD 4”] >>
-  strip_tac >> fs []);
+  strip_tac >> fs []
+QED
 
-val list_next_var_rename_props = Q.prove(`
+Triviality list_next_var_rename_props:
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧
   ssa_map_ok na ssa ∧
@@ -4230,7 +4388,8 @@ val list_next_var_rename_props = Q.prove(`
   na ≤ na' ∧
   (is_alloc_var na ⇒ is_alloc_var na') ∧
   (is_stack_var na ⇒ is_stack_var na') ∧
-  ssa_map_ok na' ssa'`,
+  ssa_map_ok na' ssa'
+Proof
   Induct>>full_simp_tac(srw_ss())[list_next_var_rename_def,next_var_rename_def]>>
   LET_ELIM_TAC>>
   first_x_assum(qspecl_then[`ssa''`,`na''`,`ys`,`ssa'''`,`na'''`]
@@ -4252,9 +4411,10 @@ val list_next_var_rename_props = Q.prove(`
       >>
         res_tac>>DECIDE_TAC))>>
   srw_tac[][]>> TRY(DECIDE_TAC)>> full_simp_tac(srw_ss())[]>>
-  metis_tac[is_alloc_var_add,is_stack_var_add]);
+  metis_tac[is_alloc_var_add,is_stack_var_add]
+QED
 
-val list_next_var_rename_move_props = Q.prove(`
+Triviality list_next_var_rename_move_props:
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧
   ssa_map_ok na ssa ∧
@@ -4263,12 +4423,14 @@ val list_next_var_rename_move_props = Q.prove(`
   na ≤ na' ∧
   (is_alloc_var na ⇒ is_alloc_var na') ∧
   (is_stack_var na ⇒ is_stack_var na') ∧
-  ssa_map_ok na' ssa'`,
+  ssa_map_ok na' ssa'
+Proof
   full_simp_tac(srw_ss())[list_next_var_rename_move_def]>>LET_ELIM_TAC>>
   full_simp_tac(srw_ss())[]>>
-  imp_res_tac list_next_var_rename_props);
+  imp_res_tac list_next_var_rename_props
+QED
 
-val ssa_cc_trans_inst_props = Q.prove(`
+Triviality ssa_cc_trans_inst_props:
   ∀i ssa na i' ssa' na'.
   ssa_cc_trans_inst i ssa na = (i',ssa',na') ∧
   ssa_map_ok na ssa ∧
@@ -4276,7 +4438,8 @@ val ssa_cc_trans_inst_props = Q.prove(`
   ⇒
   na ≤ na' ∧
   is_alloc_var na' ∧
-  ssa_map_ok na' ssa'`,
+  ssa_map_ok na' ssa'
+Proof
   Induct>>srw_tac[][]>>
   TRY(Cases_on`a`)>>
   TRY(Cases_on`r`)>>
@@ -4288,13 +4451,14 @@ val ssa_cc_trans_inst_props = Q.prove(`
   TRY(metis_tac[ssa_map_ok_extend,convention_partitions,is_alloc_var_add])>>
   every_case_tac>>rw[]>>fs[]>>
   `na + 8 = na + 4 +4` by fs[]>>
-  metis_tac[is_alloc_var_add,ssa_map_ok_extend,convention_partitions]);
+  metis_tac[is_alloc_var_add,ssa_map_ok_extend,convention_partitions]
+QED
 
 val exp_tac = (LET_ELIM_TAC>>full_simp_tac(srw_ss())[next_var_rename_def]>>
     TRY(DECIDE_TAC)>>
     metis_tac[ssa_map_ok_extend,convention_partitions,is_alloc_var_add]);
 
-val fix_inconsistencies_props = Q.prove(`
+Triviality fix_inconsistencies_props:
   ∀ssaL ssaR na a b na' ssaU.
   fix_inconsistencies ssaL ssaR na = (a,b,na',ssaU) ∧
   is_alloc_var na ∧
@@ -4303,22 +4467,25 @@ val fix_inconsistencies_props = Q.prove(`
   ⇒
   na ≤ na' ∧
   is_alloc_var na' ∧
-  ssa_map_ok na' ssaU`,
+  ssa_map_ok na' ssaU
+Proof
   full_simp_tac(srw_ss())[fix_inconsistencies_def]>>LET_ELIM_TAC>>
   imp_res_tac merge_moves_frame>>
   pop_assum(qspecl_then[`ssaR`,`ssaL`,`var_union`] assume_tac)>>
   Q.ISPECL_THEN [`var_union`,`na''`,`ssa_L'`,`ssa_R'`] assume_tac fake_moves_frame>>
   rev_full_simp_tac(srw_ss())[LET_THM]>>
-  DECIDE_TAC)
+  DECIDE_TAC
+QED
 
 val th =
   (MATCH_MP
     (PROVE[]``((a ⇒ b) ∧ (c ⇒ d)) ⇒ ((a ∨ c) ⇒ b ∨ d)``)
     (CONJ is_stack_var_flip is_alloc_var_flip))
 
-val flip_rw = Q.prove(
-  `is_stack_var(na+2) = is_alloc_var na ∧
-    is_alloc_var(na+2) = is_stack_var na`,
+Triviality flip_rw:
+  is_stack_var(na+2) = is_alloc_var na ∧
+    is_alloc_var(na+2) = is_stack_var na
+Proof
   conj_tac >> (reverse EQ_TAC >-
     metis_tac[is_alloc_var_flip,is_stack_var_flip]) >>
   full_simp_tac(srw_ss())[is_alloc_var_def,is_stack_var_def]>>
@@ -4327,7 +4494,8 @@ val flip_rw = Q.prove(
   disch_then(qspecl_then[`na`,`2`](SUBST1_TAC o SYM)) >>
   `na MOD 4 < 4` by full_simp_tac(srw_ss())[]>>
   imp_res_tac (DECIDE ``n:num<4⇒(n=0)∨(n=1)∨(n=2)∨(n=3)``)>>
-  full_simp_tac(srw_ss())[]));
+  full_simp_tac(srw_ss())[])
+QED
 
 val list_next_var_rename_props_2 =
   list_next_var_rename_props
@@ -4338,28 +4506,34 @@ val list_next_var_rename_props_2 =
   |> DISCH_ALL
   |> REWRITE_RULE[flip_rw];
 
-val ssa_map_ok_lem = Q.prove(`
-  ssa_map_ok na ssa ⇒ ssa_map_ok (na+2) ssa`,
-  metis_tac[ssa_map_ok_more, DECIDE``na:num ≤ na+2``]);
+Triviality ssa_map_ok_lem:
+  ssa_map_ok na ssa ⇒ ssa_map_ok (na+2) ssa
+Proof
+  metis_tac[ssa_map_ok_more, DECIDE``na:num ≤ na+2``]
+QED
 
-val list_next_var_rename_move_props_2 = Q.prove(`
+Triviality list_next_var_rename_move_props_2:
   ∀ls ssa na ls' ssa' na'.
   (is_alloc_var na ∨ is_stack_var na) ∧ ssa_map_ok na ssa ∧
   list_next_var_rename_move ssa (na+2) ls = (ls',ssa',na') ⇒
   (na+2) ≤ na' ∧
   (is_alloc_var na ⇒ is_stack_var na') ∧
   (is_stack_var na ⇒ is_alloc_var na') ∧
-  ssa_map_ok na' ssa'`,
+  ssa_map_ok na' ssa'
+Proof
   ntac 7 strip_tac>>imp_res_tac list_next_var_rename_move_props>>
   full_simp_tac(srw_ss())[]>>
-  metis_tac[is_stack_var_flip,is_alloc_var_flip,ssa_map_ok_lem]);
+  metis_tac[is_stack_var_flip,is_alloc_var_flip,ssa_map_ok_lem]
+QED
 
-val ssa_map_ok_inter = Q.prove(`
+Triviality ssa_map_ok_inter:
   ssa_map_ok na ssa ⇒
-  ssa_map_ok na (inter ssa ssa')`,
+  ssa_map_ok na (inter ssa ssa')
+Proof
   full_simp_tac(srw_ss())[ssa_map_ok_def,lookup_inter]>>srw_tac[][]>>EVERY_CASE_TAC>>
   full_simp_tac(srw_ss())[]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 (*Prove the properties that hold of ssa_cc_trans independent of semantics*)
 Theorem ssa_cc_trans_props[local]:
@@ -4576,30 +4750,35 @@ Proof
     metis_tac[convention_partitions] )
 QED
 
-val PAIR_ZIP_MEM = Q.prove(`
+Triviality PAIR_ZIP_MEM:
   LENGTH c = LENGTH d ∧
   MEM (a,b) (ZIP (c,d)) ⇒
-  MEM a c ∧ MEM b d`,
+  MEM a c ∧ MEM b d
+Proof
   srw_tac[][]>>imp_res_tac MEM_ZIP>>
   full_simp_tac(srw_ss())[MEM_EL]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val ALOOKUP_ZIP_MEM = Q.prove(`
+Triviality ALOOKUP_ZIP_MEM:
   LENGTH a = LENGTH b ∧
   ALOOKUP (ZIP (a,b)) x = SOME y
   ⇒
-  MEM x a ∧ MEM y b`,
+  MEM x a ∧ MEM y b
+Proof
   srw_tac[][]>>imp_res_tac ALOOKUP_MEM>>
-  metis_tac[PAIR_ZIP_MEM]);
+  metis_tac[PAIR_ZIP_MEM]
+QED
 
-val ALOOKUP_ALL_DISTINCT_REMAP = Q.prove(`
+Triviality ALOOKUP_ALL_DISTINCT_REMAP:
   ∀ls x f y n.
   LENGTH ls = LENGTH x ∧
   ALL_DISTINCT (MAP f ls) ∧
   n < LENGTH ls ∧
   ALOOKUP (ZIP (ls,x)) (EL n ls) = SOME y
   ⇒
-  ALOOKUP (ZIP (MAP f ls,x)) (f (EL n ls)) = SOME y`,
+  ALOOKUP (ZIP (MAP f ls,x)) (f (EL n ls)) = SOME y
+Proof
   Induct>>srw_tac[][]>>
   Cases_on`x`>>full_simp_tac(srw_ss())[]>>
   imp_res_tac ALL_DISTINCT_MAP>>
@@ -4612,11 +4791,14 @@ val ALOOKUP_ALL_DISTINCT_REMAP = Q.prove(`
     (SPOSE_NOT_THEN assume_tac>>
     first_x_assum(qspec_then`n'` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
     metis_tac[EL_MAP])>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val set_toAList_keys = Q.prove(`
-  set (MAP FST (toAList t)) = domain t`,
-  full_simp_tac(srw_ss())[toAList_domain,EXTENSION]);
+Triviality set_toAList_keys:
+  set (MAP FST (toAList t)) = domain t
+Proof
+  full_simp_tac(srw_ss())[toAList_domain,EXTENSION]
+QED
 
 val is_phy_var_tac =
     full_simp_tac(srw_ss())[is_phy_var_def]>>
@@ -4624,13 +4806,14 @@ val is_phy_var_tac =
     `∀k.(2:num)*k=k*2` by DECIDE_TAC>>
     metis_tac[arithmeticTheory.MOD_EQ_0];
 
-val ssa_cc_trans_exp_correct = Q.prove(
-`∀st w cst ssa na res.
+Triviality ssa_cc_trans_exp_correct:
+  ∀st w cst ssa na res.
   word_exp st w = SOME res ∧
   word_state_eq_rel st cst ∧
   ssa_locals_rel na ssa st.locals cst.locals
   ⇒
-  word_exp cst (ssa_cc_trans_exp ssa w) = SOME res`,
+  word_exp cst (ssa_cc_trans_exp ssa w) = SOME res
+Proof
   ho_match_mp_tac word_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,ssa_cc_trans_exp_def]>>
   qpat_x_assum`A=SOME res` mp_tac
@@ -4657,7 +4840,8 @@ val ssa_cc_trans_exp_correct = Q.prove(
     fs[])
   >-
     (Cases_on`word_exp st w`>>
-    res_tac>>full_simp_tac(srw_ss())[word_state_eq_rel_def,mem_load_def]));
+    res_tac>>full_simp_tac(srw_ss())[word_state_eq_rel_def,mem_load_def])
+QED
 
 val exp_tac =
     (last_x_assum kall_tac>>
@@ -4675,14 +4859,16 @@ val setup_tac = Cases_on`word_exp st expr`>>full_simp_tac(srw_ss())[]>>
                 rev_full_simp_tac(srw_ss())[word_state_eq_rel_def]>>
                 full_simp_tac(srw_ss())[Abbr`expr`,ssa_cc_trans_exp_def,option_lookup_def,set_var_def];
 
-val get_var_set_vars_notin = Q.prove(`
+Triviality get_var_set_vars_notin:
   ¬MEM v ls ∧
   LENGTH ls = LENGTH vs ⇒
-  get_var v (set_vars ls vs st) = get_var v st`,
+  get_var v (set_vars ls vs st) = get_var v st
+Proof
   fs[get_var_def,set_vars_def,lookup_alist_insert]>>
   rw[]>>CASE_TAC>>fs[]>>
   imp_res_tac ALOOKUP_ZIP_MEM>>
-  fs[]);
+  fs[]
+QED
 
 Theorem ssa_locals_rel_delete_left:
   ssa_locals_rel na ssa stl cstl ⇒
@@ -6647,7 +6833,7 @@ Proof
 QED
 
 (*For starting up*)
-val setup_ssa_props = Q.prove(`
+Triviality setup_ssa_props:
   is_alloc_var lim ∧
   domain st.locals = set (even_list n) ⇒
   let (mov:'a wordLang$prog,ssa,na) = setup_ssa n lim (prog:'a wordLang$prog) in
@@ -6657,7 +6843,8 @@ val setup_ssa_props = Q.prove(`
     ssa_map_ok na ssa ∧
     ssa_locals_rel na ssa st.locals cst.locals ∧
     is_alloc_var na ∧
-    lim ≤ na`,
+    lim ≤ na
+Proof
   srw_tac[][setup_ssa_def]>>
   full_simp_tac(srw_ss())[word_state_eq_rel_def,evaluate_def]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -6715,11 +6902,13 @@ val setup_ssa_props = Q.prove(`
     full_simp_tac(srw_ss())[Abbr`args`]>>
     full_simp_tac(srw_ss())[even_list_def,MEM_GENLIST]>>
     `is_phy_var x` by is_phy_var_tac>>
-    metis_tac[convention_partitions]);
+    metis_tac[convention_partitions]
+QED
 
-val max_var_exp_max = Q.prove(`
+Triviality max_var_exp_max:
   ∀exp.
-    every_var_exp (λx. x≤ max_var_exp exp) exp`,
+    every_var_exp (λx. x≤ max_var_exp exp) exp
+Proof
   ho_match_mp_tac max_var_exp_ind>>
   srw_tac[][every_var_exp_def,max_var_exp_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM]>>srw_tac[][]>>res_tac>>
@@ -6729,16 +6918,19 @@ val max_var_exp_max = Q.prove(`
   Q.ISPECL_THEN [`ls'`] assume_tac list_max_max>>
   full_simp_tac(srw_ss())[EVERY_MEM,Abbr`ls'`,MEM_MAP,PULL_EXISTS]>>
   pop_assum(qspec_then`a` assume_tac)>>rev_full_simp_tac(srw_ss())[]>>
-  DECIDE_TAC);
+  DECIDE_TAC
+QED
 
-val max_var_inst_max = Q.prove(`
+Triviality max_var_inst_max:
   ∀inst.
-    every_var_inst (λx. x ≤ max_var_inst inst) inst`,
+    every_var_inst (λx. x ≤ max_var_inst inst) inst
+Proof
   ho_match_mp_tac max_var_inst_ind>>
   srw_tac[][every_var_inst_def,max_var_inst_def]>>
   TRY(Cases_on`ri`)>>full_simp_tac(srw_ss())[every_var_imm_def]>>
   TRY(IF_CASES_TAC)>>full_simp_tac(srw_ss())[]>>
-  DECIDE_TAC);
+  DECIDE_TAC
+QED
 
 Theorem max_var_max:
     ∀prog.
@@ -6798,10 +6990,11 @@ Proof
     res_tac>>every_case_tac>>fs[]
 QED
 
-val limit_var_props = Q.prove(`
+Triviality limit_var_props:
   limit_var prog = lim ⇒
   is_alloc_var lim ∧
-  every_var (λx. x< lim) prog`,
+  every_var (λx. x< lim) prog
+Proof
   reverse (srw_tac[][limit_var_def,is_alloc_var_def])
   >-
     (qspec_then `prog` assume_tac max_var_max >>
@@ -6831,7 +7024,8 @@ val limit_var_props = Q.prove(`
   full_simp_tac std_ss [EVAL “0<4:num”]>>
   first_x_assum(qspecl_then [`x+(4- x MOD 4)`,`1`] assume_tac)>>
   pop_assum sym_sub_tac>>
-  full_simp_tac(srw_ss())[]);
+  full_simp_tac(srw_ss())[]
+QED
 
 (*Full correctness theorem*)
 Theorem full_ssa_cc_trans_correct:
@@ -6873,13 +7067,14 @@ QED
    and preserves some syntactic conventions
 *)
 
-val fake_moves_conventions = Q.prove(`
+Triviality fake_moves_conventions:
   ∀ls ssaL ssaR na.
   let (a,b,c,d,e) = fake_moves ls ssaL ssaR na in
   every_stack_var is_stack_var a ∧
   every_stack_var is_stack_var b ∧
   call_arg_convention a ∧
-  call_arg_convention b`,
+  call_arg_convention b
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>>
   LET_ELIM_TAC>>
   TRY(first_x_assum (assume_tac o SYM)>>
@@ -6887,23 +7082,26 @@ val fake_moves_conventions = Q.prove(`
   EVERY_CASE_TAC>>
   first_x_assum(qspecl_then[`ssaL`,`ssaR`,`na`] mp_tac)>>LET_ELIM_TAC>>
   full_simp_tac(srw_ss())[LET_THM,fake_move_def]>>rpt VAR_EQ_TAC>>
-  full_simp_tac(srw_ss())[call_arg_convention_def,every_stack_var_def,fake_moves_def,inst_arg_convention_def]);
+  full_simp_tac(srw_ss())[call_arg_convention_def,every_stack_var_def,fake_moves_def,inst_arg_convention_def]
+QED
 
-val fix_inconsistencies_conventions = Q.prove(`
+Triviality fix_inconsistencies_conventions:
   ∀ssaL ssaR na.
   let (a:'a wordLang$prog,b:'a wordLang$prog,c,d) =
     fix_inconsistencies ssaL ssaR na in
   every_stack_var is_stack_var a ∧
   every_stack_var is_stack_var b ∧
   call_arg_convention a ∧
-  call_arg_convention b`,
+  call_arg_convention b
+Proof
   full_simp_tac(srw_ss())[fix_inconsistencies_def,inst_arg_convention_def,call_arg_convention_def,every_stack_var_def,UNCURRY]>>
   rpt strip_tac>>
   srw_tac[][]>>unabbrev_all_tac>>
   full_simp_tac(srw_ss())[every_stack_var_def,call_arg_convention_def]>>
   qabbrev_tac `ls = MAP FST (toAList (union ssaL ssaR))` >>
   Q.SPECL_THEN [`ls`,`ssa_L'`,`ssa_R'`,`na'`]
-  assume_tac fake_moves_conventions>>rev_full_simp_tac(srw_ss())[LET_THM]);
+  assume_tac fake_moves_conventions>>rev_full_simp_tac(srw_ss())[LET_THM]
+QED
 
 (*Prove that the transform sets up arbitrary programs with
   the appropriate conventions*)
@@ -7102,13 +7300,14 @@ Proof
    fs[every_stack_var_def,call_arg_convention_def]
 QED
 
-val setup_ssa_props_2 = Q.prove(`
+Triviality setup_ssa_props_2:
   is_alloc_var lim ⇒
   let (mov:'a wordLang$prog,ssa,na) = setup_ssa n lim (prog:'a wordLang$prog) in
     ssa_map_ok na ssa ∧
     is_alloc_var na ∧
     pre_alloc_conventions mov ∧
-    lim ≤ na`,
+    lim ≤ na
+Proof
   srw_tac[][setup_ssa_def,list_next_var_rename_move_def,pre_alloc_conventions_def]>>
   full_simp_tac(srw_ss())[word_state_eq_rel_def,evaluate_def,every_stack_var_def,call_arg_convention_def]>>
   imp_res_tac list_next_var_rename_lemma_1>>
@@ -7116,7 +7315,8 @@ val setup_ssa_props_2 = Q.prove(`
   full_simp_tac(srw_ss())[ALL_DISTINCT_MAP]>>
   TRY(`ssa_map_ok lim LN` by
     full_simp_tac(srw_ss())[ssa_map_ok_def,lookup_def]>>
-  imp_res_tac list_next_var_rename_props>>NO_TAC));
+  imp_res_tac list_next_var_rename_props>>NO_TAC)
+QED
 
 Theorem full_ssa_cc_trans_pre_alloc_conventions:
  ∀n prog.
@@ -7132,19 +7332,22 @@ Proof
   rev_full_simp_tac(srw_ss())[pre_alloc_conventions_def,every_stack_var_def,call_arg_convention_def,LET_THM]
 QED
 
-val fake_moves_wf_cutsets = Q.prove(`
+Triviality fake_moves_wf_cutsets:
   ∀ls A B C L R D E G.
   fake_moves ls A B C = (L,R,D,E,G) ⇒
-  wf_cutsets L ∧ wf_cutsets R`,
+  wf_cutsets L ∧ wf_cutsets R
+Proof
   Induct>>fs[fake_moves_def,wf_cutsets_def]>>rw[]>>
   pairarg_tac>>fs[]>>EVERY_CASE_TAC>>fs[]>>
   rveq>>fs[wf_cutsets_def,fake_move_def]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val ssa_cc_trans_wf_cutsets = Q.prove(`
+Triviality ssa_cc_trans_wf_cutsets:
   ∀prog ssa na.
   let (prog',ssa',na') = ssa_cc_trans prog ssa na in
-  wf_cutsets prog'`,
+  wf_cutsets prog'
+Proof
   ho_match_mp_tac ssa_cc_trans_ind>>fs[wf_cutsets_def,ssa_cc_trans_def,fix_inconsistencies_def,list_next_var_rename_move_def]>>
   rw[]>>
   rpt(pairarg_tac>>fs[])>>rveq>>fs[wf_cutsets_def]>>
@@ -7160,7 +7363,8 @@ val ssa_cc_trans_wf_cutsets = Q.prove(`
   >>
   EVERY_CASE_TAC>>fs[]>>rveq>>fs[wf_cutsets_def,wf_fromAList]>>
   rpt(pairarg_tac>>fs[])>>rveq>>fs[wf_cutsets_def,wf_fromAList]>>
-  metis_tac[fake_moves_wf_cutsets]);
+  metis_tac[fake_moves_wf_cutsets]
+QED
 
 Theorem full_ssa_cc_trans_wf_cutsets:
     ∀n prog.
@@ -7175,15 +7379,17 @@ Proof
   rfs[]
 QED
 
-val fake_moves_distinct_tar_reg = Q.prove(`
+Triviality fake_moves_distinct_tar_reg:
   ∀ls ssal ssar na l r a b c conf.
   fake_moves ls ssal ssar na = (l,r,a,b,c) ⇒
   every_inst distinct_tar_reg l ∧
-  every_inst distinct_tar_reg r`,
+  every_inst distinct_tar_reg r
+Proof
   Induct>>full_simp_tac(srw_ss())[fake_moves_def]>>srw_tac[][]>>full_simp_tac(srw_ss())[every_inst_def]>>
   pop_assum mp_tac>> LET_ELIM_TAC>> EVERY_CASE_TAC>> full_simp_tac(srw_ss())[LET_THM]>>
   unabbrev_all_tac>>
-  metis_tac[fake_move_def,every_inst_def,distinct_tar_reg_def]);
+  metis_tac[fake_move_def,every_inst_def,distinct_tar_reg_def]
+QED
 
 Theorem ssa_cc_trans_distinct_tar_reg:
   ∀prog ssa na.
@@ -7357,10 +7563,11 @@ Proof
   simp[flat_exp_conventions_def]
 QED
 
-val ssa_cc_trans_flat_exp_conventions = Q.prove(`
+Triviality ssa_cc_trans_flat_exp_conventions:
   ∀prog ssa na.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (FST (ssa_cc_trans prog ssa na))`,
+  flat_exp_conventions (FST (ssa_cc_trans prog ssa na))
+Proof
   ho_match_mp_tac ssa_cc_trans_ind>>full_simp_tac(srw_ss())[ssa_cc_trans_def]>>srw_tac[][]>>
   unabbrev_all_tac>>
   full_simp_tac(srw_ss())[flat_exp_conventions_def]
@@ -7400,7 +7607,7 @@ val ssa_cc_trans_flat_exp_conventions = Q.prove(`
     IF_CASES_TAC >>
     fs[flat_exp_conventions_ShareInst] >>
     simp[ssa_cc_trans_exp_def]
-);
+QED
 
 Theorem full_ssa_cc_trans_flat_exp_conventions:
     ∀prog n.
@@ -7613,11 +7820,12 @@ val is_phy_var_tac =
     `∀k.(2:num)*k=k*2` by DECIDE_TAC>>
     metis_tac[arithmeticTheory.MOD_EQ_0];
 
-val call_arg_convention_preservation = Q.prove(`
+Triviality call_arg_convention_preservation:
   ∀prog f.
   every_var (λx. is_phy_var x ⇒ f x = x) prog ∧
   call_arg_convention prog ⇒
-  call_arg_convention (apply_colour f prog)`,
+  call_arg_convention (apply_colour f prog)
+Proof
   ho_match_mp_tac call_arg_convention_ind>>
   srw_tac[][call_arg_convention_def,every_var_def]>>
   EVERY_CASE_TAC>>unabbrev_all_tac>>
@@ -7634,7 +7842,8 @@ val call_arg_convention_preservation = Q.prove(`
   qpat_x_assum`args = A` (SUBST_ALL_TAC o SYM)>>
   full_simp_tac(srw_ss())[EVERY_MEM,miscTheory.MAP_EQ_ID]>>
   rev_full_simp_tac(srw_ss())[]>>
-  first_x_assum match_mp_tac>> is_phy_var_tac);
+  first_x_assum match_mp_tac>> is_phy_var_tac
+QED
 
 (*Composing with a function using apply_colour*)
 Theorem every_var_inst_apply_colour_inst:
@@ -7710,21 +7919,24 @@ Proof
     Cases_on`y'`>>full_simp_tac(srw_ss())[MEM_toAList,domain_lookup])
 QED
 
-val every_var_exp_get_reads_exp = Q.prove(`
-  ∀exp. every_var_exp (λx. MEM x (get_reads_exp exp)) exp`,
+Triviality every_var_exp_get_reads_exp:
+  ∀exp. every_var_exp (λx. MEM x (get_reads_exp exp)) exp
+Proof
   assume_tac every_var_exp_get_live_exp>>
   rw[]>>pop_assum(qspec_then`exp` assume_tac)>>
   ho_match_mp_tac every_var_exp_mono>>
-  HINT_EXISTS_TAC>>fs[get_reads_exp_get_live_exp]);
+  HINT_EXISTS_TAC>>fs[get_reads_exp_get_live_exp]
+QED
 
 val exp_tac =
   assume_tac (Q.SPEC `exp` every_var_exp_get_reads_exp)>>
   ho_match_mp_tac every_var_exp_mono>>
   HINT_EXISTS_TAC>>fs[in_clash_tree_def];
 
-val every_var_in_get_clash_tree = Q.prove(`
+Triviality every_var_in_get_clash_tree:
   ∀prog.
-  every_var (in_clash_tree (get_clash_tree prog)) prog`,
+  every_var (in_clash_tree (get_clash_tree prog)) prog
+Proof
   ho_match_mp_tac get_clash_tree_ind>>rw[get_clash_tree_def]>>
   fs[every_var_def,in_clash_tree_def,EVERY_MEM,in_clash_tree_def,every_name_def,toAList_domain]>>
   TRY(exp_tac)
@@ -7742,30 +7954,36 @@ val every_var_in_get_clash_tree = Q.prove(`
   >>
     EVERY_CASE_TAC>>
     fs[in_clash_tree_def,domain_numset_list_insert,domain_union]>>
-    metis_tac[every_var_mono,in_clash_tree_def]);
+    metis_tac[every_var_mono,in_clash_tree_def]
+QED
 
-val every_var_T = Q.prove(`
+Triviality every_var_T:
   ∀prog.
-  every_var (λx. T) prog`,
+  every_var (λx. T) prog
+Proof
   rw[]>>
   mp_tac (Q.SPEC`prog` max_var_max)>>
   rw[]>>
   ho_match_mp_tac every_var_mono>>HINT_EXISTS_TAC>>
-  fs[]);
+  fs[]
+QED
 
-val every_var_is_phy_var_total_colour = Q.prove(`
-  every_var is_phy_var (apply_colour (total_colour col) prog)`,
+Triviality every_var_is_phy_var_total_colour:
+  every_var is_phy_var (apply_colour (total_colour col) prog)
+Proof
   match_mp_tac every_var_apply_colour>>
   qexists_tac`\x. T`>>
   simp[every_var_T]>>
   fs[total_colour_def]>>rw[]>>
   TOP_CASE_TAC>>fs[]>>
-  is_phy_var_tac)
+  is_phy_var_tac
+QED
 
-val oracle_colour_ok_conventions = Q.prove(`
+Triviality oracle_colour_ok_conventions:
   pre_alloc_conventions prog ∧
   oracle_colour_ok k col_opt (get_clash_tree prog) prog ls = SOME x ⇒
-  post_alloc_conventions k x`,
+  post_alloc_conventions k x
+Proof
   fs[oracle_colour_ok_def]>>EVERY_CASE_TAC>>
   fs[post_alloc_conventions_def,pre_alloc_conventions_def]>>
   rw[]>>fs[every_var_is_phy_var_total_colour]>>
@@ -7777,7 +7995,8 @@ val oracle_colour_ok_conventions = Q.prove(`
   fs[GSYM MEM_toAList]>>
   fs[EVERY_MEM,FORALL_PROD]>>
   first_x_assum drule>>rw[]>>
-  metis_tac[is_phy_var_def,EVEN_MOD2,EVEN_EXISTS,TWOxDIV2]);
+  metis_tac[is_phy_var_def,EVEN_MOD2,EVEN_EXISTS,TWOxDIV2]
+QED
 
 Theorem pre_post_conventions_word_alloc:
     ∀fc c alg prog k col_opt.
@@ -7845,10 +8064,11 @@ Proof
   metis_tac[word_alloc_two_reg_inst_lem]
 QED
 
-val word_alloc_flat_exp_conventions_lem = Q.prove(`
+Triviality word_alloc_flat_exp_conventions_lem:
   ∀f prog.
   flat_exp_conventions prog ⇒
-  flat_exp_conventions (apply_colour f prog)`,
+  flat_exp_conventions (apply_colour f prog)
+Proof
   ho_match_mp_tac apply_colour_ind>>full_simp_tac(srw_ss())[flat_exp_conventions_def]>>srw_tac[][]
   >-
     (EVERY_CASE_TAC>>unabbrev_all_tac>>full_simp_tac(srw_ss())[flat_exp_conventions_def])
@@ -7857,7 +8077,8 @@ val word_alloc_flat_exp_conventions_lem = Q.prove(`
   >>
     gvs[DefnBase.one_line_ify NONE flat_exp_conventions_def] >>
     first_x_assum mp_tac >>
-    rpt (TOP_CASE_TAC >> simp[]) );
+    rpt (TOP_CASE_TAC >> simp[])
+QED
 
 Theorem word_alloc_flat_exp_conventions:
     ∀fc c alg k prog col_opt.
@@ -7869,11 +8090,12 @@ Proof
   metis_tac[word_alloc_flat_exp_conventions_lem]
 QED
 
-val word_alloc_full_inst_ok_less_lem = Q.prove(`
+Triviality word_alloc_full_inst_ok_less_lem:
   ∀f prog c.
   full_inst_ok_less c prog ∧
   EVERY (λ(x,y). (f x) ≠ (f y)) (get_forced c prog []) ⇒
-  full_inst_ok_less c (apply_colour f prog)`,
+  full_inst_ok_less c (apply_colour f prog)
+Proof
   ho_match_mp_tac apply_colour_ind>>
   fs[full_inst_ok_less_def,get_forced_def]>>rw[]>>
   TRY
@@ -7885,27 +8107,32 @@ val word_alloc_full_inst_ok_less_lem = Q.prove(`
     EVERY_CASE_TAC>>unabbrev_all_tac>>
     gvs[get_forced_def,DefnBase.one_line_ify NONE
       exp_to_addr_def,AllCaseEqs(),apply_colour_exp_def]>>
-    metis_tac[EVERY_get_forced] );
+    metis_tac[EVERY_get_forced]
+QED
 
 (*
-val lookup_undir_g_insert_existing = Q.prove(`
+Triviality lookup_undir_g_insert_existing:
   lookup x G = SOME v ⇒
   lookup x (undir_g_insert a b G) =
   if x = a then SOME (insert b () v)
   else if x = b then SOME (insert a () v)
-  else SOME v`,
+  else SOME v
+Proof
   rw[undir_g_insert_def,dir_g_insert_def,lookup_insert]>>
-  fs[insert_shadow]);
+  fs[insert_shadow]
+QED
 *)
 
-val forced_distinct_col = Q.prove(`
+Triviality forced_distinct_col:
   EVERY (λ(x,y). (sp_default spcol) x = (sp_default spcol) y ⇒ x = y) ls /\
   EVERY (λx,y. x ≠ y) ls ==>
-  EVERY (λ(x,y). (total_colour spcol) x <> (total_colour spcol) y) ls`,
+  EVERY (λ(x,y). (total_colour spcol) x <> (total_colour spcol) y) ls
+Proof
   fs[EVERY_MEM,FORALL_PROD]>>rw[]>>
   first_x_assum drule>>
   fs[total_colour_rw]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Theorem word_alloc_full_inst_ok_less:
     ∀fc alg k prog col_opt c.
@@ -7932,14 +8159,16 @@ Proof
 QED
 
 (* label preservation theorems *)
-val fake_moves_no_labs = Q.prove(`
+Triviality fake_moves_no_labs:
   ∀ls a b c d e f g h.
   fake_moves ls a b c = (d,e,f,g,h) ⇒
-  extract_labels d = [] ∧ extract_labels e = []`,
+  extract_labels d = [] ∧ extract_labels e = []
+Proof
   Induct>>fs[fake_moves_def,extract_labels_def,fake_move_def]>>rw[]>>
   rpt(pairarg_tac>>fs[])>>
   EVERY_CASE_TAC>>fs[]>>rveq>>fs[extract_labels_def]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Theorem full_ssa_cc_trans_lab_pres:
     ∀prog n.

--- a/compiler/backend/proofs/word_instProofScript.sml
+++ b/compiler/backend/proofs/word_instProofScript.sml
@@ -26,13 +26,16 @@ Proof
   metis_tac[PERM_APPEND]
 QED
 
-val EL_FILTER = Q.prove(`
-  ∀ls x. x < LENGTH (FILTER P ls) ⇒ P (EL x (FILTER P ls))`,
+Triviality EL_FILTER:
+  ∀ls x. x < LENGTH (FILTER P ls) ⇒ P (EL x (FILTER P ls))
+Proof
   Induct>>srw_tac[][]>>
-  Cases_on`x`>>full_simp_tac(srw_ss())[EL]);
+  Cases_on`x`>>full_simp_tac(srw_ss())[EL]
+QED
 
-val PERM_SWAP = Q.prove(`
-  PERM (A ++ B ++ C) (B++(A++C))`,
+Triviality PERM_SWAP:
+  PERM (A ++ B ++ C) (B++(A++C))
+Proof
   full_simp_tac(srw_ss())[PERM_DEF]>>srw_tac[][]>>
   match_mp_tac LIST_EQ>>CONJ_ASM1_TAC
   >-
@@ -42,7 +45,8 @@ val PERM_SWAP = Q.prove(`
   imp_res_tac EL_FILTER>>
   last_x_assum SUBST_ALL_TAC>>
   imp_res_tac EL_FILTER>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 (* Instruction selection and assorted optimisation correctness
 0) pull_exp correctness -- this does pull_ops and optimize_consts
@@ -56,20 +60,23 @@ val PERM_SWAP = Q.prove(`
 *)
 
 (* pull_exp correctness *)
-val convert_sub_ok = Q.prove(`
+Triviality convert_sub_ok:
   ∀ls.
-  word_exp s (convert_sub ls) = word_exp s (Op Sub ls)`,
+  word_exp s (convert_sub ls) = word_exp s (Op Sub ls)
+Proof
   ho_match_mp_tac convert_sub_ind>>srw_tac[][convert_sub_def,word_exp_def]>>unabbrev_all_tac>>
   full_simp_tac(srw_ss())[word_op_def,the_words_def]>>
   EVERY_CASE_TAC>>
-  simp[]);
+  simp[]
+QED
 
 (*In general, any permutation works*)
-val word_exp_op_permute_lem = Q.prove(`
+Triviality word_exp_op_permute_lem:
   op ≠ Sub ⇒
   ∀ls ls'.
   PERM ls ls' ⇒
-  word_exp s (Op op ls) = word_exp s (Op op ls')`,
+  word_exp s (Op op ls) = word_exp s (Op op ls')
+Proof
   strip_tac>>
   ho_match_mp_tac PERM_STRONG_IND>>srw_tac[][]>>
   full_simp_tac(srw_ss())[word_exp_def,LET_THM,the_words_def]>>
@@ -84,7 +91,8 @@ val word_exp_op_permute_lem = Q.prove(`
   Cases_on`the_words A`>>
   Cases_on`the_words Z`>>
   fs[word_op_def]>>
-  Cases_on`op`>>fs[]);
+  Cases_on`op`>>fs[]
+QED
 
 (*Remove tail recursion to make proof easier...*)
 Definition pull_ops_simp_def:
@@ -95,37 +103,43 @@ Definition pull_ops_simp_def:
     |  _  => x::(pull_ops_simp op xs))
 End
 
-val pull_ops_simp_pull_ops_perm = Q.prove(`
+Triviality pull_ops_simp_pull_ops_perm:
   ∀ls x.
-  PERM (pull_ops op ls x) ((pull_ops_simp op ls)++x)`,
+  PERM (pull_ops op ls x) ((pull_ops_simp op ls)++x)
+Proof
   Induct>>full_simp_tac(srw_ss())[pull_ops_def,pull_ops_simp_def]>>srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[]>>
   TRY(qpat_abbrev_tac`A = B::x`>>
   first_x_assum(qspec_then`A` assume_tac)>>full_simp_tac(srw_ss())[Abbr`A`])>>
   TRY(first_x_assum(qspec_then`l++x` assume_tac))>>
-  metis_tac[PERM_SWAP,PERM_TRANS,PERM_SWAP_SIMP,PERM_SYM]);
+  metis_tac[PERM_SWAP,PERM_TRANS,PERM_SWAP_SIMP,PERM_SYM]
+QED
 
-val pull_ops_simp_pull_ops_word_exp = Q.prove(`
+Triviality pull_ops_simp_pull_ops_word_exp:
   op ≠ Sub ⇒
-  word_exp s (Op op (pull_ops op ls [])) = word_exp s (Op op (pull_ops_simp op ls))`,
+  word_exp s (Op op (pull_ops op ls [])) = word_exp s (Op op (pull_ops_simp op ls))
+Proof
   strip_tac>> imp_res_tac word_exp_op_permute_lem>>
   pop_assum match_mp_tac>>
   assume_tac pull_ops_simp_pull_ops_perm>>
-  pop_assum (qspecl_then [`ls`,`[]`] assume_tac)>>full_simp_tac(srw_ss())[]);
+  pop_assum (qspecl_then [`ls`,`[]`] assume_tac)>>full_simp_tac(srw_ss())[]
+QED
 
 (* TODO: Maybe move to props, if these are needed elsewhere *)
 
-val word_exp_op_mono = Q.prove(`
+Triviality word_exp_op_mono:
   op ≠ Sub ⇒
   word_exp s (Op op ls) = word_exp s (Op op ls') ⇒
   word_exp s (Op op (x::ls)) =
-  word_exp s (Op op (x::ls'))`,
+  word_exp s (Op op (x::ls'))
+Proof
   srw_tac[][word_exp_def,LET_THM]>>
   fs[the_words_def]>>Cases_on`word_exp s x`>>fs[]>>
   Cases_on`x'`>>fs[]>>
   rpt(qpat_x_assum`A=B` mp_tac)>>ntac 2 (TOP_CASE_TAC>>fs[])>>
-  Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def]);
+  Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def]
+QED
 
-val the_words_append = Q.prove(`
+Triviality the_words_append:
   ∀ls ls'.
   the_words (ls ++ ls') =
   case the_words ls of
@@ -133,19 +147,22 @@ val the_words_append = Q.prove(`
   | SOME w =>
     (case the_words ls' of
       NONE => NONE
-    | SOME w' => SOME(w ++ w'))`,
+    | SOME w' => SOME(w ++ w'))
+Proof
   Induct>>fs[the_words_def]>>rw[]>>
   TOP_CASE_TAC>>fs[]>>
   TOP_CASE_TAC>>fs[]>>
   Cases_on`the_words ls`>>fs[]>>
-  Cases_on`the_words ls'`>>fs[]);
+  Cases_on`the_words ls'`>>fs[]
+QED
 
-val word_exp_op_op = Q.prove(`
+Triviality word_exp_op_op:
   op ≠ Sub ⇒
   ∀ls ls'.
   word_exp s (Op op ls) = word_exp s (Op op ls') ⇒
   word_exp s (Op op (l ++ ls)) =
-  word_exp s (Op op ((Op op l) :: ls'))`,
+  word_exp s (Op op ((Op op l) :: ls'))
+Proof
   srw_tac[][word_exp_def,LET_THM]>>
   fs[the_words_append]>>
   qpat_abbrev_tac`xx = MAP f l`>>
@@ -155,12 +172,14 @@ val word_exp_op_op = Q.prove(`
   Cases_on`op`>> fs[word_op_def,FOLDR_APPEND]>>
   rw[Abbr`xx`]>>
   rpt(pop_assum kall_tac)>>
-  Induct_on`x`>>fs[]);
+  Induct_on`x`>>fs[]
+QED
 
-val pull_ops_ok = Q.prove(`
+Triviality pull_ops_ok:
   op ≠ Sub ⇒
   ∀ls. word_exp s (Op op (pull_ops op ls [])) =
-         word_exp s (Op op ls)`,
+         word_exp s (Op op ls)
+Proof
   strip_tac>>
   full_simp_tac(srw_ss())[pull_ops_simp_pull_ops_word_exp]>>
   Induct>>srw_tac[][pull_ops_simp_def]>>Cases_on`op`>>full_simp_tac(srw_ss())[]>>
@@ -168,33 +187,39 @@ val pull_ops_ok = Q.prove(`
   IF_CASES_TAC>>full_simp_tac(srw_ss())[word_exp_op_mono]>>
   `b ≠ Sub` by srw_tac[][]>>
   imp_res_tac word_exp_op_op>>
-  pop_assum (qspec_then`l` assume_tac)>>full_simp_tac(srw_ss())[]);
+  pop_assum (qspec_then`l` assume_tac)>>full_simp_tac(srw_ss())[]
+QED
 
 (* Done with pull_ops, next is optimize_consts *)
 
-val word_exp_swap_head = Q.prove(`
+Triviality word_exp_swap_head:
   ∀B.
   op ≠ Sub ⇒
   word_exp s (Op op A) = SOME (Word w) ⇒
-  word_exp s (Op op (B++A)) = word_exp s (Op op (Const w::B))`,
+  word_exp s (Op op (B++A)) = word_exp s (Op op (Const w::B))
+Proof
   fs[word_exp_def,the_words_append,the_words_def]>>rw[]>>
   FULL_CASE_TAC>>fs[]>>
   FULL_CASE_TAC>>fs[word_op_def]>>
   Cases_on`op`>>fs[FOLDR_APPEND]>>
   rpt(pop_assum kall_tac)>>
-  Induct_on`x'`>>full_simp_tac(srw_ss())[]);
+  Induct_on`x'`>>full_simp_tac(srw_ss())[]
+QED
 
-val EVERY_is_const_word_exp = Q.prove(`
+Triviality EVERY_is_const_word_exp:
   ∀ls. EVERY is_const ls ⇒
-  EVERY IS_SOME (MAP (λa. word_exp s a) ls)`,
-  Induct>>srw_tac[][]>>Cases_on`h`>>full_simp_tac(srw_ss())[is_const_def,word_exp_def]);
+  EVERY IS_SOME (MAP (λa. word_exp s a) ls)
+Proof
+  Induct>>srw_tac[][]>>Cases_on`h`>>full_simp_tac(srw_ss())[is_const_def,word_exp_def]
+QED
 
-val all_consts_simp = Q.prove(`
+Triviality all_consts_simp:
   op ≠ Sub ⇒
   ∀ls.
   EVERY is_const ls ⇒
   word_exp s (Op op ls) =
-  SOME( Word(THE (word_op op (MAP rm_const ls))))`,
+  SOME( Word(THE (word_op op (MAP rm_const ls))))
+Proof
   strip_tac>>Induct>>full_simp_tac(srw_ss())[word_exp_def,the_words_def]
   >-
     (full_simp_tac(srw_ss())[word_op_def]>>
@@ -203,12 +228,14 @@ val all_consts_simp = Q.prove(`
   ntac 2 strip_tac>>
   Cases_on`h`>>full_simp_tac(srw_ss())[is_const_def,word_exp_def]>>
   FULL_CASE_TAC>>fs[EVERY_is_const_word_exp]>>
-  Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def,rm_const_def]);
+  Cases_on`op`>>full_simp_tac(srw_ss())[word_op_def,rm_const_def]
+QED
 
-val optimize_consts_ok = Q.prove(`
+Triviality optimize_consts_ok:
   op ≠ Sub ⇒
   ∀ls. word_exp s (optimize_consts op ls) =
-       word_exp s (Op op ls)`,
+       word_exp s (Op op ls)
+Proof
   strip_tac>>srw_tac[][optimize_consts_def]>>
   Cases_on`const_ls`>>full_simp_tac(srw_ss())[]
   >-
@@ -237,12 +264,14 @@ val optimize_consts_ok = Q.prove(`
     qpat_abbrev_tac`A = h'::t'`>>
     qpat_abbrev_tac`Z = h::t`>>
     `h:: (t ++A) = Z ++A` by full_simp_tac(srw_ss())[]>>pop_assum SUBST_ALL_TAC>>
-    metis_tac[PERM_APPEND]);
+    metis_tac[PERM_APPEND]
+QED
 
-val pull_exp_ok = Q.prove(`
+Triviality pull_exp_ok:
   ∀exp s x.
   word_exp s exp = SOME x ⇒
-  word_exp s (pull_exp exp) = SOME x`,
+  word_exp s (pull_exp exp) = SOME x
+Proof
   ho_match_mp_tac pull_exp_ind>>srw_tac[][]>>
   full_simp_tac(srw_ss())[pull_exp_def,LET_THM]>>
   TRY(full_simp_tac(srw_ss())[op_consts_def,word_exp_def,LET_THM,word_op_def,the_words_def]>>
@@ -283,24 +312,29 @@ val pull_exp_ok = Q.prove(`
     fs[])>>
   EVERY_CASE_TAC>>fs[]>>
   res_tac>>fs[]>>
-  rfs[]);
+  rfs[]
+QED
 
 (* pull_exp syntax *)
-val convert_sub_every_var_exp = Q.prove(`
+Triviality convert_sub_every_var_exp:
   ∀ls.
   (∀x. MEM x ls ⇒ every_var_exp P x) ⇒
-  every_var_exp P (convert_sub ls)`,
+  every_var_exp P (convert_sub ls)
+Proof
   ho_match_mp_tac convert_sub_ind>>srw_tac[][convert_sub_def]>>
-  full_simp_tac(srw_ss())[every_var_exp_def,EVERY_MEM]);
+  full_simp_tac(srw_ss())[every_var_exp_def,EVERY_MEM]
+QED
 
-val optimize_consts_every_var_exp = Q.prove(`
+Triviality optimize_consts_every_var_exp:
   ∀ls.
   (∀x. MEM x ls ⇒ every_var_exp P x) ⇒
-  every_var_exp P (optimize_consts op ls)`,
+  every_var_exp P (optimize_consts op ls)
+Proof
   srw_tac[][optimize_consts_def]>>
   `PERM ls (const_ls++nconst_ls)` by metis_tac[PERM_PARTITION]>>full_simp_tac(srw_ss())[]>>
   imp_res_tac PERM_MEM_EQ>>
-  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_exp_def,LET_THM,EVERY_MEM]);
+  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_exp_def,LET_THM,EVERY_MEM]
+QED
 
 val pull_ops_every_var_exp = Q.prove(`
   ∀ls acc.
@@ -309,23 +343,26 @@ val pull_ops_every_var_exp = Q.prove(`
   Induct>>full_simp_tac(srw_ss())[pull_ops_def]>>srw_tac[][]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[every_var_exp_def]>>
   metis_tac[ETA_AX,EVERY_APPEND,every_var_exp_def]) |> REWRITE_RULE[EVERY_MEM];
 
-val pull_exp_every_var_exp = Q.prove(`
+Triviality pull_exp_every_var_exp:
   ∀exp.
   every_var_exp P exp ⇒
-  every_var_exp P (pull_exp exp)`,
+  every_var_exp P (pull_exp exp)
+Proof
   ho_match_mp_tac pull_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,pull_exp_def,every_var_exp_def,EVERY_MEM,EVERY_MAP,LET_THM]>>srw_tac[][]
   >-
     metis_tac[convert_sub_every_var_exp,MEM_MAP,PULL_EXISTS]
   >>
     match_mp_tac optimize_consts_every_var_exp>>
     match_mp_tac pull_ops_every_var_exp>>srw_tac[][]>>
-    metis_tac[MEM_MAP]);
+    metis_tac[MEM_MAP]
+QED
 
 (* flatten_exp correctness *)
-val flatten_exp_ok = Q.prove(`
+Triviality flatten_exp_ok:
   ∀exp s x.
   word_exp s exp = SOME x ⇒
-  word_exp s (flatten_exp exp) = SOME x`,
+  word_exp s (flatten_exp exp) = SOME x
+Proof
   ho_match_mp_tac flatten_exp_ind>>srw_tac[][]>>
   fs[word_exp_def,flatten_exp_def]
   >-
@@ -351,7 +388,8 @@ val flatten_exp_ok = Q.prove(`
     FULL_CASE_TAC>>fs[]>>
     first_x_assum(qspec_then`s` assume_tac)>>rfs[]>>
     first_x_assum(qspec_then`s` assume_tac)>>rfs[])>>
-    res_tac>>fs[]);
+    res_tac>>fs[]
+QED
 
 (*All ops are 2 args. Technically, we should probably check that Sub has 2 args. However, the semantics already checks that and it will get removed later*)
 Definition binary_branch_exp_def:
@@ -369,10 +407,12 @@ Termination
 End
 
 (* flatten_exp syntax *)
-val flatten_exp_binary_branch_exp = Q.prove(`
+Triviality flatten_exp_binary_branch_exp:
   ∀exp.
-  binary_branch_exp (flatten_exp exp)`,
-  ho_match_mp_tac flatten_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,flatten_exp_def,binary_branch_exp_def,EVERY_MEM,EVERY_MAP]);
+  binary_branch_exp (flatten_exp exp)
+Proof
+  ho_match_mp_tac flatten_exp_ind>>full_simp_tac(srw_ss())[op_consts_def,flatten_exp_def,binary_branch_exp_def,EVERY_MEM,EVERY_MAP]
+QED
 
 Theorem flatten_exp_every_var_exp[local]:
   ∀exp.
@@ -632,9 +672,11 @@ Proof
       full_simp_tac(srw_ss())[word_sh_def]))
 QED
 
-val locals_rm = Q.prove(`
-  D with locals := D.locals = D`,
-  full_simp_tac(srw_ss())[state_component_equality]);
+Triviality locals_rm:
+  D with locals := D.locals = D
+Proof
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (*  Main semantics theorem for inst selection:
     The inst-selected program gives same result but
@@ -945,11 +987,13 @@ Proof
 QED
 
 (* inst_select syntax *)
-val inst_select_exp_flat_exp_conventions = Q.prove(`
+Triviality inst_select_exp_flat_exp_conventions:
   ∀c tar temp exp.
-  flat_exp_conventions (inst_select_exp c tar temp exp)`,
+  flat_exp_conventions (inst_select_exp c tar temp exp)
+Proof
   ho_match_mp_tac inst_select_exp_ind>>srw_tac[][]>>full_simp_tac(srw_ss())[inst_select_exp_def,flat_exp_conventions_def,LET_THM]>>
-  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_exp_def,LET_THM]);
+  EVERY_CASE_TAC>>full_simp_tac(srw_ss())[flat_exp_conventions_def,inst_select_exp_def,LET_THM]
+QED
 
 Theorem inst_select_flat_exp_conventions:
   ∀c temp prog.
@@ -963,14 +1007,15 @@ Proof
 QED
 
 (*Less restrictive version of inst_ok guaranteed by inst_select*)
-val inst_select_exp_full_inst_ok_less = Q.prove(`
+Triviality inst_select_exp_full_inst_ok_less:
   ∀c tar temp exp.
   addr_offset_ok c 0w ⇒
-  full_inst_ok_less c (inst_select_exp c tar temp exp)`,
+  full_inst_ok_less c (inst_select_exp c tar temp exp)
+Proof
   ho_match_mp_tac inst_select_exp_ind>>rw[]>>
   fs[inst_select_exp_def,LET_THM,inst_ok_less_def,full_inst_ok_less_def]>>
   every_case_tac>>fs[full_inst_ok_less_def,inst_ok_less_def,inst_select_exp_def,LET_THM]
-  );
+QED
 
 Theorem inst_select_full_inst_ok_less:
   ∀c temp prog.
@@ -1082,11 +1127,13 @@ Proof
 QED
 
 (* label preservation stuff *)
-val inst_select_exp_no_lab = Q.prove(`
+Triviality inst_select_exp_no_lab:
   ∀c temp temp' exp.
-  extract_labels (inst_select_exp c temp temp' exp) = []`,
+  extract_labels (inst_select_exp c temp temp' exp) = []
+Proof
   ho_match_mp_tac inst_select_exp_ind>>rw[inst_select_exp_def]>>fs[extract_labels_def]>>
-  rpt(TOP_CASE_TAC>>fs[extract_labels_def,inst_select_exp_def]))
+  rpt(TOP_CASE_TAC>>fs[extract_labels_def,inst_select_exp_def])
+QED
 
 Theorem inst_select_lab_pres:
   ∀c temp prog.

--- a/compiler/backend/proofs/word_simpProofScript.sml
+++ b/compiler/backend/proofs/word_simpProofScript.sml
@@ -41,9 +41,11 @@ Proof
   \\ metis_tac [ALL_DISTINCT_PERM,MEM_PERM]
 QED
 
-val labels_rel_TRANS = Q.prove(
-  `labels_rel xs ys /\ labels_rel ys zs ==> labels_rel xs zs`,
-  fs [labels_rel_def] \\ rw [] \\ fs [SUBSET_DEF]);
+Triviality labels_rel_TRANS:
+  labels_rel xs ys /\ labels_rel ys zs ==> labels_rel xs zs
+Proof
+  fs [labels_rel_def] \\ rw [] \\ fs [SUBSET_DEF]
+QED
 
 (** verification of Seq_assoc **)
 
@@ -1423,20 +1425,24 @@ Proof
   simp [extract_labels_Seq_assoc]
 QED
 
-val dest_Seq_no_inst = Q.prove(`
+Triviality dest_Seq_no_inst:
   ∀prog.
   every_inst (inst_ok_less ac) prog ⇒
   every_inst (inst_ok_less ac) (FST (dest_Seq prog)) ∧
-  every_inst (inst_ok_less ac) (SND (dest_Seq prog))`,
-  ho_match_mp_tac dest_Seq_ind>>rw[dest_Seq_def]>>fs[every_inst_def])
+  every_inst (inst_ok_less ac) (SND (dest_Seq prog))
+Proof
+  ho_match_mp_tac dest_Seq_ind>>rw[dest_Seq_def]>>fs[every_inst_def]
+QED
 
-val Seq_assoc_no_inst = Q.prove(`
+Triviality Seq_assoc_no_inst:
   ∀p1 p2.
   every_inst (inst_ok_less ac) p1 ∧ every_inst (inst_ok_less ac) p2 ⇒
-  every_inst (inst_ok_less ac) (Seq_assoc p1 p2)`,
+  every_inst (inst_ok_less ac) (Seq_assoc p1 p2)
+Proof
   ho_match_mp_tac Seq_assoc_ind>>fs[Seq_assoc_def,SmartSeq_def]>>rw[]>>
   fs[every_inst_def]>>
-  every_case_tac>>fs[])
+  every_case_tac>>fs[]
+QED
 
 Triviality try_if_hoist2_no_inst:
   ! N p1 interm dummy p2 s.

--- a/compiler/backend/proofs/word_to_stackProofScript.sml
+++ b/compiler/backend/proofs/word_to_stackProofScript.sml
@@ -207,13 +207,17 @@ Proof
   fs[FLOOKUP_UPDATE]
 QED
 
-val MEM_TAKE = Q.prove(
-  `!xs n x. MEM x (TAKE n xs) ==> MEM x xs`,
-  Induct \\ fs [TAKE_def] \\ rw [] \\ res_tac \\ fs []);
+Triviality MEM_TAKE:
+  !xs n x. MEM x (TAKE n xs) ==> MEM x xs
+Proof
+  Induct \\ fs [TAKE_def] \\ rw [] \\ res_tac \\ fs []
+QED
 
-val MEM_LASTN_ALT = Q.prove(
-  `!xs n x. MEM x (LASTN n xs) ==> MEM x xs`,
-  fs [LASTN_def] \\ rw [] \\ imp_res_tac MEM_TAKE \\ fs []);
+Triviality MEM_LASTN_ALT:
+  !xs n x. MEM x (LASTN n xs) ==> MEM x xs
+Proof
+  fs [LASTN_def] \\ rw [] \\ imp_res_tac MEM_TAKE \\ fs []
+QED
 
 Theorem clock_add_0[simp]:
    ((t with clock := t.clock + 0) = t:('a,'c,'ffi) stackSem$state) /\
@@ -229,19 +233,25 @@ Proof
   \\ rpt strip_tac \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac
 QED
 
-val TAKE_TAKE_MIN = Q.prove(
-    `!xs m n. TAKE n (TAKE m xs) = TAKE (MIN m n) xs`,
-    Induct \\ Cases_on `m` \\ Cases_on `n` \\ fs [MIN_DEF]
-    \\ rw [] \\ fs [] \\ Cases_on`n` \\ fs[]);
+Triviality TAKE_TAKE_MIN:
+  !xs m n. TAKE n (TAKE m xs) = TAKE (MIN m n) xs
+Proof
+  Induct \\ Cases_on `m` \\ Cases_on `n` \\ fs [MIN_DEF]
+    \\ rw [] \\ fs [] \\ Cases_on`n` \\ fs[]
+QED
 
-val TAKE_DROP_EQ = Q.prove(
-  `!xs n m. TAKE m (DROP n xs) = DROP n (TAKE (m + n) xs)`,
+Triviality TAKE_DROP_EQ:
+  !xs n m. TAKE m (DROP n xs) = DROP n (TAKE (m + n) xs)
+Proof
   Induct \\ fs [] \\ rw [] \\ fs [] \\ Cases_on`n` \\ fs[]
-  \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac);
+  \\ rpt (AP_TERM_TAC ORELSE AP_THM_TAC) \\ decide_tac
+QED
 
-val DROP_TAKE_NIL = Q.prove(
-  `DROP n (TAKE n xs) = []`,
-  rw[DROP_NIL,LENGTH_TAKE_EQ]);
+Triviality DROP_TAKE_NIL:
+  DROP n (TAKE n xs) = []
+Proof
+  rw[DROP_NIL,LENGTH_TAKE_EQ]
+QED
 
 Theorem TAKE_LUPDATE[simp]:
    !xs n x i. TAKE n (LUPDATE x i xs) = LUPDATE x i (TAKE n xs)
@@ -277,9 +287,11 @@ Proof
 QED
 end
 
-val MIN_ADD = Q.prove(
-  `MIN m1 m2 + n = MIN (m1 + n) (m2 + n)`,
-  fs [MIN_DEF] \\ decide_tac);
+Triviality MIN_ADD:
+  MIN m1 m2 + n = MIN (m1 + n) (m2 + n)
+Proof
+  fs [MIN_DEF] \\ decide_tac
+QED
 
 Definition list_LUPDATE_def:
   (list_LUPDATE [] n ys = ys) /\
@@ -298,32 +310,38 @@ Proof
   Induct \\ fs [list_LUPDATE_def]
 QED
 
-val LLOOKUP_list_LUPDATE_IGNORE = Q.prove(
-  `!xs i n ys.
+Triviality LLOOKUP_list_LUPDATE_IGNORE:
+  !xs i n ys.
       i + LENGTH xs <= n ==>
-      LLOOKUP (list_LUPDATE xs i ys) n = LLOOKUP ys n`,
+      LLOOKUP (list_LUPDATE xs i ys) n = LLOOKUP ys n
+Proof
   Induct \\ fs [list_LUPDATE_def] \\ rpt strip_tac
   \\ `(i+1) + LENGTH xs <= n` by decide_tac \\ res_tac
-  \\ `i <> n` by decide_tac \\ fs [LLOOKUP_LUPDATE]);
+  \\ `i <> n` by decide_tac \\ fs [LLOOKUP_LUPDATE]
+QED
 
-val DROP_list_LUPDATE = Q.prove(
-  `!ys n m xs.
+Triviality DROP_list_LUPDATE:
+  !ys n m xs.
       n <= m ==>
       DROP n (list_LUPDATE ys m xs) =
-      list_LUPDATE ys (m - n) (DROP n xs)`,
+      list_LUPDATE ys (m - n) (DROP n xs)
+Proof
   Induct
   \\ fs [list_LUPDATE_def,LENGTH_NIL,PULL_FORALL]
   \\ rpt strip_tac \\ `n <= m + 1` by decide_tac
   \\ rw [] \\ `m + 1 - n = m - n + 1 /\ ~(m < n)` by decide_tac
-  \\ fs [DROP_LUPDATE]);
+  \\ fs [DROP_LUPDATE]
+QED
 
-val DROP_list_LUPDATE_IGNORE = Q.prove(
-  `!xs i ys n.
+Triviality DROP_list_LUPDATE_IGNORE:
+  !xs i ys n.
       LENGTH xs + i <= n ==>
-      DROP n (list_LUPDATE xs i ys) = DROP n ys`,
+      DROP n (list_LUPDATE xs i ys) = DROP n ys
+Proof
   Induct \\ fs [list_LUPDATE_def] \\ rpt strip_tac
   \\ `LENGTH xs + (i+1) <= n /\ i < n` by decide_tac
-  \\ fs [DROP_LUPDATE]);
+  \\ fs [DROP_LUPDATE]
+QED
 
 Theorem list_LUPDATE_NIL[simp]:
    !xs i. list_LUPDATE xs i [] = []
@@ -331,9 +349,11 @@ Proof
   Induct \\ fs [list_LUPDATE_def,LUPDATE_def]
 QED
 
-val LUPDATE_TAKE_LEMMA = Q.prove(
-  `!xs n w. LUPDATE w n xs = TAKE n xs ++ LUPDATE w 0 (DROP n xs)`,
-  Induct \\ Cases_on `n` \\ fs [LUPDATE_def]);
+Triviality LUPDATE_TAKE_LEMMA:
+  !xs n w. LUPDATE w n xs = TAKE n xs ++ LUPDATE w 0 (DROP n xs)
+Proof
+  Induct \\ Cases_on `n` \\ fs [LUPDATE_def]
+QED
 
 Theorem list_LUPDATE_TAKE_DROP:
    !xs (ys:'a list) n.
@@ -364,14 +384,17 @@ QED
 
 (* move to stackProps? *)
 
-val DIV_ADD_1 = Q.prove(
-  `0 < d ==> (m DIV d + 1 = (m + d) DIV d)`,
+Triviality DIV_ADD_1:
+  0 < d ==> (m DIV d + 1 = (m + d) DIV d)
+Proof
   rpt strip_tac
   \\ ASSUME_TAC (ADD_DIV_ADD_DIV |> Q.SPECL [`d`] |> UNDISCH
-      |> Q.SPECL [`1`,`m`] |> ONCE_REWRITE_RULE [ADD_COMM]) \\ fs []);
+      |> Q.SPECL [`1`,`m`] |> ONCE_REWRITE_RULE [ADD_COMM]) \\ fs []
+QED
 
-val LENGTH_word_list_lemma = Q.prove(
-  `!xs d. 0 < d ==> (LENGTH (word_list xs d) = (LENGTH xs - 1) DIV d + 1)`,
+Triviality LENGTH_word_list_lemma:
+  !xs d. 0 < d ==> (LENGTH (word_list xs d) = (LENGTH xs - 1) DIV d + 1)
+Proof
   recInduct word_list_ind
   \\ rpt strip_tac \\ fsrw_tac[] []
   \\ once_rewrite_tac [word_list_def] \\ fsrw_tac[] [] \\ rw []
@@ -382,7 +405,8 @@ val LENGTH_word_list_lemma = Q.prove(
   THEN1 (`LENGTH xs - 1 < d` by decide_tac
          \\ imp_res_tac LESS_DIV_EQ_ZERO \\ fsrw_tac[] [])
   \\ imp_res_tac DIV_ADD_1 \\ fsrw_tac[] []
-  \\ AP_THM_TAC \\ AP_TERM_TAC \\ decide_tac);
+  \\ AP_THM_TAC \\ AP_TERM_TAC \\ decide_tac
+QED
 
 Theorem LENGTH_word_list:
    !xs d. LENGTH (word_list xs d) =
@@ -394,10 +418,12 @@ QED
 
 (* move to wordProps? *)
 
-val list_rearrange_I = Q.prove(
-  `(list_rearrange I = I)`,
+Triviality list_rearrange_I:
+  (list_rearrange I = I)
+Proof
   fs [list_rearrange_def,FUN_EQ_THM]
-  \\ fs [BIJ_DEF,INJ_DEF,SURJ_DEF,GENLIST_ID]);
+  \\ fs [BIJ_DEF,INJ_DEF,SURJ_DEF,GENLIST_ID]
+QED
 
 (* state relation *)
 
@@ -631,13 +657,15 @@ End
 
 (* correctness proof *)
 
-val evaluate_SeqStackFree = Q.prove(
-  `t.use_stack /\ t.stack_space <= LENGTH t.stack ==>
+Triviality evaluate_SeqStackFree:
+  t.use_stack /\ t.stack_space <= LENGTH t.stack ==>
     evaluate (SeqStackFree f p,t) =
-    evaluate (Seq (StackFree f) p,t)`,
+    evaluate (Seq (StackFree f) p,t)
+Proof
   fsrw_tac[] [SeqStackFree_def] \\ srw_tac[] [stackSemTheory.evaluate_def]
   THEN1 (`F` by decide_tac) \\ AP_TERM_TAC
-  \\ fs [stackSemTheory.state_component_equality]);
+  \\ fs [stackSemTheory.state_component_equality]
+QED
 
 val convs_def = LIST_CONJ
   [wordPropsTheory.post_alloc_conventions_def,
@@ -651,74 +679,89 @@ val convs_def = LIST_CONJ
 val nn = ``(NONE:(num # 'a wordLang$prog # num # num) option)``
 
 (*
-val LENGTH_write_bitmap = Q.prove(
-  `state_rel k f f' (s:('a,'ffi) wordSem$state) t /\ 1 <= f ==>
-    (LENGTH ((write_bitmap (names:num_set) k f'):'a word list) + f' = f)`,
+Triviality LENGTH_write_bitmap:
+  state_rel k f f' (s:('a,'ffi) wordSem$state) t /\ 1 <= f ==>
+    (LENGTH ((write_bitmap (names:num_set) k f'):'a word list) + f' = f)
+Proof
   fs [state_rel_def,write_bitmap_def,LET_DEF]
   \\ fs [LENGTH_word_list] \\ rpt strip_tac
   \\ `~(dimindex (:'a) <= 1) /\ f <> 0` by decide_tac \\ fs []
-  \\ decide_tac);
+  \\ decide_tac
+QED
 *)
 
 val DROP_list_LUPDATE_lemma =
   MATCH_MP DROP_list_LUPDATE (SPEC_ALL LESS_EQ_REFL) |> SIMP_RULE std_ss []
 
-val bits_to_word_bit = Q.prove(
-  `!bs i.
+Triviality bits_to_word_bit:
+  !bs i.
       i < dimindex (:'a) /\ i < LENGTH bs ==>
-      ((bits_to_word bs:'a word) ' i = EL i bs)`,
+      ((bits_to_word bs:'a word) ' i = EL i bs)
+Proof
   Induct \\ fs [] \\ Cases_on `i` \\ fs []
   \\ Cases \\ fs [bits_to_word_def,word_or_def,fcpTheory.FCP_BETA,
        word_index,word_lsl_def,ADD1] \\ rpt strip_tac
-  \\ first_x_assum match_mp_tac \\ fs [] \\ decide_tac);
+  \\ first_x_assum match_mp_tac \\ fs [] \\ decide_tac
+QED
 
-val bits_to_word_miss = Q.prove(
-  `!bs i.
+Triviality bits_to_word_miss:
+  !bs i.
       i < dimindex (:'a) /\ LENGTH bs <= i ==>
-      ~((bits_to_word bs:'a word) ' i)`,
+      ~((bits_to_word bs:'a word) ' i)
+Proof
   Induct \\ fs [] THEN1 (EVAL_TAC \\ fs [word_0])
   \\ Cases_on `i` \\ fs [] \\ NTAC 2 strip_tac
   \\ `n < dimindex (:'a)` by decide_tac \\ res_tac
   \\ Cases_on `h` \\ fs [bits_to_word_def,word_or_def,fcpTheory.FCP_BETA,
-       word_index,word_lsl_def,ADD1]);
+       word_index,word_lsl_def,ADD1]
+QED
 
-val bits_to_word_NOT_0 = Q.prove(
-  `!bs. LENGTH bs <= dimindex (:'a) /\ EXISTS I bs ==>
-         (bits_to_word bs <> 0w:'a word)`,
+Triviality bits_to_word_NOT_0:
+  !bs. LENGTH bs <= dimindex (:'a) /\ EXISTS I bs ==>
+         (bits_to_word bs <> 0w:'a word)
+Proof
   fs [fcpTheory.CART_EQ] \\ rpt strip_tac
   \\ fs [EXISTS_MEM,MEM_EL]
   \\ Q.EXISTS_TAC `n`   \\ fs []
   \\ `n < dimindex (:'a)` by decide_tac \\ fs [word_0]
-  \\ fs [bits_to_word_bit]);
+  \\ fs [bits_to_word_bit]
+QED
 
-val list_LUPDATE_write_bitmap_NOT_NIL = Q.prove(
-  `8 <= dimindex (:'a) ==>
+Triviality list_LUPDATE_write_bitmap_NOT_NIL:
+  8 <= dimindex (:'a) ==>
     (list_LUPDATE (MAP Word (write_bitmap names k f')) 0 xs <>
-     [Word (0w:'a word)])`,
+     [Word (0w:'a word)])
+Proof
   Cases_on `xs` \\ fs [list_LUPDATE_NIL]
   \\ fs [write_bitmap_def,LET_DEF,Once word_list_def]
   \\ strip_tac \\ `~(dimindex (:'a) <= 1)` by decide_tac \\ fs []
   \\ rw [] \\ rpt disj1_tac
   \\ match_mp_tac bits_to_word_NOT_0 \\ fs [LENGTH_TAKE_EQ]
-  \\ fs [MIN_LE,MIN_ADD] \\ decide_tac);
+  \\ fs [MIN_LE,MIN_ADD] \\ decide_tac
+QED
 
-val word_or_eq_0 = Q.prove(
-  `((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)`,
+Triviality word_or_eq_0:
+  ((w || v) = 0w) <=> (w = 0w) /\ (v = 0w)
+Proof
   srw_tac [wordsLib.WORD_BIT_EQ_ss] []
-  \\ metis_tac [])
+  \\ metis_tac []
+QED
 
-val shift_shift_lemma = Q.prove(
-  `~(word_msb w) ==> (w ≪ 1 ⋙ 1 = w)`,
+Triviality shift_shift_lemma:
+  ~(word_msb w) ==> (w ≪ 1 ⋙ 1 = w)
+Proof
   srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ Cases_on `i + 1 < dimindex (:α)`
   \\ full_simp_tac (srw_ss()++wordsLib.WORD_BIT_EQ_ss) [NOT_LESS]
   \\ `i = dimindex (:'a) - 1` by decide_tac
-  \\ simp [])
+  \\ simp []
+QED
 
-val bit_length_bits_to_word = Q.prove(
-  `!qs.
+Triviality bit_length_bits_to_word:
+  !qs.
       LENGTH qs + 1 < dimindex (:'a) ==>
-      bit_length (bits_to_word (qs ++ [T]):'a word) = LENGTH qs + 1`,
+      bit_length (bits_to_word (qs ++ [T]):'a word) = LENGTH qs + 1
+Proof
   Induct THEN1
    (fs [] \\ fs [Once bit_length_def] \\ fs [Once bit_length_def]
     \\ fs [bits_to_word_def] \\ EVAL_TAC)
@@ -738,28 +781,34 @@ val bit_length_bits_to_word = Q.prove(
       bits_to_word (qs ++ [T]):'a word` by
    (match_mp_tac shift_shift_lemma \\ fs [word_msb_def]
     \\ match_mp_tac bits_to_word_miss \\ fs [] \\ decide_tac)
-  \\ fs [ADD1,word_or_eq_0]);
+  \\ fs [ADD1,word_or_eq_0]
+QED
 
-val GENLIST_bits_to_word_alt = Q.prove(
-  `LENGTH (xs ++ ys) <= dimindex (:'a) ==>
-    GENLIST (\i. (bits_to_word (xs ++ ys):'a word) ' i) (LENGTH xs) = xs`,
+Triviality GENLIST_bits_to_word_alt:
+  LENGTH (xs ++ ys) <= dimindex (:'a) ==>
+    GENLIST (\i. (bits_to_word (xs ++ ys):'a word) ' i) (LENGTH xs) = xs
+Proof
   fs [LIST_EQ_REWRITE] \\ rpt strip_tac
   \\ `EL x xs = EL x (xs ++ ys)` by fs [EL_APPEND1]
   \\ pop_assum (fn th => once_rewrite_tac [th])
   \\ match_mp_tac bits_to_word_bit
-  \\ fs [] \\ decide_tac);
+  \\ fs [] \\ decide_tac
+QED
 
-val GENLIST_bits_to_word = Q.prove(
-  `LENGTH qs' + 1 < dimindex (:'a) ==>
-    GENLIST (\i. (bits_to_word (qs' ++ [T]):'a word) ' i) (LENGTH qs') = qs'`,
+Triviality GENLIST_bits_to_word:
+  LENGTH qs' + 1 < dimindex (:'a) ==>
+    GENLIST (\i. (bits_to_word (qs' ++ [T]):'a word) ' i) (LENGTH qs') = qs'
+Proof
   rpt strip_tac \\ match_mp_tac GENLIST_bits_to_word_alt
-  \\ fs [] \\ decide_tac);
+  \\ fs [] \\ decide_tac
+QED
 
-val read_bitmap_word_list = Q.prove(
-  `8 <= dimindex (:'a) ==>
+Triviality read_bitmap_word_list:
+  8 <= dimindex (:'a) ==>
     read_bitmap
       ((word_list (qs ++ [T]) (dimindex (:'a) - 1)) ++ (xs:'a word list)) =
-    SOME qs`,
+    SOME qs
+Proof
   completeInduct_on `LENGTH (qs:bool list)` \\ rpt strip_tac \\ fs [PULL_FORALL]
   \\ rw [] \\ once_rewrite_tac [word_list_def]
   \\ `dimindex (:'a) - 1 <> 0` by decide_tac \\ fs []
@@ -799,11 +848,13 @@ val read_bitmap_word_list = Q.prove(
   \\ AP_THM_TAC \\ AP_TERM_TAC
   \\ Q.ABBREV_TAC `ts = TAKE (dimindex (:'a) - 1) qs` \\ fs []
   \\ match_mp_tac GENLIST_bits_to_word_alt \\ fs []
-  \\ decide_tac);
+  \\ decide_tac
+QED
 
-val APPEND_LEMMA = Q.prove(
-  `n1 + n2 + n3 <= LENGTH xs ==>
-    ?xs2 xs3. (DROP n1 xs = xs2 ++ xs3) /\ n2 = LENGTH xs2`,
+Triviality APPEND_LEMMA:
+  n1 + n2 + n3 <= LENGTH xs ==>
+    ?xs2 xs3. (DROP n1 xs = xs2 ++ xs3) /\ n2 = LENGTH xs2
+Proof
   rpt strip_tac
   \\ `n1 <= LENGTH xs` by decide_tac
   \\ Q.PAT_X_ASSUM `n1 + n2 + n3 <= LENGTH xs` MP_TAC
@@ -812,7 +863,8 @@ val APPEND_LEMMA = Q.prove(
   \\ rename [‘n2 + (n3 + LENGTH xs1) ≤ LENGTH xs1 + LENGTH xs2’]
   \\ `n2 <= LENGTH xs2` by decide_tac
   \\ imp_res_tac LESS_EQ_LENGTH
-  \\ rw [] \\ metis_tac []);
+  \\ rw [] \\ metis_tac []
+QED
 
 Theorem read_bitmap_write_bitmap:
    8 ≤ dimindex (:α) ⇒
@@ -877,28 +929,33 @@ val read_bitmap_write_bitmap = Q.prove(
 
 *)
 
-val abs_stack_IMP_LENGTH = Q.prove(
-  `∀bs wstack sstack lens stack.
-    abs_stack bs wstack sstack lens = SOME stack ⇒ LENGTH stack = LENGTH wstack ∧ LENGTH lens = LENGTH wstack`,
+Triviality abs_stack_IMP_LENGTH:
+  ∀bs wstack sstack lens stack.
+    abs_stack bs wstack sstack lens = SOME stack ⇒ LENGTH stack = LENGTH wstack ∧ LENGTH lens = LENGTH wstack
+Proof
   recInduct (theorem "abs_stack_ind")
   \\ fs [abs_stack_def,LET_THM] \\ rpt strip_tac
-  \\ EVERY_CASE_TAC \\ fs [] \\ rw [])
+  \\ EVERY_CASE_TAC \\ fs [] \\ rw []
+QED
 
-val SORTED_FST_LESS_IMP = Q.prove(
-  `!xs x.
+Triviality SORTED_FST_LESS_IMP:
+  !xs x.
       SORTED (\x y. FST x > FST y:num) (x::xs) ==>
       SORTED (\x y. FST x > FST y) xs /\ ~(MEM x xs) /\
-      (!y. MEM y xs ==> FST x > FST y)`,
+      (!y. MEM y xs ==> FST x > FST y)
+Proof
   Induct \\ fs [SORTED_DEF]
   \\ ntac 3 strip_tac \\ res_tac \\ rpt strip_tac
-  \\ rw [] \\ fs [] \\ res_tac \\ decide_tac);
+  \\ rw [] \\ fs [] \\ res_tac \\ decide_tac
+QED
 
-val SORTED_IMP_EQ_LISTS = Q.prove(
-  `!xs ys.
+Triviality SORTED_IMP_EQ_LISTS:
+  !xs ys.
       SORTED (\x y. FST x > FST y:num) ys /\
       SORTED (\x y. FST x > FST y) xs /\
       (!x. MEM x ys <=> MEM x xs) ==>
-      (xs = ys)`,
+      (xs = ys)
+Proof
   Induct \\ fs [] \\ Cases_on `ys` \\ fs [] THEN1 metis_tac []
   THEN1 (CCONTR_TAC THEN fs [] THEN metis_tac [])
   \\ ntac 2 strip_tac
@@ -915,7 +972,8 @@ val SORTED_IMP_EQ_LISTS = Q.prove(
   THEN1
    (first_assum (mp_tac o Q.SPEC `h'`)
     \\ imp_res_tac SORTED_FST_LESS_IMP
-    \\ rpt strip_tac \\ fs [] \\ fs []));
+    \\ rpt strip_tac \\ fs [] \\ fs [])
+QED
 
 Theorem transitive_key_val_compare:
    transitive key_val_compare
@@ -935,41 +993,50 @@ Proof
   \\ wordsLib.WORD_DECIDE_TAC
 QED
 
-val SORTS_QSORT_key_val_compare = Q.prove(
-  `SORTS QSORT key_val_compare`,
+Triviality SORTS_QSORT_key_val_compare:
+  SORTS QSORT key_val_compare
+Proof
   match_mp_tac QSORT_SORTS >>
-  MATCH_ACCEPT_TAC (CONJ transitive_key_val_compare total_key_val_compare))
+  MATCH_ACCEPT_TAC (CONJ transitive_key_val_compare total_key_val_compare)
+QED
 
 val MEM_QSORT = SORTS_QSORT_key_val_compare
   |> SIMP_RULE std_ss [SORTS_DEF]
   |> SPEC_ALL |> CONJUNCT1
   |> MATCH_MP MEM_PERM |> GSYM |> GEN_ALL
 
-val SORTED_weaken2 = Q.prove(`
+Triviality SORTED_weaken2:
   ∀ls. SORTED R ls ∧
   ALL_DISTINCT ls ∧
   (∀x y. MEM x ls ∧ MEM y ls ∧ x ≠ y ∧ R x y ⇒ R' x y) ⇒
-  SORTED R' ls`,
+  SORTED R' ls
+Proof
   Induct>>rw[]>>Cases_on`ls`>>fs[SORTED_DEF]>>
-  metis_tac[])
+  metis_tac[]
+QED
 
-val EVEN_GT = Q.prove(`
+Triviality EVEN_GT:
   ∀a b.
   EVEN a ∧ EVEN b ∧
   a > b ⇒
-  a DIV 2 > b DIV 2`,
+  a DIV 2 > b DIV 2
+Proof
   fs[EVEN_EXISTS]>>rw[]>>
   fsrw_tac[][MULT_DIV,MULT_COMM]>>
-  DECIDE_TAC)
+  DECIDE_TAC
+QED
 
-val transitive_GT = Q.prove(`
-  transitive ($> : (num->num->bool))`,
-  fs[transitive_def]>>DECIDE_TAC)
+Triviality transitive_GT:
+  transitive ($> : (num->num->bool))
+Proof
+  fs[transitive_def]>>DECIDE_TAC
+QED
 
-val env_to_list_K_I_IMP = Q.prove(
-  `!env l oracle.
+Triviality env_to_list_K_I_IMP:
+  !env l oracle.
       env_to_list env (K I) = (l,oracle) ==>
-      SORTED (\x y. FST x > FST y) l /\ oracle = K I /\ PERM (toAList env) l`,
+      SORTED (\x y. FST x > FST y) l /\ oracle = K I /\ PERM (toAList env) l
+Proof
   fs [env_to_list_def,LET_DEF,FUN_EQ_THM,list_rearrange_I] \\ rw []
   \\ pop_assum kall_tac
   \\ qspec_then `toAList env` mp_tac (SORTS_QSORT_key_val_compare
@@ -983,7 +1050,8 @@ val env_to_list_K_I_IMP = Q.prove(
   \\ Induct_on `l` \\ fs []
   \\ Cases_on `l` \\ fs [SORTED_DEF] \\ rw []
   \\ res_tac \\ fs [key_val_compare_def,LET_DEF]
-  \\ pairarg_tac \\ fs [] \\ pairarg_tac \\ fs [])
+  \\ pairarg_tac \\ fs [] \\ pairarg_tac \\ fs []
+QED
 
 Theorem isPREFIX_DROP:
   ∀s t i.
@@ -1213,9 +1281,10 @@ val push_env_set_store = Q.prove(
     set_store AllocSize (Word c) (push_env env ^nn s)`,
   fs [push_env_def,set_store_def,env_to_list_def,LET_DEF])|> INST_TYPE [beta|-> alpha, gamma|->beta];
 
-val state_rel_set_store_0 = Q.prove(
-  `state_rel k 0 0 s5 t5 len ==>
-    state_rel k 0 0 (set_store AllocSize w s5) (set_store AllocSize w t5) len`,
+Triviality state_rel_set_store_0:
+  state_rel k 0 0 s5 t5 len ==>
+    state_rel k 0 0 (set_store AllocSize w s5) (set_store AllocSize w t5) len
+Proof
   rpt strip_tac
   \\ fs [state_rel_def,set_store_def,stackSemTheory.set_store_def,LET_DEF,
          FLOOKUP_DEF] \\ REPEAT STRIP_TAC \\ rfs[]
@@ -1223,36 +1292,45 @@ val state_rel_set_store_0 = Q.prove(
   \\ fs [fmap_EXT,DRESTRICT_DEF,EXTENSION]
   \\ rpt strip_tac  THEN1 (Cases_on `x = Handler` \\ fs [])
   \\ fs [FAPPLY_FUPDATE_THM,DOMSUB_FAPPLY_THM]
-  \\ metis_tac[]);
+  \\ metis_tac[]
+QED
 
-val MAP_SND_MAP_FST = Q.prove(
-  `!xs f. MAP SND (MAP_FST f xs) = MAP SND xs`,
-  Induct \\ fs [MAP,MAP_FST_def,FORALL_PROD]);
+Triviality MAP_SND_MAP_FST:
+  !xs f. MAP SND (MAP_FST f xs) = MAP SND xs
+Proof
+  Induct \\ fs [MAP,MAP_FST_def,FORALL_PROD]
+QED
 
-val read_bitmap_not_empty = Q.prove(`
+Triviality read_bitmap_not_empty:
   read_bitmap stack = SOME a ⇒
-  stack ≠ []`,
+  stack ≠ []
+Proof
   rw[]>>CCONTR_TAC>>
   fs[]>>
-  fs[read_bitmap_def])
+  fs[read_bitmap_def]
+QED
 
-val n2w_lsr_1 = Q.prove(
-  `n < dimword (:'a) ==> n2w n >>> 1 = (n2w (n DIV 2)):'a word`,
+Triviality n2w_lsr_1:
+  n < dimword (:'a) ==> n2w n >>> 1 = (n2w (n DIV 2)):'a word
+Proof
   once_rewrite_tac [GSYM w2n_11] \\ rewrite_tac [w2n_lsr] \\ fs []
-  \\ fs [DIV_LT_X] \\ decide_tac);
+  \\ fs [DIV_LT_X] \\ decide_tac
+QED
 
-val handler_bitmap_props = Q.prove(`
+Triviality handler_bitmap_props:
   good_dimindex(:'a) ⇒
-  read_bitmap ((4w:'a word)::stack) = SOME [F;F]`,
+  read_bitmap ((4w:'a word)::stack) = SOME [F;F]
+Proof
   fs [read_bitmap_def,good_dimindex_def] \\ strip_tac
   \\ `~(word_msb 4w)` by fs [word_msb_def,wordsTheory.word_index] \\ fs []
   \\ `4 < dimword (:'a) /\ 2 < dimword (:'a)` by fs [dimword_def]
   \\ `bit_length 4w = 3` by
    (NTAC 4 (fs [dimword_def,Once bit_length_def,n2w_lsr_1,EVAL ``1w ⋙ 1``]))
-  \\ fs [] \\ EVAL_TAC \\ rw [] \\ decide_tac)
+  \\ fs [] \\ EVAL_TAC \\ rw [] \\ decide_tac
+QED
 
-val enc_stack_lemma = Q.prove(
-  `∀bs (wstack:'a stack_frame list) sstack lens astack bs'.
+Triviality enc_stack_lemma:
+  ∀bs (wstack:'a stack_frame list) sstack lens astack bs'.
       good_dimindex(:'a) ∧
       LENGTH bs + 1 < dimword (:'a) ∧
       abs_stack bs wstack sstack lens = SOME astack ∧
@@ -1260,7 +1338,8 @@ val enc_stack_lemma = Q.prove(
       1 ≤ LENGTH bs ∧
       HD bs = 4w ∧
       stack_rel_aux k len wstack astack ⇒
-      enc_stack bs sstack = SOME (enc_stack wstack)`,
+      enc_stack bs sstack = SOME (enc_stack wstack)
+Proof
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   fs[enc_stack_def]>>
   rw[]>>
@@ -1301,24 +1380,28 @@ val enc_stack_lemma = Q.prove(
   \\ simp[handler_bitmap_props] >>
   simp[filter_bitmap_def]>>
   simp[Once stackSemTheory.enc_stack_def]>>
-  simp[full_read_bitmap_def,MAP_SND_MAP_FST]);
+  simp[full_read_bitmap_def,MAP_SND_MAP_FST]
+QED
 
-val IMP_enc_stack = Q.prove(
-  `state_rel k 0 0 s1 t1 lens
+Triviality IMP_enc_stack:
+  state_rel k 0 0 s1 t1 lens
     ==>
     (enc_stack t1.bitmaps (DROP t1.stack_space t1.stack) =
-       SOME (enc_stack s1.stack))`,
+       SOME (enc_stack s1.stack))
+Proof
   fs [state_rel_def,LET_DEF] \\ rpt strip_tac
   \\ fs [stack_rel_def] \\ imp_res_tac enc_stack_lemma>>
-  simp[]);
+  simp[]
+QED
 
-val map_bitmap_success = Q.prove(`
+Triviality map_bitmap_success:
   ∀bs stack a b ls.
   filter_bitmap bs stack = SOME(a,b) ∧
   LENGTH ls = LENGTH a ⇒
   ∃x z.
   map_bitmap bs ls stack = SOME(x,[],DROP (LENGTH bs) stack) ∧
-  filter_bitmap bs x = SOME(ls,[])`,
+  filter_bitmap bs x = SOME(ls,[])
+Proof
   ho_match_mp_tac filter_bitmap_ind>>fs[filter_bitmap_def,map_bitmap_def]>>
   rw[LENGTH_NIL]
   >-
@@ -1326,26 +1409,32 @@ val map_bitmap_success = Q.prove(`
   >>
     EVERY_CASE_TAC>>fs[]>>
     rveq>>Cases_on`ls`>>fs[map_bitmap_def,filter_bitmap_def]>>
-    res_tac>>fs[filter_bitmap_def])
+    res_tac>>fs[filter_bitmap_def]
+QED
 
 (*Might need to extend c as well*)
-val map_bitmap_more = Q.prove(`
+Triviality map_bitmap_more:
   ∀bs ls stack n a c ls'.
   map_bitmap bs ls stack = SOME(a,[],c) ⇒
-  map_bitmap bs (ls++ls') stack = SOME(a,ls',c)`,
+  map_bitmap bs (ls++ls') stack = SOME(a,ls',c)
+Proof
   ho_match_mp_tac map_bitmap_ind>>fs[map_bitmap_def]>>rw[]>>
-  pop_assum mp_tac>>ntac 3 TOP_CASE_TAC>>fs[])
+  pop_assum mp_tac>>ntac 3 TOP_CASE_TAC>>fs[]
+QED
 
-val map_bitmap_more_simp = Q.prove(`
+Triviality map_bitmap_more_simp:
   map_bitmap bs (TAKE (LENGTH l) ls) stack = SOME (a,[],c) ⇒
-  map_bitmap bs ls stack = SOME (a,DROP (LENGTH l) ls,c)`,
-  metis_tac[TAKE_DROP,map_bitmap_more])
+  map_bitmap bs ls stack = SOME (a,DROP (LENGTH l) ls,c)
+Proof
+  metis_tac[TAKE_DROP,map_bitmap_more]
+QED
 
 (*These two are actually implied by s_key_eq*)
-val word_stack_dec_stack_shape = Q.prove(`
+Triviality word_stack_dec_stack_shape:
   ∀ls wstack res n.
   dec_stack ls wstack = SOME res ∧ n < LENGTH wstack ⇒
-  (is_handler_frame (EL n wstack) ⇔ is_handler_frame (EL n res))`,
+  (is_handler_frame (EL n wstack) ⇔ is_handler_frame (EL n res))
+Proof
   ho_match_mp_tac dec_stack_ind>>fs[dec_stack_def,is_handler_frame_def]>>
   rw[]>>
   EVERY_CASE_TAC>>fs[]>>
@@ -1354,13 +1443,15 @@ val word_stack_dec_stack_shape = Q.prove(`
   Cases_on`m`>-
     (Cases_on`handler`>>
     simp[is_handler_frame_def])>>
-  simp[]);
+  simp[]
+QED
 
-val sorted_env_zip = Q.prove(`
+Triviality sorted_env_zip:
   ∀l:(num,'a word_loc) alist ls:'a word_loc list x n.
   sorted_env (StackFrame n l x) ∧
   LENGTH ls = LENGTH l⇒
-  sorted_env (StackFrame n (ZIP (MAP FST l, ls)) x)`,
+  sorted_env (StackFrame n (ZIP (MAP FST l, ls)) x)
+Proof
   fs[sorted_env_def]>>
   Induct>>fs[LENGTH_NIL]>>rw[]>>
   Cases_on`ls`>>fs[]>>
@@ -1370,23 +1461,28 @@ val sorted_env_zip = Q.prove(`
     DECIDE_TAC)>>
   fs[SORTED_EQ,MEM_ZIP,PULL_EXISTS,MEM_EL]>>
   rw[]>>res_tac>>
-  fs[Abbr`R`,EL_MAP]);
+  fs[Abbr`R`,EL_MAP]
+QED
 
-val word_stack_dec_stack_sorted = Q.prove(`
+Triviality word_stack_dec_stack_sorted:
   ∀(ls:'a word_loc list) (wstack:'a stack_frame list) res.
   dec_stack ls wstack = SOME res ∧
   EVERY sorted_env wstack ⇒
-  EVERY sorted_env res`,
+  EVERY sorted_env res
+Proof
   ho_match_mp_tac dec_stack_ind>>fs[dec_stack_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[]>>rveq>>
   rfs[]>>
   match_mp_tac sorted_env_zip>>
-  simp[])
+  simp[]
+QED
 
-val abs_stack_empty = Q.prove(`
+Triviality abs_stack_empty:
   ∀bs ls stack lens.
-  abs_stack bs [] ls lens = SOME stack ⇒ ls = [Word 0w] ∧ lens = []`,
-  rpt Cases>>fs[abs_stack_def])
+  abs_stack bs [] ls lens = SOME stack ⇒ ls = [Word 0w] ∧ lens = []
+Proof
+  rpt Cases>>fs[abs_stack_def]
+QED
 
 Definition abs_frame_eq_def:
   abs_frame_eq p q ⇔
@@ -1395,16 +1491,18 @@ Definition abs_frame_eq_def:
   LENGTH (SND (SND p)) = LENGTH (SND (SND q))
 End
 
-val LIST_REL_abs_frame_eq_handler_val = Q.prove(`
+Triviality LIST_REL_abs_frame_eq_handler_val:
   ∀xs ys.
   LIST_REL abs_frame_eq xs ys ⇒
-  handler_val xs = handler_val ys`,
+  handler_val xs = handler_val ys
+Proof
   ho_match_mp_tac LIST_REL_ind>>
   fs[handler_val_def,abs_frame_eq_def,FORALL_PROD]>>rw[]>>
-  Cases_on`p_1`>>fs[handler_val_def])
+  Cases_on`p_1`>>fs[handler_val_def]
+QED
 
 (*Prove the inductive bits first...*)
-val dec_stack_lemma1 = Q.prove(`
+Triviality dec_stack_lemma1:
   ∀bs (wstack:'a stack_frame list) sstack lens astack wdec ls.
   good_dimindex(:'a) ∧
   1 ≤ LENGTH bs ∧
@@ -1420,7 +1518,8 @@ val dec_stack_lemma1 = Q.prove(`
   abs_stack bs wdec sdec lens = SOME bstack ∧
   stack_rel_aux k len wdec bstack ∧
   (*They have exactly the same shape*)
-  LIST_REL abs_frame_eq astack bstack`,
+  LIST_REL abs_frame_eq astack bstack
+Proof
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   fsrw_tac[][dec_stack_def,enc_stack_def]>>
   srw_tac[][]>>
@@ -1522,9 +1621,10 @@ val dec_stack_lemma1 = Q.prove(`
     >>
     fsrw_tac[][abs_frame_eq_def]>>
     simp[] >>
-    fs[LENGTH_TAKE]));
+    fs[LENGTH_TAKE])
+QED
 
-val dec_stack_lemma = Q.prove(`
+Triviality dec_stack_lemma:
   good_dimindex(:'a) ∧
   1 ≤ LENGTH t1.bitmaps ∧
   HD t1.bitmaps = 4w ∧
@@ -1538,7 +1638,8 @@ val dec_stack_lemma = Q.prove(`
     ?yy:'a word_loc list. dec_stack t1.bitmaps x0 (DROP t1.stack_space t1.stack) = SOME yy /\
          (t1.stack_space + LENGTH yy = LENGTH t1.stack) /\
          stack_rel k s1.handler x (SOME (t1.store ' Handler)) yy
-            (LENGTH t1.stack) t1.bitmaps lens`,
+            (LENGTH t1.stack) t1.bitmaps lens
+Proof
   rw[]>>
   fs[stack_rel_def]>>
   drule (GEN_ALL dec_stack_lemma1)>>
@@ -1562,7 +1663,7 @@ val dec_stack_lemma = Q.prove(`
     pop_assum(qspec_then`s1.handler+1` mp_tac)>>impl_tac>-
       DECIDE_TAC>>
     metis_tac[LIST_REL_abs_frame_eq_handler_val])
-  );
+QED
 
 Triviality dec_stack_stack_size:
   !xs st st'.
@@ -1576,11 +1677,11 @@ Proof
   res_tac >> simp[]
 QED
 
-val gc_state_rel = Q.prove(
-  `(gc (s1:('a,num # 'c,'ffi) wordSem$state) = SOME s2) /\ state_rel k 0 0 s1 (t1:('a,'c,'ffi) stackSem$state) lens /\ (s1.locals = LN) ==>
+Triviality gc_state_rel:
+  (gc (s1:('a,num # 'c,'ffi) wordSem$state) = SOME s2) /\ state_rel k 0 0 s1 (t1:('a,'c,'ffi) stackSem$state) lens /\ (s1.locals = LN) ==>
     ?(t2:('a,'c,'ffi) stackSem$state). gc t1 = SOME t2 /\ state_rel k 0 0 s2 t2 lens
     /\ LENGTH t2.stack = LENGTH t1.stack /\ t2.stack_space = t1.stack_space
-`,
+Proof
   fs [gc_def,LET_DEF]
   \\ Cases_on `s1.gc_fun (enc_stack s1.stack,s1.memory,s1.mdomain,s1.store)` \\ fs []
   \\ PairCases_on `x` \\ fs [] \\ Cases_on `dec_stack x0 s1.stack` \\ fs []
@@ -1602,10 +1703,10 @@ val gc_state_rel = Q.prove(
   \\ TRY(qmatch_goalsub_abbrev_tac `post_alloc_conventions _` >> metis_tac[])
   \\ TRY(qmatch_goalsub_abbrev_tac `flat_exp_conventions _` >> metis_tac[])
   \\ metis_tac[dec_stack_stack_size]
-    );
+QED
 
-val alloc_alt = Q.prove(
-  `FST (alloc c names (s:('a,num # 'c,'ffi) wordSem$state)) <>
+Triviality alloc_alt:
+  FST (alloc c names (s:('a,num # 'c,'ffi) wordSem$state)) <>
     SOME (Error:'a wordSem$result) ==>
     (alloc c names (s:('a,num # 'c,'ffi) wordSem$state) =
      case cut_env names s.locals of
@@ -1625,31 +1726,36 @@ val alloc_alt = Q.prove(
                        NONE => (SOME Error,s')
                      | SOME T => (NONE,s')
                      | SOME F =>
-                         (SOME NotEnoughSpace, flush_state T s'))`,
+                         (SOME NotEnoughSpace, flush_state T s'))
+Proof
   fs [alloc_def]
   \\ Cases_on `cut_env names s.locals` \\ fs []
   \\ fs [gc_def,set_store_def,push_env_def,LET_DEF,
          env_to_list_def,pop_env_def,flush_state_def]
   \\ BasicProvers.EVERY_CASE_TAC
    \\ fs [state_component_equality] \\ rw []
-   \\ fs [state_component_equality] \\ rw []);
+   \\ fs [state_component_equality] \\ rw []
+QED
 
 (*MEM to an EL characterization for index lists*)
-val MEM_index_list_LIM = Q.prove(`
+Triviality MEM_index_list_LIM:
   ∀ls n v k.
   MEM (n,v) (index_list ls k) ⇒
-  n-k < LENGTH ls`,
+  n-k < LENGTH ls
+Proof
   Induct>>fs[index_list_def]>>rw[]
   >-
     DECIDE_TAC
   >>
   res_tac>>
-  DECIDE_TAC)
+  DECIDE_TAC
+QED
 
-val MEM_index_list_EL = Q.prove(`
+Triviality MEM_index_list_EL:
   ∀ls n v.
   MEM (n,v) (index_list ls k) ⇒
-  EL (LENGTH ls - (n-k+1)) ls = v`,
+  EL (LENGTH ls - (n-k+1)) ls = v
+Proof
   Induct>>fs[index_list_def,FORALL_PROD]>>rw[]>>
   simp[ADD1]>>
   res_tac>>
@@ -1657,7 +1763,8 @@ val MEM_index_list_EL = Q.prove(`
   imp_res_tac MEM_index_list_LIM>>
   `LENGTH ls +1 - (n-k+1) = SUC(LENGTH ls - (n-k+1))` by DECIDE_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  simp[])
+  simp[]
+QED
 
 Type result = ``:'a wordSem$result``
 
@@ -1685,8 +1792,8 @@ Proof
   Cases_on `opt2` >> fs[s_frame_key_eq_def,s_key_eq_stack_size]
 QED
 
-val alloc_IMP_alloc = Q.prove(
-  `(wordSem$alloc c names (s:('a,num # 'c,'ffi) wordSem$state) = (res:'a result option,s1)) /\
+Triviality alloc_IMP_alloc:
+  (wordSem$alloc c names (s:('a,num # 'c,'ffi) wordSem$state) = (res:'a result option,s1)) /\
     (∀x. x ∈ domain names ⇒ EVEN x /\ k ≤ x DIV 2) /\
     1 ≤ f /\
     state_rel k f f' s t5 lens /\
@@ -1700,7 +1807,8 @@ val alloc_IMP_alloc = Q.prove(
                                                    /\ t1.stack_space = t5.stack_space
       else
         res = SOME NotEnoughSpace /\ res1 = SOME (Halt (Word 1w)) /\
-        s1.clock = t1.clock /\ s1.ffi = t1.ffi`,
+        s1.clock = t1.clock /\ s1.ffi = t1.ffi
+Proof
   Cases_on `FST (alloc c names (s:('a,num # 'c,'ffi) wordSem$state)) = SOME (Error:'a result)`
   THEN1 (rpt strip_tac \\ fsrw_tac[] [] \\ rfs [])
   \\ fsrw_tac[] [alloc_alt, stackSemTheory.alloc_def]
@@ -1836,20 +1944,22 @@ val alloc_IMP_alloc = Q.prove(
   \\ EVERY_CASE_TAC \\ fsrw_tac[] []
   \\ imp_res_tac FLOOKUP_SUBMAP \\ fsrw_tac[] [] \\ srw_tac[] [] \\ fsrw_tac[] []
   \\ fsrw_tac[] [state_rel_def]
-    );
+QED
 
-val word_gc_empty_frame = Q.prove(`
+Triviality word_gc_empty_frame:
   gc (s with stack:= (StackFrame n [] NONE::s.stack)) = SOME x ∧
   pop_env x = SOME y ⇒
   y.locals = LN ∧
-  gc s = SOME (y with <|locals:=s.locals; locals_size:=s.locals_size|>)`,
+  gc s = SOME (y with <|locals:=s.locals; locals_size:=s.locals_size|>)
+Proof
   fs[gc_def,enc_stack_def,dec_stack_def,LET_THM]>>EVERY_CASE_TAC>>
   rw[]>>fs[pop_env_def]>>
   rveq>>fs[fromAList_def]>>
   rw[]>>rveq>>fs[pop_env_def]>>
-  fs[state_component_equality])
+  fs[state_component_equality]
+QED
 
-val alloc_IMP_alloc2 = Q.prove(`
+Triviality alloc_IMP_alloc2:
   (wordSem$alloc c names (s:('a,num # 'c,'ffi) wordSem$state) = (res:'a result option,s1)) ∧
   state_rel k 0 0 s t lens ∧
   domain names = {} ∧
@@ -1861,7 +1971,8 @@ val alloc_IMP_alloc2 = Q.prove(`
       t1.stack_space = t.stack_space
     else
       res = SOME NotEnoughSpace /\ res1 = SOME (Halt (Word 1w)) ∧
-      s1.clock = t1.clock /\ s1.ffi = t1.ffi`,
+      s1.clock = t1.clock /\ s1.ffi = t1.ffi
+Proof
   Cases_on `FST (alloc c names (s:('a,num # 'c,'ffi) wordSem$state)) = SOME (Error:'a result)`
   THEN1 (rpt strip_tac \\ fs [] \\ rfs [])
   \\ fs [alloc_alt, stackSemTheory.alloc_def]
@@ -1929,7 +2040,8 @@ val alloc_IMP_alloc2 = Q.prove(`
   \\ fs[dec_stack_def,CaseEq"option",CaseEq"prod",CaseEq"bool"]
   \\ fs[state_component_equality] >> rveq >> fs[]
   \\ imp_res_tac dec_stack_stack_size
-  \\ fs[]);
+  \\ fs[]
+QED
 
 Definition compile_result_def:
   (compile_result (Result w1 w2) = Result w1) ∧
@@ -1941,10 +2053,12 @@ Definition compile_result_def:
 End
 val _ = export_rewrites["compile_result_def"];
 
-val Halt_EQ_compile_result = Q.prove(
-  `(Halt (Word 1w) = compile_result z <=> z = NotEnoughSpace) /\
-    (good_dimindex (:'a) ==> Halt (Word (2w:'a word)) <> compile_result z)`,
-  Cases_on `z` \\ fs [] \\ fs [good_dimindex_def] \\ rw [] \\ fs [dimword_def]);
+Triviality Halt_EQ_compile_result:
+  (Halt (Word 1w) = compile_result z <=> z = NotEnoughSpace) /\
+    (good_dimindex (:'a) ==> Halt (Word (2w:'a word)) <> compile_result z)
+Proof
+  Cases_on `z` \\ fs [] \\ fs [good_dimindex_def] \\ rw [] \\ fs [dimword_def]
+QED
 
 val stack_evaluate_add_clock_NONE =
   stackPropsTheory.evaluate_add_clock
@@ -1955,36 +2069,43 @@ Definition push_locals_def:
     stack := StackFrame s.locals_size (FST (env_to_list s.locals (K I))) NONE :: s.stack |>
 End
 
-val LASTN_LENGTH_ID2 = Q.prove(`
+Triviality LASTN_LENGTH_ID2:
   ∀stack x.
   (x+1 = LENGTH stack) ⇒
   LASTN (x+1) stack =
-  HD stack::LASTN x stack`,
+  HD stack::LASTN x stack
+Proof
   fs[LASTN_LENGTH_ID]>>Induct>>rw[]>>
   `x = LENGTH stack` by DECIDE_TAC>>
-  fs[LASTN_CONS,LASTN_LENGTH_ID])
+  fs[LASTN_CONS,LASTN_LENGTH_ID]
+QED
 
-val stack_rel_aux_LENGTH = Q.prove(`
+Triviality stack_rel_aux_LENGTH:
   ∀k len xs ys.
   stack_rel_aux k len xs ys ⇒
-  LENGTH xs = LENGTH ys`,
-  ho_match_mp_tac (theorem "stack_rel_aux_ind")>>fs[stack_rel_aux_def])
+  LENGTH xs = LENGTH ys
+Proof
+  ho_match_mp_tac (theorem "stack_rel_aux_ind")>>fs[stack_rel_aux_def]
+QED
 
-val LASTN_MORE = Q.prove(`
+Triviality LASTN_MORE:
   ∀ls n.
-  ¬(n < LENGTH ls) ⇒ LASTN n ls = ls`,
+  ¬(n < LENGTH ls) ⇒ LASTN n ls = ls
+Proof
   fs[LASTN_def]>>Induct>>rw[]>>
   Cases_on`n < LENGTH ls`>>
   fs[TAKE_APPEND1,LENGTH_REVERSE] >>
     res_tac>>
     fs[TAKE_APPEND]>>
     IF_CASES_TAC>>fs[]>>
-    DECIDE_TAC)
+    DECIDE_TAC
+QED
 
-val stack_rel_aux_LASTN = Q.prove(`
+Triviality stack_rel_aux_LASTN:
   ∀k len xs ys n.
   stack_rel_aux k len xs ys ⇒
-  stack_rel_aux k len (LASTN n xs) (LASTN n ys)`,
+  stack_rel_aux k len (LASTN n xs) (LASTN n ys)
+Proof
   ho_match_mp_tac (theorem "stack_rel_aux_ind")>>
   fs[stack_rel_aux_def]>>rw[]>>
   imp_res_tac stack_rel_aux_LENGTH
@@ -1994,12 +2115,14 @@ val stack_rel_aux_LASTN = Q.prove(`
     rename1 `LASTN m`>>
     Cases_on`m ≤ LENGTH xs`>>rfs[LASTN_CONS]>>
     `¬(m < SUC(LENGTH ys))` by DECIDE_TAC>>
-    fs[LASTN_MORE,stack_rel_aux_def])
+    fs[LASTN_MORE,stack_rel_aux_def]
+QED
 
-val abs_stack_to_stack_LENGTH = Q.prove(`
+Triviality abs_stack_to_stack_LENGTH:
   ∀bs wstack sstack lens stack.
   abs_stack bs wstack sstack lens = SOME stack ⇒
-  handler_val stack = LENGTH sstack`,
+  handler_val stack = LENGTH sstack
+Proof
   ho_match_mp_tac (theorem "abs_stack_ind")>>rw[]>>
   fs[abs_stack_def,LET_THM]>>TRY(Cases_on`w`)>>
   fs[full_read_bitmap_def]
@@ -2013,36 +2136,43 @@ val abs_stack_to_stack_LENGTH = Q.prove(`
     (pop_assum mp_tac>>
     ntac 7 TOP_CASE_TAC>>fs[]>>
     rw[]>>
-    simp[handler_val_def]))
+    simp[handler_val_def])
+QED
 
 (*Equality theorems available if n ≤ LENGTH ls*)
-val LASTN_LENGTH_BOUNDS = Q.prove(`
+Triviality LASTN_LENGTH_BOUNDS:
   ∀n ls.
   let xs = LASTN n ls in
   LENGTH xs ≤ n ∧
-  LENGTH xs ≤ LENGTH ls`,
+  LENGTH xs ≤ LENGTH ls
+Proof
   fs[LASTN_def,LET_THM]>>Induct>>fs[LENGTH_TAKE_EQ]>>rw[]>>
-  decide_tac)
+  decide_tac
+QED
 
-val LASTN_CONS_ID = Q.prove(`
+Triviality LASTN_CONS_ID:
   n = LENGTH ls ⇒
-  LASTN (SUC n) (frame::ls) = (frame::ls)`,
-  rw[]>>EVAL_TAC>>fs[])
+  LASTN (SUC n) (frame::ls) = (frame::ls)
+Proof
+  rw[]>>EVAL_TAC>>fs[]
+QED
 
 (*Strengthened version of LASTN_DROP after change to make it total*)
-val LASTN_DROP2 = Q.prove(`
+Triviality LASTN_DROP2:
   ∀l n.
-  LASTN n l = DROP (LENGTH l -n) l`,
+  LASTN n l = DROP (LENGTH l -n) l
+Proof
   Induct>>fs[LASTN_def]>>
   rw[TAKE_APPEND]>>
   Cases_on`n > LENGTH l`>>fs[ADD1]>>
   `LENGTH l - n = 0` by fs[]>>
-  simp[DROP_def]);
+  simp[DROP_def]
+QED
 
 (* Allow prefixes of (frames of) stacks to be directly dropped
   using handler_val
 *)
-val abs_stack_prefix_drop = Q.prove(`
+Triviality abs_stack_prefix_drop:
   ∀bs wstack sstack lens stack h wrest k len.
   h ≤ LENGTH wstack ∧
   LASTN h wstack = wrest ∧
@@ -2052,7 +2182,8 @@ val abs_stack_prefix_drop = Q.prove(`
   let lrest = LASTN h lens in
   let srest = LASTN (handler_val rest) sstack in
   abs_stack bs wrest srest lrest = SOME rest ∧
-  stack_rel_aux k len wrest rest`,
+  stack_rel_aux k len wrest rest
+Proof
   ho_match_mp_tac (theorem "abs_stack_ind")>>
   rpt strip_tac>>fs[LET_THM,abs_stack_def]
   >-
@@ -2125,12 +2256,14 @@ val abs_stack_prefix_drop = Q.prove(`
         imp_res_tac abs_stack_to_stack_LENGTH>>
         fs[Abbr`ls`,Abbr`frame`,handler_val_def]>>
         simp[LENGTH_TAKE])>>
-      fs[Abbr`frame`,Abbr`ls`,abs_stack_def,LET_THM,full_read_bitmap_def]);
+      fs[Abbr`frame`,Abbr`ls`,abs_stack_def,LET_THM,full_read_bitmap_def]
+QED
 
-val abs_stack_len = Q.prove(`
+Triviality abs_stack_len:
   ∀bs wstack sstack lens stack handler.
   abs_stack bs wstack sstack lens = SOME stack ⇒
-  handler_val (LASTN handler stack) ≤ LENGTH sstack`,
+  handler_val (LASTN handler stack) ≤ LENGTH sstack
+Proof
   ho_match_mp_tac (theorem "abs_stack_ind")>>rw[]>>
   fs[abs_stack_def,LET_THM]
   >-
@@ -2151,18 +2284,22 @@ val abs_stack_len = Q.prove(`
       `¬(handler < LENGTH x')` by (fs[]>>DECIDE_TAC)>>
       fs[LASTN_MORE]>>rw[]>>
       fs[LENGTH_TAKE_EQ]>>IF_CASES_TAC>>
-      DECIDE_TAC));
+      DECIDE_TAC)
+QED
 
-val EL_REVERSE_REWRITE = Q.prove(`
+Triviality EL_REVERSE_REWRITE:
   ∀l n k. n < LENGTH l ∧ k < n ⇒
-  EL (LENGTH l - n + k) l = EL (n-k -1) (REVERSE l)`,
-  rw[]>> fs[EL_REVERSE,PRE_SUB1]);
+  EL (LENGTH l - n + k) l = EL (n-k -1) (REVERSE l)
+Proof
+  rw[]>> fs[EL_REVERSE,PRE_SUB1]
+QED
 
-val LASTN_LESS = Q.prove(`
+Triviality LASTN_LESS:
   ∀ls n x xs.
   n+1 ≤ LENGTH ls ∧
   LASTN (n+1) ls = x::xs ⇒
-  LASTN n ls = xs`,
+  LASTN n ls = xs
+Proof
   Induct>>rw[]>>
   Cases_on`n+1 ≤ LENGTH ls`>>fs[]
   >-
@@ -2174,39 +2311,49 @@ val LASTN_LESS = Q.prove(`
   `n = LENGTH ls` by DECIDE_TAC>>
   `n+1 = LENGTH (h::ls)` by (fs[]>>DECIDE_TAC)>>
   imp_res_tac LASTN_LENGTH_ID2>>
-  fs[LASTN_CONS]);
+  fs[LASTN_CONS]
+QED
 
-val ALOOKUP_IFF_MEM = Q.prove(
-  `ALL_DISTINCT (MAP FST l) ==>
-    (ALOOKUP l q = SOME r <=> MEM (q,r) l)`,
-  Induct_on `l` \\ fs [FORALL_PROD,MEM_MAP] \\ rw [] \\ metis_tac []);
+Triviality ALOOKUP_IFF_MEM:
+  ALL_DISTINCT (MAP FST l) ==>
+    (ALOOKUP l q = SOME r <=> MEM (q,r) l)
+Proof
+  Induct_on `l` \\ fs [FORALL_PROD,MEM_MAP] \\ rw [] \\ metis_tac []
+QED
 
-val SORTED_CONS_IMP = Q.prove(
-  `SORTED (\x y. FST x > (FST y):num) (h::t) ==>
+Triviality SORTED_CONS_IMP:
+  SORTED (\x y. FST x > (FST y):num) (h::t) ==>
     ~(MEM h t) /\ SORTED (\x y. FST x > FST y) t /\
-    !x. MEM x t ==> FST h > FST x`,
+    !x. MEM x t ==> FST h > FST x
+Proof
   Induct_on `t` \\ fs [SORTED_DEF] \\ rw []
   \\ `SORTED (\x y. FST x > FST y) (h::t)` by
     (Cases_on `t` \\ fs [SORTED_DEF] \\ decide_tac)
   \\ fs [] \\ Cases_on `h` \\ Cases_on `h'` \\ fs []
-  \\ disj1_tac \\ decide_tac);
+  \\ disj1_tac \\ decide_tac
+QED
 
-val SORTED_IMP_ALL_DISTINCT_LEMMA = Q.prove(
-  `!l. SORTED (\x y. FST x > (FST y):num) l ==> ALL_DISTINCT (MAP FST l)`,
+Triviality SORTED_IMP_ALL_DISTINCT_LEMMA:
+  !l. SORTED (\x y. FST x > (FST y):num) l ==> ALL_DISTINCT (MAP FST l)
+Proof
   Induct \\ fs [] \\ rw [MEM_MAP]
-  \\ metis_tac [DECIDE ``m>n ==> m<>n:num``,SORTED_CONS_IMP]);
+  \\ metis_tac [DECIDE ``m>n ==> m<>n:num``,SORTED_CONS_IMP]
+QED
 
-val MEM_toAList_fromAList = Q.prove(
-  `SORTED (\x y. FST x > (FST y):num) l ==>
-    MEM a (toAList (fromAList l)) = MEM a l`,
+Triviality MEM_toAList_fromAList:
+  SORTED (\x y. FST x > (FST y):num) l ==>
+    MEM a (toAList (fromAList l)) = MEM a l
+Proof
   Cases_on `a` \\ fs [MEM_toAList,lookup_fromAList] \\ rw []
-  \\ imp_res_tac SORTED_IMP_ALL_DISTINCT_LEMMA \\ fs [ALOOKUP_IFF_MEM]);
+  \\ imp_res_tac SORTED_IMP_ALL_DISTINCT_LEMMA \\ fs [ALOOKUP_IFF_MEM]
+QED
 
-val SORTED_FST_PERM_IMP_ALIST_EQ = Q.prove(
-  `SORTED (\x y. FST x > FST y) l /\
+Triviality SORTED_FST_PERM_IMP_ALIST_EQ:
+  SORTED (\x y. FST x > FST y) l /\
     SORTED (\x y. FST x > FST y) q /\
     PERM (toAList (fromAList l)) q ==>
-    q = l`,
+    q = l
+Proof
   rw [] \\ drule MEM_PERM \\ fs [MEM_toAList_fromAList]
   \\ pop_assum kall_tac \\ rpt (pop_assum mp_tac)
   \\ Q.SPEC_TAC (`l`,`l`) \\ Induct_on `q` \\ fs [MEM]
@@ -2215,10 +2362,11 @@ val SORTED_FST_PERM_IMP_ALIST_EQ = Q.prove(
   \\ fs [] \\ rw []
   \\ imp_res_tac SORTED_CONS_IMP
   \\ `!m n:num. m > n /\ n > m ==> F` by decide_tac
-  \\ metis_tac []);
+  \\ metis_tac []
+QED
 
-val stack_rel_raise = Q.prove(`
-    n ≤ LENGTH sstack /\
+Triviality stack_rel_raise:
+  n ≤ LENGTH sstack /\
     handler+1 ≤ LENGTH wstack /\ SORTED (\x y. FST x > FST y) l /\
     LASTN (handler + 1) wstack = StackFrame m l (SOME (h1,l3,l4))::rest /\
     abs_stack bs wstack (DROP n sstack) lens = SOME stack /\
@@ -2238,7 +2386,8 @@ val stack_rel_raise = Q.prove(`
             ((NONE,payload) :: LASTN handler stack) /\
       abs_stack bs (StackFrame m (FST (env_to_list (fromAList l) (K I))) NONE::rest)
         (DROP (LENGTH sstack - handler_val (LASTN (handler+1) stack) + 3)
-           sstack) (LASTN (handler+1) lens) = SOME ((NONE,payload) :: LASTN handler stack)`,
+           sstack) (LASTN (handler+1) lens) = SOME ((NONE,payload) :: LASTN handler stack)
+Proof
   rw[]>>
   imp_res_tac abs_stack_prefix_drop>>
   fs[LET_THM]>>
@@ -2316,17 +2465,21 @@ val stack_rel_raise = Q.prove(`
   Cases_on`t'''`>>simp[]>>
   ntac 5 TOP_CASE_TAC>>
   rw[]>>
-  fs[abs_stack_def,LET_THM]);
+  fs[abs_stack_def,LET_THM]
+QED
 
-val EVERY_IMP_EVERY_LASTN = Q.prove(
-  `!xs ys P. EVERY P xs /\ LASTN n xs = ys ==> EVERY P ys`,
-  fs [EVERY_MEM] \\ rw [] \\ imp_res_tac MEM_LASTN_ALT \\ res_tac \\ fs []);
+Triviality EVERY_IMP_EVERY_LASTN:
+  !xs ys P. EVERY P xs /\ LASTN n xs = ys ==> EVERY P ys
+Proof
+  fs [EVERY_MEM] \\ rw [] \\ imp_res_tac MEM_LASTN_ALT \\ res_tac \\ fs []
+QED
 
-val LASTN_HD = Q.prove(`
+Triviality LASTN_HD:
   ∀ls x.
   x ≤ LENGTH ls ⇒
   HD (LASTN x ls) =
-  EL (LENGTH ls - x) ls`,
+  EL (LENGTH ls - x) ls
+Proof
   fs[LASTN_def]>>
   Induct>>rw[]>>
   Cases_on`x = SUC(LENGTH ls)`
@@ -2335,7 +2488,8 @@ val LASTN_HD = Q.prove(`
   >>
     `x ≤ LENGTH ls` by DECIDE_TAC>>fs[TAKE_APPEND1]>>
     `SUC (LENGTH ls) -x = SUC(LENGTH ls - x)` by DECIDE_TAC>>
-    simp[])
+    simp[]
+QED
 
 Theorem insert_bitmap_isPREFIX:
    ∀bs bs' i.
@@ -2370,13 +2524,15 @@ Proof
   \\ metis_tac[IS_PREFIX_TRANS,wLive_isPREFIX,insert_bitmap_isPREFIX]
 QED
 
-val compile_prog_isPREFIX = Q.prove(
-  `compile_prog x y k bs = (prog,fs,bs1) ==>
-  append (FST bs) ≼ append (FST bs1)`,
+Triviality compile_prog_isPREFIX:
+  compile_prog x y k bs = (prog,fs,bs1) ==>
+  append (FST bs) ≼ append (FST bs1)
+Proof
   fs [compile_prog_def,LET_THM] \\ rw []
   \\ pairarg_tac \\ fs []
   \\ imp_res_tac comp_IMP_isPREFIX
-  \\ imp_res_tac IS_PREFIX_TRANS \\ fs []);
+  \\ imp_res_tac IS_PREFIX_TRANS \\ fs []
+QED
 
 Theorem compile_word_to_stack_isPREFIX:
   ∀code k bs progs1 fs1 bs1.
@@ -2953,11 +3109,13 @@ Proof
   metis_tac[]
 QED
 
-val compile_result_NOT_2 = Q.prove(
-  `good_dimindex (:'a) ==>
-    compile_result x ≠ Halt (Word (2w:'a word))`,
+Triviality compile_result_NOT_2:
+  good_dimindex (:'a) ==>
+    compile_result x ≠ Halt (Word (2w:'a word))
+Proof
   Cases_on `x` \\ fs [compile_result_def]
-  \\ rw [good_dimindex_def] \\ fs [dimword_def]);
+  \\ rw [good_dimindex_def] \\ fs [dimword_def]
+QED
 
 Theorem MAP_o_THE_FILTER_IS_SOME:
    MAP (f o THE) (FILTER IS_SOME ls) =
@@ -2979,12 +3137,13 @@ Proof
   simp[MAP_EQ_f,MEM_FILTER,IS_SOME_EXISTS,PULL_EXISTS]
 QED
 
-val TIMES2_DIV2_lemma = Q.prove(
-  `windmill moves ∧
+Triviality TIMES2_DIV2_lemma:
+  windmill moves ∧
    EVERY EVEN (MAP FST moves) ∧
    EVERY EVEN (MAP SND moves) ⇒
    MAP ($* 2 o THE) (FILTER IS_SOME (MAP FST (parmove (MAP (DIV2 ## DIV2) moves))))
-    = MAP THE (FILTER IS_SOME (MAP FST (parmove moves)))`,
+    = MAP THE (FILTER IS_SOME (MAP FST (parmove moves)))
+Proof
   strip_tac
   \\ simp[MAP_o_THE_FILTER_IS_SOME]
   \\ simp[GSYM MAP_MAP_o]
@@ -3008,7 +3167,8 @@ val TIMES2_DIV2_lemma = Q.prove(
   \\ `MEM x (MAP FST moves)` suffices_by metis_tac[EVERY_MEM]
   \\ match_mp_tac MEM_MAP_FST_parmove
   \\ simp[MEM_MAP,EXISTS_PROD]
-  \\ metis_tac[]);
+  \\ metis_tac[]
+QED
 
 Theorem PAIR_MAP_SOME_SWAP:
    (SOME ## SOME) o (f ## g) = (OPTION_MAP f ## OPTION_MAP g) o (SOME ## SOME)
@@ -3022,14 +3182,15 @@ Proof
   simp[FUN_EQ_THM] \\ Cases \\ simp[]
 QED
 
-val parsem_parmove_DIV2_lemma = Q.prove(
-  `windmill moves ∧
+Triviality parsem_parmove_DIV2_lemma:
+  windmill moves ∧
    EVERY EVEN (MAP FST moves) ∧
    EVERY EVEN (MAP SND moves) ⇒
    MAP (parsem (MAP (SOME ## SOME) (MAP (DIV2 ## DIV2) moves)) r)
       (FILTER IS_SOME (MAP FST (parmove (MAP (DIV2 ## DIV2) moves)))) =
    (MAP (parsem (MAP (SOME ## SOME) moves) (r o OPTION_MAP DIV2))
-     (FILTER IS_SOME (MAP FST (parmove moves))))`,
+     (FILTER IS_SOME (MAP FST (parmove moves))))
+Proof
   rw[]
   \\ drule(Q.ISPEC`DIV2`(Q.GEN`f`(ONCE_REWRITE_RULE[CONJ_COMM]parmove_MAP_INJ)))
   \\ impl_tac
@@ -3070,7 +3231,8 @@ val parsem_parmove_DIV2_lemma = Q.prove(
   \\ fs[MEM_MAP]
   \\ disch_then drule
   \\ simp[] \\ disch_then kall_tac
-  \\ rveq \\ fs[]);
+  \\ rveq \\ fs[]
+QED
 
 Theorem ALOOKUP_MAP_any:
    ∀f k h ls a x.
@@ -3227,11 +3389,13 @@ Proof
   \\ IF_CASES_TAC \\ fs[]
 QED
 
-val wf_fromList2 = Q.prove(`
-  ∀ls. wf(fromList2 ls)`,
+Triviality wf_fromList2:
+  ∀ls. wf(fromList2 ls)
+Proof
   ho_match_mp_tac SNOC_INDUCT>>
   fs[fromList2_def,FOLDL_SNOC,wf_def]>>rw[]>>
-  pairarg_tac>>fs[wf_insert])
+  pairarg_tac>>fs[wf_insert]
+QED
 
 Theorem wStackLoad_append:
    wStackLoad (l1 ++ l2) = wStackLoad l1 o (wStackLoad l2)
@@ -4695,11 +4859,12 @@ Proof
 QED
 
 (*For calls*)
-val get_vars_fromList2_eq = Q.prove(`
-    get_vars (GENLIST (λx. 2*x) (LENGTH args)) s = SOME x ∧
+Triviality get_vars_fromList2_eq:
+  get_vars (GENLIST (λx. 2*x) (LENGTH args)) s = SOME x ∧
     lookup n (fromList2 x) = SOME y ⇒
-    lookup n s.locals = SOME y`,
-    rw[]>>imp_res_tac get_vars_eq>>
+    lookup n s.locals = SOME y
+Proof
+  rw[]>>imp_res_tac get_vars_eq>>
     fs[lookup_fromList2,lookup_fromList,LET_THM]>>
     fs[EVERY_MAP,EVERY_GENLIST,MAP_GENLIST]>>rfs[EL_GENLIST]>>
     qpat_x_assum`A=y` sym_sub_tac>>
@@ -4709,13 +4874,15 @@ val get_vars_fromList2_eq = Q.prove(`
     Q.ISPECL_THEN [`2n`] assume_tac DIVISION>>fs[]>>
     pop_assum(qspec_then`n` assume_tac)>>
     fs[EVEN_MOD2]>>
-    simp[]);
+    simp[]
+QED
 
 (*For returning calls*)
-val get_vars_fromList2_eq_cons = Q.prove(`
-    get_vars (GENLIST (λx. 2*(x+1)) (LENGTH args)) s = SOME x ∧
+Triviality get_vars_fromList2_eq_cons:
+  get_vars (GENLIST (λx. 2*(x+1)) (LENGTH args)) s = SOME x ∧
     lookup n (fromList2 (Loc x3 x4::x)) = SOME y ∧ n ≠ 0 ⇒
-    lookup n s.locals = SOME y`,
+    lookup n s.locals = SOME y
+Proof
   rw[]>>imp_res_tac get_vars_eq>>
   fs[lookup_fromList2,lookup_fromList,LET_THM]>>
   Cases_on`n`>>fs[]>>
@@ -4730,17 +4897,20 @@ val get_vars_fromList2_eq_cons = Q.prove(`
   fs[ADD1]>>
   Q.ISPECL_THEN [`2n`] assume_tac DIVISION>>fs[]>>
   pop_assum(qspec_then`n` assume_tac)>>
-  fs[EVEN_MOD2]>>simp[])
+  fs[EVEN_MOD2]>>simp[]
+QED
 
-val lookup_fromList2_prefix = Q.prove(`
+Triviality lookup_fromList2_prefix:
   ∀x z y.
   IS_PREFIX z x ∧
   lookup n (fromList2 x) = SOME y ⇒
-  lookup n (fromList2 z) = SOME y`,
+  lookup n (fromList2 z) = SOME y
+Proof
   fs[lookup_fromList2,lookup_fromList]>>rw[]>>
   imp_res_tac IS_PREFIX_LENGTH >- DECIDE_TAC>>
   fs[IS_PREFIX_APPEND]>>
-  fs[EL_APPEND1])
+  fs[EL_APPEND1]
+QED
 
 Theorem list_max_APPEND:
     ∀a b.
@@ -4788,7 +4958,7 @@ Proof
   EVERY_CASE_TAC>>fs[]
 QED
 
-val evaluate_wStackLoad_wReg1 = Q.prove(`
+Triviality evaluate_wStackLoad_wReg1:
   wReg1 r (k,f,f') = (x ,r') ∧
   EVEN r ∧
   get_var r (s:('a,num # 'c,'ffi)state) = SOME (Word c) ∧
@@ -4799,7 +4969,8 @@ val evaluate_wStackLoad_wReg1 = Q.prove(`
   state_rel k f f' s t' lens ∧
   LENGTH t'.stack = LENGTH t.stack /\ t'.stack_space = t.stack_space /\
   r' ≠ k+1 ∧
-  get_var r' t' = SOME (Word c)`,
+  get_var r' t' = SOME (Word c)
+Proof
   rw[wReg1_def,LET_THM,EVEN_EXISTS]>>
   fs[wStackLoad_def,stackSemTheory.evaluate_def,LET_THM,stackSemTheory.get_var_def]>>simp[]>-
     (imp_res_tac state_rel_get_var_imp>>
@@ -4813,16 +4984,19 @@ val evaluate_wStackLoad_wReg1 = Q.prove(`
   imp_res_tac state_rel_get_var_imp2>>
   fs[]>>
   simp[stackSemTheory.set_var_def,FLOOKUP_UPDATE]>>
-  fs[TWOxDIV2])
+  fs[TWOxDIV2]
+QED
 
-val evaluate_wStackLoad_clock = Q.prove(`
+Triviality evaluate_wStackLoad_clock:
   ∀x t.
   evaluate(wStackLoad x Skip,t with clock:= clk) =
   (FST (evaluate(wStackLoad x Skip,t)),
-   (SND (evaluate(wStackLoad x Skip,t))) with clock:=clk)`,
-  Induct>>fs[wStackLoad_def,FORALL_PROD,stackSemTheory.evaluate_def,LET_THM]>>rw[])
+   (SND (evaluate(wStackLoad x Skip,t))) with clock:=clk)
+Proof
+  Induct>>fs[wStackLoad_def,FORALL_PROD,stackSemTheory.evaluate_def,LET_THM]>>rw[]
+QED
 
-val evaluate_wStackLoad_wRegImm2 = Q.prove(`
+Triviality evaluate_wStackLoad_wRegImm2:
   wRegImm2 ri (k,f,f') = (x,r') ∧
   (case ri of Reg r => EVEN r | _ => T) ∧
   get_var_imm ri (s:('a,num # 'c,'ffi)state) = SOME (Word c) ∧
@@ -4833,7 +5007,8 @@ val evaluate_wStackLoad_wRegImm2 = Q.prove(`
   get_var_imm r' t' = SOME(Word c) ∧
   (∀r. r ≠ k+1 ⇒ get_var r t' = get_var r t) ∧
   state_rel k f f' s t' lens ∧
-  LENGTH t'.stack = LENGTH t.stack /\ t'.stack_space = t.stack_space`,
+  LENGTH t'.stack = LENGTH t.stack /\ t'.stack_space = t.stack_space
+Proof
   Cases_on`ri`>>rw[wRegImm2_def,LET_THM,wReg2_def,EVEN_EXISTS]>>
   fs[wStackLoad_def,stackSemTheory.evaluate_def,LET_THM,stackSemTheory.get_var_def,stackSemTheory.get_var_imm_def,get_var_imm_def]>>simp[]>-
     (imp_res_tac state_rel_get_var_imp>>
@@ -4847,38 +5022,45 @@ val evaluate_wStackLoad_wRegImm2 = Q.prove(`
   imp_res_tac state_rel_get_var_imp2>>
   fs[]>>
   simp[stackSemTheory.set_var_def,FLOOKUP_UPDATE]>>
-  fs[TWOxDIV2])
+  fs[TWOxDIV2]
+QED
 
-val evaluate_call_dest_clock = Q.prove(`
+Triviality evaluate_call_dest_clock:
   call_dest dest args (k,f,f') = (q0,dest') ⇒
   evaluate(q0,t with clock := clk) =
   (FST(evaluate(q0,t:('a,'c,'ffi)stackSem$state)),
-   (SND(evaluate(q0,t))) with clock := clk)`,
+   (SND(evaluate(q0,t))) with clock := clk)
+Proof
   Cases_on`dest`>>fs[call_dest_def,LET_THM]>>rw[]>>
   simp[stackSemTheory.evaluate_def]>>
-  pairarg_tac>>fs[]>>rveq>>fs[evaluate_wStackLoad_clock])
+  pairarg_tac>>fs[]>>rveq>>fs[evaluate_wStackLoad_clock]
+QED
 
-val evaluate_wLive_clock = Q.prove(`
+Triviality evaluate_wLive_clock:
   ∀x t q bs bs'.
   wLive x bs kf = (q,bs') ⇒
   evaluate(q, t with clock:= clk) =
   (FST (evaluate(q,t:('a,'c,'ffi)stackSem$state)),
-   (SND (evaluate(q,t)) with clock:=clk))`,
+   (SND (evaluate(q,t)) with clock:=clk))
+Proof
   PairCases_on`kf`>>fs[wLive_def,LET_THM]>>rw[]
   >-
     simp[stackSemTheory.evaluate_def]
   >>
     pairarg_tac>>fs[]>>rveq>>
     simp[stackSemTheory.evaluate_def,FORALL_PROD,stackSemTheory.inst_def,stackSemTheory.assign_def,stackSemTheory.set_var_def,stackSemTheory.word_exp_def,empty_env_def,stackSemTheory.get_var_def]>>
-    EVERY_CASE_TAC>>fs[])
+    EVERY_CASE_TAC>>fs[]
+QED
 
-val state_rel_IMP_LENGTH = Q.prove(`
+Triviality state_rel_IMP_LENGTH:
   state_rel k f f' s t lens ⇒
-  LENGTH lens = LENGTH s.stack`,
+  LENGTH lens = LENGTH s.stack
+Proof
   fs[state_rel_def,stack_rel_def,LET_THM]>>rw[]>>
-  metis_tac[abs_stack_IMP_LENGTH])
+  metis_tac[abs_stack_IMP_LENGTH]
+QED
 
-val evaluate_stack_move = Q.prove(`
+Triviality evaluate_stack_move:
   ∀n tar t offset.
   t.use_stack ∧
   t.stack_space + tar + n + offset ≤ LENGTH t.stack ∧
@@ -4898,7 +5080,8 @@ val evaluate_stack_move = Q.prove(`
   (*Copying the first frame*)
   let stack = DROP (t'.stack_space+tar) t'.stack in
   ∀x. x < n ⇒
-  EL x stack = EL (x+offset) stack`,
+  EL x stack = EL (x+offset) stack
+Proof
   Induct>>fsrw_tac[][stack_move_def,stackSemTheory.evaluate_def]>-
     simp[stackSemTheory.state_component_equality]>>
   ntac 4 strip_tac>>
@@ -4924,12 +5107,14 @@ val evaluate_stack_move = Q.prove(`
       simp[]>>
     fs[LET_THM]>>
     first_x_assum(qspec_then`x-1` mp_tac)>>
-    simp[EL_DROP])
+    simp[EL_DROP]
+QED
 
-val evaluate_stack_move_seq = Q.prove(`
+Triviality evaluate_stack_move_seq:
   ∀a b c d prog (t:('a,'c,'ffi)stackSem$state).
   evaluate (stack_move a b c d prog,t) =
-  evaluate (Seq prog (stack_move a b c d Skip),t)`,
+  evaluate (Seq prog (stack_move a b c d Skip),t)
+Proof
   Induct>>rw[]>>fs[stack_move_def,LET_THM]
   >-
     (simp[stackSemTheory.evaluate_def]>>
@@ -4941,7 +5126,8 @@ val evaluate_stack_move_seq = Q.prove(`
     rpt(pairarg_tac>>fs[])>>
     rpt (pop_assum mp_tac)>>
     IF_CASES_TAC>>fs[]>>
-    rpt IF_CASES_TAC>>fs[]);
+    rpt IF_CASES_TAC>>fs[]
+QED
 
 val evaluate_stack_move_clock = Q.prove(`
   ∀a b c d (t:('a,'c,'ffi)stackSem$state).
@@ -4955,14 +5141,17 @@ val evaluate_stack_move_clock = Q.prove(`
   (*get_var_set_var?*)
   fs[stackSemTheory.get_var_def,stackSemTheory.set_var_def,FLOOKUP_UPDATE])|>SIMP_RULE arith_ss [LET_THM];
 
-val pop_env_ffi = Q.prove(`
+Triviality pop_env_ffi:
   pop_env s = SOME s' ⇒
-  s.ffi = s'.ffi`,
-  fs[pop_env_def]>>EVERY_CASE_TAC>>fs[state_component_equality]);
+  s.ffi = s'.ffi
+Proof
+  fs[pop_env_def]>>EVERY_CASE_TAC>>fs[state_component_equality]
+QED
 
-val stack_rel_DROP_NONE = Q.prove(`
+Triviality stack_rel_DROP_NONE:
   stack_rel k whandler (StackFrame n l NONE::wstack) shandler sstack len bs (f'::lens) ⇒
-  stack_rel k whandler wstack shandler (DROP (f'+1) sstack) len bs lens`,
+  stack_rel k whandler wstack shandler (DROP (f'+1) sstack) len bs lens
+Proof
   simp[stack_rel_def]>>rw[]>>
   Cases_on`sstack`>>fs[abs_stack_def]>>qpat_x_assum`A=SOME stack` mp_tac>>
   rpt (TOP_CASE_TAC>>simp[])>>
@@ -4972,11 +5161,13 @@ val stack_rel_DROP_NONE = Q.prove(`
   `SUC (LENGTH wstack) - (whandler+1) = SUC(LENGTH wstack - (whandler +1))` by DECIDE_TAC>>
   simp[]>>rw[]>>
   imp_res_tac abs_stack_IMP_LENGTH>>
-  simp[LASTN_CONS]);
+  simp[LASTN_CONS]
+QED
 
-val stack_rel_DROP_SOME = Q.prove(`
+Triviality stack_rel_DROP_SOME:
   stack_rel k whandler (StackFrame n l (SOME (whandler',b,c))::wstack) shandler sstack len bs (f'::lens) ⇒
-  stack_rel k whandler' wstack (SOME(EL 2 sstack)) (DROP (f'+4) sstack) len bs lens`,
+  stack_rel k whandler' wstack (SOME(EL 2 sstack)) (DROP (f'+4) sstack) len bs lens
+Proof
   simp[stack_rel_def]>>rw[]>>
   Cases_on`sstack`>>fs[abs_stack_def]>>qpat_x_assum`A=SOME stack` mp_tac>>
   rpt (TOP_CASE_TAC>>simp[])>>
@@ -4984,28 +5175,35 @@ val stack_rel_DROP_SOME = Q.prove(`
   qpat_x_assum`P ⇒A=B` mp_tac>>
   simp[]>>
   imp_res_tac abs_stack_IMP_LENGTH>>
-  simp[]);
+  simp[]
+QED
 
-val LAST_GENLIST_evens = Q.prove(`
+Triviality LAST_GENLIST_evens:
   n ≠ 0 ⇒
   let reg = LAST (GENLIST (λx. 2 * (x+1)) n) in
-  reg ≠ 0 ∧ EVEN reg`,
+  reg ≠ 0 ∧ EVEN reg
+Proof
   Cases_on`n`>>
   simp[LAST_EL,GENLIST_CONS]>>
   `0 < 2n` by DECIDE_TAC>>
-  metis_tac[EVEN_MOD2,MULT_COMM,MOD_EQ_0]);
+  metis_tac[EVEN_MOD2,MULT_COMM,MOD_EQ_0]
+QED
 
-val stack_rel_cons_LEN_NONE = Q.prove(`
+Triviality stack_rel_cons_LEN_NONE:
   stack_rel k whandler (StackFrame n l NONE::wstack) shandler sstack len bs (f'::lens) ⇒
-  f'+1 ≤ LENGTH sstack`,
+  f'+1 ≤ LENGTH sstack
+Proof
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
-  rpt TOP_CASE_TAC>>simp[])
+  rpt TOP_CASE_TAC>>simp[]
+QED
 
-val stack_rel_cons_LEN_SOME = Q.prove(`
+Triviality stack_rel_cons_LEN_SOME:
   stack_rel k whandler (StackFrame n l (SOME(a,b,c))::wstack) shandler sstack len bs (f'::lens) ⇒
-  f'+4 ≤ LENGTH sstack`,
+  f'+4 ≤ LENGTH sstack
+Proof
   simp[stack_rel_def]>>Cases_on`sstack`>>simp[abs_stack_def]>>
-  rpt TOP_CASE_TAC>>simp[]);
+  rpt TOP_CASE_TAC>>simp[]
+QED
 
 Theorem stack_rel_cons_locals_size:
   stack_rel k whandler (StackFrame n l opt::t'')
@@ -5028,23 +5226,27 @@ Proof
  rw[OPTION_MAP2_DEF]
 QED
 
-val DROP_SUB = Q.prove(`
+Triviality DROP_SUB:
   a ≤ LENGTH ls ∧ b ≤ a ⇒
-  DROP (a-b) ls = (DROP(a-b) (TAKE a ls))++ DROP a ls`,
+  DROP (a-b) ls = (DROP(a-b) (TAKE a ls))++ DROP a ls
+Proof
   rw[]>>
   Q.ISPECL_THEN[`a`,`ls`] mp_tac(GSYM TAKE_DROP)>>
   disch_then SUBST_ALL_TAC>>
-  simp[GSYM DROP_APPEND1]);
+  simp[GSYM DROP_APPEND1]
+QED
 
-val DROP_SUB2 = Q.prove(`
+Triviality DROP_SUB2:
   ∀a ls b.
   b ≤ a ∧
   a = LENGTH ls ⇒
   ∃rest.
-  DROP (a-b) ls = rest ∧ LENGTH rest = b`,
+  DROP (a-b) ls = rest ∧ LENGTH rest = b
+Proof
   Induct>>
   fs[]>>rw[]>>
-  simp[]);
+  simp[]
+QED
 
 val evaluate_PushHandler = Q.prove(`
   3 ≤ t.stack_space ∧
@@ -5193,42 +5395,52 @@ val evaluate_PushHandler_clock = Q.prove(`
   TOP_CASE_TAC>>fs[empty_env_def,FLOOKUP_UPDATE]>>
   rpt(TOP_CASE_TAC>>fs[]))|>SIMP_RULE arith_ss [LET_THM];
 
-val evaluate_PopHandler_clock = Q.prove(`
+Triviality evaluate_PopHandler_clock:
   ∀(t:('a,'c,'ffi)stackSem$state).
   let prog = PopHandler (k,f:num,f':num) Skip in
   evaluate (prog,t with clock:=clk) =
   (FST (evaluate(prog,t:('a,'c,'ffi)stackSem$state)),
-   (SND (evaluate(prog,t)) with clock:=clk))`,
+   (SND (evaluate(prog,t)) with clock:=clk))
+Proof
   simp[stackSemTheory.evaluate_def,PopHandler_def,stackSemTheory.set_var_def,stackSemTheory.get_var_def,stackSemTheory.set_store_def,empty_env_def]>>rw[]>>
   EVERY_CASE_TAC>>fs[]>>
-  EVERY_CASE_TAC>>fs[]);
+  EVERY_CASE_TAC>>fs[]
+QED
 
-val evaluate_PopHandler_seq = Q.prove(`
+Triviality evaluate_PopHandler_seq:
   ∀prog (t:('a,'c,'ffi)stackSem$state).
   evaluate (PopHandler (k,f,f') prog,t) =
-  evaluate (Seq (PopHandler (k,f,f') Skip) prog,t)`,
+  evaluate (Seq (PopHandler (k,f,f') Skip) prog,t)
+Proof
   simp[stackSemTheory.evaluate_def,PopHandler_def]>>
   rw[]>>EVERY_CASE_TAC>>fs[]>>
-  EVERY_CASE_TAC>>fs[]);
+  EVERY_CASE_TAC>>fs[]
+QED
 
-val word_cmp_Word_Word = Q.prove(
-  `word_cmp cmp (Word c) (Word c') = SOME (word_cmp cmp c c')`,
+Triviality word_cmp_Word_Word:
+  word_cmp cmp (Word c) (Word c') = SOME (word_cmp cmp c c')
+Proof
   Cases_on `cmp`
-  \\ rw [labSemTheory.word_cmp_def,asmTheory.word_cmp_def]);
+  \\ rw [labSemTheory.word_cmp_def,asmTheory.word_cmp_def]
+QED
 
-val ALL_DISTINCT_MEM_toAList_fromAList = Q.prove(`
+Triviality ALL_DISTINCT_MEM_toAList_fromAList:
   ALL_DISTINCT (MAP FST ls) ⇒
   (MEM x (toAList (fromAList ls)) ⇔
-  MEM x ls)`,
+  MEM x ls)
+Proof
   Cases_on`x`>>fs[MEM_toAList,lookup_fromAList]>>
   rw[]>>
-  metis_tac[ALOOKUP_MEM,ALOOKUP_ALL_DISTINCT_MEM]);
+  metis_tac[ALOOKUP_MEM,ALOOKUP_ALL_DISTINCT_MEM]
+QED
 
-val state_rel_code_domain = Q.prove(`
+Triviality state_rel_code_domain:
   state_rel k f f' s t lens ⇒
-  domain s.code ⊆ domain t.code`,
+  domain s.code ⊆ domain t.code
+Proof
   strip_tac>>fs[state_rel_def,SUBSET_DEF,domain_lookup,EXISTS_PROD]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Theorem get_labels_wStackLoad:
    !xs p. get_labels (wStackLoad xs p) = get_labels p
@@ -5328,7 +5540,7 @@ Proof
   \\ fs[]
 QED
 
-val compile_word_to_stack_IMP_ALOOKUP = Q.prove(`
+Triviality compile_word_to_stack_IMP_ALOOKUP:
   !code k bs i progs fs bs' i' n arg_count word_prog x.
     compile_word_to_stack k code (bs,i) = (progs,fs,bs',i') /\
     ALOOKUP code n = SOME (arg_count,word_prog) /\
@@ -5338,7 +5550,8 @@ val compile_word_to_stack_IMP_ALOOKUP = Q.prove(`
       compile_prog word_prog arg_count k (bs,i) = (stack_prog,f,(bs2,i2)) ∧
       LENGTH (append bs) ≤ i ∧ i - LENGTH (append bs) ≤ LENGTH x ∧
       isPREFIX (append bs2) (DROP (i - LENGTH (append bs)) x) ∧
-      ALOOKUP progs n = SOME stack_prog`,
+      ALOOKUP progs n = SOME stack_prog
+Proof
   Induct \\ fs [] \\ strip_tac \\ PairCases_on `h`
   \\ fs [compile_word_to_stack_def] \\ rw [] \\ fs [LET_THM]
   \\ pairarg_tac \\ fs []
@@ -5352,7 +5565,7 @@ val compile_word_to_stack_IMP_ALOOKUP = Q.prove(`
   \\ asm_exists_tac \\ fs []
   \\ drule compile_prog_LENGTH
   \\ rw[] \\ fs[]
-  );
+QED
 
 val goal = ``
    λ(prog:'a wordLang$prog,s:('a,num # 'c,'ffi) wordSem$state).
@@ -9276,9 +9489,11 @@ Proof
     comp_FFI_correct, comp_OpCurrHeap_correct, comp_Call_correct,comp_ShareInst_correct]
 QED
 
-val evaluate_Seq_Skip = Q.prove(
-  `stackSem$evaluate (Seq Skip p,s) = evaluate (p,s)`,
-  fs [stackSemTheory.evaluate_def,LET_THM]);
+Triviality evaluate_Seq_Skip:
+  stackSem$evaluate (Seq Skip p,s) = evaluate (p,s)
+Proof
+  fs [stackSemTheory.evaluate_def,LET_THM]
+QED
 
 val comp_Call_lemma = comp_correct
   |> Q.SPEC `Call NONE (SOME start) [0] NONE`
@@ -9290,8 +9505,8 @@ val comp_Call_lemma = comp_correct
        EVAL  ``flat_exp_conventions (Call NONE (SOME start) [0] NONE)``,
        wordLangTheory.max_var_def,LET_DEF,MAX_DEF] |> GEN_ALL
 
-val comp_Call = Q.prove(
-  `∀start (s:('a,num # 'c,'ffi) wordSem$state) k res s1 t lens.
+Triviality comp_Call:
+  ∀start (s:('a,num # 'c,'ffi) wordSem$state) k res s1 t lens.
       evaluate (Call NONE (SOME start) [0] NONE,s) = (res,s1) /\
       res ≠ SOME Error /\ state_rel k 0 0 s t lens ⇒
       ∃ck t1:(α,'c,'ffi)stackSem$state res1.
@@ -9302,7 +9517,8 @@ val comp_Call = Q.prove(
         else
           res1 = SOME (Halt (Word 2w)) /\
           t1.ffi.io_events ≼ s1.ffi.io_events /\
-          the (s1.stack_limit + 1) s1.stack_max > s1.stack_limit`,
+          the (s1.stack_limit + 1) s1.stack_max > s1.stack_limit
+Proof
   rw [] \\ drule comp_Call_lemma \\ fs [get_labels_def]
   \\ disch_then drule
   \\ disch_then(qspecl_then[`LENGTH t.bitmaps`,`Nil`] mp_tac)
@@ -9312,7 +9528,8 @@ val comp_Call = Q.prove(
   \\ asm_exists_tac \\ fs []
   \\ conj_tac THEN1 (fs [state_rel_def,good_dimindex_def,dimword_def])
   \\ IF_CASES_TAC \\ fs []
-  \\ every_case_tac \\ fs [state_rel_def,push_locals_def,LET_DEF]);
+  \\ every_case_tac \\ fs [state_rel_def,push_locals_def,LET_DEF]
+QED
 
 Theorem state_rel_with_clock:
    state_rel a 0 0 s t lens ⇒ state_rel a 0 0 (s with clock := k) (t with clock := k) lens
@@ -9599,8 +9816,8 @@ Definition make_init_def:
      ; locals_size := SOME 0|>
 End ;
 
-val init_state_ok_IMP_state_rel = Q.prove(
-  `lookup raise_stub_location t.code = SOME (raise_stub k) /\
+Triviality init_state_ok_IMP_state_rel:
+  lookup raise_stub_location t.code = SOME (raise_stub k) /\
    lookup store_consts_stub_location t.code = SOME (store_consts_stub k) /\
     (!n word_prog arg_count.
        (lookup n code = SOME (arg_count,word_prog)) ==>
@@ -9614,8 +9831,9 @@ val init_state_ok_IMP_state_rel = Q.prove(
     domain t.code =
       raise_stub_location INSERT store_consts_stub_location INSERT domain code ∧
     init_state_ok k t coracle ==>
-    state_rel k 0 0 (make_init k t code coracle) (t:('a,'c,'ffi)stackSem$state) []`,
-   fs [state_rel_def,make_init_def,LET_DEF,lookup_def,init_state_ok_def]
+    state_rel k 0 0 (make_init k t code coracle) (t:('a,'c,'ffi)stackSem$state) []
+Proof
+  fs [state_rel_def,make_init_def,LET_DEF,lookup_def,init_state_ok_def]
    \\ strip_tac
    \\ conj_tac>-
      (rw[] >> res_tac >>
@@ -9633,7 +9851,8 @@ val init_state_ok_IMP_state_rel = Q.prove(
    \\ qmatch_asmsub_abbrev_tac `a1 = [a2]`
    \\ `LENGTH a1 = 1` by simp[]
    \\ unabbrev_all_tac
-   \\ fs[LENGTH_DROP]);
+   \\ fs[LENGTH_DROP]
+QED
 
 val init_state_ok_semantics =
   state_rel_IMP_semantics |> Q.INST [`s`|->`make_init k t code coracle`]
@@ -9923,12 +10142,14 @@ Proof
   \\ metis_tac[PAIR]
 QED
 
-val stack_move_no_labs = Q.prove(`
+Triviality stack_move_no_labs:
   ∀n a b c p.
   extract_labels p = [] ⇒
-  extract_labels (stack_move n a b c p) = []`,
+  extract_labels (stack_move n a b c p) = []
+Proof
   Induct>>rw[stack_move_def]>>
-  EVAL_TAC>>metis_tac[])
+  EVAL_TAC>>metis_tac[]
+QED
 
 Theorem word_to_stack_lab_pres:
   ∀p bs kf.
@@ -10056,40 +10277,46 @@ Proof
   \\ ntac 2 strip_tac \\ fs[]
 QED
 
-val EVEN_DIV_2_props = Q.prove(`
+Triviality EVEN_DIV_2_props:
   a MOD 2 = 0 ∧ b MOD 2 = 0 ⇒
-  (a ≠ b ⇒ a DIV 2 ≠ b DIV 2) ∧ (a ≠ 0 ⇒ a DIV 2 ≠ 0)`,
+  (a ≠ b ⇒ a DIV 2 ≠ b DIV 2) ∧ (a ≠ 0 ⇒ a DIV 2 ≠ 0)
+Proof
   strip_tac
   \\ qspec_then `a` strip_assume_tac (MATCH_MP DIVISION (DECIDE ``0<2n``))
   \\ qpat_x_assum `a = _` (fn th => once_rewrite_tac [th])
   \\ qspec_then `b` strip_assume_tac (MATCH_MP DIVISION (DECIDE ``0<2n``))
   \\ qpat_x_assum `b = _` (fn th => once_rewrite_tac [th])
-  \\ asm_simp_tac std_ss [DIV_MULT] \\ fs []);
+  \\ asm_simp_tac std_ss [DIV_MULT] \\ fs []
+QED
 
 val wconvs = [post_alloc_conventions_def,wordPropsTheory.full_inst_ok_less_def,call_arg_convention_def,wordLangTheory.every_var_def,wordLangTheory.every_stack_var_def]
 
-val call_dest_stack_asm_name = Q.prove(`
+Triviality call_dest_stack_asm_name:
   call_dest d a k = (q0,d') ⇒
   stack_asm_name c q0 ∧
   case d' of
     INR r => r ≤ (FST k)+1
-  | INL l => T`,
+  | INL l => T
+Proof
   Cases_on`d`>>EVAL_TAC>>rw[]>>
   EVAL_TAC>>
   pairarg_tac>>fs[]>>
   pop_assum mp_tac>>PairCases_on`k`>>
   EVAL_TAC>>rw[]>>
-  EVAL_TAC>>rw[])
+  EVAL_TAC>>rw[]
+QED
 
-val wLive_stack_asm_name = Q.prove(`
+Triviality wLive_stack_asm_name:
   (FST kf)+1 < c.reg_count - LENGTH c.avoid_regs ∧
   wLive q bs kf = (q1,bs') ⇒
-  stack_asm_name c q1`,
+  stack_asm_name c q1
+Proof
   PairCases_on`kf`>>
   fs[wLive_def]>>
   rw[]>-EVAL_TAC>>
   rpt(pairarg_tac>>fs[])>>
-  rveq>>EVAL_TAC>>fs[])
+  rveq>>EVAL_TAC>>fs[]
+QED
 
 Theorem word_to_stack_stack_asm_name_lem:
   ∀p bs kf c.
@@ -10678,22 +10905,28 @@ val get_code_labels_wReg = Q.prove(`
   `,
   PairCases_on`kf`>>rw[wRegWrite1_def,wRegWrite2_def]) |> SIMP_RULE std_ss [IMP_CONJ_THM];
 
-val get_code_handler_labels_wStackLoad = Q.prove(`
+Triviality get_code_handler_labels_wStackLoad:
   ∀ls.
   get_code_labels (wStackLoad ls x) = get_code_labels x ∧
-  stack_get_handler_labels n (wStackLoad ls x) = stack_get_handler_labels n x`,
-  Induct>>fs[wStackLoad_def,FORALL_PROD]);
+  stack_get_handler_labels n (wStackLoad ls x) = stack_get_handler_labels n x
+Proof
+  Induct>>fs[wStackLoad_def,FORALL_PROD]
+QED
 
-val wLive_code_labels = Q.prove(`
+Triviality wLive_code_labels:
   wLive q bs kf = (q',bs') ⇒
-  get_code_labels q' = {}`,
+  get_code_labels q' = {}
+Proof
   PairCases_on`kf`>>rw[wLive_def]>>fs[]>>
-  pairarg_tac>>fs[]>>rw[]);
+  pairarg_tac>>fs[]>>rw[]
+QED
 
-val stack_move_code_labels = Q.prove(`
+Triviality stack_move_code_labels:
   ∀a b c d e.
-  get_code_labels (stack_move a b c d e) = get_code_labels e`,
-  Induct>>rw[stack_move_def]);
+  get_code_labels (stack_move a b c d e) = get_code_labels e
+Proof
+  Induct>>rw[stack_move_def]
+QED
 
 Theorem word_to_stack_comp_code_labels:
   ∀prog bs kf n.

--- a/compiler/backend/proofs/word_to_wordProofScript.sml
+++ b/compiler/backend/proofs/word_to_wordProofScript.sml
@@ -120,19 +120,23 @@ val tac =
     call_env_def,flush_state_def,set_var_def,get_var_def,dec_clock_def,jump_exc_def,set_vars_def,mem_store_def, stack_size_def,unset_var_def]>>
     every_case_tac>>fs[state_component_equality]
 
-val rm_perm = Q.prove(`
-  s with permute:= s.permute = s`,full_simp_tac(srw_ss())[state_component_equality])
+Triviality rm_perm:
+  s with permute:= s.permute = s
+Proof
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 val size_tac= (full_simp_tac(srw_ss())[wordLangTheory.prog_size_def]>>DECIDE_TAC);
 
-val find_code_thm = Q.prove(`
+Triviality find_code_thm:
   (!n v. lookup n st.code = SOME v ==>
          ∃t k a c col.
          lookup n l = SOME (SND (compile_single t k a c ((n,v),col)))) ∧
   find_code o1 (add_ret_loc o' x) st.code st.stack_size = SOME (args,prog, locsize) ⇒
   ∃t k a c col n prog'.
   SND(compile_single t k a c ((n,LENGTH args,prog),col)) = (LENGTH args,prog') ∧
-  find_code o1 (add_ret_loc o' x) l st.stack_size = SOME(args,prog', locsize)`,
+  find_code o1 (add_ret_loc o' x) l st.stack_size = SOME(args,prog', locsize)
+Proof
   Cases_on`o1`>>simp[find_code_def]>>srw_tac[][]
   >-
     (ntac 2 (TOP_CASE_TAC>>full_simp_tac(srw_ss())[])>>
@@ -145,11 +149,14 @@ val find_code_thm = Q.prove(`
   >>
     Cases_on`lookup x' st.code`>>full_simp_tac(srw_ss())[]>>res_tac>>
     Cases_on`x''`>>full_simp_tac(srw_ss())[compile_single_def,LET_THM]>>
-    metis_tac[]);
+    metis_tac[]
+QED
 
-val pop_env_termdep = Q.prove(`
-  pop_env rst = SOME x ⇒ x.termdep = rst.termdep`,
-  full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[state_component_equality])
+Triviality pop_env_termdep:
+  pop_env rst = SOME x ⇒ x.termdep = rst.termdep
+Proof
+  full_simp_tac(srw_ss())[pop_env_def]>>EVERY_CASE_TAC>>full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (* The t k a c parameters don't need to be existentially quantified *)
 Definition code_rel_def:
@@ -159,18 +166,21 @@ Definition code_rel_def:
          lookup n ttc = SOME (SND (compile_single t k a c ((n,v),col))))
 End
 
-val compile_single_eta = Q.prove(`
+Triviality compile_single_eta:
   compile_single t k a c ((p,x),y) =
-  (p,SND (compile_single t k a c ((p,x),y)))`,
-  Cases_on`x`>>fs[compile_single_def]);
+  (p,SND (compile_single t k a c ((p,x),y)))
+Proof
+  Cases_on`x`>>fs[compile_single_def]
+QED
 
 
-val code_rel_union_fromAList = Q.prove(`
+Triviality code_rel_union_fromAList:
   ∀s l ls.
   code_rel s l ∧
   domain s = domain l
   ⇒
-  code_rel (union s (fromAList ls)) (union l (fromAList (MAP (λp. compile_single t k a c (p,NONE)) ls)))`,
+  code_rel (union s (fromAList ls)) (union l (fromAList (MAP (λp. compile_single t k a c (p,NONE)) ls)))
+Proof
   rw[code_rel_def]>>
   fs[lookup_union,case_eq_thms]
   >-
@@ -183,7 +193,8 @@ val code_rel_union_fromAList = Q.prove(`
     metis_tac[])
   >>
     first_x_assum drule>>rw[]>>
-    simp[]>>metis_tac[]);
+    simp[]>>metis_tac[]
+QED
 
 Theorem compile_single_correct[local]:
   ∀prog (st:('a,'c,'ffi) wordSem$state) l coracle cc.

--- a/compiler/backend/reg_alloc/parmoveScript.sml
+++ b/compiler/backend/reg_alloc/parmoveScript.sml
@@ -77,27 +77,32 @@ Proof
   Cases >> Cases >> simp[]
 QED
 
-val path_imp_mem = Q.prove(
-  `path (x::y) ⇒
-   ¬NULL y ⇒ MEM (SND x) (MAP FST y)`,
+Triviality path_imp_mem:
+  path (x::y) ⇒
+   ¬NULL y ⇒ MEM (SND x) (MAP FST y)
+Proof
   Induct_on`y`>>simp[]>>
-  Cases_on`x`>>Cases>>fs[])
+  Cases_on`x`>>Cases>>fs[]
+QED
 
-val path_imp_mem2 = Q.prove(
-  `path x ⇒
+Triviality path_imp_mem2:
+  path x ⇒
    ∀y. MEM y (MAP SND x) ∧
        y ≠ SND(LAST x) ⇒
-       MEM y (MAP FST x)`,
+       MEM y (MAP FST x)
+Proof
   Induct_on`x` >> simp[]>>
   Cases_on`x`>>Cases>>simp[]>>
   Cases_on`h`>>fs[] >>
   strip_tac >> fs[] >>
-  rw[] >> metis_tac[])
+  rw[] >> metis_tac[]
+QED
 
-val NoRead_path = Q.prove(
-  `∀σ. path σ ∧ windmill σ ∧ LENGTH σ ≥ 2 ∧
+Triviality NoRead_path:
+  ∀σ. path σ ∧ windmill σ ∧ LENGTH σ ≥ 2 ∧
    FST (HD σ) ≠ SND (LAST σ) ⇒
-   NoRead (TL σ) (FST (HD σ))`,
+   NoRead (TL σ) (FST (HD σ))
+Proof
   Induct >> simp[] >> Cases >> simp[] >>
   Cases_on`σ`>>fs[]>> Cases_on`h`>>fs[]>>
   strip_tac >> var_eq_tac >> fs[] >>
@@ -108,7 +113,8 @@ val NoRead_path = Q.prove(
   conj_asm1_tac >- metis_tac[] >>
   strip_tac >>
   imp_res_tac path_imp_mem2 >>
-  fs[] >> metis_tac[] )
+  fs[] >> metis_tac[]
+QED
 
 Definition wf_def:
   wf (μ,σ,τ) ⇔
@@ -354,11 +360,15 @@ End
 val _ = set_fixity"\226\137\161"(Infix(NONASSOC,450));
 Overload "\226\137\161" = ``eqenv``
 
-val eqenv_sym = Q.prove(
-  `p1 ≡ p2 ⇒ p2 ≡ p1`, rw[eqenv_def]);
+Triviality eqenv_sym:
+  p1 ≡ p2 ⇒ p2 ≡ p1
+Proof
+  rw[eqenv_def]
+QED
 
-val step_sem = Q.prove(
-  `∀s1 s2. s1 ▷ s2 ⇒ ⊢ s1 ⇒ (∀ρ. sem s1 ρ ≡ sem s2 ρ)`,
+Triviality step_sem:
+  ∀s1 s2. s1 ▷ s2 ⇒ ⊢ s1 ⇒ (∀ρ. sem s1 ρ ≡ sem s2 ρ)
+Proof
   ho_match_mp_tac step_ind >>
   conj_tac >- (
     rw[sem_def,FUN_EQ_THM,wf_def,eqenv_def] >> rpt (AP_THM_TAC) >>
@@ -430,7 +440,8 @@ val step_sem = Q.prove(
   simp[seqsem_append,seqsem_def,APPLY_UPDATE_THM] >>
   AP_THM_TAC >>
   match_mp_tac parsem_NoRead >>
-  rw[]);
+  rw[]
+QED
 
 Theorem steps_sem:
    ∀s1 s2. s1 ▷* s2 ∧ ⊢ s1 ⇒ (∀ρ. sem s1 ρ ≡ sem s2 ρ)
@@ -488,8 +499,9 @@ Overload "\226\134\170*" = ``RTC $↪``
 (* ⊢ s1 condition not included in paper;
    not sure if necessary, but couldn't get
    their proof to work *)
-val dstep_step = Q.prove(
-  `∀s1 s2. s1 ↪ s2 ⇒ ⊢ s1 ⇒ s1 ▷* s2`,
+Triviality dstep_step:
+  ∀s1 s2. s1 ↪ s2 ⇒ ⊢ s1 ⇒ s1 ▷* s2
+Proof
   ho_match_mp_tac dstep_ind >> rw[] >>
   TRY(
     qpat_abbrev_tac`n = NONE` >>
@@ -498,7 +510,8 @@ val dstep_step = Q.prove(
     `r ≠ NONE` by (strip_tac >> fs[]) >>
     srw_tac[DNF_ss][step_cases]) >>
   match_mp_tac RTC_SUBSET >> rw[step_cases] >>
-  metis_tac[CONS_APPEND,APPEND] );
+  metis_tac[CONS_APPEND,APPEND]
+QED
 
 Theorem dsteps_steps:
    ∀s1 s2. s1 ↪* s2 ⇒ ⊢ s1 ⇒ s1 ▷* s2
@@ -1163,15 +1176,17 @@ Proof
   \\ metis_tac[]
 QED
 
-val steps_MAP_INJ = Q.prove(
-  `∀s1 s2. s1 ▷* s2 ⇒
+Triviality steps_MAP_INJ:
+  ∀s1 s2. s1 ▷* s2 ⇒
     inj_on_state f s1 ⇒
-    map_state f s1 ▷* map_state f s2`,
+    map_state f s1 ▷* map_state f s2
+Proof
   ho_match_mp_tac RTC_INDUCT
   \\ rw[]
   \\ imp_res_tac step_inj_on_state
   \\ fs[]
-  \\ metis_tac[step_MAP_INJ,RTC_RULES]);
+  \\ metis_tac[step_MAP_INJ,RTC_RULES]
+QED
 
 Theorem fstep_MAP_INJ:
    ∀p. inj_on_state f p ⇒ fstep (map_state f p) = map_state f (fstep p)

--- a/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
+++ b/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
@@ -342,24 +342,27 @@ Proof
     IF_CASES_TAC>>rw[]>>fs[MEM_FILTER]
 QED
 
-val no_clash_LUPDATE_Stemp = Q.prove(`
+Triviality no_clash_LUPDATE_Stemp:
   no_clash adjls tags ⇒
-  no_clash adjls (LUPDATE Stemp n tags)`,
+  no_clash adjls (LUPDATE Stemp n tags)
+Proof
   rw[no_clash_def]>>
   fs[EL_LUPDATE]>>
   rw[]>>every_case_tac>>rw[]>>fs[]>>
   first_x_assum drule>>
   disch_then drule>>fs[]>>
-  fs[]);
+  fs[]
+QED
 
-val no_clash_LUPDATE_Fixed = Q.prove(`
+Triviality no_clash_LUPDATE_Fixed:
   undirected adjls ∧
   EVERY (λls. EVERY (λv. v < LENGTH tags) ls) adjls ∧
   n < LENGTH adjls ∧
   (∀m. MEM m (EL n adjls) ∧ m < LENGTH tags ⇒
     EL m tags ≠ Fixed x) ∧
   no_clash adjls tags ⇒
-  no_clash adjls (LUPDATE (Fixed x) n tags)`,
+  no_clash adjls (LUPDATE (Fixed x) n tags)
+Proof
   rw[no_clash_def]>>
   fs[EL_LUPDATE]>>
   rw[]
@@ -383,18 +386,21 @@ val no_clash_LUPDATE_Fixed = Q.prove(`
       metis_tac[])>>
     rw[]>>
     TOP_CASE_TAC>>simp[]>>
-    CCONTR_TAC>>fs[]);
+    CCONTR_TAC>>fs[]
+QED
 
-val remove_colours_succeeds = Q.prove(`
+Triviality remove_colours_succeeds:
   ∀adj ks s s.
   EVERY (\v. v < LENGTH s.node_tag) adj ⇒
-  ∃ls. remove_colours adj ks s = (M_success ls,s)`,
+  ∃ls. remove_colours adj ks s = (M_success ls,s)
+Proof
   ho_match_mp_tac remove_colours_ind>>rw[remove_colours_def]>>
   simp msimps>>
   Cases_on`EL x s.node_tag`>>fs[]>>
   rpt (first_x_assum drule)>>rw[]>>fs[]>>
   first_x_assum(qspec_then`n` assume_tac)>>fs[]>>
-  rfs[]);
+  rfs[]
+QED
 
 Theorem assign_Atemp_tag_correct:
     good_ra_state s ∧
@@ -442,7 +448,7 @@ Proof
   metis_tac[]
 QED
 
-val assign_Atemps_FOREACH_lem = Q.prove(`
+Triviality assign_Atemps_FOREACH_lem:
   ∀ls s ks prefs.
   good_ra_state s ∧
   no_clash s.adj_ls s.node_tag ∧
@@ -456,7 +462,8 @@ val assign_Atemps_FOREACH_lem = Q.prove(`
     (∀m.
       if MEM m ls ∧ EL m s.node_tag = Atemp
         then EL m s'.node_tag ≠ Atemp
-        else EL m s'.node_tag = EL m s.node_tag)`,
+        else EL m s'.node_tag = EL m s.node_tag)
+Proof
   Induct>>rw[st_ex_FOREACH_def]>>
   fs msimps>-
     simp[ra_state_component_equality]>>
@@ -480,7 +487,8 @@ val assign_Atemps_FOREACH_lem = Q.prove(`
     rpt(first_x_assum (qspec_then`m` mp_tac))>>
     simp[]>>
     strip_tac>>IF_CASES_TAC>>fs[]>>
-    metis_tac[]));
+    metis_tac[])
+QED
 
 Theorem assign_Atemps_correct:
     ∀k ls prefs s.
@@ -529,16 +537,18 @@ Proof
     rfs[]
 QED
 
-val SORTED_HEAD_LT = Q.prove(`
+Triviality SORTED_HEAD_LT:
   ∀ls.
   (col:num) < h ∧ SORTED (λx y. x≤y) (h::ls) ⇒
-  ¬MEM col ls`,
+  ¬MEM col ls
+Proof
   Induct>>srw_tac[][SORTED_DEF]
   >-
     DECIDE_TAC
   >>
     last_x_assum mp_tac>>impl_tac>>
-    Cases_on`ls`>>full_simp_tac(srw_ss())[SORTED_DEF]>>DECIDE_TAC);
+    Cases_on`ls`>>full_simp_tac(srw_ss())[SORTED_DEF]>>DECIDE_TAC
+QED
 
 (* Correctness for the second step *)
 Theorem unbound_colour_correct:
@@ -607,7 +617,7 @@ Proof
 QED
 
 (* Almost exactly the same as the FOREACH for Atemps *)
-val assign_Stemps_FOREACH_lem = Q.prove(`
+Triviality assign_Stemps_FOREACH_lem:
   ∀ls s k.
   good_ra_state s ∧
   no_clash s.adj_ls s.node_tag ∧
@@ -620,7 +630,8 @@ val assign_Stemps_FOREACH_lem = Q.prove(`
       if MEM m ls ∧ EL m s.node_tag = Stemp
         then ∃k'. EL m s'.node_tag = Fixed k' ∧ k ≤ k'
         else EL m s'.node_tag = EL m s.node_tag) ∧
-    s' = s with node_tag := s'.node_tag`,
+    s' = s with node_tag := s'.node_tag
+Proof
   Induct>>rw[st_ex_FOREACH_def]>>
   fs msimps>- simp[ra_state_component_equality]>>
   drule (GEN_ALL assign_Stemp_tag_correct)>>
@@ -643,7 +654,8 @@ val assign_Stemps_FOREACH_lem = Q.prove(`
     rpt(first_x_assum (qspec_then`m` mp_tac))>>
     simp[]>>
     strip_tac>>IF_CASES_TAC>>fs[]>>
-    metis_tac[]));
+    metis_tac[])
+QED
 
 Theorem assign_Stemps_correct:
     good_ra_state s ∧
@@ -678,17 +690,19 @@ QED
 (* --  Random sanity checks that will be needed at some point -- *)
 
 (* Checking that biased_pref satisfies good_pref *)
-val first_match_col_correct = Q.prove(`
+Triviality first_match_col_correct:
   ∀x ks s.
   ∃res. first_match_col ks x s = (res,s) ∧
   case res of
     M_failure v => v = Subscript
   | M_success (SOME k) => MEM k ks
-  | _ => T`,
+  | _ => T
+Proof
   Induct>>fs[first_match_col_def]>>fs msimps>>
   rw[]>>
   TOP_CASE_TAC>>fs[]>>
-  IF_CASES_TAC>>fs[]);
+  IF_CASES_TAC>>fs[]
+QED
 
 Theorem good_pref_biased_pref:
     ∀t. good_pref (biased_pref t)
@@ -737,15 +751,17 @@ Proof
   fs[domain_lookup]
 QED
 
-val list_remap_domain = Q.prove(`
+Triviality list_remap_domain:
   ∀ls ta fa n ta' fa' n'.
   list_remap ls (ta,fa,n) = (ta',fa',n') ⇒
-  domain ta' = domain ta ∪ set ls`,
+  domain ta' = domain ta ∪ set ls
+Proof
   Induct>>rw[list_remap_def]>>
   EVERY_CASE_TAC>>
   first_x_assum drule>>fs[domain_insert]>>
   fs[EXTENSION]>>
-  metis_tac[domain_lookup]);
+  metis_tac[domain_lookup]
+QED
 
 val list_remap_bij = Q.prove(`
   ∀ls ta fa n ta' fa' n'.
@@ -770,10 +786,11 @@ val list_remap_bij = Q.prove(`
       fs[domain_insert,EXTENSION])>>
     metis_tac[])|>SIMP_RULE std_ss [markerTheory.Abbrev_def];
 
-val mk_bij_aux_domain = Q.prove(`
+Triviality mk_bij_aux_domain:
   ∀ct ta fa n ta' fa' n'.
   mk_bij_aux ct (ta,fa,n) = (ta',fa',n') ⇒
-  domain ta' = domain ta ∪ {x | in_clash_tree ct x}`,
+  domain ta' = domain ta ∪ {x | in_clash_tree ct x}
+Proof
   Induct>>rw[mk_bij_aux_def]>>fs[in_clash_tree_def]
   >- (
     Cases_on`list_remap l0 (ta,fa,n)`>>Cases_on`r`>>
@@ -808,7 +825,8 @@ val mk_bij_aux_domain = Q.prove(`
     strip_tac>>
     last_x_assum drule >> simp[markerTheory.Abbrev_def]>>
     rw[]>>simp[EXTENSION]>>
-    metis_tac[]);
+    metis_tac[]
+QED
 
 val mk_bij_aux_bij = Q.prove(`
   ∀ct ta fa n ta' fa' n'.
@@ -852,17 +870,19 @@ val mk_bij_aux_bij = Q.prove(`
     strip_tac>>
     last_x_assum drule >> simp[markerTheory.Abbrev_def]) |> SIMP_RULE std_ss [markerTheory.Abbrev_def];
 
-val list_remap_wf = Q.prove(`
+Triviality list_remap_wf:
   ∀l ta fa n ta' fa' n'.
   list_remap l (ta,fa,n) = (ta',fa',n') /\
   wf ta ∧ wf fa ==>
-  wf ta' ∧ wf fa'`,
+  wf ta' ∧ wf fa'
+Proof
   Induct>>fs[list_remap_def,FORALL_PROD]>>
   rw[]>>
   EVERY_CASE_TAC>>fs[]>>
   first_x_assum drule>>
   rpt (disch_then drule)>>
-  fs[wf_insert]);
+  fs[wf_insert]
+QED
 
 Theorem mk_bij_aux_wf:
     ∀ct ta fa n ta' fa' n'.
@@ -943,16 +963,20 @@ Definition hide_def:
   hide x = x
 End
 
-val GT_TRANS = Q.prove(`
-  a:num > b ∧ b > c ⇒ a > c`,
-  fs[]);
+Triviality GT_TRANS:
+  a:num > b ∧ b > c ⇒ a > c
+Proof
+  fs[]
+QED
 
-val GT_sorted_eq = Q.prove(`
-  SORTED $> (x:num::L) ⇔ SORTED $> L ∧ ∀y. MEM y L ⇒ x > y`,
+Triviality GT_sorted_eq:
+  SORTED $> (x:num::L) ⇔ SORTED $> L ∧ ∀y. MEM y L ⇒ x > y
+Proof
   match_mp_tac SORTED_EQ>>
-  fs[transitive_def]);
+  fs[transitive_def]
+QED
 
-val sorted_insert_correct_lem = Q.prove(`
+Triviality sorted_insert_correct_lem:
   ∀ls acc.
   SORTED $> ls ∧
   SORTED $> (REVERSE acc) ∧
@@ -962,7 +986,8 @@ val sorted_insert_correct_lem = Q.prove(`
     SORTED $> (sorted_insert x acc ls) ∧
     ∀z.
     MEM z (sorted_insert x acc ls) ⇔
-    x = z ∨ MEM z ls ∨ MEM z acc)`,
+    x = z ∨ MEM z ls ∨ MEM z acc)
+Proof
   Induct>>
   fs[sorted_insert_def]
   >-
@@ -995,7 +1020,8 @@ val sorted_insert_correct_lem = Q.prove(`
       fs[GT_sorted_eq,SORTED_APPEND]>>
       Cases_on`ls`>>fs[] >> metis_tac [])>>
     simp[hide_def]>>
-    metis_tac[]);
+    metis_tac[]
+QED
 
 Theorem sorted_insert_correct:
     ∀ls.
@@ -1167,12 +1193,14 @@ Definition colouring_satisfactory_def:
 End
 
 (*TODO: this is in word_allocProof*)
-val INJ_less = Q.prove(`
+Triviality INJ_less:
   ∀f s' t s.
   INJ f s' t ∧ s ⊆ s'
   ⇒
-  INJ f s t`,
-  metis_tac[INJ_DEF,SUBSET_DEF]);
+  INJ f s t
+Proof
+  metis_tac[INJ_DEF,SUBSET_DEF]
+QED
 
 Theorem check_partial_col_success:
     ∀ls live flive col.
@@ -1248,26 +1276,32 @@ Proof
     first_x_assum(qspecl_then [`g`,`f`] mp_tac)>>rev_full_simp_tac(srw_ss())[]
 QED
 
-val domain_eq_IMAGE = Q.prove(`
-  domain s = IMAGE FST (set(toAList s))`,
+Triviality domain_eq_IMAGE:
+  domain s = IMAGE FST (set(toAList s))
+Proof
   fs[EXTENSION,EXISTS_PROD]>>
-  fs[MEM_toAList,domain_lookup]);
+  fs[MEM_toAList,domain_lookup]
+QED
 
-val is_clique_FILTER = Q.prove(`
+Triviality is_clique_FILTER:
   ∀ls.
   is_clique ls G ⇒
-  is_clique (FILTER P ls) G`,
+  is_clique (FILTER P ls) G
+Proof
   Induct>>fs[is_clique_def]>>
   strip_tac>>
   cases_on`P h`>>
   fs[MEM_FILTER]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val is_clique_subgraph = Q.prove(`
+Triviality is_clique_subgraph:
   is_clique ls s ∧
   is_subgraph s s' ⇒
-  is_clique ls s'`,
-  fs[is_clique_def,is_subgraph_def]);
+  is_clique ls s'
+Proof
+  fs[is_clique_def,is_subgraph_def]
+QED
 
 Theorem domain_numset_list_delete:
     ∀l live.
@@ -1408,41 +1442,53 @@ Proof
   metis_tac[]
 QED
 
-val ALL_DISTINCT_set_INJ = Q.prove(`
+Triviality ALL_DISTINCT_set_INJ:
   ∀ls col.
   ALL_DISTINCT (MAP col ls) ⇒
-  INJ col (set ls) UNIV`,
+  INJ col (set ls) UNIV
+Proof
   Induct>>fs[INJ_DEF]>>rw[]>>
   fs[MEM_MAP]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val IMAGE_DIFF = Q.prove(`
+Triviality IMAGE_DIFF:
   INJ f (s ∪ t) UNIV ⇒
   IMAGE f (s DIFF t) =
-  (IMAGE f s DIFF IMAGE f t)`,
+  (IMAGE f s DIFF IMAGE f t)
+Proof
   rw[EXTENSION,INJ_DEF]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val set_FILTER = Q.prove(`
+Triviality set_FILTER:
   set (FILTER P live) =
-  set live DIFF (λx. ¬P x)`,
+  set live DIFF (λx. ¬P x)
+Proof
   rw[EXTENSION,MEM_FILTER]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val MEM_MAP_IMAGE = Q.prove(`
-   (λx. MEM x (MAP f l)) = IMAGE f (set l)`,
-   rw[EXTENSION,MEM_MAP]);
+Triviality MEM_MAP_IMAGE:
+  (λx. MEM x (MAP f l)) = IMAGE f (set l)
+Proof
+  rw[EXTENSION,MEM_MAP]
+QED
 
-val domain_difference = Q.prove(`
-  domain(difference s t) = domain s DIFF domain t`,
+Triviality domain_difference:
+  domain(difference s t) = domain s DIFF domain t
+Proof
   fs[EXTENSION,domain_lookup,lookup_difference]>>
   rw[EQ_IMP_THM]>>fs[]>>
-  metis_tac[option_nchotomy]);
+  metis_tac[option_nchotomy]
+QED
 
-val UNION_DIFF_3 = Q.prove(`
- s DIFF t ∪ t = s ∪ t`,
- rw[EXTENSION]>>
- metis_tac[]);
+Triviality UNION_DIFF_3:
+  s DIFF t ∪ t = s ∪ t
+Proof
+  rw[EXTENSION]>>
+ metis_tac[]
+QED
 
 Theorem check_partial_col_domain:
     ∀ls f live flive v.
@@ -1856,7 +1902,7 @@ QED
 
 (* Again, this characterization is only needed for the conventions,
    but not for the correctness theorem *)
-val mk_tags_st_ex_FOREACH_lem = Q.prove(`
+Triviality mk_tags_st_ex_FOREACH_lem:
   ∀ls s fa.
   good_ra_state s ∧
   EVERY (\v. v < s.dim) ls ⇒
@@ -1875,7 +1921,8 @@ val mk_tags_st_ex_FOREACH_lem = Q.prove(`
       else if is_stack_var (fa x) then EL x s'.node_tag = Stemp
       else EL x s'.node_tag = Atemp)
     else
-       EL x s'.node_tag = EL x s.node_tag)`,
+       EL x s'.node_tag = EL x s.node_tag)
+Proof
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps
   >-
     simp[ra_state_component_equality]>>
@@ -1899,7 +1946,8 @@ val mk_tags_st_ex_FOREACH_lem = Q.prove(`
     rw[]>>fs[Once convention_partitions])
   >-
     (`¬is_alloc_var (fa h) ∧ ¬ is_stack_var (fa h)` by fs[is_stack_var_def,is_alloc_var_def]>>
-    metis_tac[convention_partitions]));
+    metis_tac[convention_partitions])
+QED
 
 Theorem mk_tags_succeeds:
     good_ra_state s ∧
@@ -1930,13 +1978,15 @@ Proof
   \\ simp[MULT_DIV]
 QED
 
-val extract_color_st_ex_MAP_lem = Q.prove(`
+Triviality extract_color_st_ex_MAP_lem:
   ∀ls s.
   EVERY (λ(k,v). v < LENGTH s.node_tag) ls ⇒
   st_ex_MAP (λ(k,v). do t <- node_tag_sub v; return (k,extract_tag t) od) ls s =
-  (M_success(MAP (λ(k,v). (k,extract_tag (EL v s.node_tag))) ls),s)`,
+  (M_success(MAP (λ(k,v). (k,extract_tag (EL v s.node_tag))) ls),s)
+Proof
   Induct>>fs[st_ex_MAP_def]>>fs msimps>>rw[]>>
-  Cases_on`h`>>fs[]);
+  Cases_on`h`>>fs[]
+QED
 
 Theorem extract_color_succeeds:
     good_ra_state s ∧
@@ -1966,13 +2016,14 @@ QED
 
 (* As an example, we don't bother fully characterizing
    st_ex_PARTITION, but merely that show it succeeds *)
-val st_ex_PARTITION_split_degree = Q.prove(`
+Triviality st_ex_PARTITION_split_degree:
   ∀atemps k lss lss' s.
   good_ra_state s ⇒
   ?ts fs. st_ex_PARTITION (split_degree s.dim k) atemps lss lss' s =
     (M_success (ts,fs),s) ∧
   EVERY (λx. MEM x (lss) ∨ MEM x atemps ) ts ∧
-  EVERY (λx. MEM x (lss') ∨ MEM x atemps ) fs`,
+  EVERY (λx. MEM x (lss') ∨ MEM x atemps ) fs
+Proof
   Induct_on`atemps`>>fs[st_ex_PARTITION_def,EXISTS_PROD]>>fs msimps>>
   fs[EVERY_MEM]>>
   rw[split_degree_def]>>rfs msimps>>
@@ -1995,15 +2046,17 @@ val st_ex_PARTITION_split_degree = Q.prove(`
     metis_tac[MEM])
   >>
     (first_x_assum(qspecl_then [`k`,`h::lss`,`lss'`] assume_tac)>>fs[]>>
-    metis_tac[MEM]));
+    metis_tac[MEM])
+QED
 
-val st_ex_PARTITION_move_related_sub = Q.prove(`
+Triviality st_ex_PARTITION_move_related_sub:
   ∀atemps lss lss' s.
   EVERY (λx. x < LENGTH s.move_related) atemps ⇒
   ?ts fs. st_ex_PARTITION move_related_sub atemps lss lss' s =
     (M_success (ts,fs),s) ∧
   EVERY (λx. MEM x lss ∨ MEM x atemps ) ts ∧
-  EVERY (λx. MEM x lss' ∨ MEM x atemps ) fs`,
+  EVERY (λx. MEM x lss' ∨ MEM x atemps ) fs
+Proof
   Induct_on`atemps`>>fs[st_ex_PARTITION_def,EXISTS_PROD]>>fs msimps>>
   fs[EVERY_MEM]>>rw[]>>
   first_x_assum drule>>rw[]
@@ -2012,30 +2065,33 @@ val st_ex_PARTITION_move_related_sub = Q.prove(`
     metis_tac[MEM])
   >-
     (first_x_assum(qspecl_then [`lss`,`h::lss'`] assume_tac)>>fs[]>>
-    metis_tac[MEM]));
+    metis_tac[MEM])
+QED
 
 (* This is currently more general than necessary because it doesn't
    do any coalescing (yet) *)
-val dec_deg_success = Q.prove(`
+Triviality dec_deg_success:
   ∀ls s.
   EVERY (λv. v < s.dim) ls ∧
   good_ra_state s ⇒
   ∃d. st_ex_FOREACH ls dec_deg s = (M_success (),s with degrees :=d) ∧
   LENGTH d = LENGTH s.degrees
-  `,
+Proof
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps >- fs[ra_state_component_equality]>>
   rw[dec_deg_def]>>fs msimps>>fs[degrees_accessor,Marray_sub_def]>>
   reverse IF_CASES_TAC>- fs[good_ra_state_def]>> simp[]>>
   qmatch_goalsub_abbrev_tac`st_ex_FOREACH _ _ ss`>>
   first_x_assum(qspec_then`ss` assume_tac)>>rfs[Abbr`ss`,good_ra_state_def]>>
-  simp[ra_state_component_equality]);
+  simp[ra_state_component_equality]
+QED
 
-val dec_degree_success = Q.prove(`
+Triviality dec_degree_success:
   ∀ls s.
   good_ra_state s ⇒
   ∃d.
   st_ex_FOREACH ls dec_degree s = (M_success (),s with degrees :=d)∧
-  LENGTH d = LENGTH s.degrees`,
+  LENGTH d = LENGTH s.degrees
+Proof
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps >- fs[ra_state_component_equality]>>
   rw[dec_degree_def]>>fs msimps>>
   fs[get_dim_def]>>
@@ -2047,16 +2103,19 @@ val dec_degree_success = Q.prove(`
   drule dec_deg_success>>rw[]>>simp[]>>
   first_x_assum (qspec_then `s with degrees := d` assume_tac)>>
   rfs[good_ra_state_def]>>fs[]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val MEM_smerge = Q.prove(`
+Triviality MEM_smerge:
   ∀xs ys.
   MEM x (smerge xs ys) ⇔
-  MEM x xs ∨ MEM x ys`,
+  MEM x xs ∨ MEM x ys
+Proof
   ho_match_mp_tac smerge_ind>>rw[smerge_def]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val revive_moves_success = Q.prove(`
+Triviality revive_moves_success:
   EVERY (λx. x < LENGTH s.adj_ls) ls ⇒
   ∃s'.
   revive_moves ls s = (M_success(),s') ∧
@@ -2064,7 +2123,8 @@ val revive_moves_success = Q.prove(`
     avail_moves_wl:=s'.avail_moves_wl;
     unavail_moves_wl := s'.unavail_moves_wl |> ∧
   EVERY (λx. MEM x (s.avail_moves_wl ++ s.unavail_moves_wl)) s'.avail_moves_wl ∧
-  EVERY (λx. MEM x (s.avail_moves_wl ++ s.unavail_moves_wl)) s'.unavail_moves_wl`,
+  EVERY (λx. MEM x (s.avail_moves_wl ++ s.unavail_moves_wl)) s'.unavail_moves_wl
+Proof
   rw[revive_moves_def]>>fs msimps>>
   drule st_ex_MAP_adj_ls_sub>>rw[]>>
   fs get_eqns>> fs set_eqns>>
@@ -2074,9 +2134,10 @@ val revive_moves_success = Q.prove(`
   pop_assum (assume_tac o GSYM)>>
   drule PART_MEM>>
   simp[]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val unspill_success = Q.prove(`
+Triviality unspill_success:
   ∀k s.
   good_ra_state s ⇒
   ∃s' b.
@@ -2084,7 +2145,8 @@ val unspill_success = Q.prove(`
   good_ra_state s' ∧
   is_subgraph s.adj_ls s'.adj_ls ∧
   s.dim = s'.dim ∧
-  s.node_tag = s'.node_tag`,
+  s.node_tag = s'.node_tag
+Proof
   rw[unspill_def]>> fs msimps>>
   simp get_eqns>>
   drule st_ex_PARTITION_split_degree>>
@@ -2105,9 +2167,10 @@ val unspill_success = Q.prove(`
   simp all_eqns>>
   fs[ good_ra_state_def]>>qpat_x_assum`s' = _` SUBST_ALL_TAC >> rw[]>>
   fs[EVERY_MEM,is_subgraph_refl]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val push_stack_success = Q.prove(`
+Triviality push_stack_success:
   ∀ls s.
   EVERY (λx. x < s.dim) ls ∧
   good_ra_state s ⇒
@@ -2116,7 +2179,8 @@ val push_stack_success = Q.prove(`
     s with
     <| degrees:=d; move_related:=mr;stack:=st |>)∧
   LENGTH d = LENGTH s.degrees ∧
-  LENGTH mr = LENGTH s.move_related`,
+  LENGTH mr = LENGTH s.move_related
+Proof
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps
   >- fs[ra_state_component_equality]>>
   rw[push_stack_def]>>fs all_eqns>>
@@ -2126,9 +2190,10 @@ val push_stack_success = Q.prove(`
   impl_tac>-
     fs[Abbr`s'`]>>
   rw[]>>
-  simp[Abbr`s'`,ra_state_component_equality]);
+  simp[Abbr`s'`,ra_state_component_equality]
+QED
 
-val do_simplify_success = Q.prove(`
+Triviality do_simplify_success:
   ∀s.
   good_ra_state s ⇒
   ∃s' b.
@@ -2136,7 +2201,8 @@ val do_simplify_success = Q.prove(`
   good_ra_state s' ∧
   is_subgraph s.adj_ls s'.adj_ls ∧
   s.dim = s'.dim ∧
-  s.node_tag = s'.node_tag`,
+  s.node_tag = s'.node_tag
+Proof
   rw[do_simplify_def]>>fs msimps>>fs[get_simp_wl_def]>>
   rw[]>- fs[is_subgraph_refl]>>
   drule dec_degree_success>>
@@ -2147,30 +2213,34 @@ val do_simplify_success = Q.prove(`
   rw[]>>simp all_eqns>>
   qmatch_goalsub_abbrev_tac`unspill k ss`>>
   qspecl_then [`k`,`ss`] assume_tac unspill_success >>
-  rfs[Abbr`ss`,good_ra_state_def]);
+  rfs[Abbr`ss`,good_ra_state_def]
+QED
 
 (* This basically says nothing at the moment *)
-val st_ex_FILTER_is_not_coalesced = Q.prove(`
+Triviality st_ex_FILTER_is_not_coalesced:
   ∀ls acc s.
   EVERY (λx. x < LENGTH s.coalesced) ls ∧
   EVERY (λx. x < LENGTH s.coalesced) acc ⇒
   ?ts fs. st_ex_FILTER is_not_coalesced ls acc s =
     (M_success ts,s) ∧
-  EVERY (λx. x < LENGTH s.coalesced) ts`,
+  EVERY (λx. x < LENGTH s.coalesced) ts
+Proof
   Induct>>rw[]>>fs[st_ex_FILTER_def,is_not_coalesced_def]>>
   fs msimps>>
   fs[good_ra_state_def]>>fs[]>>
   IF_CASES_TAC>>fs[]>>
-  first_x_assum match_mp_tac>>fs[]);
+  first_x_assum match_mp_tac>>fs[]
+QED
 
-val consistency_ok_success = Q.prove(`
+Triviality consistency_ok_success:
   ∀x y s.
   good_ra_state s ∧
   x < s.dim ∧
   y < s.dim ⇒
   ∃b.
   consistency_ok x y s = (M_success b,s) ∧
-  (b ⇒ x < s.dim ∧ y < s.dim)`,
+  (b ⇒ x < s.dim ∧ y < s.dim)
+Proof
   rw[]>>simp[Once consistency_ok_def]>>
   IF_CASES_TAC>>simp msimps>>simp get_eqns>>
   reverse IF_CASES_TAC
@@ -2178,16 +2248,18 @@ val consistency_ok_success = Q.prove(`
     fs[good_ra_state_def]>>
   fs[is_Fixed_def]>>fs msimps>>
   EVERY_CASE_TAC>>simp msimps>>
-  fs[good_ra_state_def]);
+  fs[good_ra_state_def]
+QED
 
-val st_ex_FILTER_consistency_ok = Q.prove(`
+Triviality st_ex_FILTER_consistency_ok:
   ∀ls acc s.
   good_ra_state s ∧
   EVERY (λ(p:num,x,y). x < s.dim ∧ y < s.dim) ls
   ⇒
   ?ts. st_ex_FILTER (λ(_,x,y). consistency_ok x y) ls acc s =
     (M_success ts,s) ∧
-  EVERY (λ(p,(x,y)). x < s.dim ∧ y < s.dim ∨ MEM (p,(x,y)) acc) ts`,
+  EVERY (λ(p,(x,y)). x < s.dim ∧ y < s.dim ∨ MEM (p,(x,y)) acc) ts
+Proof
   Induct>>rw[]>>fs[st_ex_FILTER_def]>>
   fs msimps
   >-
@@ -2205,20 +2277,23 @@ val st_ex_FILTER_consistency_ok = Q.prove(`
   rfs[]>>
   fs[EVERY_MEM,FORALL_PROD]>>
   rw[]>>first_x_assum drule>>fs[]>>rw[]>>
-  fs[]>>metis_tac[]);
+  fs[]>>metis_tac[]
+QED
 
 (* do_coalesce *)
-val st_ex_FILTER_considered_var = Q.prove(`
+Triviality st_ex_FILTER_considered_var:
   ∀ls acc s.
   EVERY (λx. x < LENGTH s.node_tag) ls ∧
   EVERY (λx. x < LENGTH s.node_tag) acc ⇒
   ?ts fs. st_ex_FILTER (considered_var k) ls acc s =
     (M_success ts,s) ∧
-  EVERY (λx. x < LENGTH s.node_tag) ts`,
+  EVERY (λx. x < LENGTH s.node_tag) ts
+Proof
   Induct>>rw[]>>fs[st_ex_FILTER_def,considered_var_def,is_Atemp_def,is_Fixed_k_def]>>
   fs msimps>>
   fs[good_ra_state_def]>>fs[]>>
-  IF_CASES_TAC>>fs[]);
+  IF_CASES_TAC>>fs[]
+QED
 
 val st_ex_MAP_deg_or_inf = Q.prove(`
   ∀ls s.
@@ -2240,7 +2315,7 @@ val st_ex_MAP_deg_or_inf = Q.prove(`
   first_x_assum drule>>rw[]>>
   fs[good_ra_state_def])|>GEN_ALL;
 
-val bg_ok_success = Q.prove(`
+Triviality bg_ok_success:
   good_ra_state s ∧
   x < s.dim ∧ y < s.dim ⇒
   ∃opt.
@@ -2248,7 +2323,8 @@ val bg_ok_success = Q.prove(`
   case opt of
    NONE => T
   | SOME (case1,case2) =>
-    EVERY (\v. v < s.dim) case1 ∧ EVERY (\v.v<s.dim) case2`,
+    EVERY (\v. v < s.dim) case1 ∧ EVERY (\v.v<s.dim) case2
+Proof
   rw[bg_ok_def]>>simp msimps>>
   every_case_tac>>fs[]>>TRY(fs[good_ra_state_def]>>NO_TAC)>>
   pairarg_tac>>fs[]>>
@@ -2291,9 +2367,10 @@ val bg_ok_success = Q.prove(`
   impl_tac >- (fs[good_ra_state_def,EVERY_MEM]>>metis_tac[])>>
   rw[]>>simp[]>>
   IF_CASES_TAC>>fs[good_ra_state_def,EVERY_MEM]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val coalesce_parent_success = Q.prove(`
+Triviality coalesce_parent_success:
   ∀x s.
   x < s.dim ∧
   good_ra_state s ⇒
@@ -2301,7 +2378,8 @@ val coalesce_parent_success = Q.prove(`
   coalesce_parent x s = (M_success y, s') ∧
   y < s.dim ∧
   good_ra_state s' ∧
-  s' = s with coalesced:=coal`,
+  s' = s with coalesced:=coal
+Proof
   ho_match_mp_tac coalesce_parent_ind>> rw[]>>
   simp[Once coalesce_parent_def]>>
   fs msimps>> reverse (rw[])
@@ -2334,18 +2412,21 @@ val coalesce_parent_success = Q.prove(`
   simp[ra_state_component_equality]>>
   fs[good_ra_state_def]>>
   match_mp_tac IMP_EVERY_LUPDATE>>
-  fs[]);
+  fs[]
+QED
 
-val canonize_move_success = Q.prove(`
+Triviality canonize_move_success:
   x < s.dim ∧ y < s.dim ∧ good_ra_state s ⇒
   ∃x2 y2.
   canonize_move x y s = (M_success(x2,y2),s) ∧
-  x2 < s.dim ∧ y2 < s.dim`,
+  x2 < s.dim ∧ y2 < s.dim
+Proof
   rw[canonize_move_def,is_Fixed_def]>>simp msimps>>
   fs[good_ra_state_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
-val st_ex_FIRST_consistency_ok_bg_ok = Q.prove(`
+Triviality st_ex_FIRST_consistency_ok_bg_ok:
   ∀ls acc s.
   good_ra_state s ∧
   EVERY (λ(p:num,x,y). x < s.dim ∧ y < s.dim) ls ∧
@@ -2362,7 +2443,8 @@ val st_ex_FIRST_consistency_ok_bg_ok = Q.prove(`
     EVERY (\v. v < s.dim) case1 ∧
     EVERY (\v. v < s.dim) case2 ∧
     EVERY (λ(p:num,x,y). x < s.dim ∧ y < s.dim) rest
-  | _ => T`,
+  | _ => T
+Proof
   Induct>>
   rw[st_ex_FIRST_def]>>fs msimps
   >-
@@ -2395,9 +2477,10 @@ val st_ex_FIRST_consistency_ok_bg_ok = Q.prove(`
     disch_then(qspec_then `(p,x2,y2)::acc` assume_tac)>>rfs[]>>
     metis_tac[ra_state_component_equality])
   >>
-  metis_tac[ra_state_component_equality]);
+  metis_tac[ra_state_component_equality]
+QED
 
-val do_coalesce_real_success = Q.prove(`
+Triviality do_coalesce_real_success:
   ∀x y case1 case2 s.
   y < s.dim ∧
   x < s.dim ∧
@@ -2409,7 +2492,8 @@ val do_coalesce_real_success = Q.prove(`
   good_ra_state s' ∧
   is_subgraph s.adj_ls s'.adj_ls ∧
   s.dim = s'.dim ∧
-  s.node_tag = s'.node_tag`,
+  s.node_tag = s'.node_tag
+Proof
   rw[do_coalesce_real_def]>>fs msimps>>
   reverse IF_CASES_TAC
   >-
@@ -2450,9 +2534,10 @@ val do_coalesce_real_success = Q.prove(`
   ntac 2 (TOP_CASE_TAC>>fs[])>>
   fs[ra_state_component_equality,good_ra_state_def]>>
   rw[]>>fs[]>>
-  fs[is_subgraph_def]);
+  fs[is_subgraph_def]
+QED
 
-val do_coalesce_success = Q.prove(`
+Triviality do_coalesce_success:
   ∀s.
     good_ra_state s ⇒
     ∃s' b.
@@ -2460,7 +2545,8 @@ val do_coalesce_success = Q.prove(`
      good_ra_state s' ∧
      is_subgraph s.adj_ls s'.adj_ls ∧
      s.dim = s'.dim ∧
-     s.node_tag = s'.node_tag`,
+     s.node_tag = s'.node_tag
+Proof
   rw[do_coalesce_def]>>fs msimps>>fs all_eqns>>
   FREEZE_THEN drule st_ex_FIRST_consistency_ok_bg_ok>>
   disch_then (qspecl_then [`s.avail_moves_wl`,`[]`] mp_tac)>>
@@ -2487,27 +2573,31 @@ val do_coalesce_success = Q.prove(`
   rw[] >-
     (fs[good_ra_state_def,EVERY_FILTER]>>
     fs[EVERY_MEM])>>
-  metis_tac[is_subgraph_trans]);
+  metis_tac[is_subgraph_trans]
+QED
 
-val st_ex_FOREACH_update_move_related = Q.prove(`
+Triviality st_ex_FOREACH_update_move_related:
   ∀ls s b.
   EVERY (λv. v < LENGTH s.move_related) ls ⇒
   ∃lss.
   st_ex_FOREACH ls (\x. update_move_related x b) s = (M_success (),s with move_related := lss) ∧
-  LENGTH lss = LENGTH s.move_related`,
+  LENGTH lss = LENGTH s.move_related
+Proof
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps>>
   fs[ra_state_component_equality]>>rw[]>>
   qmatch_goalsub_abbrev_tac`_ _ _ ss`>>
-  first_x_assum (qspec_then `ss` assume_tac)>>fs[Abbr`ss`]);
+  first_x_assum (qspec_then `ss` assume_tac)>>fs[Abbr`ss`]
+QED
 
-val reset_move_related_success = Q.prove(`
+Triviality reset_move_related_success:
   ∀ls s.
   good_ra_state s ∧
   EVERY (λ(p,(x,y)). x < s.dim ∧ y < s.dim) ls
   ⇒
   ∃mv.
   reset_move_related ls s = (M_success (), s with move_related:= mv) ∧
-  LENGTH mv = s.dim`,
+  LENGTH mv = s.dim
+Proof
   rw[reset_move_related_def]>>fs msimps>>
   fs[get_dim_def]>>
   `EVERY (\v. v< LENGTH s.move_related) (COUNT_LIST s.dim)` by
@@ -2522,9 +2612,10 @@ val reset_move_related_success = Q.prove(`
   Induct>>fs[st_ex_FOREACH_def]>>fs msimps>>
   fs[ra_state_component_equality,good_ra_state_def]>>
   fs[FORALL_PROD]>>rw[]>>
-  fs[is_Fixed_def]>>fs msimps);
+  fs[is_Fixed_def]>>fs msimps
+QED
 
-val do_prefreeze_success = Q.prove(`
+Triviality do_prefreeze_success:
   ∀s.
   good_ra_state s ⇒
   ∃s' b.
@@ -2532,7 +2623,8 @@ val do_prefreeze_success = Q.prove(`
   good_ra_state s' ∧
   is_subgraph s.adj_ls s'.adj_ls ∧
   s.dim = s'.dim ∧
-  s.node_tag = s'.node_tag`,
+  s.node_tag = s'.node_tag
+Proof
   rw[do_prefreeze_def]>> fs all_eqns>>
   `EVERY (\x. x < LENGTH s.coalesced) s.freeze_wl` by
     fs[good_ra_state_def]>>
@@ -2562,10 +2654,11 @@ val do_prefreeze_success = Q.prove(`
     fs[EVERY_MEM])>>
   drule do_simplify_success>>
   rw[]>>simp[]>>unabbrev_all_tac>>rfs[]>>
-  fs[good_ra_state_def]);
+  fs[good_ra_state_def]
+QED
 
 (* do freeze *)
-val do_freeze_success = Q.prove(`
+Triviality do_freeze_success:
   ∀s.
   good_ra_state s ⇒
   ∃s' b.
@@ -2573,7 +2666,8 @@ val do_freeze_success = Q.prove(`
   good_ra_state s' ∧
   is_subgraph s.adj_ls s'.adj_ls ∧
   s.dim = s'.dim ∧
-  s.node_tag = s'.node_tag`,
+  s.node_tag = s'.node_tag
+Proof
   rw[do_freeze_def]>> fs all_eqns>>
   TOP_CASE_TAC>-fs[is_subgraph_def]>>
   drule dec_degree_success>>
@@ -2591,10 +2685,11 @@ val do_freeze_success = Q.prove(`
   qspecl_then [`k`,`ss`] mp_tac unspill_success>>
   impl_tac>-
     fs[Abbr`ss`,good_ra_state_def]>>
-  rw[]>>fs[Abbr`ss`]);
+  rw[]>>fs[Abbr`ss`]
+QED
 
 (* do spill *)
-val st_ex_list_MIN_cost_success = Q.prove(`
+Triviality st_ex_list_MIN_cost_success:
   ∀ls s k v acc.
   good_ra_state s ∧
   EVERY (λv. v < s.dim) acc ∧
@@ -2602,13 +2697,15 @@ val st_ex_list_MIN_cost_success = Q.prove(`
   ∃x y.
   st_ex_list_MIN_cost sc ls (s.dim) k v acc s = (M_success (x,y),s) ∧
   x < s.dim ∧
-  EVERY (λv. v < s.dim) y`,
+  EVERY (λv. v < s.dim) y
+Proof
   Induct>>fs[st_ex_list_MIN_cost_def]>>simp msimps>>rw[]>>
   fs[degrees_accessor,Marray_sub_def]>>
   reverse (rw[])>- fs[good_ra_state_def]>>
-  rw[]);
+  rw[]
+QED
 
-val st_ex_list_MAX_deg_success = Q.prove(`
+Triviality st_ex_list_MAX_deg_success:
   ∀ls s k v acc.
   good_ra_state s ∧
   EVERY (λv. v < s.dim) acc ∧
@@ -2616,13 +2713,15 @@ val st_ex_list_MAX_deg_success = Q.prove(`
   ∃x y.
   st_ex_list_MAX_deg ls (s.dim) k v acc s = (M_success (x,y),s) ∧
   x < s.dim ∧
-  EVERY (λv. v < s.dim) y`,
+  EVERY (λv. v < s.dim) y
+Proof
   Induct>>fs[st_ex_list_MAX_deg_def]>>simp msimps>>rw[]>>
   fs[degrees_accessor,Marray_sub_def]>>
   reverse (rw[])>- fs[good_ra_state_def]>>
-  rw[]);
+  rw[]
+QED
 
-val do_spill_success = Q.prove(`
+Triviality do_spill_success:
   ∀s.
     good_ra_state s
     ⇒
@@ -2631,7 +2730,8 @@ val do_spill_success = Q.prove(`
       good_ra_state s' ∧
       is_subgraph s.adj_ls s'.adj_ls ∧
       s.dim = s'.dim ∧
-      s.node_tag = s'.node_tag`,
+      s.node_tag = s'.node_tag
+Proof
   rw[do_spill_def]>>fs msimps>>fs[get_spill_wl_def]>>fs[get_dim_def]>>
   TOP_CASE_TAC>-
     fs[is_subgraph_def]>>
@@ -2665,9 +2765,10 @@ val do_spill_success = Q.prove(`
     fs[Abbr`sss`,Abbr`ss`,good_ra_state_def]>>
   rw[]>>fs[]>>
   unabbrev_all_tac>>
-  fs[good_ra_state_def]);
+  fs[good_ra_state_def]
+QED
 
-val do_step_success = Q.prove(`
+Triviality do_step_success:
   ∀sc k s.
     good_ra_state s ⇒
     ∃b s'.
@@ -2675,7 +2776,8 @@ val do_step_success = Q.prove(`
       good_ra_state s' ∧
       is_subgraph s.adj_ls s'.adj_ls ∧
       s.dim = s'.dim ∧
-      s.node_tag = s'.node_tag`,
+      s.node_tag = s'.node_tag
+Proof
   rw[do_step_def]>>fs msimps>>
   FREEZE_THEN drule do_simplify_success>>rw[]>>simp[]>>
   IF_CASES_TAC>>fs[]>>
@@ -2686,10 +2788,11 @@ val do_step_success = Q.prove(`
   FREEZE_THEN drule do_freeze_success>>rw[]>>simp[]>>
   IF_CASES_TAC>>fs[]>- metis_tac[is_subgraph_trans]>>
   FREEZE_THEN drule do_spill_success>>rw[]>>simp[]>>
-  metis_tac[is_subgraph_trans]);
+  metis_tac[is_subgraph_trans]
+QED
 
 val drule = FREEZE_THEN drule
-val rpt_do_step_success = Q.prove(`
+Triviality rpt_do_step_success:
   ∀n s k sc.
     good_ra_state s ⇒
     ∃s'.
@@ -2697,30 +2800,35 @@ val rpt_do_step_success = Q.prove(`
       good_ra_state s' ∧
       is_subgraph s.adj_ls s'.adj_ls ∧
       s.dim = s'.dim ∧
-      s.node_tag = s'.node_tag`,
+      s.node_tag = s'.node_tag
+Proof
   Induct>>fs[rpt_do_step_def]>>fs msimps>-fs[is_subgraph_def]>>
   rw[]>>
   drule do_step_success>> disch_then(qspecl_then[`sc`,`k`] assume_tac)>>rfs[]>>
-  metis_tac[is_subgraph_trans,do_step_success]);
+  metis_tac[is_subgraph_trans,do_step_success]
+QED
 
-val full_consistency_ok_success = Q.prove(`
+Triviality full_consistency_ok_success:
   ∀x y s.
   good_ra_state s ⇒
   ∃b.
   full_consistency_ok k x y s = (M_success b,s) ∧
-  (b ⇒ x < s.dim ∧ y < s.dim)`,
+  (b ⇒ x < s.dim ∧ y < s.dim)
+Proof
   rw[]>>simp[Once full_consistency_ok_def]>>
   rpt(IF_CASES_TAC>>simp msimps>>simp get_eqns)>>
   fs[is_Fixed_k_def,is_Atemp_def]>>fs msimps>>
   EVERY_CASE_TAC>>simp msimps>>
-  fs[good_ra_state_def]);
+  fs[good_ra_state_def]
+QED
 
-val st_ex_FILTER_full_consistency_ok = Q.prove(`
+Triviality st_ex_FILTER_full_consistency_ok:
   ∀ls acc s.
   good_ra_state s ⇒
   ?ts. st_ex_FILTER (λ(_,x,y). full_consistency_ok k x y) ls acc s =
     (M_success ts,s) ∧
-  EVERY (λ(p,(x,y)). x < s.dim ∧ y < s.dim ∨ MEM (p,(x,y)) acc) ts`,
+  EVERY (λ(p,(x,y)). x < s.dim ∧ y < s.dim ∨ MEM (p,(x,y)) acc) ts
+Proof
   Induct>>rw[]>>fs[st_ex_FILTER_def]>>
   fs msimps
   >-
@@ -2736,9 +2844,10 @@ val st_ex_FILTER_full_consistency_ok = Q.prove(`
   rfs[]>>
   fs[EVERY_MEM,FORALL_PROD]>>
   rw[]>>first_x_assum drule>>fs[]>>rw[]>>
-  fs[]>>metis_tac[]);
+  fs[]>>metis_tac[]
+QED
 
-val do_alloc1_success = Q.prove(`
+Triviality do_alloc1_success:
   good_ra_state s ∧
   EVERY (λ(p:num,x,y). x < s.dim ∧ y < s.dim) moves
   ⇒
@@ -2748,7 +2857,8 @@ val do_alloc1_success = Q.prove(`
   is_subgraph s.adj_ls s'.adj_ls ∧
   (* This allows the coalescing phase to modify the adjacency list *)
   s'.dim = s.dim ∧
-  s'.node_tag = s.node_tag`,
+  s'.node_tag = s.node_tag
+Proof
   rw[do_alloc1_def]>>simp msimps>>
   simp[get_dim_def,init_alloc1_heu_def]>> simp msimps>>
   qmatch_goalsub_abbrev_tac`_ is_Atemp ls lss s`>>
@@ -2840,7 +2950,8 @@ val do_alloc1_success = Q.prove(`
     (fs[Abbr`sss`,good_ra_state_def,Abbr`lss`,EVERY_MEM]>>
     metis_tac[])>>
   rw[]>>simp[get_stack_def]>>
-  fs[Abbr`sss`,Abbr`ss`]);
+  fs[Abbr`sss`,Abbr`ss`]
+QED
 
 Theorem no_clash_colouring_satisfactory:
     no_clash adjls node_tag ∧
@@ -2912,9 +3023,11 @@ Proof
     metis_tac[]
 QED
 
-val opt_split = Q.prove(`
-  a ≠ NONE ⇔ a = SOME ()`,
-  Cases_on`a`>>fs[]);
+Triviality opt_split:
+  a ≠ NONE ⇔ a = SOME ()
+Proof
+  Cases_on`a`>>fs[]
+QED
 
 Theorem INJ_IMG_lookup:
     ∀x. INJ g UNIV UNIV ∧

--- a/compiler/backend/semantics/bviPropsScript.sml
+++ b/compiler/backend/semantics/bviPropsScript.sml
@@ -302,10 +302,11 @@ Proof
   simp [dec_clock_def, state_component_equality]
 QED
 
-val do_app_inv_clock = Q.prove(
-  `case do_app op (REVERSE a) s of
+Triviality do_app_inv_clock:
+  case do_app op (REVERSE a) s of
     | Rerr e => (do_app op (REVERSE a) (inc_clock n s) = Rerr e)
-    | Rval (v,s1) => (do_app op (REVERSE a) (inc_clock n s) = Rval (v,inc_clock n s1))`,
+    | Rval (v,s1) => (do_app op (REVERSE a) (inc_clock n s) = Rval (v,inc_clock n s1))
+Proof
   Cases_on `op = Install` THEN1
    (Q.SPEC_TAC(`REVERSE a`,`a`) \\ gen_tac \\ CASE_TAC
     \\ fs [do_app_def,do_install_def,UNCURRY,inc_clock_def] \\ rfs []
@@ -318,7 +319,8 @@ val do_app_inv_clock = Q.prove(
   \\ imp_res_tac bvlPropsTheory.do_app_change_clock
   \\ imp_res_tac bvlPropsTheory.do_app_change_clock_err
   \\ rfs [] \\ fs[state_component_equality] \\ fs[] \\ rw[] \\ fs[]
-  \\ fs[bvlSemTheory.state_component_equality] \\ fs[] \\ rw[] \\ fs[]);
+  \\ fs[bvlSemTheory.state_component_equality] \\ fs[] \\ rw[] \\ fs[]
+QED
 
 Theorem evaluate_inv_clock:
    !xs env t1 res t2 n.
@@ -429,8 +431,9 @@ Proof
   \\ rw[] \\ metis_tac[subspt_FOLDL_union]
 QED
 
-val evaluate_global_mono_lemma = Q.prove(
-  `∀xs env s. IS_SOME s.global ⇒ IS_SOME((SND (evaluate (xs,env,s))).global)`,
+Triviality evaluate_global_mono_lemma:
+  ∀xs env s. IS_SOME s.global ⇒ IS_SOME((SND (evaluate (xs,env,s))).global)
+Proof
   recInduct evaluate_ind \\ rw[evaluate_def,case_eq_thms,pair_case_eq]
   \\ every_case_tac \\ fs[] \\ rfs[] \\ fs[]
   \\ Cases_on `op = Install`
@@ -438,7 +441,8 @@ val evaluate_global_mono_lemma = Q.prove(
   \\ fs[do_app_aux_def,case_eq_thms] \\ rw[]
   \\ every_case_tac \\ fs [do_install_def,UNCURRY]
   \\ every_case_tac \\ fs [do_install_def]
-  \\ rw [] \\ fs []);
+  \\ rw [] \\ fs []
+QED
 
 Theorem evaluate_global_mono:
    ∀xs env s res t. (evaluate (xs,env,s) = (res,t)) ⇒ IS_SOME s.global ⇒ IS_SOME t.global
@@ -603,25 +607,33 @@ Proof
   metis_tac[IS_PREFIX_TRANS,do_app_io_events_mono]
 QED
 
-val do_app_inc_clock = Q.prove(
-  `do_app op vs (inc_clock x y) =
-   map_result (λ(v,s). (v,s with clock := x + y.clock)) I (do_app op vs y)`,
+Triviality do_app_inc_clock:
+  do_app op vs (inc_clock x y) =
+   map_result (λ(v,s). (v,s with clock := x + y.clock)) I (do_app op vs y)
+Proof
   Cases_on`do_app op vs y` >>
   imp_res_tac do_app_change_clock_err >>
   TRY(Cases_on`a`>>imp_res_tac do_app_change_clock) >>
-  full_simp_tac(srw_ss())[inc_clock_def] >> simp[])
+  full_simp_tac(srw_ss())[inc_clock_def] >> simp[]
+QED
 
-val dec_clock_1_inc_clock = Q.prove(
-  `x ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock (x-1) s`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_1_inc_clock:
+  x ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock (x-1) s
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
-val dec_clock_1_inc_clock2 = Q.prove(
-  `s.clock ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock x (dec_clock 1 s)`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_1_inc_clock2:
+  s.clock ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock x (dec_clock 1 s)
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
-val dec_clock_inc_clock = Q.prove(
-  `¬(s.clock < n) ⇒ dec_clock n (inc_clock x s) = inc_clock x (dec_clock n s)`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_inc_clock:
+  ¬(s.clock < n) ⇒ dec_clock n (inc_clock x s) = inc_clock x (dec_clock n s)
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
 Theorem inc_clock_eq_0[simp]:
    (inc_clock extra s).clock = 0 ⇔ s.clock = 0 ∧ extra = 0
@@ -657,12 +669,13 @@ Proof
             inc_clock_ffi,dec_clock_ffi]
 QED
 
-val take_drop_lem = Q.prove (
-  `!skip env.
+Triviality take_drop_lem:
+  !skip env.
     skip < LENGTH env ∧
     skip + SUC n ≤ LENGTH env ∧
     DROP skip env ≠ [] ⇒
-    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)`,
+    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)
+Proof
   Induct_on `n` >>
   srw_tac[][TAKE1, HD_DROP] >>
   `skip + SUC n ≤ LENGTH env` by decide_tac >>
@@ -675,7 +688,8 @@ val take_drop_lem = Q.prove (
   `n + (1 + skip) < LENGTH env` by decide_tac >>
   `(n+1) + skip < LENGTH env` by decide_tac >>
   srw_tac[][EL_DROP] >>
-  srw_tac [ARITH_ss] []);
+  srw_tac [ARITH_ss] []
+QED
 
 Theorem evaluate_genlist_vars:
    !skip env n (st:('c,'ffi) bviSem$state).

--- a/compiler/backend/semantics/bviSemScript.sml
+++ b/compiler/backend/semantics/bviSemScript.sml
@@ -26,9 +26,11 @@ Definition dec_clock_def:
   dec_clock x s = s with clock := s.clock - x
 End
 
-val LESS_EQ_dec_clock = Q.prove(
-  `r.clock <= (dec_clock x s).clock ==> r.clock <= s.clock`,
-  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
+Triviality LESS_EQ_dec_clock:
+  r.clock <= (dec_clock x s).clock ==> r.clock <= s.clock
+Proof
+  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC
+QED
 
 Definition bvi_to_bvl_def:
   (bvi_to_bvl:('c,'ffi) bviSem$state->('c,'ffi) bvlSem$state) s =
@@ -165,9 +167,11 @@ Definition fix_clock_def:
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (res,s1) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
 (* The semantics of expression evaluation is defined next. For
    convenience of subsequent proofs, the evaluation function is

--- a/compiler/backend/semantics/bvlPropsScript.sml
+++ b/compiler/backend/semantics/bvlPropsScript.sml
@@ -48,9 +48,11 @@ val do_app_split_list = prove(
     ?v vs1. vs = v::vs1 /\ do_app op (v::vs1) s = res``,
   Cases_on `vs` \\ fs []);
 
-val pair_lam_lem = Q.prove (
-`!f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)`,
- srw_tac[][]);
+Triviality pair_lam_lem:
+  !f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)
+Proof
+  srw_tac[][]
+QED
 
 val do_app_cases_val = save_thm ("do_app_cases_val",
   ``do_app op vs s = Rval (v,s')`` |>
@@ -598,25 +600,33 @@ Proof
   metis_tac[IS_PREFIX_TRANS,do_app_io_events_mono]
 QED
 
-val do_app_inc_clock = Q.prove(
-  `do_app op vs (inc_clock x y) =
-   map_result (λ(v,s). (v,s with clock := x + y.clock)) I (do_app op vs y)`,
+Triviality do_app_inc_clock:
+  do_app op vs (inc_clock x y) =
+   map_result (λ(v,s). (v,s with clock := x + y.clock)) I (do_app op vs y)
+Proof
   Cases_on`do_app op vs y` >>
   imp_res_tac do_app_change_clock_err >>
   TRY(Cases_on`a`>>imp_res_tac do_app_change_clock) >>
-  full_simp_tac(srw_ss())[inc_clock_def] >> simp[])
+  full_simp_tac(srw_ss())[inc_clock_def] >> simp[]
+QED
 
-val dec_clock_1_inc_clock = Q.prove(
-  `x ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock (x-1) s`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_1_inc_clock:
+  x ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock (x-1) s
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
-val dec_clock_1_inc_clock2 = Q.prove(
-  `s.clock ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock x (dec_clock 1 s)`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_1_inc_clock2:
+  s.clock ≠ 0 ⇒ dec_clock 1 (inc_clock x s) = inc_clock x (dec_clock 1 s)
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
-val dec_clock_inc_clock = Q.prove(
-  `¬(s.clock < n) ⇒ dec_clock n (inc_clock x s) = inc_clock x (dec_clock n s)`,
-  simp[state_component_equality,inc_clock_def,dec_clock_def])
+Triviality dec_clock_inc_clock:
+  ¬(s.clock < n) ⇒ dec_clock n (inc_clock x s) = inc_clock x (dec_clock n s)
+Proof
+  simp[state_component_equality,inc_clock_def,dec_clock_def]
+QED
 
 Theorem evaluate_add_to_clock_io_events_mono:
    ∀exps env s extra.
@@ -642,12 +652,13 @@ Proof
             inc_clock_ffi,dec_clock_ffi]
 QED
 
-val take_drop_lem = Q.prove (
-  `!skip env.
+Triviality take_drop_lem:
+  !skip env.
     skip < LENGTH env ∧
     skip + SUC n ≤ LENGTH env ∧
     DROP skip env ≠ [] ⇒
-    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)`,
+    EL skip env::TAKE n (DROP (1 + skip) env) = TAKE (n + 1) (DROP skip env)
+Proof
   Induct_on `n` >>
   srw_tac[][TAKE1, HD_DROP] >>
   `skip + SUC n ≤ LENGTH env` by decide_tac >>
@@ -660,7 +671,8 @@ val take_drop_lem = Q.prove (
   `n + (1 + skip) < LENGTH env` by decide_tac >>
   `(n+1) + skip < LENGTH env` by decide_tac >>
   srw_tac[][EL_DROP] >>
-  srw_tac [ARITH_ss] []);
+  srw_tac [ARITH_ss] []
+QED
 
 Theorem evaluate_genlist_vars:
    !skip env n st.
@@ -743,14 +755,16 @@ Proof
   \\ imp_res_tac do_build_SUBSET \\ fs [SUBSET_DEF]
 QED
 
-val evaluate_refs_SUBSET_lemma = Q.prove(
-  `!xs env s. FDOM s.refs SUBSET FDOM (SND (evaluate (xs,env,s))).refs`,
+Triviality evaluate_refs_SUBSET_lemma:
+  !xs env s. FDOM s.refs SUBSET FDOM (SND (evaluate (xs,env,s))).refs
+Proof
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ BasicProvers.EVERY_CASE_TAC \\ full_simp_tac(srw_ss())[]
   \\ REV_FULL_SIMP_TAC std_ss []
   \\ IMP_RES_TAC SUBSET_TRANS
   \\ full_simp_tac(srw_ss())[dec_clock_def] \\ full_simp_tac(srw_ss())[]
-  \\ IMP_RES_TAC do_app_refs_SUBSET \\ full_simp_tac(srw_ss())[SUBSET_DEF]);
+  \\ IMP_RES_TAC do_app_refs_SUBSET \\ full_simp_tac(srw_ss())[SUBSET_DEF]
+QED
 
 Theorem evaluate_refs_SUBSET:
    (evaluate (xs,env,s) = (res,t)) ==> FDOM s.refs SUBSET FDOM t.refs

--- a/compiler/backend/semantics/bvlSemScript.sml
+++ b/compiler/backend/semantics/bvlSemScript.sml
@@ -477,9 +477,11 @@ Definition fix_clock_def:
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (res,s1) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
 (* The semantics of expression evaluation is defined next. For
    convenience of subsequent proofs, the evaluation function is

--- a/compiler/backend/semantics/closPropsScript.sml
+++ b/compiler/backend/semantics/closPropsScript.sml
@@ -1001,9 +1001,11 @@ Proof
   \\ fs [] \\ Cases_on ‘e’ \\ fs []
 QED
 
-val pair_lam_lem = Q.prove (
-`!f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)`,
- srw_tac[][]);
+Triviality pair_lam_lem:
+  !f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)
+Proof
+  srw_tac[][]
+QED
 
 val do_app_split_list = prove(
   ``do_app op vs s = res
@@ -1454,8 +1456,11 @@ Proof
    simp [])
 QED
 
-val revnil = Q.prove(`[] = REVERSE l ⇔ l = []`,
-  CONV_TAC (LAND_CONV (REWR_CONV EQ_SYM_EQ)) >> simp[])
+Triviality revnil:
+  [] = REVERSE l ⇔ l = []
+Proof
+  CONV_TAC (LAND_CONV (REWR_CONV EQ_SYM_EQ)) >> simp[]
+QED
 
 Theorem dest_closure_full_maxapp:
    dest_closure max_app NONE c vs = SOME (Full_app b env r) ∧ r ≠ [] ⇒
@@ -1703,16 +1708,18 @@ Proof
   \\ fs [initial_state_def]
 QED
 
-val do_app_io_events_mono = Q.prove(
-  `do_app op vs s = Rval(v,s') ⇒
-   s.ffi.io_events ≼ s'.ffi.io_events`,
+Triviality do_app_io_events_mono:
+  do_app op vs s = Rval(v,s') ⇒
+   s.ffi.io_events ≼ s'.ffi.io_events
+Proof
   srw_tac[][do_app_cases_val] >>
   full_simp_tac(srw_ss())[LET_THM,
      semanticPrimitivesTheory.store_alloc_def,
      semanticPrimitivesTheory.store_lookup_def,
      semanticPrimitivesTheory.store_assign_def] >> srw_tac[][] >>
   full_simp_tac(srw_ss())[ffiTheory.call_FFI_def] >>
-  every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][]);
+  every_case_tac >> full_simp_tac(srw_ss())[] >> srw_tac[][]
+QED
 
 Theorem evaluate_io_events_mono:
    (∀p. ((SND(SND p)):('c,'ffi) closSem$state).ffi.io_events ≼ (SND (evaluate p)).ffi.io_events) ∧
@@ -1724,10 +1731,12 @@ Proof
   metis_tac[IS_PREFIX_TRANS,do_app_io_events_mono,do_install_const]
 QED
 
-val evaluate_io_events_mono_imp = Q.prove(
-  `evaluate (es,env,s) = (r,s') ⇒
-    s.ffi.io_events ≼ s'.ffi.io_events`,
-  metis_tac[evaluate_io_events_mono,FST,SND,PAIR])
+Triviality evaluate_io_events_mono_imp:
+  evaluate (es,env,s) = (r,s') ⇒
+    s.ffi.io_events ≼ s'.ffi.io_events
+Proof
+  metis_tac[evaluate_io_events_mono,FST,SND,PAIR]
+QED
 
 val with_clock_ffi = Q.prove(
   `(s with clock := k).ffi = s.ffi`,EVAL_TAC)
@@ -2975,16 +2984,18 @@ Proof
   \\ fsrw_tac [SATISFY_ss] []
 QED
 
-val do_app_lemma_simp = Q.prove(
-  `(exc_rel $= err1 err2 <=> err1 = err2) /\
+Triviality do_app_lemma_simp:
+  (exc_rel $= err1 err2 <=> err1 = err2) /\
     LIST_REL $= xs xs /\
     simple_state_rel $= (adj_orac_rel cc f) /\
-    simple_val_rel $=`,
+    simple_val_rel $=
+Proof
   rw [] \\ fs [simple_state_rel_def,adj_orac_rel_def] \\ rw []
   THEN1
    (Cases_on `err1` \\ fs [semanticPrimitivesPropsTheory.exc_rel_def]
     \\ eq_tac \\ rw [])
-  \\ fs [simple_val_rel_def] \\ fs []);
+  \\ fs [simple_val_rel_def] \\ fs []
+QED
 
 val do_app_lemma =
   simple_val_rel_do_app

--- a/compiler/backend/semantics/closSemScript.sml
+++ b/compiler/backend/semantics/closSemScript.sml
@@ -448,9 +448,11 @@ Definition fix_clock_def:
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (res,s1) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
 (* The semantics of expression evaluation is defined next. For
    convenience of subsequent proofs, the evaluation function is
@@ -715,11 +717,12 @@ Proof
   \\ every_case_tac \\ fs[] \\ rveq \\ fs[]
 QED
 
-val evaluate_clock_help = Q.prove (
-  `(!tup vs (s2:('c,'ffi) closSem$state).
+Triviality evaluate_clock_help:
+  (!tup vs (s2:('c,'ffi) closSem$state).
       (evaluate tup = (vs,s2)) ==> s2.clock <= (SND (SND tup)).clock) ∧
     (!loc_opt f args (s1:('c,'ffi) closSem$state) vs s2.
-      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)`,
+      (evaluate_app loc_opt f args s1 = (vs,s2)) ==> s2.clock <= s1.clock)
+Proof
   ho_match_mp_tac evaluate_ind \\ REPEAT STRIP_TAC
   \\ POP_ASSUM MP_TAC \\ ONCE_REWRITE_TAC [evaluate_def]
   \\ FULL_SIMP_TAC std_ss [LET_THM] \\ BasicProvers.EVERY_CASE_TAC
@@ -729,7 +732,8 @@ val evaluate_clock_help = Q.prove (
   \\ IMP_RES_TAC fix_clock_IMP
   \\ IMP_RES_TAC do_app_const
   \\ IMP_RES_TAC do_install_clock_less_eq
-  \\ FULL_SIMP_TAC (srw_ss()) [dec_clock_def] \\ TRY DECIDE_TAC);
+  \\ FULL_SIMP_TAC (srw_ss()) [dec_clock_def] \\ TRY DECIDE_TAC
+QED
 
 Theorem evaluate_clock:
  (!xs env s1 vs s2.

--- a/compiler/backend/semantics/dataPropsScript.sml
+++ b/compiler/backend/semantics/dataPropsScript.sml
@@ -192,13 +192,17 @@ Proof
   full_simp_tac(srw_ss())[consume_space_def,add_space_def,state_component_equality] \\ DECIDE_TAC
 QED
 
-val consume_space_with_stack = Q.prove(
-  `consume_space x (y with stack := z) = OPTION_MAP (λs. s with stack := z) (consume_space x y)`,
-  EVAL_TAC >> srw_tac[][]);
+Triviality consume_space_with_stack:
+  consume_space x (y with stack := z) = OPTION_MAP (λs. s with stack := z) (consume_space x y)
+Proof
+  EVAL_TAC >> srw_tac[][]
+QED
 
-val consume_space_with_locals = Q.prove(
-  `consume_space x (y with locals := z) = OPTION_MAP (λs. s with locals := z) (consume_space x y)`,
-  EVAL_TAC >> srw_tac[][]);
+Triviality consume_space_with_locals:
+  consume_space x (y with locals := z) = OPTION_MAP (λs. s with locals := z) (consume_space x y)
+Proof
+  EVAL_TAC >> srw_tac[][]
+QED
 
 val do_app_with_stack = time Q.prove(
   `do_app op vs (s with stack := z) =
@@ -1318,19 +1322,21 @@ Proof
   \\ SRW_TAC [] []
 QED
 
-val evaluate_locals_LN_lemma = Q.prove(
-  `!c ^s.
+Triviality evaluate_locals_LN_lemma:
+  !c ^s.
       FST (evaluate (c,s)) <> NONE /\
       FST (evaluate (c,s)) <> SOME (Rerr(Rabort Rtype_error)) ==>
       ((SND (evaluate (c,s))).locals = LN) \/
-      ?t. FST (evaluate (c,s)) = SOME (Rerr(Rraise t))`,
+      ?t. FST (evaluate (c,s)) = SOME (Rerr(Rraise t))
+Proof
   recInduct evaluate_ind \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[evaluate_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[call_env_def,flush_state_def,fromList_def]
   \\ imp_res_tac do_app_err >> full_simp_tac(srw_ss())[] >> rev_full_simp_tac(srw_ss())[]
   \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[LET_DEF] \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
   \\ rpt(TOP_CASE_TAC >> fs[] >> rveq)
   \\ fs[markerTheory.Abbrev_def]
-  \\ rpt(TOP_CASE_TAC >> fs[] >> rveq));
+  \\ rpt(TOP_CASE_TAC >> fs[] >> rveq)
+QED
 
 Theorem evaluate_locals_LN:
    !c ^s res t.

--- a/compiler/backend/semantics/dataSemScript.sml
+++ b/compiler/backend/semantics/dataSemScript.sml
@@ -1032,13 +1032,17 @@ Definition fix_clock_def:
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (res,s1) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
-val LESS_EQ_dec_clock = Q.prove(
-  `r.clock <= (dec_clock s).clock ==> r.clock <= s.clock`,
-  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC);
+Triviality LESS_EQ_dec_clock:
+  r.clock <= (dec_clock s).clock ==> r.clock <= s.clock
+Proof
+  SRW_TAC [] [dec_clock_def] \\ DECIDE_TAC
+QED
 
 Definition flush_state_def:
    flush_state T ^s = s with <| locals := LN
@@ -1128,17 +1132,21 @@ Definition cut_state_opt_def:
     | SOME names => cut_state names s
 End
 
-val pop_env_clock = Q.prove(
-  `(pop_env s = SOME s1) ==> (s1.clock = s.clock)`,
+Triviality pop_env_clock:
+  (pop_env s = SOME s1) ==> (s1.clock = s.clock)
+Proof
   full_simp_tac(srw_ss())[pop_env_def]
   \\ REPEAT BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
+  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
+QED
 
-val push_env_clock = Q.prove(
-  `(push_env env b s).clock = s.clock`,
+Triviality push_env_clock:
+  (push_env env b s).clock = s.clock
+Proof
   Cases_on `b` \\ full_simp_tac(srw_ss())[push_env_def]
   \\ REPEAT BasicProvers.FULL_CASE_TAC \\ full_simp_tac(srw_ss())[]
-  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
+  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
+QED
 
 Definition find_code_def:
   (find_code (SOME p) args code ssize =

--- a/compiler/backend/semantics/flatPropsScript.sml
+++ b/compiler/backend/semantics/flatPropsScript.sml
@@ -259,14 +259,16 @@ Proof
   \\ rw [] \\ fs []
 QED
 
-val build_rec_env_help_lem = Q.prove (
-  `∀funs env funs'.
+Triviality build_rec_env_help_lem:
+  ∀funs env funs'.
   FOLDR (λ(f,x,e) env'. (f, flatSem$Recclosure env funs' f)::env') env' funs =
-  MAP (λ(fn,n,e). (fn, Recclosure env funs' fn)) funs ++ env'`,
+  MAP (λ(fn,n,e). (fn, Recclosure env funs' fn)) funs ++ env'
+Proof
   Induct >>
   srw_tac[][] >>
   PairCases_on `h` >>
-  srw_tac[][]);
+  srw_tac[][]
+QED
 
 (* Alternate definition for build_rec_env *)
 Theorem build_rec_env_merge:
@@ -350,17 +352,20 @@ Proof
   fs []
 QED
 
-val do_app_add_to_clock = Q.prove (
-  `do_app ^s op es = SOME (t, r)
+Triviality do_app_add_to_clock:
+  do_app ^s op es = SOME (t, r)
    ==>
    do_app (s with clock := s.clock + k) op es =
-     SOME (t with clock := t.clock + k, r)`,
-  rw [do_app_cases] \\ fs []);
+     SOME (t with clock := t.clock + k, r)
+Proof
+  rw [do_app_cases] \\ fs []
+QED
 
-val do_app_add_to_clock_NONE = Q.prove (
-  `do_app ^s op es = NONE
+Triviality do_app_add_to_clock_NONE:
+  do_app ^s op es = NONE
    ==>
-   do_app (s with clock := s.clock + k) op es = NONE`,
+   do_app (s with clock := s.clock + k) op es = NONE
+Proof
   Cases_on `op`
   \\ disch_then (mp_tac o SIMP_RULE (srw_ss()) [do_app_def, case_eq_thms])
   \\ rw []
@@ -368,7 +373,8 @@ val do_app_add_to_clock_NONE = Q.prove (
   \\ fs [case_eq_thms, pair_case_eq] \\ rw [] \\ fs []
   \\ rpt (pairarg_tac \\ fs [])
   \\ fs [bool_case_eq, case_eq_thms]
-  \\ fs [IS_SOME_EXISTS,CaseEq"option",CaseEq"store_v"]);
+  \\ fs [IS_SOME_EXISTS,CaseEq"option",CaseEq"store_v"]
+QED
 
 Theorem evaluate_add_to_clock:
    (∀env ^s es s' r.
@@ -626,29 +632,35 @@ Proof
   \\ rw[Once pmatch_nil]
 QED
 
-val evaluate_decs_add_to_clock_initial_state = Q.prove(
-  `r ≠ SOME (Rabort Rtimeout_error) ∧
+Triviality evaluate_decs_add_to_clock_initial_state:
+  r ≠ SOME (Rabort Rtimeout_error) ∧
    evaluate_decs (initial_state ffi k ec) decs = (s',r) ⇒
    evaluate_decs (initial_state ffi (ck + k) ec) decs =
-   (s' with clock := s'.clock + ck,r)`,
+   (s' with clock := s'.clock + ck,r)
+Proof
   rw [initial_state_def]
-  \\ imp_res_tac evaluate_decs_add_to_clock \\ fs []);
+  \\ imp_res_tac evaluate_decs_add_to_clock \\ fs []
+QED
 
-val evaluate_decs_add_to_clock_initial_state_io_events_mono = Q.prove (
-  `evaluate_decs (initial_state ffi k ec) prog = (s',r) ==>
+Triviality evaluate_decs_add_to_clock_initial_state_io_events_mono:
+  evaluate_decs (initial_state ffi k ec) prog = (s',r) ==>
    s'.ffi.io_events ≼
-   (FST (evaluate_decs (initial_state ffi (k+ck) ec) prog)).ffi.io_events`,
+   (FST (evaluate_decs (initial_state ffi (k+ck) ec) prog)).ffi.io_events
+Proof
   rw [initial_state_def]
   \\ qmatch_assum_abbrev_tac `evaluate_decs s1 _ = _`
   \\ qispl_then
          [`prog`,`s1`,`ck`] mp_tac
          (evaluate_decs_add_to_clock_io_events_mono)
-  \\ fs [Abbr`s1`]);
+  \\ fs [Abbr`s1`]
+QED
 
-val initial_state_with_clock = Q.prove (
-  `(initial_state ffi k ec with clock := (initial_state ffi k ec).clock + ck) =
-   initial_state ffi (k + ck) ec`,
-  rw [initial_state_def]);
+Triviality initial_state_with_clock:
+  (initial_state ffi k ec with clock := (initial_state ffi k ec).clock + ck) =
+   initial_state ffi (k + ck) ec
+Proof
+  rw [initial_state_def]
+QED
 
 val SND_SND_lemma = prove(
   ``(SND x) = y <=> ?y1. x = (y1, y)``,

--- a/compiler/backend/semantics/flatSemScript.sml
+++ b/compiler/backend/semantics/flatSemScript.sml
@@ -631,9 +631,11 @@ Definition fix_clock_def:
   fix_clock s (s1,res) = (s1 with clock := MIN s.clock s1.clock,res)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (s1,res) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (s1,res) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
 Theorem pmatch_rows_Match_exp_size:
   !pes s v env e.
@@ -828,14 +830,18 @@ val eqs = LIST_CONJ (map prove_case_eq_thm
 
 val case_eq_thms = save_thm ("case_eq_thms", eqs)
 
-val pair_case_eq = Q.prove (
-`pair_CASE x f = v ⇔ ?x1 x2. x = (x1,x2) ∧ f x1 x2 = v`,
- Cases_on `x` >>
- srw_tac[][]);
+Triviality pair_case_eq:
+  pair_CASE x f = v ⇔ ?x1 x2. x = (x1,x2) ∧ f x1 x2 = v
+Proof
+  Cases_on `x` >>
+ srw_tac[][]
+QED
 
-val pair_lam_lem = Q.prove (
-`!f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)`,
- srw_tac[][]);
+Triviality pair_lam_lem:
+  !f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)
+Proof
+  srw_tac[][]
+QED
 
 val do_app_cases = save_thm ("do_app_cases",
 ``do_app st op vs = SOME (st',v)`` |>

--- a/compiler/backend/semantics/labSemScript.sml
+++ b/compiler/backend/semantics/labSemScript.sml
@@ -317,9 +317,10 @@ Definition asm_code_length_def:
      asm_code_length ((Section k ys)::xs) + if is_Label y then 0 else 1:num)
 End
 
-val asm_fetch_IMP = Q.prove(
-  `(asm_fetch s = SOME x) ==>
-    s.pc < asm_code_length s.code`,
+Triviality asm_fetch_IMP:
+  (asm_fetch s = SOME x) ==>
+    s.pc < asm_code_length s.code
+Proof
   fs [asm_fetch_def,asm_code_length_def]
   \\ Q.SPEC_TAC (`s.pc`,`pc`)
   \\ Q.SPEC_TAC (`s.code`,`xs`)
@@ -327,7 +328,8 @@ val asm_fetch_IMP = Q.prove(
   \\ rpt strip_tac \\ fs [asm_fetch_aux_def,asm_code_length_def]
   \\ Cases_on `is_Label y` \\ fs []
   \\ Cases_on `pc = 0` \\ fs []
-  \\ res_tac \\ decide_tac);
+  \\ res_tac \\ decide_tac
+QED
 
 Definition lab_to_loc_def:
   lab_to_loc (Lab n1 n2) = Loc n1 n2

--- a/compiler/backend/semantics/stackPropsScript.sml
+++ b/compiler/backend/semantics/stackPropsScript.sml
@@ -595,19 +595,22 @@ Definition clock_neutral_def:
   (clock_neutral r <=> F)
 End
 
-val inst_clock_neutral = Q.prove(
-  `(inst i s = SOME t ==> inst i (s with clock := k) = SOME (t with clock := k)) /\
-    (inst i s = NONE ==> inst i (s with clock := k) = NONE)`,
+Triviality inst_clock_neutral:
+  (inst i s = SOME t ==> inst i (s with clock := k) = SOME (t with clock := k)) /\
+    (inst i s = NONE ==> inst i (s with clock := k) = NONE)
+Proof
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,word_exp_def,set_var_def,LET_DEF,set_fp_var_def]
   \\ srw_tac[][state_component_equality]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_exp_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_exp_def]
   \\ full_simp_tac(srw_ss())[mem_load_def,get_var_def,mem_store_def,get_fp_var_def]
-  \\ srw_tac[][state_component_equality]);
+  \\ srw_tac[][state_component_equality]
+QED
 
-val inst_clock_neutral_ffi = Q.prove(
-  `(inst i s = SOME t ==> inst i (s with ffi := k) = SOME (t with ffi := k)) /\
-    (inst i s = NONE ==> inst i (s with ffi := k) = NONE)`,
+Triviality inst_clock_neutral_ffi:
+  (inst i s = SOME t ==> inst i (s with ffi := k) = SOME (t with ffi := k)) /\
+    (inst i s = NONE ==> inst i (s with ffi := k) = NONE)
+Proof
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,word_exp_def,set_var_def,LET_DEF,state_component_equality,set_fp_var_def]>>
   reverse full_case_tac>>fs[]>>
   TRY
@@ -618,7 +621,8 @@ val inst_clock_neutral_ffi = Q.prove(
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_exp_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[word_exp_def]
   \\ full_simp_tac(srw_ss())[mem_load_def,get_var_def,mem_store_def,get_fp_var_def]
-  \\ srw_tac[][state_component_equality]));
+  \\ srw_tac[][state_component_equality])
+QED
 
 Theorem evaluate_clock_neutral:
    !prog s res t.

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -613,9 +613,11 @@ Definition fix_clock_def:
   fix_clock s (res,s1) = (res,s1 with clock := MIN s.clock s1.clock)
 End
 
-val fix_clock_IMP = Q.prove(
-  `fix_clock s x = (res,s1) ==> s1.clock <= s.clock`,
-  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []);
+Triviality fix_clock_IMP:
+  fix_clock s x = (res,s1) ==> s1.clock <= s.clock
+Proof
+  Cases_on `x` \\ fs [fix_clock_def] \\ rw [] \\ fs []
+QED
 
 Definition STOP_def:
   STOP x = x

--- a/compiler/backend/semantics/targetPropsScript.sml
+++ b/compiler/backend/semantics/targetPropsScript.sml
@@ -15,10 +15,12 @@ Definition shift_interfer_def:
     s with next_interfer := shift_seq k s.next_interfer
 End
 
-val shift_interfer_intro = Q.prove(
-  `shift_interfer k1 (shift_interfer k2 c) =
-    shift_interfer (k1+k2) c`,
-  full_simp_tac(srw_ss())[shift_interfer_def,shift_seq_def,ADD_ASSOC]);
+Triviality shift_interfer_intro:
+  shift_interfer k1 (shift_interfer k2 c) =
+    shift_interfer (k1+k2) c
+Proof
+  full_simp_tac(srw_ss())[shift_interfer_def,shift_seq_def,ADD_ASSOC]
+QED
 
 Theorem bytes_in_memory_SUBSET:
   !p.
@@ -238,9 +240,11 @@ Proof
   \\ imp_res_tac asserts2_first \\ fs[]
 QED
 
-val enc_ok_not_empty = Q.prove(
-  `enc_ok c /\ asm_ok w c ==> (c.encode w <> [])`,
-  METIS_TAC [listTheory.LENGTH_NIL,enc_ok_def]);
+Triviality enc_ok_not_empty:
+  enc_ok c /\ asm_ok w c ==> (c.encode w <> [])
+Proof
+  METIS_TAC [listTheory.LENGTH_NIL,enc_ok_def]
+QED
 
 Theorem asm_step_IMP_evaluate_step = Q.prove(`
   !c s1 ms1 io i s2.

--- a/compiler/backend/semantics/wordPropsScript.sml
+++ b/compiler/backend/semantics/wordPropsScript.sml
@@ -1165,11 +1165,13 @@ Proof
   imp_res_tac pop_env_code_gc_fun_clock>>fs[]
 QED
 
-val inst_code_gc_fun_const = Q.prove(`
+Triviality inst_code_gc_fun_const:
   inst i s = SOME t ⇒
      s.code = t.code /\ s.gc_fun = t.gc_fun /\ s.sh_mdomain = t.sh_mdomain /\ s.mdomain = t.mdomain /\ s.be = t.be
-     ∧ s.compile = t.compile ∧ s.stack_size = t.stack_size ∧ s.stack_limit = t.stack_limit`,
-  Cases_on`i`>>fs[inst_def,assign_def]>>EVERY_CASE_TAC>>fs[set_var_def,state_component_equality,mem_store_def,set_fp_var_def]);
+     ∧ s.compile = t.compile ∧ s.stack_size = t.stack_size ∧ s.stack_limit = t.stack_limit
+Proof
+  Cases_on`i`>>fs[inst_def,assign_def]>>EVERY_CASE_TAC>>fs[set_var_def,state_component_equality,mem_store_def,set_fp_var_def]
+QED
 
 Theorem evaluate_consts:
    !xs s1 vs s2.
@@ -1277,13 +1279,15 @@ Proof
 QED
 
 (*transitive*)
-val s_frame_key_eq_trans = Q.prove(
-  `!a b c. s_frame_key_eq a b /\ s_frame_key_eq b c ==>
-            s_frame_key_eq a c`,
+Triviality s_frame_key_eq_trans:
+  !a b c. s_frame_key_eq a b /\ s_frame_key_eq b c ==>
+            s_frame_key_eq a c
+Proof
   Cases_on`a`>>Cases_on`b`>>Cases_on`c`>>
   Cases_on`o'`>>Cases_on`o''`>>Cases_on`o'''`>>
   Cases_on`o0`>>Cases_on`o0'`>>Cases_on`o0''`>>
-  full_simp_tac(srw_ss())[s_frame_key_eq_def]);
+  full_simp_tac(srw_ss())[s_frame_key_eq_def]
+QED
 
 Theorem s_key_eq_trans:
    !a b c. s_key_eq a b /\ s_key_eq b c ==>
@@ -1294,26 +1298,32 @@ Proof
   srw_tac[][]>>metis_tac[s_frame_key_eq_trans]
 QED
 
-val s_frame_val_eq_trans = Q.prove(
-  `!a b c. s_frame_val_eq a b /\ s_frame_val_eq b c ==>
-            s_frame_val_eq a c`,
+Triviality s_frame_val_eq_trans:
+  !a b c. s_frame_val_eq a b /\ s_frame_val_eq b c ==>
+            s_frame_val_eq a c
+Proof
   Cases_on`a`>>Cases_on`b`>>Cases_on`c`>>
   Cases_on`o'`>>Cases_on`o''`>>Cases_on`o'''`>>
   Cases_on`o0`>>Cases_on`o0'`>>Cases_on`o0''`>>
-  full_simp_tac(srw_ss())[s_frame_val_eq_def]);
+  full_simp_tac(srw_ss())[s_frame_val_eq_def]
+QED
 
-val s_val_eq_trans = Q.prove(
-  `!a b c. s_val_eq a b /\ s_val_eq b c ==>
-            s_val_eq a c`,
+Triviality s_val_eq_trans:
+  !a b c. s_val_eq a b /\ s_val_eq b c ==>
+            s_val_eq a c
+Proof
   Induct>>
   Cases_on`b`>>Cases_on`c`>>full_simp_tac(srw_ss())[s_val_eq_def]>>
-  srw_tac[][]>>metis_tac[s_frame_val_eq_trans]);
+  srw_tac[][]>>metis_tac[s_frame_val_eq_trans]
+QED
 
 (*Symmetric*)
-val s_frame_key_eq_sym = Q.prove(
-  `!a b. s_frame_key_eq a b <=> s_frame_key_eq b a`,
+Triviality s_frame_key_eq_sym:
+  !a b. s_frame_key_eq a b <=> s_frame_key_eq b a
+Proof
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>
-  Cases_on`o0`>>Cases_on`o0'`>>full_simp_tac(srw_ss())[s_frame_key_eq_def,EQ_SYM_EQ]);
+  Cases_on`o0`>>Cases_on`o0'`>>full_simp_tac(srw_ss())[s_frame_key_eq_def,EQ_SYM_EQ]
+QED
 
 Theorem s_key_eq_sym:
    !a b. s_key_eq a b <=> s_key_eq b a
@@ -1322,10 +1332,12 @@ Proof
   strip_tac>>metis_tac[s_frame_key_eq_sym]
 QED
 
-val s_frame_val_eq_sym = Q.prove(
-   `!a b. s_frame_val_eq a b <=> s_frame_val_eq b a`,
+Triviality s_frame_val_eq_sym:
+  !a b. s_frame_val_eq a b <=> s_frame_val_eq b a
+Proof
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>
-  Cases_on`o0`>>Cases_on`o0'`>>full_simp_tac(srw_ss())[s_frame_val_eq_def,EQ_SYM_EQ]);
+  Cases_on`o0`>>Cases_on`o0'`>>full_simp_tac(srw_ss())[s_frame_val_eq_def,EQ_SYM_EQ]
+QED
 
 Theorem s_val_eq_sym:
    !a b. s_val_eq a b <=> s_val_eq b a
@@ -1334,10 +1346,12 @@ Proof
   strip_tac>>metis_tac[s_frame_val_eq_sym]
 QED
 
-val s_frame_val_and_key_eq = Q.prove(
-  `!s t. s_frame_val_eq s t /\ s_frame_key_eq s t ==> s = t`,
+Triviality s_frame_val_and_key_eq:
+  !s t. s_frame_val_eq s t /\ s_frame_key_eq s t ==> s = t
+Proof
   Cases>>Cases>>Cases_on`o'`>>Cases_on`o''`>>Cases_on`o0`>>Cases_on`o0'`>>
-  full_simp_tac(srw_ss())[s_frame_val_eq_def,s_frame_key_eq_def,LIST_EQ_MAP_PAIR]);
+  full_simp_tac(srw_ss())[s_frame_val_eq_def,s_frame_key_eq_def,LIST_EQ_MAP_PAIR]
+QED
 
 Theorem s_val_and_key_eq:
    !s t. s_val_eq s t /\ s_key_eq s t ==> s =t
@@ -1348,13 +1362,15 @@ Proof
   Cases_on`t`>>full_simp_tac(srw_ss())[s_val_eq_def,s_key_eq_def,s_frame_val_and_key_eq]
 QED
 
-val dec_stack_stack_key_eq = Q.prove(
-  `!wl st st'. dec_stack wl st = SOME st' ==> s_key_eq st st'`,
+Triviality dec_stack_stack_key_eq:
+  !wl st st'. dec_stack wl st = SOME st' ==> s_key_eq st st'
+Proof
   ho_match_mp_tac dec_stack_ind>>srw_tac[][dec_stack_def]>>
   full_simp_tac(srw_ss())[s_key_eq_def]>>
   every_case_tac>>full_simp_tac(srw_ss())[]>>srw_tac[][]>>full_simp_tac(srw_ss())[dec_stack_def]>>srw_tac[][]>>
   Cases_on `handler`>>
-  full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def,MAP_ZIP,NOT_LESS]);
+  full_simp_tac(srw_ss())[s_key_eq_def,s_frame_key_eq_def,MAP_ZIP,NOT_LESS]
+QED
 
 (*gc preserves the stack_key relation*)
 Theorem gc_s_key_eq:
@@ -1365,16 +1381,19 @@ Proof
   full_simp_tac(srw_ss())[state_component_equality]>>rev_full_simp_tac(srw_ss())[]
 QED
 
-val s_val_eq_enc_stack = Q.prove(
-  `!st st'. s_val_eq st st' ==> enc_stack st = enc_stack st'`,
+Triviality s_val_eq_enc_stack:
+  !st st'. s_val_eq st st' ==> enc_stack st = enc_stack st'
+Proof
   Induct>>Cases_on`st'`>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   Cases_on`h`>>Cases_on`h'`>>Cases_on`o''`>>Cases_on`o'`>>Cases_on`o0'`>>Cases_on`o0`>>
-  full_simp_tac(srw_ss())[s_frame_val_eq_def,enc_stack_def]);
+  full_simp_tac(srw_ss())[s_frame_val_eq_def,enc_stack_def]
+QED
 
-val s_val_eq_dec_stack = Q.prove(
-  `!q st st' x. s_val_eq st st' /\ dec_stack q st = SOME x ==>
-    ?y. dec_stack q st' = SOME y /\ s_val_eq x y`,
-   ho_match_mp_tac dec_stack_ind >> srw_tac[][] >>
+Triviality s_val_eq_dec_stack:
+  !q st st' x. s_val_eq st st' /\ dec_stack q st = SOME x ==>
+    ?y. dec_stack q st' = SOME y /\ s_val_eq x y
+Proof
+  ho_match_mp_tac dec_stack_ind >> srw_tac[][] >>
    Cases_on`st'`>>full_simp_tac(srw_ss())[s_val_eq_def,s_val_eq_refl]>>
    Cases_on`h`>>full_simp_tac(srw_ss())[dec_stack_def]>>
    pop_assum mp_tac>>CASE_TAC >>
@@ -1385,7 +1404,8 @@ val s_val_eq_dec_stack = Q.prove(
     (Cases_on `handler` \\ Cases_on `o'` \\ Cases_on `o0` \\ full_simp_tac(srw_ss())[s_frame_val_eq_def]
      \\ metis_tac[LENGTH_MAP]) \\ full_simp_tac(srw_ss())[NOT_LESS]
    \\ Cases_on `handler` \\ Cases_on `o'` \\ Cases_on `o0` \\ full_simp_tac(srw_ss())[s_frame_val_eq_def,s_val_eq_def]
-   \\ full_simp_tac(srw_ss())[MAP_ZIP,LENGTH_TAKE]);
+   \\ full_simp_tac(srw_ss())[MAP_ZIP,LENGTH_TAKE]
+QED
 
 (*gc succeeds on all stacks related by stack_val and there are relations
   in the result*)
@@ -1482,17 +1502,21 @@ Proof
     ,EXISTS_PROD,domain_lookup]
 QED
 
-val get_vars_stack_swap = Q.prove(
-  `!l s t. s.locals = t.locals ==>
-    get_vars l s = get_vars l t`,
+Triviality get_vars_stack_swap:
+  !l s t. s.locals = t.locals ==>
+    get_vars l s = get_vars l t
+Proof
   Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_def]>>
   srw_tac[][]>> every_case_tac>>
-  metis_tac[NOT_NONE_SOME,SOME_11]);
+  metis_tac[NOT_NONE_SOME,SOME_11]
+QED
 
-val get_vars_stack_swap_simp = Q.prove(
-  `!args. get_vars args (s with stack := xs) = get_vars args s`,
+Triviality get_vars_stack_swap_simp:
+  !args. get_vars args (s with stack := xs) = get_vars args s
+Proof
   `(s with stack:=xs).locals = s.locals` by full_simp_tac(srw_ss())[]>>
-  metis_tac[get_vars_stack_swap]);
+  metis_tac[get_vars_stack_swap]
+QED
 
 Theorem s_val_eq_length:
    !s t. s_val_eq s t ==> LENGTH s = LENGTH t
@@ -1508,57 +1532,73 @@ Proof
   Cases>>full_simp_tac(srw_ss())[s_key_eq_def]
 QED
 
-val s_val_eq_APPEND = Q.prove(
-  `!s t x y. (s_val_eq s t /\ s_val_eq x y)==> s_val_eq (s++x) (t++y)`,
+Triviality s_val_eq_APPEND:
+  !s t x y. (s_val_eq s t /\ s_val_eq x y)==> s_val_eq (s++x) (t++y)
+Proof
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
-  srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def]);
+  srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def]
+QED
 
-val s_val_eq_REVERSE = Q.prove(
-  `!s t. s_val_eq s t ==> s_val_eq (REVERSE s) (REVERSE t)`,
+Triviality s_val_eq_REVERSE:
+  !s t. s_val_eq s t ==> s_val_eq (REVERSE s) (REVERSE t)
+Proof
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
-  srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def,s_val_eq_APPEND]);
+  srw_tac[][]>>full_simp_tac(srw_ss())[s_val_eq_def,s_val_eq_APPEND]
+QED
 
-val s_val_eq_TAKE = Q.prove(
-  `!s t n. s_val_eq s t ==> s_val_eq (TAKE n s) (TAKE n t)`,
+Triviality s_val_eq_TAKE:
+  !s t n. s_val_eq s t ==> s_val_eq (TAKE n s) (TAKE n t)
+Proof
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>rw[]>>
-  Cases_on`n`>>fs[s_val_eq_def]);
+  Cases_on`n`>>fs[s_val_eq_def]
+QED
 
-val s_val_eq_LASTN = Q.prove(
-  `!s t n. s_val_eq s t
-    ==> s_val_eq (LASTN n s) (LASTN n t)`,
+Triviality s_val_eq_LASTN:
+  !s t n. s_val_eq s t
+    ==> s_val_eq (LASTN n s) (LASTN n t)
+Proof
   ho_match_mp_tac (fetch "-" "s_val_eq_ind")>>
   srw_tac[][LASTN_def]>>full_simp_tac(srw_ss())[s_val_eq_def]>>
   `s_val_eq [x] [y]` by full_simp_tac(srw_ss())[s_val_eq_def]>>
   `s_val_eq (REVERSE s ++ [x]) (REVERSE t ++[y])` by
     full_simp_tac(srw_ss())[s_val_eq_APPEND,s_val_eq_REVERSE]>>
   IMP_RES_TAC s_val_eq_TAKE>>
-  metis_tac[s_val_eq_REVERSE]);
+  metis_tac[s_val_eq_REVERSE]
+QED
 
-val s_key_eq_APPEND = Q.prove(
-  `!s t x y. (s_key_eq s t /\ s_key_eq x y)==> s_key_eq (s++x) (t++y)`,
+Triviality s_key_eq_APPEND:
+  !s t x y. (s_key_eq s t /\ s_key_eq x y)==> s_key_eq (s++x) (t++y)
+Proof
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
-  srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def]);
+  srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def]
+QED
 
-val s_key_eq_REVERSE = Q.prove(
-  `!s t. s_key_eq s t ==> s_key_eq (REVERSE s) (REVERSE t)`,
+Triviality s_key_eq_REVERSE:
+  !s t. s_key_eq s t ==> s_key_eq (REVERSE s) (REVERSE t)
+Proof
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
-  srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def,s_key_eq_APPEND]);
+  srw_tac[][]>>full_simp_tac(srw_ss())[s_key_eq_def,s_key_eq_APPEND]
+QED
 
-val s_key_eq_TAKE = Q.prove(
-  `!s t n. s_key_eq s t ==> s_key_eq (TAKE n s) (TAKE n t)`,
+Triviality s_key_eq_TAKE:
+  !s t n. s_key_eq s t ==> s_key_eq (TAKE n s) (TAKE n t)
+Proof
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
-  rw[]>>Cases_on`n`>>fs[s_key_eq_def]);
+  rw[]>>Cases_on`n`>>fs[s_key_eq_def]
+QED
 
-val s_key_eq_LASTN = Q.prove(
-  `!s t n. s_key_eq s t
-    ==> s_key_eq (LASTN n s) (LASTN n t)`,
+Triviality s_key_eq_LASTN:
+  !s t n. s_key_eq s t
+    ==> s_key_eq (LASTN n s) (LASTN n t)
+Proof
   ho_match_mp_tac (fetch "-" "s_key_eq_ind")>>
   srw_tac[][LASTN_def]>>full_simp_tac(srw_ss())[s_key_eq_def]>>
   `s_key_eq [x] [y]` by full_simp_tac(srw_ss())[s_key_eq_def]>>
   `s_key_eq (REVERSE s ++ [x]) (REVERSE t ++[y])` by
     full_simp_tac(srw_ss())[s_key_eq_APPEND,s_key_eq_REVERSE]>>
   IMP_RES_TAC s_key_eq_TAKE>>
-  metis_tac[s_key_eq_REVERSE]);
+  metis_tac[s_key_eq_REVERSE]
+QED
 
 Theorem s_key_eq_tail:
   !a b c d. s_key_eq (a::b) (c::d) ==> s_key_eq b d
@@ -1566,22 +1606,26 @@ Proof
   full_simp_tac(srw_ss())[s_key_eq_def]
 QED
 
-val s_val_eq_tail = Q.prove(
- `!a b c d. s_val_eq (a::b) (c::d) ==> s_val_eq b d`,
-  full_simp_tac(srw_ss())[s_val_eq_def]);
+Triviality s_val_eq_tail:
+  !a b c d. s_val_eq (a::b) (c::d) ==> s_val_eq b d
+Proof
+  full_simp_tac(srw_ss())[s_val_eq_def]
+QED
 
-val s_key_eq_LASTN_exists = Q.prove(
-  `!s t n m e y xs. s_key_eq s t /\
+Triviality s_key_eq_LASTN_exists:
+  !s t n m e y xs. s_key_eq s t /\
     LASTN n s = StackFrame m e (SOME y)::xs
     ==> ?e' ls. LASTN n t = StackFrame m e' (SOME y)::ls
         /\ MAP FST e' = MAP FST e
-        /\ s_key_eq xs ls`,
-   rpt strip_tac>>
+        /\ s_key_eq xs ls
+Proof
+  rpt strip_tac>>
    IMP_RES_TAC s_key_eq_LASTN>>
    first_x_assum (qspec_then `n` assume_tac)>> rev_full_simp_tac(srw_ss())[]>>
    Cases_on`LASTN n t`>>
    full_simp_tac(srw_ss())[s_key_eq_def]>>
-   Cases_on`h`>>Cases_on`o'`>>Cases_on`o0`>>full_simp_tac(srw_ss())[s_frame_key_eq_def]);
+   Cases_on`h`>>Cases_on`o'`>>Cases_on`o0`>>full_simp_tac(srw_ss())[s_frame_key_eq_def]
+QED
 
 Theorem s_val_eq_LASTN_exists:
    !s t n m e y xs. s_val_eq s t /\
@@ -1604,12 +1648,16 @@ Proof
   metis_tac[LASTN_LENGTH_ID]
 QED
 
-val handler_eq = Q.prove(
-  `x with handler := x.handler = x`, full_simp_tac(srw_ss())[state_component_equality]);
+Triviality handler_eq:
+  x with handler := x.handler = x
+Proof
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (*Stack is irrelevant to word_exp*)
-val word_exp_stack_swap = Q.prove(
-  `!s e st. word_exp s e = word_exp (s with stack:=st) e`,
+Triviality word_exp_stack_swap:
+  !s e st. word_exp s e = word_exp (s with stack:=st) e
+Proof
   ho_match_mp_tac word_exp_ind>>
   srw_tac[][word_exp_def]
   >-
@@ -1621,7 +1669,8 @@ val word_exp_stack_swap = Q.prove(
     (`ls = ls'` by
       (unabbrev_all_tac>>fs[MEM_MAP,MAP_EQ_f]))>>
     fs[])>>
-  every_case_tac>>full_simp_tac(srw_ss())[]);
+  every_case_tac>>full_simp_tac(srw_ss())[]
+QED
 
 Theorem s_val_eq_stack_size:
   ∀xs ys.
@@ -2363,13 +2412,18 @@ QED
 
 (*--Permute Swap Lemma--*)
 
-val ignore_inc = Q.prove(`
+Triviality ignore_inc:
   ∀perm:num->num->num.
-  (λn. perm(n+0)) = perm`,srw_tac[][FUN_EQ_THM]);
+  (λn. perm(n+0)) = perm
+Proof
+  srw_tac[][FUN_EQ_THM]
+QED
 
-val ignore_perm = Q.prove(`
-  ∀st. st with permute := st.permute = st` ,
-  srw_tac[][]>>full_simp_tac(srw_ss())[state_component_equality]);
+Triviality ignore_perm:
+  ∀st. st with permute := st.permute = st
+Proof
+  srw_tac[][]>>full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 Theorem get_vars_perm:
     ∀args.get_vars args (st with permute:=perm) = get_vars args st
@@ -2387,11 +2441,13 @@ Proof
   full_simp_tac(srw_ss())[state_component_equality]
 QED
 
-val gc_perm = Q.prove(`
+Triviality gc_perm:
   gc st = SOME x ⇒
-  gc (st with permute:=perm) = SOME (x with permute := perm)`,
+  gc (st with permute:=perm) = SOME (x with permute := perm)
+Proof
   full_simp_tac(srw_ss())[gc_def,LET_THM]>>every_case_tac>>
-  full_simp_tac(srw_ss())[state_component_equality]);
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 Theorem get_var_perm:
     get_var n (st with permute:=perm) =
@@ -2437,10 +2493,12 @@ Proof
   full_simp_tac(srw_ss())[set_fp_var_def]
 QED
 
-val get_vars_perm = Q.prove(`
+Triviality get_vars_perm:
   ∀ls. get_vars ls (st with permute:=perm) =
-  (get_vars ls st)`,
-  Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_perm]);
+  (get_vars ls st)
+Proof
+  Induct>>full_simp_tac(srw_ss())[get_vars_def,get_var_perm]
+QED
 
 Theorem set_vars_perm[simp]:
     ∀ls. set_vars ls x (st with permute := perm) =
@@ -2449,10 +2507,12 @@ Proof
   full_simp_tac(srw_ss())[set_vars_def]
 QED
 
-val word_state_rewrites = Q.prove(`
+Triviality word_state_rewrites:
   (st with clock:=A) with permute:=B =
-  (st with <|clock:=A ;permute:=B|>)`,
-  full_simp_tac(srw_ss())[]);
+  (st with <|clock:=A ;permute:=B|>)
+Proof
+  full_simp_tac(srw_ss())[]
+QED
 
 val perm_assum_tac = (first_x_assum(qspec_then`perm`assume_tac)>>
           full_simp_tac(srw_ss())[dec_clock_def,push_env_def,env_to_list_def,LET_THM]>>
@@ -2475,22 +2535,26 @@ Proof
       (unabbrev_all_tac>>fs[MAP_EQ_f])>> fs[]
 QED
 
-val mem_store_perm = Q.prove(`
+Triviality mem_store_perm:
   mem_store a (w:'a word_loc) (s with permute:=perm) =
   case mem_store a w s of
     NONE => NONE
-  | SOME x => SOME(x with permute:=perm)`,
+  | SOME x => SOME(x with permute:=perm)
+Proof
   full_simp_tac(srw_ss())[mem_store_def]>>every_case_tac>>
-  full_simp_tac(srw_ss())[state_component_equality]);
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
-val jump_exc_perm = Q.prove(`
+Triviality jump_exc_perm:
   jump_exc (st with permute:=perm) =
   case jump_exc st of
     NONE => NONE
-  | SOME (x,l1,l2) => SOME (x with permute:=perm,l1,l2)`,
+  | SOME (x,l1,l2) => SOME (x with permute:=perm,l1,l2)
+Proof
   full_simp_tac(srw_ss())[jump_exc_def]>>
   every_case_tac>>
-  full_simp_tac(srw_ss())[state_component_equality]);
+  full_simp_tac(srw_ss())[state_component_equality]
+QED
 
 (*For any target result permute, we can find an initial permute such that the
   final permute is equal to the target *)
@@ -2909,30 +2973,36 @@ Proof
   metis_tac[locals_rel_get_var]
 QED
 
-val locals_rel_set_var = Q.prove(`
+Triviality locals_rel_set_var:
   ∀n s t.
   locals_rel temp s t ⇒
-  locals_rel temp (insert n v s) (insert n v t)`,
-  srw_tac[][]>>full_simp_tac(srw_ss())[locals_rel_def,lookup_insert]);
+  locals_rel temp (insert n v s) (insert n v t)
+Proof
+  srw_tac[][]>>full_simp_tac(srw_ss())[locals_rel_def,lookup_insert]
+QED
 
-val locals_rel_delete = Q.prove(`
+Triviality locals_rel_delete:
   ∀n s t.
   locals_rel temp s t ⇒
-  locals_rel temp (delete n s) (delete n t)`,
-  rw[locals_rel_def,lookup_delete]);
+  locals_rel temp (delete n s) (delete n t)
+Proof
+  rw[locals_rel_def,lookup_delete]
+QED
 
-val locals_rel_cut_env = Q.prove(`
+Triviality locals_rel_cut_env:
   locals_rel temp loc loc' ∧
   every_name (λx. x < temp) names ∧
   cut_env names loc = SOME x ⇒
-  cut_env names loc' = SOME x`,
+  cut_env names loc' = SOME x
+Proof
   srw_tac[][locals_rel_def,cut_env_def,SUBSET_DEF,every_name_def]>>
   full_simp_tac(srw_ss())[EVERY_MEM,toAList_domain]
   >- metis_tac[domain_lookup]
   >>
   full_simp_tac(srw_ss())[lookup_inter]>>srw_tac[][]>>every_case_tac>>
   full_simp_tac(srw_ss())[domain_lookup]>>res_tac>>
-  metis_tac[option_CLAUSES]);
+  metis_tac[option_CLAUSES]
+QED
 
 (*Extra temporaries not mentioned in program
   do not affect evaluation*)
@@ -3535,14 +3605,16 @@ Proof
   metis_tac[env_to_list_ALL_DISTINCT,FST]
 QED
 
-val max_var_exp_IMP = Q.prove(`
+Triviality max_var_exp_IMP:
   ∀exp.
   P 0 ∧ every_var_exp P exp ⇒
-  P (max_var_exp exp)`,
+  P (max_var_exp exp)
+Proof
   ho_match_mp_tac max_var_exp_ind>>fs[max_var_exp_def,every_var_exp_def]>>
   srw_tac[][]>>
   match_mp_tac list_max_intro>>
-  fs[EVERY_MAP,EVERY_MEM]);
+  fs[EVERY_MAP,EVERY_MEM]
+QED
 
 Theorem max_var_intro:
     ∀prog.

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -409,17 +409,21 @@ Definition pop_env_def:
     | _ => NONE
 End
 
-val push_env_clock = Q.prove(
-  `(wordSem$push_env env b ^s).clock = s.clock`,
+Triviality push_env_clock:
+  (wordSem$push_env env b ^s).clock = s.clock
+Proof
   Cases_on `b` \\ TRY(PairCases_on`x`) \\ full_simp_tac(srw_ss())[push_env_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
-  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
+  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
+QED
 
-val pop_env_clock = Q.prove(
-  `(wordSem$pop_env ^s = SOME s1) ==> (s1.clock = s.clock)`,
+Triviality pop_env_clock:
+  (wordSem$pop_env ^s = SOME s1) ==> (s1.clock = s.clock)
+Proof
   full_simp_tac(srw_ss())[pop_env_def]
   \\ every_case_tac \\ full_simp_tac(srw_ss())[]
-  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]);
+  \\ SRW_TAC [] [] \\ full_simp_tac(srw_ss())[]
+QED
 
 Definition jump_exc_def:
   jump_exc ^s =
@@ -783,15 +787,19 @@ Definition bad_dest_args_def:
   bad_dest_args dest args ⇔ dest = NONE ∧ args = []
 End
 
-val termdep_rw = Q.prove(
-  `((call_env p_1 ss ^s).termdep = s.termdep) /\
+Triviality termdep_rw:
+  ((call_env p_1 ss ^s).termdep = s.termdep) /\
     ((dec_clock s).termdep = s.termdep) /\
-    ((set_var n v s).termdep = s.termdep)`,
-  EVAL_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]);
+    ((set_var n v s).termdep = s.termdep)
+Proof
+  EVAL_TAC \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+QED
 
-val fix_clock_IMP_LESS_EQ = Q.prove(
-  `!x. fix_clock ^s x = (res,s1) ==> s1.clock <= s.clock /\ s1.termdep = s.termdep`,
-  full_simp_tac(srw_ss())[fix_clock_def,FORALL_PROD] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ decide_tac);
+Triviality fix_clock_IMP_LESS_EQ:
+  !x. fix_clock ^s x = (res,s1) ==> s1.clock <= s.clock /\ s1.termdep = s.termdep
+Proof
+  full_simp_tac(srw_ss())[fix_clock_def,FORALL_PROD] \\ srw_tac[][] \\ full_simp_tac(srw_ss())[] \\ decide_tac
+QED
 
 Definition MustTerminate_limit_def[nocompute]:
   MustTerminate_limit (:'a) =
@@ -1093,13 +1101,15 @@ Proof
   simp[]
 QED
 
-val inst_clock = Q.prove(
-  `inst i s = SOME s2 ==> s2.clock <= s.clock /\ s2.termdep = s.termdep`,
+Triviality inst_clock:
+  inst i s = SOME s2 ==> s2.clock <= s.clock /\ s2.termdep = s.termdep
+Proof
   Cases_on `i` \\ full_simp_tac(srw_ss())[inst_def,assign_def,get_vars_def,LET_THM]
   \\ every_case_tac
   \\ SRW_TAC [] [set_var_def] \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[mem_store_def] \\ SRW_TAC [] []
-  \\ EVAL_TAC \\ fs[]);
+  \\ EVAL_TAC \\ fs[]
+QED
 
 Theorem evaluate_clock:
    !xs s1 vs s2. (evaluate (xs,s1) = (vs,s2)) ==>

--- a/compiler/bootstrap/translation/arm7ProgScript.sml
+++ b/compiler/bootstrap/translation/arm7ProgScript.sml
@@ -21,9 +21,11 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "arm7Prog");
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -50,15 +52,19 @@ fun def_of_const tm = let
 
 val _ = (find_def_for_const := def_of_const);
 
-val v2w_rw = Q.prove(`
-  v2w [P] = if P then 1w else 0w`,
-  rw[]>>EVAL_TAC);
+Triviality v2w_rw:
+  v2w [P] = if P then 1w else 0w
+Proof
+  rw[]>>EVAL_TAC
+QED
 
-val notw = Q.prove(`
-  !a. ~a = (-1w ?? a)`,
-  srw_tac[wordsLib.WORD_BIT_EQ_ss][]);
+Triviality notw:
+  !a. ~a = (-1w ?? a)
+Proof
+  srw_tac[wordsLib.WORD_BIT_EQ_ss][]
+QED
 
-val if_ARM_BadCode = Q.prove(`
+Triviality if_ARM_BadCode:
   (case
   (if P then
      ARM c
@@ -70,8 +76,10 @@ val if_ARM_BadCode = Q.prove(`
   | Thumb2 w => i w
   | ThumbEE w => j w
   ) =
-  if P then f c else g d`,
-    rw[]);
+  if P then f c else g d
+Proof
+  rw[]
+QED
 
 (*val IS_SOME_rw = Q.prove(`
   (if IS_SOME A then B else C) =
@@ -82,8 +90,8 @@ val if_ARM_BadCode = Q.prove(`
 
 (* TODO? more Manual rewrites to get rid of MachineCode type, which probably isn't that expensive *)
 
-val exh_machine_code = Q.prove(`
-∀v f.
+Triviality exh_machine_code:
+  ∀v f.
 (case
   case v of
     (N,imms,immr) =>
@@ -92,22 +100,30 @@ of
   ARM8 w => g w
 | BadCode v3 => h) =
   case v of (N,imms,immr) =>
-  g( f N imms immr)`,
-  rw[]>>PairCases_on`v`>>rw[])
+  g( f N imms immr)
+Proof
+  rw[]>>PairCases_on`v`>>rw[]
+QED
 
-val LIST_BIND_option = Q.prove(`
+Triviality LIST_BIND_option:
   LIST_BIND (case P of NONE => A | SOME v => B v) f =
-  case P of NONE => LIST_BIND A f | SOME v => LIST_BIND (B v) f`,
-  Cases_on`P`>>rw[]);
+  case P of NONE => LIST_BIND A f | SOME v => LIST_BIND (B v) f
+Proof
+  Cases_on`P`>>rw[]
+QED
 
-val LIST_BIND_pair = Q.prove(`
+Triviality LIST_BIND_pair:
   LIST_BIND (case P of (l,r) => A l r) f =
-  case P of (l,r) => LIST_BIND (A l r) f`,
-  Cases_on`P`>>rw[]);
+  case P of (l,r) => LIST_BIND (A l r) f
+Proof
+  Cases_on`P`>>rw[]
+QED
 
-val notw = Q.prove(`
-  !a. ~a = (-1w ?? a)`,
-  srw_tac[wordsLib.WORD_BIT_EQ_ss][]);
+Triviality notw:
+  !a. ~a = (-1w ?? a)
+Proof
+  srw_tac[wordsLib.WORD_BIT_EQ_ss][]
+QED
 *)
 val defaults = [arm7_encode_def,arm7_encode1_def,encode_def,e_data_def,EncodeImmShift_def,v2w_rw,e_load_def,arm7_encode_fail_def,e_multiply_def,e_branch_def,Aligned_def,Align_def,e_store_def];
 

--- a/compiler/bootstrap/translation/arm8ProgScript.sml
+++ b/compiler/bootstrap/translation/arm8ProgScript.sml
@@ -22,9 +22,11 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "arm8Prog");
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -51,21 +53,25 @@ fun def_of_const tm = let
 
 val _ = (find_def_for_const := def_of_const);
 
-val IS_SOME_rw = Q.prove(`
+Triviality IS_SOME_rw:
   (if IS_SOME a then b else c) =
     case a of
     SOME v => b
-  | NONE => c`,
-  Cases_on`a`>>rw[IS_SOME_DEF]);
+  | NONE => c
+Proof
+  Cases_on`a`>>rw[IS_SOME_DEF]
+QED
 
-val v2w_rw = Q.prove(`
-  v2w [P] = if P then 1w else 0w`,
-  rw[]>>EVAL_TAC);
+Triviality v2w_rw:
+  v2w [P] = if P then 1w else 0w
+Proof
+  rw[]>>EVAL_TAC
+QED
 
 (* TODO? more Manual rewrites to get rid of MachineCode type, which probably isn't that expensive *)
 
-val exh_machine_code = Q.prove(`
-∀v f.
+Triviality exh_machine_code:
+  ∀v f.
 (case
   case v of
     (n,imms,immr) =>
@@ -74,22 +80,30 @@ of
   ARM8 w => g w
 | BadCode v3 => h) =
   case v of (n,imms,immr) =>
-  g( f n imms immr)`,
-  rw[]>>PairCases_on`v`>>rw[])
+  g( f n imms immr)
+Proof
+  rw[]>>PairCases_on`v`>>rw[]
+QED
 
-val LIST_BIND_option = Q.prove(`
+Triviality LIST_BIND_option:
   LIST_BIND (case P of NONE => a | SOME v => b v) f =
-  case P of NONE => LIST_BIND a f | SOME v => LIST_BIND (b v) f`,
-  Cases_on`P`>>rw[]);
+  case P of NONE => LIST_BIND a f | SOME v => LIST_BIND (b v) f
+Proof
+  Cases_on`P`>>rw[]
+QED
 
-val LIST_BIND_pair = Q.prove(`
+Triviality LIST_BIND_pair:
   LIST_BIND (case P of (l,r) => a l r) f =
-  case P of (l,r) => LIST_BIND (a l r) f`,
-  Cases_on`P`>>rw[]);
+  case P of (l,r) => LIST_BIND (a l r) f
+Proof
+  Cases_on`P`>>rw[]
+QED
 
-val notw = Q.prove(`
-  !a. ~a = (-1w ?? a)`,
-  srw_tac[wordsLib.WORD_BIT_EQ_ss][]);
+Triviality notw:
+  !a. ~a = (-1w ?? a)
+Proof
+  srw_tac[wordsLib.WORD_BIT_EQ_ss][]
+QED
 
 val defaults = [arm8_ast_def, arm8_encode_def, Encode_def,
   NoOperation_def, arm8_enc_mov_imm_def, e_data_def,
@@ -249,8 +263,9 @@ Termination
   THEN FULL_SIMP_TAC (srw_ss()) [wordsTheory.word_0, wordsTheory.LSR_LESS]
 End
 
-val CountTrailing_eq = Q.prove(`
-  ∀b w. CountTrailing (b,w) = ct_curr b w`,
+Triviality CountTrailing_eq:
+  ∀b w. CountTrailing (b,w) = ct_curr b w
+Proof
   ho_match_mp_tac (fetch "-" "ct_curr_ind")>>
   rpt strip_tac>>
   PURE_REWRITE_TAC[Once ct_curr_def,word_bit_test]>>
@@ -261,7 +276,8 @@ val CountTrailing_eq = Q.prove(`
     simp[])
   >>
     simp[Once CountTrailing_def,word_bit_test]>>
-    metis_tac[]);
+    metis_tac[]
+QED
 
 val res = translate ct_curr_def
 
@@ -286,21 +302,25 @@ val v2n_side = Q.prove(`
   EVAL_TAC>>
   fs[l2n_side]) |> update_precondition;
 
-val notw = Q.prove(`
-  !a. ~a = (-1w ?? (a))`,
-  srw_tac[wordsLib.WORD_BIT_EQ_ss][]);
+Triviality notw:
+  !a. ~a = (-1w ?? (a))
+Proof
+  srw_tac[wordsLib.WORD_BIT_EQ_ss][]
+QED
 
 val res = translate (EVAL``w2v (w:word6)`` |> SIMP_RULE (srw_ss()) [word_bit_test,word_bit_def,word_bit])
 
-val Num_rw = Q.prove(`
+Triviality Num_rw:
   (if len < 1 then NONE
   else
     f (Num len)) =
   if len < 1 then NONE
-    else f (Num (ABS len))`,
+    else f (Num (ABS len))
+Proof
   rw[]>>
   `0 ≤ len` by intLib.COOPER_TAC>>
-  metis_tac[integerTheory.INT_ABS_EQ_ID])
+  metis_tac[integerTheory.INT_ABS_EQ_ID]
+QED
 
 val res = translate (specv64 ``:'M`` DecodeBitMasks_def |> SIMP_RULE
   (srw_ss()++ARITH_ss) [hsb_compute, v2w_Ones, Replicate_def,

--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -118,7 +118,11 @@ val r = pan_passesTheory.pan_to_target_all_def |> spec32
 val r = pan_passesTheory.opsize_to_display_def |> translate;
 val r = pan_passesTheory.shape_to_str_def |> translate;
 val r = pan_passesTheory.insert_es_def |> translate;
-val lem = Q.prove(‘dimindex(:32) = 32’, EVAL_TAC);
+Triviality lem:
+  dimindex(:32) = 32
+Proof
+  EVAL_TAC
+QED
 val r = pan_passesTheory.pan_exp_to_display_def |> spec32 |> SIMP_RULE std_ss [byteTheory.bytes_in_word_def,lem] |> translate;
 val r = pan_passesTheory.crep_exp_to_display_def |> spec32 |> translate;
 val r = pan_passesTheory.loop_exp_to_display_def |> spec32 |> translate;

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -119,7 +119,11 @@ val r = pan_passesTheory.pan_to_target_all_def |> spec64
 val r = pan_passesTheory.opsize_to_display_def |> translate;
 val r = pan_passesTheory.shape_to_str_def |> translate;
 val r = pan_passesTheory.insert_es_def |> translate;
-val lem = Q.prove(‘dimindex(:64) = 64’, EVAL_TAC);
+Triviality lem:
+  dimindex(:64) = 64
+Proof
+  EVAL_TAC
+QED
 val r = pan_passesTheory.pan_exp_to_display_def |> spec64 |> SIMP_RULE std_ss [byteTheory.bytes_in_word_def,lem] |> translate;
 val r = pan_passesTheory.crep_exp_to_display_def |> spec64 |> translate;
 val r = pan_passesTheory.loop_exp_to_display_def |> spec64 |> translate;

--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -18,9 +18,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 Theorem option_map_thm[local]:
   OPTION_MAP f x = case x of NONE => NONE | SOME y => SOME(f y)
@@ -100,7 +102,11 @@ val _ = translate $ spec32 nested_decs_def;
 
 val _ = translate $ spec32 nested_seq_def;
 
-val lem = Q.prove(‘dimindex(:32) = 32’, EVAL_TAC);
+Triviality lem:
+  dimindex(:32) = 32
+Proof
+  EVAL_TAC
+QED
 
 val _ = translate $ SIMP_RULE std_ss [byteTheory.bytes_in_word_def,lem] $ spec32 stores_def;
 

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -18,9 +18,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-   Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 Theorem option_map_thm[local]:
   OPTION_MAP f x = case x of NONE => NONE | SOME y => SOME(f y)
@@ -104,7 +106,11 @@ val _ = translate $ spec64 nested_decs_def;
 
 val _ = translate $ spec64 nested_seq_def;
 
-val lem = Q.prove(‘dimindex(:64) = 64’, EVAL_TAC);
+Triviality lem:
+  dimindex(:64) = 64
+Proof
+  EVAL_TAC
+QED
 
 val _ = translate $ SIMP_RULE std_ss [byteTheory.bytes_in_word_def,lem] $ spec64 stores_def;
 

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -66,9 +66,11 @@ val _ = (find_def_for_const := def_of_const);
 
 (* type inference: t_walkstar and t_unify *)
 
-val PRECONDITION_INTRO = Q.prove(
-  `(b ==> (x = y)) ==> (x = if PRECONDITION b then y else x)`,
-  Cases_on `b` THEN SIMP_TAC std_ss [PRECONDITION_def]);
+Triviality PRECONDITION_INTRO:
+  (b ==> (x = y)) ==> (x = if PRECONDITION b then y else x)
+Proof
+  Cases_on `b` THEN SIMP_TAC std_ss [PRECONDITION_def]
+QED
 
 Theorem t_vwalk_ind:
    !P.
@@ -114,9 +116,11 @@ Proof
   METIS_TAC [unifyTheory.t_walkstar_ind]
 QED
 
-val expand_lemma = Q.prove(
-  `t_walkstar s = \x. t_walkstar s x`,
-  SIMP_TAC std_ss [FUN_EQ_THM]);
+Triviality expand_lemma:
+  t_walkstar s = \x. t_walkstar s x
+Proof
+  SIMP_TAC std_ss [FUN_EQ_THM]
+QED
 
 val _ = translate
   (unifyTheory.t_walkstar_eqn
@@ -148,9 +152,11 @@ Proof
   THEN POP_ASSUM HO_MATCH_MP_TAC THEN METIS_TAC []
 QED
 
-val EXISTS_LEMMA = Q.prove(
-  `!xs P. EXISTS P xs = EXISTS I (MAP P xs)`,
-  Induct THEN SRW_TAC [] []);
+Triviality EXISTS_LEMMA:
+  !xs P. EXISTS P xs = EXISTS I (MAP P xs)
+Proof
+  Induct THEN SRW_TAC [] []
+QED
 
 val _ = translate
   (unifyTheory.t_oc_eqn
@@ -265,10 +271,12 @@ val _ = translate (def_of_const ``infer_type_subst``)
 val _ = translate rich_listTheory.COUNT_LIST_AUX_def
 val _ = translate rich_listTheory.COUNT_LIST_compute
 
-val pair_abs_hack = Q.prove(
-  `(\(v2:string,v1:infer_t). (v2,0,v1)) =
-    (\v3. case v3 of (v2,v1) => (v2,0:num,v1))`,
-  SIMP_TAC (srw_ss()) [FUN_EQ_THM,FORALL_PROD]);
+Triviality pair_abs_hack:
+  (\(v2:string,v1:infer_t). (v2,0,v1)) =
+    (\v3. case v3 of (v2,v1) => (v2,0:num,v1))
+Proof
+  SIMP_TAC (srw_ss()) [FUN_EQ_THM,FORALL_PROD]
+QED
 
 fun fix_infer_induction_thm def = let
   val const = def |> SPEC_ALL |> CONJUNCTS |> hd |> SPEC_ALL |> concl
@@ -299,17 +307,23 @@ fun fix_infer_induction_thm def = let
   val _ = save_thm(ind_name,ind)
   in () end handle HOL_ERR _ => ();
 
-val if_apply = Q.prove(
-  `!b. (if b then x1 else x2) x = if b then x1 x else x2 x`,
-  Cases THEN SRW_TAC [] []);
+Triviality if_apply:
+  !b. (if b then x1 else x2) x = if b then x1 x else x2 x
+Proof
+  Cases THEN SRW_TAC [] []
+QED
 
-val option_case_apply = Q.prove(
-  `!oo. option_CASE oo x1 x2 x = option_CASE oo (x1 x) (\y. x2 y x)`,
-  Cases THEN SRW_TAC [] []);
+Triviality option_case_apply:
+  !oo. option_CASE oo x1 x2 x = option_CASE oo (x1 x) (\y. x2 y x)
+Proof
+  Cases THEN SRW_TAC [] []
+QED
 
-val pr_CASE = Q.prove(
-  `pair_CASE (x,y) f = f x y`,
-  SRW_TAC [] []);
+Triviality pr_CASE:
+  pair_CASE (x,y) f = f x y
+Proof
+  SRW_TAC [] []
+QED
 
 val op_apply =
   let
@@ -321,10 +335,12 @@ val op_apply =
     val rthm3 = Q.ISPEC `\g. g (y : 'b)` rthm2
   in BETA_RULE rthm3 |> Q.GEN ‘x’ end;
 
-val list_apply = Q.prove(
-  `!op. (list_CASE op x1 x2) y =
-         (list_CASE op (x1 y) (\z1 z2. x2 z1 z2 y))`,
-  Cases THEN SRW_TAC [] []);
+Triviality list_apply:
+  !op. (list_CASE op x1 x2) y =
+         (list_CASE op (x1 y) (\z1 z2. x2 z1 z2 y))
+Proof
+  Cases THEN SRW_TAC [] []
+QED
 
 (* Converts PMATCH case expressions applied to an argument, e.g.
 
@@ -452,13 +468,17 @@ val _ = translate (typeSystemTheory.build_ctor_tenv_def
          |> REWRITE_RULE [MAP_type_name_subst]
                     |> SIMP_RULE std_ss [lemma]);
 
-val EVERY_INTRO = Q.prove(
-  `(!x::set s. P x) = EVERY P s`,
-  SIMP_TAC std_ss [res_quanTheory.RES_FORALL,EVERY_MEM]);
+Triviality EVERY_INTRO:
+  (!x::set s. P x) = EVERY P s
+Proof
+  SIMP_TAC std_ss [res_quanTheory.RES_FORALL,EVERY_MEM]
+QED
 
-val EVERY_EQ_EVERY = Q.prove(
-  `!xs. EVERY P xs = EVERY I (MAP P xs)`,
-  Induct THEN SRW_TAC [] []);
+Triviality EVERY_EQ_EVERY:
+  !xs. EVERY P xs = EVERY I (MAP P xs)
+Proof
+  Induct THEN SRW_TAC [] []
+QED
 
 val _ = translate (infer_def ``check_freevars``
                    |> RW1 [EVERY_EQ_EVERY])
@@ -602,13 +622,15 @@ val _ = print "Translated infer_d\n";
 
 val infer_d_side_def = fetch "-" "infer_d_side_def";
 
-val generalise_list_length = Q.prove (
-  `!min start s x.
-    LENGTH x = LENGTH (SND (SND (generalise_list min start s (MAP f (MAP SND x)))))`,
+Triviality generalise_list_length:
+  !min start s x.
+    LENGTH x = LENGTH (SND (SND (generalise_list min start s (MAP f (MAP SND x)))))
+Proof
   induct_on `x` >>
   srw_tac[] [generalise_def] >>
   srw_tac[] [] >>
-  metis_tac [SND]);
+  metis_tac [SND]
+QED
 
 Definition gen_d_ind_def:
   (gen_d_ind (Dmod n ds) = gen_ds_ind ds) /\

--- a/compiler/bootstrap/translation/lexerProgScript.sml
+++ b/compiler/bootstrap/translation/lexerProgScript.sml
@@ -102,19 +102,23 @@ val num_from_hex_string_alt_side = Q.prove(`
     strip_tac>>
     fs[]) |> update_precondition;
 
-val read_string_side = Q.prove(`
+Triviality read_string_side:
   ∀x y l.
-  read_string_side x y l ⇔ T`,
+  read_string_side x y l ⇔ T
+Proof
   ho_match_mp_tac read_string_ind>>
   rw[]>>
-  simp[Once (fetch"-""read_string_side_def")]);
+  simp[Once (fetch"-""read_string_side_def")]
+QED
 
-val next_sym_alt_side = Q.prove(`
-  ∀x l. next_sym_alt_side x l ⇔ T`,
+Triviality next_sym_alt_side:
+  ∀x l. next_sym_alt_side x l ⇔ T
+Proof
   ho_match_mp_tac next_sym_alt_ind>>rw[]>>
   simp[Once (fetch"-""next_sym_alt_side_def"),num_from_dec_string_alt_side,read_string_side,num_from_hex_string_alt_side]>>
   rw[]>>
-  fs[FALSE_def]);
+  fs[FALSE_def]
+QED
 
 val lexer_fun_aux_side = Q.prove(`
   ∀x l. lexer_fun_aux_side x l ⇔ T`,

--- a/compiler/bootstrap/translation/mipsProgScript.sml
+++ b/compiler/bootstrap/translation/mipsProgScript.sml
@@ -20,9 +20,11 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "mipsProg");
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/printingProgScript.sml
+++ b/compiler/bootstrap/translation/printingProgScript.sml
@@ -17,9 +17,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -137,14 +137,16 @@ val _ = m_translate split_degree_def;
 val _ = translate sort_moves_def;
 val _ = translate smerge_def;
 
-val rewrite_subs = Q.prove(`
+Triviality rewrite_subs:
   (st_ex_MAP adj_ls_sub = st_ex_MAP (\v. adj_ls_sub v)) ∧
   (st_ex_MAP node_tag_sub = st_ex_MAP (\v. node_tag_sub v)) ∧
   (st_ex_PARTITION move_related_sub = st_ex_PARTITION (\v. move_related_sub v)) ∧
   (st_ex_MAP degrees_sub = st_ex_MAP (\v. degrees_sub v)) ∧
   (st_ex_FILTER (considered_var k) xs ys = st_ex_FILTER (\v. considered_var k v) xs ys) ∧
-  (st_ex_MAP (deg_or_inf kk) xs = st_ex_MAP (\x. deg_or_inf kk x) xs)`,
-  metis_tac[ETA_AX]);
+  (st_ex_MAP (deg_or_inf kk) xs = st_ex_MAP (\x. deg_or_inf kk x) xs)
+Proof
+  metis_tac[ETA_AX]
+QED
 
 val _ = translate sorted_mem_def;
 
@@ -230,8 +232,8 @@ val _ = m_translate do_reg_alloc_def;
 
 (* Finish the monadic translation *)
 (* Rewrite reg_alloc_aux before giving it to the monadic translator *)
-val reg_alloc_aux_trans_def = Q.prove(
- `∀k mtable ct forced x.
+Triviality reg_alloc_aux_trans_def:
+  ∀k mtable ct forced x.
      reg_alloc_aux alg sc k mtable ct forced x =
      run_ira_state (do_reg_alloc alg sc k mtable ct forced x)
        <|adj_ls := (SND(SND x),[]);
@@ -245,8 +247,10 @@ val reg_alloc_aux_trans_def = Q.prove(
          unavail_moves_wl := [];
          coalesced := (SND(SND x),0);
          move_related := (SND(SND x),F);
-         stack := []|>`,
- Cases_on `x` >> Cases_on `r` >> fs[reg_alloc_aux_def]);
+         stack := []|>
+Proof
+  Cases_on `x` >> Cases_on `r` >> fs[reg_alloc_aux_def]
+QED
 
 val def = reg_alloc_aux_trans_def
 val _ = m_translate_run reg_alloc_aux_trans_def;

--- a/compiler/bootstrap/translation/riscvProgScript.sml
+++ b/compiler/bootstrap/translation/riscvProgScript.sml
@@ -20,9 +20,11 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "riscvProg");
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -54,9 +56,11 @@ val _ = translate (conv64_RHS integer_wordTheory.WORD_LTi)
 val spec_word_bit1 = word_bit |> ISPEC``foo:word32`` |> SPEC``11n``|> SIMP_RULE std_ss [word_bit_test] |> CONV_RULE (wordsLib.WORD_CONV)
 val spec_word_bit2 = word_bit |> ISPEC``foo:word64`` |> SPEC``31n``|> SIMP_RULE std_ss [word_bit_test] |> CONV_RULE (wordsLib.WORD_CONV)
 
-val v2w_rw = Q.prove(`
-  v2w [P] = if P then 1w else 0w`,
-  rw[]>>EVAL_TAC);
+Triviality v2w_rw:
+  v2w [P] = if P then 1w else 0w
+Proof
+  rw[]>>EVAL_TAC
+QED
 
 val defaults = [riscv_ast_def, riscv_encode_def, Encode_def,
   Itype_def, opc_def, riscv_const32_def, Utype_def, Rtype_def,
@@ -147,9 +151,11 @@ val riscv_enc1_4 = reconstruct_case ``riscv_enc (Inst (Mem m n a))``
   (Addr n' c)))`` (rand o rator o rator o rand o rand)
   riscv_enc1_4_aux];
 
-val notw2w = Q.prove(`
-  !a. ~w2w a = (-1w ?? (w2w a))`,
-  srw_tac[wordsLib.WORD_BIT_EQ_ss][]);
+Triviality notw2w:
+  !a. ~w2w a = (-1w ?? (w2w a))
+Proof
+  srw_tac[wordsLib.WORD_BIT_EQ_ss][]
+QED
 
 val riscv_enc1_5 = el 5 riscv_enc1s;
 
@@ -158,12 +164,14 @@ val riscv_simp1 = reconstruct_case ``riscv_enc (Inst i)`` (rand o
   riscv_enc1_5] |> SIMP_RULE std_ss[notw2w, word_2comp_def,
   dimword_32, dimword_20] |> gconv;
 
-val if_eq1w = Q.prove(`
+Triviality if_eq1w:
   ((if w2w (c ⋙ m && 1w:word64) = 1w:word20 then 1w:word1 else 0w) && 1w)
   =
-  w2w (c ⋙ m && 1w)`,
+  w2w (c ⋙ m && 1w)
+Proof
   rw[]>>fs[]>>
-  blastLib.FULL_BBLAST_TAC);
+  blastLib.FULL_BBLAST_TAC
+QED
 
 val riscv_simp2 = riscv_enc2 |> SIMP_RULE (srw_ss() ++ LET_ss) (Once
   COND_RAND::COND_RATOR::defaults) |> wc_simp |> we_simp |> gconv |>

--- a/compiler/bootstrap/translation/sexp_parserProgScript.sml
+++ b/compiler/bootstrap/translation/sexp_parserProgScript.sml
@@ -148,16 +148,20 @@ Proof
   fs[EVERY_MEM,lexer_implTheory.unhex_alt_def]
 QED
 
-val lemma = Q.prove(`
+Triviality lemma:
   isHexDigit x ∧ isHexDigit y ∧ A ∧ B ∧ ¬isPrint (CHR (num_from_hex_string[x;y])) ⇔
-  isHexDigit x ∧ isHexDigit y ∧ A ∧ B ∧ ¬isPrint (CHR (num_from_hex_string_alt[x;y]))`,
+  isHexDigit x ∧ isHexDigit y ∧ A ∧ B ∧ ¬isPrint (CHR (num_from_hex_string_alt[x;y]))
+Proof
   rw[EQ_IMP_THM,num_from_hex_string_alt_intro]
-  \\ rfs[num_from_hex_string_alt_intro]);
+  \\ rfs[num_from_hex_string_alt_intro]
+QED
 
-val lemma2 = Q.prove(`
+Triviality lemma2:
   isHexDigit x ∧ isHexDigit y ⇒
-  num_from_hex_string [x;y] = num_from_hex_string_alt [x;y]`,
-  rw[num_from_hex_string_alt_intro]);
+  num_from_hex_string [x;y] = num_from_hex_string_alt [x;y]
+Proof
+  rw[num_from_hex_string_alt_intro]
+QED
 
 val _ = ml_translatorLib.use_string_type false;
 
@@ -410,8 +414,11 @@ val print_sexp_alt_side = Q.prove(
 
 val _ = translate print_sexp_alt_thm;
 
-val listsexp_alt = Q.prove(`listsexp = FOLDR (λs1 s2. SX_CONS s1 s2) nil`,
-  rpt(CHANGED_TAC(CONV_TAC (DEPTH_CONV ETA_CONV))) >> simp[listsexp_def]);
+Triviality listsexp_alt:
+  listsexp = FOLDR (λs1 s2. SX_CONS s1 s2) nil
+Proof
+  rpt(CHANGED_TAC(CONV_TAC (DEPTH_CONV ETA_CONV))) >> simp[listsexp_def]
+QED
 
 val _ = translate listsexp_alt
 
@@ -421,16 +428,22 @@ val _ = ml_translatorLib.use_string_type false;
 
 val _ = translate HEX_def
 
-val l2n_side_thm = Q.prove(`!n l. l2n_side n l <=> (l <> [] ==> n <> 0)`,
+Triviality l2n_side_thm:
+  !n l. l2n_side n l <=> (l <> [] ==> n <> 0)
+Proof
   strip_tac >>
   Induct >>
   rpt strip_tac >>
   PURE_ONCE_REWRITE_TAC[lexerProgTheory.l2n_side_def] >>
   rw[] >>
-  Cases_on `l = []` >> fs[])
+  Cases_on `l = []` >> fs[]
+QED
 
-val s2n_side_thm = Q.prove(`!n f l. s2n_side n f l <=> (l <> [] ==> n <> 0)`,
-  rw[l2n_side_thm,lexerProgTheory.s2n_side_def]);
+Triviality s2n_side_thm:
+  !n f l. s2n_side n f l <=> (l <> [] ==> n <> 0)
+Proof
+  rw[l2n_side_thm,lexerProgTheory.s2n_side_def]
+QED
 
 Definition hex_alt_def:
   hex_alt x = if x < 16 then HEX x else #"0"

--- a/compiler/bootstrap/translation/to_bviProgScript.sml
+++ b/compiler/bootstrap/translation/to_bviProgScript.sml
@@ -30,9 +30,11 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/to_bvlProgScript.sml
+++ b/compiler/bootstrap/translation/to_bvlProgScript.sml
@@ -31,9 +31,11 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/to_closProgScript.sml
+++ b/compiler/bootstrap/translation/to_closProgScript.sml
@@ -32,9 +32,11 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -225,9 +227,11 @@ val r = translate clos_opTheory.SmartOp_def;
 
 val r = translate clos_knownTheory.merge_alt;
 
-val num_abs_intro = Q.prove(`
-  ∀x. Num x = if 0 ≤ x then Num (ABS x) else Num x`,
-  rw[]>>intLib.COOPER_TAC);
+Triviality num_abs_intro:
+  ∀x. Num x = if 0 ≤ x then Num (ABS x) else Num x
+Proof
+  rw[]>>intLib.COOPER_TAC
+QED
 
 val r = translate (clos_knownTheory.known_op_def
                    |> ONCE_REWRITE_RULE [num_abs_intro]

--- a/compiler/bootstrap/translation/to_dataProgScript.sml
+++ b/compiler/bootstrap/translation/to_dataProgScript.sml
@@ -32,9 +32,11 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/to_flatProgScript.sml
+++ b/compiler/bootstrap/translation/to_flatProgScript.sml
@@ -31,9 +31,11 @@ fun list_mk_fun_type [ty] = ty
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 

--- a/compiler/bootstrap/translation/to_target32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_target32ProgScript.sml
@@ -19,9 +19,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -279,21 +281,25 @@ val _ = m_translate_run enc_secs_32_aux_def;
 
 val _ = translate enc_secs_32_def;
 
-val monadic_enc32_enc_line_hash_32_ls_side_def = Q.prove(`
+Triviality monadic_enc32_enc_line_hash_32_ls_side_def:
   ∀a b c d e.
   d ≠ 0 ⇒
-  monadic_enc32_enc_line_hash_32_ls_side a b c d e ⇔ T`,
+  monadic_enc32_enc_line_hash_32_ls_side a b c d e ⇔ T
+Proof
   Induct_on`e`>>
   simp[Once (fetch "-" "monadic_enc32_enc_line_hash_32_ls_side_def")]>>
-  EVAL_TAC>>rw[]>>fs[]);
+  EVAL_TAC>>rw[]>>fs[]
+QED
 
-val monadic_enc32_enc_sec_hash_32_ls_side_def = Q.prove(`
+Triviality monadic_enc32_enc_sec_hash_32_ls_side_def:
   ∀a b c d e.
   d ≠ 0 ⇒
-  monadic_enc32_enc_sec_hash_32_ls_side a b c d e ⇔ T`,
+  monadic_enc32_enc_sec_hash_32_ls_side a b c d e ⇔ T
+Proof
   Induct_on`e`>>
   simp[Once (fetch "-" "monadic_enc32_enc_sec_hash_32_ls_side_def")]>>
-  metis_tac[monadic_enc32_enc_line_hash_32_ls_side_def]);
+  metis_tac[monadic_enc32_enc_line_hash_32_ls_side_def]
+QED
 
 Theorem monadic_enc32_enc_secs_32_side_def[allow_rebind] = Q.prove(`
   monadic_enc32_enc_secs_32_side a b c ⇔ T`,
@@ -334,11 +340,13 @@ Definition remove_labels_hash_def:
     remove_labels_loop init_clock c pos labs ffis (enc_secs_32 c.encode hash_size sec_list)
 End
 
-val remove_labels_hash_correct = Q.prove(`
+Triviality remove_labels_hash_correct:
   remove_labels_hash c.init_clock c.asm_conf c.pos c.labels ffis c.hash_size sec_list =
-  remove_labels c.init_clock c.asm_conf c.pos c.labels ffis sec_list`,
+  remove_labels c.init_clock c.asm_conf c.pos c.labels ffis sec_list
+Proof
   simp [FUN_EQ_THM, remove_labels_hash_def, remove_labels_def,
-        enc_secs_32_correct]);
+        enc_secs_32_correct]
+QED
 
 val res = translate (remove_labels_hash_def |> spec32);
 

--- a/compiler/bootstrap/translation/to_target64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_target64ProgScript.sml
@@ -19,9 +19,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -279,21 +281,25 @@ val _ = m_translate_run enc_secs_64_aux_def;
 
 val _ = translate enc_secs_64_def;
 
-val monadic_enc64_enc_line_hash_64_ls_side_def = Q.prove(`
+Triviality monadic_enc64_enc_line_hash_64_ls_side_def:
   ∀a b c d e.
   d ≠ 0 ⇒
-  monadic_enc64_enc_line_hash_64_ls_side a b c d e ⇔ T`,
+  monadic_enc64_enc_line_hash_64_ls_side a b c d e ⇔ T
+Proof
   Induct_on`e`>>
   simp[Once (fetch "-" "monadic_enc64_enc_line_hash_64_ls_side_def")]>>
-  EVAL_TAC>>rw[]>>fs[]);
+  EVAL_TAC>>rw[]>>fs[]
+QED
 
-val monadic_enc64_enc_sec_hash_64_ls_side_def = Q.prove(`
+Triviality monadic_enc64_enc_sec_hash_64_ls_side_def:
   ∀a b c d e.
   d ≠ 0 ⇒
-  monadic_enc64_enc_sec_hash_64_ls_side a b c d e ⇔ T`,
+  monadic_enc64_enc_sec_hash_64_ls_side a b c d e ⇔ T
+Proof
   Induct_on`e`>>
   simp[Once (fetch "-" "monadic_enc64_enc_sec_hash_64_ls_side_def")]>>
-  metis_tac[monadic_enc64_enc_line_hash_64_ls_side_def]);
+  metis_tac[monadic_enc64_enc_line_hash_64_ls_side_def]
+QED
 
 Theorem monadic_enc64_enc_secs_64_side_def[allow_rebind] = Q.prove(`
   monadic_enc64_enc_secs_64_side a b c ⇔ T`,
@@ -334,11 +340,13 @@ Definition remove_labels_hash_def:
     remove_labels_loop init_clock c pos labs ffis (enc_secs_64 c.encode hash_size sec_list)
 End
 
-val remove_labels_hash_correct = Q.prove(`
+Triviality remove_labels_hash_correct:
   remove_labels_hash c.init_clock c.asm_conf c.pos c.labels ffis c.hash_size sec_list =
-  remove_labels c.init_clock c.asm_conf c.pos c.labels ffis sec_list`,
+  remove_labels c.init_clock c.asm_conf c.pos c.labels ffis sec_list
+Proof
   simp [FUN_EQ_THM, remove_labels_hash_def, remove_labels_def,
-        enc_secs_64_correct]);
+        enc_secs_64_correct]
+QED
 
 val res = translate (remove_labels_hash_def |> spec64);
 

--- a/compiler/bootstrap/translation/to_word32ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word32ProgScript.sml
@@ -19,9 +19,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -121,16 +123,18 @@ val _ = translate (GiveUp_def |> wcomp_simp |> conv32)
 
 val _ = matches:= [``foo:'a wordLang$prog``,``foo:'a wordLang$exp``]
 
-val assign_rw = Q.prove(`
+Triviality assign_rw:
   (i < 0 ⇒ n2w (Num (4 * (0 -i))) = n2w (Num (ABS (4*(0-i))))) ∧
-  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))`,
+  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))
+Proof
   rw[]
   >-
     (`0 ≤ 4* -i` by intLib.COOPER_TAC>>
     metis_tac[integerTheory.INT_ABS_EQ_ID])
   >>
     `0 ≤ 4*i` by intLib.COOPER_TAC>>
-    metis_tac[integerTheory.INT_ABS_EQ_ID])
+    metis_tac[integerTheory.INT_ABS_EQ_ID]
+QED
 
 (* TODO: word_mul should maybe target a real op ?
    TODO: econv might be going too far with case simplification
@@ -280,7 +284,11 @@ fun tweak_assign_def th =
 val res = all_assign_defs |> CONJUNCTS |> map tweak_assign_def |> map translate;
 val res = translate (assign_def |> tweak_assign_def);
 
-val lemma = Q.prove(`!A B. A = B ==> B ≠ A ==> F`,metis_tac[])
+Triviality lemma:
+  !A B. A = B ==> B ≠ A ==> F
+Proof
+  metis_tac[]
+QED
 
 (*
 val data_to_word_assign_side = Q.prove(`
@@ -326,21 +334,25 @@ val res = translate (word_cseTheory.word_common_subexp_elim_def |> spec32);
 
 val _ = translate (const_fp_inst_cs_def |> spec32 |> econv)
 
-val rws = Q.prove(`
+Triviality rws:
   ($+ = λx y. x + y) ∧
   ($&& = λx y. x && y) ∧
   ($|| = λx y. x || y) ∧
-  ($?? = λx y. x ?? y)`,
-  fs[FUN_EQ_THM])
+  ($?? = λx y. x ?? y)
+Proof
+  fs[FUN_EQ_THM]
+QED
 
 val _ = translate (wordLangTheory.word_op_def |> ONCE_REWRITE_RULE [rws,WORD_NOT_0] |> spec32 |> gconv)
 
-val word_msb_rw = Q.prove(
-  `word_msb (a:word32) ⇔ (a>>>31) <> 0w`,
+Triviality word_msb_rw:
+  word_msb (a:word32) ⇔ (a>>>31) <> 0w
+Proof
   rw[word_msb_def,fcpTheory.CART_EQ,word_index,word_lsr_def,fcpTheory.FCP_BETA]
   \\ rw[EQ_IMP_THM]
   >- ( qexists_tac`0` \\ simp[] )
-  \\ `i = 0` by decide_tac \\ fs[]);
+  \\ `i = 0` by decide_tac \\ fs[]
+QED
 
 val arith_shift_right_ind_orig = arith_shift_right_ind;
 
@@ -435,10 +447,12 @@ val _ = translate (conv32 remove_dead_inst_def)
 val _ = translate (conv32 get_live_inst_def)
 val _ = translate (spec32 remove_dead_def)
 
-val lem = Q.prove(`
+Triviality lem:
   dimindex(:64) = 64 ∧
-  dimindex(:32) = 32`,
-  EVAL_TAC);
+  dimindex(:32) = 32
+Proof
+  EVAL_TAC
+QED
 
 val _ = translate (INST_TYPE [alpha|->``:32``,beta|->``:32``] get_forced_pmatch
                   |> SIMP_RULE (bool_ss++ARITH_ss) [lem])

--- a/compiler/bootstrap/translation/to_word64ProgScript.sml
+++ b/compiler/bootstrap/translation/to_word64ProgScript.sml
@@ -19,9 +19,11 @@ val RW = REWRITE_RULE
 
 val _ = add_preferred_thy "-";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -121,16 +123,18 @@ val _ = translate (GiveUp_def |> wcomp_simp |> conv64)
 
 val _ = matches:= [``foo:'a wordLang$prog``,``foo:'a wordLang$exp``]
 
-val assign_rw = Q.prove(`
+Triviality assign_rw:
   (i < 0 ⇒ n2w (Num (4 * (0 -i))) = n2w (Num (ABS (4*(0-i))))) ∧
-  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))`,
+  (¬(i < 0) ⇒ n2w (Num (4 * i)) = n2w (Num (ABS (4*i))))
+Proof
   rw[]
   >-
     (`0 ≤ 4* -i` by intLib.COOPER_TAC>>
     metis_tac[integerTheory.INT_ABS_EQ_ID])
   >>
     `0 ≤ 4*i` by intLib.COOPER_TAC>>
-    metis_tac[integerTheory.INT_ABS_EQ_ID])
+    metis_tac[integerTheory.INT_ABS_EQ_ID]
+QED
 
 (* TODO: word_mul should maybe target a real op ?
    TODO: econv might be going too far with case simplification
@@ -270,7 +274,11 @@ fun tweak_assign_def th =
 val res = all_assign_defs |> CONJUNCTS |> map tweak_assign_def |> map translate;
 val res = translate (assign_def |> tweak_assign_def);
 
-val lemma = Q.prove(`!A B. A = B ==> B ≠ A ==> F`,metis_tac[])
+Triviality lemma:
+  !A B. A = B ==> B ≠ A ==> F
+Proof
+  metis_tac[]
+QED
 
 (*
 val data_to_word_assign_side = Q.prove(`
@@ -316,21 +324,25 @@ val res = translate (word_cseTheory.word_common_subexp_elim_def |> spec64);
 
 val _ = translate (const_fp_inst_cs_def |> spec64 |> econv)
 
-val rws = Q.prove(`
+Triviality rws:
   ($+ = λx y. x + y) ∧
   ($&& = λx y. x && y) ∧
   ($|| = λx y. x || y) ∧
-  ($?? = λx y. x ?? y)`,
-  fs[FUN_EQ_THM])
+  ($?? = λx y. x ?? y)
+Proof
+  fs[FUN_EQ_THM]
+QED
 
 val _ = translate (wordLangTheory.word_op_def |> ONCE_REWRITE_RULE [rws,WORD_NOT_0] |> spec64 |> gconv)
 
-val word_msb_rw = Q.prove(
-  `word_msb (a:word64) ⇔ (a>>>63) <> 0w`,
+Triviality word_msb_rw:
+  word_msb (a:word64) ⇔ (a>>>63) <> 0w
+Proof
   rw[word_msb_def,fcpTheory.CART_EQ,word_index,word_lsr_def,fcpTheory.FCP_BETA]
   \\ rw[EQ_IMP_THM]
   >- ( qexists_tac`0` \\ simp[] )
-  \\ `i = 0` by decide_tac \\ fs[]);
+  \\ `i = 0` by decide_tac \\ fs[]
+QED
 
 val arith_shift_right_ind_orig = arith_shift_right_ind;
 
@@ -427,10 +439,12 @@ val _ = translate (conv64 remove_dead_inst_def)
 val _ = translate (conv64 get_live_inst_def)
 val _ = translate (spec64 remove_dead_def)
 
-val lem = Q.prove(`
+Triviality lem:
   dimindex(:64) = 64 ∧
-  dimindex(:32) = 32`,
-  EVAL_TAC);
+  dimindex(:32) = 32
+Proof
+  EVAL_TAC
+QED
 
 val _ = translate (INST_TYPE [alpha|->``:64``,beta|->``:64``] get_forced_pmatch
                   |> SIMP_RULE (bool_ss++ARITH_ss) [lem])

--- a/compiler/bootstrap/translation/x64ProgScript.sml
+++ b/compiler/bootstrap/translation/x64ProgScript.sml
@@ -20,9 +20,11 @@ val _ = ml_translatorLib.ml_prog_update (ml_progLib.open_module "x64Prog");
 val _ = add_preferred_thy "-";
 val _ = add_preferred_thy "termination";
 
-val NOT_NIL_AND_LEMMA = Q.prove(
-  `(b <> [] /\ x) = if b = [] then F else x`,
-  Cases_on `b` THEN FULL_SIMP_TAC std_ss []);
+Triviality NOT_NIL_AND_LEMMA:
+  (b <> [] /\ x) = if b = [] then F else x
+Proof
+  Cases_on `b` THEN FULL_SIMP_TAC std_ss []
+QED
 
 val extra_preprocessing = ref [MEMBER_INTRO,MAP];
 
@@ -46,26 +48,33 @@ fun def_of_const tm = let
 
 val _ = (find_def_for_const := def_of_const);
 
-val v2w_rw = Q.prove(`
-  v2w [P] = if P then 1w else 0w`,
-  rw[]>>EVAL_TAC);
+Triviality v2w_rw:
+  v2w [P] = if P then 1w else 0w
+Proof
+  rw[]>>EVAL_TAC
+QED
 
 val _ = translate (conv64_RHS integer_wordTheory.WORD_LEi)
 
-val zreg2num_totalnum2zerg = Q.prove(`
-  Zreg2num (total_num2Zreg n) = if n < 16 then n else 0`,
-  EVAL_TAC>>IF_CASES_TAC>>fs[Zreg2num_num2Zreg]);
+Triviality zreg2num_totalnum2zerg:
+  Zreg2num (total_num2Zreg n) = if n < 16 then n else 0
+Proof
+  EVAL_TAC>>IF_CASES_TAC>>fs[Zreg2num_num2Zreg]
+QED
 
-val zreg2num_num2zerg_MOD8 = Q.prove(`
-  Zreg2num (num2Zreg (n MOD 8)) = n MOD 8`,
+Triviality zreg2num_num2zerg_MOD8:
+  Zreg2num (num2Zreg (n MOD 8)) = n MOD 8
+Proof
   `n MOD 8 < 8` by fs[] >>
   `n MOD 8 < 16` by DECIDE_TAC>>
-  fs[Zreg2num_num2Zreg]);
+  fs[Zreg2num_num2Zreg]
+QED
 
-val n2w_MOD8_simps = Q.prove(`
+Triviality n2w_MOD8_simps:
   n2w (n MOD 8) :word4 >>> 3 = 0w /\
   (n2w (n MOD 8) :word4 && 7w) = n2w (n MOD 8) ∧
-  BITS 3 0 (n MOD 8) =n MOD 8`,
+  BITS 3 0 (n MOD 8) =n MOD 8
+Proof
   FULL_BBLAST_TAC>>
   `n MOD 8 < 8` by fs[]>>
   `n MOD 8 = 0 \/
@@ -76,41 +85,56 @@ val n2w_MOD8_simps = Q.prove(`
   n MOD 8 = 5 \/
   n MOD 8 = 6 \/
   n MOD 8 = 7` by DECIDE_TAC>>
-  fs[]);
+  fs[]
+QED
 
-val Zbinop_name2num_x64_sh = Q.prove(`
+Triviality Zbinop_name2num_x64_sh:
   ∀s.Zbinop_name2num (x64_sh s) =
   case s of
     Lsl => 12
   | Lsr => 13
   | Asr => 15
-  | Ror => 9`,  Cases>>EVAL_TAC);
+  | Ror => 9
+Proof
+  Cases>>EVAL_TAC
+QED
 
-val x64_sh_notZtest = Q.prove(`
-  ∀s.(x64_sh s) ≠ Ztest `,Cases>>EVAL_TAC);
+Triviality x64_sh_notZtest:
+  ∀s.(x64_sh s) ≠ Ztest
+Proof
+  Cases>>EVAL_TAC
+QED
 
-val exh_if_collapse = Q.prove(`
-  ((if P then Ztest else Zcmp) = Ztest) ⇔ P `,rw[]);
+Triviality exh_if_collapse:
+  ((if P then Ztest else Zcmp) = Ztest) ⇔ P
+Proof
+  rw[]
+QED
 
-val is_rax_zr_thm = Q.prove(`
+Triviality is_rax_zr_thm:
   is_rax (Zr (total_num2Zreg n)) ⇔
-  n = 0 ∨ n ≥ 16`,
+  n = 0 ∨ n ≥ 16
+Proof
   rw[is_rax_def]>>
   EVAL_TAC>>rw[]>>
   rpt(Cases_on`n`>>EVAL_TAC>>fs[]>>
-  Cases_on`n'`>>EVAL_TAC>>fs[]))
+  Cases_on`n'`>>EVAL_TAC>>fs[])
+QED
 
 (* commute list case, option case and if *)
-val case_ifs = Q.prove(`
+Triviality case_ifs:
   ((case
     if P then
       l1
     else l2
   of
     [] => A
-  | ls => B ls) = if P then case l1 of [] => A | ls => B ls else case l2 of [] => A | ls => B ls)`,rw[])
+  | ls => B ls) = if P then case l1 of [] => A | ls => B ls else case l2 of [] => A | ls => B ls)
+Proof
+  rw[]
+QED
 
-val case_ifs2 = Q.prove(`
+Triviality case_ifs2:
   ((case
     if P then
       SOME (a,b,c)
@@ -118,12 +142,15 @@ val case_ifs2 = Q.prove(`
   of
     NONE => A
   | SOME (a,b,c) => B a b c) = if P then B a b c else A)
-  `,
-  rw[])
+Proof
+  rw[]
+QED
 
-val if_neq = Q.prove(`
-  (if P then [x] else []) ≠ [] ⇔ P`,
-  rw[])
+Triviality if_neq:
+  (if P then [x] else []) ≠ [] ⇔ P
+Proof
+  rw[]
+QED
 
 val fconv = SIMP_RULE (srw_ss()) [SHIFT_ZERO,case_ifs,case_ifs2,if_neq]
 
@@ -151,11 +178,13 @@ val x64_enc1s = x64_enc1 |> SIMP_RULE (srw_ss() ++ LET_ss ++ DatatypeSimps.expan
 
 val x64_enc1_1 = el 1 x64_enc1s
 
-val simp_rw = Q.prove(`
+Triviality simp_rw:
   (if ((1w:word4 && n2w (if n < 16 then n else 0) ⋙ 3) = 1w) then 1w else 0w:word4) =
-  (1w && n2w (if n < 16 then n else 0) ⋙ 3)`,
+  (1w && n2w (if n < 16 then n else 0) ⋙ 3)
+Proof
   rw[]>>fs[]>>
-  blastLib.FULL_BBLAST_TAC);
+  blastLib.FULL_BBLAST_TAC
+QED
 
 val x64_enc1_2 = el 2 x64_enc1s |> wc_simp |> we_simp |> gconv |>
  bconv |> SIMP_RULE std_ss [SHIFT_ZERO,Q.ISPEC`Zsize_CASE`
@@ -270,9 +299,11 @@ else if is_conj t then
 else
   false
 
-val case_append = Q.prove(`
-  (case a ++ [b;c] ++ d of [] => x | ls => ls) = a++[b;c]++d`,
-  EVERY_CASE_TAC>>fs[]);
+Triviality case_append:
+  (case a ++ [b;c] ++ d of [] => x | ls => ls) = a++[b;c]++d
+Proof
+  EVERY_CASE_TAC>>fs[]
+QED
 
 val x64_enc3_2_th =
   x64_enc3_2 |> CONJUNCTS
@@ -286,9 +317,11 @@ val x64_simp3 =
 
 val x64_simp4 = x64_enc4 |> SIMP_RULE (srw_ss() ++ LET_ss) defaults |> wc_simp |> we_simp |> gconv |> SIMP_RULE std_ss [SHIFT_ZERO]
 
-val case_append2 = Q.prove(`
-  (case a ++ [b;c] of [] => e | ls => ls) = a++[b;c]`,
-  EVERY_CASE_TAC>>fs[]);
+Triviality case_append2:
+  (case a ++ [b;c] of [] => e | ls => ls) = a++[b;c]
+Proof
+  EVERY_CASE_TAC>>fs[]
+QED
 
 val x64_simp5 = x64_enc5 |> SIMP_RULE (srw_ss() ++ LET_ss) defaults |>
 wc_simp |> we_simp |> gconv |> SIMP_RULE std_ss [SHIFT_ZERO] |> bconv

--- a/compiler/encoders/ag32/proofs/ag32_targetProofScript.sml
+++ b/compiler/encoders/ag32/proofs/ag32_targetProofScript.sml
@@ -10,8 +10,8 @@ val () = wordsLib.guess_lengths()
 
 (* some lemmas ---------------------------------------------------------- *)
 
-val bytes_in_memory_thm = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm:
+  !w s state a b c d.
       target_state_rel ag32_target s state /\
       bytes_in_memory s.pc [a; b; c; d] s.mem s.mem_domain ==>
       aligned 2 state.PC /\
@@ -22,16 +22,17 @@ val bytes_in_memory_thm = Q.prove(
       state.PC + 3w IN s.mem_domain /\
       state.PC + 2w IN s.mem_domain /\
       state.PC + 1w IN s.mem_domain /\
-      state.PC IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, ag32_target_def, ag32_config_def,
+      state.PC IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, ag32_target_def, ag32_config_def,
        ag32_ok_def, miscTheory.bytes_in_memory_def,
        alignmentTheory.aligned_extract, set_sepTheory.fun2set_eq,
        wordsTheory.WORD_LS_word_T]
    \\ fs []
-   )
+QED
 
-val bytes_in_memory_thm2 = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm2:
+  !w s state a b c d.
       target_state_rel ag32_target s state /\
       bytes_in_memory (s.pc + w) [a; b; c; d] s.mem s.mem_domain ==>
       (state.MEM (state.PC + w) = a) /\
@@ -41,38 +42,44 @@ val bytes_in_memory_thm2 = Q.prove(
       state.PC + w + 3w IN s.mem_domain /\
       state.PC + w + 2w IN s.mem_domain /\
       state.PC + w + 1w IN s.mem_domain /\
-      state.PC + w IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, ag32_target_def, ag32_config_def,
+      state.PC + w IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, ag32_target_def, ag32_config_def,
        ag32_ok_def, miscTheory.bytes_in_memory_def, set_sepTheory.fun2set_eq]
-   )
+QED
 
-val add_carry_lem = Q.prove(
-  `!w: word32. 0x100000000 <= w2n w + 0xFFFFFFFF <=> w <> 0w`,
-  Cases \\ simp [])
+Triviality add_carry_lem:
+  !w: word32. 0x100000000 <= w2n w + 0xFFFFFFFF <=> w <> 0w
+Proof
+  Cases \\ simp []
+QED
 
-val add_carry_lem2 = Q.prove(
-  `!a b. n2w (w2n a + (w2n b + 1)) = a + b + 1w`,
+Triviality add_carry_lem2:
+  !a b. n2w (w2n a + (w2n b + 1)) = a + b + 1w
+Proof
   Cases
   \\ Cases
   \\ simp [wordsTheory.word_add_n2w]
-  )
+QED
 
-val shift_lem = Q.prove(
-  `!n. n < 32 ==> (w2n (sw2sw (n2w n : word6) : word32) = n)`,
+Triviality shift_lem:
+  !n. n < 32 ==> (w2n (sw2sw (n2w n : word6) : word32) = n)
+Proof
   rpt strip_tac
   \\ full_simp_tac std_ss [wordsTheory.NUMERAL_LESS_THM]
   \\ simp []
-  )
+QED
 
-val long_mul_lem = Q.prove(
-  `!a : word32 b : word32.
+Triviality long_mul_lem:
+  !a : word32 b : word32.
     n2w ((w2n a * w2n b) DIV 4294967296) =
-    (63 >< 32) (w2w a * w2w b : word64) : word32`,
+    (63 >< 32) (w2w a * w2w b : word64) : word32
+Proof
   Cases
   \\ Cases
   \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_mul_n2w,
          wordsTheory.word_extract_n2w, bitTheory.BITS_THM]
-  )
+QED
 
 val jump_lem =
   blastLib.BBLAST_PROVE
@@ -96,11 +103,12 @@ val load_lem =
   blastLib.BBLAST_PROVE
    ``!c: word32.  0xFFFFFFE0w <= c /\ c <= 31w ==> (sw2sw (w2w c :word6) = c)``
 
-val load_lem2 = Q.prove(
-  `!c : word32. aligned 2 c ==> ((31 >< 2) c @@ (0w : word2) = c)`,
+Triviality load_lem2:
+  !c : word32. aligned 2 c ==> ((31 >< 2) c @@ (0w : word2) = c)
+Proof
   simp [alignmentTheory.aligned_extract]
   \\ blastLib.BBLAST_TAC
-  )
+QED
 
 val load_lem3 =
   blastLib.BBLAST_PROVE
@@ -146,9 +154,11 @@ val enc_ok_rwts =
    ag32 target_ok
    ------------------------------------------------------------------------- *)
 
-val length_ag32_encode = Q.prove(
-  `!i. (LENGTH (ag32_encode1 i) = 4) /\ (ag32_encode1 i <> [])`,
-  rw [ag32_encode1_def])
+Triviality length_ag32_encode:
+  !i. (LENGTH (ag32_encode1 i) = 4) /\ (ag32_encode1 i <> [])
+Proof
+  rw [ag32_encode1_def]
+QED
 
 val ag32_encoding = Q.prove (
    `!i. let l = ag32_enc i in (LENGTH l MOD 4 = 0) /\ l <> []`,
@@ -161,9 +171,10 @@ val ag32_encoding = Q.prove (
    )
    |> SIMP_RULE (srw_ss()++boolSimps.LET_ss) [ag32_enc_def]
 
-val ag32_target_ok = Q.prove (
-   `target_ok ag32_target`,
-   rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality ag32_target_ok:
+  target_ok ag32_target
+Proof
+  rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
         ag32_proj_def, ag32_target_def, ag32_config, ag32_ok_def,
         set_sepTheory.fun2set_eq, ag32_encoding] @ enc_ok_rwts)
    >| [ Cases_on `0w <= w1` \\ Cases_on `0w <= w2`,
@@ -175,13 +186,14 @@ val ag32_target_ok = Q.prove (
    \\ lfs (enc_rwts @ encode_extra_rwts)
    \\ rw [length_ag32_encode]
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
-val aligned_pc = Q.prove(
-  `!a : word32. aligned 2 a ==> (((31 >< 2) a : word30) @@ (0w : word2) = a)`,
+Triviality aligned_pc:
+  !a : word32. aligned 2 a ==> (((31 >< 2) a : word30) @@ (0w : word2) = a)
+Proof
   simp [alignmentTheory.aligned_extract]
   \\ blastLib.BBLAST_TAC
-  )
+QED
 
 Theorem concat_bytes:
   !w: word32. (31 >< 24) w @@ (23 >< 16) w @@ (15 >< 8) w @@ (7 >< 0) w = w
@@ -189,22 +201,26 @@ Proof
   blastLib.BBLAST_TAC
 QED
 
-val funcT_thm = Q.prove(
-  `!func.
+Triviality funcT_thm:
+  !func.
      num2funcT
        (w2n (v2w
          [BIT 3 (funcT2num func); BIT 2 (funcT2num func);
-          BIT 1 (funcT2num func); BIT 0 (funcT2num func)] : word4)) = func`,
-  Cases \\ simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss) [])
+          BIT 1 (funcT2num func); BIT 0 (funcT2num func)] : word4)) = func
+Proof
+  Cases \\ simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss) []
+QED
 
-val shiftT_thm = Q.prove(
-  `!shiftOp.
+Triviality shiftT_thm:
+  !shiftOp.
      num2shiftT
        (w2n ((1 >< 0) (v2w
          [BIT 3 (shiftT2num shiftOp); BIT 2 (shiftT2num shiftOp);
           BIT 1 (shiftT2num shiftOp); BIT 0 (shiftT2num shiftOp)] : word4))) =
-     shiftOp`,
-  Cases \\ simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss) [])
+     shiftOp
+Proof
+  Cases \\ simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss) []
+QED
 
 fun tac q l = qmatch_goalsub_rename_tac q \\ MAP_EVERY Cases_on l
 
@@ -240,17 +256,18 @@ Proof
   \\ CONV_TAC blastLib.BBLAST_CONV
 QED
 
-val ag32_run = Q.prove(
-  `!i ms.
+Triviality ag32_run:
+  !i ms.
      (ms.MEM ms.PC = (7 >< 0) (Encode i)) /\
      (ms.MEM (ms.PC + 1w) = (15 >< 8) (Encode i)) /\
      (ms.MEM (ms.PC + 2w) = (23 >< 16) (Encode i)) /\
      (ms.MEM (ms.PC + 3w) = (31 >< 24) (Encode i)) /\
      aligned 2 ms.PC ==>
-     (Next ms = Run i ms)`,
+     (Next ms = Run i ms)
+Proof
   simp [ag32Theory.Next_def, aligned_pc, concat_bytes, Decode_Encode,
         wordsTheory.WORD_LS_word_T]
-  )
+QED
 
 local
   val ms = ``ms: ag32_state``
@@ -303,15 +320,17 @@ val state_tac =
   \\ full_simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss) [load_lem2, store_lem]
   \\ blastLib.FULL_BBLAST_TAC
 
-val bytes_in_memory_IMP_all_pcs_MEM = Q.prove(
- `!env a xs m dm.
+Triviality bytes_in_memory_IMP_all_pcs_MEM:
+  !env a xs m dm.
    bytes_in_memory a xs m dm /\
    (*(!(i:num) ms'. (∀a. a ∈ dm ⇒ (env i ms').MEM a = ms'.MEM a)) ==>*)
    (!(i:num) ms'. fun2set ((env i ms').MEM, dm) = fun2set (ms'.MEM, dm)) ==>
-   (!i ms'. (∀pc. pc ∈ all_pcs (LENGTH xs) a 0 ==> (env i ms').MEM pc = ms'.MEM pc))`,
- simp [set_sepTheory.fun2set_eq] \\ Induct_on `xs`
+   (!i ms'. (∀pc. pc ∈ all_pcs (LENGTH xs) a 0 ==> (env i ms').MEM pc = ms'.MEM pc))
+Proof
+  simp [set_sepTheory.fun2set_eq] \\ Induct_on `xs`
  \\ rw [asmPropsTheory.all_pcs_def, miscTheory.bytes_in_memory_def]
- \\ metis_tac []);
+ \\ metis_tac []
+QED
 
 local
    fun number_of_instructions asl =

--- a/compiler/encoders/arm7/proofs/arm7_targetProofScript.sml
+++ b/compiler/encoders/arm7/proofs/arm7_targetProofScript.sml
@@ -11,9 +11,11 @@ val () = wordsLib.guess_lengths ()
 
 (* some lemmas ---------------------------------------------------------- *)
 
-val valid_immediate = Q.prove(
-  `!i. IS_SOME (EncodeARMImmediate i) = valid_immediate i`,
-  simp [valid_immediate_def])
+Triviality valid_immediate:
+  !i. IS_SOME (EncodeARMImmediate i) = valid_immediate i
+Proof
+  simp [valid_immediate_def]
+QED
 
 val valid_immediate2 =
    valid_immediate
@@ -30,12 +32,13 @@ val arm7_config =
 val arm7_asm_ok =
   REWRITE_RULE [valid_immediate] arm7_targetTheory.arm7_asm_ok
 
-val lem1 = Q.prove(
-   `!n m. n < 16 /\ n <> 13 /\ n <> 15 ==>
-          RName_PC <> R_mode m (n2w n) /\ n MOD 16 <> 15`,
-   CONV_TAC (Conv.ONCE_DEPTH_CONV SYM_CONV)
+Triviality lem1:
+  !n m. n < 16 /\ n <> 13 /\ n <> 15 ==>
+          RName_PC <> R_mode m (n2w n) /\ n MOD 16 <> 15
+Proof
+  CONV_TAC (Conv.ONCE_DEPTH_CONV SYM_CONV)
    \\ simp [arm_stepTheory.R_x_pc]
-   )
+QED
 
 val lem2 = asmLib.v2w_BIT_n2w 4
 val lem3 = asmLib.v2w_BIT_n2w 5
@@ -65,19 +68,21 @@ val lem5 =
    blastLib.BBLAST_PROVE
       ``~(0w <= c) /\ 0xFFFFF001w <= c ==> -1w * c <=+ 4095w: word32``
 
-val lem6 = Q.prove(
-   `!s state c n.
+Triviality lem6:
+  !s state c n.
       target_state_rel arm7_target s state /\ n < 16 /\ n <> 13 /\ n <> 15 /\
       aligned 2 (c + s.regs n) ==>
-      aligned 2 (c + state.REG (R_mode state.CPSR.M (n2w n)))`,
-   rw [asmPropsTheory.target_state_rel_def, alignmentTheory.aligned_extract,
+      aligned 2 (c + state.REG (R_mode state.CPSR.M (n2w n)))
+Proof
+  rw [asmPropsTheory.target_state_rel_def, alignmentTheory.aligned_extract,
        arm7_target_def, arm7_config_def, lem1]
-   )
+QED
 
-val lem7 = Q.prove(
-   `!a: word24. aligned 2 (sw2sw ((a @@ (0w: word2)): 26 word) : word32)`,
-   srw_tac [wordsLib.WORD_EXTRACT_ss] [alignmentTheory.aligned_extract]
-   )
+Triviality lem7:
+  !a: word24. aligned 2 (sw2sw ((a @@ (0w: word2)): 26 word) : word32)
+Proof
+  srw_tac [wordsLib.WORD_EXTRACT_ss] [alignmentTheory.aligned_extract]
+QED
 
 fun bprove tm =
    Q.prove (tm, simp [markerTheory.Abbrev_def, alignmentTheory.aligned_extract]
@@ -115,11 +120,12 @@ val lem11 =
    (REWRITE_RULE [wordsTheory.WORD_ADD_0] o  Q.INST [`c` |-> `0w`] o
     Drule.SPEC_ALL) lem6
 
-val lem12 = Q.prove(
-   `!x: word32. aligned 2 x ==> ~word_bit 1 x /\ ~word_bit 0 x`,
-   simp [alignmentTheory.aligned_extract]
+Triviality lem12:
+  !x: word32. aligned 2 x ==> ~word_bit 1 x /\ ~word_bit 0 x
+Proof
+  simp [alignmentTheory.aligned_extract]
    \\ blastLib.BBLAST_TAC
-   )
+QED
 
 (*
 val lem12 =
@@ -160,15 +166,16 @@ fun tac n =
    \\ blastLib.FULL_BBLAST_TAC
    \\ blastLib.BBLAST_TAC
 
-val decode_imm_thm = Q.prove(
-   `!c.
+Triviality decode_imm_thm:
+  !c.
       valid_immediate c ==>
       let imm12 = THE (EncodeARMImmediate c) in
          w2w (v2w [imm12 ' 7; imm12 ' 6; imm12 ' 5; imm12 ' 4;
                    imm12 ' 3; imm12 ' 2; imm12 ' 1; imm12 ' 0]: word8) #>>
          w2n (v2w [imm12 ' 11; imm12 ' 10; imm12 ' 9; imm12 ' 8; F] : word5) =
-         c`,
-   strip_tac
+         c
+Proof
+  strip_tac
    \\ simp_tac std_ss [valid_immediate_def, armTheory.EncodeARMImmediate_def]
    \\ qabbrev_tac `i = EncodeARMImmediate_aux (15w,c)`
    \\ pop_assum mp_tac
@@ -189,7 +196,7 @@ val decode_imm_thm = Q.prove(
    \\ Cases_on `(31 >< 8) (c #<< 28) = 0w: word24` >- tac 15
    \\ Cases_on `(31 >< 8) (c #<< 30) = 0w: word24` >- tac 16
    \\ tac 17
-   )
+QED
 
 val decode_imm_thm = SIMP_RULE (bool_ss++boolSimps.LET_ss) [] decode_imm_thm
 
@@ -214,26 +221,28 @@ val decode_imm12_thm =
        (w2w (v2w [c ' 11; c ' 10; c ' 9; c ' 8; c ' 7; c ' 6;
                   c ' 5; c ' 4; c ' 3; c ' 2; c ' 1; c ' 0] : word12) = c)``
 
-val decode_neg_imm12_thm = Q.prove(
-   `!c: word32 d.
+Triviality decode_neg_imm12_thm:
+  !c: word32 d.
        0xFFFFF001w <= c /\ ~(0w <= c) /\ Abbrev (d = -1w * c) ==>
        (-1w *
         w2w (v2w [d ' 11; d ' 10; d ' 9; d ' 8; d ' 7; d ' 6;
-                  d ' 5; d ' 4; d ' 3; d ' 2; d ' 1; d ' 0] : word12) = c)`,
-   rw []
+                  d ' 5; d ' 4; d ' 3; d ' 2; d ' 1; d ' 0] : word12) = c)
+Proof
+  rw []
    \\ qunabbrev_tac `d`
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
-val decode_imm8_thm1 = Q.prove(
-   `!c: word32.
+Triviality decode_imm8_thm1:
+  !c: word32.
        8w <= c /\ c <= 263w ==>
        (EncodeARMImmediate (c + 0xFFFFFFF8w) =
-        SOME ((7 >< 0) (c + 0xFFFFFFF8w)))`,
-   rw [armTheory.EncodeARMImmediate_def,
+        SOME ((7 >< 0) (c + 0xFFFFFFF8w)))
+Proof
+  rw [armTheory.EncodeARMImmediate_def,
        Once armTheory.EncodeARMImmediate_aux_def]
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 val decode_imm8_thm2 =
    blastLib.BBLAST_PROVE
@@ -244,14 +253,15 @@ val decode_imm8_thm2 =
                     c ' 4 <=> c ' 3; ~c ' 3; c ' 2; c ' 1; c ' 0]: word8) =
          c - 8w)``
 
-val decode_imm8_thm3 = Q.prove(
-   `!c: word32.
+Triviality decode_imm8_thm3:
+  !c: word32.
        ~(8w <= c) /\ 0xFFFFFF09w <= c ==>
-       (EncodeARMImmediate (-1w * c + 8w) = SOME ((7 >< 0) (-1w * c + 8w)))`,
-   rw [armTheory.EncodeARMImmediate_def,
+       (EncodeARMImmediate (-1w * c + 8w) = SOME ((7 >< 0) (-1w * c + 8w)))
+Proof
+  rw [armTheory.EncodeARMImmediate_def,
        Once armTheory.EncodeARMImmediate_aux_def]
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 val decode_imm8_thm4 =
    blastLib.BBLAST_PROVE
@@ -363,16 +373,18 @@ val loc_lem =
      ``(15 >< 8) (-1w * a + 8w : word32) : word8``,
      ``(7 >< 0) (-1w * a + 8w : word32) : word8``]
 
-val word_lo_not_carry = Q.prove(
-   `!a b. (a <+ b) = ~CARRY_OUT a (~b) T`,
-   simp [wordsTheory.ADD_WITH_CARRY_SUB, wordsTheory.WORD_NOT_LOWER_EQUAL]
-   )
+Triviality word_lo_not_carry:
+  !a b. (a <+ b) = ~CARRY_OUT a (~b) T
+Proof
+  simp [wordsTheory.ADD_WITH_CARRY_SUB, wordsTheory.WORD_NOT_LOWER_EQUAL]
+QED
 
-val word_lt_n_eq_v = Q.prove(
-   `!a b: word32. (a < b) = ((word_bit 31 (a + -1w * b) <> OVERFLOW a (~b) T))`,
-   simp [wordsTheory.ADD_WITH_CARRY_SUB, GSYM wordsTheory.WORD_LO]
+Triviality word_lt_n_eq_v:
+  !a b: word32. (a < b) = ((word_bit 31 (a + -1w * b) <> OVERFLOW a (~b) T))
+Proof
+  simp [wordsTheory.ADD_WITH_CARRY_SUB, GSYM wordsTheory.WORD_LO]
    \\ blastLib.BBLAST_TAC
-   )
+QED
 
 val SetPassCondition =
    utilsLib.map_conv
@@ -412,93 +424,108 @@ in
         |> REWRITE_RULE [wordsTheory.w2n_eq_0]
 end
 
-val reg_mode_eq = Q.prove(
-   `!m ms1 ms2.
+Triviality reg_mode_eq:
+  !m ms1 ms2.
        (ms1.REG o R_mode m = ms2.REG o R_mode m) <=>
        (!i. ms1.REG (R_mode m (n2w i)) = ms2.REG (R_mode m (n2w i))) /\
-       (ms1.REG RName_PC = ms2.REG RName_PC)`,
-   rw [FUN_EQ_THM]
+       (ms1.REG RName_PC = ms2.REG RName_PC)
+Proof
+  rw [FUN_EQ_THM]
    \\ eq_tac
    \\ strip_tac
    >- metis_tac [arm_stepTheory.R_mode]
    \\ Cases
    \\ simp []
-   )
+QED
 
-val aligned_add = Q.prove(
-   `!p a b. aligned p a ==> (aligned p (a + b) = aligned p b)`,
-   metis_tac [wordsTheory.WORD_ADD_COMM, alignmentTheory.aligned_add_sub]
-   )
+Triviality aligned_add:
+  !p a b. aligned p a ==> (aligned p (a + b) = aligned p b)
+Proof
+  metis_tac [wordsTheory.WORD_ADD_COMM, alignmentTheory.aligned_add_sub]
+QED
 
 val _ = diminish_srw_ss ["MOD"]
 
-val adc_lem1 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem1:
+  !r2 r3 : word32 r4 : word32.
       CARRY_OUT r2 r3 (CARRY_OUT r4 (-1w) T) <=>
-      4294967296 <= w2n r2 + (w2n r3 + 1)`,
+      4294967296 <= w2n r2 + (w2n r3 + 1)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem2 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem2:
+  !r2 r3 : word32 r4 : word32.
       FST (add_with_carry (r2,r3,CARRY_OUT r4 (-1w) T)) =
-      n2w (w2n r2 + (w2n r3 + 1))`,
+      n2w (w2n r2 + (w2n r3 + 1))
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem3 = Q.prove(
-  `!r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3`,
+Triviality adc_lem3:
+  !r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem4 = Q.prove(
-  `!r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)`,
+Triviality adc_lem4:
+  !r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val mul_long_lem1 = Q.prove(
-  `!a : word32 b. (31 >< 0) (w2w a * w2w b : word64) = a * b`,
+Triviality mul_long_lem1:
+  !a : word32 b. (31 >< 0) (w2w a * w2w b : word64) = a * b
+Proof
   srw_tac [wordsLib.WORD_EXTRACT_ss]
-    [Once wordsTheory.WORD_EXTRACT_OVER_MUL])
+    [Once wordsTheory.WORD_EXTRACT_OVER_MUL]
+QED
 
-val mul_long_lem2 = Q.prove(
-  `!a : word32 b : word32.
+Triviality mul_long_lem2:
+  !a : word32 b : word32.
     n2w ((w2n a * w2n b) DIV 4294967296) =
-    (63 >< 32) (w2w a * w2w b : word64) : word32`,
+    (63 >< 32) (w2w a * w2w b : word64) : word32
+Proof
   Cases
   \\ Cases
   \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_mul_n2w,
          wordsTheory.word_extract_n2w, bitTheory.BITS_THM]
-  )
+QED
 
-val adc_lem1 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem1:
+  !r2 r3 : word32 r4 : word32.
       CARRY_OUT r2 r3 (CARRY_OUT r4 (-1w) T) <=>
-      4294967296 <= w2n r2 + (w2n r3 + 1)`,
+      4294967296 <= w2n r2 + (w2n r3 + 1)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem2 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem2:
+  !r2 r3 : word32 r4 : word32.
       FST (add_with_carry (r2,r3,CARRY_OUT r4 (-1w) T)) =
-      n2w (w2n r2 + (w2n r3 + 1))`,
+      n2w (w2n r2 + (w2n r3 + 1))
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem3 = Q.prove(
-  `!r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3`,
+Triviality adc_lem3:
+  !r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem4 = Q.prove(
-  `!r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)`,
+Triviality adc_lem4:
+  !r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val float_is_nan = Q.prove(
-  `!x. float_is_nan x = (float_value x = NaN)`,
+Triviality float_is_nan:
+  !x. float_is_nan x = (float_value x = NaN)
+Proof
   rw [binary_ieeeTheory.float_is_nan_def]
-  \\ CASE_TAC)
+  \\ CASE_TAC
+QED
 
 val fp_tac =
   Cases_on `float_value (fp64_to_float a)`
@@ -517,53 +544,62 @@ val fp_tac =
          binary_ieeeTheory.float_equal_def,
          binary_ieeeTheory.float_compare_def]
 
-val fp_lem1 = Q.prove(
-  `fp64_lessThan a b ==> ~fp64_isNan a /\ ~fp64_isNan b /\ ~fp64_equal a b`,
+Triviality fp_lem1:
+  fp64_lessThan a b ==> ~fp64_isNan a /\ ~fp64_isNan b /\ ~fp64_equal a b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem2 = Q.prove(
-  `fp64_lessEqual a b ==>
-   (fp64_equal a b \/ fp64_lessThan a b) /\ ~fp64_isNan a /\ ~fp64_isNan b`,
+Triviality fp_lem2:
+  fp64_lessEqual a b ==>
+   (fp64_equal a b \/ fp64_lessThan a b) /\ ~fp64_isNan a /\ ~fp64_isNan b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem3 = Q.prove(
-  `~fp64_lessEqual a b ==> ~fp64_lessThan a b /\ ~fp64_equal a b`,
+Triviality fp_lem3:
+  ~fp64_lessEqual a b ==> ~fp64_lessThan a b /\ ~fp64_equal a b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem4 = Q.prove(
-  `fp64_greaterThan a b ==>
-   ~fp64_lessThan a b /\ ~fp64_isNan a /\ ~fp64_isNan b /\ ~fp64_equal a b`,
+Triviality fp_lem4:
+  fp64_greaterThan a b ==>
+   ~fp64_lessThan a b /\ ~fp64_isNan a /\ ~fp64_isNan b /\ ~fp64_equal a b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem5 = Q.prove(
-  `~fp64_greaterThan a b ==>
-   fp64_equal a b \/ fp64_lessThan a b \/ fp64_isNan a \/ fp64_isNan b`,
+Triviality fp_lem5:
+  ~fp64_greaterThan a b ==>
+   fp64_equal a b \/ fp64_lessThan a b \/ fp64_isNan a \/ fp64_isNan b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem6 = Q.prove(
-  `fp64_greaterEqual a b ==>
-   ~fp64_lessThan a b /\ ~fp64_isNan a /\ ~fp64_isNan b`,
+Triviality fp_lem6:
+  fp64_greaterEqual a b ==>
+   ~fp64_lessThan a b /\ ~fp64_isNan a /\ ~fp64_isNan b
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem7 = Q.prove(
-  `~fp64_greaterEqual a b ==>
-   ~fp64_equal a b /\ (fp64_lessThan a b \/ fp64_isNan a \/ fp64_isNan b)`,
+Triviality fp_lem7:
+  ~fp64_greaterEqual a b ==>
+   ~fp64_equal a b /\ (fp64_lessThan a b \/ fp64_isNan a \/ fp64_isNan b)
+Proof
   fp_tac
-  )
+QED
 
-val fp_lem8 = Q.prove(
-  `fp64_equal a b ==> ~fp64_isNan a /\ ~fp64_isNan b`,
+Triviality fp_lem8:
+  fp64_equal a b ==> ~fp64_isNan a /\ ~fp64_isNan b
+Proof
   fp_tac
-  )
+QED
 
-val fp_to_int_lem = Q.prove(
-  `!i w : word32. (w2i w = i) ==> -0x80000000 <= i /\ i <= 0x7FFFFFFF`,
+Triviality fp_to_int_lem:
+  !i w : word32. (w2i w = i) ==> -0x80000000 <= i /\ i <= 0x7FFFFFFF
+Proof
   ntac 3 strip_tac
   \\ assume_tac
        (integer_wordTheory.w2i_le
@@ -574,12 +610,13 @@ val fp_to_int_lem = Q.prove(
         |> Q.ISPEC `w : word32`
         |> SIMP_RULE (srw_ss()) [])
   \\ rfs []
-  )
+QED
 
-val fp_to_int_lem2 = Q.prove(
-  `!n. n < 32 ==> n DIV 2 < 32n`,
+Triviality fp_to_int_lem2:
+  !n. n < 32 ==> n DIV 2 < 32n
+Proof
   simp [arithmeticTheory.DIV_LT_X]
-  )
+QED
 
 (* some rewrites ---------------------------------------------------------- *)
 
@@ -606,8 +643,8 @@ val enc_ok_rwts =
 
 (* some custom tactics ---------------------------------------------------- *)
 
-val bytes_in_memory_thm = Q.prove(
-   `!s state a b c d.
+Triviality bytes_in_memory_thm:
+  !s state a b c d.
       target_state_rel arm7_target s state /\
       bytes_in_memory s.pc [a; b; c; d] s.mem s.mem_domain ==>
       (state.exception = NoException) /\
@@ -628,14 +665,15 @@ val bytes_in_memory_thm = Q.prove(
       state.REG RName_PC + 3w IN s.mem_domain /\
       state.REG RName_PC + 2w IN s.mem_domain /\
       state.REG RName_PC + 1w IN s.mem_domain /\
-      state.REG RName_PC IN s.mem_domain`,
-   rw [asmPropsTheory.sym_target_state_rel, arm7_ok_def, arm7_target_def,
+      state.REG RName_PC IN s.mem_domain
+Proof
+  rw [asmPropsTheory.sym_target_state_rel, arm7_ok_def, arm7_target_def,
        arm7_config_def, miscTheory.bytes_in_memory_def]
    \\ rfs [alignmentTheory.aligned_extract]
-   )
+QED
 
-val bytes_in_memory_thm2 = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm2:
+  !w s state a b c d.
       target_state_rel arm7_target s state /\
       bytes_in_memory (s.pc + w) [a; b; c; d] s.mem s.mem_domain ==>
       (state.MEM (state.REG RName_PC + w + 3w) = d) /\
@@ -645,11 +683,12 @@ val bytes_in_memory_thm2 = Q.prove(
       state.REG RName_PC + w + 3w IN s.mem_domain /\
       state.REG RName_PC + w + 2w IN s.mem_domain /\
       state.REG RName_PC + w + 1w IN s.mem_domain /\
-      state.REG RName_PC + w IN s.mem_domain`,
-   rw [asmPropsTheory.sym_target_state_rel, arm7_ok_def, arm7_target_def,
+      state.REG RName_PC + w IN s.mem_domain
+Proof
+  rw [asmPropsTheory.sym_target_state_rel, arm7_ok_def, arm7_target_def,
        arm7_config_def, miscTheory.bytes_in_memory_def]
    \\ rfs []
-   )
+QED
 
 val arm_op2 = HolKernel.syntax_fns2 "arm"
 
@@ -731,29 +770,33 @@ in
      ORELSE next_state_tac0 [false, true]
 end
 
-val adc_lem1 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem1:
+  !r2 r3 : word32 r4 : word32.
       CARRY_OUT r2 r3 (CARRY_OUT r4 (-1w) T) <=>
-      4294967296 <= w2n r2 + (w2n r3 + 1)`,
+      4294967296 <= w2n r2 + (w2n r3 + 1)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem2 = Q.prove(
-  `!r2 r3 : word32 r4 : word32.
+Triviality adc_lem2:
+  !r2 r3 : word32 r4 : word32.
       FST (add_with_carry (r2,r3,CARRY_OUT r4 (-1w) T)) =
-      n2w (w2n r2 + (w2n r3 + 1))`,
+      n2w (w2n r2 + (w2n r3 + 1))
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem3 = Q.prove(
-  `!r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3`,
+Triviality adc_lem3:
+  !r2 r3 : word32. CARRY_OUT r2 r3 F <=> 4294967296 <= w2n r2 + w2n r3
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
-val adc_lem4 = Q.prove(
-  `!r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)`,
+Triviality adc_lem4:
+  !r2 r3 : word32. FST (add_with_carry (r2,r3,F)) = n2w (w2n r2 + w2n r3)
+Proof
   rw [wordsTheory.add_with_carry_def]
-)
+QED
 
 local
    val i_tm = ``R_mode ms.CPSR.M (n2w i)``
@@ -932,26 +975,30 @@ end
    arm7 target_ok
    ------------------------------------------------------------------------- *)
 
-val length_arm7_encode1 = Q.prove(
-  `!c i. LENGTH (arm7_encode1 c i) = 4`,
+Triviality length_arm7_encode1:
+  !c i. LENGTH (arm7_encode1 c i) = 4
+Proof
   Cases
   \\ rw [arm7_encode_def, arm7_encode1_def, arm7_encode_fail_def]
   \\ CASE_TAC
   \\ simp []
-  )
+QED
 
-val length_arm7_encode = Q.prove(
-  `!l. LENGTH (arm7_encode l) = 4 * LENGTH l`,
+Triviality length_arm7_encode:
+  !l. LENGTH (arm7_encode l) = 4 * LENGTH l
+Proof
   Induct >- rw [arm7_encode_def]
   \\ Cases
   \\ rw [arm7_encode_def, length_arm7_encode1]
   \\ fs [arm7_encode_def]
-  )
+QED
 
-val arm7_encode_not_nil = Q.prove(
-  `(!c i. arm7_encode1 c i <> []) /\ (!l. (arm7_encode l <> []) = (l <> []))`,
+Triviality arm7_encode_not_nil:
+  (!c i. arm7_encode1 c i <> []) /\ (!l. (arm7_encode l <> []) = (l <> []))
+Proof
   simp_tac std_ss
-    [GSYM listTheory.LENGTH_NIL, length_arm7_encode1, length_arm7_encode])
+    [GSYM listTheory.LENGTH_NIL, length_arm7_encode1, length_arm7_encode]
+QED
 
 val arm7_encoding = Q.prove (
    `!i. let l = arm7_enc i in (LENGTH l MOD 4 = 0) /\ l <> []`,
@@ -964,9 +1011,10 @@ val arm7_encoding = Q.prove (
    )
    |> SIMP_RULE (bool_ss++boolSimps.LET_ss) []
 
-val arm7_target_ok = Q.prove (
-   `target_ok arm7_target`,
-   rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality arm7_target_ok:
+  target_ok arm7_target
+Proof
+  rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
         arm7_proj_def, arm7_target_def, arm7_config, arm7_ok_def,
         set_sepTheory.fun2set_eq, arm7_encoding] @ enc_ok_rwts)
    \\ rfs [reg_mode_eq]
@@ -974,7 +1022,7 @@ val arm7_target_ok = Q.prove (
    \\ lfs enc_rwts
    \\ NTAC 3 (rw [Once valid_immediate2])
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 (* -------------------------------------------------------------------------
    arm7 encoder_correct

--- a/compiler/encoders/arm8/proofs/arm8_targetProofScript.sml
+++ b/compiler/encoders/arm8/proofs/arm8_targetProofScript.sml
@@ -45,51 +45,55 @@ fun and_max ty =
    |> Thm.INST_TYPE [Type.alpha |-> ty]
    |> REWRITE_RULE [EVAL (wordsSyntax.mk_word_T ty)]
 
-val lsl_lem1 = Q.prove(
-   `!w:word6.
+Triviality lsl_lem1:
+  !w:word6.
       (if v2n (field 5 0 (w2v w)) + 1 < 64 then
           64
-       else v2n (field 5 0 (w2v w)) + 1) = 64`,
-   lrw []
+       else v2n (field 5 0 (w2v w)) + 1) = 64
+Proof
+  lrw []
    \\ Cases_on `v2n (field 5 0 (w2v w)) = 63`
    >- simp []
    \\ qspec_then `field 5 0 (w2v w)` assume_tac bitstringTheory.v2n_lt
    \\ fs []
    \\ decide_tac
-   )
+QED
 
-val lsl_lem2 = Q.prove(
-   `!w:word6. (if w2n w + 1 < 64 then 64 else w2n w + 1) = 64`,
-   lrw []
+Triviality lsl_lem2:
+  !w:word6. (if w2n w + 1 < 64 then 64 else w2n w + 1) = 64
+Proof
+  lrw []
    \\ Cases_on `w2n w = 63`
    >- simp []
    \\ Q.ISPEC_THEN `w` assume_tac wordsTheory.w2n_lt
    \\ fs []
    \\ decide_tac
-   )
+QED
 
 val lsl_lem3 = ev
    ``v2w (PAD_LEFT F 64
             (PAD_LEFT T (v2n (field 5 0 (w2v (63w: word6))) + 1) [])): word64``
 
-val lsl_lem4 = Q.prove(
-   `!n. n < 64 ==> ((64 - n + 63) MOD 64 = 63 - n)`,
-   lrw []
+Triviality lsl_lem4:
+  !n. n < 64 ==> ((64 - n + 63) MOD 64 = 63 - n)
+Proof
+  lrw []
    \\ asm_simp_tac bool_ss
          [arithmeticTheory.ADD_MODULUS_RIGHT, DECIDE ``0n < 64``,
           DECIDE ``n < 64n ==> (127 - n = 64 + (63 - n)) /\ 63 - n < 64``,
           arithmeticTheory.LESS_MOD]
-   )
+QED
 
-val lsl_lem5 = Q.prove(
-   `!n. n < 64 ==>
-        (v2w (PAD_LEFT F 64 (PAD_LEFT T n [])) : word64 = (FCP i. i < n))`,
-   srw_tac [fcpLib.FCP_ss] []
+Triviality lsl_lem5:
+  !n. n < 64 ==>
+        (v2w (PAD_LEFT F 64 (PAD_LEFT T n [])) : word64 = (FCP i. i < n))
+Proof
+  srw_tac [fcpLib.FCP_ss] []
    \\ rewrite_tac [bitstringTheory.word_index_v2w]
    \\ simp [bitstringTheory.testbit, listTheory.PAD_LEFT]
    \\ Cases_on `63 - i < 64 - n`
    \\ simp [rich_listTheory.EL_APPEND1, rich_listTheory.EL_APPEND2]
-   )
+QED
 
 val lsl_lem6 = DECIDE ``n < 64n ==> (63 - n + 1 = 64 - n)``
 
@@ -133,9 +137,10 @@ Proof
    \\ simp [] \\ EVAL_TAC \\ wordsLib.WORD_DECIDE_TAC
 QED
 
-val lsr_lem1 = Q.prove(
-   `!n. v2n (field 5 0 (w2v (n2w n : word6))) = n MOD 64`,
-   REPEAT strip_tac
+Triviality lsr_lem1:
+  !n. v2n (field 5 0 (w2v (n2w n : word6))) = n MOD 64
+Proof
+  REPEAT strip_tac
    \\ strip_assume_tac
          (Q.ISPEC `n2w n: word6` bitstringTheory.ranged_bitstring_nchotomy)
    \\ simp [bitstringTheory.w2v_v2w, bitstringTheory.word_extract_v2w,
@@ -143,11 +148,12 @@ val lsr_lem1 = Q.prove(
    \\ rfs [markerTheory.Abbrev_def, bitstringTheory.field_id_imp,
            GSYM bitstringTheory.n2w_v2n, arithmeticTheory.LESS_MOD]
    \\ metis_tac [bitstringTheory.v2n_lt, EVAL ``2n ** 6n``]
-   )
+QED
 
-val lsr_lem2 = Q.prove(
-   `!n. v2w (rotate (PAD_LEFT F 64 (PAD_LEFT T 64 [])) n) = UINT_MAXw: word64`,
-   strip_tac
+Triviality lsr_lem2:
+  !n. v2w (rotate (PAD_LEFT F 64 (PAD_LEFT T 64 [])) n) = UINT_MAXw: word64
+Proof
+  strip_tac
    \\ `PAD_LEFT F 64 (PAD_LEFT T 64 []) =
        fixwidth (dimindex(:64)) (PAD_LEFT F 64 (PAD_LEFT T 64 []))`
    by EVAL_TAC
@@ -158,7 +164,7 @@ val lsr_lem2 = Q.prove(
    \\ simp [wordsTheory.ROR_UINT_MAX
             |> Thm.INST_TYPE [Type.alpha |-> ``:64``]
             |> CONV_RULE EVAL]
-   )
+QED
 
 Theorem lsr:
    !n x wmask: word64 tmask.
@@ -190,8 +196,11 @@ Theorem asr =
   |> REWRITE_RULE
        [blastLib.BBLAST_PROVE ``word_msb (w:word64) = word_bit 63 w``]
 
-val asr_lem1 = Q.prove(
-   `!m. m < 64 ==> (MIN m 64 = m)`, rw [arithmeticTheory.MIN_DEF])
+Triviality asr_lem1:
+  !m. m < 64 ==> (MIN m 64 = m)
+Proof
+  rw [arithmeticTheory.MIN_DEF]
+QED
 
 Theorem asr2:
    !n x wmask: word64 tmask.
@@ -261,23 +270,26 @@ val rfs = rev_full_simp_tac (srw_ss())
    arm8 target_ok
    ------------------------------------------------------------------------- *)
 
-val length_arm8_encode = Q.prove(
-  `!i. LENGTH (arm8_encode i) = 4`,
+Triviality length_arm8_encode:
+  !i. LENGTH (arm8_encode i) = 4
+Proof
   Cases
   \\ rw [arm8_encode_def]
   \\ CASE_TAC
   \\ simp []
-  )
+QED
 
-val length_arm8_enc = Q.prove(
-  `!l. LENGTH (LIST_BIND l arm8_encode) = 4 * LENGTH l`,
+Triviality length_arm8_enc:
+  !l. LENGTH (LIST_BIND l arm8_encode) = 4 * LENGTH l
+Proof
   Induct \\ rw [length_arm8_encode]
-  )
+QED
 
-val arm8_encode_not_nil = Q.prove(
-  `!i. arm8_encode i <> []`,
+Triviality arm8_encode_not_nil:
+  !i. arm8_encode i <> []
+Proof
   simp_tac std_ss [GSYM listTheory.LENGTH_NIL, length_arm8_encode]
-  )
+QED
 
 Theorem arm8_encoding[local]:
   !i. let l = arm8_enc i in (LENGTH l MOD 4 = 0) /\ l <> []
@@ -295,9 +307,10 @@ Theorem arm8_encoding = arm8_encoding |>
     SIMP_RULE (srw_ss()++boolSimps.LET_ss)
        [arm8_enc_def, listTheory.LIST_BIND_def]
 
-val arm8_target_ok = Q.prove (
-   `target_ok arm8_target`,
-   rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality arm8_target_ok:
+  target_ok arm8_target
+Proof
+  rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
         arm8_proj_def, arm8_target_def, arm8_config, arm8_ok_def,
         set_sepTheory.fun2set_eq, arm8_encoding] @ enc_ok_rwts)
    >| [all_tac, Cases_on `ri` \\ Cases_on `cmp`, all_tac, all_tac]
@@ -305,7 +318,7 @@ val arm8_target_ok = Q.prove (
    \\ rw[]
    \\ lfs enc_rwts
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 (* -------------------------------------------------------------------------
    arm8 encoder_correct

--- a/compiler/encoders/asm/asmPropsScript.sml
+++ b/compiler/encoders/asm/asmPropsScript.sml
@@ -330,21 +330,25 @@ Proof
   \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
 QED
 
-val SND_read_mem_word_consts = Q.prove(
-  `!n a s. ((SND (read_mem_word a n s)).be = s.be) /\
+Triviality SND_read_mem_word_consts:
+  !n a s. ((SND (read_mem_word a n s)).be = s.be) /\
             ((SND (read_mem_word a n s)).lr = s.lr) /\
             ((SND (read_mem_word a n s)).align = s.align) /\
-            ((SND (read_mem_word a n s)).mem_domain = s.mem_domain)`,
+            ((SND (read_mem_word a n s)).mem_domain = s.mem_domain)
+Proof
   Induct \\ full_simp_tac(srw_ss())[read_mem_word_def,LET_DEF]
   \\ CONV_TAC (DEPTH_CONV PairRules.PBETA_CONV)
-  \\ full_simp_tac(srw_ss())[assert_def])
+  \\ full_simp_tac(srw_ss())[assert_def]
+QED
 
-val write_mem_word_consts = Q.prove(
-  `!n a w s. ((write_mem_word a n w s).be = s.be) /\
+Triviality write_mem_word_consts:
+  !n a w s. ((write_mem_word a n w s).be = s.be) /\
               ((write_mem_word a n w s).lr = s.lr) /\
               ((write_mem_word a n w s).align = s.align) /\
-              ((write_mem_word a n w s).mem_domain = s.mem_domain)`,
-  Induct \\ full_simp_tac(srw_ss())[write_mem_word_def,LET_DEF,assert_def,upd_mem_def])
+              ((write_mem_word a n w s).mem_domain = s.mem_domain)
+Proof
+  Induct \\ full_simp_tac(srw_ss())[write_mem_word_def,LET_DEF,assert_def,upd_mem_def]
+QED
 
 Theorem binop_upd_consts[simp]:
    ((binop_upd a b c d x).mem_domain = x.mem_domain) ∧

--- a/compiler/encoders/mips/proofs/mips_targetProofScript.sml
+++ b/compiler/encoders/mips/proofs/mips_targetProofScript.sml
@@ -12,8 +12,8 @@ val ERR = mk_HOL_ERR "mips_targetProofTheory";
 
 (* some lemmas ---------------------------------------------------------- *)
 
-val bytes_in_memory_thm = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm:
+  !w s state a b c d.
       target_state_rel mips_target s state /\
       bytes_in_memory s.pc [a; b; c; d] s.mem s.mem_domain ==>
       (state.exception = NoException) /\
@@ -35,15 +35,16 @@ val bytes_in_memory_thm = Q.prove(
       state.PC + 3w IN s.mem_domain /\
       state.PC + 2w IN s.mem_domain /\
       state.PC + 1w IN s.mem_domain /\
-      state.PC IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
+      state.PC IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
        mips_ok_def, miscTheory.bytes_in_memory_def,
        alignmentTheory.aligned_extract, set_sepTheory.fun2set_eq]
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
-val bytes_in_memory_thm2 = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm2:
+  !w s state a b c d.
       target_state_rel mips_target s state /\
       bytes_in_memory (s.pc + w) [a; b; c; d] s.mem s.mem_domain ==>
       (state.MEM (state.PC + w) = a) /\
@@ -53,10 +54,11 @@ val bytes_in_memory_thm2 = Q.prove(
       state.PC + w + 3w IN s.mem_domain /\
       state.PC + w + 2w IN s.mem_domain /\
       state.PC + w + 1w IN s.mem_domain /\
-      state.PC + w IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
+      state.PC + w IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
        mips_ok_def, miscTheory.bytes_in_memory_def, set_sepTheory.fun2set_eq]
-   )
+QED
 
 val lem1 = asmLib.v2w_BIT_n2w 5
 
@@ -64,14 +66,15 @@ val lem4 =
    blastLib.BBLAST_CONV ``(1 >< 0) (x: word64) = 0w: word2``
    |> Thm.EQ_IMP_RULE |> fst
 
-val lem5 = Q.prove(
-   `!s state.
+Triviality lem5:
+  !s state.
      target_state_rel mips_target s state ==>
      !n. n < 32 /\ mips_reg_ok n ==>
-         (s.regs n = state.gpr (n2w n)) /\ n <> 0 /\ n2w n <> 1w : word5`,
-   lrw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
+         (s.regs n = state.gpr (n2w n)) /\ n <> 0 /\ n2w n <> 1w : word5
+Proof
+  lrw [asmPropsTheory.target_state_rel_def, mips_target_def, mips_config_def,
         mips_reg_ok_def]
-   )
+QED
 
 val lem6 =
    blastLib.BBLAST_PROVE
@@ -82,12 +85,13 @@ val lem6 =
                 c ' 10; c ' 9; c ' 8; c ' 7; c ' 6; c ' 5;
                 c ' 4; c ' 3; c ' 2; c ' 1; c ' 0]: word16) = c)``
 
-val lem7 = Q.prove(
-   `(!c: word64. aligned 3 c ==> ((2 >< 0) c = 0w: word3)) /\
-    (!c: word64. aligned 2 c ==> ((1 >< 0) c = 0w: word2))`,
-   simp [alignmentTheory.aligned_extract]
+Triviality lem7:
+  (!c: word64. aligned 3 c ==> ((2 >< 0) c = 0w: word3)) /\
+    (!c: word64. aligned 2 c ==> ((1 >< 0) c = 0w: word2))
+Proof
+  simp [alignmentTheory.aligned_extract]
    \\ blastLib.BBLAST_TAC
-   )
+QED
 
 val lem8 =
    blastLib.BBLAST_PROVE
@@ -120,39 +124,47 @@ val lem10 =
 
 val lem12 = utilsLib.mk_cond_rand_thms [optionSyntax.is_some_tm]
 
-val adc_lem1 = Q.prove(
-  `((if b then 1w else 0w) = (v2w [x] || v2w [y] : word64)) <=> (b = (x \/ y))`,
-  rw [] \\ blastLib.BBLAST_TAC)
+Triviality adc_lem1:
+  ((if b then 1w else 0w) = (v2w [x] || v2w [y] : word64)) <=> (b = (x \/ y))
+Proof
+  rw [] \\ blastLib.BBLAST_TAC
+QED
 
-val adc_lem2 = Q.prove(
-  `!r2 : word64 r3 : word64.
+Triviality adc_lem2:
+  !r2 : word64 r3 : word64.
     (18446744073709551616 <= w2n r2 + w2n r3 + 1 <=>
      18446744073709551616w <=+ w2w r2 + w2w r3 + 1w : 65 word) /\
     (18446744073709551616 <= w2n r2 + w2n r3 <=>
-     18446744073709551616w <=+ w2w r2 + w2w r3 : 65 word)`,
-   Cases
+     18446744073709551616w <=+ w2w r2 + w2w r3 : 65 word)
+Proof
+  Cases
    \\ Cases
    \\ imp_res_tac wordsTheory.BITS_ZEROL_DIMINDEX
    \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_add_n2w,
-          wordsTheory.word_ls_n2w])
+          wordsTheory.word_ls_n2w]
+QED
 
-val mul_long1 = Q.prove(
-  `!a : word64 b. (63 >< 0) (w2w a * w2w b : word128) = a * b`,
+Triviality mul_long1:
+  !a : word64 b. (63 >< 0) (w2w a * w2w b : word128) = a * b
+Proof
   srw_tac [wordsLib.WORD_EXTRACT_ss]
-    [Once wordsTheory.WORD_EXTRACT_OVER_MUL])
+    [Once wordsTheory.WORD_EXTRACT_OVER_MUL]
+QED
 
-val mul_long2 = Q.prove(
-  `!a : word64 b : word64.
+Triviality mul_long2:
+  !a : word64 b : word64.
     n2w ((w2n a * w2n b) DIV 18446744073709551616) =
-    (127 >< 64) (w2w a * w2w b : word128) : word64`,
+    (127 >< 64) (w2w a * w2w b : word128) : word64
+Proof
   Cases
   \\ Cases
   \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_mul_n2w,
          wordsTheory.word_extract_n2w, bitTheory.BITS_THM]
-  )
+QED
 
-val ror = Q.prove(
-  `!w : word64 n. n < 64n ==> ((w << (64 - n) || w >>> n) = w #>> n)`,
+Triviality ror:
+  !w : word64 n. n < 64n ==> ((w << (64 - n) || w >>> n) = w #>> n)
+Proof
   srw_tac [fcpLib.FCP_ss]
     [wordsTheory.word_or_def, wordsTheory.word_ror, wordsTheory.word_bits_def,
      wordsTheory.word_lsl_def, wordsTheory.word_lsr_def,
@@ -161,7 +173,7 @@ val ror = Q.prove(
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ Cases_on `i + n < 64`
   \\ simp []
-  )
+QED
 
 val mips_overflow =
   REWRITE_RULE
@@ -179,9 +191,10 @@ val mips_sub_overflow =
          (((x ?? y) && ~(y ?? (x - y))) >>> 63 = 1w)``]
     (Q.INST_TYPE [`:'a` |-> `:64`] integer_wordTheory.sub_overflow)
 
-val fp_to_int_lem = Q.prove(
-  `!i w : word64.
-      (w2i w = i) ==> -0x8000000000000000 <= i /\ i <= 0x7FFFFFFFFFFFFFFF`,
+Triviality fp_to_int_lem:
+  !i w : word64.
+      (w2i w = i) ==> -0x8000000000000000 <= i /\ i <= 0x7FFFFFFFFFFFFFFF
+Proof
   ntac 3 strip_tac
   \\ assume_tac
        (integer_wordTheory.w2i_le
@@ -192,7 +205,7 @@ val fp_to_int_lem = Q.prove(
         |> Q.ISPEC `w : word64`
         |> SIMP_RULE (srw_ss()) [])
   \\ rfs []
-  )
+QED
 
 val gt_not_leq =
    CONJ (intLib.ARITH_PROVE ``(i > j : int) = ~(i <= j)``)
@@ -431,14 +444,17 @@ end
    mips target_ok
    ------------------------------------------------------------------------- *)
 
-val length_mips_encode = Q.prove(
-  `!i. LENGTH (mips_encode i) = 4`,
-  rw [mips_encode_def])
+Triviality length_mips_encode:
+  !i. LENGTH (mips_encode i) = 4
+Proof
+  rw [mips_encode_def]
+QED
 
-val length_mips_enc = Q.prove(
-  `!l. LENGTH (LIST_BIND l mips_encode) = 4 * LENGTH l`,
+Triviality length_mips_enc:
+  !l. LENGTH (LIST_BIND l mips_encode) = 4 * LENGTH l
+Proof
   Induct \\ rw [length_mips_encode]
-  )
+QED
 
 val mips_encoding = Q.prove (
    `!i. let n = LENGTH (mips_enc i) in (n MOD 4 = 0) /\ n <> 0`,
@@ -451,9 +467,10 @@ val mips_encoding = Q.prove (
    )
    |> SIMP_RULE (srw_ss()++boolSimps.LET_ss) [mips_enc_def]
 
-val mips_target_ok = Q.prove (
-   `target_ok mips_target`,
-   rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality mips_target_ok:
+  target_ok mips_target
+Proof
+  rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
         mips_proj_def, mips_target_def, mips_config, mips_ok_def,
         set_sepTheory.fun2set_eq, mips_encoding] @ enc_ok_rwts)
    >| [Cases_on `0xFFFFFFFFFFFE0004w <= w1 /\ w1 <= 0x20003w`
@@ -472,7 +489,7 @@ val mips_target_ok = Q.prove (
    \\ full_simp_tac (srw_ss()++boolSimps.LET_ss)
         (asmPropsTheory.offset_monotonic_def :: enc_ok_rwts)
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 (* -------------------------------------------------------------------------
    mips encoder_correct

--- a/compiler/encoders/monadic_enc/monadic_enc32Script.sml
+++ b/compiler/encoders/monadic_enc/monadic_enc32Script.sml
@@ -183,12 +183,13 @@ Definition good_table_32_def:
   LENGTH s.hash_tab_32 = n
 End
 
-val lookup_ins_table_32_correct = Q.prove(`
+Triviality lookup_ins_table_32_correct:
   good_table_32 enc n s ∧
   0 < n ⇒
   ∃s'.
   lookup_ins_table_32 enc n aa s = (M_success (enc aa), s') ∧
-  good_table_32 enc n s'`,
+  good_table_32 enc n s'
+Proof
   rw[]>>fs[lookup_ins_table_32_def]>>
   simp msimps>>
   reverse IF_CASES_TAC
@@ -209,43 +210,49 @@ val lookup_ins_table_32_correct = Q.prove(`
   fs[EVERY_MEM]>>
   rw[]>> first_x_assum drule>>
   disch_then drule>>
-  fs[]);
+  fs[]
+QED
 
-val enc_line_hash_32_correct = Q.prove(‘
+Triviality enc_line_hash_32_correct:
   ∀line.
     good_table_32 enc n s ∧ 0 < n ⇒
     ∃s'.
      enc_line_hash_32 enc skip_len n line s =
        (M_success (enc_line enc skip_len line),s') ∧
-     good_table_32 enc n s'’,
+     good_table_32 enc n s'
+Proof
   Cases>>fs[enc_line_hash_32_def,enc_line_def]>>
   fs msimps>>
   qmatch_goalsub_abbrev_tac`lookup_ins_table_32 _ _ aa`>>
   rw[]>>
-  old_drule lookup_ins_table_32_correct>>rw[]>>simp[]);
+  old_drule lookup_ins_table_32_correct>>rw[]>>simp[]
+QED
 
-val enc_line_hash_32_ls_correct = Q.prove(`
+Triviality enc_line_hash_32_ls_correct:
   ∀xs s.
   good_table_32 enc n s ∧ 0 < n ⇒
   ∃s'.
   enc_line_hash_32_ls enc skip_len n xs s =
   (M_success (MAP (enc_line enc skip_len) xs), s') ∧
-  good_table_32 enc n s'`,
+  good_table_32 enc n s'
+Proof
   Induct>>fs[enc_line_hash_32_ls_def]>>
   fs msimps>>
   rw[]>> simp[]>>
   old_drule enc_line_hash_32_correct>>
   disch_then (qspec_then `h` assume_tac)>>rfs[]>>
   first_x_assum drule>>
-  rw[]>>simp[]);
+  rw[]>>simp[]
+QED
 
-val enc_sec_hash_32_ls_correct = Q.prove(`
+Triviality enc_sec_hash_32_ls_correct:
   ∀xs s.
   good_table_32 enc n s ∧ 0 < n ⇒
   ∃s'.
   enc_sec_hash_32_ls enc skip_len n xs s =
   (M_success (MAP (enc_sec enc skip_len) xs), s') ∧
-  good_table_32 enc n s'`,
+  good_table_32 enc n s'
+Proof
   Induct>>fs[enc_sec_hash_32_ls_def]>>
   fs msimps>>
   rw[]>> simp[]>>
@@ -254,7 +261,8 @@ val enc_sec_hash_32_ls_correct = Q.prove(`
   simp[]>>
   disch_then(qspec_then`l` assume_tac)>>fs[]>>
   first_x_assum drule>>rw[]>>
-  simp[enc_sec_def]);
+  simp[enc_sec_def]
+QED
 
 Theorem enc_secs_32_correct:
   enc_secs_32 enc n xs =

--- a/compiler/encoders/monadic_enc/monadic_enc64Script.sml
+++ b/compiler/encoders/monadic_enc/monadic_enc64Script.sml
@@ -183,12 +183,13 @@ Definition good_table_64_def:
   LENGTH s.hash_tab_64 = n
 End
 
-val lookup_ins_table_64_correct = Q.prove(`
+Triviality lookup_ins_table_64_correct:
   good_table_64 enc n s ∧
   0 < n ⇒
   ∃s'.
   lookup_ins_table_64 enc n aa s = (M_success (enc aa), s') ∧
-  good_table_64 enc n s'`,
+  good_table_64 enc n s'
+Proof
   rw[]>>fs[lookup_ins_table_64_def]>>
   simp msimps>>
   reverse IF_CASES_TAC
@@ -209,43 +210,49 @@ val lookup_ins_table_64_correct = Q.prove(`
   fs[EVERY_MEM]>>
   rw[]>> first_x_assum old_drule>>
   disch_then old_drule>>
-  fs[]);
+  fs[]
+QED
 
-val enc_line_hash_64_correct = Q.prove(`
+Triviality enc_line_hash_64_correct:
   ∀line.
   good_table_64 enc n s ∧ 0 < n ⇒
   ∃s'.
   enc_line_hash_64 enc skip_len n line s =
   (M_success (enc_line enc skip_len line),s') ∧
-  good_table_64 enc n s'`,
+  good_table_64 enc n s'
+Proof
   Cases>>fs[enc_line_hash_64_def,enc_line_def]>>
   fs msimps>>
   qmatch_goalsub_abbrev_tac`lookup_ins_table_64 _ _ aa`>>
   rw[]>>
-  old_drule lookup_ins_table_64_correct>>rw[]>>simp[]);
+  old_drule lookup_ins_table_64_correct>>rw[]>>simp[]
+QED
 
-val enc_line_hash_64_ls_correct = Q.prove(`
+Triviality enc_line_hash_64_ls_correct:
   ∀xs s.
   good_table_64 enc n s ∧ 0 < n ⇒
   ∃s'.
   enc_line_hash_64_ls enc skip_len n xs s =
   (M_success (MAP (enc_line enc skip_len) xs), s') ∧
-  good_table_64 enc n s'`,
+  good_table_64 enc n s'
+Proof
   Induct>>fs[enc_line_hash_64_ls_def]>>
   fs msimps>>
   rw[]>> simp[]>>
   old_drule enc_line_hash_64_correct>>
   disch_then (qspec_then `h` assume_tac)>>rfs[]>>
   first_x_assum old_drule>>
-  rw[]>>simp[]);
+  rw[]>>simp[]
+QED
 
-val enc_sec_hash_64_ls_correct = Q.prove(`
+Triviality enc_sec_hash_64_ls_correct:
   ∀xs s.
   good_table_64 enc n s ∧ 0 < n ⇒
   ∃s'.
   enc_sec_hash_64_ls enc skip_len n xs s =
   (M_success (MAP (enc_sec enc skip_len) xs), s') ∧
-  good_table_64 enc n s'`,
+  good_table_64 enc n s'
+Proof
   Induct>>fs[enc_sec_hash_64_ls_def]>>
   fs msimps>>
   rw[]>> simp[]>>
@@ -254,7 +261,8 @@ val enc_sec_hash_64_ls_correct = Q.prove(`
   simp[]>>
   disch_then(qspec_then`l` assume_tac)>>fs[]>>
   first_x_assum old_drule>>rw[]>>
-  simp[enc_sec_def]);
+  simp[enc_sec_def]
+QED
 
 Theorem enc_secs_64_correct:
   enc_secs_64 enc n xs =

--- a/compiler/encoders/riscv/proofs/riscv_targetProofScript.sml
+++ b/compiler/encoders/riscv/proofs/riscv_targetProofScript.sml
@@ -10,8 +10,8 @@ val () = wordsLib.guess_lengths()
 
 (* some lemmas ---------------------------------------------------------- *)
 
-val bytes_in_memory_thm = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm:
+  !w s state a b c d.
       target_state_rel riscv_target s state /\
       bytes_in_memory s.pc [a; b; c; d] s.mem s.mem_domain ==>
       (state.exception = NoException) /\
@@ -26,15 +26,16 @@ val bytes_in_memory_thm = Q.prove(
       state.c_PC state.procID + 3w IN s.mem_domain /\
       state.c_PC state.procID + 2w IN s.mem_domain /\
       state.c_PC state.procID + 1w IN s.mem_domain /\
-      state.c_PC state.procID IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, riscv_target_def, riscv_config_def,
+      state.c_PC state.procID IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, riscv_target_def, riscv_config_def,
        riscv_ok_def, miscTheory.bytes_in_memory_def,
        alignmentTheory.aligned_extract, set_sepTheory.fun2set_eq]
    \\ fs []
-   )
+QED
 
-val bytes_in_memory_thm2 = Q.prove(
-   `!w s state a b c d.
+Triviality bytes_in_memory_thm2:
+  !w s state a b c d.
       target_state_rel riscv_target s state /\
       bytes_in_memory (s.pc + w) [a; b; c; d] s.mem s.mem_domain ==>
       (state.MEM8 (state.c_PC state.procID + w) = a) /\
@@ -44,12 +45,13 @@ val bytes_in_memory_thm2 = Q.prove(
       state.c_PC state.procID + w + 3w IN s.mem_domain /\
       state.c_PC state.procID + w + 2w IN s.mem_domain /\
       state.c_PC state.procID + w + 1w IN s.mem_domain /\
-      state.c_PC state.procID + w IN s.mem_domain`,
-   rw [asmPropsTheory.target_state_rel_def, riscv_target_def, riscv_config_def,
+      state.c_PC state.procID + w IN s.mem_domain
+Proof
+  rw [asmPropsTheory.target_state_rel_def, riscv_target_def, riscv_config_def,
        riscv_ok_def, miscTheory.bytes_in_memory_def,
        alignmentTheory.aligned_extract, set_sepTheory.fun2set_eq]
    \\ fs []
-   )
+QED
 
 val lem1 = asmLib.v2w_BIT_n2w 5
 val lem2 = asmLib.v2w_BIT_n2w 6
@@ -61,11 +63,12 @@ val lem4 = blastLib.BBLAST_PROVE
             c ' 4; c ' 3; c ' 2; c ' 1; c ' 0] : word12) = c : word64)``
 
 
-val lem5 = Q.prove(
-  `aligned 2 (c: word64) ==> ~c ' 1`,
+Triviality lem5:
+  aligned 2 (c: word64) ==> ~c ' 1
+Proof
   simp [alignmentTheory.aligned_extract]
   \\ blastLib.BBLAST_TAC
-  )
+QED
 
 val lem6 = blastLib.BBLAST_PROVE
   ``(((31 >< 0) (c: word64) : word32) ' 11 = c ' 11) /\
@@ -75,21 +78,25 @@ val lem6 = blastLib.BBLAST_PROVE
 val lem7 = CONJ (bitstringLib.v2w_n2w_CONV ``v2w [F] : word64``)
                 (bitstringLib.v2w_n2w_CONV ``v2w [T] : word64``)
 
-val lem8 = Q.prove(
-  `((if b then 1w else 0w : word64) = (v2w [x] || v2w [y])) = (b = (x \/ y))`,
-  rw [] \\ blastLib.BBLAST_TAC)
+Triviality lem8:
+  ((if b then 1w else 0w : word64) = (v2w [x] || v2w [y])) = (b = (x \/ y))
+Proof
+  rw [] \\ blastLib.BBLAST_TAC
+QED
 
-val lem9 = Q.prove(
-  `!r2 : word64 r3 : word64.
+Triviality lem9:
+  !r2 : word64 r3 : word64.
     (18446744073709551616 <= w2n r2 + (w2n r3 + 1) <=>
      18446744073709551616w <=+ w2w r2 + w2w r3 + 1w : 65 word) /\
     (18446744073709551616 <= w2n r2 + w2n r3 <=>
-     18446744073709551616w <=+ w2w r2 + w2w r3 : 65 word)`,
-   Cases
+     18446744073709551616w <=+ w2w r2 + w2w r3 : 65 word)
+Proof
+  Cases
    \\ Cases
    \\ imp_res_tac wordsTheory.BITS_ZEROL_DIMINDEX
    \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_add_n2w,
-          wordsTheory.word_ls_n2w])
+          wordsTheory.word_ls_n2w]
+QED
 
 val lem10 =
   blastLib.BBLAST_CONV
@@ -109,15 +116,16 @@ val lem12b =
               (0w : word12)) +
        sw2sw ((11 >< 0) c && ~2w) = c : word64)``
 
-val mul_long = Q.prove(
-  `!a : word64 b : word64.
+Triviality mul_long:
+  !a : word64 b : word64.
     n2w ((w2n a * w2n b) DIV 18446744073709551616) =
-    (127 >< 64) (w2w a * w2w b : word128) : word64`,
+    (127 >< 64) (w2w a * w2w b : word128) : word64
+Proof
   Cases
   \\ Cases
   \\ fs [wordsTheory.w2w_n2w, wordsTheory.word_mul_n2w,
          wordsTheory.word_extract_n2w, bitTheory.BITS_THM]
-  )
+QED
 
 val riscv_overflow =
   REWRITE_RULE
@@ -135,8 +143,9 @@ val riscv_sub_overflow =
          (((x ?? y) && ~(y ?? (x - y))) >>> 63 = 1w)``]
     (Q.INST_TYPE [`:'a` |-> `:64`] integer_wordTheory.sub_overflow)
 
-val ror = Q.prove(
-  `!w : word64 n. n < 64n ==> ((w << (64 - n) || w >>> n) = w #>> n)`,
+Triviality ror:
+  !w : word64 n. n < 64n ==> ((w << (64 - n) || w >>> n) = w #>> n)
+Proof
   srw_tac [fcpLib.FCP_ss]
     [wordsTheory.word_or_def, wordsTheory.word_ror, wordsTheory.word_bits_def,
      wordsTheory.word_lsl_def, wordsTheory.word_lsr_def,
@@ -145,7 +154,7 @@ val ror = Q.prove(
   \\ srw_tac [wordsLib.WORD_BIT_EQ_ss] []
   \\ Cases_on `i + n < 64`
   \\ simp []
-  )
+QED
 
 (* appears to not be relevant
 
@@ -369,14 +378,16 @@ in
     end
 end
 
-val bytes_in_memory_IMP_all_pcs_MEM8 = Q.prove(
- `!env a xs m dm.
+Triviality bytes_in_memory_IMP_all_pcs_MEM8:
+  !env a xs m dm.
    bytes_in_memory a xs m dm /\
    (!(i:num) ms'. (∀a. a ∈ dm ⇒ (env i ms').MEM8 a = ms'.MEM8 a)) ==>
-   (!i ms'. (∀pc. pc ∈ all_pcs (LENGTH xs) a 0 ==> (env i ms').MEM8 pc = ms'.MEM8 pc))`,
- Induct_on `xs`
+   (!i ms'. (∀pc. pc ∈ all_pcs (LENGTH xs) a 0 ==> (env i ms').MEM8 pc = ms'.MEM8 pc))
+Proof
+  Induct_on `xs`
  \\ rw [asmPropsTheory.all_pcs_def, miscTheory.bytes_in_memory_def]
- \\ metis_tac []);
+ \\ metis_tac []
+QED
 
 local
    fun number_of_instructions asl =
@@ -437,13 +448,17 @@ end
    riscv target_ok
    ------------------------------------------------------------------------- *)
 
-val length_riscv_encode = Q.prove(
-  `!i. LENGTH (riscv_encode i) = 4`,
-  rw [riscv_encode_def])
+Triviality length_riscv_encode:
+  !i. LENGTH (riscv_encode i) = 4
+Proof
+  rw [riscv_encode_def]
+QED
 
-val riscv_encode_not_nil = Q.prove(
-  `!i. riscv_encode i <> []`,
-  simp_tac std_ss [length_riscv_encode, GSYM listTheory.LENGTH_NIL])
+Triviality riscv_encode_not_nil:
+  !i. riscv_encode i <> []
+Proof
+  simp_tac std_ss [length_riscv_encode, GSYM listTheory.LENGTH_NIL]
+QED
 
 val riscv_encoding = Q.prove (
    `!i. let l = riscv_enc i in (LENGTH l MOD 4 = 0) /\ l <> []`,
@@ -456,9 +471,10 @@ val riscv_encoding = Q.prove (
    )
    |> SIMP_RULE (srw_ss()++boolSimps.LET_ss) [riscv_enc_def]
 
-val riscv_target_ok = Q.prove (
-   `target_ok riscv_target`,
-   rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality riscv_target_ok:
+  target_ok riscv_target
+Proof
+  rw ([asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
         riscv_proj_def, riscv_target_def, riscv_config, riscv_ok_def,
         set_sepTheory.fun2set_eq, riscv_encoding] @ enc_ok_rwts)
    >| [Cases_on `-0x100000w <= w1 /\ w1 <= 0xFFFFFw`
@@ -475,7 +491,7 @@ val riscv_target_ok = Q.prove (
          (asmPropsTheory.offset_monotonic_def :: enc_ok_rwts)
    \\ DISCH_THEN kall_tac
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
 (* -------------------------------------------------------------------------
    riscv encoder_correct

--- a/compiler/encoders/x64/proofs/x64_targetProofScript.sml
+++ b/compiler/encoders/x64/proofs/x64_targetProofScript.sml
@@ -25,12 +25,14 @@ val const_lem1 =
      ``!c: word64. ((63 >< 31) c = 0w: 33 word) ==>
                    0xFFFFFFFF80000000w <= c /\ c <= 0x7FFFFFFFw``
 
-val const_lem2 = Q.prove(
-   `!c: word64.
+Triviality const_lem2:
+  !c: word64.
        [(7 >< 0) c; (15 >< 8) c; (23 >< 16) c; (31 >< 24) c]: word8 list =
        [( 7 ><  0) (w2w c : word32); (15 ><  8) (w2w c : word32);
-        (23 >< 16) (w2w c : word32); (31 >< 24) (w2w c : word32)]`,
-   simp [] \\ blastLib.BBLAST_TAC)
+        (23 >< 16) (w2w c : word32); (31 >< 24) (w2w c : word32)]
+Proof
+  simp [] \\ blastLib.BBLAST_TAC
+QED
 
 val const_lem3 =
    Drule.LIST_CONJ
@@ -109,13 +111,17 @@ val loc_lem4 =
           0xFFFFFFFF80000007w <= c /\ c <= 0x80000006w ==>
           (sw2sw (w2w (c + 0xFFFFFFFFFFFFFFF9w): word32) = c - 7w)``
 
-val binop_lem1 = Q.prove(
-   `((if b then [x] else []) <> []) = b`,
-   rw [])
+Triviality binop_lem1:
+  ((if b then [x] else []) <> []) = b
+Proof
+  rw []
+QED
 
-val binop_lem5 = Q.prove(
-   `!c: word64. [(7 >< 0) c]: word8 list = [I (w2w c : word8)]`,
-   simp [] \\ blastLib.BBLAST_TAC)
+Triviality binop_lem5:
+  !c: word64. [(7 >< 0) c]: word8 list = [I (w2w c : word8)]
+Proof
+  simp [] \\ blastLib.BBLAST_TAC
+QED
 
 val binop_lem6 =
    blastLib.BBLAST_PROVE
@@ -129,27 +135,29 @@ val binop_lem7 =
           0xFFFFFFFF80000000w <= c /\ c <= 0x7FFFFFFFw ==>
           (sw2sw (w2w c: word32) = c)``
 
-val binop_lem9b = Q.prove(
-   `!n. n < 64 ==>
-        (0xFFFFFFFFFFFFFF80w: word64) <= n2w n /\ n2w n <= (0x7Fw: word64)`,
-   lrw [wordsTheory.word_le_n2w]
+Triviality binop_lem9b:
+  !n. n < 64 ==>
+        (0xFFFFFFFFFFFFFF80w: word64) <= n2w n /\ n2w n <= (0x7Fw: word64)
+Proof
+  lrw [wordsTheory.word_le_n2w]
    \\ `n < 2 ** 63` by simp []
    \\ simp [bitTheory.NOT_BIT_GT_TWOEXP]
-   )
+QED
 
-val binop_lem9 = Q.prove(
-   `!i: word64 n.
+Triviality binop_lem9:
+  !i: word64 n.
        n < 64 /\ Abbrev (i = n2w n) ==>
        0xFFFFFFFFFFFFFF80w <= i /\ i <= 0x7Fw /\ i <+ 64w /\
-       (w2n (w2w i: word6) = n)`,
-   Cases
+       (w2n (w2w i: word6) = n)
+Proof
+  Cases
    \\ lrw [wordsTheory.word_le_n2w, wordsTheory.word_lo_n2w,
            wordsTheory.w2w_n2w]
    \\ `n' < 18446744073709551616` by decide_tac
    \\ fs [markerTheory.Abbrev_def]
    \\ `n' < 2 ** 63` by simp []
    \\ simp [bitTheory.NOT_BIT_GT_TWOEXP]
-   )
+QED
 
 val binop_lem10 =
    blastLib.BBLAST_PROVE
@@ -165,16 +173,17 @@ val binop_lem10b =
        [wordsTheory.word_lo_n2w, arithmeticTheory.LESS_MOD,
         blastLib.BBLAST_PROVE ``(w2w a : word8) = (7 >< 0) (a : word64)``]
 
-val mem_lem1 = Q.prove(
-   `!a n s state.
+Triviality mem_lem1:
+  !a n s state.
        target_state_rel x64_target s state /\ n < 16 /\ n <> 4 /\ n <> 5 /\
        s.regs n + a IN s.mem_domain ==>
-       (state.MEM (state.REG (num2Zreg n) + a) = s.mem (s.regs n + a))`,
-   rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def]
-   )
+       (state.MEM (state.REG (num2Zreg n) + a) = s.mem (s.regs n + a))
+Proof
+  rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def]
+QED
 
-val mem_lem2 = Q.prove(
-   `!a n s state.
+Triviality mem_lem2:
+  !a n s state.
     target_state_rel x64_target s state /\ n < 16 /\ n <> 4 /\ n <> 5 /\
     s.regs n + a IN s.mem_domain /\
     s.regs n + a + 1w IN s.mem_domain /\
@@ -182,13 +191,14 @@ val mem_lem2 = Q.prove(
     s.regs n + a + 3w IN s.mem_domain ==>
     (read_mem32 state.MEM (state.REG (num2Zreg n) + a) =
      s.mem (s.regs n + a + 3w) @@ s.mem (s.regs n + a + 2w) @@
-     s.mem (s.regs n + a + 1w) @@ s.mem (s.regs n + a))`,
-   rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def,
+     s.mem (s.regs n + a + 1w) @@ s.mem (s.regs n + a))
+Proof
+  rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def,
        x64_stepTheory.read_mem32_def]
-   )
+QED
 
-val mem_lem3 = Q.prove(
-   `!a n s state.
+Triviality mem_lem3:
+  !a n s state.
     target_state_rel x64_target s state /\ n < 16 /\ n <> 4 /\ n <> 5 /\
     s.regs n + a IN s.mem_domain /\
     s.regs n + a + 1w IN s.mem_domain /\
@@ -202,10 +212,11 @@ val mem_lem3 = Q.prove(
      s.mem (s.regs n + a + 7w) @@ s.mem (s.regs n + a + 6w) @@
      s.mem (s.regs n + a + 5w) @@ s.mem (s.regs n + a + 4w) @@
      s.mem (s.regs n + a + 3w) @@ s.mem (s.regs n + a + 2w) @@
-     s.mem (s.regs n + a + 1w) @@ s.mem (s.regs n + a))`,
-   rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def,
+     s.mem (s.regs n + a + 1w) @@ s.mem (s.regs n + a))
+Proof
+  rw [asmPropsTheory.target_state_rel_def, x64_target_def, x64_config_def,
        x64_stepTheory.read_mem64_def]
-   )
+QED
 
 val mem_lem4 =
    blastLib.BBLAST_PROVE
@@ -217,39 +228,45 @@ val mem_lem5 =
           0xFFFFFFFFFFFFFF80w <= c /\ c <= 0x7Fw ==>
           (sw2sw (w2w c: word8) = c)``
 
-val mem_lem6 = Q.prove(
-   `!r. (2 >< 0) r <> (4w: word3) /\ (2 >< 0) r <> (5w: word3) ==>
-        (r = RegNot4or5 r)`,
-   rw [x64_stepTheory.RegNot4or5_def])
+Triviality mem_lem6:
+  !r. (2 >< 0) r <> (4w: word3) /\ (2 >< 0) r <> (5w: word3) ==>
+        (r = RegNot4or5 r)
+Proof
+  rw [x64_stepTheory.RegNot4or5_def]
+QED
 
-val mem_lem7 = Q.prove(
-   `!r. (2 >< 0) r <> (4w: word3) ==> (r = RegNot4 r)`,
-   rw [x64_stepTheory.RegNot4_def])
+Triviality mem_lem7:
+  !r. (2 >< 0) r <> (4w: word3) ==> (r = RegNot4 r)
+Proof
+  rw [x64_stepTheory.RegNot4_def]
+QED
 
-val mem_lem8 = Q.prove(
-   `!r:word4 n.
+Triviality mem_lem8:
+  !r:word4 n.
        ~(3 < n) /\ Abbrev (r = n2w n) ==>
        num2Zreg (w2n r) <> RSP /\
        num2Zreg (w2n r) <> RBP /\
        num2Zreg (w2n r) <> RSI /\
-       num2Zreg (w2n r) <> RDI`,
-   wordsLib.Cases_word_value
+       num2Zreg (w2n r) <> RDI
+Proof
+  wordsLib.Cases_word_value
    \\ rw [x64Theory.num2Zreg_thm]
    \\ Cases_on `3 < n`
    \\ simp [markerTheory.Abbrev_def]
-   )
+QED
 
 (*
-val mem_lem9 = Q.prove(
-   `!n r: word4.
+Triviality mem_lem9:
+  !n r: word4.
       n < 16 /\ n <> 4 /\ Abbrev (r = n2w n) /\ ((2 >< 0) r = 4w: word3) ==>
-      (zR12 = num2Zreg n)`,
-   wordsLib.Cases_on_word_value `r`
+      (zR12 = num2Zreg n)
+Proof
+  wordsLib.Cases_on_word_value `r`
    \\ rw []
    \\ rfs [markerTheory.Abbrev_def]
    \\ pop_assum (SUBST_ALL_TAC o SYM)
    \\ simp [x64Theory.num2Zreg_thm]
-   )
+QED
 
 val mem_lem10 = Q.prove(
    `!n r: word4.
@@ -274,8 +291,8 @@ val mem_lem13 =
    blastLib.BBLAST_PROVE
       ``!a: word4. v2w [a ' 2; a ' 1; a ' 0] = (2 >< 0) a : word3``
 
-val mem_lem14 = Q.prove(
-  `!w m :word64 -> word8.
+Triviality mem_lem14:
+  !w m :word64 -> word8.
    (w + 7w =+ b7)
      ((w + 6w =+ b6)
         ((w + 5w =+ b5)
@@ -291,21 +308,23 @@ val mem_lem14 = Q.prove(
               ((w + 4w =+ b4)
                  ((w + 5w =+ b5)
                     ((w + 6w =+ b6)
-                       ((w + 7w =+ b7) m)))))))`,
-   rw [combinTheory.APPLY_UPDATE_THM, FUN_EQ_THM]
+                       ((w + 7w =+ b7) m)))))))
+Proof
+  rw [combinTheory.APPLY_UPDATE_THM, FUN_EQ_THM]
    \\ rw []
    \\ full_simp_tac (srw_ss()++wordsLib.WORD_CANCEL_ss) []
-   )
+QED
 
-val mem_lem15 = Q.prove(
-  `!w v:word64 m :word64 -> word8.
+Triviality mem_lem15:
+  !w v:word64 m :word64 -> word8.
    (w + 3w =+ b3) ((w + 2w =+ b2) ((w + 1w =+ b1) ((w =+ b0) m))) =
-   (w =+ b0) ((w + 1w =+ b1) ((w + 2w =+ b2) ((w + 3w =+ b3) m)))`,
-   srw_tac [wordsLib.WORD_EXTRACT_ss]
+   (w =+ b0) ((w + 1w =+ b1) ((w + 2w =+ b2) ((w + 3w =+ b3) m)))
+Proof
+  srw_tac [wordsLib.WORD_EXTRACT_ss]
       [combinTheory.APPLY_UPDATE_THM, FUN_EQ_THM]
    \\ rw []
    \\ full_simp_tac (srw_ss()++wordsLib.WORD_CANCEL_ss) []
-   )
+QED
 
 val cmp_lem1 =
    blastLib.BBLAST_PROVE
@@ -328,35 +347,40 @@ val cmp_lem3 = Thm.CONJ
        ((a + -1w * b) ' 63 <=/=>
         (a ' 63 <=/=> b ' 63) /\ ((a + -1w * b) ' 63 <=/=> a ' 63)) <=> a < b``)
 
-val cmp_lem4 = Q.prove(
-   `!w: word64 a b.
-      (7 >< 0) w :: a :: b : word8 list = I (w2w w : word8) :: a :: b`,
-   simp [] \\ blastLib.BBLAST_TAC)
+Triviality cmp_lem4:
+  !w: word64 a b.
+      (7 >< 0) w :: a :: b : word8 list = I (w2w w : word8) :: a :: b
+Proof
+  simp [] \\ blastLib.BBLAST_TAC
+QED
 
-val cmp_lem5 = Q.prove(
-   `!c: word64.
+Triviality cmp_lem5:
+  !c: word64.
        0xFFFFFFFFFFFFFF80w <= c /\ c <= 0x7Fw ==>
        (((if (7 >< 7) c = 1w: word8 then 0xFFFFFFFFFFFFFF00w else 0w) ||
-         ((7 >< 0) c)) = c)`,
-   rw []
+         ((7 >< 0) c)) = c)
+Proof
+  rw []
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
-val cmp_lem6 = Q.prove(
-   `!c: word64.
+Triviality cmp_lem6:
+  !c: word64.
        0xFFFFFFFF80000000w <= c /\ c <= 0x7FFFFFFFw ==>
        (((if (31 >< 31) c = 1w: word32 then 0xFFFFFFFF00000000w else 0w) ||
-         (31 >< 0) c) = c)`,
-   rw []
+         (31 >< 0) c) = c)
+Proof
+  rw []
    \\ blastLib.FULL_BBLAST_TAC
-   )
+QED
 
-val cmp_lem7 = Q.prove(
-   `!rm. is_rax rm = (Zr RAX = rm)`,
-   Cases \\ rw [x64Theory.is_rax_def]
+Triviality cmp_lem7:
+  !rm. is_rax rm = (Zr RAX = rm)
+Proof
+  Cases \\ rw [x64Theory.is_rax_def]
    \\ CASE_TAC
    \\ simp []
-   )
+QED
 
 val cmp_lem8 =
    blastLib.BBLAST_PROVE
@@ -419,29 +443,32 @@ val adc_lem2 = blastLib.BBLAST_PROVE ``a <+ 1w : word64 <=> (a = 0w)``
 val overflow_lem =
   blastLib.BBLAST_PROVE ``!a: word64. word_bit 63 a = word_msb a``
 
-val is_rax = Q.prove(
-   `!n. n < 16 ==> ((RAX = num2Zreg n) = (n = 0))`,
-   rw [] \\ fs [wordsTheory.NUMERAL_LESS_THM]
-   )
+Triviality is_rax:
+  !n. n < 16 ==> ((RAX = num2Zreg n) = (n = 0))
+Proof
+  rw [] \\ fs [wordsTheory.NUMERAL_LESS_THM]
+QED
 
-val is_rdx = Q.prove(
-   `!n. n < 16 ==> ((RDX = num2Zreg n) = (n = 2))`,
-   rw [] \\ fs [wordsTheory.NUMERAL_LESS_THM]
-   )
+Triviality is_rdx:
+  !n. n < 16 ==> ((RDX = num2Zreg n) = (n = 2))
+Proof
+  rw [] \\ fs [wordsTheory.NUMERAL_LESS_THM]
+QED
 
-val xmm_reg = Q.prove(
-  `(!n. n < 8 ==> ((3 >< 3) (n2w n : word4) = 0w : word1)) /\
+Triviality xmm_reg:
+  (!n. n < 8 ==> ((3 >< 3) (n2w n : word4) = 0w : word1)) /\
    (!n. n < 8 ==> ((3 >< 3) (w2w (n2w n : word3) : word4) = 0w : word1)) /\
    (!n. n < 8 ==> ~word_bit 3 (n2w n : word4)) /\
    (!n. n < 16 /\ ~(n < 8) ==> ((3 >< 3) (n2w n : word4) = 1w : word1)) /\
-   !n. n < 16 /\ ~(n < 8) ==> word_bit 3 (n2w n : word4)`,
+   !n. n < 16 /\ ~(n < 8) ==> word_bit 3 (n2w n : word4)
+Proof
   rpt strip_tac
   >- fs [wordsTheory.NUMERAL_LESS_THM]
   >- fs [wordsTheory.NUMERAL_LESS_THM]
   >- (fs [wordsTheory.NUMERAL_LESS_THM] \\ rfs [])
   \\ pop_assum mp_tac
   \\ fs [wordsTheory.NUMERAL_LESS_THM]
-  )
+QED
 
 val Zreg2num_num2Zreg_8 =
   x64Theory.Zreg2num_num2Zreg
@@ -450,23 +477,25 @@ val Zreg2num_num2Zreg_8 =
   |> SIMP_RULE arith_ss []
   |> Drule.GEN_ALL
 
-val xmm_reg2 = Q.prove(
-  `(!n r : word4.
+Triviality xmm_reg2:
+  (!n r : word4.
       n < 8 /\ Abbrev (r = n2w n) ==>
       (RexReg (F, v2w [r ' 2; r ' 1; r ' 0]) = num2Zreg n)) /\
    (!n r : word4.
       ~(n < 8) /\ n < 16 /\ Abbrev (r = n2w n) ==>
-      (RexReg (T, v2w [r ' 2; r ' 1; r ' 0]) = num2Zreg n))`,
-   rpt strip_tac
+      (RexReg (T, v2w [r ' 2; r ' 1; r ' 0]) = num2Zreg n))
+Proof
+  rpt strip_tac
    \\ full_simp_tac (srw_ss()++bitstringLib.v2w_n2w_ss)
         [Abbr `r`, wordsTheory.NUMERAL_LESS_THM, x64Theory.RexReg_def]
    \\ fs []
-   )
+QED
 
-val xmm_reg3 = Q.prove(
-  `!n. n < 8 ==> (w2w (n2w n : word3) = n2w n : word4)`,
+Triviality xmm_reg3:
+  !n. n < 8 ==> (w2w (n2w n : word3) = n2w n : word4)
+Proof
   rpt strip_tac \\ fs [wordsTheory.NUMERAL_LESS_THM]
-  )
+QED
 
 val extract_double =
   blastLib.BBLAST_PROVE
@@ -478,27 +507,30 @@ val extract_double =
        w2w w2 : word64) /\
      !w: word128. (31 >< 0) ((63 >< 0) w : word64) = (31 >< 0) w : word32``
 
-val fp_abs = Q.prove(
-  `!w. fp64_abs w = (0x7FFFFFFFFFFFFFFFw && w)`,
+Triviality fp_abs:
+  !w. fp64_abs w = (0x7FFFFFFFFFFFFFFFw && w)
+Proof
   simp [machine_ieeeTheory.fp64_abs_def, machine_ieeeTheory.fp64_to_float_def,
         binary_ieeeTheory.float_abs_def, machine_ieeeTheory.float_to_fp64_def]
   \\ blastLib.BBLAST_TAC
-  )
+QED
 
-val fp_neg = Q.prove(
-  `!w. fp64_negate w = (0x8000000000000000w ?? w)`,
+Triviality fp_neg:
+  !w. fp64_negate w = (0x8000000000000000w ?? w)
+Proof
   simp [machine_ieeeTheory.fp64_negate_def,
         machine_ieeeTheory.fp64_to_float_def,
         binary_ieeeTheory.float_negate_def,
         machine_ieeeTheory.float_to_fp64_def]
   \\ blastLib.BBLAST_TAC
-  )
+QED
 
-val fp_compare = Q.prove(
-  `(!a b. fp64_equal a b = (fp64_compare a b = EQ)) /\
+Triviality fp_compare:
+  (!a b. fp64_equal a b = (fp64_compare a b = EQ)) /\
    (!a b. fp64_lessThan a b = (fp64_compare a b = LT)) /\
    (!a b. fp64_lessEqual a b =
-          ((fp64_compare a b = LT) \/ (fp64_compare a b = EQ)))`,
+          ((fp64_compare a b = LT) \/ (fp64_compare a b = EQ)))
+Proof
   simp [machine_ieeeTheory.fp64_equal_def,
         machine_ieeeTheory.fp64_lessEqual_def,
         machine_ieeeTheory.fp64_lessThan_def,
@@ -508,11 +540,12 @@ val fp_compare = Q.prove(
         binary_ieeeTheory.float_less_equal_def]
   \\ rpt strip_tac
   \\ CASE_TAC
-  )
+QED
 
-val fp_to_int_lem = Q.prove(
-  `!i w : word32.
-      (w2i w = i) ==> -0x80000000 <= i /\ i <= 0x7FFFFFFF`,
+Triviality fp_to_int_lem:
+  !i w : word32.
+      (w2i w = i) ==> -0x80000000 <= i /\ i <= 0x7FFFFFFF
+Proof
   ntac 3 strip_tac
   \\ assume_tac
        (integer_wordTheory.w2i_le
@@ -523,7 +556,7 @@ val fp_to_int_lem = Q.prove(
         |> Q.ISPEC `w : word32`
         |> SIMP_RULE (srw_ss()) [])
   \\ rfs []
-  )
+QED
 
 (* some rewrites ---------------------------------------------------------- *)
 
@@ -851,21 +884,24 @@ val fp_cmp_tac =
    x64 target_ok
    ------------------------------------------------------------------------- *)
 
-val x64_encoding = Q.prove (
-   `!i. x64_enc i <> []`,
-   strip_tac
+Triviality x64_encoding:
+  !i. x64_enc i <> []
+Proof
+  strip_tac
    \\ Cases_on `LIST_BIND (x64_ast i) x64_encode`
    \\ simp [x64_enc_def, x64_dec_fail_def]
-   );
+QED
 
-val x64_cmp_neq_p = Q.prove(
-  `!cmp. x64_cmp cmp <> Z_P`,
+Triviality x64_cmp_neq_p:
+  !cmp. x64_cmp cmp <> Z_P
+Proof
   Cases \\ simp [x64_cmp_def]
-  );
+QED
 
-val x64_target_ok = Q.prove (
-   `target_ok x64_target`,
-   rw [asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
+Triviality x64_target_ok:
+  target_ok x64_target
+Proof
+  rw [asmPropsTheory.target_ok_def, asmPropsTheory.target_state_rel_def,
        x64_proj_def, x64_target_def, x64_config, x64_encoding, x64_ok_def,
        set_sepTheory.fun2set_eq, asmPropsTheory.enc_ok_def]
    >| [simp encode_rwts,
@@ -881,7 +917,7 @@ val x64_target_ok = Q.prove (
    \\ full_simp_tac (srw_ss()++boolSimps.LET_ss)
         (asmPropsTheory.offset_monotonic_def :: x64_cmp_neq_p :: enc_ok_rwts)
    \\ rw [jump_lem1, jump_lem3, jump_lem4, jump_lem5, jump_lem6, loc_lem1]
-   );
+QED
 
 (* -------------------------------------------------------------------------
    x64 encoder_correct

--- a/compiler/encoders/x64/x64_eval_encodeScript.sml
+++ b/compiler/encoders/x64/x64_eval_encodeScript.sml
@@ -8,17 +8,20 @@ val () = new_theory "x64_eval_encode"
 
 val () = Feedback.set_trace "TheoryPP.include_docs" 0
 
-val not_fail = Q.prove(
-   `(case a ++ b :: c of [] => x64_dec_fail | v2::v3 => v2::v3) =
-    a ++ b :: c`,
-   Cases_on `a`  \\ rw [])
+Triviality not_fail:
+  (case a ++ b :: c of [] => x64_dec_fail | v2::v3 => v2::v3) =
+    a ++ b :: c
+Proof
+  Cases_on `a`  \\ rw []
+QED
 
-val lem = Q.prove(
-  `!n. n MOD 8 < 16`,
+Triviality lem:
+  !n. n MOD 8 < 16
+Proof
   strip_tac
   \\ `n MOD 8 < 8` by simp []
   \\ simp []
-  )
+QED
 
 val Zreg2num_num2Zreg =
   x64Theory.Zreg2num_num2Zreg
@@ -28,13 +31,14 @@ val Zreg2num_num2Zreg =
 val xmm_reg =
   blastLib.BBLAST_PROVE ``((3 >< 3) (w2w (a : word3) : word4) = 0w : word1)``
 
-val xmm_reg2 = Q.prove(
-  `!n. (3 >< 3) (n2w (n MOD 8) : word4) = 0w : word1`,
+Triviality xmm_reg2:
+  !n. (3 >< 3) (n2w (n MOD 8) : word4) = 0w : word1
+Proof
   strip_tac
   \\ `n MOD 8 < 8` by simp []
   \\ qabbrev_tac `m = n MOD 8`
   \\ fs [wordsTheory.NUMERAL_LESS_THM]
-  )
+QED
 
 local
   val n = ["skip", "const", "binop reg", "binop imm", "shift", "div",

--- a/compiler/inference/inferPropsScript.sml
+++ b/compiler/inference/inferPropsScript.sml
@@ -359,29 +359,35 @@ Proof
   rw [infer_st_component_equality]
 QED
 
-val st_ex_return_success = Q.prove (
-`!v st v' st'.
+Triviality st_ex_return_success:
+  !v st v' st'.
   (st_ex_return v st = (Success v', st')) =
-  ((v = v') ∧ (st = st'))`,
-rw [st_ex_return_def]);
+  ((v = v') ∧ (st = st'))
+Proof
+  rw [st_ex_return_def]
+QED
 
-val st_ex_bind_success = Q.prove (
-`!f g st st' v.
+Triviality st_ex_bind_success:
+  !f g st st' v.
  (st_ex_bind f g st = (Success v, st')) =
- ?v' st''. (f st = (Success v', st'')) /\ (g v' st'' = (Success v, st'))`,
-rw [st_ex_bind_def] >>
+ ?v' st''. (f st = (Success v', st'')) /\ (g v' st'' = (Success v, st'))
+Proof
+  rw [st_ex_bind_def] >>
 cases_on `f st` >>
 rw [] >>
 cases_on `q` >>
-rw []);
+rw []
+QED
 
-val fresh_uvar_success = Q.prove (
-`!st t st'.
+Triviality fresh_uvar_success:
+  !st t st'.
   (fresh_uvar st = (Success t, st')) =
   ((t = Infer_Tuvar st.next_uvar) ∧
-   (st' = st with next_uvar := st.next_uvar + 1))`,
-rw [fresh_uvar_def] >>
-metis_tac []);
+   (st' = st with next_uvar := st.next_uvar + 1))
+Proof
+  rw [fresh_uvar_def] >>
+metis_tac []
+QED
 
 Theorem n_fresh_uvar_success:
  !n st ts st'.
@@ -401,15 +407,17 @@ eq_tac >>
 srw_tac [ARITH_ss] [arithmeticTheory.ADD1]
 QED
 
-val apply_subst_success = Q.prove (
-`!t1 st1 t2 st2.
+Triviality apply_subst_success:
+  !t1 st1 t2 st2.
   (apply_subst t1 st1 = (Success t2, st2))
   =
   ((st2 = st1) ∧
-   (t2 = t_walkstar st1.subst t1))`,
-rw [st_ex_return_def, st_ex_bind_def, LET_THM, apply_subst_def, read_def] >>
+   (t2 = t_walkstar st1.subst t1))
+Proof
+  rw [st_ex_return_def, st_ex_bind_def, LET_THM, apply_subst_def, read_def] >>
 eq_tac >>
-rw []);
+rw []
+QED
 
 Theorem add_constraint_success:
  !l t1 t2 st st' x.
@@ -422,16 +430,17 @@ full_case_tac >>
 metis_tac []
 QED
 
-val add_constraints_success = Q.prove (
-`!l ts1 ts2 st st' x.
+Triviality add_constraints_success:
+  !l ts1 ts2 st st' x.
   (add_constraints l ts1 ts2 st = (Success x, st'))
   =
   ((LENGTH ts1 = LENGTH ts2) ∧
    ((x = ()) ∧
    (st.next_uvar = st'.next_uvar) ∧
    (st.next_id = st'.next_id) ∧
-   pure_add_constraints st.subst (ZIP (ts1,ts2)) st'.subst))`,
-ho_match_mp_tac add_constraints_ind >>
+   pure_add_constraints st.subst (ZIP (ts1,ts2)) st'.subst))
+Proof
+  ho_match_mp_tac add_constraints_ind >>
 rw [add_constraints_def, pure_add_constraints_def, st_ex_return_success,
     failwith_def, st_ex_bind_success, add_constraint_success] >>
 TRY (cases_on `x`) >>
@@ -440,35 +449,42 @@ metis_tac [infer_st_component_equality] >>
 eq_tac >>
 rw [] >>
 cases_on `t_unify st.subst t1 t2` >>
-fs []);
+fs []
+QED
 
-val add_constraints_nil2_success = Q.prove (
-`(add_constraints l ts1 [] st = (Success x, st'))
-  = (ts1 = [] /\ st = st')`,
+Triviality add_constraints_nil2_success:
+  (add_constraints l ts1 [] st = (Success x, st'))
+  = (ts1 = [] /\ st = st')
+Proof
   Cases_on `ts1` \\ simp [add_constraints_def]
   \\ simp [failwith_def, st_ex_bind_success, st_ex_return_success]
-);
+QED
 
-val add_constraints_cons2_success = Q.prove (
-`(add_constraints l ts1 (t2 :: ts2) st = (Success x, st'))
+Triviality add_constraints_cons2_success:
+  (add_constraints l ts1 (t2 :: ts2) st = (Success x, st'))
   = (?t1 tl1 st''. ts1 = t1 :: tl1 /\
     add_constraint l t1 t2 st = (Success (), st'') /\
-    add_constraints l tl1 ts2 st'' = (Success x, st'))`,
+    add_constraints l tl1 ts2 st'' = (Success x, st'))
+Proof
   Cases_on `ts1` \\ simp [add_constraints_def]
   \\ simp [failwith_def, st_ex_bind_success, st_ex_return_success]
-);
+QED
 
-val failwith_success = Q.prove (
-`!l m st v st'. (failwith l m st = (Success v, st')) = F`,
-rw [failwith_def]);
+Triviality failwith_success:
+  !l m st v st'. (failwith l m st = (Success v, st')) = F
+Proof
+  rw [failwith_def]
+QED
 
-val lookup_st_ex_success = Q.prove (
-`!loc x err l st v st'.
+Triviality lookup_st_ex_success:
+  !loc x err l st v st'.
   (lookup_st_ex loc err x l st = (Success v, st'))
   =
-  ((nsLookup l x = SOME v) ∧ (st = st'))`,
- rw [lookup_st_ex_def, failwith_def, st_ex_return_success]
- >> every_case_tac);
+  ((nsLookup l x = SOME v) ∧ (st = st'))
+Proof
+  rw [lookup_st_ex_def, failwith_def, st_ex_return_success]
+ >> every_case_tac
+QED
 
 val op_data = {nchotomy = op_nchotomy, case_def = op_case_def};
 val op_case_eq = prove_case_eq_thm op_data;
@@ -522,25 +538,29 @@ val constrain_op_success =
 
 val _ = save_thm ("constrain_op_success", constrain_op_success);
 
-val get_next_uvar_success = Q.prove (
-`!st v st'.
+Triviality get_next_uvar_success:
+  !st v st'.
   (get_next_uvar st = (Success v, st'))
   =
-  ((v = st.next_uvar) ∧ (st = st'))`,
-rw [get_next_uvar_def] >>
-metis_tac []);
+  ((v = st.next_uvar) ∧ (st = st'))
+Proof
+  rw [get_next_uvar_def] >>
+metis_tac []
+QED
 
 val apply_subst_list_success =
   SIMP_CONV (srw_ss()) [apply_subst_list_def, LET_THM]
   ``(apply_subst_list ts st = (Success v, st'))``
 
-val guard_success = Q.prove (
-`∀P l m st v st'.
+Triviality guard_success:
+  ∀P l m st v st'.
   (guard P l m st = (Success v, st'))
   =
-  (P ∧ (v = ()) ∧ (st = st'))`,
-rw [guard_def, st_ex_return_def, failwith_def] >>
-metis_tac []);
+  (P ∧ (v = ()) ∧ (st = st'))
+Proof
+  rw [guard_def, st_ex_return_def, failwith_def] >>
+metis_tac []
+QED
 
 Theorem check_dups_success:
    !l f ls s r s'.
@@ -675,13 +695,15 @@ Proof
  fs [LAMBDA_PROD, combinTheory.o_DEF]
 QED
 
-val option_case_eq = Q.prove (
-`!opt f g v st st'.
+Triviality option_case_eq:
+  !opt f g v st st'.
   ((case opt of NONE => f | SOME x => g x) st = (Success v, st')) =
-  (((opt = NONE) ∧ (f st = (Success v, st'))) ∨ (?x. (opt = SOME x) ∧ (g x st = (Success v, st'))))`,
-rw [] >>
+  (((opt = NONE) ∧ (f st = (Success v, st'))) ∨ (?x. (opt = SOME x) ∧ (g x st = (Success v, st'))))
+Proof
+  rw [] >>
 cases_on `opt` >>
-fs []);
+fs []
+QED
 
 val success_eqns =
   LIST_CONJ [st_ex_return_success, st_ex_bind_success, fresh_uvar_success,
@@ -772,19 +794,21 @@ QED
 
 (* ---------- Dealing with the constraint set ---------- *)
 
-val pure_add_constraints_append2 = Q.prove (
-`!s1 ts s2 t1 t2.
+Triviality pure_add_constraints_append2:
+  !s1 ts s2 t1 t2.
   t_wfs s1 ∧
   pure_add_constraints s1 ts s2 ∧
   (t_walkstar s1 t1 = t_walkstar s1 t2)
   ⇒
-  (t_walkstar s2 t1 = t_walkstar s2 t2)`,
-induct_on `ts` >>
+  (t_walkstar s2 t1 = t_walkstar s2 t2)
+Proof
+  induct_on `ts` >>
 rw [pure_add_constraints_def] >>
 rw [] >>
 PairCases_on `h` >>
 fs [pure_add_constraints_def] >>
-metis_tac [t_unify_wfs, t_unify_apply2]);
+metis_tac [t_unify_wfs, t_unify_apply2]
+QED
 
 Theorem pure_add_constraints_apply:
  !s1 ts s2.
@@ -1053,10 +1077,12 @@ rw [t_vars_eqn, check_t_def, EVERY_MEM, SUBSET_DEF, MEM_MAP] >>
 metis_tac []
 QED
 
-val check_s_more = Q.prove (
-`!s tvs uvs. check_s tvs (count uvs) s ⇒ check_s tvs (count (uvs + 1)) s`,
-rw [check_s_def] >>
-metis_tac [check_t_more3]);
+Triviality check_s_more:
+  !s tvs uvs. check_s tvs (count uvs) s ⇒ check_s tvs (count (uvs + 1)) s
+Proof
+  rw [check_s_def] >>
+metis_tac [check_t_more3]
+QED
 
 Theorem check_s_more2:
  !s uvs. check_s tvs (count uvs) s ⇒ !uvs'. uvs ≤ uvs' ⇒ check_s tvs (count uvs') s
@@ -1148,13 +1174,14 @@ fs [check_s_def, FLOOKUP_DEF] >>
 metis_tac [check_t_def, IN_UNION]
 QED
 
-val t_walkstar_check' = Q.prove (
-`!s. t_wfs s ⇒
+Triviality t_walkstar_check':
+  !s. t_wfs s ⇒
   !t tvs uvs.
     check_s tvs (uvs ∪ FDOM s) s ∧
     check_t tvs (uvs ∪ FDOM s) t
     ⇒
-    check_t tvs uvs (t_walkstar s t)`,
+    check_t tvs uvs (t_walkstar s t)
+Proof
   NTAC 2 STRIP_TAC >>
   imp_res_tac t_walkstar_ind >>
   pop_assum ho_match_mp_tac >>
@@ -1183,7 +1210,8 @@ val t_walkstar_check' = Q.prove (
     cases_on `t_vwalk s n` >>
     fs [check_t_def, EVERY_MAP] >>
     fs [EVERY_MEM] >>
-    metis_tac [t_vwalk_to_var]);
+    metis_tac [t_vwalk_to_var]
+QED
 
 Theorem t_walkstar_check:
  !s t tvs uvs.
@@ -1196,12 +1224,13 @@ Proof
 metis_tac [t_walkstar_check']
 QED
 
-val t_walkstar_uncheck_lem = Q.prove (
-  `!s. t_wfs s ⇒
+Triviality t_walkstar_uncheck_lem:
+  !s. t_wfs s ⇒
     ∀t max_tvs uvs.
     check_t max_tvs uvs (t_walkstar s t) ⇒
-    check_t max_tvs (uvs ∪ FDOM s) t`,
- ntac 2 strip_tac
+    check_t max_tvs (uvs ∪ FDOM s) t
+Proof
+  ntac 2 strip_tac
  >> old_drule t_walkstar_ind
  >> fs [GSYM PULL_FORALL]
  >> disch_then ho_match_mp_tac
@@ -1215,7 +1244,8 @@ val t_walkstar_uncheck_lem = Q.prove (
  >> pop_assum kall_tac
  >> every_case_tac
  >> simp [check_t_def]
- >> fs [check_s_def, FLOOKUP_DEF]);
+ >> fs [check_s_def, FLOOKUP_DEF]
+QED
 
 Theorem t_walkstar_uncheck:
    !s t max_tvs uvs.
@@ -1226,8 +1256,8 @@ Proof
  metis_tac [t_walkstar_uncheck_lem]
 QED
 
-val t_unify_check_s_help = Q.prove (
-`(!s t1 t2. t_wfs s ⇒
+Triviality t_unify_check_s_help:
+  (!s t1 t2. t_wfs s ⇒
     !tvs uvs s'. check_s tvs uvs s ∧
            check_t tvs uvs t1 ∧
            check_t tvs uvs t2 ∧
@@ -1240,7 +1270,8 @@ val t_unify_check_s_help = Q.prove (
            EVERY (check_t tvs uvs) ts2 ∧
            (ts_unify s ts1 ts2 = SOME s')
            ⇒
-           check_s tvs uvs s')`,
+           check_s tvs uvs s')
+Proof
   ho_match_mp_tac t_unify_strongind >>
   rw []
   >- (
@@ -1274,7 +1305,8 @@ val t_unify_check_s_help = Q.prove (
    fs [ts_unify_def] >>
    rw [] >- metis_tac [] >>
    cases_on `t_unify s h h'` >>
-   fs []);
+   fs []
+QED
 
 Theorem check_t_walkstar:
  (!t tvs s.
@@ -1295,19 +1327,21 @@ Proof
   metis_tac []
 QED
 
-val t_walkstar_no_vars = Q.prove (
-`!tvs uvs t s.
+Triviality t_walkstar_no_vars:
+  !tvs uvs t s.
   t_wfs s ∧
   uvs = {} ∧
   check_t tvs uvs t
   ⇒
-  t_walkstar s t = t`,
+  t_walkstar s t = t
+Proof
   ho_match_mp_tac check_t_ind >>
   srw_tac [ARITH_ss] [check_t_def, apply_subst_t_eqn] >>
   fs [t_walkstar_eqn1] >>
   induct_on `ts` >>
   rw [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Theorem t_walkstar_no_vars:
  !tvs t s.
@@ -1435,15 +1469,16 @@ Proof
       metis_tac [infer_p_wfs, check_t_more3])
 QED
 
-val check_infer_type_subst = Q.prove (
-`(!t tvs uvs.
+Triviality check_infer_type_subst:
+  (!t tvs uvs.
   check_freevars 0 tvs t
   ⇒
   check_t 0 (count (LENGTH tvs + uvs)) (infer_type_subst (ZIP (tvs, MAP (λn. Infer_Tuvar (uvs + n)) (COUNT_LIST (LENGTH tvs)))) t)) ∧
  (!ts tvs uvs.
   EVERY (check_freevars 0 tvs) ts
   ⇒
-  EVERY (\t. check_t 0 (count (LENGTH tvs + uvs)) (infer_type_subst (ZIP (tvs, MAP (λn. Infer_Tuvar (uvs + n)) (COUNT_LIST (LENGTH tvs)))) t)) ts)`,
+  EVERY (\t. check_t 0 (count (LENGTH tvs + uvs)) (infer_type_subst (ZIP (tvs, MAP (λn. Infer_Tuvar (uvs + n)) (COUNT_LIST (LENGTH tvs)))) t)) ts)
+Proof
   ho_match_mp_tac t_induction >>
   rw [check_freevars_def, check_t_def, infer_type_subst_alt]
   >- (
@@ -1457,7 +1492,8 @@ val check_infer_type_subst = Q.prove (
     qmatch_goalsub_abbrev_tac`MAP f2 _` >>
     `f1 = f2` by (unabbrev_all_tac \\ simp[FUN_EQ_THM]) >>
     fs[ADD1])
-  >> metis_tac [EVERY_MAP]);
+  >> metis_tac [EVERY_MAP]
+QED
 
 (* moved this one around a bit *)
 Theorem infer_type_subst_empty_check:
@@ -1624,19 +1660,21 @@ Proof
  >> fs [EL_MAP, LENGTH_COUNT_LIST, check_t_def, EL_COUNT_LIST]
 QED
 
-val check_t_infer_db_subst = Q.prove (
-`(!t uvs tvs.
+Triviality check_t_infer_db_subst:
+  (!t uvs tvs.
    check_t 0 (count (uvs + tvs)) (infer_deBruijn_subst (MAP (\n. Infer_Tuvar (uvs + n)) (COUNT_LIST tvs)) t)
    =
    check_t tvs (count (uvs + tvs)) t) ∧
  (!ts uvs tvs.
    EVERY (check_t 0 (count (uvs + tvs)) o infer_deBruijn_subst (MAP (\n. Infer_Tuvar (uvs + n)) (COUNT_LIST tvs))) ts
    =
-   EVERY (check_t tvs (count (uvs + tvs))) ts)`,
-ho_match_mp_tac infer_t_induction >>
+   EVERY (check_t tvs (count (uvs + tvs))) ts)
+Proof
+  ho_match_mp_tac infer_t_induction >>
 rw [check_t_def, infer_deBruijn_subst_alt, LENGTH_COUNT_LIST,
     EL_MAP, EL_COUNT_LIST, EVERY_MAP] >>
-metis_tac []);
+metis_tac []
+QED
 
 Theorem check_t_infer_db_subst2:
  (!t tvs1 tvs2.
@@ -2242,26 +2280,29 @@ Proof
    >> simp [check_s_more])
 QED
 
-val generalise_complete_lemma = Q.prove (
-`!tvs ts.
+Triviality generalise_complete_lemma:
+  !tvs ts.
   (∀uv. uv ∈ FDOM (FEMPTY |++ ts) ⇒ ∃tv. (FEMPTY |++ ts) ' uv = tv ∧ tv < tvs)
   ⇒
-  (∀uv. uv ∈ FDOM (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) ts) ⇒ ∃tv. (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) ts) ' uv = Infer_Tvar_db tv ∧ tv < tvs)`,
+  (∀uv. uv ∈ FDOM (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) ts) ⇒ ∃tv. (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) ts) ' uv = Infer_Tvar_db tv ∧ tv < tvs)
+Proof
   rw [FDOM_FUPDATE_LIST, MEM_MAP] >>
   PairCases_on `y'` >>
   fs [] >>
   `y'0 ∈ FDOM (FEMPTY |++ ts)`
           by (rw [FDOM_FUPDATE_LIST, MEM_MAP] >> metis_tac [FST]) >>
-  metis_tac [FST, fupdate_list_map]);
+  metis_tac [FST, fupdate_list_map]
+QED
 
-val generalise_complete_lemma2 = Q.prove (
-`!s ts.
+Triviality generalise_complete_lemma2:
+  !s ts.
   t_wfs s ∧
   ALL_DISTINCT (MAP FST ts) ∧
   EVERY (\t. t = Infer_Tapp [] TC_unit ∨ ?tvs. t = Infer_Tvar_db tvs) (MAP SND ts) ∧
   DISJOINT (FDOM s) (FDOM (FEMPTY |++ ts))
   ⇒
-  pure_add_constraints s (MAP (\(uv,t). (Infer_Tuvar uv, t)) ts) (s |++ ts)`,
+  pure_add_constraints s (MAP (\(uv,t). (Infer_Tuvar uv, t)) ts) (s |++ ts)
+Proof
   induct_on `ts` >>
   rw [pure_add_constraints_def, FUPDATE_LIST_THM] >>
   PairCases_on `h` >>
@@ -2282,7 +2323,8 @@ val generalise_complete_lemma2 = Q.prove (
   `DISJOINT (FDOM (s |+ (h0,h1))) (FDOM (FEMPTY |++ ts))` by
     (fs [DISJOINT_DEF, EXTENSION, FDOM_FUPDATE_LIST] >>
     metis_tac []) >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Definition infer_subst_var_def:
 (infer_subst_var s (Infer_Tuvar n) =
@@ -2292,13 +2334,14 @@ Definition infer_subst_var_def:
 (infer_subst_var s t = t)
 End
 
-val generalise_complete_lemma4 = Q.prove (
-`!s. t_wfs s ⇒
+Triviality generalise_complete_lemma4:
+  !s. t_wfs s ⇒
   !t s'. t_wfs (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') ∧
          ALL_DISTINCT (MAP FST s') ∧
          DISJOINT (FDOM s) (FDOM (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s')) ⇒
-         infer_subst_var (FEMPTY |++ s') (t_vwalk s t) = t_vwalk (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') t`,
- strip_tac >>
+         infer_subst_var (FEMPTY |++ s') (t_vwalk s t) = t_vwalk (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') t
+Proof
+  strip_tac >>
  strip_tac >>
  imp_res_tac (DISCH_ALL t_vwalk_ind) >>
  pop_assum ho_match_mp_tac >>
@@ -2325,15 +2368,17 @@ val generalise_complete_lemma4 = Q.prove (
      metis_tac [])
  >- (fs [flookup_thm, DISJOINT_DEF, EXTENSION, FDOM_FUPDATE_LIST, MAP_MAP_o,
          combinTheory.o_DEF, LAMBDA_PROD, MEM_MAP, EXISTS_PROD] >>
-     metis_tac []));
+     metis_tac [])
+QED
 
-val generalise_complete_lemma5 = Q.prove (
-`!s. t_wfs s ⇒
+Triviality generalise_complete_lemma5:
+  !s. t_wfs s ⇒
   !t s'. t_wfs (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') ⇒
          ALL_DISTINCT (MAP FST s') ∧
          DISJOINT (FDOM s) (FDOM (FEMPTY |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s')) ⇒
-         infer_subst (FEMPTY |++ s') (t_walkstar s t) = t_walkstar (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') t`,
- strip_tac >>
+         infer_subst (FEMPTY |++ s') (t_walkstar s t) = t_walkstar (s |++ MAP (λ(uv,tv). (uv,Infer_Tvar_db tv)) s') t
+Proof
+  strip_tac >>
  strip_tac >>
  imp_res_tac t_walkstar_ind >>
  pop_assum ho_match_mp_tac >>
@@ -2352,13 +2397,16 @@ val generalise_complete_lemma5 = Q.prove (
  fs [infer_subst_def, infer_subst_var_def] >>
  rw [MAP_MAP_o, MAP_EQ_f] >>
  cases_on `FLOOKUP (FEMPTY |++ s') n'` >>
- fs []);
+ fs []
+QED
 
-val fst_lem = Q.prove (
-`FST = (\(x,y).x)`,
-rw [FUN_EQ_THM] >>
+Triviality fst_lem:
+  FST = (\(x,y).x)
+Proof
+  rw [FUN_EQ_THM] >>
 PairCases_on `x` >>
-rw []);
+rw []
+QED
 
 val t_ind = t_induction
   |> Q.SPECL[`P`,`EVERY P`]
@@ -2768,10 +2816,12 @@ Proof
      \\ metis_tac[])
 QED
 
-val init_infer_state_wfs = Q.prove (
-  `t_wfs (init_infer_state st).subst ∧
-   check_s 0 ∅ (init_infer_state st).subst`,
- rw [check_s_def, init_infer_state_def, t_wfs_def]);
+Triviality init_infer_state_wfs:
+  t_wfs (init_infer_state st).subst ∧
+   check_s 0 ∅ (init_infer_state st).subst
+Proof
+  rw [check_s_def, init_infer_state_def, t_wfs_def]
+QED
 
 Theorem init_infer_state_next_uvar[simp]:
    (init_infer_state st).next_uvar = 0
@@ -2839,18 +2889,23 @@ val let_tac =
    >> fs [sub_completion_def, EVERY_MEM, MEM_MAP, PULL_EXISTS]
    >> metis_tac [check_t_more2, check_t_more5, MEM_EL, DECIDE ``x + 0n = x``];
 
-val eta2_thm = Q.prove (
-`(\x. f a b x) = f a b`, metis_tac []);
+Triviality eta2_thm:
+  (\x. f a b x) = f a b
+Proof
+  metis_tac []
+QED
 
-val check_env_letrec_lem2 = Q.prove (
-  `∀funs.
+Triviality check_env_letrec_lem2:
+  ∀funs.
     nsAll (λx (tvs,t). check_t tvs (count (LENGTH funs)) t)
       (alist_to_ns (MAP2 (λ(f,x,e) uvar. (f,0,uvar))
                       funs
-                      (MAP (λn. Infer_Tuvar n) (COUNT_LIST (LENGTH funs)))))`,
- rw []
+                      (MAP (λn. Infer_Tuvar n) (COUNT_LIST (LENGTH funs)))))
+Proof
+  rw []
  >> Q.SPECL_THEN [`LENGTH funs`, `funs`, `0n`] mp_tac check_env_letrec_lem
- >> simp []);
+ >> simp []
+QED
 
 Theorem ienv_ok_extend_dec_ienv:
    !e1 e2 n. ienv_ok n e1 ∧ ienv_ok n e2 ⇒ ienv_ok n (extend_dec_ienv e1 e2)
@@ -3056,22 +3111,26 @@ Proof
   metis_tac[LESS_EQ_TRANS]
 QED
 
-val count_list_one = Q.prove (
-`COUNT_LIST 1 = [0]`,
-metis_tac [COUNT_LIST_def, MAP, DECIDE ``1 = SUC 0``]);
+Triviality count_list_one:
+  COUNT_LIST 1 = [0]
+Proof
+  metis_tac [COUNT_LIST_def, MAP, DECIDE ``1 = SUC 0``]
+QED
 
-val check_freevars_more_append = Q.prove (
-`(!t x fvs1 fvs2.
+Triviality check_freevars_more_append:
+  (!t x fvs1 fvs2.
   check_freevars x fvs1 t ⇒
   check_freevars x (fvs2++fvs1) t ∧
   check_freevars x (fvs1++fvs2) t) ∧
  (!ts x fvs1 fvs2.
   EVERY (check_freevars x fvs1) ts ⇒
   EVERY (check_freevars x (fvs2++fvs1)) ts ∧
-  EVERY (check_freevars x (fvs1++fvs2)) ts)`,
-Induct >>
+  EVERY (check_freevars x (fvs1++fvs2)) ts)
+Proof
+  Induct >>
 rw [check_freevars_def] >>
-metis_tac []);
+metis_tac []
+QED
 
 (*
 Theorem t_to_freevars_check:

--- a/compiler/inference/proofs/inferCompleteScript.sml
+++ b/compiler/inference/proofs/inferCompleteScript.sml
@@ -11,16 +11,17 @@ open preamble semanticPrimitivesTheory namespacePropsTheory
 
 val _ = new_theory "inferComplete";
 
-val generalise_no_uvars = Q.prove (
-`(!t m n s dbvars.
+Triviality generalise_no_uvars:
+  (!t m n s dbvars.
   check_t dbvars {} t
   ⇒
   generalise m n s t = (0,s,t)) ∧
  (!ts m n s dbvars.
   EVERY (check_t dbvars {}) ts
   ⇒
-  generalise_list m n s ts = (0,s,ts))`,
- ho_match_mp_tac infer_tTheory.infer_t_induction >>
+  generalise_list m n s ts = (0,s,ts))
+Proof
+  ho_match_mp_tac infer_tTheory.infer_t_induction >>
  srw_tac[] [generalise_def, check_t_def]
  >- metis_tac [PAIR_EQ] >>
  rw [PULL_FORALL] >>
@@ -31,7 +32,8 @@ val generalise_no_uvars = Q.prove (
  first_x_assum (qspecl_then [`s'`, `n`, `m`] mp_tac) >>
  rw [] >>
  rw [] >>
- metis_tac [PAIR_EQ]);
+ metis_tac [PAIR_EQ]
+QED
 
 val t_ind = t_induction
   |> Q.SPECL[`P`,`EVERY P`]
@@ -294,12 +296,14 @@ Proof
     metis_tac [check_freevars_more, nub_set, SUBSET_DEF])
 QED
 
-val env_rel_complete_bind = Q.prove(`
+Triviality env_rel_complete_bind:
   env_rel_complete FEMPTY ienv tenv Empty ⇒
-  env_rel_complete FEMPTY ienv tenv (bind_tvar tvs Empty)`,
+  env_rel_complete FEMPTY ienv tenv (bind_tvar tvs Empty)
+Proof
   fs[env_rel_complete_def,bind_tvar_def,lookup_var_def,lookup_varE_def,tveLookup_def]>>rw[]>>every_case_tac>>fs[]>>
   res_tac>>fs[]>> TRY(metis_tac[])>>
-  match_mp_tac tscheme_approx_weakening>>asm_exists_tac>>fs[t_wfs_def]);
+  match_mp_tac tscheme_approx_weakening>>asm_exists_tac>>fs[t_wfs_def]
+QED
 
 Theorem type_pe_determ_canon_infer_e:
  !loc ienv p e st st' t t' new_bindings s.
@@ -564,7 +568,11 @@ QED
 fun str_assums strs = ConseqConv.DISCH_ASM_CONSEQ_CONV_TAC
         (ConseqConv.CONSEQ_REWRITE_CONV ([], strs, []));
 
-val ap_lemma = Q.prove (`!f. x = y ==> f x = f y`, fs []);
+Triviality ap_lemma:
+  !f. x = y ==> f x = f y
+Proof
+  fs []
+QED
 
 Theorem inf_set_tids_extend_dec_ienv:
    inf_set_tids_ienv (count n) ienv2
@@ -1631,8 +1639,9 @@ Proof
       simp_tac std_ss [nsAppend_nsSing, GSYM nsAppend_assoc]))
 QED
 
-val n_fresh_uvar_rw = Q.prove(`
-  ∀n st.n_fresh_uvar n st = (Success (GENLIST (λi.Infer_Tuvar(i+st.next_uvar)) n), st with next_uvar := st.next_uvar + n)`,
+Triviality n_fresh_uvar_rw:
+  ∀n st.n_fresh_uvar n st = (Success (GENLIST (λi.Infer_Tuvar(i+st.next_uvar)) n), st with next_uvar := st.next_uvar + n)
+Proof
   Induct>>simp[Once n_fresh_uvar_def]
   >-
     (EVAL_TAC>>fs[infer_st_component_equality])
@@ -1640,10 +1649,11 @@ val n_fresh_uvar_rw = Q.prove(`
     rw[st_ex_bind_def,fresh_uvar_def,st_ex_return_def,ADD1]>>
     simp[GENLIST_CONS,GSYM ADD1]>>
     AP_THM_TAC>>AP_TERM_TAC>>fs[o_DEF]>>
-    fs[FUN_EQ_THM])
+    fs[FUN_EQ_THM]
+QED
 
-val t_walkstar_infer_deBruijn_subst = Q.prove(`
- t_wfs s ∧
+Triviality t_walkstar_infer_deBruijn_subst:
+  t_wfs s ∧
  LENGTH ls = tvs ∧
  EVERY (check_t y {}) ls ∧
  (∀n. n < tvs ⇒ t_walkstar s (Infer_Tuvar n) = EL n ls)
@@ -1657,16 +1667,18 @@ val t_walkstar_infer_deBruijn_subst = Q.prove(`
   EVERY (check_t tvs {}) ts
   ⇒
   MAP ((t_walkstar s) o (infer_deBruijn_subst ls)) ts =
-  MAP ((t_walkstar s) o (infer_deBruijn_subst (GENLIST Infer_Tuvar tvs))) ts))`,
+  MAP ((t_walkstar s) o (infer_deBruijn_subst (GENLIST Infer_Tuvar tvs))) ts))
+Proof
   strip_tac>>ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,infer_deBruijn_subst_alt]>>
   fs[EVERY_MEM,MEM_EL]
   >-
     metis_tac[t_walkstar_no_vars]
   >>
-    fs[t_walkstar_eqn1,MAP_MAP_o,MAP_EQ_f]);
+    fs[t_walkstar_eqn1,MAP_MAP_o,MAP_EQ_f]
+QED
 
-val infer_deBruijn_subst_check_t = Q.prove(`
+Triviality infer_deBruijn_subst_check_t:
   EVERY (check_t tvs {}) ls
   ⇒
   (∀t.
@@ -1676,11 +1688,13 @@ val infer_deBruijn_subst_check_t = Q.prove(`
   (∀ts.
   EVERY (check_t (LENGTH ls) {}) ts
   ⇒
-  EVERY (check_t tvs {}) (MAP (infer_deBruijn_subst ls) ts))`,
+  EVERY (check_t tvs {}) (MAP (infer_deBruijn_subst ls) ts))
+Proof
   strip_tac>>ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def,infer_deBruijn_subst_alt]>>
   fs[EVERY_MEM,MEM_EL]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
 Theorem check_tscheme_inst_complete:
    !tvs_spec t_spec tvs_impl t_impl id.

--- a/compiler/inference/proofs/inferSoundScript.sml
+++ b/compiler/inference/proofs/inferSoundScript.sml
@@ -9,8 +9,8 @@ open typeSystemTheory astTheory semanticPrimitivesTheory inferTheory unifyTheory
 
 val _ = new_theory "inferSound";
 
-val letrec_lemma2 = Q.prove (
-`!funs_ts l l' s s'.
+Triviality letrec_lemma2:
+  !funs_ts l l' s s'.
  (!t1 t2. t_walkstar s t1 = t_walkstar s t2 ⇒  t_walkstar s' t1 = t_walkstar s' t2) ∧
  (LENGTH funs_ts = LENGTH l) ∧
  (LENGTH funs_ts = LENGTH l') ∧
@@ -18,8 +18,9 @@ val letrec_lemma2 = Q.prove (
  ⇒
  (MAP2 (λ(f,x,e) t. (f,t)) l (MAP (λn. convert_t (t_walkstar s' (Infer_Tuvar n))) l')
   =
-  MAP2 (λ(x,y,z) t. (x,convert_t (t_walkstar s' t))) l funs_ts)`,
-induct_on `funs_ts` >>
+  MAP2 (λ(x,y,z) t. (x,convert_t (t_walkstar s' t))) l funs_ts)
+Proof
+  induct_on `funs_ts` >>
 cases_on `l` >>
 cases_on `l'` >>
 rw [] >>
@@ -27,15 +28,18 @@ fs [] >|
 [PairCases_on `h` >>
      rw [] >>
      metis_tac [],
- metis_tac []]);
+ metis_tac []]
+QED
 
-val sub_completion_empty = Q.prove (
-`!m n s s'. sub_completion m n s [] s' ⇔ count n ⊆ FDOM s' ∧ (∀uv. uv ∈ FDOM s' ⇒ check_t m ∅ (t_walkstar s' (Infer_Tuvar uv))) ∧ s = s'`,
- rw [sub_completion_def, pure_add_constraints_def] >>
- metis_tac []);
+Triviality sub_completion_empty:
+  !m n s s'. sub_completion m n s [] s' ⇔ count n ⊆ FDOM s' ∧ (∀uv. uv ∈ FDOM s' ⇒ check_t m ∅ (t_walkstar s' (Infer_Tuvar uv))) ∧ s = s'
+Proof
+  rw [sub_completion_def, pure_add_constraints_def] >>
+ metis_tac []
+QED
 
-val generalise_none = Q.prove (
-`(!t s' t' x.
+Triviality generalise_none:
+  (!t s' t' x.
    check_t 0 x t ∧
    generalise 0 0 FEMPTY t = (0, s', t')
    ⇒
@@ -46,8 +50,9 @@ val generalise_none = Q.prove (
    generalise_list 0 0 FEMPTY ts = (0, s', ts')
    ⇒
    s' = FEMPTY ∧
-   EVERY (check_t 0 {}) ts)`,
- ho_match_mp_tac infer_t_induction >>
+   EVERY (check_t 0 {}) ts)
+Proof
+  ho_match_mp_tac infer_t_induction >>
  rw [generalise_def, check_t_def, LET_THM, LAMBDA_PROD]
  >- (`?n s' t'. generalise_list 0 0 FEMPTY ts = (n,s',t')` by metis_tac [pair_CASES] >>
      fs [] >>
@@ -62,13 +67,16 @@ val generalise_none = Q.prove (
  `?n s' t'. generalise_list 0 n' s'' ts = (n,s',t')` by metis_tac [pair_CASES] >>
  fs [] >>
  rw [] >>
- metis_tac []);
+ metis_tac []
+QED
 
-val lookup_var_empty = Q.prove(`
+Triviality lookup_var_empty:
   lookup_var x (bind_tvar tvs Empty) tenv =
-  lookup_var x Empty tenv`,
+  lookup_var x Empty tenv
+Proof
   rw[bind_tvar_def,lookup_var_def,lookup_varE_def]>>
-  EVERY_CASE_TAC>>fs[tveLookup_def]);
+  EVERY_CASE_TAC>>fs[tveLookup_def]
+QED
 
 (* TODO: This should be generalized eventually *)
 Theorem env_rel_complete_bind:
@@ -93,12 +101,14 @@ Definition set_ids_def:
   set_ids n1 (n2:num) = {m | n1 ≤ m ∧ m < n2}
 End
 
-val set_ids_eq = Q.prove(`
+Triviality set_ids_eq:
   set_ids n1 n2 =
-  set (GENLIST (λx. x + n1) (n2-n1))`,
+  set (GENLIST (λx. x + n1) (n2-n1))
+Proof
   fs[set_ids_def,EXTENSION,MEM_MAP,MEM_GENLIST]>>
   rw[EQ_IMP_THM]>>
-  qexists_tac`x-n1`>>fs[]);
+  qexists_tac`x-n1`>>fs[]
+QED
 
 Theorem set_ids_same[simp]:
    set_ids x x = {}
@@ -880,25 +890,28 @@ Proof
   metis_tac []
 QED
 
-val check_freevars_nub = Q.prove (
-`(!t x fvs.
+Triviality check_freevars_nub:
+  (!t x fvs.
   check_freevars x fvs t ⇒
   check_freevars x (nub fvs) t) ∧
  (!ts x fvs.
   EVERY (check_freevars x fvs) ts ⇒
-  EVERY (check_freevars x (nub fvs)) ts)`,
-Induct >>
-rw [check_freevars_def] >> metis_tac[]);
+  EVERY (check_freevars x (nub fvs)) ts)
+Proof
+  Induct >>
+rw [check_freevars_def] >> metis_tac[]
+QED
 
-val check_specs_sound = Q.prove (
-  `!mn tenvT idecls1 ienv1 specs st1 idecls2 ienv2 st2.
+Triviality check_specs_sound:
+  !mn tenvT idecls1 ienv1 specs st1 idecls2 ienv2 st2.
     check_specs mn tenvT idecls1 ienv1 specs st1 = (Success (idecls2,ienv2), st2) ∧
     tenv_abbrev_ok tenvT
     ⇒
     ?decls3 ienv3.
       type_specs mn tenvT specs decls3 (ienv_to_tenv ienv3) ∧
       convert_decls idecls2 = union_decls decls3 (convert_decls idecls1) ∧
-      ienv2 = extend_dec_ienv ienv3 ienv1`,
+      ienv2 = extend_dec_ienv ienv3 ienv1
+Proof
   ho_match_mp_tac check_specs_ind >>
   rw [check_specs_def, success_eqns]
   >- (
@@ -1014,7 +1027,8 @@ val check_specs_sound = Q.prove (
     qexists_tac `decls3` >>
     simp [ienv_to_tenv_def, extend_dec_tenv_def, extend_dec_ienv_def,
           union_decls_def, convert_decls_def] >>
-    metis_tac [GSYM nsAppend_assoc, nsAppend_nsSing, INSERT_SING_UNION, UNION_ASSOC]));
+    metis_tac [GSYM nsAppend_assoc, nsAppend_nsSing, INSERT_SING_UNION, UNION_ASSOC])
+QED
 
 Theorem infer_top_sound:
    !idecls ienv t_op st1 idecls' ienv' st2 tenv.

--- a/compiler/inference/proofs/infer_eCompleteScript.sml
+++ b/compiler/inference/proofs/infer_eCompleteScript.sml
@@ -83,12 +83,13 @@ Proof
 QED
 
 (*1 direction is sufficient to imply the other*)
-val pure_add_constraints_swap_lemma = Q.prove(
-`t_wfs s ∧
+Triviality pure_add_constraints_swap_lemma:
+  t_wfs s ∧
   pure_add_constraints s (a++b) sx
   ⇒
   ?si. pure_add_constraints s (b++a) si ∧
-       t_compat si sx `,
+       t_compat si sx
+Proof
   rw[]>>
   imp_res_tac t_compat_pure_add_constraints_2>>
   fs[pure_add_constraints_append]>>
@@ -101,7 +102,8 @@ val pure_add_constraints_swap_lemma = Q.prove(
   HINT_EXISTS_TAC>>
   Q.SPECL_THEN [`a`,`si`,`sx`] assume_tac t_compat_pure_add_constraints_1>>
   rfs[]>>
-  HINT_EXISTS_TAC>>fs[]);
+  HINT_EXISTS_TAC>>fs[]
+QED
 
 Theorem pure_add_constraints_swap:
  t_wfs s ∧
@@ -136,9 +138,10 @@ val extend_t_vR_WF = prove
   imp_res_tac check_t_t_vars>>
   fs[FLOOKUP_DEF]);
 
-val not_t_oc = Q.prove(
-`(!t s v lim. t_wfs s ∧ check_t lim {} t ⇒ ¬ t_oc s t v) ∧
-  (!ts s t v lim. t_wfs s ∧ EVERY (check_t lim {}) ts ⇒ ~ EXISTS (\t. t_oc s t v) ts)`,
+Triviality not_t_oc:
+  (!t s v lim. t_wfs s ∧ check_t lim {} t ⇒ ¬ t_oc s t v) ∧
+  (!ts s t v lim. t_wfs s ∧ EVERY (check_t lim {}) ts ⇒ ~ EXISTS (\t. t_oc s t v) ts)
+Proof
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[check_t_def]>>
   TRY (res_tac>>metis_tac[])>>
@@ -147,16 +150,19 @@ val not_t_oc = Q.prove(
   rfs[]>> res_tac>>
   fs[t_walk_eqn]>>
   fs[EVERY_MEM,EXISTS_MEM]>>
-  res_tac);
+  res_tac
+QED
 
-val FDOM_extend = Q.prove (
-` FDOM s = count next_uvar ⇒
-   FDOM (s |+ (next_uvar, n)) = count (SUC next_uvar)`,
-   fs[FDOM_FUPDATE,count_def,INSERT_DEF,SET_EQ_SUBSET,SUBSET_DEF]>>
+Triviality FDOM_extend:
+  FDOM s = count next_uvar ⇒
+   FDOM (s |+ (next_uvar, n)) = count (SUC next_uvar)
+Proof
+  fs[FDOM_FUPDATE,count_def,INSERT_DEF,SET_EQ_SUBSET,SUBSET_DEF]>>
    rw[]>- DECIDE_TAC>-
    (res_tac>>DECIDE_TAC)>>
    Cases_on`x=next_uvar`>>fs[]>>
-   `x<next_uvar` by DECIDE_TAC>>fs[]);
+   `x<next_uvar` by DECIDE_TAC>>fs[]
+QED
 
 Theorem pure_add_constraints_exists:
  !s ts next_uvar lim.
@@ -224,14 +230,15 @@ val check_t_t_walkstar = prove
     metis_tac[MEM_MAP]);
 
 (*Ignore increment on deBrujin vars*)
-val t_walkstar_ignore_inc = Q.prove(
-`t_wfs s ⇒
+Triviality t_walkstar_ignore_inc:
+  t_wfs s ⇒
 (!t.(!uv. uv ∈ FDOM s ⇒ check_t 0 {} (t_walkstar s (Infer_Tuvar uv)))
 ⇒
 t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ∧
 (!ts. (!t.(!uv. uv ∈ FDOM s ⇒ check_t 0 {} (t_walkstar s (Infer_Tuvar uv)))
 ⇒
-EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))`,
+EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))
+Proof
   strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
   rw[]>>
@@ -252,13 +259,15 @@ EVERY (\t. t_walkstar (infer_deBruijn_inc tvs o_f s) t = t_walkstar s t) ts))`,
   fs[t_walkstar_eqn,t_walk_eqn,Once t_vwalk_eqn]>>
   simp[EQ_SYM_EQ,Once t_vwalk_eqn]>>
   `FLOOKUP s n = NONE` by fs[flookup_thm]>>
-  fs[infer_deBruijn_inc_def]);
+  fs[infer_deBruijn_inc_def]
+QED
 
 (*Adding a list of keys that did not already exist is safe*)
-val SUBMAP_FUPDATE_LIST_NON_EXIST = Q.prove(
-`set (MAP FST ls) ∩ (FDOM s) = {}
+Triviality SUBMAP_FUPDATE_LIST_NON_EXIST:
+  set (MAP FST ls) ∩ (FDOM s) = {}
   ⇒
-  s SUBMAP (s|++ls)`,
+  s SUBMAP (s|++ls)
+Proof
   Induct_on`ls`>>fs[FUPDATE_LIST_THM]>>
   rw[]>>
   Cases_on`h`>>
@@ -273,11 +282,13 @@ val SUBMAP_FUPDATE_LIST_NON_EXIST = Q.prove(
     >>
       fs[FUPDATE_FUPDATE_LIST_COMMUTES]>>DISJ1_TAC>>
       fs[FDOM_FUPDATE_LIST])>>
-  metis_tac[SUBMAP_TRANS]);
+  metis_tac[SUBMAP_TRANS]
+QED
 
-val t_vwalk_o_f_id = Q.prove(
-`t_wfs s ⇒
-  !t. t_vwalk (infer_deBruijn_inc 0 o_f s) t = t_vwalk s t`,
+Triviality t_vwalk_o_f_id:
+  t_wfs s ⇒
+  !t. t_vwalk (infer_deBruijn_inc 0 o_f s) t = t_vwalk s t
+Proof
   strip_tac>>
   ho_match_mp_tac (Q.INST[`s`|->`s`]t_vwalk_ind)>>
   rw[]>>
@@ -287,11 +298,13 @@ val t_vwalk_o_f_id = Q.prove(
   fs[FLOOKUP_o_f]>>
   every_case_tac>>
   fs[FLOOKUP_o_f,infer_deBruijn_inc0]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val t_walkstar_o_f_id = Q.prove(
-`t_wfs s ⇒
-  !t. t_walkstar ((infer_deBruijn_inc 0) o_f s) t  = t_walkstar s t`,
+Triviality t_walkstar_o_f_id:
+  t_wfs s ⇒
+  !t. t_walkstar ((infer_deBruijn_inc 0) o_f s) t  = t_walkstar s t
+Proof
   rw[]>>
   imp_res_tac t_walkstar_ind>>
   Q.SPEC_TAC (`t`, `t`) >>
@@ -304,16 +317,20 @@ val t_walkstar_o_f_id = Q.prove(
   >>
   every_case_tac>>
   fs[MAP_EQ_f]>>rw[]>>res_tac>>
-  fs[t_walkstar_eqn]);
+  fs[t_walkstar_eqn]
+QED
 
-val deBruijn_subst_id = Q.prove(
-`(!t. deBruijn_subst 0 [] t = t) ∧
-  (!ts. MAP (deBruijn_subst 0 []) ts = ts)`,
-  Induct>>rw[]>>fs[deBruijn_subst_def,MAP_EQ_ID]);
+Triviality deBruijn_subst_id:
+  (!t. deBruijn_subst 0 [] t = t) ∧
+  (!ts. MAP (deBruijn_subst 0 []) ts = ts)
+Proof
+  Induct>>rw[]>>fs[deBruijn_subst_def,MAP_EQ_ID]
+QED
 
-val tscheme_approx_weakening2 = Q.prove(`
+Triviality tscheme_approx_weakening2:
   tscheme_approx tvs s t1 t2 ∧ t_compat s s' ∧ FDOM s ⊆ FDOM s' ⇒
-  tscheme_approx tvs s' t1 t2`,
+  tscheme_approx tvs s' t1 t2
+Proof
   Cases_on`t1`>>Cases_on`t2`>>rw[tscheme_approx_def]>>
   qexists_tac`subst'`>>fs[]>>
   rw[]
@@ -322,31 +339,36 @@ val tscheme_approx_weakening2 = Q.prove(`
     metis_tac[check_t_more5])
   >>
   first_x_assum(qspec_then`subst` assume_tac)>>rfs[]>>
-  fs[t_compat_def]>>metis_tac[]);
+  fs[t_compat_def]>>metis_tac[]
+QED
 
-val env_rel_complete_t_compat = Q.prove(
-`t_compat s s' ∧
+Triviality env_rel_complete_t_compat:
+  t_compat s s' ∧
   FDOM s ⊆ FDOM s' ∧
   t_wfs s' ∧
   env_rel_complete s ienv tenv tenvE ⇒
-  env_rel_complete s' ienv tenv tenvE`,
+  env_rel_complete s' ienv tenv tenvE
+Proof
   rw[env_rel_complete_def]
   >-
     metis_tac[]
   >>
   res_tac>>
-  metis_tac[tscheme_approx_weakening2]);
+  metis_tac[tscheme_approx_weakening2]
+QED
 
-val NOT_SOME_NONE = Q.prove(
-`(!x. A ≠ SOME x) ⇒ A = NONE`,
-metis_tac[optionTheory.option_nchotomy]);
+Triviality NOT_SOME_NONE:
+  (!x. A ≠ SOME x) ⇒ A = NONE
+Proof
+  metis_tac[optionTheory.option_nchotomy]
+QED
 
-val t_walk_submap_walkstar = Q.prove(
-`
-!s s'. s SUBMAP s' ∧ t_wfs s ∧ t_wfs s'
+Triviality t_walk_submap_walkstar:
+  !s s'. s SUBMAP s' ∧ t_wfs s ∧ t_wfs s'
 ⇒
 (!h. t_walk s (t_walkstar s' h) = t_walkstar s' h) ∧
-(!hs. MAP ((t_walk s) o t_walkstar s') hs = MAP (t_walkstar s') hs)`,
+(!hs. MAP ((t_walk s) o t_walkstar s') hs = MAP (t_walkstar s') hs)
+Proof
   ntac 3 strip_tac>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>rw[]>>
   fs[t_walkstar_eqn,t_walk_eqn,MAP_MAP_o]>>
@@ -356,52 +378,56 @@ val t_walk_submap_walkstar = Q.prove(
   `n' ∉ FDOM s` by
     metis_tac[SUBMAP_DEF]>>
   imp_res_tac flookup_thm>>
-  fs[]);
+  fs[]
+QED
 
-val t_unify_to_pure_add_constraints = Q.prove(
-`
-!s s' h t constraints s''.
+Triviality t_unify_to_pure_add_constraints:
+  !s s' h t constraints s''.
 pure_add_constraints s (constraints ++ [h,t]) s'' ⇒
 (?s'. pure_add_constraints s constraints s' ∧
-t_unify s' h t = SOME s'')`,
+t_unify s' h t = SOME s'')
+Proof
   rw[pure_add_constraints_append]>>
   Q.EXISTS_TAC`s2`>>fs[]>>
-  fs[pure_add_constraints_def]);
+  fs[pure_add_constraints_def]
+QED
 
-val add_constraint_success2 = Q.prove(
-`
+Triviality add_constraint_success2:
   !l t1 t2 st st' x.
   add_constraint l t1 t2 st = (Success x, st') ⇔
   x = () ∧
   pure_add_constraints st.subst [t1,t2] st'.subst ∧
   st'.next_uvar = st.next_uvar ∧
-  st'.next_id = st.next_id`,
+  st'.next_id = st.next_id
+Proof
   rw[add_constraint_success,pure_add_constraints_def,EQ_IMP_THM]>>
-  rw[infer_st_rewrs,infer_st_component_equality]);
+  rw[infer_st_rewrs,infer_st_component_equality]
+QED
 
-val pure_add_constraints_combine = Q.prove(
-`
-(?st'. (pure_add_constraints st.subst ls st'.subst ∧ st'.next_uvar = x1 ∧ st'.next_id = x2) ∧
+Triviality pure_add_constraints_combine:
+  (?st'. (pure_add_constraints st.subst ls st'.subst ∧ st'.next_uvar = x1 ∧ st'.next_id = x2) ∧
 (pure_add_constraints st'.subst ls' st''.subst ∧ y1 = st'.next_uvar ∧ y2 = st'.next_id))
 ⇔
-pure_add_constraints st.subst (ls++ls') st''.subst ∧ y1 = x1 ∧ y2 = x2`,
-
-fs[pure_add_constraints_def,EQ_IMP_THM]>>rw[]
+pure_add_constraints st.subst (ls++ls') st''.subst ∧ y1 = x1 ∧ y2 = x2
+Proof
+  fs[pure_add_constraints_def,EQ_IMP_THM]>>rw[]
 >-
   metis_tac[pure_add_constraints_append]
 >>
   fs[pure_add_constraints_append]>>
-  Q.EXISTS_TAC `<| subst:= s2 ; next_uvar := x1 ; next_id:=x2|>`>>fs[]);
+  Q.EXISTS_TAC `<| subst:= s2 ; next_uvar := x1 ; next_id:=x2|>`>>fs[]
+QED
 
-val t_unify_ignore = Q.prove(
-`(!s t t'.
+Triviality t_unify_ignore:
+  (!s t t'.
   t_wfs s ⇒
   t_walkstar s t = t_walkstar s t' ⇒
   t_unify s t t' = SOME s) ∧
   (!s ts ts'.
   t_wfs s ⇒
   MAP (t_walkstar s) ts = MAP (t_walkstar s) ts' ⇒
-  ts_unify s ts ts' = SOME s)`,
+  ts_unify s ts ts' = SOME s)
+Proof
   ho_match_mp_tac t_unify_strongind>>rw[]>>
   fs[t_unify_eqn]>-
   (full_case_tac>>
@@ -410,7 +436,8 @@ val t_unify_ignore = Q.prove(
   fs[t_walkstar_eqn]>>every_case_tac>>fs[]>>
   metis_tac[])>>
   Cases_on`ts`>>Cases_on`ts'`>>
-  fs[ts_unify_def]);
+  fs[ts_unify_def]
+QED
 
 Theorem pure_add_constraints_ignore:
  !s ls. t_wfs s ∧ EVERY (λx,y. t_walkstar s x = t_walkstar s y) ls
@@ -425,25 +452,28 @@ Proof
 QED
 
 (*t_compat preserves all grounded (no unification variable after walk) terms*)
-val t_compat_ground = Q.prove(
-`t_compat a b
+Triviality t_compat_ground:
+  t_compat a b
   ⇒
   ∀uv. uv ∈ FDOM a ∧
        check_t tvs {} (t_walkstar a (Infer_Tuvar uv))
        ⇒ uv ∈ FDOM b ∧
-         check_t tvs {} (t_walkstar b (Infer_Tuvar uv))`,
+         check_t tvs {} (t_walkstar b (Infer_Tuvar uv))
+Proof
   rw[t_compat_def]>>
   first_x_assum (qspec_then `Infer_Tuvar uv` assume_tac)>>
   imp_res_tac t_walkstar_no_vars>>
   fs[check_t_def]>>
-  metis_tac[t_walkstar_tuvar_props]);
+  metis_tac[t_walkstar_tuvar_props]
+QED
 
-val t_walkstar_tuvar_props2 = Q.prove(
-`t_wfs s ∧ t_walkstar s x = Infer_Tuvar uv
+Triviality t_walkstar_tuvar_props2:
+  t_wfs s ∧ t_walkstar s x = Infer_Tuvar uv
   ⇒
   ?k. x = Infer_Tuvar k ∧
       (k = uv ⇒ k ∉ FDOM s) ∧
-      (k ≠ uv ⇒ k ∈ FDOM s)`,
+      (k ≠ uv ⇒ k ∈ FDOM s)
+Proof
   rw[]>>
   Cases_on`x`>>
   TRY
@@ -454,7 +484,8 @@ val t_walkstar_tuvar_props2 = Q.prove(
   fs[t_walkstar_tuvar_props]>>
   SPOSE_NOT_THEN assume_tac>>
   imp_res_tac t_walkstar_tuvar_props>>
-  fs[]);
+  fs[]
+QED
 
 (*Remove every uvar in the FDOM if we walkstar using a completed map*)
 Theorem check_t_less:
@@ -534,8 +565,7 @@ Proof
 QED
 
 (*Free properties when extending the completed map with uvar->ground var*)
-val extend_one_props = Q.prove(
-`
+Triviality extend_one_props:
   t_wfs st.subst ∧
   t_wfs s ∧
   pure_add_constraints st.subst constraints s ∧
@@ -551,7 +581,8 @@ val extend_one_props = Q.prove(
     (constraints ++ [(Infer_Tuvar st.next_uvar,unconvert_t t)]) s' ∧
   FDOM s' = count (st.next_uvar +1) ∧
   t_walkstar s' (Infer_Tuvar st.next_uvar) = unconvert_t t ∧
-  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))`,
+  ∀uv. uv ∈ FDOM s' ⇒ check_t n {} (t_walkstar s' (Infer_Tuvar uv))
+Proof
   strip_tac>>
   fs[LET_THM]>>
   imp_res_tac check_freevars_to_check_t>>
@@ -589,7 +620,8 @@ val extend_one_props = Q.prove(
      >>
        `uv <st.next_uvar` by DECIDE_TAC>>
        imp_res_tac t_walkstar_SUBMAP>>
-       metis_tac[pure_add_constraints_success,t_walkstar_no_vars]);
+       metis_tac[pure_add_constraints_success,t_walkstar_no_vars]
+QED
 
 (*This occurs when looking up a list updated fmap*)
 val ALOOKUP_lemma = GEN_ALL (prove(
@@ -610,15 +642,17 @@ val ALOOKUP_lemma = GEN_ALL (prove(
   fs[MEM_ZIP,LENGTH_COUNT_LIST]>>HINT_EXISTS_TAC>>
   fs[EL_MAP,LENGTH_COUNT_LIST,EL_COUNT_LIST]));
 
-val submap_t_walkstar_replace = Q.prove(
-`t_wfs s' ∧
+Triviality submap_t_walkstar_replace:
+  t_wfs s' ∧
   s SUBMAP s' ∧
   check_t n {} (t_walkstar s h)
   ⇒
-  t_walkstar s h = t_walkstar s' h`,
+  t_walkstar s h = t_walkstar s' h
+Proof
   rw[]>>
   imp_res_tac t_walkstar_SUBMAP>>
-  metis_tac[t_walkstar_no_vars]);
+  metis_tac[t_walkstar_no_vars]
+QED
 
 Theorem extend_multi_props:
  !st constraints s ts n.
@@ -807,9 +841,8 @@ val extend_uvar_tac = Q_TAC extend_uvar_tac;
 
 fun TRY1 tac = TRY (tac >> NO_TAC)
 
-val constrain_op_complete_simple_helper = Q.prove(
-`
-!n.
+Triviality constrain_op_complete_simple_helper:
+  !n.
 sub_completion n st.next_uvar st.subst constraints s ∧
 type_op op ts t ∧
 MAP (convert_t o (t_walkstar s)) ts' = ts ∧
@@ -828,7 +861,8 @@ st'.next_uvar = st.next_uvar ∧
 st'.next_id = st.next_id ∧
 pure_add_constraints st.subst xs st'.subst ==>
 constrain_op l op ts' st = (Success t',st')
-)`,
+)
+Proof
   rw []
   \\ imp_res_tac sub_completion_wfs
   \\ `?is_case. is_case op` by (qexists_tac `\x. T` \\ simp [])
@@ -845,11 +879,10 @@ constrain_op l op ts' st = (Success t',st')
   \\ irule pure_add_constraints_ignore
   \\ simp [t_walkstar_eqn1]
   \\ unconversion_tac
-);
+QED
 
-val constrain_op_complete = Q.prove(
-`
-!n.
+Triviality constrain_op_complete:
+  !n.
 type_op op ts t ∧
 sub_completion n st.next_uvar st.subst constraints s ∧
 FDOM st.subst ⊆ count st.next_uvar ∧
@@ -865,7 +898,8 @@ sub_completion n st'.next_uvar st'.subst constraints' s' ∧
 t_compat s s' ∧
 FDOM st'.subst ⊆ count st'.next_uvar ∧
 FDOM s' = count st'.next_uvar ∧
-t = convert_t (t_walkstar s' t')`,
+t = convert_t (t_walkstar s' t')
+Proof
   strip_tac>>
   `?is_case. is_case op` by (qexists_tac `\x. T` >> simp [])>>
   strip_tac>>
@@ -1048,7 +1082,8 @@ t = convert_t (t_walkstar s' t')`,
     replace_uvar_tac>>
     `t_walkstar s' h' = Infer_Tapp [] Tint_num` by
       metis_tac[submap_t_walkstar_replace]>>
-    rest_uvar_tac));
+    rest_uvar_tac)
+QED
 
 Definition simp_tenv_invC_def:
   simp_tenv_invC s tvs tenv tenvE ⇔
@@ -1061,27 +1096,33 @@ Definition simp_tenv_invC_def:
   ?t. ALOOKUP tenvE n = SOME t
 End
 
-val simp_tenv_invC_empty = Q.prove(
-`simp_tenv_invC s n [] []`,
-  rw[simp_tenv_invC_def])
+Triviality simp_tenv_invC_empty:
+  simp_tenv_invC s n [] []
+Proof
+  rw[simp_tenv_invC_def]
+QED
 
-val simp_tenv_invC_more = Q.prove(
-`simp_tenv_invC s tvs tenv tenvE ∧
+Triviality simp_tenv_invC_more:
+  simp_tenv_invC s tvs tenv tenvE ∧
   t_compat s s' ⇒
-  simp_tenv_invC s' tvs tenv tenvE`,
+  simp_tenv_invC s' tvs tenv tenvE
+Proof
   rw[simp_tenv_invC_def]>>
   res_tac>>
   fs[t_compat_def]>>
-  metis_tac[check_freevars_to_check_t,t_walkstar_no_vars]);
+  metis_tac[check_freevars_to_check_t,t_walkstar_no_vars]
+QED
 
-val simp_tenv_invC_append = Q.prove(
-`simp_tenv_invC s'' tvs tenv tenvE ∧
+Triviality simp_tenv_invC_append:
+  simp_tenv_invC s'' tvs tenv tenvE ∧
   simp_tenv_invC s'' tvs tenv' tenvE'
   ⇒
-  simp_tenv_invC s'' tvs (tenv'++tenv) (tenvE' ++ tenvE)`,
+  simp_tenv_invC s'' tvs (tenv'++tenv) (tenvE' ++ tenvE)
+Proof
   rw[simp_tenv_invC_def]>>
   fs[ALOOKUP_APPEND]>>
-  every_case_tac>>res_tac>>fs[]>>metis_tac[]);
+  every_case_tac>>res_tac>>fs[]>>metis_tac[]
+QED
 
 (*convert on both sides of eqn*)
 Theorem convert_bi_remove:
@@ -1097,8 +1138,7 @@ Proof
 QED
 
 (*Substituting every tvs away with something that has no tvs leaves none left*)
-val infer_type_subst_check_t_less = Q.prove(
-`
+Triviality infer_type_subst_check_t_less:
   LENGTH ls = LENGTH tvs ∧
   EVERY (check_t n {}) ls ⇒
   (!t.
@@ -1108,7 +1148,8 @@ val infer_type_subst_check_t_less = Q.prove(
   (!ts.
   EVERY (check_freevars n tvs) ts
   ⇒
-  EVERY (check_t n {}) (MAP (infer_type_subst (ZIP(tvs,ls))) ts))`,
+  EVERY (check_t n {}) (MAP (infer_type_subst (ZIP(tvs,ls))) ts))
+Proof
   strip_tac>>
   Induct>>rw[]
   >-
@@ -1123,7 +1164,8 @@ val infer_type_subst_check_t_less = Q.prove(
     metis_tac[EVERY_EL])
   >>
     fs[infer_type_subst_alt,check_t_def,check_freevars_def]>>
-    fs[EVERY_MAP]>>metis_tac[]);
+    fs[EVERY_MAP]>>metis_tac[]
+QED
 
 Theorem infer_p_complete:
   (!tvs tenv p t tenvE.
@@ -1431,22 +1473,24 @@ Proof
   impl_tac>>fs[]
 QED
 
-val lookup_var_bind_var_list = Q.prove(
-`!bindings.
+Triviality lookup_var_bind_var_list:
+  !bindings.
   lookup_var x (bind_var_list 0 bindings tenvE) tenv =
   case x of
   Short id =>
     (case ALOOKUP bindings id of
       SOME t => SOME (0,t)
     | NONE => lookup_var x tenvE tenv)
-  | _ => lookup_var x tenvE tenv`,
+  | _ => lookup_var x tenvE tenv
+Proof
   Induct>>rw[bind_var_list_def]>>Cases_on`x`>>
   fs[lookup_var_def,lookup_varE_def]>>
   fs[tveLookup_bvl,deBruijn_inc0]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
 (*This should be general enough to prove both Mat and Handle cases*)
-val infer_pes_complete = Q.prove(`
+Triviality infer_pes_complete:
   ∀pes st' constraints' s'.
   pes ≠ [] ∧
   ienv_ok (count uvar) ienv ∧
@@ -1481,7 +1525,8 @@ val infer_pes_complete = Q.prove(`
   sub_completion (num_tvs tenvE) st''.next_uvar st''.subst constraints'' s'' ∧
   FDOM st''.subst ⊆ count st''.next_uvar ∧
   FDOM s'' = count st''.next_uvar ∧
-  t_compat s' s''`,
+  t_compat s' s''
+Proof
   Induct>- rw[]>>
   rpt GEN_TAC>>
   strip_tac>>
@@ -1632,15 +1677,17 @@ val infer_pes_complete = Q.prove(`
     rw[]>>
     fs[Abbr`nst`]>>
     qexists_tac`s'''''`>>qexists_tac`constraints'''''`>>fs[]>>
-    metis_tac[t_compat_trans]));
+    metis_tac[t_compat_trans])
+QED
 
-val deBrujin_subst_excess = Q.prove(`
+Triviality deBrujin_subst_excess:
   (∀n targs t t'.
   check_freevars (LENGTH targs) [] t ∧
   deBruijn_subst n targs t = t'
   ⇒
   ∀ls.
-  deBruijn_subst n (targs++ls) t = t')`,
+  deBruijn_subst n (targs++ls) t = t')
+Proof
   ho_match_mp_tac deBruijn_subst_ind>>
   fs[deBruijn_subst_def]>>rw[]
   >-
@@ -1651,21 +1698,24 @@ val deBrujin_subst_excess = Q.prove(`
     (fs[check_freevars_def]>>
     `n' < LENGTH targs +n` by DECIDE_TAC>>fs[])
   >>
-  fs[MAP_EQ_f,check_freevars_def,EVERY_MEM])
+  fs[MAP_EQ_f,check_freevars_def,EVERY_MEM]
+QED
 
-val convert_infer_deBruijn_subst = Q.prove(`
+Triviality convert_infer_deBruijn_subst:
   ∀subst t.
   check_t (LENGTH subst) {} t ⇒
   convert_t (infer_deBruijn_subst subst t) =
-  deBruijn_subst 0 (MAP convert_t subst) (convert_t t)`,
+  deBruijn_subst 0 (MAP convert_t subst) (convert_t t)
+Proof
   gen_tac \\ ho_match_mp_tac infer_t_ind >>
   rw[infer_deBruijn_subst_alt]>>
   EVAL_TAC>>simp[EL_MAP]>>rw[]>>fs[check_t_def]>>
   fs[MAP_MAP_o,MAP_EQ_f]>>rw[]>>
   first_assum (match_mp_tac o MP_CANON)>>
-  fs[EVERY_MEM]);
+  fs[EVERY_MEM]
+QED
 
-val t_walkstar_infer_db_subst = Q.prove(`
+Triviality t_walkstar_infer_db_subst:
   ∀s s' uvars subst tvs.
   s SUBMAP s' ∧ t_wfs s' ∧
   FDOM s = count uvars ∧
@@ -1679,7 +1729,8 @@ val t_walkstar_infer_db_subst = Q.prove(`
   ∀ts.
   EVERY (check_t (LENGTH subst) (count uvars)) ts ⇒
   MAP (t_walkstar s o infer_deBruijn_subst subst) ts =
-  MAP (t_walkstar s' o infer_deBruijn_subst (MAP (λn. Infer_Tuvar (n + uvars)) (COUNT_LIST (LENGTH subst)))) ts`,
+  MAP (t_walkstar s' o infer_deBruijn_subst (MAP (λn. Infer_Tuvar (n + uvars)) (COUNT_LIST (LENGTH subst)))) ts
+Proof
   ntac 6 strip_tac>>
   imp_res_tac t_wfs_SUBMAP>>
   ho_match_mp_tac infer_tTheory.infer_t_induction>>
@@ -1693,16 +1744,19 @@ val t_walkstar_infer_db_subst = Q.prove(`
   >>
     fs[check_t_def]>>res_tac>>
     imp_res_tac t_walkstar_no_vars>>
-    metis_tac[t_walkstar_SUBMAP]);
+    metis_tac[t_walkstar_SUBMAP]
+QED
 
-val ienv_val_ok_more = Q.prove(`
+Triviality ienv_val_ok_more:
   (ienv_val_ok cuvs env ∧ cuvs ⊆ cuvs' ⇒
   ienv_val_ok cuvs' env) ∧
   (ienv_val_ok (count uvs) env ∧ uvs ≤ uvs' ⇒
-  ienv_val_ok (count uvs') env)`,
+  ienv_val_ok (count uvs') env)
+Proof
   rw[ienv_val_ok_def,FORALL_PROD,nsAll_def]>>
   res_tac>>fs[]>>
-  metis_tac[check_t_more4,check_t_more5]);
+  metis_tac[check_t_more4,check_t_more5]
+QED
 
 Theorem infer_e_complete:
   (!tenv tenvE e t.

--- a/compiler/inference/proofs/infer_eSoundScript.sml
+++ b/compiler/inference/proofs/infer_eSoundScript.sml
@@ -18,14 +18,16 @@ val _ = new_theory "infer_eSound";
 
 (* ---------- sub_completion ---------- *)
 
-val sub_completion_unify = Q.prove (
-`!st t1 t2 s1 n ts s2 n.
+Triviality sub_completion_unify:
+  !st t1 t2 s1 n ts s2 n.
   (t_unify st.subst t1 t2 = SOME s1) ∧
   sub_completion n (st.next_uvar + 1) s1 ts s2
   ⇒
-  sub_completion n st.next_uvar st.subst ((t1,t2)::ts) s2`,
-rw [sub_completion_def, pure_add_constraints_def] >>
-full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF, count_add1]);
+  sub_completion n st.next_uvar st.subst ((t1,t2)::ts) s2
+Proof
+  rw [sub_completion_def, pure_add_constraints_def] >>
+full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF, count_add1]
+QED
 
 Theorem sub_completion_unify2:
  !t1 t2 s1 ts s2 n s3 next_uvar.
@@ -37,20 +39,22 @@ Proof
 rw [sub_completion_def, pure_add_constraints_def]
 QED
 
-val sub_completion_infer = Q.prove (
-`!l ienv e st1 t st2 n ts2 s.
+Triviality sub_completion_infer:
+  !l ienv e st1 t st2 n ts2 s.
   infer_e l ienv e st1 = (Success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
-  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s`,
-rw [sub_completion_def, pure_add_constraints_append] >>
+  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
+Proof
+  rw [sub_completion_def, pure_add_constraints_append] >>
 imp_res_tac infer_e_constraints >>
 imp_res_tac infer_e_next_uvar_mono >>
 qexists_tac `ts` >>
 rw [] >|
 [qexists_tac `st2.subst` >>
      rw [],
- full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF]]);
+ full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF]]
+QED
 
 Theorem sub_completion_add_constraints:
  !s1 ts1 s2 n next_uvar s3 ts2.
@@ -70,25 +74,29 @@ fs [pure_add_constraints_def, pure_add_constraints_append] >>
 metis_tac []
 QED
 
-val sub_completion_more_vars = Q.prove (
-`!m n1 n2 s1 ts s2.
-  sub_completion m (n1 + n2) s1 ts s2 ⇒ sub_completion m n1 s1 ts s2`,
-rw [sub_completion_def] >>
+Triviality sub_completion_more_vars:
+  !m n1 n2 s1 ts s2.
+  sub_completion m (n1 + n2) s1 ts s2 ⇒ sub_completion m n1 s1 ts s2
+Proof
+  rw [sub_completion_def] >>
 rw [] >>
-full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF]);
+full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF]
+QED
 
-val sub_completion_infer_es = Q.prove (
-`!l cenv es st1 t st2 n ts2 s.
+Triviality sub_completion_infer_es:
+  !l cenv es st1 t st2 n ts2 s.
   infer_es l cenv es st1 = (Success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
-  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s`,
-induct_on `es` >>
+  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
+Proof
+  induct_on `es` >>
 rw [infer_e_def, success_eqns] >-
 metis_tac [APPEND] >>
 res_tac >>
 imp_res_tac sub_completion_infer >>
-metis_tac [APPEND_ASSOC]);
+metis_tac [APPEND_ASSOC]
+QED
 
 Theorem sub_completion_infer_p:
   (!l cenv p st t env st' tvs extra_constraints s.
@@ -137,13 +145,14 @@ Proof
       metis_tac [APPEND_ASSOC])
 QED
 
-val sub_completion_infer_pes = Q.prove (
-`!l ienv pes t1 t2 st1 t st2 n ts2 s.
+Triviality sub_completion_infer_pes:
+  !l ienv pes t1 t2 st1 t st2 n ts2 s.
   infer_pes l ienv pes t1 t2 st1 = (Success (), st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
-  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s`,
-induct_on `pes` >>
+  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
+Proof
+  induct_on `pes` >>
 rw [infer_e_def, success_eqns] >-
 metis_tac [APPEND] >>
 PairCases_on `h` >>
@@ -159,15 +168,17 @@ fs [] >>
 imp_res_tac sub_completion_unify2 >>
 imp_res_tac sub_completion_infer_p >>
 fs [] >>
-metis_tac [APPEND, APPEND_ASSOC]);
+metis_tac [APPEND, APPEND_ASSOC]
+QED
 
-val sub_completion_infer_funs = Q.prove (
-`!l ienv funs st1 t st2 n ts2 s.
+Triviality sub_completion_infer_funs:
+  !l ienv funs st1 t st2 n ts2 s.
   infer_funs l ienv funs st1 = (Success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
-  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s`,
-induct_on `funs` >>
+  ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
+Proof
+  induct_on `funs` >>
 rw [infer_e_def, success_eqns] >-
 metis_tac [APPEND] >>
 PairCases_on `h` >>
@@ -175,7 +186,8 @@ fs [infer_e_def, success_eqns] >>
 res_tac >>
 imp_res_tac sub_completion_infer >>
 fs [] >>
-metis_tac [sub_completion_more_vars, APPEND_ASSOC]);
+metis_tac [sub_completion_more_vars, APPEND_ASSOC]
+QED
 
 Theorem sub_completion_apply:
  !n uvars s1 ts s2 t1 t2.
@@ -201,25 +213,28 @@ fs [] >>
 metis_tac [t_unify_apply2, t_unify_wfs]
 QED
 
-val sub_completion_apply_list = Q.prove (
-`!n uvars s1 ts s2 ts1 ts2.
+Triviality sub_completion_apply_list:
+  !n uvars s1 ts s2 ts1 ts2.
   t_wfs s1 ∧
   (MAP (t_walkstar s1) ts1 = MAP (t_walkstar s1) ts2) ∧
   sub_completion n uvars s1 ts s2
   ⇒
-  (MAP (t_walkstar s2) ts1 = MAP (t_walkstar s2) ts2)`,
-induct_on `ts1` >>
+  (MAP (t_walkstar s2) ts1 = MAP (t_walkstar s2) ts2)
+Proof
+  induct_on `ts1` >>
 rw [] >>
 cases_on `ts2` >>
 fs [] >>
-metis_tac [sub_completion_apply]);
+metis_tac [sub_completion_apply]
+QED
 
-val sub_completion_check = Q.prove (
-`!tvs m s uvar s' extra_constraints.
+Triviality sub_completion_check:
+  !tvs m s uvar s' extra_constraints.
 sub_completion m (uvar + tvs) s' extra_constraints s
 ⇒
-EVERY (λn. check_freevars m [] (convert_t (t_walkstar s (Infer_Tuvar (uvar + n))))) (COUNT_LIST tvs)`,
-induct_on `tvs` >>
+EVERY (λn. check_freevars m [] (convert_t (t_walkstar s (Infer_Tuvar (uvar + n))))) (COUNT_LIST tvs)
+Proof
+  induct_on `tvs` >>
 rw [sub_completion_def, COUNT_LIST_SNOC, EVERY_SNOC] >>
 fs [sub_completion_def] >|
 [qpat_x_assum `!m' s. P m' s` match_mp_tac >>
@@ -231,7 +246,8 @@ fs [sub_completion_def] >|
  fs [SUBSET_DEF] >>
      `uvar+tvs < uvar + SUC tvs`
             by full_simp_tac (srw_ss()++ARITH_ss) [SUBSET_DEF] >>
-     metis_tac [check_t_to_check_freevars,ADD_COMM]]);
+     metis_tac [check_t_to_check_freevars,ADD_COMM]]
+QED
 
 (* ---------- Soundness ---------- *)
 
@@ -378,14 +394,15 @@ Proof
       metis_tac [])
 QED
 
-val letrec_lemma = Q.prove (
-`!funs funs_ts s st.
+Triviality letrec_lemma:
+  !funs funs_ts s st.
   (MAP (λn. convert_t (t_walkstar s (Infer_Tuvar (st.next_uvar + n)))) (COUNT_LIST (LENGTH funs)) =
    MAP (\t. convert_t (t_walkstar s t)) funs_ts)
   ⇒
   (MAP2 (λ(f,x,e) t. (f,t)) funs (MAP (λn. convert_t (t_walkstar s (Infer_Tuvar (st.next_uvar + n)))) (COUNT_LIST (LENGTH funs))) =
-   MAP2 (λ(x,y,z) t. (x,convert_t (t_walkstar s t))) funs funs_ts)`,
-induct_on `funs` >>
+   MAP2 (λ(x,y,z) t. (x,convert_t (t_walkstar s t))) funs funs_ts)
+Proof
+  induct_on `funs` >>
 srw_tac[] [] >>
 cases_on `funs_ts` >>
 fsrw_tac[] [COUNT_LIST_def] >>
@@ -394,21 +411,24 @@ srw_tac[] [] >|
      rw [],
  qpat_x_assum `!x. P x` match_mp_tac >>
      qexists_tac `st with next_uvar := st.next_uvar + 1` >>
-     fsrw_tac[] [MAP_MAP_o, combinTheory.o_DEF, DECIDE ``x + SUC y = x + 1 + y``]]);
+     fsrw_tac[] [MAP_MAP_o, combinTheory.o_DEF, DECIDE ``x + SUC y = x + 1 + y``]]
+QED
 
-val map_zip_lem = Q.prove (
-`!funs ts.
+Triviality map_zip_lem:
+  !funs ts.
   (LENGTH funs = LENGTH ts)
   ⇒
   (MAP (λx. FST ((λ((x',y,z),t). (x',convert_t (t_walkstar s t))) x)) (ZIP (funs,ts))
    =
-   MAP FST funs)`,
-induct_on `funs` >>
+   MAP FST funs)
+Proof
+  induct_on `funs` >>
 rw [] >>
 cases_on `ts` >>
 fs [] >>
 PairCases_on `h` >>
-rw []);
+rw []
+QED
 
 Theorem word_tc_cases:
     (word_tc wz = Tword8_num ⇔ wz = W8) ∧
@@ -434,12 +454,13 @@ val binop_tac =
  srw_tac[] [type_op_cases, Tint_def, Tstring_def, Tref_def, Tfn_def, Texn_def, Tchar_def,word_tc_cases] >>
  metis_tac [MAP, infer_e_next_uvar_mono, check_env_more, word_size_nchotomy];
 
-val constrain_op_sub_completion = Q.prove (
-`sub_completion (num_tvs tenv) st.next_uvar st.subst extra_constraints s ∧
+Triviality constrain_op_sub_completion:
+  sub_completion (num_tvs tenv) st.next_uvar st.subst extra_constraints s ∧
  constrain_op l op ts st' = (Success t,st)
  ⇒
- ∃c. sub_completion (num_tvs tenv) st'.next_uvar st'.subst c s`,
- rw [] >>
+ ∃c. sub_completion (num_tvs tenv) st'.next_uvar st'.subst c s
+Proof
+  rw [] >>
  fs [constrain_op_success] >>
  every_case_tac >>
  fs [success_eqns] >>
@@ -447,20 +468,23 @@ val constrain_op_sub_completion = Q.prove (
  fs [] >>
  rw [] >>
  fs [infer_st_rewrs, success_eqns] >>
- metis_tac [sub_completion_unify2, sub_completion_unify]);
+ metis_tac [sub_completion_unify2, sub_completion_unify]
+QED
 
-val constrain_op_sound = Q.prove (
-`t_wfs st.subst ∧
+Triviality constrain_op_sound:
+  t_wfs st.subst ∧
  sub_completion (num_tvs tenv) st'.next_uvar st'.subst c s ∧
  constrain_op l op ts st = (Success t,st')
  ⇒
- type_op op (MAP (convert_t o t_walkstar s) ts) (convert_t (t_walkstar s t))`,
- fs[constrain_op_success] >>
+ type_op op (MAP (convert_t o t_walkstar s) ts) (convert_t (t_walkstar s t))
+Proof
+  fs[constrain_op_success] >>
  rw [] >>
  fs [fresh_uvar_def,infer_st_rewrs,Tchar_def,Tword64_def] >> rw[] >>
  TRY pairarg_tac >>
  fs [success_eqns] >>
- binop_tac);
+ binop_tac
+QED
 
 Theorem infer_deBruijn_subst_walkstar:
    !ts t s.

--- a/compiler/inference/proofs/type_dCanonScript.sml
+++ b/compiler/inference/proofs/type_dCanonScript.sml
@@ -272,23 +272,26 @@ Definition good_remap_def:
     Tlist_num :: (Tbool_num :: prim_type_nums)
 End
 
-val ts_tid_rename_type_subst = Q.prove(`
+Triviality ts_tid_rename_type_subst:
   ∀s t f.
   ts_tid_rename f (type_subst s t) =
-  type_subst (ts_tid_rename f o_f s) (ts_tid_rename f t)`,
+  type_subst (ts_tid_rename f o_f s) (ts_tid_rename f t)
+Proof
   ho_match_mp_tac type_subst_ind>>
   rw[type_subst_def,ts_tid_rename_def]
   >- (
     TOP_CASE_TAC>>fs[FLOOKUP_o_f,ts_tid_rename_def])
   >>
-    fs[MAP_MAP_o,MAP_EQ_f]);
+    fs[MAP_MAP_o,MAP_EQ_f]
+QED
 
-val ts_tid_rename_type_name_subst = Q.prove(`
+Triviality ts_tid_rename_type_name_subst:
   ∀tenvt t f tenv.
   good_remap f ∧
   check_type_names tenvt t ⇒
   ts_tid_rename f (type_name_subst tenvt t) =
-  type_name_subst (nsMap (λ(ls,t). (ls,ts_tid_rename f t)) tenvt) t`,
+  type_name_subst (nsMap (λ(ls,t). (ls,ts_tid_rename f t)) tenvt) t
+Proof
   ho_match_mp_tac type_name_subst_ind>>rw[]>>
   fs[type_name_subst_def,ts_tid_rename_def,check_type_names_def,EVERY_MEM]
   >- (
@@ -305,16 +308,19 @@ val ts_tid_rename_type_name_subst = Q.prove(`
     fs[GSYM alist_to_fmap_MAP_values]>>
     AP_TERM_TAC>>
     match_mp_tac LIST_EQ>>fs[EL_MAP,EL_ZIP]>>
-    metis_tac[EL_MEM]));
+    metis_tac[EL_MEM])
+QED
 
-val check_type_names_ts_tid_rename = Q.prove(`
+Triviality check_type_names_ts_tid_rename:
   ∀tenvt t.
   check_type_names tenvt t <=>
-  check_type_names (nsMap (λ(ls,t). (ls,ts_tid_rename f t)) tenvt) t`,
+  check_type_names (nsMap (λ(ls,t). (ls,ts_tid_rename f t)) tenvt) t
+Proof
   ho_match_mp_tac check_type_names_ind>>rw[check_type_names_def]>>
   fs[EVERY_MEM,nsLookup_nsMap]>>
   Cases_on`nsLookup tenvt tn`>>fs[]>>
-  pairarg_tac>>fs[]);
+  pairarg_tac>>fs[]
+QED
 
 Definition extend_bij_def:
   extend_bij (f:type_ident->type_ident) g ids n v =
@@ -352,12 +358,14 @@ Proof
 QED
 
 (* needs monotonicity of set_tids_tenv *)
-val set_tids_tenv_extend_dec_tenv = Q.prove(`
+Triviality set_tids_tenv_extend_dec_tenv:
   ∀s t s' t'.
   set_tids_tenv (s' ∪ s) t' ∧
   set_tids_tenv (s' ∪ s) t ⇒
-  set_tids_tenv (s' ∪ s) (extend_dec_tenv t' t)`,
-  rw[extend_dec_tenv_def,set_tids_tenv_def,nsAll_nsAppend]);
+  set_tids_tenv (s' ∪ s) (extend_dec_tenv t' t)
+Proof
+  rw[extend_dec_tenv_def,set_tids_tenv_def,nsAll_nsAppend]
+QED
 
 Theorem set_tids_tenv_remap:
    set_tids_tenv tids tenv ⇒
@@ -371,27 +379,35 @@ Proof
   \\ metis_tac[]
 QED
 
-val good_remap_extend_bij = Q.prove(`
+Triviality good_remap_extend_bij:
   good_remap f ∧ prim_tids F ids ⇒
-  good_remap (extend_bij f g ids n)`,
-  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]);
+  good_remap (extend_bij f g ids n)
+Proof
+  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]
+QED
 
 (*
-val good_remap_extend_bij = Q.prove(`
+Triviality good_remap_extend_bij:
   good_remap f ∧ prim_tids T tids ⇒
-  good_remap (extend_bij f g tids n)`,
-  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]);
+  good_remap (extend_bij f g tids n)
+Proof
+  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]
+QED
 
-val good_remap_extend_bij = Q.prove(`
+Triviality good_remap_extend_bij:
   good_remap f ∧ prim_tids T tids ⇒
-  good_remap (extend_bij f g tids ids n)`,
-  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]);
+  good_remap (extend_bij f g tids ids n)
+Proof
+  rw[good_remap_def, extend_bij_def, prim_tids_def,prim_type_nums_def]
+QED
 *)
 
-val remap_tenv_extend_dec_tenv = Q.prove(`
+Triviality remap_tenv_extend_dec_tenv:
   remap_tenv f (extend_dec_tenv t t') =
-  extend_dec_tenv (remap_tenv f t) (remap_tenv f t')`,
-  fs[remap_tenv_def,extend_dec_tenv_def,nsMap_nsAppend]);
+  extend_dec_tenv (remap_tenv f t) (remap_tenv f t')
+Proof
+  fs[remap_tenv_def,extend_dec_tenv_def,nsMap_nsAppend]
+QED
 
 Theorem BIJ_extend_bij:
     DISJOINT tids ids ∧
@@ -450,22 +466,26 @@ Proof
   rw[set_tids_subset_def, SUBSET_DEF]
 QED
 
-val set_tids_tenv_mono = Q.prove(`
+Triviality set_tids_tenv_mono:
   set_tids_tenv tids tenv ∧ tids ⊆ tids' ⇒
-  set_tids_tenv tids' tenv`,
+  set_tids_tenv tids' tenv
+Proof
   fs[set_tids_tenv_def]>>rw[]>>
   irule nsAll_mono
   \\ goal_assum(first_assum o mp_then Any mp_tac)
   \\ rw[]
   \\ pairarg_tac \\ fs[EVERY_MEM,SUBSET_DEF]
-  \\ metis_tac[set_tids_subset_mono,SUBSET_DEF]);
+  \\ metis_tac[set_tids_subset_mono,SUBSET_DEF]
+QED
 
-val check_freevars_ts_tid_rename = Q.prove(`
+Triviality check_freevars_ts_tid_rename:
   ∀ts ls t.
   check_freevars ts ls (ts_tid_rename f t) ⇔
-  check_freevars ts ls t`,
+  check_freevars ts ls t
+Proof
   ho_match_mp_tac check_freevars_ind>>
-  fs[ts_tid_rename_def,check_freevars_def,EVERY_MAP,EVERY_MEM]);
+  fs[ts_tid_rename_def,check_freevars_def,EVERY_MAP,EVERY_MEM]
+QED
 
 Definition sing_renum_def:
   sing_renum m n = λx. if x = m then n else x
@@ -479,14 +499,15 @@ val ast_t_ind = ast_t_induction
   |> SIMP_RULE (srw_ss()) []
   |> Q.GEN`P`;
 
-val sing_renum_NOT_tscheme_inst = Q.prove(`
+Triviality sing_renum_NOT_tscheme_inst:
   ∀t.
   m ∈ set_tids t ∧
   m ≠ n ⇒
   ts_tid_rename (sing_renum m n) t ≠ t ∧
   ∀tvs tvs'.
   ¬tscheme_inst (tvs,ts_tid_rename (sing_renum m n) t) (tvs',t) ∧
-  ¬tscheme_inst (tvs',t) (tvs,ts_tid_rename (sing_renum m n) t)`,
+  ¬tscheme_inst (tvs',t) (tvs,ts_tid_rename (sing_renum m n) t)
+Proof
   ho_match_mp_tac t_ind>>rw[]>>
   fs[set_tids_def,ts_tid_rename_def,sing_renum_def]>>
   rw[]>>
@@ -512,7 +533,8 @@ val sing_renum_NOT_tscheme_inst = Q.prove(`
     \\ fsrw_tac[DNF_ss][tscheme_inst_def]
     \\ disj2_tac \\ disj2_tac
     \\ fs[check_freevars_def,EVERY_MEM,MEM_MAP,PULL_EXISTS,MAP_MAP_o,MAP_EQ_ID]
-    \\ metis_tac[]));
+    \\ metis_tac[])
+QED
 
 Theorem sing_renum_NOTIN_ID:
    ∀t.
@@ -603,17 +625,21 @@ Definition remap_tenvE_def:
   (remap_tenvE f (Bind_name s n t e) = Bind_name s n (ts_tid_rename f t) (remap_tenvE f e))
 End
 
-val num_tvs_remap_tenvE = Q.prove(`
-  ∀tenvE. num_tvs (remap_tenvE f tenvE) = num_tvs tenvE`,
-  Induct>>fs[remap_tenvE_def]);
+Triviality num_tvs_remap_tenvE:
+  ∀tenvE. num_tvs (remap_tenvE f tenvE) = num_tvs tenvE
+Proof
+  Induct>>fs[remap_tenvE_def]
+QED
 
-val remap_tenvE_bind_var_list = Q.prove(`
+Triviality remap_tenvE_bind_var_list:
   ∀n env tenvE.
   remap_tenvE f (bind_var_list n env tenvE) =
-  bind_var_list n (MAP (λ(n,t). (n, ts_tid_rename f t)) env) (remap_tenvE f tenvE)`,
+  bind_var_list n (MAP (λ(n,t). (n, ts_tid_rename f t)) env) (remap_tenvE f tenvE)
+Proof
   ho_match_mp_tac bind_var_list_ind>>
   fs[bind_var_list_def,remap_tenvE_def]>>
-  rw[]);
+  rw[]
+QED
 
 Theorem remap_tenvE_bind_tvar:
    remap_tenvE f (bind_tvar tvs e) = bind_tvar tvs (remap_tenvE f e)
@@ -621,32 +647,38 @@ Proof
   rw[bind_tvar_def, remap_tenvE_def]
 QED
 
-val deBruijn_inc_ts_tid_rename = Q.prove(`
+Triviality deBruijn_inc_ts_tid_rename:
   ∀skip n t.
   ts_tid_rename f (deBruijn_inc skip n t) =
-  deBruijn_inc skip n (ts_tid_rename f t)`,
+  deBruijn_inc skip n (ts_tid_rename f t)
+Proof
   ho_match_mp_tac deBruijn_inc_ind>>
   rw[deBruijn_inc_def,ts_tid_rename_def,MAP_MAP_o]>>
-  fs[MAP_EQ_f]);
+  fs[MAP_EQ_f]
+QED
 
-val lookup_varE_remap_tenvE = Q.prove(`
+Triviality lookup_varE_remap_tenvE:
   ∀n tenvE.
   lookup_varE n (remap_tenvE f tenvE)
-  = OPTION_MAP (λid,t. (id, ts_tid_rename f t)) (lookup_varE n tenvE)`,
+  = OPTION_MAP (λid,t. (id, ts_tid_rename f t)) (lookup_varE n tenvE)
+Proof
   fs[lookup_varE_def]>>Cases>>fs[]>>
   qabbrev_tac`n=0n`>>
   pop_assum kall_tac>>qid_spec_tac`n`>>
   Induct_on`tenvE`>>fs[remap_tenvE_def,tveLookup_def]>>rw[]>>
-  fs[deBruijn_inc_ts_tid_rename]);
+  fs[deBruijn_inc_ts_tid_rename]
+QED
 
-val ts_tid_rename_deBruijn_subst = Q.prove(`
+Triviality ts_tid_rename_deBruijn_subst:
   ∀n targs t.
   ts_tid_rename f (deBruijn_subst n targs t) =
-  deBruijn_subst n (MAP (ts_tid_rename f) targs) (ts_tid_rename f t)`,
+  deBruijn_subst n (MAP (ts_tid_rename f) targs) (ts_tid_rename f t)
+Proof
   ho_match_mp_tac deBruijn_subst_ind>>rw[]>>
   rw[ts_tid_rename_def,deBruijn_subst_def]>>
   fs[EL_MAP,MAP_MAP_o]>>
-  fs[MAP_EQ_f]);
+  fs[MAP_EQ_f]
+QED
 
 Theorem type_e_ts_tid_rename:
     good_remap f ⇒
@@ -910,13 +942,14 @@ Theorem remap_tenv_LINVI
      set_tids_tenv_def]
 *)
 
-val type_p_ts_tid_rename_sing_renum = Q.prove(`
+Triviality type_p_ts_tid_rename_sing_renum:
   m ∉ tids ∧ prim_tids T tids ∧
   type_p tvs tenv p t bindings ∧
   set_tids_tenv tids tenv
   ⇒
   type_p tvs tenv p (ts_tid_rename (sing_renum m n) t)
-  (MAP (λ(nn,t). (nn,ts_tid_rename (sing_renum m n) t)) bindings)`,
+  (MAP (λ(nn,t). (nn,ts_tid_rename (sing_renum m n) t)) bindings)
+Proof
   rw[]>>
   `good_remap (sing_renum m n)` by
     (fs[good_remap_def,sing_renum_def]>>
@@ -929,14 +962,16 @@ val type_p_ts_tid_rename_sing_renum = Q.prove(`
   strip_tac>> first_x_assum drule>>
   drule sing_renum_NOTIN_tenv_ID>>
   simp[]>>rw[]>>
-  metis_tac[type_p_tenv_equiv]);
+  metis_tac[type_p_tenv_equiv]
+QED
 
-val type_e_ts_tid_rename_sing_renum = Q.prove(`
+Triviality type_e_ts_tid_rename_sing_renum:
   m ∉ tids ∧ prim_tids T tids ∧
   type_e tenv tenvE e t ∧
   set_tids_tenv tids tenv
   ⇒
-  type_e tenv (remap_tenvE (sing_renum m n) tenvE) e (ts_tid_rename (sing_renum m n) t)`,
+  type_e tenv (remap_tenvE (sing_renum m n) tenvE) e (ts_tid_rename (sing_renum m n) t)
+Proof
   rw[]>>
   `good_remap (sing_renum m n)` by
     (fs[good_remap_def,sing_renum_def]>>
@@ -949,7 +984,8 @@ val type_e_ts_tid_rename_sing_renum = Q.prove(`
   strip_tac>> first_x_assum drule>>
   drule sing_renum_NOTIN_tenv_ID>>
   simp[]>>rw[]>>
-  metis_tac[type_e_tenv_equiv]);
+  metis_tac[type_e_tenv_equiv]
+QED
 
 Theorem type_funs_ts_tid_rename_sing_renum:
     m ∉ tids ∧ prim_tids T tids ∧
@@ -974,7 +1010,7 @@ Proof
   metis_tac[type_e_tenv_equiv]
 QED
 
-val type_pe_bindings_tids = Q.prove(`
+Triviality type_pe_bindings_tids:
   prim_tids T tids ∧
   set_tids_tenv tids tenv ∧
   type_p tvs tenv p t bindings ∧
@@ -985,7 +1021,8 @@ val type_pe_bindings_tids = Q.prove(`
       LIST_REL tscheme_inst
         (MAP SND (MAP (λ(n,t). (n,tvs',t)) bindings'))
         (MAP SND (MAP (λ(n,t). (n,tvs,t)) bindings))) ⇒
-  ∀p_1 p_2. MEM (p_1,p_2) bindings ⇒ set_tids_subset tids p_2`,
+  ∀p_1 p_2. MEM (p_1,p_2) bindings ⇒ set_tids_subset tids p_2
+Proof
   CCONTR_TAC>>fs[set_tids_subset_def,SUBSET_DEF]>>
   drule (GEN_ALL type_p_ts_tid_rename_sing_renum)>>
   rpt (disch_then drule)>>
@@ -1005,7 +1042,8 @@ val type_pe_bindings_tids = Q.prove(`
   fs[EL_MAP]>>
   qpat_x_assum`(_,_)=_` sym_sub_tac>>fs[]>>
   `x ≠ x+1` by fs[]>>
-  metis_tac[sing_renum_NOT_tscheme_inst]);
+  metis_tac[sing_renum_NOT_tscheme_inst]
+QED
 
 Theorem type_funs_bindings_tids:
    type_funs tenv (bind_var_list 0 bindings (bind_tvar tvs Empty)) funs bindings ∧

--- a/compiler/inference/proofs/type_eDetermScript.sml
+++ b/compiler/inference/proofs/type_eDetermScript.sml
@@ -13,10 +13,12 @@ open namespaceTheory
 
 val _ = new_theory "type_eDeterm";
 
-val sub_completion_empty = Q.prove (
-`!m n s s'. sub_completion m n s [] s' ⇔ count n ⊆ FDOM s' ∧ (∀uv. uv ∈ FDOM s' ⇒ check_t m ∅ (t_walkstar s' (Infer_Tuvar uv))) ∧ s = s'`,
- rw [sub_completion_def, pure_add_constraints_def] >>
- metis_tac []);
+Triviality sub_completion_empty:
+  !m n s s'. sub_completion m n s [] s' ⇔ count n ⊆ FDOM s' ∧ (∀uv. uv ∈ FDOM s' ⇒ check_t m ∅ (t_walkstar s' (Infer_Tuvar uv))) ∧ s = s'
+Proof
+  rw [sub_completion_def, pure_add_constraints_def] >>
+ metis_tac []
+QED
 
 Theorem type_p_pat_bindings:
  (∀tvs tenv p t new_bindings.
@@ -149,10 +151,11 @@ Proof
     metis_tac[check_freevars_empty_convert_unconvert_id]
 QED
 
-val unconvert_11 = Q.prove (
-`!t1 t2. check_freevars 0 [] t1 ∧ check_freevars 0 [] t2 ⇒
-  (unconvert_t t1 = unconvert_t t2 ⇔ t1 = t2)`,
- ho_match_mp_tac unconvert_t_ind >>
+Triviality unconvert_11:
+  !t1 t2. check_freevars 0 [] t1 ∧ check_freevars 0 [] t2 ⇒
+  (unconvert_t t1 = unconvert_t t2 ⇔ t1 = t2)
+Proof
+  ho_match_mp_tac unconvert_t_ind >>
  rw [unconvert_t_def] >>
  Cases_on `t2` >>
  fs [unconvert_t_def, check_freevars_def] >>
@@ -165,7 +168,8 @@ val unconvert_11 = Q.prove (
  `x < LENGTH l` by metis_tac [LENGTH_MAP] >>
  `EL x (MAP (λa. unconvert_t a) ts) = EL x (MAP (λa. unconvert_t a) l)` by metis_tac [] >>
  rfs [EL_MAP] >>
- metis_tac [EL_MEM]);
+ metis_tac [EL_MEM]
+QED
 
 Theorem infer_e_type_pe_determ:
  !loc ienv p e st st' t t' tenv' s.

--- a/compiler/inference/unifyScript.sml
+++ b/compiler/inference/unifyScript.sml
@@ -2047,12 +2047,13 @@ Definition t_vwalk_def[nocompute]:
   t_vwalk s v = decode_infer_t (vwalk (encode_infer_t o_f s) v)
 End
 
-val t_vwalk_ind' = Q.prove (
-`!s'. t_wfs s' ⇒
+Triviality t_vwalk_ind':
+  !s'. t_wfs s' ⇒
    ∀P.
      (∀v. (∀v1 u. (FLOOKUP s' v = SOME v1) ∧ (v1 = Infer_Tuvar u) ⇒ P u) ⇒ P v) ⇒
-     ∀v. P v`,
-ntac 4 STRIP_TAC >>
+     ∀v. P v
+Proof
+  ntac 4 STRIP_TAC >>
 fs [t_wfs_def] >>
 imp_res_tac (DISCH_ALL vwalk_ind) >>
 pop_assum ho_match_mp_tac >>
@@ -2060,7 +2061,8 @@ rw [] >>
 qpat_x_assum `∀v. (∀u. (FLOOKUP s' v = SOME (Infer_Tuvar u)) ⇒ P u) ⇒ P v` ho_match_mp_tac >>
 rw [] >>
 qpat_x_assum `∀u. Q u ⇒ P u` ho_match_mp_tac >>
-rw [FLOOKUP_o_f, encode_infer_t_def]);
+rw [FLOOKUP_o_f, encode_infer_t_def]
+QED
 
 val t_vwalk_ind = save_thm("t_vwalk_ind", (UNDISCH o Q.SPEC `s`) t_vwalk_ind')
 
@@ -2108,13 +2110,14 @@ t_oc s t v = oc (encode_infer_t o_f s) (encode_infer_t t) v
 End
 
 (*
-val t_oc_ind' = Q.prove (
-`∀s oc'.
+Triviality t_oc_ind':
+  ∀s oc'.
   t_wfs s ∧
   (∀t v. v ∈ t_vars t ∧ v ∉ FDOM s ⇒ oc' t v) ∧
   (∀t v u t'. u ∈ t_vars t ∧ (t_vwalk s u = t') ∧ oc' t' v ⇒ oc' t v) ⇒
-  (∀a0 a1. oc (FMAP_MAP2 (λ(n,t). encode_infer_t t) s) a0 a1 ⇒ !a0'. (a0 = encode_infer_t a0') ⇒ oc' a0' a1)`,
-NTAC 3 STRIP_TAC >>
+  (∀a0 a1. oc (FMAP_MAP2 (λ(n,t). encode_infer_t t) s) a0 a1 ⇒ !a0'. (a0 = encode_infer_t a0') ⇒ oc' a0' a1)
+Proof
+  NTAC 3 STRIP_TAC >>
 ho_match_mp_tac oc_ind >>
 rw [] >|
 [qpat_x_assum `∀t v. v ∈ t_vars t ∧ v ∉ FDOM s ⇒ oc' t v` ho_match_mp_tac >>
@@ -2124,7 +2127,8 @@ rw [] >|
      qexists_tac `u` >>
      rw [] >>
      pop_assum ho_match_mp_tac >>
-     rw [encode_vwalk]]);
+     rw [encode_vwalk]]
+QED
 
 Theorem t_oc_ind:
  ∀s oc'.
@@ -2138,9 +2142,10 @@ metis_tac [t_oc_ind', FMAP2_FMAP2, FMAP2_id, decode_left_inverse]
 QED
 *)
 
-val encode_vwalk = Q.prove (
-`!s. t_wfs s ⇒ !u. vwalk (encode_infer_t o_f s) u = encode_infer_t (t_vwalk s u)`,
-NTAC 2 STRIP_TAC >>
+Triviality encode_vwalk:
+  !s. t_wfs s ⇒ !u. vwalk (encode_infer_t o_f s) u = encode_infer_t (t_vwalk s u)
+Proof
+  NTAC 2 STRIP_TAC >>
 ho_match_mp_tac t_vwalk_ind >>
 rw [] >>
 `wfs (encode_infer_t o_f s)` by metis_tac [t_wfs_def] >>
@@ -2149,14 +2154,17 @@ rw [Once t_vwalk_eqn, FLOOKUP_o_f] >>
 cases_on `FLOOKUP s u` >>
 rw [encode_infer_t_def] >>
 cases_on `x` >>
-rw [encode_infer_t_def]);
+rw [encode_infer_t_def]
+QED
 
-val t_oc_eqn_help = Q.prove (
-`!l v s.
+Triviality t_oc_eqn_help:
+  !l v s.
   oc (encode_infer_t o_f s) (encode_infer_ts l) v ⇔
-  EXISTS (λt. oc (encode_infer_t o_f s) (encode_infer_t t) v) l`,
-induct_on `l` >>
-rw [encode_infer_t_def]);
+  EXISTS (λt. oc (encode_infer_t o_f s) (encode_infer_t t) v) l
+Proof
+  induct_on `l` >>
+rw [encode_infer_t_def]
+QED
 
 Theorem t_oc_eqn:
  !s. t_wfs s ⇒
@@ -2208,26 +2216,30 @@ Definition ts_unify_def:
 (ts_unify s _ _ = NONE)
 End
 
-val encode_walk = Q.prove(
-  `∀s. t_wfs s ⇒
-      ∀t. walk (encode_infer_t o_f s) (encode_infer_t t) = encode_infer_t (t_walk s t)`,
+Triviality encode_walk:
+  ∀s. t_wfs s ⇒
+      ∀t. walk (encode_infer_t o_f s) (encode_infer_t t) = encode_infer_t (t_walk s t)
+Proof
   rw[walk_def] >>
   imp_res_tac encode_vwalk >>
   fs[] >>
   BasicProvers.EVERY_CASE_TAC >>
   rw[t_walk_def,decode_left_inverse] >>
-  metis_tac[decode_left_inverse])
+  metis_tac[decode_left_inverse]
+QED
 
-val encode_pair_cases = Q.prove(
-  `(∀t t1 t2.
+Triviality encode_pair_cases:
+  (∀t t1 t2.
     (encode_infer_t t = Pair t1 t2) ⇒
       ((t1 = Const Tapp_tag) ∧
-       (∃tc ts. t2 = Pair (Const (TC_tag tc)) (encode_infer_ts ts))))`,
+       (∃tc ts. t2 = Pair (Const (TC_tag tc)) (encode_infer_ts ts))))
+Proof
   Cases >> rw[encode_infer_t_def] >>
-  PROVE_TAC[])
+  PROVE_TAC[]
+QED
 
-val encode_unify_lemma = Q.prove (
-`!s t1 t2 s' t1' t2'.
+Triviality encode_unify_lemma:
+  !s t1 t2 s' t1' t2'.
   (s = (encode_infer_t o_f s')) ∧
   (((t1 = encode_infer_t t1') ∧ (t2 = encode_infer_t t2')) ∨
    (∃c. (t1 = Const c) ∧ (t2 = Const c) ∧ (t1' = t2')) ∨
@@ -2244,8 +2256,9 @@ val encode_unify_lemma = Q.prove (
   t_wfs s' ⇒
   (unify s t1 t2
    =
-   OPTION_MAP ((o_f) encode_infer_t) (t_unify s' t1' t2'))`,
-ho_match_mp_tac unify_ind >>
+   OPTION_MAP ((o_f) encode_infer_t) (t_unify s' t1' t2'))
+Proof
+  ho_match_mp_tac unify_ind >>
 simp[] >>
 rw [t_unify_def] >>
 fs[t_wfs_def, option_map_case, combinTheory.o_DEF] >>
@@ -2362,17 +2375,20 @@ TRY (
   simp[Once unify_def] >>
   rw[] >>
   metis_tac[o_f_o_f] ) >>
-metis_tac[o_f_FUPDATE,o_f_DOMSUB,FUPDATE_PURGE,encode_walk,t_wfs_def])
+metis_tac[o_f_FUPDATE,o_f_DOMSUB,FUPDATE_PURGE,encode_walk,t_wfs_def]
+QED
 
-val encode_unify = Q.prove (
-`!s t1 t2 s' t1' t2'.
+Triviality encode_unify:
+  !s t1 t2 s' t1' t2'.
   (s = encode_infer_t o_f s') ∧
   (t1 = encode_infer_t t1') ∧ (t2 = encode_infer_t t2') ∧
   t_wfs s' ⇒
   (unify s t1 t2
    =
-   OPTION_MAP ((o_f) encode_infer_t) (t_unify s' t1' t2'))`,
-metis_tac[encode_unify_lemma])
+   OPTION_MAP ((o_f) encode_infer_t) (t_unify s' t1' t2'))
+Proof
+  metis_tac[encode_unify_lemma]
+QED
 
 Theorem wfs_unify[local]:
   !s t1 t2 s'. wfs s ∧ (unify s t1 t2 = SOME s') ⇒ wfs s'
@@ -2640,14 +2656,16 @@ Proof
   simp[t_walkstar_def, cwalkstar_def]
 QED
 
-val ts_walkstar_thm = Q.prove (
-`!l s.
+Triviality ts_walkstar_thm:
+  !l s.
   t_wfs s ⇒
   (decode_infer_ts ((encode_infer_t o_f s) ◁ encode_infer_ts l) =
-   MAP (t_walkstar s) l)`,
-induct_on `l` >>
+   MAP (t_walkstar s) l)
+Proof
+  induct_on `l` >>
 rw [t_wfs_def, encode_infer_t_def, Once walkstar_def, decode_infer_t_def] >>
-rw [t_walkstar_def]);
+rw [t_walkstar_def]
+QED
 
 Theorem t_walkstar_eqn:
  !s. t_wfs s ⇒
@@ -2727,8 +2745,8 @@ Proof
   metis_tac[encode_infer_t_11,o_f_FAPPLY]
 QED
 
-val t_unify_strongind' = Q.prove(
-`!P0 P1.
+Triviality t_unify_strongind':
+  !P0 P1.
     (!s t1 t2.
        t_wfs s ∧
        (!ts1 ts2 tc2.
@@ -2746,8 +2764,9 @@ val t_unify_strongind' = Q.prove(
           ts1 = t1::ts1' /\ ts2 = t2::ts2' ==> P0 s t1 t2) ==>
        P1 s ts1 ts2) ==>
     (!s t1 t2. t_wfs s ==> (t_wfs s ==> P0 s t1 t2)) /\
-    (!s ts1 ts2. t_wfs s ==> (t_wfs s ⇒ P1 s ts1 ts2))`,
-NTAC 3 STRIP_TAC >>
+    (!s ts1 ts2. t_wfs s ==> (t_wfs s ⇒ P1 s ts1 ts2))
+Proof
+  NTAC 3 STRIP_TAC >>
 ho_match_mp_tac t_unify_ind >>
 rw [] >>
 cases_on `ts1` >>
@@ -2755,16 +2774,18 @@ cases_on `ts2` >>
 fs [] >>
 qpat_x_assum `!s ts1 ts2. Q s ts1 ts2 ⇒ P1 s ts1 ts2` match_mp_tac >>
 rw [] >>
-metis_tac [t_unify_unifier]);
+metis_tac [t_unify_unifier]
+QED
 
 val t_unify_strongind = save_thm("t_unify_strongind", SIMP_RULE (bool_ss) [] t_unify_strongind');
 
-val encode_walkstar = Q.prove (
-`!s t.
+Triviality encode_walkstar:
+  !s t.
   t_wfs s ⇒
   walkstar (encode_infer_t o_f s) (encode_infer_t t) =
-  encode_infer_t (t_walkstar s t)`,
-rw [] >>
+  encode_infer_t (t_walkstar s t)
+Proof
+  rw [] >>
 imp_res_tac t_walkstar_ind >>
 Q.SPEC_TAC (`t`,`t`) >>
 pop_assum ho_match_mp_tac >>
@@ -2779,7 +2800,8 @@ pop_assum mp_tac >>
 pop_assum (fn _ => all_tac) >>
 induct_on `l` >>
 rw [encode_infer_t_def] >>
-rw [Once walkstar_def]);
+rw [Once walkstar_def]
+QED
 
 Theorem t_walkstar_FEMPTY:
  !t.(t_walkstar FEMPTY t = t)

--- a/compiler/parsing/cmlPEGScript.sml
+++ b/compiler/parsing/cmlPEGScript.sml
@@ -582,9 +582,11 @@ val test1 = time EVAL
                         SymbolT ">"; AlphaT "x"] 0)
               [] NONE [] done failed”
 
-val frange_image = Q.prove(
-  `FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)`,
-  simp[finite_mapTheory.FRANGE_DEF, pred_setTheory.EXTENSION] >> metis_tac[]);
+Triviality frange_image:
+  FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)
+Proof
+  simp[finite_mapTheory.FRANGE_DEF, pred_setTheory.EXTENSION] >> metis_tac[]
+QED
 
 val peg_range =
     SIMP_CONV (srw_ss())
@@ -757,9 +759,11 @@ set_diff (TypeBase.constructors_of ``:MMLnonT``)
                       ``nDtypeCons``])
 *)
 
-val subexprs_pnt = Q.prove(
-  `subexprs (pnt n) = {pnt n}`,
-  simp[subexprs_def, pnt_def]);
+Triviality subexprs_pnt:
+  subexprs (pnt n) = {pnt n}
+Proof
+  simp[subexprs_def, pnt_def]
+QED
 
 val PEG_exprs = save_thm(
   "PEG_exprs",

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -16,9 +16,11 @@ val _ = set_grammar_ancestry ["simpleSexp", "ast", "location","fpSem"]
 val _ = option_monadsyntax.temp_add_option_monadsyntax()
 
 (* TODO: this is duplicated in parserProgTheory *)
-val monad_unitbind_assert = Q.prove(
-  `!b x. monad_unitbind (assert b) x = if b then x else NONE`,
-  Cases THEN EVAL_TAC THEN SIMP_TAC std_ss []);
+Triviality monad_unitbind_assert:
+  !b x. monad_unitbind (assert b) x = if b then x else NONE
+Proof
+  Cases THEN EVAL_TAC THEN SIMP_TAC std_ss []
+QED
 
 Overload lift[local] = ``OPTION_MAP``
 
@@ -189,13 +191,17 @@ Proof
   \\ simp[stringTheory.CHR_ORD]
 QED
 
-val isHexDigit_alt = Q.prove(
-  `isHexDigit c ⇔ c ∈ set "0123456789abcdefABCDEF"`,
-  rw[stringTheory.isHexDigit_def, EQ_IMP_THM] >> CONV_TAC EVAL >> simp[]);
+Triviality isHexDigit_alt:
+  isHexDigit c ⇔ c ∈ set "0123456789abcdefABCDEF"
+Proof
+  rw[stringTheory.isHexDigit_def, EQ_IMP_THM] >> CONV_TAC EVAL >> simp[]
+QED
 
-val UNHEX_lt16 = Q.prove(
-  `isHexDigit c ⇒ UNHEX c < 16`,
-  dsimp[isHexDigit_alt, ASCIInumbersTheory.UNHEX_def]);
+Triviality UNHEX_lt16:
+  isHexDigit c ⇒ UNHEX c < 16
+Proof
+  dsimp[isHexDigit_alt, ASCIInumbersTheory.UNHEX_def]
+QED
 
 Theorem isAlpha_isUpper_isLower:
    isAlpha c ⇒ (isUpper c ⇎ isLower c)

--- a/compiler/parsing/lexer_implScript.sml
+++ b/compiler/parsing/lexer_implScript.sml
@@ -279,46 +279,58 @@ Termination
    THEN FULL_SIMP_TAC (srw_ss()) [LENGTH] THEN DECIDE_TAC
 End
 
-val EVERY_isDigit_imp = Q.prove(`
+Triviality EVERY_isDigit_imp:
   EVERY isDigit x ⇒
-  MAP UNHEX x = MAP unhex_alt x`,
-  rw[]>>match_mp_tac LIST_EQ>>fs[EL_MAP,EVERY_EL,unhex_alt_def,isDigit_def,isHexDigit_def])
+  MAP UNHEX x = MAP unhex_alt x
+Proof
+  rw[]>>match_mp_tac LIST_EQ>>fs[EL_MAP,EVERY_EL,unhex_alt_def,isDigit_def,isHexDigit_def]
+QED
 
-val toNum_rw = Q.prove(`
+Triviality toNum_rw:
   ∀x. EVERY isDigit x ⇒
-  toNum x = num_from_dec_string_alt x`,
+  toNum x = num_from_dec_string_alt x
+Proof
   rw[ASCIInumbersTheory.s2n_def,ASCIInumbersTheory.num_from_dec_string_def,num_from_dec_string_alt_def]>>
   AP_TERM_TAC>>
   match_mp_tac EVERY_isDigit_imp>>
-  metis_tac[rich_listTheory.EVERY_REVERSE])
+  metis_tac[rich_listTheory.EVERY_REVERSE]
+QED
 
-val EVERY_isHexDigit_imp = Q.prove(`
+Triviality EVERY_isHexDigit_imp:
   EVERY isHexDigit x ⇒
-  MAP UNHEX x = MAP unhex_alt x`,
-  rw[]>>match_mp_tac LIST_EQ>>fs[EL_MAP,EVERY_EL,unhex_alt_def])
+  MAP UNHEX x = MAP unhex_alt x
+Proof
+  rw[]>>match_mp_tac LIST_EQ>>fs[EL_MAP,EVERY_EL,unhex_alt_def]
+QED
 
-val num_from_hex_string_rw = Q.prove(`
+Triviality num_from_hex_string_rw:
   ∀x. EVERY isHexDigit x ⇒
-  num_from_hex_string x = num_from_hex_string_alt x`,
+  num_from_hex_string x = num_from_hex_string_alt x
+Proof
   rw[ASCIInumbersTheory.s2n_def,ASCIInumbersTheory.num_from_hex_string_def,num_from_hex_string_alt_def]>>
   AP_TERM_TAC>>
   match_mp_tac EVERY_isHexDigit_imp>>
-  metis_tac[rich_listTheory.EVERY_REVERSE])
+  metis_tac[rich_listTheory.EVERY_REVERSE]
+QED
 
-val EVERY_IMPLODE = Q.prove(`
+Triviality EVERY_IMPLODE:
   ∀ls P.
-  EVERY P (IMPLODE ls) ⇔ EVERY P ls`,
-  Induct>>fs[])
+  EVERY P (IMPLODE ls) ⇔ EVERY P ls
+Proof
+  Induct>>fs[]
+QED
 
-val read_while_P_lem = Q.prove(`
+Triviality read_while_P_lem:
   ∀ls rest P x y.
   EVERY P rest ∧
   read_while P ls rest = (x,y) ⇒
-  EVERY P x`,
+  EVERY P x
+Proof
   Induct>>fs[read_while_def]>>rw[]>>
   fs[EVERY_IMPLODE,rich_listTheory.EVERY_REVERSE]>>
   first_assum match_mp_tac>>fs[]>>
-  qexists_tac`STRING h rest`>>fs[])
+  qexists_tac`STRING h rest`>>fs[]
+QED
 
 Theorem read_while_P[local]:
   ∀ls P x y. read_while P ls "" = (x,y) ⇒ EVERY P x
@@ -372,11 +384,12 @@ Definition lex_until_toplevel_semicolon_def:
   lex_until_toplevel_semicolon input = lex_aux [] 0 input
 End
 
-val lex_aux_LESS = Q.prove(
-  `!acc d input l.
+Triviality lex_aux_LESS:
+  !acc d input l.
       (lex_aux acc d input l = SOME (ts, l', rest)) ==>
       if acc = [] then LENGTH rest < LENGTH input
-                  else LENGTH rest <= LENGTH input`,
+                  else LENGTH rest <= LENGTH input
+Proof
   HO_MATCH_MP_TAC (fetch "-" "lex_aux_ind")
   THEN REPEAT STRIP_TAC THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [lex_aux_def]
@@ -390,7 +403,8 @@ val lex_aux_LESS = Q.prove(
   THEN FULL_SIMP_TAC (srw_ss()) []
   THEN RES_TAC THEN IMP_RES_TAC arithmeticTheory.LESS_EQ_LESS_TRANS
   THEN IMP_RES_TAC (DECIDE ``n < m ==> n <= m:num``)
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+QED
 
 Theorem lex_until_toplevel_semicolon_LESS:
    (lex_until_toplevel_semicolon input l = SOME (ts, l', rest)) ==>
@@ -430,11 +444,12 @@ Definition lex_until_top_semicolon_alt_def:
   lex_until_top_semicolon_alt input = lex_aux_alt [] 0 input
 End
 
-val lex_aux_alt_LESS = Q.prove(
-  `!acc d input l.
+Triviality lex_aux_alt_LESS:
+  !acc d input l.
       (lex_aux_alt acc d input l = SOME (ts, l', rest)) ==>
       if acc = [] then LENGTH rest < LENGTH input
-                  else LENGTH rest <= LENGTH input`,
+                  else LENGTH rest <= LENGTH input
+Proof
   HO_MATCH_MP_TAC (fetch "-" "lex_aux_alt_ind")
   THEN REPEAT STRIP_TAC THEN POP_ASSUM MP_TAC
   THEN ONCE_REWRITE_TAC [lex_aux_alt_def]
@@ -447,7 +462,8 @@ val lex_aux_alt_LESS = Q.prove(
   THEN TRY (Cases_on `h`) THEN FULL_SIMP_TAC (srw_ss()) []
   THEN RES_TAC THEN IMP_RES_TAC arithmeticTheory.LESS_EQ_LESS_TRANS
   THEN IMP_RES_TAC (DECIDE ``n < m ==> n <= m:num``)
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+QED
 
 Theorem lex_until_top_semicolon_alt_LESS:
    (lex_until_top_semicolon_alt input l = SOME (ts, l', rest)) ==>
@@ -544,11 +560,12 @@ Definition lex_until_toplevel_semicolon_tokens_def:
   lex_until_toplevel_semicolon_tokens input = lex_aux_tokens [] 0 input
 End
 
-val lex_aux_tokens_LESS = Q.prove(
-  `!acc d input.
+Triviality lex_aux_tokens_LESS:
+  !acc d input.
       (lex_aux_tokens acc d input = SOME (t,rest)) ==>
       (if acc = [] then LENGTH rest < LENGTH input
-                   else LENGTH rest <= LENGTH input)`,
+                   else LENGTH rest <= LENGTH input)
+Proof
   Induct_on `input`
   THEN1 (EVAL_TAC >> SRW_TAC [] [LENGTH] >> SRW_TAC [] [LENGTH])
   >> SIMP_TAC (srw_ss()) [Once lex_aux_tokens_def,LET_DEF]
@@ -557,7 +574,8 @@ val lex_aux_tokens_LESS = Q.prove(
   >> TRY (Cases_on `h`) >> RES_TAC
   >> FULL_SIMP_TAC (srw_ss()) [] >> RES_TAC
   >> FULL_SIMP_TAC (srw_ss()) [] >> RES_TAC
-  >> Cases_on `q` >> Cases_on `d` >> fs[] >> res_tac >> fs[]);
+  >> Cases_on `q` >> Cases_on `d` >> fs[] >> res_tac >> fs[]
+QED
 
 Definition lex_impl_all_tokens_def:
   lex_impl_all_tokens input =
@@ -590,16 +608,18 @@ val lex_aux_tokens_thm = Q.prove(
   >> SRW_TAC [] [] >> SRW_TAC [] []
   >> ASM_SIMP_TAC std_ss [GSYM lexer_fun_aux_def]) |> SIMP_RULE std_ss [];
 
-val lex_impl_all_tokens_thm = Q.prove(
-  `!input l. lex_impl_all input l =
-            lex_impl_all_tokens (lexer_fun_aux input l)`,
+Triviality lex_impl_all_tokens_thm:
+  !input l. lex_impl_all input l =
+            lex_impl_all_tokens (lexer_fun_aux input l)
+Proof
   HO_MATCH_MP_TAC (fetch "-" "lex_impl_all_ind") >> REPEAT STRIP_TAC
   >> SIMP_TAC std_ss [Once lex_impl_all_def,Once lex_impl_all_tokens_def]
   >> fs [lex_until_toplevel_semicolon_tokens_def]
   >> fs [lex_until_toplevel_semicolon_def]
   >> MP_TAC (lex_aux_tokens_thm |> Q.SPECL [`input`, `l`, `[]`,`0`])
   >> Cases_on `lex_aux [] 0 input l` >> fs[]
-  >> Cases_on `x` >> Cases_on `r` >> fs[]);
+  >> Cases_on `x` >> Cases_on `r` >> fs[]
+QED
 
 val lex_aux_tokens_thm = Q.prove(
   `!input d acc.
@@ -628,8 +648,9 @@ val lex_aux_tokens_thm = Q.prove(
   >> fs [Once toplevel_semi_dex_def,LENGTH,arithmeticTheory.ADD1])
   |> Q.SPECL [`input`,`0`,`[]`] |> Q.GEN `res` |> SIMP_RULE std_ss [LENGTH];
 
-val split_top_level_semi_thm = Q.prove(
-  `!input. split_top_level_semi input = lex_impl_all_tokens input`,
+Triviality split_top_level_semi_thm:
+  !input. split_top_level_semi input = lex_impl_all_tokens input
+Proof
   HO_MATCH_MP_TAC split_top_level_semi_ind >> REPEAT STRIP_TAC
   >> SIMP_TAC std_ss [Once split_top_level_semi_def,Once lex_impl_all_tokens_def,
       Once lex_until_toplevel_semicolon_tokens_def]
@@ -638,7 +659,8 @@ val split_top_level_semi_thm = Q.prove(
   >> Cases_on `x` >> FULL_SIMP_TAC (srw_ss()) []
   >> FULL_SIMP_TAC std_ss [TAKE_LENGTH_APPEND,DROP_LENGTH_APPEND]
   >> STRIP_TAC >> RES_TAC >> POP_ASSUM MP_TAC
-  >> FULL_SIMP_TAC std_ss [TAKE_LENGTH_APPEND,DROP_LENGTH_APPEND]);
+  >> FULL_SIMP_TAC std_ss [TAKE_LENGTH_APPEND,DROP_LENGTH_APPEND]
+QED
 
 Theorem lexer_correct:
    !input. split_top_level_semi (lexer_fun_aux input l) = lex_impl_all input l

--- a/compiler/parsing/ocaml/camlPEGScript.sml
+++ b/compiler/parsing/ocaml/camlPEGScript.sml
@@ -1076,9 +1076,11 @@ val cml_wfpeg_thm = save_thm(
   "cml_wfpeg_thm",
   LIST_CONJ (List.foldl wfnt [] topo_nts))
 
-val subexprs_pnt = Q.prove(
-  `subexprs (pnt n) = {pnt n}`,
-  simp [pegTheory.subexprs_def, pnt_def]);
+Triviality subexprs_pnt:
+  subexprs (pnt n) = {pnt n}
+Proof
+  simp [pegTheory.subexprs_def, pnt_def]
+QED
 
 Theorem PEG_exprs =
    “Gexprs camlPEG”

--- a/compiler/parsing/proofs/cmlNTPropsScript.sml
+++ b/compiler/parsing/proofs/cmlNTPropsScript.sml
@@ -9,7 +9,11 @@ val _ = new_theory "cmlNTProps";
 
 val _ = set_grammar_ancestry ["gramProps"]
 
-val disjImpI = Q.prove(`~p \/ q ⇔ p ⇒ q`, DECIDE_TAC)
+Triviality disjImpI:
+  ~p \/ q ⇔ p ⇒ q
+Proof
+  DECIDE_TAC
+QED
 
 Theorem firstSet_nUQTyOp[simp]:
   firstSet cmlG (NN nUQTyOp::rest) =

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -20,10 +20,12 @@ val skths = [GSYM RIGHT_EXISTS_IMP_THM, SKOLEM_THM]
 val SKRULE = SRULE skths
 val SKTAC = gs skths
 
-val option_case_eq = Q.prove(
-  ‘(option_CASE optv n sf = v) ⇔
-     optv = NONE ∧ n = v ∨ ∃v0. optv = SOME v0 ∧ sf v0 = v’,
-  Cases_on `optv` >> simp[]);
+Triviality option_case_eq:
+  (option_CASE optv n sf = v) ⇔
+     optv = NONE ∧ n = v ∨ ∃v0. optv = SOME v0 ∧ sf v0 = v
+Proof
+  Cases_on `optv` >> simp[]
+QED
 Theorem MAP_EQ_CONS[local]:
   MAP f l = h::t <=> ∃h0 t0. l = h0::t0 ∧ f h0 = h ∧ MAP f t0 = t
 Proof metis_tac[MAP_EQ_CONS]
@@ -177,7 +179,11 @@ Proof
   rename [‘hdi = (_,_)’] >> Cases_on ‘hdi’ >> simp[] >> metis_tac[]
 QED
 
-val disjImpI = Q.prove(`~p \/ q ⇔ p ⇒ q`, DECIDE_TAC)
+Triviality disjImpI:
+  ~p \/ q ⇔ p ⇒ q
+Proof
+  DECIDE_TAC
+QED
 
 Theorem ptree_head_eq_tok0[local]:
   (ptree_head pt = TOK tk) ⇔ (?l. pt = Lf (TOK tk,l))
@@ -304,10 +310,12 @@ Proof
   drule_all not_peg0_LENGTH_decreases >> simp[]
 QED
 
-val list_case_lemma = Q.prove(
-  `([x] = case a of [] => [] | h::t => f h t) ⇔
-    (a ≠ [] ∧ [x] = f (HD a) (TL a))`,
-  Cases_on `a` >> simp[]);
+Triviality list_case_lemma:
+  ([x] = case a of [] => [] | h::t => f h t) ⇔
+    (a ≠ [] ∧ [x] = f (HD a) (TL a))
+Proof
+  Cases_on `a` >> simp[]
+QED
 
 (* only the subs = [x] and subs = [x;y] cases are relevant *)
 Definition left_insert1_def:
@@ -667,7 +675,11 @@ Proof
 QED
 
 val elim_disjineq = Q.prove( `p \/ x ≠ y ⇔ (x = y ⇒ p)`, DECIDE_TAC)
-val elim_det = Q.prove(`(!x. P x ⇔ (x = y)) ==> P y`, METIS_TAC[])
+Triviality elim_det:
+  (!x. P x ⇔ (x = y)) ==> P y
+Proof
+  METIS_TAC[]
+QED
 
 Theorem peg_seql_NONE_det:
    peg_eval G (i0, seql syms f) (Failure fl fe) ⇒

--- a/examples/bot/MonitorProgScript.sml
+++ b/examples/bot/MonitorProgScript.sml
@@ -34,19 +34,23 @@ val spec64= INST_TYPE[alpha|->``:64``]
 val gconv = CONV_RULE (DEPTH_CONV wordsLib.WORD_GROUND_CONV)
 val econv = CONV_RULE wordsLib.WORD_EVAL_CONV
 
-val word_msb_rw32 = Q.prove(
-  `word_msb (a:word32) ⇔ (a>>>31) <> 0w`,
+Triviality word_msb_rw32:
+  word_msb (a:word32) ⇔ (a>>>31) <> 0w
+Proof
   rw[word_msb_def,fcpTheory.CART_EQ,word_index,word_lsr_def,fcpTheory.FCP_BETA]
   \\ rw[EQ_IMP_THM]
   >- ( qexists_tac`0` \\ simp[] )
-  \\ `i = 0` by decide_tac \\ fs[]);
+  \\ `i = 0` by decide_tac \\ fs[]
+QED
 
-val word_msb_rw64 = Q.prove(
-  `word_msb (a:word64) ⇔ (a>>>63) <> 0w`,
+Triviality word_msb_rw64:
+  word_msb (a:word64) ⇔ (a>>>63) <> 0w
+Proof
   rw[word_msb_def,fcpTheory.CART_EQ,word_index,word_lsr_def,fcpTheory.FCP_BETA]
   \\ rw[EQ_IMP_THM]
   >- ( qexists_tac`0` \\ simp[] )
-  \\ `i = 0` by decide_tac \\ fs[]);
+  \\ `i = 0` by decide_tac \\ fs[]
+QED
 
 val inlines = SIMP_RULE std_ss [NEG_INF_def,POS_INF_def,sw2sw_w2w,word_msb_rw32,word_msb_rw64,word_mul_def,word_2comp_def, divfloor_def, divceil_def, word_smod_def, word_sdiv_def]
 
@@ -72,16 +76,17 @@ val res = translate (divl_def |> inlines |> econv);
 val res = translate (divu_def |> inlines |> econv);
 val res = translate (divPair_def |> inlines |> econv);
 
-val lem = Q.prove(`
+Triviality lem:
   (wle 0w c ⇒ c ≠ 0w) ∧
   (wle 0w c ∧ wleq c d ⇒ d ≠ 0w) ∧
   (¬wleq c 0w ∧ wleq c d ⇒ c ≠ 0w ∧ d ≠ 0w) ∧
   (¬wleq 0w d ⇒ d ≠ 0w) ∧
   (¬wleq 0w d ∧ wleq c d ⇒ c ≠ 0w)
-  `,
+Proof
   EVAL_TAC>>rw[]>>
   CCONTR_TAC>>fs[]>>
-  blastLib.FULL_BBLAST_TAC);
+  blastLib.FULL_BBLAST_TAC
+QED
 
 val divpair_side = Q.prove(`
   divpair_side a b c d ⇔ T`,

--- a/examples/bot/MonitorProofScript.sml
+++ b/examples/bot/MonitorProofScript.sml
@@ -30,8 +30,11 @@ Definition hide_def:
   hide f p r <=> if f then p else r
 End
 
-val hideF = Q.prove(`
-  hide F p r = r`, fs[hide_def])
+Triviality hideF:
+  hide F p r = r
+Proof
+  fs[hide_def]
+QED
 
 Definition body_step_def:
   body_step flg w w' <=>
@@ -142,73 +145,90 @@ Definition wf_mach_def:
     LENGTH (w.wo.transition_oracle n inp) = sensorlen)
 End
 
-val MAP_ZIP2 = Q.prove(`
+Triviality MAP_ZIP2:
   LENGTH xs = LENGTH ys ⇒
   MAP (λ(x,t). (x,f t)) (ZIP (xs,ys)) =
-  ZIP (xs, MAP f ys)`,
-  fs[LIST_EQ_REWRITE] >>rw[EL_MAP,EL_ZIP]);
+  ZIP (xs, MAP f ys)
+Proof
+  fs[LIST_EQ_REWRITE] >>rw[EL_MAP,EL_ZIP]
+QED
 
-val ZIP_ID = Q.prove(`
-  ZIP(ls,ls) = MAP (λx. x,x) ls`,
-  fs[LIST_EQ_REWRITE,EL_ZIP,EL_MAP]);
+Triviality ZIP_ID:
+  ZIP(ls,ls) = MAP (λx. x,x) ls
+Proof
+  fs[LIST_EQ_REWRITE,EL_ZIP,EL_MAP]
+QED
 
-val MEM_ALOOKUP_APPEND = Q.prove(`
+Triviality MEM_ALOOKUP_APPEND:
   MEM x (MAP FST ls) ⇒
-  ALOOKUP (ls++xs) x = ALOOKUP (ls++ys) x`,
+  ALOOKUP (ls++xs) x = ALOOKUP (ls++ys) x
+Proof
   rw[ALOOKUP_APPEND]>>
-  TOP_CASE_TAC>>fs[ALOOKUP_NONE]);
+  TOP_CASE_TAC>>fs[ALOOKUP_NONE]
+QED
 
-val MEM_ALOOKUP_APPEND_REV = Q.prove(`
+Triviality MEM_ALOOKUP_APPEND_REV:
   ALL_DISTINCT (MAP FST ls) ∧
   MEM x (MAP FST ls) ⇒
-  ALOOKUP (ls++xs) x = ALOOKUP (REVERSE ls++ys) x`,
+  ALOOKUP (ls++xs) x = ALOOKUP (REVERSE ls++ys) x
+Proof
   rw[ALOOKUP_APPEND]>>
   TOP_CASE_TAC>>fs[ALOOKUP_NONE]>>
-  simp[alookup_distinct_reverse]);
+  simp[alookup_distinct_reverse]
+QED
 
-val NOT_MEM_ALOOKUP_APPEND = Q.prove(`
+Triviality NOT_MEM_ALOOKUP_APPEND:
   ¬MEM x (MAP FST ls) ⇒
-  ALOOKUP (ls++xs) x = ALOOKUP xs x`,
+  ALOOKUP (ls++xs) x = ALOOKUP xs x
+Proof
   rw[ALOOKUP_APPEND]>>
   TOP_CASE_TAC>>fs[]>>
   imp_res_tac ALOOKUP_MEM>>fs[MEM_MAP,FORALL_PROD]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val APPEND_ASSOC4 = Q.prove(`
+Triviality APPEND_ASSOC4:
   (a ++ b ++ c ++ d):'a list =
-  (a++b) ++ (c++d)`,
-  fs[]);
+  (a++b) ++ (c++d)
+Proof
+  fs[]
+QED
 
-val no_overlap_APPEND = Q.prove(`
+Triviality no_overlap_APPEND:
   no_overlap ls (xs++ys) ⇔
-  no_overlap ls xs ∧ no_overlap ls ys`,
+  no_overlap ls xs ∧ no_overlap ls ys
+Proof
   fs[no_overlap_thm]>>
-  metis_tac[]);
+  metis_tac[]
+QED
 
-val state_rel_lookup_const = Q.prove(`
+Triviality state_rel_lookup_const:
   wf_config w.wc ∧
   wf_mach w /\
   MEM x w.wc.const_names ∧
   state_rel w st ⇒
   ALOOKUP st x =
   ALOOKUP
-  (ZIP (w.wc.const_names,MAP (λx. (x,x)) w.ws.const_vals)) x`,
+  (ZIP (w.wc.const_names,MAP (λx. (x,x)) w.ws.const_vals)) x
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
   pop_assum sym_sub_tac>>
   simp[GSYM ZIP_APPEND]>>
   dep_rewrite.DEP_ONCE_REWRITE_TAC [NOT_MEM_ALOOKUP_APPEND]>>
-  fs[ZIP_ID,MAP_ZIP,no_overlap_thm]);
+  fs[ZIP_ID,MAP_ZIP,no_overlap_thm]
+QED
 
-val state_rel_lookup_sensor = Q.prove(`
+Triviality state_rel_lookup_sensor:
   wf_config w.wc ∧
   wf_mach w /\
   MEM x w.wc.sensor_names ∧
   state_rel w st ⇒
   ALOOKUP st x =
   ALOOKUP
-  (ZIP (w.wc.sensor_names,MAP (λx. (x,x)) w.ws.sensor_vals)++rest) x`,
+  (ZIP (w.wc.sensor_names,MAP (λx. (x,x)) w.ws.sensor_vals)++rest) x
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
@@ -216,9 +236,10 @@ val state_rel_lookup_sensor = Q.prove(`
   simp[GSYM ZIP_APPEND,ZIP_ID]>>
   PURE_REWRITE_TAC [GSYM APPEND_ASSOC]>>
   match_mp_tac MEM_ALOOKUP_APPEND>>
-  fs[MAP_ZIP]);
+  fs[MAP_ZIP]
+QED
 
-val state_rel_lookup_full = Q.prove(`
+Triviality state_rel_lookup_full:
   wf_config w.wc ∧
   wf_mach w /\
   (MEM x w.wc.const_names ∨ MEM x w.wc.ctrl_names ∨ MEM x w.wc.sensor_names) ∧
@@ -227,7 +248,8 @@ val state_rel_lookup_full = Q.prove(`
   ALOOKUP
   (ZIP (w.wc.sensor_names,MAP (λx. (x,x)) w.ws.sensor_vals) ++
    ZIP (w.wc.ctrl_names,MAP (λx. (x,x)) w.ws.ctrl_vals) ++
-   ZIP (w.wc.const_names,MAP (λx. (x,x)) w.ws.const_vals)) x`,
+   ZIP (w.wc.const_names,MAP (λx. (x,x)) w.ws.const_vals)) x
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
@@ -235,9 +257,10 @@ val state_rel_lookup_full = Q.prove(`
   simp[GSYM ZIP_APPEND,ZIP_ID]>>
   PURE_REWRITE_TAC [GSYM APPEND_ASSOC]>>
   match_mp_tac MEM_ALOOKUP_APPEND>>
-  fs[MAP_ZIP]);
+  fs[MAP_ZIP]
+QED
 
-val state_rel_lookup_const2 = Q.prove(`
+Triviality state_rel_lookup_const2:
   wf_config w.wc ∧
   wf_mach w /\
   MEM x w.wc.const_names ∧
@@ -246,7 +269,8 @@ val state_rel_lookup_const2 = Q.prove(`
   ALOOKUP
   (ZIP (w.wc.sensor_names, w.ws.sensor_vals) ++
    ZIP (w.wc.ctrl_names, w.ws.ctrl_vals) ++
-   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v`,
+   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
@@ -262,9 +286,10 @@ val state_rel_lookup_const2 = Q.prove(`
     metis_tac[EL_MEM])>>
   fs[ALOOKUP_ZIP_MAP_SND]>>
   simp[ALOOKUP_EXISTS_IFF,MEM_ZIP]>>
-  metis_tac[MEM_EL]);
+  metis_tac[MEM_EL]
+QED
 
-val state_rel_lookup_sensor2 = Q.prove(`
+Triviality state_rel_lookup_sensor2:
   wf_config w.wc ∧
   wf_mach w /\
   MEM x w.wc.sensor_names ∧
@@ -273,7 +298,8 @@ val state_rel_lookup_sensor2 = Q.prove(`
   ALOOKUP
   (ZIP (w.wc.sensor_names, w.ws.sensor_vals) ++
    ZIP (w.wc.ctrl_names, w.ws.ctrl_vals) ++
-   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v`,
+   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
@@ -288,9 +314,10 @@ val state_rel_lookup_sensor2 = Q.prove(`
   dep_rewrite.DEP_ONCE_REWRITE_TAC [Q.SPEC `[]` (GEN_ALL MEM_ALOOKUP_APPEND)]>>
   simp[MAP_ZIP]>>
   simp[ALOOKUP_EXISTS_IFF,MEM_ZIP]>>
-  metis_tac[MEM_EL]);
+  metis_tac[MEM_EL]
+QED
 
-val state_rel_lookup_ctrl2 = Q.prove(`
+Triviality state_rel_lookup_ctrl2:
   wf_config w.wc ∧
   wf_mach w /\
   MEM x w.wc.ctrl_names ∧
@@ -299,7 +326,8 @@ val state_rel_lookup_ctrl2 = Q.prove(`
   ALOOKUP
   (ZIP (w.wc.sensor_names, w.ws.sensor_vals) ++
    ZIP (w.wc.ctrl_names, w.ws.ctrl_vals) ++
-   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v`,
+   ZIP (w.wc.const_names,w.ws.const_vals)) x = SOME v
+Proof
   rw[]>>fs[state_rel_def,wf_config_def,wf_mach_def]>>
   pop_assum(qspec_then`x` assume_tac)>>
   rfs[]>>
@@ -309,11 +337,13 @@ val state_rel_lookup_ctrl2 = Q.prove(`
   simp[ALOOKUP_ZIP_MAP_SND]>>
   simp[GSYM ZIP_APPEND]>>
   simp[ALOOKUP_EXISTS_IFF,MEM_ZIP]>>
-  metis_tac[MEM_EL]);
+  metis_tac[MEM_EL]
+QED
 
-val MAP_lookup_var = Q.prove(`
+Triviality MAP_lookup_var:
   ALL_DISTINCT vars ∧ LENGTH vars = LENGTH vals ⇒
-  MAP (lookup_var (REVERSE (ZIP(vars,vals)) ++ rest)) vars = vals`,
+  MAP (lookup_var (REVERSE (ZIP(vars,vals)) ++ rest)) vars = vals
+Proof
   rw[]>>
   fs[LIST_EQ_REWRITE]>>
   simp[EL_MAP,lookup_var_def]>>
@@ -322,25 +352,30 @@ val MAP_lookup_var = Q.prove(`
   dep_rewrite.DEP_REWRITE_TAC [alookup_distinct_reverse]>>
   simp[MAP_ZIP]>>
   Q.ISPECL_THEN [`ZIP(vars,vals)`,`x`] assume_tac ALOOKUP_ALL_DISTINCT_EL>>
-  rfs[MAP_ZIP,EL_ZIP]);
+  rfs[MAP_ZIP,EL_ZIP]
+QED
 
-val is_point_MAP_cancel = Q.prove(`
+Triviality is_point_MAP_cancel:
   EVERY is_point ls ⇒
   MAP (λx. (x,x))
-    (MAP FST ls) = ls`,
+    (MAP FST ls) = ls
+Proof
   rw[]>>simp[MAP_EQ_ID,MAP_MAP_o]>>fs[EVERY_MEM,is_point_def]>>
-  metis_tac[FST,SND,PAIR]);
+  metis_tac[FST,SND,PAIR]
+QED
 
-val ALOOKUP_REV_SAME_SKIP = Q.prove(`
+Triviality ALOOKUP_REV_SAME_SKIP:
   ALL_DISTINCT (MAP FST xs) ∧
   (¬MEM x (MAP FST xs) ⇒ ALOOKUP ls x = ALOOKUP rs x)
   ⇒
-  ALOOKUP (REVERSE xs ++ ls) x = ALOOKUP (xs ++ rs) x`,
+  ALOOKUP (REVERSE xs ++ ls) x = ALOOKUP (xs ++ rs) x
+Proof
   rw[ALOOKUP_APPEND]>>
   simp[alookup_distinct_reverse]>>
   TOP_CASE_TAC>>fs[]>>
   first_x_assum match_mp_tac>>
-  metis_tac[ALOOKUP_NONE]);
+  metis_tac[ALOOKUP_NONE]
+QED
 
 Theorem w8_to_w32_w32_to_w8:
   ∀l. w8_to_w32 (w32_to_w8 l) = l
@@ -882,16 +917,18 @@ Definition init_step_def:
   init_step w = cwfsem_bi_val w.wc.init (mk_state w)
 End
 
-val ALL_DISTINCT_ALOOKUP_REV = Q.prove(`
+Triviality ALL_DISTINCT_ALOOKUP_REV:
   ALL_DISTINCT (MAP FST ls) ∧
   ALOOKUP xs x = ALOOKUP ys x ⇒
-  ALOOKUP (ls++xs) x = ALOOKUP ((REVERSE ls)++ys) x`,
+  ALOOKUP (ls++xs) x = ALOOKUP ((REVERSE ls)++ys) x
+Proof
   rw[]>>
   Cases_on`MEM x (MAP FST ls)`
   >-
     metis_tac[MEM_ALOOKUP_APPEND_REV]
   >>
-  dep_rewrite.DEP_REWRITE_TAC [NOT_MEM_ALOOKUP_APPEND]>>fs[MEM_MAP]);
+  dep_rewrite.DEP_REWRITE_TAC [NOT_MEM_ALOOKUP_APPEND]>>fs[MEM_MAP]
+QED
 
 Theorem init_step_init_sandbox:
   wf_config w.wc ∧
@@ -968,13 +1005,15 @@ val bot_st = get_ml_prog_state();
 Overload WORD32 =``WORD:word32 -> v -> bool``;
 
 (* Helper lemmas *)
-val MAP4_empty = Q.prove(`
+Triviality MAP4_empty:
   LENGTH ls < 4 ⇒
-  MAP4 f ls = []`,
+  MAP4 f ls = []
+Proof
   Cases_on`ls`>>fs[MAP4_def]>>
   Cases_on`t`>>fs[MAP4_def]>>
   Cases_on`t'`>>fs[MAP4_def]>>
-  Cases_on`t`>>fs[MAP4_def]);
+  Cases_on`t`>>fs[MAP4_def]
+QED
 
 Theorem w32_to_w8_APPEND:
   ∀a b. w32_to_w8 (a ++ b) = w32_to_w8 a ++ w32_to_w8 b

--- a/examples/bot/botFFIProofScript.sml
+++ b/examples/bot/botFFIProofScript.sml
@@ -96,13 +96,14 @@ Proof
   \\ metis_tac[]
 QED
 
-val call_FFI_rel_IMP = Q.prove(`
+Triviality call_FFI_rel_IMP:
   ∀st st'.
   call_FFI_rel^* st st' ==>
   st.oracle = bot_ffi_oracle ⇒
   ∃ls.
     st'.io_events = st.io_events ++ ls ∧
-    extract_mach st.ffi_state ls = SOME st'.ffi_state`,
+    extract_mach st.ffi_state ls = SOME st'.ffi_state
+Proof
   HO_MATCH_MP_TAC RTC_INDUCT \\ rw [] \\ fs [extract_mach_def]
   \\ fs [evaluatePropsTheory.call_FFI_rel_def]
   \\ fs [ffiTheory.call_FFI_def]
@@ -110,7 +111,8 @@ val call_FFI_rel_IMP = Q.prove(`
   \\ fs[extract_mach_def,bot_ffi_oracle_def]
   \\ qpat_x_assum`_ = Oracle_return f l` mp_tac
   \\ fs[MAP_ZIP]
-  \\ rpt(IF_CASES_TAC \\fs[] >- ntac 2 (TOP_CASE_TAC\\simp[])));
+  \\ rpt(IF_CASES_TAC \\fs[] >- ntac 2 (TOP_CASE_TAC\\simp[]))
+QED
 
 val main_call = ``(Dlet unknown_loc (Pcon NONE []) (App Opapp [Var (Short fname); Con NONE []]))``
 

--- a/examples/bot/botFFIScript.sml
+++ b/examples/bot/botFFIScript.sml
@@ -311,17 +311,21 @@ Proof
   metis_tac[]
 QED
 
-val encode_default_11 = Q.prove(`
+Triviality encode_default_11:
   ∀x y.
-  MAP encode_trm x = MAP encode_trm y ⇒ x = y`,
-  Induct>>fs[]>>Cases_on`y`>>fs[encode_trm_11]);
+  MAP encode_trm x = MAP encode_trm y ⇒ x = y
+Proof
+  Induct>>fs[]>>Cases_on`y`>>fs[encode_trm_11]
+QED
 
-val encode_mach_config_11 = Q.prove(`
+Triviality encode_mach_config_11:
   encode_mach_config x = encode_mach_config y ⇔
-  x = y`,
+  x = y
+Proof
   fs[encode_mach_config_def]>>
   rw[EQ_IMP_THM]>>fs comp_eq>>
-  fs[MAP_Str_11,encode_fml_11,encode_sum_list_11,encode_default_11]);
+  fs[MAP_Str_11,encode_fml_11,encode_sum_list_11,encode_default_11]
+QED
 
 Definition encode_word32_list_inner_def:
   encode_word32_list_inner = iList o (MAP (iStr o w2s 2 CHR))
@@ -342,24 +346,30 @@ Definition encode_mach_state_inner_def:
   (encode_word32_list_inner ws.sensor_vals))
 End
 
-val encode_mach_state_11 = Q.prove(`
+Triviality encode_mach_state_11:
   encode_mach_state x = encode_mach_state y ⇔
-  x = y`,
+  x = y
+Proof
   rw[encode_mach_state_def]>>fs comp_eq>>
-  metis_tac[encode_word32_list_11]);
+  metis_tac[encode_word32_list_11]
+QED
 
-val encode_word32_list_inner_11 = Q.prove(`
-  !x y. encode_word32_list_inner x = encode_word32_list_inner y <=> x = y`,
+Triviality encode_word32_list_inner_11:
+  !x y. encode_word32_list_inner x = encode_word32_list_inner y <=> x = y
+Proof
   Induct \\ Cases_on `y`
   \\ fs [encode_word32_list_inner_def]
-  \\ metis_tac[w2sCHR_11]);
+  \\ metis_tac[w2sCHR_11]
+QED
 
-val encode_mach_state_inner_11 = Q.prove(`
+Triviality encode_mach_state_inner_11:
   encode_mach_state_inner x =
   encode_mach_state_inner y <=>
-  x = y`,
+  x = y
+Proof
   rw[encode_mach_state_inner_def]>>fs comp_eq>>
-  metis_tac[encode_word32_list_inner_11]);
+  metis_tac[encode_word32_list_inner_11]
+QED
 
 val decode_encode_mach_state_inner = new_specification("decode_encode_mach_state_inner",["decode_mach_state_inner"],
   prove(``?decode. !cls. decode (encode_mach_state_inner cls) = SOME cls``,
@@ -388,12 +398,14 @@ Definition encode_stop_oracle_def:
       Num (if stop_oracle (get_num num) then 1 else 0))
 End
 
-val encode_stop_oracle_11 = Q.prove(`
+Triviality encode_stop_oracle_11:
   encode_stop_oracle x = encode_stop_oracle y ==>
-  x = y`,
+  x = y
+Proof
   rw[]>>fs[FUN_EQ_THM,encode_stop_oracle_def]>>rw[]>>
   pop_assum(qspec_then`iNum x'` assume_tac)>>fs[get_num_def]>>
-  every_case_tac>>fs[]);
+  every_case_tac>>fs[]
+QED
 
 Definition encode_ctrl_oracle_def:
   encode_ctrl_oracle ctrl_oracle =
@@ -433,9 +445,10 @@ Definition encode_transition_oracle_def:
     encode_word32_list (transition_oracle (get_num num) (get_st_ctrl_pair stpr))))
 End
 
-val encode_transition_oracle_11 = Q.prove(`
+Triviality encode_transition_oracle_11:
   encode_transition_oracle f = encode_transition_oracle f' ==>
-  f = f'`,
+  f = f'
+Proof
   rw[encode_transition_oracle_def]>>
   fs[FUN_EQ_THM]>>
   rw[]>>
@@ -446,7 +459,8 @@ val encode_transition_oracle_11 = Q.prove(`
   `∀x:word32. s2w 2 ORD (w2s 2 CHR x)= x` by
      (rw[]>>match_mp_tac s2w_w2s>>fs[])>>
   fs[]>>
-  metis_tac[encode_word32_list_11]);
+  metis_tac[encode_word32_list_11]
+QED
 
 Definition encode_mach_oracle_def:
   encode_mach_oracle wo =
@@ -455,12 +469,14 @@ Definition encode_mach_oracle_def:
   (encode_stop_oracle wo.stop_oracle))
 End
 
-val encode_mach_oracle_11 = Q.prove(`
+Triviality encode_mach_oracle_11:
   encode_mach_oracle x = encode_mach_oracle y ⇔
-  x = y`,
+  x = y
+Proof
   fs[encode_mach_oracle_def]>>rw[EQ_IMP_THM]>>
   fs comp_eq>>
-  metis_tac[encode_transition_oracle_11,encode_ctrl_oracle_11,encode_stop_oracle_11]);
+  metis_tac[encode_transition_oracle_11,encode_ctrl_oracle_11,encode_stop_oracle_11]
+QED
 
 Definition encode_def:
   encode w =

--- a/examples/bot/compile/botProgScript.sml
+++ b/examples/bot/compile/botProgScript.sml
@@ -39,13 +39,15 @@ Definition parse_AssignAnyPar_def:
     else NONE)
 End
 
-val parse_AssignAnyPar_inv = Q.prove(`
+Triviality parse_AssignAnyPar_inv:
   ∀seq ls.
   parse_AssignAnyPar seq = SOME ls ⇒
-  AssignAnyPar ls = seq`,
+  AssignAnyPar ls = seq
+Proof
   ho_match_mp_tac (fetch "-" "parse_AssignAnyPar_ind")>>
   rw[]>>fs[parse_AssignAnyPar_def]>>
-  EVERY_CASE_TAC>>rw[]>>fs[AssignAnyPar_def,Skip_def]);
+  EVERY_CASE_TAC>>rw[]>>fs[AssignAnyPar_def,Skip_def]
+QED
 
 (* Invert AssignPar *)
 Definition parse_AssignPar_def:
@@ -58,13 +60,15 @@ Definition parse_AssignPar_def:
     else NONE)
 End
 
-val parse_AssignPar_inv = Q.prove(`
+Triviality parse_AssignPar_inv:
   ∀seq ls ts.
   parse_AssignPar seq = SOME (ls,ts) ⇒
-  AssignPar ls ts = seq`,
+  AssignPar ls ts = seq
+Proof
   ho_match_mp_tac (fetch "-" "parse_AssignPar_ind")>>
   rw[]>>fs[parse_AssignPar_def]>>
-  EVERY_CASE_TAC>>rw[]>>fs[AssignPar_def,Skip_def]);
+  EVERY_CASE_TAC>>rw[]>>fs[AssignPar_def,Skip_def]
+QED
 
 Definition parse_AssignVarPar_def:
   parse_AssignVarPar p =
@@ -75,10 +79,11 @@ Definition parse_AssignVarPar_def:
 End
 
 (* Invert AssignVarPar *)
-val parse_AssignVarPar_inv = Q.prove(`
+Triviality parse_AssignVarPar_inv:
   ∀seq ls ts.
   parse_AssignVarPar seq = SOME (ls,ts) ⇒
-  AssignVarPar ls ts = seq`,
+  AssignVarPar ls ts = seq
+Proof
   rw[AssignVarPar_def,parse_AssignVarPar_def]>>
   fs[OPTION_JOIN_EQ_SOME]>>
   pairarg_tac>>fs[]>>
@@ -89,7 +94,8 @@ val parse_AssignVarPar_inv = Q.prove(`
   qid_spec_tac`ts'`>>
   qid_spec_tac`ts`>>
   pop_assum kall_tac>>
-  Induct>>Cases_on`ts'`>>fs[]>>Cases_on`h`>>fs[OPT_MMAP_def]);
+  Induct>>Cases_on`ts'`>>fs[]>>Cases_on`h`>>fs[OPT_MMAP_def]
+QED
 
 (* Parses the initialization block
   consts := *;
@@ -191,13 +197,15 @@ Definition mk_config_def:
   |>
 End
 
-val parse_sandbox_inv = Q.prove(`
+Triviality parse_sandbox_inv:
   parse_sandbox p = SOME res ⇒
-  p = full_sandbox (mk_config res)`,
+  p = full_sandbox (mk_config res)
+Proof
   fs[parse_sandbox_def,parse_header_def,parse_body_def,parse_body1_def,parse_body2_def]>>
   EVERY_CASE_TAC>>rw[]>>
   fs[mk_config_def,full_sandbox_def,init_sandbox_def,body_sandbox_def,hide_def]>>
-  metis_tac[parse_AssignAnyPar_inv,parse_AssignPar_inv,parse_AssignVarPar_inv]);
+  metis_tac[parse_AssignAnyPar_inv,parse_AssignPar_inv,parse_AssignVarPar_inv]
+QED
 
 fun check_fv trm =
   let val fvs = free_vars trm  in
@@ -633,14 +641,16 @@ Definition init_state_def:
   eventually I w.wo.stop_oracle)
 End
 
-val init_state_imp_sandbox_hp = Q.prove(`
+Triviality init_state_imp_sandbox_hp:
   init_state w ⇒
-  sandbox_hp = full_sandbox w.wc`,
+  sandbox_hp = full_sandbox w.wc
+Proof
   rw[init_state_def]>>
   simp[init_wc_def]>>
   match_mp_tac parse_sandbox_inv>>
   fs[sandbox_hp_def,parse_th]>>
-  EVAL_TAC);
+  EVAL_TAC
+QED
 
 Theorem bot_main_spec:
   init_state w ∧
@@ -727,17 +737,19 @@ val SPLIT_SING = prove(
   ``SPLIT s ({x},t) <=> x IN s /\ t = s DELETE x``,
   fs [SPLIT_def,IN_DISJOINT,EXTENSION] \\ metis_tac []);
 
-val SPLIT_th = Q.prove(`
+Triviality SPLIT_th:
   wf_mach w ⇒
   (∃h1 h2.
       SPLIT (st2heap (bot_proj1,bot_proj2) (botProg_st_9 (bot_ffi w)))
-        (h1,h2) ∧ IOBOT w h1)`,
+        (h1,h2) ∧ IOBOT w h1)
+Proof
   fs [IOBOT_def,SEP_CLAUSES,IOx_def,bot_ffi_part_def,
       IO_def,SEP_EXISTS_THM,PULL_EXISTS,one_def] >>
   rw[]>>simp[fetch "-" "botProg_st_9_def",cfStoreTheory.st2heap_def]>>
   fs [SPLIT_SING,cfAppTheory.FFI_part_NOT_IN_store2heap]
   \\ rw [cfStoreTheory.ffi2heap_def] \\ EVAL_TAC
-  \\ fs [parts_ok_bot_ffi]);
+  \\ fs [parts_ok_bot_ffi]
+QED
 
 val semantics_thm = MATCH_MP th (UNDISCH SPLIT_th) |> DISCH_ALL
 val prog_tm = rhs(concl prog_rewrite)

--- a/examples/catProgScript.sml
+++ b/examples/catProgScript.sml
@@ -175,8 +175,8 @@ Definition catfiles_string_def:
     concat (MAP (λfnm. file_contents fnm fs) fns)
 End
 
-val cat_spec0 = Q.prove(
-  `∀fns fnsv fs.
+Triviality cat_spec0:
+  ∀fns fnsv fs.
      LIST_TYPE FILENAME fns fnsv ∧
      EVERY (inFS_fname fs) fns ∧
      hasFreeFD fs
@@ -185,7 +185,8 @@ val cat_spec0 = Q.prove(
        (STDIO fs)
        (POSTv u.
           &UNIT_TYPE () u *
-          STDIO (add_stdout fs (catfiles_string fs fns)))`,
+          STDIO (add_stdout fs (catfiles_string fs fns)))
+Proof
   Induct >>
   rpt strip_tac >> xcf "cat" (get_ml_prog_state()) >>
   fs[LIST_TYPE_def] >>
@@ -210,7 +211,8 @@ val cat_spec0 = Q.prove(
   imp_res_tac add_stdo_o \\
   simp[Abbr`fs0`] \\
   simp[Once file_contents_def,SimpR``(==>>)``,concat_cons] \\
-  simp[file_contents_add_stdout] \\ xsimpl);
+  simp[file_contents_add_stdout] \\ xsimpl
+QED
 
 val cat_spec = save_thm(
   "cat_spec",

--- a/examples/cost/lcgLoopProgScript.sml
+++ b/examples/cost/lcgLoopProgScript.sml
@@ -26,10 +26,12 @@ End
 val _ = translate HEX_def;
 val _ = translate n2l_acc_def;
 
-val hex_side_imp = Q.prove(`
-  n < 10 ⇒ hex_side n`,
+Triviality hex_side_imp:
+  n < 10 ⇒ hex_side n
+Proof
   EVAL_TAC>>
-  rw[]);
+  rw[]
+QED
 
 val n2l_acc_side = Q.prove(`
   ∀n acc. n2l_acc_side n acc ⇔ T`,

--- a/examples/divScript.sml
+++ b/examples/divScript.sml
@@ -32,8 +32,11 @@ QED
 
 (* Lemma needed for examples with integers *)
 
-val eq_v_INT_thm = Q.prove(`(INT --> INT --> BOOL) $= eq_v`,
-  metis_tac[DISCH_ALL mlbasicsProgTheory.eq_v_thm,EqualityType_NUM_BOOL]);
+Triviality eq_v_INT_thm:
+  (INT --> INT --> BOOL) $= eq_v
+Proof
+  metis_tac[DISCH_ALL mlbasicsProgTheory.eq_v_thm,EqualityType_NUM_BOOL]
+QED
 
 (* A conditionally terminating loop *)
 
@@ -896,14 +899,16 @@ Proof
   rw[FUN_EQ_THM,cell_def,REF_def,SEP_EXISTS,cond_STAR]
 QED
 
-val LTAKE_LNTH_EQ = Q.prove(
-  `!x ll y. LTAKE (LENGTH x) ll = SOME x
+Triviality LTAKE_LNTH_EQ:
+  !x ll y. LTAKE (LENGTH x) ll = SOME x
    /\ y < LENGTH x
-   ==> LNTH y ll = SOME(EL y x)`,
+   ==> LNTH y ll = SOME(EL y x)
+Proof
   Induct_on `x` >> rw[LTAKE] >>
   Cases_on `ll` >> fs[] >>
   PURE_FULL_CASE_TAC >> fs[] >> rveq >>
-  Cases_on `y` >> fs[]);
+  Cases_on `y` >> fs[]
+QED
 
 Theorem LTAKE_LPREFIX:
   !x ll.
@@ -994,29 +999,36 @@ Proof
   metis_tac[]
 QED
 
-val push_cond = Q.prove(`
-   m ~~>> v * (&C * B) = cond C * (m ~~>> v * B)
+Triviality push_cond:
+  m ~~>> v * (&C * B) = cond C * (m ~~>> v * B)
 /\ m ~~>> v * &C = &C * m ~~>> v
 /\ REF_LIST rv rvs A l * (&C * B) = cond C * (REF_LIST rv rvs A l * B)
 /\ REF_LIST rv rvs A l * &C = &C * REF_LIST rv rvs A l
-`,
-  simp[AC STAR_COMM STAR_ASSOC]);
+Proof
+  simp[AC STAR_COMM STAR_ASSOC]
+QED
 
-val EL_LENGTH_TAKE = Q.prove(
-  `!h e. EL (LENGTH l) (h::TAKE (LENGTH l) (e::l))
-   = EL(LENGTH l) (h::e::l)`,
- Induct_on `l` >> fs[]);
+Triviality EL_LENGTH_TAKE:
+  !h e. EL (LENGTH l) (h::TAKE (LENGTH l) (e::l))
+   = EL(LENGTH l) (h::e::l)
+Proof
+  Induct_on `l` >> fs[]
+QED
 
-val EL_LENGTH_TAKE2 = Q.prove(
-  `!h e l. n < LENGTH l ==>
+Triviality EL_LENGTH_TAKE2:
+  !h e l. n < LENGTH l ==>
    EL n (h::TAKE n (e::l))
-   = EL n (h::e::l)`,
- Induct_on `n` >> rw[] >>
- Cases_on `l` >> fs[]);
+   = EL n (h::e::l)
+Proof
+  Induct_on `n` >> rw[] >>
+ Cases_on `l` >> fs[]
+QED
 
-val PRE_SUB = Q.prove(
-  `!n. n <> 0 ==> PRE n = n - 1`,
-  Cases >> simp[]);
+Triviality PRE_SUB:
+  !n. n <> 0 ==> PRE n = n - 1
+Proof
+  Cases >> simp[]
+QED
 
 Theorem REF_LIST_rv_loc:
   REF_LIST rv rvs n l h ==> ?loc. rv = Loc loc
@@ -1112,18 +1124,21 @@ Proof
   simp[]
 QED
 
-val highly_specific_MOD_lemma = Q.prove(
-  `!n a. n < a
+Triviality highly_specific_MOD_lemma:
+  !n a. n < a
    ==> (n + 2) MOD (a + 1)
-    = if n + 1 = a then 0 else (n + 1) MOD a + 1`,
-  rw[] >> rw[]);
+    = if n + 1 = a then 0 else (n + 1) MOD a + 1
+Proof
+  rw[] >> rw[]
+QED
 
-val highly_specific_MOD_lemma2 = Q.prove(
- `0 < LENGTH l
+Triviality highly_specific_MOD_lemma2:
+  0 < LENGTH l
   ==>
   EL ((i+1) MOD LENGTH l) (CONS (LAST l) (FRONT l))
-  = EL (i MOD LENGTH l) l`,
-strip_tac >>
+  = EL (i MOD LENGTH l) l
+Proof
+  strip_tac >>
 Cases_on `1 < LENGTH l` >-
   (Cases_on `i MOD LENGTH l = LENGTH l - 1` >-
      (drule(GSYM MOD_PLUS) >>
@@ -1148,7 +1163,8 @@ Cases_on `1 < LENGTH l` >-
    match_mp_tac EL_FRONT >>
    Q.ISPEC_THEN `l` assume_tac SNOC_CASES >>
    fs[] >> rveq >> fs[FRONT_APPEND]) >>
-  Cases_on `l` >> fs[] >> Cases_on `t` >> fs[]);
+  Cases_on `l` >> fs[] >> Cases_on `t` >> fs[]
+QED
 
 Theorem LIST_ROTATE_CONS_NEXT:
   !n l. n < LENGTH l ==> ?l'.
@@ -1173,8 +1189,8 @@ Proof
   >> Cases_on `t` >> fs[]
 QED
 
-val LNTH_LREPEAT_ub = Q.prove(
-  `!n l.
+Triviality LNTH_LREPEAT_ub:
+  !n l.
     (l <> []
     /\
     ∀x.
@@ -1185,7 +1201,7 @@ val LNTH_LREPEAT_ub = Q.prove(
     LNTH n ub
     =
     LNTH n (LAPPEND (fromList (MAP put_char_event l)) ub)
-  `,
+Proof
   rpt strip_tac >>
   `~LFINITE(LREPEAT l)`
     by(rw[LFINITE_LLENGTH,LLENGTH_MAP,LLENGTH_LREPEAT,NULL_EQ] >>
@@ -1226,21 +1242,24 @@ val LNTH_LREPEAT_ub = Q.prove(
   simp[EL_MAP] >>
   IF_CASES_TAC >- simp[] >>
   `0 < LENGTH l` by(Cases_on `l` >> fs[]) >>
-  simp[SUB_MOD]);
+  simp[SUB_MOD]
+QED
 
-val LPREFIX_ub_LAPPEND = Q.prove(
-  `l <> [] /\
+Triviality LPREFIX_ub_LAPPEND:
+  l <> [] /\
    (∀x.
     LPREFIX
      (fromList (THE (LTAKE x (LMAP put_char_event (LREPEAT l)))))
      ub
    )
-   ==> ub = LAPPEND (fromList(MAP put_char_event l)) ub`,
+   ==> ub = LAPPEND (fromList(MAP put_char_event l)) ub
+Proof
   rpt strip_tac >>
   simp[LTAKE_EQ,PULL_FORALL] >>
   Induct_on `n` >> rw[] >>
   fs[LTAKE_SNOC_LNTH] >>
-  metis_tac[LNTH_LREPEAT_ub]);
+  metis_tac[LNTH_LREPEAT_ub]
+QED
 
 val _ = process_topdecs `
   fun pointerLoop c = (

--- a/examples/filterProgScript.sml
+++ b/examples/filterProgScript.sml
@@ -48,9 +48,12 @@ Definition language_def:
                  ^(matcher_certificate |> concl |> dest_forall |> snd |> rhs |> rator)
 End
 
-val match_string_eq = Q.prove(`match_string = language o explode`,
+Triviality match_string_eq:
+  match_string = language o explode
+Proof
   `!s. match_string s = (language o explode) s` suffices_by metis_tac[]
-  >> rw[match_string_def,language_def,matcher_def,matcher_certificate]);
+  >> rw[match_string_def,language_def,matcher_def,matcher_certificate]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Translator setup boilerplate                                              *)
@@ -85,30 +88,39 @@ val spec64 = INST_TYPE[alpha|->``:64``]
 
 val _ = translate matcher_def
 
-val mem_tolist = Q.prove(`MEM (toList l) (MAP toList ll) = MEM l ll`,
-  Induct_on `ll` >> fs[]);
+Triviality mem_tolist:
+  MEM (toList l) (MAP toList ll) = MEM l ll
+Proof
+  Induct_on `ll` >> fs[]
+QED
 
-val length_tolist_cancel = Q.prove(
-  `!n. n < LENGTH l ==> LENGTH (EL n (MAP mlvector$toList l)) = length (EL n l)`,
+Triviality length_tolist_cancel:
+  !n. n < LENGTH l ==> LENGTH (EL n (MAP mlvector$toList l)) = length (EL n l)
+Proof
   Induct_on `l`
   >> fs[]
   >> rpt strip_tac
   >> Cases_on `n`
-  >> fs[mlvectorTheory.length_toList]);
+  >> fs[mlvectorTheory.length_toList]
+QED
 
-val EL_map_toList = Q.prove(`!n. n < LENGTH l ==> EL n' (EL n (MAP toList l)) = sub (EL n l) n'`,
+Triviality EL_map_toList:
+  !n. n < LENGTH l ==> EL n' (EL n (MAP toList l)) = sub (EL n l) n'
+Proof
   Induct_on `l`
   >> fs[]
   >> rpt strip_tac
   >> Cases_on `n`
-  >> fs[mlvectorTheory.EL_toList]);
+  >> fs[mlvectorTheory.EL_toList]
+QED
 
-val exec_dfa_side_imp = Q.prove(
-  `!finals table n s.
+Triviality exec_dfa_side_imp:
+  !finals table n s.
    good_vec (MAP toList (toList table)) (toList finals)
     /\ EVERY (λc. MEM (ORD c) ALPHABET) (EXPLODE s)
     /\ n < length finals
-   ==> exec_dfa_side finals table n s`,
+   ==> exec_dfa_side finals table n s
+Proof
   Induct_on `s`
   >- fs[fetch "-" "exec_dfa_side_def"]
   >> PURE_ONCE_REWRITE_TAC [fetch "-" "exec_dfa_side_def"]
@@ -126,13 +138,16 @@ val exec_dfa_side_imp = Q.prove(
     >- metis_tac[]
     >> first_x_assum(ASSUME_TAC o Q.SPECL [`toList (EL n l)`,`ORD h`])
     >> first_x_assum(MATCH_MP_TAC o Q.SPECL [`n`,`ORD h`,`x1`])
-    >> rfs[mlvectorTheory.length_toList,mem_tolist,EL_map_toList,length_tolist_cancel]);
+    >> rfs[mlvectorTheory.length_toList,mem_tolist,EL_map_toList,length_tolist_cancel]
+QED
 
-val all_ord_string = Q.prove
-(`EVERY (\c. MEM (ORD c) ALPHABET) s
+Triviality all_ord_string:
+  EVERY (\c. MEM (ORD c) ALPHABET) s
    <=>
-  EVERY (\c. ORD c < alphabet_size) s`,
- simp_tac list_ss [mem_alphabet_iff]);
+  EVERY (\c. ORD c < alphabet_size) s
+Proof
+  simp_tac list_ss [mem_alphabet_iff]
+QED
 
 val good_vec_thm =
  SIMP_RULE std_ss [dom_Brz_alt_equal]
@@ -606,9 +621,11 @@ Proof
   Induct >> Cases_on `ll1` >> rw[] >> rw[] >> metis_tac[]
 QED
 
-val LLENGTH_NONE_LTAKE = Q.prove(
-  `!n ll. LLENGTH ll = NONE ==> ?l. LTAKE n ll = SOME l`,
-  Induct >> Cases_on `ll` >> rw[]);
+Triviality LLENGTH_NONE_LTAKE:
+  !n ll. LLENGTH ll = NONE ==> ?l. LTAKE n ll = SOME l
+Proof
+  Induct >> Cases_on `ll` >> rw[]
+QED
 
 Definition is_emit_def:
   is_emit (IO_event s _ _) = (s = ExtCall "emit_string")
@@ -792,24 +809,29 @@ Proof
         qexists_tac `n0 - n` >> simp[] >> metis_tac[]))
 QED
 
-val cut_at_null_simplify = Q.prove(`(?n' e'.
+Triviality cut_at_null_simplify:
+  (?n' e'.
    SOME e' =
      LNTH n'
         (fromList
          (next_filter_events f
          iarr input)) ∧ is_emit e')
-  = f(cut_at_null_w input)`,
+  = f(cut_at_null_w input)
+Proof
   rw[EQ_IMP_THM,next_filter_events] >-
     (qexists_tac `SUC 0` >> fs[is_emit_def]) >-
     (rename1 `LNTH n` >> Cases_on `n` >> fs[] >> rveq >> fs[is_emit_def] >>
-     CCONTR_TAC >> fs[] >> rveq >> fs[is_emit_def]));
+     CCONTR_TAC >> fs[] >> rveq >> fs[is_emit_def])
+QED
 
 val LFLATTEN_fromList_GENLIST =
     LFLATTEN_fromList |> Q.SPEC `GENLIST f n` |> SIMP_RULE std_ss [MAP_GENLIST,o_DEF]
 
-val LFILTER_fromList = Q.prove(`
-  !l. LFILTER f (fromList l) = fromList(FILTER f l)`,
-  Induct >> rw[]);
+Triviality LFILTER_fromList:
+  !l. LFILTER f (fromList l) = fromList(FILTER f l)
+Proof
+  Induct >> rw[]
+QED
 
 Theorem forward_matching_lines_div_spec:
   !input output rv.

--- a/examples/grepProgScript.sml
+++ b/examples/grepProgScript.sml
@@ -217,30 +217,39 @@ QED
 
 val r = translate regexp_matcher_with_limit_def;
 
-val mem_tolist = Q.prove(`MEM (toList l) (MAP toList ll) = MEM l ll`,
-  Induct_on `ll` >> fs[]);
+Triviality mem_tolist:
+  MEM (toList l) (MAP toList ll) = MEM l ll
+Proof
+  Induct_on `ll` >> fs[]
+QED
 
-val EL_map_toList = Q.prove(`!n. n < LENGTH l ==> EL n' (EL n (MAP toList l)) = sub (EL n l) n'`,
+Triviality EL_map_toList:
+  !n. n < LENGTH l ==> EL n' (EL n (MAP toList l)) = sub (EL n l) n'
+Proof
   Induct_on `l`
   >> fs[]
   >> rpt strip_tac
   >> Cases_on `n`
-  >> fs[mlvectorTheory.EL_toList]);
+  >> fs[mlvectorTheory.EL_toList]
+QED
 
-val length_tolist_cancel = Q.prove(
-  `!n. n < LENGTH l ==> LENGTH (EL n (MAP mlvector$toList l)) = length (EL n l)`,
+Triviality length_tolist_cancel:
+  !n. n < LENGTH l ==> LENGTH (EL n (MAP mlvector$toList l)) = length (EL n l)
+Proof
   Induct_on `l`
   >> fs[]
   >> rpt strip_tac
   >> Cases_on `n`
-  >> fs[mlvectorTheory.length_toList]);
+  >> fs[mlvectorTheory.length_toList]
+QED
 
-val exec_dfa_side_imp = Q.prove(
-  `!finals table n s.
+Triviality exec_dfa_side_imp:
+  !finals table n s.
    good_vec (MAP toList (toList table)) (toList finals)
     /\ EVERY (λc. MEM (ORD c) ALPHABET) (EXPLODE s)
     /\ n < length finals
-   ==> exec_dfa_side finals table n s`,
+   ==> exec_dfa_side finals table n s
+Proof
   Induct_on `s`
   >- fs[fetch "-" "exec_dfa_side_def"]
   >> PURE_ONCE_REWRITE_TAC [fetch "-" "exec_dfa_side_def"]
@@ -258,27 +267,32 @@ val exec_dfa_side_imp = Q.prove(
     >- metis_tac[]
     >> first_x_assum(ASSUME_TAC o Q.SPECL [`toList (EL n l)`,`ORD h`])
     >> first_x_assum(MATCH_MP_TAC o Q.SPECL [`n`,`ORD h`,`x1`])
-    >> rfs[mlvectorTheory.length_toList,mem_tolist,EL_map_toList,length_tolist_cancel]);
+    >> rfs[mlvectorTheory.length_toList,mem_tolist,EL_map_toList,length_tolist_cancel]
+QED
 
-val compile_regexp_with_limit_dom_brz = Q.prove(
-  `!r result.
+Triviality compile_regexp_with_limit_dom_brz:
+  !r result.
     compile_regexp_with_limit r = SOME result
     ==> dom_Brz empty (singleton (normalize r) ())
-                (1,singleton (normalize r) 0, [])`,
+                (1,singleton (normalize r) 0, [])
+Proof
   rw[compile_regexp_with_limit_def, dom_Brz_def, MAXNUM_32_def]
   >> every_case_tac
-  >> metis_tac [IS_SOME_EXISTS]);
+  >> metis_tac [IS_SOME_EXISTS]
+QED
 
-val compile_regexp_with_limit_lookup = Q.prove(
-  `!r state_numbering delta accepts.
+Triviality compile_regexp_with_limit_lookup:
+  !r state_numbering delta accepts.
    compile_regexp_with_limit r = SOME(state_numbering,delta,accepts)
-   ==> IS_SOME(lookup regexp_compare (normalize r) state_numbering)`,
+   ==> IS_SOME(lookup regexp_compare (normalize r) state_numbering)
+Proof
   rpt strip_tac
   >> `normalize r ∈ fdom regexp_compare state_numbering`
        by(metis_tac[compile_regexp_with_limit_dom_brz,
                     compile_regexp_good_vec,
                     compile_regexp_with_limit_sound])
-  >> fs[regexp_mapTheory.fdom_def]);
+  >> fs[regexp_mapTheory.fdom_def]
+QED
 
 Theorem tolist_fromlist_map_cancel:
    MAP mlvector$toList (MAP fromList ll) = ll
@@ -290,17 +304,21 @@ QED
 val compile_regexp_with_limit_side_def =
     fetch"-" "compile_regexp_with_limit_side_def"
 
-val lem = Q.prove
-(`!bst. balanced_map$null bst <=> (bst = Tip)`,
- Cases >> rw[balanced_mapTheory.null_def]);
+Triviality lem:
+  !bst. balanced_map$null bst <=> (bst = Tip)
+Proof
+  Cases >> rw[balanced_mapTheory.null_def]
+QED
 
 val brz_side_def =
   fetch "-" "brz_side_def"
     |> simp_rule [deleteFindmin_side_thm,lem]
 
-val brz_side_thm = Q.prove
-(`!a b c d. brz_side a b c d`,
- Induct_on `d` >> rw[Once brz_side_def]);
+Triviality brz_side_thm:
+  !a b c d. brz_side a b c d
+Proof
+  Induct_on `d` >> rw[Once brz_side_def]
+QED
 
 val regexp_matcher_with_limit_side_def = Q.prove
 (`!r s. regexp_matcher_with_limit_side r s ⇔ T`,

--- a/examples/insertSortProgScript.sml
+++ b/examples/insertSortProgScript.sml
@@ -40,16 +40,18 @@ end;
 `;
 val insertsort_st = ml_progLib.add_prog insertsort ml_progLib.pick_name (basis_st());
 
-val list_rel_perm_help = Q.prove (
-  `!l1 l2.
+Triviality list_rel_perm_help:
+  !l1 l2.
     PERM l1 l2
     ⇒
     !l3 l4.
       LIST_REL r (MAP FST l1) (MAP SND l1)
       ⇒
-      LIST_REL r (MAP FST l2) (MAP SND l2)`,
+      LIST_REL r (MAP FST l2) (MAP SND l2)
+Proof
   ho_match_mp_tac PERM_IND >>
-  rw []);
+  rw []
+QED
 
 Theorem list_rel_perm:
    !r l1 l2 l3 l4.
@@ -91,9 +93,11 @@ Proof
   metis_tac [ZIP_APPEND, LENGTH]
 QED
 
-val arith = Q.prove (
-  `!x:num. x ≠ 0 ⇒ &(x-1) = &x - 1:int`,
-  rw [int_arithTheory.INT_NUM_SUB]);
+Triviality arith:
+  !x:num. x ≠ 0 ⇒ &(x-1) = &x - 1:int
+Proof
+  rw [int_arithTheory.INT_NUM_SUB]
+QED
 
 val eq_num_v_thm =
   MATCH_MP

--- a/examples/lcsScript.sml
+++ b/examples/lcsScript.sml
@@ -7,44 +7,70 @@ val _ = new_theory "lcs";
 
 (* Miscellaneous lemmas that may belong elsewhere *)
 
-val sub_suc_0 = Q.prove(`x - SUC x = 0`,
-  Induct_on `x` >> fs[SUB]);
+Triviality sub_suc_0:
+  x - SUC x = 0
+Proof
+  Induct_on `x` >> fs[SUB]
+QED
 
-val take_suc_length = Q.prove(`TAKE (SUC (LENGTH l)) l = l`,
-  Induct_on `l` >> fs[])
+Triviality take_suc_length:
+  TAKE (SUC (LENGTH l)) l = l
+Proof
+  Induct_on `l` >> fs[]
+QED
 
-val is_suffix_length = Q.prove(`IS_SUFFIX l1 l2 ==> LENGTH l1 >= LENGTH l2`,
+Triviality is_suffix_length:
+  IS_SUFFIX l1 l2 ==> LENGTH l1 >= LENGTH l2
+Proof
   rpt strip_tac
   >> first_assum(assume_tac o MATCH_MP IS_SUFFIX_IS_SUBLIST)
-  >> fs[IS_SUBLIST_APPEND]);
+  >> fs[IS_SUBLIST_APPEND]
+QED
 
-val is_suffix_take = Q.prove(`
+Triviality is_suffix_take:
   IS_SUFFIX l (h::r) ==>
-  (TAKE (LENGTH l − LENGTH r) l = TAKE (LENGTH l − SUC(LENGTH r)) l ++ [h])`,
+  (TAKE (LENGTH l − LENGTH r) l = TAKE (LENGTH l − SUC(LENGTH r)) l ++ [h])
+Proof
   fs[IS_SUFFIX_APPEND]
   >> rpt strip_tac
   >> fs[]
-  >> fs[TAKE_APPEND, GSYM ADD1, take_suc_length, sub_suc_0]);
+  >> fs[TAKE_APPEND, GSYM ADD1, take_suc_length, sub_suc_0]
+QED
 
-val is_suffix_drop = Q.prove(`
-IS_SUFFIX l (h::r) ==> (DROP (LENGTH l − SUC(LENGTH r)) l = h::r)`,
+Triviality is_suffix_drop:
+  IS_SUFFIX l (h::r) ==> (DROP (LENGTH l − SUC(LENGTH r)) l = h::r)
+Proof
   fs[IS_SUFFIX_APPEND]
   >> rpt strip_tac
   >> fs[]
   >> fs[GSYM ADD1]
   >> PURE_REWRITE_TAC [GSYM APPEND_ASSOC, DROP_LENGTH_APPEND]
-  >> fs[]);
+  >> fs[]
+QED
 
-val suc_ge = Q.prove(`(SUC x >= SUC y) = (x >= y)`, fs[]);
+Triviality suc_ge:
+  (SUC x >= SUC y) = (x >= y)
+Proof
+  fs[]
+QED
 
-val take_singleton_one = Q.prove(`
-  (TAKE n r = [e]) ==> (TAKE 1 r = [e])`,
-  Cases_on `r` >> Cases_on `n` >> fs[]);
+Triviality take_singleton_one:
+  (TAKE n r = [e]) ==> (TAKE 1 r = [e])
+Proof
+  Cases_on `r` >> Cases_on `n` >> fs[]
+QED
 
-val sub_le_suc = Q.prove(`n ≥ SUC m ==> (n + SUC l − SUC m = n + l − m)`, fs[]);
+Triviality sub_le_suc:
+  n ≥ SUC m ==> (n + SUC l − SUC m = n + l − m)
+Proof
+  fs[]
+QED
 
-val if_length_lemma = Q.prove(`TAKE (if LENGTH r <= 1 then 1 else LENGTH r) r = r`,
-  Induct_on `r` >> rw[] >> Cases_on `r` >> fs[]);
+Triviality if_length_lemma:
+  TAKE (if LENGTH r <= 1 then 1 else LENGTH r) r = r
+Proof
+  Induct_on `r` >> rw[] >> Cases_on `r` >> fs[]
+QED
 
 (* The predicate
     lcs l1 l2 l3
@@ -258,15 +284,17 @@ Proof
   fs[lcs_def,common_subsequence_def,is_subsequence_refl,is_subsequence_length]
 QED
 
-val is_subsequence_greater = Q.prove(
-  `!l' l. is_subsequence l' l /\ LENGTH l ≤ LENGTH l'
-  ==> l = l'`,
+Triviality is_subsequence_greater:
+  !l' l. is_subsequence l' l /\ LENGTH l ≤ LENGTH l'
+  ==> l = l'
+Proof
   ho_match_mp_tac (theorem "is_subsequence_ind")
   >> rpt strip_tac
    >- fs[quantHeuristicsTheory.LIST_LENGTH_0]
    >> Cases_on `l`
     >> fs[is_subsequence_cons,is_subsequence_nil]
-    >> rfs[]);
+    >> rfs[]
+QED
 
 Theorem lcs_refl':
    lcs l' l l = (l = l')
@@ -283,8 +311,11 @@ Proof
   metis_tac[lcs_def,common_subsequence_sym]
 QED
 
-val lcs_empty = Q.prove(`lcs [] l [] /\ lcs [] [] l`,
-  fs[lcs_def,common_subsequence_def,is_subsequence_nil]);
+Triviality lcs_empty:
+  lcs [] l [] /\ lcs [] [] l
+Proof
+  fs[lcs_def,common_subsequence_def,is_subsequence_nil]
+QED
 
 Theorem lcs_empty':
    (lcs l l' [] = (l = [])) /\ (lcs l [] l' = (l = []))
@@ -631,8 +662,9 @@ Proof
   >> rw[naive_lcs_clauses, MIN_DEF, longest_def]
 QED
 
-val naive_lcs_length = Q.prove(
-  `!l l' h. LENGTH(naive_lcs l l') + 1 >= LENGTH(naive_lcs l (l' ++ [h]))`,
+Triviality naive_lcs_length:
+  !l l' h. LENGTH(naive_lcs l l') + 1 >= LENGTH(naive_lcs l (l' ++ [h]))
+Proof
   ho_match_mp_tac (theorem "naive_lcs_ind")
   >> rpt strip_tac
   >> fs[naive_lcs_clauses]
@@ -640,10 +672,12 @@ val naive_lcs_length = Q.prove(
       >> fs[])
   >> rw[longest_def] >> fs[GSYM ADD1, suc_ge]
   >> rpt(first_x_assum(assume_tac o Q.SPEC `h`))
-  >> fs[]);
+  >> fs[]
+QED
 
-val naive_lcs_length' = Q.prove(
-  `!l l' h. LENGTH(naive_lcs l l') + 1 >= LENGTH(naive_lcs (l ++ [h]) l')`,
+Triviality naive_lcs_length':
+  !l l' h. LENGTH(naive_lcs l l') + 1 >= LENGTH(naive_lcs (l ++ [h]) l')
+Proof
   ho_match_mp_tac (theorem "naive_lcs_ind")
   >> rpt strip_tac
   >> fs[naive_lcs_clauses]
@@ -652,7 +686,8 @@ val naive_lcs_length' = Q.prove(
       >> fs[longest_def])
   >> rw[longest_def] >> fs[GSYM ADD1, suc_ge]
   >> rpt(first_x_assum(assume_tac o Q.SPEC `h`))
-  >> fs[]);
+  >> fs[]
+QED
 
 (* Main correctness theorem for the naive lcs algorithm *)
 
@@ -679,9 +714,11 @@ Definition longest'_def:
   longest' (l,n) (l',n') = if n:num >= n' then (l,n) else (l',n')
 End
 
-val longest'_thm = Q.prove(
-  `!l l'. longest' l l' = if SND l >= SND l' then l else l'`,
-  Cases >> Cases >> fs[longest'_def]);
+Triviality longest'_thm:
+  !l l'. longest' l l' = if SND l >= SND l' then l else l'
+Proof
+  Cases >> Cases >> fs[longest'_def]
+QED
 
 Definition dynamic_lcs_row_def:
    (dynamic_lcs_row h [] previous_col previous_row ddl = [])

--- a/examples/lpr_checker/lpr_parsingScript.sml
+++ b/examples/lpr_checker/lpr_parsingScript.sml
@@ -972,14 +972,16 @@ Definition parse_vb_until_nn_def:
   )
 End
 
-val parse_vb_until_nn_length = Q.prove(`
+Triviality parse_vb_until_nn_length:
   ∀ls acc a b c.
   parse_vb_until_nn ls acc = (a,b,c) ∧ a ≠ 0 ⇒
-  LENGTH c < LENGTH ls`,
+  LENGTH c < LENGTH ls
+Proof
   Induct>>fs[parse_vb_until_nn_def]>>
   rw[]>>every_case_tac>>fs[]>>
   first_x_assum drule>>
-  fs[]);
+  fs[]
+QED
 
 Definition parse_vb_PR_hint_def:
   parse_vb_PR_hint id xs acc =

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProofScript.sml
@@ -134,11 +134,13 @@ val _ = Parse.hide "mem";
 val mem = ``mem:'U->'U-> bool``;
 Overload reader[local] = ``\inp r. readLines init_state inp r``
 
-val all_lines_stdin_fs = Q.prove (
-  `all_lines_inode (stdin_fs inp) (UStream «stdin»)
+Triviality all_lines_stdin_fs:
+  all_lines_inode (stdin_fs inp) (UStream «stdin»)
    =
-   lines_of (implode inp)`,
-  EVAL_TAC);
+   lines_of (implode inp)
+Proof
+  EVAL_TAC
+QED
 
 Theorem reader_extract_writes:
    wfcl cl ∧

--- a/examples/opentheory/monadIO/readerIOProgScript.sml
+++ b/examples/opentheory/monadIO/readerIOProgScript.sml
@@ -229,14 +229,15 @@ Proof
   metis_tac [holrefs_INTRO, EvalM_init_reader_wrap]
 QED
 
-val EvalM_readline_wrap = Q.prove (
- `Eval env xv (PAIR_TYPE STRING_TYPE READER_STATE_TYPE x) /\
+Triviality EvalM_readline_wrap:
+  Eval env xv (PAIR_TYPE STRING_TYPE READER_STATE_TYPE x) /\
   nsLookup env.v (Short "readline_wrap") = SOME readline_wrap_v
   ==>
   EvalM F env st
     (App Opapp [Var (Short "readline_wrap"); xv])
     (MONAD (SUM_TYPE STRING_TYPE READER_STATE_TYPE) HOL_EXN_TYPE
-       (readLine_wrap x)) (HOL_STORE, p:'ffi ffi_proj)`,
+       (readLine_wrap x)) (HOL_STORE, p:'ffi ffi_proj)
+Proof
   ho_match_mp_tac EvalM_from_app \\ rw []
   >-
    (PairCases_on `x`
@@ -248,17 +249,20 @@ val EvalM_readline_wrap = Q.prove (
   \\ asm_exists_tac \\ fs []
   \\ CONV_TAC SWAP_EXISTS_CONV
   \\ qexists_tac `s`
-  \\ xsimpl);
+  \\ xsimpl
+QED
 
-val EvalM_holrefs_readline_wrap = Q.prove (
- `Eval env xv (PAIR_TYPE STRING_TYPE READER_STATE_TYPE x) /\
+Triviality EvalM_holrefs_readline_wrap:
+  Eval env xv (PAIR_TYPE STRING_TYPE READER_STATE_TYPE x) /\
   nsLookup env.v (Short "readline_wrap") = SOME readline_wrap_v
   ==>
   EvalM F env st
     (App Opapp [Var (Short "readline_wrap"); xv])
     (MONAD (SUM_TYPE STRING_TYPE READER_STATE_TYPE) HOL_EXN_TYPE
-       (holrefs (readLine_wrap x))) (STATE_STORE, p:'ffi ffi_proj)`,
-  metis_tac [holrefs_INTRO, EvalM_readline_wrap]);
+       (holrefs (readLine_wrap x))) (STATE_STORE, p:'ffi ffi_proj)
+Proof
+  metis_tac [holrefs_INTRO, EvalM_readline_wrap]
+QED
 
 Theorem EvalM_context:
    Eval env uv (UNIT_TYPE u) /\

--- a/examples/patchProgScript.sml
+++ b/examples/patchProgScript.sml
@@ -27,7 +27,9 @@ val _ = find_def_for_const := def_of_const;
 
 val _ = translate parse_patch_header_def;
 
-val tokens_less_eq = Q.prove(`!s f. EVERY (\x. strlen x <= strlen s) (tokens f s)`,
+Triviality tokens_less_eq:
+  !s f. EVERY (\x. strlen x <= strlen s) (tokens f s)
+Proof
   Induct >> Ho_Rewrite.PURE_ONCE_REWRITE_TAC[SWAP_FORALL_THM]
   >> PURE_ONCE_REWRITE_TAC[TOKENS_eq_tokens_sym]
   >> recInduct TOKENS_ind >> rpt strip_tac
@@ -38,28 +40,38 @@ val tokens_less_eq = Q.prove(`!s f. EVERY (\x. strlen x <= strlen s) (tokens f s
        by(rpt strip_tac >> PURE_ONCE_REWRITE_TAC[GSYM SPLITP_LENGTH] >> fs[])
        >> drule EVERY_MONOTONIC >> pop_assum kall_tac >> disch_then match_mp_tac >> rw[])
   >> `!x. (λx. strlen x <= STRLEN t) x ==> (λx. strlen x <= SUC (STRLEN t)) x` by fs[]
-  >> drule EVERY_MONOTONIC >> pop_assum kall_tac >> disch_then match_mp_tac >> rw[]);
+  >> drule EVERY_MONOTONIC >> pop_assum kall_tac >> disch_then match_mp_tac >> rw[]
+QED
 
-val tokens_sum_less_eq = Q.prove(`!s f. SUM(MAP strlen (tokens f s)) <= strlen s`,
+Triviality tokens_sum_less_eq:
+  !s f. SUM(MAP strlen (tokens f s)) <= strlen s
+Proof
   Induct >> Ho_Rewrite.PURE_ONCE_REWRITE_TAC[SWAP_FORALL_THM]
   >> PURE_REWRITE_TAC[TOKENS_eq_tokens_sym,explode_thm,MAP_MAP_o]
   >> recInduct TOKENS_ind >> rpt strip_tac
   >> fs[TOKENS_def] >> pairarg_tac >> fs[] >> Cases_on `l` >> rw[] >> rfs[]
   >> fs[SPLITP_NIL_FST] >> fs[SPLITP] >> every_case_tac
   >> fs[] >> rveq
-  >> CONV_TAC(RAND_CONV(ONCE_REWRITE_CONV[GSYM SPLITP_LENGTH])) >> fs[]);
+  >> CONV_TAC(RAND_CONV(ONCE_REWRITE_CONV[GSYM SPLITP_LENGTH])) >> fs[]
+QED
 
-val tokens_not_nil = Q.prove(`!s f. EVERY (\x. x <> strlit "") (tokens f s)`,
+Triviality tokens_not_nil:
+  !s f. EVERY (\x. x <> strlit "") (tokens f s)
+Proof
   Induct >> Ho_Rewrite.PURE_ONCE_REWRITE_TAC[SWAP_FORALL_THM]
   >> PURE_REWRITE_TAC[TOKENS_eq_tokens_sym,explode_thm]
   >> recInduct TOKENS_ind >> rpt strip_tac
   >> rw[TOKENS_def] >> pairarg_tac >> fs[] >> reverse(Cases_on `l`)
-  >> fs[implode_def]);
+  >> fs[implode_def]
+QED
 
-val tokens_two_less = Q.prove(`!s f s1 s2. tokens f s = [s1;s2] ==> strlen s1 < strlen s /\ strlen s2 < strlen s`,
+Triviality tokens_two_less:
+  !s f s1 s2. tokens f s = [s1;s2] ==> strlen s1 < strlen s /\ strlen s2 < strlen s
+Proof
   ntac 2 strip_tac >> qspecl_then [`s`,`f`] assume_tac tokens_sum_less_eq
   >> qspecl_then [`s`,`f`] assume_tac tokens_not_nil
-  >> Induct >> Cases >> Induct >> Cases >> rpt strip_tac >> fs[]);
+  >> Induct >> Cases >> Induct >> Cases >> rpt strip_tac >> fs[]
+QED
 
 Theorem hexDigit_IMP_digit:
   !c. isDigit c ==> isHexDigit c

--- a/examples/queueProgScript.sml
+++ b/examples/queueProgScript.sml
@@ -207,11 +207,12 @@ Proof
   simp[EL_APPEND1, EL_APPEND2]
 QED
 
-val dequeue_spec_noexn = Q.prove(
-    `!qv xv vs x. app (p:'ffi ffi_proj) ^(fetch_v "dequeue" st) [qv]
+Triviality dequeue_spec_noexn:
+  !qv xv vs x. app (p:'ffi ffi_proj) ^(fetch_v "dequeue" st) [qv]
           (QUEUE A mx vs qv * &(vs ≠ []))
-          (POSTv v. &(A (HD vs) v) * QUEUE A mx (TL vs) qv)`,
-    rpt strip_tac >>
+          (POSTv v. &(A (HD vs) v) * QUEUE A mx (TL vs) qv)
+Proof
+  rpt strip_tac >>
     xcf "dequeue" st >> simp[QUEUE_def] >> xpull >> xs_auto_tac >>
     reverse(rw[]) >- EVAL_TAC >> xlet_auto >- xsimpl >> xif >>
     qexists_tac `F` >> simp[] >> xs_auto_tac
@@ -224,7 +225,8 @@ val dequeue_spec_noexn = Q.prove(
     strip_tac >>
     rpt (goal_assum (first_assum o mp_then Any mp_tac)) >>
     Cases_on `vs` >> fs[integerTheory.INT_SUB] >>
-    metis_tac[lqueue_dequeue, LIST_REL_REL_lqueue_HD]);
+    metis_tac[lqueue_dequeue, LIST_REL_REL_lqueue_HD]
+QED
 
 Theorem dequeue_spec:
    ∀p qv xv vs x A mx.

--- a/examples/quicksortProgScript.sml
+++ b/examples/quicksortProgScript.sml
@@ -15,16 +15,18 @@ val _ = translation_extends"basisProg";
 
 (* TODO: move *)
 
-val list_rel_perm_help = Q.prove (
-  `!l1 l2.
+Triviality list_rel_perm_help:
+  !l1 l2.
     PERM l1 l2
     ⇒
     !l3 l4.
       LIST_REL r (MAP FST l1) (MAP SND l1)
       ⇒
-      LIST_REL r (MAP FST l2) (MAP SND l2)`,
+      LIST_REL r (MAP FST l2) (MAP SND l2)
+Proof
   ho_match_mp_tac PERM_IND >>
-  rw []);
+  rw []
+QED
 
 Theorem list_rel_perm:
    !r l1 l2 l3 l4.
@@ -40,30 +42,35 @@ Proof
   rw [MAP_ZIP]
 QED
 
-val split_list = Q.prove (
-  `!l x. x < LENGTH l ⇒ ?l1 l2. x = LENGTH l1 ∧ l = l1++[EL x l]++l2`,
+Triviality split_list:
+  !l x. x < LENGTH l ⇒ ?l1 l2. x = LENGTH l1 ∧ l = l1++[EL x l]++l2
+Proof
   induct_on `l` >>
   rw [] >>
   Cases_on `x` >>
   fs [] >>
-  metis_tac [APPEND, LENGTH]);
+  metis_tac [APPEND, LENGTH]
+QED
 
-val split_list2 = Q.prove (
-  `!l1 l2 l3 l4.
+Triviality split_list2:
+  !l1 l2 l3 l4.
     LENGTH l1 < LENGTH l3 ∧ l1++l2 = l3++l4
     ⇒
-    ?l1'. l3 = l1++l1'`,
+    ?l1'. l3 = l1++l1'
+Proof
   induct_on `l1` >>
   rw [] >>
   Cases_on `l3` >>
   fs [] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val perm_swap_help = Q.prove (
-  `!l x y.
+Triviality perm_swap_help:
+  !l x y.
     x < LENGTH l ∧ y < LENGTH l ∧ y < x
     ⇒
-    PERM l (LUPDATE (EL x l) y (LUPDATE (EL y l) x l))`,
+    PERM l (LUPDATE (EL x l) y (LUPDATE (EL y l) x l))
+Proof
   rw [] >>
   `?l1 l2. LENGTH l1 = x ∧ l = l1++[EL x l]++l2`
   by metis_tac [split_list] >>
@@ -85,7 +92,8 @@ val perm_swap_help = Q.prove (
   fs [FILTER_APPEND, EL_APPEND_EQN] >>
   Cases_on `l1''` >>
   fs [] >>
-  rw [FILTER_APPEND]);
+  rw [FILTER_APPEND]
+QED
 
 Theorem perm_swap:
    !l x y.
@@ -112,12 +120,14 @@ Proof
   fs [LUPDATE_def]
 QED
 
-val el_append_length1 = Q.prove (
-  `!n l1 l2. EL (n + LENGTH l1) (l1 ++ l2) = EL n l2`,
+Triviality el_append_length1:
+  !n l1 l2. EL (n + LENGTH l1) (l1 ++ l2) = EL n l2
+Proof
   Induct_on `l1` >>
   rw [EL_CONS] >>
   `PRE (n + SUC (LENGTH l1)) = n + LENGTH l1` by decide_tac >>
-  metis_tac []);
+  metis_tac []
+QED
 
 Theorem front_zip:
    !l1 l2.
@@ -235,9 +245,11 @@ Definition partition_pred_def:
       EVERY (\e. ¬cmp e pivot) elems2
 End
 
-val perm_helper = Q.prove(
-  `!a b c. PERM b c ∧ PERM a b ⇒ PERM a c`,
-  metis_tac [PERM_SYM, PERM_TRANS]);
+Triviality perm_helper:
+  !a b c. PERM b c ∧ PERM a b ⇒ PERM a c
+Proof
+  metis_tac [PERM_SYM, PERM_TRANS]
+QED
 
 Theorem partition_spec:
    !a ffi_p cmp cmp_v arr_v pivot pivot_v lower_v upper_v elem_vs1 elem_vs2 elem_vs3 elems2.

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -332,15 +332,17 @@ Proof
     [`l1`,`l2`]
 QED
 
-val lemmas = Q.prove(
-  `(2 + 2 * n - 1 = 2 * n + 1:num) /\
+Triviality lemmas:
+  (2 + 2 * n - 1 = 2 * n + 1:num) /\
     (2 + 2 * n' = 2 * n'' + 2 <=> n' = n'':num) /\
     (2 * m = 2 * n <=> (m = n)) /\
     ((2 * n'' + 1) DIV 2 = n'') /\
     ((2 * n) DIV 2 = n) /\
     (2 + 2 * n' <> 2 * n'' + 1) /\
-    (2 * m + 1 <> 2 * n' + 2)`,
-  intLib.ARITH_TAC);
+    (2 * m + 1 <> 2 * n' + 2)
+Proof
+  intLib.ARITH_TAC
+QED
 
 Definition lookup_any_def:
   lookup_any x sp d =
@@ -353,15 +355,17 @@ Definition fromList2_def:
   fromList2 l = SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (0,LN) l)
 End
 
-val EVEN_fromList2_lemma = Q.prove(
-  `!l n t.
+Triviality EVEN_fromList2_lemma:
+  !l n t.
       EVEN n /\ (!x. x IN domain t ==> EVEN x) ==>
-      !x. x IN domain (SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (n,t) l)) ==> EVEN x`,
+      !x. x IN domain (SND (FOLDL (\(i,t) a. (i + 2,insert i a t)) (n,t) l)) ==> EVEN x
+Proof
   Induct \\ full_simp_tac(srw_ss())[FOLDL] \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[PULL_FORALL]
   \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`n+2`,`insert n h t`,`x`])
   \\ full_simp_tac(srw_ss())[] \\ SRW_TAC [] [] \\ POP_ASSUM MATCH_MP_TAC
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[] \\ full_simp_tac(srw_ss())[EVEN_EXISTS]
-  \\ Q.EXISTS_TAC `SUC m` \\ DECIDE_TAC);
+  \\ Q.EXISTS_TAC `SUC m` \\ DECIDE_TAC
+QED
 
 Theorem EVEN_fromList2:
    !l n. n IN domain (fromList2 l) ==> EVEN n
@@ -2442,33 +2446,37 @@ Proof
     \\ fs[DROP_EL_CONS]
 QED
 
-val FRONT_APPEND' = Q.prove(
-  `!l h a b t. l = h ++ [a; b] ++ t ==>
-      FRONT l = h ++ FRONT([a; b] ++ t)`,
-      Induct \\ rw[FRONT_DEF, FRONT_APPEND]
+Triviality FRONT_APPEND':
+  !l h a b t. l = h ++ [a; b] ++ t ==>
+      FRONT l = h ++ FRONT([a; b] ++ t)
+Proof
+  Induct \\ rw[FRONT_DEF, FRONT_APPEND]
       >-(rw[LIST_EQ_REWRITE])
       \\ Cases_on `h'` \\ fs[FRONT_APPEND, FRONT_DEF]
-);
+QED
 
 
-val EVERY_NOT_IMP = Q.prove(
-  `!ls a. (EVERY ($~ o (\x. x = a)) ls) ==> (LIST_ELEM_COUNT a ls = 0)`,
-    Induct \\ rw[LIST_ELEM_COUNT_DEF] \\ fs[LIST_ELEM_COUNT_DEF]
-);
+Triviality EVERY_NOT_IMP:
+  !ls a. (EVERY ($~ o (\x. x = a)) ls) ==> (LIST_ELEM_COUNT a ls = 0)
+Proof
+  Induct \\ rw[LIST_ELEM_COUNT_DEF] \\ fs[LIST_ELEM_COUNT_DEF]
+QED
 
-val LIST_ELEM_COUNT_CONS = Q.prove(
-  `!h t a. LIST_ELEM_COUNT a (h::t) = LIST_ELEM_COUNT a [h] + LIST_ELEM_COUNT a t`,
-    simp_tac std_ss [Once CONS_APPEND, LIST_ELEM_COUNT_THM]
-);
+Triviality LIST_ELEM_COUNT_CONS:
+  !h t a. LIST_ELEM_COUNT a (h::t) = LIST_ELEM_COUNT a [h] + LIST_ELEM_COUNT a t
+Proof
+  simp_tac std_ss [Once CONS_APPEND, LIST_ELEM_COUNT_THM]
+QED
 
-val FRONT_COUNT_IMP = Q.prove(
-  `!l1 l2 a. l1 <> [] /\ FRONT l1 = l2 ==> (LIST_ELEM_COUNT a l2 = LIST_ELEM_COUNT a l1) \/ (LIST_ELEM_COUNT a l2 + 1 = LIST_ELEM_COUNT a l1)`,
-    gen_tac \\ Induct_on `l1` \\ gen_tac \\ Cases_on `l2` \\ rw[FRONT_DEF]
+Triviality FRONT_COUNT_IMP:
+  !l1 l2 a. l1 <> [] /\ FRONT l1 = l2 ==> (LIST_ELEM_COUNT a l2 = LIST_ELEM_COUNT a l1) \/ (LIST_ELEM_COUNT a l2 + 1 = LIST_ELEM_COUNT a l1)
+Proof
+  gen_tac \\ Induct_on `l1` \\ gen_tac \\ Cases_on `l2` \\ rw[FRONT_DEF]
     >-(Cases_on `h = a` \\ rw[LIST_ELEM_COUNT_DEF])
     \\ rw[LIST_ELEM_COUNT_DEF] \\ fs[LIST_ELEM_COUNT_DEF]
     \\ Cases_on `LENGTH (FILTER (\x. x = a) l1)`
     \\ first_x_assum (qspecl_then [`a`] mp_tac) \\ rw[] \\ rfs[]
-);
+QED
 
 Definition CONCAT_WITH_aux_def:
     (CONCAT_WITH_aux [] l fl = REVERSE fl ++ FLAT l) /\
@@ -4351,35 +4359,41 @@ Proof
   fs[good_dimindex_def]
 QED
 
-val byte_index_LESS_IMP = Q.prove(
-  `(dimindex (:'a) = 32 \/ dimindex (:'a) = 64) /\
+Triviality byte_index_LESS_IMP:
+  (dimindex (:'a) = 32 \/ dimindex (:'a) = 64) /\
     byte_index (a:'a word) be < byte_index (a':'a word) be /\ i < 8 ==>
     byte_index a be + i < byte_index a' be /\
     byte_index a be <= i + byte_index a' be /\
     byte_index a be + 8 <= i + byte_index a' be /\
-    i + byte_index a' be < byte_index a be + dimindex (:α)`,
+    i + byte_index a' be < byte_index a be + dimindex (:α)
+Proof
   fs [byte_index_def,LET_DEF] \\ Cases_on `be` \\ fs []
   \\ rpt strip_tac \\ rfs [] \\ fs []
   \\ `w2n a MOD 4 < 4` by (match_mp_tac MOD_LESS \\ decide_tac)
   \\ `w2n a' MOD 4 < 4` by (match_mp_tac MOD_LESS \\ decide_tac)
   \\ `w2n a MOD 8 < 8` by (match_mp_tac MOD_LESS \\ decide_tac)
   \\ `w2n a' MOD 8 < 8` by (match_mp_tac MOD_LESS \\ decide_tac)
-  \\ decide_tac);
+  \\ decide_tac
+QED
 
-val NOT_w2w_bit = Q.prove(
-  `8 <= i /\ i < dimindex (:'b) ==> ~((w2w:word8->'b word) w ' i)`,
-  rpt strip_tac \\ rfs [w2w] \\ decide_tac);
+Triviality NOT_w2w_bit:
+  8 <= i /\ i < dimindex (:'b) ==> ~((w2w:word8->'b word) w ' i)
+Proof
+  rpt strip_tac \\ rfs [w2w] \\ decide_tac
+QED
 
 val LESS4 = DECIDE ``n < 4 <=> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num)``
 val LESS8 = DECIDE ``n < 8 <=> (n = 0) \/ (n = 1) \/ (n = 2) \/ (n = 3:num) \/
                                (n = 4) \/ (n = 5) \/ (n = 6) \/ (n = 7)``
 
-val DIV_EQ_DIV_IMP = Q.prove(
-  `0 < d /\ n <> n' /\ (n DIV d * d = n' DIV d * d) ==> n MOD d <> n' MOD d`,
+Triviality DIV_EQ_DIV_IMP:
+  0 < d /\ n <> n' /\ (n DIV d * d = n' DIV d * d) ==> n MOD d <> n' MOD d
+Proof
   rpt strip_tac \\ Q.PAT_X_ASSUM `n <> n'` mp_tac \\ fs []
   \\ MP_TAC (Q.SPEC `d` DIVISION) \\ fs []
   \\ rpt strip_tac \\ pop_assum (fn th => once_rewrite_tac [th])
-  \\ fs []);
+  \\ fs []
+QED
 
 Theorem get_byte_set_byte_diff:
    good_dimindex (:'a) /\ a <> a' /\ (byte_align a = byte_align a') ==>

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -422,10 +422,12 @@ End
 
 (** Properties for proving well-formedness of the Pancake grammar. *)
 
-val frange_image = Q.prove(
-  ‘FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)’,
+Triviality frange_image:
+  FRANGE fm = IMAGE (FAPPLY fm) (FDOM fm)
+Proof
   simp[finite_mapTheory.FRANGE_DEF, pred_setTheory.EXTENSION]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
 val peg_range =
     SIMP_CONV (srw_ss())
@@ -693,9 +695,11 @@ val pancake_wfpeg_thm2 = save_thm(
   "pancake_wfpeg_FunNT_thm",
   LIST_CONJ (List.foldl (wfnt “pancake_peg with start := mknt FunNT”) [] (topo_nts @ [“ProgNT”])))
 
-val subexprs_mknt = Q.prove(
-  ‘subexprs (mknt n) = {mknt n}’,
-  simp[subexprs_def, mknt_def]);
+Triviality subexprs_mknt:
+  subexprs (mknt n) = {mknt n}
+Proof
+  simp[subexprs_def, mknt_def]
+QED
 
 Theorem PEG_wellformed[simp]:
   wfG pancake_peg

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -362,10 +362,12 @@ Proof
   rpt (res_tac >> fs [])
 QED
 
-val fix_clock_evaluate = Q.prove(
-  `fix_clock s (evaluate (prog,s)) = evaluate (prog,s)`,
+Triviality fix_clock_evaluate:
+  fix_clock s (evaluate (prog,s)) = evaluate (prog,s)
+Proof
   Cases_on `evaluate (prog,s)` \\ fs [fix_clock_def]
-  \\ imp_res_tac evaluate_clock \\ fs [GSYM NOT_LESS, state_component_equality]);
+  \\ imp_res_tac evaluate_clock \\ fs [GSYM NOT_LESS, state_component_equality]
+QED
 
 val evaluate_ind = save_thm("evaluate_ind[allow_rebind]",
   REWRITE_RULE [fix_clock_evaluate] evaluate_ind);

--- a/semantics/proofs/cmlPtreeConversionPropsScript.sml
+++ b/semantics/proofs/cmlPtreeConversionPropsScript.sml
@@ -395,10 +395,12 @@ Proof
   simp[ptree_Op_def, tokcheck_def, tokcheckl_def, singleSymP_def]
 QED
 
-val MAP_TK11 = Q.prove(
-  `∀l1 l2. MAP TK l1 = MAP TK l2 ⇔ l1 = l2`,
+Triviality MAP_TK11:
+  ∀l1 l2. MAP TK l1 = MAP TK l2 ⇔ l1 = l2
+Proof
   Induct_on `l1` >> simp[] >> rpt gen_tac >>
-  Cases_on `l2` >> simp[]);
+  Cases_on `l2` >> simp[]
+QED
 val _ = augment_srw_ss [rewrites [MAP_TK11]]
 
 Theorem OpID_OK:

--- a/semantics/proofs/evaluatePropsScript.sml
+++ b/semantics/proofs/evaluatePropsScript.sml
@@ -127,13 +127,15 @@ Proof
   metis_tac[PAIR,FST,evaluate_call_FFI_rel]
 QED
 
-val evaluate_decs_call_FFI_rel = Q.prove(
-  `∀s e d.
-     RTC call_FFI_rel s.ffi (FST (evaluate_decs s e d)).ffi`,
+Triviality evaluate_decs_call_FFI_rel:
+  ∀s e d.
+     RTC call_FFI_rel s.ffi (FST (evaluate_decs s e d)).ffi
+Proof
   ho_match_mp_tac evaluate_decs_ind >>
   srw_tac[][evaluate_decs_def] >>
   every_case_tac >> full_simp_tac(srw_ss())[] >>
-  metis_tac[RTC_TRANSITIVE,transitive_def,evaluate_call_FFI_rel,FST]);
+  metis_tac[RTC_TRANSITIVE,transitive_def,evaluate_call_FFI_rel,FST]
+QED
 
 Theorem evaluate_decs_call_FFI_rel_imp:
    ∀s e p s' r.
@@ -711,12 +713,17 @@ Proof
   simp_tac bool_ss evaluate_decs_lemmas
 QED
 
-val add_lemma = Q.prove (
- `!(k:num) k'. ?extra. k = k' + extra ∨ k' = k + extra`,
- intLib.ARITH_TAC);
+Triviality add_lemma:
+  !(k:num) k'. ?extra. k = k' + extra ∨ k' = k + extra
+Proof
+  intLib.ARITH_TAC
+QED
 
-val with_clock_ffi = Q.prove(
-  `(s with clock := k).ffi = s.ffi`,EVAL_TAC);
+Triviality with_clock_ffi:
+  (s with clock := k).ffi = s.ffi
+Proof
+  EVAL_TAC
+QED
 
 Theorem evaluate_decs_clock_determ:
  !s e p s1 r1 s2 r2 k1 k2.

--- a/semantics/proofs/gramPropsScript.sml
+++ b/semantics/proofs/gramPropsScript.sml
@@ -141,22 +141,31 @@ end
 val cmlG_FDOM = save_thm("cmlG_FDOM",
   SIMP_CONV (srw_ss()) [cmlG_def] ``FDOM cmlG.rules``)
 
-val paireq = Q.prove(
-  `(x,y) = z ⇔ x = FST z ∧ y = SND z`, Cases_on `z` >> simp[])
+Triviality paireq:
+  (x,y) = z ⇔ x = FST z ∧ y = SND z
+Proof
+  Cases_on `z` >> simp[]
+QED
 
-val GSPEC_INTER = Q.prove(
-  `GSPEC f ∩ Q =
-    GSPEC (S ($, o FST o f) (S ($/\ o SND o f) (Q o FST o f)))`,
+Triviality GSPEC_INTER:
+  GSPEC f ∩ Q =
+    GSPEC (S ($, o FST o f) (S ($/\ o SND o f) (Q o FST o f)))
+Proof
   simp[GSPECIFICATION, EXTENSION, SPECIFICATION] >> qx_gen_tac `e` >>
-  simp[paireq] >> metis_tac[])
+  simp[paireq] >> metis_tac[]
+QED
 
-val RIGHT_INTER_OVER_UNION = Q.prove(
-  `(a ∪ b) ∩ c = (a ∩ c) ∪ (b ∩ c)`,
-  simp[EXTENSION] >> metis_tac[]);
+Triviality RIGHT_INTER_OVER_UNION:
+  (a ∪ b) ∩ c = (a ∩ c) ∪ (b ∩ c)
+Proof
+  simp[EXTENSION] >> metis_tac[]
+QED
 
-val GSPEC_applied = Q.prove(
-  `GSPEC f x ⇔ x IN GSPEC f`,
-  simp[SPECIFICATION])
+Triviality GSPEC_applied:
+  GSPEC f x ⇔ x IN GSPEC f
+Proof
+  simp[SPECIFICATION]
+QED
 
 val c1 = Cong (DECIDE ``(p = p') ==> ((p /\ q) = (p' /\ q))``)
 val condc =
@@ -177,16 +186,20 @@ val safenml = LIST_CONJ (List.take(CONJUNCTS nullableML_def, 2))
 
 val nullML_t = prim_mk_const {Thy = "NTproperties", Name = "nullableML"}
 
-val nullloop_th = Q.prove(
-  `nullableML G (N INSERT sn) (NT N :: rest) = F`,
-  simp[Once nullableML_def]);
+Triviality nullloop_th:
+  nullableML G (N INSERT sn) (NT N :: rest) = F
+Proof
+  simp[Once nullableML_def]
+QED
 
-val null2 = Q.prove(
-  `nullableML G sn (x :: y :: z) <=>
+Triviality null2:
+  nullableML G sn (x :: y :: z) <=>
       nullableML G sn [x] ∧ nullableML G sn [y] ∧
-      nullableML G sn z`,
+      nullableML G sn z
+Proof
   simp[Once nullableML_by_singletons, SimpLHS] >>
-  dsimp[] >> simp[GSYM nullableML_by_singletons]);
+  dsimp[] >> simp[GSYM nullableML_by_singletons]
+QED
 
 
 fun prove_nullable domapp sn acc G_t t = let

--- a/semantics/proofs/namespacePropsScript.sml
+++ b/semantics/proofs/namespacePropsScript.sml
@@ -1192,10 +1192,12 @@ Proof
   rw [nsLookupMod_def]
 QED
 
-val lemma = Q.prove (
-  `(?x. y = SOME x) ⇔ y ≠ NONE`,
+Triviality lemma:
+  (?x. y = SOME x) ⇔ y ≠ NONE
+Proof
   Cases_on `y` >>
-  rw []);
+  rw []
+QED
 
 Theorem nsDom_nsAppend_equal:
    !n1 n2 n3 n4.

--- a/semantics/proofs/semanticPrimitivesPropsScript.sml
+++ b/semantics/proofs/semanticPrimitivesPropsScript.sml
@@ -233,14 +233,18 @@ val wz_thms = { nchotomy = word_size_nchotomy, case_def = word_size_case_def}
 val eqs = LIST_CONJ (map prove_case_eq_thm
   [op_thms, list_thms, option_thms, v_thms, store_v_thms, lit_thms, eq_v_thms, wz_thms])
 
-val pair_case_eq = Q.prove (
-`pair_CASE x f = v ⇔ ?x1 x2. x = (x1,x2) ∧ f x1 x2 = v`,
- Cases_on `x` >>
- srw_tac[][]);
+Triviality pair_case_eq:
+  pair_CASE x f = v ⇔ ?x1 x2. x = (x1,x2) ∧ f x1 x2 = v
+Proof
+  Cases_on `x` >>
+ srw_tac[][]
+QED
 
-val pair_lam_lem = Q.prove (
-`!f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)`,
- srw_tac[][]);
+Triviality pair_lam_lem:
+  !f v z. (let (x,y) = z in f x y) = v ⇔ ∃x1 x2. z = (x1,x2) ∧ (f x1 x2 = v)
+Proof
+  srw_tac[][]
+QED
 
 val do_app_cases = save_thm ("do_app_cases",
 ``do_app (s,t) op vs = SOME (st',v)`` |>
@@ -350,14 +354,16 @@ Proof
   every_case_tac >> full_simp_tac(srw_ss())[]
 QED
 
-val build_rec_env_help_lem = Q.prove (
-  `∀funs env funs'.
+Triviality build_rec_env_help_lem:
+  ∀funs env funs'.
     FOLDR (λ(f,x,e) env'. nsBind f (Recclosure env funs' f) env') env' funs =
-    nsAppend (alist_to_ns (MAP (λ(f,n,e). (f, Recclosure env funs' f)) funs)) env'`,
- Induct >>
+    nsAppend (alist_to_ns (MAP (λ(f,n,e). (f, Recclosure env funs' f)) funs)) env'
+Proof
+  Induct >>
  srw_tac[][] >>
  PairCases_on `h` >>
- srw_tac[][]);
+ srw_tac[][]
+QED
 
 (* Alternate definition for build_rec_env *)
 Theorem build_rec_env_merge:

--- a/semantics/proofs/semanticsPropsScript.sml
+++ b/semantics/proofs/semanticsPropsScript.sml
@@ -69,8 +69,11 @@ Proof
   MATCH_ACCEPT_TAC evaluate_prog_io_events_chain
 QED
 
-val with_clock_ffi = Q.prove(
-  `(s with clock := x).ffi = s.ffi`,EVAL_TAC)
+Triviality with_clock_ffi:
+  (s with clock := x).ffi = s.ffi
+Proof
+  EVAL_TAC
+QED
 
 val tac1 =
     metis_tac[semanticPrimitivesTheory.result_11,evaluate_decs_ffi_mono_clock,io_events_mono_def,
@@ -157,11 +160,13 @@ Definition state_invariant_def:
     type_sound_invariant st.sem_st st.sem_env ctMap tenvS {} st.tenv
 End
 
-val clock_lemmas = Q.prove(
-  `((x with clock := c).clock = c) ∧
+Triviality clock_lemmas:
+  ((x with clock := c).clock = c) ∧
    (((x with clock := c) with clock := d) = (x with clock := d)) ∧
-   (x with clock := x.clock = x)`,
-  srw_tac[][semanticPrimitivesTheory.state_component_equality])
+   (x with clock := x.clock = x)
+Proof
+  srw_tac[][semanticPrimitivesTheory.state_component_equality]
+QED
 
 Theorem semantics_deterministic:
    state_invariant st ⇒
@@ -239,9 +244,11 @@ Proof
   \\ full_simp_tac(srw_ss())[extend_with_resource_limit_def]
 QED
 
-val isPREFIX_IMP_LPREFIX = Q.prove(
-  `!xs ys. isPREFIX xs ys ==> LPREFIX (fromList xs) (fromList ys)`,
-  full_simp_tac(srw_ss())[LPREFIX_def,llistTheory.from_toList]);
+Triviality isPREFIX_IMP_LPREFIX:
+  !xs ys. isPREFIX xs ys ==> LPREFIX (fromList xs) (fromList ys)
+Proof
+  full_simp_tac(srw_ss())[LPREFIX_def,llistTheory.from_toList]
+QED
 
 Theorem implements_trans:
    implements y z ==> implements x y ==> implements x z

--- a/semantics/proofs/typeSoundScript.sml
+++ b/semantics/proofs/typeSoundScript.sml
@@ -45,11 +45,13 @@ Proof
  >> rw []
 QED
 
-val fst_triple = Q.prove (
-`(\ (x,y,z). x) = FST`,
- rw [FUN_EQ_THM]
+Triviality fst_triple:
+  (\ (x,y,z). x) = FST
+Proof
+  rw [FUN_EQ_THM]
  >> pairarg_tac
- >> rw []);
+ >> rw []
+QED
 
 Theorem disjoint_image:
   !s1 s2 f. DISJOINT (IMAGE f s1) (IMAGE f s2) ⇒ DISJOINT s1 s2
@@ -58,17 +60,21 @@ Proof
  >> metis_tac []
 QED
 
-val sing_list = Q.prove (
-`!l. LENGTH l = 1 ⇔ ?x. l = [x]`,
- Cases
+Triviality sing_list:
+  !l. LENGTH l = 1 ⇔ ?x. l = [x]
+Proof
+  Cases
  >> rw []
  >> Cases_on `t`
- >> rw []);
+ >> rw []
+QED
 
-val EVERY_LIST_REL = Q.prove (
-`EVERY (\x. f x y) l = LIST_REL (\x y. f x y) l (REPLICATE (LENGTH l) y)`,
- induct_on `l` >>
- srw_tac[][REPLICATE]);
+Triviality EVERY_LIST_REL:
+  EVERY (\x. f x y) l = LIST_REL (\x y. f x y) l (REPLICATE (LENGTH l) y)
+Proof
+  induct_on `l` >>
+ srw_tac[][REPLICATE]
+QED
 
 Theorem v_unchanged[simp]:
  !tenv x. tenv with v := tenv.v = tenv
@@ -134,8 +140,8 @@ Proof
   fs [type_sv_def]
 QED
 
-val has_lists_v_to_list = Q.prove (
-`!ctMap tvs tenvS t3.
+Triviality has_lists_v_to_list:
+  !ctMap tvs tenvS t3.
   ctMap_ok ctMap ∧
   ctMap_has_lists ctMap ∧
   type_v tvs ctMap tenvS v (Tlist t3)
@@ -143,8 +149,9 @@ val has_lists_v_to_list = Q.prove (
   ?vs. v_to_list v = SOME vs ∧
   EVERY (\v. type_v tvs ctMap tenvS v t3) vs ∧
   (t3 = Tchar ⇒ ?vs. v_to_char_list v = SOME vs) ∧
-  (t3 = Tstring ⇒ ∃str. vs_to_string vs = SOME str)`,
- measureInduct_on `v_size v` >>
+  (t3 = Tstring ⇒ ∃str. vs_to_string vs = SOME str)
+Proof
+  measureInduct_on `v_size v` >>
  srw_tac[][] >>
  pop_assum mp_tac >>
  srw_tac[][Once type_v_cases] >>
@@ -176,7 +183,8 @@ val has_lists_v_to_list = Q.prove (
  rw [] >>
  rw [] >>
  imp_res_tac (SIMP_RULE (srw_ss()) [] prim_canonical_values_thm) >>
- rw [v_to_char_list_def, vs_to_string_def]);
+ rw [v_to_char_list_def, vs_to_string_def]
+QED
 
 Theorem ctor_canonical_values_thm:
    (type_v tvs ctMap tenvS v Tbool ∧ ctMap_ok ctMap ∧ ctMap_has_bools ctMap ⇒
@@ -226,13 +234,15 @@ Proof
     fs [])
 QED
 
-val same_type_refl = Q.prove (
-  `!t. same_type t t`,
+Triviality same_type_refl:
+  !t. same_type t t
+Proof
   Cases_on `t` >>
-  rw [same_type_def]);
+  rw [same_type_def]
+QED
 
-val eq_same_type = Q.prove (
-`(!v1 v2 tvs ctMap cns tenvS t.
+Triviality eq_same_type:
+  (!v1 v2 tvs ctMap cns tenvS t.
   ctMap_ok ctMap ∧
   type_v tvs ctMap tenvS v1 t ∧
   type_v tvs ctMap tenvS v2 t
@@ -243,7 +253,8 @@ val eq_same_type = Q.prove (
   LIST_REL (type_v tvs ctMap tenvS) vs1 ts ∧
   LIST_REL (type_v tvs ctMap tenvS) vs2 ts
   ⇒
-  do_eq_list vs1 vs2 ≠ Eq_type_error)`,
+  do_eq_list vs1 vs2 ≠ Eq_type_error)
+Proof
   ho_match_mp_tac do_eq_ind >>
   rw [do_eq_def] >>
   TRY (
@@ -302,38 +313,43 @@ val eq_same_type = Q.prove (
     metis_tac [])
   >- (FULL_CASE_TAC \\
      full_simp_tac(srw_ss())[bool_case_eq]
-     \\ metis_tac[]));
+     \\ metis_tac[])
+QED
 
-val type_env_conv_thm = Q.prove (
-  `∀ctMap envC tenvC.
+Triviality type_env_conv_thm:
+  ∀ctMap envC tenvC.
      nsAll2 (type_ctor ctMap) envC tenvC ⇒
      ∀cn tvs ts tn ti.
        (nsLookup tenvC cn = SOME (tvs,ts,ti) ⇒
         ?cn' stamp.
           nsLookup envC cn = SOME (LENGTH ts,stamp) ∧
           FLOOKUP ctMap stamp = SOME (tvs, ts, ti)) ∧
-       (nsLookup tenvC cn = NONE ⇒ nsLookup envC cn = NONE)`,
- rw []
+       (nsLookup tenvC cn = NONE ⇒ nsLookup envC cn = NONE)
+Proof
+  rw []
  >> imp_res_tac nsAll2_nsLookup2
  >> TRY (PairCases_on `v1`)
  >> fs [type_ctor_def] >>
  rw [] >>
- metis_tac [nsAll2_nsLookup_none]);
+ metis_tac [nsAll2_nsLookup_none]
+QED
 
-val type_funs_fst = Q.prove (
-`!tenv tenvE funs tenv'.
+Triviality type_funs_fst:
+  !tenv tenvE funs tenv'.
   type_funs tenv tenvE funs tenv'
   ⇒
-  MAP FST funs = MAP FST tenv'`,
- induct_on `funs` >>
+  MAP FST funs = MAP FST tenv'
+Proof
+  induct_on `funs` >>
  srw_tac[][] >>
  pop_assum (mp_tac o SIMP_RULE (srw_ss()) [Once type_e_cases]) >>
  srw_tac[][] >>
  srw_tac[][] >>
- metis_tac []);
+ metis_tac []
+QED
 
-val type_recfun_env_help = Q.prove (
-`∀fn funs funs' ctMap tenv bindings tenvE env tenvS tvs bindings'.
+Triviality type_recfun_env_help:
+  ∀fn funs funs' ctMap tenv bindings tenvE env tenvS tvs bindings'.
   ALL_DISTINCT (MAP FST funs') ∧
   tenv_ok tenv ∧
   type_all_env ctMap tenvS env (tenv with v := add_tenvE tenvE tenv.v) ∧
@@ -345,8 +361,9 @@ val type_recfun_env_help = Q.prove (
   ⇒
   LIST_REL (λ(x,y) (x',y'). x = x' ∧ (λ(tvs,t). type_v tvs ctMap tenvS y t) y')
     (MAP (λ(fn,n,e). (fn,Recclosure env funs' fn)) funs)
-    (MAP (λ(x,t). (x,tvs,t)) bindings)`,
- induct_on `funs`
+    (MAP (λ(x,t). (x,tvs,t)) bindings)
+Proof
+  induct_on `funs`
  >> srw_tac[][]
  >> pop_assum mp_tac
  >> simp [Once type_e_cases]
@@ -377,10 +394,11 @@ val type_recfun_env_help = Q.prove (
    >> simp []
    >> rw []
    >> fs []
-   >> metis_tac [SOME_11, NOT_SOME_NONE]));
+   >> metis_tac [SOME_11, NOT_SOME_NONE])
+QED
 
-val type_recfun_env = Q.prove (
-`∀funs ctMap tenvS tvs tenv tenvE env bindings.
+Triviality type_recfun_env:
+  ∀funs ctMap tenvS tvs tenv tenvE env bindings.
   tenv_ok tenv ∧
   type_all_env ctMap tenvS env (tenv with v := add_tenvE tenvE tenv.v) ∧
   tenv_val_exp_ok tenvE ∧
@@ -390,8 +408,10 @@ val type_recfun_env = Q.prove (
   ⇒
   LIST_REL (λ(x,y) (x',y'). x = x' ∧ (λ(tvs,t). type_v tvs ctMap tenvS y t) y')
     (MAP (λ(fn,n,e). (fn,Recclosure env funs fn)) funs)
-    (MAP (λ(x,t). (x,tvs,t)) bindings)`,
-metis_tac [type_recfun_env_help]);
+    (MAP (λ(x,t). (x,tvs,t)) bindings)
+Proof
+  metis_tac [type_recfun_env_help]
+QED
 
 val type_v_exn = SIMP_RULE (srw_ss()) [] (Q.prove (
 `!tvs cenv senv.
@@ -405,15 +425,16 @@ val type_v_exn = SIMP_RULE (srw_ss()) [] (Q.prove (
  metis_tac [type_v_rules]));
 
  (*
-val v_to_list_type = Q.prove (
-`!v vs.
+Triviality v_to_list_type:
+  !v vs.
   ctMap_ok ctMap ∧
   ctMap_has_lists ctMap ∧
   v_to_list v = SOME vs ∧
   type_v 0 ctMap tenvS v (Tapp [t] (TC_name (Short "list")))
   ⇒
-  type_v tvs ctMap tenvS (Vectorv vs) (Tapp [t] TC_vector)`,
- ho_match_mp_tac v_to_list_ind >>
+  type_v tvs ctMap tenvS (Vectorv vs) (Tapp [t] TC_vector)
+Proof
+  ho_match_mp_tac v_to_list_ind >>
  srw_tac[][v_to_list_def]
  >- full_simp_tac(srw_ss())[Once type_v_cases] >>
  every_case_tac >>
@@ -431,16 +452,18 @@ val v_to_list_type = Q.prove (
  full_simp_tac(srw_ss())[tid_exn_to_tc_def] >>
  res_tac >>
  FIRST_X_ASSUM (mp_tac o SIMP_RULE (srw_ss()) [Once type_v_cases]) >>
- srw_tac[][]);
+ srw_tac[][]
+QED
 
-val v_to_char_list_type = Q.prove (
-`!v vs.
+Triviality v_to_char_list_type:
+  !v vs.
   ctMap_has_lists ctMap ∧
   v_to_char_list v = SOME vs ∧
   type_v 0 ctMap tenvS v (Tapp [t] (TC_name (Short "list")))
   ⇒
-  type_v tvs ctMap tenvS (Litv (StrLit (IMPLODE vs))) (Tstring)`,
- ho_match_mp_tac v_to_char_list_ind >>
+  type_v tvs ctMap tenvS (Litv (StrLit (IMPLODE vs))) (Tstring)
+Proof
+  ho_match_mp_tac v_to_char_list_ind >>
  srw_tac[][v_to_char_list_def]
  >- full_simp_tac(srw_ss())[Once type_v_cases] >>
  every_case_tac >>
@@ -448,22 +471,27 @@ val v_to_char_list_type = Q.prove (
  srw_tac[][] >>
  qpat_x_assum `type_v x0 x1 x2 (Conv x3 x4) x5` (mp_tac o SIMP_RULE (srw_ss()) [Once type_v_cases]) >>
  srw_tac[][] >>
- srw_tac[][Once type_v_cases]);
+ srw_tac[][Once type_v_cases]
+QED
 
  *)
 
-val type_v_Boolv = Q.prove(
-  `ctMap_has_bools ctMap ⇒ type_v tvs ctMap tenvS (Boolv b) Tbool`,
+Triviality type_v_Boolv:
+  ctMap_has_bools ctMap ⇒ type_v tvs ctMap tenvS (Boolv b) Tbool
+Proof
   srw_tac[][Boolv_def] >>
   srw_tac[][Once type_v_cases,LENGTH_NIL] >>
   full_simp_tac(srw_ss())[ctMap_has_bools_def] >>
-  srw_tac[][Once type_v_cases]);
+  srw_tac[][Once type_v_cases]
+QED
 
-val remove_lambda_prod = Q.prove (
-`(\ (x,y). P x y) = (\xy. P (FST xy) (SND xy))`,
- rw [FUN_EQ_THM]
+Triviality remove_lambda_prod:
+  (\ (x,y). P x y) = (\xy. P (FST xy) (SND xy))
+Proof
+  rw [FUN_EQ_THM]
  >> pairarg_tac
- >> rw []);
+ >> rw []
+QED
 
 Theorem opapp_type_sound:
  !ctMap tenvS vs ts t.
@@ -2168,14 +2196,15 @@ val let_tac =
       >> metis_tac [weakCT_refl, type_v_weakening, store_type_extension_weakS])
     >- metis_tac [DIFF_EQ_EMPTY, weakCT_refl]);
 
-val build_tdefs_build_tenv = Q.prove (
-  `!tenvT (tds : type_def) (tids : type_ident list) next (ctMap : ctMap).
+Triviality build_tdefs_build_tenv:
+  !tenvT (tds : type_def) (tids : type_ident list) next (ctMap : ctMap).
     EVERY (λ(_, _, ctors). ALL_DISTINCT (MAP FST ctors)) tds ∧
     LENGTH tds = LENGTH tids ⇒
     nsAll2
       (type_ctor (ctMap |++ REVERSE (type_def_to_ctMap tenvT next tds tids)))
       (build_tdefs next tds : env_ctor)
-      (build_ctor_tenv tenvT tds tids)`,
+      (build_ctor_tenv tenvT tds tids)
+Proof
   ho_match_mp_tac build_ctor_tenv_ind >>
   rw [build_tdefs_def, build_ctor_tenv_def, type_def_to_ctMap_def] >>
   fs [] >>
@@ -2238,19 +2267,24 @@ val build_tdefs_build_tenv = Q.prove (
       drule ALOOKUP_MEM >>
       rw [] >>
       drule mem_type_def_to_ctMap >>
-      rw [])));
+      rw []))
+QED
 
-val type_sound_invariant_union = Q.prove (
-  `type_sound_invariant st env ctMap tenvS (tids1 ∪ tids2) tenv
+Triviality type_sound_invariant_union:
+  type_sound_invariant st env ctMap tenvS (tids1 ∪ tids2) tenv
    ⇒
-   type_sound_invariant st env ctMap tenvS tids1 tenv`,
+   type_sound_invariant st env ctMap tenvS tids1 tenv
+Proof
   rw [type_sound_invariant_def, consistent_ctMap_def] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val check_ctor_tenv_dups = Q.prove (
-  `!tenvT tds. check_ctor_tenv tenvT tds ⇒ EVERY check_dup_ctors tds`,
+Triviality check_ctor_tenv_dups:
+  !tenvT tds. check_ctor_tenv tenvT tds ⇒ EVERY check_dup_ctors tds
+Proof
   ho_match_mp_tac check_ctor_tenv_ind >>
-  rw [check_ctor_tenv_def]);
+  rw [check_ctor_tenv_def]
+QED
 
 Theorem type_all_env_extend:
    type_all_env ctMap tenvS env1 tenv1
@@ -2871,12 +2905,14 @@ type_sound_invariant st env tdecs ctMap tenvS tenv ⇔
     st.defined_mods ⊆ tdecs_no_sig.defined_mods
 End
 
-val tscheme_inst2_lemma = Q.prove (
-  `(λid. tscheme_inst2 (Long mn id)) = tscheme_inst2`,
- rw [FUN_EQ_THM]
+Triviality tscheme_inst2_lemma:
+  (λid. tscheme_inst2 (Long mn id)) = tscheme_inst2
+Proof
+  rw [FUN_EQ_THM]
  >> PairCases_on `x`
  >> PairCases_on `x'`
- >> rw [tscheme_inst2_def]);
+ >> rw [tscheme_inst2_def]
+QED
 
 Theorem tops_type_sound_no_extra_checks:
   ∀(st:'ffi semanticPrimitives$state) env tops st' env' r tdecs1 ctMap tenvS tenv tdecs1' tenv'.

--- a/semantics/proofs/typeSysPropsScript.sml
+++ b/semantics/proofs/typeSysPropsScript.sml
@@ -218,25 +218,28 @@ induct_on `ts` >>
 full_simp_tac(srw_ss())[]
 QED
 
-val deBuijn_inc_lem1 = Q.prove (
-`!sk i2 t i1.
-  deBruijn_inc sk i1 (deBruijn_inc 0 (sk + i2) t) = deBruijn_inc 0 (i1 + (sk + i2)) t`,
-ho_match_mp_tac deBruijn_inc_ind >>
+Triviality deBuijn_inc_lem1:
+  !sk i2 t i1.
+  deBruijn_inc sk i1 (deBruijn_inc 0 (sk + i2) t) = deBruijn_inc 0 (i1 + (sk + i2)) t
+Proof
+  ho_match_mp_tac deBruijn_inc_ind >>
 srw_tac[][deBruijn_inc_def] >>
 srw_tac[][] >-
 decide_tac >-
 decide_tac >>
 induct_on `ts` >>
-srw_tac[][]);
+srw_tac[][]
+QED
 
-val type_subst_deBruijn_inc_single = Q.prove (
-`!s t ts tvs inc sk.
+Triviality type_subst_deBruijn_inc_single:
+  !s t ts tvs inc sk.
   (LENGTH tvs = LENGTH ts) ∧
   (s = alist_to_fmap (ZIP (tvs,ts))) ∧
   check_freevars 0 tvs t ⇒
   (deBruijn_inc sk inc (type_subst s t) =
-   type_subst (alist_to_fmap (ZIP (tvs, MAP (\t. deBruijn_inc sk inc t) ts))) t)`,
- recInduct type_subst_ind >>
+   type_subst (alist_to_fmap (ZIP (tvs, MAP (\t. deBruijn_inc sk inc t) ts))) t)
+Proof
+  recInduct type_subst_ind >>
  srw_tac[][deBruijn_inc_def, type_subst_def, check_freevars_def]
  >- (every_case_tac >>
      full_simp_tac(srw_ss())[deBruijn_inc_def, ALOOKUP_NONE]
@@ -251,7 +254,8 @@ val type_subst_deBruijn_inc_single = Q.prove (
          simp [ALOOKUP_ZIP_MAP_SND]))
  >- (srw_tac[][rich_listTheory.MAP_EQ_f, MAP_MAP_o] >>
      full_simp_tac(srw_ss())[EVERY_MEM] >>
-     metis_tac []));
+     metis_tac [])
+QED
 
 Theorem type_subst_deBruijn_inc_list:
  !ts' ts tvs inc sk.
@@ -265,14 +269,16 @@ Proof
  metis_tac [type_subst_deBruijn_inc_single]
 QED
 
-val check_freevars_deBruijn_inc = Q.prove (
-`!tvs tvs' t. check_freevars tvs tvs' t ⇒
-  !n n'. check_freevars (n+tvs) tvs' (deBruijn_inc n' n t)`,
-ho_match_mp_tac check_freevars_ind >>
+Triviality check_freevars_deBruijn_inc:
+  !tvs tvs' t. check_freevars tvs tvs' t ⇒
+  !n n'. check_freevars (n+tvs) tvs' (deBruijn_inc n' n t)
+Proof
+  ho_match_mp_tac check_freevars_ind >>
 srw_tac[][check_freevars_def, deBruijn_inc_def] >>
 full_simp_tac(srw_ss())[EVERY_MAP, EVERY_MEM] >>
 srw_tac[][check_freevars_def] >>
-decide_tac);
+decide_tac
+QED
 
 Theorem nil_deBruijn_inc:
  ∀skip tvs t.
@@ -365,14 +371,15 @@ decide_tac >>
 decide_tac
 QED
 
-val type_subst_deBruijn_subst_single = Q.prove (
-`!s t tvs tvs' ts ts' inc.
+Triviality type_subst_deBruijn_subst_single:
+  !s t tvs tvs' ts ts' inc.
   (LENGTH tvs = LENGTH ts) ∧
   check_freevars 0 tvs t ∧
   (s = alist_to_fmap (ZIP (tvs,ts))) ⇒
   (deBruijn_subst inc ts' (type_subst (alist_to_fmap (ZIP (tvs,ts))) t) =
-   type_subst (alist_to_fmap (ZIP (tvs,MAP (\t. deBruijn_subst inc ts' t) ts))) t)`,
- recInduct type_subst_ind >>
+   type_subst (alist_to_fmap (ZIP (tvs,MAP (\t. deBruijn_subst inc ts' t) ts))) t)
+Proof
+  recInduct type_subst_ind >>
  srw_tac[][deBruijn_subst_def, deBruijn_inc_def, type_subst_def, check_freevars_def]
  >- (every_case_tac >>
      full_simp_tac(srw_ss())[deBruijn_subst_def, deBruijn_inc_def] >>
@@ -380,7 +387,8 @@ val type_subst_deBruijn_subst_single = Q.prove (
      simp [ALOOKUP_ZIP_MAP_SND])
  >- (srw_tac[][rich_listTheory.MAP_EQ_f, MAP_MAP_o] >>
      full_simp_tac(srw_ss())[EVERY_MEM] >>
-     metis_tac []));
+     metis_tac [])
+QED
 
 Theorem type_subst_deBruijn_subst_list:
  !t tvs tvs' ts ts' ts'' inc.
@@ -394,16 +402,17 @@ srw_tac[][] >>
 metis_tac [type_subst_deBruijn_subst_single]
 QED
 
-val check_freevars_lem = Q.prove (
-`!l tvs' t.
+Triviality check_freevars_lem:
+  !l tvs' t.
   check_freevars l tvs' t ⇒
   !targs n1 tvs.
     (l = n1 + (LENGTH targs)) ∧
     EVERY (check_freevars tvs tvs') targs
      ⇒
      check_freevars (n1 + tvs) tvs'
-       (deBruijn_subst n1 (MAP (deBruijn_inc 0 n1) targs) t)`,
-ho_match_mp_tac check_freevars_ind >>
+       (deBruijn_subst n1 (MAP (deBruijn_inc 0 n1) targs) t)
+Proof
+  ho_match_mp_tac check_freevars_ind >>
 srw_tac[][deBruijn_inc_def, deBruijn_subst_def, check_freevars_def] >|
 [full_simp_tac(srw_ss())[EVERY_MAP, EVERY_MEM] >>
      metis_tac [],
@@ -415,7 +424,8 @@ srw_tac[][deBruijn_inc_def, deBruijn_subst_def, check_freevars_def] >|
                      arithmeticTheory.ADD_COMM, arithmeticTheory.ADD_ASSOC],
       decide_tac,
       decide_tac,
-      decide_tac]]);
+      decide_tac]]
+QED
 
 Theorem nil_deBruijn_subst:
  ∀skip tvs t. check_freevars skip [] t ⇒ (deBruijn_subst skip tvs t = t)
@@ -463,8 +473,8 @@ full_simp_tac (srw_ss()++ARITH_ss) [check_freevars_def, EL_MAP, MEM_EL] >>
 metis_tac [check_freevars_deBruijn_inc]
 QED
 
-val type_e_subst_lem5 = Q.prove (
-`(!t n inc n' targs.
+Triviality type_e_subst_lem5:
+  (!t n inc n' targs.
    deBruijn_inc n inc
          (deBruijn_subst (n + n') (MAP (deBruijn_inc 0 (n + n')) targs) t) =
    deBruijn_subst (n + inc + n') (MAP (deBruijn_inc 0 (n + inc + n')) targs)
@@ -473,12 +483,14 @@ val type_e_subst_lem5 = Q.prove (
    MAP (deBruijn_inc n inc)
          (MAP (deBruijn_subst (n + n') (MAP (deBruijn_inc 0 (n + n')) targs)) ts) =
    MAP (deBruijn_subst (n + inc + n') (MAP (deBruijn_inc 0 (n + inc + n')) targs))
-         (MAP (deBruijn_inc n inc) ts))`,
-ho_match_mp_tac t_induction >>
+         (MAP (deBruijn_inc n inc) ts))
+Proof
+  ho_match_mp_tac t_induction >>
 srw_tac[][deBruijn_subst_def, deBruijn_inc_def] >>
 srw_tac[][] >>
 full_simp_tac (srw_ss()++ARITH_ss) [EL_MAP] >>
-metis_tac [deBuijn_inc_lem1]);
+metis_tac [deBuijn_inc_lem1]
+QED
 
 Theorem subst_inc_cancel:
  (!t ts inc.
@@ -496,22 +508,24 @@ full_simp_tac (srw_ss()++ARITH_ss) [] >>
 metis_tac []
 QED
 
-val type_e_subst_lem7 = Q.prove (
-`(!t sk targs targs' tvs' tvs''.
+Triviality type_e_subst_lem7:
+  (!t sk targs targs' tvs' tvs''.
   (deBruijn_subst sk (MAP (deBruijn_inc 0 sk) targs') (deBruijn_subst 0 targs t) =
    deBruijn_subst 0 (MAP (deBruijn_subst sk (MAP (deBruijn_inc 0 sk) targs')) targs)
      (deBruijn_subst (LENGTH targs + sk) (MAP (deBruijn_inc 0 (LENGTH targs + sk)) targs') t))) ∧
  (!ts sk targs targs' tvs' tvs''.
   (MAP (deBruijn_subst sk (MAP (deBruijn_inc 0 sk) targs')) (MAP (deBruijn_subst 0 targs) ts) =
   (MAP (deBruijn_subst 0 (MAP (deBruijn_subst sk (MAP (deBruijn_inc 0 sk) targs')) targs))
-       (MAP (deBruijn_subst (LENGTH targs + sk) (MAP (deBruijn_inc 0 (LENGTH targs + sk)) targs')) ts))))`,
-ho_match_mp_tac t_induction >>
+       (MAP (deBruijn_subst (LENGTH targs + sk) (MAP (deBruijn_inc 0 (LENGTH targs + sk)) targs')) ts))))
+Proof
+  ho_match_mp_tac t_induction >>
 srw_tac[][deBruijn_subst_def, deBruijn_inc_def] >>
 full_simp_tac(srw_ss())[EL_MAP, MAP_MAP_o, combinTheory.o_DEF] >>
 srw_tac[][] >>
 full_simp_tac (srw_ss()++ARITH_ss) [EL_MAP, deBruijn_subst_def, check_freevars_def] >>
 rw[] >> fs[] >>
-metis_tac [subst_inc_cancel, LENGTH_MAP]);
+metis_tac [subst_inc_cancel, LENGTH_MAP]
+QED
 
 Theorem deBruijn_subst_id:
  (!t n. check_freevars n [] t ⇒ (deBruijn_subst 0 (MAP Tvar_db (COUNT_LIST n)) t = t)) ∧
@@ -821,18 +835,20 @@ induct_on `e1` >>
 srw_tac[][tenv_val_exp_ok_def, db_merge_def]
 QED
 
-val tveLookup_freevars = Q.prove (
-`!e n inc t tvs.
+Triviality tveLookup_freevars:
+  !e n inc t tvs.
   tenv_val_exp_ok e ∧
   tveLookup n inc e = SOME (tvs, t)
   ⇒
-  check_freevars (tvs+inc+num_tvs e) [] t`,
- induct_on `e` >>
+  check_freevars (tvs+inc+num_tvs e) [] t
+Proof
+  induct_on `e` >>
  srw_tac[][tveLookup_def, num_tvs_def, tenv_val_exp_ok_def] >|
  [metis_tac [arithmeticTheory.ADD_ASSOC],
   imp_res_tac check_freevars_deBruijn_inc >>
       metis_tac [arithmeticTheory.ADD_ASSOC, arithmeticTheory.ADD_COMM],
-  metis_tac []]);
+  metis_tac []]
+QED
 
 Theorem tveLookup_no_tvs:
  !tvs l tenv n t.
@@ -1599,8 +1615,8 @@ Proof
  >> metis_tac []
 QED
 
-val type_e_subst_lem = Q.prove (
-`∀tenv tenvE e t targs tvs targs'.
+Triviality type_e_subst_lem:
+  ∀tenv tenvE e t targs tvs targs'.
   type_e tenv (Bind_name x 0 t1 (bind_tvar (LENGTH targs) tenvE)) e t ∧
   num_tvs tenvE = 0 ∧
   tenv_abbrev_ok tenv.t ∧
@@ -1610,13 +1626,15 @@ val type_e_subst_lem = Q.prove (
   EVERY (check_freevars tvs []) targs ∧
   check_freevars (LENGTH targs) [] t1
   ⇒
-  type_e tenv (Bind_name x 0 (deBruijn_subst 0 targs t1) (bind_tvar tvs tenvE)) e (deBruijn_subst 0 targs t)`,
- srw_tac[][] >>
+  type_e tenv (Bind_name x 0 (deBruijn_subst 0 targs t1) (bind_tvar tvs tenvE)) e (deBruijn_subst 0 targs t)
+Proof
+  srw_tac[][] >>
  drule (GEN_ALL (CONJUNCT1 type_e_subst))
  >> simp [tenv_val_exp_ok_def]
  >> rpt (disch_then drule)
  >> disch_then (qspec_then `Bind_name x 0 t1 Empty` mp_tac)
- >> simp [db_merge_def, deBruijn_subst_tenvE_def, deBruijn_inc0]);
+ >> simp [db_merge_def, deBruijn_subst_tenvE_def, deBruijn_inc0]
+QED
 
 
  (*
@@ -1682,10 +1700,12 @@ Proof
   fs []
 QED
 
-val o_f_FRANGE2 = Q.prove (
-  `(?x. y = f x ∧ x ∈ FRANGE g) ⇒ y ∈ FRANGE (f o_f g)`,
+Triviality o_f_FRANGE2:
+  (?x. y = f x ∧ x ∈ FRANGE g) ⇒ y ∈ FRANGE (f o_f g)
+Proof
   rw [FRANGE_DEF] >>
-  metis_tac [o_f_FAPPLY]);
+  metis_tac [o_f_FAPPLY]
+QED
 
 Theorem ctMap_ok_merge_imp:
    !ctMap1 ctMap2.
@@ -1770,10 +1790,12 @@ Proof
   fs []
 QED
 
-val fupdate2_union = Q.prove (
-  `!m a1 a2. m |++ a1 |++ a2 = FEMPTY |++ a2 ⊌ (m |++ a1)`,
+Triviality fupdate2_union:
+  !m a1 a2. m |++ a1 |++ a2 = FEMPTY |++ a2 ⊌ (m |++ a1)
+Proof
   rw [FLOOKUP_EXT, FUN_EQ_THM, FLOOKUP_FUNION, flookup_fupdate_list] >>
-  every_case_tac);
+  every_case_tac
+QED
 
 Theorem ctMap_ok_type_defs:
    !tenvT next tds tids.
@@ -1945,26 +1967,29 @@ Proof
 QED
  *)
 
-val all_distinct_map_fst_lemma = Q.prove (
-`!l v. ALL_DISTINCT (MAP (\(x,y). x) l) ⇒ ALL_DISTINCT (MAP (\(x,y). (x, v)) l)`,
- Induct_on `l`
+Triviality all_distinct_map_fst_lemma:
+  !l v. ALL_DISTINCT (MAP (\(x,y). x) l) ⇒ ALL_DISTINCT (MAP (\(x,y). (x, v)) l)
+Proof
+  Induct_on `l`
  >> rw [MEM_MAP]
  >> pairarg_tac
  >> rw []
  >> pairarg_tac
  >> rw []
  >> fs [MEM_MAP, LAMBDA_PROD, FORALL_PROD]
- >> metis_tac []);
+ >> metis_tac []
+QED
 
  (*
-val check_ctor_tenv_type_decs_to_ctMap_lemma = Q.prove (
-  `!tenvT tds mn tvs tn c cn ts.
+Triviality check_ctor_tenv_type_decs_to_ctMap_lemma:
+  !tenvT tds mn tvs tn c cn ts.
     check_ctor_tenv tenvT (REVERSE tds) ∧
     MEM (tvs,tn,c) (REVERSE tds) ∧
     MEM (cn,ts) c
     ⇒
-    FLOOKUP (type_decs_to_ctMap mn tenvT (REVERSE tds)) (cn, TypeId (mk_id mn tn)) = SOME (tvs, MAP (type_name_subst tenvT) ts)`,
- Induct_on `tds`
+    FLOOKUP (type_decs_to_ctMap mn tenvT (REVERSE tds)) (cn, TypeId (mk_id mn tn)) = SOME (tvs, MAP (type_name_subst tenvT) ts)
+Proof
+  Induct_on `tds`
  >> rw [check_ctor_tenv_def]
  >> fs [MEM_MAP]
  >- (
@@ -1999,7 +2024,8 @@ val check_ctor_tenv_type_decs_to_ctMap_lemma = Q.prove (
    >> rw [ALOOKUP_NONE, MEM_MAP]
    >> rw [METIS_PROVE [] ``x ∨ y ⇔ ~x ⇒ y``]
    >> pairarg_tac
-   >> fs []));
+   >> fs [])
+QED
 
 Theorem check_ctor_tenv_type_decs_to_ctMap:
    !tenvT tds mn tvs tn c cn ts.
@@ -2203,11 +2229,13 @@ Proof
                arithmeticTheory.GREATER_EQ]
 QED
 
-val remove_lambda_prod = Q.prove (
-`(\(x,y). P x y) = (\xy. P (FST xy) (SND xy))`,
- rw [FUN_EQ_THM]
+Triviality remove_lambda_prod:
+  (\(x,y). P x y) = (\xy. P (FST xy) (SND xy))
+Proof
+  rw [FUN_EQ_THM]
  >> pairarg_tac
- >> rw []);
+ >> rw []
+QED
 
 val type_subst_lem1 =
 (GEN_ALL o
@@ -2575,8 +2603,8 @@ QED
  *)
 
  (*
-val type_ds_no_dup_types_helper = Q.prove (
-`!uniq mn decls tenv ds decls' tenv'.
+Triviality type_ds_no_dup_types_helper:
+  !uniq mn decls tenv ds decls' tenv'.
   type_ds uniq mn decls tenv ds decls' tenv'
   ⇒
   DISJOINT decls.defined_types decls'.defined_types ∧
@@ -2587,8 +2615,9 @@ val type_ds_no_dup_types_helper = Q.prove (
                 | Dletrec _ v8 => []
                 | Dtabbrev _ x y z => []
                 | Dtype _ tds => MAP (λ(tvs,tn,ctors). mk_id mn tn) tds
-                | Dexn _ v10 v11 => []) ds))`,
- induct_on `ds` >>
+                | Dexn _ v10 v11 => []) ds))
+Proof
+  induct_on `ds` >>
  srw_tac[][empty_decls_def] >>
  pop_assum (assume_tac o SIMP_RULE (srw_ss()) [Once type_ds_cases,EXISTS_PROD]) >>
  full_simp_tac(srw_ss())[empty_decls_def,EXISTS_PROD,extend_dec_tenv_def] >>
@@ -2605,7 +2634,8 @@ val type_ds_no_dup_types_helper = Q.prove (
  full_simp_tac(srw_ss())[] >>
  srw_tac[][] >>
  full_simp_tac(srw_ss())[DISJOINT_DEF, EXTENSION] >>
- metis_tac []);
+ metis_tac []
+QED
 
 Theorem type_ds_no_dup_types:
  !uniq mn decls tenv ds decls' tenv'.
@@ -2877,13 +2907,14 @@ Proof
  >> metis_tac [type_top_decls_ok]
 QED
 
-val type_no_dup_top_types_lem = Q.prove (
-`!uniq decls1 tenv prog decls1' res.
+Triviality type_no_dup_top_types_lem:
+  !uniq decls1 tenv prog decls1' res.
   type_prog uniq decls1 tenv prog decls1' res
   ⇒
   ALL_DISTINCT (prog_to_top_types prog) ∧
-  DISJOINT decls1.defined_types (IMAGE (mk_id []) (set (prog_to_top_types prog)))`,
- ho_match_mp_tac type_prog_ind >>
+  DISJOINT decls1.defined_types (IMAGE (mk_id []) (set (prog_to_top_types prog)))
+Proof
+  ho_match_mp_tac type_prog_ind >>
  srw_tac[][semanticPrimitivesTheory.prog_to_top_types_def] >>
  every_case_tac >>
  srw_tac[][] >>
@@ -2917,14 +2948,16 @@ val type_no_dup_top_types_lem = Q.prove (
      full_simp_tac(srw_ss())[DISJOINT_DEF, EXTENSION, union_decls_def] >>
      srw_tac[][] >>
      full_simp_tac(srw_ss())[MEM_MAP,LAMBDA_PROD, EXISTS_PROD, mk_id_def, FORALL_PROD] >>
-     metis_tac []));
+     metis_tac [])
+QED
 
-val type_no_dup_top_types_lem2 = Q.prove (
-`!uniq decls1 tenv prog decls1' tenv'.
+Triviality type_no_dup_top_types_lem2:
+  !uniq decls1 tenv prog decls1' tenv'.
   type_prog uniq decls1 tenv prog decls1' tenv'
   ⇒
-  no_dup_top_types prog (IMAGE TypeId decls1.defined_types)`,
- srw_tac[][semanticPrimitivesTheory.no_dup_top_types_def]
+  no_dup_top_types prog (IMAGE TypeId decls1.defined_types)
+Proof
+  srw_tac[][semanticPrimitivesTheory.no_dup_top_types_def]
  >- metis_tac [type_no_dup_top_types_lem] >>
  imp_res_tac type_no_dup_top_types_lem >>
  full_simp_tac(srw_ss())[DISJOINT_DEF, EXTENSION] >>
@@ -2932,7 +2965,8 @@ val type_no_dup_top_types_lem2 = Q.prove (
  cases_on `x` >>
  srw_tac[][MEM_MAP] >>
  full_simp_tac(srw_ss())[mk_id_def] >>
- metis_tac []);
+ metis_tac []
+QED
 
 Theorem type_no_dup_top_types:
  !decls1 tenv prog decls1' tenv' uniq decls2 decls_no_sig.
@@ -2957,13 +2991,14 @@ Proof
  metis_tac []
 QED
 
-val type_no_dup_mods_lem = Q.prove (
-`!uniq decls1 tenv prog decls1' res.
+Triviality type_no_dup_mods_lem:
+  !uniq decls1 tenv prog decls1' res.
   type_prog uniq decls1 tenv prog decls1' res
   ⇒
   ALL_DISTINCT (prog_to_mods prog) ∧
-  DISJOINT decls1.defined_mods (set (prog_to_mods prog))`,
- ho_match_mp_tac type_prog_ind >>
+  DISJOINT decls1.defined_mods (set (prog_to_mods prog))
+Proof
+  ho_match_mp_tac type_prog_ind >>
  srw_tac[][semanticPrimitivesTheory.prog_to_mods_def] >>
  every_case_tac >>
  srw_tac[][] >>
@@ -2974,7 +3009,8 @@ val type_no_dup_mods_lem = Q.prove (
  >- (full_simp_tac(srw_ss())[union_decls_def, DISJOINT_DEF, EXTENSION] >>
      metis_tac [])
  >- (full_simp_tac(srw_ss())[union_decls_def, DISJOINT_DEF, EXTENSION] >>
-     metis_tac []));
+     metis_tac [])
+QED
 
 Theorem type_no_dup_mods:
  !uniq decls1 tenv prog decls1' tenv'.
@@ -3024,30 +3060,34 @@ Proof
   simp[EXTENSION] >> metis_tac[]
 QED
 
-val type_p_closed = Q.prove(
-  `(∀tvs tcenv p t tenv.
+Triviality type_p_closed:
+  (∀tvs tcenv p t tenv.
        type_p tvs tcenv p t tenv ⇒
        pat_bindings p [] = MAP FST tenv) ∧
     (∀tvs cenv ps ts tenv.
       type_ps tvs cenv ps ts tenv ⇒
-      pats_bindings ps [] = MAP FST tenv)`,
+      pats_bindings ps [] = MAP FST tenv)
+Proof
   ho_match_mp_tac type_p_ind >>
   simp[astTheory.pat_bindings_def] >>
   srw_tac[][] >> full_simp_tac(srw_ss())[SUBSET_DEF] >>
-  srw_tac[][Once pat_bindings_accum]);
+  srw_tac[][Once pat_bindings_accum]
+QED
 
-val type_funs_dom = Q.prove (
-  `!tenv funs tenv'.
+Triviality type_funs_dom:
+  !tenv funs tenv'.
     type_funs tenv funs tenv'
     ⇒
-    IMAGE FST (set funs) = IMAGE FST (set tenv')`,
-   Induct_on `funs` >>
+    IMAGE FST (set funs) = IMAGE FST (set tenv')
+Proof
+  Induct_on `funs` >>
    srw_tac[][Once type_e_cases] >>
    srw_tac[][] >>
-   metis_tac []);
+   metis_tac []
+QED
 
-val type_e_closed = Q.prove(
-  `(∀tenv e t.
+Triviality type_e_closed:
+  (∀tenv e t.
       type_e tenv e t
       ⇒
       FV e ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)) ∧
@@ -3057,7 +3097,8 @@ val type_e_closed = Q.prove(
       FV_list es ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)) ∧
     (∀tenv funs ts.
       type_funs tenv funs ts ⇒
-      FV_defs funs ⊆ (IMAGE Short (tenv_names tenv.v)) ∪ tmenv_dom tenv.m)`,
+      FV_defs funs ⊆ (IMAGE Short (tenv_names tenv.v)) ∪ tmenv_dom tenv.m)
+Proof
   ho_match_mp_tac type_e_strongind >>
   strip_tac >- simp[] >>
   strip_tac >- simp[] >>
@@ -3157,12 +3198,14 @@ val type_e_closed = Q.prove(
   res_tac >>
   fsrw_tac[DNF_ss][MEM_MAP,FV_defs_MAP,UNCURRY] >>
   srw_tac[][] >>
-  metis_tac []);
+  metis_tac []
+QED
 
-val type_d_closed = Q.prove(
-  `∀uniq mno decls tenv d w x.
+Triviality type_d_closed:
+  ∀uniq mno decls tenv d w x.
       type_d uniq mno decls tenv d w x ⇒
-        FV_dec d ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)`,
+        FV_dec d ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)
+Proof
   ho_match_mp_tac type_d_ind >>
   strip_tac >- (
     simp[bind_tvar_def] >>
@@ -3189,27 +3232,31 @@ val type_d_closed = Q.prove(
     imp_res_tac type_funs_dom >>
     full_simp_tac(srw_ss())[EXTENSION] >>
     metis_tac[]) >>
-  simp[]);
+  simp[]
+QED
 
   (*
-val type_d_new_dec_vs = Q.prove (
-  `!uniq mn decls tenv d decls' new_tenv.
+Triviality type_d_new_dec_vs:
+  !uniq mn decls tenv d decls' new_tenv.
     type_d uniq mn decls tenv d decls' new_tenv
     ⇒
-    set (new_dec_vs d) = set (MAP FST tenv')`,
-   srw_tac[][type_d_cases, new_dec_vs_def] >>
+    set (new_dec_vs d) = set (MAP FST tenv')
+Proof
+  srw_tac[][type_d_cases, new_dec_vs_def] >>
    srw_tac[][new_dec_vs_def] >>
    imp_res_tac type_p_closed >>
    srw_tac[][tenv_add_tvs_def, MAP_MAP_o, combinTheory.o_DEF, LAMBDA_PROD] >>
    full_simp_tac(srw_ss())[LET_THM, LIST_TO_SET_MAP, FST_pair, IMAGE_COMPOSE] >>
-   metis_tac [type_funs_dom]);
+   metis_tac [type_funs_dom]
+QED
    *)
 
    (*
-val type_ds_closed = Q.prove(
-  `∀uniq mn decls tenv ds w x. type_ds uniq mn decls tenv ds w x ⇒
+Triviality type_ds_closed:
+  ∀uniq mn decls tenv ds w x. type_ds uniq mn decls tenv ds w x ⇒
      !mn'. mn = SOME mn' ⇒
-      FV_decs ds ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)`,
+      FV_decs ds ⊆ (IMAGE Short (tenv_names tenv.v) ∪ tmenv_dom tenv.m)
+Proof
   ho_match_mp_tac type_ds_ind >>
   srw_tac[][FV_decs_def] >>
   imp_res_tac type_d_closed >>
@@ -3220,7 +3267,8 @@ val type_ds_closed = Q.prove(
   full_simp_tac(srw_ss())[] >>
   srw_tac[][] >>
   full_simp_tac(srw_ss())[MEM_MAP] >>
-  metis_tac [type_d_new_dec_vs,MEM_MAP]);
+  metis_tac [type_d_new_dec_vs,MEM_MAP]
+QED
   *)
 
   (*
@@ -3242,24 +3290,27 @@ Proof
 QED
   *)
 
-val type_env_dom = Q.prove (
-  `!ctMap tenvS env tenv.
+Triviality type_env_dom:
+  !ctMap tenvS env tenv.
     type_env ctMap tenvS env tenv ⇒
-    IMAGE Short (set (MAP FST env)) = IMAGE Short (tenv_names tenv)`,
-   induct_on `env` >>
+    IMAGE Short (set (MAP FST env)) = IMAGE Short (tenv_names tenv)
+Proof
+  induct_on `env` >>
    ONCE_REWRITE_TAC [typeSoundInvariantsTheory.type_v_cases] >>
    full_simp_tac(srw_ss())[tenv_names_def] >>
    full_simp_tac(srw_ss())[tenv_names_def] >>
    srw_tac[][] >>
    srw_tac[][] >>
-   metis_tac []);
+   metis_tac []
+QED
 
-val weakM_dom = Q.prove (
-  `!tenvM1 tenvM2.
+Triviality weakM_dom:
+  !tenvM1 tenvM2.
     weakM tenvM1 tenvM2
     ⇒
-    tmenv_dom tenvM2 ⊆ tmenv_dom tenvM1`,
-   srw_tac[][weakM_def, SUBSET_DEF] >>
+    tmenv_dom tenvM2 ⊆ tmenv_dom tenvM1
+Proof
+  srw_tac[][weakM_def, SUBSET_DEF] >>
    res_tac >>
    srw_tac[][] >>
    full_simp_tac(srw_ss())[weakE_def] >>
@@ -3269,13 +3320,15 @@ val weakM_dom = Q.prove (
    srw_tac[][] >>
    imp_res_tac ALOOKUP_MEM >>
    full_simp_tac(srw_ss())[MEM_MAP] >>
-   metis_tac [FST, pair_CASES]);
+   metis_tac [FST, pair_CASES]
+QED
 
-val type_env_dom2 = Q.prove (
-  `!ctMap tenvS env tenv.
+Triviality type_env_dom2:
+  !ctMap tenvS env tenv.
     type_env ctMap tenvS env (bind_var_list2 tenv Empty) ⇒
-    (set (MAP FST env) = set (MAP FST tenv))`,
-   induct_on `env` >>
+    (set (MAP FST env) = set (MAP FST tenv))
+Proof
+  induct_on `env` >>
    ONCE_REWRITE_TAC [typeSoundInvariantsTheory.type_v_cases] >>
    full_simp_tac(srw_ss())[bind_var_list2_def, tenv_names_def] >>
    full_simp_tac(srw_ss())[tenv_names_def] >>
@@ -3284,14 +3337,16 @@ val type_env_dom2 = Q.prove (
    cases_on `tenv` >>
    TRY (PairCases_on `h`) >>
    full_simp_tac(srw_ss())[bind_var_list2_def] >>
-   metis_tac []);
+   metis_tac []
+QED
 
-val consistent_mod_env_dom = Q.prove (
-  `!tenvS tenvC envM tenvM.
+Triviality consistent_mod_env_dom:
+  !tenvS tenvC envM tenvM.
     consistent_mod_env tenvS tenvC envM tenvM
     ⇒
-    (tmenv_dom tenvM = {Long m x | ∃e. ALOOKUP envM m = SOME e ∧ MEM x (MAP FST e)})`,
-   induct_on `envM` >>
+    (tmenv_dom tenvM = {Long m x | ∃e. ALOOKUP envM m = SOME e ∧ MEM x (MAP FST e)})
+Proof
+  induct_on `envM` >>
    srw_tac[][]
    >- (Cases_on `tenvM` >>
        full_simp_tac(srw_ss())[Once type_v_cases]) >>
@@ -3310,7 +3365,8 @@ val consistent_mod_env_dom = Q.prove (
    srw_tac[][] >>
    res_tac >>
    full_simp_tac(srw_ss())[] >>
-   metis_tac []);
+   metis_tac []
+QED
    *)
 
    (*

--- a/semantics/proofs/weakeningScript.sml
+++ b/semantics/proofs/weakeningScript.sml
@@ -73,80 +73,96 @@ Proof
  rw [weakS_def, FLOOKUP_UPDATE, flookup_thm]
 QED
 
-val weak_tenvE_freevars = Q.prove (
-`!tenv tenv' tvs t.
+Triviality weak_tenvE_freevars:
+  !tenv tenv' tvs t.
   weak_tenvE tenv' tenv ∧
   check_freevars (num_tvs tenv) tvs t ⇒
-  check_freevars (num_tvs tenv') tvs t`,
-rw [weak_tenvE_def] >>
-metis_tac [check_freevars_add]);
+  check_freevars (num_tvs tenv') tvs t
+Proof
+  rw [weak_tenvE_def] >>
+metis_tac [check_freevars_add]
+QED
 
-val weak_tenvE_bind = Q.prove (
-`!tenv tenv' n tvs t.
+Triviality weak_tenvE_bind:
+  !tenv tenv' n tvs t.
   weak_tenvE tenv' tenv ⇒
-  weak_tenvE (Bind_name n tvs t tenv') (Bind_name n tvs t tenv)`,
-rw [weak_tenvE_def, tveLookup_def] >>
+  weak_tenvE (Bind_name n tvs t tenv') (Bind_name n tvs t tenv)
+Proof
+  rw [weak_tenvE_def, tveLookup_def] >>
 every_case_tac >>
-rw []);
+rw []
+QED
 
-val weak_tenvE_opt_bind = Q.prove (
-`!tenv tenv' n tvs t.
+Triviality weak_tenvE_opt_bind:
+  !tenv tenv' n tvs t.
   weak_tenvE tenv' tenv ⇒
-  weak_tenvE (opt_bind_name n tvs t tenv') (opt_bind_name n tvs t tenv)`,
- rw [weak_tenvE_def, num_tvs_def, opt_bind_name_def, tveLookup_def] >>
+  weak_tenvE (opt_bind_name n tvs t tenv') (opt_bind_name n tvs t tenv)
+Proof
+  rw [weak_tenvE_def, num_tvs_def, opt_bind_name_def, tveLookup_def] >>
  every_case_tac >>
  fs [tveLookup_def, num_tvs_def] >>
  every_case_tac >>
- fs []);
+ fs []
+QED
 
-val weak_tenvE_bind_tvar = Q.prove (
-`!tenv tenv' tvs.
+Triviality weak_tenvE_bind_tvar:
+  !tenv tenv' tvs.
   weak_tenvE tenv' tenv ⇒
-  weak_tenvE (bind_tvar tvs tenv') (bind_tvar tvs tenv)`,
-rw [weak_tenvE_def, num_tvs_def, bind_tvar_def, tveLookup_def] >>
-decide_tac);
+  weak_tenvE (bind_tvar tvs tenv') (bind_tvar tvs tenv)
+Proof
+  rw [weak_tenvE_def, num_tvs_def, bind_tvar_def, tveLookup_def] >>
+decide_tac
+QED
 
-val weak_tenvE_bind_tvar2 = Q.prove (
-`!tenv tenv' n tvs t.
+Triviality weak_tenvE_bind_tvar2:
+  !tenv tenv' n tvs t.
   tenv_val_exp_ok tenv ∧
   num_tvs tenv = 0 ∧
   weak_tenvE tenv' tenv ⇒
-  weak_tenvE (bind_tvar tvs tenv') (bind_tvar 0 tenv)`,
- rw [weak_tenvE_def, num_tvs_def, bind_tvar_def]
- >> metis_tac [tveLookup_no_tvs]);
+  weak_tenvE (bind_tvar tvs tenv') (bind_tvar 0 tenv)
+Proof
+  rw [weak_tenvE_def, num_tvs_def, bind_tvar_def]
+ >> metis_tac [tveLookup_no_tvs]
+QED
 
-val weak_tenvE_bind_var_list = Q.prove (
-`!bindings tenvE tenvE' n tvs t .
+Triviality weak_tenvE_bind_var_list:
+  !bindings tenvE tenvE' n tvs t .
   weak_tenvE tenvE' tenvE ⇒
-  weak_tenvE (bind_var_list tvs bindings tenvE') (bind_var_list tvs bindings tenvE)`,
-induct_on `bindings` >>
+  weak_tenvE (bind_var_list tvs bindings tenvE') (bind_var_list tvs bindings tenvE)
+Proof
+  induct_on `bindings` >>
 rw [weak_tenvE_def, bind_var_list_def, num_tvs_def] >>
 PairCases_on `h` >>
 fs [bind_var_list_def, tveLookup_def] >>
 every_case_tac >>
 fs [weak_tenvE_def] >>
-PROVE_TAC []);
+PROVE_TAC []
+QED
 
-val eLookupC_weak = Q.prove (
-  `∀cn tenv tenv' tvs ts tn.
+Triviality eLookupC_weak:
+  ∀cn tenv tenv' tvs ts tn.
     weak_tenv tenv' tenv ∧
     nsLookup tenv.c cn = SOME (tvs,ts,tn)
     ⇒
-    nsLookup tenv'.c cn = SOME (tvs,ts,tn)`,
- rw [weak_tenv_def, namespaceTheory.nsSub_def]);
+    nsLookup tenv'.c cn = SOME (tvs,ts,tn)
+Proof
+  rw [weak_tenv_def, namespaceTheory.nsSub_def]
+QED
 
-val eLookupV_weak = Q.prove (
-  `∀n tenv tenv' tvs t.
+Triviality eLookupV_weak:
+  ∀n tenv tenv' tvs t.
     weak_tenv tenv' tenv ∧
     nsLookup tenv.v n = SOME (tvs,t)
     ⇒
-    ∃tvs' t'. nsLookup tenv'.v n = SOME (tvs',t') ∧ tscheme_inst (tvs,t) (tvs',t')`,
- rw [weak_tenv_def, namespaceTheory.nsSub_def, tscheme_inst2_def]
- >> metis_tac [pair_CASES]);
+    ∃tvs' t'. nsLookup tenv'.v n = SOME (tvs',t') ∧ tscheme_inst (tvs,t) (tvs',t')
+Proof
+  rw [weak_tenv_def, namespaceTheory.nsSub_def, tscheme_inst2_def]
+ >> metis_tac [pair_CASES]
+QED
 
       (*
-val weakE_lookup = Q.prove (
-`!n env env' tvs t.
+Triviality weakE_lookup:
+  !n env env' tvs t.
   weakE env' env ∧
   (ALOOKUP env n = SOME (tvs, t))
   ⇒
@@ -155,30 +171,36 @@ val weakE_lookup = Q.prove (
     check_freevars tvs' [] t' ∧
     (LENGTH subst = tvs') ∧
     EVERY (check_freevars tvs []) subst ∧
-    (deBruijn_subst 0 subst t' = t)`,
- rw [weakE_def] >>
+    (deBruijn_subst 0 subst t' = t)
+Proof
+  rw [weakE_def] >>
  qpat_x_assum `!cn. P cn` (MP_TAC o Q.SPEC `n`) >>
  rw [] >>
  every_case_tac >>
  fs [] >>
- metis_tac []);
+ metis_tac []
+QED
 
-val weak_tenvM_lookup_lem = Q.prove (
-`!tvs.
-  EVERY (λx. check_freevars tvs [] (Tvar_db x)) (COUNT_LIST tvs)`,
-Induct >>
+Triviality weak_tenvM_lookup_lem:
+  !tvs.
+  EVERY (λx. check_freevars tvs [] (Tvar_db x)) (COUNT_LIST tvs)
+Proof
+  Induct >>
 rw [COUNT_LIST_def, check_freevars_def, EVERY_MAP] >>
-fs [check_freevars_def]);
+fs [check_freevars_def]
+QED
 
-val weak_tenvM_lookup = Q.prove (
-`!mn tenvM tenvM' tenv tenv' tvs t.
+Triviality weak_tenvM_lookup:
+  !mn tenvM tenvM' tenv tenv' tvs t.
   weakM tenvM' tenvM ∧
   FLOOKUP tenvM mn = SOME tenv
   ⇒
   ?tenv'.
     FLOOKUP tenvM' mn = SOME tenv' ∧
-    weakE tenv' tenv`,
- rw [weakM_def]);
+    weakE tenv' tenv
+Proof
+  rw [weakM_def]
+QED
 
  *)
 
@@ -201,14 +223,15 @@ Proof
  metis_tac [weak_def, check_freevars_add, EVERY_MEM, eLookupC_weak]
 QED
 
-val type_e_weakening_lem = Q.prove (
-`(!tenv tenvE e t. type_e tenv tenvE e t ⇒
+Triviality type_e_weakening_lem:
+  (!tenv tenvE e t. type_e tenv tenvE e t ⇒
     ∀tenv' tenvE'. weak tenv' tenv ∧ weak_tenvE tenvE' tenvE ⇒ type_e tenv' tenvE' e t) ∧
  (!tenv tenvE es ts. type_es tenv tenvE es ts ⇒
     ∀tenv' tenvE'. weak tenv' tenv ∧ weak_tenvE tenvE' tenvE ⇒ type_es tenv' tenvE' es ts) ∧
  (!tenv tenvE funs bindings. type_funs tenv tenvE funs bindings ⇒
-    ∀tenv' tenvE'. weak tenv' tenv ∧ weak_tenvE tenvE' tenvE ⇒ type_funs tenv' tenvE' funs bindings)`,
- ho_match_mp_tac type_e_ind >>
+    ∀tenv' tenvE'. weak tenv' tenv ∧ weak_tenvE tenvE' tenvE ⇒ type_funs tenv' tenvE' funs bindings)
+Proof
+  ho_match_mp_tac type_e_ind >>
  rw [weak_def] >>
  rw [Once type_e_cases]
  >- metis_tac [weak_tenvE_freevars]
@@ -291,7 +314,8 @@ val type_e_weakening_lem = Q.prove (
  >- (
    first_x_assum match_mp_tac  >>
    rw [] >>
-   metis_tac [weak_tenvE_bind, weak_tenvE_bind_tvar, weak_tenvE_freevars]));
+   metis_tac [weak_tenvE_bind, weak_tenvE_bind_tvar, weak_tenvE_freevars])
+QED
 
 Theorem type_e_weakening:
  (!tenv tenvE e t tenv' tenvE'.
@@ -304,22 +328,26 @@ Proof
 metis_tac [type_e_weakening_lem]
 QED
 
-val gt_0 = Q.prove (
-`!x:num.x ≥ 0`,
-decide_tac);
+Triviality gt_0:
+  !x:num.x ≥ 0
+Proof
+  decide_tac
+QED
 
 Definition weakCT_def:
 weakCT cenv_impl cenv_spec ⇔ cenv_spec SUBMAP cenv_impl
 End
 
-val weak_ctMap_lookup = Q.prove (
-`∀ctMap ctMap' tvs ts stamp.
+Triviality weak_ctMap_lookup:
+  ∀ctMap ctMap' tvs ts stamp.
   weakCT ctMap' ctMap ∧
   FLOOKUP ctMap stamp = SOME (tvs,ts)
   ⇒
-  FLOOKUP ctMap' stamp = SOME (tvs,ts)`,
-rw [weakCT_def] >>
-metis_tac [FLOOKUP_SUBMAP]);
+  FLOOKUP ctMap' stamp = SOME (tvs,ts)
+Proof
+  rw [weakCT_def] >>
+metis_tac [FLOOKUP_SUBMAP]
+QED
 
 Theorem weakCT_refl:
  !ctMap. weakCT ctMap ctMap
@@ -369,8 +397,8 @@ Proof
  >> metis_tac [FLOOKUP_SUBMAP]
 QED
 
-val type_tenv_val_weakening_lemma = Q.prove (
-`!ctMap tenvS tenvV envV ctMap' tenvS'.
+Triviality type_tenv_val_weakening_lemma:
+  !ctMap tenvS tenvV envV ctMap' tenvS'.
   weakCT ctMap' ctMap ∧
   weakS tenvS' tenvS ∧
   nsAll2 (λi v (tvs,t).
@@ -382,8 +410,9 @@ val type_tenv_val_weakening_lemma = Q.prove (
             type_v tvs' ctMap' tenvS' v t)
          envV tenvV
   ⇒
-  nsAll2 (λi v (tvs,t). type_v tvs ctMap' tenvS' v t) envV tenvV`,
- rw [type_all_env_def, weakCT_def, weakS_def]
+  nsAll2 (λi v (tvs,t). type_v tvs ctMap' tenvS' v t) envV tenvV
+Proof
+  rw [type_all_env_def, weakCT_def, weakS_def]
  >> irule nsAll2_mono
  >> qexists_tac `(λi v (tvs,t).
            ∀tvs' ctMap' tenvS'.
@@ -392,13 +421,16 @@ val type_tenv_val_weakening_lemma = Q.prove (
              type_v tvs' ctMap' tenvS' v t) `
  >> rw []
  >> pairarg_tac
- >> fs []);
+ >> fs []
+QED
 
-val remove_lambda_prod = Q.prove (
-`(\(x,y). P x y) = (\xy. P (FST xy) (SND xy))`,
- rw [FUN_EQ_THM]
+Triviality remove_lambda_prod:
+  (\(x,y). P x y) = (\xy. P (FST xy) (SND xy))
+Proof
+  rw [FUN_EQ_THM]
  >> pairarg_tac
- >> rw []);
+ >> rw []
+QED
 
 Theorem type_v_weakening:
  (!tvs ctMap tenvS v t. type_v tvs ctMap tenvS v t ⇒
@@ -555,13 +587,15 @@ weakCT_only_other_mods mn ctMap' ctMap =
     (?mn' x. mn ≠ SOME mn' ∧ (tn = TypeId (Long mn' x) ∨ tn = TypeExn (Long mn' x)))
 End
 
-val weakCT_only_other_mods_merge = Q.prove (
-`!mn ctMap1 ctMap2 ctMap3.
+Triviality weakCT_only_other_mods_merge:
+  !mn ctMap1 ctMap2 ctMap3.
   weakCT_only_other_mods mn ctMap2 ctMap3
   ⇒
-  weakCT_only_other_mods mn (FUNION ctMap1 ctMap2) (FUNION ctMap1 ctMap3)`,
-rw [weakCT_only_other_mods_def] >>
-metis_tac []);
+  weakCT_only_other_mods mn (FUNION ctMap1 ctMap2) (FUNION ctMap1 ctMap3)
+Proof
+  rw [weakCT_only_other_mods_def] >>
+metis_tac []
+QED
 
 Theorem weak_decls_only_mods_union:
  !decls1 decls2 decls3.

--- a/translator/ml_optimiseScript.sml
+++ b/translator/ml_optimiseScript.sml
@@ -24,16 +24,20 @@ val _ = new_theory "ml_optimise";
 
 (* first an optimisation combinator: BOTTOM_UP_OPT *)
 
-val MEM_exp_size1 = Q.prove(
-  `!xs a. MEM a xs ==> exp_size a <= exp6_size xs`,
+Triviality MEM_exp_size1:
+  !xs a. MEM a xs ==> exp_size a <= exp6_size xs
+Proof
   Induct THEN FULL_SIMP_TAC (srw_ss()) [exp_size_def]
-  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC);
+  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC
+QED
 
-val MEM_exp_size2 = Q.prove(
-  `!ys p x. MEM (p,x) ys ==> exp_size x < exp3_size ys`,
+Triviality MEM_exp_size2:
+  !ys p x. MEM (p,x) ys ==> exp_size x < exp3_size ys
+Proof
   Induct THEN FULL_SIMP_TAC (srw_ss()) [exp_size_def] THEN Cases
   THEN FULL_SIMP_TAC std_ss [exp_size_def]
-  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC);
+  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC std_ss [] THEN RES_TAC THEN DECIDE_TAC
+QED
 
 val exp6_size_SNOC = prove(
   ``!xs y. exp6_size (xs ++ [y]) = exp6_size xs + exp6_size [y]``,
@@ -381,9 +385,10 @@ Definition abs2let_def:
              | rest => rest
 End
 
-val abs2let_thm = Q.prove(
-  `!env s exp t res. eval_rel s env exp t res ==>
-                     eval_rel s env (abs2let exp) t res`,
+Triviality abs2let_thm:
+  !env s exp t res. eval_rel s env exp t res ==>
+                     eval_rel s env (abs2let exp) t res
+Proof
   rpt strip_tac
   \\ Cases_on `abs2let exp = exp` \\ fs []
   \\ `?v e y. exp = App Opapp [Fun v e; y]` by
@@ -398,7 +403,8 @@ val abs2let_thm = Q.prove(
   \\ disch_then (qspec_then `1` mp_tac) \\ fs []
   \\ `(st' with clock := st'.clock) = st'` by fs [state_component_equality]
   \\ fs [namespaceTheory.nsOptBind_def]
-  \\ rw [] \\ fs [state_component_equality]);
+  \\ rw [] \\ fs [state_component_equality]
+QED
 
 (* rewrite optimisation: let x = y in x --> y *)
 
@@ -408,9 +414,10 @@ Definition let_id_def:
   (let_id rest = rest)
 End
 
-val let_id_thm = Q.prove(
-  `!env s exp t res. eval_rel s env exp t res ==>
-                     eval_rel s env (let_id exp) t res`,
+Triviality let_id_thm:
+  !env s exp t res. eval_rel s env exp t res ==>
+                     eval_rel s env (let_id exp) t res
+Proof
   rpt strip_tac
   \\ Cases_on `let_id exp = exp` \\ fs []
   \\ `?v x y. exp = Let (SOME v) x (Var (Short v))` by
@@ -421,7 +428,8 @@ val let_id_thm = Q.prove(
   \\ qexists_tac `ck1`
   \\ rveq \\ fs []
   \\ fs [state_component_equality,namespaceTheory.nsOptBind_def]
-  \\ imp_res_tac evaluate_sing \\ fs []);
+  \\ imp_res_tac evaluate_sing \\ fs []
+QED
 
 
 (* rewrite optimisations: x - n + n --> x and x + n - n --> x *)
@@ -445,14 +453,17 @@ Definition opt_sub_add_def:
          | _ => x
 End
 
-val dest_binop_thm = Q.prove(
-  `!x. (dest_binop x = SOME (x1,x2,x3)) <=> (x = App (Opn x1) [x2; x3])`,
+Triviality dest_binop_thm:
+  !x. (dest_binop x = SOME (x1,x2,x3)) <=> (x = App (Opn x1) [x2; x3])
+Proof
   HO_MATCH_MP_TAC (fetch "-" "dest_binop_ind")
-  \\ FULL_SIMP_TAC (srw_ss()) [dest_binop_def]);
+  \\ FULL_SIMP_TAC (srw_ss()) [dest_binop_def]
+QED
 
-val opt_sub_add_thm = Q.prove(
-  `!env s exp t res. eval_rel s env exp t res ==>
-                     eval_rel s env (opt_sub_add exp) t res`,
+Triviality opt_sub_add_thm:
+  !env s exp t res. eval_rel s env exp t res ==>
+                     eval_rel s env (opt_sub_add exp) t res
+Proof
   rpt strip_tac
   \\ Cases_on `opt_sub_add exp = exp` \\ fs []
   \\ fs [opt_sub_add_def]
@@ -477,7 +488,8 @@ val opt_sub_add_thm = Q.prove(
   \\ rveq \\ fs [] \\ rveq \\ fs []
   \\ fs [opn_lookup_def, dest_binop_def,
        intLib.COOPER_PROVE ``i + i2 - i2 = i:int``,
-       intLib.COOPER_PROVE ``i - i2 + i2 = i:int``]);
+       intLib.COOPER_PROVE ``i - i2 + i2 = i:int``]
+QED
 
 (* top-level optimiser *)
 

--- a/translator/ml_pmatch_demoScript.sml
+++ b/translator/ml_pmatch_demoScript.sml
@@ -106,9 +106,11 @@ End
 
 val res = translate TRANS_def;
 
-val PAIR_EQ_COLLAPSE = Q.prove (
-`(((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))`,
-Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[])
+Triviality PAIR_EQ_COLLAPSE:
+  (((FST x = (a:'a)) /\ (SND x = (b:'b))) = (x = (a, b)))
+Proof
+  Cases_on `x` THEN SIMP_TAC std_ss [] THEN METIS_TAC[]
+QED
 
 val pabs_elim_ss =
     simpLib.conv_ss
@@ -197,8 +199,8 @@ Definition raconv_def:
     | _ => F
 End
 
-val raconv_PMATCH = Q.prove(
-  `^(rhs(concl(SPEC_ALL raconv_def))) =
+Triviality raconv_PMATCH:
+  ^(rhs(concl(SPEC_ALL raconv_def))) =
     case (tm1,tm2) of
     | (Var _ _, Var _ _) => alphavars env tm1 tm2
     | (Const _ _, Const _ _) => (tm1 = tm2)
@@ -209,8 +211,10 @@ val raconv_PMATCH = Q.prove(
             | (Var n1 ty1,Var n2 ty2)
                 => (ty1 = ty2) ∧ raconv ((v1,v2)::env) t1 t2
             | _ => F)
-    | _ => F`,
-  rpt tac)
+    | _ => F
+Proof
+  rpt tac
+QED
 
 val raconv_def = fix raconv_def "raconv_def" raconv_PMATCH
 

--- a/translator/ml_progScript.sml
+++ b/translator/ml_progScript.sml
@@ -422,10 +422,12 @@ Proof
   \\ fs [write_def,empty_env_def]
 QED
 
-val FOLDR_LEMMA = Q.prove(
-  `!xs ys. FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) [] xs ++ ys =
-           FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) ys xs`,
-  Induct \\ FULL_SIMP_TAC (srw_ss()) [FORALL_PROD]);
+Triviality FOLDR_LEMMA:
+  !xs ys. FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) [] xs ++ ys =
+           FOLDR (\(x1,x2,x3) x4. (x1, f x1 x2 x3) :: x4) ys xs
+Proof
+  Induct \\ FULL_SIMP_TAC (srw_ss()) [FORALL_PROD]
+QED
 
 (* Delays the write in build_rec_env *)
 Theorem Decls_Dletrec:
@@ -732,12 +734,14 @@ QED
 
 (* appending a Letrec *)
 
-val build_rec_env_APPEND = Q.prove(
-  `nsAppend (build_rec_env funs cl_env nsEmpty) add_to_env =
-   build_rec_env funs cl_env add_to_env`,
+Triviality build_rec_env_APPEND:
+  nsAppend (build_rec_env funs cl_env nsEmpty) add_to_env =
+   build_rec_env funs cl_env add_to_env
+Proof
   fs [build_rec_env_def] \\ qspec_tac (`Recclosure cl_env funs`,`xxx`)
   \\ qspec_tac (`add_to_env`,`xs`)
-  \\ Induct_on `funs` \\ fs [FORALL_PROD]);
+  \\ Induct_on `funs` \\ fs [FORALL_PROD]
+QED
 
 Theorem ML_code_Dletrec:
    !fns locs. ML_code env0 ((comm, s1, prog, env2) :: bls) s2 ==>
@@ -903,11 +907,13 @@ QED
 (* theorems about old lookup functions *)
 (* FIXME: everything below this line is unlikely to be needed. *)
 
-val nsLookupMod_nsBind = Q.prove(`
+Triviality nsLookupMod_nsBind:
   p ≠ [] ⇒
-  nsLookupMod (nsBind k v env) p = nsLookupMod env p`,
+  nsLookupMod (nsBind k v env) p = nsLookupMod env p
+Proof
   Cases_on`env`>>fs[nsBind_def]>> Induct_on`p`>>
-  fs[nsLookupMod_def]);
+  fs[nsLookupMod_def]
+QED
 
 Theorem nsLookup_write:
    (nsLookup (write n v env).v (Short name) =

--- a/translator/ml_translatorScript.sml
+++ b/translator/ml_translatorScript.sml
@@ -651,27 +651,33 @@ Proof
   \\ Cases_on `fp1` \\ Cases_on `fp2` \\ fs[types_match_def, compress_word_def]
 QED
 
-val do_eq_succeeds = Q.prove(`
+Triviality do_eq_succeeds:
   (!a x1 v1 x2 v2. EqualityType a /\ a x1 v1 /\ a x2 v2 ==>
-                   (do_eq v1 v2 = Eq_val (x1 = x2)))`,
- rw [EqualityType_def]
+                   (do_eq v1 v2 = Eq_val (x1 = x2)))
+Proof
+  rw [EqualityType_def]
  \\ res_tac
  \\ imp_res_tac type_match_implies_do_eq_succeeds
  \\ Cases_on `v1 = v2`
- \\ fs []);
+ \\ fs []
+QED
 
-val empty_state_with_refs_eq = Q.prove(
-  `empty_state with refs := r =
+Triviality empty_state_with_refs_eq:
+  empty_state with refs := r =
    s2 with <| refs := r'; ffi := f |> ⇔
    ∃refs ffi.
    s2 = empty_state with <| refs := refs; ffi := ffi |> ∧
-   r' = r ∧ f = empty_state.ffi`,
-  rw[state_component_equality,EQ_IMP_THM]);
+   r' = r ∧ f = empty_state.ffi
+Proof
+  rw[state_component_equality,EQ_IMP_THM]
+QED
 
-val empty_state_with_ffi_elim = Q.prove(
-   `empty_state with <| refs := r; ffi := empty_state.ffi |> =
-    empty_state with refs := r`,
-  rw[state_component_equality]);
+Triviality empty_state_with_ffi_elim:
+  empty_state with <| refs := r; ffi := empty_state.ffi |> =
+    empty_state with refs := r
+Proof
+  rw[state_component_equality]
+QED
 
 val Eval2_tac =
   first_x_assum (qspec_then `refs` strip_assume_tac)
@@ -928,15 +934,17 @@ QED
 
 (* arithmetic for integers *)
 
-val Eval_Opn = Q.prove(
-  `!f n1 n2.
+Triviality Eval_Opn:
+  !f n1 n2.
         Eval env x1 (INT n1) ==>
         Eval env x2 (INT n2) ==>
         PRECONDITION (((f = Divide) \/ (f = Modulo)) ==> ~(n2 = 0)) ==>
-        Eval env (App (Opn f) [x1;x2]) (INT (opn_lookup f n1 n2))`,
+        Eval env (App (Opn f) [x1;x2]) (INT (opn_lookup f n1 n2))
+Proof
   rw[Eval_rw,INT_def,PRECONDITION_def]
   \\ Eval2_tac \\ fs [do_app_def] \\ rw []
-  \\ fs [state_component_equality]);
+  \\ fs [state_component_equality]
+QED
 
 local
   fun f name q =
@@ -950,14 +958,16 @@ in
   val Eval_INT_MOD  = f "INT_MOD" `Modulo`
 end;
 
-val Eval_Opb = Q.prove(
-  `!f n1 n2.
+Triviality Eval_Opb:
+  !f n1 n2.
         Eval env x1 (INT n1) ==>
         Eval env x2 (INT n2) ==>
-        Eval env (App (Opb f) [x1;x2]) (BOOL (opb_lookup f n1 n2))`,
+        Eval env (App (Opb f) [x1;x2]) (BOOL (opb_lookup f n1 n2))
+Proof
   rw[Eval_rw,INT_def,PRECONDITION_def,BOOL_def]
   \\ Eval2_tac \\ fs [do_app_def] \\ rw []
-  \\ fs [state_component_equality]);
+  \\ fs [state_component_equality]
+QED
 
 local
   fun f name q = let
@@ -1204,31 +1214,37 @@ Proof
   tac
 QED
 
-val DISTRIB_ANY = Q.prove(
-  `(p * m + p * n = p * (m + n)) /\
+Triviality DISTRIB_ANY:
+  (p * m + p * n = p * (m + n)) /\
     (p * m + n * p = p * (m + n)) /\
     (m * p + p * n = p * (m + n)) /\
     (m * p + n * p = p * (m + n:num)) /\
     (p * m - p * n = p * (m - n)) /\
     (p * m - n * p = p * (m - n)) /\
     (m * p - p * n = p * (m - n)) /\
-    (m * p - n * p = p * (m - n:num))`,
-  fs [LEFT_ADD_DISTRIB]);
+    (m * p - n * p = p * (m - n:num))
+Proof
+  fs [LEFT_ADD_DISTRIB]
+QED
 
-val MOD_COMMON_FACTOR_ANY = Q.prove(
-  `!n p q. 0 < n ∧ 0 < q ==>
+Triviality MOD_COMMON_FACTOR_ANY:
+  !n p q. 0 < n ∧ 0 < q ==>
             ((n * p) MOD (n * q) = n * p MOD q) /\
             ((p * n) MOD (n * q) = n * p MOD q) /\
             ((n * p) MOD (q * n) = n * p MOD q) /\
-            ((p * n) MOD (q * n) = n * p MOD q)`,
-  fs [GSYM MOD_COMMON_FACTOR]);
+            ((p * n) MOD (q * n) = n * p MOD q)
+Proof
+  fs [GSYM MOD_COMMON_FACTOR]
+QED
 
-val Eval_word_add_lemma = Q.prove(
-  `dimindex (:'a) <= k ==>
+Triviality Eval_word_add_lemma:
+  dimindex (:'a) <= k ==>
     (2 ** (k − dimindex (:α)) * q MOD dimword (:α)) MOD 2 ** k =
-    (2 ** (k − dimindex (:α)) * q) MOD 2 ** k`,
+    (2 ** (k − dimindex (:α)) * q) MOD 2 ** k
+Proof
   rw [] \\ fs [LESS_EQ_EXISTS]
-  \\ rw [EXP_ADD,dimword_def,MOD_COMMON_FACTOR_ANY]);
+  \\ rw [EXP_ADD,dimword_def,MOD_COMMON_FACTOR_ANY]
+QED
 
 Theorem Eval_word_add:
     Eval env x1 (WORD (w1:'a word)) /\
@@ -1271,10 +1287,11 @@ Proof
   \\ imp_res_tac Eval_word_sub_lemma \\ fs []
 QED
 
-val w2n_w2w_8 = Q.prove(
-  `dimindex (:α) < 8 ==>
+Triviality w2n_w2w_8:
+  dimindex (:α) < 8 ==>
     w2n ((w2w:'a word ->word8) w << (8 − dimindex (:α)) >>>
-            (8 − dimindex (:α))) = w2n w`,
+            (8 − dimindex (:α))) = w2n w
+Proof
   Cases_on `w` \\ fs [w2n_lsr,w2w_def,WORD_MUL_LSL,word_mul_n2w,dimword_def]
   \\ rw []  \\ drule (DECIDE ``n<m ==> n <= m:num``)
   \\ fs [LESS_EQ_EXISTS] \\ fs [] \\ rw []
@@ -1282,12 +1299,14 @@ val w2n_w2w_8 = Q.prove(
   \\ full_simp_tac std_ss []
   \\ full_simp_tac bool_ss [GSYM (EVAL ``2n ** 8``),EXP_ADD]
   \\ full_simp_tac std_ss [MOD_COMMON_FACTOR_ANY]
-  \\ fs [MULT_DIV]);
+  \\ fs [MULT_DIV]
+QED
 
-val w2n_w2w_64 = Q.prove(
-  `dimindex (:α) < 64 ==>
+Triviality w2n_w2w_64:
+  dimindex (:α) < 64 ==>
     w2n ((w2w:'a word ->word64) w << (64 − dimindex (:α)) >>>
-            (64 − dimindex (:α))) = w2n w`,
+            (64 − dimindex (:α))) = w2n w
+Proof
   Cases_on `w` \\ fs [w2n_lsr,w2w_def,WORD_MUL_LSL,word_mul_n2w,dimword_def]
   \\ rw []  \\ drule (DECIDE ``n<m ==> n <= m:num``)
   \\ fs [LESS_EQ_EXISTS] \\ fs [] \\ rw []
@@ -1295,7 +1314,8 @@ val w2n_w2w_64 = Q.prove(
   \\ full_simp_tac std_ss []
   \\ full_simp_tac bool_ss [GSYM (EVAL ``2n ** 64``),EXP_ADD]
   \\ full_simp_tac std_ss [MOD_COMMON_FACTOR_ANY]
-  \\ fs [MULT_DIV]);
+  \\ fs [MULT_DIV]
+QED
 
 Theorem Eval_w2n:
     Eval env x1 (WORD (w:'a word)) ==>
@@ -2331,14 +2351,18 @@ Proof
 QED
 *)
 
-val UNCURRY1 = Q.prove(
-  `!f. UNCURRY f = \x. case x of (x,y) => f x y`,
+Triviality UNCURRY1:
+  !f. UNCURRY f = \x. case x of (x,y) => f x y
+Proof
   STRIP_TAC \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,pair_case_def]
-  \\ Cases \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,pair_case_def]);
+  \\ Cases \\ FULL_SIMP_TAC std_ss [FUN_EQ_THM,pair_case_def]
+QED
 
-val UNCURRY2 = Q.prove(
-  `!x y f. pair_CASE x f y  = pair_CASE x (\z1 z2. f z1 z2 y)`,
-  Cases \\ EVAL_TAC \\ SIMP_TAC std_ss []);
+Triviality UNCURRY2:
+  !x y f. pair_CASE x f y  = pair_CASE x (\z1 z2. f z1 z2 y)
+Proof
+  Cases \\ EVAL_TAC \\ SIMP_TAC std_ss []
+QED
 
 val UNCURRY3 = Q.prove(
   `pair_CASE (x,y) f = f x y`,
@@ -2425,18 +2449,21 @@ Termination
   \\ Q.EXISTS_TAC `LENGTH xs` \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]
 End
 
-val ASHADOW_PREFIX = Q.prove(
-  `!xs ys.
+Triviality ASHADOW_PREFIX:
+  !xs ys.
       ALL_DISTINCT (MAP FST xs) /\
       EVERY (\y. ~(MEM y (MAP FST ys))) (MAP FST xs) ==>
-      (ASHADOW (xs ++ ys) = xs ++ ASHADOW ys)`,
+      (ASHADOW (xs ++ ys) = xs ++ ASHADOW ys)
+Proof
   Induct \\ fs [FORALL_PROD,ASHADOW_def]
   \\ REPEAT STRIP_TAC \\ SRW_TAC [] []
   \\ fs [EVERY_MEM,FORALL_PROD,EXISTS_MEM,MEM_MAP,EXISTS_PROD,PULL_EXISTS]
-  \\ Cases_on `y` \\ fs [] \\ RES_TAC);
+  \\ Cases_on `y` \\ fs [] \\ RES_TAC
+QED
 
-val MEM_MAP_ASHADOW = Q.prove(
-  `!xs y. MEM y (MAP FST (ASHADOW xs)) = MEM y (MAP FST xs)`,
+Triviality MEM_MAP_ASHADOW:
+  !xs y. MEM y (MAP FST (ASHADOW xs)) = MEM y (MAP FST xs)
+Proof
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs[] THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
@@ -2446,25 +2473,31 @@ val MEM_MAP_ASHADOW = Q.prove(
      fs [rich_listTheory.LENGTH_FILTER_LEQ]
   \\ `LENGTH (FILTER (\y. FST h <> FST y) t) < SUC (LENGTH t)` by DECIDE_TAC
   \\ RES_TAC \\ fs[]
-  \\ fs [MEM_MAP,MEM_FILTER] \\ METIS_TAC []);
+  \\ fs [MEM_MAP,MEM_FILTER] \\ METIS_TAC []
+QED
 
-val EVERY_ALOOKUP_LEMMA = Q.prove(
-  `!xs. ALL_DISTINCT (MAP FST xs) ==>
-         EVERY (\ (x,y,z). ALOOKUP xs x = SOME (y,z)) xs`,
+Triviality EVERY_ALOOKUP_LEMMA:
+  !xs. ALL_DISTINCT (MAP FST xs) ==>
+         EVERY (\ (x,y,z). ALOOKUP xs x = SOME (y,z)) xs
+Proof
   Induct \\ srw_tac [] [] \\ PairCases_on `h` \\ fs []
   \\ fs [EVERY_MEM,FORALL_PROD] \\ rpt strip_tac
   \\ res_tac \\ Cases_on `h0 = p_1`
-  \\ fs [MEM_MAP,FORALL_PROD] \\ metis_tac []);
+  \\ fs [MEM_MAP,FORALL_PROD] \\ metis_tac []
+QED
 
-val ALOOKUP_FILTER = Q.prove(
-  `!t a q. q <> a ==> (ALOOKUP (FILTER (\y. q <> FST y) t) a = ALOOKUP t a)`,
+Triviality ALOOKUP_FILTER:
+  !t a q. q <> a ==> (ALOOKUP (FILTER (\y. q <> FST y) t) a = ALOOKUP t a)
+Proof
   Induct THEN1 (EVAL_TAC \\ SIMP_TAC std_ss [])
   \\ fs [alistTheory.ALOOKUP_def,FORALL_PROD]
   \\ REPEAT STRIP_TAC \\ Cases_on `p_1 = a` \\ fs []
-  \\ SRW_TAC [] []);
+  \\ SRW_TAC [] []
+QED
 
-val ALOOKUP_ASHADOW = Q.prove(
-  `!xs a. ALOOKUP (ASHADOW xs) a = ALOOKUP xs a`,
+Triviality ALOOKUP_ASHADOW:
+  !xs a. ALOOKUP (ASHADOW xs) a = ALOOKUP xs a
+Proof
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs [] THEN1 EVAL_TAC
@@ -2474,10 +2507,12 @@ val ALOOKUP_ASHADOW = Q.prove(
   \\ RES_TAC \\ fs [ALOOKUP_FILTER]
   \\ MATCH_MP_TAC LESS_EQ_LESS_TRANS
   \\ Q.EXISTS_TAC `LENGTH t`
-  \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]);
+  \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]
+QED
 
-val ALL_DISTINCT_MAP_FST_ASHADOW = Q.prove(
-  `!xs. ALL_DISTINCT (MAP FST (ASHADOW xs))`,
+Triviality ALL_DISTINCT_MAP_FST_ASHADOW:
+  !xs. ALL_DISTINCT (MAP FST (ASHADOW xs))
+Proof
   STRIP_TAC \\ completeInduct_on `LENGTH xs`
   \\ REPEAT STRIP_TAC \\ fs [PULL_FORALL]
   \\ Cases_on `xs` \\ fs [] THEN1 EVAL_TAC
@@ -2487,7 +2522,8 @@ val ALL_DISTINCT_MAP_FST_ASHADOW = Q.prove(
   \\ FIRST_X_ASSUM MATCH_MP_TAC
   \\ MATCH_MP_TAC LESS_EQ_LESS_TRANS
   \\ Q.EXISTS_TAC `LENGTH t` \\ fs []
-  \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]);
+  \\ fs [rich_listTheory.LENGTH_FILTER_LEQ]
+QED
 
 (* size lemmas *)
 
@@ -2525,15 +2561,17 @@ Proof
   \\ fs [type_names_def] \\ fs [FORALL_PROD,listTheory.MAP_EQ_f]
 QED
 
-val lookup_APPEND = Q.prove(
-  `!xs ys n. ~(MEM n (MAP FST ys)) ==>
-              (ALOOKUP (xs ++ ys) n = ALOOKUP xs n)`,
+Triviality lookup_APPEND:
+  !xs ys n. ~(MEM n (MAP FST ys)) ==>
+              (ALOOKUP (xs ++ ys) n = ALOOKUP xs n)
+Proof
   Induct THEN1
    (FULL_SIMP_TAC std_ss [APPEND] \\ Induct
     \\ FULL_SIMP_TAC std_ss [MAP,MEM,FORALL_PROD] >>
     rw [])
   \\ FULL_SIMP_TAC std_ss [FORALL_PROD,APPEND]
-  \\ rw []);
+  \\ rw []
+QED
 
 Theorem FEVERY_DRESTRICT_FUPDATE:
    FEVERY P (DRESTRICT (f |+ (x,y)) (COMPL s)) <=>
@@ -2559,16 +2597,20 @@ Proof
   rw[Eval_rw,EQ_IMP_THM,empty_state_def]
 QED
 
-val evaluate_Var_nsLookup = Q.prove(
-   `eval_rel s env (Var id) s' r <=>
-    ?v. nsLookup env.v id = SOME r ∧ s' = s`,
+Triviality evaluate_Var_nsLookup:
+  eval_rel s env (Var id) s' r <=>
+    ?v. nsLookup env.v id = SOME r ∧ s' = s
+Proof
   fs [eval_rel_def,evaluate_def,lookup_var_def,option_case_eq,
-      state_component_equality] \\ rw [] \\ eq_tac \\ rw []);
+      state_component_equality] \\ rw [] \\ eq_tac \\ rw []
+QED
 
-val evaluate_Var = Q.prove(
-   `eval_rel s env (Var (Short n)) s' r <=>
-    ?v. lookup_var n env = SOME r ∧ s' = s`,
-  fs [evaluate_Var_nsLookup,lookup_var_def]);
+Triviality evaluate_Var:
+  eval_rel s env (Var (Short n)) s' r <=>
+    ?v. lookup_var n env = SOME r ∧ s' = s
+Proof
+  fs [evaluate_Var_nsLookup,lookup_var_def]
+QED
 
 Theorem Eval_Var_nsLookup:
    Eval env (Var id) P <=> case nsLookup env.v id of NONE => F | SOME v => P v

--- a/translator/ml_translator_demoScript.sml
+++ b/translator/ml_translator_demoScript.sml
@@ -40,9 +40,11 @@ val lookup_qsort = save_thm("lookup_qsort",
 
 (* --- a more concrete example, not much use --- *)
 
-val Eval_Var_lemma = Q.prove(
-  `(lookup_var name env = SOME x) /\ P x ==> Eval env (Var (Short name)) P`,
-  fs[Eval_Var]);
+Triviality Eval_Var_lemma:
+  (lookup_var name env = SOME x) /\ P x ==> Eval env (Var (Short name)) P
+Proof
+  fs[Eval_Var]
+QED
 
 Theorem ML_QSORT_CORRECT:
    !env tys a ord R l xs refs.

--- a/translator/ml_translator_testScript.sml
+++ b/translator/ml_translator_testScript.sml
@@ -261,10 +261,12 @@ val _ = (print_asts := true);
 
 (* test no_ind *)
 
-val word64_msb_thm = Q.prove(
-  `!w. word_msb (w:word64) =
-         ((w && 0x8000000000000000w) = 0x8000000000000000w)`,
-  blastLib.BBLAST_TAC);
+Triviality word64_msb_thm:
+  !w. word_msb (w:word64) =
+         ((w && 0x8000000000000000w) = 0x8000000000000000w)
+Proof
+  blastLib.BBLAST_TAC
+QED
 
 val res = translate word64_msb_thm;
 

--- a/translator/monadic/cfMonadScript.sml
+++ b/translator/monadic/cfMonadScript.sml
@@ -63,35 +63,42 @@ fun EXTRACT_PURE_FACTS_TAC (g as (asl, w)) =
   end;
 (***********************************************************************************************)
 
-val REFS_PRED_lemma = Q.prove(
-`SPLIT (st2heap (p : 'ffi ffi_proj)  st) (h1, h2) /\ H refs h1 ==> REFS_PRED (H,p) refs st`,
-rw[REFS_PRED_def, STAR_def]
+Triviality REFS_PRED_lemma:
+  SPLIT (st2heap (p : 'ffi ffi_proj)  st) (h1, h2) /\ H refs h1 ==> REFS_PRED (H,p) refs st
+Proof
+  rw[REFS_PRED_def, STAR_def]
 \\ qexists_tac `h1`
 \\ qexists_tac `h2`
 \\ fs[SAT_GC]
-);
+QED
 
-val HPROP_SPLIT3 = Q.prove(
-`(H1 * H2 * H3) h ==> ?h1 h2 h3. SPLIT3 h (h1, h2, h3) /\ H1 h1 /\ H2 h2 /\ H3 h3`,
-rw[STAR_def, SPLIT_def, SPLIT3_def]
+Triviality HPROP_SPLIT3:
+  (H1 * H2 * H3) h ==> ?h1 h2 h3. SPLIT3 h (h1, h2, h3) /\ H1 h1 /\ H2 h2 /\ H3 h3
+Proof
+  rw[STAR_def, SPLIT_def, SPLIT3_def]
 \\ fs[DISJOINT_UNION]
-\\ metis_tac[]);
+\\ metis_tac[]
+QED
 
-val HPROP_SPLIT3_clock0 = Q.prove(
-`(H1 * H2 * H3) (st2heap p st) ==>
- ?h1 h2 h3. SPLIT3 (st2heap p (st with clock := 0)) (h1, h2, h3) /\ H1 h1 /\ H2 h2 /\ H3 h3`,
-rw[STAR_def, SPLIT_def, SPLIT3_def]
+Triviality HPROP_SPLIT3_clock0:
+  (H1 * H2 * H3) (st2heap p st) ==>
+ ?h1 h2 h3. SPLIT3 (st2heap p (st with clock := 0)) (h1, h2, h3) /\ H1 h1 /\ H2 h2 /\ H3 h3
+Proof
+  rw[STAR_def, SPLIT_def, SPLIT3_def]
 \\ fs[DISJOINT_UNION, st2heap_def]
-\\ metis_tac[]);
+\\ metis_tac[]
+QED
 
-val REFS_PRED_from_SPLIT = Q.prove(
-  `!state (st : 'ffi semanticPrimitives$state) H p h1 h2.
+Triviality REFS_PRED_from_SPLIT:
+  !state (st : 'ffi semanticPrimitives$state) H p h1 h2.
    H state h1 ==>
    SPLIT (st2heap p st) (h1,h2) ==>
-   REFS_PRED (H,p) state st`,
-   rw[REFS_PRED_def]
+   REFS_PRED (H,p) state st
+Proof
+  rw[REFS_PRED_def]
    \\ rw[STAR_def]
-   \\ metis_tac[SAT_GC]);
+   \\ metis_tac[SAT_GC]
+QED
 
 Theorem ArrowP_PURE_to_app:
    !A B f fv x1 xv1 xv2 xvl H Q ro state p.

--- a/translator/monadic/examples/floyd_warshallProgScript.sml
+++ b/translator/monadic/examples/floyd_warshallProgScript.sml
@@ -261,14 +261,16 @@ Proof
   Cases_on`n`>>fs[]
 QED
 
-val adj_mat_sub_SUCCESS = Q.prove(`
+Triviality adj_mat_sub_SUCCESS:
   ∀s. i < s.dim ∧ j < s.dim ∧
   LENGTH s.adj_mat = s.dim * s.dim ⇒
   ∃v.
-  adj_mat_sub (i + j *s.dim) s = (M_success v, s)`,
+  adj_mat_sub (i + j *s.dim) s = (M_success v, s)
+Proof
   rw[]>> drule lemma>>
   disch_then (qspec_then `i` assume_tac)>>rfs[]>>
-  rw[adj_mat_sub_def,Marray_sub_def]);
+  rw[adj_mat_sub_def,Marray_sub_def]
+QED
 
 val update_adj_mat_def = fetch "-" "update_adj_mat_def"
 
@@ -287,20 +289,22 @@ Proof
   Cases_on`n`>>fs[LUPDATE_def]
 QED
 
-val update_adj_mat_SUCCESS = Q.prove(`
+Triviality update_adj_mat_SUCCESS:
   ∀s.
     i < s.dim ∧ j < s.dim ∧
     LENGTH s.adj_mat = s.dim * s.dim ⇒
   ∃res.
   update_adj_mat (j + i *s.dim) v s = (M_success (), res) ∧
   res.dim = s.dim ∧
-  LENGTH res.adj_mat = res.dim * res.dim`,
+  LENGTH res.adj_mat = res.dim * res.dim
+Proof
   rw[update_adj_mat_def]>>
   fs[Marray_update_def]>>
   qspecl_then [`i`,`j`] mp_tac lemma>>
-  rpt (disch_then drule)>>fs[]);
+  rpt (disch_then drule)>>fs[]
+QED
 
-val relax_SUCCESS = Q.prove(`
+Triviality relax_SUCCESS:
   i < s.dim ∧
   k < s.dim ∧
   j < s.dim ∧
@@ -308,15 +312,17 @@ val relax_SUCCESS = Q.prove(`
   ∃res.
   relax i k j s = (M_success (),res) ∧
   res.dim = s.dim ∧
-  LENGTH res.adj_mat = res.dim * res.dim`,
+  LENGTH res.adj_mat = res.dim * res.dim
+Proof
   rw[]>>
   fs[relax_def,st_ex_bind_def,get_weight_def,reind_def,get_dim_def,
      st_ex_return_def,set_weight_def]>>
   imp_res_tac adj_mat_sub_SUCCESS>>rfs[]>>
   every_case_tac>>fs[]>>
-  imp_res_tac update_adj_mat_SUCCESS>>rfs[]);
+  imp_res_tac update_adj_mat_SUCCESS>>rfs[]
+QED
 
-val floyd_warshall_SUCCESS_j = Q.prove(`
+Triviality floyd_warshall_SUCCESS_j:
   ∀j s.
   i < s.dim ∧
   k < s.dim ∧
@@ -325,7 +331,8 @@ val floyd_warshall_SUCCESS_j = Q.prove(`
   ∃res.
   st_ex_FOR j s.dim (\j. relax i k j) s = (M_success (),res) ∧
   res.dim = s.dim ∧
-  LENGTH res.adj_mat = res.dim * s.dim`,
+  LENGTH res.adj_mat = res.dim * s.dim
+Proof
   Induct_on`s.dim-j`
   >-
     rw[Once st_ex_FOR_def,st_ex_return_def]
@@ -333,9 +340,10 @@ val floyd_warshall_SUCCESS_j = Q.prove(`
     rw[Once st_ex_FOR_def,st_ex_bind_def]>>
     `j < s.dim` by fs[]>>
     assume_tac relax_SUCCESS>>rfs[]>>
-    first_x_assum(qspecl_then[`res`,`j+1`] assume_tac)>>rfs[]);
+    first_x_assum(qspecl_then[`res`,`j+1`] assume_tac)>>rfs[]
+QED
 
-val floyd_warshall_SUCCESS_i = Q.prove(`
+Triviality floyd_warshall_SUCCESS_i:
   ∀i s.
   k < s.dim ∧
   LENGTH s.adj_mat = s.dim * s.dim
@@ -344,7 +352,8 @@ val floyd_warshall_SUCCESS_i = Q.prove(`
   st_ex_FOR i s.dim (\i. st_ex_FOR 0 s.dim (\j. relax i k j)) s =
     (M_success (),res) ∧
   res.dim = s.dim ∧
-  LENGTH res.adj_mat = res.dim * s.dim`,
+  LENGTH res.adj_mat = res.dim * s.dim
+Proof
   Induct_on`s.dim-i`
   >-
     rw[Once st_ex_FOR_def,st_ex_return_def]
@@ -352,9 +361,10 @@ val floyd_warshall_SUCCESS_i = Q.prove(`
     rw[Once st_ex_FOR_def,st_ex_bind_def]>>
     `i < s.dim` by fs[]>>
     imp_res_tac (floyd_warshall_SUCCESS_j |> Q.SPEC `0n`) >>rfs[]>>
-    first_x_assum(qspecl_then[`res''`,`i+1`] assume_tac)>>rfs[]);
+    first_x_assum(qspecl_then[`res''`,`i+1`] assume_tac)>>rfs[]
+QED
 
-val floyd_warshall_SUCCESS_k = Q.prove(`
+Triviality floyd_warshall_SUCCESS_k:
   ∀k s.
   LENGTH s.adj_mat = s.dim * s.dim ⇒
   ∃res.
@@ -362,14 +372,16 @@ val floyd_warshall_SUCCESS_k = Q.prove(`
   (λk. st_ex_FOR 0 s.dim (λi. st_ex_FOR 0 s.dim (λj. relax i k j))) s =
   (M_success (),res) ∧
   res.dim = s.dim ∧
-  LENGTH res.adj_mat = res.dim * res.dim`,
+  LENGTH res.adj_mat = res.dim * res.dim
+Proof
   Induct_on`s.dim-k`>-
     rw[Once st_ex_FOR_def,st_ex_return_def]
   >>
     rw[Once st_ex_FOR_def,st_ex_bind_def]>>
     `k < s.dim` by fs[]>>
     imp_res_tac (floyd_warshall_SUCCESS_i |> Q.SPEC `0n`) >>rfs[]>>
-    first_x_assum(qspecl_then[`res`,`k+1`] assume_tac)>>rfs[]);
+    first_x_assum(qspecl_then[`res`,`k+1`] assume_tac)>>rfs[]
+QED
 
 (* Prove that the algorithm is always successful (?) *)
 Theorem do_floyd_SUCCESS:

--- a/translator/monadic/examples/poly_array_sortProgScript.sml
+++ b/translator/monadic/examples/poly_array_sortProgScript.sml
@@ -1305,11 +1305,12 @@ val run_quicksort_v_thm = m_translate_run run_quicksort_def;
 
 val qsort_v_thm = translate qsort_def;
 
-val qsort_v_precond = Q.prove(
-  `∀ cmp l . strict_weak_order cmp ⇒ qsort_side cmp l`,
+Triviality qsort_v_precond:
+  ∀ cmp l . strict_weak_order cmp ⇒ qsort_side cmp l
+Proof
   rw[fetch "-" "qsort_side_def"] >>
   metis_tac[run_quicksort_Success]
-)
+QED
 
 (* TODO update precondition doesn't seem to work here
 val _ = qsort_v_precond |> update_precondition

--- a/translator/monadic/examples/test_assumProgScript.sml
+++ b/translator/monadic/examples/test_assumProgScript.sml
@@ -17,10 +17,11 @@ Definition STATE_PINV_def:
   STATE_PINV = \state. EVEN state.the_num /\ (state.the_string = "")
 End
 
-val STATE_PINV_VALID = Q.prove (
-  `(state.the_num = 0) /\ (state.the_string = "") ==> STATE_PINV state`,
+Triviality STATE_PINV_VALID:
+  (state.the_num = 0) /\ (state.the_string = "") ==> STATE_PINV state
+Proof
   rw[STATE_PINV_def]
-);
+QED
 
 (* Data type for the exceptions *)
 Datatype:
@@ -85,14 +86,16 @@ End
 val mf6_v_thm = m_translate mf6_def;
 
 val length_v_thm = translate listTheory.LENGTH;
-val ZIP_def2 = Q.prove(
-  `ZIP x = dtcase x of
+Triviality ZIP_def2:
+  ZIP x = dtcase x of
       (x::l1, y::l2) => (x, y) :: ( ZIP (l1,l2) )
     | ([], [])       => []
-    | _              => []`,
-PairCases_on ‘x’ \\ Cases_on `x0`
+    | _              => []
+Proof
+  PairCases_on ‘x’ \\ Cases_on `x0`
 \\ Cases_on `x1`
-\\ fs[ZIP_def]);
+\\ fs[ZIP_def]
+QED
 
 val zip_v_thm = translate ZIP_def2;
 

--- a/translator/monadic/examples/test_runScript.sml
+++ b/translator/monadic/examples/test_runScript.sml
@@ -97,10 +97,11 @@ Definition f11_def:
 End
 val f11_v_thm = m_translate f11_def;
 val f11_side_def = fetch "-" "f11_side_def"
-val f11_side_true = Q.prove(
-    `!xs st. f11_side st xs`,
-    Induct \\ rw[Once f11_side_def]
-  );
+Triviality f11_side_true:
+  !xs st. f11_side st xs
+Proof
+  Induct \\ rw[Once f11_side_def]
+QED
 
 Definition f12_def:
   f12 x = ((return (1:num)) otherwise (return 0))

--- a/translator/monadic/ml_monad_translatorBaseScript.sml
+++ b/translator/monadic/ml_monad_translatorBaseScript.sml
@@ -149,9 +149,11 @@ Proof
   metis_tac[]
 QED
 
-val NEG_DISJ_TO_IMP = Q.prove(
-  `!A B. ~A \/ ~B <=> A /\ B ==> F`,
-  rw[]);
+Triviality NEG_DISJ_TO_IMP:
+  !A B. ~A \/ ~B <=> A /\ B ==> F
+Proof
+  rw[]
+QED
 
 Theorem store2heap_aux_DISJOINT:
    !n s1 s2. DISJOINT (store2heap_aux n s1) (store2heap_aux (n + LENGTH s1) s2)
@@ -697,13 +699,16 @@ Proof
   \\ rw[]
 QED
 
-val GC_ABSORB_L = Q.prove(`!A B s. (A * B * GC) s ==> (A * GC) s`,
-rw[]
+Triviality GC_ABSORB_L:
+  !A B s. (A * B * GC) s ==> (A * GC) s
+Proof
+  rw[]
 \\ fs[GSYM STAR_ASSOC]
 \\ fs[Once STAR_def]
 \\ qexists_tac `u`
 \\ qexists_tac `v`
-\\ fs[SAT_GC]);
+\\ fs[SAT_GC]
+QED
 
 Theorem st2heap_SPLIT:
   SPLIT (st2heap ffi (s with refs := s.refs ++ junk))

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -44,33 +44,47 @@ Proof
 QED
 (* -- *)
 
-val GC_ABSORB_L = Q.prove(`!A B s. (A * B * GC) s ==> (A * GC) s`,
+Triviality GC_ABSORB_L:
+  !A B s. (A * B * GC) s ==> (A * GC) s
+Proof
   rw[]
   \\ fs[GSYM STAR_ASSOC]
   \\ fs[Once STAR_def]
   \\ qexists_tac `u`
   \\ qexists_tac `v`
-  \\ fs[SAT_GC]);
+  \\ fs[SAT_GC]
+QED
 
-val GC_ABSORB_R = Q.prove(`!A B s. (A * GC * B) s ==> (A * GC) s`,
+Triviality GC_ABSORB_R:
+  !A B s. (A * GC * B) s ==> (A * GC) s
+Proof
   rw[]
   \\ `A * GC * B = A * B * GC` by metis_tac[STAR_COMM, STAR_ASSOC]
   \\ pop_assum(fn x => fs[x])
-  \\ imp_res_tac GC_ABSORB_L);
+  \\ imp_res_tac GC_ABSORB_L
+QED
 
 val HCOND_EXTRACT = cfLetAutoTheory.HCOND_EXTRACT;
 
-val REF_EXISTS_LOC = Q.prove(`(rv ~~> v * H) s ==> ?l. rv = Loc l`,
-  rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM, GSYM STAR_ASSOC, HCOND_EXTRACT]);
+Triviality REF_EXISTS_LOC:
+  (rv ~~> v * H) s ==> ?l. rv = Loc l
+Proof
+  rw[REF_def, SEP_CLAUSES, SEP_EXISTS_THM, GSYM STAR_ASSOC, HCOND_EXTRACT]
+QED
 
-val ARRAY_EXISTS_LOC  = Q.prove(`(ARRAY rv v * H) s ==> ?l. rv = Loc l`,
-  rw[STAR_def, SEP_EXISTS_THM, SEP_CLAUSES, REF_def, ARRAY_def, cond_def]);
+Triviality ARRAY_EXISTS_LOC:
+  (ARRAY rv v * H) s ==> ?l. rv = Loc l
+Proof
+  rw[STAR_def, SEP_EXISTS_THM, SEP_CLAUSES, REF_def, ARRAY_def, cond_def]
+QED
 
-val UNIQUE_CELLS = Q.prove(
-  `!p s. !l xv xv' H H'. (l ~~>> xv * H) (st2heap p s) /\ (l ~~>> xv' * H') (st2heap p s) ==> xv' = xv`,
+Triviality UNIQUE_CELLS:
+  !p s. !l xv xv' H H'. (l ~~>> xv * H) (st2heap p s) /\ (l ~~>> xv' * H') (st2heap p s) ==> xv' = xv
+Proof
   rw[] >>
   imp_res_tac st2heap_CELL_MEM >>
-  imp_res_tac store2heap_IN_unique_key);
+  imp_res_tac store2heap_IN_unique_key
+QED
 
 (* Should be moved *)
 fun list_dest f tm =
@@ -689,9 +703,10 @@ Proof
   \\ fs [EvalM_def,PURE_def,PULL_EXISTS,FUN_FORALL] \\ METIS_TAC []
 QED
 
-val M_FUN_FORALL_PUSH1 = Q.prove(
-  `(FUN_FORALL x. ArrowP ro ^H a (PURE (b x))) =
-   (ArrowP ro H a (PURE (FUN_FORALL x. b x)))`,
+Triviality M_FUN_FORALL_PUSH1:
+  (FUN_FORALL x. ArrowP ro ^H a (PURE (b x))) =
+   (ArrowP ro H a (PURE (FUN_FORALL x. b x)))
+Proof
   rw[FUN_EQ_THM,FUN_FORALL,ArrowP_def,PURE_def,PULL_EXISTS]
   \\ reverse EQ_TAC >- METIS_TAC[] \\ rw[]
   \\ first_x_assum drule \\ rw[]
@@ -714,7 +729,8 @@ val M_FUN_FORALL_PUSH1 = Q.prove(
   \\ drule evaluate_add_to_clock \\ fs []
   \\ disch_then (qspec_then `ck'` strip_assume_tac)
   \\ disch_then (qspec_then `ck` strip_assume_tac)
-  \\ fs []);
+  \\ fs []
+QED
 
 val M_FUN_FORALL_PUSH2 = Q.prove(
   `(FUN_FORALL x. ArrowP ro H ((PURE (a x))) b) =
@@ -997,52 +1013,64 @@ Definition write_list_def:
   (write_list (n::nl) (v::vl) env = write_list nl vl (write n v env))
 End
 
-val pats_bindings_MAP_Pvar = Q.prove(
- `!bind_names already_bound.
+Triviality pats_bindings_MAP_Pvar:
+  !bind_names already_bound.
   pats_bindings (MAP (\x. Pvar x) bind_names) already_bound =
-  (REVERSE bind_names) ++ already_bound`,
-  Induct_on `bind_names` >> rw[pat_bindings_def]);
+  (REVERSE bind_names) ++ already_bound
+Proof
+  Induct_on `bind_names` >> rw[pat_bindings_def]
+QED
 
-val ALL_DISTINCT_pats_bindings = Q.prove(
- `!bind_names. ALL_DISTINCT bind_names ==>
-  ALL_DISTINCT (pats_bindings (MAP (λx. Pvar x) bind_names) [])`,
+Triviality ALL_DISTINCT_pats_bindings:
+  !bind_names. ALL_DISTINCT bind_names ==>
+  ALL_DISTINCT (pats_bindings (MAP (λx. Pvar x) bind_names) [])
+Proof
   Induct_on `bind_names` >> rw[pat_bindings_def]
   \\ rw[pats_bindings_MAP_Pvar]
   \\ PURE_ONCE_REWRITE_TAC[GSYM ALL_DISTINCT_REVERSE]
   \\ PURE_REWRITE_TAC[REVERSE_APPEND]
-  \\ rw[]);
+  \\ rw[]
+QED
 
-val pmatch_list_MAP_Pvar = Q.prove(
- `!bind_names paramsv env already_bound s.
+Triviality pmatch_list_MAP_Pvar:
+  !bind_names paramsv env already_bound s.
   LENGTH paramsv = LENGTH bind_names==>
-  pmatch_list env s (MAP (λx. Pvar x) bind_names) paramsv already_bound = Match ((REVERSE(ZIP (bind_names,paramsv))) ++ already_bound)`,
+  pmatch_list env s (MAP (λx. Pvar x) bind_names) paramsv already_bound = Match ((REVERSE(ZIP (bind_names,paramsv))) ++ already_bound)
+Proof
   Induct_on `bind_names` >> rw[pmatch_def]
-  \\ Cases_on `paramsv` \\ fs[pmatch_def]);
+  \\ Cases_on `paramsv` \\ fs[pmatch_def]
+QED
 
-val nsAppend_append = Q.prove(
- `!a b env. nsAppend (Bind (a ++ b) []) env = nsAppend (Bind a []) (nsAppend (Bind b []) env)`,
-  Induct_on `a` >> rw[namespaceTheory.nsAppend_def]);
+Triviality nsAppend_append:
+  !a b env. nsAppend (Bind (a ++ b) []) env = nsAppend (Bind a []) (nsAppend (Bind b []) env)
+Proof
+  Induct_on `a` >> rw[namespaceTheory.nsAppend_def]
+QED
 
-val write_list_eq = Q.prove(
- `!bind_names paramsv l1 l2 cenv.
+Triviality write_list_eq:
+  !bind_names paramsv l1 l2 cenv.
   LENGTH paramsv = LENGTH bind_names ==>
-  write_list bind_names paramsv (sem_env (Bind l1 l2) cenv) = sem_env (Bind ((REVERSE (ZIP (bind_names,paramsv))) ++ l1) l2) cenv`,
+  write_list bind_names paramsv (sem_env (Bind l1 l2) cenv) = sem_env (Bind ((REVERSE (ZIP (bind_names,paramsv))) ++ l1) l2) cenv
+Proof
   Induct_on `bind_names`
   >> Cases_on `paramsv`
   >> rw[namespaceTheory.nsAppend_def, namespaceTheory.alist_to_ns_def, write_list_def, write_def]
   >> rw (TypeBase.updates_of ``:v sem_env``)
-  >> rw[namespaceTheory.nsBind_def]);
+  >> rw[namespaceTheory.nsBind_def]
+QED
 
-val nsAppend_write_list_eq = Q.prove(
- `!bind_names paramsv env.
+Triviality nsAppend_write_list_eq:
+  !bind_names paramsv env.
   LENGTH paramsv = LENGTH bind_names ==>
-  env with v := nsAppend (alist_to_ns (REVERSE (ZIP (bind_names,paramsv)))) env.v = write_list bind_names paramsv env`,
+  env with v := nsAppend (alist_to_ns (REVERSE (ZIP (bind_names,paramsv)))) env.v = write_list bind_names paramsv env
+Proof
   rw[namespaceTheory.nsAppend_def, namespaceTheory.alist_to_ns_def]
   \\ Cases_on `env`
   \\ Cases_on `n`
   \\ rw[write_list_eq]
   \\ rw[sem_env_component_equality]
-  \\ rw[namespaceTheory.nsAppend_def]);
+  \\ rw[namespaceTheory.nsAppend_def]
+QED
 
 Theorem EvalM_handle:
   !cons_name stamp CORRECT_CONS PARAMS_CONDITIONS EXN_TYPE
@@ -1165,15 +1193,19 @@ Definition LIST_CONJ_def:
   LIST_CONJ (x::l) = (x /\ LIST_CONJ l)
 End
 
-val LIST_CONJ_APPEND = Q.prove(
- `!a b. LIST_CONJ (a++b) = (LIST_CONJ a /\ LIST_CONJ b)`,
+Triviality LIST_CONJ_APPEND:
+  !a b. LIST_CONJ (a++b) = (LIST_CONJ a /\ LIST_CONJ b)
+Proof
   Induct_on `a` >> rw[LIST_CONJ_def]
-  \\ EQ_TAC >> rw[LIST_CONJ_def]);
+  \\ EQ_TAC >> rw[LIST_CONJ_def]
+QED
 
-val LIST_CONJ_REVERSE = Q.prove(
- `!x. LIST_CONJ (REVERSE x) = LIST_CONJ x`,
+Triviality LIST_CONJ_REVERSE:
+  !x. LIST_CONJ (REVERSE x) = LIST_CONJ x
+Proof
   Induct_on `x` >> rw[LIST_CONJ_def, LIST_CONJ_APPEND]
-  \\ EQ_TAC >> rw[]);
+  \\ EQ_TAC >> rw[]
+QED
 
 val LIST_CONJ_Eval = prove(
   ``!xs Ps s:'d state.
@@ -1372,12 +1404,13 @@ Definition RES_MONAD:
 End
 
 (* Validity of a store extension *)
-val valid_state_refs_frame_extension = Q.prove(
-  `!H junk. A (cons x) res ==>
+Triviality valid_state_refs_frame_extension:
+  !H junk. A (cons x) res ==>
             (STATE_REFS A ptrs state * H) (st2heap (p:'ffi ffi_proj) s) ==>
     (STATE_REFS A (Loc (LENGTH (s.refs ++ junk))::ptrs)
      (cons x::state) * H * GC) (st2heap p
-        (s with refs := s.refs ++ junk ++ [Refv res]))`,
+        (s with refs := s.refs ++ junk ++ [Refv res]))
+Proof
   rw[]
   \\ rw[Once STATE_REFS_def]
   \\ rw[GSYM STAR_ASSOC]
@@ -1401,23 +1434,27 @@ val valid_state_refs_frame_extension = Q.prove(
   \\ qexists_tac `res`
   \\ EXTRACT_PURE_FACTS_TAC
   \\ fs[store2heap_aux_def, REF_def, cell_def, one_def]
-  \\ fs[SEP_EXISTS_THM, HCOND_EXTRACT]);
+  \\ fs[SEP_EXISTS_THM, HCOND_EXTRACT]
+QED
 
-val valid_state_refs_extension = Q.prove(
-  `A (cons x) res
+Triviality valid_state_refs_extension:
+  A (cons x) res
    ==>
    REFS_PRED (STATE_REFS A ptrs,p:'ffi ffi_proj) refs s
    ==>
    REFS_PRED (STATE_REFS A (Loc (LENGTH (s.refs ++ junk))::ptrs), p)
              (cons x ::refs)
-             (s with refs := s.refs ++ junk ++ [Refv res])`,
+             (s with refs := s.refs ++ junk ++ [Refv res])
+Proof
   rw [REFS_PRED_def, REFS_PRED_FRAME_def]
   \\ imp_res_tac valid_state_refs_frame_extension
-  \\ fs[GSYM STAR_ASSOC, GC_STAR_GC]);
+  \\ fs[GSYM STAR_ASSOC, GC_STAR_GC]
+QED
 
-val STATE_REFS_LENGTH = Q.prove(
-  `!ptrs state H.
-   (STATE_REFS A ptrs state * H) s ==> LENGTH ptrs = LENGTH state`,
+Triviality STATE_REFS_LENGTH:
+  !ptrs state H.
+   (STATE_REFS A ptrs state * H) s ==> LENGTH ptrs = LENGTH state
+Proof
   Induct
   >-(
       rw[STATE_REFS_def]
@@ -1434,12 +1471,14 @@ val STATE_REFS_LENGTH = Q.prove(
   \\ fs[GSYM STAR_ASSOC]
   \\ pop_assum(fn x => SIMP_RULE bool_ss [Once STAR_COMM] x |> ASSUME_TAC)
   \\ fs[GSYM STAR_ASSOC]
-  \\ last_x_assum imp_res_tac);
+  \\ last_x_assum imp_res_tac
+QED
 
-val valid_state_refs_reduction = Q.prove(
-  `(STATE_REFS A (rv::ptrs) refs * H * GC) s
+Triviality valid_state_refs_reduction:
+  (STATE_REFS A (rv::ptrs) refs * H * GC) s
    ==>
-   (STATE_REFS A ptrs (TL refs) * H * GC) s`,
+   (STATE_REFS A ptrs (TL refs) * H * GC) s
+Proof
   rw[]
   \\ fs[GSYM STAR_ASSOC]
   \\ imp_res_tac STATE_REFS_LENGTH
@@ -1449,7 +1488,8 @@ val valid_state_refs_reduction = Q.prove(
   \\ fs[GSYM STAR_ASSOC]
   \\ last_x_assum(fn x => SIMP_RULE bool_ss [Once STAR_COMM] x |> ASSUME_TAC)
   \\ fs[STAR_ASSOC]
-  \\ imp_res_tac GC_ABSORB_R);
+  \\ imp_res_tac GC_ABSORB_R
+QED
 
 (* Validity of ref_bind *)
 
@@ -1537,12 +1577,13 @@ Proof
 QED
 
 (* Validity of a deref operation *)
-val STATE_REFS_EXTRACT = Q.prove(
-  `!ptrs1 r ptrs2 refs TYPE H (p:'ffi ffi_proj) s.
+Triviality STATE_REFS_EXTRACT:
+  !ptrs1 r ptrs2 refs TYPE H (p:'ffi ffi_proj) s.
    ((STATE_REFS TYPE (ptrs1 ++ [r] ++ ptrs2) refs) * H) (st2heap p s) ==>
    ((STATE_REFS TYPE ptrs1 (TAKE (LENGTH ptrs1) refs) *
    (STATE_REF TYPE r (EL (LENGTH ptrs1) refs)) *
-   (STATE_REFS TYPE ptrs2 (DROP (LENGTH ptrs1 + 1) refs)) * H)) (st2heap p s)`,
+   (STATE_REFS TYPE ptrs2 (DROP (LENGTH ptrs1 + 1) refs)) * H)) (st2heap p s)
+Proof
   Induct
   >-(
       rw[]
@@ -1564,17 +1605,19 @@ val STATE_REFS_EXTRACT = Q.prove(
   \\ qpat_x_assum `H' (st2heap p s)` (fn x => PURE_ONCE_REWRITE_RULE[GSYM STAR_ASSOC] x |> ASSUME_TAC)
   \\ rw[Once (GSYM STAR_ASSOC)]
   \\ last_x_assum imp_res_tac
-  \\ fs[SUC_ONE_ADD]);
+  \\ fs[SUC_ONE_ADD]
+QED
 
-val STATE_REFS_EXTRACT_2 = Q.prove(
-  `!ptrs1 r ptrs2 refs1 x refs2 TYPE H (p:'ffi ffi_proj) s.
+Triviality STATE_REFS_EXTRACT_2:
+  !ptrs1 r ptrs2 refs1 x refs2 TYPE H (p:'ffi ffi_proj) s.
   LENGTH ptrs1 = LENGTH refs1 ==>
   LENGTH ptrs2 = LENGTH refs2 ==>
   (STATE_REFS TYPE (ptrs1 ++ [r] ++ ptrs2) (refs1 ++ [x] ++ refs2) * H) (st2heap p s) ==>
   (STATE_REFS TYPE ptrs1 refs1 *
   STATE_REF TYPE r x *
   STATE_REFS TYPE ptrs2 refs2 *
-  H) (st2heap p s)`,
+  H) (st2heap p s)
+Proof
   rw[]
   \\ imp_res_tac STATE_REFS_EXTRACT
   \\ sg `TAKE (LENGTH ptrs1) (refs1 ++ [x] ++ refs2) = refs1`
@@ -1594,15 +1637,17 @@ val STATE_REFS_EXTRACT_2 = Q.prove(
       >> pop_assum(fn x => PURE_REWRITE_TAC[x])
       >> PURE_REWRITE_TAC[DROP_LENGTH_APPEND]
       >> fs[])
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val STATE_REFS_RECONSTRUCT = Q.prove(
-  `!ptrs1 r ptrs2 refs1 y refs2 TYPE H (p:'ffi ffi_proj) s.
+Triviality STATE_REFS_RECONSTRUCT:
+  !ptrs1 r ptrs2 refs1 y refs2 TYPE H (p:'ffi ffi_proj) s.
   ((STATE_REFS TYPE ptrs1 refs1) *
   (STATE_REF TYPE r y) *
   (STATE_REFS TYPE ptrs2 refs2) *
   H) (st2heap p s) ==>
-  ((STATE_REFS TYPE (ptrs1 ++ [r] ++ ptrs2) (refs1 ++ [y] ++ refs2)) * H) (st2heap p s)`,
+  ((STATE_REFS TYPE (ptrs1 ++ [r] ++ ptrs2) (refs1 ++ [y] ++ refs2)) * H) (st2heap p s)
+Proof
   Induct
   >-(
       rw[]
@@ -1618,7 +1663,8 @@ val STATE_REFS_RECONSTRUCT = Q.prove(
   \\ rw[Once STAR_COMM]
   \\ fs[STAR_ASSOC]
   \\ first_x_assum (fn x => PURE_ONCE_REWRITE_RULE[GSYM STAR_ASSOC] x |> ASSUME_TAC)
-  \\ rw[Once (GSYM STAR_ASSOC)]);
+  \\ rw[Once (GSYM STAR_ASSOC)]
+QED
 
 Theorem STATE_REFS_DECOMPOSE:
    !ptrs1 r ptrs2 refs TYPE H (p:'ffi ffi_proj) s. ((STATE_REFS TYPE (ptrs1 ++ [r] ++ ptrs2) refs) * H) (st2heap p s) <=>
@@ -1789,11 +1835,12 @@ Proof
   \\ fs[EL_APPEND1]
 QED
 
-val UPDATE_STATE_REFS = Q.prove(
-  `!ptrs2 l ptrs1 x res TYPE junk refs p s.
+Triviality UPDATE_STATE_REFS:
+  !ptrs2 l ptrs1 x res TYPE junk refs p s.
   TYPE x res ==>
   REFS_PRED_FRAME ro (STATE_REFS TYPE (ptrs1 ++ [Loc l] ++ ptrs2),p:'ffi ffi_proj) (refs, s)
-  (ref_assign (LENGTH ptrs2) x refs, s with refs := LUPDATE (Refv res) l (s.refs ++ junk))`,
+  (ref_assign (LENGTH ptrs2) x refs, s with refs := LUPDATE (Refv res) l (s.refs ++ junk))
+Proof
   rw[]
   \\ fs[REFS_PRED_def, REFS_PRED_FRAME_def]
   \\ rw[]
@@ -1824,7 +1871,8 @@ val UPDATE_STATE_REFS = Q.prove(
   \\ imp_res_tac store2heap_IN_LENGTH
   \\ imp_res_tac STATE_APPEND_JUNK
   \\ fs[LUPDATE_APPEND1]
-  \\ metis_tac[STAR_ASSOC, STAR_COMM]);
+  \\ metis_tac[STAR_ASSOC, STAR_COMM]
+QED
 
 Theorem EvalM_Mref_assign:
    nsLookup env.v (Short rname) = SOME rv ==>
@@ -1889,27 +1937,34 @@ Proof
 QED
 
 (* Resizable arrays *)
-val ABS_NUM_EQ = Q.prove(`Num(ABS(&n))=n`,
-  rw[DB.fetch "integer" "Num", integerTheory.INT_ABS]);
+Triviality ABS_NUM_EQ:
+  Num(ABS(&n))=n
+Proof
+  rw[DB.fetch "integer" "Num", integerTheory.INT_ABS]
+QED
 
-val do_app_Opderef_REF = Q.prove(
-  `(REF (Loc loc) v * H refs) (st2heap (p:'ffi ffi_proj) s) ==>
+Triviality do_app_Opderef_REF:
+  (REF (Loc loc) v * H refs) (st2heap (p:'ffi ffi_proj) s) ==>
   !junk. do_app (s.refs ++ junk, s.ffi) Opderef [Loc loc] =
-    SOME ((s.refs ++ junk, s.ffi), Rval v)`,
+    SOME ((s.refs ++ junk, s.ffi), Rval v)
+Proof
   rw[do_app_def]
   \\ imp_res_tac store_lookup_REF_st2heap_junk
-  \\ fs[with_same_ffi]);
+  \\ fs[with_same_ffi]
+QED
 
-val do_app_Alength_ARRAY = Q.prove(
-  `(ARRAY rv v * H) (st2heap (p:'ffi ffi_proj) s) ==>
+Triviality do_app_Alength_ARRAY:
+  (ARRAY rv v * H) (st2heap (p:'ffi ffi_proj) s) ==>
   do_app (s.refs, s.ffi) Alength [rv] =
-  SOME ((s.refs, s.ffi), Rval (Litv(IntLit(int_of_num(LENGTH v)))))`,
+  SOME ((s.refs, s.ffi), Rval (Litv(IntLit(int_of_num(LENGTH v)))))
+Proof
   rw[do_app_def]
   \\ fs[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM]
   \\ fs[GSYM STAR_ASSOC, HCOND_EXTRACT]
   \\ imp_res_tac store_lookup_CELL_st2heap
   \\ first_x_assum(qspec_then `[]` ASSUME_TAC)
-  \\ fs[]);
+  \\ fs[]
+QED
 
 Theorem EvalM_R_Marray_length:
    !vname loc TYPE EXC_TYPE H get_arr x env.
@@ -1949,17 +2004,19 @@ QED
 val Conv_Subscript = EVAL ``sub_exn_v`` |> concl |> rand
 val Stamp_Subscript = Conv_Subscript |> rator |> rand |> rand
 
-val do_app_Asub_ARRAY = Q.prove(
- `(ARRAY rv v * H) (st2heap (p:'ffi ffi_proj) s) ==>
+Triviality do_app_Asub_ARRAY:
+  (ARRAY rv v * H) (st2heap (p:'ffi ffi_proj) s) ==>
   !junk. do_app (s.refs ++ junk, s.ffi) Asub [rv; Litv (IntLit (&n))] =
     if n < LENGTH v then SOME ((s.refs ++ junk, s.ffi), Rval (EL n v))
-    else SOME ((s.refs ++ junk, s.ffi), Rerr (Rraise ^Conv_Subscript))`,
+    else SOME ((s.refs ++ junk, s.ffi), Rerr (Rraise ^Conv_Subscript))
+Proof
   rw[do_app_def]
   \\ fs[ARRAY_def, SEP_CLAUSES, SEP_EXISTS_THM]
   \\ fs[GSYM STAR_ASSOC, HCOND_EXTRACT]
   \\ imp_res_tac store_lookup_CELL_st2heap
   \\ fs[ABS_NUM_EQ]
-  \\ Cases_on `n ≥ LENGTH v` \\ fs[] \\ EVAL_TAC);
+  \\ Cases_on `n ≥ LENGTH v` \\ fs[] \\ EVAL_TAC
+QED
 
 val evaluate_empty_state_IMP_2 =
   evaluate_empty_state_IMP
@@ -2319,17 +2376,23 @@ Proof
   \\ rfs []
 QED
 
-val HPROP_TO_GC_R = Q.prove(`(A * B) s ==> (A * GC) s`,
+Triviality HPROP_TO_GC_R:
+  (A * B) s ==> (A * GC) s
+Proof
   rw[STAR_def]
   \\ qexists_tac `u`
   \\ qexists_tac `v`
-  \\ fs[SAT_GC]);
+  \\ fs[SAT_GC]
+QED
 
-val HPROP_TO_GC_L = Q.prove(`(A * B) s ==> (GC * B) s`,
+Triviality HPROP_TO_GC_L:
+  (A * B) s ==> (GC * B) s
+Proof
   rw[STAR_def]
   \\ qexists_tac `u`
   \\ qexists_tac `v`
-  \\ fs[SAT_GC]);
+  \\ fs[SAT_GC]
+QED
 
 Theorem EvalM_R_Marray_alloc:
    !vname loc TYPE EXC_TYPE H get_arr set_arr n x env nexp xexp.
@@ -2856,8 +2919,9 @@ Definition EvalSt_def:
       P res /\ REFS_PRED_FRAME T H (st, s) (st2, s2)
 End
 
-val LENGTH_Mem_IN_store2heap = Q.prove(
-  `!refs n. n < LENGTH refs ==> (Mem n (EL n refs)) IN (store2heap refs)`,
+Triviality LENGTH_Mem_IN_store2heap:
+  !refs n. n < LENGTH refs ==> (Mem n (EL n refs)) IN (store2heap refs)
+Proof
   ASSUME_TAC(Q.ISPEC `\refs. !n. n < LENGTH refs ==>
                 (Mem n (EL n refs)) IN (store2heap refs)` SNOC_INDUCT)
   \\ fs[]
@@ -2872,13 +2936,15 @@ val LENGTH_Mem_IN_store2heap = Q.prove(
   \\ rw[EL_APPEND1]
   \\ suff_tac ``(Mem n (EL n l)) IN (store2heap l)``
   >-(rw[store2heap_append])
-  \\ rw[]);
+  \\ rw[]
+QED
 
-val REFS_PRED_FRAME_partial_frame_rule = Q.prove(
-  `!s refs'.
+Triviality REFS_PRED_FRAME_partial_frame_rule:
+  !s refs'.
      (!F. F (st2heap p s) ==>
      (F * GC) (st2heap p (s with refs := refs'))) ==>
-  ?junk. refs' = s.refs ++ junk`,
+  ?junk. refs' = s.refs ++ junk
+Proof
   rw[]
   \\ first_x_assum(qspec_then `(\h. h = store2heap s.refs) * (\h. h = ffi2heap p s.ffi)` ASSUME_TAC)
   \\ `((\h. h = store2heap s.refs) * (\h. h = ffi2heap p s.ffi)) (st2heap p s)` by simp[st2heap_def, STAR_def, st2heap_SPLIT_FFI]
@@ -2911,7 +2977,8 @@ val REFS_PRED_FRAME_partial_frame_rule = Q.prove(
       \\ fs[])
   \\ imp_res_tac (SPEC_ALL IS_PREFIX_THM |> EQ_IMP_RULE |> snd)
   \\ imp_res_tac IS_PREFIX_APPEND
-  \\ rw[]);
+  \\ rw[]
+QED
 
 Theorem EvalSt_to_Eval:
    EvalSt env st exp P ((\s. emp),p) ==> Eval env exp P
@@ -2939,22 +3006,26 @@ Definition handle_mult_def:
     Handle exp1 [(Pvar "e",(Con (SOME (Short ename)) [Var (Short "e")]))]
 End
 
-val evaluate_handle_mult_Rval = Q.prove(
-  `!cons_names exp1 ename res s s2 env.
+Triviality evaluate_handle_mult_Rval:
+  !cons_names exp1 ename res s s2 env.
      evaluate s env [exp1] = (s2, Rval res) ==>
-     evaluate s env [handle_mult cons_names exp1 ename] = (s2, Rval res)`,
+     evaluate s env [handle_mult cons_names exp1 ename] = (s2, Rval res)
+Proof
   Cases
   \\ rw[handle_mult_def]
-  \\ rw[evaluate_def, astTheory.getOpClass_def]);
+  \\ rw[evaluate_def, astTheory.getOpClass_def]
+QED
 
-val evaluate_handle_mult_Rabort = Q.prove(
-  `!cons_names exp1 ename res s s2 env.
+Triviality evaluate_handle_mult_Rabort:
+  !cons_names exp1 ename res s s2 env.
      evaluate s env [exp1] = (s2, Rerr (Rabort res)) ==>
      evaluate s env [handle_mult cons_names exp1 ename] =
-       (s2, Rerr (Rabort res))`,
+       (s2, Rerr (Rabort res))
+Proof
   Cases
   \\ rw[handle_mult_def]
-  \\ rw[evaluate_def, astTheory.getOpClass_def]);
+  \\ rw[evaluate_def, astTheory.getOpClass_def]
+QED
 
 val EVERY_CONJ_1 = GSYM EVERY_CONJ |> SPEC_ALL |> EQ_IMP_RULE
                      |> fst |> PURE_REWRITE_RULE[GSYM AND_IMP_INTRO];
@@ -2966,44 +3037,52 @@ Definition handle_all_def:
     Handle exp [(Pvar "e",(Con (SOME (Short ename)) [Var (Short "e")]))]
 End
 
-val evaluate_handle_all_Rval = Q.prove(
-  `!exp1 ename res s s2 env.
+Triviality evaluate_handle_all_Rval:
+  !exp1 ename res s s2 env.
      evaluate s env [exp1] = (s2, Rval res) ==>
-     evaluate s env [handle_all exp1 ename] = (s2, Rval res)`,
+     evaluate s env [handle_all exp1 ename] = (s2, Rval res)
+Proof
   Cases
   \\ rw[handle_all_def]
-  \\ rw[evaluate_def, astTheory.getOpClass_def]);
+  \\ rw[evaluate_def, astTheory.getOpClass_def]
+QED
 
-val evaluate_handle_all_Rabort = Q.prove(
-  `!exp1 ename res s s2 env.
+Triviality evaluate_handle_all_Rabort:
+  !exp1 ename res s s2 env.
      evaluate s env [exp1] = (s2, Rerr (Rabort res)) ==>
-     evaluate s env [handle_all exp1 ename] = (s2, Rerr (Rabort res))`,
+     evaluate s env [handle_all exp1 ename] = (s2, Rerr (Rabort res))
+Proof
   Cases
   \\ rw[handle_all_def]
-  \\ rw[evaluate_def, astTheory.getOpClass_def]);
+  \\ rw[evaluate_def, astTheory.getOpClass_def]
+QED
 
-val evaluate_Success_CONS = Q.prove(
-  `evaluate s env [e] = (s', Rval [v]) ==>
+Triviality evaluate_Success_CONS:
+  evaluate s env [e] = (s', Rval [v]) ==>
   lookup_cons (Short "M_success") env = SOME (1,TypeStamp "M_success" exc_stamp) ==>
-  evaluate s env [Con (SOME (Short "M_success")) [e]] = (s', Rval [Conv (SOME (TypeStamp "M_success" exc_stamp)) [v]])`,
+  evaluate s env [Con (SOME (Short "M_success")) [e]] = (s', Rval [Conv (SOME (TypeStamp "M_success" exc_stamp)) [v]])
+Proof
   rw[]
   \\ rw[evaluate_def, astTheory.getOpClass_def]
   \\ fs[lookup_cons_def]
   \\ fs[do_con_check_def, build_conv_def, namespaceTheory.nsOptBind_def]
   \\ fs[namespaceTheory.id_to_n_def]
   \\ rw[evaluate_def, astTheory.getOpClass_def]
-  \\ every_case_tac \\ fs []);
+  \\ every_case_tac \\ fs []
+QED
 
-val evaluate_Success_CONS_err = Q.prove(
-  `evaluate s env [e] = (s', Rerr v) ==>
+Triviality evaluate_Success_CONS_err:
+  evaluate s env [e] = (s', Rerr v) ==>
   lookup_cons (Short "M_success") env = SOME (1,TypeStamp "M_success" exc_stamp) ==>
-  evaluate s env [Con (SOME (Short "M_success")) [e]] = (s', Rerr v)`,
+  evaluate s env [Con (SOME (Short "M_success")) [e]] = (s', Rerr v)
+Proof
   rw[]
   \\ rw[evaluate_def, astTheory.getOpClass_def]
   \\ fs[lookup_cons_def]
   \\ fs[do_con_check_def, build_conv_def, namespaceTheory.nsOptBind_def]
   \\ fs[namespaceTheory.id_to_n_def]
-  \\ every_case_tac \\ fs []);
+  \\ every_case_tac \\ fs []
+QED
 
 (* For the dynamic store initialisation *)
 (* It is not possible to use register_type here... *)
@@ -3079,33 +3158,39 @@ Proof
   \\ metis_tac[]
 QED
 
-val nsAppend_build_rec_env_eq_lemma = Q.prove(
-  `!funs funs0 cl_env v0 v1.
+Triviality nsAppend_build_rec_env_eq_lemma:
+  !funs funs0 cl_env v0 v1.
     nsAppend (FOLDR (λ(f,x,e) env'. nsBind f
       (Recclosure cl_env funs0 f) env') v1 funs) v0 =
     FOLDR (λ(f,x,e) env'. nsBind f
-      (Recclosure cl_env funs0 f) env') (nsAppend v1 v0) funs`,
+      (Recclosure cl_env funs0 f) env') (nsAppend v1 v0) funs
+Proof
   Induct_on `funs`
   >-(fs[merge_env_def, build_rec_env_def, namespaceTheory.nsAppend_def])
   \\ rw[]
   \\ Cases_on `h`
   \\ Cases_on `r`
-  \\ fs[namespaceTheory.nsAppend_def, namespaceTheory.nsBind_def]);
+  \\ fs[namespaceTheory.nsAppend_def, namespaceTheory.nsBind_def]
+QED
 
-val nsAppend_build_rec_env_eq = Q.prove(
-  `!funs cl_env v0 v1.
+Triviality nsAppend_build_rec_env_eq:
+  !funs cl_env v0 v1.
      nsAppend (build_rec_env funs cl_env v1) v0 =
-     build_rec_env funs cl_env (nsAppend v1 v0)`,
+     build_rec_env funs cl_env (nsAppend v1 v0)
+Proof
   fs[build_rec_env_def]
-  \\ fs[nsAppend_build_rec_env_eq_lemma]);
+  \\ fs[nsAppend_build_rec_env_eq_lemma]
+QED
 
-val merge_build_rec_env = Q.prove(
-  `!funs env1 env0.
+Triviality merge_build_rec_env:
+  !funs env1 env0.
      merge_env <|v := (build_rec_env funs (merge_env env1 env0) env1.v);
                  c := env1.c|> env0 =
      (merge_env env1 env0) with v :=
-        build_rec_env funs (merge_env env1 env0) (merge_env env1 env0).v`,
-  fs[merge_env_def, nsAppend_build_rec_env_eq]);
+        build_rec_env funs (merge_env env1 env0) (merge_env env1 env0).v
+Proof
+  fs[merge_env_def, nsAppend_build_rec_env_eq]
+QED
 
 Theorem EvalSt_Letrec_Fun:
    !funs env exp st P H.
@@ -3143,15 +3228,19 @@ Proof
   \\ rw[namespaceTheory.nsAppend_def, namespaceTheory.nsBind_def]
 QED
 
-val evaluate_Var_IMP = Q.prove(
- `evaluate s1 env [Var (Short name)] = (s2, Rval [v]) ==>
-  nsLookup env.v (Short name) = SOME v`,
-  rw[evaluate_def, astTheory.getOpClass_def] \\ every_case_tac \\ fs []);
+Triviality evaluate_Var_IMP:
+  evaluate s1 env [Var (Short name)] = (s2, Rval [v]) ==>
+  nsLookup env.v (Short name) = SOME v
+Proof
+  rw[evaluate_def, astTheory.getOpClass_def] \\ every_case_tac \\ fs []
+QED
 
-val evaluate_Var_same_state = Q.prove(
- `evaluate s1 env [Var (Short name)] = (s2, res) <=>
-  evaluate s1 env [Var (Short name)] = (s2, res) /\ s2 = s1`,
-  EQ_TAC \\ rw[evaluate_def, astTheory.getOpClass_def] \\ every_case_tac \\ fs []);
+Triviality evaluate_Var_same_state:
+  evaluate s1 env [Var (Short name)] = (s2, res) <=>
+  evaluate s1 env [Var (Short name)] = (s2, res) /\ s2 = s1
+Proof
+  EQ_TAC \\ rw[evaluate_def, astTheory.getOpClass_def] \\ every_case_tac \\ fs []
+QED
 
 Theorem EvalSt_Opref:
    !exp get_ref_exp get_ref loc_name TYPE st_name env H P st.
@@ -3396,31 +3485,41 @@ Proof
   rw[Eval_def,eval_rel_def,evaluate_def, astTheory.getOpClass_def,state_component_equality]
 QED
 
-val nsBind_to_write = Q.prove(
-  `<|v := nsBind name v env1; c := env2|> =
-   write name v <|v := env1; c := env2|>`,
-  fs[write_def,sem_env_component_equality]);
+Triviality nsBind_to_write:
+  <|v := nsBind name v env1; c := env2|> =
+   write name v <|v := env1; c := env2|>
+Proof
+  fs[write_def,sem_env_component_equality]
+QED
 
-val nsLookup_write_simp = Q.prove(
-  `nsLookup (write name1 exp env).v (Short name2) =
+Triviality nsLookup_write_simp:
+  nsLookup (write name1 exp env).v (Short name2) =
    if name1 = name2 then SOME exp
-   else nsLookup env.v (Short name2)`,
+   else nsLookup env.v (Short name2)
+Proof
   Cases_on `name1 = name2`
-  \\ fs[namespaceTheory.nsLookup_def, merge_env_def, write_def]);
+  \\ fs[namespaceTheory.nsLookup_def, merge_env_def, write_def]
+QED
 
-val sem_env_same_components = Q.prove(
-  `<|v := env.v; c := env.c|> = (env : v sem_env)`,
-  fs[sem_env_component_equality]);
+Triviality sem_env_same_components:
+  <|v := env.v; c := env.c|> = (env : v sem_env)
+Proof
+  fs[sem_env_component_equality]
+QED
 
-val lookup_cons_write_simp = Q.prove(
-  `lookup_cons name2 (write name1 exp env) =
-   lookup_cons name2 env`,
-  fs[lookup_cons_def, write_def]);
+Triviality lookup_cons_write_simp:
+  lookup_cons name2 (write name1 exp env) =
+   lookup_cons name2 env
+Proof
+  fs[lookup_cons_def, write_def]
+QED
 
-val lookup_cons_build_rec_env_simp = Q.prove(
-  `lookup_cons name2 <|v := build_rec_env exp env env.v; c := env.c|> =
-   lookup_cons name2 env`,
-  fs[lookup_cons_def]);
+Triviality lookup_cons_build_rec_env_simp:
+  lookup_cons name2 <|v := build_rec_env exp env env.v; c := env.c|> =
+   lookup_cons name2 env
+Proof
+  fs[lookup_cons_def]
+QED
 
 val LOOKUP_ASSUM_SIMP = save_thm("LOOKUP_ASSUM_SIMP",
   LIST_CONJ[nsBind_to_write,Eval_Var_SIMP,Eval_lookup_var,

--- a/translator/monadic/monad_base/ml_monadBaseScript.sml
+++ b/translator/monadic/monad_base/ml_monadBaseScript.sml
@@ -358,51 +358,59 @@ End
 val _ = ParseExtras.temp_tight_equality ();
 
 (* Rules to deal with the monads *)
-val st_ex_return_success = Q.prove(
-  `!v st r st'.
+Triviality st_ex_return_success:
+  !v st r st'.
      st_ex_return v st = (r, st')
      <=>
-     r = M_success v ∧ st' = st`,
-  rw [st_ex_return_def] \\ metis_tac[]);
+     r = M_success v ∧ st' = st
+Proof
+  rw [st_ex_return_def] \\ metis_tac[]
+QED
 
-val st_ex_bind_success = Q.prove (
-  `!f g st st' v.
+Triviality st_ex_bind_success:
+  !f g st st' v.
      st_ex_bind f g st = (M_success v, st')
      <=>
      ?v' st''.
        f st = (M_success v', st'') /\
-       g v' st'' = (M_success v, st')`,
+       g v' st'' = (M_success v, st')
+Proof
   rw [st_ex_bind_def] >>
   cases_on `f st` >>
   rw [] >>
   cases_on `q` >>
-  rw []);
+  rw []
+QED
 
-val otherwise_success = Q.prove(
-  `(x otherwise y) s = (M_success v, s')
+Triviality otherwise_success:
+  (x otherwise y) s = (M_success v, s')
    <=>
    x s = (M_success v, s') \/
-   ?e s''. x s = (M_failure e, s'') /\ y s'' = (M_success v, s')`,
+   ?e s''. x s = (M_failure e, s'') /\ y s'' = (M_success v, s')
+Proof
   fs[otherwise_def]
   \\ EQ_TAC
   >> DISCH_TAC
   >> Cases_on `x s`
   >> Cases_on `q`
-  >> fs[]);
+  >> fs[]
+QED
 
-val otherwise_failure = Q.prove(
-  `(x otherwise y) s = (M_failure e, s')
+Triviality otherwise_failure:
+  (x otherwise y) s = (M_failure e, s')
    <=>
-   ?e' s''. x s = (M_failure e', s'') /\ y s'' = (M_failure e, s')`,
+   ?e' s''. x s = (M_failure e', s'') /\ y s'' = (M_failure e, s')
+Proof
   fs[otherwise_def]
   \\ EQ_TAC
   >> DISCH_TAC
   >> Cases_on `x s`
   >> Cases_on `q`
-  >> fs[]);
+  >> fs[]
+QED
 
-val otherwise_eq = Q.prove(
-  `(x otherwise y) s = (r, s')
+Triviality otherwise_eq:
+  (x otherwise y) s = (r, s')
    <=>
    (?v. ((x s = (M_success v, s') /\ r = M_success v) \/
          (?e s''. x s = (M_failure e, s'') /\
@@ -410,114 +418,133 @@ val otherwise_eq = Q.prove(
                   r = M_success v))) \/
    (?e e' s''. x s = (M_failure e', s'') /\
                y s'' = (M_failure e, s') /\
-               r = M_failure e)`,
+               r = M_failure e)
+Proof
   Cases_on `x s`
   \\ Cases_on `r`
   \\ fs[otherwise_success, otherwise_failure]
   \\ rw[]
-  \\ metis_tac[]);
+  \\ metis_tac[]
+QED
 
-val can_success = Q.prove(
-  `can f x s = (M_failure e, s') <=> F`,
+Triviality can_success:
+  can f x s = (M_failure e, s') <=> F
+Proof
   rw[can_def, otherwise_def, st_ex_ignore_bind_def]
   \\ Cases_on `f x s`
   \\ Cases_on `q`
   \\ fs[st_ex_return_def]
-);
+QED
 
-val Marray_length_success = Q.prove(
-  `!get_arr s r s'.
+Triviality Marray_length_success:
+  !get_arr s r s'.
      Marray_length get_arr s = (r, s')
      <=>
      r = M_success (LENGTH (get_arr s)) /\
-     s' = s`,
-  rw[Marray_length_def] \\ metis_tac[]);
+     s' = s
+Proof
+  rw[Marray_length_def] \\ metis_tac[]
+QED
 
-val Marray_sub_success = Q.prove(
-  `!get_arr e n s v s'.
+Triviality Marray_sub_success:
+  !get_arr e n s v s'.
      Marray_sub get_arr e n s = (M_success v, s')
      <=>
-     n < LENGTH (get_arr s) /\ v = EL n (get_arr s) /\ s' = s`,
+     n < LENGTH (get_arr s) /\ v = EL n (get_arr s) /\ s' = s
+Proof
   rw[Marray_sub_def]
   \\ EQ_TAC
   >> simp[GSYM AND_IMP_INTRO]
   >> rpt DISCH_TAC
   >> Cases_on `n < LENGTH (get_arr s)`
   >> rw[]
-  \\ fs [Msub_eq, Msub_exn_eq]);
+  \\ fs [Msub_eq, Msub_exn_eq]
+QED
 
-val Marray_sub_failure = Q.prove(
-  `!get_arr e n s e' s'.
+Triviality Marray_sub_failure:
+  !get_arr e n s e' s'.
      Marray_sub get_arr e n s = (M_failure e', s')
      <=>
-     n >= LENGTH (get_arr s) /\ e' = e /\ s' = s`,
+     n >= LENGTH (get_arr s) /\ e' = e /\ s' = s
+Proof
   rw[Marray_sub_def]
   \\ EQ_TAC
   >> simp[GSYM AND_IMP_INTRO]
   >> rpt DISCH_TAC
   >> Cases_on `n < LENGTH (get_arr s)`
   >> rw[]
-  \\ fs [Msub_eq, Msub_exn_eq]);
+  \\ fs [Msub_eq, Msub_exn_eq]
+QED
 
-val Marray_sub_eq = Q.prove(
-  `Marray_sub get_arr e n s = (r, s')
+Triviality Marray_sub_eq:
+  Marray_sub get_arr e n s = (r, s')
    <=>
    (n < LENGTH (get_arr s) /\ s' = s /\ r = M_success (EL n (get_arr s))) \/
-   (n >= LENGTH (get_arr s) /\ s' = s /\ r = M_failure e)`,
+   (n >= LENGTH (get_arr s) /\ s' = s /\ r = M_failure e)
+Proof
   Cases_on `r`
   >> fs[Marray_sub_success, Marray_sub_failure]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val Marray_update_success = Q.prove(
-  `!get_arr set_arr e n x s s'.
+Triviality Marray_update_success:
+  !get_arr set_arr e n x s s'.
      Marray_update get_arr set_arr e n x s = (M_success v, s')
      <=>
      n < LENGTH (get_arr s) /\
      v = () /\
-     s' = set_arr (LUPDATE x n (get_arr s)) s`,
+     s' = set_arr (LUPDATE x n (get_arr s)) s
+Proof
   rw[Marray_update_def]
   \\ EQ_TAC
   >> simp[GSYM AND_IMP_INTRO]
   >> rpt DISCH_TAC
   >> Cases_on `n < LENGTH (get_arr s)`
-  \\ fs [Mupdate_eq, Mupdate_exn_eq]);
+  \\ fs [Mupdate_eq, Mupdate_exn_eq]
+QED
 
-val Marray_update_failure = Q.prove(
-  `!get_arr set_arr e e' n x s s'.
+Triviality Marray_update_failure:
+  !get_arr set_arr e e' n x s s'.
      Marray_update get_arr set_arr e n x s = (M_failure e', s')
      <=>
      n >= LENGTH (get_arr s) /\
      e' = e /\
-     s' = s`,
+     s' = s
+Proof
   rw[Marray_update_def]
   \\ EQ_TAC
   >> simp[GSYM AND_IMP_INTRO]
   >> rpt DISCH_TAC
   >> Cases_on `n < LENGTH (get_arr s)` \\ fs []
-  \\ fs [Mupdate_eq, Mupdate_exn_eq]);
+  \\ fs [Mupdate_eq, Mupdate_exn_eq]
+QED
 
-val Marray_update_eq = Q.prove(
-  `Marray_update get_arr set_arr e n x s = (r, s')
+Triviality Marray_update_eq:
+  Marray_update get_arr set_arr e n x s = (r, s')
    <=>
    (n < LENGTH (get_arr s) /\
     s' = set_arr (LUPDATE x n (get_arr s)) s /\
     r = M_success ()) \/
    (n >= LENGTH (get_arr s) /\
     s' = s /\
-    r = M_failure e)`,
+    r = M_failure e)
+Proof
   Cases_on `r`
   >> Cases_on `n < LENGTH (get_arr s)`
   >> fs[Marray_update_success, Marray_update_failure]
-  >> metis_tac[]);
+  >> metis_tac[]
+QED
 
-val Marray_alloc_success = Q.prove(
-  `Marray_alloc set_arr n x s = (r, s')
+Triviality Marray_alloc_success:
+  Marray_alloc set_arr n x s = (r, s')
    <=>
    r = M_success () /\
-   s' = set_arr (REPLICATE n x) s`,
+   s' = set_arr (REPLICATE n x) s
+Proof
   rw[Marray_alloc_def]
   \\ EQ_TAC
-  >> simp[GSYM AND_IMP_INTRO]);
+  >> simp[GSYM AND_IMP_INTRO]
+QED
 
 val monad_eqs = LIST_CONJ
   [ st_ex_return_success, st_ex_bind_success, otherwise_eq, can_success,

--- a/translator/okasaki-examples/BankersQueueScript.sml
+++ b/translator/okasaki-examples/BankersQueueScript.sml
@@ -54,36 +54,46 @@ Definition queue_inv_def:
     (lenf = LENGTH f) /\ lenr <= lenf
 End
 
-val empty_thm = Q.prove(
-  `!xs. queue_inv xs empty = (xs = [])`,
-  EVAL_TAC THEN SIMP_TAC std_ss []);
+Triviality empty_thm:
+  !xs. queue_inv xs empty = (xs = [])
+Proof
+  EVAL_TAC THEN SIMP_TAC std_ss []
+QED
 
-val is_empty_thm = Q.prove(
-  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
+Triviality is_empty_thm:
+  !q xs. queue_inv xs q ==> (is_empty q = (xs = []))
+Proof
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
-  THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,LENGTH_NIL,REV_DEF]);
+  THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,LENGTH_NIL,REV_DEF]
+QED
 
-val snoc_thm = Q.prove(
-  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
+Triviality snoc_thm:
+  !q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)
+Proof
   Cases THEN Cases_on `l` THEN1
    (EVAL_TAC THEN SRW_TAC [] []
     THEN FULL_SIMP_TAC std_ss [LENGTH_NIL,REV_DEF,APPEND,LENGTH] THEN EVAL_TAC)
   THEN FULL_SIMP_TAC std_ss [queue_inv_def,snoc_def,checkf_def]
-  THEN SRW_TAC [] [queue_inv_def] THEN DECIDE_TAC);
+  THEN SRW_TAC [] [queue_inv_def] THEN DECIDE_TAC
+QED
 
-val head_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
+Triviality head_thm:
+  !q x xs. queue_inv (x::xs) q ==> (head q = x)
+Proof
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
-  THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL,REV_DEF]);
+  THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL,REV_DEF]
+QED
 
-val tail_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
+Triviality tail_thm:
+  !q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)
+Proof
   Cases THEN Cases_on `l` THEN1
    (FULL_SIMP_TAC std_ss [queue_inv_def,APPEND,tail_def]
     THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) []
     THEN REPEAT STRIP_TAC THEN `F` by DECIDE_TAC)
   THEN FULL_SIMP_TAC std_ss [queue_inv_def,APPEND,tail_def]
   THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [queue_inv_def,checkf_def]
-  THEN SRW_TAC [] [queue_inv_def] THEN DECIDE_TAC);
+  THEN SRW_TAC [] [queue_inv_def] THEN DECIDE_TAC
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/BatchedQueueScript.sml
+++ b/translator/okasaki-examples/BatchedQueueScript.sml
@@ -53,29 +53,39 @@ Definition queue_inv_def:
     (q = xs ++ REVERSE ys) /\ ((xs = []) ==> (ys = []))
 End
 
-val empty_thm = Q.prove(
-  `!xs. queue_inv xs empty = (xs = [])`,
-  EVAL_TAC THEN SIMP_TAC std_ss []);
+Triviality empty_thm:
+  !xs. queue_inv xs empty = (xs = [])
+Proof
+  EVAL_TAC THEN SIMP_TAC std_ss []
+QED
 
-val is_empty_thm = Q.prove(
-  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
-  Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] [REV_DEF]);
+Triviality is_empty_thm:
+  !q xs. queue_inv xs q ==> (is_empty q = (xs = []))
+Proof
+  Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] [REV_DEF]
+QED
 
-val snoc_thm = Q.prove(
-  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
+Triviality snoc_thm:
+  !q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)
+Proof
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
-    [queue_inv_def,snoc_def,REVERSE_DEF,checkf_def,APPEND]);
+    [queue_inv_def,snoc_def,REVERSE_DEF,checkf_def,APPEND]
+QED
 
-val head_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
+Triviality head_thm:
+  !q x xs. queue_inv (x::xs) q ==> (head q = x)
+Proof
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [queue_inv_def,head_def,REVERSE_DEF,checkf_def,APPEND]
-  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss()) []);
+  THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss()) []
+QED
 
-val tail_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
+Triviality tail_thm:
+  !q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)
+Proof
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
   THEN TRY (Cases_on `t`) THEN EVAL_TAC
-  THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,REV_DEF]);
+  THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,REV_DEF]
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/BinomialHeapScript.sml
+++ b/translator/okasaki-examples/BinomialHeapScript.sml
@@ -137,24 +137,27 @@ val r = translate delete_min_def;
 
 (* Functional correctness proof *)
 
-val ins_bag = Q.prove (
-`!get_key leq t h.
+Triviality ins_bag:
+  !get_key leq t h.
   heap_to_bag (ins_tree get_key leq t h) =
-  BAG_UNION (tree_to_bag t) (heap_to_bag h)`,
-induct_on `h` >>
+  BAG_UNION (tree_to_bag t) (heap_to_bag h)
+Proof
+  induct_on `h` >>
 rw [heap_to_bag_def, ins_tree_def, link_def] >>
 cases_on `t` >>
 cases_on `h'` >>
-srw_tac [BAG_ss] [heap_to_bag_def, ins_tree_def, link_def, BAG_INSERT_UNION]);
+srw_tac [BAG_ss] [heap_to_bag_def, ins_tree_def, link_def, BAG_INSERT_UNION]
+QED
 
-val ins_heap_ordered = Q.prove (
-`!get_key leq t h.
+Triviality ins_heap_ordered:
+  !get_key leq t h.
   WeakLinearOrder leq ∧
   is_heap_ordered_tree get_key leq t ∧
   is_heap_ordered get_key leq h
   ⇒
-  is_heap_ordered get_key leq (ins_tree get_key leq t h)`,
-induct_on `h` >>
+  is_heap_ordered get_key leq (ins_tree get_key leq t h)
+Proof
+  induct_on `h` >>
 rw [is_heap_ordered_def, ins_bag, ins_tree_def] >>
 cases_on `t` >>
 cases_on `h'` >>
@@ -163,7 +166,8 @@ fs [] >>
 Q.PAT_X_ASSUM `!get_key leq t. P get_key leq t` match_mp_tac >>
 rw [is_heap_ordered_def] >>
 fs [is_heap_ordered_def, BAG_EVERY, heap_to_bag_def] >>
-metis_tac [WeakLinearOrder, WeakOrder, transitive_def, WeakLinearOrder_neg]);
+metis_tac [WeakLinearOrder, WeakOrder, transitive_def, WeakLinearOrder_neg]
+QED
 
 Theorem insert_bag:
  !get_key leq s h.
@@ -216,8 +220,8 @@ fs [is_heap_ordered_def, BAG_EVERY, heap_to_bag_def] >>
 metis_tac [WeakLinearOrder, WeakOrder, transitive_def, WeakLinearOrder_neg]
 QED
 
-val remove_min_tree = Q.prove (
-`∀get_key leq h t h'.
+Triviality remove_min_tree:
+  ∀get_key leq h t h'.
   WeakLinearOrder leq ∧
   (h ≠ []) ∧
   is_heap_ordered get_key leq h ∧
@@ -226,8 +230,9 @@ val remove_min_tree = Q.prove (
   is_heap_ordered get_key leq h' ∧
   is_heap_ordered_tree get_key leq t ∧
   (heap_to_bag h = BAG_UNION (heap_to_bag h') (tree_to_bag t)) ∧
-  (!y. BAG_IN y (heap_to_bag h') ⇒ leq (get_key (root t)) (get_key y))`,
-induct_on `h` >>
+  (!y. BAG_IN y (heap_to_bag h') ⇒ leq (get_key (root t)) (get_key y))
+Proof
+  induct_on `h` >>
 rw [heap_to_bag_def] >>
 cases_on `h` >>
 cases_on `t` >>
@@ -284,7 +289,8 @@ full_simp_tac (srw_ss()++BAG_ss)
 
  metis_tac [WeakLinearOrder, WeakOrder, WeakLinearOrder_neg, root_def,
             transitive_def]
-]);
+]
+QED
 
 Theorem find_min_correct:
  !h get_key leq.
@@ -305,27 +311,33 @@ fs [BAG_EVERY, heap_to_bag_def, root_def, is_heap_ordered_def] >>
 metis_tac [WeakLinearOrder, WeakOrder, reflexive_def]
 QED
 
-val reverse_heap_ordered = Q.prove (
-`!get_key leq l.
-  is_heap_ordered get_key leq l ⇒ is_heap_ordered get_key leq (REVERSE l)`,
-induct_on `l` >>
+Triviality reverse_heap_ordered:
+  !get_key leq l.
+  is_heap_ordered get_key leq l ⇒ is_heap_ordered get_key leq (REVERSE l)
+Proof
+  induct_on `l` >>
 rw [is_heap_ordered_def] >>
 res_tac >>
 POP_ASSUM MP_TAC >>
 Q.SPEC_TAC (`REVERSE l`, `l'`) >>
 rw [] >>
 induct_on `l'` >>
-rw [is_heap_ordered_def]);
+rw [is_heap_ordered_def]
+QED
 
-val append_bag = Q.prove (
-`!h1 h2. heap_to_bag (h1++h2) = BAG_UNION (heap_to_bag h1) (heap_to_bag h2)`,
-induct_on `h1` >>
-srw_tac [BAG_ss] [heap_to_bag_def]);
+Triviality append_bag:
+  !h1 h2. heap_to_bag (h1++h2) = BAG_UNION (heap_to_bag h1) (heap_to_bag h2)
+Proof
+  induct_on `h1` >>
+srw_tac [BAG_ss] [heap_to_bag_def]
+QED
 
-val reverse_bag = Q.prove (
-`!l. heap_to_bag (REVERSE l) = heap_to_bag l`,
-induct_on `l` >>
-srw_tac [BAG_ss] [append_bag, heap_to_bag_def]);
+Triviality reverse_bag:
+  !l. heap_to_bag (REVERSE l) = heap_to_bag l
+Proof
+  induct_on `l` >>
+srw_tac [BAG_ss] [append_bag, heap_to_bag_def]
+QED
 
 Theorem delete_min_correct:
  !h get_key leq.
@@ -375,13 +387,15 @@ End
 
 val is_binomial_tree_ind = fetch "-" "is_binomial_tree_ind";
 
-val exp2_mod2 = Q.prove (
-`!x. x ≠ 0 ⇒ (2 ** x MOD 2 = 0)`,
-induct_on `x` >>
+Triviality exp2_mod2:
+  !x. x ≠ 0 ⇒ (2 ** x MOD 2 = 0)
+Proof
+  induct_on `x` >>
 rw [] >>
 cases_on `x = 0`>>
 fs [arithmeticTheory.ADD1, arithmeticTheory.EXP_ADD,
-    arithmeticTheory.MOD_EQ_0]);
+    arithmeticTheory.MOD_EQ_0]
+QED
 
 Theorem is_binomial_tree_size:
  !t. is_binomial_tree t ⇒ (heap_tree_size t = 2 ** rank t)
@@ -402,23 +416,28 @@ is_binomial_heap h <=>
   EVERY is_binomial_tree h ∧ SORTED ($< : num->num->bool) (MAP rank h)
 End
 
-val trans_less = Q.prove (
-`transitive ($< : num->num->bool)`,
-rw [transitive_def] >>
-decide_tac);
+Triviality trans_less:
+  transitive ($< : num->num->bool)
+Proof
+  rw [transitive_def] >>
+decide_tac
+QED
 
-val trans_great = Q.prove (
-`transitive ($> : num->num->bool)`,
-rw [transitive_def] >>
-decide_tac);
+Triviality trans_great:
+  transitive ($> : num->num->bool)
+Proof
+  rw [transitive_def] >>
+decide_tac
+QED
 
-val link_binomial_tree = Q.prove (
-`!get_key leq t1 t2.
+Triviality link_binomial_tree:
+  !get_key leq t1 t2.
   is_binomial_tree t1 ∧ is_binomial_tree t2 ∧ (rank t1 = rank t2)
   ⇒
   is_binomial_tree (link get_key leq t1 t2) ∧
-  (rank (link get_key leq t1 t2) = rank t1 + 1)`,
-cases_on `t1` >>
+  (rank (link get_key leq t1 t2) = rank t1 + 1)
+Proof
+  cases_on `t1` >>
 cases_on `t2` >>
 rw [link_def, is_binomial_tree_def, rank_def] >>
 cases_on `l` >>
@@ -426,17 +445,19 @@ cases_on `l'` >>
 fs [is_binomial_tree_def, SORTED_EQ, SORTED_DEF, trans_great] >>
 rw [] >>
 res_tac >>
-decide_tac);
+decide_tac
+QED
 
-val ins_binomial_heap = Q.prove (
-`!get_key leq t h.
+Triviality ins_binomial_heap:
+  !get_key leq t h.
   is_binomial_tree t ∧
   is_binomial_heap h ∧
   (!t'. MEM t' h ⇒ rank t ≤ rank t')
   ⇒
   is_binomial_heap (ins_tree get_key leq t h) ∧
-  (!r. (r < rank t) ⇒ EVERY (\t'. r < rank t') (ins_tree get_key leq t h))`,
-induct_on `h` >>
+  (!r. (r < rank t) ⇒ EVERY (\t'. r < rank t') (ins_tree get_key leq t h))
+Proof
+  induct_on `h` >>
 rw [is_binomial_heap_def, trans_less, SORTED_EQ, SORTED_DEF, ins_tree_def] >>
 `rank t ≤ rank h'` by metis_tac [] >-
 decide_tac >-
@@ -448,7 +469,8 @@ fs [is_binomial_heap_def, MEM_MAP] >>
  (rank (link get_key leq t h') = rank t + 1)`
               by metis_tac [link_binomial_tree] >>
 metis_tac [DECIDE ``!(x:num) y . x < y ==> x < y + 1``,
-           DECIDE ``!(x:num) y . x < y ==> x + 1 ≤ y``]);
+           DECIDE ``!(x:num) y . x < y ==> x + 1 ≤ y``]
+QED
 
 Theorem merge_binomial_heap:
  !get_key leq h1 h2.
@@ -496,12 +518,13 @@ rw [insert_def] >>
 metis_tac [ins_binomial_heap, rank_def, DECIDE ``!(x:num). 0 ≤ x``]
 QED
 
-val remove_min_binomial_heap = Q.prove (
-`!get_key leq h t h'.
+Triviality remove_min_binomial_heap:
+  !get_key leq h t h'.
   (h ≠ []) ∧ is_binomial_heap h ∧ ((t,h') = remove_min_tree get_key leq h)
   ⇒
-  PERM (t::h') h ∧ is_binomial_tree t ∧ is_binomial_heap h'`,
-induct_on `h` >>
+  PERM (t::h') h ∧ is_binomial_tree t ∧ is_binomial_heap h'
+Proof
+  induct_on `h` >>
 rw [remove_min_tree_def] >>
 cases_on `h` >>
 fs [remove_min_tree_def, is_binomial_heap_def, LET_THM, SORTED_DEF] >>
@@ -518,11 +541,13 @@ metis_tac [] >>
 `MEM y (MAP rank (q::r))` by metis_tac [MEM_MAP, MEM] >>
 `MEM y (MAP rank (h'''::t'))` by metis_tac [PERM_MEM_EQ, PERM_MAP] >>
 fs [] >>
-metis_tac [MEM_MAP, trans_less, transitive_def]);
+metis_tac [MEM_MAP, trans_less, transitive_def]
+QED
 
-val delete_lem = Q.prove (
-`!n a l. is_binomial_tree (Node n a l) ⇒ is_binomial_heap (REVERSE l)`,
-induct_on `l` >>
+Triviality delete_lem:
+  !n a l. is_binomial_tree (Node n a l) ⇒ is_binomial_heap (REVERSE l)
+Proof
+  induct_on `l` >>
 rw [is_binomial_tree_def, is_binomial_heap_def, SORTED_DEF] >>
 fs [is_binomial_heap_def, rich_listTheory.ALL_EL_REVERSE, trans_great,
     SORTED_EQ] >-
@@ -531,7 +556,8 @@ fs [SORTED_APPEND] >>
 rw [trans_less, SORTED_DEF, sorted_reverse, rich_listTheory.MAP_REVERSE,
     GSYM arithmeticTheory.GREATER_DEF] >>
 `(\(x:num) y. x > y) = $>` by metis_tac [] >>
-rw []);
+rw []
+QED
 
 Theorem delete_min_binomial_heap:
  !get_key leq h.
@@ -552,10 +578,12 @@ QED
 
 val remove_min_tree_side_def = fetch "-" "remove_min_tree_side_def"
 
-val remove_min_tree_side = Q.prove (
-`!get_key leq h. remove_min_tree_side get_key leq h = (h ≠ [])`,
-Induct_on `h`
+Triviality remove_min_tree_side:
+  !get_key leq h. remove_min_tree_side get_key leq h = (h ≠ [])
+Proof
+  Induct_on `h`
 THEN SIMP_TAC std_ss [Once remove_min_tree_side_def]
-THEN Cases_on `h` THEN FULL_SIMP_TAC (srw_ss()) []);
+THEN Cases_on `h` THEN FULL_SIMP_TAC (srw_ss()) []
+QED
 
 val _ = export_theory ();

--- a/translator/okasaki-examples/BottomUpMergeSortScript.sml
+++ b/translator/okasaki-examples/BottomUpMergeSortScript.sml
@@ -105,56 +105,67 @@ val r = translate sort_def;
  * least-to-most significant. E.g., if the size is 9, there should be 2 lists,
  * the first of length 1, and the second of length 8.*)
 
-val sortable_inv_sorted = Q.prove (
-`!leq size segs m. sortable_inv leq (size,segs) m ⇒ EVERY (SORTED leq) segs`,
-recInduct sortable_inv_ind >>
+Triviality sortable_inv_sorted:
+  !leq size segs m. sortable_inv leq (size,segs) m ⇒ EVERY (SORTED leq) segs
+Proof
+  recInduct sortable_inv_ind >>
 rw [] >>
 POP_ASSUM (ASSUME_TAC o SIMP_RULE (srw_ss()) [Once sortable_inv_def]) >>
 fs [] >>
 every_case_tac >>
-fs []);
+fs []
+QED
 
-val mrg_sorted = Q.prove (
-`!leq xs ys.
+Triviality mrg_sorted:
+  !leq xs ys.
   WeakLinearOrder leq ∧ SORTED leq xs ∧ SORTED leq ys
   ⇒
-  SORTED leq (mrg leq xs ys)`,
-recInduct mrg_ind >>
+  SORTED leq (mrg leq xs ys)
+Proof
+  recInduct mrg_ind >>
 rw [SORTED_DEF,mrg_def] >|
 [cases_on `xs`, cases_on `ys`] >>
 fs [SORTED_DEF, mrg_def] >>
 every_case_tac >>
 fs [SORTED_DEF] >>
-metis_tac [WeakLinearOrder_neg]);
+metis_tac [WeakLinearOrder_neg]
+QED
 
-val mrg_perm = Q.prove (
-`!leq xs ys. PERM (mrg leq xs ys) (xs++ys)`,
-recInduct mrg_ind >>
+Triviality mrg_perm:
+  !leq xs ys. PERM (mrg leq xs ys) (xs++ys)
+Proof
+  recInduct mrg_ind >>
 rw [mrg_def] >>
 metis_tac [PERM_FUN_APPEND, PERM_CONS_IFF, CONS_PERM, PERM_SWAP_AT_FRONT,
-           PERM_TRANS, PERM_REFL]);
+           PERM_TRANS, PERM_REFL]
+QED
 
-val mrg_length = Q.prove (
-`!leq xs ys. LENGTH (mrg leq xs ys) = LENGTH xs + LENGTH ys`,
-recInduct mrg_ind >>
-srw_tac [ARITH_ss] [mrg_def]);
+Triviality mrg_length:
+  !leq xs ys. LENGTH (mrg leq xs ys) = LENGTH xs + LENGTH ys
+Proof
+  recInduct mrg_ind >>
+srw_tac [ARITH_ss] [mrg_def]
+QED
 
-val mrg_bag = Q.prove (
-`!leq xs ys.
-  list_to_bag (mrg leq xs ys) = BAG_UNION (list_to_bag xs) (list_to_bag ys)`,
-recInduct mrg_ind >>
-srw_tac [BAG_ss] [list_to_bag_def, mrg_def, BAG_INSERT_UNION]);
+Triviality mrg_bag:
+  !leq xs ys.
+  list_to_bag (mrg leq xs ys) = BAG_UNION (list_to_bag xs) (list_to_bag ys)
+Proof
+  recInduct mrg_ind >>
+srw_tac [BAG_ss] [list_to_bag_def, mrg_def, BAG_INSERT_UNION]
+QED
 
-val add_seg_sub_inv = Q.prove (
-`!leq size segs n seg.
+Triviality add_seg_sub_inv:
+  !leq size segs n seg.
   WeakLinearOrder leq ∧
   (n ≠ 0) ∧
   sortable_inv leq (size,segs) n ∧
   SORTED leq seg ∧
   (LENGTH seg = n)
   ⇒
-  sortable_inv leq (size+1, add_seg leq seg segs size) n`,
-recInduct sortable_inv_ind >>
+  sortable_inv leq (size+1, add_seg leq seg segs size) n
+Proof
+  recInduct sortable_inv_ind >>
 rw [] >|
 [fs [Once sortable_inv_def] >>
      rw [Once add_seg_def] >>
@@ -187,15 +198,17 @@ rw [] >|
           every_case_tac >>
           fs [arithmeticTheory.EVEN_ADD] >>
           metis_tac [intLib.ARITH_PROVE
-                     ``!n:num. ~EVEN n ⇒ (n DIV 2 + 1 = (n + 1) DIV 2)``]]]);
+                     ``!n:num. ~EVEN n ⇒ (n DIV 2 + 1 = (n + 1) DIV 2)``]]]
+QED
 
-val add_seg_bag = Q.prove (
-`!leq size segs n seg SIZE.
+Triviality add_seg_bag:
+  !leq size segs n seg SIZE.
   sortable_inv leq (size,segs) n
   ⇒
   (sortable_to_bag (SIZE, add_seg leq seg segs size) =
-   BAG_UNION (list_to_bag seg) (sortable_to_bag (SIZE-LENGTH seg,segs)))`,
-recInduct sortable_inv_ind >>
+   BAG_UNION (list_to_bag seg) (sortable_to_bag (SIZE-LENGTH seg,segs)))
+Proof
+  recInduct sortable_inv_ind >>
 rw [] >|
 [fs [Once sortable_inv_def] >>
      rw [Once add_seg_def, sortable_to_bag_def],
@@ -204,7 +217,8 @@ rw [] >|
      fs [] >>
      srw_tac [BAG_AC_ss]
              [Once add_seg_def, sortable_to_bag_def, mrg_bag, mrg_length,
-              arithmeticTheory.SUB_PLUS]]);
+              arithmeticTheory.SUB_PLUS]]
+QED
 
 Theorem add_bag:
  !leq x size segs.
@@ -229,21 +243,25 @@ match_mp_tac add_seg_sub_inv >>
 rw [SORTED_DEF]
 QED
 
-val mrg_all_sorted = Q.prove (
-`!leq xs segs.
+Triviality mrg_all_sorted:
+  !leq xs segs.
   WeakLinearOrder leq ∧
   EVERY (SORTED leq) segs ∧ SORTED leq xs
   ⇒
-  SORTED leq (mrg_all leq xs segs)`,
-induct_on `segs` >>
+  SORTED leq (mrg_all leq xs segs)
+Proof
+  induct_on `segs` >>
 rw [mrg_all_def] >>
-metis_tac [mrg_sorted]);
+metis_tac [mrg_sorted]
+QED
 
-val mrg_all_perm = Q.prove (
-`!leq xs segs. PERM (mrg_all leq xs segs) (xs++FLAT segs)`,
-induct_on `segs` >>
+Triviality mrg_all_perm:
+  !leq xs segs. PERM (mrg_all leq xs segs) (xs++FLAT segs)
+Proof
+  induct_on `segs` >>
 rw [mrg_all_def] >>
-metis_tac [mrg_perm, PERM_CONG, PERM_REFL, PERM_TRANS]);
+metis_tac [mrg_perm, PERM_CONG, PERM_REFL, PERM_TRANS]
+QED
 
 Theorem sort_sorted:
  !leq size segs.
@@ -255,10 +273,12 @@ rw [sort_def] >>
 metis_tac [sortable_inv_sorted, SORTED_DEF, mrg_all_sorted]
 QED
 
-val sortable_to_bag_lem = Q.prove (
-`!size segs. sortable_to_bag (size,segs) = list_to_bag (FLAT segs)`,
-induct_on `segs` >>
-rw [sortable_to_bag_def, list_to_bag_def, list_to_bag_append]);
+Triviality sortable_to_bag_lem:
+  !size segs. sortable_to_bag (size,segs) = list_to_bag (FLAT segs)
+Proof
+  induct_on `segs` >>
+rw [sortable_to_bag_def, list_to_bag_def, list_to_bag_append]
+QED
 
 Theorem sort_bag:
  !leq x size segs.
@@ -274,21 +294,25 @@ QED
 
 val add_seg_side_cases = fetch "-" "add_seg_side_def"
 
-val add_seg_side = Q.prove (
-`!leq size segs n seg.
-  sortable_inv leq (size,segs) n ⇒ add_seg_side leq seg segs size`,
-recInduct sortable_inv_ind >>
+Triviality add_seg_side:
+  !leq size segs n seg.
+  sortable_inv leq (size,segs) n ⇒ add_seg_side leq seg segs size
+Proof
+  recInduct sortable_inv_ind >>
 rw [] >>
 ONCE_REWRITE_TAC [Once add_seg_side_cases] >>
 rw [] >>
 fs [sortable_inv_def] >>
 ONCE_REWRITE_TAC [Once add_seg_side_cases] >>
-rw []);
+rw []
+QED
 
-val add_side = Q.prove (
-`!leq x size segs n.
-  sortable_inv leq (size,segs) n ⇒ add_side leq x (size,segs)`,
-rw [fetch "-" "add_side_def"] >>
-metis_tac [add_seg_side]);
+Triviality add_side:
+  !leq x size segs n.
+  sortable_inv leq (size,segs) n ⇒ add_side leq x (size,segs)
+Proof
+  rw [fetch "-" "add_side_def"] >>
+metis_tac [add_seg_side]
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/ImplicitQueueScript.sml
+++ b/translator/okasaki-examples/ImplicitQueueScript.sml
@@ -111,74 +111,97 @@ Definition queue_inv_def:
   queue_inv q t <=> queue_ok 0 t /\ (q = flatten t)
 End
 
-val empty_thm = Q.prove(
-  `queue_inv [] empty`,
-  EVAL_TAC);
+Triviality empty_thm:
+  queue_inv [] empty
+Proof
+  EVAL_TAC
+QED
 
-val exps_NOT_NIL = Q.prove(
-  `!e. ~(exps e = [])`,
-  Induct THEN EVAL_TAC THEN FULL_SIMP_TAC std_ss [APPEND_eq_NIL]);
+Triviality exps_NOT_NIL:
+  !e. ~(exps e = [])
+Proof
+  Induct THEN EVAL_TAC THEN FULL_SIMP_TAC std_ss [APPEND_eq_NIL]
+QED
 
-val is_empty_thm = Q.prove(
-  `!xs q. queue_inv xs q ==> (is_empty q = (xs = []))`,
+Triviality is_empty_thm:
+  !xs q. queue_inv xs q ==> (is_empty q = (xs = []))
+Proof
   Cases THEN Cases THEN EVAL_TAC
   THEN1 (Cases_on `d` THEN EVAL_TAC THEN SIMP_TAC std_ss [exps_NOT_NIL])
   THEN1 (Cases_on `d0` THEN EVAL_TAC THEN ONCE_REWRITE_TAC [EQ_SYM_EQ]
          THEN SIMP_TAC std_ss [exps_NOT_NIL,APPEND_eq_NIL])
-  THEN Cases_on `d` THEN EVAL_TAC);
+  THEN Cases_on `d` THEN EVAL_TAC
+QED
 
-val flatten_snoc = Q.prove(
-  `!x y n. queue_ok n x ==> (flatten (snoc x y) = flatten x ++ exps y)`,
+Triviality flatten_snoc:
+  !x y n. queue_ok n x ==> (flatten (snoc x y) = flatten x ++ exps y)
+Proof
   Induct THEN Cases_on `d`
   THEN FULL_SIMP_TAC (srw_ss()) [snoc_def,flatten_def,digits_def,
       empty_def,queue_ok_def,two_def] THEN REPEAT STRIP_TAC
-  THEN RES_TAC THEN FULL_SIMP_TAC std_ss [exps_def,APPEND_ASSOC]);
+  THEN RES_TAC THEN FULL_SIMP_TAC std_ss [exps_def,APPEND_ASSOC]
+QED
 
-val queue_ok_snoc = Q.prove(
-  `!q y n. queue_ok n q /\ depth n y ==> queue_ok n (snoc q y)`,
+Triviality queue_ok_snoc:
+  !q y n. queue_ok n q /\ depth n y ==> queue_ok n (snoc q y)
+Proof
   Induct THEN Cases_on `d`
   THEN FULL_SIMP_TAC (srw_ss()) [snoc_def,queue_ok_def,ddepth_def,two_def,
     only_digits_def,EVERY_DEF,empty_def] THEN REPEAT STRIP_TAC
   THEN Q.PAT_X_ASSUM `!x.bbb` MATCH_MP_TAC
-  THEN FULL_SIMP_TAC (srw_ss()) [depth_def]);
+  THEN FULL_SIMP_TAC (srw_ss()) [depth_def]
+QED
 
-val snoc_thm = Q.prove(
-  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q (Once x))`,
+Triviality snoc_thm:
+  !q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q (Once x))
+Proof
   STRIP_TAC THEN SIMP_TAC std_ss [queue_inv_def] THEN REPEAT STRIP_TAC
   THEN IMP_RES_TAC flatten_snoc THEN FULL_SIMP_TAC std_ss [exps_def]
-  THEN MATCH_MP_TAC queue_ok_snoc THEN FULL_SIMP_TAC std_ss [] THEN EVAL_TAC);
+  THEN MATCH_MP_TAC queue_ok_snoc THEN FULL_SIMP_TAC std_ss [] THEN EVAL_TAC
+QED
 
-val depth_0 = Q.prove(
-  `!e. depth 0 e ==> ?x. e = Once x`,
-  Cases THEN SIMP_TAC (srw_ss()) [depth_def]);
+Triviality depth_0:
+  !e. depth 0 e ==> ?x. e = Once x
+Proof
+  Cases THEN SIMP_TAC (srw_ss()) [depth_def]
+QED
 
-val head_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> (head q = Once x)`,
+Triviality head_thm:
+  !q x xs. queue_inv (x::xs) q ==> (head q = Once x)
+Proof
   Cases THEN TRY (Cases_on `d`) THEN TRY (Cases_on `d0`)
   THEN EVAL_TAC THEN SIMP_TAC (srw_ss()) []
   THEN REPEAT STRIP_TAC THEN IMP_RES_TAC depth_0
-  THEN FULL_SIMP_TAC (srw_ss()) [exps_def])
+  THEN FULL_SIMP_TAC (srw_ss()) [exps_def]
+QED
 
-val depth_IMP = Q.prove(
-  `!t n. depth n t ==> (LENGTH (exps t) = 2**n)`,
+Triviality depth_IMP:
+  !t n. depth n t ==> (LENGTH (exps t) = 2**n)
+Proof
   Induct THEN1 (EVAL_TAC THEN FULL_SIMP_TAC std_ss [])
   THEN Cases THEN FULL_SIMP_TAC std_ss [depth_def,ADD1]
   THEN REPEAT STRIP_TAC THEN RES_TAC
-  THEN FULL_SIMP_TAC (srw_ss()) [exps_def,GSYM ADD1,EXP] THEN DECIDE_TAC);
+  THEN FULL_SIMP_TAC (srw_ss()) [exps_def,GSYM ADD1,EXP] THEN DECIDE_TAC
+QED
 
-val LENGTH_EQ_APPEND_EQ = Q.prove(
-  `!xs xs2 ys ys2.
-      (LENGTH xs = LENGTH ys) /\ (xs ++ xs2 = ys ++ ys2) ==> (xs2 = ys2)`,
-  Induct THEN Cases_on `ys` THEN FULL_SIMP_TAC (srw_ss()) [ADD1]);
+Triviality LENGTH_EQ_APPEND_EQ:
+  !xs xs2 ys ys2.
+      (LENGTH xs = LENGTH ys) /\ (xs ++ xs2 = ys ++ ys2) ==> (xs2 = ys2)
+Proof
+  Induct THEN Cases_on `ys` THEN FULL_SIMP_TAC (srw_ss()) [ADD1]
+QED
 
-val is_empty_EQ = Q.prove(
-  `!q. is_empty q = (q = Shallow Zero)`,
-  Cases THEN Cases_on `d` THEN EVAL_TAC);
+Triviality is_empty_EQ:
+  !q. is_empty q = (q = Shallow Zero)
+Proof
+  Cases THEN Cases_on `d` THEN EVAL_TAC
+QED
 
-val tail_lemma = Q.prove(
-  `!q n x xs.
+Triviality tail_lemma:
+  !q n x xs.
       queue_ok n q /\ (exps x ++ xs = flatten q) /\ depth n x ==>
-      queue_ok n (tail q) /\ (xs = flatten (tail q))`,
+      queue_ok n (tail q) /\ (xs = flatten (tail q))
+Proof
   Induct THEN1 (Cases_on `d`
     THEN FULL_SIMP_TAC (srw_ss()) [flatten_def,digits_def,exps_NOT_NIL,tail_def,
            queue_ok_def,empty_def,ddepth_def,EVERY_DEF,two_def,only_digits_def]
@@ -232,12 +255,15 @@ val tail_lemma = Q.prove(
   THEN Q.PAT_X_ASSUM `!x.bbb` (MP_TAC o GSYM o Q.SPECL [`n+1`,`head q`,`ts`])
   THEN FULL_SIMP_TAC std_ss []
   THEN MATCH_MP_TAC (METIS_PROVE [] ``b /\ (b1 ==> b2) ==> (b ==> b1) ==> b2``)
-  THEN FULL_SIMP_TAC std_ss [exps_def,depth_def]);
+  THEN FULL_SIMP_TAC std_ss [exps_def,depth_def]
+QED
 
-val tail_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
+Triviality tail_thm:
+  !q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)
+Proof
   FULL_SIMP_TAC std_ss [queue_inv_def] THEN NTAC 4 STRIP_TAC
   THEN MATCH_MP_TAC tail_lemma THEN Q.EXISTS_TAC `Once x`
-  THEN FULL_SIMP_TAC std_ss [exps_def,APPEND,depth_def]);
+  THEN FULL_SIMP_TAC std_ss [exps_def,APPEND,depth_def]
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/LazyPairingHeapScript.sml
+++ b/translator/okasaki-examples/LazyPairingHeapScript.sml
@@ -95,11 +95,12 @@ Definition merge_def:
                  Empty))
 End
 
-val merge_size = Q.prove (
-`!get_key leq h1 h2.
+Triviality merge_size:
+  !get_key leq h1 h2.
   heap_size (\x.0) (merge get_key leq h1 h2) =
-  heap_size (\x.0) h1 + heap_size (\x.0) h2`,
-recInduct (fetch "-" "merge_ind") >>
+  heap_size (\x.0) h1 + heap_size (\x.0) h2
+Proof
+  recInduct (fetch "-" "merge_ind") >>
 srw_tac [ARITH_ss] [merge_def, heap_size_def] >|
 [cases_on `h1`, cases_on `h1'`] >>
 full_simp_tac (srw_ss()++ARITH_ss) [] >>
@@ -110,13 +111,16 @@ cases_on `leq (get_key y) (get_key a)` >>
 full_simp_tac (srw_ss()++ARITH_ss) [] >>
 cases_on `leq (get_key x) (get_key a)` >>
 full_simp_tac (srw_ss()++numSimps.ARITH_AC_ss) [heap_size_def, merge_def] >>
-full_simp_tac (srw_ss()++ARITH_ss) []);
+full_simp_tac (srw_ss()++ARITH_ss) []
+QED
 
-val merge_size_lem = Q.prove (
-`(heap_size (\x.0) (merge get_key leq (Tree x h1 h2) h1') <
-  heap_size (\x.0) h1 + heap_size (\x.0) h2 + heap_size (\x.0) h1' + 2) = T`,
-rw [merge_size, heap_size_def] >>
-decide_tac);
+Triviality merge_size_lem:
+  (heap_size (\x.0) (merge get_key leq (Tree x h1 h2) h1') <
+  heap_size (\x.0) h1 + heap_size (\x.0) h2 + heap_size (\x.0) h1' + 2) = T
+Proof
+  rw [merge_size, heap_size_def] >>
+decide_tac
+QED
 
 (* Remove the size constraints *)
 
@@ -127,7 +131,7 @@ val merge_ind =
   SIMP_RULE (srw_ss()) [merge_size_lem, LET_THM] (fetch "-" "merge_ind");
 val _ = save_thm ("merge_ind[allow_rebind]",merge_ind);
 
-val merge_thm = Q.prove(`
+Triviality merge_thm:
   merge get_key leq a b =
     case (a,b) of
     | (a,Empty) => a
@@ -144,8 +148,10 @@ val merge_thm = Q.prove(`
           | Empty => Tree y (Tree x h1 h2) h2'
           | _ =>
             Tree y Empty (merge get_key leq
-                         (merge get_key leq (Tree x h1 h2) h1') h2')`,
-  Cases_on `a` THEN Cases_on `b` THEN SIMP_TAC (srw_ss()) [merge_def]);
+                         (merge get_key leq (Tree x h1 h2) h1') h2')
+Proof
+  Cases_on `a` THEN Cases_on `b` THEN SIMP_TAC (srw_ss()) [merge_def]
+QED
 
 val _ = translate merge_thm;
 
@@ -274,14 +280,18 @@ QED
 val delete_min_side_def = fetch "-" "delete_min_side_def"
 val find_min_side_def = fetch "-" "find_min_side_def"
 
-val delete_min_side = Q.prove (
-`!get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)`,
-cases_on `h` >>
-rw [delete_min_side_def]);
+Triviality delete_min_side:
+  !get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)
+Proof
+  cases_on `h` >>
+rw [delete_min_side_def]
+QED
 
-val find_min_side = Q.prove (
-`!h. find_min_side h = (h ≠ Empty)`,
-cases_on `h` >>
-rw [find_min_side_def]);
+Triviality find_min_side:
+  !h. find_min_side h = (h ≠ Empty)
+Proof
+  cases_on `h` >>
+rw [find_min_side_def]
+QED
 
 val _ = export_theory ();

--- a/translator/okasaki-examples/LeftistHeapScript.sml
+++ b/translator/okasaki-examples/LeftistHeapScript.sml
@@ -183,20 +183,24 @@ QED
 val delete_min_side_def = fetch "-" "delete_min_side_def"
 val find_min_side_def = fetch "-" "find_min_side_def"
 
-val delete_min_side = Q.prove (
-`!get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)`,
-rw [delete_min_side_def] >>
+Triviality delete_min_side:
+  !get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)
+Proof
+  rw [delete_min_side_def] >>
 eq_tac >>
 rw [] >>
 cases_on `h` >>
-rw []);
+rw []
+QED
 
-val find_min_side = Q.prove (
-`!h. find_min_side h = (h ≠ Empty)`,
-rw [find_min_side_def] >>
+Triviality find_min_side:
+  !h. find_min_side h = (h ≠ Empty)
+Proof
+  rw [find_min_side_def] >>
 eq_tac >>
 rw [] >>
 cases_on `h` >>
-rw []);
+rw []
+QED
 
 val _ = export_theory ();

--- a/translator/okasaki-examples/PairingHeapScript.sml
+++ b/translator/okasaki-examples/PairingHeapScript.sml
@@ -150,18 +150,22 @@ fs [BAG_EVERY] >>
 metis_tac [WeakLinearOrder, WeakOrder, reflexive_def]
 QED
 
-val merge_pairs_bag = Q.prove (
-`!get_key leq hs. heap_to_bag (merge_pairs get_key leq hs) = heaps_to_bag hs`,
-recInduct merge_pairs_ind >>
-srw_tac [BAG_ss] [merge_pairs_def, heap_to_bag_def, merge_bag]);
+Triviality merge_pairs_bag:
+  !get_key leq hs. heap_to_bag (merge_pairs get_key leq hs) = heaps_to_bag hs
+Proof
+  recInduct merge_pairs_ind >>
+srw_tac [BAG_ss] [merge_pairs_def, heap_to_bag_def, merge_bag]
+QED
 
-val merge_pairs_heap_ordered = Q.prove (
-`!get_key leq hs.
+Triviality merge_pairs_heap_ordered:
+  !get_key leq hs.
   WeakLinearOrder leq ∧ EVERY (is_heap_ordered get_key leq) hs
   ⇒
-  is_heap_ordered get_key leq (merge_pairs get_key leq hs)`,
-recInduct merge_pairs_ind >>
-rw [merge_pairs_def, is_heap_ordered_def, merge_heap_ordered]);
+  is_heap_ordered get_key leq (merge_pairs get_key leq hs)
+Proof
+  recInduct merge_pairs_ind >>
+rw [merge_pairs_def, is_heap_ordered_def, merge_heap_ordered]
+QED
 
 Theorem delete_min_correct:
  !h get_key leq.
@@ -183,14 +187,18 @@ QED
 val delete_min_side_def = fetch "-" "delete_min_side_def"
 val find_min_side_def = fetch "-" "find_min_side_def"
 
-val delete_min_side = Q.prove (
-`!get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)`,
-cases_on `h` >>
-rw [delete_min_side_def]);
+Triviality delete_min_side:
+  !get_key leq h. delete_min_side get_key leq h = (h ≠ Empty)
+Proof
+  cases_on `h` >>
+rw [delete_min_side_def]
+QED
 
-val find_min_side = Q.prove (
-`!h. find_min_side h = (h ≠ Empty)`,
-cases_on `h` >>
-rw [find_min_side_def]);
+Triviality find_min_side:
+  !h. find_min_side h = (h ≠ Empty)
+Proof
+  cases_on `h` >>
+rw [find_min_side_def]
+QED
 
 val _ = export_theory ()

--- a/translator/okasaki-examples/PhysicistsQueueScript.sml
+++ b/translator/okasaki-examples/PhysicistsQueueScript.sml
@@ -62,25 +62,34 @@ Definition queue_inv_def:
     lenr <= lenf /\ ((w = []) ==> (q = [])) /\ isPREFIX w f
 End
 
-val empty_thm = Q.prove(
-  `!xs. queue_inv xs empty = (xs = [])`,
-  EVAL_TAC THEN SIMP_TAC std_ss []);
+Triviality empty_thm:
+  !xs. queue_inv xs empty = (xs = [])
+Proof
+  EVAL_TAC THEN SIMP_TAC std_ss []
+QED
 
-val is_empty_thm = Q.prove(
-  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
+Triviality is_empty_thm:
+  !q xs. queue_inv xs q ==> (is_empty q = (xs = []))
+Proof
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
-  THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [APPEND_eq_NIL,LENGTH_NIL]);
+  THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [APPEND_eq_NIL,LENGTH_NIL]
+QED
 
-val isPREFIX_APPEND = Q.prove(
-  `!xs ys. isPREFIX xs (xs ++ ys)`,
-  Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]);
+Triviality isPREFIX_APPEND:
+  !xs ys. isPREFIX xs (xs ++ ys)
+Proof
+  Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]
+QED
 
-val isPREFIX_REFL = Q.prove(
-  `!xs ys. isPREFIX xs xs`,
-  Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]);
+Triviality isPREFIX_REFL:
+  !xs ys. isPREFIX xs xs
+Proof
+  Induct THEN FULL_SIMP_TAC (srw_ss()) [isPREFIX]
+QED
 
-val snoc_thm = Q.prove(
-  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
+Triviality snoc_thm:
+  !q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)
+Proof
   Cases THEN Cases_on `l`
   THEN FULL_SIMP_TAC (srw_ss()) [queue_inv_def,snoc_def,check_def,checkw_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss())
@@ -88,15 +97,19 @@ val snoc_thm = Q.prove(
   THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss())
     [queue_inv_def,snoc_def,check_def,checkw_def,ADD1]
   THEN FULL_SIMP_TAC std_ss [isPREFIX_APPEND,GSYM APPEND_ASSOC]
-  THEN DECIDE_TAC);
+  THEN DECIDE_TAC
+QED
 
-val head_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
+Triviality head_thm:
+  !q x xs. queue_inv (x::xs) q ==> (head q = x)
+Proof
   Cases THEN Cases_on `l` THEN EVAL_TAC THEN SRW_TAC [] []
-  THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL]);
+  THEN Cases_on `l0` THEN FULL_SIMP_TAC (srw_ss()) [REVERSE_DEF,LENGTH_NIL]
+QED
 
-val tail_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
+Triviality tail_thm:
+  !q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)
+Proof
   Cases THEN Cases_on `l`
   THEN FULL_SIMP_TAC (srw_ss()) [queue_inv_def,tail_def,check_def,checkw_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss())
@@ -109,6 +122,7 @@ val tail_thm = Q.prove(
   THEN1 (Cases_on `t'` THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,checkw_def,queue_inv_def]
     THEN FULL_SIMP_TAC std_ss [queue_inv_def]
     THEN REPEAT STRIP_TAC THEN FULL_SIMP_TAC (srw_ss())
-      [LENGTH_NIL,checkw_def,isPREFIX_REFL,isPREFIX_APPEND] THEN DECIDE_TAC));
+      [LENGTH_NIL,checkw_def,isPREFIX_REFL,isPREFIX_APPEND] THEN DECIDE_TAC)
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/RealTimeQueueScript.sml
+++ b/translator/okasaki-examples/RealTimeQueueScript.sml
@@ -63,51 +63,65 @@ Definition queue_inv_def:
   queue_inv q (QUEUE f r s) <=> prop 0 q (QUEUE f r s)
 End
 
-val empty_thm = Q.prove(
-  `!xs. queue_inv xs empty = (xs = [])`,
-  EVAL_TAC THEN SIMP_TAC std_ss []);
+Triviality empty_thm:
+  !xs. queue_inv xs empty = (xs = [])
+Proof
+  EVAL_TAC THEN SIMP_TAC std_ss []
+QED
 
-val is_empty_thm = Q.prove(
-  `!q xs. queue_inv xs q ==> (is_empty q = (xs = []))`,
+Triviality is_empty_thm:
+  !q xs. queue_inv xs q ==> (is_empty q = (xs = []))
+Proof
   Cases THEN Cases_on `l`
-  THEN SRW_TAC [] [LENGTH_NIL,queue_inv_def,is_empty_def,prop_def,LENGTH]);
+  THEN SRW_TAC [] [LENGTH_NIL,queue_inv_def,is_empty_def,prop_def,LENGTH]
+QED
 
-val rotate_thm = Q.prove(
-  `!f r s.
+Triviality rotate_thm:
+  !f r s.
       (LENGTH r = LENGTH f + 1) ==>
-      (rotate (QUEUE f r s) = f ++ REVERSE r ++ s)`,
+      (rotate (QUEUE f r s) = f ++ REVERSE r ++ s)
+Proof
   Induct
   THEN Cases_on `r` THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,rotate_def]
   THEN Cases_on `t` THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,rotate_def]
   THEN REPEAT STRIP_TAC
   THEN `LENGTH (h'::t') = LENGTH f + 1` by (EVAL_TAC THEN DECIDE_TAC)
-  THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,GSYM APPEND_ASSOC,APPEND]);
+  THEN FULL_SIMP_TAC std_ss [REVERSE_DEF,GSYM APPEND_ASSOC,APPEND]
+QED
 
-val exec_thm = Q.prove(
-  `prop 1 xs (QUEUE f r s) ==>
-    queue_inv xs (exec (QUEUE f r s))`,
+Triviality exec_thm:
+  prop 1 xs (QUEUE f r s) ==>
+    queue_inv xs (exec (QUEUE f r s))
+Proof
   Cases_on `s` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,exec_def,LET_DEF,prop_def,queue_inv_def]
-  THEN REPEAT STRIP_TAC THEN DECIDE_TAC);
+  THEN REPEAT STRIP_TAC THEN DECIDE_TAC
+QED
 
-val snoc_thm = Q.prove(
-  `!q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)`,
+Triviality snoc_thm:
+  !q xs x. queue_inv xs q ==> queue_inv (xs ++ [x]) (snoc q x)
+Proof
   Cases THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,snoc_def]
   THEN REPEAT STRIP_TAC THEN MATCH_MP_TAC exec_thm
-  THEN FULL_SIMP_TAC (srw_ss()) [prop_def] THEN DECIDE_TAC);
+  THEN FULL_SIMP_TAC (srw_ss()) [prop_def] THEN DECIDE_TAC
+QED
 
-val head_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> (head q = x)`,
+Triviality head_thm:
+  !q x xs. queue_inv (x::xs) q ==> (head q = x)
+Proof
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,head_def]
-  THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,REVERSE_DEF]);
+  THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,REVERSE_DEF]
+QED
 
-val tail_thm = Q.prove(
-  `!q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)`,
+Triviality tail_thm:
+  !q x xs. queue_inv (x::xs) q ==> queue_inv xs (tail q)
+Proof
   Cases THEN Cases_on `l` THEN FULL_SIMP_TAC (srw_ss())
     [rotate_thm,LET_DEF,prop_def,queue_inv_def,tail_def]
   THEN SRW_TAC [] [] THEN FULL_SIMP_TAC (srw_ss()) [LENGTH_NIL,REVERSE_DEF]
-  THEN MATCH_MP_TAC exec_thm THEN EVAL_TAC THEN DECIDE_TAC);
+  THEN MATCH_MP_TAC exec_thm THEN EVAL_TAC THEN DECIDE_TAC
+QED
 
 val _ = export_theory();

--- a/translator/okasaki-examples/RedBlackSetScript.sml
+++ b/translator/okasaki-examples/RedBlackSetScript.sml
@@ -187,36 +187,43 @@ val r = translate insert_def;
 
 (* Proof of functional correctness *)
 
-val balance'_correct = Q.prove (
-`!c a x b. balance' c a x b = balance c a x b`,
-recInduct balance_ind >>
+Triviality balance'_correct:
+  !c a x b. balance' c a x b = balance c a x b
+Proof
+  recInduct balance_ind >>
 rw [balance'_def, balance_def, balance_left_left_def, balance_left_right_def,
     balance_right_left_def, balance_right_right_def] >>
-REPEAT (BasicProvers.FULL_CASE_TAC));
+REPEAT (BasicProvers.FULL_CASE_TAC)
+QED
 
-val balance'_tree = Q.prove (
-`!c t1 x t2. ∃c' t1' x' t2'. (balance' c t1 x t2 = Tree c' t1' x' t2')`,
-recInduct balance_ind >>
+Triviality balance'_tree:
+  !c t1 x t2. ∃c' t1' x' t2'. (balance' c t1 x t2 = Tree c' t1' x' t2')
+Proof
+  recInduct balance_ind >>
 rw [balance'_def, balance_left_left_def, balance_left_right_def,
     balance_right_left_def, balance_right_right_def] >>
-REPEAT BasicProvers.FULL_CASE_TAC);
+REPEAT BasicProvers.FULL_CASE_TAC
+QED
 
-val balance'_set = Q.prove (
-`!c t1 x t2. tree_to_set (balance' c t1 x t2) = tree_to_set (Tree c t1 x t2)`,
-recInduct balance_ind >>
+Triviality balance'_set:
+  !c t1 x t2. tree_to_set (balance' c t1 x t2) = tree_to_set (Tree c t1 x t2)
+Proof
+  recInduct balance_ind >>
 srw_tac [PRED_SET_AC_ss]
         [balance'_def, balance_left_left_def, balance_left_right_def,
          balance_right_left_def, balance_right_right_def,
          tree_to_set_def] >>
 REPEAT BasicProvers.FULL_CASE_TAC >>
-srw_tac [PRED_SET_AC_ss] [tree_to_set_def]);
+srw_tac [PRED_SET_AC_ss] [tree_to_set_def]
+QED
 
-val balance'_bst = Q.prove (
-`!c t1 x t2.
+Triviality balance'_bst:
+  !c t1 x t2.
   transitive lt ∧ is_bst lt (Tree c t1 x t2)
   ⇒
-  is_bst lt (balance' c t1 x t2)`,
-recInduct balance_ind >>
+  is_bst lt (balance' c t1 x t2)
+Proof
+  recInduct balance_ind >>
 rw [transitive_def, balance'_def,  balance_left_left_def,
     balance_left_right_def, balance_right_left_def,
     balance_right_right_def, is_bst_def, tree_to_set_def] >>
@@ -227,36 +234,43 @@ REPEAT BasicProvers.FULL_CASE_TAC >>
 fs [transitive_def, balance'_def,  balance_left_left_def,
     balance_left_right_def, balance_right_left_def,
     balance_right_right_def, is_bst_def, tree_to_set_def] >>
-metis_tac []);
+metis_tac []
+QED
 
-val ins_tree = Q.prove (
-`!lt x t. ?c t1 y t2. (ins lt x t = Tree c t1 y t2)`,
-cases_on `t` >>
+Triviality ins_tree:
+  !lt x t. ?c t1 y t2. (ins lt x t = Tree c t1 y t2)
+Proof
+  cases_on `t` >>
 rw [ins_def] >>
-metis_tac [balance'_tree]);
+metis_tac [balance'_tree]
+QED
 
-val ins_set = Q.prove (
-`∀lt x t.
+Triviality ins_set:
+  ∀lt x t.
   StrongLinearOrder lt
   ⇒
-  (tree_to_set (ins lt x t) = {x} ∪ tree_to_set t)`,
-induct_on `t` >>
+  (tree_to_set (ins lt x t) = {x} ∪ tree_to_set t)
+Proof
+  induct_on `t` >>
 rw [tree_to_set_def, ins_def, balance'_set] >>
 fs [] >>
 srw_tac [PRED_SET_AC_ss] [] >>
 `x = a` by (fs [StrongLinearOrder, StrongOrder, irreflexive_def,
                 transitive_def, trichotomous] >>
             metis_tac []) >>
-rw []);
+rw []
+QED
 
-val ins_bst = Q.prove (
-`!lt x t. StrongLinearOrder lt ∧ is_bst lt t ⇒ is_bst lt (ins lt x t)`,
-induct_on `t` >>
+Triviality ins_bst:
+  !lt x t. StrongLinearOrder lt ∧ is_bst lt t ⇒ is_bst lt (ins lt x t)
+Proof
+  induct_on `t` >>
 rw [is_bst_def, ins_def, tree_to_set_def] >>
 match_mp_tac balance'_bst >>
 rw [is_bst_def] >>
 imp_res_tac ins_set >>
-fs [StrongLinearOrder, StrongOrder]);
+fs [StrongLinearOrder, StrongOrder]
+QED
 
 Theorem insert_set:
  ∀lt x t.
@@ -306,30 +320,35 @@ QED
  * and that the number of black nodes is the same on each path from
  * the root to the leaves. *)
 
-val case_opt_lem = Q.prove (
-`!x f z.
+Triviality case_opt_lem:
+  !x f z.
   ((case x of NONE => NONE | SOME y => f y) = SOME z) =
-  (?y. (x = SOME y) ∧ (f y = SOME z))`,
-cases_on `x` >>
-rw []);
+  (?y. (x = SOME y) ∧ (f y = SOME z))
+Proof
+  cases_on `x` >>
+rw []
+QED
 
-val balance_inv2_black = Q.prove (
-`!c t1 a t2 n.
+Triviality balance_inv2_black:
+  !c t1 a t2 n.
   (red_black_invariant2 t1 = SOME n) ∧
   (red_black_invariant2 t2 = SOME n) ∧
   (c = Black)
   ⇒
-  (red_black_invariant2 (balance c t1 a t2) = SOME (n+1))`,
-recInduct balance_ind >>
+  (red_black_invariant2 (balance c t1 a t2) = SOME (n+1))
+Proof
+  recInduct balance_ind >>
 rw [balance_def, red_black_invariant2_def, case_opt_lem] >>
-metis_tac []);
+metis_tac []
+QED
 
-val ins_inv2 = Q.prove (
-`!leq x t n.
+Triviality ins_inv2:
+  !leq x t n.
   (red_black_invariant2 t = SOME n)
   ⇒
-  (red_black_invariant2 (ins leq x t) = SOME n)`,
-induct_on `t` >>
+  (red_black_invariant2 (ins leq x t) = SOME n)
+Proof
+  induct_on `t` >>
 rw [red_black_invariant2_def, ins_def, case_opt_lem] >>
 every_case_tac >>
 cases_on `c` >>
@@ -338,7 +357,8 @@ rw [] >|
 [metis_tac [balance_inv2_black, balance'_correct],
  rw [balance'_def, red_black_invariant2_def, case_opt_lem],
  metis_tac [balance_inv2_black, balance'_correct],
- rw [balance'_def, red_black_invariant2_def, case_opt_lem]]);
+ rw [balance'_def, red_black_invariant2_def, case_opt_lem]]
+QED
 
 Theorem insert_invariant2:
  !leq x t n.
@@ -367,36 +387,42 @@ Definition rbinv1_root_def:
   red_black_invariant1 t1 ∧ red_black_invariant1 t2)
 End
 
-val balance_inv1_black = Q.prove (
-`!c t1 a t2 n.
+Triviality balance_inv1_black:
+  !c t1 a t2 n.
   red_black_invariant1 t1 ∧ rbinv1_root t2 ∧ (c = Black)
   ⇒
   red_black_invariant1 (balance c t1 a t2) ∧
-  red_black_invariant1 (balance c t2 a t1)`,
-recInduct balance_ind >>
-rw [balance_def, red_black_invariant1_def, rbinv1_root_def, not_red_def]);
+  red_black_invariant1 (balance c t2 a t1)
+Proof
+  recInduct balance_ind >>
+rw [balance_def, red_black_invariant1_def, rbinv1_root_def, not_red_def]
+QED
 
-val inv1_lemma = Q.prove (
-`!t. red_black_invariant1 t ⇒ rbinv1_root t`,
-cases_on `t` >>
+Triviality inv1_lemma:
+  !t. red_black_invariant1 t ⇒ rbinv1_root t
+Proof
+  cases_on `t` >>
 rw [red_black_invariant1_def, rbinv1_root_def] >>
 cases_on `c` >>
-fs [red_black_invariant1_def]);
+fs [red_black_invariant1_def]
+QED
 
-val ins_inv1 = Q.prove (
-`!leq x t.
+Triviality ins_inv1:
+  !leq x t.
   red_black_invariant1 t
   ⇒
   (not_red t ⇒ red_black_invariant1 (ins leq x t)) ∧
-  (¬not_red t ⇒ rbinv1_root (ins leq x t))`,
-induct_on `t` >>
+  (¬not_red t ⇒ rbinv1_root (ins leq x t))
+Proof
+  induct_on `t` >>
 rw [red_black_invariant1_def, rbinv1_root_def, ins_def, not_red_def] >>
 cases_on `c` >>
 fs [red_black_invariant1_def, not_red_def] >|
 [metis_tac [balance_inv1_black, balance'_correct, inv1_lemma],
  rw [balance'_def, rbinv1_root_def],
  metis_tac [balance_inv1_black, balance'_correct, inv1_lemma],
- rw [balance'_def, rbinv1_root_def]]);
+ rw [balance'_def, rbinv1_root_def]]
+QED
 
 Theorem insert_invariant1:
  !leq x t. red_black_invariant1 t ⇒ red_black_invariant1 (insert leq x t)
@@ -421,10 +447,12 @@ QED
 
 val insert_side_def = fetch "-" "insert_side_def"
 
-val insert_side = Q.prove (
-`∀leq x t. insert_side leq x t`,
-rw [insert_side_def] >>
+Triviality insert_side:
+  ∀leq x t. insert_side leq x t
+Proof
+  rw [insert_side_def] >>
 `?c t1 y t2. ins leq x t = Tree c t1 y t2` by metis_tac [ins_tree] >>
-rw []);
+rw []
+QED
 
 val _ = export_theory ();

--- a/translator/okasaki-examples/SplayHeapScript.sml
+++ b/translator/okasaki-examples/SplayHeapScript.sml
@@ -73,12 +73,13 @@ val r = translate partition_def;
 val partition_ind = fetch "-" "partition_ind"
 val heap_size_def = fetch "-" "heap_size_def"
 
-val partition_size = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_size:
+  !get_key leq p h1 h2 h3.
   ((h2,h3) = partition get_key leq p h1)
   ⇒
-  heap_size f h2 ≤ heap_size f h1 ∧ heap_size f h3 ≤ heap_size f h1`,
-recInduct partition_ind >>
+  heap_size f h2 ≤ heap_size f h1 ∧ heap_size f h3 ≤ heap_size f h1
+Proof
+  recInduct partition_ind >>
 rw [heap_size_def, partition_def] >>
 every_case_tac >>
 fs [] >>
@@ -87,7 +88,8 @@ cases_on `partition get_key leq pivot h0` >>
 cases_on `partition get_key leq pivot h` >>
 fs [LET_THM] >>
 rw [heap_size_def] >>
-decide_tac);
+decide_tac
+QED
 
 Definition insert_def:
 insert get_key leq x t =
@@ -134,12 +136,13 @@ val delete_min_ind = fetch "-" "delete_min_ind"
 
 (* Functional correctnes proof *)
 
-val partition_bags = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_bags:
+  !get_key leq p h1 h2 h3.
   ((h2,h3) = partition get_key leq p h1)
   ⇒
-  (heap_to_bag h1 = BAG_UNION (heap_to_bag h2) (heap_to_bag h3))`,
-recInduct partition_ind >>
+  (heap_to_bag h1 = BAG_UNION (heap_to_bag h2) (heap_to_bag h3))
+Proof
+  recInduct partition_ind >>
 rw [partition_def, heap_to_bag_def] >>
 every_case_tac >>
 fs [] >>
@@ -148,18 +151,20 @@ cases_on `partition get_key leq pivot h0` >>
 cases_on `partition get_key leq pivot h` >>
 fs [LET_THM] >>
 rw [heap_to_bag_def, BAG_UNION_INSERT] >>
-metis_tac [ASSOC_BAG_UNION, COMM_BAG_UNION, BAG_INSERT_commutes]);
+metis_tac [ASSOC_BAG_UNION, COMM_BAG_UNION, BAG_INSERT_commutes]
+QED
 
-val partition_split = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_split:
+  !get_key leq p h1 h2 h3.
   transitive leq ∧
   trichotomous leq ∧
   ((h2,h3) = partition get_key leq p h1) ∧
   is_heap_ordered get_key leq h1
   ⇒
   BAG_EVERY (\y. leq (get_key y) (get_key p)) (heap_to_bag h2) ∧
-  BAG_EVERY (\y. ¬leq (get_key y) (get_key p)) (heap_to_bag h3)`,
-recInduct partition_ind >>
+  BAG_EVERY (\y. ¬leq (get_key y) (get_key p)) (heap_to_bag h3)
+Proof
+  recInduct partition_ind >>
 rw [partition_def, heap_to_bag_def, is_heap_ordered_def] >>
 every_case_tac >>
 fs [] >>
@@ -170,29 +175,33 @@ cases_on `partition get_key leq pivot h` >>
 fs [LET_THM, heap_to_bag_def] >>
 rw [] >>
 fs [BAG_EVERY, transitive_def, trichotomous] >>
-metis_tac []);
+metis_tac []
+QED
 
-val partition_heap_ordered_lem = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_heap_ordered_lem:
+  !get_key leq p h1 h2 h3.
   (partition get_key leq p h1 = (h2, h3)) ⇒
   BAG_EVERY P (heap_to_bag h1) ⇒
-  BAG_EVERY P (heap_to_bag h2) ∧ BAG_EVERY P (heap_to_bag h3)`,
-rw [] >>
+  BAG_EVERY P (heap_to_bag h2) ∧ BAG_EVERY P (heap_to_bag h3)
+Proof
+  rw [] >>
 `heap_to_bag h1 =
  BAG_UNION (heap_to_bag h2) (heap_to_bag h3)`
           by metis_tac [partition_bags] >>
 rw [] >>
 fs [BAG_EVERY_UNION] >>
-rw []);
+rw []
+QED
 
-val partition_heap_ordered = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_heap_ordered:
+  !get_key leq p h1 h2 h3.
   WeakLinearOrder leq ∧
   ((h2,h3) = partition get_key leq p h1) ∧
   is_heap_ordered get_key leq h1
   ⇒
-  is_heap_ordered get_key leq h2 ∧ is_heap_ordered get_key leq h3`,
-recInduct partition_ind >>
+  is_heap_ordered get_key leq h2 ∧ is_heap_ordered get_key leq h3
+Proof
+  recInduct partition_ind >>
 RW_TAC pure_ss [] >-
 fs [partition_def, is_heap_ordered_def] >-
 fs [partition_def, is_heap_ordered_def] >>
@@ -214,7 +223,8 @@ metis_tac [partition_heap_ordered_lem] >-
 metis_tac [partition_heap_ordered_lem] >-
 metis_tac [partition_heap_ordered_lem] >-
 (fs [BAG_EVERY] >>
- metis_tac [transitive_def, WeakLinearOrder, WeakOrder]));
+ metis_tac [transitive_def, WeakLinearOrder, WeakOrder])
+QED
 
 Theorem insert_bag:
  !h get_key leq x.
@@ -333,14 +343,18 @@ QED
 val delete_min_side_def = fetch "-" "delete_min_side_def"
 val find_min_side_def = fetch "-" "find_min_side_def"
 
-val delete_min_side = Q.prove (
-`!h. delete_min_side h = (h ≠ Empty)`,
-recInduct delete_min_ind THEN REPEAT STRIP_TAC
-THEN ONCE_REWRITE_TAC [delete_min_side_def] THEN SRW_TAC [] []);
+Triviality delete_min_side:
+  !h. delete_min_side h = (h ≠ Empty)
+Proof
+  recInduct delete_min_ind THEN REPEAT STRIP_TAC
+THEN ONCE_REWRITE_TAC [delete_min_side_def] THEN SRW_TAC [] []
+QED
 
-val find_min_side = Q.prove (
-`!h. find_min_side h = (h ≠ Empty)`,
-recInduct find_min_ind THEN REPEAT STRIP_TAC
-THEN ONCE_REWRITE_TAC [find_min_side_def] THEN SRW_TAC [] []);
+Triviality find_min_side:
+  !h. find_min_side h = (h ≠ Empty)
+Proof
+  recInduct find_min_ind THEN REPEAT STRIP_TAC
+THEN ONCE_REWRITE_TAC [find_min_side_def] THEN SRW_TAC [] []
+QED
 
 val _ = export_theory()

--- a/translator/okasaki-examples/benchmarkScript.sml
+++ b/translator/okasaki-examples/benchmarkScript.sml
@@ -139,12 +139,13 @@ val r = translate partition_def;
 val partition_ind = fetch "-" "partition_ind"
 val heap_size_def = fetch "-" "heap_size_def"
 
-val partition_size = Q.prove (
-`!get_key leq p h1 h2 h3.
+Triviality partition_size:
+  !get_key leq p h1 h2 h3.
   ((h2,h3) = partition get_key leq p h1)
   ⇒
-  heap_size f h2 ≤ heap_size f h1 ∧ heap_size f h3 ≤ heap_size f h1`,
-recInduct partition_ind >>
+  heap_size f h2 ≤ heap_size f h1 ∧ heap_size f h3 ≤ heap_size f h1
+Proof
+  recInduct partition_ind >>
 rw [heap_size_def, partition_def] >>
 every_case_tac >>
 fs [] >>
@@ -153,7 +154,8 @@ cases_on `partition get_key leq pivot h0` >>
 cases_on `partition get_key leq pivot h` >>
 fs [LET_THM] >>
 rw [heap_size_def] >>
-decide_tac);
+decide_tac
+QED
 
 Definition insert_def:
 insert get_key leq x t =

--- a/translator/okasaki-examples/okasaki_miscScript.sml
+++ b/translator/okasaki-examples/okasaki_miscScript.sml
@@ -74,26 +74,32 @@ Induct_on `l1` >>
 srw_tac [BAG_ss] [list_to_bag_def, BAG_INSERT_UNION]
 QED
 
-val list_to_bag_to_perm = Q.prove (
-`!l1 l2. PERM l1 l2 ⇒ (list_to_bag l1 = list_to_bag l2)`,
-HO_MATCH_MP_TAC PERM_IND >>
-srw_tac [BAG_ss] [list_to_bag_def, BAG_INSERT_UNION]);
+Triviality list_to_bag_to_perm:
+  !l1 l2. PERM l1 l2 ⇒ (list_to_bag l1 = list_to_bag l2)
+Proof
+  HO_MATCH_MP_TAC PERM_IND >>
+srw_tac [BAG_ss] [list_to_bag_def, BAG_INSERT_UNION]
+QED
 
-val perm_to_list_to_bag_lem = Q.prove (
-`!l1 l2 x.
+Triviality perm_to_list_to_bag_lem:
+  !l1 l2 x.
   (list_to_bag (FILTER ($= x) l1) = list_to_bag (FILTER ($= x) l2))
   ⇒
-  (FILTER ($= x) l1 = FILTER ($= x) l2)`,
-induct_on `l1` >>
+  (FILTER ($= x) l1 = FILTER ($= x) l2)
+Proof
+  induct_on `l1` >>
 rw [] >>
 induct_on `l2` >>
 rw [] >>
-fs [list_to_bag_def]);
+fs [list_to_bag_def]
+QED
 
-val perm_to_list_to_bag = Q.prove (
-`!l1 l2. (list_to_bag l1 = list_to_bag l2) ⇒ PERM l1 l2`,
-rw [PERM_DEF] >>
-metis_tac [perm_to_list_to_bag_lem, list_to_bag_filter]);
+Triviality perm_to_list_to_bag:
+  !l1 l2. (list_to_bag l1 = list_to_bag l2) ⇒ PERM l1 l2
+Proof
+  rw [PERM_DEF] >>
+metis_tac [perm_to_list_to_bag_lem, list_to_bag_filter]
+QED
 
 Theorem list_to_bag_perm:
  !l1 l2. (list_to_bag l1 = list_to_bag l2) = PERM l1 l2
@@ -101,15 +107,17 @@ Proof
 metis_tac [perm_to_list_to_bag, list_to_bag_to_perm]
 QED
 
-val sorted_reverse_lem = Q.prove (
-`!R l. transitive R ∧ SORTED R l ⇒ SORTED (\x y. R y x) (REVERSE l)`,
-induct_on `l` >>
+Triviality sorted_reverse_lem:
+  !R l. transitive R ∧ SORTED R l ⇒ SORTED (\x y. R y x) (REVERSE l)
+Proof
+  induct_on `l` >>
 rw [SORTED_DEF] >>
 qmatch_goalsub_abbrev_tac ‘SORTED RR’ >>
 ‘transitive RR’ by (fs [transitive_def] >> metis_tac []) >>
 unabbrev_all_tac >>
 rw [SORTED_DEF,SORTED_APPEND] >>
-metis_tac [SORTED_EQ]);
+metis_tac [SORTED_EQ]
+QED
 
 Theorem sorted_reverse:
  !R l. transitive R ⇒ (SORTED R (REVERSE l) = SORTED (\x y. R y x) l)

--- a/translator/other-examples/auxiliary/ninetyOneScript.sml
+++ b/translator/other-examples/auxiliary/ninetyOneScript.sml
@@ -28,26 +28,30 @@ val [E] = map DISCH_ALL (Defn.eqns_of N_aux_defn);
       works when the termination relation has not yet been supplied.
  ---------------------------------------------------------------------------*)
 
-val Npartly_correct = Q.prove
-(`WF R /\
+Triviality Npartly_correct:
+  WF R /\
   (!x. ~(x > 100) ==> R (N_aux R (x + 11)) x) /\
   (!x. ~(x > 100) ==> R (x + 11) x)
     ==>
-  !n. N(n) = if n>100 then n-10 else 91`,
- STRIP_TAC THEN recInduct Nind
+  !n. N(n) = if n>100 then n-10 else 91
+Proof
+  STRIP_TAC THEN recInduct Nind
    THEN RW_TAC arith_ss []
    THEN ONCE_REWRITE_TAC [Neqn]
-   THEN RW_TAC arith_ss []);
+   THEN RW_TAC arith_ss []
+QED
 
-val N_aux_partial_correctness = Q.prove
-(`WF R /\
+Triviality N_aux_partial_correctness:
+  WF R /\
   (!x. ~(x > 100) ==> R (N_aux R (x + 11)) x) /\
   (!x. ~(x > 100) ==> R (x + 11) x)
     ==>
-  !n. N_aux R n = if n>100 then n-10 else 91`,
- STRIP_TAC THEN recInduct N_aux_ind
+  !n. N_aux R n = if n>100 then n-10 else 91
+Proof
+  STRIP_TAC THEN recInduct N_aux_ind
    THEN RW_TAC arith_ss []
-   THEN RW_TAC arith_ss [E]);
+   THEN RW_TAC arith_ss [E]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Termination of 91 is a bit tricky.                                        *)
@@ -55,9 +59,11 @@ val N_aux_partial_correctness = Q.prove
 
 val lem = DECIDE ``~(x > 100) ==> (101-y < 101-x = x<y)``;
 
-val unexpand_measure = Q.prove
-(`(\x' x''. 101 < x' + (101 - x'') /\ x'' < 101) = measure \x. 101-x`,
- RW_TAC arith_ss [FUN_EQ_THM, measure_thm]);
+Triviality unexpand_measure:
+  (\x' x''. 101 < x' + (101 - x'') /\ x'' < 101) = measure \x. 101-x
+Proof
+  RW_TAC arith_ss [FUN_EQ_THM, measure_thm]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Get the auxiliary rec. eqns, instantiate with termination relation, and   *)

--- a/translator/other-examples/auxiliary/regexpMatchScript.sml
+++ b/translator/other-examples/auxiliary/regexpMatchScript.sml
@@ -53,9 +53,11 @@ fun RENAME_FREES_TAC [] = ALL_TAC
 (* Miscellaneous lemma; should already exist in HOL                          *)
 (*---------------------------------------------------------------------------*)
 
-val MEM_EXISTS_LEM = Q.prove
-(`!x l. MEM x l = EXISTS (\y. y = x) l`,
- Induct_on `l` THEN EVAL_TAC THEN METIS_TAC []);
+Triviality MEM_EXISTS_LEM:
+  !x l. MEM x l = EXISTS (\y. y = x) l
+Proof
+  Induct_on `l` THEN EVAL_TAC THEN METIS_TAC []
+QED
 
 val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
 
@@ -105,30 +107,38 @@ End
 (* Some basic equivalences for regular expressions.                          *)
 (*---------------------------------------------------------------------------*)
 
-val regexp_repeat_thm = Q.prove
-(`!r w.sem (Repeat r) w = sem (Epsilon + (r # (Repeat r))) w`,
- RW_TAC std_ss [] THEN EQ_TAC THEN RW_TAC list_ss [sem_def, FLAT]
+Triviality regexp_repeat_thm:
+  !r w.sem (Repeat r) w = sem (Epsilon + (r # (Repeat r))) w
+Proof
+  RW_TAC std_ss [] THEN EQ_TAC THEN RW_TAC list_ss [sem_def, FLAT]
  THENL [Cases_on `wlist` THEN RW_TAC list_ss [FLAT], ALL_TAC, ALL_TAC]
- THEN METIS_TAC [FLAT,EVERY_DEF]);
+ THEN METIS_TAC [FLAT,EVERY_DEF]
+QED
 
-val repeat_to_ncat_thm = Q.prove
-(`!r w.sem (Repeat r) w ==> ?n. sem (FUNPOW ($# r) n Epsilon) w`,
- RW_TAC list_ss [sem_def, FLAT, FUNPOW_SUC]
+Triviality repeat_to_ncat_thm:
+  !r w.sem (Repeat r) w ==> ?n. sem (FUNPOW ($# r) n Epsilon) w
+Proof
+  RW_TAC list_ss [sem_def, FLAT, FUNPOW_SUC]
    THEN Q.EXISTS_TAC `LENGTH wlist`
    THEN Induct_on `wlist`
    THEN RW_TAC list_ss [sem_def, FLAT, FUNPOW_SUC]
-   THEN EVAL_TAC THEN METIS_TAC []);
+   THEN EVAL_TAC THEN METIS_TAC []
+QED
 
-val ncat_to_repeat_thm = Q.prove
-(`!r w n. sem (FUNPOW ($# r) n Epsilon) w ==> sem (Repeat r) w`,
- Induct_on `n` THENL [ALL_TAC, POP_ASSUM MP_TAC] THEN EVAL_TAC
+Triviality ncat_to_repeat_thm:
+  !r w n. sem (FUNPOW ($# r) n Epsilon) w ==> sem (Repeat r) w
+Proof
+  Induct_on `n` THENL [ALL_TAC, POP_ASSUM MP_TAC] THEN EVAL_TAC
    THEN RW_TAC list_ss [sem_def,FUNPOW_SUC] THENL
    [METIS_TAC [FLAT, EVERY_DEF],
-    RES_TAC THEN Q.EXISTS_TAC `w1::wlist` THEN METIS_TAC [EVERY_DEF,FLAT]]);
+    RES_TAC THEN Q.EXISTS_TAC `w1::wlist` THEN METIS_TAC [EVERY_DEF,FLAT]]
+QED
 
-val repeat_equals_ncat_thm = Q.prove
-(`!r w. sem (Repeat r) w = ?n. sem (FUNPOW ($# r) n Epsilon) w`,
- METIS_TAC [ncat_to_repeat_thm, repeat_to_ncat_thm]);
+Triviality repeat_equals_ncat_thm:
+  !r w. sem (Repeat r) w = ?n. sem (FUNPOW ($# r) n Epsilon) w
+Proof
+  METIS_TAC [ncat_to_repeat_thm, repeat_to_ncat_thm]
+QED
 
 
 (* ------------------------------------------------------------------------- *)
@@ -218,9 +228,10 @@ val _ = save_thm ("match_ind", match_ind);
 (* Match implies the semantics                                               *)
 (*---------------------------------------------------------------------------*)
 
-val match_implies_sem = Q.prove
-(`!rl w s. match rl w s ==> sem (FOLDR $# Epsilon rl) w`,
- recInduct match_ind THEN RW_TAC list_ss [match_def, sem_def] THENL
+Triviality match_implies_sem:
+  !rl w s. match rl w s ==> sem (FOLDR $# Epsilon rl) w
+Proof
+  recInduct match_ind THEN RW_TAC list_ss [match_def, sem_def] THENL
  [METIS_TAC [APPEND],
   METIS_TAC [],
   METIS_TAC [],
@@ -230,7 +241,8 @@ val match_implies_sem = Q.prove
   FULL_SIMP_TAC list_ss []
     THEN MAP_EVERY Q.EXISTS_TAC [`w1 ++ FLAT wlist`, `w2'`]
     THEN RW_TAC list_ss []
-    THEN METIS_TAC [FLAT,EVERY_DEF]]);
+    THEN METIS_TAC [FLAT,EVERY_DEF]]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Semantics imply match                                                     *)
@@ -265,8 +277,8 @@ End
 val m_ind  = fetch "-" "m_ind";
 val ms_ind = fetch "-" "match_seq_ind";
 
-val m_ind_thm = Q.prove
-(`!P:'a regexp list # 'a list # 'a regexp list option ->
+Triviality m_ind_thm:
+  !P:'a regexp list # 'a list # 'a regexp list option ->
      'a regexp list # 'a list # 'a regexp list option -> bool.
   (!t w s x. P (Epsilon::t,w,s) x) /\
   (!c t d w s x. P (Charset c::t,d::w,s) x) /\
@@ -275,8 +287,10 @@ val m_ind_thm = Q.prove
   (!r t w s x. P (Repeat r::t,w,s) x) /\
   (!c t s x. P (Charset c::t,[],s) x) /\
   (!w s. P ([],w) s) ==>
-  !v v1 v2 v3 v4 v5. P (v,v1,v2) (v3,v4,v5)`,
- METIS_TAC [ABS_PAIR_THM,m_ind]);
+  !v v1 v2 v3 v4 v5. P (v,v1,v2) (v3,v4,v5)
+Proof
+  METIS_TAC [ABS_PAIR_THM,m_ind]
+QED
 
 val m_thm = SIMP_RULE list_ss [] (Q.prove
 (`!rl w s rl' w' s' r l.
@@ -286,23 +300,27 @@ val m_thm = SIMP_RULE list_ss [] (Q.prove
       ((rl = Repeat r::l) /\ (w = w'))`,
  recInduct m_ind_thm THEN RW_TAC list_ss [m_def]));
 
-val m_thm2 = Q.prove
-(`!rl w s rl' w' s'. ~(w = w') ==> m (rl, w, s) (rl',w',s') ==> (s' = NONE)`,
- recInduct m_ind_thm THEN RW_TAC list_ss [m_def]);
+Triviality m_thm2:
+  !rl w s rl' w' s'. ~(w = w') ==> m (rl, w, s) (rl',w',s') ==> (s' = NONE)
+Proof
+  recInduct m_ind_thm THEN RW_TAC list_ss [m_def]
+QED
 
-val cases_lemma = Q.prove
-(`!a: 'a regexp list # 'a list # 'a regexp list option.
+Triviality cases_lemma:
+  !a: 'a regexp list # 'a list # 'a regexp list option.
      (?x. a = ([],[],x)) \/ (?h t x. a = ([],h::t,x)) \/
      (?t w s. a = (Epsilon::t,w,s)) \/
      (?c t w s. a = (Charset c::t,[],s)) \/
      (?c d t w s. a = (Charset c::t,d::w,s)) \/
      (?r1 r2 t w s. a = ((r1+r2)::t,w,s)) \/
      (?r1 r2 t w s. a = ((r1#r2)::t,w,s)) \/
-     (?r t w s. a = (Repeat r::t,w,s))`,
- METIS_TAC [list_CASES,ABS_PAIR_THM,regexp_cases]);
+     (?r t w s. a = (Repeat r::t,w,s))
+Proof
+  METIS_TAC [list_CASES,ABS_PAIR_THM,regexp_cases]
+QED
 
-val ms_ind_thm = Q.prove
-(`!P:('a regexp list # 'a list # 'a regexp list option) list -> bool.
+Triviality ms_ind_thm:
+  !P:('a regexp list # 'a list # 'a regexp list option) list -> bool.
     P [] /\
     (!x. P [([],[],x)]) /\
     (!r t w s. P [(Repeat r::t,w,s)]) /\
@@ -326,15 +344,19 @@ val ms_ind_thm = Q.prove
     (!c w s h1 t1. P (([],c::w,s)::h1::t1)) /\
     (!s h1 t1. P (([],[],s)::h1::t1))
    ==>
-       !v. P v`,
- GEN_TAC THEN STRIP_TAC THEN MATCH_MP_TAC ms_ind THEN
- METIS_TAC [ABS_PAIR_THM, cases_lemma]);
+       !v. P v
+Proof
+  GEN_TAC THEN STRIP_TAC THEN MATCH_MP_TAC ms_ind THEN
+ METIS_TAC [ABS_PAIR_THM, cases_lemma]
+QED
 
-val match_seq_down_closed = Q.prove
-(`!L1 L2. match_seq (L1 ++ L2) ==> match_seq L2`,
- Induct THEN RW_TAC list_ss [match_seq_def]
+Triviality match_seq_down_closed:
+  !L1 L2. match_seq (L1 ++ L2) ==> match_seq L2
+Proof
+  Induct THEN RW_TAC list_ss [match_seq_def]
    THEN Cases_on `L1++L2`
-   THEN FULL_SIMP_TAC list_ss [match_seq_def]);
+   THEN FULL_SIMP_TAC list_ss [match_seq_def]
+QED
 
 
 (*---------------------------------------------------------------------------*)
@@ -362,22 +384,28 @@ End
 val csp_def = change_stop_on_prefix_def;
 val csp_ind = fetch "-" "change_stop_on_prefix_ind";
 
-val csp_step_lem = Q.prove
-(`!alist stop rl w s x.
+Triviality csp_step_lem:
+  !alist stop rl w s x.
     (alist = ((rl,w,s)::x)) ==>
-    ?t. change_stop_on_prefix alist stop = (rl,w,stop)::t`,
- recInduct csp_ind THEN RW_TAC list_ss [csp_def]);
+    ?t. change_stop_on_prefix alist stop = (rl,w,stop)::t
+Proof
+  recInduct csp_ind THEN RW_TAC list_ss [csp_def]
+QED
 
 val csp_step = SIMP_RULE list_ss [] csp_step_lem;
 
-val change_stop_on_prefix_thm = Q.prove
-(`!L stop. match_seq L ==> match_seq (change_stop_on_prefix L stop)`,
- recInduct ms_ind_thm THEN RW_TAC list_ss [match_seq_def,m_def,csp_def] THEN
- METIS_TAC [match_seq_def, m_def, csp_step]);
+Triviality change_stop_on_prefix_thm:
+  !L stop. match_seq L ==> match_seq (change_stop_on_prefix L stop)
+Proof
+  recInduct ms_ind_thm THEN RW_TAC list_ss [match_seq_def,m_def,csp_def] THEN
+ METIS_TAC [match_seq_def, m_def, csp_step]
+QED
 
-val LENGTH_CSP = Q.prove
-(`!l s. LENGTH (change_stop_on_prefix l s) = LENGTH l`,
- recInduct csp_ind THEN RW_TAC list_ss [csp_def]);
+Triviality LENGTH_CSP:
+  !l s. LENGTH (change_stop_on_prefix l s) = LENGTH l
+Proof
+  recInduct csp_ind THEN RW_TAC list_ss [csp_def]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* If match sequences m1 and m2 represent matching rl1 against w1 and rl2    *)
@@ -398,25 +426,30 @@ Definition compose_m_seq_def:
        x1 ++ TL x2)
 End
 
-val compose_m_seq_null = Q.prove
-(`(!x. compose_m_seq [] x = x) /\ (!x. compose_m_seq x [] = x)`,
- CONJ_TAC THEN Cases THEN RW_TAC list_ss [compose_m_seq_def] THEN
- Q.ID_SPEC_TAC `h` THEN SIMP_TAC list_ss [FORALL_PROD,compose_m_seq_def]);
+Triviality compose_m_seq_null:
+  (!x. compose_m_seq [] x = x) /\ (!x. compose_m_seq x [] = x)
+Proof
+  CONJ_TAC THEN Cases THEN RW_TAC list_ss [compose_m_seq_def] THEN
+ Q.ID_SPEC_TAC `h` THEN SIMP_TAC list_ss [FORALL_PROD,compose_m_seq_def]
+QED
 
-val lem = Q.prove
-(`!mseq r w s r1 w1 s1 s2 x.
+Triviality lem:
+  !mseq r w s r1 w1 s1 s2 x.
      (mseq = ((r1,w1,s1)::x)) ==>
       match_seq mseq ==>
       m (r,w,s) (r1,w1, s2) ==>
-      match_seq ((r,w,s)::change_stop_on_prefix ((r1,w1,s1)::x) s2)`,
- recInduct ms_ind_thm
+      match_seq ((r,w,s)::change_stop_on_prefix ((r1,w1,s1)::x) s2)
+Proof
+  recInduct ms_ind_thm
   THEN NTAC 2 (RW_TAC list_ss
          [csp_step, change_stop_on_prefix_def, match_seq_def, m_def])
-  THEN METIS_TAC [CONS_ACYCLIC,list_CASES, CONS_11]);
+  THEN METIS_TAC [CONS_ACYCLIC,list_CASES, CONS_11]
+QED
 
-val compose_m_seq_thm = Q.prove
-(`!x1 x2. match_seq x1 ==> match_seq x2 ==> match_seq (compose_m_seq x1 x2)`,
- REPEAT STRIP_TAC
+Triviality compose_m_seq_thm:
+  !x1 x2. match_seq x1 ==> match_seq x2 ==> match_seq (compose_m_seq x1 x2)
+Proof
+  REPEAT STRIP_TAC
    THEN Induct_on `x1`
    THEN RW_TAC list_ss []
    THEN `(?rl w s. h = (rl,w,s)) /\
@@ -443,19 +476,22 @@ val compose_m_seq_thm = Q.prove
              (?r. h = Repeat r)` by METIS_TAC [regexp_cases]
        THEN NTAC 2 (RW_TAC list_ss [] THEN
                     FULL_SIMP_TAC list_ss [LET_THM, m_def, match_seq_def,
-                                           compose_m_seq_def])]);
+                                           compose_m_seq_def])]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Match sequence suffixes can be swapped out.                               *)
 (*---------------------------------------------------------------------------*)
 
-val match_seq_lemma = Q.prove
-(`!a x y z. match_seq (x++[a]++z) /\ match_seq ([a]++y)
-            ==> match_seq (x++[a]++y)`,
- Induct_on `x`
+Triviality match_seq_lemma:
+  !a x y z. match_seq (x++[a]++z) /\ match_seq ([a]++y)
+            ==> match_seq (x++[a]++y)
+Proof
+  Induct_on `x`
    THEN RW_TAC list_ss []
    THEN Cases_on `x`
-   THEN METIS_TAC [APPEND, match_seq_def]);
+   THEN METIS_TAC [APPEND, match_seq_def]
+QED
 
 
 (*---------------------------------------------------------------------------*)
@@ -463,16 +499,19 @@ val match_seq_lemma = Q.prove
 (* starts with ([r], w, NONE).                                               *)
 (*---------------------------------------------------------------------------*)
 
-val lem = Q.prove
-(`!(r: 'a regexp list) (w:'a list) s r' w' s' x x'.
+Triviality lem:
+  !(r: 'a regexp list) (w:'a list) s r' w' s' x x'.
   ?t. compose_m_seq ((r, w, s)::x) ((r', w', s')::x')
         =
-      (r++r', w++w', OPTION_MAP (\e.e++r') s)::t`,
- RW_TAC list_ss [compose_m_seq_def, LET_THM]);
+      (r++r', w++w', OPTION_MAP (\e.e++r') s)::t
+Proof
+  RW_TAC list_ss [compose_m_seq_def, LET_THM]
+QED
 
-val sem_implies_match_seq_exists = Q.prove
-(`!r w. sem r w ==> ?x. match_seq (([r], w, NONE)::x)`,
- Induct THENL
+Triviality sem_implies_match_seq_exists:
+  !r w. sem r w ==> ?x. match_seq (([r], w, NONE)::x)
+Proof
+  Induct THENL
  [RW_TAC list_ss [sem_def]
     THEN Q.EXISTS_TAC `[([],[],NONE)]`
     THEN RW_TAC list_ss [match_seq_def, m_def],
@@ -509,7 +548,8 @@ val sem_implies_match_seq_exists = Q.prove
                (Q.SPECL [`SOME[Repeat r]`, `[r]++[Repeat r]`,
                          `w1++w2`, `NONE`, `t`] csp_step)
        THEN FULL_SIMP_TAC list_ss [match_seq_def]
-       THEN METIS_TAC [m_def, compose_m_seq_thm, change_stop_on_prefix_thm]]]);
+       THEN METIS_TAC [m_def, compose_m_seq_thm, change_stop_on_prefix_thm]]]
+QED
 
 
 (*---------------------------------------------------------------------------*)
@@ -548,70 +588,85 @@ Definition split_def:
                                 else split P t (acc++[h]))
 End
 
-val split_thm = Q.prove
-(`!P l acc l1 v l2.
-     (split P l acc = (SOME (l1, v, l2))) ==> (l1 ++ [v] ++ l2 = acc ++ l)`,
- Induct_on `l`
+Triviality split_thm:
+  !P l acc l1 v l2.
+     (split P l acc = (SOME (l1, v, l2))) ==> (l1 ++ [v] ++ l2 = acc ++ l)
+Proof
+  Induct_on `l`
    THEN RW_TAC list_ss [split_def]
-   THEN METIS_TAC [APPEND, APPEND_ASSOC]);
+   THEN METIS_TAC [APPEND, APPEND_ASSOC]
+QED
 
-val split_thm2 = Q.prove
-(`!P l acc l1 v l2.
-     (split P l acc = (SOME (l1, v, l2))) ==> ?l3. (l1 = acc++l3)`,
- Induct_on `l`
+Triviality split_thm2:
+  !P l acc l1 v l2.
+     (split P l acc = (SOME (l1, v, l2))) ==> ?l3. (l1 = acc++l3)
+Proof
+  Induct_on `l`
    THEN RW_TAC list_ss [split_def] THENL
    [Q.EXISTS_TAC `[]` THEN RW_TAC list_ss [],
-    RES_TAC THEN Q.EXISTS_TAC `[h]++l3` THEN RW_TAC list_ss []]);
+    RES_TAC THEN Q.EXISTS_TAC `[h]++l3` THEN RW_TAC list_ss []]
+QED
 
-val split_thm3 = Q.prove
-(`!P l acc l1 v l2 l3.
+Triviality split_thm3:
+  !P l acc l1 v l2 l3.
     (split P l (l3 ++ acc) = SOME (l3++l1, v, l2))
        =
-    (split P l acc = (SOME (l1, v, l2)))`,
- Induct_on `l`
+    (split P l acc = (SOME (l1, v, l2)))
+Proof
+  Induct_on `l`
     THEN RW_TAC list_ss [split_def]
-    THEN METIS_TAC [APPEND_ASSOC]);
+    THEN METIS_TAC [APPEND_ASSOC]
+QED
 
-val split_thm4 = Q.prove
-(`!P l acc. (split P l acc = NONE) ==> ~EXISTS P l`,
- Induct_on `l`
+Triviality split_thm4:
+  !P l acc. (split P l acc = NONE) ==> ~EXISTS P l
+Proof
+  Induct_on `l`
    THEN RW_TAC list_ss [split_def]
    THEN FULL_SIMP_TAC list_ss []
-   THEN METIS_TAC []);
+   THEN METIS_TAC []
+QED
 
-val split_thm5 = Q.prove
-(`!P l acc acc2. (split P l acc = NONE) ==> (split P l acc2 = NONE)`,
- Induct_on `l`
+Triviality split_thm5:
+  !P l acc acc2. (split P l acc = NONE) ==> (split P l acc2 = NONE)
+Proof
+  Induct_on `l`
    THEN RW_TAC list_ss [split_def]
-   THEN METIS_TAC [split_def]);
+   THEN METIS_TAC [split_def]
+QED
 
-val split_prop_thm = Q.prove
-(`!L P a b c acc. (split P L acc = SOME(a,b,c)) ==> P b`,
- Induct
+Triviality split_prop_thm:
+  !L P a b c acc. (split P L acc = SOME(a,b,c)) ==> P b
+Proof
+  Induct
    THEN RW_TAC list_ss [split_def]
-   THEN METIS_TAC []);
+   THEN METIS_TAC []
+QED
 
-val split_cong_thm = Q.prove
-(`!l P acc P' l' acc'.
+Triviality split_cong_thm:
+  !l P acc P' l' acc'.
      (l=l') /\ (!x. MEM x l ==> (P x = P' x)) /\ (acc=acc')
-       ==> (split P l acc = split P' l' acc')`,
- Induct_on `l`
+       ==> (split P l acc = split P' l' acc')
+Proof
+  Induct_on `l`
    THEN RW_TAC list_ss [split_def]
-   THEN FULL_SIMP_TAC list_ss [split_def]);
+   THEN FULL_SIMP_TAC list_ss [split_def]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* If a cycle exists in a match sequence, then the part of the sequence      *)
 (* before the cycle contains the Repeat expressions that lead to the cycle.  *)
 (*---------------------------------------------------------------------------*)
 
-val match_seq_find_lemma = Q.prove
-(`!ms l1 r l w z.
+Triviality match_seq_find_lemma:
+  !ms l1 r l w z.
   match_seq ms
    ==> (split (\x. ?r l w. x = (Repeat r::l, w, SOME (Repeat r::l))) ms [] =
         SOME (l1,(Repeat r::l,w,SOME(Repeat r::l)), z))
    ==> (~((SND(SND(HD ms))) = SOME (Repeat r::l)) \/ ~((FST(SND(HD ms))) = w))
-   ==> ?s. MEM (Repeat r::l, w, s) l1`,
- Induct
+   ==> ?s. MEM (Repeat r::l, w, s) l1
+Proof
+  Induct
     THEN FULL_SIMP_TAC list_ss [split_def, match_seq_def, m_def]
     THEN REPEAT GEN_TAC
     THEN `(l1 = []) \/ ?h1 t1. l1 = h1::t1` by METIS_TAC [list_CASES]
@@ -643,7 +698,8 @@ val match_seq_find_lemma = Q.prove
           FULL_SIMP_TAC list_ss [] THEN RW_TAC list_ss []
             THEN `?a1 b1 c1. h = (a1,b1,c1)` by METIS_TAC [ABS_PAIR_THM]
             THEN RW_TAC list_ss [] THEN FULL_SIMP_TAC list_ss [match_seq_def]
-            THEN METIS_TAC [m_thm,m_thm2,NOT_SOME_NONE]]));
+            THEN METIS_TAC [m_thm,m_thm2,NOT_SOME_NONE]])
+QED
 
 
 (*---------------------------------------------------------------------------*)
@@ -683,8 +739,8 @@ val NS_IND = fetch "-" "NS_ind";
 (* One step of NS preserves match sequences                                  *)
 (*---------------------------------------------------------------------------*)
 
-val match_seq_surg_thm = Q.prove
-(`!ms l1 bad_r bad_w z x1 rl w1 s1 y.
+Triviality match_seq_surg_thm:
+  !ms l1 bad_r bad_w z x1 rl w1 s1 y.
         match_seq ms ==>
         (split (\x. ?r l w. x = (Repeat r::l, w, SOME (Repeat r::l))) ms [] =
          SOME (l1, (bad_r, bad_w, bad_s), z)) ==>
@@ -693,8 +749,9 @@ val match_seq_surg_thm = Q.prove
         if (?ra L. (rl = Repeat ra::L) /\ (FST(HD z) = L)) then
           match_seq (x1 ++ [(rl, w1, s1)] ++ change_stop_on_prefix z s1)
         else
-          match_seq (x1 ++ [(rl, w1, s1)] ++ z)`,
- Induct THENL
+          match_seq (x1 ++ [(rl, w1, s1)] ++ z)
+Proof
+  Induct THENL
  [RW_TAC list_ss []
     THEN IMP_RES_TAC split_thm
     THEN FULL_SIMP_TAC list_ss [],
@@ -742,11 +799,13 @@ val match_seq_surg_thm = Q.prove
                            match_seq_def]
         THEN `?r l. bad_r = Repeat r::l` by (IMP_RES_TAC split_prop_thm \\ fs[])
         THEN POP_ASSUM MP_TAC THEN EVAL_TAC THEN RW_TAC list_ss []
-        \\ fs[m_def]]]]);
+        \\ fs[m_def]]]]
+QED
 
-val NS_match_thm = Q.prove
-(`!ms. match_seq ms ==> match_seq (NS ms)`,
- recInduct NS_IND THEN RW_TAC list_ss []
+Triviality NS_match_thm:
+  !ms. match_seq ms ==> match_seq (NS ms)
+Proof
+  recInduct NS_IND THEN RW_TAC list_ss []
    THEN ONCE_REWRITE_TAC [NS_def] THEN CASE_TAC THENL
    [METIS_TAC [],
     REPEAT CASE_TAC
@@ -762,11 +821,13 @@ val NS_match_thm = Q.prove
      THEN RW_TAC list_ss [match_seq_def]
      THEN IMP_RES_TAC match_seq_surg_thm
      THEN FULL_SIMP_TAC list_ss []
-     THEN RW_TAC list_ss [] THEN METIS_TAC []]);
+     THEN RW_TAC list_ss [] THEN METIS_TAC []]
+QED
 
-val NS_is_normal_thm = Q.prove
-(`!ms r w t. ~MEM (Repeat r::t, w, SOME (Repeat r::t)) (NS ms)`,
- recInduct NS_IND THEN RW_TAC list_ss []
+Triviality NS_is_normal_thm:
+  !ms r w t. ~MEM (Repeat r::t, w, SOME (Repeat r::t)) (NS ms)
+Proof
+  recInduct NS_IND THEN RW_TAC list_ss []
    THEN ONCE_REWRITE_TAC [NS_def]
    THEN CASE_TAC THENL
    [IMP_RES_TAC split_thm4
@@ -787,21 +848,25 @@ val NS_is_normal_thm = Q.prove
       THEN FULL_SIMP_TAC list_ss []
       THEN RW_TAC list_ss []
       THEN FULL_SIMP_TAC list_ss []
-      THEN METIS_TAC []]);
+      THEN METIS_TAC []]
+QED
 
-val lem = Q.prove
-(`EXISTS (\y. y = (a,b,c)) L ==> EXISTS (\y. ?c. y = (a,b,c)) L`,
-Induct_on `L` THEN EVAL_TAC THEN RW_TAC list_ss [] THEN METIS_TAC[]);
+Triviality lem:
+  EXISTS (\y. y = (a,b,c)) L ==> EXISTS (\y. ?c. y = (a,b,c)) L
+Proof
+  Induct_on `L` THEN EVAL_TAC THEN RW_TAC list_ss [] THEN METIS_TAC[]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* Normalizing a match sequence doesn't change the first element             *)
 (*---------------------------------------------------------------------------*)
 
-val  NS_HD_THM = Q.prove
-(`!t t' r w. (t = (r,w,NONE)::t') ==>
+Triviality NS_HD_THM:
+  !t t' r w. (t = (r,w,NONE)::t') ==>
               match_seq t ==>
-             ?t''. (NS t = (r, w, NONE)::t'')`,
- recInduct NS_IND THEN RW_TAC list_ss []
+             ?t''. (NS t = (r, w, NONE)::t'')
+Proof
+  recInduct NS_IND THEN RW_TAC list_ss []
    THEN ONCE_REWRITE_TAC [NS_def]
    THEN REPEAT CASE_TAC
    THEN REPEAT (POP_ASSUM MP_TAC)
@@ -822,16 +887,19 @@ val  NS_HD_THM = Q.prove
      THEN `h = (r,w,NONE)` by (IMP_RES_TAC split_thm THEN FULL_SIMP_TAC list_ss [])
      THEN IMP_RES_TAC match_seq_surg_thm
      THEN Cases_on `a1` THEN RW_TAC list_ss [match_seq_def]
-     THEN IMP_RES_TAC split_thm THEN FULL_SIMP_TAC list_ss []]);
+     THEN IMP_RES_TAC split_thm THEN FULL_SIMP_TAC list_ss []]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* The semantics imply match.                                                *)
 (*---------------------------------------------------------------------------*)
 
-val sem_implies_match = Q.prove
-(`!r w. sem r w ==> match [r] w NONE`,
- METIS_TAC [sem_implies_match_seq_exists, NS_match_thm,
-            NS_is_normal_thm, NS_HD_THM, witness_implies_match_thm]);
+Triviality sem_implies_match:
+  !r w. sem r w ==> match [r] w NONE
+Proof
+  METIS_TAC [sem_implies_match_seq_exists, NS_match_thm,
+            NS_is_normal_thm, NS_HD_THM, witness_implies_match_thm]
+QED
 
 (*---------------------------------------------------------------------------*)
 (* match correctly implements the semantics.                                 *)

--- a/translator/other-examples/example_copying_gcScript.sml
+++ b/translator/other-examples/example_copying_gcScript.sml
@@ -12,16 +12,18 @@ val res = translate rel_move_def;
 val res = translate rel_move_list_def;
 val res = translate rel_gc_step_def;
 
-val rel_gc_loop_thm = Q.prove(
-  `rel_gc_loop z y =
+Triviality rel_gc_loop_thm:
+  rel_gc_loop z y =
      case y of (i,j,m,b,e,b2,e2) =>
        if i = j then (i,m)
        else if ¬(i < j ∧ j ≤ e) then (i,m)
        else
          let (i,j,m) = rel_gc_step z (i,j,m,b,e,b2,e2) in
          let (i,m) = rel_gc_loop z (i,j,m,b,e,b2,e2) in
-           (i,m)`,
-  PairCases_on `y` \\ fs [Once rel_gc_loop_def]);
+           (i,m)
+Proof
+  PairCases_on `y` \\ fs [Once rel_gc_loop_def]
+QED
 
 val res = translate rel_gc_loop_thm;
 val res = translate RANGE_def;

--- a/translator/other-examples/example_primality_testScript.sml
+++ b/translator/other-examples/example_primality_testScript.sml
@@ -27,18 +27,22 @@ val _ = translation_extends "ListProg";
 
 val res = translate EVEN_MOD2;
 
-val UNIT_thm = Q.prove(
-  `UNIT x s = (x,s)`,
-  FULL_SIMP_TAC std_ss [state_transformerTheory.UNIT_DEF]);
+Triviality UNIT_thm:
+  UNIT x s = (x,s)
+Proof
+  FULL_SIMP_TAC std_ss [state_transformerTheory.UNIT_DEF]
+QED
 
 val _ = translate UNIT_thm;
 
 val def = find_def ``BIND``;
 val _ = translate (SIMP_RULE std_ss [FUN_EQ_THM] def);
 
-val lemma = Q.prove(
-  `prob_while_cut c b n = \x. prob_while_cut c b n x`,
-  SIMP_TAC std_ss [FUN_EQ_THM]);
+Triviality lemma:
+  prob_while_cut c b n = \x. prob_while_cut c b n x
+Proof
+  SIMP_TAC std_ss [FUN_EQ_THM]
+QED
 
 val def = find_def ``prob_while_cut``
           |> ONCE_REWRITE_RULE [lemma] |> SIMP_RULE std_ss []

--- a/translator/std_preludeScript.sml
+++ b/translator/std_preludeScript.sml
@@ -66,9 +66,10 @@ val res = translate (DECIDE ``PRE n = n-1``);
 
 (* while, owhile and least *)
 
-val IS_SOME_OWHILE_THM = Q.prove(
-  `!g f x. (IS_SOME (OWHILE g f x)) =
-            ?n. ~ g (FUNPOW f n x) /\ !m. m < n ==> g (FUNPOW f m x)`,
+Triviality IS_SOME_OWHILE_THM:
+  !g f x. (IS_SOME (OWHILE g f x)) =
+            ?n. ~ g (FUNPOW f n x) /\ !m. m < n ==> g (FUNPOW f m x)
+Proof
   REPEAT STRIP_TAC THEN Cases_on `OWHILE g f x`
   THEN FULL_SIMP_TAC (srw_ss()) [OWHILE_EQ_NONE]
   THEN FULL_SIMP_TAC std_ss [OWHILE_def]
@@ -76,7 +77,8 @@ val IS_SOME_OWHILE_THM = Q.prove(
   THEN (Q.INST [`P`|->`\n. ~g (FUNPOW f n x)`] FULL_LEAST_INTRO
       |> SIMP_RULE std_ss [] |> IMP_RES_TAC)
   THEN ASM_SIMP_TAC std_ss [] THEN REPEAT STRIP_TAC
-  THEN IMP_RES_TAC LESS_LEAST THEN FULL_SIMP_TAC std_ss []);
+  THEN IMP_RES_TAC LESS_LEAST THEN FULL_SIMP_TAC std_ss []
+QED
 
 Theorem WHILE_ind:
    !P. (!p g x. (p x ==> P p g (g x)) ==> P p g x) ==>
@@ -106,15 +108,19 @@ Proof
 SIMP_TAC std_ss [FUN_EQ_THM,ADD1]
 QED
 
-val LEAST_LEMMA = Q.prove(
-  `$LEAST P = WHILE (\x. ~(P x)) (\x. x + 1) 0`,
-  SIMP_TAC std_ss [LEAST_DEF,o_DEF,SUC_LEMMA]);
+Triviality LEAST_LEMMA:
+  $LEAST P = WHILE (\x. ~(P x)) (\x. x + 1) 0
+Proof
+  SIMP_TAC std_ss [LEAST_DEF,o_DEF,SUC_LEMMA]
+QED
 
 val res = translate LEAST_LEMMA;
 
-val FUNPOW_LEMMA = Q.prove(
-  `!n m. FUNPOW (\x. x + 1) n m = n + m`,
-  Induct THEN FULL_SIMP_TAC std_ss [FUNPOW,ADD1,AC ADD_COMM ADD_ASSOC]);
+Triviality FUNPOW_LEMMA:
+  !n m. FUNPOW (\x. x + 1) n m = n + m
+Proof
+  Induct THEN FULL_SIMP_TAC std_ss [FUNPOW,ADD1,AC ADD_COMM ADD_ASSOC]
+QED
 
 val least_side_thm = Q.prove(
   `!s. least_side s = ~(s = {})`,


### PR DESCRIPTION
Note we only remove instances where foo contains the result of Q.prove, not a modified version through use of |>.

```py
import os
import re
import sys

def match_comment_parens(s, start_idx):
    if s[start_idx:start_idx + 2] == '(*':
        paren_count = 0
        comment_content = ""
        for i, char in enumerate(s[start_idx:], start=start_idx):
            if char == '(' and s[i + 1] == '*':
                paren_count += 1
            elif char == '*' and i + 1 < len(s) and s[i + 1] == ')':
                paren_count -= 1
                comment_content += char
                if paren_count == 0:
                    comment_content += ")"
                    i += 1
                    while i + 1 < len(s) and s[i + 1].isspace():
                        i += 1
                        comment_content += s[i]
                    return comment_content, i + 1
            comment_content += char
        return None
    return "", start_idx

def transform_definition(s):
    done_before = 0

    pattern = re.compile(r"\nval[ \t]+([a-zA-Z0-9][a-zA-Z0-9_']*)\s*=\s*Q.prove\s*")

    match = pattern.search(s, done_before)

    while match:
        re_start, re_end = match.span()

        comment_parens, comment_end = match_comment_parens(s, re_end)

        if s[comment_end] == '(':
            paren_count = 0
            paren_content = ""
            for i, char in enumerate(s[comment_end:]):
                if char == '(':
                    paren_count += 1
                elif char == ')':
                    paren_count -= 1
                paren_content += char
                if paren_count == 0:
                    break
            paren_length = len(paren_content)
            paren_content = paren_content[1:paren_length-1]

            match2 = re.search(r"\s*(?:`|‘)([^`’]*?)(?:`|’)\s*,(.*)", paren_content, re.DOTALL)

            if match2:
                if comment_parens == "":
                    replacement = f"\nTriviality {match.group(1)}:\n  {match2.group(1).strip()}\nProof\n  {match2.group(2).strip()}\nQED"
                else:
                    replacement = f"\n{comment_parens}Triviality {match.group(1)}:\n  {match2.group(1).strip()}\nProof\n  {match2.group(2).strip()}\nQED"
                if comment_end + paren_length < len(s) and s[comment_end + paren_length] == ';':
                    s = s[:re_start] + replacement + s[comment_end+paren_length+1:]
                elif comment_end + paren_length + 1< len(s) and s[(comment_end + paren_length):(comment_end + paren_length+2)] == "\n\n":
                    s = s[:re_start] + replacement + s[comment_end+paren_length:]
                else:
                    done_before = comment_end + paren_length
            else:
                done_before = comment_end
        else:
            done_before = comment_end

        match = pattern.search(s, done_before)

    return s

def process_sml_file(filepath):
    with open(filepath, 'r') as file:
        content = file.read()

    transformed_content = transform_definition(content)

    with open(filepath, 'w') as file:
        file.write(transformed_content)

def find_and_transform_sml_files(directory):
    for root, _, files in os.walk(directory):
        for file in files:
            if (file.endswith("Script.sml")):
                    filepath = os.path.join(root, file)
                    print(f"Processing file: {filepath}")
                    process_sml_file(filepath)

if __name__ == "__main__":
    if len(sys.argv) != 2:
        print("Usage: python script.py <directory>")
        sys.exit(1)

    directory_to_search = sys.argv[1]

    if not os.path.isdir(directory_to_search):
        print(f"Error: {directory_to_search} is not a valid directory.")
        sys.exit(1)

    find_and_transform_sml_files(directory_to_search)
```