### PR TITLE
pancake/loop: extend Break/Continue with nesting-depth num

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -318,21 +318,6 @@ val _ = translate $ spec32 vars_of_exp_def;
 
 val res = translate $ spec32 shrink_def;
 
-val ind_lemma = Q.prove(
-  `^(hd (hyp res))`,
-  PURE_REWRITE_TAC [fetch "-" "loop_live_shrink_ind_def"]
-  \\ rpt gen_tac
-  \\ rpt (disch_then strip_assume_tac)
-  \\ match_mp_tac (latest_ind ())
-  \\ rpt strip_tac
-  \\ TRY (last_x_assum match_mp_tac
-          \\ rpt strip_tac
-          \\ fs [FORALL_PROD] \\ NO_TAC)
-  \\ last_x_assum (match_mp_tac o MP_CANON)
-  \\ rpt strip_tac
-  \\ fs [FORALL_PROD])
-  |> update_precondition;
-
 val _ = translate $ spec32 mark_all_def;
 
 val _ = translate $ spec32 comp_def;

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -322,20 +322,6 @@ val _ = translate $ spec64 vars_of_exp_def;
 
 val res = translate $ spec64 shrink_def;
 
-val ind_lemma = Q.prove(
-  `^(hd (hyp res))`,
-  PURE_REWRITE_TAC [fetch "-" "loop_live_shrink_ind_def"]
-  \\ rpt gen_tac
-  \\ rpt (disch_then strip_assume_tac)
-  \\ match_mp_tac (latest_ind ())
-  \\ rpt strip_tac
-  \\ TRY (last_x_assum match_mp_tac
-          \\ rpt strip_tac
-          \\ fs [FORALL_PROD] \\ NO_TAC)
-  \\ last_x_assum (match_mp_tac o MP_CANON)
-  \\ rpt strip_tac
-  \\ fs [FORALL_PROD]) |> update_precondition;
-
 val _ = translate $ spec64 mark_all_def;
 
 val _ = translate $ spec64 comp_def;

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -111,8 +111,8 @@ End
 
 Definition compile_def:
   (compile _ _ (Skip:'a crepLang$prog) = (Skip:'a loopLang$prog)) /\
