### PR TITLE
mlstring: Rename str to chr_to_str

### DIFF
--- a/basis/StringProgScript.sml
+++ b/basis/StringProgScript.sml
@@ -53,7 +53,8 @@ val _ = ml_prog_update open_local_in_block;
 val _ = next_ml_names := ["concatWith"];
 val result = translate concatWith_def;
 
-val result = translate str_def;
+val _ = next_ml_names := ["str"];
+val result = translate chr_to_str_def;
 
 val _ = ml_prog_update open_local_block;
 val result = translate translate_aux_def;

--- a/basis/TextIOProofScript.sml
+++ b/basis/TextIOProofScript.sml
@@ -457,12 +457,12 @@ QED
 Theorem fsupdate_add_stdout_str:
   STD_streams fs ∧ get_file_content fs 1 = SOME (content,pos) ⇒
   (fsupdate fs 1 0 (pos + 1) (insert_atI [c] pos content)) =
-  (add_stdout fs (str c))
+  (add_stdout fs (toString c))
 Proof
   rpt strip_tac
   \\ drule_all fsupdate_add_stdout_implode
   \\ disch_then $ qspec_then ‘[c]’ assume_tac
-  \\ gvs [str_def]
+  \\ gvs [chr_to_str_def]
 QED
 
 Theorem fsupdate_add_stderr_implode:
@@ -1049,7 +1049,7 @@ Proof
         simp[Abbr`f`,Abbr`st`,Abbr`ns`, mk_ffi_next_def,
              ffi_open_in_def, (* decode_encode_FS, *) Abbr`fd0`,
              getNullTermStr_add_null, MEM_MAP, ORD_BOUND, ORD_eq_0,
-             dimword_8, MAP_MAP_o, o_DEF, char_BIJ,str_def,strcat_thm,
+             dimword_8, MAP_MAP_o, o_DEF, char_BIJ,chr_to_str_def,strcat_thm,
              LENGTH_explode,REPLICATE_compute,LUPDATE_compute,explode_implode] >>
         imp_res_tac inFS_fname_ALOOKUP_EXISTS >>
         imp_res_tac nextFD_ltX >>
@@ -1081,7 +1081,7 @@ Proof
       simp[Abbr`f`,Abbr`st`,Abbr`ns`, mk_ffi_next_def,
            ffi_open_in_def, (* decode_encode_FS, *) Abbr`fd0`,
            getNullTermStr_add_null, MEM_MAP, ORD_BOUND, ORD_eq_0,
-           dimword_8, MAP_MAP_o, o_DEF, char_BIJ,str_def,strcat_thm,
+           dimword_8, MAP_MAP_o, o_DEF, char_BIJ,chr_to_str_def,strcat_thm,
            implode_explode, LENGTH_explode] >>
       fs[not_inFS_fname_openFile,STRING_TYPE_def] \\ xsimpl >>
       qpat_abbrev_tac `new_events = events ++ _` >>
@@ -1518,7 +1518,7 @@ Theorem output1_stdOut_spec:
   CHAR c cv ⇒
   app (p:'ffi ffi_proj) TextIO_output1_v [stdout_v; cv]
     (STDIO fs)
-    (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stdout fs (str c)))
+    (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stdout fs (toString c)))
 Proof
   strip_tac
   \\ rewrite_tac [Once STDIO_STD_streams] \\ xpull
@@ -1546,7 +1546,7 @@ Theorem output1_stdout_spec:
    CHAR c cv ∧ fdv = stdout_v ==>
    app (p:'ffi ffi_proj) TextIO_output1_v
      [fdv; cv] (STDIO fs)
-     (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stdout fs (str c)))
+     (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stdout fs (toString c)))
 Proof
   reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ strip_tac \\ xpull)
   \\ strip_tac
@@ -1558,7 +1558,7 @@ Theorem output1_stderr_spec:
    CHAR c cv ∧ fdv = stderr_v ==>
    app (p:'ffi ffi_proj) TextIO_output1_v
      [fdv; cv] (STDIO fs)
-     (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stderr fs (str c)))
+     (POSTv uv. &UNIT_TYPE () uv * STDIO (add_stderr fs (toString c)))
 Proof
   reverse(Cases_on`STD_streams fs`) >- (fs[STDIO_def] \\ strip_tac \\ xpull)
   \\ strip_tac
@@ -3552,7 +3552,7 @@ QED
 Theorem exists_chr_isSuffix:
   !P l.
       EXISTS ($= c) l ==>
