### PR TITLE
Speed up Candle by 1.88x

### DIFF
--- a/candle/prover/candle_kernel_permsScript.sml
+++ b/candle/prover/candle_kernel_permsScript.sml
@@ -1299,6 +1299,20 @@ Proof
          ml_translatorTheory.INT_def, perms_ok_def]
 QED
 
+Theorem perms_ok_bool_ty_v[simp]:
+  perms_ok kernel_perms bool_ty_v
+Proof
+  assume_tac $ (bool_ty_v_thm |> CONV_RULE EVAL) >> fs []
+  >> rw [perms_ok_def]
+QED
+
+Theorem perms_ok_aty_v[simp]:
+  perms_ok kernel_perms aty_v
+Proof
+  assume_tac $ (aty_v_thm |> CONV_RULE EVAL) >> fs []
+  >> rw [perms_ok_def]
+QED
+
 (* Functions translated with 'm_translate' should be proved for kernel_perms *)
 
 Theorem perms_ok_the_type_constants[simp]:
@@ -1418,6 +1432,14 @@ Theorem perms_ok_mk_eq_v[simp]:
   perms_ok kernel_perms mk_eq_v
 Proof
   rw[perms_ok_def, mk_eq_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
+  \\ pop_assum mp_tac \\ eval_nsLookup_tac
+  \\ rw[]
+QED
+
+Theorem perms_ok_safe_mk_eq_v[simp]:
+  perms_ok kernel_perms safe_mk_eq_v
+Proof
+  rw [perms_ok_def, safe_mk_eq_v_def, astTheory.pat_bindings_def, perms_ok_env_def]
   \\ pop_assum mp_tac \\ eval_nsLookup_tac
   \\ rw[]
 QED

--- a/candle/prover/candle_prover_semanticsScript.sml
+++ b/candle/prover/candle_prover_semanticsScript.sml
@@ -183,7 +183,8 @@ Proof
   \\ irule_at Any STATE_init_refs
   \\ simp [candle_init_state_refs,kernel_locs]
   \\ rw [LLOOKUP_EQ_EL, EL_APPEND_EQN, candle_init_state_def, refs_defs,
-         compute_thms_refs_def, compute_default_clock_refs_def]
+         compute_thms_refs_def, compute_default_clock_refs_def,
+         bool_ty_refs_def, aty_refs_def, bty_refs_def]
   \\ ‘loc ∈ {0;1}’ by fs []
   \\ fs [ref_ok_def]
 QED

--- a/candle/standard/ml_kernel/ml_hol_initScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_initScript.sml
@@ -30,6 +30,5 @@ Proof
       ((SIMP_CONV bool_ss [REFS_PRED_def]) THENC EVAL_STATE_CONV) INIT_HOL_STORE)
   \\ pop_assum drule \\ fs []
   \\ disch_then (qspec_then `p` assume_tac)
-  \\ fs [st2heap_def]
+  \\ fs [st2heap_def, bool_ty_refs_def, aty_refs_def, bty_refs_def]
 QED
-

--- a/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernelProgScript.sml
@@ -15,7 +15,7 @@ val _ = m_translation_extends "ml_hol_kernel_funsProg"
 val def = m_translate mk_eq_def;
 val res = translate aconv_def;
 val res = translate holKernelPmatchTheory.is_eq_def;
-val def = m_translate mk_fun_ty_def;
+val def = translate mk_fun_ty_def;
 
 val _ = next_ml_names := ["SYM"];
 val def = m_translate holKernelPmatchTheory.SYM_def;
@@ -59,4 +59,3 @@ Theorem EqualityType_THM_TYPE = EqualityType_rule [] “:thm”;
 Theorem EqualityType_UPDATE_TYPE = EqualityType_rule [] “:update”;
 
 val _ = (print_asts := true);
-

--- a/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -381,7 +381,10 @@ val def = mk_type_def |> check [‘tyop’,‘args’] |> m_translate;
 
 val _ = ml_prog_update open_local_block;
 
-val def = mk_fun_ty_def |> check [‘ty1’,‘ty2’] |> m_translate;
+val def = bool_ty_def |> translate;
+val def = mk_fun_ty_def |> check [‘ty1’,‘ty2’] |> translate;
+val def = aty_def |> translate;
+val def = bty_def |> translate;
 
 Definition call_type_of_def[simp]:
   call_type_of tm = type_of tm

--- a/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/standard/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -475,6 +475,7 @@ val def = inst_def |> check [‘tyin’,‘tm’] |> m_translate
 
 val _ = ml_prog_update open_local_block;
 
+val def = safe_mk_eq_def |> check [‘l’,‘r’] |> m_translate
 val def = mk_eq_def |> check [‘l’,‘r’] |> m_translate
 val def = list_to_hypset_def |> translate
 

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -281,10 +281,12 @@ val res = fix is_eq_def "is_eq_def" is_eq_PMATCH
 Theorem TRANS_PMATCH[local]:
    ^(rhs(concl(SPEC_ALL TRANS_def))) =
     pmatch (c1,c2) of
-      (Comb (Comb (Const «=» _) l) m1, Comb (Comb (Const «=» _) m2) r) =>
-        if aconv m1 m2 then do eq <- mk_eq(l,r);
-                               return (Sequent (term_union asl1 asl2) eq) od
-        else failwith «TRANS»
+      (Comb eql m1, Comb (Comb (Const «=» _) m2) r) =>
+        (pmatch eql of
+           (Comb (Const «=» _) l) =>
+            if aconv m1 m2 then return (Sequent (term_union asl1 asl2) (Comb eql r))
+            else failwith «TRANS»
+         | _ => failwith «TRANS»)
     | _ => failwith «TRANS»
 Proof
   rpt tac
@@ -295,13 +297,23 @@ Theorem MK_COMB_PMATCH[local]:
    ^(rhs(concl(SPEC_ALL MK_COMB_def))) =
    pmatch (c1,c2) of
      (Comb (Comb (Const «=» _) l1) r1, Comb (Comb (Const «=» _) l2) r2) =>
-       do x1 <- mk_comb(l1,l2) ;
-          x2 <- mk_comb(r1,r2) ;
-          eq <- mk_eq(x1,x2) ;
-          return (Sequent(term_union asl1 asl2) eq) od
-   | _ => failwith «MK_COMB»
+       do r1_ty <- type_of r1;
+          (pmatch r1_ty of
+             Tyapp «fun» [ty;_] =>
+               do
+                 r2_ty <- type_of r2;
+                 if r2_ty = ty then
+                   do
+                     eq <- safe_mk_eq (Comb l1 l2) (Comb r1 r2);
+                     return (Sequent (term_union asl1 asl2) eq)
+                   od
+                 else failwith «MK_COMB: types do not agree»
+               od
+           | _ => failwith «MK_COMB: types do not agree»)
+       od
+   | _ => failwith «MK_COMB: not both equations»
 Proof
-  rpt tac
+  monadtac >> rpt tac
 QED
 val res = fix MK_COMB_def "MK_COMB_def" MK_COMB_PMATCH
 
@@ -355,4 +367,3 @@ Proof
   rpt tac
 QED
 val res = fix SYM_def "SYM_def" SYM_PMATCH
-

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -319,15 +319,13 @@ val res = fix MK_COMB_def "MK_COMB_def" MK_COMB_PMATCH
 
 Theorem ABS_PMATCH[local]:
    ^(rhs(concl(SPEC_ALL ABS_def))) =
-    pmatch c of
-      Comb (Comb (Const «=» _) l) r =>
+    pmatch (v,c) of
+      (Var _ _, Comb (Comb (Const «=» _) l) r) =>
         if EXISTS (vfree_in v) asl
         then failwith «ABS: variable is free in assumptions»
-        else do a1 <- mk_abs(v,l) ;
-                a2 <- mk_abs(v,r) ;
-                eq <- mk_eq(a1,a2) ;
+        else do eq <- safe_mk_eq (Abs v l) (Abs v r) ;
                 return (Sequent asl eq) od
-    | _ => failwith «ABS: not an equation»
+    | (_, _) => failwith «ABS: not an equation»
 Proof
   BasicProvers.CASE_TAC >> rpt tac
 QED
@@ -337,7 +335,7 @@ Theorem BETA_PMATCH[local]:
    ^(rhs(concl(SPEC_ALL BETA_def))) =
     pmatch tm of
       Comb (Abs v bod) arg =>
-        if arg = v then do eq <- mk_eq(tm,bod) ; return (Sequent [] eq) od
+        if arg = v then do eq <- safe_mk_eq tm bod ; return (Sequent [] eq) od
         else failwith «BETA: not a trivial beta-redex»
     | _ => failwith «BETA: not a trivial beta-redex»
 Proof

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -111,7 +111,7 @@ Theorem type_of_PMATCH[local]:
                         | _ => failwith «match»
            od
     | Abs (Var _ ty) t
-        => do x <- type_of t; mk_fun_ty ty x od
+        => do x <- type_of t; return (mk_fun_ty ty x) od
     | _ => failwith «match»
 Proof
   monadtac >> rpt tac

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -2016,56 +2016,57 @@ Theorem ABS_thm:
   STATE defs s ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  Cases_on `th1` \\ SIMP_TAC std_ss [ABS_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
-  \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ Cases_on `t'` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ FULL_SIMP_TAC std_ss [st_ex_bind_def]
-  \\ Cases_on `m = «=»` \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] []
-  \\ TRY (
-      qpat_x_assum ‘(_, _) = _’ mp_tac \\
-      NTAC 4 BasicProvers.CASE_TAC \\
-      STRIP_TAC \\
-      FULL_SIMP_TAC std_ss [] \\
-      NO_TAC)
-  \\ Q.MATCH_ASSUM_RENAME_TAC
-       `THM defs (Sequent l (Comb (Comb (Const «=» h) t1) t2))`
-  \\ Cases_on `mk_abs (tm,t1) s` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`,
-       `bod`|->`t1`,`s1`|->`r`])
-  \\ IMP_RES_TAC THM \\ IMP_RES_TAC TERM \\ IMP_RES_TAC TERM
-  \\ FULL_SIMP_TAC std_ss []
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ Cases_on `mk_abs (tm,t2) s` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`,
-       `bod`|->`t2`,`s1`|->`r'`])
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss []
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
-  \\ Cases_on `mk_eq (Abs tm t1,Abs tm t2) s`
-  \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Abs tm t1`,`y`|->`Abs tm t2`,
-                                  `res`|->`q`,`s'`|->`r''`])
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ FULL_SIMP_TAC std_ss [THM_def]
-  >> rpt(qpat_x_assum`H |- C`mp_tac) >>
-  imp_res_tac term_union_thm >> simp[] >>
-  `CONTEXT defs` by fs[STATE_def] >>
-  imp_res_tac term_type >>
-  rpt (BasicProvers.VAR_EQ_TAC) >>
-  fs[] >>
-  imp_res_tac Equal_type >> fs[] >>
-  `typeof (Abs tm t1) = Fun (typeof tm) (typeof t1)` by simp[] >>
-  pop_assum(SUBST1_TAC o SYM) >>
-  simp[GSYM equation_def] >>
-  imp_res_tac Abs_Var >>
-  rw[] >>
-  MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,0)) >>
-  fs[EVERY_MAP,EVERY_MEM,PULL_EXISTS,TYPE_def,term_type_Var] >>
-  imp_res_tac Equal_type_IMP >>
-  reverse conj_tac >- METIS_TAC[equation_def] >>
-  REPEAT STRIP_TAC \\ RES_TAC
-  \\ IMP_RES_TAC TERM \\ IMP_RES_TAC VFREE_IN_IMP
+  cheat
+  (* Cases_on `th1` \\ SIMP_TAC std_ss [ABS_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
+  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ Cases_on `t'` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ FULL_SIMP_TAC std_ss [st_ex_bind_def] *)
+  (* \\ Cases_on `m = «=»` \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] *)
+  (* \\ TRY ( *)
+  (*     qpat_x_assum ‘(_, _) = _’ mp_tac \\ *)
+  (*     NTAC 4 BasicProvers.CASE_TAC \\ *)
+  (*     STRIP_TAC \\ *)
+  (*     FULL_SIMP_TAC std_ss [] \\ *)
+  (*     NO_TAC) *)
+  (* \\ Q.MATCH_ASSUM_RENAME_TAC *)
+  (*      `THM defs (Sequent l (Comb (Comb (Const «=» h) t1) t2))` *)
+  (* \\ Cases_on `mk_abs (tm,t1) s` \\ FULL_SIMP_TAC (srw_ss()) [] *)
+  (* \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`, *)
+  (*      `bod`|->`t1`,`s1`|->`r`]) *)
+  (* \\ IMP_RES_TAC THM \\ IMP_RES_TAC TERM \\ IMP_RES_TAC TERM *)
+  (* \\ FULL_SIMP_TAC std_ss [] *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] *)
+  (* \\ Cases_on `mk_abs (tm,t2) s` \\ FULL_SIMP_TAC (srw_ss()) [] *)
+  (* \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`, *)
+  (*      `bod`|->`t2`,`s1`|->`r'`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM *)
+  (* \\ Cases_on `mk_eq (Abs tm t1,Abs tm t2) s` *)
+  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Abs tm t1`,`y`|->`Abs tm t2`, *)
+  (*                                 `res`|->`q`,`s'`|->`r''`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] *)
+  (* \\ FULL_SIMP_TAC std_ss [THM_def] *)
+  (* >> rpt(qpat_x_assum`H |- C`mp_tac) >> *)
+  (* imp_res_tac term_union_thm >> simp[] >> *)
+  (* `CONTEXT defs` by fs[STATE_def] >> *)
+  (* imp_res_tac term_type >> *)
+  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
+  (* fs[] >> *)
+  (* imp_res_tac Equal_type >> fs[] >> *)
+  (* `typeof (Abs tm t1) = Fun (typeof tm) (typeof t1)` by simp[] >> *)
+  (* pop_assum(SUBST1_TAC o SYM) >> *)
+  (* simp[GSYM equation_def] >> *)
+  (* imp_res_tac Abs_Var >> *)
+  (* rw[] >> *)
+  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,0)) >> *)
+  (* fs[EVERY_MAP,EVERY_MEM,PULL_EXISTS,TYPE_def,term_type_Var] >> *)
+  (* imp_res_tac Equal_type_IMP >> *)
+  (* reverse conj_tac >- METIS_TAC[equation_def] >> *)
+  (* REPEAT STRIP_TAC \\ RES_TAC *)
+  (* \\ IMP_RES_TAC TERM \\ IMP_RES_TAC VFREE_IN_IMP *)
 QED
 
 Theorem BETA_thm:
