### PR TITLE
Simplify Pancake parse tree conversion for progs

### DIFF
--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -420,6 +420,21 @@ val error_line_ex2 =
 
 val error_line_ex2_parse = check_failure $ parse_pancake error_line_ex2
 
+val error_line_ex3 =
+‘
+  fun foo() {
+    skip;
+    while (1) {
+      skip;
+      skip;
+      skeep;
+      skip;
+    }
+  }
+’
+
+val error_line_ex3_parse = check_failure $ parse_pancake error_line_ex3
+
 (** Function pointers
 
     & can only be used to get the address of functions.
@@ -478,7 +493,17 @@ val empty_blocks =
   fun j() { if(1) { x = 5; } else { } }
   ’
 
-val empty_body_parse = check_success $ parse_pancake empty_blocks;
+val empty_blocks_parse = check_success $ parse_pancake empty_blocks;
+
+(* Dec blocks with no subsequent prog *)
+val empty_dec_prog =
+ ‘
+  fun f() { var x = 0; }
+
+  fun g() { var 1 x = f(); }
+  ’
+
+val empty_dec_prog_parse = check_success $ parse_pancake empty_dec_prog;
 
 (* Using the annotation comment syntax. *)
 val annot_fun =

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -125,6 +125,15 @@ Definition try_default_def:
   try_default s t = choicel [s; empty $ mkleaf (t, unknown_loc)]
 End
 
+(* add single Skip in place of empty Prog - will generate unnecessary Skips if used without caution *)
+Definition try_ProgNT_def:
+  try_ProgNT =
+    choicel [
+      seql [consume_tok RCurT; empty $ mkleaf (KeywordT SkipK, unknown_loc)] (mksubtree ProgNT);
+      mknt ProgNT
+    ]
+End
+
 Definition pancake_peg_def[nocompute]:
   pancake_peg = <|
     start := mknt FunListNT;
@@ -146,7 +155,7 @@ Definition pancake_peg_def[nocompute]:
                           ];
                           consume_tok RParT;
                           consume_tok LCurT;
