### PR TITLE
Shape checking for Pancake

### DIFF
--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -33,10 +33,15 @@ val res = translate $ errorLogMonadTheory.bind_def;
 val res = translate $ errorLogMonadTheory.log_def;
 val res = translate $ errorLogMonadTheory.error_def;
 
+val res = translate $ panStaticTheory.sh_bd_from_sh_def;
+val res = translate $ panStaticTheory.sh_bd_from_bd_def;
+val res = translate $ panStaticTheory.sh_bd_has_shape_def;
+val res = translate $ panStaticTheory.sh_bd_eq_shapes_def;
+val res = translate $ panStaticTheory.index_sh_bd_def;
 val res = translate $ panStaticTheory.based_merge_def;
-val res = translate $ panStaticTheory.based_cmp_def;
-val res = translate $ panStaticTheory.branch_vbases_def;
-val res = translate $ panStaticTheory.seq_vbases_def;
+val res = translate $ panStaticTheory.sh_bd_branch_def;
+val res = translate $ panStaticTheory.branch_loc_inf_def;
+val res = translate $ panStaticTheory.seq_loc_inf_def;
 
 val res = translate $ panStaticTheory.last_to_str_def;
 val res = translate $ panStaticTheory.next_is_reachable_def;
@@ -52,21 +57,25 @@ val res = translate $ panStaticTheory.get_memop_msg_def;
 val res = translate $ panStaticTheory.get_oparg_msg_def;
 val res = translate $ panStaticTheory.get_unreach_msg_def;
 val res = translate $ panStaticTheory.get_rogue_msg_def;
+val res = translate $ panStaticTheory.get_non_word_msg_def;
+val res = translate $ panStaticTheory.get_shape_mismatch_msg_def;
 
 val res = translate $ panStaticTheory.first_repeat_def;
 val res = translate $ panStaticTheory.binop_to_str_def;
 val res = translate $ panStaticTheory.panop_to_str_def;
 
+val res = translate $ panStaticTheory.scope_check_fun_name_def;
 val res = translate $ panStaticTheory.scope_check_global_var_def;
 val res = translate $ panStaticTheory.scope_check_local_var_def;
-val res = translate $ panStaticTheory.scope_check_var_def;
-val res = translate $ panStaticTheory.scope_check_fun_name_def;
+val res = translate $ panStaticTheory.check_redec_var_def;
+val res = translate $ panStaticTheory.check_export_params_def;
+val res = translate $ panStaticTheory.check_operands_def;
+val res = translate $ panStaticTheory.check_func_args_def;
 
 val res = translate $ spec32 $ panStaticTheory.static_check_exp_def;
-val res = translate $ panStaticTheory.check_redec_var_def;
 val res = translate $ spec32 $ panStaticTheory.static_check_prog_def;
-val res = translate $ spec32 $ panStaticTheory.static_check_funs_def;
-val res = translate $ spec32 $ panStaticTheory.static_check_globals_def;
+val res = translate $ spec32 $ panStaticTheory.static_check_progs_def;
+val res = translate $ spec32 $ panStaticTheory.static_check_decls_def;
 val res = translate $ spec32 $ panStaticTheory.static_check_def;
 
 Definition max_heap_limit_32_def:

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -80,6 +80,10 @@ val res = translate $ spec64 $ panStaticTheory.static_check_progs_def;
 val res = translate $ spec64 $ panStaticTheory.static_check_decls_def;
 val res = translate $ spec64 $ panStaticTheory.static_check_def;
 