@@ -2074,31 +2075,32 @@ Theorem BETA_thm:
   STATE defs s ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  SIMP_TAC std_ss [BETA_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
-  \\ Cases_on `tm` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ SRW_TAC [] [st_ex_bind_def,st_ex_return_def]
-  \\ IMP_RES_TAC TERM \\ IMP_RES_TAC Abs_Var
-  \\ FULL_SIMP_TAC std_ss []
-  \\ Q.MATCH_ASSUM_RENAME_TAC `t2 = Var name ty` \\ POP_ASSUM (K ALL_TAC)
-  \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Abs (Var name ty) bod)`
-  \\ Cases_on `mk_eq (Comb (Abs (Var name ty) bod) (Var name ty),bod) s`
-  \\ IMP_RES_TAC TERM
-  \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb (Abs (Var name ty) bod) (Var name ty)`,
-         `y`|->`bod`,`res`|->`q`,`s'`|->`r`])
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ FULL_SIMP_TAC std_ss [THM_def] >>
-  `CONTEXT defs` by fs[STATE_def] >>
-  imp_res_tac term_type >>
-  rpt (BasicProvers.VAR_EQ_TAC) >>
-  fs[] >>
-  `typeof (bod) = typeof (Comb (Abs (Var name ty) (bod)) (Var name ty))` by simp[] >>
-  pop_assum SUBST1_TAC >>
-  simp_tac std_ss [GSYM equation_def] >>
-  MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,2)) >>
-  fs[CONTEXT_def,TERM_def,TYPE_def] >>
-  METIS_TAC[extends_theory_ok,init_theory_ok]
+  cheat
+  (* SIMP_TAC std_ss [BETA_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
+  (* \\ Cases_on `tm` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ SRW_TAC [] [st_ex_bind_def,st_ex_return_def] *)
+  (* \\ IMP_RES_TAC TERM \\ IMP_RES_TAC Abs_Var *)
+  (* \\ FULL_SIMP_TAC std_ss [] *)
+  (* \\ Q.MATCH_ASSUM_RENAME_TAC `t2 = Var name ty` \\ POP_ASSUM (K ALL_TAC) *)
+  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Abs (Var name ty) bod)` *)
+  (* \\ Cases_on `mk_eq (Comb (Abs (Var name ty) bod) (Var name ty),bod) s` *)
+  (* \\ IMP_RES_TAC TERM *)
+  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb (Abs (Var name ty) bod) (Var name ty)`, *)
+  (*        `y`|->`bod`,`res`|->`q`,`s'`|->`r`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ FULL_SIMP_TAC std_ss [THM_def] >> *)
+  (* `CONTEXT defs` by fs[STATE_def] >> *)
+  (* imp_res_tac term_type >> *)
+  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
+  (* fs[] >> *)
+  (* `typeof (bod) = typeof (Comb (Abs (Var name ty) (bod)) (Var name ty))` by simp[] >> *)
+  (* pop_assum SUBST1_TAC >> *)
+  (* simp_tac std_ss [GSYM equation_def] >> *)
+  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,2)) >> *)
+  (* fs[CONTEXT_def,TERM_def,TYPE_def] >> *)
+  (* METIS_TAC[extends_theory_ok,init_theory_ok] *)
 QED
 
 Theorem ASSUME_thm:
@@ -2161,27 +2163,28 @@ Theorem DEDUCT_ANTISYM_RULE_thm:
     (DEDUCT_ANTISYM_RULE th1 th2 s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
-  \\ SIMP_TAC std_ss [DEDUCT_ANTISYM_RULE_def,LET_DEF,st_ex_bind_def]
-  \\ Cases_on `mk_eq (t,t') s` \\ STRIP_TAC
-  \\ IMP_RES_TAC THM
-  \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`t`,
-         `y`|->`t'`,`res`|->`q`,`s'`|->`r`])
-  \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ FULL_SIMP_TAC std_ss [THM_def]
-  >> simp[] >>
-  rpt (BasicProvers.VAR_EQ_TAC) >>
-  `EVERY (TERM defs) (term_remove t' l) ∧
-   EVERY (TERM defs) (term_remove t l')` by (
-    conj_tac >>
-    MATCH_MP_TAC EVERY_term_remove >>
-    simp[]) >>
-  `CONTEXT defs` by fs[STATE_def] >>
-  imp_res_tac term_type >>
-  simp[GSYM equation_def] >>
-  MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,3)) >>
-  simp[]
+  cheat
+  (* Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
+  (* \\ SIMP_TAC std_ss [DEDUCT_ANTISYM_RULE_def,LET_DEF,st_ex_bind_def] *)
+  (* \\ Cases_on `mk_eq (t,t') s` \\ STRIP_TAC *)
+  (* \\ IMP_RES_TAC THM *)
+  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`t`, *)
+  (*        `y`|->`t'`,`res`|->`q`,`s'`|->`r`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ FULL_SIMP_TAC std_ss [THM_def] *)
+  (* >> simp[] >> *)
+  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
+  (* `EVERY (TERM defs) (term_remove t' l) ∧ *)
+  (*  EVERY (TERM defs) (term_remove t l')` by ( *)
+  (*   conj_tac >> *)
+  (*   MATCH_MP_TAC EVERY_term_remove >> *)
+  (*   simp[]) >> *)
+  (* `CONTEXT defs` by fs[STATE_def] >> *)
+  (* imp_res_tac term_type >> *)
+  (* simp[GSYM equation_def] >> *)
+  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,3)) >> *)
+  (* simp[] *)
 QED
 
 Theorem image_lemma[local]:
@@ -3176,13 +3179,6 @@ Proof
   \\ CCONTR_TAC \\ fs[st_ex_return_def,raise_Failure_def] \\ rw[]
 QED
 
-Theorem ABS_not_clash[simp]:
-   ABS x y z ≠ (M_failure (Clash tm),refs)
-Proof
-  Cases_on`y` \\ rw [ABS_def, st_ex_return_def, st_ex_bind_def, raise_Failure_def]
-  \\ every_case_tac \\ fs [case_eq_thms] \\ CCONTR_TAC \\ fs []
-QED
-
 Theorem mk_type_not_clash[simp]:
    !a b. mk_type a b <> (M_failure (Clash tm), refs)
 Proof
@@ -3196,6 +3192,13 @@ Theorem safe_mk_eq_not_clash[simp]:
 Proof
   simp [safe_mk_eq_def, st_ex_bind_def, st_ex_return_def]
   >> every_case_tac >> CCONTR_TAC >> gvs []
+QED
+
+Theorem ABS_not_clash[simp]:
+   ABS x y z ≠ (M_failure (Clash tm),refs)
+Proof
+  Cases_on`y` \\ rw [ABS_def, st_ex_return_def, st_ex_bind_def, raise_Failure_def]
+  \\ every_case_tac \\ fs [case_eq_thms] \\ CCONTR_TAC \\ fs []
 QED
 
 Theorem MK_COMB_not_clash[simp]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -2142,28 +2142,27 @@ Theorem DEDUCT_ANTISYM_RULE_thm:
     (DEDUCT_ANTISYM_RULE th1 th2 s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  cheat
-  (* Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
-  (* \\ SIMP_TAC std_ss [DEDUCT_ANTISYM_RULE_def,LET_DEF,st_ex_bind_def] *)
-  (* \\ Cases_on `mk_eq (t,t') s` \\ STRIP_TAC *)
-  (* \\ IMP_RES_TAC THM *)
-  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`t`, *)
-  (*        `y`|->`t'`,`res`|->`q`,`s'`|->`r`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ FULL_SIMP_TAC std_ss [THM_def] *)
-  (* >> simp[] >> *)
-  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
-  (* `EVERY (TERM defs) (term_remove t' l) ∧ *)
-  (*  EVERY (TERM defs) (term_remove t l')` by ( *)
-  (*   conj_tac >> *)
-  (*   MATCH_MP_TAC EVERY_term_remove >> *)
-  (*   simp[]) >> *)
-  (* `CONTEXT defs` by fs[STATE_def] >> *)
-  (* imp_res_tac term_type >> *)
-  (* simp[GSYM equation_def] >> *)
-  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,3)) >> *)
-  (* simp[] *)
+  Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
+  \\ SIMP_TAC std_ss [DEDUCT_ANTISYM_RULE_def,LET_DEF,st_ex_bind_def]
+  \\ Cases_on `safe_mk_eq t t' s` \\ STRIP_TAC
+  \\ IMP_RES_TAC THM
+  \\ drule safe_mk_eq_thm \\ disch_then drule
+  \\ impl_tac >- (imp_res_tac THM_term_ok_bool >> gvs [])
+  \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC
+  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
+  \\ FULL_SIMP_TAC std_ss [THM_def]
+  >> simp[] >>
+  rpt (BasicProvers.VAR_EQ_TAC) >>
+  `EVERY (TERM defs) (term_remove t' l) ∧
+   EVERY (TERM defs) (term_remove t l')` by (
+    conj_tac >>
+    MATCH_MP_TAC EVERY_term_remove >>
+    simp[]) >>
+  `CONTEXT defs` by fs[STATE_def] >>
+  imp_res_tac term_type >>
+  simp[GSYM equation_def] >>
+  MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,3)) >>
+  simp[]
 QED
 
 Theorem image_lemma[local]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -886,6 +886,34 @@ Proof
        Once rev_assocd_def]) \\ SRW_TAC [] [] \\ METIS_TAC []
 QED
 
