### PR TITLE
Factor the per-directory README.md rule into developers/readme.mk.

### DIFF
--- a/Holmakefile
+++ b/Holmakefile
@@ -4,6 +4,4 @@ all: $(DEFAULT_TARGETS) README.md examples/compilation/x64/proofs/helloProofTheo
 .PHONY: all
 
 README_SOURCES = LICENSE developers examples build-instructions.sh how-to.md
-DIRS = $(wildcard */)
-README.md: developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/basis/Holmakefile
+++ b/basis/Holmakefile
@@ -7,9 +7,7 @@ all: $(DEFAULT_TARGETS) README.md basis_ffi.o
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml) $(wildcard *.c) dependency-order
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/basis/pure/Holmakefile
+++ b/basis/pure/Holmakefile
@@ -4,10 +4,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(HOLDIR)/examples/formal-languages/regular \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/candle/Holmakefile
+++ b/candle/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/Holmakefile
+++ b/candle/overloading/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/ml_checker/Holmakefile
+++ b/candle/overloading/ml_checker/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/ml_kernel/Holmakefile
+++ b/candle/overloading/ml_kernel/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/monadic/Holmakefile
+++ b/candle/overloading/monadic/Holmakefile
@@ -4,7 +4,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator/monadic\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/semantics/Holmakefile
+++ b/candle/overloading/semantics/Holmakefile
@@ -4,7 +4,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/overloading/syntax/Holmakefile
+++ b/candle/overloading/syntax/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc ../../syntax-lib
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/prover/Holmakefile
+++ b/candle/prover/Holmakefile
@@ -16,6 +16,4 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/prover/compute/Holmakefile
+++ b/candle/prover/compute/Holmakefile
@@ -15,6 +15,4 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/set-theory/Holmakefile
+++ b/candle/set-theory/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/Holmakefile
+++ b/candle/standard/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/ml_kernel/Holmakefile
+++ b/candle/standard/ml_kernel/Holmakefile
@@ -7,11 +7,7 @@ INCLUDES = $(CAKEMLDIR)/misc\
 	   $(CAKEMLDIR)/characteristic\
 	   ../monadic
 
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/monadic/Holmakefile
+++ b/candle/standard/monadic/Holmakefile
@@ -4,7 +4,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator/monadic\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/semantics/Holmakefile
+++ b/candle/standard/semantics/Holmakefile
@@ -4,7 +4,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/syntax/Holmakefile
+++ b/candle/standard/syntax/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc ../../syntax-lib
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/candle/standard/syntax/little_theories/Holmakefile
+++ b/candle/standard/syntax/little_theories/Holmakefile
@@ -4,9 +4,6 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../syntax-lib
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/candle/syntax-lib/Holmakefile
+++ b/candle/syntax-lib/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/characteristic/Holmakefile
+++ b/characteristic/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/hoare-triple\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/characteristic/examples/Holmakefile
+++ b/characteristic/examples/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/regular\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/Holmakefile
+++ b/compiler/Holmakefile
@@ -11,7 +11,6 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_DIRS = $(patsubst bootstrap/,,$(patsubst encoders/,,$(wildcard */)))
 sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY

--- a/compiler/Holmakefile
+++ b/compiler/Holmakefile
@@ -11,10 +11,8 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(patsubst bootstrap/,,$(patsubst encoders/,,$(wildcard */)))
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+README_DIRS = $(patsubst bootstrap/,,$(patsubst encoders/,,$(wildcard */)))
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/compiler/backend/Holmakefile
+++ b/compiler/backend/Holmakefile
@@ -7,10 +7,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/backend/San/Holmakefile
+++ b/compiler/backend/San/Holmakefile
@@ -5,7 +5,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proof
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/ag32/Holmakefile
+++ b/compiler/backend/ag32/Holmakefile
@@ -4,7 +4,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/basis\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/ag32/proofs/Holmakefile
+++ b/compiler/backend/ag32/proofs/Holmakefile
@@ -9,7 +9,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/arm7/Holmakefile
+++ b/compiler/backend/arm7/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure .. ../../encoders/arm7
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/arm7/proofs/Holmakefile
+++ b/compiler/backend/arm7/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../encoders/arm7/proofs ../../semantics ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/arm8/Holmakefile
+++ b/compiler/backend/arm8/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure .. ../../encoders/arm8
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/arm8/proofs/Holmakefile
+++ b/compiler/backend/arm8/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../encoders/arm8/proofs ../../semantics ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/arm8_asl/Holmakefile
+++ b/compiler/backend/arm8_asl/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../arm8/proofs ../../encoders/arm8_asl/proofs ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 

