### PR TITLE
Holprojs

### DIFF
--- a/Holmakefile
+++ b/Holmakefile
@@ -1,4 +1,4 @@
-INCLUDES = developers examples/compilation/x64/proofs
+INCLUDES = developers
 
 all: $(DEFAULT_TARGETS) README.md examples/compilation/x64/proofs/helloProofTheory.sig
 .PHONY: all

--- a/basis/Holmakefile
+++ b/basis/Holmakefile
@@ -1,8 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
-					 $(CAKEMLDIR)/semantics $(CAKEMLDIR)/characteristic\
-					 $(CAKEMLDIR)/translator $(CAKEMLDIR)/translator/monadic\
-					 $(CAKEMLDIR)/compiler/printing  pure
-
 all: $(DEFAULT_TARGETS) README.md basis_ffi.o
 .PHONY: all
 

--- a/basis/pure/Holmakefile
+++ b/basis/pure/Holmakefile
@@ -1,6 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(HOLDIR)/examples/formal-languages/regular \
-    $(HOLDIR)/examples/data-structures/balanced_bst
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/candle/standard/Holmakefile
+++ b/candle/standard/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES =
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/candle/standard/semantics/Holmakefile
+++ b/candle/standard/semantics/Holmakefile
@@ -1,6 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis/pure\
-					 ../../syntax-lib ../../set-theory ../syntax
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/candle/standard/syntax/Holmakefile
+++ b/candle/standard/syntax/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc ../../syntax-lib
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/backend/Holmakefile
+++ b/compiler/backend/Holmakefile
@@ -1,9 +1,3 @@
-INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
-					 $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs\
-					 $(CAKEMLDIR)/basis/pure\
-					 pattern_matching\
-					 ../encoders/asm reg_alloc $(HOLDIR)/examples/algorithms
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/backend/arm8_asl/holproject.toml
+++ b/compiler/backend/arm8_asl/holproject.toml
@@ -1,0 +1,1 @@
+name = "arm8_asl/backend"

--- a/compiler/backend/arm8_asl/holproject.toml
+++ b/compiler/backend/arm8_asl/holproject.toml
@@ -1,1 +1,0 @@
-name = "arm8_asl/backend"

--- a/compiler/backend/proofs/Holmakefile
+++ b/compiler/backend/proofs/Holmakefile
@@ -1,10 +1,3 @@
-INCLUDES = $(HOLDIR)/examples/machine-code/multiword\
-					 $(HOLDIR)/examples/machine-code/hoare-triple\
-					 $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs\
-					 ..  ../semantics ../../encoders/asm ../gc\
-					 ../reg_alloc ../reg_alloc/proofs\
-					 $(HOLDIR)/examples/algorithms
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/encoders/arm8_asl/holproject.toml
+++ b/compiler/encoders/arm8_asl/holproject.toml
@@ -1,0 +1,1 @@
+name = "arm8_asl_encoder"

--- a/compiler/encoders/arm8_asl/holproject.toml
+++ b/compiler/encoders/arm8_asl/holproject.toml
@@ -1,1 +1,0 @@
-name = "arm8_asl_encoder"

--- a/compiler/inference/proofs/Holmakefile
+++ b/compiler/inference/proofs/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics $(CAKEMLDIR)/semantics/proofs ..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/parsing/Holmakefile
+++ b/compiler/parsing/Holmakefile
@@ -1,7 +1,3 @@
-INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
-           $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics \
-	   $(CAKEMLDIR)/semantics/proofs
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/parsing/ocaml/Holmakefile
+++ b/compiler/parsing/ocaml/Holmakefile
@@ -1,10 +1,3 @@
-INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
-           $(CAKEMLDIR)/misc\
-	   $(CAKEMLDIR)/semantics\
-	   $(CAKEMLDIR)/semantics/proofs\
-	   $(CAKEMLDIR)/basis/pure\
-	   ..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/compiler/parsing/proofs/Holmakefile
+++ b/compiler/parsing/proofs/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/semantics/proofs ..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/compilation/x64/holproject.toml
+++ b/examples/compilation/x64/holproject.toml
@@ -1,0 +1,1 @@
+name = "x64_compilation"