+Theorem safe_mk_eq_thm:
+  (safe_mk_eq x y s = (res, s')) ⇒
+  (TERM defs x ∧ TERM defs y ∧ STATE defs s) ⇒
+  (typeof x = typeof y) ⇒
+  (s' = s) ∧
+  ∀t. (res = M_success t) ⇒
+      (t = Comb (Comb (Equal (term_type x)) x) y) ∧ TERM defs t
+Proof
+  ntac 3 strip_tac
+  >> qhdtm_x_assum ‘safe_mk_eq’ mp_tac
+  >> simp [safe_mk_eq_def, try_def, otherwise_def, st_ex_bind_def,
+           st_ex_return_def]
+  >> qspec_then ‘x’ mp_tac type_of_thm
+  >> impl_tac >- simp []
+  >> strip_tac >> simp []
+  >> TOP_CASE_TAC
+  >> drule mk_type_thm >> disch_then drule >> simp []
+  >> strip_tac >> TOP_CASE_TAC >> strip_tac >> gvs []
+  >> ‘CONTEXT defs’ by fs [STATE_def]
+  >> imp_res_tac term_type
+  >> imp_res_tac CONTEXT_std_sig
+  >> gvs [TERM_def, is_std_sig_def, TYPE_def, type_ok_def]
+  >> imp_res_tac term_ok_welltyped
+  >> simp [term_ok_def, type_ok_def]
+  >> qexists ‘[(typeof y, aty)]’
+  >> simp[REV_ASSOCD]
+QED
+
 Theorem mk_eq_thm:
   (mk_eq(x,y)s = (res,s')) ==>
   TERM defs x /\ TERM defs y /\ STATE defs s ==>
@@ -1745,18 +1773,17 @@ Theorem REFL_thm:
    TERM defs tm /\ STATE defs s /\ (REFL tm s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  cheat
-  (* SIMP_TAC std_ss [REFL_def,st_ex_bind_def] \\ Cases_on `mk_eq(tm,tm) s` *)
-  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC mk_eq_thm *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ Q.PAT_X_ASSUM `xxx = th` (ASSUME_TAC o GSYM) *)
-  (* \\ FULL_SIMP_TAC (srw_ss()) [THM_def,domain_def] >> *)
-  (* rw[] >> *)
-  (* fs[STATE_def] >> rw[] >> imp_res_tac term_type *)
-  (* \\ simp[GSYM equation_def] *)
-  (* \\ MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,8)) >> *)
-  (* fs[CONTEXT_def,TERM_def] >> *)
-  (* METIS_TAC[extends_theory_ok,init_theory_ok] *)
+  SIMP_TAC std_ss [REFL_def,st_ex_bind_def] \\ Cases_on `safe_mk_eq tm tm s`
+  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC safe_mk_eq_thm
+  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
+  \\ Q.PAT_X_ASSUM `xxx = th` (ASSUME_TAC o GSYM)
+  \\ FULL_SIMP_TAC (srw_ss()) [THM_def,domain_def] >>
+  rw[] >>
+  fs[STATE_def] >> rw[] >> imp_res_tac term_type
+  \\ simp[GSYM equation_def]
+  \\ MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,8)) >>
+  fs[CONTEXT_def,TERM_def] >>
+  METIS_TAC[extends_theory_ok,init_theory_ok]
 QED
 
 Theorem TRANS_thm:
@@ -3147,6 +3174,13 @@ Proof
   \\ fs [case_eq_thms, bool_case_eq, COND_RATOR]
 QED
 
+Theorem safe_mk_eq_not_clash[simp]:
+   safe_mk_eq x y s ≠ (M_failure(Clash tm),refs)
+Proof
+  simp [safe_mk_eq_def, st_ex_bind_def, st_ex_return_def]
+  >> every_case_tac >> CCONTR_TAC >> gvs []
+QED
+
 Theorem ASSUME_not_clash[simp]:
    !a b. ASSUME a b <> (M_failure (Clash tm), refs)
 Proof
@@ -3226,8 +3260,7 @@ QED
 Theorem REFL_not_clash[simp]:
    REFL a b <> (M_failure (Clash tm),refs)
 Proof
-  cheat
-  (* rw [REFL_def, st_ex_bind_def, st_ex_return_def, case_eq_thms] *)
+  simp [REFL_def, st_ex_bind_def, st_ex_return_def, AllCaseEqs()]
 QED
 
 Theorem TRANS_not_clash[simp]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -1976,11 +1976,37 @@ Proof
       ‘THM _ (Sequent _ (Comb (Comb (Const «=» h1) f1) f2))’,
       ‘THM _ (Sequent _ (Comb (Comb (Const «=» h2) x1) x2))’,
     ]
-  \\ drule_then (qspec_then ‘defs’ mp_tac) safe_mk_eq_thm
-  \\ impl_tac >- cheat
-  \\ Cases_on ‘res'’ \\ gvs []
-  \\ rpt strip_tac \\ gvs []
-  \\ cheat
+  \\ `CONTEXT defs` by fs [STATE_def]
+  \\ imp_res_tac THM
+  (* both sides of each equation have equal type *)
+  \\ `TERM defs (Comb (Const «=» h1) f1) ∧ TERM defs (Comb (Const «=» h2) x1)`
+       by rfs [TERM_Comb]
+  \\ imp_res_tac TERM_Eq_x
+  \\ `welltyped (Comb (Comb (Const «=» h1) f1) f2) ∧
+      welltyped (Comb (Comb (Const «=» h2) x1) x2)`
+       by (fs [TERM_def] \\ imp_res_tac term_ok_welltyped \\ fs [])
+  \\ gvs [TERM_Comb]
+  \\ imp_res_tac type_of_thm
+  \\ imp_res_tac term_type
+  \\ gvs []
+  (* hence the new combinations Comb f1 x1 and Comb f2 x2 are well-formed *)
+  \\ `TERM defs (Comb f1 x1)` by gvs [TERM_Comb]
+  \\ `TERM defs (Comb f2 x2)` by gvs [TERM_Comb]
+  \\ `typeof (Comb f1 x1) = typeof (Comb f2 x2)` by simp []
+  \\ drule_all safe_mk_eq_thm
+  \\ strip_tac
+  \\ Cases_on ‘res'’ \\ fs []
+  (* close the remaining goal with the MK_COMB derivation rule *)
+  \\ fs [THM_def]
+  \\ qspecl_then [‘defs’,‘Comb f1 x1’] mp_tac term_type
+  \\ (impl_tac >- simp []) \\ strip_tac
+  \\ qpat_x_assum ‘term_type (Comb f1 x1) = _’ (fn th => rewrite_tac [th])
+  \\ PURE_ONCE_REWRITE_TAC [GSYM equation_def]
+  \\ match_mp_tac (List.nth (CONJUNCTS proves_rules, 7))
+  \\ rpt conj_tac
+  >- fs [equation_def]
+  >- fs [equation_def]
+  \\ fs []
 QED
 
 Theorem ABS_thm:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -412,6 +412,24 @@ Proof
   \\ fs[STATE_def] >> METIS_TAC[CONTEXT_fun]
 QED
 
+Theorem mk_type_bool[local]:
+  STATE defs s ⇒ (mk_type («bool»,[]) s = (M_success Bool, s))
+Proof
+  strip_tac
+  >> ‘∀a. MEM («bool», a) s.the_type_constants ⇔ (a = 0)’ by
+    (gvs [STATE_def]
+     >> rw[] >> imp_res_tac CONTEXT_ALL_DISTINCT >>
+     imp_res_tac CONTEXT_std_sig >>
+     fs[is_std_sig_def] >>
+     imp_res_tac ALOOKUP_ALL_DISTINCT_MEM >>
+     EQ_TAC >> rw[] >> res_tac >> fs[] >>
+     imp_res_tac ALOOKUP_MEM)
+  >> simp [mk_type_def, st_ex_bind_def, try_def, otherwise_def, st_ex_return_def]
+  >> namedCases_on ‘get_type_arity «bool» s’ ["res s'"]
+  >> drule_then assume_tac get_type_arity_thm >> simp []
+  >> Cases_on ‘res’ >> gvs []
+QED
+
 Theorem dest_type_thm:
    !ty s z s'.
       STATE defs s /\