-  (compile _ _ Break = Break) /\
-  (compile _ _ Continue = Continue) /\
+  (compile _ _ Break = Break 0) /\
+  (compile _ _ Continue = Continue 0) /\
   (compile _ _ Tick = Tick) /\
   (compile ctxt l (Return e) =
     let (p, le, ntmp, nl) = compile_exp ctxt (ctxt.vmax + 1) l e in
@@ -171,7 +171,7 @@ Definition compile_def:
      Loop l (nested_seq (np ++ [
                 Assign tmp le;
                 If NotEqual tmp (Imm 0w)
-                   (Seq lp Continue) Break l]))
+                   (Seq lp (Continue 0)) (Break 0) l]))
           l) /\
   (compile ctxt l (Call call_type e es) =
    let dest = find_lab ctxt e;

--- a/pancake/loopLangScript.sml
+++ b/pancake/loopLangScript.sml
@@ -39,8 +39,8 @@ Datatype:
        | Seq prog prog
        | If cmp num ('a reg_imm) prog prog num_set
        | Loop num_set prog num_set     (* names in, body, names out *)
-       | Break
-       | Continue
+       | Break num
+       | Continue num
        | Raise num
        | Return (num list)
        | ShMem memop num ('a exp)
@@ -114,8 +114,8 @@ End
 
 Definition acc_vars_def:
   (acc_vars (Seq p1 p2) l = acc_vars p1 (acc_vars p2 l)) ∧
-  (acc_vars Break l = (l:num_set)) ∧
-  (acc_vars Continue l = l) ∧
+  (acc_vars (Break _) l = (l:num_set)) ∧
+  (acc_vars (Continue _) l = l) ∧
   (acc_vars (Loop l1 body l2) l = acc_vars body l) ∧
   (acc_vars (If x1 x2 x3 p1 p2 l1) l = acc_vars p1 (acc_vars p2 l)) ∧
   (acc_vars (Arith arith) l =

--- a/pancake/loop_liveScript.sml
+++ b/pancake/loop_liveScript.sml
@@ -65,53 +65,56 @@ End
    auxiliary function is used to find a fixed-point. *)
 
 Definition shrink_def:
-  (shrink b (Seq p1 p2) l =
-     let (p2,l) = shrink b p2 l in
-     let (p1,l) = shrink b p1 l in
+  (shrink (lt:(num_set # num_set) list) (Seq p1 p2) l =
+     let (p2,l) = shrink lt p2 l in
+     let (p1,l) = shrink lt p1 l in
        (Seq p1 p2, l)) /\
-  (shrink b (Loop live_in body live_out) l =
+  (shrink lt (Loop live_in body live_out) l =
      let l2 = inter live_out l in
-       case fixedpoint live_in LN l2 body of
+     let bex = union live_in l2 in
+       case fixedpoint lt live_in LN bex body of
        | SOME (body,l0) =>
            (let l = inter live_in l0 in (Loop l body l2, l))
-       | NONE => let (b,_) = shrink (live_in,l2) body l2 in
+       | NONE => let (b,_) = shrink ((live_in,l2)::lt) body bex in
                    (Loop live_in b l2, live_in)) /\
-  (shrink b (If x1 x2 x3 p1 p2 l1) l =
+  (shrink lt (If x1 x2 x3 p1 p2 l1) l =
      let l = inter l l1 in
-     let (p1,l1) = shrink b p1 l in
-     let (p2,l2) = shrink b p2 l in
+     let (p1,l1) = shrink lt p1 l in
+     let (p2,l2) = shrink lt p2 l in
      let l3 = (case x3 of Reg r => insert r () LN | _ => LN) in
        (If x1 x2 x3 p1 p2 l, insert x2 () (union l3 (union l1 l2)))) /\
-  (shrink b (Mark p1) l = shrink b p1 l) /\
-  (shrink b Break l = (Break,SND b)) /\
-  (shrink b Continue l = (Continue,FST b)) /\
-  (shrink b Fail l = (Fail,LN)) /\
-  (shrink b Skip l = (Skip,l)) /\
-  (shrink b (Return vs) l = (Return vs, list_insert vs LN)) /\
-  (shrink b (Raise v) l = (Raise v, insert v () LN)) /\
-  (shrink b (Arith arith) l =
+  (shrink lt (Mark p1) l = shrink lt p1 l) /\
+  (shrink lt (Break n) l =
+     (Break n, case oEL n lt of SOME (_, brk) => brk | NONE => LN)) /\
+  (shrink lt (Continue n) l =
+     (Continue n, case oEL n lt of SOME (cont, _) => cont | NONE => LN)) /\
+  (shrink lt Fail l = (Fail,LN)) /\
+  (shrink lt Skip l = (Skip,l)) /\
+  (shrink lt (Return vs) l = (Return vs, list_insert vs LN)) /\
+  (shrink lt (Raise v) l = (Raise v, insert v () LN)) /\
+  (shrink lt (Arith arith) l =
    (Arith arith, arith_vars arith l)
   ) ∧
-  (shrink b (LocValue n m) l =
+  (shrink lt (LocValue n m) l =
      case lookup n l of
      | NONE => (Skip,l)
      | SOME _ => (LocValue n m, delete n l)) ∧
-  (shrink b (Assign n x) l =
+  (shrink lt (Assign n x) l =
      case lookup n l of
      | NONE => (Skip,l)
      | SOME _ => (Assign n x, vars_of_exp x (delete n l))) ∧
-  (shrink b (ShMem op r ad) l =
+  (shrink lt (ShMem op r ad) l =
    (ShMem op r ad, (*case lookup r l of
                      NONE => l
                    | _ => if is_load op
                           then vars_of_exp ad (insert r () l)
                           else l)*)
   vars_of_exp ad (insert r () l))) ∧
-  (shrink b (Store e n) l =
+  (shrink lt (Store e n) l =
     (Store e n, vars_of_exp e (insert n () l))) ∧
-  (shrink b (SetGlobal name e) l =
+  (shrink lt (SetGlobal name e) l =
     (SetGlobal name e, vars_of_exp e l)) ∧
-  (shrink b (Call ret dest args handler) l =
+  (shrink lt (Call ret dest args handler) l =
      let a = fromAList (MAP (λx. (x,())) args) in
      case ret of
      | NONE => (Call NONE dest args NONE, union a l)
@@ -120,35 +123,35 @@ Definition shrink_def:
         | NONE => let l3 = (list_delete ns (inter l l1)) in
                     (Call (SOME (ns,l3)) dest args NONE, union a l3)
         | SOME (e,h,r,live_out) =>
-            let (r,l2) = shrink b r l in
-            let (h,l3) = shrink b h l in
+            let (r,l2) = shrink lt r l in
+            let (h,l3) = shrink lt h l in
             let l1 = inter l1 (union (list_delete ns l2) (delete e l3)) in
               (Call (SOME (ns,l1)) dest args (SOME (e,h,r,inter l live_out)),
                union a l1)) ∧
-  (shrink b (FFI n r1 r2 r3 r4 l1) l =
+  (shrink lt (FFI n r1 r2 r3 r4 l1) l =
    (FFI n r1 r2 r3 r4 (inter l1 l),
       insert r1 () (insert r2 () (insert r3 () (insert r4 () (inter l1 l)))))) ∧
-  (shrink b (Load32 x y) l =
+  (shrink lt (Load32 x y) l =
     (Load32 x y, insert x () (delete y l))) ∧
-  (shrink b (LoadByte x y) l =
+  (shrink lt (LoadByte x y) l =
     (LoadByte x y, insert x () (delete y l))) ∧
-  (shrink b (Store32 x y) l =
+  (shrink lt (Store32 x y) l =
     (Store32 x y, insert x () (insert y () l))) ∧
-  (shrink b (StoreByte x y) l =
+  (shrink lt (StoreByte x y) l =
     (StoreByte x y, insert x () (insert y () l))) ∧
-  (shrink b prog l = (prog,l)) /\
+  (shrink lt prog l = (prog,l)) /\
 
-  (fixedpoint live_in l1 l2 body =
-     let (b,l0) = shrink (inter live_in l1,l2) body l2 in
+  (fixedpoint lt live_in l1 l2 body =
+     let (b,l0) = shrink ((inter live_in l1,l2)::lt) body l2 in
      let l0' = inter live_in l0 in
        if l0' = l1 then (* fixed point found! *) SOME (b,l0) else
        if size l0' ≤ size l1 then (* no progress made, not possible *) NONE else
-         fixedpoint live_in l0' l2 body)
+         fixedpoint lt live_in l0' l2 body)
 Termination
   WF_REL_TAC `inv_image (measure I LEX measure I LEX measure I)
                (λx. case x of
                     | INL (_,c,_) => (prog_size (K 0) c, 0:num, 0)
-                    | INR (live_in,l1,l2,body) =>
+                    | INR (_,live_in,l1,l2,body) =>
                         (prog_size (K 0) body, 1, size live_in - size l1))`
   \\ rw []
   \\ fs [GSYM NOT_LESS]
@@ -163,13 +166,13 @@ Theorem exp_ind = vars_of_exp_ind
   |> Q.GENL [‘P’,‘Q’];
 
 Theorem fixedpoint_thm:
-  ∀live_in l1 l2 (body:'a loopLang$prog) l0 b.
-    fixedpoint live_in l1 l2 body = SOME (b, l0) ⇒
-    shrink (inter live_in l0, l2) body l2 = (b, l0)
+  ∀lt live_in l1 l2 (body:'a loopLang$prog) l0 b.
+    fixedpoint lt live_in l1 l2 body = SOME (b, l0) ⇒
+    shrink ((inter live_in l0, l2)::lt) body l2 = (b, l0)
 Proof
   qmatch_abbrev_tac ‘entire_goal’
   \\ qsuff_tac
-    ‘(∀b (prog:'a loopLang$prog) l d. shrink b prog l = d ⇒ T) ∧ entire_goal’
+    ‘(∀lt (prog:'a loopLang$prog) l d. shrink lt prog l = d ⇒ T) ∧ entire_goal’
   THEN1 fs []
   \\ unabbrev_all_tac
   \\ ho_match_mp_tac shrink_ind \\ fs [] \\ rw []
@@ -213,7 +216,7 @@ Definition mark_all_def:
 End
 
 Definition comp_def:
-  comp prog = FST (mark_all (FST (shrink (LN,LN) prog LN)))
+  comp prog = FST (mark_all (FST (shrink [] prog LN)))
 End
 
 Definition optimise_def:

--- a/pancake/loop_to_wordScript.sml
+++ b/pancake/loop_to_wordScript.sml
@@ -96,8 +96,8 @@ Definition comp_def:
       (Seq Tick
          (Seq (wordLang$Loop (mk_new_cutset ctxt l1) wbody (mk_new_cutset ctxt l2))
               Tick),l)) /\
-  (comp ctxt Break l    = (Break 0,l)) /\
-  (comp ctxt Continue l = (Continue 0,l)) /\
+  (comp ctxt (Break n) l    = (Break n,l)) /\
+  (comp ctxt (Continue n) l = (Continue n,l)) /\
   (comp ctxt (Raise v) l = (Raise (find_var ctxt v),l)) /\
   (comp ctxt (Return vs) l = (Return 0 (MAP (find_var ctxt) vs),l)) /\
   (comp ctxt Tick l = (Tick,l)) /\

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -552,8 +552,8 @@ Definition loop_prog_to_display_def:
   (loop_prog_to_display ns (Raise n) = item_with_num «raise» n) ∧
   (loop_prog_to_display ns (Return ns0) = item_with_nums «return» ns0) ∧
   (loop_prog_to_display ns Tick = empty_item «tick») ∧
-  (loop_prog_to_display ns Break = empty_item «break») ∧
-  (loop_prog_to_display ns Continue = empty_item «continue») ∧
+  (loop_prog_to_display ns (Break n) = item_with_num «break» n) ∧
+  (loop_prog_to_display ns (Continue n) = item_with_num «continue» n) ∧
   (loop_prog_to_display ns Fail = empty_item «fail») ∧
   (loop_prog_to_display ns (Load32 n1 n2) =
     item_with_nums «load_32» [n1;n2]) ∧

--- a/pancake/proofs/crep_to_loopProofScript.sml
+++ b/pancake/proofs/crep_to_loopProofScript.sml
@@ -122,8 +122,8 @@ Theorem ncompile_correct:
       (res1 =
        case res of
          NONE => NONE
-       | SOME Break => SOME Break
-       | SOME Continue => SOME Continue
+       | SOME Break => SOME (Break 0)
+       | SOME Continue => SOME (Continue 0)
        | SOME (Return v) => SOME (Result [wlab_wloc v])
        | SOME (Exception eid) => SOME (Exception (Word eid))
        | SOME TimeOut => SOME TimeOut
@@ -2014,35 +2014,111 @@ Resume ncompile_correct[ShMem]:
      CaseEq"option",CaseEq"bool",CaseEq"ffi_result"]>>
   fs[wlab_wloc_def]>>
   rveq>>fs[crepSemTheory.set_var_def,set_var_def]>>
-  fs [state_rel_def]>>
-  gvs[] >>~- ([‘SharedMem MappedRead’],
-   fs[locals_rel_def]>>rw[]>-
-     (imp_res_tac compile_exp_out_rel >>
-      rveq >>
-      drule cut_sets_union_domain_subset >>strip_tac>>
-      match_mp_tac SUBSET_TRANS >>
-      qexists_tac ‘domain (cut_sets l (nested_seq p))’ >>
-      fs [] >>
-      metis_tac [SUBSET_INSERT_RIGHT]) >>
-    fs[lookup_insert,FLOOKUP_UPDATE]>>
-    FULL_CASE_TAC>-gvs[wlab_wloc_def]>>
-    first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac>>
-    first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac>>
-    rfs[]>>
-    ‘n <> n'’ by
-      (CCONTR_TAC>>fs[distinct_vars_def]>>
-       first_x_assum $ qspecl_then [‘v’, ‘vname’, ‘n'’] assume_tac>>
-       gvs[])>>fs[])>>
-  (*write*)
-  fs[CaseEq"word_lab",CaseEq"word_loc",CaseEq"bool",
-     CaseEq"ffi_result"]>>
-  rveq>>fs[]>>gvs[wlab_wloc_def]>>
-  ‘subspt l l'’ by (
-    imp_res_tac compile_exp_out_rel >> fs [] >>
-    imp_res_tac comp_syn_impl_cut_sets_subspt >> fs [] >>
-    rveq >> metis_tac [subspt_trans]) >>
-  match_mp_tac locals_rel_cutset_prop >>
-  metis_tac []
+  gvs[state_rel_def] >~
+   [‘call_FFI _ (SharedMem MappedRead) [0w] _ = FFI_return _ _’] >-
+    (fs [locals_rel_def] \\ rw []
+     >- (imp_res_tac compile_exp_out_rel \\ rveq
+         \\ drule cut_sets_union_domain_subset \\ strip_tac
+         \\ match_mp_tac SUBSET_TRANS
+         \\ qexists_tac ‘domain (cut_sets l (nested_seq p))’ \\ fs []
+         \\ metis_tac [SUBSET_INSERT_RIGHT])
+     \\ fs [lookup_insert, FLOOKUP_UPDATE]
+     \\ FULL_CASE_TAC >- gvs [wlab_wloc_def]
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ rfs []
+     \\ ‘n <> n'’ by
+       (CCONTR_TAC \\ fs [distinct_vars_def]
+        \\ first_x_assum $ qspecl_then [‘v’, ‘vname’, ‘n'’] assume_tac
+        \\ gvs [])
+     \\ fs []) >~
+   [‘call_FFI _ (SharedMem MappedRead) [1w] _ = FFI_return _ _’] >-
+    (fs [locals_rel_def] \\ rw []
+     >- (imp_res_tac compile_exp_out_rel \\ rveq
+         \\ drule cut_sets_union_domain_subset \\ strip_tac
+         \\ match_mp_tac SUBSET_TRANS
+         \\ qexists_tac ‘domain (cut_sets l (nested_seq p))’ \\ fs []
+         \\ metis_tac [SUBSET_INSERT_RIGHT])
+     \\ fs [lookup_insert, FLOOKUP_UPDATE]
+     \\ FULL_CASE_TAC >- gvs [wlab_wloc_def]
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ rfs []
+     \\ ‘n <> n'’ by
+       (CCONTR_TAC \\ fs [distinct_vars_def]
+        \\ first_x_assum $ qspecl_then [‘v’, ‘vname’, ‘n'’] assume_tac
+        \\ gvs [])
+     \\ fs []) >~
+   [‘call_FFI _ (SharedMem MappedRead) [2w] _ = FFI_return _ _’] >-
+    (fs [locals_rel_def] \\ rw []
+     >- (imp_res_tac compile_exp_out_rel \\ rveq
+         \\ drule cut_sets_union_domain_subset \\ strip_tac
+         \\ match_mp_tac SUBSET_TRANS
+         \\ qexists_tac ‘domain (cut_sets l (nested_seq p))’ \\ fs []
+         \\ metis_tac [SUBSET_INSERT_RIGHT])
+     \\ fs [lookup_insert, FLOOKUP_UPDATE]
+     \\ FULL_CASE_TAC >- gvs [wlab_wloc_def]
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ rfs []
+     \\ ‘n <> n'’ by
+       (CCONTR_TAC \\ fs [distinct_vars_def]
+        \\ first_x_assum $ qspecl_then [‘v’, ‘vname’, ‘n'’] assume_tac
+        \\ gvs [])
+     \\ fs []) >~
+   [‘call_FFI _ (SharedMem MappedRead) [4w] _ = FFI_return _ _’] >-
+    (fs [locals_rel_def] \\ rw []
+     >- (imp_res_tac compile_exp_out_rel \\ rveq
+         \\ drule cut_sets_union_domain_subset \\ strip_tac
+         \\ match_mp_tac SUBSET_TRANS
+         \\ qexists_tac ‘domain (cut_sets l (nested_seq p))’ \\ fs []
+         \\ metis_tac [SUBSET_INSERT_RIGHT])
+     \\ fs [lookup_insert, FLOOKUP_UPDATE]
+     \\ FULL_CASE_TAC >- gvs [wlab_wloc_def]
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ first_x_assum $ qspecl_then [‘vname’, ‘v'’] assume_tac
+     \\ rfs []
+     \\ ‘n <> n'’ by
+       (CCONTR_TAC \\ fs [distinct_vars_def]
+        \\ first_x_assum $ qspecl_then [‘v’, ‘vname’, ‘n'’] assume_tac
+        \\ gvs [])
+     \\ fs [])
+   >- (fs[CaseEq"word_lab",CaseEq"word_loc",CaseEq"bool",
+          CaseEq"ffi_result"]>>
+       rveq>>fs[]>>gvs[wlab_wloc_def]>>
+       ‘subspt l l'’ by (
+         imp_res_tac compile_exp_out_rel >> fs [] >>
+         imp_res_tac comp_syn_impl_cut_sets_subspt >> fs [] >>
+         rveq >> metis_tac [subspt_trans]) >>
+       match_mp_tac locals_rel_cutset_prop >>
+       metis_tac [])
+   >- (fs[CaseEq"word_lab",CaseEq"word_loc",CaseEq"bool",
+          CaseEq"ffi_result"]>>
+       rveq>>fs[]>>gvs[wlab_wloc_def]>>
+       ‘subspt l l'’ by (
+         imp_res_tac compile_exp_out_rel >> fs [] >>
+         imp_res_tac comp_syn_impl_cut_sets_subspt >> fs [] >>
+         rveq >> metis_tac [subspt_trans]) >>
+       match_mp_tac locals_rel_cutset_prop >>
+       metis_tac [])
+   >- (fs[CaseEq"word_lab",CaseEq"word_loc",CaseEq"bool",
+          CaseEq"ffi_result"]>>
+       rveq>>fs[]>>gvs[wlab_wloc_def]>>
+       ‘subspt l l'’ by (
+         imp_res_tac compile_exp_out_rel >> fs [] >>
+         imp_res_tac comp_syn_impl_cut_sets_subspt >> fs [] >>
+         rveq >> metis_tac [subspt_trans]) >>
+       match_mp_tac locals_rel_cutset_prop >>
+       metis_tac [])
+   >- (fs[CaseEq"word_lab",CaseEq"word_loc",CaseEq"bool",
+          CaseEq"ffi_result"]>>
+       rveq>>fs[]>>gvs[wlab_wloc_def]>>
+       ‘subspt l l'’ by (
+         imp_res_tac compile_exp_out_rel >> fs [] >>
+         imp_res_tac comp_syn_impl_cut_sets_subspt >> fs [] >>
+         rveq >> metis_tac [subspt_trans]) >>
+       match_mp_tac locals_rel_cutset_prop >>
+       metis_tac [])
 QED
 
 Resume ncompile_correct[Assign]:
@@ -2557,13 +2633,13 @@ Resume ncompile_correct[While]:
    TOP_CASE_TAC >> fs [] >>
    strip_tac >> rveq >> fs [] >>
    TRY (
-   rename [‘evaluate _ = (SOME Break,_)’] >>
+   rename [‘evaluate _ = (SOME (Break _),_)’] >>
    qmatch_goalsub_abbrev_tac ‘nested_seq (_ ++ pp)’ >>
    qpat_x_assum ‘evaluate (nested_seq np, _) = _’ assume_tac >>
    drule evaluate_add_clock_eq >>
    fs [] >>
    disch_then (qspec_then ‘ck' + 1’ assume_tac) >>
-   qpat_x_assum ‘evaluate _ = (SOME Break,t1)’ assume_tac >>
+   qpat_x_assum ‘evaluate _ = (SOME (Break _),t1)’ assume_tac >>
    drule evaluate_add_clock_eq >>
    disch_then (qspec_then ‘1’ assume_tac) >>
    qexists_tac ‘ck + ck' + 1’ >>
@@ -2608,7 +2684,7 @@ Resume ncompile_correct[While]:
      fs [ctxt_max_def] >> res_tac >> rfs []) >>
    fs [lookup_inter, lookup_insert, domain_lookup]) >>
    TRY (
-   rename [‘evaluate _ = (SOME Continue,_)’] >>
+   rename [‘evaluate _ = (SOME (Continue _),_)’] >>
    (* instantiating IH *)
    first_x_assum (qspecl_then [‘t1’, ‘ctxt’ , ‘l’] mp_tac) >>
    impl_tac >- fs [] >>
@@ -2616,7 +2692,7 @@ Resume ncompile_correct[While]:
    fs [Once compile_def] >>
    pairarg_tac >> fs [] >>
    rveq >> rfs [] >>
-   qpat_x_assum ‘evaluate _ = (SOME Continue,t1)’ assume_tac >>
+   qpat_x_assum ‘evaluate _ = (SOME (Continue _),t1)’ assume_tac >>
    drule evaluate_add_clock_eq >>
    fs [] >>
    disch_then (qspec_then ‘ck''’ assume_tac) >>
@@ -3700,8 +3776,8 @@ code_rel2 nctxt s_code t_code ==>
   state_rel s' t' /\
   (res' = case res of
            NONE => NONE
-         | SOME Break => SOME Break
-         | SOME Continue => SOME Continue
+         | SOME Break => SOME (Break 0)
+         | SOME Continue => SOME (Continue 0)
          | SOME (Return v) => SOME (Result [wlab_wloc v])
          | SOME (Exception eid) => SOME (Exception (Word eid))
          | SOME TimeOut => SOME TimeOut

--- a/pancake/proofs/loop_callProofScript.sml
+++ b/pancake/proofs/loop_callProofScript.sml
@@ -24,8 +24,8 @@ Proof
   >~ [`loopLang$Skip`] >- suspend "Skip"
   >~ [`loopLang$Fail`] >- suspend "Fail"
   >~ [`loopLang$Tick`] >- suspend "Tick"
-  >~ [`loopLang$Continue`] >- suspend "Continue"
-  >~ [`loopLang$Break`] >- suspend "Break"
+  >~ [`loopLang$Continue _`] >- suspend "Continue"
+  >~ [`loopLang$Break _`] >- suspend "Break"
   >~ [`loopLang$Mark`] >- suspend "Mark"
   >~ [`loopLang$Return`] >- suspend "Return"
   >~ [`loopLang$Raise`] >- suspend "Raise"
@@ -375,18 +375,28 @@ Resume compile_correct[Loop]:
   rveq >> fs [] >>
   qpat_x_assum ‘evaluate (Loop _ _ _,_) = (_,_)’ mp_tac >>
   once_rewrite_tac [evaluate_def] >>
-  TOP_CASE_TAC >> fs [] >> rveq >>
+  TOP_CASE_TAC >> fs [] >>
   reverse TOP_CASE_TAC >> fs [] >> rveq >> fs []
+  >- (strip_tac >> rveq >> fs [labels_in_def, lookup_def]) >>
+  ‘∀rv rs. evaluate (body,r) = (rv,rs) ∧ rv ≠ SOME Error ⇒
+     evaluate (np,r) = (rv,rs)’ by (
+    rpt strip_tac >>
+    last_x_assum (qspecl_then [‘rv’, ‘rs’, ‘LN’] mp_tac) >>
+    simp [labels_in_def, lookup_def]) >>
+  Cases_on ‘evaluate (body,r)’ >> fs [] >>
+  rename1 ‘evaluate (body,r) = (rv,rs)’ >>
+  reverse (Cases_on ‘rv’) >> fs []
   >- (
-   strip_tac >> rveq >>
-   fs [labels_in_def, lookup_def]) >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >>
-  TOP_CASE_TAC >> fs [] >> rveq >> fs [] >> (
-  strip_tac >> rveq >> fs [] >>
-  res_tac >> fs [labels_in_def, lookup_def]) >>
-  first_x_assum (qspec_then ‘LN’ mp_tac) >>
-  fs [labels_in_def, lookup_def]
+    Cases_on ‘x’ >> fs [] >>
+    rpt strip_tac >> rveq >> fs [labels_in_def, lookup_def] >>
+    Cases_on ‘n’ >> fs [] >>
+    qpat_x_assum ‘∀l'. res ≠ SOME Error ∧ _ ⇒ _’
+      (qspec_then ‘LN’ mp_tac) >>
+    simp [lookup_def]) >>
+  strip_tac >>
+  qpat_x_assum ‘∀res' s1' l'. evaluate _ = _ ∧ _ ∧ _ ⇒ _’
+    (qspecl_then [‘res’, ‘s1’, ‘LN’] mp_tac) >>
+  simp [labels_in_def, lookup_def]
 QED
 
 Resume compile_correct[Arith]:

--- a/pancake/proofs/loop_liveProofScript.sml
+++ b/pancake/proofs/loop_liveProofScript.sml
@@ -14,9 +14,9 @@ val _ = temp_delsimps ["fromAList_def", "domain_union",
                        "sptree.insert_notEmpty", "sptree.isEmpty_union"];
 
 Theorem compile_correct:
-  ∀v v1 res s1 p l0 locals prog1 l1.
+  ∀v v1 res s1 lt locals prog1 l1 l0.
     evaluate (v,v1) = (res,s1) ∧ res ≠ SOME Error ∧
-    shrink p v l0 = (prog1,l1) ∧ subspt (inter v1.locals l1) locals ⇒
+    shrink lt v l0 = (prog1,l1) ∧ subspt (inter v1.locals l1) locals ⇒
     ∃new_locals.
       evaluate (prog1,v1 with locals := locals) =
       (res,s1 with locals := new_locals) ∧
@@ -24,8 +24,12 @@ Theorem compile_correct:
         NONE => subspt (inter s1.locals l0) new_locals
       | SOME (Result v5) => new_locals = s1.locals
       | SOME (Exception v6) => new_locals = s1.locals
-      | SOME Break => subspt (inter s1.locals (SND p)) new_locals
-      | SOME Continue => subspt (inter s1.locals (FST p)) new_locals
+      | SOME (Break n) => (case oEL n lt of
+                           | SOME (_, brk) => subspt (inter s1.locals brk) new_locals
+                           | NONE => T)
+      | SOME (Continue n) => (case oEL n lt of
+                              | SOME (cont, _) => subspt (inter s1.locals cont) new_locals
+                              | NONE => T)
       | SOME TimeOut => new_locals = s1.locals
       | SOME (FinalFFI v7) => new_locals = s1.locals
       | SOME Error => new_locals = s1.locals
@@ -35,8 +39,8 @@ Proof
   >~ [`loopLang$Skip`] >- suspend "Skip"
   >~ [`loopLang$Fail`] >- suspend "Fail"
   >~ [`loopLang$Tick`] >- suspend "Tick"
-  >~ [`loopLang$Continue`] >- suspend "Continue"
-  >~ [`loopLang$Break`] >- suspend "Break"
+  >~ [`loopLang$Continue _`] >- suspend "Continue"
+  >~ [`loopLang$Break _`] >- suspend "Break"
   >~ [`loopLang$Mark`] >- suspend "Mark"
   >~ [`loopLang$Return`] >- suspend "Return"
   >~ [`loopLang$Raise`] >- suspend "Raise"
@@ -74,12 +78,18 @@ QED
 
 Resume compile_correct[Continue]:
   fs [shrink_def,evaluate_def]
-  \\ fs [state_component_equality]
+  \\ rw [] \\ fs [state_component_equality]
+  \\ CASE_TAC \\ fs []
+  \\ rename1 ‘oEL _ _ = SOME x’
+  \\ PairCases_on ‘x’ \\ fs []
 QED
 
 Resume compile_correct[Break]:
   fs [shrink_def,evaluate_def]
-  \\ fs [state_component_equality]
+  \\ rw [] \\ fs [state_component_equality]
+  \\ CASE_TAC \\ fs []
+  \\ rename1 ‘oEL _ _ = SOME x’
+  \\ PairCases_on ‘x’ \\ fs []
 QED
 
 Resume compile_correct[Mark]:
@@ -122,82 +132,206 @@ Proof
   fs [subspt_def,SUBSET_DEF]
 QED
 
+Theorem subspt_inter_domain_cut[local]:
+  ∀X m1 m2.
+    domain X ⊆ domain m1 ∧ subspt (inter m1 X) m2 ⇒
+    domain X ⊆ domain m2
+Proof
+  rw [SUBSET_DEF, domain_lookup, subspt_lookup, lookup_inter_alt]
+  \\ res_tac \\ fs []
+  \\ first_x_assum drule
+  \\ disch_then (qspec_then ‘v’ mp_tac) \\ fs []
+QED
+
+Theorem subspt_inter_union_R[local]:
+  ∀A B C D.
+    subspt (inter A (union B C)) D ⇒ subspt (inter A C) D
+Proof
+  rw [subspt_lookup, lookup_inter_alt]
+  \\ first_x_assum (qspec_then ‘x’ mp_tac)
+  \\ disch_then (qspec_then ‘y’ mp_tac) \\ fs [domain_union]
+QED
+
 Resume compile_correct[Loop]:
   rpt gen_tac \\ disch_then assume_tac \\ fs [] \\ rpt gen_tac
   \\ once_rewrite_tac [evaluate_def]
   \\ once_rewrite_tac [shrink_def] \\ fs []
   \\ TOP_CASE_TAC
   \\ reverse (Cases_on ‘q’) \\ fs []
-  THEN1
-   (fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"bool"] \\ rveq \\ fs []
-    \\ strip_tac \\ fs [] \\ rveq \\ fs []
-    \\ rpt (pairarg_tac \\ fs [])
-    \\ rveq \\ fs []
-    \\ TRY (PairCases_on ‘v’ \\ fs [] \\ rveq \\ fs [])
-    \\ once_rewrite_tac [evaluate_def] \\ fs [cut_res_def,cut_state_def]
-    \\ IF_CASES_TAC \\ fs []
-    \\ fs [subspt_lookup,lookup_inter_alt,SUBSET_DEF,domain_lookup]
-    \\ res_tac \\ res_tac \\ rfs [])
+  >- ((* Loop_cut_fail: cut failed *)
+      strip_tac
+      \\ gvs [cut_res_def, cut_state_def, CaseEq"option", CaseEq"bool"]
+      >- (Cases_on ‘shrink ((live_in,inter live_out l0)::lt) body
+                           (union live_in (inter live_out l0))’
+          \\ gvs []
+          \\ once_rewrite_tac [evaluate_def]
+          \\ gvs [cut_res_def, cut_state_def]
+          \\ ‘domain l1 ⊆ domain locals’ by
+             (irule subspt_inter_domain_cut
+              \\ qexists_tac ‘s.locals’ \\ fs [])
+          \\ gvs [])
+      \\ Cases_on ‘v’ \\ gvs []
+      \\ once_rewrite_tac [evaluate_def]
+      \\ gvs [cut_res_def, cut_state_def]
+      \\ ‘domain (inter live_in r) ⊆ domain locals’ by
+         (irule subspt_inter_domain_cut
+          \\ qexists_tac ‘s.locals’
+          \\ fs [SUBSET_DEF, domain_inter])
+      \\ gvs [])
   \\ fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"prod",CaseEq"bool",dec_clock_def]
   \\ Cases_on ‘evaluate (body,r)’ \\ fs []
-  \\ Cases_on ‘q’ THEN1 (rw[] \\ fs []) \\ fs [PULL_EXISTS]
-  \\ reverse (Cases_on ‘fixedpoint live_in LN (inter live_out l0) body’) \\ fs []
-  THEN1
-   (strip_tac \\ rveq \\ fs []
-    \\ drule fixedpoint_thm \\ strip_tac
-    \\ rename [‘_ = (new_body,new_in)’]
-    \\ once_rewrite_tac [evaluate_def]
-    \\ fs [cut_res_def,cut_state_def]
-    \\ reverse IF_CASES_TAC THEN1
-     (qsuff_tac ‘F’ \\ fs [] \\ drule subspt_IMP_domain
-      \\ fs [domain_inter,SUBSET_DEF] \\ metis_tac [])
-    \\ fs [dec_clock_def]
-    \\ Cases_on ‘x = Error’ \\ rveq \\ fs []
-    \\ qmatch_goalsub_abbrev_tac ‘(_,s6)’
-    \\ last_x_assum drule
-    \\ disch_then (qspec_then ‘s6.locals’ mp_tac)
-    \\ impl_tac THEN1
-     (unabbrev_all_tac \\ fs []
-      \\ fs [subspt_lookup,lookup_inter_alt,domain_inter])
-    \\ strip_tac \\ fs [Abbr‘s6’]
-    \\ Cases_on ‘x’ \\ fs [] \\ rveq \\ fs []
-    THEN1
-     (Cases_on ‘domain live_out ⊆ domain r'.locals’ \\ fs []
-      \\ reverse IF_CASES_TAC \\ fs [] THEN1
-       (imp_res_tac subspt_IMP_domain \\ fs [domain_inter,SUBSET_DEF]
-        \\ metis_tac [])
-      \\ IF_CASES_TAC \\ fs [] \\ rveq \\ fs []
-      \\ fs [state_component_equality]
-      \\ fs [subspt_lookup,lookup_inter_alt,domain_inter])
-    \\ first_x_assum (qspecl_then [‘p’,‘l0’] mp_tac)
-    \\ once_rewrite_tac [shrink_def] \\ fs [])
-  \\ pairarg_tac \\ fs []
-  \\ strip_tac \\ rveq \\ fs []
-  \\ Cases_on ‘x = Error’ \\ rveq \\ fs []
-  \\ once_rewrite_tac [evaluate_def]
-  \\ fs [cut_res_def,cut_state_def]
-  \\ reverse IF_CASES_TAC THEN1
-   (qsuff_tac ‘F’ \\ fs [] \\ drule subspt_IMP_domain
-    \\ fs [domain_inter,SUBSET_DEF] \\ metis_tac [])
-  \\ fs [dec_clock_def]
-  \\ qmatch_goalsub_abbrev_tac ‘(_,s6)’
-  \\ last_x_assum drule
-  \\ disch_then (qspec_then ‘s6.locals’ mp_tac)
-  \\ impl_tac THEN1
-   (unabbrev_all_tac \\ fs []
-    \\ fs [subspt_lookup,lookup_inter_alt,domain_inter])
-  \\ strip_tac \\ fs [Abbr‘s6’]
-  \\ Cases_on ‘x’ \\ fs [] \\ rveq \\ fs []
-  THEN1
-   (Cases_on ‘domain live_out ⊆ domain r'.locals’ \\ fs []
-    \\ reverse IF_CASES_TAC \\ fs [] THEN1
-     (imp_res_tac subspt_IMP_domain \\ fs [domain_inter,SUBSET_DEF]
-      \\ metis_tac [])
-    \\ IF_CASES_TAC \\ fs [] \\ rveq \\ fs []
-    \\ fs [state_component_equality]
-    \\ fs [subspt_lookup,lookup_inter_alt,domain_inter])
-  \\ first_x_assum (qspecl_then [‘p’,‘l0’] mp_tac)
-  \\ once_rewrite_tac [shrink_def] \\ fs []
+  \\ Cases_on ‘q’
+  >- ((* Loop_body_NONE: body returned NONE *)
+      rpt strip_tac \\ gvs []
+      >- ((* no_fix case *)
+          Cases_on ‘shrink ((live_in, inter live_out l0)::lt) body
+                           (union live_in (inter live_out l0))’
+          \\ gvs []
+          \\ once_rewrite_tac [loopSemTheory.evaluate_def]
+          \\ gvs [loopSemTheory.cut_res_def, loopSemTheory.cut_state_def]
+          \\ ‘domain l1 ⊆ domain locals’ by
+             (irule subspt_inter_domain_cut
+              \\ qexists_tac ‘s.locals’ \\ fs [])
+          \\ gvs []
+          \\ qpat_x_assum ‘shrink _ body _ = _’ mp_tac
+          \\ disch_then assume_tac
+          \\ first_assum (fn th => drule_then mp_tac th)
+          \\ disch_then (qspec_then ‘inter locals l1’ mp_tac)
+          \\ impl_tac
+          >- (fs [subspt_lookup, lookup_inter_alt, CaseEq"option"]
+              \\ rw [] \\ res_tac \\ gvs [])
+          \\ strip_tac
+          \\ fs [loopSemTheory.dec_clock_def]
+          \\ qpat_x_assum ‘∀_ _ _ _ _. shrink _ (Loop _ _ _) _ = _ ∧ _ ⇒ _’
+               (qspecl_then [‘lt’, ‘new_locals’,
+                             ‘loopLang$Loop l1 q (inter live_out l0)’,
+                             ‘l1’, ‘l0’] mp_tac)
+          \\ impl_tac
+          >- (once_rewrite_tac [loop_liveTheory.shrink_def] \\ fs []
+              \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option", domain_union]
+              \\ rw [] \\ res_tac \\ gvs [])
+          \\ strip_tac
+          \\ asm_exists_tac \\ fs [])
+      \\ (* fix case *)
+         drule fixedpoint_thm \\ strip_tac
+      \\ once_rewrite_tac [loopSemTheory.evaluate_def]
+      \\ gvs [loopSemTheory.cut_res_def, loopSemTheory.cut_state_def]
+      \\ ‘domain (inter live_in v2) ⊆ domain locals’ by
+         (irule subspt_inter_domain_cut
+          \\ qexists_tac ‘s.locals’ \\ fs [SUBSET_DEF, domain_inter])
+      \\ gvs []
+      \\ qpat_x_assum ‘shrink _ body _ = _’ mp_tac
+      \\ disch_then assume_tac
+      \\ first_assum (fn th => drule_then mp_tac th)
+      \\ disch_then (qspec_then ‘inter locals (inter live_in v2)’ mp_tac)
+      \\ impl_tac
+      >- (fs [subspt_lookup, lookup_inter_alt, CaseEq"option"]
+          \\ rw [] \\ res_tac \\ gvs [domain_inter])
+      \\ strip_tac
+      \\ fs [loopSemTheory.dec_clock_def]
+      \\ qpat_x_assum ‘∀_ _ _ _ _. shrink _ (Loop _ _ _) _ = _ ∧ _ ⇒ _’
+           (qspecl_then [‘lt’, ‘new_locals’,
+                         ‘loopLang$Loop (inter live_in v2) v1 (inter live_out l0)’,
+                         ‘inter live_in v2’, ‘l0’] mp_tac)
+      \\ impl_tac
+      >- (once_rewrite_tac [loop_liveTheory.shrink_def] \\ fs []
+          \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option", domain_union,
+                 domain_inter]
+          \\ rw [] \\ res_tac \\ gvs [])
+      \\ strip_tac
+      \\ asm_exists_tac \\ fs [])
+  \\ fs [PULL_EXISTS]
+  \\ reverse (Cases_on ‘fixedpoint lt live_in LN (union live_in (inter live_out l0)) body’) \\ fs []
+  >- ((* Loop_fix *)
+      rpt strip_tac
+      \\ gvs []
+      \\ ‘x ≠ Error’ by (Cases_on ‘x’ \\ gvs [])
+      \\ drule fixedpoint_thm \\ strip_tac
+      \\ once_rewrite_tac [evaluate_def]
+      \\ gvs [cut_res_def, cut_state_def]
+      \\ ‘domain (inter live_in v2) ⊆ domain locals’ by
+         (irule subspt_inter_domain_cut
+          \\ qexists_tac ‘s.locals’
+          \\ fs [SUBSET_DEF, domain_inter])
+      \\ gvs []
+      \\ last_x_assum
+           (qspecl_then [‘(inter live_in v2, union live_in (inter live_out l0))::lt’,
+                         ‘inter locals (inter live_in v2)’,
+                         ‘v1’, ‘v2’, ‘union live_in (inter live_out l0)’] mp_tac)
+      \\ impl_tac
+      >- (fs []
+          \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option", domain_inter]
+          \\ rw [] \\ res_tac \\ gvs [])
+      \\ strip_tac
+      \\ Cases_on ‘x’ \\ gvs [dec_clock_def, cut_res_def, cut_state_def]
+      \\ Cases_on ‘n’ \\ gvs [oEL_def, LLOOKUP_def]
+      >- ((* Loop_fix_Break_0 *)
+          imp_res_tac subspt_inter_union_R
+          \\ Cases_on ‘domain live_out ⊆ domain r'.locals’ \\ gvs []
+          \\ ‘domain (inter live_out l0) ⊆ domain new_locals’ by
+             (irule subspt_inter_domain_cut
+              \\ qexists_tac ‘r'.locals’
+              \\ fs [SUBSET_DEF, domain_inter])
+          \\ gvs []
+          \\ Cases_on ‘r'.clock = 0’ \\ gvs []
+          \\ qexists_tac ‘inter new_locals (inter live_out l0)’
+          \\ fs [loopSemTheory.state_component_equality]
+          \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option"]
+          \\ rw [] \\ res_tac \\ fs [domain_inter] \\ res_tac \\ fs [])
+      >- (qexists_tac ‘new_locals’ \\ fs [])
+      >- ((* Loop_fix_Continue_0 *)
+          first_x_assum
+            (qspecl_then [‘lt’, ‘new_locals’,
+                          ‘Loop (inter live_in v2) v1 (inter live_out l0)’,
+                          ‘inter live_in v2’, ‘l0’] mp_tac)
+          \\ impl_tac
+          >- (once_rewrite_tac [shrink_def] \\ fs [])
+          \\ strip_tac \\ asm_exists_tac \\ fs [])
+      >- (qexists_tac ‘new_locals’ \\ fs []))
+  >- ((* Loop_no_fix *)
+      rpt strip_tac
+      \\ gvs []
+      \\ Cases_on ‘shrink ((live_in,inter live_out l0)::lt) body
+                           (union live_in (inter live_out l0))’
+      \\ gvs []
+      \\ ‘x ≠ Error’ by (Cases_on ‘x’ \\ gvs [])
+      \\ once_rewrite_tac [evaluate_def]
+      \\ gvs [cut_res_def, cut_state_def]
+      \\ ‘domain l1 ⊆ domain locals’ by
+         (irule subspt_inter_domain_cut
+          \\ qexists_tac ‘s.locals’ \\ fs [])
+      \\ gvs []
+      \\ last_x_assum
+           (qspecl_then [‘(l1,inter live_out l0)::lt’, ‘inter locals l1’,
+                         ‘q’, ‘r’, ‘union l1 (inter live_out l0)’] mp_tac)
+      \\ impl_tac
+      >- (fs []
+          \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option"]
+          \\ rw [] \\ res_tac \\ gvs [])
+      \\ strip_tac
+      \\ Cases_on ‘x’ \\ gvs [dec_clock_def, cut_res_def, cut_state_def]
+      \\ Cases_on ‘n’ \\ gvs [oEL_def, LLOOKUP_def]
+      >- ((* Loop_no_fix_Break_0 *)
+          Cases_on ‘domain live_out ⊆ domain r'.locals’ \\ gvs []
+          \\ ‘domain (inter live_out l0) ⊆ domain new_locals’ by
+             (irule subspt_inter_domain_cut
+              \\ qexists_tac ‘r'.locals’
+              \\ fs [SUBSET_DEF, domain_inter])
+          \\ gvs []
+          \\ Cases_on ‘r'.clock = 0’ \\ gvs []
+          \\ qexists_tac ‘inter new_locals (inter live_out l0)’
+          \\ fs [loopSemTheory.state_component_equality]
+          \\ fs [subspt_lookup, lookup_inter_alt, CaseEq"option"]
+          \\ rw [] \\ res_tac \\ fs [domain_inter] \\ res_tac \\ fs [])
+      >- (qexists_tac ‘new_locals’ \\ fs [])
+      >- ((* Loop_no_fix_Continue_0 *)
+          first_x_assum
+            (qspecl_then [‘lt’, ‘new_locals’, ‘Loop l1 q (inter live_out l0)’,
+                          ‘l1’, ‘l0’] mp_tac)
+          \\ impl_tac
+          >- (once_rewrite_tac [shrink_def] \\ fs [])
+          \\ strip_tac \\ asm_exists_tac \\ fs [])
+      >- (qexists_tac ‘new_locals’ \\ fs []))
 QED
 
 Theorem vars_of_exp_acc:
@@ -206,23 +340,56 @@ Theorem vars_of_exp_acc:
      domain (union (vars_of_exp exp LN) l)
 Proof
   qsuff_tac ‘
-  (∀(exp:'a loopLang$exp) (l:num_set) l.
-     domain (vars_of_exp exp l) =
-     domain (union (vars_of_exp exp LN) l)) ∧
-  (∀(exp:'a loopLang$exp list) (l:num_set) l x.
-     domain (vars_of_exp_list exp l) =
-     domain (union (vars_of_exp_list exp LN) l))’ THEN1 metis_tac []
-  \\ ho_match_mp_tac vars_of_exp_ind \\ rw []
-  \\ once_rewrite_tac [vars_of_exp_def]
-  THEN1 fs [domain_insert,domain_union,EXTENSION]
-  THEN1 fs [domain_insert,domain_union,EXTENSION]
-  \\ TRY (rpt (pop_assum (qspec_then ‘l’ mp_tac)) \\ fs [] \\ NO_TAC)
-  \\ Cases_on ‘exp’ \\ fs []
-  \\ simp_tac std_ss [domain_union]
-  \\ rpt (pop_assum (fn th => once_rewrite_tac [th]))
-  \\ simp_tac std_ss [domain_union]
-  \\ fs [domain_insert,domain_union,EXTENSION] \\ metis_tac []
+    (∀(exp:'a loopLang$exp) (l_unused:num_set).
+       ∀l. domain (vars_of_exp exp l) =
+           domain (union (vars_of_exp exp LN) l)) ∧
+    (∀(exps:'a loopLang$exp list) (l_unused:num_set).
+       ∀l. domain (vars_of_exp_list exps l) =
+           domain (union (vars_of_exp_list exps LN) l))’
+  THEN1 metis_tac []
+  \\ ho_match_mp_tac vars_of_exp_ind
+  \\ rpt conj_tac
+  >- (* Var *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                \\ fs [domain_union] \\ ASM_SET_TAC [])
+  >- (* Const *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                  \\ fs [domain_union])
+  >- (* BaseAddr *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                     \\ fs [domain_union])
+  >- (* TopAddr *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                    \\ fs [domain_union])
+  >- (* Lookup *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                   \\ fs [domain_union])
+  >- (* Load *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                 \\ metis_tac [])
+  >- (* Op *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+               \\ metis_tac [])
+  >- (* Shift *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+                  \\ metis_tac [])
+  >- suspend "list_case"
 QED
+
+Resume vars_of_exp_acc[list_case]:
+  rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
+  \\ Cases_on ‘exps’
+  >- (rewrite_tac [listTheory.list_case_def] \\ BETA_TAC
+      \\ rewrite_tac [sptreeTheory.union_LN])
+  \\ rewrite_tac [listTheory.list_case_def] \\ BETA_TAC
+  \\ qpat_x_assum ‘∀exp xs'. _’ (qspecl_then [‘h’, ‘t’] mp_tac)
+  \\ impl_tac >- simp []
+  \\ strip_tac
+  \\ qpat_x_assum ‘∀x exps'. _’ (qspecl_then [‘h’, ‘t’] mp_tac)
+  \\ impl_tac >- simp []
+  \\ strip_tac
+  \\ qpat_x_assum ‘∀l. domain (vars_of_exp h l) = _’ (fn th =>
+       assume_tac (Q.SPEC ‘vars_of_exp_list t l’ th) \\
+       assume_tac (Q.SPEC ‘vars_of_exp_list t LN’ th))
+  \\ first_x_assum (qspec_then ‘l’ assume_tac)
+  \\ pop_assum mp_tac \\ pop_assum mp_tac \\ pop_assum mp_tac
+  \\ rewrite_tac [domain_union]
+  \\ ASM_SET_TAC []
+QED
+
+Finalise vars_of_exp_acc;
 
 Theorem vars_of_exp_mono:
   ∀exp l. subspt l (vars_of_exp exp l)
@@ -405,19 +572,16 @@ Resume compile_correct[Call]:
     \\ IF_CASES_TAC \\ fs [] \\ rveq \\ fs []
     \\ fs [dec_clock_def] \\ fs [state_component_equality]
     \\ Cases_on ‘res’ \\ fs [] \\ fs [subspt_lookup,lookup_inter_alt]
-    \\ Cases_on ‘x'’ \\ fs [] \\ fs [subspt_lookup,lookup_inter_alt])
+    \\ Cases_on ‘x'’ \\ fs [] \\ rpt CASE_TAC \\ fs [subspt_lookup,lookup_inter_alt])
   \\ rename [‘Call (SOME z)’] \\ PairCases_on ‘z’ \\ fs []
-  \\ reverse (Cases_on ‘ALL_DISTINCT z0’) >- (fs [] \\ rveq \\ fs [])
-  \\ fs []
   \\ Cases_on ‘handler’ \\ fs [shrink_def] \\ rveq \\ fs []
-  >- (fs [evaluate_def,cut_res_def,cut_state_def]
+  >- ((* no handler *)
+      fs [evaluate_def,cut_res_def,cut_state_def]
       \\ Cases_on ‘domain z1 ⊆ domain s.locals’ \\ fs []
       \\ reverse IF_CASES_TAC \\ fs []
-      THEN1
-       (imp_res_tac subspt_IMP_domain
-        \\ fs [domain_inter,domain_union,domain_delete,
-               SUBSET_DEF,domain_fromAList,MEM_MAP,EXISTS_PROD]
-        \\ pop_assum mp_tac \\ fs [] \\ metis_tac [])
+      \\ imp_res_tac subspt_IMP_domain
+      \\ rfs [SUBSET_DEF, domain_inter, domain_union, domain_list_delete,
+              domain_fromAList, MEM_MAP, EXISTS_PROD]
       \\ IF_CASES_TAC \\ fs [] \\ rveq \\ fs [dec_clock_def]
       \\ fs [CaseEq"prod",CaseEq"option"] \\ rveq \\ fs []
       \\ fs [CaseEq"loopSem$result"] \\ rveq \\ fs [set_var_def,set_vars_def]
@@ -429,102 +593,96 @@ Resume compile_correct[Call]:
            ‘alist_insert z0 retvs (inter locals (list_delete z0 (inter l0 z1)))’
       \\ fs [state_component_equality,subspt_lookup,
              lookup_inter_alt,lookup_alist_insert_any]
-      \\ qx_genl_tac [‘k’,‘v’] \\ strip_tac
-      \\ Cases_on ‘ALOOKUP (ZIP (z0,retvs)) k’ \\ fs []
+      \\ rw [] \\ Cases_on ‘ALOOKUP (ZIP (z0,retvs)) x'’ \\ fs []
       \\ ‘MAP FST (ZIP (z0,retvs)) = z0’ by fs [MAP_ZIP]
-      \\ rw []
-      \\ fs [domain_inter,ALOOKUP_NONE]
+      \\ fs [ALOOKUP_NONE, domain_inter]
       \\ first_x_assum irule
-      \\ fs [domain_union,domain_list_delete,domain_inter,domain_fromAList])
-  \\ PairCases_on ‘x'’ \\ fs []
+      \\ fs [domain_union, domain_list_delete, domain_inter])
+  \\ (* handler *)
+  PairCases_on ‘x'’ \\ fs []
   \\ fs [evaluate_def,cut_res_def,cut_state_def]
   \\ Cases_on ‘domain z1 ⊆ domain s.locals’ \\ fs []
   \\ rpt (pairarg_tac \\ fs []) \\ rveq
   \\ fs [evaluate_def,cut_res_def,cut_state_def]
   \\ reverse IF_CASES_TAC \\ fs []
-  THEN1
-   (imp_res_tac subspt_IMP_domain
-    \\ fs [domain_inter,domain_union,domain_delete,SUBSET_DEF]
-    \\ pop_assum mp_tac \\ fs [] \\ metis_tac [])
+  \\ imp_res_tac subspt_IMP_domain
+  \\ rfs [SUBSET_DEF, domain_inter, domain_union, domain_list_delete,
+          domain_delete, domain_fromAList, MEM_MAP, EXISTS_PROD]
+  \\ ‘∀x. x ∈ domain z1 ∧
+          (x ∈ domain l2 ∧ ¬MEM x z0 ∨ x ∈ domain l3 ∧ x ≠ x'0) ⇒
+          x ∈ domain locals’ by metis_tac []
+  \\ fs []
+  \\ Cases_on ‘s.clock = 0’ \\ fs [] \\ rveq
+  >- (fs [loopSemTheory.state_component_equality]
+      \\ IF_CASES_TAC \\ fs []
+      \\ metis_tac [])
   \\ IF_CASES_TAC \\ fs [] \\ rveq \\ fs []
   \\ fs [dec_clock_def,CaseEq"prod",CaseEq"option"] \\ rveq \\ fs []
-  \\ qpat_x_assum ‘∀x. _’ kall_tac
-  \\ fs [CaseEq"loopSem$result"] \\ rveq \\ fs []
-  \\ rpt (fs [state_component_equality] \\ NO_TAC)
+  \\ Cases_on ‘v11’ \\ fs []
   \\ fs [set_var_def,set_vars_def]
-  >~ [‘evaluate (y1,_) = (SOME (loopSem$Result _),_)’]
-     >- (Cases_on ‘LENGTH retvs = LENGTH z0’ \\ fs []
-         \\ rveq \\ fs []
-         \\ qmatch_goalsub_abbrev_tac ‘evaluate (r',st1)’
-         \\ Cases_on ‘evaluate
-              (x'2,st with
-                   locals := alist_insert z0 retvs (inter s.locals z1))’
-         \\ fs []
-         \\ Cases_on ‘q = SOME Error’
-         THEN1 (fs [cut_res_def])
-         \\ fs []
-         \\ first_x_assum drule
-         \\ disch_then (qspec_then ‘st1.locals’ mp_tac)
-         \\ impl_tac
-         >- (fs [Abbr‘st1’,subspt_lookup,lookup_inter_alt,
-                 lookup_alist_insert_any]
-             \\ ‘MAP FST (ZIP (z0,retvs)) = z0’ by fs [MAP_ZIP]
-             \\ qx_genl_tac [‘k’,‘v’] \\ strip_tac
-             \\ Cases_on ‘ALOOKUP (ZIP (z0,retvs)) k’ \\ fs []
-             \\ ‘¬MEM k z0’ by gvs [ALOOKUP_NONE]
-             \\ rw []
-             \\ ‘k ∈ domain
-                       (inter z1
-                          (union (list_delete z0 l2) (delete x'0 l3)))’ by
-                  fs [domain_inter,domain_union,domain_list_delete]
-             \\ fs []
-             \\ first_x_assum irule
-             \\ fs [domain_union,domain_inter,domain_fromAList])
-         \\ strip_tac \\ fs []
-         \\ unabbrev_all_tac \\ fs []
-         \\ reverse (Cases_on ‘q’) \\ fs []
-         THEN1
-          (Cases_on ‘x'’ \\ fs [cut_res_def,state_component_equality]
-           \\ Cases_on ‘res’ \\ fs []
-           \\ Cases_on ‘x'’ \\ fs [] \\ fs [subspt_lookup])
-         \\ fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"bool"]
-         \\ fs [state_component_equality,domain_inter,domain_union,
-                dec_clock_def]
-         \\ fs [SUBSET_DEF] \\ rw []
-         \\ rpt (qpat_x_assum ‘inter _ _ = _’ (assume_tac o GSYM)) \\ fs []
-         \\ fs [subspt_lookup,lookup_inter_alt,domain_inter]
-         \\ fs [domain_lookup] \\ res_tac \\ res_tac \\ fs [])
-  >~ [‘evaluate (y1,_) = (SOME (loopSem$Exception _),_)’]
-     >- (qmatch_goalsub_abbrev_tac ‘evaluate (h',st1)’
-         \\ Cases_on ‘evaluate
-              (x'1,st with
-                   locals := insert x'0 exn (inter s.locals z1))’
-         \\ fs []
-         \\ Cases_on ‘q = SOME Error’
-         THEN1 (fs [cut_res_def])
-         \\ fs []
-         \\ first_x_assum drule
-         \\ disch_then (qspec_then ‘st1.locals’ mp_tac)
-         \\ impl_tac
-         >- (fs [Abbr‘st1’,subspt_lookup,lookup_inter_alt,lookup_insert,
-                 domain_union,domain_inter,domain_list_delete,domain_delete,
-                 domain_fromAList]
-             \\ rw [] \\ fs [])
-         \\ strip_tac \\ fs []
-         \\ unabbrev_all_tac \\ fs []
-         \\ reverse (Cases_on ‘q’) \\ fs []
-         THEN1
-          (Cases_on ‘x'’ \\ fs [cut_res_def,state_component_equality]
-           \\ Cases_on ‘res’ \\ fs []
-           \\ Cases_on ‘x'’ \\ fs [] \\ fs [subspt_lookup])
-         \\ fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"bool"]
-         \\ fs [state_component_equality,domain_inter,domain_union,
-                dec_clock_def]
-         \\ fs [SUBSET_DEF] \\ rw []
-         \\ rpt (qpat_x_assum ‘inter _ _ = _’ (assume_tac o GSYM)) \\ fs []
-         \\ fs [subspt_lookup,lookup_inter_alt,domain_inter]
-         \\ fs [domain_lookup] \\ res_tac \\ res_tac \\ fs [])
-  \\ fs [state_component_equality]
+  \\ rpt strip_tac \\ rveq \\ fs [state_component_equality]
+  \\ rpt (qpat_x_assum ‘x' ∉ domain locals’ mp_tac \\ metis_tac [])
+  >~ [‘evaluate (y1,_) = (SOME (loopSem$Result _),_)’] >-
+   (Cases_on ‘LENGTH l ≠ LENGTH z0’ \\ fs [] \\ rveq \\ fs [state_component_equality]
+    \\ qmatch_goalsub_abbrev_tac ‘evaluate (r',st1)’
+    \\ Cases_on ‘evaluate (x'2,st with locals := alist_insert z0 l (inter s.locals z1))’
+    \\ fs []
+    \\ Cases_on ‘q = SOME Error’
+    >- fs [cut_res_def]
+    \\ fs []
+    \\ first_x_assum drule
+    \\ disch_then (qspec_then ‘st1.locals’ mp_tac)
+    \\ impl_tac
+    >- (fs [Abbr‘st1’,subspt_lookup,lookup_inter_alt,lookup_alist_insert_any]
+        \\ ‘MAP FST (ZIP (z0,l)) = z0’ by fs [MAP_ZIP]
+        \\ qx_genl_tac [‘k’,‘v’] \\ strip_tac
+        \\ Cases_on ‘ALOOKUP (ZIP (z0,l)) k’ \\ fs []
+        \\ ‘¬MEM k z0’ by gvs [ALOOKUP_NONE]
+        \\ rw []
+        \\ ‘k ∈ domain (inter z1 (union (list_delete z0 l2) (delete x'0 l3)))’ by
+             fs [domain_inter,domain_union,domain_list_delete]
+        \\ fs []
+        \\ first_x_assum irule
+        \\ fs [domain_union,domain_inter,domain_fromAList])
+    \\ strip_tac \\ fs []
+    \\ unabbrev_all_tac \\ fs []
+    \\ reverse (Cases_on ‘q’) \\ fs []
+    >- (Cases_on ‘x'’ \\ fs [cut_res_def,state_component_equality]
+        \\ Cases_on ‘res’ \\ fs []
+        \\ Cases_on ‘x'’ \\ fs []
+        \\ rpt CASE_TAC \\ gvs [subspt_lookup])
+    \\ fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"bool"]
+    \\ fs [state_component_equality,domain_inter,domain_union,dec_clock_def]
+    \\ fs [SUBSET_DEF] \\ rw []
+    \\ rpt (qpat_x_assum ‘inter _ _ = _’ (assume_tac o GSYM)) \\ fs []
+    \\ fs [subspt_lookup,lookup_inter_alt,domain_inter]
+    \\ fs [domain_lookup] \\ res_tac \\ res_tac \\ fs [])
+  \\ qmatch_goalsub_abbrev_tac ‘evaluate (h',st1)’
+  \\ Cases_on ‘evaluate (x'1,st with locals := insert x'0 w (inter s.locals z1))’
+  \\ fs []
+  \\ Cases_on ‘q = SOME Error’
+  >- fs [cut_res_def]
+  \\ fs []
+  \\ first_x_assum drule
+  \\ disch_then (qspec_then ‘st1.locals’ mp_tac)
+  \\ impl_tac
+  >- (fs [Abbr‘st1’,subspt_lookup,lookup_inter_alt,lookup_insert,
+          domain_union,domain_inter,domain_list_delete,domain_delete,
+          domain_fromAList]
+      \\ rw [] \\ fs [])
+  \\ strip_tac \\ fs []
+  \\ unabbrev_all_tac \\ fs []
+  \\ reverse (Cases_on ‘q’) \\ fs []
+  >- (Cases_on ‘x'’ \\ fs [cut_res_def,state_component_equality]
+      \\ Cases_on ‘res’ \\ fs []
+      \\ Cases_on ‘x'’ \\ fs []
+      \\ rpt CASE_TAC \\ gvs [subspt_lookup])
+  \\ fs [cut_res_def,cut_state_def,CaseEq"option",CaseEq"bool"]
+  \\ fs [state_component_equality,domain_inter,domain_union,dec_clock_def]
+  \\ fs [SUBSET_DEF] \\ rw []
+  \\ rpt (qpat_x_assum ‘inter _ _ = _’ (assume_tac o GSYM)) \\ fs []
+  \\ fs [subspt_lookup,lookup_inter_alt,domain_inter]
+  \\ fs [domain_lookup] \\ res_tac \\ res_tac \\ fs []
 QED
 
 Resume compile_correct[Store]:
@@ -638,7 +796,7 @@ Resume compile_correct[ShMem]:
      first_assum $ irule>>fs[]>>
      irule dom_vars_of_exp_in>>fs[])>>
   fs[Abbr ‘X’]>>
-  TRY (irule_at Any EQ_REFL)>>
+  rpt (irule_at Any EQ_REFL) >>
   gvs[subspt_lookup,lookup_insert,lookup_inter_EQ]>>
   rpt strip_tac>>
   every_case_tac>>fs[]>>
@@ -657,91 +815,84 @@ Theorem mark_correct:
   evaluate (FST (mark_all prog),s) = (res,s1)
 Proof
   recInduct evaluate_ind \\ rpt conj_tac
-  >~ [‘loopLang$Seq’]
-     >- (rw [] \\ fs [mark_all_def]
-         \\ rpt (pairarg_tac \\ fs [] \\ rveq)
-         \\ TOP_CASE_TAC \\ fs []
-         \\ fs [evaluate_def]
-         \\ rpt (pairarg_tac \\ gs [] \\ rveq)
-         \\ every_case_tac \\ fs [])
-  >~ [‘loopLang$If’]
-     >- (rw [] \\ fs [mark_all_def]
-         \\ rpt (pairarg_tac \\ fs [] \\ rveq)
-         \\ TOP_CASE_TAC \\ fs []
-         \\ fs [evaluate_def]
-         \\ every_case_tac \\ fs []
-         \\ Cases_on ‘evaluate (c1,s)’ \\ fs []
-         \\ Cases_on ‘q’ \\ fs [cut_res_def] \\ rveq \\ gs []
-         \\ fs [cut_res_def]
-         \\ Cases_on ‘evaluate (c2,s)’ \\ fs []
-         \\ Cases_on ‘q’ \\ fs [cut_res_def] \\ rveq \\ gs []
-         \\ fs [cut_res_def])
-  >~ [‘loopLang$Loop’]
-     >- (rw [] \\ fs [mark_all_def]
-         \\ rpt (pairarg_tac \\ fs [] \\ rveq)
-         \\ fs [cut_res_def]
-         \\ FULL_CASE_TAC \\ fs []
-         >- (fs [cut_state_def]
-             \\ fs [Once evaluate_def, cut_res_def]
-             \\ fs [cut_state_def])
-         \\ FULL_CASE_TAC \\ fs []
-         >- (fs [cut_state_def]
-             \\ fs [Once evaluate_def, cut_res_def]
-             \\ fs [cut_state_def])
-         \\ Cases_on ‘evaluate (body,dec_clock x)’ \\ fs []
-         \\ Cases_on ‘q’ \\ fs []
-         >- (fs [Once evaluate_def]
-             \\ every_case_tac \\ fs [] \\ rveq
-             \\ gs [cut_res_def])
-         \\ Cases_on ‘x'’ \\ fs []
-         >~ [‘SOME Continue’]
-            >- (last_x_assum mp_tac
-                \\ rewrite_tac [Once evaluate_def]
-                \\ strip_tac
-                \\ rewrite_tac [Once evaluate_def]
-                \\ TOP_CASE_TAC \\ fs []
-                \\ TOP_CASE_TAC \\ fs []
-                \\ fs [cut_res_def]
-                \\ Cases_on ‘cut_state live_in s’ \\ fs []
-                \\ Cases_on ‘x'.clock = 0’ \\ fs [] \\ rveq \\ gs [])
-         \\ fs [Once evaluate_def]
-         \\ every_case_tac \\ fs [] \\ rveq
-         \\ gs [cut_res_def])
-  >~ [‘loopLang$Call’]
-     >- (rw [] \\ fs [mark_all_def]
-         \\ fs [evaluate_def]
-         \\ TOP_CASE_TAC \\ fs []
-         >- rw [evaluate_def]
-         \\ TOP_CASE_TAC \\ fs []
-         \\ TOP_CASE_TAC \\ fs []
-         \\ TOP_CASE_TAC \\ fs []
-         \\ pairarg_tac \\ fs []
-         \\ pairarg_tac \\ fs []
-         \\ TOP_CASE_TAC \\ fs []
-         \\ rw [evaluate_def]
-         \\ every_case_tac \\ fs [] \\ rveq \\ fs []
-         \\ Cases_on
-              ‘evaluate (q'',set_vars q'³' l (r'⁴' with locals := r''.locals))’
-         \\ Cases_on
-              ‘evaluate (q',set_var q w (r'⁴' with locals := r''.locals))’
-         \\ fs []
-         \\ rveq
-         \\ every_case_tac \\ fs [] \\ rveq \\ gs [cut_res_def])
+  >~ [‘loopLang$Seq’] >- suspend "Seq"
+  >~ [‘loopLang$If’] >- suspend "If"
+  >~ [‘loopLang$Loop’] >- suspend "Loop"
+  >~ [‘loopLang$Call’] >- suspend "Call"
   \\ rw [] \\ fs [mark_all_def,evaluate_def]
 QED
+
+Resume mark_correct[Seq]:
+  rw [] \\ fs [mark_all_def]
+  \\ rpt (pairarg_tac \\ fs [] \\ rveq)
+  \\ TOP_CASE_TAC \\ fs []
+  \\ fs [evaluate_def]
+  \\ rpt (pairarg_tac \\ gs [] \\ rveq)
+  \\ every_case_tac \\ fs []
+QED
+
+Resume mark_correct[If]:
+  rw [] \\ fs [mark_all_def]
+  \\ rpt (pairarg_tac \\ fs [] \\ rveq)
+  \\ TOP_CASE_TAC \\ fs []
+  \\ fs [evaluate_def]
+  \\ every_case_tac \\ fs []
+  \\ Cases_on ‘evaluate (c1,s)’ \\ fs []
+  \\ Cases_on ‘q’ \\ fs [cut_res_def] \\ rveq \\ gs []
+  \\ fs [cut_res_def]
+  \\ Cases_on ‘evaluate (c2,s)’ \\ fs []
+  \\ Cases_on ‘q’ \\ fs [cut_res_def] \\ rveq \\ gs []
+  \\ fs [cut_res_def]
+QED
+
+Resume mark_correct[Loop]:
+  rw [] \\ fs [mark_all_def]
+  \\ rpt (pairarg_tac \\ fs [] \\ rveq)
+  \\ qpat_x_assum ‘evaluate (Loop _ _ _, _) = _’ mp_tac
+  \\ once_rewrite_tac [loopSemTheory.evaluate_def]
+  \\ Cases_on ‘cut_res live_in (NONE:'a result option,s)’ \\ Cases_on ‘q’ \\ fs []
+  \\ strip_tac \\ Cases_on ‘evaluate (body, r)’ \\ fs []
+  \\ Cases_on ‘q’ \\ fs []
+  \\ Cases_on ‘x’ \\ fs []
+  \\ Cases_on ‘n’ \\ fs []
+QED
+
+Resume mark_correct[Call]:
+  rw [] \\ fs [mark_all_def]
+  \\ fs [evaluate_def]
+  \\ TOP_CASE_TAC \\ fs []
+  >- rw [evaluate_def]
+  \\ TOP_CASE_TAC \\ fs []
+  \\ TOP_CASE_TAC \\ fs []
+  \\ TOP_CASE_TAC \\ fs []
+  \\ pairarg_tac \\ fs []
+  \\ pairarg_tac \\ fs []
+  \\ TOP_CASE_TAC \\ fs []
+  \\ rw [evaluate_def]
+  \\ every_case_tac \\ fs [] \\ rveq \\ fs []
+  \\ Cases_on
+       ‘evaluate (q'',set_vars q'³' l (r'⁴' with locals := r''.locals))’
+  \\ Cases_on
+       ‘evaluate (q',set_var q w (r'⁴' with locals := r''.locals))’
+  \\ fs []
+  \\ rveq
+  \\ every_case_tac \\ fs [] \\ rveq \\ gs [cut_res_def]
+QED
+
+Finalise mark_correct;
 
 Theorem comp_correct:
   evaluate (prog,s) = (res,s1) ∧
   res ≠ SOME Error ∧
-  res ≠ SOME Break ∧
-  res ≠ SOME Continue ∧
+  (∀n. res ≠ SOME (Break n)) ∧
+  (∀n. res ≠ SOME (Continue n)) ∧
   res ≠ NONE ⇒
   evaluate (comp prog,s) = (res,s1)
 Proof
   strip_tac
   \\ drule compile_correct \\ fs []
   \\ fs [comp_def]
-  \\ Cases_on ‘shrink (LN,LN) prog LN’ \\ fs []
+  \\ Cases_on ‘shrink [] prog LN’ \\ fs []
   \\ disch_then drule
   \\ disch_then (qspec_then ‘s.locals’ mp_tac)
   \\ impl_tac THEN1 fs [subspt_lookup,lookup_inter_alt]
@@ -757,8 +908,8 @@ QED
 Theorem optimise_correct:
   evaluate (prog,s) = (res,s1) ∧
   res ≠ SOME Error ∧
-  res ≠ SOME Break ∧
-  res ≠ SOME Continue ∧
+  (∀n. res ≠ SOME (Break n)) ∧
+  (∀n. res ≠ SOME (Continue n)) ∧
   res ≠ NONE  ⇒
   evaluate (optimise prog,s) = (res,s1)
 Proof
@@ -774,4 +925,3 @@ Proof
   drule comp_correct >>
   fs []
 QED
-

--- a/pancake/proofs/loop_to_wordProofScript.sml
+++ b/pancake/proofs/loop_to_wordProofScript.sml
@@ -73,22 +73,22 @@ val goal =
                    t1.stack = t.stack ∧ t1.handler = t.handler
          | SOME (Result v) => state_rel s1 t1 ∧ res1 = SOME (Result retv v) ∧
                                      t1.stack = t.stack ∧ t1.handler = t.handler
-         | SOME TimeOut => res1 = SOME TimeOut
-         | SOME (FinalFFI f) => res1 = SOME (FinalFFI f)
          | SOME (Exception v) =>
             state_rel s1 t1 ∧
             (res1 ≠ SOME Error ⇒ ∃u1 u2. res1 = SOME (Exception u1 u2)) ∧
             ∀r l1 l2. jump_exc (t1 with <| stack := t.stack;
                                            handler := t.handler |>) = SOME (r,l1,l2) ⇒
                       res1 = SOME (Exception (Loc l1 l2) v) ∧ r = t1
-         | SOME Break => state_rel s1 t1 ∧ res1 = SOME (Break 0) ∧
-                         lookup 0 t1.locals = SOME retv ∧
-                         locals_rel ctxt s1.locals t1.locals ∧
-                         t1.stack = t.stack ∧ t1.handler = t.handler
-         | SOME Continue => state_rel s1 t1 ∧ res1 = SOME (Continue 0) ∧
-                            lookup 0 t1.locals = SOME retv ∧
-                            locals_rel ctxt s1.locals t1.locals ∧
-                            t1.stack = t.stack ∧ t1.handler = t.handler
+         | SOME (Break n) => state_rel s1 t1 ∧ res1 = SOME (Break n) ∧
+                             lookup 0 t1.locals = SOME retv ∧
+                             locals_rel ctxt s1.locals t1.locals ∧
+                             t1.stack = t.stack ∧ t1.handler = t.handler
+         | SOME (Continue n) => state_rel s1 t1 ∧ res1 = SOME (Continue n) ∧
+                                lookup 0 t1.locals = SOME retv ∧
+                                locals_rel ctxt s1.locals t1.locals ∧
+                                t1.stack = t.stack ∧ t1.handler = t.handler
+         | SOME TimeOut => res1 = SOME TimeOut
+         | SOME (FinalFFI f) => res1 = SOME (FinalFFI f)
          | _ => F``
 
 val ind_thm = loopSemTheory.evaluate_ind
@@ -102,8 +102,8 @@ Proof
   >~ [`loopLang$Skip`] >- suspend "Skip"
   >~ [`loopLang$Fail`] >- suspend "Fail"
   >~ [`loopLang$Tick`] >- suspend "Tick"
-  >~ [`loopLang$Continue`] >- suspend "Continue"
-  >~ [`loopLang$Break`] >- suspend "Break"
+  >~ [`loopLang$Continue _`] >- suspend "Continue"
+  >~ [`loopLang$Break _`] >- suspend "Break"
   >~ [`loopLang$Mark`] >- suspend "Mark"
   >~ [`loopLang$Return`] >- suspend "Return"
   >~ [`loopLang$Raise`] >- suspend "Raise"
@@ -552,13 +552,10 @@ Resume compile_correct[Loop]:
   simp [evaluate_def] >>
   fs [cut_state_def, dec_clock_def] >>
   Cases_on ‘evaluate (body,dec_clock (s with locals := inter s.locals live_in))’ >>
-  rename1 ‘evaluate _ = (resb, sb)’ >>
+  rename1 ‘evaluate _ = (resb,sb)’ >>
   strip_tac >>
-  ‘resb ≠ SOME Error’ by (
-    Cases_on ‘resb’ >> gvs [] >>
-    Cases_on ‘x’ >> gvs []
-  ) >>
-  qpat_x_assum ‘∀s'. cut_res _ _ = _ ⇒ _’
+  ‘resb ≠ SOME Error’ by (strip_tac >> gvs []) >>
+  qpat_x_assum ‘∀s'. cut_res live_in (NONE,s) = (NONE,s') ⇒ _’
     (qspec_then ‘dec_clock (s with locals := inter s.locals live_in)’ mp_tac) >>
   impl_tac
   >- simp [loopSemTheory.cut_res_def, loopSemTheory.cut_state_def,
@@ -569,40 +566,96 @@ Resume compile_correct[Loop]:
   impl_tac
   >- gvs [state_rel_def, loopSemTheory.dec_clock_def] >>
   strip_tac >>
-  (* Case-split body result. Error/Result/TimeOut/FinalFFI auto-close. *)
-  Cases_on ‘resb’ >> gvs [] >>
-  Cases_on ‘x’ >> gvs []
-  >- ( (* Exception: cont_loop F, exit_loop = id, propagate via body IH *)
-    qexistsl_tac [‘t1’,‘res1’] >>
-    ‘res1 = SOME Error ∨ ∃u1 u2. res1 = SOME (Exception u1 u2)’ by metis_tac [] >>
-    gvs []
-  )
-  >- ( (* Break: cut_res live_out, then outer trailing Tick fires on NONE *)
-    qpat_x_assum ‘cut_res live_out (NONE,sb) = _’ mp_tac >>
-    simp [Once loopSemTheory.cut_res_def, loopSemTheory.cut_state_def] >>
-    Cases_on ‘domain live_out ⊆ domain sb.locals’ >> fs [] >>
-    drule cut_env_mk_new_cutset >>
-    rpt (disch_then drule) >> strip_tac >>
-    drule cut_env_mk_new_cutset_IMP >> strip_tac >>
-    simp [] >>
-    ‘sb.clock = t1.clock’ by fs [state_rel_def] >>
-    IF_CASES_TAC >> fs []
-    >- (strip_tac >> rveq >> gvs [flush_state_def]) >>
-    strip_tac >> rveq >>
-    fs [loopSemTheory.dec_clock_def, dec_clock_def, state_rel_def]
-  ) >>
-  (* Continue: apply Loop-IH at t' = t1 via evaluate_tick_loop_tick_unfold *)
+  namedCases_on ‘resb’ ["", "rb"]
+  >- suspend "Loop_bodyNONE" >>
+  namedCases_on ‘rb’ ["wlist", "wloc", "bn", "cn", "", "fe", ""] >>
+  gvs []
+  >- suspend "Loop_Exception"
+  >- suspend "Loop_Break"
+  >- suspend "Loop_Continue"
+QED
+
+Resume compile_correct[Loop_bodyNONE]:
+  fs [] >>
   Cases_on ‘t1.clock = 0’ >> fs [] >>
   imp_res_tac state_rel_IMP >>
   gvs []
-  >- ( (* t1.clock = 0: both sides TimeOut *)
+  >- (
     qpat_x_assum ‘evaluate (Loop _ _ _,sb) = _’ mp_tac >>
     simp [Once loopSemTheory.evaluate_def,
           loopSemTheory.cut_res_def, loopSemTheory.cut_state_def] >>
     Cases_on ‘domain live_in ⊆ domain sb.locals’ >> fs [] >>
     strip_tac >> gvs []
   ) >>
-  qpat_x_assum ‘∀s' s''. cut_res live_in (NONE,s) = (NONE,s') ∧ _ ⇒ _’
+  qpat_x_assum ‘∀s' s''. cut_res live_in (NONE,s) = (NONE,s') ∧
+                          evaluate (body,s') = (NONE,s'') ⇒ _’
+    (qspecl_then [‘dec_clock (s with locals := inter s.locals live_in)’, ‘sb’] mp_tac) >>
+  impl_tac
+  >- (
+    simp [loopSemTheory.cut_res_def, loopSemTheory.cut_state_def,
+          loopSemTheory.dec_clock_def] >>
+    gvs []
+  ) >>
+  disch_then (qspecl_then [‘res’,‘s1’,‘t1’,‘ctxt’,‘retv’,‘l’] mp_tac) >>
+  impl_tac
+  >- (
+    gvs [] >>
+    simp [Once loopSemTheory.evaluate_def,
+          loopSemTheory.cut_res_def, loopSemTheory.cut_state_def] >>
+    gvs []
+  ) >>
+  strip_tac >>
+  ‘t1.clock ≠ 0’ by fs [] >>
+  qspecl_then [‘t1’,‘mk_new_cutset ctxt live_in’,
+               ‘mk_new_cutset ctxt live_out’,‘wbody’]
+    mp_tac (GEN_ALL evaluate_tick_loop_tick_unfold) >>
+  impl_tac >- fs [] >>
+  strip_tac >>
+  qexistsl_tac [‘t1'’,‘res1’] >>
+  fs [STOP_def] >>
+  qpat_x_assum ‘t1.clock = sb.clock’ (fn t => simp [t] >> assume_tac t) >>
+  qpat_x_assum ‘evaluate (FST _,t1) = _’ mp_tac >>
+  simp [] >> strip_tac >>
+  Cases_on ‘res’ >> fs [] >>
+  rename1 ‘res = SOME _’ >>
+  Cases_on ‘x’ >> fs []
+QED
+
+Resume compile_correct[Loop_Exception]:
+  qexistsl_tac [‘t1’,‘res1’] >>
+  Cases_on ‘res1 = SOME Error’ >> gvs []
+QED
+
+Resume compile_correct[Loop_Break]:
+  Cases_on ‘bn’ >> gvs [] >>
+  qpat_x_assum ‘cut_res live_out (NONE, sb) = _’ mp_tac >>
+  simp [Once loopSemTheory.cut_res_def, loopSemTheory.cut_state_def] >>
+  Cases_on ‘domain live_out ⊆ domain sb.locals’ >> fs [] >>
+  drule cut_env_mk_new_cutset >>
+  rpt (disch_then drule) >> strip_tac >>
+  drule cut_env_mk_new_cutset_IMP >> strip_tac >>
+  simp [] >>
+  ‘sb.clock = t1.clock’ by fs [state_rel_def] >>
+  IF_CASES_TAC >> fs []
+  >- (strip_tac >> rveq >> gvs [flush_state_def]) >>
+  strip_tac >> rveq >>
+  fs [loopSemTheory.dec_clock_def, dec_clock_def, state_rel_def]
+QED
+
+Resume compile_correct[Loop_Continue]:
+  Cases_on ‘cn’ >> gvs [] >>
+  Cases_on ‘t1.clock = 0’ >> fs [] >>
+  imp_res_tac state_rel_IMP >>
+  gvs []
+  >- (
+    qpat_x_assum ‘evaluate (Loop _ _ _,sb) = _’ mp_tac >>
+    simp [Once loopSemTheory.evaluate_def,
+          loopSemTheory.cut_res_def, loopSemTheory.cut_state_def] >>
+    Cases_on ‘domain live_in ⊆ domain sb.locals’ >> fs [] >>
+    strip_tac >> gvs []
+  ) >>
+  qpat_x_assum ‘∀s' s''. cut_res live_in (NONE,s) = (NONE,s') ∧
+                          evaluate (body,s') = (SOME (Continue 0),s'') ⇒ _’
     (qspecl_then [‘dec_clock (s with locals := inter s.locals live_in)’, ‘sb’] mp_tac) >>
   impl_tac
   >- (
@@ -895,7 +948,63 @@ Resume compile_correct[Call]:
         >> fs [loopSemTheory.find_code_def]
         >> imp_res_tac locals_rel_get_vars >> CCONTR_TAC >> fs [])
   >> Cases_on ‘ret’ >> fs []
-  >- ((* TailCall: ret = NONE *)
+  >- suspend "Call_TailCall"
+  >> (* Returning: ret = SOME _ *)
+     fs [comp_def,evaluate_def]
+  >> imp_res_tac locals_rel_get_vars >> fs [add_ret_loc_def]
+  >> fs [get_vars_def,get_var_def]
+  >> simp [bad_dest_args_def,call_env_def,dec_clock_def]
+  >> PairCases_on ‘x’ >> PairCases_on ‘l’
+  >> fs [] >> imp_res_tac state_rel_IMP
+  >> reverse (Cases_on ‘ALL_DISTINCT x0’) >- (fs [] >> rveq >> fs [])
+  >> fs []
+  >> ‘∃args1 prog1 ss1 ctxt1 l2.
+       find_code dest (Loc l0 l1::argvals) t.code t.stack_size = SOME (args1,prog1,ss1) ∧
+       FST (comp ctxt1 new_code l2) = prog1 ∧
+       lookup 0 (fromList2 args1) = SOME (Loc l0 l1) ∧
+       locals_rel ctxt1 new_env (fromList2 args1) ∧
+       domain (acc_vars new_code LN) ⊆ domain ctxt1’ by
+    (qpat_x_assum ‘_ = (res,_)’ kall_tac
+     >> rpt (qpat_x_assum ‘∀x. _’ kall_tac)
+     >> Cases_on ‘dest’ >> fs [loopSemTheory.find_code_def]
+     >-
+      (fs [CaseEq"word_loc",CaseEq"num",CaseEq"option",CaseEq"prod",CaseEq"bool"]
+       >> rveq >> fs [code_rel_def,state_rel_def]
+       >> first_x_assum drule >> strip_tac >> fs []
+       >> fs [find_code_def]
+       >> ‘∃x l. argvals = SNOC x l’ by metis_tac [SNOC_CASES]
+       >> qpat_x_assum ‘_ = Loc loc 0’ mp_tac
+       >> rveq >> rewrite_tac [GSYM SNOC,LAST_SNOC,FRONT_SNOC] >> fs []
+       >> strip_tac >> rveq >> fs []
+       >> simp [comp_func_def]
+       >> qmatch_goalsub_abbrev_tac ‘comp ctxt2 _ ll2’
+       >> qexists_tac ‘ctxt2’ >> qexists_tac ‘ll2’ >> fs []
+       >> conj_tac >- fs [lookup_fromList2,lookup_fromList]
+       >> simp [Abbr‘ctxt2’,domain_make_ctxt,set_fromNumSet,
+                domain_difference,domain_toNumSet, SUBSET_DEF]
+       >> match_mp_tac locals_rel_make_ctxt
+       >> fs [IN_DISJOINT,set_fromNumSet,domain_difference,
+              domain_toNumSet,GSYM IMP_DISJ_THM])
+     >> fs [CaseEq"word_loc",CaseEq"num",CaseEq"option",CaseEq"prod",CaseEq"bool"]
+     >> rveq >> fs [code_rel_def,state_rel_def]
+     >> first_x_assum drule >> strip_tac >> fs []
+     >> fs [find_code_def]
+     >> simp [comp_func_def]
+     >> qmatch_goalsub_abbrev_tac ‘comp ctxt2 _ ll2’
+     >> qexists_tac ‘ctxt2’ >> qexists_tac ‘ll2’ >> fs []
+     >> conj_tac >- fs [lookup_fromList2,lookup_fromList]
+     >> simp [Abbr‘ctxt2’,domain_make_ctxt,set_fromNumSet,
+              domain_difference,domain_toNumSet, SUBSET_DEF]
+     >> match_mp_tac locals_rel_make_ctxt
+     >> fs [IN_DISJOINT,set_fromNumSet,domain_difference,
+            domain_toNumSet,GSYM IMP_DISJ_THM])
+  >> Cases_on ‘handler’ >> fs []
+  >- suspend "Call_NOhandler"
+  >- suspend "Call_SOMEhandler"
+QED
+
+Resume compile_correct[Call_TailCall]:
+  (* TailCall: ret = NONE *)
       fs [comp_def,evaluate_def]
       >> imp_res_tac locals_rel_get_vars >> fs [add_ret_loc_def]
       >> fs [get_vars_def,get_var_def]
@@ -960,58 +1069,11 @@ Resume compile_correct[Call]:
           >> rename [‘bad_fun_return (SOME tt)’] >> Cases_on ‘tt’ >> fs [])
       >> conj_tac >- (Cases_on ‘res1’ >> simp [CaseEq"option"] >> fs [])
       >> rpt gen_tac >> strip_tac >> pop_assum mp_tac
-      >> qunabbrev_tac ‘tt’ >> fs [])
-  >> (* Returning: ret = SOME _ *)
-     fs [comp_def,evaluate_def]
-  >> imp_res_tac locals_rel_get_vars >> fs [add_ret_loc_def]
-  >> fs [get_vars_def,get_var_def]
-  >> simp [bad_dest_args_def,call_env_def,dec_clock_def]
-  >> PairCases_on ‘x’ >> PairCases_on ‘l’
-  >> fs [] >> imp_res_tac state_rel_IMP
-  >> reverse (Cases_on ‘ALL_DISTINCT x0’) >- (fs [] >> rveq >> fs [])
-  >> fs []
-  >> ‘∃args1 prog1 ss1 ctxt1 l2.
-       find_code dest (Loc l0 l1::argvals) t.code t.stack_size = SOME (args1,prog1,ss1) ∧
-       FST (comp ctxt1 new_code l2) = prog1 ∧
-       lookup 0 (fromList2 args1) = SOME (Loc l0 l1) ∧
-       locals_rel ctxt1 new_env (fromList2 args1) ∧
-       domain (acc_vars new_code LN) ⊆ domain ctxt1’ by
-    (qpat_x_assum ‘_ = (res,_)’ kall_tac
-     >> rpt (qpat_x_assum ‘∀x. _’ kall_tac)
-     >> Cases_on ‘dest’ >> fs [loopSemTheory.find_code_def]
-     >-
-      (fs [CaseEq"word_loc",CaseEq"num",CaseEq"option",CaseEq"prod",CaseEq"bool"]
-       >> rveq >> fs [code_rel_def,state_rel_def]
-       >> first_x_assum drule >> strip_tac >> fs []
-       >> fs [find_code_def]
-       >> ‘∃x l. argvals = SNOC x l’ by metis_tac [SNOC_CASES]
-       >> qpat_x_assum ‘_ = Loc loc 0’ mp_tac
-       >> rveq >> rewrite_tac [GSYM SNOC,LAST_SNOC,FRONT_SNOC] >> fs []
-       >> strip_tac >> rveq >> fs []
-       >> simp [comp_func_def]
-       >> qmatch_goalsub_abbrev_tac ‘comp ctxt2 _ ll2’
-       >> qexists_tac ‘ctxt2’ >> qexists_tac ‘ll2’ >> fs []
-       >> conj_tac >- fs [lookup_fromList2,lookup_fromList]
-       >> simp [Abbr‘ctxt2’,domain_make_ctxt,set_fromNumSet,
-                domain_difference,domain_toNumSet, SUBSET_DEF]
-       >> match_mp_tac locals_rel_make_ctxt
-       >> fs [IN_DISJOINT,set_fromNumSet,domain_difference,
-              domain_toNumSet,GSYM IMP_DISJ_THM])
-     >> fs [CaseEq"word_loc",CaseEq"num",CaseEq"option",CaseEq"prod",CaseEq"bool"]
-     >> rveq >> fs [code_rel_def,state_rel_def]
-     >> first_x_assum drule >> strip_tac >> fs []
-     >> fs [find_code_def]
-     >> simp [comp_func_def]
-     >> qmatch_goalsub_abbrev_tac ‘comp ctxt2 _ ll2’
-     >> qexists_tac ‘ctxt2’ >> qexists_tac ‘ll2’ >> fs []
-     >> conj_tac >- fs [lookup_fromList2,lookup_fromList]
-     >> simp [Abbr‘ctxt2’,domain_make_ctxt,set_fromNumSet,
-              domain_difference,domain_toNumSet, SUBSET_DEF]
-     >> match_mp_tac locals_rel_make_ctxt
-     >> fs [IN_DISJOINT,set_fromNumSet,domain_difference,
-            domain_toNumSet,GSYM IMP_DISJ_THM])
-  >> Cases_on ‘handler’ >> fs []
-  >- ((* NOhandler: handler = NONE *)
+      >> qunabbrev_tac ‘tt’ >> fs []
+QED
+
+Resume compile_correct[Call_NOhandler]:
+  (* NOhandler: handler = NONE *)
       fs [evaluate_def,add_ret_loc_def,domain_mk_new_cutset_not_empty,cut_res_def]
       >> fs [loopSemTheory.cut_state_def]
       >> Cases_on ‘domain x1 ⊆ domain s.locals’ >> fs []
@@ -1076,8 +1138,11 @@ Resume compile_correct[Call]:
       >> fs [jump_exc_def,NOT_LESS]
       >> Cases_on ‘LENGTH t.stack <= t.handler’ >> fs [LASTN_ADD_CONS]
       >> simp [CaseEq"option",CaseEq"prod",CaseEq"bool",set_var_def,CaseEq"list",
-               CaseEq"stack_frame"] >> rw [] >> fs [])
-  >> (* SOMEhandler: handler = SOME _ *)
+               CaseEq"stack_frame"] >> rw [] >> fs []
+QED
+
+Resume compile_correct[Call_SOMEhandler]:
+  (* SOMEhandler: handler = SOME _ *)
      PairCases_on ‘x’ >> fs []
   >> rpt (pairarg_tac >> fs [])
   >> fs [evaluate_def, add_ret_loc_def, domain_mk_new_cutset_not_empty, cut_res_def]
@@ -1110,7 +1175,12 @@ Resume compile_correct[Call]:
   >> strip_tac >> fs []
   >> Cases_on ‘res2’ >> fs [] >> rveq >> fs []
   >> fs [loopSemTheory.dec_clock_def]
-  >- ((* SOMEhandler_Result: res2 = Result *)
+  >- suspend "Call_SOMEh_Result"
+  >- suspend "Call_SOMEh_Exception"
+QED
+
+Resume compile_correct[Call_SOMEh_Result]:
+  ((* SOMEhandler_Result: res2 = Result *)
       Cases_on ‘LENGTH l = LENGTH x0’ >> fs []
       >> Cases_on ‘evaluate (x2,set_vars x0 l (st with locals := inter s.locals x1))’ >> fs []
       >> Cases_on ‘q = SOME Error’ >- fs [cut_res_def] >> fs []
@@ -1173,33 +1243,36 @@ Resume compile_correct[Call]:
          qpat_x_assum ‘comp ctxt x2 l1' = _’ (assume_tac o GSYM)
       >> fs []
       >> Cases_on ‘x’ >> fs [Abbr‘tt’]
-      >- ((* Exception *)
+      >- ((* Result *)
           qexists ‘t1'’
           >> qpat_x_assum ‘evaluate (FST _, _) = _’ mp_tac
           >> qpat_x_assum ‘evaluate (p2', _) = _’ mp_tac
           >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
           >> rpt strip_tac >> gvs [])
+      >- ((* Exception *)
+          qexists ‘t1'’
+          >> qpat_x_assum ‘evaluate (FST _, _) = _’ mp_tac
+          >> qpat_x_assum ‘evaluate (p2', _) = _’ mp_tac
+          >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
+          >> rpt strip_tac >> gvs []
+          >> qexists ‘res'’ >> Cases_on ‘res'’ >> fs []
+          >> rpt strip_tac >> fs [])
       >- ((* Break *)
-          qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
-          >> fs [] >> rveq
-          >> qexists ‘s1'’ >> qexists ‘res'’
-          >> rw [])
+          qexists ‘s1'’ >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
+          >> fs [] >> rveq >> gvs [])
       >- ((* Continue *)
-          qexists ‘t1'’ >> fs []
-          >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM) >> fs [])
+          qexists ‘s1'’ >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
+          >> fs [] >> rveq >> gvs [])
       >- ((* TimeOut *)
-          qexists ‘t1'’ >> fs []
-          >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM) >> fs [])
-      >- ((* FinalFFI *)
-          qexists ‘t1'’ >> fs []
-          >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM) >> fs [])
-      >> (* Error *)
-         qexists ‘t1'’
-      >> qpat_x_assum ‘evaluate (FST _, _) = _’ mp_tac
-      >> qpat_x_assum ‘evaluate (p2', _) = _’ mp_tac
-      >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
-      >> rpt strip_tac >> gvs [])
-  >> (* SOMEhandler_Exception *)
+          qexists ‘s1'’ >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
+          >> fs [] >> rveq >> gvs [])
+      >> ((* FinalFFI *)
+          qexists ‘s1'’ >> qpat_x_assum ‘(p2',_,_) = comp _ _ _’ (assume_tac o GSYM)
+          >> fs [] >> rveq >> gvs []))
+QED
+
+Resume compile_correct[Call_SOMEh_Exception]:
+  (* SOMEhandler_Exception *)
      qpat_x_assum ‘∀x. _’ (assume_tac o REWRITE_RULE [IMP_DISJ_THM])
   >> rename [‘loopSem$set_var hvar w _’]
   >> Cases_on ‘evaluate (x1',set_var hvar w (st with locals := inter s.locals x1))’ >> fs []

--- a/pancake/proofs/pan_to_wordProofScript.sml
+++ b/pancake/proofs/pan_to_wordProofScript.sml
@@ -528,7 +528,7 @@ Theorem every_inst_ok_loop_live:
 Proof
   rw[loop_liveTheory.comp_def] \\
   ‘(∀p prog q. every_prog (loop_inst_ok c) ^prog ⇒ every_prog (loop_inst_ok c) (FST $ shrink p prog q)) ∧
-   (∀p q r prog. every_prog (loop_inst_ok c) ^prog ⇒ OPTION_ALL (every_prog (loop_inst_ok c) o FST) (fixedpoint p q r prog))
+   (∀p q r s prog. every_prog (loop_inst_ok c) ^prog ⇒ OPTION_ALL (every_prog (loop_inst_ok c) o FST) (fixedpoint p q r s prog))
   ’
     by(pop_assum kall_tac \\
        ho_match_mp_tac loop_liveTheory.shrink_ind \\ rw[] \\

--- a/pancake/semantics/loopPropsScript.sml
+++ b/pancake/semantics/loopPropsScript.sml
@@ -59,7 +59,7 @@ Definition comp_syntax_ok_def:
   (comp_syntax_ok l (Assign n e) = T) ∧
   (comp_syntax_ok l (Loop lin p lout) = (l = lin ∧ l = lout ∧ comp_syntax_ok lin p)) ∧
   (comp_syntax_ok l (Arith arith) = T) ∧
-  (comp_syntax_ok l Break = T) ∧
+  (comp_syntax_ok l (Break _) = T) ∧
   (comp_syntax_ok l (LocValue n m) = T) ∧
   (comp_syntax_ok l (Load32 n m) = T) ∧
   (comp_syntax_ok l (LoadByte n m) = T) ∧
@@ -120,6 +120,11 @@ Proof
   \\ TOP_CASE_TAC \\ fs []
   \\ TOP_CASE_TAC \\ fs []
   \\ TOP_CASE_TAC \\ fs []
+  >- (first_x_assum match_mp_tac
+      \\ fs [cut_res_def,CaseEq"option",CaseEq"bool",cut_state_def]
+      \\ rveq \\ fs [dec_clock_def]
+      \\ imp_res_tac evaluate_clock \\ fs [dec_clock_def])
+  \\ TOP_CASE_TAC \\ fs []
   \\ TOP_CASE_TAC \\ fs []
   \\ first_x_assum match_mp_tac
   \\ fs [cut_res_def,CaseEq"option",CaseEq"bool",cut_state_def]
@@ -130,8 +135,8 @@ QED
 Theorem evaluate_no_Break_Continue:
   ∀prog s res t.
     evaluate (prog, s) = (res,t) ∧
-    every_prog (\r. r ≠ Break ∧ r ≠ Continue) prog ⇒
-    res ≠ SOME Break ∧ res ≠ SOME Continue
+    every_prog (\r. (∀n. r ≠ Break n) ∧ (∀n. r ≠ Continue n)) prog ⇒
+    (∀n. res ≠ SOME (Break n)) ∧ (∀n. res ≠ SOME (Continue n))
 Proof
   recInduct evaluate_ind \\ fs [] \\ rpt conj_tac \\ rpt gen_tac \\ strip_tac
   \\ (rename [‘Loop’] ORELSE
@@ -327,7 +332,7 @@ QED
 Theorem unassigned_vars_evaluate_same:
   !p s res t n v.
     evaluate (p,s) = (res,t) /\
-    (res = NONE ∨ res = SOME Continue ∨ res = SOME Break) /\
+    (res = NONE ∨ (∃n. res = SOME (Continue n)) ∨ (∃n. res = SOME (Break n))) /\
     lookup n s.locals = SOME v /\
     ~MEM n (assigned_vars p) /\ survives n p ==>
     lookup n t.locals = lookup n s.locals
@@ -391,13 +396,221 @@ Resume unassigned_vars_evaluate_same[Loop]:
   reverse (cases_on ‘domain live_in ⊆ domain s.locals’)
   >- rw [] >>
   rw [] >>
-  FULL_CASE_TAC >>
-  cases_on ‘q’ >> fs [] >>
-  fs [Once cut_res_def, cut_state_def] >>
-  fs [survives_def, assigned_vars_def, dec_clock_def] >>
-  fs [AllCaseEqs()] >> rveq >> fs [] >>
-  res_tac >> rfs [lookup_inter, AllCaseEqs(), domain_lookup]
+  qpat_x_assum ‘survives n _’ mp_tac >>
+  qpat_x_assum ‘¬MEM n (assigned_vars _)’ mp_tac >>
+  rewrite_tac [survives_def, assigned_vars_def] >>
+  rpt strip_tac >>
+  ‘lookup n (inter s.locals live_in) = SOME v’ by
+    (simp [lookup_inter_alt] >> ASM_REWRITE_TAC []) >>
+  Cases_on ‘evaluate (body, s with <|locals := inter s.locals live_in;
+                                     clock := s.clock - 1|>)’ >>
+  qpat_x_assum ‘_ = (res,t)’ mp_tac
+  >~ [‘_ = (NONE,_)’] >- suspend "Loop_resN"
+  >~ [‘_ = (SOME (Continue _),_)’] >- suspend "Loop_resC"
+  >- suspend "Loop_resB"
 QED
+
+Resume unassigned_vars_evaluate_same[Loop_resN]:
+  Cases_on ‘q’ >> simp []
+  >~ [‘evaluate (Loop _ _ _, _) = _ ⇒ _’]
+  >- (strip_tac >>
+      qpat_x_assum ‘∀v4 s' v s''.
+                    cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                    evaluate (body,s') = (v,s'') ∧ v = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’,
+                      ‘NONE’, ‘r’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then irule >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [] >>
+      qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then (qspecl_then [‘NONE’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [])
+  >> rename1 ‘evaluate (body, _) = (SOME body_res, _)’ >>
+  Cases_on ‘body_res’ >> simp []
+  >~ [‘(SOME (Continue _), _)’]
+  >- (rename1 ‘Continue cont_k’ >>
+      Cases_on ‘cont_k’ >> simp []
+      >- (strip_tac >>
+          qpat_x_assum ‘∀v4 s' v s'' v3 v12.
+                        cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                        evaluate (body,s') = (v,s'') ∧ v = SOME v3 ∧
+                        v3 = Continue v12 ∧ v12 = 0 ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’,
+                          ‘SOME (Continue 0)’, ‘r’,
+                          ‘Continue 0’, ‘0’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then irule >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [] >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then (qspecl_then [‘SOME (Continue 0)’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [])
+      >> rw [])
+  >~ [‘(SOME (Break _), _)’]
+  >- (rename1 ‘Break brk_k’ >>
+      Cases_on ‘brk_k’ >> simp []
+      >- (Cases_on ‘domain live_out ⊆ domain r.locals’ >> simp [] >>
+          IF_CASES_TAC >> simp [] >>
+          rw [] >>
+          simp [lookup_inter_alt, domain_lookup] >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then (qspecl_then [‘SOME (Break 0)’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [domain_lookup])
+      >> rw [])
+  >> rw []
+QED
+
+Resume unassigned_vars_evaluate_same[Loop_resC]:
+  Cases_on ‘q’ >> simp []
+  >~ [‘evaluate (Loop _ _ _, _) = _ ⇒ _’]
+  >- (strip_tac >>
+      qpat_x_assum ‘∀v4 s' v s''.
+                    cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                    evaluate (body,s') = (v,s'') ∧ v = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’,
+                      ‘NONE’, ‘r’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then irule >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [] >>
+      qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then (qspecl_then [‘NONE’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [])
+  >> rename1 ‘evaluate (body, _) = (SOME body_res, _)’ >>
+  Cases_on ‘body_res’ >> simp []
+  >~ [‘evaluate (body, _) = (SOME (Continue _), _)’]
+  >- (rename1 ‘evaluate (body, _) = (SOME (Continue cont_k), _)’ >>
+      Cases_on ‘cont_k’ >> simp []
+      >- (strip_tac >>
+          qpat_x_assum ‘∀v4 s' v s'' v3 v12.
+                        cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                        evaluate (body,s') = (v,s'') ∧ v = SOME v3 ∧
+                        v3 = Continue v12 ∧ v12 = 0 ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’,
+                          ‘SOME (Continue 0)’, ‘r’,
+                          ‘Continue 0’, ‘0’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then irule >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [] >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then (qspecl_then [‘SOME (Continue 0)’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [])
+      >- (strip_tac >> rveq >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then irule >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC []))
+  >- (rename1 ‘evaluate (body, _) = (SOME (Break brk_k), _)’ >>
+      Cases_on ‘brk_k’ >> simp []
+      >- (Cases_on ‘domain live_out ⊆ domain r.locals’ >> simp [] >>
+          IF_CASES_TAC >> simp []))
+QED
+
+Resume unassigned_vars_evaluate_same[Loop_resB]:
+  Cases_on ‘q’ >> simp []
+  >~ [‘evaluate (Loop _ _ _, _) = _ ⇒ _’]
+  >- (strip_tac >>
+      qpat_x_assum ‘∀v4 s' v s''.
+                    cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                    evaluate (body,s') = (v,s'') ∧ v = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’,
+                      ‘NONE’, ‘r’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then irule >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [] >>
+      qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+        (qspecl_then [‘NONE’,
+                      ‘s with <|locals := inter s.locals live_in;
+                                clock := s.clock - 1|>’] mp_tac) >>
+      simp [cut_res_def, cut_state_def, dec_clock_def] >>
+      disch_then (qspecl_then [‘NONE’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+      simp [assigned_vars_def, survives_def] >>
+      ASM_REWRITE_TAC [])
+  >> rename1 ‘evaluate (body, _) = (SOME body_res, _)’ >>
+  Cases_on ‘body_res’ >> simp []
+  >~ [‘evaluate (body, _) = (SOME (Continue _), _)’]
+  >- (rename1 ‘evaluate (body, _) = (SOME (Continue cont_k), _)’ >>
+      Cases_on ‘cont_k’ >> simp []
+      >- (strip_tac >>
+          qpat_x_assum ‘∀v4 s' v s'' v3 v12.
+                        cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ∧
+                        evaluate (body,s') = (v,s'') ∧ v = SOME v3 ∧
+                        v3 = Continue v12 ∧ v12 = 0 ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’,
+                          ‘SOME (Continue 0)’, ‘r’,
+                          ‘Continue 0’, ‘0’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then irule >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC [] >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then (qspecl_then [‘SOME (Continue 0)’, ‘r’, ‘n’, ‘v’] mp_tac) >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC []))
+  >~ [‘evaluate (body, _) = (SOME (Break _), _)’]
+  >- (rename1 ‘evaluate (body, _) = (SOME (Break brk_k), _)’ >>
+      Cases_on ‘brk_k’ >> simp []
+      >- (Cases_on ‘domain live_out ⊆ domain r.locals’ >> simp [] >>
+          IF_CASES_TAC >> simp [])
+      >- (strip_tac >> rveq >>
+          qpat_x_assum ‘∀v4 s'. cut_res live_in (NONE,s) = (v4,s') ∧ v4 = NONE ⇒ _’
+            (qspecl_then [‘NONE’,
+                          ‘s with <|locals := inter s.locals live_in;
+                                    clock := s.clock - 1|>’] mp_tac) >>
+          simp [cut_res_def, cut_state_def, dec_clock_def] >>
+          disch_then irule >>
+          simp [assigned_vars_def, survives_def] >>
+          ASM_REWRITE_TAC []))
+QED
+
 
 Resume unassigned_vars_evaluate_same[Call]:
   rpt strip_tac >>
@@ -424,7 +637,7 @@ Resume unassigned_vars_evaluate_same[Call]:
           Cases_on ‘y’ >> fs [] >> imp_res_tac MEM_ZIP2 >> rveq >>
           fs [] >> metis_tac [EL_MEM]) >>
       strip_tac >> fs [lookup_inter, domain_lookup])
-  >~ [‘cut_res _ (evaluate (_, st with locals := alist_insert ns retvs _)) = (SOME Continue, _)’]
+  >~ [‘cut_res _ (evaluate (_, st with locals := alist_insert ns retvs _)) = (SOME (Continue _), _)’]
   >- (cases_on ‘evaluate (r,st with locals := alist_insert ns retvs (inter s.locals live))’ >>
       fs [cut_res_def, AllCaseEqs(), cut_state_def, dec_clock_def] >> rveq >> fs [] >>
       last_x_assum (qspecl_then [‘n’,‘v’] mp_tac) >>
@@ -434,7 +647,7 @@ Resume unassigned_vars_evaluate_same[Call]:
           Cases_on ‘y’ >> fs [] >> imp_res_tac MEM_ZIP2 >> rveq >>
           fs [] >> metis_tac [EL_MEM]) >>
       strip_tac >> fs [lookup_inter, domain_lookup])
-  >~ [‘cut_res _ (evaluate (_, st with locals := alist_insert ns retvs _)) = (SOME Break, _)’]
+  >~ [‘cut_res _ (evaluate (_, st with locals := alist_insert ns retvs _)) = (SOME (Break _), _)’]
   >- (cases_on ‘evaluate (r,st with locals := alist_insert ns retvs (inter s.locals live))’ >>
       fs [cut_res_def, AllCaseEqs(), cut_state_def, dec_clock_def] >> rveq >> fs [] >>
       last_x_assum (qspecl_then [‘n’,‘v’] mp_tac) >>
@@ -450,11 +663,11 @@ Resume unassigned_vars_evaluate_same[Call]:
       qpat_x_assum ‘∀a b. _ ⇒ lookup _ _ = SOME _’ (qspecl_then [‘n’,‘v’] mp_tac) >>
       impl_tac >- simp [] >>
       strip_tac >> fs [lookup_inter, domain_lookup])
-  >~ [‘cut_res _ (evaluate (_, st with locals := insert exn_v exn_val _)) = (SOME Continue, _)’]
+  >~ [‘cut_res _ (evaluate (_, st with locals := insert exn_v exn_val _)) = (SOME (Continue _), _)’]
   >- (cases_on ‘evaluate (h,st with locals := insert exn_v exn_val (inter s.locals live))’ >>
       fs [cut_res_def, AllCaseEqs(), cut_state_def, dec_clock_def] >> rveq >> fs []) >>
-  (* Call_Exn_Break catchall — original names n', exn (pre-rename). *)
-  cases_on ‘evaluate (h,st with locals := insert n' exn (inter s.locals live))’ >>
+  (* Call_Exn_Break catchall. *)
+  cases_on ‘evaluate (h,st with locals := insert n'' exn (inter s.locals live))’ >>
   fs [cut_res_def, AllCaseEqs(), cut_state_def, dec_clock_def] >> rveq >> fs []
 QED
 
@@ -789,29 +1002,7 @@ Proof
   >~ [‘FFI’] >-
    (fs [evaluate_def, AllCaseEqs (), cut_state_def, call_env_def] >>
     rveq >> fs [])
-  >~ [‘Loop’] >-
-   (fs [Once evaluate_def] >>
-    TOP_CASE_TAC >> fs [] >>
-    cases_on ‘cut_res live_in ((NONE:'a result option),s)’ >>
-    fs [] >>
-    ‘q' <> SOME TimeOut’ by (
-      CCONTR_TAC >>
-      fs [cut_res_def, cut_state_def, AllCaseEqs(), dec_clock_def]) >>
-    drule cut_res_add_clock >>
-    disch_then (qspec_then ‘ck’ mp_tac) >> fs [] >>
-    strip_tac >> fs [] >> rveq >>
-    TOP_CASE_TAC >> fs [] >>
-    cases_on ‘evaluate (body,r')’ >> fs [] >> rveq >>
-    cases_on ‘q’ >> fs [] >>
-    cases_on ‘x’ >> fs [] >> rveq >> fs []
-    >- (imp_res_tac cut_res_add_clock >> res_tac >> fs []) >>
-    first_x_assum match_mp_tac >>
-    TOP_CASE_TAC >> fs [] >>
-    reverse TOP_CASE_TAC >> fs []
-    >- fs [Once evaluate_def] >>
-    TOP_CASE_TAC >> fs [] >>
-    TOP_CASE_TAC >> fs [] >>
-    fs [Once evaluate_def])
+  >~ [‘Loop’] >- suspend "Loop"
   >~ [‘Call’] >-
    (fs [evaluate_def, get_vars_clock_upd_eq, dec_clock_def] >>
     ntac 4 (TOP_CASE_TAC >> fs [])
@@ -858,6 +1049,41 @@ Proof
       DefnBase.one_line_ify NONE loop_arith_def] >> rveq >>
   gvs [state_component_equality]
 QED
+
+Resume evaluate_add_clock_eq[Loop]:
+  fs [Once evaluate_def] >>
+  TOP_CASE_TAC >> fs [] >>
+  cases_on ‘cut_res live_in ((NONE:'a result option),s)’ >>
+  fs [] >>
+  ‘q' <> SOME TimeOut’ by (
+    CCONTR_TAC >>
+    fs [cut_res_def, cut_state_def, AllCaseEqs(), dec_clock_def]) >>
+  drule cut_res_add_clock >>
+  disch_then (qspec_then ‘ck’ mp_tac) >> fs [] >>
+  strip_tac >> fs [] >> rveq >>
+  TOP_CASE_TAC >> fs [] >>
+  cases_on ‘evaluate (body,r')’ >> fs [] >> rveq >>
+  cases_on ‘q’ >> fs []
+  >- (* body = NONE: recursive Loop *)
+   (first_x_assum match_mp_tac >> fs [Once evaluate_def]) >>
+  cases_on ‘x’ >> fs [] >> rveq >> fs []
+  >~ [‘Continue n’] >-
+   (cases_on ‘n’ >> fs []
+    >- (* Continue 0: recursive Loop *)
+     (first_x_assum match_mp_tac >> fs [Once evaluate_def]) >>
+    (* Continue (SUC k): exit_loop *)
+    rveq >> fs [])
+  >~ [‘Break n’] >-
+   (cases_on ‘n’ >> fs []
+    >- (* Break 0: cut_res live_out *)
+     (imp_res_tac cut_res_add_clock >> res_tac >> fs []) >>
+    (* Break (SUC k): exit_loop *)
+    rveq >> fs []) >>
+  (* Result / Exception / TimeOut / FinalFFI / Error: exit_loop = res *)
+  rveq >> fs []
+QED
+
+Finalise evaluate_add_clock_eq;
 
 Theorem evaluate_nested_seq_comb_seq:
   !p q t.
@@ -1042,82 +1268,81 @@ Resume evaluate_add_clock_io_events_mono[If]:
 QED
 
 Resume evaluate_add_clock_io_events_mono[Loop]:
-  once_rewrite_tac [evaluate_def, LET_THM] >>
-  TOP_CASE_TAC >> fs [] >>
-  reverse TOP_CASE_TAC
-  >- (fs [cut_res_def, cut_state_def, AllCaseEqs()] >> rveq >> fs [] >>
-      Cases_on ‘extra = 0’ >> fs [dec_clock_def] >>
-      Cases_on ‘evaluate (body,
-           s with <|locals := inter s.locals live_in; clock := extra - 1|>)’ >>
-      fs [] >>
-      every_case_tac >> fs [] >> rveq >> fs [] >>
-      imp_res_tac evaluate_io_events_mono >> fs [] >>
-      metis_tac [IS_PREFIX_TRANS, evaluate_io_events_mono, SND, PAIR]) >>
-  fs [cut_res_def, cut_state_def, AllCaseEqs()] >> rveq >> fs [dec_clock_def] >>
-  first_x_assum (qspec_then ‘extra’ assume_tac) >>
-  Cases_on ‘evaluate
-                (body,
-                 s with
-                   <|locals := inter s.locals live_in; clock := s.clock - 1|>)’ >>
-  fs [] >>
-  Cases_on ‘evaluate
-                (body,
-                 s with
-                 <|locals := inter s.locals live_in;
-                 clock := extra + s.clock - 1|>)’ >>
-  fs [] >>
-  Cases_on ‘q’ >> fs [] >> rveq >> fs []
-  >- (Cases_on ‘q'’ >> fs [] >>
-      reverse (Cases_on ‘x’) >> fs []
-      >- (Cases_on ‘evaluate (Loop live_in body live_out,r')’ >>
-          drule evaluate_io_events_mono >> fs [] >>
-          metis_tac [IS_PREFIX_TRANS]) >>
-      every_case_tac >> fs []) >>
-  Cases_on ‘x’ >> fs [] >> rveq >> fs []
-  >~ [‘evaluate _ = (SOME Break,_)’]
-  >- (every_case_tac >> fs [] >> rveq >> fs [] >>
-      Cases_on ‘evaluate (Loop live_in body live_out,r')’ >>
-      drule evaluate_io_events_mono >> fs [] >>
-      metis_tac [IS_PREFIX_TRANS])
-  >~ [‘evaluate _ = (SOME TimeOut,_)’]
-  >- (Cases_on ‘q'’ >> fs [] >>
-      rename1 ‘evaluate _ = (SOME res,r')’ >>
-      Cases_on ‘res’ >> fs []
-      >~ [‘evaluate _ = (SOME Break,r')’]
-      >- (Cases_on ‘domain live_out ⊆ domain r'.locals’ >> fs [] >>
-          Cases_on ‘r'.clock = 0’ >> fs [])
-      >~ [‘evaluate _ = (SOME Continue,r')’]
-      >- (Cases_on ‘evaluate (Loop live_in body live_out,r')’ >>
-          drule evaluate_io_events_mono >> fs [] >>
-          metis_tac [IS_PREFIX_TRANS]))
-  >~ [‘evaluate _ = (SOME Continue,_)’]
-  >- (qpat_x_assum ‘evaluate (body,_) = (SOME Continue,r)’ assume_tac >>
-      drule evaluate_add_clock_eq >> fs [] >>
-      disch_then (qspec_then ‘extra’ assume_tac) >>
-      fs [] >> rveq >> fs [] >>
-      first_x_assum (qspec_then ‘r’ mp_tac) >> simp [] >>
-      disch_then (qspec_then ‘extra’ mp_tac) >>
-      fs [])
-  >~ [‘evaluate _ = (SOME (Result _),_)’]
-  >- (qpat_x_assum ‘evaluate _ = (SOME (Result _),_)’ assume_tac >>
-      drule evaluate_add_clock_eq >> simp [] >>
-      disch_then (qspec_then ‘extra’ mp_tac) >>
-      strip_tac >> fs [] >> rveq >> fs [])
-  >~ [‘evaluate _ = (SOME (Exception _),_)’]
-  >- (qpat_x_assum ‘evaluate _ = (SOME (Exception _),_)’ assume_tac >>
-      drule evaluate_add_clock_eq >> simp [] >>
-      disch_then (qspec_then ‘extra’ mp_tac) >>
-      strip_tac >> fs [] >> rveq >> fs [])
-  >~ [‘evaluate _ = (SOME (FinalFFI _),_)’]
-  >- (qpat_x_assum ‘evaluate _ = (SOME (FinalFFI _),_)’ assume_tac >>
-      drule evaluate_add_clock_eq >> simp [] >>
-      disch_then (qspec_then ‘extra’ mp_tac) >>
-      strip_tac >> fs [] >> rveq >> fs [])
-  >~ [‘evaluate _ = (SOME Error,_)’]
-  >- (qpat_x_assum ‘evaluate _ = (SOME Error,_)’ assume_tac >>
-      drule evaluate_add_clock_eq >> simp [] >>
-      disch_then (qspec_then ‘extra’ mp_tac) >>
-      strip_tac >> fs [] >> rveq >> fs [])
+  Cases_on ‘FST (evaluate (Loop live_in body live_out, s)) = SOME TimeOut’
+  >- suspend "Loop_TimeOut"
+  >> Cases_on ‘evaluate (Loop live_in body live_out, s)’ >> fs [] >>
+  drule evaluate_add_clock_eq >> fs [] >>
+  disch_then (qspec_then ‘extra’ mp_tac) >> fs []
+QED
+
+Resume evaluate_add_clock_io_events_mono[Loop_TimeOut]:
+  pop_assum mp_tac >>
+  once_rewrite_tac [evaluate_def] >>
+  Cases_on ‘cut_res live_in (NONE,s)’ >>
+  reverse (Cases_on ‘q’)
+  >- (* outer cut_res = (SOME _, _): per cut_res_def must be TimeOut *)
+   (fs [cut_res_def, AllCaseEqs ()] >> gvs [] >>
+    Cases_on ‘extra = 0’ >> gvs [cut_state_def, dec_clock_def] >>
+    Cases_on
+      ‘evaluate (body, s with <|locals := inter s.locals live_in; clock := extra - 1|>)’ >>
+    drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+    Cases_on ‘q’ >> fs []
+    >- (Cases_on ‘evaluate (Loop live_in body live_out, r)’ >>
+        drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+        ‘s.ffi.io_events ≼ r'.ffi.io_events’
+          by metis_tac [IS_PREFIX_TRANS] >> fs []) >>
+    Cases_on ‘x’ >> fs []
+    >~ [‘Break n’]
+    >- (Cases_on ‘n’ >> fs [] >>
+        IF_CASES_TAC >> fs [] >>
+        IF_CASES_TAC >> fs [])
+    >~ [‘Continue n’]
+    >- (Cases_on ‘n’ >> fs [] >>
+        Cases_on ‘evaluate (Loop live_in body live_out, r)’ >>
+        drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+        ‘s.ffi.io_events ≼ r'.ffi.io_events’
+          by metis_tac [IS_PREFIX_TRANS] >> fs [])) >>
+  (* outer cut_res = (NONE, r): body evaluates; align via cut_res_add_clock *)
+  ‘cut_res live_in (NONE, s with clock := extra + s.clock) =
+     (NONE, r with clock := extra + r.clock)’
+    by (irule cut_res_add_clock >> fs []) >>
+  fs [cut_res_def, AllCaseEqs ()] >>
+  strip_tac >>
+  Cases_on ‘evaluate (body, r)’ >> fs [] >>
+  Cases_on ‘q = SOME TimeOut’ >> fs []
+  >- (* body timed out: use IH_body + IS_PREFIX_TRANS *)
+   (last_x_assum (qspec_then ‘extra’ mp_tac) >>
+    Cases_on ‘evaluate (body, r with clock := extra + r.clock)’ >> fs [] >>
+    strip_tac >>
+    ‘r'.ffi.io_events ≼ r''.ffi.io_events’ by metis_tac [] >>
+    Cases_on ‘q'’ >> fs []
+    >- (Cases_on ‘evaluate (Loop live_in body live_out, r'')’ >>
+        drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+        metis_tac [IS_PREFIX_TRANS]) >>
+    Cases_on ‘x’ >> fs []
+    >~ [‘Break n’]
+    >- (Cases_on ‘n’ >> fs [] >>
+        Cases_on ‘cut_state live_out r''’ >> fs [] >>
+        rw [] >> fs [cut_state_def] >>
+        rveq >> fs [dec_clock_def] >>
+        Cases_on ‘evaluate (Loop live_in body live_out, r'')’ >>
+        drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+        metis_tac [IS_PREFIX_TRANS])
+    >~ [‘Continue n’]
+    >- (Cases_on ‘n’ >> fs [] >>
+        Cases_on ‘evaluate (Loop live_in body live_out, r'')’ >>
+        drule_then assume_tac evaluate_io_events_mono >> fs [] >>
+        metis_tac [IS_PREFIX_TRANS])) >>
+  (* body OK (no TimeOut): align via evaluate_add_clock_eq *)
+  drule evaluate_add_clock_eq >> simp [] >>
+  disch_then (qspec_then ‘extra’ mp_tac) >>
+  strip_tac >> fs [] >>
+  Cases_on ‘q’ >> fs [] >>
+  Cases_on ‘x’ >> fs [] >>
+  Cases_on ‘n’ >> fs [] >>
+  fs [cut_state_def] >>
+  rw [] >> fs [] >>
+  rw [] >> fs [dec_clock_def]
 QED
 
 Resume evaluate_add_clock_io_events_mono[Call]:

--- a/pancake/semantics/loopSemScript.sml
+++ b/pancake/semantics/loopSemScript.sml
@@ -29,8 +29,8 @@ val state_component_equality = theorem "state_component_equality";
 Datatype:
   result = Result    (('w word_loc) list)
          | Exception ('w word_loc)
-         | Break
-         | Continue
+         | Break num
+         | Continue num
          | TimeOut
          | FinalFFI final_event
          | Error
@@ -255,6 +255,12 @@ Proof
   Induct \\ Cases_on ‘vs’ \\ gvs [set_vars_def]
 QED
 
+Definition exit_loop_def[simp]:
+  exit_loop (SOME (Break n)) = SOME (Break (n - 1)) ∧
+  exit_loop (SOME (Continue n)) = SOME (Continue (n - 1)) ∧
+  exit_loop res = res
+End
+
 Definition evaluate_def:
   (evaluate (Skip:'a loopLang$prog,^s) = (NONE, s)) /\
   (evaluate (Fail:'a loopLang$prog,^s) = (SOME Error, s)) /\
@@ -315,16 +321,16 @@ Definition evaluate_def:
           cut_res live_out (evaluate (if b then c1 else c2,s))
     | _ => (SOME Error,s))) /\
   (evaluate (Mark p,s) = evaluate (p,s)) /\
-  (evaluate (Break,s) = (SOME Break,s)) /\
-  (evaluate (Continue,s) = (SOME Continue,s)) /\
+  (evaluate (Break k,s) = (SOME (Break k),s)) /\
+  (evaluate (Continue k,s) = (SOME (Continue k),s)) /\
   (evaluate (Loop live_in body live_out,s) =
     (case cut_res live_in (NONE,s) of
      | (NONE,s) =>
         (case fix_clock s (evaluate (body,s)) of
-         | (SOME Continue,s) => evaluate (Loop live_in body live_out,s)
-         | (SOME Break,s) => cut_res live_out (NONE,s)
-         | (NONE,s) => (SOME Error,s)
-         | res => res)
+         | (NONE,s) => evaluate (Loop live_in body live_out,s)
+         | (SOME (Continue 0),s) => evaluate (Loop live_in body live_out,s)
+         | (SOME (Break 0),s) => cut_res live_out (NONE,s)
+         | (res,s) => (exit_loop res,s))
      | res => res)) /\
   (evaluate (Raise n,s) =
      case lookup n s.locals of
@@ -366,8 +372,8 @@ Definition evaluate_def:
                if s.clock = 0 then (SOME TimeOut,s with locals := LN)
                else (case evaluate (prog, dec_clock s with locals := env) of
                      | (NONE,s) => (SOME Error,s)
-                     | (SOME Continue,s) => (SOME Error,s)
-                     | (SOME Break,s) => (SOME Error,s)
+                     | (SOME (Continue _),s) => (SOME Error,s)
+                     | (SOME (Break _),s) => (SOME Error,s)
                      | (SOME res,s) => (SOME res,s)))
           | SOME (ns,live) =>
             if ¬ALL_DISTINCT ns then (SOME Error,s) else
@@ -388,8 +394,8 @@ Definition evaluate_def:
                          | SOME (n,h,_,live_out) =>
                              cut_res live_out
                                (evaluate (h, set_var n exn (st with locals := s.locals))))
-                    | (SOME Continue,st) => (SOME Error, st)
-                    | (SOME Break,st) => (SOME Error, st)
+                    | (SOME (Continue _),st) => (SOME Error, st)
+                    | (SOME (Break _),st) => (SOME Error, st)
                     | (NONE,st) => (SOME Error, st)
                     | res => res)
              | res => res)))) /\
@@ -447,6 +453,8 @@ Proof
   TRY (Cases_on ‘op’>>fs[sh_mem_op_def,sh_mem_store_def,sh_mem_load_def]>>
        fs[ffiTheory.call_FFI_def]>>every_case_tac>>fs[]>>
        rveq>>fs[set_var_def,call_env_def])
+  \\ fs [CaseEq"num"] \\ rveq \\ fs []
+  \\ every_case_tac \\ fs [] \\ rveq \\ fs [cut_state_def,dec_clock_def]
   \\ rename [‘cut_res _ xx’] \\ PairCases_on ‘xx’ \\ fs []
   \\ fs [cut_res_def]
   \\ every_case_tac \\ fs [] \\ rveq \\ fs [cut_state_def]


### PR DESCRIPTION
Mirror wordLang's depth-aware Break num / Continue num at loopLang. Plumb through loopSem (cont_loop/exit_loop, Loop clause, Call/DeclCall), loopProps, loop_to_word, crep_to_loop, loop_call, and loop_live (lt : (num_set # num_set) list indexed by depth; shrink Loop body's exit-live widened to union live_in l2).

All touched proofs admit; zero cheats; pan_to_wordTheory builds clean.