### PR TITLE
Improve implementation of String.concatWith

### DIFF
--- a/basis/ListProgScript.sml
+++ b/basis/ListProgScript.sml
@@ -86,6 +86,9 @@ val result = translate list_compare_def;
 val result = next_ml_names := ["concat"];
 val result = translate FLAT;
 
+val result = next_ml_names := ["intersperse"];
+val result = translate mllistTheory.intersperse_def;
+
 (* the let is introduced to produce slight better code (smaller stack frames) *)
 Theorem MAP_let[local]:
     MAP f xs =

--- a/basis/StringProgScript.sml
+++ b/basis/StringProgScript.sml
@@ -46,10 +46,6 @@ val extract_side_thm = Q.prove(
   `!s i opt. extract_side s i opt`,
   rw [extract_side_def, arithmeticTheory.MIN_DEF] ) |> update_precondition
 
-val _ = ml_prog_update open_local_block;
-val res = translate concatWith_aux_def;
-val _ = ml_prog_update open_local_in_block;
-
 val _ = next_ml_names := ["concatWith"];
 val result = translate concatWith_def;
 

--- a/basis/pure/mllistScript.sml
+++ b/basis/pure/mllistScript.sml
@@ -8,6 +8,12 @@ Ancestors
   indexedLists[qualified] toto[qualified]
   sorting mergesort
 
+Definition intersperse_def:
+  intersperse _ []        = [] ∧
+  intersperse _ [x]       = [x] ∧
+  intersperse sep (x::xs) = x::sep::intersperse sep xs
+End
+
 (* ===== TODO: TO BE PORTED TO HOL (better theorems for mergesort_tail) ===== *)
 Theorem merge_tail_MEM:
   !negate R xs ys acc. MEM x (merge_tail negate R xs ys acc) = ((MEM x xs) \/ (MEM x ys) \/ (MEM x acc))

--- a/basis/pure/mlstringScript.sml
+++ b/basis/pure/mlstringScript.sml
@@ -259,33 +259,9 @@ Proof
   rw[strcat_thm]
 QED
 
-Definition concatWith_aux_def:
-  (concatWith_aux s [] bool = implode []) /\
-  (concatWith_aux s (h::t) T = strcat h (concatWith_aux s t F)) /\
-  (concatWith_aux s (h::t) F = strcat s (concatWith_aux s (h::t) T))
-Termination
-  wf_rel_tac `inv_image ($< LEX $<) (\(s,l,b). (LENGTH l, if b then 0n else 1))` \\
-  rw[]
-End
-
 Definition concatWith_def:
-  concatWith s l = concatWith_aux s l T
+  concatWith s l = concat (intersperse s l)
 End
-
-Theorem concatWith_CONCAT_WITH_aux[local]:
-  !s l fl. (CONCAT_WITH_aux s l fl = REVERSE fl ++ explode (concatWith (implode s) (MAP implode l)))
-Proof
-  ho_match_mp_tac CONCAT_WITH_aux_ind
-  \\ rw[CONCAT_WITH_aux_def, concatWith_def, concatWith_aux_def, strcat_thm]
-  >-(Induct_on `l` \\ rw[MAP, concatWith_aux_def, strcat_thm]
-  \\ Cases_on `l` \\ rw[concatWith_aux_def, explode_implode, strcat_thm])
-QED
-
-Theorem concatWith_CONCAT_WITH:
-   !s l. CONCAT_WITH s l = explode (concatWith (implode s) (MAP implode l))
-Proof
-    rw[concatWith_def, CONCAT_WITH_def, concatWith_CONCAT_WITH_aux]
-QED
 
 Definition chr_to_str_def:
   chr_to_str (c: char) = implode [c]

--- a/basis/types.txt
+++ b/basis/types.txt
@@ -35,6 +35,7 @@ List.takeUntil: ('a -> bool) -> 'a list -> 'a list
 List.dropUntil: ('a -> bool) -> 'a list -> 'a list
 List.cmp: ('a -> 'b -> ordering) -> 'a list -> 'b list -> ordering
 List.concat: 'a list list -> 'a list
+List.intersperse: 'a -> 'a list -> 'a list
 List.map: ('a -> 'b) -> 'a list -> 'b list
 List.mapi: (int -> 'a -> 'b) -> 'a list -> 'b list
 List.mapPartial: ('a -> 'b option) -> 'a list -> 'b list

--- a/developers/changes-since-release.md
+++ b/developers/changes-since-release.md
@@ -4,6 +4,17 @@ Changes since release v3400:
 
 ## Basis library
 
+### List
+
+`List.intersperse`,
+which inserts a given element between every consecutive pair of elements in a list,
+has been added to basis.
+
+### String
+
+`String.concatWith` has been reimplemented using `concat` and `intersperse`,
+avoiding potentially quadratic behavior due to left-associative concatenations (#1425).
+
 ### TextIO
 
 `TextIO.output`'s behavior is now linear in the size of the string
@@ -38,6 +49,9 @@ Theorem get_mode_fsupdate[simp]:
 ```
 
 ## Miscellaneous 
+
+`CONCAT_WITH` (misc) and `concatWith_CONCAT_WITH` (mlstring)
+have been removed due to being unused.
 
 inferScript.sml now uses the state-exception monad defined in
 ml_monadBase instead of a locally defined version of it.

--- a/misc/miscScript.sml
+++ b/misc/miscScript.sml
@@ -2488,20 +2488,6 @@ Proof
     \\ first_x_assum (qspecl_then [`a`] mp_tac) \\ rw[] \\ rfs[]
 QED
 
-Definition CONCAT_WITH_aux_def:
-    (CONCAT_WITH_aux [] l fl = REVERSE fl ++ FLAT l) /\
-    (CONCAT_WITH_aux (h::t) [] fl = REVERSE fl) /\
-    (CONCAT_WITH_aux (h::t) ((h1::t1)::ls) fl = CONCAT_WITH_aux (h::t) (t1::ls) (h1::fl)) /\
-    (CONCAT_WITH_aux (h::t) ([]::[]) fl = REVERSE fl) /\
-    (CONCAT_WITH_aux (h::t) ([]::(h'::t')) fl = CONCAT_WITH_aux (h::t) (h'::t') (REVERSE(h::t) ++ fl))
-End
-
-val CONCAT_WITH_AUX_ind = theorem"CONCAT_WITH_aux_ind";
-
-Definition CONCAT_WITH_def:
-    CONCAT_WITH s l = CONCAT_WITH_aux s l []
-End
-
 Theorem OPT_MMAP_MAP_o:
    !ls. OPT_MMAP f (MAP g ls) = OPT_MMAP (f o g) ls
 Proof


### PR DESCRIPTION
- Add List.intersperse to basis
- Fix String.concatWith to not be quadratic in the worst case
- Remove of unused CONCAT_WITH (misc) and concatWith_CONCAT_WITH (mlstring)

Closes #1425 