@@ -890,9 +908,9 @@ Theorem safe_mk_eq_thm:
   (safe_mk_eq x y s = (res, s')) ⇒
   (TERM defs x ∧ TERM defs y ∧ STATE defs s) ⇒
   (typeof x = typeof y) ⇒
-  (s' = s) ∧
-  ∀t. (res = M_success t) ⇒
-      (t = Comb (Comb (Equal (term_type x)) x) y) ∧ TERM defs t
+  (s' = s) ∧ (∀t. (res ≠ M_failure t)) ∧
+  (∀t. (res = M_success t) ⇒
+       (t = Comb (Comb (Equal (term_type x)) x) y) ∧ TERM defs t)
 Proof
   ntac 3 strip_tac
   >> qhdtm_x_assum ‘safe_mk_eq’ mp_tac
@@ -903,7 +921,8 @@ Proof
   >> strip_tac >> simp []
   >> TOP_CASE_TAC
   >> drule mk_type_thm >> disch_then drule >> simp []
-  >> strip_tac >> TOP_CASE_TAC >> strip_tac >> gvs []
+  >> strip_tac >> reverse TOP_CASE_TAC >> strip_tac >> gvs []
+  >- (drule_then assume_tac mk_type_bool >> fs [])
   >> ‘CONTEXT defs’ by fs [STATE_def]
   >> imp_res_tac term_type
   >> imp_res_tac CONTEXT_std_sig
@@ -1940,46 +1959,28 @@ Theorem MK_COMB_thm:
     (MK_COMB (th1,th2) s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  cheat
-  (* Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
-  (* \\ SIMP_TAC std_ss [MK_COMB_def] *)
-  (* \\ BasicProvers.EVERY_CASE_TAC *)
-  (* \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ SRW_TAC [] [st_ex_bind_def] \\ IMP_RES_TAC THM *)
-  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h1) f1) f2)` *)
-  (* \\ POP_ASSUM MP_TAC *)
-  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h2) x1) x2)` *)
-  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM *)
-  (* \\ Cases_on `mk_comb (f1,x1) s` *)
-  (* \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f1`,`a`|->`x1`,`res`|->`q`,`s1`|->`r`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ IMP_RES_TAC TERM *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ Cases_on `mk_comb (f2,x2) s` *)
-  (* \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f2`,`a`|->`x2`,`res`|->`q`,`s1`|->`r'`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ Cases_on `mk_eq (Comb f1 x1,Comb f2 x2) s` *)
-  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb f1 x1`, *)
-  (*        `y`|->`Comb f2 x2`,`res`|->`q`,`s'`|->`r''`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ FULL_SIMP_TAC std_ss [THM_def] >> *)
-  (* rpt(qpat_x_assum`H |- C`mp_tac) >> *)
-  (* imp_res_tac term_union_thm >> simp[] >> *)
-  (* `CONTEXT defs` by fs[STATE_def] >> *)
-  (* imp_res_tac term_type >> *)
-  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
-  (* fs[] >> *)
-  (* imp_res_tac Equal_type >> fs[] >> *)
-  (* imp_res_tac Equal_type_IMP >> *)
-  (* ntac 2 (pop_assum(mp_tac o SYM)) >> *)
-  (* `codomain (typeof (f1)) = typeof (Comb (f1) (x1))` by simp[] >> *)
-  (* pop_assum SUBST1_TAC >> simp_tac std_ss [GSYM equation_def] >> *)
-  (* rw[] >> *)
-  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,7)) >> *)
-  (* qpat_x_assum`TERM x (Comb f1 x1)`mp_tac >> simp[TERM_Comb] >> strip_tac >> *)
-  (* fs[TERM_def] >> imp_res_tac term_ok_welltyped >> simp[] *)
+  Cases_on ‘th1’ \\ Cases_on ‘th2’ \\ once_rewrite_tac [EQ_SYM_EQ]
+  \\ simp [MK_COMB_def]
+  (* case splits are a bit slow *)
+  \\ every_case_tac
+  \\ gvs [raise_Failure_def, st_ex_bind_def, st_ex_return_def]
+  \\ rename1 ‘type_of f2 _’
+  \\ qspec_then ‘f2’ assume_tac type_of_state \\ fs []
+  \\ ntac 13 TOP_CASE_TAC
+  \\ rename1 ‘type_of x2 _’
+  \\ qspec_then ‘x2’ assume_tac type_of_state \\ fs []
+  \\ ntac 3 TOP_CASE_TAC \\ gvs []
+  \\ strip_tac
+  \\ rename [
+      ‘safe_mk_eq (Comb f1 x1) (Comb f2 x2) _ = (res', _)’,
+      ‘THM _ (Sequent _ (Comb (Comb (Const «=» h1) f1) f2))’,
+      ‘THM _ (Sequent _ (Comb (Comb (Const «=» h2) x1) x2))’,
+    ]
+  \\ drule_then (qspec_then ‘defs’ mp_tac) safe_mk_eq_thm
+  \\ impl_tac >- cheat
+  \\ Cases_on ‘res'’ \\ gvs []
+  \\ rpt strip_tac \\ gvs []
+  \\ cheat
 QED
 
 Theorem ABS_thm:
@@ -3156,16 +3157,6 @@ Proof
   \\ every_case_tac \\ fs [case_eq_thms] \\ CCONTR_TAC \\ fs []
 QED
 
-Theorem MK_COMB_not_clash[simp]:
-   MK_COMB (a,b) c <> (M_failure (Clash tm), refs)
-Proof
-  cheat
-  (* Cases_on `a` \\ Cases_on `b` \\ rw [MK_COMB_def] *)
-  (* \\ rw [raise_Failure_def, st_ex_return_def, st_ex_bind_def] *)
-  (* \\ every_case_tac \\ fs [case_eq_thms] *)
-  (* \\ CCONTR_TAC \\ fs [] *)
-QED
-
 Theorem mk_type_not_clash[simp]:
    !a b. mk_type a b <> (M_failure (Clash tm), refs)
 Proof
@@ -3179,6 +3170,15 @@ Theorem safe_mk_eq_not_clash[simp]:
 Proof
   simp [safe_mk_eq_def, st_ex_bind_def, st_ex_return_def]
   >> every_case_tac >> CCONTR_TAC >> gvs []
+QED
+
+Theorem MK_COMB_not_clash[simp]:
+   MK_COMB (a,b) c <> (M_failure (Clash tm), refs)
+Proof
+  Cases_on `a` \\ Cases_on `b` \\ rw [MK_COMB_def]
+  \\ rw [raise_Failure_def, st_ex_return_def, st_ex_bind_def]
+  \\ every_case_tac \\ fs [case_eq_thms]
+  \\ CCONTR_TAC \\ fs []
 QED
 
 Theorem ASSUME_not_clash[simp]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -1745,17 +1745,18 @@ Theorem REFL_thm:
    TERM defs tm /\ STATE defs s /\ (REFL tm s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  SIMP_TAC std_ss [REFL_def,st_ex_bind_def] \\ Cases_on `mk_eq(tm,tm) s`
-  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC mk_eq_thm
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ Q.PAT_X_ASSUM `xxx = th` (ASSUME_TAC o GSYM)
-  \\ FULL_SIMP_TAC (srw_ss()) [THM_def,domain_def] >>
-  rw[] >>
-  fs[STATE_def] >> rw[] >> imp_res_tac term_type
-  \\ simp[GSYM equation_def]
-  \\ MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,8)) >>
-  fs[CONTEXT_def,TERM_def] >>
-  METIS_TAC[extends_theory_ok,init_theory_ok]
+  cheat
+  (* SIMP_TAC std_ss [REFL_def,st_ex_bind_def] \\ Cases_on `mk_eq(tm,tm) s` *)
+  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC mk_eq_thm *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ Q.PAT_X_ASSUM `xxx = th` (ASSUME_TAC o GSYM) *)
+  (* \\ FULL_SIMP_TAC (srw_ss()) [THM_def,domain_def] >> *)
+  (* rw[] >> *)
+  (* fs[STATE_def] >> rw[] >> imp_res_tac term_type *)
+  (* \\ simp[GSYM equation_def] *)
+  (* \\ MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,8)) >> *)
+  (* fs[CONTEXT_def,TERM_def] >> *)
+  (* METIS_TAC[extends_theory_ok,init_theory_ok] *)
 QED
 
 Theorem TRANS_thm:
@@ -1912,45 +1913,46 @@ Theorem MK_COMB_thm:
     (MK_COMB (th1,th2) s = (res, s')) ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
-  \\ SIMP_TAC std_ss [MK_COMB_def]
-  \\ BasicProvers.EVERY_CASE_TAC
-  \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def]
-  \\ SRW_TAC [] [st_ex_bind_def] \\ IMP_RES_TAC THM
-  \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h1) f1) f2)`
-  \\ POP_ASSUM MP_TAC
-  \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h2) x1) x2)`
-  \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM
-  \\ Cases_on `mk_comb (f1,x1) s`
-  \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f1`,`a`|->`x1`,`res`|->`q`,`s1`|->`r`])
-  \\ FULL_SIMP_TAC std_ss [] \\ IMP_RES_TAC TERM
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ Cases_on `mk_comb (f2,x2) s`
-  \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f2`,`a`|->`x2`,`res`|->`q`,`s1`|->`r'`])
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ Cases_on `mk_eq (Comb f1 x1,Comb f2 x2) s`
-  \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb f1 x1`,
-         `y`|->`Comb f2 x2`,`res`|->`q`,`s'`|->`r''`])
-  \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def]
-  \\ FULL_SIMP_TAC std_ss [THM_def] >>
-  rpt(qpat_x_assum`H |- C`mp_tac) >>
-  imp_res_tac term_union_thm >> simp[] >>
-  `CONTEXT defs` by fs[STATE_def] >>
-  imp_res_tac term_type >>
-  rpt (BasicProvers.VAR_EQ_TAC) >>
-  fs[] >>
-  imp_res_tac Equal_type >> fs[] >>
-  imp_res_tac Equal_type_IMP >>
-  ntac 2 (pop_assum(mp_tac o SYM)) >>
-  `codomain (typeof (f1)) = typeof (Comb (f1) (x1))` by simp[] >>
-  pop_assum SUBST1_TAC >> simp_tac std_ss [GSYM equation_def] >>
-  rw[] >>
-  MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,7)) >>
-  qpat_x_assum`TERM x (Comb f1 x1)`mp_tac >> simp[TERM_Comb] >> strip_tac >>
-  fs[TERM_def] >> imp_res_tac term_ok_welltyped >> simp[]
+  cheat
+  (* Cases_on `th1` \\ Cases_on `th2` \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
+  (* \\ SIMP_TAC std_ss [MK_COMB_def] *)
+  (* \\ BasicProvers.EVERY_CASE_TAC *)
+  (* \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
+  (* \\ SRW_TAC [] [st_ex_bind_def] \\ IMP_RES_TAC THM *)
+  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h1) f1) f2)` *)
+  (* \\ POP_ASSUM MP_TAC *)
+  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Comb (Comb (Const «=» h2) x1) x2)` *)
+  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM *)
+  (* \\ Cases_on `mk_comb (f1,x1) s` *)
+  (* \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f1`,`a`|->`x1`,`res`|->`q`,`s1`|->`r`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ IMP_RES_TAC TERM *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ Cases_on `mk_comb (f2,x2) s` *)
+  (* \\ MP_TAC (mk_comb_thm |> Q.INST [`f`|->`f2`,`a`|->`x2`,`res`|->`q`,`s1`|->`r'`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ Cases_on `mk_eq (Comb f1 x1,Comb f2 x2) s` *)
+  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb f1 x1`, *)
+  (*        `y`|->`Comb f2 x2`,`res`|->`q`,`s'`|->`r''`]) *)
+  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
+  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
+  (* \\ FULL_SIMP_TAC std_ss [THM_def] >> *)
+  (* rpt(qpat_x_assum`H |- C`mp_tac) >> *)
+  (* imp_res_tac term_union_thm >> simp[] >> *)
+  (* `CONTEXT defs` by fs[STATE_def] >> *)
+  (* imp_res_tac term_type >> *)
+  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
+  (* fs[] >> *)
+  (* imp_res_tac Equal_type >> fs[] >> *)
+  (* imp_res_tac Equal_type_IMP >> *)
+  (* ntac 2 (pop_assum(mp_tac o SYM)) >> *)
+  (* `codomain (typeof (f1)) = typeof (Comb (f1) (x1))` by simp[] >> *)
+  (* pop_assum SUBST1_TAC >> simp_tac std_ss [GSYM equation_def] >> *)
+  (* rw[] >> *)
+  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,7)) >> *)
+  (* qpat_x_assum`TERM x (Comb f1 x1)`mp_tac >> simp[TERM_Comb] >> strip_tac >> *)
+  (* fs[TERM_def] >> imp_res_tac term_ok_welltyped >> simp[] *)
 QED
 
 Theorem ABS_thm:
@@ -3130,10 +3132,11 @@ QED
 Theorem MK_COMB_not_clash[simp]:
    MK_COMB (a,b) c <> (M_failure (Clash tm), refs)
 Proof
-  Cases_on `a` \\ Cases_on `b` \\ rw [MK_COMB_def]
-  \\ rw [raise_Failure_def, st_ex_return_def, st_ex_bind_def]
-  \\ every_case_tac \\ fs [case_eq_thms]
-  \\ CCONTR_TAC \\ fs []
+  cheat
+  (* Cases_on `a` \\ Cases_on `b` \\ rw [MK_COMB_def] *)
+  (* \\ rw [raise_Failure_def, st_ex_return_def, st_ex_bind_def] *)
+  (* \\ every_case_tac \\ fs [case_eq_thms] *)
+  (* \\ CCONTR_TAC \\ fs [] *)
 QED
 
 Theorem mk_type_not_clash[simp]:
@@ -3223,7 +3226,8 @@ QED
 Theorem REFL_not_clash[simp]:
    REFL a b <> (M_failure (Clash tm),refs)
 Proof
-  rw [REFL_def, st_ex_bind_def, st_ex_return_def, case_eq_thms]
+  cheat
+  (* rw [REFL_def, st_ex_bind_def, st_ex_return_def, case_eq_thms] *)
 QED
 
 Theorem TRANS_not_clash[simp]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -10,6 +10,7 @@ Ancestors
   holSyntaxExtra
 
 val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
+val _ = augment_srw_ss [rewrites [aty_def, bool_ty_def]];
 
 val _ = ParseExtras.temp_loose_equality();
 val _ = hide"str";
@@ -498,13 +499,12 @@ Proof
 QED
 
 Theorem mk_fun_ty_thm:
-   !ty1 ty2 s z s'.
-      STATE defs s /\ EVERY (TYPE defs) [ty1;ty2] /\
-      (mk_fun_ty ty1 ty2 s = (z,s')) ==> (s' = s) /\
-      ?i. (z = M_success i) /\ (i = Tyapp «fun» [ty1;ty2]) /\ TYPE defs i
+  ∀ty1 ty2.
+    CONTEXT defs ∧ EVERY (TYPE defs) [ty1; ty2] ∧
+    (mk_fun_ty ty1 ty2 = i) ⇒
+    (i = Fun ty1 ty2) ∧ TYPE defs i
 Proof
-  SIMP_TAC std_ss [mk_fun_ty_def] \\ REPEAT STRIP_TAC
-  \\ IMP_RES_TAC mk_type_thm \\ FULL_SIMP_TAC (srw_ss()) []
+  rw [mk_fun_ty_def] >> irule TYPE_Fun >> simp []
 QED
 
 (* ------------------------------------------------------------------------- *)
@@ -619,12 +619,7 @@ Proof
   \\ FULL_SIMP_TAC (srw_ss()) [] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ]
   \\ ASM_SIMP_TAC (srw_ss()) [Once term_type_def]
   \\ rw[st_ex_bind_def]
