### PR TITLE
Word copy update for remove redundant `Get`s

### DIFF
--- a/compiler/backend/proofs/wordConvsProofScript.sml
+++ b/compiler/backend/proofs/wordConvsProofScript.sml
@@ -1784,10 +1784,13 @@ Proof
     >- metis_tac[]
   )
   >- (
-    gvs[remove_eq_def]>>every_case_tac>>simp[empty_eq_def]>>
+    gvs[remove_eq_def, set_store_eq_def]>>every_case_tac>>gvs[empty_eq_def, lookup_insert]
+    >>~- ([`lookup_store_eq _ _ = SOME _`],
     pairarg_tac>>gvs[copy_prop_move_def,set_eq_def,remove_eq_def]>>
     every_case_tac>>rw[lookup_insert,empty_eq_def]>>
     metis_tac[])
+    >> metis_tac[]
+  )
 QED
 
 Theorem pre_alloc_conventions_copy_prop_aux[local]:

--- a/compiler/backend/proofs/word_copyProofScript.sml
+++ b/compiler/backend/proofs/word_copyProofScript.sml
@@ -732,7 +732,7 @@ Proof
     gvs[AllCaseEqs(),empty_eq_inv,set_store_eq_inv]
   )
   >- (
-    gvs[AllCaseEqs(),UNCURRY_EQ,remove_eq_inv]>>
+    gvs[AllCaseEqs(),UNCURRY_EQ,remove_eq_inv,set_store_eq_inv]>>
     metis_tac[copy_prop_move_inv])
 QED
 
@@ -1068,6 +1068,62 @@ Proof
   metis_tac[lookup_store_eq_set_store_eq_2,CPstate_modelsD]
 QED
 
+Theorem lookup_eq_remove_t_same:
+  lookup_eq (remove_eq cs t) t = t
+Proof
+  fs[lookup_eq_def, remove_eq_def]
+QED
+
+Theorem lookup_store_eq_set_store_eq_same:
+  lookup x cs.to_eq = NONE ∧
+  is_alloc_var x ⇒
+  lookup_store_eq (set_store_eq cs s x) s = SOME x
+Proof
+  fs[lookup_store_eq_def, set_store_eq_def]
+QED
+
+Theorem set_store_eq_model_set_var:
+  CPstate_inv cs ∧
+  CPstate_models cs st ∧
+  lookup_store_eq cs s = NONE ∧
+  get_store s st = SOME w ⇒
+  CPstate_models (set_store_eq (remove_eq cs n) s n) (set_var n w st)
+Proof
+  rw[] >>
+  reverse (Cases_on `is_alloc_var n`)
+  >- simp[set_store_eq_def, empty_eq_model]
+  >> irule CPstate_modelsI
+  >> simp[Once CONJ_ASSOC]
+  >> reverse CONJ_ASM2_TAC
+  >- simp[set_store_eq_inv, remove_eq_inv]
+  >> gvs[lookup_eq_set_store_eq]
+  >> `CPstate_inv (remove_eq cs n)` by simp[remove_eq_inv]
+  >> drule_all remove_eq_model_set_var
+  >> disch_then $ qspecl_then [`w`, `n`] assume_tac >> fs[]
+  >> drule lookup_eq_set_store_eq
+  >> disch_then imp_res_tac
+  >> simp[]
+  >> conj_tac
+  >- (
+    drule CPstate_modelsD >> disch_then imp_res_tac >> fs[]
+  )
+  >> rw[]
+  >> rev_drule CPstate_modelsD
+  >> disch_then imp_res_tac
+  >> Cases_on `s = x` >> gvs[]
+  >- (
+    simp[set_var_def, lookup_insert]
+    >> Cases_on `y = n` >> fs[lookup_eq_remove_t_same]
+    >- fs[get_store_def, lookup_insert1, set_var_def]
+    >> drule_at (Pos $ el 2) lookup_store_eq_set_store_eq_same
+    >> disch_then $ qspecl_then [`s`, `remove_eq cs n`] assume_tac >> gvs[]
+    >> metis_tac[lookup_eq_remove_eq_t]
+  )
+  >> drule CPstate_modelsD >> disch_then imp_res_tac >> fs[]
+  >> pop_assum irule
+  >> metis_tac[lookup_store_eq_set_store_eq_2]
+QED
+
 Theorem copy_prop_correct:
   ∀prog cs st prog' cs' err st'.
   CPstate_inv cs ∧
@@ -1100,7 +1156,8 @@ Proof
     gvs[copy_prop_prog_def,CaseEq "option"]
     >- (
       gvs[evaluate_def,AllCaseEqs()]>>
-      metis_tac[remove_eq_model_set_var])>>
+      metis_tac[set_store_eq_model_set_var]
+    )>>
     reverse (gvs[AllCaseEqs(),UNCURRY_EQ])
     >- ( (* v = n, Skip case *)
       drule_all lookup_store_eq_SOME>>

--- a/compiler/backend/word_copyScript.sml
+++ b/compiler/backend/word_copyScript.sml
@@ -338,7 +338,7 @@ Definition copy_prop_prog_def:
   (copy_prop_prog (Get n name) cs =
     case lookup_store_eq cs name of
       NONE =>
-        (Get n name, remove_eq cs n)
+        (Get n name, set_store_eq (remove_eq cs n) name n)
     | SOME v =>
       if v ≠ n then
       let (xs',cs') = copy_prop_move [(n,v)] cs in


### PR DESCRIPTION
This is the implementation for the issue #1383. This allows multiple `Get`s from the same stores to be changed to `Move`s.
