### PR TITLE
Fix link to binary in developers/bin/Holmakefile

### DIFF
--- a/developers/bin/Holmakefile
+++ b/developers/bin/Holmakefile
@@ -15,7 +15,7 @@ all: cake-$(ARCH)-$(WORD_SIZE).tar.gz cake.S cake
 
 #was: http://www.cse.chalmers.se/~myreen/cake-$(ARCH)-$(WORD_SIZE).tar.gz
 cake-$(ARCH)-$(WORD_SIZE).tar.gz:
-	curl -O https://people.mpi-sws.org/~hbecker/files/cake-$(ARCH)-$(WORD_SIZE).tar.gz
+	curl -O https://github.com/CakeML/cakeml/releases/latest/download/cake-$(ARCH)-$(WORD_SIZE).tar.gz
 
 cake.S: cake-$(ARCH)-$(WORD_SIZE).tar.gz
 	tar -xvzf cake-$(ARCH)-$(WORD_SIZE).tar.gz --strip-components 1

--- a/developers/bin/Holmakefile
+++ b/developers/bin/Holmakefile
@@ -15,7 +15,7 @@ all: cake-$(ARCH)-$(WORD_SIZE).tar.gz cake.S cake
 
 #was: http://www.cse.chalmers.se/~myreen/cake-$(ARCH)-$(WORD_SIZE).tar.gz
 cake-$(ARCH)-$(WORD_SIZE).tar.gz:
-	curl -O https://github.com/CakeML/cakeml/releases/latest/download/cake-$(ARCH)-$(WORD_SIZE).tar.gz
+	curl -LO https://github.com/CakeML/cakeml/releases/latest/download/cake-$(ARCH)-$(WORD_SIZE).tar.gz
 
 cake.S: cake-$(ARCH)-$(WORD_SIZE).tar.gz
 	tar -xvzf cake-$(ARCH)-$(WORD_SIZE).tar.gz --strip-components 1


### PR DESCRIPTION
Seems like the [previous link](https://people.mpi-sws.org/~hbecker/files/cake-x64-64.tar.gz) is dead, leading to the regression suite failing with:
```
Starting work on cake-x64-64.tar.gz
README.md                                                           (0s)     OK
cake-x64-64.tar.gz                                                  (0s)     OK
Starting work on cake.S
cake.S                                                              (0s)FAIL<2>
 
 gzip: stdin: not in gzip format
 tar: Child returned status 1
 tar: Error is not recoverable: exiting now
 ```