-  \\ Cases_on `mk_fun_ty ty (term_type t0) s`
-  \\ FULL_SIMP_TAC std_ss []
-  \\ sg `EVERY (TYPE defs) [ty; term_type t0]`
-  THEN1 FULL_SIMP_TAC std_ss [EVERY_DEF,term_type]
-  \\ IMP_RES_TAC mk_fun_ty_thm
-  \\ FULL_SIMP_TAC (srw_ss()) [st_ex_bind_def]
+  \\ simp [mk_fun_ty_def]
 QED
 
 Theorem alphavars_thm[local]:
@@ -919,10 +914,7 @@ Proof
   >> qspec_then ‘x’ mp_tac type_of_thm
   >> impl_tac >- simp []
   >> strip_tac >> simp []
-  >> TOP_CASE_TAC
-  >> drule mk_type_thm >> disch_then drule >> simp []
-  >> strip_tac >> reverse TOP_CASE_TAC >> strip_tac >> gvs []
-  >- (drule_then assume_tac mk_type_bool >> fs [])
+  >> strip_tac >> gvs []
   >> ‘CONTEXT defs’ by fs [STATE_def]
   >> imp_res_tac term_type
   >> imp_res_tac CONTEXT_std_sig
@@ -1926,9 +1918,6 @@ Proof
   IMP_RES_TAC map_type_of_state >> var_eq_tac >>
   every_case_tac >> fs[] >>
   rpt var_eq_tac >> simp[] >>
-  qspecl_then[`«bool»`,`[]`,`s`]mp_tac mk_type_thm >>
-  simp[] >> strip_tac >>
-  rpt var_eq_tac >> simp[] >>
   fs[THM_def] >>
   match_mp_tac proves_ACONV >>
   first_assum(match_exists_tac o concl) >>
@@ -2113,11 +2102,7 @@ Proof
   \\ STRIP_TAC \\ MP_TAC (type_of_thm |> Q.SPEC `tm`)
   \\ FULL_SIMP_TAC std_ss [] \\ STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ FULL_SIMP_TAC (srw_ss()) [st_ex_bind_def]
-  \\ MP_TAC (mk_type_thm |> Q.SPECL [`«bool»`,`[]`,`s`])
-  \\ Cases_on `mk_type («bool»,[]) s`
   \\ FULL_SIMP_TAC (srw_ss()) [EVERY_DEF]
-  \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) []
-  \\ STRIP_TAC \\ FULL_SIMP_TAC std_ss []
   \\ Cases_on `term_type tm = Bool`
   \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def,st_ex_return_def]
   \\ FULL_SIMP_TAC std_ss [THM_def]
@@ -3066,10 +3051,7 @@ Theorem new_axiom_thm:
 Proof
   rw[new_axiom_def,st_ex_bind_def] >>
   imp_res_tac type_of_thm >> rw[] >>
-  qspecl_then[`«bool»`,`[]`,`s`]mp_tac mk_type_thm >>
-  Cases_on`mk_type («bool»,[]) s`>>simp[] >>
-  Cases_on`q`>>simp[]>>strip_tac>>
-  BasicProvers.CASE_TAC >> simp[raise_Failure_def,st_ex_return_def] >>
+  simp[raise_Failure_def,st_ex_return_def] >>
   simp[get_the_axioms_def,set_the_axioms_def] >>
   simp[add_def_def,st_ex_bind_def,get_the_context_def,set_the_context_def] >>
   qexists_tac`NewAxiom p` >>
@@ -3136,15 +3118,6 @@ Theorem dest_type_not_clash[simp]:
    dest_type x y ≠ (M_failure (Clash tm),refs)
 Proof
   Cases_on`x` \\ EVAL_TAC
-QED
-
-Theorem mk_fun_ty_not_clash[simp]:
-   mk_fun_ty t a r ≠ (M_failure(Clash tm),refs)
-Proof
-  Cases_on`t`
-  \\ rw [mk_fun_ty_def, mk_type_def, st_ex_bind_def, st_ex_return_def,
-         raise_Failure_def, try_def, otherwise_def]
-  \\ fs [case_eq_thms, bool_case_eq, COND_RATOR]
 QED
 
 Theorem type_of_not_clash[simp]:

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -2812,14 +2812,13 @@ Proof
   simp[mk_var_def,Once term_type_def] >>
   strip_tac >> Cases_on`q`>>fs[] >>
   simp[Once st_ex_bind_def] >>
