### PR TITLE
Refactor usages of state-exception monad

### DIFF
--- a/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
+++ b/candle/overloading/ml_kernel/ml_hol_kernel_funsProgScript.sml
@@ -539,10 +539,8 @@ val _ = instance_subst_ind |> update_precondition;
 val def = holSyntaxTheory.is_reserved_name_def |> translate
 val def = check_overloads_def |> m_translate
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = ``raise_Fail``
 
 val def = holSyntaxTheory.wellformed_compute_def |> translate

--- a/candle/overloading/monadic/holKernelPmatchScript.sml
+++ b/candle/overloading/monadic/holKernelPmatchScript.sml
@@ -11,12 +11,8 @@ Libs
   preamble patternMatchesLib patternMatchesSyntax
 
 val _ = monadsyntax.temp_add_monadsyntax()
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
-Overload ex_return[local] = ``st_ex_return``
 Overload failwith[local] = ``raise_Fail``
 Overload raise_clash[local] = ``raise_Clash``
 Overload handle_clash[local] = ``handle_Clash``
@@ -355,4 +351,3 @@ Proof
   rpt tac
 QED
 val res = fix SYM_def "SYM_def" SYM_PMATCH
-

--- a/candle/overloading/monadic/holKernelProofScript.sml
+++ b/candle/overloading/monadic/holKernelProofScript.sml
@@ -6,18 +6,16 @@ Theory holKernelProof
 Libs
   preamble
 Ancestors
-  mlstring mllist ml_monadBase holKernel holSyntaxLib
+  ml_monadBase mlstring mllist holKernel holSyntaxLib
   holSyntax holSyntaxExtra
 
 val _ = temp_delsimps ["lift_disj_eq", "lift_imp_disj"]
 
 val _ = ParseExtras.temp_loose_equality();
 val _ = hide"str";
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
-Overload ex_return[local] = ``st_ex_return``
+
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = ``raise_Fail``
 Overload raise_clash[local] = ``raise_Clash``
 Overload handle_clash[local] = ``handle_Clash``
@@ -877,7 +875,7 @@ QED
 
 Theorem mk_eq_lemma[local]:
   inst [(term_type x,aty)] (Const «=» (Fun aty (Fun aty Bool))) s =
-    ex_return
+    st_ex_return
         (Const «=»
            (Fun (term_type x) (Fun (term_type x) Bool))) s
 Proof