--- a/compiler/backend/cv_compute/Holmakefile
+++ b/compiler/backend/cv_compute/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = .. ../serialiser ../../encoders/x64 ../../encoders/ag32 ../../encoder
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/gc/Holmakefile
+++ b/compiler/backend/gc/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/mips/Holmakefile
+++ b/compiler/backend/mips/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure .. ../../encoders/mips
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/mips/proofs/Holmakefile
+++ b/compiler/backend/mips/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../encoders/mips/proofs ../../semantics ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/pattern_matching/Holmakefile
+++ b/compiler/backend/pattern_matching/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/proofs/Holmakefile
+++ b/compiler/backend/proofs/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/backend/reg_alloc/Holmakefile
+++ b/compiler/backend/reg_alloc/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/unverified/reg_alloc $(CAKEMLDIR)/tran
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/reg_alloc/proofs/Holmakefile
+++ b/compiler/backend/reg_alloc/proofs/Holmakefile
@@ -2,7 +2,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator/monadic ..
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/riscv/Holmakefile
+++ b/compiler/backend/riscv/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure .. ../../encoders/riscv
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/riscv/proofs/Holmakefile
+++ b/compiler/backend/riscv/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../encoders/riscv/proofs ../../semantics .
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/semantics/Holmakefile
+++ b/compiler/backend/semantics/Holmakefile
@@ -6,10 +6,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proof
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/backend/serialiser/Holmakefile
+++ b/compiler/backend/serialiser/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../translator ../../encoders/asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/x64/Holmakefile
+++ b/compiler/backend/x64/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure .. ../../encoders/x64
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/backend/x64/proofs/Holmakefile
+++ b/compiler/backend/x64/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../../../encoders/x64/proofs ../../semantics ../
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/benchmarks/Holmakefile
+++ b/compiler/benchmarks/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = cakeml_benchmarks/cakeml mlton_benchmarks/cakeml
 all: $(DEFAULT_TARGETS) README.md cakeml_report.html mlton_report.html
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(dprot $(CAKEMLDIR)/developers/readme_gen) readmePrefix $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 CAKEML_PLOTS = cakeml_plot1noerr.svg cakeml_plot2noerr.svg cakeml_plot3noerr.svg cakeml_all.dat
 MLTON_PLOTS = mlton_plot1noerr.svg mlton_plot2noerr.svg mlton_plot3noerr.svg mlton_all.dat

--- a/compiler/benchmarks/cakeml_benchmarks/cakeml/Holmakefile
+++ b/compiler/benchmarks/cakeml_benchmarks/cakeml/Holmakefile
@@ -4,9 +4,7 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml) $(wildcard *.cml)
-DIRS = $(wildcard */)
-README.md: $(dprot $(CAKEMLDIR)/developers/readme_gen) readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: $(dprot $(CAKEMLDIR)/unverified/sexpr-bootstrap/x64/64/cake.S)
 	$(CP) $< $@

--- a/compiler/benchmarks/mlton_benchmarks/cakeml/Holmakefile
+++ b/compiler/benchmarks/mlton_benchmarks/cakeml/Holmakefile
@@ -4,9 +4,7 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml) $(wildcard *.cml)
-DIRS = $(wildcard */)
-README.md: $(dprot $(CAKEMLDIR)/developers/readme_gen) readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: $(dprot $(CAKEMLDIR)/unverified/sexpr-bootstrap/x64/64/cake.S)
 	$(CP) $< $@

--- a/compiler/bootstrap/compilation/ag32/32/Holmakefile
+++ b/compiler/bootstrap/compilation/ag32/32/Holmakefile
@@ -7,10 +7,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis $(CAKEMLDIR)/cv_translator 
 all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: *$(ARCH)BootstrapScript.sml
 

--- a/compiler/bootstrap/compilation/ag32/32/proofs/Holmakefile
+++ b/compiler/bootstrap/compilation/ag32/32/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/bootstrap/compilation/arm8/64/Holmakefile
+++ b/compiler/bootstrap/compilation/arm8/64/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../..\
 all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: *$(ARCH)BootstrapScript.sml
 