-  simp[Once mk_comb_def,type_of_def,st_ex_return_def,Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[dest_type_def,st_ex_return_def] >>
   simp[Abbr`absty`] >>
   simp[Once st_ex_bind_def] >>
-  simp[Once mk_eq_def,try_def,otherwise_def,type_of_def,st_ex_return_def,Once st_ex_bind_def] >>
+  simp[Once safe_mk_eq_def,try_def,otherwise_def,type_of_def,st_ex_return_def,Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[dest_type_def,st_ex_return_def] >>
   simp[Once st_ex_bind_def] >>
@@ -2884,7 +2883,7 @@ Proof
     rfs[] >> fs[] >>
     Cases_on`q`>>fs[] ) >>
   simp[Once st_ex_bind_def] >>
-  simp[Once mk_eq_def,try_def,otherwise_def,type_of_def,st_ex_return_def,Once st_ex_bind_def] >>
+  simp[Once safe_mk_eq_def,try_def,otherwise_def,type_of_def,st_ex_return_def,Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[dest_type_def,st_ex_return_def] >>
   simp[Once st_ex_bind_def] >>
@@ -2903,7 +2902,7 @@ Proof
   simp[dest_type_def,st_ex_return_def] >>
   simp[Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
-  simp[mk_eq_def,try_def,otherwise_def,Once type_of_def,Once st_ex_bind_def] >>
+  simp[safe_mk_eq_def,try_def,otherwise_def,Once type_of_def,Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   simp[Once st_ex_bind_def] >>
   `CONTEXT s2.the_context` by fs[STATE_def] >>

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -1998,6 +1998,18 @@ Proof
   \\ fs []
 QED
 
+Theorem term_type_Const[local]:
+  term_type (Const n ty) = ty
+Proof
+  simp [term_type_def]
+QED
+
+Theorem term_type_Comb_Equal[local]:
+  term_type (Comb (Equal ty) ty') = Fun ty Bool
+Proof
+  simp [term_type_def]
+QED
+
 Theorem ABS_thm:
   (ABS tm th1 s = (res, s')) /\
   TERM defs tm /\
@@ -2005,57 +2017,39 @@ Theorem ABS_thm:
   STATE defs s ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  cheat
-  (* Cases_on `th1` \\ SIMP_TAC std_ss [ABS_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
-  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ Cases_on `t'` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ FULL_SIMP_TAC std_ss [st_ex_bind_def] *)
-  (* \\ Cases_on `m = «=»` \\ FULL_SIMP_TAC (srw_ss()) [] \\ SRW_TAC [] [] *)
-  (* \\ TRY ( *)
-  (*     qpat_x_assum ‘(_, _) = _’ mp_tac \\ *)
-  (*     NTAC 4 BasicProvers.CASE_TAC \\ *)
-  (*     STRIP_TAC \\ *)
-  (*     FULL_SIMP_TAC std_ss [] \\ *)
-  (*     NO_TAC) *)
-  (* \\ Q.MATCH_ASSUM_RENAME_TAC *)
-  (*      `THM defs (Sequent l (Comb (Comb (Const «=» h) t1) t2))` *)
-  (* \\ Cases_on `mk_abs (tm,t1) s` \\ FULL_SIMP_TAC (srw_ss()) [] *)
-  (* \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`, *)
-  (*      `bod`|->`t1`,`s1`|->`r`]) *)
-  (* \\ IMP_RES_TAC THM \\ IMP_RES_TAC TERM \\ IMP_RES_TAC TERM *)
-  (* \\ FULL_SIMP_TAC std_ss [] *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] *)
-  (* \\ Cases_on `mk_abs (tm,t2) s` \\ FULL_SIMP_TAC (srw_ss()) [] *)
-  (* \\ MP_TAC (mk_abs_thm |> Q.SPECL [`q`] |> Q.INST [`bvar`|->`tm`, *)
-  (*      `bod`|->`t2`,`s1`|->`r'`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC \\ FULL_SIMP_TAC std_ss [] *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ REPEAT STRIP_TAC \\ IMP_RES_TAC TERM *)
-  (* \\ Cases_on `mk_eq (Abs tm t1,Abs tm t2) s` *)
-  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Abs tm t1`,`y`|->`Abs tm t2`, *)
-  (*                                 `res`|->`q`,`s'`|->`r''`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [] *)
-  (* \\ FULL_SIMP_TAC std_ss [THM_def] *)
-  (* >> rpt(qpat_x_assum`H |- C`mp_tac) >> *)
-  (* imp_res_tac term_union_thm >> simp[] >> *)
-  (* `CONTEXT defs` by fs[STATE_def] >> *)
-  (* imp_res_tac term_type >> *)
-  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
-  (* fs[] >> *)
-  (* imp_res_tac Equal_type >> fs[] >> *)
-  (* `typeof (Abs tm t1) = Fun (typeof tm) (typeof t1)` by simp[] >> *)
-  (* pop_assum(SUBST1_TAC o SYM) >> *)
-  (* simp[GSYM equation_def] >> *)
-  (* imp_res_tac Abs_Var >> *)
-  (* rw[] >> *)
-  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,0)) >> *)
-  (* fs[EVERY_MAP,EVERY_MEM,PULL_EXISTS,TYPE_def,term_type_Var] >> *)
-  (* imp_res_tac Equal_type_IMP >> *)
-  (* reverse conj_tac >- METIS_TAC[equation_def] >> *)
-  (* REPEAT STRIP_TAC \\ RES_TAC *)
-  (* \\ IMP_RES_TAC TERM \\ IMP_RES_TAC VFREE_IN_IMP *)
+  simp [oneline ABS_def, raise_Failure_def, st_ex_return_def]
+  >> every_case_tac >> simp []
+  >> simp [st_ex_bind_def]
+  >> TOP_CASE_TAC
+  >> strip_tac
+  >> ‘CONTEXT defs’ by fs [STATE_def]
+  >> rename1 ‘safe_mk_eq (Abs (Var m t) t0') (Abs (Var m t) t0) _ = (res', _)’
+  >> drule safe_mk_eq_thm >> disch_then $ qspec_then ‘defs’ mp_tac >> simp []
+  >> impl_keep_tac
+  >-
+   (imp_res_tac THM
+    >> drule_then assume_tac TERM_Comb
+    >> fs [TERM_Abs, TERM_Var_SIMP]
+    >> imp_res_tac Equal_type >> gvs []
+    >> gvs [term_type_Const, term_type_Comb_Equal]
+    >> imp_res_tac term_type >> gvs [])
+  >> strip_tac >> gvs []
+  >> Cases_on ‘res'’ >> fs [] >> gvs []
+  >> fs [THM_def]
+  >> ‘(term_type (Abs (Var m t) t0')) = (typeof (Abs (Var m t) t0'))’ by
+    imp_res_tac term_type
+  >> pop_assum SUBST_ALL_TAC
+  >> simp [GSYM equation_def]
+  >> irule (List.nth(CONJUNCTS proves_rules,0))
+  >> conj_tac
+  >- fs [EVERY_MEM, vfree_in_thm]
+  >> conj_tac
+  >- fs [TERM_def, term_ok_def]
+  >> fs [equation_def]
+  >> imp_res_tac proves_term_ok >> gvs [term_ok_def]
+  >> qpat_x_assum ‘_ has_type _’ mp_tac
+  >> simp [Ntimes has_type_cases 3]
+  >> rw [] >> gvs []
 QED
 
 Theorem BETA_thm:
@@ -2064,32 +2058,32 @@ Theorem BETA_thm:
   STATE defs s ==>
     (s' = s) /\ !th. (res = M_success th) ==> THM defs th
 Proof
-  cheat
-  (* SIMP_TAC std_ss [BETA_def] \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] *)
-  (* \\ Cases_on `tm` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ Cases_on `t` \\ FULL_SIMP_TAC (srw_ss()) [raise_Failure_def] *)
-  (* \\ SRW_TAC [] [st_ex_bind_def,st_ex_return_def] *)
-  (* \\ IMP_RES_TAC TERM \\ IMP_RES_TAC Abs_Var *)
-  (* \\ FULL_SIMP_TAC std_ss [] *)
-  (* \\ Q.MATCH_ASSUM_RENAME_TAC `t2 = Var name ty` \\ POP_ASSUM (K ALL_TAC) *)
-  (* \\ Q.MATCH_ASSUM_RENAME_TAC `TERM defs (Abs (Var name ty) bod)` *)
-  (* \\ Cases_on `mk_eq (Comb (Abs (Var name ty) bod) (Var name ty),bod) s` *)
-  (* \\ IMP_RES_TAC TERM *)
-  (* \\ MP_TAC (mk_eq_thm |> Q.INST [`x`|->`Comb (Abs (Var name ty) bod) (Var name ty)`, *)
-  (*        `y`|->`bod`,`res`|->`q`,`s'`|->`r`]) *)
-  (* \\ FULL_SIMP_TAC std_ss [] \\ REPEAT STRIP_TAC *)
-  (* \\ Cases_on `q` \\ FULL_SIMP_TAC (srw_ss()) [st_ex_return_def] *)
-  (* \\ FULL_SIMP_TAC std_ss [THM_def] >> *)
-  (* `CONTEXT defs` by fs[STATE_def] >> *)
-  (* imp_res_tac term_type >> *)
-  (* rpt (BasicProvers.VAR_EQ_TAC) >> *)
-  (* fs[] >> *)
-  (* `typeof (bod) = typeof (Comb (Abs (Var name ty) (bod)) (Var name ty))` by simp[] >> *)
-  (* pop_assum SUBST1_TAC >> *)
-  (* simp_tac std_ss [GSYM equation_def] >> *)
-  (* MATCH_MP_TAC(List.nth(CONJUNCTS proves_rules,2)) >> *)
-  (* fs[CONTEXT_def,TERM_def,TYPE_def] >> *)
-  (* METIS_TAC[extends_theory_ok,init_theory_ok] *)
+  simp [BETA_def, raise_Failure_def, st_ex_return_def]
+  >> every_case_tac >> gvs []
+  >> simp [st_ex_bind_def]
+  >> TOP_CASE_TAC
+  >> strip_tac
+  >> ‘CONTEXT defs’ by fs [STATE_def]
+  >> drule $ iffLR TERM_Comb
+  >> disch_then drule
+  >> strip_tac
+  >> imp_res_tac Abs_Var >> gvs []
+  >> drule $ iffLR TERM_Abs >> strip_tac
+  >> drule safe_mk_eq_thm >> disch_then drule
+  >> impl_tac >- simp []
+  >> strip_tac
+  >> rename1 ‘safe_mk_eq _ _ _ = (q, r)’
+  >> Cases_on ‘q’ >> fs [] >> gvs []
+  >> simp [THM_def]
+  >> qmatch_goalsub_abbrev_tac ‘Equal (term_type tm)’
+  >> qspecl_then [‘defs’, ‘tm’] mp_tac (cj 1 term_type)
+  >> impl_tac >- simp []
+  >> strip_tac >> pop_assum SUBST1_TAC
+  >> rewrite_tac [GSYM equation_def]
+  >> unabbrev_all_tac
+  >> irule $ List.nth(CONJUNCTS proves_rules,2)
+  >> fs [CONTEXT_def, TERM_def, TYPE_def]
+  >> metis_tac [extends_theory_ok, init_theory_ok]
 QED
 
 Theorem ASSUME_thm:

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -299,13 +299,21 @@ End
   let bty = mk_vartype "B";;
 *)
 
-Definition mk_fun_ty_def:
-  mk_fun_ty ty1 ty2 = mk_type(«fun»,[ty1; ty2])
+Definition bool_ty_def:
+  bool_ty = Tyapp «bool» []
 End
 
-Overload bool_ty[local] = ``mk_type(«bool»,[])``
-Overload aty[local] = ``mk_vartype «A»``
-Overload bty[local] = ``mk_vartype «B»``
+Definition mk_fun_ty_def:
+  mk_fun_ty ty1 ty2 = Tyapp «fun» [ty1; ty2]
+End
+
+Definition aty_def:
+  aty = Tyvar «A»
+End
+
+Definition bty_def:
+  bty = Tyvar «B»
+End
 
 (*
   let constants() = !the_term_constants
@@ -343,7 +351,7 @@ Definition type_of_def:
                      case x of (_,_::ty1::_) => return ty1
                              | _ => failwith «match»
                   od
-    | Abs (Var _ ty) t => do x <- type_of t; mk_fun_ty ty x od
+    | Abs (Var _ ty) t => do x <- type_of t; return (mk_fun_ty ty x) od
     | _ => failwith «match»
 End
 
@@ -810,8 +818,7 @@ Definition safe_mk_eq_def:
   safe_mk_eq l r =
   do
     ty <- type_of l;
-    bty <- bool_ty;
-    return (Comb (Comb (Const «=» (Tyapp «fun» [ty; Tyapp «fun» [ty;bty]])) l) r)
+    return (Comb (Comb (Const «=» (Tyapp «fun» [ty; Tyapp «fun» [ty;bool_ty]])) l) r)
   od
 End
 
@@ -936,9 +943,8 @@ Definition ALPHA_THM_def:
     let h' = list_to_hypset h' [] in
     if EVERY (λx. EXISTS (aconv x) h') h then
       do
-        bty <- bool_ty;
         tys <- map type_of h';
-        if EVERY (λty. ty = bty) tys then
+        if EVERY (λty. ty = bool_ty) tys then
           return (Sequent h' c')
         else failwith «ALPHA_THM»
       od
@@ -1025,8 +1031,7 @@ End
 Definition ASSUME_def:
   ASSUME tm =
     do ty <- type_of tm ;
-       bty <- bool_ty ;
-       if ty = bty then return (Sequent [tm] tm)
+       if ty = bool_ty then return (Sequent [tm] tm)
        else failwith «ASSUME: not a proposition» od
 End
 
@@ -1118,8 +1123,7 @@ End
 Definition new_axiom_def:
   new_axiom tm =
     do ty <- type_of tm ;
-       bty <- bool_ty ;
-       if ty = bty then
+       if ty = bool_ty then
          do th <- return (Sequent [] tm) ;
             ax <- get_the_axioms ;
             set_the_axioms (th :: ax) ;
@@ -1257,9 +1261,7 @@ Definition new_basic_type_definition_def:
     do rty <- type_of x ;
        add_type (tyname, LENGTH tyvars) ;
        aty <- mk_type(tyname,tyvars) ;
-       repty <- mk_fun_ty aty rty ;
-       absty <- mk_fun_ty rty aty ;
-       add_constants[(absname,absty);(repname,repty)] ;
+       add_constants[(absname,mk_fun_ty rty aty);(repname,mk_fun_ty aty rty)] ;
        add_def (TypeDefn tyname P absname repname) ;
        rep <- mk_const(repname,[]) ;
        abs <- mk_const(absname,[]) ;

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -1269,13 +1269,11 @@ Definition new_basic_type_definition_def:
        a <- return (mk_var(«a»,aty)) ;
        r <- return (mk_var(«r»,rty)) ;
        x1 <- mk_comb(rep,a) ;
-       x2 <- mk_comb(abs,x1) ;
-       eq1 <- mk_eq(x2,a) ;
+       eq1 <- safe_mk_eq (Comb abs x1) a ;
        y1 <- mk_comb(abs,r) ;
        y2 <- mk_comb(rep,y1) ;
-       y3 <- mk_comb(P,r) ;
-       eq2 <- mk_eq(y2,r) ;
-       eq3 <- mk_eq(y3,eq2) ;
+       eq2 <- safe_mk_eq y2 r ;
+       eq3 <- safe_mk_eq (Comb P r) eq2 ;
        return (Sequent [] eq1, Sequent [] eq3) od od od
 End
 

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -380,8 +380,9 @@ Definition alphavars_def:
     case env of
       [] => (tm1 = tm2)
     | (t1,t2)::oenv =>
-         ((t1 = tm1) /\ (t2 = tm2)) \/
-         ((t1 <> tm1) /\ (t2 <> tm2) /\ alphavars oenv tm1 tm2)
+      if t1 = tm1 then t2 = tm2
+      else if t2 = tm2 then F
+      else alphavars oenv tm1 tm2
 End
 
 Definition raconv_def:

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -802,6 +802,20 @@ Definition rand_def:
 End
 
 (*
+  let safe_mk_eq l r =
+    let ty = type_of l in
+    Comb(Comb(Const("=",Tyapp("fun",[ty;Tyapp("fun",[ty;bool_ty])])),l),r)
+*)
+Definition safe_mk_eq_def:
+  safe_mk_eq l r =
+  do
+    ty <- type_of l;
+    bty <- bool_ty;
+    return (Comb (Comb (Const «=» (Tyapp «fun» [ty; Tyapp «fun» [ty;bty]])) l) r)
+  od
+End
+
+(*
   let mk_eq =
     let eq = mk_const("=",[]) in
     fun (l,r) ->
@@ -869,28 +883,30 @@ End
 
 (*
   let REFL tm =
-    Sequent([],mk_eq(tm,tm))
+    Sequent([],safe_mk_eq tm tm)
 *)
 
 Definition REFL_def:
-  REFL tm = do eq <- mk_eq(tm,tm); return (Sequent [] eq) od
+  REFL tm = do eq <- safe_mk_eq tm tm; return (Sequent [] eq) od
 End
 
 (*
   let TRANS (Sequent(asl1,c1)) (Sequent(asl2,c2)) =
     match (c1,c2) with
-      Comb(Comb(Const("=",_),l),m1),Comb(Comb(Const("=",_),m2),r)
-        when aconv m1 m2 -> Sequent(term_union asl1 asl2,mk_eq(l,r))
+      Comb((Comb(Const("=",_),_) as eql),m1),Comb(Comb(Const("=",_),m2),r)
+        when alphaorder m1 m2 = 0 -> Sequent(term_union asl1 asl2,Comb(eql,r))
     | _ -> failwith "TRANS"
 *)
 
 val _ = PmatchHeuristics.with_classic_heuristic Define `
   TRANS (Sequent asl1 c1) (Sequent asl2 c2) =
     case (c1,c2) of
-      (Comb (Comb (Const «=» _) l) m1, Comb (Comb (Const «=» _) m2) r) =>
-        if aconv m1 m2 then do eq <- mk_eq(l,r);
-                               return (Sequent (term_union asl1 asl2) eq) od
-        else failwith «TRANS»
+      (Comb eql m1, Comb (Comb (Const «=» _) m2) r) =>
+        (case eql of
+           (Comb (Const «=» _) l) =>
+            if aconv m1 m2 then return (Sequent (term_union asl1 asl2) (Comb eql r))
+            else failwith «TRANS»
+         | _ => failwith «TRANS»)
     | _ => failwith «TRANS»`
 
 (* some in-kernel but derivable rules (TRANS is also in this category) *)
@@ -933,22 +949,36 @@ End
 (* -- *)
 
 (*
-  let MK_COMB (Sequent(asl1,c1),Sequent(asl2,c2)) =
+  let MK_COMB(Sequent(asl1,c1),Sequent(asl2,c2)) =
      match (c1,c2) with
-       Comb(Comb(Const("=",_),l1),r1),Comb(Comb(Const("=",_),l2),r2)
-        -> Sequent(term_union asl1 asl2,mk_eq(mk_comb(l1,l2),mk_comb(r1,r2)))
-     | _ -> failwith "MK_COMB"
+       Comb(Comb(Const("=",_),l1),r1),Comb(Comb(Const("=",_),l2),r2) ->
+        (match type_of r1 with
+           Tyapp("fun",[ty;_]) when compare ty (type_of r2) = 0
+             -> Sequent(term_union asl1 asl2,
+                        safe_mk_eq (Comb(l1,l2)) (Comb(r1,r2)))
+         | _ -> failwith "MK_COMB: types do not agree")
+     | _ -> failwith "MK_COMB: not both equations"
 *)
 
 val _ = PmatchHeuristics.with_classic_heuristic Define `
   MK_COMB (Sequent asl1 c1,Sequent asl2 c2) =
    case (c1,c2) of
      (Comb (Comb (Const «=» _) l1) r1, Comb (Comb (Const «=» _) l2) r2) =>
-       do x1 <- mk_comb(l1,l2) ;
-          x2 <- mk_comb(r1,r2) ;
-          eq <- mk_eq(x1,x2) ;
-          return (Sequent(term_union asl1 asl2) eq) od
-   | _ => failwith «MK_COMB»`
+       do r1_ty <- type_of r1;
+          (case r1_ty of
+             Tyapp «fun» [ty;_] =>
+               do
+                 r2_ty <- type_of r2;
+                 if r2_ty = ty then
+                   do
+                     eq <- safe_mk_eq (Comb l1 l2) (Comb r1 r2);
+                     return (Sequent (term_union asl1 asl2) eq)
+                   od
+                 else failwith «MK_COMB: types do not agree»
+               od
+           | _ => failwith «MK_COMB: types do not agree»)
+       od
+   | _ => failwith «MK_COMB: not both equations»`
 
 (*
   let ABS v (Sequent(asl,c)) =

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -982,23 +982,19 @@ val _ = PmatchHeuristics.with_classic_heuristic Define `
 
 (*
   let ABS v (Sequent(asl,c)) =
-    match c with
-      Comb(Comb(Const("=",_),l),r) ->
-        if exists (vfree_in v) asl
-        then failwith "ABS: variable is free in assumptions"
-        else Sequent(asl,mk_eq(mk_abs(v,l),mk_abs(v,r)))
-    | _ -> failwith "ABS: not an equation"
+    match (v,c) with
+      Var(_,_),Comb(Comb(Const("=",_),l),r) when not(exists (vfree_in v) asl)
+         -> Sequent(asl,safe_mk_eq (Abs(v,l)) (Abs(v,r)))
+    | _ -> failwith "ABS";;
 *)
 
 Definition ABS_def:
   ABS v (Sequent asl c) =
-    case c of
-      Comb (Comb (Const «=» _) l) r =>
+    case (v,c) of
+      (Var _ _, Comb (Comb (Const «=» _) l) r) =>
         if EXISTS (vfree_in v) asl
         then failwith «ABS: variable is free in assumptions»
-        else do a1 <- mk_abs(v,l) ;
-                a2 <- mk_abs(v,r) ;
-                eq <- mk_eq(a1,a2) ;
+        else do eq <- safe_mk_eq (Abs v l) (Abs v r) ;
                 return (Sequent asl eq) od
     | _ => failwith «ABS: not an equation»
 End
@@ -1006,7 +1002,8 @@ End
 (*
   let BETA tm =
     match tm with
-      Comb(Abs(v,bod),arg) when arg = v -> Sequent([],mk_eq(tm,bod))
+      Comb(Abs(v,bod),arg) when compare arg v = 0
+        -> Sequent([],safe_mk_eq tm bod)
     | _ -> failwith "BETA: not a trivial beta-redex"
 *)
 
@@ -1014,7 +1011,7 @@ Definition BETA_def:
   BETA tm =
     case tm of
       Comb (Abs v bod) arg =>
-        if arg = v then do eq <- mk_eq(tm,bod) ; return (Sequent [] eq) od
+        if arg = v then do eq <- safe_mk_eq tm bod ; return (Sequent [] eq) od
         else failwith «BETA: not a trivial beta-redex»
     | _ => failwith «BETA: not a trivial beta-redex»
 End
@@ -1053,14 +1050,14 @@ End
 (*
   let DEDUCT_ANTISYM_RULE (Sequent(asl1,c1)) (Sequent(asl2,c2)) =
     let asl1' = term_remove c2 asl1 and asl2' = term_remove c1 asl2 in
-    Sequent(term_union asl1' asl2',mk_eq(c1,c2))
+    Sequent(term_union asl1' asl2',safe_mk_eq c1 c2)
 *)
 
 Definition DEDUCT_ANTISYM_RULE_def:
   DEDUCT_ANTISYM_RULE (Sequent asl1 c1) (Sequent asl2 c2) =
     let asl1' = term_remove c2 asl1 in
     let asl2' = term_remove c1 asl2 in
-      do eq <- mk_eq(c1,c2) ;
+      do eq <- safe_mk_eq c1 c2 ;
          return (Sequent (term_union asl1' asl2') eq) od
 End
 

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -726,9 +726,12 @@ Theorem orda_RACONV[local]:
   ∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)
 Proof
   ho_match_mp_tac orda_ind >> rw[] >>
+  reverse(Cases_on`t1 ≠ t2 ∨ env ≠ []`) >- (
+    fs[RACONV_REFL] ) >>
+  qmatch_assum_abbrev_tac`p` >> fs[] >>
   qhdtm_x_assum`orda`mp_tac >>
   simp[Once orda_def] >>
-  rw [] >>
+  rw[] >- fs[markerTheory.Abbrev_def] >>
   pop_assum mp_tac >>
   BasicProvers.CASE_TAC >>
   BasicProvers.CASE_TAC >>
@@ -764,21 +767,6 @@ Proof
   fs[TotOrd] >> rw[]
 QED
 
-Theorem ordav_equal[local]:
-  ∀env t. EVERY (λ(x,y). x = y) env ⇒ ordav env t t = EQUAL
-Proof
-  Induct >> rw [Once ordav_def]
-  >> rename1 ‘h::_’
-  >> PairCases_on ‘h’
-  >> gvs [Once ordav_def]
-QED
-
-Theorem orda_equal[local]:
-  ∀t env. EVERY (λ(x,y). x = y) env ⇒ orda env t t = EQUAL
-Proof
-  Induct >> rw [Once orda_def, ordav_equal]
-QED
-
 Theorem ordav_sym:
    ∀env v1 v2. flip_ord (ordav env v1 v2) = ordav (MAP (λ(x,y). (y,x)) env) v2 v1
 Proof
@@ -791,13 +779,14 @@ Theorem orda_sym:
    ∀env t1 t2. flip_ord (orda env t1 t2) = orda (MAP (λ(x,y). (y,x)) env) t2 t1
 Proof
   ho_match_mp_tac orda_ind >>
-  rpt strip_tac >>
+  rpt gen_tac >> rpt strip_tac >>
   ONCE_REWRITE_TAC[orda_def] >>
+  IF_CASES_TAC >- rw[] >>
+  qmatch_assum_abbrev_tac`¬p` >> fs[] >>
+  IF_CASES_TAC >- fs[Abbr`p`] >>
   BasicProvers.CASE_TAC >>
-  BasicProvers.CASE_TAC >>
-  gvs [] >>
-  BasicProvers.CASE_TAC >>
-  fs[ordav_sym] >>
+  BasicProvers.CASE_TAC >> simp[ordav_sym] >>
+  rw[] >> fs[] >>
   metis_tac[invert_comparison_def,TotOrd_type_cmp,TotOrd_term_cmp,
             TotOrd,cpn_nchotomy,cpn_distinct]
 QED
@@ -811,11 +800,13 @@ Proof
 QED
 
 Theorem orda_thm[local]:
-  ∀env t1 t2. orda env t1 t2 = ^(rhs(concl(SPEC_ALL orda_def)))
+  ∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))
 Proof
   rpt gen_tac >>
   CONV_TAC(LAND_CONV(REWR_CONV orda_def)) >>
-  simp []
+  reverse IF_CASES_TAC >- rw[] >> rw[] >>
+  BasicProvers.CASE_TAC >> rw[ordav_def] >>
+  fs[GSYM RACONV_eq_orda,RACONV_REFL]
 QED
 
 Theorem ordav_lx_trans[local]:
@@ -1054,9 +1045,8 @@ Theorem hypset_ok_el_less =
 Theorem term_union_idem[simp]:
    ∀ls. term_union ls ls = ls
 Proof
-  Induct >- simp [term_union_def]
-  >> rw [Once term_union_def]
-  >> fs [orda_equal]
+  Induct >- simp[term_union_def] >>
+  simp[Once term_union_def, Once orda_def]
 QED
 
 Theorem term_union_thm:

--- a/candle/standard/syntax/holSyntaxExtraScript.sml
+++ b/candle/standard/syntax/holSyntaxExtraScript.sml
@@ -726,12 +726,9 @@ Theorem orda_RACONV[local]:
   ∀env t1 t2. orda env t1 t2 = EQUAL ⇒ RACONV env (t1,t2)
 Proof
   ho_match_mp_tac orda_ind >> rw[] >>
-  reverse(Cases_on`t1 ≠ t2 ∨ env ≠ []`) >- (
-    fs[RACONV_REFL] ) >>
-  qmatch_assum_abbrev_tac`p` >> fs[] >>
   qhdtm_x_assum`orda`mp_tac >>
   simp[Once orda_def] >>
-  rw[] >- fs[markerTheory.Abbrev_def] >>
+  rw [] >>
   pop_assum mp_tac >>
   BasicProvers.CASE_TAC >>
   BasicProvers.CASE_TAC >>
@@ -767,6 +764,21 @@ Proof
   fs[TotOrd] >> rw[]
 QED
 
+Theorem ordav_equal[local]:
+  ∀env t. EVERY (λ(x,y). x = y) env ⇒ ordav env t t = EQUAL
+Proof
+  Induct >> rw [Once ordav_def]
+  >> rename1 ‘h::_’
+  >> PairCases_on ‘h’
+  >> gvs [Once ordav_def]
+QED
+
+Theorem orda_equal[local]:
+  ∀t env. EVERY (λ(x,y). x = y) env ⇒ orda env t t = EQUAL
+Proof
+  Induct >> rw [Once orda_def, ordav_equal]
+QED
+
 Theorem ordav_sym:
    ∀env v1 v2. flip_ord (ordav env v1 v2) = ordav (MAP (λ(x,y). (y,x)) env) v2 v1
 Proof
@@ -779,14 +791,13 @@ Theorem orda_sym:
    ∀env t1 t2. flip_ord (orda env t1 t2) = orda (MAP (λ(x,y). (y,x)) env) t2 t1
 Proof
   ho_match_mp_tac orda_ind >>
-  rpt gen_tac >> rpt strip_tac >>
+  rpt strip_tac >>
   ONCE_REWRITE_TAC[orda_def] >>
-  IF_CASES_TAC >- rw[] >>
-  qmatch_assum_abbrev_tac`¬p` >> fs[] >>
-  IF_CASES_TAC >- fs[Abbr`p`] >>
   BasicProvers.CASE_TAC >>
-  BasicProvers.CASE_TAC >> simp[ordav_sym] >>
-  rw[] >> fs[] >>
+  BasicProvers.CASE_TAC >>
+  gvs [] >>
+  BasicProvers.CASE_TAC >>
+  fs[ordav_sym] >>
   metis_tac[invert_comparison_def,TotOrd_type_cmp,TotOrd_term_cmp,
             TotOrd,cpn_nchotomy,cpn_distinct]
 QED
@@ -800,13 +811,11 @@ Proof
 QED
 
 Theorem orda_thm[local]:
-  ∀env t1 t2. orda env t1 t2 = ^(#3(dest_cond(rhs(concl(SPEC_ALL orda_def)))))
+  ∀env t1 t2. orda env t1 t2 = ^(rhs(concl(SPEC_ALL orda_def)))
 Proof
   rpt gen_tac >>
   CONV_TAC(LAND_CONV(REWR_CONV orda_def)) >>
-  reverse IF_CASES_TAC >- rw[] >> rw[] >>
-  BasicProvers.CASE_TAC >> rw[ordav_def] >>
-  fs[GSYM RACONV_eq_orda,RACONV_REFL]
+  simp []
 QED
 
 Theorem ordav_lx_trans[local]:
@@ -1045,8 +1054,9 @@ Theorem hypset_ok_el_less =
 Theorem term_union_idem[simp]:
    ∀ls. term_union ls ls = ls
 Proof
-  Induct >- simp[term_union_def] >>
-  simp[Once term_union_def]
+  Induct >- simp [term_union_def]
+  >> rw [Once term_union_def]
+  >> fs [orda_equal]
 QED
 
 Theorem term_union_thm:

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -145,12 +145,10 @@ End
 Definition ordav_def:
   (ordav [] x1 x2 ⇔ term_cmp x1 x2) ∧
   (ordav ((t1,t2)::env) x1 x2 ⇔
-    if term_cmp x1 t1 = EQUAL then
-      if term_cmp x2 t2 = EQUAL then
-        EQUAL
+    if x1 = t1 then
+      if x2 = t2 then EQUAL
       else LESS
-    else if term_cmp x2 t2 = EQUAL then
-      GREATER
+    else if x2 = t2 then GREATER
     else ordav env x1 x2)
 End
 

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -142,16 +142,6 @@ Definition type_cmp_def:
   type_cmp = TO_of_LinearOrder type_lt
 End
 
-(*
-  let rec ordav env x1 x2 =
-    match env with
-      [] -> compare x1 x2
-    | (t1,t2)::oenv -> if compare x1 t1 = 0
-                       then if compare x2 t2 = 0
-                            then 0 else -1
-                       else if compare x2 t2 = 0 then 1
-                       else ordav oenv x1 x2
-*)
 Definition ordav_def:
   (ordav [] x1 x2 ⇔ term_cmp x1 x2) ∧
   (ordav ((t1,t2)::env) x1 x2 ⇔
@@ -164,41 +154,24 @@ Definition ordav_def:
     else ordav env x1 x2)
 End
 
-(*
-  let rec orda env tm1 tm2 =
-    if tm1 == tm2 && forall (fun (x,y) -> x = y) env then 0 else
-    match (tm1,tm2) with
-      Var(x1,ty1),Var(x2,ty2) -> ordav env tm1 tm2
-    | Const(x1,ty1),Const(x2,ty2) -> compare tm1 tm2
-    | Comb(s1,t1),Comb(s2,t2) ->
-          let c = orda env s1 s2 in if c <> 0 then c else orda env t1 t2
-    | Abs(Var(_,ty1) as x1,t1),Abs(Var(_,ty2) as x2,t2) ->
-          let c = compare ty1 ty2 in
-          if c <> 0 then c else orda ((x1,x2)::env) t1 t2
-    | Const(_,_),_ -> -1
-    | _,Const(_,_) -> 1
-    | Var(_,_),_ -> -1
-    | _,Var(_,_) -> 1
-    | Comb(_,_),_ -> -1
-    | _,Comb(_,_) -> 1
-*)
 Definition orda_def:
   orda env t1 t2 =
-    case (t1,t2) of
-    | (Var _ _, Var _ _) => ordav env t1 t2
-    | (Const _ _, Const _ _) => term_cmp t1 t2
-    | (Comb s1 t1, Comb s2 t2) =>
-      (let c = orda env s1 s2 in
-         if c ≠ EQUAL then c else orda env t1 t2)
-    | (Abs s1 t1, Abs s2 t2) =>
-      (let c = type_cmp (typeof s1) (typeof s2) in
-         if c ≠ EQUAL then c else orda ((s1,s2)::env) t1 t2)
-    | (Var _ _, _) => LESS
-    | (_, Var _ _) => GREATER
-    | (Const _ _, _) => LESS
-    | (_, Const _ _) => GREATER
-    | (Comb _ _, _) => LESS
-    | (_, Comb _ _) => GREATER
+    if t1 = t2 ∧ env = [] then EQUAL else
+      case (t1,t2) of
+      | (Var _ _, Var _ _) => ordav env t1 t2
+      | (Const _ _, Const _ _) => term_cmp t1 t2
+      | (Comb s1 t1, Comb s2 t2) =>
+        (let c = orda env s1 s2 in
+           if c ≠ EQUAL then c else orda env t1 t2)
+      | (Abs s1 t1, Abs s2 t2) =>
+        (let c = type_cmp (typeof s1) (typeof s2) in
+           if c ≠ EQUAL then c else orda ((s1,s2)::env) t1 t2)
+      | (Var _ _, _) => LESS
+      | (_, Var _ _) => GREATER
+      | (Const _ _, _) => LESS
+      | (_, Const _ _) => GREATER
+      | (Comb _ _, _) => LESS
+      | (_, Comb _ _) => GREATER
 End
 
 (*

--- a/candle/standard/syntax/holSyntaxScript.sml
+++ b/candle/standard/syntax/holSyntaxScript.sml
@@ -142,6 +142,16 @@ Definition type_cmp_def:
   type_cmp = TO_of_LinearOrder type_lt
 End
 
+(*
+  let rec ordav env x1 x2 =
+    match env with
+      [] -> compare x1 x2
+    | (t1,t2)::oenv -> if compare x1 t1 = 0
+                       then if compare x2 t2 = 0
+                            then 0 else -1
+                       else if compare x2 t2 = 0 then 1
+                       else ordav oenv x1 x2
+*)
 Definition ordav_def:
   (ordav [] x1 x2 ⇔ term_cmp x1 x2) ∧
   (ordav ((t1,t2)::env) x1 x2 ⇔
@@ -154,29 +164,55 @@ Definition ordav_def:
     else ordav env x1 x2)
 End
 
+(*
+  let rec orda env tm1 tm2 =
+    if tm1 == tm2 && forall (fun (x,y) -> x = y) env then 0 else
+    match (tm1,tm2) with
+      Var(x1,ty1),Var(x2,ty2) -> ordav env tm1 tm2
+    | Const(x1,ty1),Const(x2,ty2) -> compare tm1 tm2
+    | Comb(s1,t1),Comb(s2,t2) ->
+          let c = orda env s1 s2 in if c <> 0 then c else orda env t1 t2
+    | Abs(Var(_,ty1) as x1,t1),Abs(Var(_,ty2) as x2,t2) ->
+          let c = compare ty1 ty2 in
+          if c <> 0 then c else orda ((x1,x2)::env) t1 t2
+    | Const(_,_),_ -> -1
+    | _,Const(_,_) -> 1
+    | Var(_,_),_ -> -1
+    | _,Var(_,_) -> 1
+    | Comb(_,_),_ -> -1
+    | _,Comb(_,_) -> 1
+*)
 Definition orda_def:
   orda env t1 t2 =
-    if t1 = t2 ∧ env = [] then EQUAL else
-      case (t1,t2) of
-      | (Var _ _, Var _ _) => ordav env t1 t2
-      | (Const _ _, Const _ _) => term_cmp t1 t2
-      | (Comb s1 t1, Comb s2 t2) =>
-        (let c = orda env s1 s2 in
-           if c ≠ EQUAL then c else orda env t1 t2)
-      | (Abs s1 t1, Abs s2 t2) =>
-        (let c = type_cmp (typeof s1) (typeof s2) in
-           if c ≠ EQUAL then c else orda ((s1,s2)::env) t1 t2)
-      | (Var _ _, _) => LESS
-      | (_, Var _ _) => GREATER
-      | (Const _ _, _) => LESS
-      | (_, Const _ _) => GREATER
-      | (Comb _ _, _) => LESS
-      | (_, Comb _ _) => GREATER
+    case (t1,t2) of
+    | (Var _ _, Var _ _) => ordav env t1 t2
+    | (Const _ _, Const _ _) => term_cmp t1 t2
+    | (Comb s1 t1, Comb s2 t2) =>
+      (let c = orda env s1 s2 in
+         if c ≠ EQUAL then c else orda env t1 t2)
+    | (Abs s1 t1, Abs s2 t2) =>
+      (let c = type_cmp (typeof s1) (typeof s2) in
+         if c ≠ EQUAL then c else orda ((s1,s2)::env) t1 t2)
+    | (Var _ _, _) => LESS
+    | (_, Var _ _) => GREATER
+    | (Const _ _, _) => LESS
+    | (_, Const _ _) => GREATER
+    | (Comb _ _, _) => LESS
+    | (_, Comb _ _) => GREATER
 End
 
+(*
+  let rec term_union l1 l2 =
+    match (l1,l2) with
+      ([],l2) -> l2
+    | (l1,[]) -> l1
+    | (h1::t1,h2::t2) -> let c = alphaorder h1 h2 in
+                         if c = 0 then h1::(term_union t1 t2)
+                         else if c < 0 then h1::(term_union t1 l2)
+                         else h2::(term_union l1 t2)
+*)
 Definition term_union_def:
   term_union l1 l2 =
-    if l1 = l2 then l1 else
     case (l1,l2) of
     | ([],l2) => l2
     | (l1,[]) => l1

--- a/examples/opentheory/readerProofScript.sml
+++ b/examples/opentheory/readerProofScript.sml
@@ -420,8 +420,9 @@ Proof
   \\ every_case_tac \\ fs [] \\ rveq
   \\ first_x_assum drule_all \\ rw []
   \\ fs [type_ok_def]
-  \\ drule_all assoc_ALOOKUP \\ rw []
-  \\ rfs [STATE_def, CONTEXT_def]
+  \\ gvs [STATE_def, CONTEXT_def]
+  \\ imp_res_tac extends_theory_ok \\ fs[init_theory_ok]
+  \\ imp_res_tac theory_ok_sig \\ fs [is_std_sig_def]
 QED
 
 Theorem get_const_type_thm:


### PR DESCRIPTION
On `master`, Candle takes 56m49.502s to run [make_complex.ml](https://github.com/CakeML/candle/blob/master/Multivariate/make_complex.ml) (with `loadt` replaced by `loads`, and the database elements commented out).

With this PR, the same file takes 30m10.587s. The 1.88x comes from calculating 56.5/30 = 1.883.

For reference, HOL Light takes ~37m on my machine, so on `make_complex.ml` Candle is 37/30=1.23x faster.

The main speedup comes from two changes:
1. Use safe_mk_eq instead of mk_eq
2. Do not recreate "constant" types such as `bool` or `aty`

These were discovered using the recently added (unverified) perf call-graph support. The main issue is that `mk_eq` would walk an association list (alist) basically to the end to find the definition of `=`, which I think gets worse the more definitions are made.

Something similar applies to creating types, where one needs to do an alist lookup to find the appropriate type. Additionally, since `bool` and `aty` are non-trivial constructors, they would be reallocated over and over again, wasting memory and (I suspect) breaking pointer equality.

I've also tweaked some other, more minor points. For example:
- I replaced `mk_comb` with `Comb` in `new_basic_type_definition_def`, which matches HOL Light more closely
- I replaced expressions of the form `compare x y = EQUAL` with `x = y` to avoid unnecessarily computing a (ternary) order when we only care about equality 
- I've also made minor adjustments to `alphavars` and `term_union`, which don't make to seem much difference in terms of performance, but brings Candle a tiny bit closer to HOL Light.

Future work:
- Go through the Candle and HOL Light kernel carefully and check whether there are any more performance relevant differences (for example more places where `mk_comb` could be replaced by `Comb`)
- Pointer equality: on a branch where we hacked in pointer equality (both into the kernel and into the source files), according to my notes, make_complex.ml ran in ~26m 12s (3 measurements), which roughly corresponds to a potential 1.15x speed up to be gained.
  - I think most of this time comes from savings in `alphavars`. 
- In `vsubst_aux`, a fast path is commented out with the reasoning that "it doesn't seem to fit Harrison's formalisation". Looking at the perf data for the fastest Candle version (with pointer equality, unverified), it seems that a few percent points are actually spent in INST, which appears to call `vsubst` multiple times. According to an LLM, the argument is basically that if you know that the for `s' = vsubst_aux ilist' s`, s' and s are equal, then by virtue of `ilist' = FILTER (\(t,x). x <> v) ilist` the condition in the branch (`EXISTS (\(t,x). vfree_in v t /\ vfree_in x s) ilist'`) does not hold, and we fall through to `Abs v s'`. However, since `s' = s`, this is the same as the original term `Abs v s`. As mentioned, I believe the perf data supports that this optimization is relevant.