### PR TITLE
Rename CakeML `TextIO.inputLine` to `TextIO.inputLineWith`

### DIFF
--- a/basis/TextIOProgScript.sml
+++ b/basis/TextIOProgScript.sml
@@ -472,12 +472,16 @@ End
 val _ = ml_prog_update open_local_in_block;
 
 Quote add_cakeml:
-  fun inputLine c0 is = inputUntil_2 is c0 []
+  fun inputLineWith c0 is = inputUntil_2 is c0 []
+End
+
+Quote add_cakeml:
+  fun inputLine is = inputLineWith #"\n" is
 End
 
 Quote add_cakeml:
   fun inputLineTokens c0 is tokP mp =
-    case inputLine c0 is of
+    case inputLineWith c0 is of
       None => None
     | Some l =>
       Some (List.map mp (String.tokens tokP l))
@@ -487,7 +491,7 @@ val _ = ml_prog_update open_local_block;
 
 Quote add_cakeml:
   fun inputLines_aux c0 is acc =
-     case inputLine c0 is of
+     case inputLineWith c0 is of
        None => List.rev acc
      | Some l => inputLines_aux c0 is (l::acc)
 End
@@ -525,7 +529,7 @@ Quote add_cakeml:
       None => y
     | Some c => fold_chars_loop f is (f c y);
   fun fold_lines_loop c0 f is y =
-    case inputLine c0 is of
+    case inputLineWith c0 is of
       None => y
     | Some c => fold_lines_loop c0 f is (f c y);
   fun fold_tokens_loop c0 tokP mp fld is y =

--- a/basis/TextIOProofScript.sml
+++ b/basis/TextIOProofScript.sml
@@ -6807,11 +6807,11 @@ Proof
   gvs[EVERY_MEM,EXISTS_MEM]
 QED
 
-Theorem inputLine_spec_STR[local]:
+Theorem inputLineWith_spec_STR[local]:
   CHAR c0 c0v /\
   EVERY (\c. c <> c0) to_read /\
   (text <> "" ==> HD text = c0) ==>