@@ -2349,7 +2347,7 @@ Theorem check_overloads_thm:
      (∀msg. (res = M_failure msg) ⇒ (s' = s))
 Proof
   simp_tac std_ss [check_overloads_def,GSYM STRCAT_SHADOW_def] >>
-  simp[st_ex_bind_def,get_the_term_constants_def] >>
+  simp[st_ex_bind_def,st_ex_ignore_bind_def,get_the_term_constants_def] >>
   rpt gen_tac >>
   PURE_CASE_TAC >>
   drule forall_thm >>
@@ -2444,7 +2442,7 @@ Theorem new_specification_thm:
 Proof
   Cases_on`th` >>
   simp_tac std_ss [new_specification_def,GSYM STRCAT_SHADOW_def] >>
-  simp[st_ex_bind_def,st_ex_return_def] >>
+  simp[st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def] >>
   rpt strip_tac >>
   Q.PAT_ABBREV_TAC`(f:term -> hol_refs -> ((((mlstring#type)#term), hol_exn) exc#hol_refs)) = X` >>
   `EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (t::l)` by (
@@ -3256,7 +3254,7 @@ Theorem new_overloading_specification_thm:
 Proof
   Cases_on`th` >>
   simp_tac std_ss [new_overloading_specification_def,GSYM STRCAT_SHADOW_def] >>
-  simp[st_ex_bind_def,st_ex_return_def] >>
+  simp[st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def] >>
   rpt strip_tac >>
   Q.PAT_ABBREV_TAC`(f:term -> hol_refs -> ((((mlstring#type)#term), hol_exn) exc#hol_refs)) = X` >>
   `EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (t::l)` by (
@@ -3547,7 +3545,7 @@ Proof
   simp[Once st_ex_bind_def] >>
   Q.PAT_ABBREV_TAC`vs:string list = sort R X` >>
   simp[add_type_def,can_def,otherwise_def,st_ex_return_def] >>
-  ntac 2 (simp[Once st_ex_bind_def]) >>
+  simp[Once st_ex_bind_def, Once st_ex_ignore_bind_def] >>
   simp[Once st_ex_bind_def,get_the_type_constants_def] >>
   simp[Once st_ex_bind_def,set_the_type_constants_def] >>
   simp[Once st_ex_ignore_bind_def] >>
@@ -3579,6 +3577,7 @@ Proof
   fs[oneTheory.one] >>
   simp[Once st_ex_bind_def,add_def_def,get_the_context_def] >>
   simp[Once st_ex_bind_def,set_the_context_def] >>
+  simp[Once st_ex_ignore_bind_def] >>
   Q.PAT_ABBREV_TAC`s2 = s1 with <|the_term_constants := X; the_context := Y|>` >>
   `STATE s2.the_context s2` by (
     fs[STATE_def] >>
@@ -3847,7 +3846,8 @@ Proof
   Cases_on`add_constants [(name,ty)] s`>>simp[] >>
   Cases_on`q`>>simp[oneTheory.one] >>
   imp_res_tac STATE_ALL_DISTINCT >> rw[] >>
-  rw[add_def_def,st_ex_bind_def,get_the_context_def,set_the_context_def] >>
+  rw[add_def_def,st_ex_bind_def,st_ex_ignore_bind_def,
+     get_the_context_def,set_the_context_def] >>
   qexists_tac`NewConst name ty` >>
   conj_tac >- (
     fs[STATE_def] >>
@@ -3872,7 +3872,7 @@ Theorem new_axiom_thm:
     | (M_success th, s') => (?d. THM (d::defs) th ∧ STATE (d::defs) s' /\
                                !th. THM defs th ==> THM (d::defs) th)
 Proof
-  rw[new_axiom_def,st_ex_bind_def] >>
+  rw[new_axiom_def,st_ex_bind_def,st_ex_ignore_bind_def] >>
   imp_res_tac type_of_thm >> rw[] >>
   qspecl_then[`«bool»`,`[]`,`s`]mp_tac mk_type_thm >>
   Cases_on`mk_type («bool»,[]) s`>>simp[] >>
@@ -4134,8 +4134,10 @@ QED
 Theorem new_specification_not_clash[simp]:
    new_specification a b <> (M_failure (Clash tm),refs)
 Proof
-  Cases_on `a` \\ rw [new_specification_def, st_ex_bind_def, raise_Fail_def,
-                      st_ex_return_def, case_eq_thms, bool_case_eq, COND_RATOR]
+  Cases_on `a`
+  \\ rw [new_specification_def, st_ex_bind_def, raise_Fail_def,
+         st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms, bool_case_eq,
+         COND_RATOR]
   \\ ho_match_mp_tac map_not_clash_thm \\ rw []
   \\ rw [case_eq_thms, bool_case_eq, COND_RATOR, ELIM_UNCURRY]
 QED
@@ -4158,11 +4160,12 @@ QED
 Theorem new_basic_type_definition_not_clash[simp]:
    new_basic_type_definition (a, b, c, d) e <> (M_failure (Clash tm),refs)
 Proof
-  Cases_on `d` \\ rw [new_basic_type_definition_def, st_ex_bind_def,
-                      st_ex_return_def, raise_Fail_def, can_def,
-                      get_type_arity_def, get_the_type_constants_def,
-                      otherwise_def, try_def, case_eq_thms, bool_case_eq,
-                      COND_RATOR, ELIM_UNCURRY]
+  Cases_on `d`
+  \\ rw [new_basic_type_definition_def, st_ex_bind_def, st_ex_ignore_bind_def,
+         st_ex_return_def, raise_Fail_def, can_def,
+         get_type_arity_def, get_the_type_constants_def,
+         otherwise_def, try_def, case_eq_thms, bool_case_eq,
+         COND_RATOR, ELIM_UNCURRY]
 QED
 
 Theorem vsubst_not_clash[simp]:
@@ -4186,21 +4189,21 @@ Theorem new_axiom_not_clash[simp]:
   new_axiom ax s ≠ (M_failure (Clash tm), t)
 Proof
   strip_tac
-  \\ fs [new_axiom_def, st_ex_bind_def, st_ex_return_def, raise_Fail_def,
-         case_eq_thms, bool_case_eq, COND_RATOR, get_the_axioms_def,
+  \\ fs [new_axiom_def, st_ex_bind_def, st_ex_ignore_bind_def, st_ex_return_def,
+         raise_Fail_def, case_eq_thms, bool_case_eq, COND_RATOR, get_the_axioms_def,
          set_the_axioms_def] \\ rw [] \\ fs []
 QED
 
 Theorem new_constant_not_clash[simp]:
   new_constant (a,b) s ≠ (M_failure (Clash tm), t)
 Proof
-  rw [new_constant_def, st_ex_bind_def, st_ex_return_def, case_eq_thms]
+  rw [new_constant_def, st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms]
 QED
 
 Theorem new_type_not_clash[simp]:
   new_type (a,b) s ≠ (M_failure (Clash tm), t)
 Proof
-  rw [new_type_def, st_ex_bind_def, st_ex_return_def, case_eq_thms]
+  rw [new_type_def, st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms]
 QED
 
 Theorem dest_abs_not_clash[simp]:

--- a/candle/overloading/monadic/holKernelScript.sml
+++ b/candle/overloading/monadic/holKernelScript.sml
@@ -12,11 +12,7 @@ Ancestors
 val _ = ParseExtras.temp_loose_equality();
 val _ = patternMatchesSyntax.temp_enable_pmatch();
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 

--- a/candle/standard/monadic/holKernelPmatchScript.sml
+++ b/candle/standard/monadic/holKernelPmatchScript.sml
@@ -12,11 +12,8 @@ Libs
 
 val _ = monadsyntax.temp_add_monadsyntax()
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
-Overload ex_return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = ``raise_Failure``
 Overload raise_clash[local] = ``raise_Clash``
 Overload handle_clash[local] = ``handle_Clash``

--- a/candle/standard/monadic/holKernelProofScript.sml
+++ b/candle/standard/monadic/holKernelProofScript.sml
@@ -14,11 +14,9 @@ val _ = augment_srw_ss [rewrites [aty_def, bool_ty_def]];
 
 val _ = ParseExtras.temp_loose_equality();
 val _ = hide"str";
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
-Overload ex_return[local] = ``st_ex_return``
+
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = ``raise_Failure``
 Overload raise_clash[local] = ``raise_Clash``
 Overload handle_clash[local] = ``handle_Clash``
@@ -890,7 +888,7 @@ QED
 
 Theorem mk_eq_lemma[local]:
   inst [(term_type x,aty)] (Const «=» (Fun aty (Fun aty Bool))) s =
-    ex_return
+    st_ex_return
         (Const «=»
            (Fun (term_type x) (Fun (term_type x) Bool))) s
 Proof
@@ -2419,7 +2417,7 @@ Theorem new_specification_thm:
 Proof
   Cases_on`th` >>
   simp_tac std_ss [new_specification_def,GSYM STRCAT_SHADOW_def] >>
-  simp[st_ex_bind_def,st_ex_return_def] >>
+  simp[st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def] >>
   rpt strip_tac >>
   Q.PAT_ABBREV_TAC`(f:term -> hol_refs -> ((((mlstring#type)#term), hol_exn) exc#hol_refs)) = X` >>
   `EVERY (λt. term_ok (sigof defs) t ∧ (typeof t = Bool)) (t::l)` by (
@@ -2746,6 +2744,7 @@ Proof
   fs[oneTheory.one] >>
   simp[Once st_ex_bind_def,add_def_def,get_the_context_def] >>
   simp[Once st_ex_bind_def,set_the_context_def] >>
+  simp[st_ex_ignore_bind_def] >>
   Q.PAT_ABBREV_TAC`s2 = s1 with <|the_term_constants := X; the_context := Y|>` >>
   `STATE s2.the_context s2` by (
     fs[STATE_def] >>
@@ -3011,7 +3010,7 @@ Theorem new_constant_thm:
     | (M_success (), s') => (?d. STATE (d::defs) s' /\
                            !th. THM defs th ==> THM (d::defs) th)
 Proof
-  rw[new_constant_def,st_ex_bind_def] >>
+  rw[new_constant_def,st_ex_bind_def,st_ex_ignore_bind_def] >>
   qspecl_then[`[(name,ty)]`,`s`]mp_tac add_constants_thm >>
   Cases_on`add_constants [(name,ty)] s`>>simp[] >>
   Cases_on`q`>>simp[oneTheory.one] >>
@@ -3041,7 +3040,7 @@ Theorem new_axiom_thm:
     | (M_success th, s') => (?d. THM (d::defs) th ∧ STATE (d::defs) s' /\
                                !th. THM defs th ==> THM (d::defs) th)
 Proof
-  rw[new_axiom_def,st_ex_bind_def] >>
+  rw[new_axiom_def,st_ex_bind_def,st_ex_ignore_bind_def] >>
   imp_res_tac type_of_thm >> rw[] >>
   simp[raise_Failure_def,st_ex_return_def] >>
   simp[get_the_axioms_def,set_the_axioms_def] >>
@@ -3298,8 +3297,10 @@ QED
 Theorem new_specification_not_clash[simp]:
    new_specification a b <> (M_failure (Clash tm),refs)
 Proof
-  Cases_on `a` \\ rw [new_specification_def, st_ex_bind_def, raise_Failure_def,
-                      st_ex_return_def, case_eq_thms, bool_case_eq, COND_RATOR]
+  Cases_on `a`
+  \\ rw [new_specification_def, st_ex_bind_def, raise_Failure_def,
+         st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms, bool_case_eq,
+         COND_RATOR]
   \\ ho_match_mp_tac map_not_clash_thm \\ rw []
   \\ rw [case_eq_thms, bool_case_eq, COND_RATOR, ELIM_UNCURRY]
 QED
@@ -3322,11 +3323,12 @@ QED
 Theorem new_basic_type_definition_not_clash[simp]:
    new_basic_type_definition (a, b, c, d) e <> (M_failure (Clash tm),refs)
 Proof
-  Cases_on `d` \\ rw [new_basic_type_definition_def, st_ex_bind_def,
-                      st_ex_return_def, raise_Failure_def, can_def,
-                      get_type_arity_def, get_the_type_constants_def,
-                      otherwise_def, try_def, case_eq_thms, bool_case_eq,
-                      COND_RATOR, ELIM_UNCURRY]
+  Cases_on `d`
+  \\ rw [new_basic_type_definition_def, st_ex_bind_def, st_ex_ignore_bind_def,
+         st_ex_return_def, raise_Failure_def, can_def,
+         get_type_arity_def, get_the_type_constants_def,
+         otherwise_def, try_def, case_eq_thms, bool_case_eq,
+         COND_RATOR, ELIM_UNCURRY]
 QED
 
 Theorem vsubst_not_clash[simp]:
@@ -3350,21 +3352,21 @@ Theorem new_axiom_not_clash[simp]:
   new_axiom ax s ≠ (M_failure (Clash tm), t)
 Proof
   strip_tac
-  \\ fs [new_axiom_def, st_ex_bind_def, st_ex_return_def, raise_Failure_def,
-         case_eq_thms, bool_case_eq, COND_RATOR, get_the_axioms_def,
-         set_the_axioms_def] \\ rw [] \\ fs []
+  \\ fs [new_axiom_def, st_ex_bind_def, st_ex_ignore_bind_def,
+         st_ex_return_def, raise_Failure_def, case_eq_thms, bool_case_eq,
+         COND_RATOR, get_the_axioms_def, set_the_axioms_def] \\ rw [] \\ fs []
 QED
 
 Theorem new_constant_not_clash[simp]:
   new_constant (a,b) s ≠ (M_failure (Clash tm), t)
 Proof
-  rw [new_constant_def, st_ex_bind_def, st_ex_return_def, case_eq_thms]
+  rw [new_constant_def, st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms]
 QED
 
 Theorem new_type_not_clash[simp]:
   new_type (a,b) s ≠ (M_failure (Clash tm), t)
 Proof
-  rw [new_type_def, st_ex_bind_def, st_ex_return_def, case_eq_thms]
+  rw [new_type_def, st_ex_ignore_bind_def, st_ex_return_def, case_eq_thms]
 QED
 
 Theorem dest_abs_not_clash[simp]:

--- a/candle/standard/monadic/holKernelScript.sml
+++ b/candle/standard/monadic/holKernelScript.sml
@@ -12,11 +12,7 @@ Ancestors
 val _ = ParseExtras.temp_loose_equality();
 val _ = patternMatchesSyntax.temp_enable_pmatch();
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 

--- a/compiler/backend/reg_alloc/linear_scanScript.sml
+++ b/compiler/backend/reg_alloc/linear_scanScript.sml
@@ -9,11 +9,8 @@ Ancestors
 
 val _ = ParseExtras.temp_tight_equality();
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_disable_monad "state";
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 

--- a/compiler/backend/reg_alloc/proofs/linear_scanProofScript.sml
+++ b/compiler/backend/reg_alloc/proofs/linear_scanProofScript.sml
@@ -14,11 +14,7 @@ val _ = disable_tyabbrev_printing "alist"
 
 val _ = ParseExtras.temp_tight_equality();
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 
@@ -2131,7 +2127,7 @@ Proof
   fs[Marray_update_def]
 QED
 
-val msimps = [st_ex_bind_def,st_ex_return_def];
+val msimps = [st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def];
 
 Definition lookup_default_id_def:
     lookup_default_id s x = option_CASE (lookup x s) x (\x.x)

--- a/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
+++ b/compiler/backend/reg_alloc/proofs/reg_allocProofScript.sml
@@ -14,10 +14,7 @@ val _ = monadsyntax.temp_add_monadsyntax()
 val _ = diminish_srw_ss ["ABBREV"]
 val _ = set_trace "BasicProvers.var_eq_old" 1
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 (* Edge from node x to node y, in terms of an adjacency list *)
 Definition has_edge_def:
@@ -84,7 +81,7 @@ Definition good_pref_def:
     | SOME k => MEM k ks
 End
 
-val msimps = [st_ex_bind_def,st_ex_return_def];
+val msimps = [st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def];
 
 val get_eqns = [get_dim_def, get_unavail_moves_wl_def,get_avail_moves_wl_def,get_simp_wl_def,get_spill_wl_def,set_spill_wl_def,get_freeze_wl_def,get_stack_def];
 

--- a/compiler/backend/reg_alloc/reg_allocScript.sml
+++ b/compiler/backend/reg_alloc/reg_allocScript.sml
@@ -10,11 +10,8 @@ Ancestors
 
 val _ = ParseExtras.temp_tight_equality();
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_disable_monad "state";
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 

--- a/compiler/bootstrap/compilation/x64/64/proofs/replProofScript.sml
+++ b/compiler/bootstrap/compilation/x64/64/proofs/replProofScript.sml
@@ -434,7 +434,7 @@ val _ = map Parse.hide ["types","types_v","parse","parse_v"];
 
 Theorem repl_types_alt:
   repl_types T (ffi,rs) (types,s,env) ∧
-  infertype_prog_inc types decs = Success new_t ⇒
+  infertype_prog_inc types decs = M_success new_t ⇒
   evaluate_decs s env decs ≠ (new_s,Rerr (Rabort Rtype_error))
 Proof
   rw [] \\ imp_res_tac repl_types_thm \\ fs []
@@ -552,7 +552,7 @@ Proof
   (* case split on result of check_and_tweak *)
   \\ rename [‘evaluate _ _ [Mat _ _]’]
   \\ Cases_on ‘check_and_tweak (decs,types,input_str)’
-  \\ gvs [inferProgTheory.INFER_EXC_TYPE_def]
+  \\ gvs []
   THEN1
    (rename [‘_ = INL msg’]
     \\ simp [Once evaluate_def]

--- a/compiler/bootstrap/translation/inferProgScript.sml
+++ b/compiler/bootstrap/translation/inferProgScript.sml
@@ -3,13 +3,13 @@
 *)
 Theory inferProg[no_sig_docs]
 Ancestors
-  parserProg reg_allocProg infer ml_translator semanticPrimitives
+  ml_monadBase parserProg reg_allocProg infer ml_translator semanticPrimitives
   inferProps
 Libs
   preamble ml_translatorLib
 
 open preamble parserProgTheory
-     reg_allocProgTheory inferTheory
+     reg_allocProgTheory
      ml_translatorLib ml_translatorTheory
      semanticPrimitivesTheory inferPropsTheory;
 
@@ -259,8 +259,8 @@ Theorem anub_ind =
 val _ = translate (REWRITE_RULE[MEMBER_INTRO] miscTheory.anub_def)
 
 val _ = (extra_preprocessing :=
-  [MEMBER_INTRO, MAP, OPTION_BIND_THM, inferTheory.st_ex_bind_def,
-   inferTheory.st_ex_return_def, failwith_def, guard_def, read_def, write_def]);
+  [MEMBER_INTRO, MAP, OPTION_BIND_THM, st_ex_bind_def, st_ex_ignore_bind_def,
+   st_ex_return_def, failwith_def, guard_def, read_def, write_def]);
 
 val _ = translate (def_of_const ``id_to_string``)
 val _ = translate (def_of_const ``lookup_st_ex``)

--- a/compiler/bootstrap/translation/reg_allocProgScript.sml
+++ b/compiler/bootstrap/translation/reg_allocProgScript.sml
@@ -26,11 +26,7 @@ val _ = translation_extends "basisProg";
 *)
 
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = hide "state";
 

--- a/compiler/compilerScript.sml
+++ b/compiler/compilerScript.sml
@@ -253,31 +253,31 @@ Definition compile_def:
       then parse_sexp_input input
       else parse_cml_input input
     of
-    | INL msg => (Failure (ParseError msg), Nil)
+    | INL msg => (M_failure (ParseError msg), Nil)
     | INR prog =>
        let _ = empty_ffi «finished: lexing and parsing» in
        let full_prog = if c.exclude_prelude then prog else prelude ++ prog in
        case
          if c.skip_type_inference
-         then Success c.inferencer_config
+         then M_success c.inferencer_config
          else infertype_prog c.inferencer_config full_prog
        of
-       | Failure (locs, msg) =>
-           (Failure (TypeError (concat [msg; « at »;
+       | M_failure (locs, msg) =>
+           (M_failure (TypeError (concat [msg; « at »;
                locs_to_string (implode input) locs])), Nil)
-       | Success ic =>
+       | M_success ic =>
           let _ = empty_ffi «finished: type inference» in
           if c.only_print_types then
-            (Failure (TypeError (concat ([«\n»] ++
+            (M_failure (TypeError (concat ([«\n»] ++
                                          inf_env_to_types_string ic ++
                                          [«\n»]))), Nil)
           else if c.only_print_sexp then
-            (Failure (TypeError (implode
+            (M_failure (TypeError (implode
                ("\n" ++ print_sexp (listsexp (MAP decsexp full_prog))))),Nil)
           else
           case backend_passes$compile_tap c.asm_config c.backend_config full_prog of
-          | (NONE, td) => (Failure AssembleError, td)
-          | (SOME (bytes,data,c), td) => (Success (bytes,data,c), td)
+          | (NONE, td) => (M_failure AssembleError, td)
+          | (SOME (bytes,data,c), td) => (M_success (bytes,data,c), td)
 End
 
 Definition compile_pancake_def:
@@ -285,18 +285,18 @@ Definition compile_pancake_def:
   let _ = empty_ffi «finished: start up» in
   case panPtreeConversion$parse_topdecs_to_ast input of
   | INR errs =>
-    ((Failure $ ParseError $ concat $
+    ((M_failure $ ParseError $ concat $
        MAP (λ(msg,loc). concat [msg; « at »;
                                 locs_to_string (implode input) (SOME loc); «\n»])
            errs), Nil, [])
   | INL funs =>
       case static_check funs of
-      | (error e, warns) => (Failure $ StaticError e, Nil, MAP StaticError warns)
+      | (error e, warns) => (M_failure $ StaticError e, Nil, MAP StaticError warns)
       | (return (), warns) =>
           let _ = empty_ffi «finished: lexing and parsing» in
           case pan_passes$pan_compile_tap asm_conf c funs of
-          | (NONE,td) => (Failure AssembleError, td, MAP StaticError warns)
-          | (SOME (bytes,data,c),td) => (Success (bytes,data,c), td, MAP StaticError warns)
+          | (NONE,td) => (M_failure AssembleError, td, MAP StaticError warns)
+          | (SOME (bytes,data,c),td) => (M_success (bytes,data,c), td, MAP StaticError warns)
 End
 
 (* The top-level compiler *)
@@ -666,10 +666,10 @@ Definition has_pancake_flag_def:
 End
 
 Definition format_compiler_result_def:
-  format_compiler_result bytes_export (Failure err) =
+  format_compiler_result bytes_export (M_failure err) =
     (List[]:mlstring app_list, error_to_str err) ∧
   format_compiler_result bytes_export
-    (Success ((bytes:word8 list),(data:'a word list),(c:backend$config))) =
+    (M_success ((bytes:word8 list),(data:'a word list),(c:backend$config))) =
     (bytes_export (the [] c.lab_conf.ffi_names) bytes data, implode "")
 End
 
@@ -703,13 +703,13 @@ Definition compile_64_def:
              only_print_sexp     := sexpprint;
              |> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,c), td) =>
+          (M_success (bytes,data,c), td) =>
             (add_tap_output td (export
               (ffinames_to_string_list
                 $ the [] c.lab_conf.ffi_names)
                 bytes data c.symbols c.exported mainret F),
               implode "")
-        | (Failure err, td) => (add_tap_output td (List []), error_to_str err))
+        | (M_failure err, td) => (add_tap_output td (List []), error_to_str err))
     | INR err =>
     (List[], error_to_str (ConfigError (get_err_str ext_conf))))
   | _ =>
@@ -738,9 +738,9 @@ Definition compile_pancake_64_def:
           | INL ext_conf =>
               let ext_conf = pancake_backend_conf ext_conf in
               case compiler$compile_pancake aconf ext_conf input of
-              | (Failure err, td, warns) =>
+              | (M_failure err, td, warns) =>
                   (List[], concat (MAP error_to_str (err::(if nowarn then [] else warns))))
-              | (Success (bytes, data, c), td, warns) =>
+              | (M_success (bytes, data, c), td, warns) =>
                   (add_tap_output td
                     (export (ffinames_to_string_list $
                       the [] c.lab_conf.ffi_names) bytes data c.symbols
@@ -784,13 +784,13 @@ Definition compile_32_def:
              only_print_sexp     := sexpprint;
              |> in
         (case compiler$compile compiler_conf basis input of
-          (Success (bytes,data,c), td) =>
+          (M_success (bytes,data,c), td) =>
             (add_tap_output td (export
               (ffinames_to_string_list $
                 the [] c.lab_conf.ffi_names)
                 bytes data c.symbols c.exported mainret F),
               implode "")
-        | (Failure err, td) => (List [], error_to_str err))
+        | (M_failure err, td) => (List [], error_to_str err))
     | INR err =>
     (List[], error_to_str (ConfigError (get_err_str ext_conf))))
   | _ =>
@@ -814,9 +814,9 @@ Definition compile_pancake_32_def:
           | INL ext_conf =>
               let ext_conf = pancake_backend_conf ext_conf in
               case compiler$compile_pancake aconf ext_conf input of
-              | (Failure err, td, warns) =>
+              | (M_failure err, td, warns) =>
                   (List[], concat (MAP error_to_str (err::(if nowarn then [] else warns))))
-              | (Success (bytes, data, c), td, warns) =>
+              | (M_success (bytes, data, c), td, warns) =>
                   (add_tap_output td
                     (export (ffinames_to_string_list $
                       the [] c.lab_conf.ffi_names) bytes data c.symbols

--- a/compiler/encoders/monadic_enc/monadic_enc32Script.sml
+++ b/compiler/encoders/monadic_enc/monadic_enc32Script.sml
@@ -8,11 +8,8 @@ Libs
   preamble ml_monadBaseLib
 
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_disable_monad "state";
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 (* Data type for the exceptions *)
 Datatype:
@@ -127,7 +124,7 @@ Definition enc_secs_32_def:
     | M_failure _ => []
 End
 
-val msimps = [st_ex_bind_def,st_ex_return_def];
+val msimps = [st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def];
 
 Theorem Msub_eqn[simp]:
     ∀e n ls v.
@@ -280,4 +277,3 @@ Proof
   rw[]>>
   fs[enc_sec_list_def]
 QED
-

--- a/compiler/encoders/monadic_enc/monadic_enc64Script.sml
+++ b/compiler/encoders/monadic_enc/monadic_enc64Script.sml
@@ -8,11 +8,8 @@ Libs
   preamble ml_monadBaseLib
 
 val _ = monadsyntax.temp_add_monadsyntax()
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_disable_monad "state";
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 (* Data type for the exceptions *)
 Datatype:
@@ -127,7 +124,7 @@ Definition enc_secs_64_def:
     | M_failure _ => []
 End
 
-val msimps = [st_ex_bind_def,st_ex_return_def];
+val msimps = [st_ex_bind_def,st_ex_ignore_bind_def,st_ex_return_def];
 
 Theorem Msub_eqn[simp]:
     ∀e n ls v.
@@ -280,4 +277,3 @@ Proof
   rw[]>>
   fs[enc_sec_list_def]
 QED
-

--- a/compiler/inference/Holmakefile
+++ b/compiler/inference/Holmakefile
@@ -3,7 +3,7 @@ HOLUNIFDIR = $(HOLDIR)/examples/algorithms/unification/triangular/first-order
 INCLUDES = $(HOLUNIFDIR) $(HOLUNIFDIR)/compilation \
            $(CAKEMLDIR)/misc $(CAKEMLDIR)/semantics \
            $(CAKEMLDIR)/semantics/proofs $(CAKEMLDIR)/basis/pure \
-           ../../translator
+           ../../translator ../../translator/monadic/monad_base
 
 all: $(DEFAULT_TARGETS) README.md
 .PHONY: all

--- a/compiler/inference/inferPropsScript.sml
+++ b/compiler/inference/inferPropsScript.sml
@@ -5,7 +5,7 @@
 Theory inferProps
 Ancestors
   namespaceProps typeSystem ast semanticPrimitives infer unify
-  infer_t typeSysProps
+  infer_t typeSysProps ml_monadBase
 Libs
   preamble
 
@@ -362,7 +362,7 @@ QED
 
 Theorem st_ex_return_success[local]:
   !v st v' st'.
-  (st_ex_return v st = (Success v', st')) =
+  (st_ex_return v st = (M_success v', st')) =
   ((v = v') ∧ (st = st'))
 Proof
   rw [st_ex_return_def]
@@ -370,8 +370,8 @@ QED
 
 Theorem st_ex_bind_success[local]:
   !f g st st' v.
- (st_ex_bind f g st = (Success v, st')) =
- ?v' st''. (f st = (Success v', st'')) /\ (g v' st'' = (Success v, st'))
+ (st_ex_bind f g st = (M_success v, st')) =
+ ?v' st''. (f st = (M_success v', st'')) /\ (g v' st'' = (M_success v, st'))
 Proof
   rw [st_ex_bind_def] >>
 cases_on `f st` >>
@@ -380,9 +380,21 @@ cases_on `q` >>
 rw []
 QED
 
+Theorem st_ex_ignore_bind_success[local]:
+  !f g st st' v.
+ (st_ex_ignore_bind f g st = (M_success v, st')) =
+ ?v' st''. (f st = (M_success v', st'')) /\ (g st'' = (M_success v, st'))
+Proof
+  rw [st_ex_ignore_bind_def] >>
+cases_on `f st` >>
+rw [] >>
+cases_on `q` >>
+rw []
+QED
+
 Theorem fresh_uvar_success[local]:
   !st t st'.
-  (fresh_uvar st = (Success t, st')) =
+  (fresh_uvar st = (M_success t, st')) =
   ((t = Infer_Tuvar st.next_uvar) ∧
    (st' = st with next_uvar := st.next_uvar + 1))
 Proof
@@ -392,7 +404,7 @@ QED
 
 Theorem n_fresh_uvar_success:
  !n st ts st'.
-  (n_fresh_uvar n st = (Success ts, st')) =
+  (n_fresh_uvar n st = (M_success ts, st')) =
   ((ts = MAP (\n. Infer_Tuvar (st.next_uvar + n)) (COUNT_LIST n)) ∧
    (st' = st with next_uvar := st.next_uvar + n))
 Proof
@@ -410,7 +422,7 @@ QED
 
 Theorem apply_subst_success[local]:
   !t1 st1 t2 st2.
-  (apply_subst t1 st1 = (Success t2, st2))
+  (apply_subst t1 st1 = (M_success t2, st2))
   =
   ((st2 = st1) ∧
    (t2 = t_walkstar st1.subst t1))
@@ -422,7 +434,7 @@ QED
 
 Theorem add_constraint_success:
  !l t1 t2 st st' x.
-  (add_constraint l t1 t2 st = (Success x, st'))
+  (add_constraint l t1 t2 st = (M_success x, st'))
   =
   ((x = ()) ∧ (?s. (t_unify st.subst t1 t2 = SOME s) ∧ (st' = st with subst := s)))
 Proof
@@ -433,7 +445,7 @@ QED
 
 Theorem add_constraints_success[local]:
   !l ts1 ts2 st st' x.
-  (add_constraints l ts1 ts2 st = (Success x, st'))
+  (add_constraints l ts1 ts2 st = (M_success x, st'))
   =
   ((LENGTH ts1 = LENGTH ts2) ∧
    ((x = ()) ∧
@@ -454,7 +466,7 @@ fs []
 QED
 
 Theorem add_constraints_nil2_success[local]:
-  (add_constraints l ts1 [] st = (Success x, st'))
+  (add_constraints l ts1 [] st = (M_success x, st'))
   = (ts1 = [] /\ st = st')
 Proof
   Cases_on `ts1` \\ simp [add_constraints_def]
@@ -462,24 +474,24 @@ Proof
 QED
 
 Theorem add_constraints_cons2_success[local]:
-  (add_constraints l ts1 (t2 :: ts2) st = (Success x, st'))
+  (add_constraints l ts1 (t2 :: ts2) st = (M_success x, st'))
   = (?t1 tl1 st''. ts1 = t1 :: tl1 /\
-    add_constraint l t1 t2 st = (Success (), st'') /\
-    add_constraints l tl1 ts2 st'' = (Success x, st'))
+    add_constraint l t1 t2 st = (M_success (), st'') /\
+    add_constraints l tl1 ts2 st'' = (M_success x, st'))
 Proof
   Cases_on `ts1` \\ simp [add_constraints_def]
   \\ simp [failwith_def, st_ex_bind_success, st_ex_return_success]
 QED
 
 Theorem failwith_success[local]:
-  !l m st v st'. (failwith l m st = (Success v, st')) = F
+  !l m st v st'. (failwith l m st = (M_success v, st')) = F
 Proof
   rw [failwith_def]
 QED
 
 Theorem lookup_st_ex_success[local]:
   !loc x err l st v st'.
-  (lookup_st_ex loc err x l st = (Success v, st'))
+  (lookup_st_ex loc err x l st = (M_success v, st'))
   =
   ((nsLookup l x = SOME v) ∧ (st = st'))
 Proof
@@ -525,7 +537,7 @@ Proof
 QED
 
 val constrain_op_success =
-  ``(constrain_op l op ts st = (Success v, st'))``
+  ``(constrain_op l op ts st = (M_success v, st'))``
   |> (REWRITE_CONV [Once constrain_op_op_case, op_case_eq]
     THENC SIMP_CONV (srw_ss () ++ CONJ_ss) [constrain_op_case_def,
         op_simple_constraints_def, LET_THM, bool_case_eq,
@@ -542,7 +554,7 @@ Theorem constrain_op_success =
 
 Theorem get_next_uvar_success[local]:
   !st v st'.
-  (get_next_uvar st = (Success v, st'))
+  (get_next_uvar st = (M_success v, st'))
   =
   ((v = st.next_uvar) ∧ (st = st'))
 Proof
@@ -552,11 +564,11 @@ QED
 
 val apply_subst_list_success =
   SIMP_CONV (srw_ss()) [apply_subst_list_def, LET_THM]
-  ``(apply_subst_list ts st = (Success v, st'))``
+  ``(apply_subst_list ts st = (M_success v, st'))``
 
 Theorem guard_success[local]:
   ∀P l m st v st'.
-  (guard P l m st = (Success v, st'))
+  (guard P l m st = (M_success v, st'))
   =
   (P ∧ (v = ()) ∧ (st = st'))
 Proof
@@ -566,7 +578,7 @@ QED
 
 Theorem check_dups_success:
    !l f ls s r s'.
-    check_dups l f ls s = (Success r, s')
+    check_dups l f ls s = (M_success r, s')
     ⇔
     s' = s ∧ ALL_DISTINCT ls
 Proof
@@ -577,18 +589,19 @@ QED
 
 Theorem type_name_check_subst_success:
    (!t l f tenvT tvs r (s:'a) s'.
-    type_name_check_subst l f tenvT tvs t s = (Success r, s')
+    type_name_check_subst l f tenvT tvs t s = (M_success r, s')
     ⇔
     s = s' ∧ r = type_name_subst tenvT t ∧
     check_freevars_ast tvs t ∧ check_type_names tenvT t) ∧
    (!ts l f tenvT tvs r (s:'a) s'.
-    type_name_check_subst_list l f tenvT tvs ts s = (Success r, s')
+    type_name_check_subst_list l f tenvT tvs ts s = (M_success r, s')
     ⇔
     s = s' ∧ r = MAP (type_name_subst tenvT) ts ∧
     EVERY (check_freevars_ast tvs) ts ∧ EVERY (check_type_names tenvT) ts)
 Proof
  Induct >>
- rw [type_name_check_subst_def, st_ex_bind_def, guard_def, st_ex_return_def,
+ rw [type_name_check_subst_def, st_ex_bind_def, st_ex_ignore_bind_def,
+     guard_def, st_ex_return_def,
      check_freevars_ast_def, check_type_names_def, failwith_def,
      type_name_subst_def] >>
  every_case_tac >>
@@ -603,7 +616,7 @@ QED
 
 Theorem check_ctor_types_success:
    !l tenvT tvs ts s s'.
-   check_ctor_types l tenvT tvs ts s = (Success (),s') ⇔
+   check_ctor_types l tenvT tvs ts s = (M_success (),s') ⇔
    s = s' ∧
    EVERY (λ(cn,ts).  EVERY (check_freevars_ast tvs) ts ∧
    EVERY (check_type_names tenvT) ts) ts
@@ -611,7 +624,7 @@ Proof
   Induct_on `ts` >>
   rw [check_ctor_types_def, st_ex_return_def] >>
   PairCases_on `h` >>
-  rw [check_ctor_types_def, st_ex_bind_def] >>
+  rw [check_ctor_types_def, st_ex_ignore_bind_def] >>
   every_case_tac >>
   fs [type_name_check_subst_success] >>
   CCONTR_TAC >>
@@ -638,13 +651,14 @@ QED
 Theorem check_ctors_success:
   !l tenvT tds s s'.
    ALL_DISTINCT (MAP (FST o SND) tds) ⇒
-   (check_ctors l tenvT tds s = (Success (),s') ⇔
+   (check_ctors l tenvT tds s = (M_success (),s') ⇔
     s' = s ∧ check_ctor_tenv tenvT tds)
 Proof
   Induct_on `tds` >>
   rw [] >>
   TRY (PairCases_on `h`) >>
   fs [check_ctor_tenv_def, check_type_definition_def, st_ex_bind_def,
+      st_ex_ignore_bind_def,
       check_ctors_def, st_ex_return_def, check_dup_ctors_thm]
   >- metis_tac [] >>
   every_case_tac >>
@@ -666,7 +680,7 @@ Proof
     fs [] >>
     rw [check_ctor_types_def, st_ex_return_def] >>
     PairCases_on `h` >>
-    fs [check_ctor_types_def, st_ex_return_def, st_ex_bind_def] >>
+    fs [check_ctor_types_def, st_ex_return_def, st_ex_ignore_bind_def] >>
     every_case_tac >>
     fs [type_name_check_subst_success] >>
     rw [] >>
@@ -678,11 +692,11 @@ QED
 
 Theorem check_type_definition_success:
    !l tenvT tds s r s'.
-    check_type_definition l tenvT tds s = (Success r, s')
+    check_type_definition l tenvT tds s = (M_success r, s')
     ⇔
     s' = s ∧ check_ctor_tenv tenvT tds
 Proof
- rw [check_type_definition_def, st_ex_bind_def] >>
+ rw [check_type_definition_def, st_ex_ignore_bind_def] >>
  every_case_tac >>
  fs [check_dups_success]
  >- metis_tac [check_ctors_success] >>
@@ -699,8 +713,8 @@ QED
 
 Theorem option_case_eq[local]:
   !opt f g v st st'.
-  ((case opt of NONE => f | SOME x => g x) st = (Success v, st')) =
-  (((opt = NONE) ∧ (f st = (Success v, st'))) ∨ (?x. (opt = SOME x) ∧ (g x st = (Success v, st'))))
+  ((case opt of NONE => f | SOME x => g x) st = (M_success v, st')) =
+  (((opt = NONE) ∧ (f st = (M_success v, st'))) ∨ (?x. (opt = SOME x) ∧ (g x st = (M_success v, st'))))
 Proof
   rw [] >>
 cases_on `opt` >>
@@ -708,7 +722,8 @@ fs []
 QED
 
 val success_eqns =
-  LIST_CONJ [st_ex_return_success, st_ex_bind_success, fresh_uvar_success,
+  LIST_CONJ [st_ex_return_success, st_ex_bind_success, st_ex_ignore_bind_success,
+             fresh_uvar_success,
              apply_subst_success, add_constraint_success, lookup_st_ex_success,
              n_fresh_uvar_success, failwith_success, add_constraints_success,
              oneTheory.one, check_type_definition_success,
@@ -734,7 +749,7 @@ QED
 
 Theorem infer_funs_length:
  !l ienv funs ts st1 st2.
-  (infer_funs l ienv funs st1 = (Success ts, st2)) ⇒
+  (infer_funs l ienv funs st1 = (M_success ts, st2)) ⇒
   (LENGTH funs = LENGTH ts)
 Proof
 induct_on `funs` >>
@@ -751,8 +766,8 @@ Theorem type_name_check_subst_state:
   (!ts l err tenvT fvs (st:'a) r st'. type_name_check_subst_list l err tenvT fvs ts st = (r,st') ⇒ st = st')
 Proof
   Induct >>
-  rw [type_name_check_subst_def, st_ex_bind_def, guard_def, st_ex_return_def,
-      failwith_def, lookup_st_ex_def] >>
+  rw [type_name_check_subst_def, st_ex_bind_def, st_ex_ignore_bind_def,
+      guard_def, st_ex_return_def, failwith_def, lookup_st_ex_def] >>
   every_case_tac >>
   fs [] >>
   rw [] >>
@@ -765,11 +780,11 @@ QED
 
 Theorem infer_p_bindings:
  (!l cenv p st t env st'.
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     (pat_bindings p = MAP FST env)) ∧
  (!l cenv ps st ts env st'.
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
     (pats_bindings ps = MAP FST env))
 Proof
@@ -840,11 +855,11 @@ QED
 
 Theorem infer_p_constraints:
  (!l cenv p st t env st'.
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     (?ts. pure_add_constraints st.subst ts st'.subst)) ∧
  (!l cenv ps st ts env st'.
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
     (?ts'. pure_add_constraints st.subst ts' st'.subst))
 Proof
@@ -858,19 +873,19 @@ QED
 
 Theorem infer_e_constraints:
  (!l ienv e st st' t.
-    (infer_e l ienv e st = (Success t, st'))
+    (infer_e l ienv e st = (M_success t, st'))
     ⇒
     (?ts. pure_add_constraints st.subst ts st'.subst)) ∧
  (!l ienv es st st' ts.
-    (infer_es l ienv es st = (Success ts, st'))
+    (infer_es l ienv es st = (M_success ts, st'))
     ⇒
     (?ts. pure_add_constraints st.subst ts st'.subst)) ∧
  (!l ienv pes t1 t2 st st'.
-    (infer_pes l ienv pes t1 t2 st = (Success (), st'))
+    (infer_pes l ienv pes t1 t2 st = (M_success (), st'))
     ⇒
     (?ts. pure_add_constraints st.subst ts st'.subst)) ∧
  (!l ienv funs st st' ts'.
-    (infer_funs l ienv funs st = (Success ts', st'))
+    (infer_funs l ienv funs st = (M_success ts', st'))
     ⇒
     (?ts. pure_add_constraints st.subst ts st'.subst))
 Proof
@@ -915,11 +930,11 @@ QED
 
 Theorem infer_p_next_uvar_mono:
  (!l cenv p st t env st'.
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar) ∧
  (!l cenv ps st ts env st'.
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar)
 Proof
@@ -935,19 +950,19 @@ QED
 
 Theorem infer_e_next_uvar_mono:
  (!l ienv e st st' t.
-    (infer_e l ienv e st = (Success t, st'))
+    (infer_e l ienv e st = (M_success t, st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar) ∧
  (!l ienv es st st' ts.
-    (infer_es l ienv es st = (Success ts, st'))
+    (infer_es l ienv es st = (M_success ts, st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar) ∧
  (!l ienv pes t1 t2 st st'.
-    (infer_pes l ienv pes t1 t2 st = (Success (), st'))
+    (infer_pes l ienv pes t1 t2 st = (M_success (), st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar) ∧
  (!l ienv funs st st' ts.
-    (infer_funs l ienv funs st = (Success ts, st'))
+    (infer_funs l ienv funs st = (M_success ts, st'))
     ⇒
     st.next_uvar ≤ st'.next_uvar)
 Proof
@@ -970,12 +985,12 @@ QED
 Theorem infer_p_wfs:
  (!l cenv p st t env st'.
     t_wfs st.subst ∧
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     t_wfs st'.subst) ∧
  (!l cenv ps st ts env st'.
     t_wfs st.subst ∧
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
    t_wfs st'.subst)
 Proof
@@ -990,22 +1005,22 @@ QED
 
 Theorem infer_e_wfs:
  (!l ienv e st st' t.
-    infer_e l ienv e st = (Success t, st') ∧
+    infer_e l ienv e st = (M_success t, st') ∧
     t_wfs st.subst
     ⇒
     t_wfs st'.subst) ∧
  (!l ienv es st st' ts.
-    infer_es l ienv es st = (Success ts, st') ∧
+    infer_es l ienv es st = (M_success ts, st') ∧
     t_wfs st.subst
     ⇒
     t_wfs st'.subst) ∧
  (!l ienv pes t1 t2 st st'.
-    infer_pes l ienv pes t1 t2 st = (Success (), st') ∧
+    infer_pes l ienv pes t1 t2 st = (M_success (), st') ∧
     t_wfs st.subst
     ⇒
     t_wfs st'.subst) ∧
  (!l ienv funs st st' ts'.
-    infer_funs l ienv funs st = (Success ts', st') ∧
+    infer_funs l ienv funs st = (M_success ts', st') ∧
     t_wfs st.subst
     ⇒
     t_wfs st'.subst)
@@ -1397,12 +1412,12 @@ QED
 
 Theorem infer_p_check_t:
  (!l cenv p st t env st'.
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     EVERY (\(x,t). check_t 0 (count st'.next_uvar) t) env ∧
     check_t 0 (count st'.next_uvar) t) ∧
  (!l cenv ps st ts env st'.
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
     EVERY (\(x,t). check_t 0 (count st'.next_uvar) t) env ∧
     EVERY (check_t 0 (count st'.next_uvar)) ts)
@@ -1521,11 +1536,11 @@ QED
 
 Theorem type_name_check_subst_thm:
   (!t l err tenvT fvs (st:'a) r st'.
-    type_name_check_subst l err tenvT fvs t st = (Success r,st') ⇒
+    type_name_check_subst l err tenvT fvs t st = (M_success r,st') ⇒
     check_freevars_ast fvs t ∧ check_type_names tenvT t ∧
     r = type_name_subst tenvT t) ∧
   (!ts l err tenvT fvs (st:'a) rs st'.
-    type_name_check_subst_list l err tenvT fvs ts st = (Success rs,st') ⇒
+    type_name_check_subst_list l err tenvT fvs ts st = (M_success rs,st') ⇒
     EVERY (check_freevars_ast fvs) ts ∧ EVERY (check_type_names tenvT) ts ∧
     rs = MAP (type_name_subst tenvT) ts)
 Proof
@@ -1544,12 +1559,12 @@ Theorem type_name_check_subst_comp_thm:
     check_freevars_ast fvs t ∧ check_type_names tenvT t
     ⇒
     type_name_check_subst l err tenvT fvs t st =
-      (Success (type_name_subst tenvT t), st)) ∧
+      (M_success (type_name_subst tenvT t), st)) ∧
   (!ts l err tenvT fvs (st:'a) rs st'.
     EVERY (check_freevars_ast fvs) ts ∧ EVERY (check_type_names tenvT) ts
     ⇒
     type_name_check_subst_list l err tenvT fvs ts st =
-      (Success (MAP (type_name_subst tenvT) ts),st))
+      (M_success (MAP (type_name_subst tenvT) ts),st))
 Proof
   Induct >>
   rw [check_type_names_def, type_name_check_subst_def, check_freevars_def,
@@ -1561,7 +1576,7 @@ QED
 
 Theorem infer_p_check_s:
  (!l ienv p st t env st' tvs.
-  infer_p l ienv p st = (Success (t,env), st') ∧
+  infer_p l ienv p st = (M_success (t,env), st') ∧
   t_wfs st.subst ∧
   tenv_ctor_ok ienv.inf_c ∧
   tenv_abbrev_ok ienv.inf_t ∧
@@ -1569,7 +1584,7 @@ Theorem infer_p_check_s:
   ⇒
   check_s tvs (count st'.next_uvar) st'.subst) ∧
  (!l ienv ps st ts env st' tvs.
-  infer_ps l ienv ps st = (Success (ts,env), st') ∧
+  infer_ps l ienv ps st = (M_success (ts,env), st') ∧
   t_wfs st.subst ∧
   tenv_ctor_ok ienv.inf_c ∧
   tenv_abbrev_ok ienv.inf_t ∧
@@ -1584,7 +1599,7 @@ Proof
   >- metis_tac [check_s_more]
   >- (PairCases_on `v'` >>
       metis_tac [check_s_more2, infer_p_next_uvar_mono])
-  >- (rename1 `infer_ps _ _ _ _ = (Success v1, st1)` >>
+  >- (rename1 `infer_ps _ _ _ _ = (M_success v1, st1)` >>
       PairCases_on `v1` >>
       fs [] >>
       first_x_assum old_drule >>
@@ -1705,22 +1720,22 @@ QED
 
 Theorem infer_e_check_t:
   (∀l ienv e st st' t.
-     infer_e l ienv e st = (Success t, st') ∧
+     infer_e l ienv e st = (M_success t, st') ∧
      ienv_val_ok (count st.next_uvar) ienv.inf_v
      ⇒
     check_t 0 (count st'.next_uvar) t) ∧
   (∀l ienv es st st' ts.
-     infer_es l ienv es st = (Success ts, st') ∧
+     infer_es l ienv es st = (M_success ts, st') ∧
      ienv_val_ok (count st.next_uvar) ienv.inf_v
      ⇒
      EVERY (check_t 0 (count st'.next_uvar)) ts) ∧
   (∀l ienv pes t1 t2 st st'.
-     infer_pes l ienv pes t1 t2 st = (Success (), st') ∧
+     infer_pes l ienv pes t1 t2 st = (M_success (), st') ∧
     ienv_val_ok (count st.next_uvar) ienv.inf_v
      ⇒
      T) ∧
   (∀l ienv funs st st' ts'.
-     infer_funs l ienv funs st = (Success ts', st') ∧
+     infer_funs l ienv funs st = (M_success ts', st') ∧
      ienv_val_ok (count st.next_uvar) ienv.inf_v
      ⇒
      EVERY (check_t 0 (count st'.next_uvar)) ts')
@@ -1826,7 +1841,7 @@ val check_t_more_1 =
 
 Theorem constrain_op_wfs:
    !l tvs op ts t st st'.
-    constrain_op l op ts st = (Success t, st') ∧
+    constrain_op l op ts st = (M_success t, st') ∧
     t_wfs st.subst
     ⇒
     t_wfs st'.subst
@@ -1848,7 +1863,7 @@ QED
 
 Theorem constrain_op_check_t:
    !l tvs op ts t st st'.
-    constrain_op l op ts st = (Success t, st') ∧
+    constrain_op l op ts st = (M_success t, st') ∧
     EVERY (check_t 0 (count st.next_uvar)) ts
     ⇒
     check_t 0 (count st'.next_uvar) t
@@ -1864,7 +1879,7 @@ QED
 
 Theorem constrain_op_check_s:
    !l tvs op ts t st st'.
-    constrain_op l op ts st = (Success t, st') ∧
+    constrain_op l op ts st = (M_success t, st') ∧
     t_wfs st.subst ∧
     EVERY (check_t 0 (count st.next_uvar)) ts ∧
     check_s tvs (count st.next_uvar) st.subst
@@ -1928,21 +1943,21 @@ QED
 
 Theorem infer_e_check_s:
  (!l ienv e st st' t tvs.
-    infer_e l ienv e st = (Success t, st') ∧
+    infer_e l ienv e st = (M_success t, st') ∧
     t_wfs st.subst ∧
     ienv_ok (count st.next_uvar) ienv ∧
     check_s tvs (count st.next_uvar) st.subst
     ⇒
     check_s tvs (count st'.next_uvar) st'.subst) ∧
  (!l ienv es st st' ts tvs.
-    infer_es l ienv es st = (Success ts, st') ∧
+    infer_es l ienv es st = (M_success ts, st') ∧
     t_wfs st.subst ∧
     ienv_ok (count st.next_uvar) ienv ∧
     check_s tvs (count st.next_uvar) st.subst
     ⇒
     check_s tvs (count st'.next_uvar) st'.subst) ∧
  (!l ienv pes t1 t2 st st' tvs.
-    infer_pes l ienv pes t1 t2 st = (Success (), st') ∧
+    infer_pes l ienv pes t1 t2 st = (M_success (), st') ∧
     t_wfs st.subst ∧
     ienv_ok (count st.next_uvar) ienv ∧
     check_t 0 (count st.next_uvar) t1 ∧
@@ -1951,7 +1966,7 @@ Theorem infer_e_check_s:
     ⇒
     check_s tvs (count st'.next_uvar) st'.subst) ∧
  (!l ienv funs st st' ts' tvs.
-    infer_funs l ienv funs st = (Success ts', st') ∧
+    infer_funs l ienv funs st = (M_success ts', st') ∧
     t_wfs st.subst ∧
     ienv_ok (count st.next_uvar) ienv ∧
     check_s tvs (count st.next_uvar) st.subst
@@ -2226,7 +2241,7 @@ Proof
  >- (
    pairarg_tac
    >> fs [success_eqns]
-   >> rename1 `infer_p _ _ _ _ = (Success (t1',bindings1),st1)`
+   >> rename1 `infer_p _ _ _ _ = (M_success (t1',bindings1),st1)`
    >> old_drule (REWRITE_RULE [Once CONJ_SYM] (CONJUNCT1 infer_p_wfs))
    >> rw []
    >> old_drule (CONJUNCT1 infer_p_check_t)
@@ -2245,7 +2260,7 @@ Proof
    >> `check_t tvs (count st1.next_uvar) t1 ∧ check_t tvs (count st1.next_uvar) t1'`
      by metis_tac [check_t_more2, check_t_more4, DECIDE ``!y. y + 0n = y``]
    >> rw []
-   >> qmatch_assum_abbrev_tac `infer_e _ (ienv with inf_v := nsAppend bindings2 ienv.inf_v) _ _ = (Success t2', st2)`
+   >> qmatch_assum_abbrev_tac `infer_e _ (ienv with inf_v := nsAppend bindings2 ienv.inf_v) _ _ = (M_success t2', st2)`
    >> `ienv_val_ok (count st1.next_uvar) (nsAppend bindings2 ienv.inf_v)`
      by (
        fs [ienv_ok_def, ienv_val_ok_def, Abbr `bindings2`]
@@ -2905,7 +2920,7 @@ val let_tac =
    >> old_drule (CONJUNCT1 infer_e_next_uvar_mono)
    >> old_drule (CONJUNCT1 infer_p_next_uvar_mono)
    >> rw []
-   >> rename1 `infer_p _ _ _ st2 = (Success (t2, env2), st3)`
+   >> rename1 `infer_p _ _ _ st2 = (M_success (t2, env2), st3)`
    >> `check_t 0 (count st3.next_uvar) t1` by metis_tac [check_t_more4]
    >> fs []
    >> old_drule t_unify_wfs
@@ -2952,12 +2967,12 @@ QED
 
 Theorem infer_d_check:
  (!d ienv st1 st2 ienv'.
-  infer_d ienv d st1 = (Success ienv', st2) ∧
+  infer_d ienv d st1 = (M_success ienv', st2) ∧
   ienv_ok {} ienv
   ⇒
   ienv_ok {} ienv') ∧
  (!ds ienv st1 st2 ienv'.
-  infer_ds ienv ds st1 = (Success ienv', st2) ∧
+  infer_ds ienv ds st1 = (M_success ienv', st2) ∧
   ienv_ok {} ienv
   ⇒
   ienv_ok {} ienv')
@@ -2973,7 +2988,7 @@ Proof
    qmatch_assum_abbrev_tac
      `infer_funs _ (ienv with inf_v := nsAppend bindings ienv.inf_v) _ _ = _`
    >> rename1 `init_infer_state s0`
-   >> rename1 `infer_funs _ _ funs _ = (Success funs_ts, st1)`
+   >> rename1 `infer_funs _ _ funs _ = (M_success funs_ts, st1)`
    >> rename1 `pure_add_constraints _ _ st2.subst`
    >> `ienv_ok (count (LENGTH funs)) (ienv with inf_v := nsAppend bindings ienv.inf_v)`
      by (
@@ -3078,11 +3093,11 @@ QED
 
 Theorem infer_p_next_id_const:
  (!l cenv p st t env st'.
-    (infer_p l cenv p st = (Success (t,env), st'))
+    (infer_p l cenv p st = (M_success (t,env), st'))
     ⇒
     st.next_id = st'.next_id) ∧
  (!l cenv ps st ts env st'.
-    (infer_ps l cenv ps st = (Success (ts,env), st'))
+    (infer_ps l cenv ps st = (M_success (ts,env), st'))
     ⇒
     st.next_id = st'.next_id)
 Proof
@@ -3097,19 +3112,19 @@ QED
 
 Theorem infer_e_next_id_const:
  (!l ienv e st st' t.
-    (infer_e l ienv e st = (Success t, st'))
+    (infer_e l ienv e st = (M_success t, st'))
     ⇒
     st.next_id = st'.next_id) ∧
  (!l ienv es st st' ts.
-    (infer_es l ienv es st = (Success ts, st'))
+    (infer_es l ienv es st = (M_success ts, st'))
     ⇒
     st.next_id = st'.next_id) ∧
  (!l ienv pes t1 t2 st st'.
-    (infer_pes l ienv pes t1 t2 st = (Success (), st'))
+    (infer_pes l ienv pes t1 t2 st = (M_success (), st'))
     ⇒
     st.next_id = st'.next_id) ∧
  (!l ienv funs st st' ts.
-    (infer_funs l ienv funs st = (Success ts, st'))
+    (infer_funs l ienv funs st = (M_success ts, st'))
     ⇒
     st.next_id = st'.next_id)
 Proof
@@ -3127,10 +3142,10 @@ QED
 
 Theorem infer_d_next_id_mono:
  (!d ienv st t st'.
-  infer_d ienv d st = (Success t, st') ⇒
+  infer_d ienv d st = (M_success t, st') ⇒
   st.next_id ≤ st'.next_id) ∧
  (!ds ienv st ts st'.
-  (infer_ds ienv ds st = (Success ts, st') ⇒
+  (infer_ds ienv ds st = (M_success ts, st') ⇒
   st.next_id ≤ st'.next_id))
 Proof
   Induct>>rw[]>>
@@ -3580,7 +3595,7 @@ End
 
 Theorem infer_p_inf_set_tids:
   (!l cenv p st t env st'.
-  (infer_p l cenv p st = (Success (t,env), st'))
+  (infer_p l cenv p st = (M_success (t,env), st'))
   ⇒
   prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
   ∧ t_wfs st.subst
@@ -3589,7 +3604,7 @@ Theorem infer_p_inf_set_tids:
   EVERY (inf_set_tids_subset tids o SND) env ∧
   inf_set_tids_subst tids st'.subst) ∧
   (!l cenv ps st ts env st'.
-  (infer_ps l cenv ps st = (Success (ts,env), st'))
+  (infer_ps l cenv ps st = (M_success (ts,env), st'))
   ⇒
   prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
   ∧ t_wfs st.subst
@@ -3604,13 +3619,13 @@ Proof
   simp[inf_set_tids_subset_def,inf_set_tids_def]>>
   TRY(fs[hide_def,prim_tids_def,prim_type_nums_def]>>NO_TAC)
   >- (
-    rename1`infer_ps _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_ps _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     fs[hide_def,SUBSET_DEF,MEM_MAP,PULL_EXISTS,EVERY_MEM,inf_set_tids_subset_def]>>
     fs[prim_tids_def,prim_type_nums_def]>>
     metis_tac[])
   >- (
-    rename1`infer_ps _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_ps _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     fs[hide_def,SUBSET_DEF,MEM_MAP,PULL_EXISTS,EVERY_MEM,inf_set_tids_subset_def,MEM_COUNT_LIST]>>
     rw[]
@@ -3646,13 +3661,13 @@ Proof
         simp[MAP_ZIP,LENGTH_COUNT_LIST,SUBSET_DEF,PULL_EXISTS]>>
         simp[MEM_MAP,PULL_EXISTS,MEM_COUNT_LIST,inf_set_tids_def]))
   >- (
-    rename1`infer_p _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_p _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     fs[hide_def,SUBSET_DEF,MEM_MAP,PULL_EXISTS,EVERY_MEM,inf_set_tids_subset_def]>>
     fs[prim_tids_def,prim_type_nums_def]>>
     metis_tac[])
   >- ( (* Pas case *)
-    rename1`infer_p _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_p _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     fs[hide_def,SUBSET_DEF,MEM_MAP,PULL_EXISTS,EVERY_MEM,inf_set_tids_subset_def]>>
     fs[prim_tids_def,prim_type_nums_def]>>
@@ -3680,11 +3695,11 @@ Proof
     match_mp_tac set_tids_subset_type_name_subst>>
     fs[inf_set_tids_ienv_def,prim_tids_def,prim_type_nums_def,inf_set_tids_unconvert,inf_set_tids_subset_def,set_tids_subset_def])
   >- (
-    rename1`infer_p _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_p _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     simp[]>>
     strip_tac>>
-    rename1`infer_ps _ _ _ _ = (Success vv,_)`>>
+    rename1`infer_ps _ _ _ _ = (M_success vv,_)`>>
     Cases_on`vv`>> first_x_assum old_drule>>
     impl_tac>- (
       imp_res_tac infer_p_wfs>>
@@ -3695,7 +3710,7 @@ Proof
 QED
 
 Theorem constrain_op_set_tids:
-   constrain_op l op ts st = (Success t, st') ∧
+   constrain_op l op ts st = (M_success t, st') ∧
    EVERY (inf_set_tids_subset tids) ts ∧
    inf_set_tids_subst tids st.subst ∧
    t_wfs st.subst ∧ prim_tids T tids
@@ -3736,7 +3751,7 @@ QED
 
 Theorem infer_e_inf_set_tids:
   (!l cenv p st t st'.
-    (infer_e l cenv p st = (Success t, st'))
+    (infer_e l cenv p st = (M_success t, st'))
     ⇒
     prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
     ∧ t_wfs st.subst
@@ -3744,7 +3759,7 @@ Theorem infer_e_inf_set_tids:
     inf_set_tids_subset tids t ∧
     inf_set_tids_subst tids st'.subst) ∧
   (!l cenv ps st ts st'.
-    (infer_es l cenv ps st = (Success ts, st'))
+    (infer_es l cenv ps st = (M_success ts, st'))
     ⇒
     prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
     ∧ t_wfs st.subst
@@ -3752,7 +3767,7 @@ Theorem infer_e_inf_set_tids:
     EVERY (inf_set_tids_subset tids) ts ∧
     inf_set_tids_subst tids st'.subst) ∧
   (!l cenv ps t1 t2 st st'.
-    (infer_pes l cenv ps t1 t2 st = (Success (), st'))
+    (infer_pes l cenv ps t1 t2 st = (M_success (), st'))
     ⇒
     prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
     ∧ inf_set_tids_subset tids t1
@@ -3761,7 +3776,7 @@ Theorem infer_e_inf_set_tids:
     ⇒
     inf_set_tids_subst tids st'.subst) ∧
   (!l cenv funs st ts st'.
-    (infer_funs l cenv funs st = (Success ts, st'))
+    (infer_funs l cenv funs st = (M_success ts, st'))
     ⇒
     prim_tids T tids ∧ inf_set_tids_ienv tids cenv ∧ inf_set_tids_subst tids st.subst
     ∧ t_wfs st.subst
@@ -3899,7 +3914,7 @@ Proof
     rpt(t_unify_set_tids |> CONJUNCT1 |> SIMP_RULE std_ss [PULL_FORALL,AND_IMP_INTRO]
         |> first_x_assum o mp_then(Pat`t_unify`)(qspec_then ‘tids’ mp_tac))
     \\ simp[inf_set_tids_subset_def,inf_set_tids_def]
-    \\ rename1`infer_p _ _ _ _ = (Success pp,_)`
+    \\ rename1`infer_p _ _ _ _ = (M_success pp,_)`
     \\ Cases_on`pp`
     \\ imp_res_tac infer_p_wfs
     \\ fs[]
@@ -4011,13 +4026,13 @@ QED
 
 Theorem infer_d_inf_set_tids:
    (∀d ienv st ienv' st'.
-     infer_d ienv d st = (Success ienv', st') ∧
+     infer_d ienv d st = (M_success ienv', st') ∧
      start_type_id ≤ st.next_id ∧
      inf_set_tids_ienv (count st.next_id) ienv
      ⇒
      inf_set_tids_ienv (count st'.next_id) ienv') ∧
   (∀ds ienv st ienv' st'.
-     infer_ds ienv ds st = (Success ienv', st') ∧
+     infer_ds ienv ds st = (M_success ienv', st') ∧
      start_type_id ≤ st.next_id ∧
      inf_set_tids_ienv (count st.next_id) ienv
      ⇒
@@ -4188,12 +4203,12 @@ QED
 
 Theorem infer_d_wfs:
    (∀d ienv st ienv' st'.
-     infer_d ienv d st = (Success ienv', st') ∧
+     infer_d ienv d st = (M_success ienv', st') ∧
      t_wfs st.subst
      ⇒
      t_wfs st'.subst) ∧
   (∀ds ienv st ienv' st'.
-     infer_ds ienv ds st = (Success ienv', st') ∧
+     infer_ds ienv ds st = (M_success ienv', st') ∧
      t_wfs st.subst
      ⇒
      t_wfs st'.subst)

--- a/compiler/inference/inferScript.sml
+++ b/compiler/inference/inferScript.sml
@@ -4,21 +4,15 @@
 Theory infer
 Ancestors
   misc ast namespace typeSystem namespaceProps infer_t unify
-  string primTypes
+  string primTypes ml_monadBase
 Libs
   preamble
 
 val _ = monadsyntax.temp_add_monadsyntax()
 val _ = patternMatchesSyntax.temp_enable_pmatch();
 
-(*  The inferencer uses a state monad internally to keep track of unifications at the expressions level *)
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
-(* 'a is the type of the state, 'b is the type of successful computations, and
- * 'c is the type of exceptions *)
-
-Datatype:
-  exc = Success 'a | Failure 'b
-End
 
 Type err_var = (type_of ``primTypes$prim_tenv.t``)
 
@@ -27,29 +21,9 @@ Datatype:
                     err : err_var |>
 End
 
-Type M = ``:'a -> ('b, 'c) exc # 'a``
-
-Definition st_ex_bind_def:
-  (st_ex_bind : (α, β, γ) M -> (β -> (α, δ, γ) M) -> (α, δ, γ) M) x f =
-  λs.
-    case x s of
-      (Success y,s) => f y s
-    | (Failure x,s) => (Failure x,s)
-End
-
-Definition st_ex_return_def:
-  (st_ex_return (*: α -> (β, α, γ) M*)) x =
-    λs. (Success x, s)
-End
-
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload return[local] = ``st_ex_return``
-
 Definition failwith_def:
   (failwith : loc_err_info -> α -> (β, γ, (locs option # α)) M) l msg =
-    (\s. (Failure (l.loc, msg), s))
+    (\s. (M_failure (l.loc, msg), s))
 End
 
 Definition guard_def:
@@ -58,19 +32,19 @@ End
 
 Definition read_def:
   (read : (α, α, β) M) =
-  \s. (Success s, s)
+  \s. (M_success s, s)
 End
 
 Definition write_def:
   (write : α -> (α, unit, β) M) v =
-  \s. (Success (), v)
+  \s. (M_success (), v)
 End
 
 Definition lookup_st_ex_def:
   lookup_st_ex l err id ienv st =
     case nsLookup ienv id of
-    | NONE => (Failure (l.loc, concat [«Undefined »; err; «: »; id_to_string id]), st)
-    | SOME v => (Success v, st)
+    | NONE => (M_failure (l.loc, concat [«Undefined »; err; «: »; id_to_string id]), st)
+    | SOME v => (M_success v, st)
 End
 
 Datatype:
@@ -82,7 +56,7 @@ End
 
 Definition fresh_uvar_def:
   (fresh_uvar : (infer_st, infer_t, α) M) =
-  \s. (Success (Infer_Tuvar s.next_uvar), s with <| next_uvar := s.next_uvar + 1 |>)
+  \s. (M_success (Infer_Tuvar s.next_uvar), s with <| next_uvar := s.next_uvar + 1 |>)
 End
 
 Definition n_fresh_uvar_def:
@@ -99,7 +73,7 @@ End
 Definition n_fresh_id_def:
   n_fresh_id n =
   λs.
-  (Success (GENLIST (λx. s.next_id+x) n), s with next_id := s.next_id+n)
+  (M_success (GENLIST (λx. s.next_id+x) n), s with next_id := s.next_id+n)
 End
 
 (* Doesn't reset the ID component *)
@@ -110,7 +84,7 @@ End
 Definition init_state_def:
   init_state =
   \st.
-    (Success (), init_infer_state st)
+    (M_success (), init_infer_state st)
 End
 
 Definition add_constraint_def:
@@ -118,14 +92,14 @@ Definition add_constraint_def:
   \st.
     case t_unify st.subst t1 t2 of
       | NONE =>
-          (Failure (l.loc, concat [«Type mismatch between »;
+          (M_failure (l.loc, concat [«Type mismatch between »;
                                    inf_type_to_string l.err
                                          (t_walkstar st.subst t1);
                                    « and »;
                                    inf_type_to_string l.err
                                          (t_walkstar st.subst t2)]), st)
       | SOME s =>
-          (Success (), st with <| subst := s |>)
+          (M_success (), st with <| subst := s |>)
 End
 
 Definition add_constraints_def:
@@ -142,7 +116,7 @@ End
 
 Definition get_next_uvar_def:
 get_next_uvar =
-  \st. (Success st.next_uvar, st)
+  \st. (M_success st.next_uvar, st)
 End
 
 Definition apply_subst_def:
@@ -294,17 +268,24 @@ End
 
 Theorem bind_guard:
   st_ex_bind (guard b l x) g =
-  λs. if b then g () s else (Failure (l.loc,x),s)
+  λs. if b then g () s else (M_failure (l.loc,x),s)
 Proof
-  rw [st_ex_bind_def,FUN_EQ_THM,guard_def,st_ex_return_def,failwith_def]
+  rw [st_ex_bind_def,guard_def,st_ex_return_def,failwith_def]
+QED
+
+Theorem ignore_bind_guard:
+  st_ex_ignore_bind (guard b l x) g =
+  λs. if b then g s else (M_failure (l.loc,x),s)
+Proof
+  rw [st_ex_ignore_bind_def,guard_def,st_ex_return_def,failwith_def]
 QED
 
 Theorem st_ex_bind_pair:
   monad_bind x f =
   (λs.
      case x s of
-     | (Success (y,z),s) => f (y,z) s
-     | (Failure x,s) => (Failure x,s))
+     | (M_success (y,z),s) => f (y,z) s
+     | (M_failure x,s) => (M_failure x,s))
 Proof
   gvs [st_ex_bind_def,FUN_EQ_THM]
   \\ rw [] \\ Cases_on ‘x s’ \\ gvs []
@@ -315,8 +296,8 @@ Theorem st_ex_bind_triple:
   monad_bind x f =
   (λs.
      case x s of
-     | (Success (y,z,q),s) => f (y,z,q) s
-     | (Failure x,s) => (Failure x,s))
+     | (M_success (y,z,q),s) => f (y,z,q) s
+     | (M_failure x,s) => (M_failure x,s))
 Proof
   gvs [st_ex_bind_def,FUN_EQ_THM]
   \\ rw [] \\ Cases_on ‘x s’ \\ gvs []
@@ -325,76 +306,77 @@ QED
 
 val type_name_check_subst_alt =
   type_name_check_subst_def
-  |> SRULE [bind_guard]
+  |> SRULE [bind_guard, ignore_bind_guard]
   |> SRULE [st_ex_bind_pair]
-  |> SRULE [st_ex_bind_def,lookup_st_ex_def,st_ex_return_def];
+  |> SRULE [st_ex_bind_def,st_ex_ignore_bind_def,lookup_st_ex_def,
+            st_ex_return_def];
 
 Definition type_name_check_sub_def:
    (type_name_check_sub l tenvT fvs (Atvar tv) =
-        (λs. if MEM tv fvs then (Success (Tvar tv),s)
-             else (Failure (l.loc,INR tv),s))) ∧
+        (λs. if MEM tv fvs then (M_success (Tvar tv),s)
+             else (M_failure (l.loc,INR tv),s))) ∧
    (type_name_check_sub l tenvT fvs (Attup ts) =
         (λs. case type_name_check_sub_list l tenvT fvs ts s of
-               (Success ts',s) => (Success (Ttup ts'),s)
-             | (Failure x,s) => (Failure x,s))) ∧
+               (M_success ts',s) => (M_success (Ttup ts'),s)
+             | (M_failure x,s) => (M_failure x,s))) ∧
    (type_name_check_sub l tenvT fvs (Atfun t1 t2) =
         (λs. case type_name_check_sub l tenvT fvs t1 s of
-               (Success t1',s) =>
+               (M_success t1',s) =>
                  (case type_name_check_sub l tenvT fvs t2 s of
-                    (Success t2',s) => (Success (Tfn t1' t2'),s)
-                  | (Failure x,s) => (Failure x,s))
-             | (Failure x,s) => (Failure x,s))) ∧
+                    (M_success t2',s) => (M_success (Tfn t1' t2'),s)
+                  | (M_failure x,s) => (M_failure x,s))
+             | (M_failure x,s) => (M_failure x,s))) ∧
    (type_name_check_sub l tenvT fvs (Atapp ts tc) =
         (λs. case type_name_check_sub_list l tenvT fvs ts s of
-               (Success ts',s) =>
+               (M_success ts',s) =>
                  (case
                     case nsLookup tenvT tc of
                       NONE =>
-                        (Failure
+                        (M_failure
                            (l.loc, INL $
                             concat
                               [«Undefined »;
                                «type constructor»; «: »;
                                id_to_string tc]),s)
-                    | SOME v => (Success v,s)
+                    | SOME v => (M_success v,s)
                   of
-                    (Success (y,z),s) =>
+                    (M_success (y,z),s) =>
                       if LENGTH y = LENGTH ts then
-                        (Success (type_subst (alist_to_fmap (ZIP (y,ts'))) z),
+                        (M_success (type_subst (alist_to_fmap (ZIP (y,ts'))) z),
                          s)
                       else
-                        (Failure
+                        (M_failure
                            (l.loc, INL $
                             concat
                               [«Type constructor »; id_to_string tc;
                                « given »; toString (LENGTH ts);
                                « arguments, but expected »;
                                toString (LENGTH y)]),s)
-                  | (Failure x,s) => (Failure x,s))
-             | (Failure x,s) => (Failure x,s))) ∧
-   (type_name_check_sub_list l tenvT fvs [] = (λs. (Success [],s))) ∧
+                  | (M_failure x,s) => (M_failure x,s))
+             | (M_failure x,s) => (M_failure x,s))) ∧
+   (type_name_check_sub_list l tenvT fvs [] = (λs. (M_success [],s))) ∧
    (type_name_check_sub_list l tenvT fvs (t::ts) =
        (λs. case type_name_check_sub l tenvT fvs t s of
-              (Success t',s) =>
+              (M_success t',s) =>
                 (case type_name_check_sub_list l tenvT fvs ts s of
-                   (Success ts',s) => (Success (t'::ts'),s)
-                 | (Failure x,s) => (Failure x,s))
-            | (Failure x,s) => (Failure x,s)))
+                   (M_success ts',s) => (M_success (t'::ts'),s)
+                 | (M_failure x,s) => (M_failure x,s))
+            | (M_failure x,s) => (M_failure x,s)))
 End
 
 Theorem to_type_name_check_sub:
   (∀t l f tenvT fvs.
      type_name_check_subst l f tenvT fvs t =
      λs:'a. case type_name_check_sub l tenvT fvs t s of
-         | (Failure (x,INR r),s) => (Failure (x,f r),s)
-         | (Failure (x,INL r),s) => (Failure (x,r),s)
-         | (Success y,s) => (Success y,s)) ∧
+         | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+         | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+         | (M_success y,s) => (M_success y,s)) ∧
   (∀t l f tenvT fvs.
      type_name_check_subst_list l f tenvT fvs t =
      λs:'a. case type_name_check_sub_list l tenvT fvs t s of
-         | (Failure (x,INR r),s) => (Failure (x,f r),s)
-         | (Failure (x,INL r),s) => (Failure (x,r),s)
-         | (Success y,s) => (Success y,s))
+         | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+         | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+         | (M_success y,s) => (M_success y,s))
 Proof
   ho_match_mp_tac ast_t_induction \\ rpt strip_tac
   \\ simp [type_name_check_subst_alt,type_name_check_sub_def,FUN_EQ_THM]
@@ -421,16 +403,32 @@ QED
 Theorem bind_type_name_check_subst:
   (st_ex_bind (type_name_check_subst l f tenvT fvs t) g =
    λs:'a. case type_name_check_sub l tenvT fvs t s of
-          | (Failure (x,INR r),s) => (Failure (x,f r),s)
-          | (Failure (x,INL r),s) => (Failure (x,r),s)
-          | (Success y,s) => g y s) ∧
+          | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+          | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+          | (M_success y,s) => g y s) ∧
   (st_ex_bind (type_name_check_subst_list l f tenvT fvs ts) gs =
    λs:'a. case type_name_check_sub_list l tenvT fvs ts s of
-          | (Failure (x,INR r),s) => (Failure (x,f r),s)
-          | (Failure (x,INL r),s) => (Failure (x,r),s)
-          | (Success y,s) => gs y s)
+          | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+          | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+          | (M_success y,s) => gs y s)
 Proof
   rw [to_type_name_check_sub,st_ex_bind_def,FUN_EQ_THM]
+  \\ rpt (FULL_CASE_TAC \\ gvs [])
+QED
+
+Theorem ignore_bind_type_name_check_subst:
+  (st_ex_ignore_bind (type_name_check_subst l f tenvT fvs t) g =
+   λs:'a. case type_name_check_sub l tenvT fvs t s of
+          | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+          | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+          | (M_success y,s) => g s) ∧
+  (st_ex_ignore_bind (type_name_check_subst_list l f tenvT fvs ts) gs =
+   λs:'a. case type_name_check_sub_list l tenvT fvs ts s of
+          | (M_failure (x,INR r),s) => (M_failure (x,f r),s)
+          | (M_failure (x,INL r),s) => (M_failure (x,r),s)
+          | (M_success y,s) => gs s)
+Proof
+  rw [to_type_name_check_sub,st_ex_ignore_bind_def,FUN_EQ_THM]
   \\ rpt (FULL_CASE_TAC \\ gvs [])
 QED
 
@@ -450,16 +448,16 @@ End
 
 Theorem check_dups_eq_find_dup:
   ∀xs.
-    st_ex_bind (check_dups l f xs) g =
+    st_ex_ignore_bind (check_dups l f xs) g =
     λs. case find_dup xs of
-        | NONE => g () s
-        | SOME x => (Failure (l.loc, f x), s)
+        | NONE => g s
+        | SOME x => (M_failure (l.loc, f x), s)
 Proof
   Induct
   \\ simp [check_dups_def,st_ex_return_def,find_dup_def]
-  >- gvs [st_ex_bind_def]
+  >- gvs [st_ex_ignore_bind_def]
   \\ rw [failwith_def]
-  \\ gvs [st_ex_bind_def]
+  \\ gvs [st_ex_ignore_bind_def]
 QED
 
 Definition check_ctor_types_def:
@@ -475,7 +473,7 @@ Definition check_ctor_types_def:
 End
 
 Theorem check_ctor_types_expand = check_ctor_types_def
-  |> SRULE [bind_type_name_check_subst,FUN_EQ_THM,st_ex_return_def];
+  |> SRULE [ignore_bind_type_name_check_subst,FUN_EQ_THM,st_ex_return_def];
 
 Definition check_ctors_def:
   (check_ctors l tenvT [] = return ()) ∧
@@ -495,7 +493,8 @@ Definition check_ctors_def:
 End
 
 Theorem check_ctors_expand = check_ctors_def
-  |> SRULE [check_dups_eq_find_dup,FUN_EQ_THM,st_ex_bind_def,st_ex_return_def];
+  |> SRULE [check_dups_eq_find_dup,FUN_EQ_THM,st_ex_return_def]
+  |> SRULE [st_ex_ignore_bind_def];
 
 Definition check_type_definition_def:
   check_type_definition l tenvT tds =
@@ -509,7 +508,7 @@ Definition check_type_definition_def:
 End
 
 Theorem check_type_definition_expand = check_type_definition_def
-  |> SRULE [check_dups_eq_find_dup,FUN_EQ_THM,st_ex_bind_def,st_ex_return_def];
+  |> SRULE [check_dups_eq_find_dup,FUN_EQ_THM,st_ex_return_def];
 
 Definition infer_p_def:
   (infer_p l ienv (Pvar n) =
@@ -583,10 +582,10 @@ Proof
 QED
 
 Theorem infer_p_expand = infer_p_def
-  |> SRULE [check_dups_eq_find_dup,bind_guard,bind_type_name_check_subst]
+  |> SRULE [ignore_bind_guard,bind_guard,bind_type_name_check_subst]
   |> SRULE [st_ex_bind_triple]
   |> SRULE [st_ex_bind_pair]
-  |> SRULE [st_ex_bind_def,FUN_EQ_THM,st_ex_return_def,
+  |> SRULE [st_ex_bind_def,st_ex_ignore_bind_def,FUN_EQ_THM,st_ex_return_def,
             failwith_def,option_case_rand];
 
 Definition word_tc_def:
@@ -801,9 +800,9 @@ Theorem constrain_op_expand = constrain_op_case_def
   |> SRULE [st_ex_bind_def,st_ex_return_def];
 
 Theorem st_ex_bind_failure:
-  st_ex_bind f g s = (Failure r, s') <=>
-  (f s = (Failure r, s') \/
-    (?x st. f s = (Success x, st) /\ g x st = (Failure r, s')))
+  st_ex_bind f g s = (M_failure r, s') <=>
+  (f s = (M_failure r, s') \/
+    (?x st. f s = (M_success x, st) /\ g x st = (M_failure r, s')))
 Proof
   simp [st_ex_bind_def]
   \\ every_case_tac
@@ -812,7 +811,7 @@ QED
 Theorem constrain_op_error_msg_sanity:
   ∀l op args s l' s' msg.
     LENGTH args = SND (op_to_string op) ∧
-    constrain_op l op args s = (Failure (l',msg), s')
+    constrain_op l op args s = (M_failure (l',msg), s')
     ⇒
     IS_PREFIX (explode msg) "Type mismatch" ∨
     IS_PREFIX (explode msg) "Unsafe" ∨
@@ -1032,10 +1031,10 @@ Proof
 QED
 
 Theorem infer_e_expand = infer_e_def
-  |> SRULE [check_dups_eq_find_dup,bind_guard,bind_type_name_check_subst]
+  |> SRULE [check_dups_eq_find_dup,ignore_bind_guard,bind_type_name_check_subst]
   |> SRULE [st_ex_bind_triple]
   |> SRULE [st_ex_bind_pair]
-  |> SRULE [st_ex_bind_def,FUN_EQ_THM_state,st_ex_return_def,
+  |> SRULE [st_ex_bind_def,st_ex_ignore_bind_def,FUN_EQ_THM_state,st_ex_return_def,
             failwith_def,option_case_rand,COND_RATOR];
 
 Definition extend_dec_ienv_def:
@@ -1149,7 +1148,7 @@ Theorem infer_d_expand = infer_d_def
   |> SRULE [check_dups_eq_find_dup,bind_guard,bind_type_name_check_subst]
   |> SRULE [st_ex_bind_triple]
   |> SRULE [st_ex_bind_pair]
-  |> SRULE [st_ex_bind_def,FUN_EQ_THM,st_ex_return_def,
+  |> SRULE [st_ex_bind_def,st_ex_ignore_bind_def,FUN_EQ_THM,st_ex_return_def,
             failwith_def,option_case_rand];
 
 (* The starting Id should be greater than Tlist_num :: (Tbool_num :: prim_type_nums) *)
@@ -1161,16 +1160,16 @@ End
 Definition infertype_prog_def:
   infertype_prog ienv prog =
     case FST (infer_ds ienv prog (init_infer_state <| next_uvar := 0; subst := FEMPTY; next_id := start_type_id |>)) of
-    | Success new_ienv => Success (extend_dec_ienv new_ienv ienv)
-    | Failure x => Failure x
+    | M_success new_ienv => M_success (extend_dec_ienv new_ienv ienv)
+    | M_failure x => M_failure x
 End
 
 Definition infertype_prog_inc_def:
   infertype_prog_inc (ienv, next_id) prog =
   case infer_ds ienv prog (init_infer_state <| next_id := next_id |>) of
-    (Success new_ienv, st) =>
-    (Success (extend_dec_ienv new_ienv ienv, st.next_id))
-  | (Failure x, _) => Failure x
+    (M_success new_ienv, st) =>
+    (M_success (extend_dec_ienv new_ienv ienv, st.next_id))
+  | (M_failure x, _) => M_failure x
 End
 
 Definition init_config_def:

--- a/compiler/inference/infer_cvScript.sml
+++ b/compiler/inference/infer_cvScript.sml
@@ -4,6 +4,7 @@
 Theory infer_cv[no_sig_docs]
 Ancestors
   misc typeSystem ast namespace infer inferProps basis_cv unify_cv source_cv
+  ml_monadBase
 Libs
   preamble cv_transLib
 
@@ -11,7 +12,8 @@ val expand = let
   val th1 = SRULE [FUN_EQ_THM] st_ex_bind_def
   val th2 = SRULE [FUN_EQ_THM] st_ex_return_def
   val th3 = SRULE [FUN_EQ_THM,COND_RATOR,th2] guard_def
-  in SRULE [th1,th2,th3,FUN_EQ_THM] end
+  val th4 = SRULE [FUN_EQ_THM] st_ex_ignore_bind_def
+  in SRULE [th1,th2,th3,th4,FUN_EQ_THM] end
 
 val _ = cv_auto_trans $ expand failwith_def;
 val _ = cv_auto_trans $ expand read_def;
@@ -279,8 +281,8 @@ val infertype_prog_inc_eq =
 val call_infer_pre = cv_auto_trans_pre "" call_infer_def;
 
 Theorem type_name_check_sub_success:
-  type_name_check_sub l ienv.inf_t xs a s = (Success r,s1) ⇒
-  ∃f. type_name_check_subst l f ienv.inf_t xs a s = (Success r,s1)
+  type_name_check_sub l ienv.inf_t xs a s = (M_success r,s1) ⇒
+  ∃f. type_name_check_subst l f ienv.inf_t xs a s = (M_success r,s1)
 Proof
   gvs [to_type_name_check_sub]
 QED

--- a/compiler/inference/proofs/inferCompleteScript.sml
+++ b/compiler/inference/proofs/inferCompleteScript.sml
@@ -313,8 +313,8 @@ Theorem type_pe_determ_canon_infer_e:
   ienv_ok {} ienv ∧
   start_type_id ≤ ss.next_id ∧
   inf_set_tids_ienv (count ss.next_id) ienv ∧
-  infer_e loc ienv e (init_infer_state ss) = (Success t, st) ∧
-  infer_p loc ienv p st = (Success (t', new_bindings), st') ∧
+  infer_e loc ienv e (init_infer_state ss) = (M_success t, st) ∧
+  infer_p loc ienv p st = (M_success (t', new_bindings), st') ∧
   t_unify st'.subst t t' = SOME s ∧
   type_pe_determ_canon ss.next_id tenv Empty p e
   ⇒
@@ -617,7 +617,7 @@ Theorem infer_d_complete_canon:
    ?ienv' st2.
      env_rel tenv' ienv' ∧
      st2.next_id = st1.next_id + ids ∧
-     infer_d ienv d st1 = (Success ienv', st2)) ∧
+     infer_d ienv d st1 = (M_success ienv', st2)) ∧
   (!ds n tenv ids tenv' ienv st1.
    type_ds_canon n tenv ds ids tenv' ∧
    env_rel tenv ienv ∧
@@ -627,7 +627,7 @@ Theorem infer_d_complete_canon:
    ?ienv' st2.
      env_rel tenv' ienv' ∧
      st2.next_id = st1.next_id + ids ∧
-     infer_ds ienv ds st1 = (Success ienv', st2))
+     infer_ds ienv ds st1 = (M_success ienv', st2))
 Proof
   Induct>>
   rw [] >>
@@ -1383,7 +1383,7 @@ Theorem infer_ds_complete:
    start_type_id ≤ st1.next_id
    ⇒
    ∃g mapped_tenv' ienv' st2.
-     infer_ds ienv ds st1 = (Success ienv', st2) ∧
+     infer_ds ienv ds st1 = (M_success ienv', st2) ∧
      (*
      BIJ g (count st1.next_id ∪ count ids) (count (st1.next_id + ids)) ∧
      *)
@@ -1453,7 +1453,7 @@ Theorem check_specs_complete:
         decls = convert_decls idecls ∧
         env_rel tenv new_ienv ∧
         check_specs mn tenvT extra_idecls extra_ienv specs st1 =
-          (Success (append_decls idecls extra_idecls,extend_dec_ienv new_ienv extra_ienv), st2)
+          (M_success (append_decls idecls extra_idecls,extend_dec_ienv new_ienv extra_ienv), st2)
 Proof
   ho_match_mp_tac type_specs_ind >>
   rw [check_specs_def, success_eqns]
@@ -1468,7 +1468,7 @@ Proof
     disch_then (qspec_then `st1` strip_assume_tac) >>
     rw [PULL_EXISTS] >>
     qho_match_abbrev_tac
-      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ _ (extra_ienv with inf_v := nsBind name new extra_ienv.inf_v) _ _ = (Success (_ idecls new_ienv), st2)` >>
+      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ _ (extra_ienv with inf_v := nsBind name new extra_ienv.inf_v) _ _ = (M_success (_ idecls new_ienv), st2)` >>
     simp [] >>
     first_x_assum (qspecl_then [`st'`, `extra_idecls`, `(extra_ienv with inf_v := nsBind name new extra_ienv.inf_v)`] mp_tac) >>
     rw [] >>
@@ -1491,7 +1491,7 @@ Proof
  >- (
     qho_match_abbrev_tac
       `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ _ ∧ check_specs _ _ eid'
-         <| inf_v := _ ; inf_c := nsAppend new_ctors _; inf_t := nsAppend new_t _ |> _ _ = (Success (_ idecls new_ienv), st2)` >>
+         <| inf_v := _ ; inf_c := nsAppend new_ctors _; inf_t := nsAppend new_t _ |> _ _ = (M_success (_ idecls new_ienv), st2)` >>
     simp [] >>
     `tenv_abbrev_ok new_t`
       by (
@@ -1536,7 +1536,7 @@ Proof
     >- rw [extend_dec_ienv_def])
   >- (
     qho_match_abbrev_tac
-      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (_ with inf_t := nsBind name new_t _) _ _ = (Success (_ idecls new_ienv), st2)` >>
+      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (_ with inf_t := nsBind name new_t _) _ _ = (M_success (_ idecls new_ienv), st2)` >>
     simp [] >>
     `tenv_abbrev_ok (nsBind name new_t tenvT)`
       by (
@@ -1570,7 +1570,7 @@ Proof
   >- (
     fs [] >>
     qho_match_abbrev_tac
-      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (extra_ienv with inf_c := nsBind name new_c extra_ienv.inf_c) _ _ = (Success (_ idecls new_ienv), st2)` >>
+      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (extra_ienv with inf_c := nsBind name new_c extra_ienv.inf_c) _ _ = (M_success (_ idecls new_ienv), st2)` >>
     simp [] >>
     first_x_assum (qspecl_then [`st1`, `eid'`, `extra_ienv with inf_c := nsBind name new_c extra_ienv.inf_c`] mp_tac) >>
     rw [] >>
@@ -1601,7 +1601,7 @@ Proof
       metis_tac []))
   >- (
     qho_match_abbrev_tac
-      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (_ with inf_t := nsBind name new_t _) _ _ = (Success (_ idecls new_ienv), st2)` >>
+      `?st2 idecls new_ienv. _ idecls ∧ _ new_ienv ∧ check_specs _ _ eid' (_ with inf_t := nsBind name new_t _) _ _ = (M_success (_ idecls new_ienv), st2)` >>
     simp [] >>
     `tenv_abbrev_ok (nsBind name new_t tenvT)`
       by (
@@ -1639,7 +1639,7 @@ Proof
 QED
 
 Theorem n_fresh_uvar_rw[local]:
-  ∀n st.n_fresh_uvar n st = (Success (GENLIST (λi.Infer_Tuvar(i+st.next_uvar)) n), st with next_uvar := st.next_uvar + n)
+  ∀n st.n_fresh_uvar n st = (M_success (GENLIST (λi.Infer_Tuvar(i+st.next_uvar)) n), st with next_uvar := st.next_uvar + n)
 Proof
   Induct>>simp[Once n_fresh_uvar_def]
   >-

--- a/compiler/inference/proofs/inferSoundScript.sml
+++ b/compiler/inference/proofs/inferSoundScript.sml
@@ -135,13 +135,13 @@ fun str_tac strs = ConseqConv.CONSEQ_CONV_TAC
 
 Theorem infer_d_sound:
    (!d tenv ienv st1 st2 ienv'.
-    infer_d ienv d st1 = (Success ienv', st2) ∧
+    infer_d ienv d st1 = (M_success ienv', st2) ∧
     env_rel tenv ienv ∧
     start_type_id ≤ st1.next_id
     ⇒
     type_d T tenv d (set_ids st1.next_id st2.next_id) (ienv_to_tenv ienv')) ∧
   (!ds tenv ienv st1 st2 ienv'.
-    infer_ds ienv ds st1 = (Success ienv', st2) ∧
+    infer_ds ienv ds st1 = (M_success ienv', st2) ∧
     env_rel tenv ienv ∧
     start_type_id ≤ st1.next_id
     ⇒
@@ -187,7 +187,7 @@ Proof
     strip_tac >>
     pairarg_tac >>
     rename1 `generalise_list _ _ _ _ = (tvs, s2, ts)` >>
-    rename1 `Success (t2,bindings), st1'` >>
+    rename1 `M_success (t2,bindings), st1'` >>
     `?ec1 last_sub.
           ts = MAP (t_walkstar last_sub) (MAP SND bindings) ∧
           t_wfs last_sub ∧
@@ -694,8 +694,8 @@ Proof
     (* infer_ds (d::ds) *)
     rw[]>>
     fs[infer_d_def,success_eqns]>>
-    rename1 `infer_d ienv1 _ _ = (Success ienv2, sti)` >>
-    rename1 `infer_ds _ _ _ = (Success ienv3, _)` >>
+    rename1 `infer_d ienv1 _ _ = (M_success ienv2, sti)` >>
+    rename1 `infer_ds _ _ _ = (M_success ienv3, _)` >>
     rpt(first_x_assum old_drule)>>
     rpt(disch_then old_drule)>>
     strip_tac>>strip_tac>>
@@ -905,7 +905,7 @@ QED
 
 Theorem check_specs_sound[local]:
   !mn tenvT idecls1 ienv1 specs st1 idecls2 ienv2 st2.
-    check_specs mn tenvT idecls1 ienv1 specs st1 = (Success (idecls2,ienv2), st2) ∧
+    check_specs mn tenvT idecls1 ienv1 specs st1 = (M_success (idecls2,ienv2), st2) ∧
     tenv_abbrev_ok tenvT
     ⇒
     ?decls3 ienv3.
@@ -1033,7 +1033,7 @@ QED
 
 Theorem infer_top_sound:
    !idecls ienv t_op st1 idecls' ienv' st2 tenv.
-    infer_top idecls ienv t_op st1 = (Success (idecls',ienv'), st2) ∧
+    infer_top idecls ienv t_op st1 = (M_success (idecls',ienv'), st2) ∧
     env_rel tenv ienv
     ⇒
     type_top T (convert_decls idecls) tenv t_op (convert_decls idecls') (ienv_to_tenv ienv')
@@ -1052,7 +1052,7 @@ Proof
     disch_then old_drule >>
     rw [] >>
     rename1 `check_signature _ ienv.inf_t _ idecls2 ienv2 sig st2 =
-               (Success (idecls3,ienv3), st3)` >>
+               (M_success (idecls3,ienv3), st3)` >>
     Cases_on `sig` >>
     fs [check_signature_def, typeSystemTheory.check_signature_cases,
         success_eqns]
@@ -1103,7 +1103,7 @@ QED
 
 Theorem infer_prog_sound:
    !idecls ienv prog st1 idecls' ienv' st2 tenv.
-    infer_prog idecls ienv prog st1 = (Success (idecls',ienv'), st2) ∧
+    infer_prog idecls ienv prog st1 = (M_success (idecls',ienv'), st2) ∧
     env_rel tenv ienv
     ⇒
     type_prog T (convert_decls idecls) tenv prog (convert_decls idecls') (ienv_to_tenv ienv')
@@ -1121,8 +1121,8 @@ Proof
   old_drule infer_top_sound >>
   disch_then old_drule >>
   strip_tac >>
-  rename1 `infer_top idecls1 ienv1 _ _ = (Success (idecls2, ienv2), _)` >>
-  rename1 `infer_prog _ _ _ _ = (Success (idecls3, ienv3), _)` >>
+  rename1 `infer_top idecls1 ienv1 _ _ = (M_success (idecls2, ienv2), _)` >>
+  rename1 `infer_prog _ _ _ _ = (M_success (idecls3, ienv3), _)` >>
   qexists_tac `ienv_to_tenv ienv2` >>
   qexists_tac `ienv_to_tenv ienv3` >>
   qexists_tac `convert_decls idecls2` >>

--- a/compiler/inference/proofs/infer_eCompleteScript.sml
+++ b/compiler/inference/proofs/infer_eCompleteScript.sml
@@ -396,7 +396,7 @@ QED
 
 Theorem add_constraint_success2[local]:
   !l t1 t2 st st' x.
-  add_constraint l t1 t2 st = (Success x, st') ⇔
+  add_constraint l t1 t2 st = (M_success x, st') ⇔
   x = () ∧
   pure_add_constraints st.subst [t1,t2] st'.subst ∧
   st'.next_uvar = st.next_uvar ∧
@@ -862,7 +862,7 @@ Theorem constrain_op_complete_simple_helper[local]:
       st'.next_uvar = st.next_uvar ∧
       st'.next_id = st.next_id ∧
       pure_add_constraints st.subst xs st'.subst ==>
-      constrain_op l op ts' st = (Success t',st'))
+      constrain_op l op ts' st = (M_success t',st'))
 Proof
   rw []
   \\ imp_res_tac sub_completion_wfs
@@ -899,7 +899,7 @@ EVERY (check_t n {}) (MAP (t_walkstar s) ts') ∧
 check_freevars n [] t
 ⇒
 ?t' st' s' constraints'.
-constrain_op l op ts' st = (Success t',st') ∧
+constrain_op l op ts' st = (M_success t',st') ∧
 sub_completion n st'.next_uvar st'.subst constraints' s' ∧
 t_compat s s' ∧
 FDOM st'.subst ⊆ count st'.next_uvar ∧
@@ -1189,7 +1189,7 @@ Theorem infer_p_complete:
   FDOM s = count st.next_uvar
   ⇒
   ?t' new_bindings st' s' constraints'.
-    infer_p l ienv p st  = (Success (t',new_bindings),st') ∧
+    infer_p l ienv p st  = (M_success (t',new_bindings),st') ∧
     sub_completion tvs st'.next_uvar st'.subst constraints' s' ∧
     FDOM st'.subst ⊆ count st'.next_uvar ∧
     FDOM s' = count st'.next_uvar ∧
@@ -1210,7 +1210,7 @@ Theorem infer_p_complete:
   FDOM s = count st.next_uvar
   ⇒
   ?ts' new_bindings st' s' constraints'.
-    infer_ps l ienv ps st = (Success (ts',new_bindings),st') ∧
+    infer_ps l ienv ps st = (M_success (ts',new_bindings),st') ∧
     sub_completion tvs st'.next_uvar st'.subst constraints' s' ∧
     FDOM st'.subst ⊆ count st'.next_uvar ∧
     FDOM s' = count st'.next_uvar ∧
@@ -1516,7 +1516,7 @@ Theorem infer_pes_complete[local]:
         FDOM s'' = count st''.next_uvar ∧
         env_rel_complete s'' ienv' tenv (bind_var_list 0 bindings tenvE) ⇒
         ∃t'' st''' s''' constraints'''.
-          infer_e l ienv' (SND x) st'' = (Success t'',st''') ∧
+          infer_e l ienv' (SND x) st'' = (M_success t'',st''') ∧
           sub_completion (num_tvs tenvE) st'''.next_uvar st'''.subst constraints''' s''' ∧
           FDOM st'''.subst ⊆ count st'''.next_uvar ∧
           FDOM s''' = count st'''.next_uvar ∧ t_compat s'' s''' ∧
@@ -1528,7 +1528,7 @@ Theorem infer_pes_complete[local]:
   unconvert_t t2 = t_walkstar s' t2'
   ⇒
   ?st'' s'' constraints''.
-  infer_pes l ienv pes t1' t2' st' = (Success (), st'') ∧
+  infer_pes l ienv pes t1' t2' st' = (M_success (), st'') ∧
   sub_completion (num_tvs tenvE) st''.next_uvar st''.subst constraints'' s'' ∧
   FDOM st''.subst ⊆ count st''.next_uvar ∧
   FDOM s'' = count st''.next_uvar ∧
@@ -1782,7 +1782,7 @@ Theorem infer_e_complete:
      env_rel_complete s ienv tenv tenvE
      ⇒
      ?t' st' s' constraints'.
-       infer_e loc ienv e st = (Success t', st') ∧
+       infer_e loc ienv e st = (M_success t', st') ∧
        sub_completion (num_tvs tenvE) st'.next_uvar st'.subst constraints' s' ∧
        FDOM st'.subst ⊆  count st'.next_uvar ∧
        FDOM s' = count st'.next_uvar ∧
@@ -1802,7 +1802,7 @@ Theorem infer_e_complete:
      env_rel_complete s ienv tenv tenvE
      ⇒
      ?ts' st' s' constraints'.
-       infer_es loc ienv es st = (Success ts', st') ∧
+       infer_es loc ienv es st = (M_success ts', st') ∧
        sub_completion (num_tvs tenvE) st'.next_uvar st'.subst constraints' s' ∧
        FDOM st'.subst ⊆ count st'.next_uvar ∧
        FDOM s' = count st'.next_uvar ∧
@@ -1822,7 +1822,7 @@ Theorem infer_e_complete:
      env_rel_complete s ienv tenv tenvE
      ⇒
      ?env' st' s' constraints'.
-       infer_funs loc ienv funs st = (Success env', st') ∧
+       infer_funs loc ienv funs st = (M_success env', st') ∧
        sub_completion (num_tvs tenvE) st'.next_uvar st'.subst constraints' s' ∧
        FDOM st'.subst ⊆ count st'.next_uvar ∧
        FDOM s' = count st'.next_uvar ∧

--- a/compiler/inference/proofs/infer_eSoundScript.sml
+++ b/compiler/inference/proofs/infer_eSoundScript.sml
@@ -3,7 +3,7 @@
 *)
 Theory infer_eSound
 Ancestors
-  typeSystem ast semanticPrimitives infer unify infer_t
+  ml_monadBase typeSystem ast semanticPrimitives infer unify infer_t
   inferProps envRel typeSysProps namespaceProps
   typeSoundInvariants[qualified]
 Libs
@@ -36,7 +36,7 @@ QED
 
 Theorem sub_completion_infer[local]:
   !l ienv e st1 t st2 n ts2 s.
-  infer_e l ienv e st1 = (Success t, st2) ∧
+  infer_e l ienv e st1 = (M_success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
   ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
@@ -80,7 +80,7 @@ QED
 
 Theorem sub_completion_infer_es[local]:
   !l cenv es st1 t st2 n ts2 s.
-  infer_es l cenv es st1 = (Success t, st2) ∧
+  infer_es l cenv es st1 = (M_success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
   ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
@@ -95,12 +95,12 @@ QED
 
 Theorem sub_completion_infer_p:
   (!l cenv p st t env st' tvs extra_constraints s.
-    infer_p l cenv p st = (Success (t,env), st') ∧
+    infer_p l cenv p st = (M_success (t,env), st') ∧
     sub_completion tvs st'.next_uvar st'.subst extra_constraints s
     ⇒
     ?ts. sub_completion tvs st.next_uvar st.subst (ts++extra_constraints) s) ∧
   (!l cenv ps st ts env st' tvs extra_constraints s.
-    infer_ps l cenv ps st = (Success (ts,env), st') ∧
+    infer_ps l cenv ps st = (M_success (ts,env), st') ∧
     sub_completion tvs st'.next_uvar st'.subst extra_constraints s
     ⇒
     ?ts. sub_completion tvs st.next_uvar st.subst (ts++extra_constraints) s)
@@ -142,7 +142,7 @@ QED
 
 Theorem sub_completion_infer_pes[local]:
   !l ienv pes t1 t2 st1 t st2 n ts2 s.
-  infer_pes l ienv pes t1 t2 st1 = (Success (), st2) ∧
+  infer_pes l ienv pes t1 t2 st1 = (M_success (), st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
   ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
@@ -168,7 +168,7 @@ QED
 
 Theorem sub_completion_infer_funs[local]:
   !l ienv funs st1 t st2 n ts2 s.
-  infer_funs l ienv funs st1 = (Success t, st2) ∧
+  infer_funs l ienv funs st1 = (M_success t, st2) ∧
   sub_completion n st2.next_uvar st2.subst ts2 s
   ⇒
   ?ts1. sub_completion n st1.next_uvar st1.subst (ts1 ++ ts2) s
@@ -248,7 +248,7 @@ QED
 
 Theorem infer_p_sound:
   (!l ienv p st t tenv env st' tvs extra_constraints s.
-    infer_p l ienv p st = (Success (t,env), st') ∧
+    infer_p l ienv p st = (M_success (t,env), st') ∧
     t_wfs st.subst ∧
     tenv_ctor_ok tenv.c ∧
     ienv.inf_c = tenv.c ∧
@@ -258,7 +258,7 @@ Theorem infer_p_sound:
     ⇒
     type_p tvs tenv p (convert_t (t_walkstar s t)) (convert_env s env)) ∧
   (!l ienv ps st ts tenv env st' tvs extra_constraints s.
-    infer_ps l ienv ps st = (Success (ts,env), st') ∧
+    infer_ps l ienv ps st = (M_success (ts,env), st') ∧
     t_wfs st.subst ∧
     tenv_ctor_ok tenv.c ∧
     ienv.inf_c = tenv.c ∧
@@ -451,7 +451,7 @@ val binop_tac =
 
 Theorem constrain_op_sub_completion[local]:
  sub_completion (num_tvs tenv) st.next_uvar st.subst extra_constraints s ∧
- constrain_op l op ts st' = (Success t,st)
+ constrain_op l op ts st' = (M_success t,st)
  ⇒
  ∃c. sub_completion (num_tvs tenv) st'.next_uvar st'.subst c s
 Proof
@@ -470,7 +470,7 @@ QED
 Theorem constrain_op_sound[local]:
  t_wfs st.subst ∧
  sub_completion (num_tvs tenv) st'.next_uvar st'.subst c s ∧
- constrain_op l op ts st = (Success t,st')
+ constrain_op l op ts st = (M_success t,st')
  ⇒
  type_op op (MAP (convert_t o t_walkstar s) ts) (convert_t (t_walkstar s t))
 Proof
@@ -531,8 +531,8 @@ val log_tac =
    >> fs []
    >> first_x_assum drule
    >> first_x_assum drule
-   >> rename1 `infer_e _ _ e _ = (Success t1, st1)`
-   >> rename1 `infer_e _ _ e1 st1 = (Success t2, st2)`
+   >> rename1 `infer_e _ _ e _ = (M_success t1, st1)`
+   >> rename1 `infer_e _ _ e1 st1 = (M_success t2, st2)`
    >> `ienv_ok (count st1.next_uvar) ienv` by metis_tac [ienv_ok_more, infer_e_next_uvar_mono]
    >> simp []
    >> disch_then drule
@@ -561,7 +561,7 @@ val log_tac =
 
 Theorem infer_e_sound:
  (!l ienv e st st' tenv tenvE t extra_constraints s.
-    infer_e l ienv e st = (Success t, st') ∧
+    infer_e l ienv e st = (M_success t, st') ∧
     ienv_ok (count st.next_uvar) ienv ∧
     env_rel_sound s ienv tenv tenvE ∧
     t_wfs st.subst ∧
@@ -569,7 +569,7 @@ Theorem infer_e_sound:
     ⇒
     type_e tenv tenvE e (convert_t (t_walkstar s t))) ∧
  (!l ienv es st st' tenv tenvE ts extra_constraints s.
-    infer_es l ienv es st = (Success ts, st') ∧
+    infer_es l ienv es st = (M_success ts, st') ∧
     ienv_ok (count st.next_uvar) ienv ∧
     env_rel_sound s ienv tenv tenvE ∧
     t_wfs st.subst ∧
@@ -577,7 +577,7 @@ Theorem infer_e_sound:
     ⇒
     type_es tenv tenvE es (MAP (convert_t o t_walkstar s) ts)) ∧
  (!l ienv pes t1 t2 st st' tenv tenvE extra_constraints s.
-    infer_pes l ienv pes t1 t2 st = (Success (), st') ∧
+    infer_pes l ienv pes t1 t2 st = (M_success (), st') ∧
     ienv_ok (count st.next_uvar) ienv ∧
     env_rel_sound s ienv tenv tenvE ∧
     t_wfs st.subst ∧
@@ -585,7 +585,7 @@ Theorem infer_e_sound:
     ⇒
     type_pes (num_tvs tenvE) 0 tenv tenvE pes (convert_t (t_walkstar s t1)) (convert_t (t_walkstar s t2))) ∧
  (!l ienv funs st st' tenv tenvE extra_constraints s ts.
-    infer_funs l ienv funs st = (Success ts, st') ∧
+    infer_funs l ienv funs st = (M_success ts, st') ∧
     ienv_ok (count st.next_uvar) ienv ∧
     env_rel_sound s ienv tenv tenvE ∧
     t_wfs st.subst ∧
@@ -930,9 +930,9 @@ Proof
      >> metis_tac []))
  >- ( (* Letrec *)
    qmatch_assum_abbrev_tac
-       `infer_funs _ (_ with inf_v := nsAppend bindings _) _ _ = (Success funs_ts, st1)`
+       `infer_funs _ (_ with inf_v := nsAppend bindings _) _ _ = (M_success funs_ts, st1)`
    >> rename1 `pure_add_constraints st1.subst _ st2.subst`
-   >> rename1 `infer_e _ _ _ _ = (Success t, st3)`
+   >> rename1 `infer_e _ _ _ _ = (M_success t, st3)`
    >> drule (List.nth (CONJUNCTS infer_e_wfs, 3))
    >> rw []
    >> `t_wfs st2.subst ∧ t_wfs st3.subst ∧ t_wfs s`

--- a/compiler/inference/proofs/type_eDetermScript.sml
+++ b/compiler/inference/proofs/type_eDetermScript.sml
@@ -34,8 +34,8 @@ Theorem infer_pe_complete:
     type_e tenv (bind_tvar tvs Empty) e t1
     ⇒
     ?t t' new_bindings st st' s constrs s'.
-      infer_e loc ienv e (init_infer_state ss) = (Success t, st) ∧
-      infer_p loc ienv p st = (Success (t', new_bindings), st') ∧
+      infer_e loc ienv e (init_infer_state ss) = (M_success t, st) ∧
+      infer_p loc ienv p st = (M_success (t', new_bindings), st') ∧
       t_unify st'.subst t t' = SOME s ∧
       sub_completion tvs st'.next_uvar s constrs s' ∧
       FDOM s' = count st'.next_uvar ∧
@@ -170,8 +170,8 @@ Theorem infer_e_type_pe_determ:
   ALL_DISTINCT (MAP FST tenv') ∧
   ienv_ok {} ienv ∧
   env_rel_complete FEMPTY ienv tenv Empty ∧
-  infer_e loc ienv e (init_infer_state ss) = (Success t, st) ∧
-  infer_p loc ienv p st = (Success (t', tenv'), st') ∧
+  infer_e loc ienv e (init_infer_state ss) = (M_success t, st) ∧
+  infer_p loc ienv p st = (M_success (t', tenv'), st') ∧
   t_unify st'.subst t t' = SOME s ∧
   EVERY (\(n, t). check_t 0 {} (t_walkstar s t)) tenv'
   ⇒
@@ -253,8 +253,8 @@ Theorem type_pe_determ_infer_e:
   tenv_inv FEMPTY ienv.inf_v tenv.v ∧*)
   env_rel_sound FEMPTY ienv tenv Empty ∧
   ienv_ok {} ienv ∧
-  infer_e loc ienv e (init_infer_state ss) = (Success t, st) ∧
-  infer_p loc ienv p st = (Success (t', new_bindings), st') ∧
+  infer_e loc ienv e (init_infer_state ss) = (M_success t, st) ∧
+  infer_p loc ienv p st = (M_success (t', new_bindings), st') ∧
   t_unify st'.subst t t' = SOME s ∧
   type_pe_determ tenv Empty p e
   ⇒
@@ -459,7 +459,7 @@ Theorem infer_funs_complete:
   infer_funs loc
     (ienv with inf_v:= nsAppend (alist_to_ns (MAP2 (λ(f,x,e) uvar. (f,0,uvar)) funs (MAP (λn. Infer_Tuvar n)
        (COUNT_LIST (LENGTH funs))))) ienv.inf_v) funs ((init_infer_state ss) with next_uvar:= (init_infer_state ss).next_uvar + LENGTH funs) =
-    (Success funs_ts,st) ∧
+    (M_success funs_ts,st) ∧
   st.next_uvar = st'.next_uvar ∧
   st.next_id = st'.next_id ∧
   pure_add_constraints st.subst

--- a/compiler/inference/tests/basisTypeCheckScript.sml
+++ b/compiler/inference/tests/basisTypeCheckScript.sml
@@ -17,8 +17,8 @@ val basis_types = cv_eval “infertype_prog init_config basis”;
 
 val print_types = let
   val x = basis_types |> concl |> rhs
-  val _ = if can (match_term ``infer$Success _``) x then () else
-          if can (match_term ``infer$Failure _``) x then let
+  val _ = if can (match_term ``M_success _``) x then () else
+          if can (match_term ``M_failure _``) x then let
             val msg = x |> rand |> rand |> rand
             in case total stringSyntax.fromHOLstring msg of
                 SOME s => failwith ("Type inference failed for basis with message: " ^ s)

--- a/compiler/printing/printTweaksScript.sml
+++ b/compiler/printing/printTweaksScript.sml
@@ -3,7 +3,7 @@
 *)
 Theory printTweaks
 Ancestors
-  addPrintVals typeDecToPP infer
+  ml_monadBase addPrintVals typeDecToPP infer
 Libs
   BasicProvers dep_rewrite[qualified]
 
@@ -20,10 +20,10 @@ Definition add_err_message_def:
   let (ienv, inf_st) = st in
   let pmsg = [print_failure_message s] in
   case infer_ds ienv pmsg inf_st of
-  | (Success msg_ienv, inf_st2) =>
+  | (M_success msg_ienv, inf_st2) =>
         (pmsg ++ decs_ext, (extend_dec_ienv msg_ienv ienv, inf_st2))
   (* if even that fails, skip it *)
-  | (Failure _, _) => (decs_ext, (ienv, inf_st))
+  | (M_failure _, _) => (decs_ext, (ienv, inf_st))
 End
 
 Definition add_print_from_opts_def:
@@ -32,9 +32,9 @@ Definition add_print_from_opts_def:
   add_print_from_opts nm (print_opt :: xs) (decs_ext, st) =
   let (ienv, inf_st) = st in
   case infer_ds ienv [print_opt] inf_st of
-  | (Success ienv2, inf_st2) =>
+  | (M_success ienv2, inf_st2) =>
         (print_opt :: decs_ext, (extend_dec_ienv ienv2 ienv, inf_st2))
-  | (Failure x, _) =>
+  | (M_failure x, _) =>
   let (decs_ext, st) = add_err_message
         («adding val pretty-print: » ^ SND x) decs_ext st in
   add_print_from_opts nm xs (decs_ext, st)
@@ -52,19 +52,19 @@ Definition add_print_features_def:
   let (tn, ienv, next_id) = st in
   let decs2 = add_pp_decs tn.pp_fixes decs in
   case infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) of
-  (Success decs_ienv, inf_st) =>
+  (M_success decs_ienv, inf_st) =>
   let (prints, tn2) = val_prints tn ienv decs_ienv in
   let ienv2 = extend_dec_ienv decs_ienv ienv in
   let (print_decs_ext, i_st) = add_prints_from_opts prints ([], (ienv2, inf_st)) in
-  (Success (decs2 ++ REVERSE print_decs_ext, (tn2, i_st)))
-  | (Failure x, _) =>
+  (M_success (decs2 ++ REVERSE print_decs_ext, (tn2, i_st)))
+  | (M_failure x, _) =>
   (* maybe the default pretty-printer decs are the problem *)
   (case infer_ds ienv decs (init_infer_state <| next_id := next_id |>) of
-  (Success ienv3, inf_st3) =>
+  (M_success ienv3, inf_st3) =>
   let (decs_ext, i_st) = add_err_message («adding type pp funs: » ^ SND x)
         [] (extend_dec_ienv ienv3 ienv, inf_st3) in
-  (Success (decs ++ REVERSE decs_ext, (tn, i_st)))
-  | (Failure x, _) => Failure x
+  (M_success (decs ++ REVERSE decs_ext, (tn, i_st)))
+  | (M_failure x, _) => M_failure x
   )
 End
 
@@ -79,13 +79,13 @@ End
 Definition add_print_then_read_def:
   add_print_then_read types decs =
     case add_print_features types decs of
-    | Failure x => Failure x
-    | Success (new_decs,(tn,ienv,inf_st)) =>
+    | M_failure x => M_failure x
+    | M_success (new_decs,(tn,ienv,inf_st)) =>
         case infer_ds ienv read_next_dec inf_st of
-        | (Success read_ienv, inf_st2) =>
-            (Success (new_decs ++ read_next_dec,
+        | (M_success read_ienv, inf_st2) =>
+            (M_success (new_decs ++ read_next_dec,
                       (tn,extend_dec_ienv read_ienv ienv, inf_st2.next_id)))
-        | (Failure x, _) => Failure x
+        | (M_failure x, _) => M_failure x
 End
 
 Theorem eq_inf_x[local] =
@@ -95,11 +95,11 @@ Theorem eq_inf_x[local] =
 Theorem infer_ds_append:
   !xs ys ienv st. infer_ds ienv (xs ++ ys) st =
   (case infer_ds ienv xs st of
-    (Failure x, y) => (Failure x, y)
-  | (Success ienv2, st2) =>
+    (M_failure x, y) => (M_failure x, y)
+  | (M_success ienv2, st2) =>
   (case infer_ds (extend_dec_ienv ienv2 ienv) ys st2 of
-    (Failure x, y) => (Failure x, y)
-  | (Success ienv3, st3) => (Success (extend_dec_ienv ienv3 ienv2), st3)
+    (M_failure x, y) => (M_failure x, y)
+  | (M_success ienv3, st3) => (M_success (extend_dec_ienv ienv3 ienv2), st3)
   ))
 Proof
   Induct
@@ -118,10 +118,10 @@ QED
 Theorem add_err_message_infer:
   add_err_message s decs_ext (extend_dec_ienv ienv init_ienv, inf_st) =
     (decs_ext2, st2) /\
-  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (M_success ienv, inf_st) ==>
   ?ienv_res inf_st2 ienv2.
   st2 = (ienv_res, inf_st2) /\
-  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (M_success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
   simp [add_err_message_def]
@@ -135,10 +135,10 @@ Theorem add_print_from_opts_infer:
   !opts decs_ext ienv inf_st decs_ext2 ienv_res inf_st2.
   add_print_from_opts nm opts (decs_ext, (extend_dec_ienv ienv init_ienv, inf_st)) =
     (decs_ext2, st2) /\
-  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (M_success ienv, inf_st) ==>
   ?ienv_res inf_st2 ienv2.
   st2 = (ienv_res, inf_st2) /\
-  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (M_success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
   Induct
@@ -167,10 +167,10 @@ Theorem add_prints_from_opts_infer[local]:
   add_prints_from_opts opts
     (decs_ext, (extend_dec_ienv ienv init_ienv, inf_st)) =
     (decs_ext2, st2) /\
-  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (Success ienv, inf_st) ==>
+  infer_ds init_ienv (REVERSE decs_ext) init_inf_st = (M_success ienv, inf_st) ==>
   ?ienv_res inf_st2 ienv2.
   st2 = (ienv_res, inf_st2) /\
-  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (Success ienv2, inf_st2) /\
+  infer_ds init_ienv (REVERSE decs_ext2) init_inf_st = (M_success ienv2, inf_st2) /\
   ienv_res = extend_dec_ienv ienv2 init_ienv
 Proof
   Induct \\ simp [pairTheory.FORALL_PROD, add_prints_from_opts_def] \\ rw [] \\ simp []
@@ -199,10 +199,10 @@ Theorem add_prints_from_opts_infer2[local] =
     |> SIMP_RULE (srw_ss ()) [infer_d_def, st_ex_return_def, extend_none]
 
 Theorem add_print_features_succ:
-  add_print_features st decs = (infer$Success (decs2, st2)) ==>
+  add_print_features st decs = (M_success (decs2, st2)) ==>
   ?tn ienv next_id tn2 ienv2 inf_st2.
   st = (tn, ienv, next_id) /\ st2 = (tn2, extend_dec_ienv ienv2 ienv, inf_st2) /\
-  infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) = (Success ienv2, inf_st2)
+  infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) = (M_success ienv2, inf_st2)
 Proof
   fs [add_print_features_def]
   \\ rpt (pairarg_tac \\ fs [])
@@ -217,10 +217,10 @@ Proof
 QED
 
 Theorem add_print_then_read_succ:
-  add_print_then_read st decs = (infer$Success (decs2, st2)) ==>
+  add_print_then_read st decs = (M_success (decs2, st2)) ==>
   ?tn ienv next_id tn2 ienv2 inf_st2.
   st = (tn, ienv, next_id) /\ st2 = (tn2, extend_dec_ienv ienv2 ienv, inf_st2.next_id) /\
-  infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) = (Success ienv2, inf_st2)
+  infer_ds ienv decs2 (init_infer_state <| next_id := next_id |>) = (M_success ienv2, inf_st2)
 Proof
   fs [add_print_then_read_def,AllCaseEqs()]
   \\ rw []
@@ -233,7 +233,7 @@ QED
 
 (* preservation of inference invariants will be needed in translation *)
 Theorem print_features_infer_st_invs:
-  (! env ds st x st2. infer_ds env ds st = (Success x, st2) /\ P st ==> P st2) ==>
+  (! env ds st x st2. infer_ds env ds st = (M_success x, st2) /\ P st ==> P st2) ==>
   (! s ds env inf_st x y.
     printTweaks$add_err_message s ds (env, inf_st) = (x, y) /\ P inf_st ==>
         P (SND y))
@@ -246,7 +246,7 @@ Theorem print_features_infer_st_invs:
   printTweaks$add_prints_from_opts xs (ds, (env, inf_st)) = (x, y) /\ P inf_st ==>
     P (SND y))
   /\
-  (! st ds x. printTweaks$add_print_features st ds = Success x /\
+  (! st ds x. printTweaks$add_print_features st ds = M_success x /\
     P (init_infer_state <| next_id := SND (SND st) |>) ==> P (SND (SND (SND x)))
   )
 Proof

--- a/compiler/printing/test/printingTestScript.sml
+++ b/compiler/printing/test/printingTestScript.sml
@@ -105,9 +105,9 @@ val _ = print "Running inference on basis...\n";
 
 (* Based on repl_init_typesScript.sml *)
 fun check infer_res = let
-  val _ = if can (match_term ``infer$Success _``) infer_res then
+  val _ = if can (match_term ``M_success _``) infer_res then
             print "Was Success!" else
-          if can (match_term ``infer$Failure _``) infer_res then let
+          if can (match_term ``M_failure _``) infer_res then let
             val msg = infer_res |> rand |> rand |> rand |> stringSyntax.fromHOLstring
                       handle HOL_ERR _ =>
                       failwith ("Was Failure! " ^

--- a/compiler/proofs/compilerProofScript.sml
+++ b/compiler/proofs/compilerProofScript.sml
@@ -59,7 +59,7 @@ Theorem infertype_prog_correct:
    inf_set_tids_ienv (count start_type_id) ienv ∧
    set_tids_tenv (count start_type_id) st.tenv
    ⇒
-   ∃c' x. infertype_prog ienv p = if can_type_prog st p then Success c' else Failure x
+   ∃c' x. infertype_prog ienv p = if can_type_prog st p then M_success c' else M_failure x
 Proof
   strip_tac
   \\ simp[inferTheory.infertype_prog_def,
@@ -106,11 +106,11 @@ Theorem compile_correct_gen:
    ∀(st:'ffi semantics$state) (cc:α compiler$config) prelude input mc data_sp cbspace.
     initial_condition st cc mc ⇒
     case FST (compiler$compile cc prelude input) of
-    | Failure (ParseError e) => semantics st prelude input = CannotParse
-    | Failure (TypeError e) => semantics st prelude input = IllTyped
-    | Failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
-    | Failure (ConfigError e) => T (* configuration string is malformed *)
-    | Success (code,data,c) =>
+    | M_failure (ParseError e) => semantics st prelude input = CannotParse
+    | M_failure (TypeError e) => semantics st prelude input = IllTyped
+    | M_failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
+    | M_failure (ConfigError e) => T (* configuration string is malformed *)
+    | M_success (code,data,c) =>
       ∃behaviours source_decs.
         (semantics st prelude input = Execute behaviours) ∧
         parse (lexer_fun input) = SOME source_decs ∧
@@ -180,11 +180,11 @@ Theorem compile_correct_lemma:
   ∀(ffi:'ffi ffi_state) prelude input (cc:α compiler$config) mc data_sp cbspace.
     config_ok cc mc ⇒
     case FST (compiler$compile cc prelude input) of
-    | Failure (ParseError e) => semantics_init ffi prelude input = CannotParse
-    | Failure (TypeError e) => semantics_init ffi prelude input = IllTyped
-    | Failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
-    | Failure (ConfigError e) => T (* configuration string is malformed *)
-    | Success (code,data,c) =>
+    | M_failure (ParseError e) => semantics_init ffi prelude input = CannotParse
+    | M_failure (TypeError e) => semantics_init ffi prelude input = IllTyped
+    | M_failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
+    | M_failure (ConfigError e) => T (* configuration string is malformed *)
+    | M_success (code,data,c) =>
       ∃behaviours source_decs.
         (semantics_init ffi prelude input = Execute behaviours) ∧
         parse (lexer_fun input) = SOME source_decs ∧
@@ -232,7 +232,7 @@ QED
 Theorem compile_correct_safe_for_space:
   ∀(ffi:'ffi ffi_state) prelude input (cc:α compiler$config) mc data_sp cbspace code data c c'.
     config_ok cc mc ⇒
-    compiler$compile cc prelude input = (Success (code,data,c), c') ⇒
+    compiler$compile cc prelude input = (M_success (code,data,c), c') ⇒
       ∃behaviours source_decs.
         (semantics_init ffi prelude input = Execute behaviours) ∧
         parse (lexer_fun input) = SOME source_decs ∧
@@ -265,11 +265,11 @@ Theorem compile_correct = Q.prove(`
   ∀(ffi:'ffi ffi_state) prelude input (cc:α compiler$config) mc data_sp cbspace.
     config_ok cc mc ⇒
     case FST (compiler$compile cc prelude input) of
-    | Failure (ParseError e) => semantics_init ffi prelude input = CannotParse
-    | Failure (TypeError e) => semantics_init ffi prelude input = IllTyped
-    | Failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
-    | Failure (ConfigError e) => T (* configuration string is malformed *)
-    | Success (code,data,c) =>
+    | M_failure (ParseError e) => semantics_init ffi prelude input = CannotParse
+    | M_failure (TypeError e) => semantics_init ffi prelude input = IllTyped
+    | M_failure AssembleError => T (* see theorem about to_lab to avoid AssembleError *)
+    | M_failure (ConfigError e) => T (* configuration string is malformed *)
+    | M_success (code,data,c) =>
       ∃behaviours.
         (semantics_init ffi prelude input = Execute behaviours) ∧
         ∀ms.
@@ -281,7 +281,7 @@ Theorem compile_correct = Q.prove(`
              for the one without the ⊆ and extend_with_resource_limit *)`,
   rw [] \\ mp_tac (SPEC_ALL compile_correct_lemma)
   \\ fs [] \\ TOP_CASE_TAC \\ fs []
-  \\ rename [‘(Success a,_)’]
+  \\ rename [‘(M_success a,_)’]
   \\ PairCases_on `a` \\ fs [] \\ strip_tac \\ fs []
   \\ rw [] \\ first_x_assum drule \\ rw []
   \\ match_mp_tac SUBSET_TRANS

--- a/compiler/repl/repl_check_and_tweakScript.sml
+++ b/compiler/repl/repl_check_and_tweakScript.sml
@@ -15,10 +15,10 @@ val _ = Parse.hide "types"
 Definition check_and_tweak_def:
   check_and_tweak (decs, types, input_str) =
     case add_print_then_read types decs of
-    | Success (new_decs,new_types) =>
+    | M_success (new_decs,new_types) =>
         if decs_allowed new_decs then INR (new_decs, new_types)
         else INL «ERROR: input contains reserved constructor/FFI names»
-    | Failure (loc,msg) =>
+    | M_failure (loc,msg) =>
         INL (concat [«ERROR: »; msg; « at »;
                      locs_to_string input_str loc])
 End
@@ -27,7 +27,7 @@ End
 
 Theorem check_and_tweak: (* used in replProof *)
   check_and_tweak (decs,types,input_str) = INR (safe_decs,new_types) ⇒
-  infertype_prog_inc (SND types) safe_decs = Success (SND new_types) ∧
+  infertype_prog_inc (SND types) safe_decs = M_success (SND new_types) ∧
   decs_allowed safe_decs
 Proof
   fs [check_and_tweak_def,AllCaseEqs()] \\ rw []

--- a/compiler/repl/repl_init_typesScript.sml
+++ b/compiler/repl/repl_init_typesScript.sml
@@ -18,8 +18,8 @@ val eval_res_thm =
 
 val print_types = let
   val x = eval_res_thm |> concl |> rhs
-  val _ = if can (match_term ``infer$Success _``) x then () else
-          if can (match_term ``infer$Failure _``) x then let
+  val _ = if can (match_term ``M_success _``) x then () else
+          if can (match_term ``M_failure _``) x then let
             val msg = x |> rand |> rand |> rand |> stringSyntax.fromHOLstring
                       handle HOL_ERR _ =>
                       failwith ("Type inference failed. " ^
@@ -60,12 +60,12 @@ val _ = cv_trans locationTheory.unknown_loc_def
 
 Theorem CommandLine_arguments_lemma[local] =
   “case infertype_prog_inc (init_config,start_type_id) repl_prog of
-   | Failure _ => F
-   | Success env => infertype_prog_inc env
+   | M_failure _ => F
+   | M_success env => infertype_prog_inc env
     [Dlet unknown_loc Pany
       (App Opapp
         [Var (Long «CommandLine» (Short «arguments»));
-         Con NONE []])] = Success env”
+         Con NONE []])] = M_success env”
   |> cv_eval |> SRULE [repl_prog_types_thm];
 
 Theorem infertype_prog_inc_CommandLine_arguments:
@@ -73,19 +73,19 @@ Theorem infertype_prog_inc_CommandLine_arguments:
     [Dlet unknown_loc Pany
       (App Opapp
         [Var (Long «CommandLine» (Short «arguments»));
-         Con NONE []])] = Success repl_prog_types
+         Con NONE []])] = M_success repl_prog_types
 Proof
   rewrite_tac [CommandLine_arguments_lemma]
 QED
 
 Theorem Repl_charsFrom_lemma[local] =
   “case infertype_prog_inc (init_config,start_type_id) repl_prog of
-   | Failure _ => F
-   | Success env => infertype_prog_inc env
+   | M_failure _ => F
+   | M_success env => infertype_prog_inc env
     [Dlet unknown_loc Pany
       (App Opapp
         [Var (Long «Repl» (Short «charsFrom»));
-         Lit (StrLit «config_enc_str.txt»)])] = Success env”
+         Lit (StrLit «config_enc_str.txt»)])] = M_success env”
   |> cv_eval |> SRULE [repl_prog_types_thm];
 
 Theorem infertype_prog_inc_Repl_charsFrom:
@@ -93,8 +93,7 @@ Theorem infertype_prog_inc_Repl_charsFrom:
     [Dlet unknown_loc Pany
       (App Opapp
         [Var (Long «Repl» (Short «charsFrom»));
-         Lit (StrLit «config_enc_str.txt»)])] = Success repl_prog_types
+         Lit (StrLit «config_enc_str.txt»)])] = M_success repl_prog_types
 Proof
   rewrite_tac [Repl_charsFrom_lemma]
 QED
-

--- a/compiler/repl/repl_typesScript.sml
+++ b/compiler/repl/repl_typesScript.sml
@@ -47,7 +47,7 @@ QED
 Inductive repl_types:
 [repl_types_init:]
   (∀ffi rs decs types (s:'ffi semanticPrimitives$state) env ck b.
-     infertype_prog_inc (init_config, start_type_id) decs = Success types ∧
+     infertype_prog_inc (init_config, start_type_id) decs = M_success types ∧
      evaluate$evaluate_decs (init_state ffi with clock := ck) init_env decs = (s,Rval env) ∧
      EVERY (check_ref_types (FST types) (extend_dec_env env init_env)) rs ⇒
      repl_types b (ffi,rs) (types,s,extend_dec_env env init_env))
@@ -61,20 +61,20 @@ Inductive repl_types:
 [repl_types_eval:]
   (∀ffi rs decs types new_types (s:'ffi semanticPrimitives$state) env new_env new_s b.
      repl_types b (ffi,rs) (types,s,env) ∧
-     infertype_prog_inc types decs = Success new_types ∧
+     infertype_prog_inc types decs = M_success new_types ∧
      evaluate$evaluate_decs s env decs = (new_s,Rval new_env) ⇒
      repl_types b (ffi,rs) (new_types,new_s,extend_dec_env new_env env))
 [repl_types_exn:]
   (∀ffi rs decs types new_types (s:'ffi semanticPrimitives$state) env e new_s b.
      repl_types b (ffi,rs) (types,s,env) ∧
-     infertype_prog_inc types decs = Success new_types ∧
+     infertype_prog_inc types decs = M_success new_types ∧
      evaluate$evaluate_decs s env decs = (new_s,Rerr (Rraise e)) ⇒
      repl_types b (ffi,rs) (roll_back types new_types,new_s,env))
 [repl_types_exn_assign:]
   (∀ffi rs decs types new_types (s:'ffi semanticPrimitives$state) env e
     new_s name loc new_store b.
      repl_types b (ffi,rs) (types,s,env) ∧
-     infertype_prog_inc types decs = Success new_types ∧
+     infertype_prog_inc types decs = M_success new_types ∧
      evaluate$evaluate_decs s env decs = (new_s,Rerr (Rraise e)) ∧
      MEM (name,Exn,loc) rs ∧
      store_assign loc (Refv e) new_s.refs = SOME new_store ⇒
@@ -216,7 +216,7 @@ Proof
     \\ match_mp_tac ienv_ok_extend_dec_ienv
     \\ fs[ienv_ok_init_config])
   >- (
-    rename1`_ tys decs = Success _`
+    rename1`_ tys decs = M_success _`
     \\ Cases_on`tys` \\ fs[infertype_prog_inc_def]
     \\ every_case_tac \\ fs[]
     \\ drule (CONJUNCT2 infer_d_check)
@@ -239,9 +239,9 @@ Proof
     \\ drule (CONJUNCT2 infer_d_next_id_mono)
     \\ rw[init_infer_state_def])
   \\ (
-    rename1`_ tys decs = Success _`
+    rename1`_ tys decs = M_success _`
     \\ Cases_on`tys` \\ fs[infertype_prog_inc_def]
-    \\ fs[CaseEqs["infer$exc","prod"]] \\ fs[]
+    \\ fs[CaseEqs["exc","prod"]] \\ fs[]
     \\ drule (CONJUNCT2 infer_d_next_id_mono)
     \\ simp[init_infer_state_def]
     \\ rw[])
@@ -860,7 +860,7 @@ Proof
     \\ match_mp_tac check_ref_types_check_ref_types_TS
     \\ metis_tac[])
   >- (
-    rename1`_ A decs = Success _`
+    rename1`_ A decs = M_success _`
     \\ `∃tys id. A = (tys,id)` by metis_tac[PAIR]
     \\ rw[] \\ fs[infertype_prog_inc_def]
     \\ every_case_tac \\ fs[]
@@ -883,10 +883,10 @@ Proof
       (match_mp_tac DISJOINT_set_ids>>simp[init_infer_state_def])
     \\ asm_exists_tac \\ simp[])
   >- (
-    rename1`_ A decs = Success _`
+    rename1`_ A decs = M_success _`
     \\ `∃tys id. A = (tys,id)` by metis_tac[PAIR]
     \\ rw[] \\ fs[infertype_prog_inc_def]
-    \\ fs[CaseEqs["infer$exc","prod"]] \\ rveq
+    \\ fs[CaseEqs["exc","prod"]] \\ rveq
     \\ drule (CONJUNCT2 infer_d_sound)
     \\ disch_then(qspec_then `ienv_to_tenv tys` mp_tac)
     \\ impl_tac >- (
@@ -907,10 +907,10 @@ Proof
     \\ asm_exists_tac \\ simp[]
     \\ metis_tac[])
   >- (
-    rename1`_ A decs = Success _`
+    rename1`_ A decs = M_success _`
     \\ `∃tys id. A = (tys,id)` by metis_tac[PAIR]
     \\ rw[] \\ fs[infertype_prog_inc_def]
-    \\ fs[CaseEqs["infer$exc","prod"]] \\ rveq
+    \\ fs[CaseEqs["exc","prod"]] \\ rveq
     \\ drule (CONJUNCT2 infer_d_sound)
     \\ disch_then(qspec_then `ienv_to_tenv tys` mp_tac)
     \\ impl_tac >- (
@@ -939,7 +939,7 @@ Theorem repl_types_F_thm:
     repl_types F (ffi,rs) (types,s,env) ⇒
       EVERY (ref_lookup_ok s.refs) rs ∧
       ∀decs new_t new_s res.
-        infertype_prog_inc types decs = Success new_t ∧
+        infertype_prog_inc types decs = M_success new_t ∧
         evaluate_decs s env decs = (new_s,res) ⇒
         res ≠ Rerr (Rabort Rtype_error)
 Proof
@@ -949,9 +949,9 @@ Proof
   \\ drule repl_types_TS_thm
   \\ strip_tac
   \\ rw[]
-  \\ rename1`_ A decs = Success _`
+  \\ rename1`_ A decs = M_success _`
   \\ `∃tys id. A = (tys,id)` by metis_tac[PAIR]
-  \\ qpat_x_assum`_ = Success _` mp_tac
+  \\ qpat_x_assum`_ = M_success _` mp_tac
   \\ simp[infertype_prog_inc_def]
   \\ every_case_tac \\ simp[]
   \\ drule (CONJUNCT2 infer_d_sound)
@@ -1158,7 +1158,7 @@ Theorem repl_types_thm:
     repl_types b (ffi,rs) (types,s,env) ⇒
       EVERY (ref_lookup_ok s.refs) rs ∧
       ∀decs new_t new_s res.
-        infertype_prog_inc types decs = Success new_t ∧
+        infertype_prog_inc types decs = M_success new_t ∧
         evaluate_decs s env decs = (new_s,res) ⇒
         res ≠ Rerr (Rabort Rtype_error)
 Proof

--- a/developers/changes-since-release.md
+++ b/developers/changes-since-release.md
@@ -38,3 +38,12 @@ Theorem get_mode_fsupdate[simp]:
 ```
 
 ## Miscellaneous 
+
+inferScript.sml now uses the state-exception monad defined in
+ml_monadBase instead of a locally defined version of it.
+
+Some files have been refactored to use `monadsyntax.temp_enable_monad`
+instead of manual overloads of constants such as `monad_bind`.
+
+Some files have been refactored to use `st_ex_ignore_bind` instead of
+a locally defined version using `st_ex_bind`.

--- a/examples/opentheory/readerProofScript.sml
+++ b/examples/opentheory/readerProofScript.sml
@@ -10,7 +10,9 @@ Ancestors
   ml_monadBase holKernel holKernelProof holSyntax holSyntaxExtra
   reader reader_init TextIOProg TextIOProof
 
-Overload return[local] = “st_ex_return”;
+val _ = monadsyntax.temp_add_monadsyntax ();
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = “raise_Failure”;
 
 val case_eq_thms =
@@ -279,8 +281,8 @@ QED
 Theorem init_reader_not_clash[simp]:
   init_reader () refs ≠ (M_failure (Clash tm), refs')
 Proof
-  rw [init_reader_def, st_ex_bind_def, st_ex_return_def, case_eq_thms,
-      select_sym_def, ind_type_def]
+  rw [init_reader_def, st_ex_bind_def, st_ex_ignore_bind_def,
+      st_ex_return_def, case_eq_thms, select_sym_def, ind_type_def]
 QED
 
 (* -------------------------------------------------------------------------
@@ -1583,8 +1585,8 @@ Proof
   simp_tac std_ss [init_reader_success]
   \\ sg ‘STATE init_refs.the_context init_refs’
   >- (EVAL_TAC \\ rw [])
-  \\ rw [init_reader_def, st_ex_bind_def, ind_type_def, select_sym_def,
-         st_ex_return_def]
+  \\ rw [init_reader_def, st_ex_bind_def, st_ex_ignore_bind_def,
+         ind_type_def, select_sym_def, st_ex_return_def]
   \\ fs [case_eq_thms] \\ rveq
   \\ qpat_x_assum ‘_ = mk_eta_ax _ _’ (assume_tac o SYM)
   \\ dxrule_then drule_all mk_eta_ax_thm
@@ -1615,7 +1617,7 @@ Proof
   \\ ‘TERM (d'::d::init_refs.the_context) select_const’
     by (fs [new_constant_def, add_constants_def, get_the_term_constants_def,
             set_the_term_constants_def, raise_Failure_def, case_eq_thms,
-            st_ex_bind_def, add_def_def]
+            st_ex_bind_def, st_ex_ignore_bind_def, add_def_def]
         \\ FULL_CASE_TAC \\ rw []
         \\ fs [get_the_context_def, set_the_context_def] \\ rw []
         \\ fs [STATE_def, TERM_def] \\ rw [select_const_def]
@@ -1627,7 +1629,8 @@ Proof
   \\ fsrw_tac [SATISFY_ss] []
   \\ last_x_assum (mp_then Any drule mk_infinity_ax_thm)
   \\ (impl_tac >-
-   (fs [new_type_def, st_ex_bind_def, add_type_def, st_ex_return_def,
+   (fs [new_type_def, st_ex_bind_def, st_ex_ignore_bind_def,
+        add_type_def, st_ex_return_def,
         raise_Failure_def, case_eq_thms, bool_case_eq, COND_RATOR, can_def,
         otherwise_def, get_type_arity_def, get_the_type_constants_def,
         set_the_type_constants_def, add_def_def, get_the_context_def,

--- a/examples/opentheory/reader_initScript.sml
+++ b/examples/opentheory/reader_initScript.sml
@@ -7,12 +7,10 @@ Ancestors
 Libs
   preamble
 
-Overload monad_bind[local] = “st_ex_bind”
-Overload monad_unitbind[local] = “λx y. st_ex_bind x (λz. y)”
-Overload monad_ignore_bind[local] = “λx y. st_ex_bind x (λz. y)”
-Overload return[local] = “st_ex_return”
+val _ = monadsyntax.temp_add_monadsyntax ();
+val _ = monadsyntax.temp_enable_monad "st_ex";
+
 Overload failwith[local] = “raise_Failure”
-val _ = temp_add_monadsyntax()
 
 (* -------------------------------------------------------------------------
  * Kernel initialisation
@@ -287,4 +285,3 @@ Definition init_reader_def:
       return ()
     od
 End
-

--- a/translator/monadic/cfMonadLib.sml
+++ b/translator/monadic/cfMonadLib.sml
@@ -177,11 +177,8 @@ mk_app_of_ArrowP spec2
 
 (* Some tests
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload monad_ignore_bind[local] = ``\x y. st_ex_bind x (\z. y)``
-Overload ex_bind[local] = ``st_ex_bind``
-Overload ex_return[local] = ``st_ex_return``
+val _ = monadsyntax.temp_add_monadsyntax ();
+val _ = monadsyntax.temp_enable_monad "st_ex";
 
 val _ = Datatype `
   my_state =

--- a/translator/monadic/ml_monad_translatorScript.sml
+++ b/translator/monadic/ml_monad_translatorScript.sml
@@ -11,11 +11,6 @@ Libs
   ml_translatorLib ml_progLib Satisfy AC_Sort cfTacticsLib
   packLib preamble
 
-Overload monad_bind[local] = ``st_ex_bind``;
-Overload monad_unitbind[local] = ``st_ex_ignore_bind``;
-Overload monad_ignore_bind[local] = ``st_ex_ignore_bind``;
-Overload ex_bind[local] = ``st_ex_bind``;
-Overload ex_return[local] = ``st_ex_return``;
 Overload CONTAINER[local] = ``ml_translator$CONTAINER``;
 
 val _ = hide "state";
@@ -177,7 +172,7 @@ val H = mk_var("H",``:('a -> hprop) # 'ffi ffi_proj``);
 (* return *)
 Theorem EvalM_return:
    !H b. Eval env exp (a x) ==>
-         EvalM ro env st exp (MONAD a b (ex_return x)) ^H
+         EvalM ro env st exp (MONAD a b (st_ex_return x)) ^H
 Proof
   rw[Eval_def,EvalM_def,st_ex_return_def,MONAD_def]
   \\ first_x_assum(qspec_then`s.refs`strip_assume_tac)
@@ -200,7 +195,7 @@ Theorem EvalM_bind:
       EvalM ro (write name v env) (SND (x st)) e2
         (MONAD a c ((f z):('refs, 'a, 'c) M)) H) ==>
    (a1 /\ !z. (CONTAINER(FST(x st) = M_success z) ==> a2 z)) ==>
-   EvalM ro env st (Let (SOME name) e1 e2) (MONAD a c (ex_bind x f)) H
+   EvalM ro env st (Let (SOME name) e1 e2) (MONAD a c (st_ex_bind x f)) H
 Proof
   rw[EvalM_def,MONAD_def,st_ex_return_def,PULL_EXISTS, CONTAINER_def] \\ fs[]
   \\ last_x_assum drule \\ rw[]
@@ -278,7 +273,7 @@ Theorem EvalM_pure_seq:
   EvalM ro env st (Let NONE e1 e2) (MONAD a b (pure_seq y x)) ^H
 Proof
   rw []
-  \\ ‘pure_seq y x = monad_ignore_bind (ex_return y) x’ by
+  \\ ‘pure_seq y x = st_ex_ignore_bind (st_ex_return y) x’ by
     fs [pure_seq_def,st_ex_ignore_bind_def,st_ex_return_def, FUN_EQ_THM]
   \\ fs [] \\ irule EvalM_bind_ignore \\ fs []
   \\ conj_tac

--- a/translator/monadic/monad_base/ml_monadBaseScript.sml
+++ b/translator/monadic/monad_base/ml_monadBaseScript.sml
@@ -88,11 +88,6 @@ Definition st_ex_return_def:
     λs. (M_success x, s)
 End
 
-Overload monad_bind[local] = ``st_ex_bind``
-Overload monad_unitbind[local] = ``st_ex_ignore_bind``
-Overload monad_ignore_bind[local] = ``st_ex_ignore_bind``
-Overload return[local] = ``st_ex_return``
-
 val _ = add_infix ("otherwise", 400, HOLgrammars.RIGHT);
 
 Definition otherwise_def:
@@ -101,6 +96,17 @@ Definition otherwise_def:
           (M_success y, s) => (M_success y, s)
         | (M_failure e, s) => (y : ('a, 'b, 'c) M) s
 End
+
+val _ = monadsyntax.declare_monad (
+  "st_ex",
+  {bind = “st_ex_bind”,
+   unit = “st_ex_return”,
+   ignorebind = SOME “st_ex_ignore_bind”,
+   choice = SOME “$otherwise”,
+   fail = NONE,
+   guard = NONE})
+
+val _ = monadsyntax.temp_enable_monad "st_ex"
 
 Definition can_def:
   can f x = (do f x ; return T od
@@ -559,5 +565,3 @@ Theorem monad_eqs =
 Definition run_def:
   run (x : ('a, 'b, 'c) M) state = FST (x state)
 End
-
-


### PR DESCRIPTION
- use `monadsyntax.temp_enable_monad` instead of locals overloads => uses state-exception's ignore_bind (instead of overloading using st_ex_bind)
- use state-exception monad in inferScript.sml (replaces its own definition of a state-exception monad)