### PR TITLE
pancake/crep_arith: simplify constant multiplies

### DIFF
--- a/pancake/crep_arithScript.sml
+++ b/pancake/crep_arithScript.sml
@@ -64,6 +64,7 @@ Definition simp_exp_def:
     case (op, exps) of
     | (Mul, [exp1; exp2]) => (
         case (dest_const exp1, dest_const exp2) of
+        | (SOME c, SOME c2) => Const (c * c2)
         | (SOME c, _) => mul_const exp2 c
         | (_, SOME c) => mul_const exp1 c
         | _ => Crepop op exps

--- a/pancake/proofs/crep_arithProofScript.sml
+++ b/pancake/proofs/crep_arithProofScript.sml
@@ -70,7 +70,7 @@ Proof
     \\ gvs [DISJ_IMP_THM, FORALL_AND_THM, OPT_MMAP_MAP_o, combinTheory.o_DEF]
     \\ every_case_tac \\ fs []
     \\ imp_res_tac dest_const_thm
-    \\ irule EQ_TRANS \\ irule_at Any eval_mul_const
+    \\ TRY (irule EQ_TRANS \\ irule_at Any eval_mul_const)
     \\ Cases_on `op` \\ fs [crep_op_def, eval_def]
   )
 QED


### PR DESCRIPTION
For silly reasons, the multiplication simp step in crep_arith fails to simplify multiplications like 3 * 8, since 3 is the first constant considered, and it is not a power of two. Oops. This is easily fixed, and should avoid expensive multiply ops being produced by the backend.