### PR TITLE
pancake: fix incorrect precedence of not and field accesses

### DIFF
--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -19,12 +19,12 @@ Datatype:
             | IfNT | WhileNT | CallNT | RetNT | HandleNT
             | ExtCallNT | RaiseNT | ReturnNT
             | DecCallNT | RetCallNT
-            | ArgListNT | NotNT
+            | ArgListNT
             | ParamListNT
             | EBoolAndNT | EEqNT | ECmpNT
             | ELoadNT | ELoadByteNT | ELoad32NT
             | EXorNT | EOrNT | EAndNT
-            | EShiftNT | EAddNT | EMulNT | EFieldNT | EBaseNT
+            | EShiftNT | EAddNT | EMulNT | ENotNT | EFieldNT | EBaseNT
             | RawStructNT | NmdStructNT | NmdFieldListNT | NmdFieldNT
             | ShapedIdentNT | ShapeNT | ShapeCombNT
             | EqOpsNT | CmpOpsNT | ShiftOpsNT | AddOpsNT | MulOpsNT
@@ -313,9 +313,11 @@ Definition pancake_peg_def[nocompute]:
                            rpt (seql [mknt AddOpsNT; mknt EMulNT] I)
                                FLAT]
                           (mksubtree EAddNT));
-        (INL EMulNT, seql [mknt EFieldNT;
-                           rpt (seql [mknt MulOpsNT; mknt EFieldNT] I) FLAT]
+        (INL EMulNT, seql [mknt ENotNT;
+                           rpt (seql [mknt MulOpsNT; mknt ENotNT] I) FLAT]
                           (mksubtree EMulNT));
+        (INL ENotNT, seql [try (keep_tok NotT); mknt EFieldNT]
+                           (mksubtree ENotNT));
         (INL EFieldNT, seql [mknt EBaseNT;
                             rpt (seql [consume_tok DotT;
                                        choicel [keep_nat; keep_ident]
@@ -325,14 +327,11 @@ Definition pancake_peg_def[nocompute]:
         (INL EBaseNT, choicel [seql [consume_tok LParT;
                                      mknt ExpNT;
                                      consume_tok RParT] I;
-                               mknt NotNT;
                                keep_kw TrueK; keep_kw FalseK;
                                mknt RawStructNT; mknt NmdStructNT;
                                keep_kw BaseK; keep_kw BiwK; keep_kw TopK;
                                keep_int; keep_ident
                               ]);
-        (INL NotNT, seql [consume_tok NotT; mknt EBaseNT]
-                           (mksubtree NotNT));
         (INL RawStructNT, seql [consume_tok LessT; mknt ArgListNT;
                              consume_tok GreaterT]
                             (mksubtree RawStructNT));
@@ -701,8 +700,8 @@ end
 
 val topo_nts = [“MulOpsNT”, “AddOpsNT”, “ShiftOpsNT”, “CmpOpsNT”,
                 “EqOpsNT”, “ShapeNT”,
-                “ShapeCombNT”, “ShapedIdentNT”, “NotNT”, “RawStructNT”, “NmdFieldNT”, “NmdFieldListNT”, “NmdStructNT”,
-                “EBaseNT”, “EFieldNT”, “EMulNT”, “EAddNT”, “EShiftNT”, “EAndNT”, “EXorNT”, “EOrNT”,
+                “ShapeCombNT”, “ShapedIdentNT”, “RawStructNT”, “NmdFieldNT”, “NmdFieldListNT”, “NmdStructNT”,
+                “EBaseNT”, “EFieldNT”, “ENotNT”, “EMulNT”, “EAddNT”, “EShiftNT”, “EAndNT”, “EXorNT”, “EOrNT”,
                 “ELoad32NT”, “ELoadByteNT”, “ELoadNT”, “ECmpNT”, “EEqNT”, “EBoolAndNT”,
                 “ExpNT”, “ArgListNT”, “ReturnNT”,
                 “RaiseNT”, “ExtCallNT”,

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -292,9 +292,10 @@ Definition conv_Exp_def:
                       SOME $ NStruct nm flds
                    od
       | _ => NONE
-    else if isNT nodeNT NotNT then
+    else if isNT nodeNT ENotNT then
       case args of
-        [t] => lift (Cmp Equal (Const 0w)) (conv_Exp t)
+        [t] => conv_Exp t
+      | [_; t] => lift (Cmp Equal (Const 0w)) (conv_Exp t)
       | _ => NONE
     else if isNT nodeNT ELoadByteNT then
       case args of

--- a/pancake/static_checker/panStaticExamplesScript.sml
+++ b/pancake/static_checker/panStaticExamplesScript.sml
@@ -5818,3 +5818,18 @@ val static_addcarry_nstruct_operand =
 
 val warns_addcarry_nstruct_operand =
   check_static_no_warnings $ static_check_pancake parse_addcarry_nstruct_operand;
+
+val ex_not_field = `
+  fun 1 f(2 x) {
+    return !x.0;
+  }
+`;
+
+val parse_not_field =
+  check_parse_success $ parse_pancake ex_not_field;
+
+val static_not_field =
+  check_static_success $ static_check_pancake parse_not_field;
+
+val warns_not_field =
+  check_static_no_warnings $ static_check_pancake parse_not_field;


### PR DESCRIPTION
Previously, expressions like `!x.0` would be parsed as `(!x).0` instead of `!(x.0)`, leading to shape checking errors because you can't negate anything other than a single word. This PR fixes that by correcting their precedence.

This seems to have been a regression in #1393.