--- a/examples/lpr_checker/Holmakefile
+++ b/examples/lpr_checker/Holmakefile
@@ -1,7 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
-					 $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/basis\
-					 $(CAKEMLDIR)/translator $(CAKEMLDIR)/characteristic
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/lpr_checker/array/Holmakefile
+++ b/examples/lpr_checker/array/Holmakefile
@@ -1,7 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorithms \
-					 $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/basis $(CAKEMLDIR)/examples \
-					 $(CAKEMLDIR)/translator $(CAKEMLDIR)/characteristic ..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/lpr_checker/array/compilation/Holmakefile
+++ b/examples/lpr_checker/array/compilation/Holmakefile
@@ -1,6 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis $(CAKEMLDIR)/compiler $(CAKEMLDIR)/cv_translator ..
-CLINE_OPTIONS =
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/lpr_checker/array/compilation/proofs/Holmakefile
+++ b/examples/lpr_checker/array/compilation/proofs/Holmakefile
@@ -1,9 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
-					 $(CAKEMLDIR)/compiler/backend/proofs\
-					 $(CAKEMLDIR)/compiler/encoders/x64/proofs\
-					 $(CAKEMLDIR)/compiler/backend/x64/proofs\
-					 .. ../..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/lpr_checker/array/compilation/proofsARM8/Holmakefile
+++ b/examples/lpr_checker/array/compilation/proofsARM8/Holmakefile
@@ -1,11 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics/proofs\
-					 $(CAKEMLDIR)/compiler/backend/proofs\
-					 $(HOLDIR)/examples/l3-machine-code/arm8/asl-equiv \
-					 $(CAKEMLDIR)/compiler/encoders/arm8_asl \
-					 $(CAKEMLDIR)/compiler/encoders/arm8_asl/proofs\
-					 $(CAKEMLDIR)/compiler/backend/arm8_asl \
-					 .. ../..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/lpr_checker/holproject.toml
+++ b/examples/lpr_checker/holproject.toml
@@ -1,0 +1,4 @@
+name = "lpr_checker"
+
+[projects.cakeml]
+path = "../../"

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProof_ag32Script.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProof_ag32Script.sml
@@ -7,7 +7,7 @@ Theory readerProgProof_ag32
 Ancestors
   semanticsProps backendProof ag32_configProof ag32_memory
   ag32_memoryProof ag32_ffi_codeProof ag32_machine_config
-  ag32_basis_ffiProof readerProg readerCompile holSoundness
+  ag32_basis_ffiProof readerProg readerCompile_ag32 holSoundness
 Libs
   preamble
 

--- a/examples/opentheory/compilation/ag32/proofs/readerProgProog_ag32Script.sml
+++ b/examples/opentheory/compilation/ag32/proofs/readerProgProog_ag32Script.sml
@@ -3,7 +3,7 @@
   checker. The theorem reaches the next-state function of the
   verified hardware platform called Silver.
 *)
-Theory readerProgProof
+Theory readerProgProof_ag32
 Ancestors
   semanticsProps backendProof ag32_configProof ag32_memory
   ag32_memoryProof ag32_ffi_codeProof ag32_machine_config

--- a/examples/opentheory/compilation/ag32/readerCompile_ag32Script.sml
+++ b/examples/opentheory/compilation/ag32/readerCompile_ag32Script.sml
@@ -2,7 +2,7 @@
   In-logic compilation of the OpenTheory article checker to the
   Silver ISA.
 *)
-Theory readerCompile
+Theory readerCompile_ag32
 Ancestors
   readerProg
 Libs

--- a/examples/opentheory/holproject.toml
+++ b/examples/opentheory/holproject.toml
@@ -1,0 +1,1 @@
+name = "opentheory"

--- a/examples/opentheory/holproject.toml
+++ b/examples/opentheory/holproject.toml
@@ -1,1 +1,4 @@
 name = "opentheory"
+
+[projects.cakeml]
+path = "../../"

--- a/examples/pseudo_bool/holproject.toml
+++ b/examples/pseudo_bool/holproject.toml
@@ -1,0 +1,1 @@
+name = "pseudo_bool"

--- a/examples/sat_encodings/holproject.toml
+++ b/examples/sat_encodings/holproject.toml
@@ -1,0 +1,1 @@
+name = "sat_encodings"

--- a/examples/scpog_checker/Holmakefile
+++ b/examples/scpog_checker/Holmakefile
@@ -1,8 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
-					 $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/basis\
-					 $(CAKEMLDIR)/translator $(CAKEMLDIR)/characteristic \
-					 $(CAKEMLDIR)/examples/lpr_checker
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/examples/scpog_checker/holproject.toml
+++ b/examples/scpog_checker/holproject.toml
@@ -1,0 +1,7 @@
+name = "scpog_checker"
+
+[projects.cakeml]
+path = "../.."
+
+[projects.lpr_checker]
+path = "../lpr_checker"