+val _ = res |> hyp |> null orelse
+        failwith ("Unproved side condition in the translation of " ^
+                  "panStaticTheory.static_check_def.");
+
 Definition max_heap_limit_64_def:
                                   max_heap_limit_64 c =
 ^(spec64 data_to_wordTheory.max_heap_limit_def

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -35,10 +35,15 @@ val res = translate $ errorLogMonadTheory.bind_def;
 val res = translate $ errorLogMonadTheory.log_def;
 val res = translate $ errorLogMonadTheory.error_def;
 
+val res = translate $ panStaticTheory.sh_bd_from_sh_def;
+val res = translate $ panStaticTheory.sh_bd_from_bd_def;
+val res = translate $ panStaticTheory.sh_bd_has_shape_def;
+val res = translate $ panStaticTheory.sh_bd_eq_shapes_def;
+val res = translate $ panStaticTheory.index_sh_bd_def;
 val res = translate $ panStaticTheory.based_merge_def;
-val res = translate $ panStaticTheory.based_cmp_def;
-val res = translate $ panStaticTheory.branch_vbases_def;
-val res = translate $ panStaticTheory.seq_vbases_def;
+val res = translate $ panStaticTheory.sh_bd_branch_def;
+val res = translate $ panStaticTheory.branch_loc_inf_def;
+val res = translate $ panStaticTheory.seq_loc_inf_def;
 
 val res = translate $ panStaticTheory.last_to_str_def;
 val res = translate $ panStaticTheory.next_is_reachable_def;
@@ -54,21 +59,25 @@ val res = translate $ panStaticTheory.get_memop_msg_def;
 val res = translate $ panStaticTheory.get_oparg_msg_def;
 val res = translate $ panStaticTheory.get_unreach_msg_def;
 val res = translate $ panStaticTheory.get_rogue_msg_def;
+val res = translate $ panStaticTheory.get_non_word_msg_def;
+val res = translate $ panStaticTheory.get_shape_mismatch_msg_def;
 
 val res = translate $ panStaticTheory.first_repeat_def;
 val res = translate $ panStaticTheory.binop_to_str_def;
 val res = translate $ panStaticTheory.panop_to_str_def;
 
+val res = translate $ panStaticTheory.scope_check_fun_name_def;
 val res = translate $ panStaticTheory.scope_check_global_var_def;
 val res = translate $ panStaticTheory.scope_check_local_var_def;
-val res = translate $ panStaticTheory.scope_check_var_def;
-val res = translate $ panStaticTheory.scope_check_fun_name_def;
+val res = translate $ panStaticTheory.check_redec_var_def;
+val res = translate $ panStaticTheory.check_export_params_def;
+val res = translate $ panStaticTheory.check_operands_def;
+val res = translate $ panStaticTheory.check_func_args_def;
 
 val res = translate $ spec64 $ panStaticTheory.static_check_exp_def;
-val res = translate $ panStaticTheory.check_redec_var_def;
 val res = translate $ spec64 $ panStaticTheory.static_check_prog_def;
-val res = translate $ spec64 $ panStaticTheory.static_check_funs_def;
-val res = translate $ spec64 $ panStaticTheory.static_check_globals_def;
+val res = translate $ spec64 $ panStaticTheory.static_check_progs_def;
+val res = translate $ spec64 $ panStaticTheory.static_check_decls_def;
 val res = translate $ spec64 $ panStaticTheory.static_check_def;
 
 Definition max_heap_limit_64_def:

--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -414,20 +414,25 @@ val res = translate $ conv_shift_def;
 
 Overload ptree_size[local] = ``parsetree_size (K 0) (K 0) (K 0)``;
 
+val res = translate $ conv_default_shape_def;
+
 Definition conv_ShapeList_def:
   (conv_Shape_alt tree =
-   case conv_int tree of
-     NONE =>
-       (case argsNT tree ShapeCombNT of
-          NONE => NONE
-        | SOME ts =>
-            (case conv_ShapeList ts of
-               NONE => NONE
-             | SOME x => SOME (Comb x)))
-   | SOME n =>
-       if n < 1 then NONE
-       else if n = 1 then SOME One
-       else SOME (Comb (REPLICATE (num_of_int n) One))) ∧
+    case conv_default_shape tree of
+    | SOME s => SOME s
+    | _ =>
+      case conv_int tree of
+        NONE =>
+          (case argsNT tree ShapeCombNT of
+              NONE => NONE
+            | SOME ts =>
+                (case conv_ShapeList ts of
+                  NONE => NONE
+                | SOME x => SOME (Comb x)))
+      | SOME n =>
+          if n < 1 then NONE
+          else if n = 1 then SOME One
+          else SOME (Comb (REPLICATE (num_of_int n) One))) ∧
   (conv_ShapeList [] = SOME []) ∧
   (conv_ShapeList (x::xs) =
    (case conv_Shape_alt x of

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -420,20 +420,25 @@ val res = translate $ conv_shift_def;
 
 Overload ptree_size[local] = ``parsetree_size (K 0) (K 0) (K 0)``;
 
+val res = translate $ conv_default_shape_def;
+
 Definition conv_ShapeList_def:
   (conv_Shape_alt tree =
-   case conv_int tree of
-     NONE =>
-       (case argsNT tree ShapeCombNT of
-          NONE => NONE
-        | SOME ts =>
-            (case conv_ShapeList ts of
-               NONE => NONE
-             | SOME x => SOME (Comb x)))
-   | SOME n =>
-       if n < 1 then NONE
-       else if n = 1 then SOME One
-       else SOME (Comb (REPLICATE (num_of_int n) One))) ∧
+    case conv_default_shape tree of
+    | SOME s => SOME s
+    | _ =>
+      case conv_int tree of
+        NONE =>
+          (case argsNT tree ShapeCombNT of
+              NONE => NONE
+            | SOME ts =>
+                (case conv_ShapeList ts of
+                  NONE => NONE
+                | SOME x => SOME (Comb x)))
+      | SOME n =>
+          if n < 1 then NONE
+          else if n = 1 then SOME One
+          else SOME (Comb (REPLICATE (num_of_int n) One))) ∧
   (conv_ShapeList [] = SOME []) ∧
   (conv_ShapeList (x::xs) =
    (case conv_Shape_alt x of

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -634,7 +634,7 @@ Definition conv_Exp_alt_def:
         else if tokcheck (Lf v12) (kw TopK) then SOME TopAddr
         else if tokcheck (Lf v12) (kw BiwK) then SOME BytesInWord
         else if tokcheck (Lf v12) (kw TrueK) then SOME $ Const 1w
-                   else if tokcheck (Lf v12) (kw FalseK) then SOME $ Const 0w
+        else if tokcheck (Lf v12) (kw FalseK) then SOME $ Const 0w
         else NONE)) ∧
   (conv_binaryExps_alt trees res =
    (case trees of

--- a/pancake/NEWS.md
+++ b/pancake/NEWS.md
@@ -4,10 +4,31 @@ Pancake Changelog
 User-facing changes to the Pancake language and compiler are
 documented here when they are merged into `master`.
 
+August ??th 2025
+-------------------
+
+### Shape declarations
+
+Shapes are now expected for all local variable declarations and function returns,
+in addition to global variables and function arguments:
+
+    var 1 x = 0;
+    fun 1 foo(1 a) {
+        var 1 y = 0;
+        return y;
+    }
+
+If a shape is not provided in any place it is expected, the compiler assumes a default shape of `1`.
+
+### Extended static errors
+
+The compiler has new errors to enforce sensible usage of shapes.
+Warnings for estimated locations of memory addresses now support struct fields.
+
 August 20th 2025
 -------------------
 
-## Global variables
+### Global variables
 
 Pancake now supports global variables. Syntax examples:
 
@@ -19,13 +40,13 @@ Pancake now supports global variables. Syntax examples:
     }
     var z = 7; // ...regardless of declaration order
 
-## Top address
+### Top address
 
 The new `@top` keyword is an analogue to `@base`, which tells you where internal memory ends.
 The addressable internal memory is thus all aligned addresses `w` such that `@base <= w < @top`.
 `@base` and `@top` are always word-aligned.
 
-## Function pointers no longer supported
+### Function pointers no longer supported
 
 Previous versions of Pancake allowed storing function pointers in variables
 and internal memory. This feature is now dropped.

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -66,7 +66,7 @@ End
 
 Datatype:
   prog = Skip
-       | Dec varname ('a exp) prog
+       | Dec varname shape ('a exp) prog
        | Assign varkind varname ('a exp)  (* dest, source *)
        | Store     ('a exp) ('a exp) (* dest, source *)
        | Store32   ('a exp) ('a exp) (* dest, source *)
@@ -94,6 +94,7 @@ Datatype:
    ; export      : bool
    ; params      : (varname # shape) list
    ; body        : 'a prog
+   ; return      : shape
   |>
 End
 
@@ -146,7 +147,7 @@ End
 Definition exp_ids_def:
   (exp_ids Skip = ([]:mlstring list)) ∧
   (exp_ids (Raise e _) = [e]) ∧
-  (exp_ids (Dec _ _ p) = exp_ids p) ∧
+  (exp_ids (Dec _ _ _ p) = exp_ids p) ∧
   (exp_ids (Seq p q) = exp_ids p ++ exp_ids q) ∧
   (exp_ids (If _ p q) = exp_ids p ++ exp_ids q) ∧
   (exp_ids (While _ p) = exp_ids p) ∧
@@ -247,7 +248,7 @@ Definition functions_def:
 End
 
 Definition fun_ids_def:
-  (fun_ids (Dec _ _ p) = fun_ids p) ∧
+  (fun_ids (Dec _ _ _ p) = fun_ids p) ∧
   (fun_ids (Seq p q) = fun_ids p ++ fun_ids q) ∧
   (fun_ids (If _ p q) = fun_ids p ++ fun_ids q) ∧
   (fun_ids (While _ p) = fun_ids p) ∧

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -259,7 +259,7 @@ Definition fun_ids_def:
 End
 
 Definition free_var_ids_def:
-  (free_var_ids (Dec vn e p) = var_exp e ++ FILTER ($≠ vn) (free_var_ids p)) ∧
+  (free_var_ids (Dec vn sh e p) = var_exp e ++ FILTER ($≠ vn) (free_var_ids p)) ∧
   (free_var_ids (Seq p q) = free_var_ids p ++ free_var_ids q) ∧
   (free_var_ids (If g p q) = var_exp g ++ free_var_ids p ++ free_var_ids q) ∧
   (free_var_ids (While g p) = var_exp g ++ free_var_ids p) ∧

--- a/pancake/panStaticScript.sml
+++ b/pancake/panStaticScript.sml
@@ -562,7 +562,7 @@ Definition static_check_prog_def:
             ; last       := OtherLast
             ; var_delta  := empty mlstring$compare
             ; curr_loc   := ctxt.loc |> ∧
-  static_check_prog ctxt (Dec v e p) =
+  static_check_prog ctxt (Dec v s e p) =
     do
       (* check for reclaration *)
       check_redec_var ctxt v;

--- a/pancake/panStaticScript.sml
+++ b/pancake/panStaticScript.sml
@@ -1348,10 +1348,10 @@ Definition static_check_decls_def:
       (* check remaining decls *)
       static_check_decls fctxt (insert gctxt vname <| vshape := shape |>) decls
     od ∧
-  static_check_decls fctxt gctxt (Function fi::funs) =
+  static_check_decls fctxt gctxt (Function fi::decls) =
     do
       (* check for redeclaration *)
-      if member fi.fname fctxt
+      if member fi.name fctxt
         then error (GenErr $ concat
         (* TODO: swap this to `get_redec_msg F <loc> f TopLevel` once function locations exist *)
           [strlit "function "; fi.name; strlit " is redeclared\n"])

--- a/pancake/panStaticScript.sml
+++ b/pancake/panStaticScript.sml
@@ -310,7 +310,7 @@ End
 (*
   Get message for memory op addresses
   is_local: local vs shared
-  is_local: load vs store
+  is_load: load vs store
   is_untrust: NotTrusted vs other
 *)
 Definition get_memop_msg_def:
@@ -941,7 +941,7 @@ Definition static_check_progs_def:
   static_check_progs fctxt gctxt (Function fi::decls) =
     do
       (* setup initial checking context *)
-      ctxt <<- <| locals := FOLDL (\m p. insert m p <| based := Trusted ; locl_shape := One |>) (empty mlstring$compare) (MAP FST fi.params) (* #!TEMP *)
+      ctxt <<- <| locals := FOLDL (\m (v, s). insert m v <| based := Trusted ; locl_shape := s |>) (empty mlstring$compare) fi.params
                 ; globals := gctxt
                 ; funcs := fctxt
                 ; scope := FunScope fi.name
@@ -982,7 +982,7 @@ Definition static_check_decls_def:
                 ; last := InvisLast
                 ; loc := strlit "" |>;
       (* check initialisation expression *)
-      static_check_exp ctxt exp;
+      static_check_exp ctxt exp; (* #!TODO shape *)
       (* check for redeclaration *)
       check_redec_var (ctxt with scope := TopLevel) vname;
       (* check remaining decls *)

--- a/pancake/panStaticScript.sml
+++ b/pancake/panStaticScript.sml
@@ -200,24 +200,30 @@ End
 
 (* Determine if shaped based has a given shape *)
 Definition sh_bd_has_shape_def:
-  sh_bd_has_shape sh sb =
+  (sh_bd_has_shape sh sb =
     case (sh, sb) of
     | (One, WordB b) => T
-    | (Comb shs, StructB sbs) => EVERY2 (\x y. sh_bd_has_shape x y) shs sbs
-    | _ => F
-Termination
-	WF_REL_TAC ‘measure (shaped_based_size o SND)’
+    | (Comb shs, StructB sbs) => sh_bd_has_shape_list shs sbs
+    | _ => F) /\
+  (sh_bd_has_shape_list [] [] = T) /\
+  (sh_bd_has_shape_list (sh::shs) [] = F) /\
+  (sh_bd_has_shape_list [] (sb::sbs) = F) /\
+  sh_bd_has_shape_list (sh::shs) (sb::sbs) =
+    (sh_bd_has_shape sh sb /\ sh_bd_has_shape_list shs sbs)
 End
 
 (* Determine if two shaped baseds have the same shape *)
 Definition sh_bd_eq_shapes_def:
-  sh_bd_eq_shapes sb sh =
+  (sh_bd_eq_shapes sb sh =
     case (sb, sh) of
     | (WordB b, WordB b') => T
-    | (StructB (sbs), StructB (sbs')) => EVERY2 (\x y. sh_bd_eq_shapes x y) sbs sbs'
-    | _ => F
-Termination
-	WF_REL_TAC ‘measure (shaped_based_size o FST)’
+    | (StructB sbs, StructB sbs') => sh_bd_eq_shapes_list sbs sbs'
+    | _ => F) /\
+  (sh_bd_eq_shapes_list [] [] = T) /\
+  (sh_bd_eq_shapes_list (sb::sbs) [] = F) /\
+  (sh_bd_eq_shapes_list [] (sb::sbs) = F) /\
+  sh_bd_eq_shapes_list (sb::sbs) (sb'::sbs') =
+    (sh_bd_eq_shapes sb sb' /\ sh_bd_eq_shapes_list sbs sbs')
 End
 
 (* Lookup shaped basedness at a certain struct index *)

--- a/pancake/pan_globalsScript.sml
+++ b/pancake/pan_globalsScript.sml
@@ -70,8 +70,8 @@ Definition shape_val_def:
 End
 
 Definition compile_def:
-  (compile ctxt (Dec v e p) =
-   Dec v (compile_exp ctxt e) (compile ctxt p)) ∧
+  (compile ctxt (Dec v s e p) =
+   Dec v s (compile_exp ctxt e) (compile ctxt p)) ∧
   (compile ctxt (Assign Local v e) =
    Assign Local v (compile_exp ctxt e)) ∧
   (compile ctxt (Assign Global v e) =
@@ -150,8 +150,8 @@ Definition compile_def:
    case FLOOKUP ctxt.globals r of
    | SOME (One, addr) =>
        (let r' = strcat r «'» in
-          Dec r (compile_exp ctxt ad) $
-              Dec r' (Const 0w) $
+          Dec r One (compile_exp ctxt ad) $
+              Dec r' One (Const 0w) $
               Seq (ShMemLoad op Local r' (Var Local r)) $
               Store (Op Sub [TopAddr; Const addr]) (Var Local r'))
    | _ => Skip (* Should never happen *)) ∧
@@ -186,8 +186,8 @@ Definition fperm_name_def:
 End
 
 Definition fperm_def:
-  (fperm f g (Dec v e p) =
-   Dec v e (fperm f g p)) ∧
+  (fperm f g (Dec v s e p) =
+   Dec v s e (fperm f g p)) ∧
   (fperm f g (Seq p p') =
    Seq (fperm f g p) (fperm f g p')) ∧
   (fperm f g (If e p p') =
@@ -245,6 +245,7 @@ Definition compile_top_def:
                                ;  export := F
                                ;  params := args
                                ;  body := Seq (nested_seq decls) (TailCall start' params)
+                               ;  return := One
                               |>
       in
         new_main::funs

--- a/pancake/pan_globalsScript.sml
+++ b/pancake/pan_globalsScript.sml
@@ -120,7 +120,7 @@ Definition compile_def:
                     vn'  = fresh_name «» names;
                     flag = fresh_name «vn'» (vn'::names)
                   in
-                    Dec vn' (shape_val sh) $ Dec flag (Const 0w) $
+                    Dec vn' sh (shape_val sh) $ Dec flag One (Const 0w) $
                         Seq (Call (SOME (SOME(Local,vn'), SOME(eid, evar, Seq p' (Assign Local flag (Const 1w))))) e cexps) $
                         If (Var Local flag) Skip $
                         Store (Op Sub [TopAddr; Const addr]) (Var Local vn')

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -24,12 +24,14 @@ Definition pan_to_target_all_def:
                             Function fi => fi.name = «main»
                           | Decl _ _ _ => F) prog of
               | ([],ys) => ys
-                | (xs,[]) => Function
-                                <| name := «main»
-                                 ; export := F
-                                 ; params := []
-                                 ; body := Return (Const 0w)|>
-                                ::xs
+              | (xs,[]) => Function
+                            <| name := «main»
+                              ; export := F
+                              ; params := []
+                              ; body := Return (Const 0w)
+                              ; return := One
+                            |>
+                            ::xs
               | (xs,y::ys) => y::xs ++ ys
     in
       let
@@ -220,9 +222,9 @@ Definition pan_prog_to_display_def:
      Item NONE (strlit "while")
           [pan_exp_to_display e;
            pan_prog_to_display p]) ∧
-  (pan_prog_to_display (Dec n e p) =
+  (pan_prog_to_display (Dec n shape e p) =
      Item NONE (strlit "dec")
-          [Tuple [
+          [Tuple [String (shape_to_str shape);
                   String (strlit "local");
                   String n;
                   String (strlit ":=");
@@ -299,7 +301,7 @@ Definition pan_fun_to_display_def:
   pan_fun_to_display decl =
     case decl of
       Function fi => Tuple
-        [String «func»; String fi.name;
+        [String (shape_to_str fi.return); String «func»; String fi.name;
         Tuple (MAP (λ(s,shape). Tuple [String s;
                                        String (strlit ":");
                                        String (shape_to_str shape)]) fi.params);

--- a/pancake/pan_simpScript.sml
+++ b/pancake/pan_simpScript.sml
@@ -17,8 +17,8 @@ End
 
 Definition seq_assoc_def:
   (seq_assoc p Skip = p) /\
-  (seq_assoc p (Dec v e q) =
-    SmartSeq p (Dec v e (seq_assoc Skip q))) /\
+  (seq_assoc p (Dec v s e q) =
+    SmartSeq p (Dec v s e (seq_assoc Skip q))) /\
   (seq_assoc p (Seq q r) = seq_assoc (seq_assoc p q) r) /\
   (seq_assoc p (If e q r) =
     SmartSeq p (If e (seq_assoc Skip q) (seq_assoc Skip r))) /\
@@ -49,7 +49,7 @@ End
 
 Definition ret_to_tail_def:
   (ret_to_tail Skip = Skip) /\
-  (ret_to_tail (Dec v e q) = Dec v e (ret_to_tail q)) /\
+  (ret_to_tail (Dec v s e q) = Dec v s e (ret_to_tail q)) /\
   (ret_to_tail (Seq p q) =
     seq_call_ret (Seq (ret_to_tail p) (ret_to_tail q))) /\
   (ret_to_tail (If e p q) = If e (ret_to_tail p) (ret_to_tail q)) /\
@@ -86,7 +86,7 @@ Theorem seq_assoc_pmatch:
   seq_assoc p prog =
   case prog of
    | Skip => p
-   | (Dec v e q) => SmartSeq p (Dec v e (seq_assoc Skip q))
+   | (Dec v s e q) => SmartSeq p (Dec v s e (seq_assoc Skip q))
    | (Seq q r) => seq_assoc (seq_assoc p q) r
    | (If e q r) =>
      SmartSeq p (If e (seq_assoc Skip q) (seq_assoc Skip r))
@@ -114,7 +114,7 @@ Theorem ret_to_tail_pmatch:
   ret_to_tail p =
   case p of
    | Skip => Skip
-   | (Dec v e q) => Dec v e (ret_to_tail q)
+   | (Dec v s e q) => Dec v s e (ret_to_tail q)
    | (Seq q r) => seq_call_ret (Seq (ret_to_tail q) (ret_to_tail r))
    | (If e q r) =>
       If e (ret_to_tail q) (ret_to_tail r)

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -132,7 +132,7 @@ End
 
 Definition compile_def:
   (compile _ (Skip:'a panLang$prog) = (Skip:'a crepLang$prog)) /\
-  (compile ctxt (Dec v e p) =
+  (compile ctxt (Dec v s e p) =
    let (es, sh) = compile_exp ctxt e;
        vmax = ctxt.vmax;
        nvars = GENLIST (λx. vmax + SUC x) (size_of_shape sh);

--- a/pancake/pan_to_targetScript.sml
+++ b/pancake/pan_to_targetScript.sml
@@ -26,7 +26,9 @@ Definition compile_prog_def:
                                 <| name := «main»
                                  ; export := F
                                  ; params := []
-                                 ; body := Return (Const 0w)|>
+                                 ; body := Return (Const 0w)
+                                 ; return := One
+                                |>
                                 ::xs
                 | (xs,y::ys) => y::xs ++ ys in
     (* Compiler passes *)
@@ -60,7 +62,9 @@ Theorem compile_prog_eq:
                                 <| name := «main»
                                  ; export := F
                                  ; params := []
-                                 ; body := Return (Const 0w)|>
+                                 ; body := Return (Const 0w)
+                                 ; return := One
+                                |>
                                 ::xs
                 | (xs,y::ys) => y::xs ++ ys in
     (* Compiler passes *)

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -546,3 +546,27 @@ val annots = annot_fun_lex |> concl |> rhs |> listSyntax.dest_list |> fst
   |> filter (can (find_term (can (match_term ``AnnotCommentT``))))
 val has_annot = assert (not o null) annots;
 
+(* Default shape annotation *)
+val opt_shape_dec =
+ ‘
+  var 1 x = 0;
+  var y = 0;
+
+  fun 1 f(1 a) {
+    x = a + 1;
+    var 1 z = f(a);
+    var 1 x = 5;
+    return x;
+  }
+
+  fun g(b) {
+    y = b + 1;
+    var z = g(a);
+    var y = 5;
+    return y;
+  }
+  ’
+
+val opt_shape_dec_parse = check_success $ parse_pancake opt_shape_dec;
+
+val _ = export_theory();

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -31,6 +31,7 @@ Datatype:
   | LBrakT | RBrakT | LCurT | RCurT
   | AssignT
   | StaticT
+  | DefaultShT
   | KeywordT keyword
   | AnnotCommentT string
   | LexErrorT mlstring

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -146,6 +146,7 @@ Definition pancake_peg_def[nocompute]:
                                  seql [keep_annot; mknt TopDecListNT] (mksubtree TopDecListNT)]);
         (INL FunNT, seql [try_default (keep_kw ExportK) StaticT;
                           consume_kw FunK;
+                          try_default (mknt ShapeNT) DefaultShT;
                           keep_ident;
                           consume_tok LParT;
                           choicel
@@ -156,9 +157,9 @@ Definition pancake_peg_def[nocompute]:
                           consume_tok LCurT;
                           try_ProgNT]
                           (mksubtree FunNT));
-        (INL ParamListNT, seql [mknt ShapeNT; keep_ident;
+        (INL ParamListNT, seql [try_default (mknt ShapeNT) DefaultShT; keep_ident;
                                 rpt (seql [consume_tok CommaT;
-                                           mknt ShapeNT;
+                                           try_default (mknt ShapeNT) DefaultShT;
                                            keep_ident] I)
                                            FLAT]
                                (mksubtree ParamListNT));
@@ -188,16 +189,16 @@ Definition pancake_peg_def[nocompute]:
                               keep_kw TicK;
                               seql [consume_tok LCurT; try_ProgNT] I
                               ]);
-        (INL DecCallNT, seql [consume_kw VarK; mknt ShapeNT; keep_ident; consume_tok AssignT;
+        (INL DecCallNT, seql [consume_kw VarK; try_default (mknt ShapeNT) DefaultShT; keep_ident; consume_tok AssignT;
                               keep_ident;
                               consume_tok LParT; try (mknt ArgListNT);
                               consume_tok RParT;consume_tok SemiT]
                           (mksubtree DecCallNT));
-        (INL DecNT,seql [consume_kw VarK; keep_ident;
+        (INL DecNT,seql [consume_kw VarK; try_default (mknt ShapeNT) DefaultShT; keep_ident;
                          consume_tok AssignT; mknt ExpNT;
                          consume_tok SemiT]
                          (mksubtree DecNT));
-        (INL GlobalDecNT,seql [consume_kw VarK; mknt ShapeNT; keep_ident;
+        (INL GlobalDecNT,seql [consume_kw VarK; try_default (mknt ShapeNT) DefaultShT; keep_ident;
                          consume_tok AssignT; mknt ExpNT;
                          consume_tok SemiT]
                          (mksubtree GlobalDecNT));

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -182,11 +182,18 @@ Definition conv_cmp_def:
   else NONE
 End
 
+Definition conv_default_shape_def:
+  conv_default_shape tree =
+    case destTOK ' (destLf tree) of
+        | SOME (DefaultShT) => SOME One
+        | _ => NONE
+End
+
 (** A single tree is smaller than the forest. *)
 Definition conv_Shape_def:
   conv_Shape tree =
-    case destTOK ' (destLf tree) of
-    | SOME (DefaultShT) => SOME One
+    case conv_default_shape tree of
+    | SOME s => SOME s
     | _ =>
       case conv_int tree of
         SOME n =>

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -817,14 +817,8 @@ End
 
 Definition localise_topdec_def:
   localise_topdec ls (Decl sh v e) = Decl sh v e ∧
-<<<<<<< HEAD
   localise_topdec ls (Function fi) =
   Function $ fi with body := localise_prog (FOLDL (\m p. insert m p ()) ls (MAP FST fi.params)) fi.body
-=======
-  localise_topdec ls (Function sh f b args body) =
-  Function sh f b args $
-           localise_prog (FOLDL (\m p. insert m p ()) ls (MAP FST args)) body
->>>>>>> 2fcd73030 (Add shape declaration for local variables and function returns to parser & make all shape declarations optional with default One (up to panConcreteExamples))
 End
 
 Definition localise_topdecs_def:

--- a/pancake/proofs/panItreeSemEquivScript.sml
+++ b/pancake/proofs/panItreeSemEquivScript.sml
@@ -109,7 +109,7 @@ Definition itree_semantics_beh_def:
 End
 
 Theorem fbs_sem_div_compos_thm:
-  fbs_semantics_beh s (Dec v e prog) = SemDiverge l ∧
+  fbs_semantics_beh s (Dec v sh e prog) = SemDiverge l ∧
   eval (reclock s) e = SOME x ⇒
   fbs_semantics_beh (s with locals := s.locals |+ (v,x)) prog = SemDiverge l
 Proof
@@ -176,10 +176,10 @@ QED
 Theorem fbs_semantics_beh_simps:
   fbs_semantics_beh s Skip = SemTerminate (NONE,s) ∧
   fbs_semantics_beh s (Annot _ _) = SemTerminate (NONE,s) ∧
-  (eval (reclock s) e = NONE ⇒ fbs_semantics_beh s (Dec v e prog) ≠ SemTerminate p)
+  (eval (reclock s) e = NONE ⇒ fbs_semantics_beh s (Dec v sh e prog) ≠ SemTerminate p)
 Proof
   rw []
-  >~ [‘Dec _ _ _’]
+  >~ [‘Dec _ _ _ _’]
   >- (rw [fbs_semantics_beh_def,
           evaluate_def] >>
       rw [eval_upd_clock_eq] >>
@@ -194,7 +194,7 @@ Proof
 QED
 
 Theorem itree_semantics_beh_Dec:
-  itree_semantics_beh s (Dec vname e prog) =
+  itree_semantics_beh s (Dec vname shape e prog) =
   case eval (reclock s) e of
     NONE => SemFail
   | SOME value =>

--- a/pancake/proofs/panItreeSemEquivScript.sml
+++ b/pancake/proofs/panItreeSemEquivScript.sml
@@ -4014,7 +4014,7 @@ Proof
           dxrule FUNPOW_Tau_Vis_eq>>strip_tac>>gvs[]>>
           qmatch_asmsub_abbrev_tac ‘(prog,t)’>>
           last_x_assum $ qspec_then ‘n’ assume_tac>>fs[]>>
-          ‘s.ffi = (reclock t).ffi’ by simp[Abbr‘t’]>>
+          ‘s'.ffi = (reclock t).ffi’ by simp[Abbr‘t’]>>
           pop_assum (fn h => rewrite_tac[h])>>
           first_x_assum irule>>gvs[Abbr‘t’]>>metis_tac[])>>
       imp_res_tac strip_tau_spin>>gvs[spin_bind]>>
@@ -4452,7 +4452,7 @@ Proof
           qmatch_asmsub_abbrev_tac ‘(prog,t)’>>
           first_x_assum $ qspecl_then [‘prog’,‘t’,‘g’,‘a’] assume_tac>>
           gvs[]>>
-          ‘t.ffi = s.ffi’ by simp[Abbr‘t’]>>fs[]>>gvs[]>>
+          ‘t.ffi = s'.ffi’ by simp[Abbr‘t’]>>fs[]>>gvs[]>>
           fs[ltree_lift_Vis_alt]>>
           pairarg_tac>>fs[ltree_lift_monad_law]>>
           Cases_on ‘FST a’>>fs[]>>

--- a/pancake/proofs/pan_globalsProofScript.sml
+++ b/pancake/proofs/pan_globalsProofScript.sml
@@ -526,7 +526,7 @@ Proof
 QED
 
 Theorem compile_Dec:
-  ^(get_goal "compile _ (Dec _ _ _)")
+  ^(get_goal "compile _ (Dec _ _ _ _)")
 Proof
   rpt strip_tac >>
   gvs[evaluate_def,compile_def,AllCaseEqs(),UNCURRY_eq_pair] >>

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -1209,7 +1209,7 @@ QED
 
 
 Theorem compile_Dec:
-  ^(get_goal "compile _ (panLang$Dec _ _ _)")
+  ^(get_goal "compile _ (panLang$Dec _ _ _ _)")
 Proof
   rpt gen_tac >>
   rpt strip_tac >>

--- a/pancake/semantics/panItreeSemScript.sml
+++ b/pancake/semantics/panItreeSemScript.sml
@@ -504,7 +504,7 @@ End
 Definition h_prog_def:
   (h_prog (Skip,s) = Ret (NONE,s)) ∧
   (h_prog (Annot _ _,s) = Ret (NONE,s)) ∧
-  (h_prog (Dec vname e p,s) = h_prog_dec vname e p s) ∧
+  (h_prog (Dec vname sh e p,s) = h_prog_dec vname e p s) ∧
   (h_prog (Assign vk vname e,s) = h_prog_assign vk vname e s) ∧
   (h_prog (Store dst src,s) = h_prog_store dst src s) ∧
   (h_prog (Store32 dst src,s) = h_prog_store_32 dst src s) ∧

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -1024,7 +1024,7 @@ End
 
 Definition exps_of_def:
   (exps_of (Raise _ e) = [e]) ∧
-  (exps_of (Dec _ e p) = e::exps_of p) ∧
+  (exps_of (Dec _ _ e p) = e::exps_of p) ∧
   (exps_of (Seq p q) = exps_of p ++ exps_of q) ∧
   (exps_of (If e p q) = e::exps_of p ++ exps_of q) ∧
   (exps_of (While e p) = e::exps_of p) ∧
@@ -1070,7 +1070,7 @@ End
 
 Definition localised_prog_def:
   (localised_prog (Raise _ e) ⇔ localised_exp e) ∧
-  (localised_prog (Dec _ e p) ⇔ localised_exp e ∧ localised_prog p) ∧
+  (localised_prog (Dec _ _ e p) ⇔ localised_exp e ∧ localised_prog p) ∧
   (localised_prog (Seq p q) ⇔ localised_prog p ∧ localised_prog q) ∧
   (localised_prog (If e p q) ⇔ localised_exp e ∧ localised_prog p ∧ localised_prog q) ∧
   (localised_prog (While e p) ⇔ localised_exp e ∧ localised_prog p) ∧

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -387,7 +387,7 @@ End
 
 Definition evaluate_def:
   (evaluate (Skip:'a panLang$prog,^s) = (NONE,s)) /\
-  (evaluate (Dec v e prog, s) =
+  (evaluate (Dec v shape e prog, s) =
     case (eval s e) of
      | SOME value =>
         let (res,st) = evaluate (prog,s with locals := s.locals |+ (v,value)) in

--- a/pancake/static_checker/panStaticExamplesScript.sml
+++ b/pancake/static_checker/panStaticExamplesScript.sml
@@ -1442,8 +1442,8 @@ val warns_self_referential_global =
 
 val ex_well_scoped_globals = `
   var 1 x = 1;
-  var 2 y = x;
-  var 3 z = x + y;
+  var 1 y = x;
+  var 1 z = x + y;
 `;
 
 val parse_well_scoped_globals =

--- a/pancake/static_checker/panStaticExamplesScript.sml
+++ b/pancake/static_checker/panStaticExamplesScript.sml
@@ -111,7 +111,7 @@ val warns_ =
 (* Error: Main function parameters *)
 
 val ex_arg_main = `
-  fun main (1 a) {
+  fun 1 main (1 a) {
     return 1;
   }
 `;
@@ -129,7 +129,7 @@ val warns_arg_main =
 (* Error: Exported main function *)
 
 val ex_export_main = `
-  export fun main () {
+  export fun 1 main () {
     return 1;
   }
 `;
@@ -147,7 +147,7 @@ val warns_export_main =
 (* Error: Exported function with >4 arguments *)
 
 val ex_export_4_arg = `
-  export fun f (1 a, 1 b, 1 c, 1 d, 1 e) {
+  export fun 1 f (1 a, 1 b, 1 c, 1 d, 1 e) {
     return 1;
   }
 `;
@@ -165,7 +165,7 @@ val warns_ =
 (* Error: Missing function exit (return, tail call, etc) *)
 
 val ex_empty_fun = `
-  fun f () {}
+  fun 1 f () {}
 `;
 
 val parse_empty_fun =
@@ -179,8 +179,8 @@ val warns_empty_fun =
 
 
 val ex_no_ret_fun = `
-  fun f () {
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
     x = 1;
   }
 `;
@@ -196,7 +196,7 @@ val warns_no_ret_fun =
 
 
 val ex_while_ret_fun = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       return 1;
     }
@@ -214,8 +214,8 @@ val warns_while_ret_fun =
 
 
 val ex_half_if_ret_fun = `
-  fun f () {
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
     if true {
       return 1;
     } else {
@@ -235,7 +235,7 @@ val warns_half_if_ret_fun =
 
 
 val ex_full_if_ret_fun = `
-  fun g () {
+  fun 1 f () {
     if true {
       return 1;
     } else {
@@ -257,7 +257,7 @@ val warns_full_if_ret_fun =
 (* Error: Loop exit outside loop (break, continue) *)
 
 val ex_rogue_break = `
-  fun f () {
+  fun 1 f () {
     break;
     return 1;
   }
@@ -274,7 +274,7 @@ val warns_rogue_break =
 
 
 val ex_rogue_continue = `
-  fun f () {
+  fun 1 f () {
     continue;
     return 1;
   }
@@ -293,7 +293,7 @@ val warns_rogue_continue =
 (* Error: Function parameter names not distinct *)
 
 val ex_repeat_params = `
-  fun f (1 a, 1 b, 1 c, 1 a) {
+  fun 1 f (1 a, 1 b, 1 c, 1 a) {
     return 1;
   }
 `;
@@ -317,6 +317,7 @@ val parse_missing_arg_binop = ``
       ; params := []
       ; body := Seq (Annot «location» «(0:0 0:0)»)
                     (Return (Op Xor [Const 1w]))
+      ; return := One
       |>
   ]
 ``;
@@ -335,6 +336,7 @@ val parse_missing_arg_panop = ``
       ; params := []
       ; body := Seq (Annot «location» «(0:0 0:0)»)
                     (Return (Panop Mul [Const 1w]))
+      ; return := One
       |>
   ]
 ``;
@@ -353,6 +355,7 @@ val parse_missing_arg_sub = ``
       ; params := []
       ; body := Seq (Annot «location» «(0:0 0:0)»)
                     (Return (Op Sub [Const 1w]))
+      ; return := One
       |>
   ]
 ``;
@@ -371,6 +374,7 @@ val parse_extra_arg_panop = ``
       ; params := []
       ; body := Seq (Annot «location» «(0:0 0:0)»)
                     (Return (Panop Mul [Const 1w; Const 1w; Const 1w]))
+      ; return := One
       |>
   ]
 ``;
@@ -389,6 +393,7 @@ val parse_extra_arg_sub = ``
       ; params := []
       ; body := Seq (Annot «location» «(0:0 0:0)»)
                     (Return (Op Sub [Const 1w; Const 1w; Const 1w]))
+      ; return := One
       |>
   ]
 ``;
@@ -403,7 +408,7 @@ val warns_extra_arg_sub =
 (* Warning: Unreachable statements (after function exit, after loop exit) *)
 
 val ex_stmt_after_ret = `
-  fun f () {
+  fun 1 f () {
     return 1;
     skip;
   }
@@ -420,7 +425,7 @@ val warns_stmt_after_ret =
 
 
 val ex_stmt_after_retcall = `
-  fun f () {
+  fun 1 f () {
     return f();
     skip;
   }
@@ -437,7 +442,7 @@ val warns_stmt_after_retcall =
 
 
 val ex_stmt_after_raise = `
-  fun f () {
+  fun 1 f () {
     raise Err 1;
     skip;
   }
@@ -454,7 +459,7 @@ val warns_stmt_after_raise =
 
 
 val ex_annot_after_ret = `
-  fun j () {
+  fun 1 f () {
     return 1;
     /@ annot @/
   }
@@ -471,7 +476,7 @@ val warns_annot_after_ret =
 
 
 val ex_stmt_after_annot_after_ret = `
-  fun k () {
+  fun 1 f () {
     return 1;
     /@ annot @/
     skip;
@@ -489,9 +494,9 @@ val warns_stmt_after_annot_after_ret =
 
 
 val ex_stmt_after_inner_ret = `
-  fun f () {
+  fun 1 f () {
     {
-      var x = 12;
+      var 1 x = 12;
       return x;
     };
     skip;
@@ -509,7 +514,7 @@ val warns_stmt_after_inner_ret =
 
 
 val ex_stmt_after_always_ret = `
-  fun f () {
+  fun 1 f () {
     if true {
       return 1;
     } else {
@@ -530,7 +535,7 @@ val warns_stmt_after_always_ret =
 
 
 val ex_stmt_after_maybe_ret = `
-  fun f () {
+  fun 1 f () {
     if true {
       return 1;
     } else {
@@ -551,7 +556,7 @@ val warns_stmt_after_maybe_ret =
 
 
 val ex_maybe_stmt_after_always_ret = `
-  fun f () {
+  fun 1 f () {
     if true {
       return 1;
       skip;
@@ -572,7 +577,7 @@ val warns_stmt_after_inner_ret =
 
 
 val ex_stmt_after_loop_ret = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       return 1;
     }
@@ -591,7 +596,7 @@ val warns_stmt_after_loop_ret =
 
 
 val ex_stmt_after_brk = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       break;
       skip;
@@ -611,7 +616,7 @@ val warns_stmt_after_brk =
 
 
 val ex_stmt_after_cont = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       continue;
       skip;
@@ -631,10 +636,10 @@ val warns_stmt_after_cont =
 
 
 val ex_stmt_after_inner_brk = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       {
-        var x = 0;
+        var 1 x = 0;
         break;
       };
       skip;
@@ -654,7 +659,7 @@ val warns_stmt_after_inner_brk =
 
 
 val ex_stmt_after_always_brk = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       if true {
         break;
@@ -678,7 +683,7 @@ val warns_stmt_after_always_brk =
 
 
 val ex_stmt_after_maybe_brk = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       if true {
         break;
@@ -702,7 +707,7 @@ val warns_stmt_after_maybe_brk =
 
 
 val ex_maybe_stmt_after_always_brk = `
-  fun f () {
+  fun 1 f () {
     while (1) {
       if true {
         break;
@@ -728,8 +733,8 @@ val warns_maybe_stmt_after_always_brk =
 (* Warning: Non-base-calculated address in local memory operation *)
 
 val ex_local_word_notbased = `
-  fun f () {
-    var x = lds 1 0;
+  fun 1 f () {
+    var 1 x = lds 1 0;
     st 0, x;
 
     return 1;
@@ -747,8 +752,8 @@ val warns_local_word_notbased =
 
 
 val ex_local_byte_notbased = `
-  fun f () {
-    var x = ld8 0;
+  fun 1 f () {
+    var 1 x = ld8 0;
     st8 0, x;
 
     return 1;
@@ -766,8 +771,8 @@ val warns_local_byte_notbased =
 
 
 val ex_local_word_based = `
-  fun f () {
-    var x = lds 1 @base;
+  fun 1 f () {
+    var 1 x = lds 1 @base;
     st @base, x;
 
     return 1;
@@ -785,8 +790,8 @@ val warns_local_word_based =
 
 
 val ex_local_byte_based = `
-  fun f () {
-    var x = ld8 @base;
+  fun 1 f () {
+    var 1 x = ld8 @base;
     st8 @base, x;
 
     return 1;
@@ -804,8 +809,8 @@ val warns_local_byte_based =
 
 
 val ex_local_word_arg = `
-  fun f (1 a) {
-    var x = lds 1 a;
+  fun 1 f (1 a) {
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -823,10 +828,10 @@ val warns_local_word_arg =
 
 
 val ex_local_word_local = `
-  fun f () {
-    var a = (lds 1 @base);
+  fun 1 f () {
+    var 1 a = (lds 1 @base);
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -844,11 +849,11 @@ val warns_local_word_local =
 
 
 val ex_local_word_shared = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     !ldw a, 0;
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -866,15 +871,15 @@ val warns_local_word_shared =
 
 
 val ex_local_word_always_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = @base;
     } else {
       a = @base;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -892,15 +897,15 @@ val warns_local_word_always_based =
 
 
 val ex_local_word_else_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = 0;
     } else {
       a = @base;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -918,13 +923,13 @@ val warns_local_word_else_based =
 
 
 val ex_local_word_based_while_based = `
-  fun f () {
-    var a = @base;
+  fun 1 f () {
+    var 1 a = @base;
     while (1) {
       a = @base;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -942,13 +947,13 @@ val warns_local_word_based_while_based =
 
 
 val ex_local_word_nonbased_while_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     while (1) {
       a = @base;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -966,15 +971,15 @@ val warns_local_word_nonbased_while_based =
 
 
 val ex_local_word_always_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = 0;
     } else {
       a = 0;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -992,15 +997,15 @@ val warns_local_word_always_nonbased =
 
 
 val ex_local_word_else_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = @base;
     } else {
       a = 0;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -1018,13 +1023,13 @@ val warns_local_word_else_nonbased =
 
 
 val ex_local_word_nonbased_while_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     while (1) {
       a = 0;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -1042,13 +1047,13 @@ val warns_local_word_nonbased_while_nonbased =
 
 
 val ex_local_word_based_while_nonbased = `
-  fun f () {
-    var a = @base;
+  fun 1 f () {
+    var 1 a = @base;
     while (1) {
       a = 0;
     }
 
-    var x = lds 1 a;
+    var 1 x = lds 1 a;
     st a, x;
 
     return 1;
@@ -1068,8 +1073,8 @@ val warns_local_word_based_while_nonbased =
 (* Warning: Base-calculated address in shared memory operation *)
 
 val ex_shared_word_nonbased = `
-  fun f () {
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
     !ldw x, 0;
     !stw 0, x;
 
@@ -1089,8 +1094,8 @@ val warns_shared_word_nonbased =
 
 
 val ex_shared_word_based = `
-  fun f () {
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
     !ldw x, @base;
     !stw @base, x;
 
@@ -1109,8 +1114,8 @@ val warns_shared_word_based =
 
 
 val ex_shared_word_arg = `
-  fun f (1 a) {
-    var x = 0;
+  fun 1 f (1 a) {
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1129,10 +1134,10 @@ val warns_shared_word_arg =
 
 
 val ex_shared_word_local = `
-  fun f () {
-    var a = (lds 1 @base);
+  fun 1 f () {
+    var 1 a = (lds 1 @base);
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1151,11 +1156,11 @@ val warns_shared_word_local =
 
 
 val ex_shared_word_shared = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     !ldw a, 0;
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1174,15 +1179,15 @@ val warns_shared_word_shared =
 
 
 val ex_shared_word_always_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = @base;
     } else {
       a = @base;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1201,15 +1206,15 @@ val warns_shared_word_always_based =
 
 
 val ex_shared_word_else_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = 0;
     } else {
       a = @base;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1228,13 +1233,13 @@ val warns_shared_word_else_based =
 
 
 val ex_shared_word_based_while_based = `
-  fun f () {
-    var a = @base;
+  fun 1 f () {
+    var 1 a = @base;
     while (1) {
       a = @base;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1253,13 +1258,13 @@ val warns_shared_word_based_while_based =
 
 
 val ex_shared_word_nonbased_while_based = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     while (1) {
       a = @base;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1278,15 +1283,15 @@ val warns_shared_word_nonbased_while_based =
 
 
 val ex_shared_word_always_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = 0;
     } else {
       a = 0;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1305,15 +1310,15 @@ val warns_shared_word_always_nonbased =
 
 
 val ex_shared_word_else_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     if (1) {
       a = @base;
     } else {
       a = 0;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1332,13 +1337,13 @@ val warns_shared_word_else_nonbased =
 
 
 val ex_shared_word_nonbased_while_nonbased = `
-  fun f () {
-    var a = 0;
+  fun 1 f () {
+    var 1 a = 0;
     while (1) {
       a = 0;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1357,13 +1362,13 @@ val warns_shared_word_nonbased_while_nonbased =
 
 
 val ex_shared_word_based_while_nonbased = `
-  fun f () {
-    var a = @base;
+  fun 1 f () {
+    var 1 a = @base;
     while (1) {
       a = 0;
     }
 
-    var x = 0;
+    var 1 x = 0;
     !ldw x, a;
     !stw a, x;
 
@@ -1387,7 +1392,7 @@ val warns_shared_word_based_while_nonbased =
 (* Error: Undefined/out-of-scope functions *)
 
 val ex_undefined_fun = `
-  fun f () {
+  fun 1 f () {
     foo();
     return 1;
   }
@@ -1406,7 +1411,7 @@ val warns_undefined_fun =
 (* Error: Undefined/out-of-scope variables *)
 
 val ex_undefined_var = `
-  fun f () {
+  fun 1 f () {
     return x;
   }
 `;
@@ -1452,7 +1457,7 @@ val warns_well_scoped_globals =
 
 
 val ex_global_function_order = `
-  fun f() { return x; }
+  fun 1 f() { return x; }
   var 1 x = 1;
 `;
 
@@ -1468,10 +1473,10 @@ val warns_global_function_order =
 (* Error: Redefined functions *)
 
 val ex_redefined_fun = `
-  fun f () {
+  fun 1 f () {
     return 1;
   }
-  fun f () {
+  fun 1 f () {
     return 1;
   }
 `;
@@ -1489,9 +1494,9 @@ val warns_redefined_fun =
 (* Warning: Redefined variables *)
 
 val ex_redefined_var_dec_dec = `
-  fun f () {
-    var x = 0;
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
+    var 1 x = 0;
     return 1;
   }
 `;
@@ -1507,8 +1512,8 @@ val warns_redefined_var_dec_dec =
 
 
 val ex_redefined_var_dec_deccall = `
-  fun f () {
-    var x = 0;
+  fun 1 f () {
+    var 1 x = 0;
     var 1 x = f();
     return 1;
   }
@@ -1525,9 +1530,9 @@ val warns_redefined_var_dec_deccall =
 
 
 val ex_redefined_var_deccall_dec = `
-  fun f () {
+  fun 1 f () {
     var 1 x = f();
-    var x = 0;
+    var 1 x = 0;
     return 1;
   }
 `;
@@ -1543,7 +1548,7 @@ val warns_redefined_var_deccall_dec =
 
 
 val ex_redefined_var_deccall_deccall = `
-  fun f () {
+  fun 1 f () {
     var 1 x = f();
     var 1 x = f();
     return 1;
@@ -1577,8 +1582,8 @@ val warns_redefined_global_var =
 
 val ex_redefined_global_var_locally = `
   var 1 x = 1;
-  fun f() {
-    var x = 1;
+  fun 1 f() {
+    var 1 x = 1;
     return x;
   }
 `;
@@ -1595,7 +1600,7 @@ val warns_redefined_global_var_locally =
 
 val ex_redefined_global_var_deccall = `
   var 1 x = 1;
-  fun f() {
+  fun 1 f() {
     var 1 x = f();
     return x;
   }

--- a/pancake/static_checker/panStaticExamplesScript.sml
+++ b/pancake/static_checker/panStaticExamplesScript.sml
@@ -18,9 +18,6 @@ val [static_check_progs] = decls "static_check_progs";
 computeLib.monitoring := SOME (fn t => same_const static_check t orelse same_const static_check_decls t orelse same_const static_check_progs t);
 *)
 
-(* Add LIST_REL/EVERY2 to the compset *)
-val _ = computeLib.add_thms [LIST_REL_def] the_compset;
-
 
 (* Following copied from panConcreteExamples*)
 


### PR DESCRIPTION
* Extends the static checking (and associated tests) with various errors related to shapes, as well as a couple of non-shape checks enabled by those changes (see `pancake/panStaticScript.sml` header comment for full list)
* Shape annotations now expected for all variable declarations, function arguments and function returns to enable checking
  * If no shape is given, parser assumes shape is `1`, so most existing pancake code should still compile
  * `Dec` constructor and `Function` record extended to include shape