### PR TITLE
Add support for multi-line string literals to OCaml parser

### DIFF
--- a/compiler/parsing/ocaml/camlTestsScript.sml
+++ b/compiler/parsing/ocaml/camlTestsScript.sml
@@ -1154,6 +1154,15 @@ val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
   (SOME “C «Con» [Con NONE [V «a»; V «b»; V «c»]]”)
   ;
 
+(* 2026-07-20: add support for multi-line string literals:
+ * print "hello
+ * world"
+ *)
+
+val _ = parsetest0 “nExpr” “ptree_Expr nExpr”
+  "print \"hello\nworld\""
+  (SOME “App Opapp [V «print»; Lit (StrLit «hello\nworld»)]”)
+
 (* -------------------------------------------------------------------------
  * Declarations
  * ------------------------------------------------------------------------- *)

--- a/compiler/parsing/ocaml/caml_lexScript.sml
+++ b/compiler/parsing/ocaml/caml_lexScript.sml
@@ -342,7 +342,7 @@ Definition scan_strlit_def:
     | #"\""::cs =>
         SOME (StringS (REVERSE acc), Locs loc loc, cs)
     | #"\n"::cs =>
-        SOME (ErrorS, Locs loc (next_line loc), cs)
+        scan_strlit (#"\n"::acc) cs (next_line loc)
     | #"\\"::_ =>
         (case scan_escseq cs loc of
            NONE => SOME (ErrorS, Locs loc loc, cs)

--- a/developers/changes-since-release.md
+++ b/developers/changes-since-release.md
@@ -31,6 +31,10 @@ BVI now supports multi-arg calls/returns (with a separate constructor).
 
 ## Candle
 
+### Parser
+
+The parser now supports multi-line string literals.
+
 ## Examples
 
 ## Build infrastructure


### PR DESCRIPTION
print_string "hello
world";;

is legal OCaml code and prints

hello
world

These kinds of string literals occur in Candle; for example, in Examples/sos.ml (sdpa_default_parameters) or in 100/constructible.ml (as an argument to define_type).