### PR TITLE
Increase Infixl in npbcScript

### DIFF
--- a/examples/pseudo_bool/npbcScript.sml
+++ b/examples/pseudo_bool/npbcScript.sml
@@ -1049,7 +1049,7 @@ Overload "⇂" = “λf w. IMAGE (subst w) f”
 
 val _ = set_fixity "redundant_wrt" (Infixl 500);
 val _ = set_fixity "⊨" (Infixl 500);
-val _ = set_fixity "⇂" (Infixl 501);
+val _ = set_fixity "⇂" (Infixl 502);
 
 Definition redundant_wrt_def:
   c redundant_wrt f ⇔ (satisfiable f ⇔ satisfiable (f ∪ {c}))


### PR DESCRIPTION
Hopefully fixes
`GrammarError "Attempt to have differently associated infixes (LEFT and RIGHT) at same level(501)"`.