### PR TITLE
Make Pancake compiler always set GC to NONE

### DIFF
--- a/compiler/bootstrap/translation/compiler32ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler32ProgScript.sml
@@ -372,6 +372,8 @@ val res = translate nonzero_exit_code_for_error_msg_def;
 
 val res = translate $ spec32 compile_pancake_def;
 
+val res = translate pancake_backend_conf_def;
+
 val res = translate compile_pancake_32_def;
 
 val _ = res |> hyp |> null orelse

--- a/compiler/bootstrap/translation/compiler64ProgScript.sml
+++ b/compiler/bootstrap/translation/compiler64ProgScript.sml
@@ -388,6 +388,8 @@ val _ = res |> hyp |> null orelse
 
 val res = translate $ spec64 compile_pancake_def;
 
+val res = translate pancake_backend_conf_def;
+
 val res = translate compile_pancake_64_def;
 
 val _ = res |> hyp |> null orelse

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -53,6 +53,8 @@ OPTIONS:
                    genN   - a generational Cheney garbage collector is
                             used; the size of the nursery generation is
                             N machine words (example: --gc=gen5000)
+                This option has no effect under --pancake; the Pancake
+                compiler always uses gc=none.
 
   --target=T    specifies that compilation should produce code for target
                 T, where T can be one of x64, arm8, mips, riscv for
@@ -710,6 +712,11 @@ Definition compile_64_def:
     (List[], error_to_str (ConfigError (concat [get_err_str confexp;get_err_str topconf])))
 End
 
+Definition pancake_backend_conf_def:
+  pancake_backend_conf c =
+    c with data_conf := (c.data_conf with gc_kind := None)
+End
+
 Definition compile_pancake_64_def:
   compile_pancake_64 cl input =
   let confexp = parse_target_64 cl in
@@ -725,6 +732,7 @@ Definition compile_pancake_64_def:
           | INR err =>
               (List[], error_to_str (ConfigError (get_err_str ext_conf)))
           | INL ext_conf =>
+              let ext_conf = pancake_backend_conf ext_conf in
               case compiler$compile_pancake aconf ext_conf input of
               | (Failure err, td, warns) =>
                   (List[], concat (MAP error_to_str (err::(if nowarn then [] else warns))))
@@ -800,6 +808,7 @@ Definition compile_pancake_32_def:
           | INR err =>
               (List[], error_to_str (ConfigError (get_err_str ext_conf)))
           | INL ext_conf =>
+              let ext_conf = pancake_backend_conf ext_conf in
               case compiler$compile_pancake aconf ext_conf input of
               | (Failure err, td, warns) =>
                   (List[], concat (MAP error_to_str (err::(if nowarn then [] else warns))))

--- a/pancake/NEWS.md
+++ b/pancake/NEWS.md
@@ -4,6 +4,16 @@ Pancake Changelog
 User-facing changes to the Pancake language and compiler are
 documented here when they are merged into `master`.
 
+April 24th 2026
+-------------------
+
+### Garbage collector always disabled
+
+The Pancake compiler now unconditionally compiles with GC set to `none`; any
+`--gc=...` flag passed alongside `--pancake` is silently ignored. This removes
+the unused GC runtime that Zhewen Shen's BSc thesis (p. 35) noted was being
+linked into every Pancake binary.
+
 August 26th 2025
 -------------------
 


### PR DESCRIPTION
Pancake now ignores any `--gc=...` flags by always setting GC to NONE. This removes the unused GC runtime that Zhewen Shen's BSc thesis (p. 35) noted was being linked into every Pancake binary.

Assisted-by: Claude:claude-opus-4-7