### PR TITLE
Fix temp_remove_user_printer calls for HOL mcandidate API change

### DIFF
--- a/characteristic/cfTacticsLib.sml
+++ b/characteristic/cfTacticsLib.sml
@@ -29,7 +29,7 @@ local
 in
 fun hide_environments b =
   if b then app temp_add_user_printer printers
-  else app (ignore o temp_remove_user_printer) (map #1 printers)
+  else app (ignore o temp_remove_user_printer) (map (fn (a,b,_) => (a,b)) printers)
 end
 
 (*------------------------------------------------------------------*)

--- a/semantics/astPP.sml
+++ b/semantics/astPP.sml
@@ -835,7 +835,7 @@ val _=add_astPP("astlistprint",``x:ast$dec list``,genPrint astlistPrint);
 
 fun enable_astPP_verbose () = map temp_add_user_printer (!astPrettyPrinters);
 fun enable_astPP () = (enable_astPP_verbose();())
-fun disable_astPP_verbose () = map (fn (x,y,z) => temp_remove_user_printer x) (!astPrettyPrinters);
+fun disable_astPP_verbose () = map (fn (x,y,z) => temp_remove_user_printer (x,y)) (!astPrettyPrinters);
 fun disable_astPP () = (disable_astPP_verbose();())
 (*
 enable_astPP_verbose();


### PR DESCRIPTION
temp_remove_user_printer now takes (string * term) instead of string.