-        (isSuffix (str c) (implode (takeUntilIncl ($= c) l)) <=>
+        (isSuffix (toString c) (implode (takeUntilIncl ($= c) l)) <=>
           ($= c) (LAST (takeUntilIncl ($= c) l)))
 Proof
   strip_tac
@@ -3561,21 +3561,21 @@ Proof
   \\ Cases_on `l`
   >-(rfs[EXISTS_DEF])
   >-(Cases_on `($= c) h`
-    >-(simp[takeUntilIncl_def, isSuffix_def, str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
+    >-(simp[takeUntilIncl_def, isSuffix_def, chr_to_str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
               isStringThere_SEG, LAST_DEF])
-    >-(simp[takeUntilIncl_def, isSuffix_def, str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
+    >-(simp[takeUntilIncl_def, isSuffix_def, chr_to_str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
               isStringThere_SEG, LAST_DEF]
       \\ fs[EXISTS_DEF]
       \\ `t <> []` by (imp_res_tac EXISTS_MEM \\ imp_res_tac NOT_NULL_MEM \\ fs[NULL_EQ])
       \\ CASE_TAC
       >-(imp_res_tac takeUntilIncl_length_gt_0 \\ rfs[NOT_NIL_EQ_LENGTH_NOT_0])
       \\ simp[GSYM isStringThere_SEG]
-      \\ fs[isSuffix_def, GSYM implode_def, GSYM str_def]
+      \\ fs[isSuffix_def, GSYM implode_def, GSYM chr_to_str_def]
       \\ imp_res_tac LENGTH_takeUntilIncl_exists_geq_1
       \\ last_assum (qspecl_then [`t`] mp_tac)
       \\ disch_tac \\ fs[] \\ res_tac \\ rfs[]
       \\ eq_tac
-      >-(rfs[isStringThere_SEG, str_def, implode_def]
+      >-(rfs[isStringThere_SEG, chr_to_str_def, implode_def]
       \\ rfs[SEG1]
       \\ Cases_on `takeUntilIncl ($= c) t`
       >-fs[LAST_DEF]
@@ -3583,7 +3583,7 @@ Proof
         EL (STRLEN (STRING h' t') − 1) (STRING h' t')` by fs[STRLEN_THM, STRLEN_DEF]
       \\ rw[]
       \\ fs[EL, LAST_DEF]))
-      >-(rfs[isStringThere_SEG, str_def, implode_def]
+      >-(rfs[isStringThere_SEG, chr_to_str_def, implode_def]
       \\ rfs[SEG1]
       \\ Cases_on `takeUntilIncl ($= c) t`
       >-fs[LAST_DEF]
@@ -3596,13 +3596,13 @@ Theorem not_exists_chr_not_isSuffix:
   !l.
       0 < LENGTH l /\
       ~(EXISTS ($= c) l) ==>
-        ~(isSuffix (str c) (implode l))
+        ~(isSuffix (toString c) (implode l))
 Proof
   completeInduct_on `LENGTH (l:string)`
   \\ rpt strip_tac \\ rveq \\ fs [PULL_FORALL]
   \\ Cases_on `l`
   >-(rfs[isSuffix_def])
-  >-(fs[takeUntilIncl_def, isSuffix_def, str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
+  >-(fs[takeUntilIncl_def, isSuffix_def, chr_to_str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
               isStringThere_SEG]
     \\ `1 + STRLEN t <= STRLEN t + 1` by decide_tac
     \\ Cases_on `0 < STRLEN t`
@@ -3616,17 +3616,17 @@ QED
 
 Theorem isSuffix_char_strlen_gt_0:
   !P l.
-        isSuffix (str c) (implode l) ==> 0 < STRLEN l
+        isSuffix (toString (c: char)) (implode l) ==> 0 < STRLEN l
 Proof
   strip_tac
   \\ completeInduct_on `LENGTH (l:string)`
   \\ rpt strip_tac \\ rveq \\ fs [PULL_FORALL]
   \\ Cases_on `l`
-  >-(fs[isSuffix_def, implode_def, str_def])
+  >-(fs[isSuffix_def, implode_def, chr_to_str_def])
   >-(Cases_on `($= c) h`
-    >-(simp[takeUntilIncl_def, isSuffix_def, str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
+    >-(simp[takeUntilIncl_def, isSuffix_def, chr_to_str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
               isStringThere_SEG])
-    >-(simp[takeUntilIncl_def, isSuffix_def, str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
+    >-(simp[takeUntilIncl_def, isSuffix_def, chr_to_str_def, implode_def, NOT_NIL_EQ_LENGTH_NOT_0,
               isStringThere_SEG]))
 QED
 
@@ -3644,12 +3644,12 @@ Proof
 QED
 
 Theorem isSuffix_char_implode_strcat:
-  !l r c.
+  !l r (c: char).
         0 < STRLEN r ==>
-          (isSuffix (str c) (implode r) <=> isSuffix (str c) (implode (STRCAT l r)))
+          (isSuffix (toString c) (implode r) <=> isSuffix (toString c) (implode (STRCAT l r)))
 Proof
   rpt strip_tac
-  \\ fs[isSuffix_def, implode_def, str_def, SUC_ONE_ADD, isStringThere_SEG, SEG1]
+  \\ fs[isSuffix_def, implode_def, chr_to_str_def, SUC_ONE_ADD, isStringThere_SEG, SEG1]
   \\ eq_tac
   >-(strip_tac
     \\ fs[EL_APPEND_EQN,MAP_MAP_o, CHR_w2n_n2w_ORD]
@@ -5541,7 +5541,7 @@ End
 
 Definition lines_of_gen_def:
   lines_of_gen c0 s =
-    MAP (λx. implode x ^ (str c0)) (splitlines_at c0 (explode s))
+    MAP (λx. implode x ^ (toString c0)) (splitlines_at c0 (explode s))
 End
 
 (* TODO Maybe splitlines should be defined exactly like this. *)
@@ -5555,7 +5555,7 @@ QED
 Theorem lines_of_gen_lines_of:
   lines_of_gen #"\n" s = lines_of s
 Proof
-  simp [lines_of_gen_def, lines_of_def, splitlines_at_splitlines, str_def]
+  simp [lines_of_gen_def, lines_of_def, splitlines_at_splitlines, chr_to_str_def]
 QED
 
 Definition INSTREAM_LINES_def:
@@ -6024,8 +6024,8 @@ Proof
   \\ xsimpl
 QED
 
-Theorem str_STRING:
-  str h = implode (STRING h "")
+Theorem toString_STRING:
+  toString h = implode (STRING h "")
 Proof
   EVAL_TAC
 QED
@@ -6077,7 +6077,7 @@ Theorem all_lines_file_gen_all_lines_file[simp]:
   all_lines_file fs f
 Proof
   rw[all_lines_file_def,all_lines_file_gen_def,lines_of_def,lines_of_gen_def,
-     splitlines_at_def,splitlines_def,str_def]
+     splitlines_at_def,splitlines_def,chr_to_str_def]
 QED
 
 (* TODO Move to fsFFIProps? *)
@@ -6617,10 +6617,10 @@ Proof
     \\ xlet_auto >- (xcon \\ xsimpl)
     \\ xlet_auto >- xsimpl
     \\ xlet_auto >- (xcon \\ xsimpl)
-    \\ ‘LIST_TYPE STRING_TYPE (str c :: implode bs1 :: acc) v'’ by gvs [LIST_TYPE_def]
+    \\ ‘LIST_TYPE STRING_TYPE (toString c :: implode bs1 :: acc) v'’ by gvs [LIST_TYPE_def]
     \\ xlet ‘POSTv retv. INSTREAM_STR' fd is "" (forwardFD fs fd nr) F T *
            STDIO (forwardFD fs fd nr) *
-           & LIST_TYPE STRING_TYPE (REVERSE (str c::implode bs1::acc)) retv’
+           & LIST_TYPE STRING_TYPE (REVERSE (toString c::implode bs1::acc)) retv’
     >-
      (xapp_spec (ListProgTheory.reverse_v_thm |> GEN_ALL |> ISPEC “STRING_TYPE”)
       \\ gvs [] \\ pop_assum $ irule_at $ Pos hd \\ xsimpl)
@@ -6636,7 +6636,7 @@ Proof
     \\ drule gen_inputLine_lem1
     \\ disch_then $ qspec_then ‘[]’ mp_tac \\ gvs []
     \\ gvs [dropUntilIncl_def,mllistTheory.dropUntil_def,gen_inputLine_def]
-    \\ gvs [str_def,implode_def] \\ strip_tac
+    \\ gvs [chr_to_str_def,implode_def] \\ strip_tac
     \\ gvs [INSTREAM_STR_def,INSTREAM_STR'_def]
     \\ xsimpl \\ rpt gen_tac \\ strip_tac
     \\ gvs [] \\ xsimpl)
@@ -6713,10 +6713,10 @@ Proof
     \\ xlet_auto >- (xcon \\ xsimpl)
     \\ xlet_auto >- xsimpl
     \\ xlet_auto >- (xcon \\ xsimpl)
-    \\ ‘LIST_TYPE STRING_TYPE (str c :: implode bs1 :: []) v'’ by gvs [LIST_TYPE_def]
+    \\ ‘LIST_TYPE STRING_TYPE (toString c :: implode bs1 :: []) v'’ by gvs [LIST_TYPE_def]
     \\ xlet ‘POSTv retv. INSTREAM_STR' fd is "" (forwardFD fs fd nr) F T *
            STDIO (forwardFD fs fd nr) *
-           & LIST_TYPE STRING_TYPE (REVERSE (str c::implode bs1::[])) retv’
+           & LIST_TYPE STRING_TYPE (REVERSE (toString c::implode bs1::[])) retv’
     >-
      (xapp_spec (ListProgTheory.reverse_v_thm |> GEN_ALL |> ISPEC “STRING_TYPE”)
       \\ gvs [] \\ pop_assum $ irule_at $ Pos hd \\ xsimpl)
@@ -6726,7 +6726,7 @@ Proof
     \\ gvs [concat_append,concat_sing]
     \\ xif
     >-
-     (xcon \\ xsimpl \\ gvs [concat_def,implode_def,str_def]
+     (xcon \\ xsimpl \\ gvs [concat_def,implode_def,chr_to_str_def]
       \\ gvs [std_preludeTheory.OPTION_TYPE_def]
       \\ gvs [dropUntilIncl_def,mllistTheory.dropUntil_def,gen_inputLine_def]
       \\ gvs [INSTREAM_STR_def,INSTREAM_STR'_def]
@@ -6734,14 +6734,14 @@ Proof
       \\ rpt gen_tac \\ strip_tac
       \\ gvs [] \\ xsimpl)
     \\ xcon \\ xsimpl
-    \\ ‘bs1 ≠ []’ by (Cases_on ‘bs1’ \\ gvs [concat_def,str_def,implode_def])
+    \\ ‘bs1 ≠ []’ by (Cases_on ‘bs1’ \\ gvs [concat_def,chr_to_str_def,implode_def])
     \\ gvs [std_preludeTheory.OPTION_TYPE_def]
     \\ qexists_tac ‘nr’
     \\ drule gen_inputLine_lem1
     \\ disch_then $ qspec_then ‘[]’ mp_tac \\ gvs []
     \\ strip_tac \\ gvs []
     \\ gvs [dropUntilIncl_def,mllistTheory.dropUntil_def,gen_inputLine_def]
-    \\ gvs [str_def,implode_def,concat_def,strcat_def]
+    \\ gvs [chr_to_str_def,implode_def,concat_def,strcat_def]
     \\ gvs [INSTREAM_STR_def,INSTREAM_STR'_def]
     \\ xsimpl \\ rpt gen_tac \\ strip_tac
     \\ gvs [] \\ xsimpl)
@@ -6791,19 +6791,19 @@ Proof
 QED
 
 Theorem implode_cons_str:
-  str c ^ implode cs =
+  toString c ^ implode cs =
   implode (c::cs)
 Proof
-  rw[implode_def,strcat_def,concat_def,str_def]>>
+  rw[implode_def,strcat_def,concat_def,chr_to_str_def]>>
   TOP_CASE_TAC>>rw[]
 QED
 
 Theorem gen_inputLine_cons:
   gen_inputLine c (x::xs) =
-  if x = c then str c else str x ^ gen_inputLine c xs
+  if x = c then toString c else toString x ^ gen_inputLine c xs
 Proof
   rw[gen_inputLine_def]>>
-  gvs[takeUntilIncl_cons2,str_def,implode_cons_str]>>
+  gvs[takeUntilIncl_cons2,chr_to_str_def,implode_cons_str]>>
   gvs[EVERY_MEM,EXISTS_MEM]
 QED
 
@@ -6816,7 +6816,7 @@ Theorem inputLineWith_spec_STR[local]:
     (POSTv v. SEP_EXISTS k.
                 cond (OPTION_TYPE STRING_TYPE
                         (case to_read of
-                         | [] => (if text = "" then NONE else SOME (str c0))
+                         | [] => (if text = "" then NONE else SOME (toString c0))
                          | _ => SOME (implode (to_read ++ [c0]))) v) *
                 STDIO (forwardFD fs fd k) *
                 INSTREAM_STR fd is (TL text) (forwardFD fs fd k))
@@ -6847,16 +6847,16 @@ Proof
   every_case_tac>>gvs[]
   >- (
     Cases_on`text`>>gvs[gen_inputLine_def]>>
-    fs[takeUntilIncl_def,dropUntilIncl_def,mllistTheory.dropUntil_def,str_def]>>
+    fs[takeUntilIncl_def,dropUntilIncl_def,mllistTheory.dropUntil_def,chr_to_str_def]>>
     xsimpl)>>
   gvs[gen_inputLine_cons,dropUntilIncl_cons]>>
   drule gen_inputLine_lem1>>
   disch_then(qspec_then`text` assume_tac)>>gvs[]>>
   Cases_on`text`>>gvs[gen_inputLine_def]>>
-  fs[takeUntilIncl_def,dropUntilIncl_def,mllistTheory.dropUntil_def,str_def]>>
+  fs[takeUntilIncl_def,dropUntilIncl_def,mllistTheory.dropUntil_def,chr_to_str_def]>>
   xsimpl>>
   simp[GSYM implode_cons_str]>>
-  simp[str_def]>>
+  simp[chr_to_str_def]>>
   fs[implode_STRCAT,implode_def]
 QED
 
@@ -6948,7 +6948,7 @@ Proof
   THEN1
    (‘~EXISTS ($= c0) to_read’ by fs [EXISTS_MEM,EVERY_MEM]
     \\ drule splitlines_at_not_exists2 \\ fs []
-    \\ fs [strcat_def,concat_def,implode_def,str_def]
+    \\ fs [strcat_def,concat_def,implode_def,chr_to_str_def]
     \\ fs [TOKENS_eq_tokens_sym,o_DEF]
     \\ fs [stringTheory.TOKENS_APPEND,stringTheory.TOKENS_def]
     \\ Cases_on ‘to_read’ \\ fs [])
@@ -7518,12 +7518,12 @@ Proof
   THEN1
    (‘~EXISTS ($= c0) to_read’ by fs [EXISTS_MEM,EVERY_MEM]
     \\ drule splitlines_at_not_exists2 \\ fs []
-    \\ fs [strcat_def,concat_def,implode_def,str_def]
+    \\ fs [strcat_def,concat_def,implode_def,chr_to_str_def]
     \\ Cases_on ‘to_read’ \\ fs [])
   \\ Cases_on ‘to_read = []’ \\ fs []
   THEN1
    (Cases_on ‘text’ \\ fs [] \\ fs [splitlines_at_hd_c0]
-    \\ fs [strcat_def,concat_def,implode_def,str_def])
+    \\ fs [strcat_def,concat_def,implode_def,chr_to_str_def])
   \\ ‘EXISTS ($= c0) rest’ by (fs [] \\ Cases_on ‘text’ \\ fs [])
   \\ drule splitlines_at_takeUntil_exists2 \\ fs []
   \\ ‘takeUntil ($= c0) (STRCAT to_read text) = to_read’ by
@@ -7535,7 +7535,7 @@ Proof
     \\ qmatch_goalsub_abbrev_tac ‘DROP k (xs ++ ys)’
     \\ qsuff_tac ‘k = LENGTH xs’ \\ fs [DROP_LENGTH_APPEND]
     \\ unabbrev_all_tac \\ fs [])
-  \\ fs [] \\ Cases_on ‘to_read’ \\ fs [strcat_def,concat_def,implode_def,str_def]
+  \\ fs [] \\ Cases_on ‘to_read’ \\ fs [strcat_def,concat_def,implode_def,chr_to_str_def]
 QED
 
 

--- a/basis/fsFFIPropsScript.sml
+++ b/basis/fsFFIPropsScript.sml
@@ -1052,7 +1052,7 @@ End
 
 Theorem concat_lines_of:
    !s. concat (lines_of s) = s ∨
-        concat (lines_of s) = s ^ str #"\n"
+        concat (lines_of s) = s ^ toString #"\n"
 Proof
   rw[lines_of_def] \\
   `s = implode (explode s)` by fs [explode_implode] \\
@@ -1084,7 +1084,7 @@ QED
 
 Theorem concat_all_lines_file:
    concat (all_lines_file fs fname) = implode (THE (ALOOKUP fs.inode_tbl (File (THE (ALOOKUP fs.files fname))))) ∨
-   concat (all_lines_file fs fname) = implode (THE (ALOOKUP fs.inode_tbl (File (THE (ALOOKUP fs.files fname))))) ^ str #"\n"
+   concat (all_lines_file fs fname) = implode (THE (ALOOKUP fs.inode_tbl (File (THE (ALOOKUP fs.files fname))))) ^ toString #"\n"
 Proof
   fs [all_lines_file_def,concat_lines_of]
 QED

--- a/basis/pure/basis_cvScript.sml
+++ b/basis/pure/basis_cvScript.sml
@@ -20,7 +20,7 @@ val _ = cv_trans miscTheory.tlookup_def;
 val _ = cv_trans mlstringTheory.implode_def;
 val _ = cv_trans mlstringTheory.explode_thm;
 val _ = cv_trans mlstringTheory.strcat_thm;
-val _ = cv_trans mlstringTheory.str_def;
+val _ = cv_trans mlstringTheory.chr_to_str_def;
 val _ = cv_auto_trans mlstringTheory.concat_def;
 
 val res = cv_trans_pre "strsub_pre" mlstringTheory.strsub_def;

--- a/basis/pure/mlintScript.sml
+++ b/basis/pure/mlintScript.sml
@@ -215,7 +215,8 @@ Proof
                     , explode_def]
   in recInduct fromChars_ind
   \\ CONJ_TAC >- rw tactics
-  \\ rw [] \\ Cases_on `str'`
+  \\ rw []
+  \\ rename1 ‘fromChars _ str’ \\ Cases_on ‘str’
   \\ rw tactics
   \\ fs tactics
   end
@@ -513,8 +514,9 @@ Proof
   \\ fs[IS_SOME_EXISTS, PULL_EXISTS]
   \\ fs[EQ_IMP_THM] \\ fs[PULL_EXISTS]
   \\ rw[] \\ fs[]
+  \\ rename1 ‘fromChars _ str’
   >- (
-    qspecl_then[`str'`,`SUC v2 - padLen_DEC`,`padLen_DEC`]mp_tac fromChars_range_IS_SOME_IFF
+    qspecl_then[`str`,`SUC v2 - padLen_DEC`,`padLen_DEC`]mp_tac fromChars_range_IS_SOME_IFF
     \\ simp[]
     \\ fs[EVERY_MEM,MEM_EL,PULL_EXISTS,EL_TAKE,EL_DROP]
     \\ rw[]
@@ -525,7 +527,7 @@ Proof
   \\ impl_tac
   >- ( fs[EVERY_MEM, MEM_EL, PULL_EXISTS, LENGTH_TAKE_EQ, EL_TAKE] )
   \\ strip_tac \\ fs[]
-  \\ qspecl_then[`str'`,`SUC v2 - padLen_DEC`,`padLen_DEC`]mp_tac fromChars_range_IS_SOME_IFF
+  \\ qspecl_then[`str`,`SUC v2 - padLen_DEC`,`padLen_DEC`]mp_tac fromChars_range_IS_SOME_IFF
   \\ simp[IS_SOME_EXISTS]
   \\ fs[EVERY_MEM, MEM_EL, PULL_EXISTS, LENGTH_TAKE_EQ, EL_TAKE, EL_DROP]
 QED

--- a/basis/pure/mlstringLib.sml
+++ b/basis/pure/mlstringLib.sml
@@ -68,7 +68,7 @@ fun mlstring_case_conv tm =
 local open mlstringTheory in
 val add_mlstring_compset = computeLib.extend_compset
   [computeLib.Tys [mlstringSyntax.mlstring_ty],
-   computeLib.Defs [implode_def, str_def, concat_thm, explode_thm]]
+   computeLib.Defs [implode_def, chr_to_str_def, concat_thm, explode_thm]]
 end
 
 end

--- a/basis/pure/mlstringScript.sml
+++ b/basis/pure/mlstringScript.sml
@@ -287,20 +287,22 @@ Proof
     rw[concatWith_def, CONCAT_WITH_def, concatWith_CONCAT_WITH_aux]
 QED
 
-Definition str_def:
-  str (c: char) = implode [c]
+Definition chr_to_str_def:
+  chr_to_str (c: char) = implode [c]
 End
 
-Theorem explode_str[simp]:
-   explode (str c) = [c]
+Overload toString = “chr_to_str”
+
+Theorem explode_toString[simp]:
+   explode (toString c) = [c]
 Proof
-  rw[str_def]
+  rw[chr_to_str_def]
 QED
 
-Theorem strlen_str[simp]:
-   strlen (str c) = 1
+Theorem strlen_toString[simp]:
+   strlen (toString c) = 1
 Proof
-rw[str_def]
+rw[chr_to_str_def]
 QED
 
 Definition translate_aux_def:
@@ -517,7 +519,7 @@ Theorem TOKENS_eq_tokens_sym =
 Theorem tokens_append:
    !P s1 x s2.
     P x ==>
-      (tokens P (strcat (strcat s1 (str x)) s2) = tokens P s1 ++ tokens P s2)
+      (tokens P (strcat (strcat s1 (toString x)) s2) = tokens P s1 ++ tokens P s2)
 Proof
     rw[TOKENS_eq_tokens_sym] \\ Cases_on `s1` \\ Cases_on `s2`
     \\ rewrite_tac[GSYM MAP_APPEND] \\ AP_TERM_TAC
@@ -546,11 +548,11 @@ End
 
 Theorem substring_1_strsub:
   i < strlen s ⇒
-  substring s i 1 = str (strsub s i)
+  substring s i 1 = toString (strsub s i)
 Proof
   Cases_on`s`>>rw[substring_def]>>
   DEP_REWRITE_TAC[SEG1]>>
-  gvs[str_def,implode_def]
+  gvs[chr_to_str_def,implode_def]
 QED
 
 Theorem substring_0[simp]:

--- a/compiler/backend/exportScript.sml
+++ b/compiler/backend/exportScript.sml
@@ -170,7 +170,7 @@ QED
 Definition escape_sym_char_def:
   escape_sym_char ch = let code = ORD ch in
     if code >= 0x61 /\ code <= 0x7A \/ code >= 0x41 /\ code <= 0x5A \/
-       code >= 0x30 /\ code <= 0x39 \/ code = 0x5F then str ch else
+       code >= 0x30 /\ code <= 0x39 \/ code = 0x5F then toString ch else
     «$» ^ toString(code) ^ «_»
 End
 

--- a/compiler/backend/proofs/flat_to_closProofScript.sml
+++ b/compiler/backend/proofs/flat_to_closProofScript.sml
@@ -974,8 +974,8 @@ Proof
         v_to_list x = SOME vs /\ vs_to_string vs = SOME s₁ /\ v_rel x y ==>
         ?wss. v_to_list y = SOME (MAP ByteVector wss) /\
               MAP (CHR o w2n) (FLAT wss) = explode s₁`
-  \\ rename1 ‘vs_to_string _ = SOME strng’
-  \\ Cases_on ‘strng’
+  \\ rename1 ‘vs_to_string _ = SOME str’
+  \\ Cases_on ‘str’
   THEN1
    (rpt (disch_then drule \\ fs []) \\ strip_tac \\ fs []
     \\ `!xs ys. MAP ByteVector xs = MAP ByteVector ys <=> xs = ys` by

--- a/compiler/backend/proofs/source_to_flatProofScript.sml
+++ b/compiler/backend/proofs/source_to_flatProofScript.sml
@@ -1269,7 +1269,7 @@ Proof
       full_simp_tac(srw_ss())[v_rel_eqns, result_rel_cases, v_rel_lems] >>
       imp_res_tac v_to_char_list >>
       srw_tac[][] >>
-      namedCases_on ‘strng’ ["s"] >>
+      namedCases_on ‘str’ ["s"] >>
       fs [] >>
       Induct_on `s` >>
       fs [semanticPrimitivesTheory.list_to_v_def,flatSemTheory.list_to_v_def] >>
@@ -1282,7 +1282,7 @@ Proof
       srw_tac[][markerTheory.Abbrev_def] >>
       srw_tac[][markerTheory.Abbrev_def] >>
       full_simp_tac(srw_ss())[v_rel_lems]
-      >> rename1 ‘explode strng’ >> Cases_on ‘strng’ >> fs [])
+      >> rename1 ‘explode str’ >> Cases_on ‘str’ >> fs [])
   >~ [‘Strlen’] >- (
       srw_tac[][semanticPrimitivesPropsTheory.do_app_cases, flatSemTheory.do_app_def] >>
       full_simp_tac(srw_ss())[v_rel_eqns, result_rel_cases, v_rel_lems])

--- a/compiler/backend/semantics/flatSemScript.sml
+++ b/compiler/backend/semantics/flatSemScript.sml
@@ -381,16 +381,16 @@ Definition do_app_def:
               | NONE => NONE
               | SOME s' => SOME (s with refs := s', Rval Unitv))
      | _ => NONE)
-  | (Src CopyStrStr, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len)]) =>
+  | (Src CopyStrStr, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len)]) =>
       SOME (s,
-      (case copy_array (explode strng,off) len NONE of
+      (case copy_array (explode str,off) len NONE of
         NONE => Rerr (Rraise subscript_exn_v)
       | SOME cs => Rval (Litv(StrLit(implode cs)))))
-  | (Src CopyStrAw8, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len);
+  | (Src CopyStrAw8, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len);
                   Loc _ dst;Litv(IntLit dstoff)]) =>
       (case store_lookup dst s.refs of
         SOME (W8array ws) =>
-          (case copy_array (explode strng,off) len (SOME(ws_to_chars ws,dstoff)) of
+          (case copy_array (explode str,off) len (SOME(ws_to_chars ws,dstoff)) of
             NONE => SOME (s, Rerr (Rraise subscript_exn_v))
           | SOME cs =>
             (case store_assign dst (W8array (chars_to_ws cs)) s.refs of
@@ -431,25 +431,25 @@ Definition do_app_def:
      | SOME ls =>
        SOME (s, Rval (Litv (StrLit (implode ls))))
      | NONE => NONE)
-  | (Src Explode, [Litv (StrLit strng)]) =>
-    (SOME (s, Rval (list_to_v (MAP (\c. Litv (Char c)) (explode strng)))))
-  | (Src Strsub, [Litv (StrLit strng); Litv (IntLit i)]) =>
+  | (Src Explode, [Litv (StrLit str)]) =>
+    (SOME (s, Rval (list_to_v (MAP (\c. Litv (Char c)) (explode str)))))
+  | (Src Strsub, [Litv (StrLit str); Litv (IntLit i)]) =>
     if i < 0 then
       SOME (s, Rerr (Rraise subscript_exn_v))
     else
       let n = (Num (ABS i)) in
-        if n >= strlen strng then
+        if n >= strlen str then
           SOME (s, Rerr (Rraise subscript_exn_v))
         else
-          SOME (s, Rval (Litv (Char (strsub strng n))))
-  | (Src Strlen, [Litv (StrLit strng)]) =>
-    SOME (s, Rval (Litv(IntLit(int_of_num(strlen strng)))))
+          SOME (s, Rval (Litv (Char (strsub str n))))
+  | (Src Strlen, [Litv (StrLit str)]) =>
+    SOME (s, Rval (Litv(IntLit(int_of_num(strlen str)))))
   | (Src Strcat, [v]) =>
       (case v_to_list v of
         SOME vs =>
           (case vs_to_string vs of
-            SOME strng =>
-              SOME (s, Rval (Litv(StrLit strng)))
+            SOME str =>
+              SOME (s, Rval (Litv(StrLit str)))
           | _ => NONE)
       | _ => NONE)
   | (Src VfromList, [v]) =>

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -402,10 +402,10 @@ val _ = translate infer_tTheory.get_tyname_def;
 Theorem ty_var_name_eq:
   ty_var_name n =
     concat [«'»;
-            if n < 28 then str (CHR (n + ORD #"a")) else mlint$toString (&n)]
+            if n < 28 then toString (CHR (n + ORD #"a")) else mlint$toString (&n)]
 Proof
   rw [infer_tTheory.ty_var_name_def,mlstringTheory.implode_def]
-  \\ fs [mlstringTheory.concat_def,mlstringTheory.str_def,mlstringTheory.implode_def]
+  \\ fs [mlstringTheory.concat_def,mlstringTheory.chr_to_str_def,mlstringTheory.implode_def]
 QED
 
 val _ = translate ty_var_name_eq;

--- a/compiler/dafny/proofs/dafny_to_cakemlProofScript.sml
+++ b/compiler/dafny/proofs/dafny_to_cakemlProofScript.sml
@@ -93,7 +93,7 @@ Definition cml_dec_to_string_clos_def:
 End
 
 Definition dec_to_string_def:
-  dec_to_string n = str (CHR (48 + n))
+  dec_to_string n = toString (CHR (48 + n))
 End
 
 Definition has_list_cons_def:
@@ -122,7 +122,7 @@ Proof
            do_con_check_def, build_conv_def, do_app_def, do_arith_def, check_type_def]
   \\ ‘¬((48: int) + &n < 0 ∨ (48: int) + &n > 255)’ by (intLib.COOPER_TAC)
   \\ simp [v_to_char_list_def]
-  \\ gvs [dec_to_string_def, str_def]
+  \\ gvs [dec_to_string_def, chr_to_str_def]
   \\ AP_TERM_TAC \\ AP_THM_TAC \\ ntac 2 AP_TERM_TAC
   \\ intLib.COOPER_TAC
 QED

--- a/compiler/parsing/fromSexpScript.sml
+++ b/compiler/parsing/fromSexpScript.sml
@@ -325,7 +325,7 @@ Definition odestSXNUM_def[simp]:
 End
 
 Theorem odestSXNUM_SEXSTR[simp]:
-  odestSXNUM (SEXSTR strng) = NONE
+  odestSXNUM (SEXSTR str) = NONE
 Proof
   simp[SEXSTR_def]
 QED
@@ -362,7 +362,7 @@ Theorem sexplist_thm[simp]:
     do ph <- p h ; pt <- sexplist p t; return (ph::pt) od ∧
   (sexplist p (SX_SYM s) = if s = "nil" then return [] else fail) ∧
   sexplist p (&n) = fail ∧
-  sexplist p (SX_STR strng) = fail
+  sexplist p (SX_STR str) = fail
 Proof
   rpt strip_tac >> simp[Once sexplist_def]
 QED
@@ -411,7 +411,7 @@ QED
 Theorem strip_sxcons_thm[simp]:
   strip_sxcons ⟪ h • t ⟫ = lift (CONS h) (strip_sxcons t) ∧
   strip_sxcons (&n) = NONE ∧
-  strip_sxcons (SX_STR strng) = NONE ∧
+  strip_sxcons (SX_STR str) = NONE ∧
   strip_sxcons (SX_SYM s) = if s = "nil" then SOME [] else NONE
 Proof
   rpt strip_tac >> simp[]
@@ -1496,11 +1496,11 @@ QED
 Theorem dstrip_sexp_thm[simp]:
   dstrip_sexp ⟪SX_SYM s • args⟫ = lift (λt. (s,t)) (strip_sxcons args) ∧
   dstrip_sexp ⟪ &n • args⟫ = NONE ∧
-  dstrip_sexp ⟪SX_STR strng • args⟫ = NONE ∧
+  dstrip_sexp ⟪SX_STR str • args⟫ = NONE ∧
   dstrip_sexp ⟪ ⟪s1 • s2⟫ • args⟫ = NONE ∧
   dstrip_sexp (&n) = NONE ∧
   dstrip_sexp (SX_SYM s) = NONE ∧
-  dstrip_sexp (SX_STR strng) = NONE
+  dstrip_sexp (SX_STR str) = NONE
 Proof
   simp[dstrip_sexp_def]
 QED
@@ -1872,8 +1872,8 @@ Proof
 QED
 
 Theorem odestSXSYM_EQ_SOME[simp]:
-  (odestSXSYM s = SOME strng ⇔ s = SX_SYM (explode strng)) ∧
-  (SOME strng = odestSXSYM s ⇔ s = SX_SYM (explode strng))
+  (odestSXSYM s = SOME str ⇔ s = SX_SYM (explode str)) ∧
+  (SOME str = odestSXSYM s ⇔ s = SX_SYM (explode str))
 Proof
   Cases_on‘s’ >> simp[odestSXSYM_def] >>
   metis_tac[implode_explode,explode_implode]
@@ -1937,7 +1937,7 @@ Proof
     simp[litsexp_def, listsexp_def, PULL_EXISTS, AllCaseEqs(), SF CONJ_ss] >~
     [‘i < 0i’] >- (Cases_on ‘i’ >> simp[]) >~
     [‘STRING c ""’] >- (
-      qexists_tac ‘str c’ >> simp []>>
+      qexists_tac ‘toString c’ >> simp []>>
       EVAL_TAC) >~
     [‘w2n (c : word8)’]
     >- (Cases_on ‘c’ using ranged_word_nchotomy >> gs[dimword_def]) >>~-

--- a/compiler/parsing/lexer_implScript.sml
+++ b/compiler/parsing/lexer_implScript.sml
@@ -176,71 +176,71 @@ End
 
 Definition next_sym_alt_def:
   (next_sym_alt "" _ = NONE) /\
-  (next_sym_alt (c::strng) loc =
+  (next_sym_alt (c::str) loc =
      if c = #"\n" then (* skip new line *)
-        next_sym_alt strng (next_line loc)
+        next_sym_alt str (next_line loc)
      else if isSpace c then (* skip blank space *)
-       next_sym_alt strng (next_loc 1 loc)
+       next_sym_alt str (next_loc 1 loc)
      else if isDigit c then (* read number *)
-       if strng ≠ "" ∧ c = #"0" ∧ HD strng = #"w" then
-         if TL strng = "" then SOME (ErrorS, Locs loc loc, "")
-         else if isDigit (HD (TL strng)) then
-           let (n,rest) = read_while isDigit (TL strng) [] in
+       if str ≠ "" ∧ c = #"0" ∧ HD str = #"w" then
+         if TL str = "" then SOME (ErrorS, Locs loc loc, "")
+         else if isDigit (HD (TL str)) then
+           let (n,rest) = read_while isDigit (TL str) [] in
              SOME (WordS (num_from_dec_string_alt n),
                    Locs loc (next_loc (LENGTH n + 1) loc),
                    rest)
-         else if HD(TL strng) = #"x" then
-           let (n,rest) = read_while isHexDigit (TL (TL strng)) [] in
+         else if HD(TL str) = #"x" then
+           let (n,rest) = read_while isHexDigit (TL (TL str)) [] in
              SOME (WordS (num_from_hex_string_alt n),
                    Locs loc (next_loc (LENGTH n + 2) loc),
                    rest)
-         else SOME (ErrorS, Locs loc loc, TL strng)
+         else SOME (ErrorS, Locs loc loc, TL str)
        else
-         if strng ≠ "" ∧ c = #"0" ∧ HD strng = #"x" then
-           let (n,rest) = read_while isHexDigit (TL strng) [] in
+         if str ≠ "" ∧ c = #"0" ∧ HD str = #"x" then
+           let (n,rest) = read_while isHexDigit (TL str) [] in
              SOME (NumberS (& num_from_hex_string_alt n),
                    Locs loc (next_loc (LENGTH n) loc),
                    rest)
          else
-           let (n,rest) = read_while isDigit strng [] in
+           let (n,rest) = read_while isDigit str [] in
              SOME (NumberS (&(num_from_dec_string_alt (c::n))),
                    Locs loc (next_loc (LENGTH n) loc),
                    rest)
-     else if c = #"~" /\ strng <> "" /\ isDigit (HD strng) then (* read negative number *)
-       let (n,rest) = read_while isDigit strng [] in
+     else if c = #"~" /\ str <> "" /\ isDigit (HD str) then (* read negative number *)
+       let (n,rest) = read_while isDigit str [] in
          SOME (NumberS (0- &(num_from_dec_string_alt n)),
                Locs loc (next_loc (LENGTH n + 1) loc),
                rest)
      else if c = #"'" then (* read type variable *)
-       let (n,rest) = read_while isAlphaNumPrime strng [c] in
+       let (n,rest) = read_while isAlphaNumPrime str [c] in
          SOME (OtherS n,
                Locs loc (next_loc (LENGTH n - 1) loc),
                rest)
      else if c = #"\"" then (* read string *)
-       let (t, loc', rest) = read_string strng "" (next_loc 1 loc) in
+       let (t, loc', rest) = read_string str "" (next_loc 1 loc) in
          SOME (t, Locs loc loc', rest)
-     else if isPREFIX "*)" (c::strng) then
-       SOME (ErrorS, Locs loc (next_loc 2 loc), TL strng)
-     else if isPREFIX "#\"" (c::strng) then
-       let (t, loc', rest) = read_string (TL strng) "" (next_loc 2 loc) in
+     else if isPREFIX "*)" (c::str) then
+       SOME (ErrorS, Locs loc (next_loc 2 loc), TL str)
+     else if isPREFIX "#\"" (c::str) then
+       let (t, loc', rest) = read_string (TL str) "" (next_loc 2 loc) in
          SOME (mkCharS t, Locs loc loc', rest)
-     else if isPREFIX "#(" (c::strng) then
+     else if isPREFIX "#(" (c::str) then
        let (t, loc', rest) =
-             read_FFIcall (TL strng) "" (next_loc 2 loc)
+             read_FFIcall (TL str) "" (next_loc 2 loc)
        in
          SOME (t, Locs loc loc', rest)
-     else if isPREFIX "(*" (c::strng) then
-       case skip_comment (TL strng) (0:num) (next_loc 2 loc) of
+     else if isPREFIX "(*" (c::str) then
+       case skip_comment (TL str) (0:num) (next_loc 2 loc) of
        | NONE => SOME (ErrorS, Locs loc (next_loc 2 loc), "")
        | SOME (rest, loc') => next_sym_alt rest loc'
-     else if c = #"_" then SOME (OtherS "_", Locs loc loc, strng) else
-       let (tok,end_loc,rest) = read_Ident (STRING c strng) loc [] in
+     else if c = #"_" then SOME (OtherS "_", Locs loc loc, str) else
+       let (tok,end_loc,rest) = read_Ident (STRING c str) loc [] in
          SOME (tok,Locs loc end_loc,rest))
 Termination
    WF_REL_TAC `measure (LENGTH o FST) ` THEN REPEAT STRIP_TAC
    THEN IMP_RES_TAC (GSYM read_while_thm)
    THEN IMP_RES_TAC (GSYM read_string_thm)
-   THEN IMP_RES_TAC skip_comment_thm THEN Cases_on `strng`
+   THEN IMP_RES_TAC skip_comment_thm THEN Cases_on `str`
    THEN FULL_SIMP_TAC (srw_ss()) [LENGTH] THEN DECIDE_TAC
 End
 

--- a/examples/catProgScript.sml
+++ b/examples/catProgScript.sml
@@ -87,7 +87,7 @@ Proof
   \\ xmatch
   \\ xlet ‘POSTv uv.
              &UNIT_TYPE () uv *
-             STDIO (add_stdout (forwardFD fs fd k) (str c)) *
+             STDIO (add_stdout (forwardFD fs fd k) (toString c)) *
              INSTREAM_STR fd is rest (forwardFD fs fd k)’
   >-
    (xapp_spec output1_stdOut_spec
@@ -97,7 +97,7 @@ Proof
     \\ simp [] \\ xsimpl)
   \\ once_rewrite_tac [INSTREAM_STR_get_file_content] \\ xpull
   \\ xapp
-  \\ qexistsl [‘emp’, ‘add_stdout (forwardFD fs fd k) (str c)’, ‘fd’]
+  \\ qexistsl [‘emp’, ‘add_stdout (forwardFD fs fd k) (toString c)’, ‘fd’]
   \\ xsimpl
   \\ ‘STD_streams (forwardFD fs fd k)’ by
     (DEP_REWRITE_TAC [STD_streams_forwardFD] \\ simp [])

--- a/examples/diffScript.sml
+++ b/examples/diffScript.sml
@@ -268,7 +268,7 @@ End
 Theorem tokens_append_strlit:
   ∀P s1 x s2. P x ⇒ tokens P (s1 ^ strlit [x] ^ s2) = tokens P s1 ++ tokens P s2
 Proof
-  rw[] >> drule tokens_append >> rw[str_def,implode_def]
+  rw[] >> drule tokens_append >> rw[chr_to_str_def,implode_def]
 QED
 
 Theorem tokens_append_right_strlit:
@@ -376,9 +376,9 @@ Proof
 QED
 
 Theorem strsub_str[local]:
-   strsub (str c) 0 = c
+   strsub (toString c) 0 = c
 Proof
-  rw[str_def,implode_def,strsub_def]
+  rw[chr_to_str_def,implode_def,strsub_def]
 QED
 
 Theorem acd_simps[local]:
@@ -512,12 +512,12 @@ Theorem parse_header_cancel[local]:
 Proof
   rw[diff_single_header_def,parse_patch_header_def,
      option_case_eq,list_case_eq,PULL_EXISTS,
-     strsub_strcat,tokens_append_right_strlit,GSYM str_def,
+     strsub_strcat,tokens_append_right_strlit,GSYM chr_to_str_def,
      tokens_append,acd_simps,tokens_comma_lemma,
      tokens_comma_lemma]
   \\ rw[line_numbers_def,tokens_toString_comma,
         fromNatString_toString,
-        GSYM str_def,tokens_append,strsub_str]
+        GSYM chr_to_str_def,tokens_append,strsub_str]
 QED
 
 Theorem patch_aux_cancel_base_case[local]:

--- a/examples/echoProgScript.sml
+++ b/examples/echoProgScript.sml
@@ -46,7 +46,7 @@ Proof
   unabbrev_all_tac \\
   xsimpl >> fs[] >>
   imp_res_tac STD_streams_stdout >>
-  simp[str_def,implode_def] >>
+  simp[chr_to_str_def,implode_def] >>
   imp_res_tac add_stdo_o >> xsimpl
 QED
 

--- a/examples/filterProgScript.sml
+++ b/examples/filterProgScript.sml
@@ -272,7 +272,7 @@ QED
 Definition cut_at_null_def:
   cut_at_null s =
   case null_index s 0 of
-      NONE => strcat s (str(CHR 0))
+      NONE => strcat s (toString(CHR 0))
     | SOME n => substring s 0 (SUC n)
 End
 

--- a/examples/lpr_checker/array/lpr_composeProgScript.sml
+++ b/examples/lpr_checker/array/lpr_composeProgScript.sml
@@ -198,7 +198,7 @@ End
 Theorem line_of_gen_lines_of[simp]:
   lines_of_gen #"\n" = lines_of
 Proof
-  rw[FUN_EQ_THM,lines_of_gen_def,lines_of_def,splitlines_at_def,splitlines_def,str_def]
+  rw[FUN_EQ_THM,lines_of_gen_def,lines_of_def,splitlines_at_def,splitlines_def,chr_to_str_def]
 QED
 
 Theorem line_count_of_spec:

--- a/examples/lpr_checker/lpr_parsingScript.sml
+++ b/examples/lpr_checker/lpr_parsingScript.sml
@@ -165,7 +165,7 @@ Proof
   >-
     EVAL_TAC
   >>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]
 QED
 
@@ -181,7 +181,7 @@ Proof
   >-
     EVAL_TAC
   >>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   disch_then kall_tac>>
   simp[tokens_blanks_toStdString]>>
@@ -231,7 +231,7 @@ Theorem parse_header_line_print_header_line:
 Proof
   rw[print_header_line_def, toks_def]>>
   qmatch_goalsub_abbrev_tac`aa ^ bb ^ _ ^ cc ^ dd`>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   `aa = strlit"p" ^ strlit" " ^ strlit"cnf" ^ strlit" "` by
     (fs[Abbr`aa`]>>EVAL_TAC)>>
@@ -239,7 +239,7 @@ Proof
   first_assum(qspecl_then[`aa ^ bb`,`cc ^ dd`] assume_tac)>>fs[]>>
   `cc ^ dd = cc ^ dd ^ strlit""` by EVAL_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  `blanks #"\n" ∧ str #"\n" = strlit "\n"` by EVAL_TAC>>
+  `blanks #"\n" ∧ toString #"\n" = strlit "\n"` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   unabbrev_all_tac>>
   simp[tokens_blanks_toStdString]>>
@@ -370,7 +370,7 @@ Proof
   rw[]>>
   Cases_on`x`>>simp[print_clause_def]
   >- EVAL_TAC >>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   simp[toks_def]>>
   drule mlstringTheory.tokens_append>>simp[]>>
   simp[tokens_blanks_toStdString,tokenize_def,nocomment_line_def]
@@ -398,7 +398,7 @@ Proof
   simp[]>>
   PURE_REWRITE_TAC[GSYM mlstringTheory.strcat_assoc]>>
   PURE_REWRITE_TAC[Once mlstringTheory.strcat_assoc]>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   `tokens blanks (strlit "p") = [strlit "p"]` by EVAL_TAC>>
   simp[]
@@ -765,7 +765,7 @@ Theorem toks_strcat_d:
   toks (strlit"d " ^ y) = INL (strlit"d"):: toks y
 Proof
   simp[toks_def]>>
-  `strlit"d " = strlit"d" ^ str(#" ")` by
+  `strlit"d " = strlit"d" ^ toString(#" ")` by
     EVAL_TAC>>
   simp[]>>
   DEP_REWRITE_TAC [mlstringTheory.tokens_append]>>simp[]>>
@@ -785,7 +785,7 @@ Proof
   >-
     EVAL_TAC
   >>
-  `strlit" " = str #" "` by EVAL_TAC>>
+  `strlit" " = toString #" "` by EVAL_TAC>>
   simp[]>>
   DEP_REWRITE_TAC[mlstringTheory.tokens_append]>>simp[]>>
   CONJ_TAC >- EVAL_TAC>>
@@ -816,7 +816,7 @@ Proof
     Cases_on`l`>>simp[print_clause_def]
     >-
       EVAL_TAC>>
-    `strlit" " = str #" "` by EVAL_TAC>>
+    `strlit" " = toString #" "` by EVAL_TAC>>
     simp[toks_def]>>
     DEP_REWRITE_TAC[mlstringTheory.tokens_append]>>
     simp[tokens_blanks_toStdString,tokenize_def]>>

--- a/examples/vipr/viprProgScript.sml
+++ b/examples/vipr/viprProgScript.sml
@@ -140,7 +140,7 @@ Theorem lines_of_gen_lines_of:
   lines_of_gen #"\n" xs =
   lines_of xs
 Proof
-  rw[lines_of_def,lines_of_gen_def,splitlines_at_def,splitlines_def,str_def]
+  rw[lines_of_def,lines_of_gen_def,splitlines_at_def,splitlines_def,chr_to_str_def]
 QED
 
 Theorem main_spec_stdin:

--- a/examples/xlrup_checker/cnf_extScript.sml
+++ b/examples/xlrup_checker/cnf_extScript.sml
@@ -293,7 +293,7 @@ Definition print_lit_def:
 End
 
 Definition print_lits_def:
-  (print_lits e [] = str #"0" ^ str e) ∧
+  (print_lits (e: char) [] = toString #"0" ^ toString e) ∧
   (print_lits e (x::xs) =
     print_lit x ^ strlit(" ") ^ print_lits e xs)
 End
@@ -434,10 +434,10 @@ Proof
   Induct>>rw[print_lits_def]
   >- (
     drule mlstringTheory.tokens_append>>simp[]>>
-    `strlit (STRING #"0" (STRING c "")) = strlit"0" ^ str c` by EVAL_TAC>>
+    `strlit (STRING #"0" (STRING c "")) = strlit"0" ^ toString c` by EVAL_TAC>>
     simp[]>>
     EVAL_TAC)>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   PURE_REWRITE_TAC[GSYM strcat_assoc]>>
   disch_then (fn th => simp[th])>>
@@ -471,7 +471,7 @@ Theorem fix_hd_toks:
   SOME (toks rest)
 Proof
   rw[toks_def]>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   qmatch_goalsub_abbrev_tac`aa ^ bb`>>
   `aa = strlit[c] ^ strlit" "` by
@@ -535,8 +535,8 @@ Theorem parse_bnn_tail_print_tail:
   parse_bnn_tail (toks (print_tail k oy)) = SOME (k,oy)
 Proof
   rw[print_tail_def,toks_def]>>
-  `« 0\n» = str #" " ^ strlit"0\n"` by EVAL_TAC>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `« 0\n» = toString #" " ^ strlit"0\n"` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>
   simp[tokens_blanks_toString]>>
   `MAP tokenize (tokens blanks «0\n») = [INR 0]` by
@@ -577,7 +577,7 @@ Theorem parse_header_line_print_header_line:
 Proof
   rw[print_header_line_def, toks_def]>>
   qmatch_goalsub_abbrev_tac`aa ^ bb ^ _ ^ cc ^ dd`>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   `aa = strlit"p" ^ strlit" " ^ strlit"cnf" ^ strlit" "` by
     (fs[Abbr`aa`]>>EVAL_TAC)>>
@@ -585,7 +585,7 @@ Proof
   first_assum(qspecl_then[`aa ^ bb`,`cc ^ dd`] assume_tac)>>fs[]>>
   `cc ^ dd = cc ^ dd ^ strlit""` by EVAL_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  `blanks #"\n" ∧ str #"\n" = strlit "\n"` by EVAL_TAC>>
+  `blanks #"\n" ∧ toString #"\n" = strlit "\n"` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   unabbrev_all_tac>>
   rw[]>>
@@ -610,7 +610,7 @@ Proof
   simp[]>>
   PURE_REWRITE_TAC[GSYM mlstringTheory.strcat_assoc]>>
   PURE_REWRITE_TAC[Once mlstringTheory.strcat_assoc]>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   `tokens blanks (strlit "p") = [strlit "p"]` by EVAL_TAC>>
   simp[]
@@ -626,7 +626,7 @@ Proof
   rw[]>>
   Cases_on`x`>>simp[print_clause_def]
   >- EVAL_TAC >>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   first_x_assum drule>>
   simp[DISJ_IMP_THM,FORALL_AND_THM]>>rw[]>>
   simp[toks_def,print_lits_def]>>
@@ -678,7 +678,7 @@ Proof
   rw[parse_lits_def,print_xor_def,toks_def]>>
   `strlit "x " = strlit"x" ^ strlit" "` by EVAL_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   rw[]>>
   EVAL_TAC>>
@@ -706,7 +706,7 @@ Proof
   rw[parse_lits_def,print_bnn_def,toks_def]>>
   `strlit "b " = strlit"b" ^ strlit" "` by EVAL_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   PURE_REWRITE_TAC[GSYM strcat_assoc]>>
   DISCH_THEN (fn th => simp[th])>>
@@ -721,7 +721,7 @@ Proof
   rw[parse_xor_def,print_bnn_def,toks_def]>>
   `strlit "b " = strlit"b" ^ strlit" "` by EVAL_TAC>>
   pop_assum SUBST_ALL_TAC>>
-  `blanks #" " ∧ str #" " = strlit " "` by EVAL_TAC>>
+  `blanks #" " ∧ toString #" " = strlit " "` by EVAL_TAC>>
   drule mlstringTheory.tokens_append>>simp[]>>
   PURE_REWRITE_TAC[GSYM strcat_assoc]>>
   DISCH_THEN (fn th => simp[th])>>

--- a/pancake/parser/panLexerScript.sml
+++ b/pancake/parser/panLexerScript.sml
@@ -259,7 +259,7 @@ Definition next_atom_def:
       let (n, rest) = read_while isAlphaNumOrWild cs [c] in
       SOME (WordA n, Locs loc (next_loc (LENGTH n) loc), rest)
     else (* input not recognised *)
-      SOME (ErrA $ concat [«Unrecognised symbol: »; str c], Locs loc loc, cs)
+      SOME (ErrA $ concat [«Unrecognised symbol: »; toString c], Locs loc loc, cs)
 Termination
   WF_REL_TAC `measure (LENGTH o FST)`
   \\ simp []

--- a/semantics/alt_semantics/itree_semanticsScript.sml
+++ b/semantics/alt_semantics/itree_semanticsScript.sml
@@ -148,17 +148,17 @@ Definition do_app_def:
                   )
         | _ => NONE
       )
-    | (CopyStrStr, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len)]) =>
+    | (CopyStrStr, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len)]) =>
         SOME (s,
-        (case copy_array (explode strng,off) len NONE of
+        (case copy_array (explode str,off) len NONE of
           NONE => Rraise sub_exn_v
         | SOME cs => Rval (Litv(StrLit(implode (cs))))
         ))
-    | (CopyStrAw8, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len);
+    | (CopyStrAw8, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len);
                     Loc _ dst;Litv(IntLit dstoff)]) =>
         (case store_lookup dst s of
           SOME (W8array ws) =>
-            (case copy_array (explode strng,off) len (SOME(ws_to_chars ws,dstoff)) of
+            (case copy_array (explode str,off) len (SOME(ws_to_chars ws,dstoff)) of
               NONE => SOME (s, Rraise sub_exn_v)
             | SOME cs =>
               (case store_assign dst (W8array (chars_to_ws cs)) s of
@@ -211,27 +211,27 @@ Definition do_app_def:
           )
     | (Explode, [v]) =>
           (case v of
-            Litv (StrLit strng) =>
-              SOME (s, Rval (list_to_v (MAP (\ c .  Litv (Char c)) (explode strng))))
+            Litv (StrLit str) =>
+              SOME (s, Rval (list_to_v (MAP (\ c .  Litv (Char c)) (explode str))))
           | _ => NONE
           )
-    | (Strsub, [Litv (StrLit strng); Litv (IntLit i)]) =>
+    | (Strsub, [Litv (StrLit str); Litv (IntLit i)]) =>
         if i <( 0 : int) then
           SOME (s, Rraise sub_exn_v)
         else
           let n = (Num (ABS (I i))) in
-            if n >= strlen strng then
+            if n >= strlen str then
               SOME (s, Rraise sub_exn_v)
             else
-              SOME (s, Rval (Litv (Char (EL n (explode strng)))))
-    | (Strlen, [Litv (StrLit strng)]) =>
-        SOME (s, Rval (Litv(IntLit(int_of_num(strlen strng)))))
+              SOME (s, Rval (Litv (Char (EL n (explode str)))))
+    | (Strlen, [Litv (StrLit str)]) =>
+        SOME (s, Rval (Litv(IntLit(int_of_num(strlen str)))))
     | (Strcat, [v]) =>
         (case v_to_list v of
           SOME vs =>
             (case vs_to_string vs of
-              SOME strng =>
-                SOME (s, Rval (Litv(StrLit strng)))
+              SOME str =>
+                SOME (s, Rval (Litv(StrLit str)))
             | _ => NONE
             )
         | _ => NONE

--- a/semantics/lexer_funScript.sml
+++ b/semantics/lexer_funScript.sml
@@ -95,14 +95,14 @@ Proof
 QED
 
 Definition read_string_def:
-  read_string strng s (loc:locn) =
-    if strng = "" then (ErrorS, loc, "") else
-    if HD strng = #"\"" then (StringS s, loc, TL strng) else
-    if HD strng = #"\n" then (ErrorS, next_line loc, TL strng) else
-    if HD strng <> #"\\" then
-      read_string (TL strng) (s ++ [HD strng]) (next_loc 1 loc)
+  read_string str s (loc:locn) =
+    if str = "" then (ErrorS, loc, "") else
+    if HD str = #"\"" then (StringS s, loc, TL str) else
+    if HD str = #"\n" then (ErrorS, next_line loc, TL str) else
+    if HD str <> #"\\" then
+      read_string (TL str) (s ++ [HD str]) (next_loc 1 loc)
     else
-      case TL strng of
+      case TL str of
       | #"\\"::cs => read_string cs (s ++ "\\") (next_loc 2 loc)
       | #"\""::cs => read_string cs (s ++ "\"") (next_loc 2 loc)
       | #"a"::cs => read_string cs (s ++ [CHR 7]) (next_loc 2 loc)
@@ -117,11 +117,11 @@ Definition read_string_def:
                      NONE => (ErrorS, loc, c::cs)
                    | SOME (c, cs') => read_string cs' (s ++ [c])
                                                       (next_loc 4 loc)
-                 else (ErrorS, loc, TL strng)
-      | _ => (ErrorS, loc, TL strng)
+                 else (ErrorS, loc, TL str)
+      | _ => (ErrorS, loc, TL str)
 Termination
   WF_REL_TAC `measure (LENGTH o FST)` THEN REPEAT STRIP_TAC THEN
-  Cases_on `strng` THEN FULL_SIMP_TAC (srw_ss()) [] THEN
+  Cases_on `str` THEN FULL_SIMP_TAC (srw_ss()) [] THEN
   imp_res_tac read_char_as_3digits_reduces >> gs[]
 End
 
@@ -224,18 +224,18 @@ End
 
 Definition read_Ident_def:
   read_Ident [] loc acc = (ErrorS, loc, []) ∧
-  read_Ident (c::strng) loc acc =
+  read_Ident (c::str) loc acc =
     if is_single_char_symbol c then (* single character tokens, i.e. delimiters *)
       if NULL acc then
-        (OtherS [c], next_loc 1 loc, strng)
+        (OtherS [c], next_loc 1 loc, str)
       else
-        (ErrorS, loc, strng)
+        (ErrorS, loc, str)
     else if isSymbol c then
-      let (n,rest) = read_while isSymbol strng [c] in
+      let (n,rest) = read_while isSymbol str [c] in
       let new_loc = next_loc (LENGTH n) loc in
         read_Ident_ret acc n new_loc rest
     else if isAlpha c then
-      let (n,rest) = read_while isAlphaNumPrime strng [c] in
+      let (n,rest) = read_while isAlphaNumPrime str [c] in
       let new_loc = next_loc (LENGTH n) loc in
         case rest of
         | [] => read_Ident_ret acc n new_loc rest
@@ -243,79 +243,79 @@ Definition read_Ident_def:
           if c1 = #"." then read_Ident rest1 new_loc (n::acc)
           else read_Ident_ret acc n new_loc rest
     else (* input not recognised *)
-      (ErrorS, loc, strng)
+      (ErrorS, loc, str)
 Termination
   wf_rel_tac ‘measure (LENGTH o FST)’ \\ rw []
   \\ imp_res_tac (GSYM read_while_thm)
-  \\ Cases_on ‘strng’ \\ gvs []
+  \\ Cases_on ‘str’ \\ gvs []
 End
 
 (* next_sym reads the next symbol from a string, returning NONE if at eof *)
 Definition next_sym_def:
   (next_sym "" _ = NONE) /\
-  (next_sym (c::strng) loc =
+  (next_sym (c::str) loc =
      if c = #"\n" then (* skip new line *)
-        next_sym strng (next_line loc)
+        next_sym str (next_line loc)
      else if isSpace c then (* skip blank space *)
-       next_sym strng (next_loc 1 loc)
+       next_sym str (next_loc 1 loc)
      else if isDigit c then (* read number *)
-       if strng ≠ "" ∧ c = #"0" ∧ HD strng = #"w" then
-         if TL strng = "" then SOME (ErrorS, Locs loc loc, "")
-         else if isDigit (HD (TL strng)) then
-           let (n,rest) = read_while isDigit (TL strng) [] in
+       if str ≠ "" ∧ c = #"0" ∧ HD str = #"w" then
+         if TL str = "" then SOME (ErrorS, Locs loc loc, "")
+         else if isDigit (HD (TL str)) then
+           let (n,rest) = read_while isDigit (TL str) [] in
              SOME (WordS (num_from_dec_string n),
                    Locs loc (next_loc (LENGTH n + 1) loc),
                    rest)
-         else if HD(TL strng) = #"x" then
-           let (n,rest) = read_while isHexDigit (TL (TL strng)) [] in
+         else if HD(TL str) = #"x" then
+           let (n,rest) = read_while isHexDigit (TL (TL str)) [] in
              SOME (WordS (num_from_hex_string n),
                    Locs loc (next_loc (LENGTH n + 2) loc),
                    rest)
-         else SOME (ErrorS, Locs loc loc, TL strng)
+         else SOME (ErrorS, Locs loc loc, TL str)
        else
-         if strng ≠ "" ∧ c = #"0" ∧ HD strng = #"x" then
-           let (n,rest) = read_while isHexDigit (TL strng) [] in
+         if str ≠ "" ∧ c = #"0" ∧ HD str = #"x" then
+           let (n,rest) = read_while isHexDigit (TL str) [] in
              SOME (NumberS (& (num_from_hex_string n)),
                    Locs loc (next_loc (LENGTH n) loc),
                    rest)
          else
-           let (n,rest) = read_while isDigit strng [] in
+           let (n,rest) = read_while isDigit str [] in
              SOME (NumberS (&(num_from_dec_string (c::n))),
                    Locs loc (next_loc (LENGTH n) loc),
                    rest)
-     else if c = #"~" /\ strng <> "" /\ isDigit (HD strng) then (* read negative number *)
-       let (n,rest) = read_while isDigit strng [] in
+     else if c = #"~" /\ str <> "" /\ isDigit (HD str) then (* read negative number *)
+       let (n,rest) = read_while isDigit str [] in
          SOME (NumberS (0- &(num_from_dec_string n)),
                Locs loc (next_loc (LENGTH n + 1) loc),
                rest)
      else if c = #"'" then (* read type variable *)
-       let (n,rest) = read_while isAlphaNumPrime strng [c] in
+       let (n,rest) = read_while isAlphaNumPrime str [c] in
          SOME (OtherS n, Locs loc (next_loc (LENGTH n - 1) loc),
                rest)
      else if c = #"\"" then (* read string *)
-       let (t, loc', rest) = read_string strng "" (next_loc 1 loc) in
+       let (t, loc', rest) = read_string str "" (next_loc 1 loc) in
          SOME (t, Locs loc loc', rest)
-     else if isPREFIX "*)" (c::strng) then
-       SOME (ErrorS, Locs loc (next_loc 2 loc), TL strng)
-     else if isPREFIX "#\"" (c::strng) then
-       let (t, loc', rest) = read_string (TL strng) "" (next_loc 2 loc) in
+     else if isPREFIX "*)" (c::str) then
+       SOME (ErrorS, Locs loc (next_loc 2 loc), TL str)
+     else if isPREFIX "#\"" (c::str) then
+       let (t, loc', rest) = read_string (TL str) "" (next_loc 2 loc) in
          SOME (mkCharS t, Locs loc loc', rest)
-     else if isPREFIX "#(" (c::strng) then
-       let (t, loc', rest) = read_FFIcall (TL strng) "" (next_loc 2 loc) in
+     else if isPREFIX "#(" (c::str) then
+       let (t, loc', rest) = read_FFIcall (TL str) "" (next_loc 2 loc) in
          SOME (t, Locs loc loc', rest)
-     else if isPREFIX "(*" (c::strng) then
-       case skip_comment (TL strng) 0 (next_loc 2 loc) of
+     else if isPREFIX "(*" (c::str) then
+       case skip_comment (TL str) 0 (next_loc 2 loc) of
        | NONE => SOME (ErrorS, Locs loc (next_loc 2 loc), "")
        | SOME (rest, loc') => next_sym rest loc'
-     else if c = #"_" then SOME (OtherS "_", Locs loc loc, strng)
+     else if c = #"_" then SOME (OtherS "_", Locs loc loc, str)
      else
-       let (tok,end_loc,rest) = read_Ident (c::strng) loc [] in
+       let (tok,end_loc,rest) = read_Ident (c::str) loc [] in
          SOME (tok, Locs loc end_loc, rest))
 Termination
   wf_rel_tac ‘measure (LENGTH o FST)’ \\ rw []
   \\ imp_res_tac (GSYM read_while_thm)
   \\ imp_res_tac (GSYM read_string_thm)
-  \\ Cases_on ‘strng’ \\ gvs []
+  \\ Cases_on ‘str’ \\ gvs []
   \\ imp_res_tac skip_comment_thm \\ gvs []
 End
 

--- a/semantics/semanticPrimitivesScript.sml
+++ b/semantics/semanticPrimitivesScript.sml
@@ -1048,17 +1048,17 @@ Definition do_app_def:
                   )
         | _ => NONE
       )
-    | (CopyStrStr, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len)]) =>
+    | (CopyStrStr, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len)]) =>
         SOME ((s,t),
-        (case copy_array (explode strng,off) len NONE of
+        (case copy_array (explode str,off) len NONE of
           NONE => Rerr (Rraise sub_exn_v)
         | SOME cs => Rval (Litv(StrLit(implode(cs))))
         ))
-    | (CopyStrAw8, [Litv(StrLit strng);Litv(IntLit off);Litv(IntLit len);
+    | (CopyStrAw8, [Litv(StrLit str);Litv(IntLit off);Litv(IntLit len);
                     Loc _ dst;Litv(IntLit dstoff)]) =>
         (case store_lookup dst s of
           SOME (W8array ws) =>
-            (case copy_array (explode strng,off) len (SOME(ws_to_chars ws,dstoff)) of
+            (case copy_array (explode str,off) len (SOME(ws_to_chars ws,dstoff)) of
               NONE => SOME ((s,t), Rerr (Rraise sub_exn_v))
             | SOME cs =>
               (case store_assign dst (W8array (chars_to_ws cs)) s of
@@ -1111,27 +1111,27 @@ Definition do_app_def:
           )
     | (Explode, [v]) =>
           (case v of
-            Litv (StrLit strng) =>
-              SOME ((s,t), Rval (list_to_v (MAP (\ c .  Litv (Char c)) (explode strng))))
+            Litv (StrLit str) =>
+              SOME ((s,t), Rval (list_to_v (MAP (\ c .  Litv (Char c)) (explode str))))
           | _ => NONE
           )
-    | (Strsub, [Litv (StrLit strng); Litv (IntLit i)]) =>
+    | (Strsub, [Litv (StrLit str); Litv (IntLit i)]) =>
         if i <( 0 : int) then
           SOME ((s,t), Rerr (Rraise sub_exn_v))
         else
           let n = (Num (ABS (I i))) in
-            if n >= strlen strng then
+            if n >= strlen str then
               SOME ((s,t), Rerr (Rraise sub_exn_v))
             else
-              SOME ((s,t), Rval (Litv (Char (EL n (explode strng)))))
-    | (Strlen, [Litv (StrLit strng)]) =>
-        SOME ((s,t), Rval (Litv(IntLit(int_of_num(strlen strng)))))
+              SOME ((s,t), Rval (Litv (Char (EL n (explode str)))))
+    | (Strlen, [Litv (StrLit str)]) =>
+        SOME ((s,t), Rval (Litv(IntLit(int_of_num(strlen str)))))
     | (Strcat, [v]) =>
         (case v_to_list v of
           SOME vs =>
             (case vs_to_string vs of
-              SOME strng =>
-                SOME ((s,t), Rval (Litv(StrLit strng)))
+              SOME str =>
+                SOME ((s,t), Rval (Litv(StrLit str)))
             | _ => NONE
             )
         | _ => NONE

--- a/tutorial/solutions/wordfreqProgScript.sml
+++ b/tutorial/solutions/wordfreqProgScript.sml
@@ -83,7 +83,7 @@ Proof
   Induct \\ simp[concat_nil,concat_cons] \\ ntac 3 strip_tac \\
   rename1`insert_line t w` \\
   imp_res_tac insert_line_thm \\ fs[] \\
-  `strlit "\n" = str #"\n"` by EVAL_TAC \\
+  `strlit "\n" = toString #"\n"` by EVAL_TAC \\
   `isSpace #"\n"` by EVAL_TAC \\
   first_x_assum drule \\
   rw[frequency_concat,splitwords_concat,frequency_concat_space,splitwords_concat_space] \\

--- a/tutorial/splitwordsScript.sml
+++ b/tutorial/splitwordsScript.sml
@@ -28,14 +28,14 @@ QED
 
 Theorem splitwords_concat:
    isSpace sp ⇒
-   splitwords (s1 ^ str sp ^ s2) = splitwords s1 ++ splitwords s2
+   splitwords (s1 ^ toString sp ^ s2) = splitwords s1 ++ splitwords s2
 Proof
   rewrite_tac [GSYM strcat_assoc]
   \\ rw[splitwords_def,mlstringTheory.tokens_append,mlstringTheory.strcat_assoc]
 QED
 
 Theorem splitwords_concat_space:
-   isSpace sp ⇒ splitwords (s1 ^ str sp) = splitwords s1
+   isSpace sp ⇒ splitwords (s1 ^ toString sp) = splitwords s1
 Proof
   rw[] \\ qspec_then`implode ""`mp_tac(Q.GEN`s2`splitwords_concat) \\
   fs[mlstringTheory.strcat_thm]
@@ -47,7 +47,7 @@ Theorem splitwords_lines_of:
 Proof
   `isSpace #"\n"` by EVAL_TAC \\
   rw[all_lines_file_def,lines_of_def,MAP_MAP_o,o_DEF,
-     GSYM mlstringTheory.str_def,splitwords_concat_space] \\
+     GSYM mlstringTheory.chr_to_str_def,splitwords_concat_space] \\
   rw[splitwords_def,mlstringTheory.TOKENS_eq_tokens_sym] \\
   srw_tac[ETA_ss][GSYM o_DEF,GSYM MAP_MAP_o] \\
   simp[GSYM MAP_FLAT] \\ AP_TERM_TAC \\
@@ -91,13 +91,13 @@ QED
 
 Theorem frequency_concat:
    isSpace sp ⇒
-   frequency (s1 ^ str sp ^ s2) w = frequency s1 w + frequency s2 w
+   frequency (s1 ^ toString sp ^ s2) w = frequency s1 w + frequency s2 w
 Proof
   rw[frequency_def,splitwords_concat,FILTER_APPEND]
 QED
 
 Theorem frequency_concat_space:
-   isSpace sp ⇒ frequency (s1 ^ str sp) = frequency s1
+   isSpace sp ⇒ frequency (s1 ^ toString sp) = frequency s1
 Proof
   rw[FUN_EQ_THM,frequency_def,splitwords_concat_space]
 QED

--- a/tutorial/wordcountProgScript.sml
+++ b/tutorial/wordcountProgScript.sml
@@ -190,7 +190,7 @@ Proof
     \\ Cases_on`t'` \\ fs[] \\ xsimpl ) \\
   simp[Abbr`output`,Abbr`output'`] \\
   fs [mlintTheory.toString_thm,implode_def,strcat_def,concat_def] \\
-  simp[wc_lines_def,str_def,implode_def] \\
+  simp[wc_lines_def,chr_to_str_def,implode_def] \\
   qmatch_abbrev_tac`s1 ++ " " ++ s2 = t1 ++ " " ++ t2` \\
   `s1 = t1 ∧ s2 = t2` suffices_by rw[] \\
   simp[Abbr`s1`,Abbr`t1`,Abbr`s2`,Abbr`t2`] \\

--- a/tutorial/wordfreqProgScript.sml
+++ b/tutorial/wordfreqProgScript.sml
@@ -83,7 +83,7 @@ Proof
   Induct \\ simp[concat_nil,concat_cons] \\ ntac 3 strip_tac \\
   rename1`insert_line t w` \\
   imp_res_tac insert_line_thm \\ fs[] \\
-  `strlit "\n" = str #"\n"` by EVAL_TAC \\
+  `strlit "\n" = toString #"\n"` by EVAL_TAC \\
   `isSpace #"\n"` by EVAL_TAC \\
   first_x_assum drule \\
   rw[frequency_concat,splitwords_concat,frequency_concat_space,splitwords_concat_space] \\


### PR DESCRIPTION
This should free up the use of str for things such as parameter names in theories that also import mlstring.

HOL: str -> chr_to_str
HOL: Add toString overload for chr_to_str
HOL: strng -> str

strng was introduced in 680922ba96c3158bcdb7f7becd76a1976dbcbe16 to workaround str already being occupied, which we can now undo.

Assisted-by: Claude:claude-opus-4-7