-                          mknt ProgNT]
+                          try_ProgNT]
                           (mksubtree FunNT));
         (INL ParamListNT, seql [mknt ShapeNT; keep_ident;
                                 rpt (seql [consume_tok CommaT;
@@ -155,8 +164,8 @@ Definition pancake_peg_def[nocompute]:
                                            FLAT]
                                (mksubtree ParamListNT));
         (INL ProgNT, choicel [seql [mknt BlockNT; mknt ProgNT] (mksubtree ProgNT);
-                              seql [mknt DecCallNT; mknt ProgNT] (mksubtree DecCallNT);
-                              seql [mknt DecNT; mknt ProgNT] (mksubtree DecNT);
+                              seql [mknt DecCallNT; try_ProgNT] (mksubtree DecCallNT);
+                              seql [mknt DecNT; try_ProgNT] (mksubtree DecNT);
                               seql [keep_annot; mknt ProgNT] (mksubtree ProgNT);
                               seql [mknt StmtNT; consume_tok SemiT; mknt ProgNT] (mksubtree ProgNT);
                               consume_tok RCurT
@@ -178,7 +187,7 @@ Definition pancake_peg_def[nocompute]:
                               mknt ExtCallNT;
                               mknt RaiseNT; mknt RetCallNT; mknt ReturnNT;
                               keep_kw TicK;
-                              seql [consume_tok LCurT; mknt ProgNT] I
+                              seql [consume_tok LCurT; try_ProgNT] I
                               ]);
         (INL DecCallNT, seql [consume_kw VarK; mknt ShapeNT; keep_ident; consume_tok AssignT;
                               choicel [seql [consume_tok StarT; mknt ExpNT] I;
@@ -202,12 +211,12 @@ Definition pancake_peg_def[nocompute]:
                                 consume_tok CommaT; mknt ExpNT]
                                (mksubtree Store32NT));
         (INL IfNT, seql [consume_kw IfK; mknt ExpNT; consume_tok LCurT;
-                         mknt ProgNT;
-                         try (seql [keep_kw ElseK; consume_tok LCurT;
-                                    mknt ProgNT] I)]
+                         try_ProgNT;
+                         try_default (seql [consume_kw ElseK; consume_tok LCurT;
+                                    try_ProgNT] I) (KeywordT SkipK)]
                         (mksubtree IfNT));
         (INL WhileNT, seql [consume_kw WhileK; mknt ExpNT;
-                            consume_tok LCurT; mknt ProgNT] (mksubtree WhileNT));
+                            consume_tok LCurT; try_ProgNT] (mksubtree WhileNT));
         (INL CallNT, seql [try (choicel [keep_kw RetK; mknt RetNT]);
                            choicel [seql [consume_tok StarT; mknt ExpNT] I;
                                     mknt FLabelNT];
@@ -219,7 +228,7 @@ Definition pancake_peg_def[nocompute]:
                           (mksubtree RetNT));
         (INL HandleNT, seql [consume_kw WithK; keep_ident;
                              consume_kw InK; keep_ident;
-                             consume_tok DArrowT; consume_tok LCurT; mknt ProgNT;
+                             consume_tok DArrowT; consume_tok LCurT; try_ProgNT;
                              consume_kw HandleK]
                             (mksubtree HandleNT));
         (INL ExtCallNT, seql [keep_ffi_ident;
@@ -715,7 +724,7 @@ Proof
        choicel_def, seql_def, pegf_def, keep_tok_def, consume_tok_def,
        keep_kw_def, consume_kw_def, keep_int_def, keep_nat_def,
        keep_ident_def, keep_annot_def, keep_ffi_ident_def, try_def,
-       try_default_def] >>
+       try_default_def, try_ProgNT_def] >>
   simp(pancake_wfpeg_thm :: wfpeg_rwts @ peg0_rwts @ npeg0_rwts)
 QED
 

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -572,53 +572,17 @@ Definition conv_Prog_def:
        | _ => NONE
      else if isNT nodeNT IfNT then
        case args of
-         [e] =>
-           do e' <- conv_Exp e;
-              SOME (add_locs_annot nd (If e' Skip Skip))
-           od
-       | [e; p] =>
-           (if tokcheck p (kw ElseK) then
-              do e' <- conv_Exp e;
-                 SOME (add_locs_annot nd (If e' Skip Skip))
-              od
-            else
-              do e' <- conv_Exp e;
-                 p' <- conv_Prog p;
-                 SOME (add_locs_annot nd (If e' p' Skip))
-              od
-            )
-       | [e; p1; p2] =>
-           (if tokcheck p1 (kw ElseK) then
-              do e' <- conv_Exp e;
-                 p2' <- conv_Prog p2;
-                 SOME (add_locs_annot nd (If e' Skip p2'))
-              od
-            else if tokcheck p2 (kw ElseK) then
-              do e' <- conv_Exp e;
-                 p1' <- conv_Prog p1;
-                 SOME (add_locs_annot nd (If e' p1' Skip))
-              od
-            else
-              do e' <- conv_Exp e;
-                 p1' <- conv_Prog p1;
-                 p2' <- conv_Prog p2;
-                 SOME (add_locs_annot nd (If e' p1' p2'))
-              od)
-       | [e; p1; _; p2] =>
-              do e' <- conv_Exp e;
-                 p1' <- conv_Prog p1;
-                 p2' <- conv_Prog p2;
-                 SOME (add_locs_annot nd (If e' p1' p2'))
-              od
+       | [e; p1; p2] => do e' <- conv_Exp e;
+                           p1' <- conv_Prog p1;
+                           p2' <- conv_Prog p2;
+                           SOME (add_locs_annot nd (If e' p1' p2'))
+                        od
        | _ => NONE
      else if isNT nodeNT WhileNT then
        case args of
          [e; p] => do e' <- conv_Exp e;
                       p' <- conv_Prog p;
                       SOME (add_locs_annot nd (While e' p'))
-                   od
-       | [e] => do e' <- conv_Exp e;
-                      SOME (add_locs_annot nd (While e' Skip))
                    od
        | _ => NONE
      else if isNT nodeNT DecCallNT then
@@ -627,10 +591,6 @@ Definition conv_Prog_def:
            do (s',i',e',args') <- conv_DecCall dec;
                p' <- conv_Prog p;
                SOME $ add_locs_annot nd $ DecCall i' s' e' args' p'
-           od
-       | [dec] =>
-           do (s',i',e',args') <- conv_DecCall dec;
-               SOME $ add_locs_annot nd $ DecCall i' s' e' args' Skip
            od
        | _ => NONE
      else if isNT nodeNT CallNT then
@@ -716,15 +676,6 @@ End
 Definition conv_Fun_def:
   conv_Fun tree =
   case argsNT tree FunNT of
-    SOME [e;n;ps] =>
-      (case (argsNT ps ParamListNT) of
-         SOME args =>
-           (do ps'  <- conv_params args;
-               n'   <- conv_ident n;
-               e'   <- conv_expos e;
-               SOME (n', e', ps', Skip)
-            od)
-       | _ => NONE)
   | SOME [e;n;ps;c] =>
       (case (argsNT ps ParamListNT) of
          SOME args =>


### PR DESCRIPTION
* Currently, when a ProgNT not found for function bodies, variable declarations, handler bodies, conditional branches and loops, a `Skip` is inserted during parse tree conversion, which requires considering the length of the parse tree
* Now, the `Skip` is inserted at the parsing stage which means only one length of parse tree needs to be considered during conversion