--- a/compiler/bootstrap/compilation/arm8/64/proofs/Holmakefile
+++ b/compiler/bootstrap/compilation/arm8/64/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/bootstrap/compilation/x64/32/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/32/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../..\
 all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: *$(ARCH)BootstrapScript.sml
 

--- a/compiler/bootstrap/compilation/x64/32/proofs/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/32/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/bootstrap/compilation/x64/64/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/64/Holmakefile
@@ -8,10 +8,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis ../../../.. $(CAKEMLDIR)/un
 all: $(DEFAULT_TARGETS) README.md cake-$(ARCH)-$(WORD_SIZE).tar.gz test-hello-cake test-candle-records
 .PHONY: all test-hello-cake test-candle-records
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake.S: *$(ARCH)BootstrapScript.sml
 config_enc_str.txt: *$(ARCH)BootstrapScript.sml

--- a/compiler/bootstrap/compilation/x64/64/proofs/Holmakefile
+++ b/compiler/bootstrap/compilation/x64/64/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs $(CAKEMLDIR)/candle/p
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/bootstrap/translation/Holmakefile
+++ b/compiler/bootstrap/translation/Holmakefile
@@ -16,7 +16,4 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/dafny/Holmakefile
+++ b/compiler/dafny/Holmakefile
@@ -3,8 +3,6 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/compiler/parsi
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-# Filter out examples/ (they don't have a readmePrefix)
-README_DIRS = $(patsubst examples/,,$(wildcard */))
 sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY

--- a/compiler/dafny/Holmakefile
+++ b/compiler/dafny/Holmakefile
@@ -3,11 +3,9 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/compiler/parsi
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
 # Filter out examples/ (they don't have a readmePrefix)
