### PR TITLE
Add a minimal example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ developers/bin
 semantics/addancs
 tutorial/solutions/make_ex
 examples/vipr/compilation/cake_vipr
+examples/template/compilation/example_funs_x64
+examples/template/compilation/example_funs_arm8
 
 # regression test logs
 regression.log

--- a/developers/build-sequence
+++ b/developers/build-sequence
@@ -177,6 +177,10 @@ examples/deflate/translation/compilation
 examples/vipr
 examples/vipr/compilation
 
+examples/template
+examples/template/translation
+examples/template/compilation
+
 translator/okasaki-examples
 translator/other-examples
 translator/other-examples/auxiliary

--- a/examples/README.md
+++ b/examples/README.md
@@ -98,6 +98,10 @@ A high-level specification of words and frequencies
 An example of a stack data structure implemented using CakeML arrays, verified
 using CF.
 
+[template](template):
+A simple example of how a standalone CakeML program can be produced from
+a functional program defined as functions in HOL.
+
 [vipr](vipr):
 Formalisation of VIPR: Verifying Integer Programming Results
 https://github.com/ambros-gleixner/VIPR

--- a/examples/template/Holmakefile
+++ b/examples/template/Holmakefile
@@ -1,0 +1,12 @@
+INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
+
+all: $(DEFAULT_TARGETS) README.md
+.PHONY: all
+README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
+DIRS = $(wildcard */)
+README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
+	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+
+ifdef POLY
+HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap
+endif

--- a/examples/template/README.md
+++ b/examples/template/README.md
@@ -1,0 +1,11 @@
+A simple example of how a standalone CakeML program can be produced from
+a functional program defined as functions in HOL.
+
+[compilation](compilation):
+Compilation scripts for simple example functions.
+
+[example_funsScript.sml](example_funsScript.sml):
+Define a simple program as functions in HOL
+
+[translation](translation):
+Translation of HOL functions into CakeML programs.

--- a/examples/template/compilation/Holmakefile
+++ b/examples/template/compilation/Holmakefile
@@ -1,0 +1,21 @@
+INCLUDES = ../translation $(CAKEMLDIR)/cv_translator
+
+all: $(DEFAULT_TARGETS) README.md
+.PHONY: all
+README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
+DIRS = $(wildcard */)
+README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
+	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+
+ifdef POLY
+HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap
+endif
+
+CFLAGS+=-O2
+LDLIBS+=-lm
+
+example_funs_x64: example_funsCompileTheory.uo
+	$(CC) $(CFLAGS) -o $@ $@.S $(CAKEMLDIR)/basis/basis_ffi.c $(LDLIBS)
+
+example_funs_arm: example_funsCompileTheory.uo
+	$(CC) $(CFLAGS) -o $@ $@.S $(CAKEMLDIR)/basis/basis_ffi.c $(LDLIBS)

--- a/examples/template/compilation/README.md
+++ b/examples/template/compilation/README.md
@@ -1,0 +1,4 @@
+Compilation scripts for simple example functions.
+
+[example_funsCompileScript.sml](example_funsCompileScript.sml):
+Compile the encoder for the sudoku puzzle

--- a/examples/template/compilation/example_funsCompileScript.sml
+++ b/examples/template/compilation/example_funsCompileScript.sml
@@ -1,0 +1,16 @@
+(*
+  Compile the encoder for the sudoku puzzle
+*)
+Theory example_funsCompile
+Ancestors
+  example_funsProg
+Libs
+  preamble eval_cake_compile_x64Lib eval_cake_compile_arm8Lib
+
+Theorem example_funs_compiled_x64 =
+  eval_cake_compile_x64 "x64_" example_funs_prog_def
+                              "example_funs_x64.S";
+
+Theorem example_funs_compiled_arm8 =
+  eval_cake_compile_arm8 "arm8_" example_funs_prog_def
+                                "example_funs_arm8.S";

--- a/examples/template/compilation/readmePrefix
+++ b/examples/template/compilation/readmePrefix
@@ -1,0 +1,1 @@
+Compilation scripts for simple example functions.

--- a/examples/template/example_funsScript.sml
+++ b/examples/template/example_funsScript.sml
@@ -1,0 +1,11 @@
+(*
+  Define a simple program as functions in HOL
+*)
+Theory example_funs
+Ancestors
+  misc mlstring
+
+Definition main_function_def:
+  main_function (s:mlstring) =
+    implode (REVERSE (explode s))
+End

--- a/examples/template/readmePrefix
+++ b/examples/template/readmePrefix
@@ -1,0 +1,2 @@
+A simple example of how a standalone CakeML program can be produced from
+a functional program defined as functions in HOL.

--- a/examples/template/translation/Holmakefile
+++ b/examples/template/translation/Holmakefile
@@ -1,0 +1,12 @@
+INCLUDES = .. $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator
+
+all: $(DEFAULT_TARGETS) README.md
+.PHONY: all
+README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
+DIRS = $(wildcard */)
+README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
+	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+
+ifdef POLY
+HOLHEAP = $(CAKEMLDIR)/basis/basis-heap
+endif

--- a/examples/template/translation/README.md
+++ b/examples/template/translation/README.md
@@ -1,0 +1,4 @@
+Translation of HOL functions into CakeML programs.
+
+[example_funsProgScript.sml](example_funsProgScript.sml):
+Translate HOL functions into CakeML code

--- a/examples/template/translation/example_funsProgScript.sml
+++ b/examples/template/translation/example_funsProgScript.sml
@@ -1,0 +1,32 @@
+(*
+  Translate HOL functions into CakeML code
+*)
+Theory example_funsProg
+Ancestors
+  misc example_funs
+Libs
+  preamble basis
+
+val _ = translation_extends "basisProg";
+
+val res = translate main_function_def;
+
+val _ = type_of “main_function” = “:mlstring -> mlstring”
+        orelse failwith "The main_function has the wrong type.";
+
+val main = process_topdecs
+  `print (main_function (TextIO.inputAll TextIO.stdIn));`;
+
+val prog =
+  get_ml_prog_state ()
+  |> ml_progLib.clean_state
+  |> ml_progLib.remove_snocs
+  |> ml_progLib.get_thm
+  |> REWRITE_RULE [ml_progTheory.ML_code_def]
+  |> concl |> rator |> rator |> rand
+  |> (fn tm => “^tm ++ ^main”)
+  |> EVAL |> concl |> rand
+
+Definition example_funs_prog_def:
+  example_funs_prog = ^prog
+End

--- a/examples/template/translation/readmePrefix
+++ b/examples/template/translation/readmePrefix
@@ -1,0 +1,1 @@
+Translation of HOL functions into CakeML programs.


### PR DESCRIPTION
This template sets up files for:
- defining some HOL functions
- translating those functions to CakeML
- compiling the resulting CakeML code to arm8 and x64 binaries

This example ought to be extended to also connect to the backend proof, but that is left as future work.