-  app (p:'ffi ffi_proj) TextIO_inputLine_v [c0v; is]
+  app (p:'ffi ffi_proj) TextIO_inputLineWith_v [c0v; is]
     (STDIO fs * INSTREAM_STR fd is (to_read ++ text) fs)
     (POSTv v. SEP_EXISTS k.
                 cond (OPTION_TYPE STRING_TYPE
@@ -6822,7 +6822,7 @@ Theorem inputLine_spec_STR[local]:
                 INSTREAM_STR fd is (TL text) (forwardFD fs fd k))
 Proof
   rpt strip_tac
-  \\ xcf_with_def TextIO_inputLine_v_def
+  \\ xcf_with_def TextIO_inputLineWith_v_def
   \\ xlet_auto THEN1 (xcon \\ xsimpl)
   \\ xapp_spec inputUntil_2_spec_STR
   \\ simp[LIST_TYPE_def]
@@ -6879,7 +6879,7 @@ Theorem inputLineTokens_spec_STR[local]:
 Proof
   rpt strip_tac
   \\ xcf_with_def TextIO_inputLineTokens_v_def
-  \\ xlet_auto_spec (SOME inputLine_spec_STR)
+  \\ xlet_auto_spec (SOME inputLineWith_spec_STR)
   >- (
     qexists_tac`emp`>>
     qexists_tac`fs`>>
@@ -7490,9 +7490,9 @@ Proof
   \\ simp [std_preludeTheory.OPTION_TYPE_def]
 QED
 
-Theorem inputLine_spec_lines:
+Theorem inputLineWith_spec_lines:
   CHAR c0 c0v ⇒
-  app (p:'ffi ffi_proj) TextIO_inputLine_v [c0v; is]
+  app (p:'ffi ffi_proj) TextIO_inputLineWith_v [c0v; is]
      (STDIO fs * INSTREAM_LINES c0 fd is lines fs)
      (POSTv v.
        SEP_EXISTS k.
@@ -7501,7 +7501,7 @@ Theorem inputLine_spec_lines:
          & (OPTION_TYPE STRING_TYPE (oHD lines) v))
 Proof
   strip_tac \\ fs [INSTREAM_LINES_def] \\ xpull
-  \\ xapp_spec inputLine_spec_STR \\ rveq
+  \\ xapp_spec inputLineWith_spec_STR \\ rveq
   \\ strip_assume_tac (Q.SPEC ‘rest’ split_exists)
   \\ first_assum (irule_at Any)
   \\ first_assum (irule_at Any)
@@ -7538,6 +7538,20 @@ Proof
   \\ fs [] \\ Cases_on ‘to_read’ \\ fs [strcat_def,concat_def,implode_def,str_def]
 QED
 
+
+Theorem inputLine_spec_lines:
+  app (p:'ffi ffi_proj) TextIO_inputLine_v [is]
+     (STDIO fs * INSTREAM_LINES #"\n" fd is lines fs)
+     (POSTv v.
+       SEP_EXISTS k.
+         STDIO (forwardFD fs fd k) *
+         INSTREAM_LINES #"\n" fd is (TL lines) (forwardFD fs fd k) *
+         & (OPTION_TYPE STRING_TYPE (oHD lines) v))
+Proof
+  xcf_with_def TextIO_inputLine_v_def >> xapp >>
+  simp[CHAR_def]
+QED
+
 Theorem inputLines_aux_spec:
   !lines acc accv fs.
     CHAR c0 c0v ∧
@@ -7561,7 +7575,7 @@ Proof
          INSTREAM_LINES c0 fd is (TL lines) (forwardFD fs fd k) *
          & (OPTION_TYPE STRING_TYPE (oHD lines) v)`
   THEN1 (
-    xapp_spec inputLine_spec_lines \\ gvs[])
+    xapp_spec inputLineWith_spec_lines \\ gvs[])
   \\ Cases_on `lines` \\ fs [std_preludeTheory.OPTION_TYPE_def] \\ rveq
   \\ xmatch \\ fs []
   THEN1
@@ -7951,7 +7965,7 @@ Proof
           INSTREAM_LINES c0 fd is [] (forwardFD fs fd k) *
           &OPTION_TYPE STRING_TYPE NONE chv)’
     THEN1
-     (xapp_spec (inputLine_spec_lines |> Q.INST [‘lines’|->‘[]’] )
+     (xapp_spec (inputLineWith_spec_lines |> Q.INST [‘lines’|->‘[]’] )
       \\ qexists_tac ‘emp’
       \\ qexists_tac ‘fs’
       \\ qexists_tac ‘fd’
@@ -7968,7 +7982,7 @@ Proof
             INSTREAM_LINES c0 fd is s (forwardFD fs fd k) *
             &OPTION_TYPE STRING_TYPE (SOME h) chv)’
   THEN1
-   (xapp_spec (inputLine_spec_lines |> Q.INST [‘lines’|->‘h::s’] )
+   (xapp_spec (inputLineWith_spec_lines |> Q.INST [‘lines’|->‘h::s’] )
     \\ qexists_tac ‘emp’
     \\ qexists_tac ‘s’
     \\ qexists_tac ‘h’

--- a/examples/grepProgScript.sml
+++ b/examples/grepProgScript.sml
@@ -473,7 +473,7 @@ val parse_regexp_side = Q.prove(
 
 Quote add_cakeml:
   fun print_matching_lines match prefix fd =
-    case TextIO.inputLine #"\n" fd of None => ()
+    case TextIO.inputLineWith #"\n" fd of None => ()
     | Some ln => (if match ln then (TextIO.print prefix; TextIO.print ln) else ();
                   print_matching_lines match prefix fd)
 End

--- a/examples/lpr_checker/array/lpr_arrayParsingProgScript.sml
+++ b/examples/lpr_checker/array/lpr_arrayParsingProgScript.sml
@@ -323,14 +323,14 @@ val c0_v_thm = translate c0_def;
 
 Quote add_cakeml:
 fun parse_one_c lno fd =
-case TextIO.inputLine c0 fd of
+case TextIO.inputLineWith c0 fd of
   None => None
 | Some l =>
     (case parse_vb_string_head l of
        None => raise Fail (format_failure lno "failed to parse line (compressed format)")
      | Some (Inl d) => Some d
      | Some (Inr r) =>
-         (case TextIO.inputLine c0 fd of
+         (case TextIO.inputLineWith c0 fd of
             None => raise Fail (format_failure lno "failed to parse line (compressed format)")
           | Some y =>
               (case do_pr r y of


### PR DESCRIPTION
Also introduce new entry-point `TextIO.inputLine` that is defined to be `TextIO.inputLineWith #"\n"`.  Existing uses of `inputLine` changed to refer instead to `inputLineWith`.

The inputLine spec is a copy of the inputLineWith spec with the ‘c’ variable replaced by `#"\n"`.