-DIRS = $(patsubst examples/,,$(wildcard */))
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+README_DIRS = $(patsubst examples/,,$(wildcard */))
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/dafny/compilation/Holmakefile
+++ b/compiler/dafny/compilation/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/compiler/dafny/translation $(CAKEMLDIR
 all: $(DEFAULT_TARGETS) README.md dafny_compiler
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/compiler/dafny/proofs/Holmakefile
+++ b/compiler/dafny/proofs/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proof
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/dafny/semantics/Holmakefile
+++ b/compiler/dafny/semantics/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/compiler/dafny
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/dafny/translation/Holmakefile
+++ b/compiler/dafny/translation/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/dafny $(CAKEMLDIR)/translator $(CAKEMLDIR)/basi
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/dafny/vcg/Holmakefile
+++ b/compiler/dafny/vcg/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/dafny $(CAKEMLDIR)/compiler/dafny/semantics $(H
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/dafny/vcg/examples/Holmakefile
+++ b/compiler/dafny/vcg/examples/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/dafny/vcg $(CAKEMLDIR)/compiler/dafny/proofs $(
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/encoders/ag32/Holmakefile
+++ b/compiler/encoders/ag32/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common ../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/ag32/proofs/Holmakefile
+++ b/compiler/encoders/ag32/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = .. ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/arm7/Holmakefile
+++ b/compiler/encoders/arm7/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/arm7/proofs/Holmakefile
+++ b/compiler/encoders/arm7/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/arm/prog .. ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/arm8/Holmakefile
+++ b/compiler/encoders/arm8/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/arm8/proofs/Holmakefile
+++ b/compiler/encoders/arm8/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/arm8/prog .. ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/arm8_asl/Holmakefile
+++ b/compiler/encoders/arm8_asl/Holmakefile
@@ -4,10 +4,7 @@ INCLUDES = ../asm ../arm8\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 

--- a/compiler/encoders/arm8_asl/proofs/Holmakefile
+++ b/compiler/encoders/arm8_asl/proofs/Holmakefile
@@ -4,10 +4,7 @@ INCLUDES = .. ../../asm ../../arm8/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 

--- a/compiler/encoders/asm/Holmakefile
+++ b/compiler/encoders/asm/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common $(CAKEMLDIR)/misc $(CAKEMLD
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/mips/Holmakefile
+++ b/compiler/encoders/mips/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/mips/proofs/Holmakefile
+++ b/compiler/encoders/mips/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/mips/prog .. ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/monadic_enc/Holmakefile
+++ b/compiler/encoders/monadic_enc/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = ../../backend $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator/monadic/monad
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/riscv/Holmakefile
+++ b/compiler/encoders/riscv/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/riscv/proofs/Holmakefile
+++ b/compiler/encoders/riscv/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/riscv/prog ../ ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/tests/Holmakefile
+++ b/compiler/encoders/tests/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES = .. ../arm8 ../x64 ../mips ../riscv \
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/x64/Holmakefile
+++ b/compiler/encoders/x64/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/common\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/encoders/x64/proofs/Holmakefile
+++ b/compiler/encoders/x64/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(HOLDIR)/examples/l3-machine-code/x64/prog ../ ../../asm
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/inference/Holmakefile
+++ b/compiler/inference/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES = $(HOLUNIFDIR) $(HOLUNIFDIR)/compilation \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/inference/proofs/Holmakefile
+++ b/compiler/inference/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proof
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/inference/tests/Holmakefile
+++ b/compiler/inference/tests/Holmakefile
@@ -2,7 +2,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis ..
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/parsing/Holmakefile
+++ b/compiler/parsing/Holmakefile
@@ -5,7 +5,4 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/parsing/ocaml/Holmakefile
+++ b/compiler/parsing/ocaml/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/parsing/proofs/Holmakefile
+++ b/compiler/parsing/proofs/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/semantics/proofs ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/parsing/tests/Holmakefile
+++ b/compiler/parsing/tests/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/semantics ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/printing/Holmakefile
+++ b/compiler/printing/Holmakefile
@@ -5,7 +5,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/printing/test/Holmakefile
+++ b/compiler/printing/test/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis .. $(CAKEMLDIR)/compiler/inferen
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/proofs/Holmakefile
+++ b/compiler/proofs/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/repl/Holmakefile
+++ b/compiler/repl/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/candle/prover $(CAKEMLDIR)/basis $(CAKEMLDIR)/translator
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/compiler/scheme/compilation/Holmakefile
+++ b/compiler/scheme/compilation/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/scheme/translation $(CAKEMLDIR)/compiler $(CAKE
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/compiler/scheme/proofs/Holmakefile
+++ b/compiler/scheme/proofs/Holmakefile
@@ -12,11 +12,9 @@ INCLUDES = $(CAKEMLDIR)/translator \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
 # Filter out tests/ (they don't have a readmePrefix)
-DIRS = $(patsubst tests/,,$(wildcard */))
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+README_DIRS = $(patsubst tests/,,$(wildcard */))
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/compiler/scheme/proofs/Holmakefile
+++ b/compiler/scheme/proofs/Holmakefile
@@ -12,8 +12,6 @@ INCLUDES = $(CAKEMLDIR)/translator \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-# Filter out tests/ (they don't have a readmePrefix)
-README_DIRS = $(patsubst tests/,,$(wildcard */))
 sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY

--- a/compiler/scheme/translation/Holmakefile
+++ b/compiler/scheme/translation/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/scheme $(CAKEMLDIR)/translator # $(CAKEMLDIR)/b
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/cv_translator/Holmakefile
+++ b/cv_translator/Holmakefile
@@ -10,10 +10,8 @@ INCLUDES = $(HOLDIR)/examples/bootstrap \
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(patsubst bootstrap/,,$(patsubst encoders/,,$(wildcard */)))
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+README_DIRS = $(patsubst bootstrap/,,$(patsubst encoders/,,$(wildcard */)))
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 EXTRA_CLEANS = cake_compile_heap
 

--- a/developers/bin/Holmakefile
+++ b/developers/bin/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ARCH=x64
 WORD_SIZE=64

--- a/developers/readme.mk
+++ b/developers/readme.mk
@@ -1,0 +1,30 @@
+# Common README.md rule for cakeml-tree Holmakefiles.
+#
+# Each leaf Holmakefile sinclude's this snippet to get a `README.md`
+# target wired up the same way everywhere.  The default file list
+# covers the usual *Script.sml / *Lib.sml / *Syntax.sml triad; a
+# Holmakefile that needs more (or fewer) sources sets README_SOURCES
+# *before* the sinclude line.
+#
+# Usage:
+#   sinclude $(CAKEMLDIR)/developers/readme.mk
+#
+# Or, with extras:
+#   README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) \
+#                    $(wildcard *Syntax.sml) $(wildcard *.lem)
+#   sinclude $(CAKEMLDIR)/developers/readme.mk
+
+ifndef README_SOURCES
+README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
+endif
+
+ifndef README_DIRS
+README_DIRS = $(wildcard */)
+endif
+
+all: README.md
+.PHONY: all
+
+README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix \
+           $(patsubst %,%readmePrefix,$(README_DIRS)) $(README_SOURCES)
+	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)

--- a/developers/readme.mk
+++ b/developers/readme.mk
@@ -18,13 +18,9 @@ ifndef README_SOURCES
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
 endif
 
-ifndef README_DIRS
-README_DIRS = $(wildcard */)
-endif
-
 all: README.md
 .PHONY: all
 
 README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix \
-           $(patsubst %,%readmePrefix,$(README_DIRS)) $(README_SOURCES)
+           $(wildcard */readmePrefix) $(README_SOURCES)
 	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)

--- a/developers/readme_gen.sml
+++ b/developers/readme_gen.sml
@@ -500,21 +500,6 @@ fun assert_for_lines_of filename pred err_msg =
   orelse err (err_msg filename);
 
 fun run_full_check path = let
-  fun remove_prefix prefix s =
-    if String.isPrefix prefix s then
-      String.substring(s,String.size prefix,String.size s - String.size prefix)
-    else s
-  fun show_path p =
-    if p = path then "." else remove_prefix (path ^ "/") p
-  fun common_prefix s t = let
-    fun common (x::xs) (y::ys) = if x = y then x::(common xs ys) else []
-      | common _ _ = []
-    in implode (common (explode s) (explode t)) end
-  fun inject_readme_target p [] = ["\n",HOLMAKEFILE_SUGGESTION]
-    | inject_readme_target p (l::ls) =
-        if String.isPrefix "ifdef" l orelse String.isPrefix "ifndef" l then
-          [HOLMAKEFILE_SUGGESTION,"\n"] @ l::ls
-        else l :: inject_readme_target p ls
 (*
   val p = path
   val SOME lines = read_all_lines (p ^ "/Holmakefile")

--- a/developers/readme_gen.sml
+++ b/developers/readme_gen.sml
@@ -25,6 +25,7 @@ val MAX_LINE_COUNT = 10
 val MAX_CODE_LINE_LENGTH = 200
 val PREFIX_FILENAME = "readmePrefix"
 val OUTPUT_FILENAME = "README.md"
+val OUTPUT_MK = "developers/readme.mk"
 val CHECK_OPT = "--check"
 val AUTO_INCLUDE_SUFFIXES = ["Script.sml","Syntax.sml","Lib.sml",".lem",".c",".cml"]
 val FIRST_TARGET_PREFIX = "all: $(DEFAULT_TARGETS) README.md"
@@ -36,10 +37,7 @@ concat ["INCLUDES =\n\n",
         PHONY_SUGGESTION ^ "\n\n",
         "README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) ",
         "$(wildcard *Syntax.sml)\n",
-        "DIRS = $(wildcard */)\n",
-        "README.md: $(CAKEMLDIR)/developers/readme_gen",
-        " readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)\n",
-        "\t$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)\n"]
+        "sinclude $(CAKEMLDIR)/developers/readme.mk\n"]
 
 val ILLEGAL_STRINGS =
   [("store_thm(\"", "The Theorem syntax is to be used instead of store_thm."),
@@ -398,7 +396,10 @@ fun check_Holmakefile filename =
   case read_all_lines filename of
     NONE => err ("Unable to read: " ^ filename)
   | SOME lines => let
-      val _ = List.exists (fn s => String.isPrefix (OUTPUT_FILENAME ^ ":") s) lines
+      fun check_line s =
+          String.isPrefix (OUTPUT_FILENAME ^ ":") s orelse
+          String.isSubstring OUTPUT_MK s
+      val _ = List.exists check_line lines
               orelse (err (concat
                 ["ERROR! Every Holmakefile must include a ", OUTPUT_FILENAME,
                  " target. Consider adding:\n\n",HOLMAKEFILE_SUGGESTION,

--- a/examples/Holmakefile
+++ b/examples/Holmakefile
@@ -7,10 +7,7 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/regular $(HOLDIR)/examples/bootst
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/cnf/Holmakefile
+++ b/examples/cnf/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/cnf/array/Holmakefile
+++ b/examples/cnf/array/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorith
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/cnf/dist/Holmakefile
+++ b/examples/cnf/dist/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/cnf/dist/array/Holmakefile
+++ b/examples/cnf/dist/array/Holmakefile
@@ -6,10 +6,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/cnf/dist/array/compilation/Holmakefile
+++ b/examples/cnf/dist/array/compilation/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/cnf/dist/array/compilation/proofs/Holmakefile
+++ b/examples/cnf/dist/array/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/compilation/Holmakefile
+++ b/examples/compilation/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/compilation/ag32/Holmakefile
+++ b/examples/compilation/ag32/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS = -j1
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/compilation/ag32/proofs/Holmakefile
+++ b/examples/compilation/ag32/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/compilation/x64/Holmakefile
+++ b/examples/compilation/x64/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS = -j1
 all: $(DEFAULT_TARGETS) README.md exec
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/compilation/x64/proofs/Holmakefile
+++ b/examples/compilation/x64/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/deflate/Holmakefile
+++ b/examples/deflate/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/deflate/translation/Holmakefile
+++ b/examples/deflate/translation/Holmakefile
@@ -1,13 +1,9 @@
 INCLUDES = $(CAKEMLDIR)/examples/deflate  $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator \
             $(CAKEMLDIR)/examples $(HOLDIR)/examples/bootstrap
 
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/deflate/translation/compilation/Holmakefile
+++ b/examples/deflate/translation/compilation/Holmakefile
@@ -10,10 +10,7 @@ all: $(DEFAULT_TARGETS) README.md
 
 compile: compression decompression deflateEncode deflateDecode
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/flover/Holmakefile
+++ b/examples/flover/Holmakefile
@@ -3,7 +3,4 @@ OPTIONS = QUIT_ON_FAILURE
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/flover/Infra/Holmakefile
+++ b/examples/flover/Infra/Holmakefile
@@ -2,7 +2,4 @@ OPTIONS = QUIT_ON_FAILURE
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/flover/semantics/Holmakefile
+++ b/examples/flover/semantics/Holmakefile
@@ -3,7 +3,4 @@ OPTIONS = QUIT_ON_FAILURE
 
 all: $(DEFAULT_TARGETS) README.md
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/lpr_checker/Holmakefile
+++ b/examples/lpr_checker/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/lpr_checker/array/Holmakefile
+++ b/examples/lpr_checker/array/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorith
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/lpr_checker/array/compilation/Holmakefile
+++ b/examples/lpr_checker/array/compilation/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/lpr_checker/array/compilation/proofs/Holmakefile
+++ b/examples/lpr_checker/array/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/lpr_checker/array/compilation/proofsARM8/Holmakefile
+++ b/examples/lpr_checker/array/compilation/proofsARM8/Holmakefile
@@ -9,10 +9,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 

--- a/examples/opentheory/Holmakefile
+++ b/examples/opentheory/Holmakefile
@@ -10,10 +10,7 @@ INCLUDES = $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/opentheory/compilation/Holmakefile
+++ b/examples/opentheory/compilation/Holmakefile
@@ -6,10 +6,7 @@ all: $(DEFAULT_TARGETS) README.md
 CFLAGS+=-O2
 LDLIBS+=-lm
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/opentheory/compilation/ag32/Holmakefile
+++ b/examples/opentheory/compilation/ag32/Holmakefile
@@ -4,10 +4,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis $(CAKEMLDIR)/cv_translator $(CAK
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/opentheory/compilation/ag32/proofs/Holmakefile
+++ b/examples/opentheory/compilation/ag32/proofs/Holmakefile
@@ -9,7 +9,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/opentheory/compilation/proofs/Holmakefile
+++ b/examples/opentheory/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/pseudo_bool/Holmakefile
+++ b/examples/pseudo_bool/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/pseudo_bool/array/Holmakefile
+++ b/examples/pseudo_bool/array/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorith
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/pseudo_bool/array/compilation/Holmakefile
+++ b/examples/pseudo_bool/array/compilation/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS = -j4
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/pseudo_bool/array/compilation/proofs/Holmakefile
+++ b/examples/pseudo_bool/array/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/pseudo_bool/array/compilation/proofsARM8/Holmakefile
+++ b/examples/pseudo_bool/array/compilation/proofsARM8/Holmakefile
@@ -9,10 +9,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 

--- a/examples/pseudo_bool/cnf_encoding/Holmakefile
+++ b/examples/pseudo_bool/cnf_encoding/Holmakefile
@@ -6,7 +6,4 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/pseudo_bool/graph_encoding/Holmakefile
+++ b/examples/pseudo_bool/graph_encoding/Holmakefile
@@ -5,7 +5,4 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/sat_encodings/Holmakefile
+++ b/examples/sat_encodings/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/sat_encodings/case_studies/Holmakefile
+++ b/examples/sat_encodings/case_studies/Holmakefile
@@ -2,7 +2,4 @@ INCLUDES = $(CAKEMLDIR)/examples/sat_encodings
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/sat_encodings/demo/Holmakefile
+++ b/examples/sat_encodings/demo/Holmakefile
@@ -1,9 +1,6 @@
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 nqueens_demo.txt:
 	echo "aaa" | ./solve_nqueen.sh 8 > $@

--- a/examples/sat_encodings/translation/Holmakefile
+++ b/examples/sat_encodings/translation/Holmakefile
@@ -1,13 +1,9 @@
 INCLUDES = $(CAKEMLDIR)/examples/sat_encodings $(CAKEMLDIR)/examples/sat_encodings/case_studies $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator \
             $(CAKEMLDIR)/examples $(HOLDIR)/examples/bootstrap
 
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/sat_encodings/translation/compilation/Holmakefile
+++ b/examples/sat_encodings/translation/compilation/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/examples/sat_encodings $(CAKEMLDIR)/examples/sat_encodin
 
 all: $(DEFAULT_TARGETS) README.md graphColoring_encoder killerSudoku_encoder nQueens_encoder numBoolRange_encoder sudoku_encoder
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/scpog_checker/Holmakefile
+++ b/examples/scpog_checker/Holmakefile
@@ -6,10 +6,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/scpog_checker/array/Holmakefile
+++ b/examples/scpog_checker/array/Holmakefile
@@ -6,10 +6,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorith
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/scpog_checker/array/compilation/Holmakefile
+++ b/examples/scpog_checker/array/compilation/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/scpog_checker/array/compilation/proofs/Holmakefile
+++ b/examples/scpog_checker/array/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/examples/template/Holmakefile
+++ b/examples/template/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/template/compilation/Holmakefile
+++ b/examples/template/compilation/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = ../translation $(CAKEMLDIR)/cv_translator
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/template/translation/Holmakefile
+++ b/examples/template/translation/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = .. $(CAKEMLDIR)/misc $(CAKEMLDIR)/translator
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/vipr/Holmakefile
+++ b/examples/vipr/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/vipr/compilation/Holmakefile
+++ b/examples/vipr/compilation/Holmakefile
@@ -2,10 +2,7 @@ INCLUDES = $(CAKEMLDIR)/examples/vipr $(CAKEMLDIR)/compiler $(CAKEMLDIR)/cv_tran
 
 all: $(DEFAULT_TARGETS) README.md cake_vipr
 .PHONY: all
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/xlrup_checker/Holmakefile
+++ b/examples/xlrup_checker/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/examples/xlrup_checker/array/Holmakefile
+++ b/examples/xlrup_checker/array/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorith
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/basis/basis-heap

--- a/examples/xlrup_checker/array/compilation/Holmakefile
+++ b/examples/xlrup_checker/array/compilation/Holmakefile
@@ -4,10 +4,7 @@ CLINE_OPTIONS =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/cv_translator/cake_compile_heap

--- a/examples/xlrup_checker/array/compilation/proofs/Holmakefile
+++ b/examples/xlrup_checker/array/compilation/proofs/Holmakefile
@@ -7,7 +7,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/misc/Holmakefile
+++ b/misc/Holmakefile
@@ -5,9 +5,7 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = preamble.sml $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 EXTRA_CLEANS = cakeml-heap
 

--- a/pancake/Holmakefile
+++ b/pancake/Holmakefile
@@ -4,14 +4,11 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 					 $(CAKEMLDIR)/compiler/backend/\
 					 $(CAKEMLDIR)/compiler/encoders/asm
 
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml) NEWS.md
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/pancake/parser/Holmakefile
+++ b/pancake/parser/Holmakefile
@@ -10,10 +10,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/pancake/proofs/Holmakefile
+++ b/pancake/proofs/Holmakefile
@@ -10,10 +10,7 @@ INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/pancake/semantics/Holmakefile
+++ b/pancake/semantics/Holmakefile
@@ -9,10 +9,7 @@ INCLUDES = $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/pancake/static_checker/Holmakefile
+++ b/pancake/static_checker/Holmakefile
@@ -3,11 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc\
 			$(CAKEMLDIR)/pancake/parser\
 			$(CAKEMLDIR)/compiler/
 
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/profiler/Holmakefile
+++ b/profiler/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/characteristic
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/semantics/Holmakefile
+++ b/semantics/Holmakefile
@@ -8,9 +8,7 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = grammar.txt astPP.sml $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/semantics/alt_semantics/Holmakefile
+++ b/semantics/alt_semantics/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = .. ../../misc ../ffi
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/semantics/alt_semantics/proofs/Holmakefile
+++ b/semantics/alt_semantics/proofs/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc .. ../..  ../../proofs ../../ffi
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/semantics/ffi/Holmakefile
+++ b/semantics/ffi/Holmakefile
@@ -4,6 +4,4 @@ all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
 README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml) $(wildcard *.lem)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/semantics/proofs/Holmakefile
+++ b/semantics/proofs/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(CAKEMLDIR)/developers/readme_gen $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/translator/Holmakefile
+++ b/translator/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = ../developers ../misc ../semantics ../semantics/proofs ../basis/pure
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: ../developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect ../developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/translator/monadic/Holmakefile
+++ b/translator/monadic/Holmakefile
@@ -6,10 +6,7 @@ INCLUDES = $(CAKEMLDIR)/misc\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/translator/monadic/examples/Holmakefile
+++ b/translator/monadic/examples/Holmakefile
@@ -5,10 +5,7 @@ INCLUDES = $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/translator/monadic/monad_base/Holmakefile
+++ b/translator/monadic/monad_base/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/translator/okasaki-examples/Holmakefile
+++ b/translator/okasaki-examples/Holmakefile
@@ -3,10 +3,7 @@ INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis ..
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 ifdef POLY
 HOLHEAP = $(CAKEMLDIR)/misc/cakeml-heap

--- a/translator/other-examples/Holmakefile
+++ b/translator/other-examples/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES= $(HOLDIR)/examples/Crypto/AES\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/translator/other-examples/auxiliary/Holmakefile
+++ b/translator/other-examples/auxiliary/Holmakefile
@@ -3,7 +3,4 @@ INCLUDES =
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/tutorial/Holmakefile
+++ b/tutorial/Holmakefile
@@ -8,7 +8,4 @@ INCLUDES = $(HOLDIR)/examples/data-structures/balanced_bst\
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk

--- a/tutorial/solutions/Holmakefile
+++ b/tutorial/solutions/Holmakefile
@@ -9,10 +9,7 @@ INCLUDES = $(HOLDIR)/examples/data-structures/balanced_bst\
 all: $(DEFAULT_TARGETS) README.md exercises
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 SOLUTIONS = wordfreqProgScript.sml simple_bstScript.sml
 

--- a/unverified/sexpr-bootstrap/x64/32/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/32/Holmakefile
@@ -7,10 +7,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/bootstrap/translation \
 all: $(DEFAULT_TARGETS) README.md cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake-sexpr-$(ARCH)-$(WORD_SIZE): *$(ARCH)SexprScript.sml
 

--- a/unverified/sexpr-bootstrap/x64/64/Holmakefile
+++ b/unverified/sexpr-bootstrap/x64/64/Holmakefile
@@ -7,10 +7,7 @@ INCLUDES = $(CAKEMLDIR)/compiler/bootstrap/translation \
 all: $(DEFAULT_TARGETS) README.md cake-unverified-$(ARCH)-$(WORD_SIZE).tar.gz
 .PHONY: all
 
-README_SOURCES = $(wildcard *Script.sml) $(wildcard *Lib.sml) $(wildcard *Syntax.sml)
-DIRS = $(wildcard */)
-README.md: $(CAKEMLDIR)/developers/readme_gen readmePrefix $(patsubst %,%readmePrefix,$(DIRS)) $(README_SOURCES)
-	$(protect $(CAKEMLDIR)/developers/readme_gen) $(README_SOURCES)
+sinclude $(CAKEMLDIR)/developers/readme.mk
 
 cake-sexpr-$(ARCH)-$(WORD_SIZE): *$(ARCH)SexprScript.sml
 


### PR DESCRIPTION
Each Holmakefile `sinclude`’s the snippet that defines how to do the creation of the `README` in each directory.  Override README_SOURCES or README_DIRS before the sinclude when the directory has extra source files or wants to filter subdirectories.  Directories `developers/`, `unverified/`, and `compiler/scheme/` keep their existing, special-case rules in their Holmakefiles.

This way we don't have to repeat ourselves with the recipe, though we do still have to know to include the snippet in `developers/`