--- a/examples/vipr/Holmakefile
+++ b/examples/vipr/Holmakefile
@@ -1,4 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(CAKEMLDIR)/basis
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all

--- a/examples/vipr/compilation/Holmakefile
+++ b/examples/vipr/compilation/Holmakefile
@@ -1,4 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/examples/vipr $(CAKEMLDIR)/compiler $(CAKEMLDIR)/cv_translator
 
 all: $(DEFAULT_TARGETS) README.md cake_vipr
 .PHONY: all

--- a/examples/xlrup_checker/array/Holmakefile
+++ b/examples/xlrup_checker/array/Holmakefile
@@ -1,7 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc $(HOLDIR)/examples/algorithms \
-					 $(CAKEMLDIR)/semantics $(CAKEMLDIR)/basis/pure $(CAKEMLDIR)/basis $(CAKEMLDIR)/examples \
-					 $(CAKEMLDIR)/translator $(CAKEMLDIR)/characteristic ..
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/holproject.toml
+++ b/holproject.toml
@@ -1,0 +1,23 @@
+name = "cakeml"
+
+holpath = "CAKEMLDIR"
+
+exclude = [
+  "examples",
+  "candle/overloading",
+  "compiler/benchmarks",
+  "compiler/bootstrap/compilation/x64/32",
+  "translator/other-examples",
+  "tutorial",
+  "unverified/sexpr-bootstrap/x64/32"
+]
+
+external_includes = [
+  "$(HOLDIR)/examples/formal-languages/context-free",
+  "$(HOLDIR)/examples/algorithms",    # for spt_closure
+  "$(HOLDIR)/examples/machine-code/multiword",
+  "$(HOLDIR)/examples/machine-code/hoare-triple",
+  "$(HOLDIR)/examples/data-structures/balanced_bst",
+]
+
+

--- a/holproject.toml
+++ b/holproject.toml
@@ -3,10 +3,10 @@ name = "cakeml"
 holpath = "CAKEMLDIR"
 
 exclude = [
-  "examples",
   "candle/overloading",
   "compiler/benchmarks",
   "compiler/bootstrap/compilation/x64/32",
+  "translator/monadic/examples",
   "translator/other-examples",
   "tutorial",
   "unverified/sexpr-bootstrap/x64/32"

--- a/holproject.toml
+++ b/holproject.toml
@@ -19,6 +19,7 @@ external_includes = [
   "$(HOLDIR)/examples/machine-code/multiword",
   "$(HOLDIR)/examples/machine-code/hoare-triple",
   "$(HOLDIR)/examples/data-structures/balanced_bst",
+  "$(HOLDIR)/examples/l3-machine-code/arm8/asl-equiv",
 ]
 
 

--- a/holproject.toml
+++ b/holproject.toml
@@ -14,7 +14,8 @@ exclude = [
 
 external_includes = [
   "$(HOLDIR)/examples/formal-languages/context-free",
-  "$(HOLDIR)/examples/algorithms",    # for spt_closure
+  "$(HOLDIR)/examples/formal-languages/regular",         # for regexp_compiler
+  "$(HOLDIR)/examples/algorithms",                       # for spt_closure
   "$(HOLDIR)/examples/machine-code/multiword",
   "$(HOLDIR)/examples/machine-code/hoare-triple",
   "$(HOLDIR)/examples/data-structures/balanced_bst",

--- a/semantics/Holmakefile
+++ b/semantics/Holmakefile
@@ -1,9 +1,3 @@
-INCLUDES = $(HOLDIR)/examples/formal-languages/context-free\
-					 $(HOLDIR)/examples/pl-semantics/lprefix_lub\
-					 $(CAKEMLDIR)/developers $(CAKEMLDIR)/misc\
-                     $(CAKEMLDIR)/basis/pure \
-					 ffi
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/semantics/alt_semantics/Holmakefile
+++ b/semantics/alt_semantics/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = .. ../../misc ../ffi
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/semantics/alt_semantics/proofs/Holmakefile
+++ b/semantics/alt_semantics/proofs/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = $(CAKEMLDIR)/misc .. ../..  ../../proofs ../../ffi
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 

--- a/translator/Holmakefile
+++ b/translator/Holmakefile
@@ -1,5 +1,3 @@
-INCLUDES = ../developers ../misc ../semantics ../semantics/proofs ../basis/pure
-
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all
 


### PR DESCRIPTION
Use Holmake-compatible `holproject.toml` files across the repo to remove the need for `INCLUDES` lines and other "junk".