### PR TITLE
Another pass at speeding up CFCML

### DIFF
--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -108,9 +108,9 @@ val reduce_conv =
     (DEPTH_CONV (
       List.foldl (fn (pat, conv) => (eval_pat pat) ORELSEC conv)
                  ALL_CONV reducible_pats))
-    (* It seems that the next line makes around 29s faster; it would be good
-       to confirm this, though. Maybe doing basic simplifications first results
-       in a smaller term, meaning less work is done in the following
+    (* It seems that the next line makes npbc_arrayProg around 29s faster; it would
+       be good to confirm this, though. Maybe doing basic simplifications first
+       results in a smaller term, meaning less work is done in the following
        SIMP_CONV? *)
     THENC (STRIP_QUANT_CONV (SIMP_CONV pure_ss []))
     (* We probably do not use all of srw_ss, so there may be potential for a


### PR DESCRIPTION
The optimizations were mainly guided by looking at hotspots in `npbc_arrayProg` using the profiler. The speedup for it seems to be 10 minutes (32m => 22m). The proofs now take around 10 minutes; the rest is other stuff (probably translation; maybe that should also be profiled in the future).

Also, `TextIOProof` now takes a bit over 7 minutes.