### PR TITLE
Refactor mem_load_32 and mem_store_32 to use word_of_bytes/get_byte

### DIFF
--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -2153,7 +2153,7 @@ Proof
     fs[good_dimindex_def]>>
     Cases_on`a`>>last_x_assum mp_tac>>
     fs[mem_load32_def,labSemTheory.assert_def,labSemTheory.upd_reg_def,dec_clock_def,assert_def,
-       read_mem_word_compute,mem_load_def,upd_reg_def,upd_pc_def,mem_load_32_def,
+       read_mem_word_compute,mem_load_def,upd_reg_def,upd_pc_def,mem_load_32_alt,
        labSemTheory.addr_def,addr_def,read_reg_def,labSemTheory.mem_load_def]>>
     TOP_CASE_TAC>>fs[]>>
     pop_assum mp_tac>>TOP_CASE_TAC>>fs[]>>
@@ -2426,7 +2426,7 @@ Proof
    (`good_dimindex(:'a)` by fs[state_rel_def]>>
     fs[good_dimindex_def]>>
     Cases_on`a`>>last_x_assum mp_tac>>
-    fs[mem_store32_def,labSemTheory.assert_def,mem_store_32_def,mem_store_def,labSemTheory.addr_def,
+    fs[mem_store32_def,labSemTheory.assert_def,mem_store_32_alt,mem_store_def,labSemTheory.addr_def,
        addr_def,write_mem_word_compute,upd_pc_def,read_reg_def,assert_def,upd_mem_def,dec_clock_def,
        labSemTheory.mem_store_def,read_reg_def,labSemTheory.upd_mem_def]>>
     ntac 3 (TOP_CASE_TAC>>fs[])>>

--- a/compiler/backend/proofs/stack_removeProofScript.sml
+++ b/compiler/backend/proofs/stack_removeProofScript.sml
@@ -290,7 +290,7 @@ Theorem mem_load_32_IMP[local]:
     mem_load_32 s.memory s.mdomain s.be a = SOME x ==>
     mem_load_32 t.memory t.mdomain t.be a = SOME x
 Proof
-   full_simp_tac(srw_ss())[wordSemTheory.mem_load_32_def] \\ srw_tac[][]
+   full_simp_tac(srw_ss())[wordSemTheory.mem_load_32_alt] \\ srw_tac[][]
   \\ `s.be = t.be` by full_simp_tac(srw_ss())[state_rel_def]
   \\ ntac 5 (FULL_CASE_TAC >> fs[]) >> gvs[]
   \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
@@ -704,7 +704,7 @@ Theorem state_rel_mem_store_32:
    ∃y. mem_store_32 t.memory t.mdomain t.be a b = SOME y ∧
        state_rel jump off k (s with memory := z) (t with memory := y)
 Proof
-  fs[state_rel_def,wordSemTheory.mem_store_32_def] >>
+  fs[state_rel_def,wordSemTheory.mem_store_32_alt] >>
   rpt strip_tac
   \\ ntac 3 (pop_assum mp_tac)
   \\ BasicProvers.TOP_CASE_TAC \\ fs[]

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -800,7 +800,7 @@ Proof
     qpat_x_assum`Word _ = _`(assume_tac o SYM) >> fs[]>> rfs[]) >>
   TRY (
     rename1`mem_store32`
-    \\ fs[wordSemTheory.mem_store_32_def]
+    \\ fs[wordSemTheory.mem_store_32_alt]
     \\ every_case_tac \\ fs[]
     \\ fs[mem_store32_def,addr_def]
     \\ fs[word_exp_def,wordLangTheory.word_op_def]
@@ -817,7 +817,7 @@ Proof
     \\ match_mp_tac SWAP_IMP
     \\ disch_then old_drule
     \\ disch_then (assume_tac o SYM)
-    \\ simp[wordSemTheory.mem_store_32_def]
+    \\ simp[wordSemTheory.mem_store_32_alt]
     \\ `s1.memory = t1.mem ∧ t1.mem_domain = s1.mdomain ∧ t1.be = s1.be` by fs[state_rel_def]
     \\ fs[] \\ strip_tac
     \\ TRY (qpat_x_assum`Word _ = read_reg _ _`(assume_tac o SYM)\\ fs[])
@@ -830,7 +830,7 @@ Proof
     \\ rveq \\ simp[]) >>
   TRY (
     qhdtm_x_assum`mem_load_32`mp_tac
-    \\ fs[wordSemTheory.mem_load_32_def,labSemTheory.mem_load32_def,labSemTheory.addr_def]
+    \\ fs[wordSemTheory.mem_load_32_alt,labSemTheory.mem_load32_def,labSemTheory.addr_def]
     \\ BasicProvers.TOP_CASE_TAC \\ fs[]
     \\ fs[word_exp_def,wordLangTheory.word_op_def]
     \\ qpat_x_assum`IS_SOME _`mp_tac

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -1070,7 +1070,7 @@ Proof
         metis_tac[strong_locals_rel_subset])>>
       full_simp_tac(srw_ss())[word_state_eq_rel_def,LET_THM,set_var_def]>>
       Cases_on`x`>>simp[]>>
-      fs[mem_load_32_def]>>
+      fs[mem_load_32_alt]>>
       Cases_on`st.memory (byte_align c')`>>fs[]>>
       ntac 2 (IF_CASES_TAC>>fs[]) >> gvs[] >>
       fs[domain_union,get_writes_def,get_writes_inst_def]>>
@@ -6065,7 +6065,7 @@ Proof
       qpat_abbrev_tac`expr=((Op Add [Var n';A]))`>>
       setup_tac>>
       Cases_on`x`>>
-      full_simp_tac(srw_ss())[mem_load_32_def]>>
+      full_simp_tac(srw_ss())[mem_load_32_alt]>>
       Cases_on`st.memory (byte_align c')`>>fs[]>>
       ntac 2 (IF_CASES_TAC>>fs[])>> gvs[] >>
       match_mp_tac ssa_locals_rel_set_var>>

--- a/compiler/backend/proofs/word_elimProofScript.sml
+++ b/compiler/backend/proofs/word_elimProofScript.sml
@@ -759,7 +759,7 @@ Proof
   >- (
     (* memory cases *)
     rw[AllCaseEqs()]>>
-    gvs[word_state_rel_def,mem_store_def,domain_find_loc_state,domain_get_memory,set_var_def,mem_store_byte_aux_def,mem_store_32_def,AllCaseEqs()]
+    gvs[word_state_rel_def,mem_store_def,domain_find_loc_state,domain_get_memory,set_var_def,mem_store_byte_aux_def,mem_store_32_alt,AllCaseEqs()]
     >>~-(
       [`domain (get_locals (insert _ _ _))`],
       irule SUBSET_TRANS

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -564,7 +564,7 @@ Theorem mem_load_32_align_dm:
    mem_load_32 s.mem s.mem_domain be x = SOME y ⇒
    mem_load_32 s.mem (align_dm s).mem_domain be x = SOME y
 Proof
-  rw[mem_load_32_def]
+  rw[mem_load_32_alt]
   \\ every_case_tac \\ fs[]
   \\ fs[align_dm_def]
   \\ last_x_assum mp_tac \\ simp[]
@@ -581,7 +581,7 @@ Proof
   \\ every_case_tac \\ fs[]
   \\ imp_res_tac mem_load_32_align_dm
   \\ fs[]
-  \\ gs[mem_load_32_def]
+  \\ gs[mem_load_32_alt]
   \\ every_case_tac \\ fs[]
   \\ fs[align_dm_def]
 QED
@@ -651,7 +651,7 @@ Theorem mem_store_32_align_dm:
    mem_store_32 mem s.mem_domain be x c = SOME y ⇒
    mem_store_32 mem (align_dm s).mem_domain be x c = SOME y
 Proof
-  rw[mem_store_32_def]
+  rw[mem_store_32_alt]
   \\ every_case_tac \\ fs[]
   \\ fs[align_dm_def]
   \\ last_x_assum mp_tac \\ simp[]
@@ -668,7 +668,7 @@ Proof
   \\ every_case_tac \\ fs[]
   \\ imp_res_tac mem_store_32_align_dm
   \\ fs[]
-  \\ fs[mem_store_32_def]
+  \\ fs[mem_store_32_alt]
   \\ fs[align_dm_def]
   \\ every_case_tac \\ fs[]
 QED

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -3,7 +3,7 @@
 *)
 Theory wordSem
 Libs
-  preamble
+  preamble blastLib
 Ancestors
   mllist wordLang alignment[qualified] finite_map[qualified]
   misc[qualified] asm[qualified] fpSem[qualified]
@@ -73,6 +73,37 @@ Definition mem_load_32_def:
        | Loc _ _ => NONE
        | Word v =>
            if byte_align w IN dm
+           then SOME (word_of_bytes be (0w:word32)
+             [get_byte w v be; get_byte (w + 1w) v be;
+              get_byte (w + 2w) v be; get_byte (w + 3w) v be])
+           else NONE
+  else NONE
+End
+
+Definition mem_store_32_def:
+  mem_store_32 m dm be (w:'a word) (hw: word32) =
+  if aligned 2 w
+  then case m (byte_align w) of
+       | Word v =>
+           if byte_align w IN dm
+           then
+             let v0 = set_byte w (get_byte (0w:word32) hw be) v be in
+             let v1 = set_byte (w + 1w) (get_byte 1w hw be) v0 be in
+             let v2 = set_byte (w + 2w) (get_byte 2w hw be) v1 be in
+             let v3 = set_byte (w + 3w) (get_byte 3w hw be) v2 be in
+               SOME ((byte_align w =+ Word v3) m)
+           else NONE
+       | _ => NONE
+  else NONE
+End
+
+Theorem mem_load_32_alt:
+  mem_load_32 m dm be (w:'a word) =
+  if aligned 2 w
+  then case m (byte_align w) of
+       | Loc _ _ => NONE
+       | Word v =>
+           if byte_align w IN dm
            then
              let b0 = get_byte w v be in
              let b1 = get_byte (w + 1w) v be in
@@ -87,9 +118,15 @@ Definition mem_load_32_def:
              in SOME (v': word32)
            else NONE
   else NONE
-End
+Proof
+  rw[mem_load_32_def] >>
+  every_case_tac >> rw[] >>
+  simp[word_of_bytes_def] >>
+  EVAL_TAC >>
+  BBLAST_TAC
+QED
 
-Definition mem_store_32_def:
+Theorem mem_store_32_alt:
   mem_store_32 m dm be (w:'a word) (hw: word32) =
   if aligned 2 w
   then case m (byte_align w) of
@@ -112,7 +149,11 @@ Definition mem_store_32_def:
            else NONE
        | _ => NONE
   else NONE
-End
+Proof
+  rw[mem_store_32_def] >>
+  every_case_tac >> rw[] >>
+  EVAL_TAC
+QED
 
 Definition mem_load_byte_aux_def:
   mem_load_byte_aux m dm be w =

--- a/pancake/proofs/crep_to_loopProofScript.sml
+++ b/pancake/proofs/crep_to_loopProofScript.sml
@@ -978,7 +978,7 @@ Proof
       fs [set_var_def, wlab_wloc_def] >>
       fs [panSemTheory.mem_load_byte_def, CaseEq "word_lab",
           wordSemTheory.mem_load_byte_aux_def,
-          panSemTheory.mem_load_32_def, wordSemTheory.mem_load_32_def] >>
+          panSemTheory.mem_load_32_alt, wordSemTheory.mem_load_32_alt] >>
       drule mem_rel_intro >> strip_tac >>
       last_x_assum (qspec_then ‘byte_align c’ (mp_tac o GSYM)) >>
       strip_tac >> fs [] >>
@@ -1017,7 +1017,7 @@ Proof
       fs [set_var_def, wlab_wloc_def] >>
       fs [panSemTheory.mem_load_byte_def, CaseEq "word_lab",
           wordSemTheory.mem_load_byte_aux_def,
-          panSemTheory.mem_load_32_def, wordSemTheory.mem_load_32_def] >>
+          panSemTheory.mem_load_32_alt, wordSemTheory.mem_load_32_alt] >>
       drule mem_rel_intro >>
       disch_then (qspec_then ‘byte_align c’ (mp_tac o GSYM)) >>
       strip_tac >> fs [] >>
@@ -1811,7 +1811,7 @@ Proof
     imp_res_tac eval_some_var_cexp_local_lookup >>
     res_tac >> fs [] >> rveq >> rfs []) >>
   fs [] >> pop_assum kall_tac >>
-  fs [wordSemTheory.mem_store_32_def, panSemTheory.mem_store_32_def,
+  fs [wordSemTheory.mem_store_32_alt, panSemTheory.mem_store_32_alt,
       AllCaseEqs ()] >>
   rveq >> fs [lookup_insert] >>
   ‘st'.memory (byte_align adr) = Word v’ by (

--- a/pancake/proofs/pan_globalsProofScript.sml
+++ b/pancake/proofs/pan_globalsProofScript.sml
@@ -102,7 +102,7 @@ Proof
   >- gvs[eval_def,compile_exp_def,AllCaseEqs(),mem_load_byte_def,
          state_rel_def,SUBSET_DEF]
   >~ [‘Load32’]
-  >- (gvs[eval_def,compile_exp_def,AllCaseEqs(),mem_load_32_def,
+  >- (gvs[eval_def,compile_exp_def,AllCaseEqs(),mem_load_32_alt,
           state_rel_def,SUBSET_DEF])
   >~ [‘Op’]
   >- (gvs[eval_def,compile_exp_def,AllCaseEqs()] >>
@@ -613,11 +613,11 @@ Proof
   rw[evaluate_def,compile_def,AllCaseEqs(),UNCURRY_eq_pair,SF DNF_ss] >>
   imp_res_tac compile_exp_correct >>
   simp[] >>
-  qpat_x_assum ‘mem_store_32 _ _ _ _ _ = _’ (assume_tac o REWRITE_RULE [mem_store_32_def]) >>
+  qpat_x_assum ‘mem_store_32 _ _ _ _ _ = _’ (assume_tac o REWRITE_RULE [mem_store_32_alt]) >>
   gvs[AllCaseEqs(),good_res_def] >>
   drule_all state_rel_memory_update >>
   disch_then $ irule_at $ Pos last >>
-  gvs[state_rel_def,mem_store_32_def,SUBSET_DEF]
+  gvs[state_rel_def,mem_store_32_alt,SUBSET_DEF]
 QED
 
 Theorem compile_StoreByte:

--- a/pancake/proofs/pan_to_targetProofScript.sml
+++ b/pancake/proofs/pan_to_targetProofScript.sml
@@ -401,7 +401,7 @@ Theorem mem_load_32_const_memory[simp]:
   fun2set (m,dm) = fun2set (m',dm) ⇒
   wordSem$mem_load_32 m dm be ad = mem_load_32 m' dm be ad
 Proof
-  strip_tac>>gs[wordSemTheory.mem_load_32_def]>>
+  strip_tac>>gs[wordSemTheory.mem_load_32_alt]>>
   rpt (TOP_CASE_TAC>>gs[set_sepTheory.fun2set_eq])>>
   last_x_assum $ qspec_then ‘byte_align ad’ assume_tac>>gvs[]
 QED
@@ -412,7 +412,7 @@ Theorem mem_store_32_const_memory:
   (fun2set (THE (mem_store_32 m dm be ad hw), dm) =
     fun2set (THE (wordSem$mem_store_32 m' dm be ad hw), dm))
 Proof
-  strip_tac>>gs[wordSemTheory.mem_store_32_def]>>
+  strip_tac>>gs[wordSemTheory.mem_store_32_alt]>>
   rpt (TOP_CASE_TAC>>gs[set_sepTheory.fun2set_eq])>>
   rpt strip_tac>>
   simp[APPLY_UPDATE_THM]

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -1358,7 +1358,7 @@ Theorem eval_swap_memaddrs:
     eval (s with memaddrs := memaddrs) exp = SOME v
 Proof
   recInduct eval_ind >>
-  rw[eval_def,AllCaseEqs(),PULL_EXISTS,mem_load_byte_def,mem_load_32_def] >>
+  rw[eval_def,AllCaseEqs(),PULL_EXISTS,mem_load_byte_def,mem_load_32_alt] >>
   rpt $ irule_at (Pos last) EQ_REFL >>
   rpt $ first_assum $ irule_at (Pos last) >>
   fs[]
@@ -1397,7 +1397,7 @@ Theorem eval_swap_memory:
     eval (s with memory := mry) exp = SOME v
 Proof
   recInduct eval_ind >>
-  rw[eval_def,AllCaseEqs(),PULL_EXISTS,mem_load_byte_def,mem_load_32_def] >>
+  rw[eval_def,AllCaseEqs(),PULL_EXISTS,mem_load_byte_def,mem_load_32_alt] >>
   rpt $ irule_at (Pos last) EQ_REFL >>
   rpt $ first_assum $ irule_at (Pos last) >>
   fs[]

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -9,7 +9,7 @@ Ancestors
   ffi[qualified]
   lprefix_lub[qualified]
 Libs
-  preamble
+  preamble blastLib
 
 
 (* TODO: rename or remove *)
@@ -71,7 +71,20 @@ Definition mem_load_byte_def:
 End
 
 Definition mem_load_32_def:
-  (* returns 32 word, first or second half of w if a = 64 *)
+  mem_load_32 m dm be (w:'a word) =
+  if aligned 2 w
+  then
+    case m (byte_align w) of
+    | Word v =>
+        if byte_align w IN dm
+        then SOME (word_of_bytes be (0w:word32)
+          [get_byte w v be; get_byte (w + 1w) v be;
+           get_byte (w + 2w) v be; get_byte (w + 3w) v be])
+        else NONE
+  else NONE
+End
+
+Theorem mem_load_32_alt:
   mem_load_32 m dm be (w:'a word) =
   if aligned 2 w
   then
@@ -92,7 +105,13 @@ Definition mem_load_32_def:
           in SOME (v': word32)
         else NONE
   else NONE
-End
+Proof
+  rw[mem_load_32_def] >>
+  every_case_tac >> rw[] >>
+  simp[word_of_bytes_def] >>
+  EVAL_TAC >>
+  BBLAST_TAC
+QED
 
 Definition mem_load_def:
   (mem_load sh addr dm (m: 'a word -> 'a word_lab) =
@@ -221,7 +240,23 @@ End
 *)
 
 Definition mem_store_32_def:
-  (* takes a 32 word *)
+  mem_store_32 m dm be (w:'a word) (hw:word32) =
+  if aligned 2 w
+  then
+    case m (byte_align w) of
+    | Word v =>
+        if byte_align w IN dm
+        then
+          let v0 = set_byte w (get_byte (0w:word32) hw be) v be in
+          let v1 = set_byte (w + 1w) (get_byte 1w hw be) v0 be in
+          let v2 = set_byte (w + 2w) (get_byte 2w hw be) v1 be in
+          let v3 = set_byte (w + 3w) (get_byte 3w hw be) v2 be in
+            SOME ((byte_align w =+ Word v3) m)
+        else NONE
+  else NONE
+End
+
+Theorem mem_store_32_alt:
   mem_store_32 m dm be (w:'a word) (hw:word32) =
   if aligned 2 w
   then
@@ -244,7 +279,11 @@ Definition mem_store_32_def:
               SOME ((byte_align w =+ Word v3) m)
         else NONE
   else NONE
-End
+Proof
+  rw[mem_store_32_def] >>
+  every_case_tac >> rw[] >>
+  EVAL_TAC
+QED
 
 Definition mem_store_def:
   mem_store (addr:'a word) (w:'a word_lab) dm m =


### PR DESCRIPTION
Replace manual shift/OR byte reconstruction in mem_load_32 with word_of_bytes, and manual shift extraction in mem_store_32 with get_byte, eliminating duplicate BE/LE code paths in both wordSem and panSem. Old forms preserved as _alt theorems; downstream proofs updated to reference _alt.

@wildptr and @myreen  pointed out that the defs that shift words around using w2w are very unwieldy.