### PR TITLE
Fix Pancake static checker warnings causing non-zero exit code during compilation 

### DIFF
--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -313,7 +313,7 @@ Definition error_to_str_def:
   (error_to_str (StaticError e) =
     case e of
       ScopeErr   s => concat [strlit "### ERROR: scope error\n";  s; strlit "\n"]
-    | WarningErr s => concat [strlit "### WARNING:\n";            s; strlit "\n"]
+    | WarningErr s => concat [strlit "# WARNING:\n";              s; strlit "\n"]
     | GenErr     s => concat [strlit "### ERROR: static error\n"; s; strlit "\n"]
     | ShapeErr   s => concat [strlit "### ERROR: shape error\n";  s; strlit "\n"])
 End


### PR DESCRIPTION
The current mechanism for determining the exit code at the end of compilation checks if the `stderr` output starts with `###`, which is printed at the beginning of error messages. Warnings, as generated by the static checker, mistakenly used this prefix, causing otherwise successful compilation to be treated as failure in eg. build scripts. This PR simply removes this prefix match.