### PR TITLE
Fix interference oracles in FFI and ccache calls

### DIFF
--- a/compiler/backend/San/SanScript.sml
+++ b/compiler/backend/San/SanScript.sml
@@ -327,7 +327,7 @@ Proof
 QED
 
 Theorem san_ffi_interfer_ok:
-  ffi_interfer_ok (32w: word64) ARB san_config
+  ffi_interfer_ok (32w: word64) san_config
 Proof
   rw[ffi_interfer_ok_def,san_config_def] \\
   gvs[GSYM san_mmio_pcs_min_index_0] \\

--- a/compiler/backend/ag32/proofs/ag32_basis_ffiProofScript.sml
+++ b/compiler/backend/ag32/proofs/ag32_basis_ffiProofScript.sml
@@ -6209,7 +6209,6 @@ Theorem ag32_good_init_state:
    (∀x. x ∉ ag32_startup_addresses ⇒
       ((FUNPOW Next startup_clock ms0).MEM x = ms0.MEM x))
    ⇒
-   ∃io_regs cc_regs.
    good_init_state (ag32_machine_config ffi_names (LENGTH code) (LENGTH data))
      (FUNPOW Next startup_clock ms0)
      code 0
@@ -6222,8 +6221,6 @@ Theorem ag32_good_init_state:
         ∪ {w | n2w (code_start_offset (LENGTH ffi_names) + LENGTH code) <=+ w ∧
                w <+ n2w(code_start_offset (LENGTH ffi_names) + LENGTH code + 4 * LENGTH data) })
        {}
-     io_regs
-     cc_regs
 Proof
   strip_tac
   \\ imp_res_tac SUBSET_ffi_names_IMP_LENGTH_LESS_EQ
@@ -6310,7 +6307,6 @@ Proof
     rw[asmPropsTheory.interference_ok_def]
     \\ simp[EVAL``(ag32_machine_config _ _ _).target``]
     \\ simp[EVAL``(ag32_machine_config _ _ _).next_interfer``] )
-  \\ simp[LEFT_EXISTS_AND_THM]
   \\ conj_tac >- (
     simp[targetSemTheory.ffi_interfer_ok_def]
     \\ simp[ag32_machine_config_def]
@@ -6318,25 +6314,21 @@ Proof
     \\ simp[EVAL``ag32_target.config``,targetSemTheory.get_reg_value_def]
     \\ simp[ag32_ffi_interfer_def]
     \\ simp[LENGTH_ag32_ffi_code]
-    \\ qexists_tac`λk f n. case f of
-                           | SharedMem s => NONE
-                           | ExtCall i =>
-                             if n = 0 then OPTION_MAP n2w (ALOOKUP ffi_exitpcs i)
-                             else if i = «» then if n = 5 then SOME 0w else NONE
-                             else if n < 9 then SOME 0w else NONE`
     \\ rpt gen_tac
-    \\ strip_tac>>
-    drule lab_to_targetProofTheory.mmio_pcs_min_index_is_SOME>>
-    strip_tac>>
-    Cases_on ‘index < i’>>fs[NOT_LESS]>>
-    TRY (first_x_assum $ qspec_then ‘index’ assume_tac>>
-         fs[EL_MAP,Abbr ‘num_ffis’]>>NO_TAC)
+    \\ strip_tac
+    \\ drule lab_to_targetProofTheory.mmio_pcs_min_index_is_SOME
+    \\ strip_tac
+    \\ reverse (Cases_on ‘index < i’) \\ fs[NOT_LESS]
+    >- (
+      first_x_assum $ qspec_then ‘index’ assume_tac
+      \\ fs[EL_MAP,Abbr ‘num_ffis’])
     \\ Cases_on`EL index ffi_names = «»`
     \\ srw_tac[ETA_ss][]
     \\ fs[asmPropsTheory.target_state_rel_def]
     \\ fs[ag32_targetTheory.ag32_target_def]
     \\ fs[ag32_targetTheory.ag32_ok_def]
     \\ fs[ag32_targetTheory.ag32_config_def]
+    \\ simp[APPLY_UPDATE_THM]
     >- (
       rw[]
       \\ gvs[EL_MAP,Abbr`num_ffis`]
@@ -6366,12 +6358,6 @@ Proof
       \\ first_x_assum irule
       \\ simp[MEM_EL]
       \\ asm_exists_tac \\ simp[] )
-    \\ reverse conj_tac
-    >- (
-      simp[APPLY_UPDATE_THM]
-      \\ rpt strip_tac
-      \\ fs[IS_SOME_EXISTS,Abbr`num_ffis`,EL_MAP]
-      \\ rpt(IF_CASES_TAC \\ simp[targetSemTheory.get_reg_value_def]))
     \\ rw[]
     \\ `EL index ffi_names ∈ set(MAP FST FFI_codes)` by (
       fs[SUBSET_DEF]
@@ -6437,10 +6423,11 @@ Proof
     rw[targetSemTheory.ccache_interfer_ok_def, ag32_machine_config_def,
        lab_to_targetTheory.ffi_offset_def, ag32_ccache_interfer_def,
        heap_size_def, EVAL``ag32_target.config``]
-    \\ qmatch_goalsub_abbrev_tac`0w =+ v0`
-    \\ qexists_tac`λk n. if n = 0 then SOME v0 else NONE`
-    \\ EVAL_TAC \\ rw[]
-    \\ IF_CASES_TAC \\ simp[targetSemTheory.get_reg_value_def] )
+    \\ fs[asmPropsTheory.target_state_rel_def]
+    \\ fs[ag32_targetTheory.ag32_target_def]
+    \\ fs[ag32_targetTheory.ag32_ok_def]
+    \\ fs[ag32_targetTheory.ag32_config_def]
+    \\ simp[APPLY_UPDATE_THM] )
   \\ conj_asm1_tac >- (
     simp[targetSemTheory.code_loaded_def]
     \\ fs[asmPropsTheory.target_state_rel_def]

--- a/compiler/backend/proofs/backendProofScript.sml
+++ b/compiler/backend/proofs/backendProofScript.sml
@@ -3475,7 +3475,7 @@ Proof
   \\ disch_tac \\ fs []
   \\ fs [attach_bitmaps_def] \\ rveq \\ fs [] \\
   fs[targetSemTheory.installed_def] \\
-  qmatch_assum_abbrev_tac`good_init_state mc ms bytes cbspace tar_st m dm sdm io_regs cc_regs` \\
+  qmatch_assum_abbrev_tac`good_init_state mc ms bytes cbspace tar_st m dm sdm` \\
   qpat_x_assum`Abbrev(p7 = _)` mp_tac>>
   qmatch_goalsub_abbrev_tac`compile _ _ _ stk stoff`>>
   strip_tac \\
@@ -3487,7 +3487,7 @@ Proof
         has_fp_tern := (mc.target.config.ISA = ARMv7 /\ 2 < mc.target.config.fp_reg_count) |>)`
   \\ qabbrev_tac`lab_st:('a,lab_to_target$config,'ffi) labSem$state =
       (lab_to_targetProof$make_init
-      mc ffi io_regs cc_regs tar_st m (dm ∩ byte_aligned) (sdm ∩ byte_aligned) ms p7 (lab_to_target$compile mc.target.config)
+      mc ffi tar_st m (dm ∩ byte_aligned) (sdm ∩ byte_aligned) ms p7 (lab_to_target$compile mc.target.config)
        (mc.target.get_pc ms + n2w (LENGTH bytes)) cbspace lab_oracle)`
 
   \\ qabbrev_tac`stack_st_opt =
@@ -3708,7 +3708,7 @@ Proof
     \\ simp[ensure_fp_conf_ok_def]
     \\ AP_THM_TAC \\ AP_THM_TAC
     \\ simp[full_make_init_compile]
-    \\ simp[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l m n).compile``]
+    \\ simp[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l).compile``]
     \\ simp[Abbr`stoff`] ) \\
 
   `lab_st.ffi = ffi` by ( fs[Abbr`lab_st`] ) \\
@@ -3839,6 +3839,8 @@ Proof
     simp_tac std_ss [Once EVERY_FST_SND] \\
     qunabbrev_tac`stack_st` \\
     fs[Abbr`lab_st`,make_init_def] \\
+    fs[targetPropsTheory.target_io_regs_callee_saved,
+       targetPropsTheory.target_cc_regs_callee_saved] \\
     fs[mc_init_ok_def, mc_conf_ok_def, Abbr`stk`,byte_aligned_MOD] \\
     `max_heap_limit (:'a) c4_data_conf = max_heap_limit (:'a) c.data_conf` by
       (simp[Abbr`c4_data_conf`] \\ EVAL_TAC) \\
@@ -4043,7 +4045,7 @@ Proof
     rewrite_tac [implements'_def,extend_with_resource_limit'_def] \\
     simp[]
     \\ fs[full_make_init_compile]
-    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l m n).compile``]
+    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l).compile``]
     \\ fs[Abbr`stoff`]
     \\ fs[EVAL``(word_to_stackProof$make_init _ a b c d).compile``]
     \\ fs[Abbr`kkk`,Abbr`stk`,Abbr`stack_st`] \\ rfs[]
@@ -4062,7 +4064,7 @@ Proof
     \\ simp_tac std_ss []
     \\ disch_then(SUBST1_TAC o SYM)
     \\ simp[full_make_init_compile, Abbr`lab_st`]
-    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l m n).compile``]
+    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l).compile``]
     \\ simp[append_def]) \\
   simp[Abbr`z`] \\
   match_mp_tac implements'_strengthen \\
@@ -4171,7 +4173,7 @@ Proof
     \\ simp_tac std_ss []
     \\ disch_then(SUBST_ALL_TAC o SYM)
     \\ fs[full_make_init_compile, Abbr`lab_st`]
-    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l m n).compile``]
+    \\ fs[EVAL``(lab_to_targetProof$make_init a b c d e f g h i j k l).compile``]
     \\ simp[append_def]) \\
 
   strip_tac \\

--- a/compiler/backend/proofs/data_to_wordProofScript.sml
+++ b/compiler/backend/proofs/data_to_wordProofScript.sml
@@ -794,11 +794,17 @@ Resume data_compile_correct[MakeSpace]:
     \\ pairarg_tac \\ fs []
     \\ drule_all state_rel_cut_env_cut_env \\ strip_tac
     \\ rename [‘_ = (res1,s1)’]
-    \\ ‘alloc (alloc_size k) (adjust_sets names) (t with locals := y) = (res1,s1)’ by
+    \\ ‘state_rel c l1 l2 (s with locals := x)
+          (t with <|locals := y; fp_regs := FEMPTY|>) NONE locs’ by
+         (drule state_rel_with_fp_regs \\ simp [])
+    \\ ‘alloc (alloc_size k) (adjust_sets names)
+          (t with <|locals := y; fp_regs := FEMPTY|>) = (res1,s1)’ by
       (‘t with
-           <|locals := insert 1 (Word (alloc_size k)) y; memory := t.memory;
-             ffi := t.ffi|> =
-        (t with locals := y) with locals := insert 1 (Word (alloc_size k)) (t with locals := y).locals’ by
+           <|locals := insert 1 (Word (alloc_size k)) y; fp_regs := FEMPTY;
+             memory := t.memory; ffi := t.ffi|> =
+        (t with <|locals := y; fp_regs := FEMPTY|>) with
+          locals := insert 1 (Word (alloc_size k))
+                      (t with <|locals := y; fp_regs := FEMPTY|>).locals’ by
           gvs [wordSemTheory.state_component_equality]
        \\ full_simp_tac std_ss [alloc_locals_insert_1])
     \\ `dataSem$cut_env names x = SOME x` by

--- a/compiler/backend/proofs/data_to_word_assignProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_assignProofScript.sml
@@ -2305,7 +2305,8 @@ Theorem evaluate_SilentFFI_3:
   state_rel c l1 l2 s t NONE locs /\
   wordSem$cut_env (adjust_sets ns) t.locals = SOME env ==>
   wordSem$evaluate (SilentFFI c 3 (adjust_sets ns), t) =
-    (NONE, t with <|locals := env; memory := t.memory; ffi := t.ffi|>)
+    (NONE, t with <|locals := env; fp_regs := FEMPTY;
+                    memory := t.memory; ffi := t.ffi|>)
 Proof
   strip_tac
   \\ imp_res_tac state_rel_FLOOKUP_heap
@@ -6480,21 +6481,26 @@ Proof
   \\ `∃y. wordSem$cut_env (adjust_sets ns) t.locals = SOME y` by
        metis_tac [data_to_word_gcProofTheory.cut_env_IMP_cut_env]
   \\ `evaluate (SilentFFI c 3 (adjust_sets ns), t) =
-        (NONE, t with <|locals := y; memory := t.memory; ffi := t.ffi|>)` by
+        (NONE, t with <|locals := y; fp_regs := FEMPTY;
+                        memory := t.memory; ffi := t.ffi|>)` by
        (irule evaluate_SilentFFI_3 \\ metis_tac [])
   \\ fs []
   \\ fs [wordSemTheory.evaluate_def]
-  \\ `t with <|locals := y; memory := t.memory; ffi := s.ffi|> = t with locals := y` by
+  \\ `t with <|locals := y; fp_regs := FEMPTY; memory := t.memory; ffi := s.ffi|> =
+      t with <|locals := y; fp_regs := FEMPTY|>` by
        (qpat_x_assum `t.ffi = s.ffi` mp_tac \\ simp [wordSemTheory.state_component_equality])
   \\ fs []
   \\ `state_rel c l1 l2 (s with locals := env_narrow) (t with locals := y) NONE locs` by
        (irule data_to_word_gcProofTheory.state_rel_cut_env_cut_env \\ metis_tac [])
+  \\ drule data_to_word_gcProofTheory.state_rel_with_fp_regs
+  \\ disch_then (qspec_then `FEMPTY` assume_tac)
   \\ imp_res_tac cut_env_idempotent
   (* Apply alloc_lemma directed at the narrow-cut state_rel (operand t with locals := y). *)
-  \\ qpat_abbrev_tac `alll = alloc _ _ (t with locals := y)`
+  \\ qpat_abbrev_tac `alll = alloc _ _ (t with <|locals := y; fp_regs := FEMPTY|>)`
   \\ `?x1 x2. alll = (x1,x2)` by (Cases_on `alll` \\ fs [])
   \\ unabbrev_all_tac \\ fs []
-  \\ qpat_x_assum `state_rel c l1 l2 (s with locals := env_narrow) (t with locals := y) NONE locs`
+  \\ qpat_x_assum `state_rel c l1 l2 (s with locals := env_narrow)
+         (t with <|locals := y; fp_regs := FEMPTY|>) NONE locs`
        (mp_then Any mp_tac data_to_word_gcProofTheory.alloc_lemma)
   \\ disch_then (qspecl_then [`env_narrow`,`x2`,`x1`,`ns`] mp_tac)
   \\ fs [EVAL ``alloc_size 0``]
@@ -6527,7 +6533,8 @@ Proof
         \\ drule data_to_word_gcProofTheory.cut_env_IMP_cut_env
         \\ disch_then (qspecl_then [`env_narrow`,`ns`] mp_tac) \\ simp [])
   \\ `evaluate (SilentFFI c 3 (adjust_sets ns), x2) =
-        (NONE, x2 with <|locals := y'; memory := x2.memory; ffi := x2.ffi|>)` by
+        (NONE, x2 with <|locals := y'; fp_regs := FEMPTY;
+                         memory := x2.memory; ffi := x2.ffi|>)` by
        (irule evaluate_SilentFFI_3 \\ metis_tac [])
   \\ fs []
   \\ fs [wordSemTheory.evaluate_def]

--- a/compiler/backend/proofs/data_to_word_gcProofScript.sml
+++ b/compiler/backend/proofs/data_to_word_gcProofScript.sml
@@ -4548,6 +4548,14 @@ Proof
   srw_tac[][state_rel_def] \\ fs []
 QED
 
+(* the relation places no constraint on the FP registers *)
+Theorem state_rel_with_fp_regs:
+   state_rel a b c s1 (s2:('a,'c,'ffi) wordSem$state) d e ⇒
+   state_rel a b c s1 (s2 with fp_regs := f) d e
+Proof
+  srw_tac[][state_rel_def] \\ fs []
+QED
+
 (* -------------------------------------------------------
     init
    ------------------------------------------------------- *)
@@ -8313,11 +8321,14 @@ Proof
          \\ fs [lookup_inter_alt,domain_inter])
       \\ drule_all state_rel_cut_env_cut_env
       \\ strip_tac
+      \\ qabbrev_tac ‘t1 = t with <|locals := union y2 y1; fp_regs := FEMPTY|>’
+      \\ ‘state_rel c l1 l2 (s with locals := x) t1 NONE locs’ by
+           (simp [Abbr‘t1’] \\ drule state_rel_with_fp_regs \\ simp [])
+      \\ qpat_x_assum ‘state_rel _ _ _ _ (t with locals := _) _ _’ kall_tac
       \\ drule_at (Pos $ el 2) alloc_fail \\ gvs []
       \\ disch_then old_drule
-      \\ qabbrev_tac ‘t1 = t with locals := union y2 y1’
       \\ ‘t with
-          <|locals := insert 1 (Word (-1w)) (union y2 y1);
+          <|locals := insert 1 (Word (-1w)) (union y2 y1); fp_regs := FEMPTY;
             memory := t.memory; ffi := s.ffi|> =
           t1 with locals := insert 1 (Word (-1w)) t1.locals’ by
             gvs [Abbr‘t1’,wordSemTheory.state_component_equality]
@@ -8369,10 +8380,10 @@ Proof
          cut_env_insert_1,cut_env_adjust_sets_ODD]
   \\ drule_all cut_env_IMP_cut_env
   \\ strip_tac \\ gvs []
-  \\ qabbrev_tac ‘t1 = t with locals := y’
+  \\ qabbrev_tac ‘t1 = t with <|locals := y; fp_regs := FEMPTY|>’
   \\ qabbrev_tac ‘nw = alloc_size (w2n w DIV 4 + 1) : 'a word’
   \\ ‘t with
-      <|locals := insert 1 (Word nw) y;
+      <|locals := insert 1 (Word nw) y; fp_regs := FEMPTY;
         memory := t.memory; ffi := t.ffi|> =
       t1 with locals := insert 1 (Word nw) t1.locals’ by
     gvs [Abbr‘t1’,wordSemTheory.state_component_equality]
@@ -8384,6 +8395,9 @@ Proof
      \\ fs [lookup_inter_alt,domain_inter])
   \\ drule_all state_rel_cut_env_cut_env
   \\ strip_tac
+  \\ ‘state_rel c l1 l2 (s with locals := x) t1 NONE locs’ by
+       (simp [Abbr‘t1’] \\ drule state_rel_with_fp_regs \\ simp [])
+  \\ qpat_x_assum ‘state_rel _ _ _ _ (t with locals := _) _ _’ kall_tac
   \\ old_drule alloc_alt_gen \\ gvs []
   \\ disch_then old_drule
   \\ pairarg_tac \\ gvs []

--- a/compiler/backend/proofs/lab_filterProofScript.sml
+++ b/compiler/backend/proofs/lab_filterProofScript.sml
@@ -829,7 +829,9 @@ Proof
             (drule_all share_mem_op_FFI_return_filter_correct >>
             rw[] >>
             first_x_assum $ qspecl_then
-              [`s2' with io_regs := shift_seq 1 s2'.io_regs`,`res`,`s2`] assume_tac >>
+              [`s2' with <| io_regs := shift_seq 1 s2'.io_regs ;
+                            io_fp_regs := shift_seq 1 s2'.io_fp_regs |>`,
+               `res`,`s2`] assume_tac >>
             gvs[] >>
             last_x_assum $ qspec_then `0` assume_tac >>
             gvs[state_rel_def] >>
@@ -1011,10 +1013,12 @@ Proof
       rw[]>>
       first_x_assum(qspec_then `t1 with <|
         regs := (t1.ptr_reg =+ Loc n'' 0) (λa. get_reg_value (t1.cc_regs 0 a) (read_reg a t1) Word);
+        fp_regs := (λn. t1.cc_fp_regs 0 n);
         pc := pc';
         code := t1.code ++ SND(t1.compile_oracle 0);
         compile_oracle := shift_seq 1 t1.compile_oracle;
-        code_buffer := cb; clock:=t1.clock-1 ; cc_regs:= shift_seq 1 t1.cc_regs|>` mp_tac)>>
+        code_buffer := cb; clock:=t1.clock-1 ; cc_regs:= shift_seq 1 t1.cc_regs;
+        cc_fp_regs := shift_seq 1 t1.cc_fp_regs|>` mp_tac)>>
       simp[state_component_equality]>>
       impl_tac>- (
         rw[filter_skip_MAP,shift_seq_def]

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -9186,8 +9186,6 @@ Resume compile_correct[Install]:
       rw[]>>fs[]>>
       match_mp_tac all_enc_ok_labs_mono
       >- metis_tac[] >>
-      (* TODO: remove qexists `l1` *)
-      (* irule (Pos hd) $ DECIDE``A ==> A`` *)
       qexists `l1` >>
       gvs[asm_fetch_def] >>
       rev_drule code_similar_IMP_asm_fetch_aux_line_similar >>

--- a/compiler/backend/proofs/lab_to_targetProofScript.sml
+++ b/compiler/backend/proofs/lab_to_targetProofScript.sml
@@ -123,7 +123,7 @@ Definition asm_step_nop_def:
 End
 
 val evaluate_nop_step =
-  asm_step_IMP_evaluate_step
+  asm_step_IMP_evaluate_step_find_next
     |> SIMP_RULE std_ss [asm_step_def]
     |> SPEC_ALL |> Q.INST [`i`|->`Inst Skip`]
     |> SIMP_RULE (srw_ss()) [asm_def,inst_def,asm_ok_def,inst_ok_def,
@@ -165,8 +165,10 @@ Theorem evaluate_nop_steps[local]:
       target_state_rel c.target (s1:'a asm_state) (ms1:'state) ==>
       ?l ms2.
         !k.
-          evaluate c io (k + l) ms1 =
-          evaluate (shift_interfer l c) io k ms2 /\
+          (evaluate c io (k + l) ms1 =
+           evaluate (shift_interfer l c) io k ms2) /\
+          (find_next_interference c io (k + l) ms1 =
+           find_next_interference (shift_interfer l c) io k ms2) /\
           target_state_rel c.target
             (upd_pc
               (s1.pc +
@@ -257,12 +259,14 @@ Theorem asm_step_IMP_evaluate_step_nop:
       (!x. i <> Call x) ==>
       ?l ms2.
         !k.
-          evaluate c io (k + l) ms1 =
-          evaluate (shift_interfer l c) io k ms2 /\
+          (evaluate c io (k + l) ms1 =
+           evaluate (shift_interfer l c) io k ms2) /\
+          (find_next_interference c io (k + l) ms1 =
+           find_next_interference (shift_interfer l c) io k ms2) /\
           target_state_rel c.target s2 ms2 /\ l <> 0
 Proof
   full_simp_tac(srw_ss())[asm_step_nop_def] \\ rpt strip_tac
-  \\ (asm_step_IMP_evaluate_step
+  \\ (asm_step_IMP_evaluate_step_find_next
       |> SIMP_RULE std_ss [asm_step_def] |> SPEC_ALL |> mp_tac) \\ fs[]
   \\ full_simp_tac(srw_ss())[enc_with_nop_thm]
   \\ match_mp_tac IMP_IMP \\ strip_tac THEN1
@@ -324,8 +328,8 @@ Proof
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[GSYM PULL_FORALL]
   \\ Q.LIST_EXISTS_TAC [`l+l'`,`ms2'`]
   \\ full_simp_tac(srw_ss())[PULL_FORALL] \\ strip_tac
-  \\ first_x_assum (mp_tac o Q.SPEC `k:num`)
-  \\ qpat_x_assum `!k. xx = yy` (mp_tac o Q.SPEC `k+l':num`)
+  \\ qpat_x_assum `!k. evaluate _ io _ ms2 = _ /\ _` (mp_tac o Q.SPEC `k:num`)
+  \\ qpat_x_assum `!k. evaluate _ io _ ms1 = _ /\ _` (mp_tac o Q.SPEC `k+l':num`)
   \\ rpt strip_tac \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC]
   \\ full_simp_tac(srw_ss())[shift_interfer_def]
   \\ qpat_x_assum `target_state_rel c.target xx yy` mp_tac
@@ -776,6 +780,179 @@ Definition no_install_or_no_share_mem_def:
     no_install code
 End
 
+(* The lab-level oracles record the register residues that the machine run
+   starting from ms actually leaves behind: the k-th entry of each family is
+   read off the k-th interference application of that family.
+   This is positional, so it is kept out of state_rel (which is closed under
+   shift_interfer) and threaded through compile_correct separately. *)
+Definition oracle_tie_def:
+  oracle_tie (mc_conf:('a,'state,'b) machine_config) ms
+             (s1:('a,'c,'ffi) labSem$state) ⇔
+    s1.io_regs = target_io_regs mc_conf s1.ffi ms ∧
+    s1.io_fp_regs = target_io_fp_regs mc_conf s1.ffi ms ∧
+    s1.cc_regs = target_cc_regs mc_conf s1.ffi ms ∧
+    s1.cc_fp_regs = target_cc_fp_regs mc_conf s1.ffi ms
+End
+
+Theorem oracle_tie_shift_interfer:
+  oracle_tie mc_conf ms1 s1 ∧
+  (∀k. find_next_interference mc_conf s1.ffi (k + l) ms1 =
+       find_next_interference (shift_interfer l mc_conf) s1.ffi k ms2) ⇒
+  oracle_tie (shift_interfer l mc_conf) ms2 s1
+Proof
+  strip_tac
+  \\ ‘next_interference mc_conf s1.ffi ms1 =
+      next_interference (shift_interfer l mc_conf) s1.ffi ms2’
+       by (irule next_interference_shift \\ metis_tac[])
+  \\ drule constructed_oracles_EQ
+  \\ simp[shift_interfer_def]
+  \\ strip_tac
+  \\ gvs[oracle_tie_def]
+QED
+
+Theorem oracle_tie_step:
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  (∀k. find_next_interference mc_conf s1.ffi (k + l) ms1 =
+       find_next_interference (shift_interfer l mc_conf) s1.ffi k ms2) ∧
+  (s2:('a,'c,'ffi) labSem$state).io_regs = s1.io_regs ∧
+  s2.io_fp_regs = s1.io_fp_regs ∧
+  s2.cc_regs = s1.cc_regs ∧ s2.cc_fp_regs = s1.cc_fp_regs ∧
+  s2.ffi = s1.ffi ⇒
+  oracle_tie (shift_interfer l mc_conf) ms2 s2
+Proof
+  strip_tac
+  \\ drule_all oracle_tie_shift_interfer
+  \\ simp[oracle_tie_def]
+QED
+
+Theorem oracle_tie_ffi_step:
+  oracle_tie mc_conf ms1 s1 ∧
+  next_interference mc_conf s1.ffi ms1 =
+    SOME (FfiApp index new_bytes ms_pre ms_post, mc', ffi') ⇒
+  (∀name r.
+     s1.io_regs 0 name r =
+       if MEM r mc_conf.callee_saved_regs ∨
+          ¬(r < mc_conf.target.config.reg_count) ∨
+          MEM r mc_conf.target.config.avoid_regs
+       then NONE else SOME (mc_conf.target.get_reg ms_post r)) ∧
+  (∀i. s1.io_fp_regs 0 i = mc_conf.target.get_fp_reg ms_post i) ∧
+  target_io_regs mc' ffi' ms_post = shift_seq 1 s1.io_regs ∧
+  target_io_fp_regs mc' ffi' ms_post = shift_seq 1 s1.io_fp_regs ∧
+  target_cc_regs mc' ffi' ms_post = s1.cc_regs ∧
+  target_cc_fp_regs mc' ffi' ms_post = s1.cc_fp_regs
+Proof
+  strip_tac
+  \\ drule constructed_oracles_ffi_step
+  \\ gvs[oracle_tie_def, FUN_EQ_THM, shift_seq_def, ADD1]
+  \\ metis_tac[]
+QED
+
+Theorem oracle_tie_ccache_step:
+  oracle_tie mc_conf ms1 s1 ∧
+  next_interference mc_conf s1.ffi ms1 =
+    SOME (CcApp a1 a2 ms_pre ms_post, mc', ffi') ⇒
+  (∀r.
+     s1.cc_regs 0 r =
+       if MEM r mc_conf.callee_saved_regs ∨ r = mc_conf.ptr_reg ∨
+          ¬(r < mc_conf.target.config.reg_count) ∨
+          MEM r mc_conf.target.config.avoid_regs
+       then NONE else SOME (mc_conf.target.get_reg ms_post r)) ∧
+  (∀i. s1.cc_fp_regs 0 i = mc_conf.target.get_fp_reg ms_post i) ∧
+  target_cc_regs mc' ffi' ms_post = shift_seq 1 s1.cc_regs ∧
+  target_cc_fp_regs mc' ffi' ms_post = shift_seq 1 s1.cc_fp_regs ∧
+  target_io_regs mc' ffi' ms_post = s1.io_regs ∧
+  target_io_fp_regs mc' ffi' ms_post = s1.io_fp_regs
+Proof
+  strip_tac
+  \\ drule constructed_oracles_cc_step
+  \\ gvs[oracle_tie_def, FUN_EQ_THM, shift_seq_def, ADD1]
+  \\ metis_tac[]
+QED
+
+Theorem oracle_tie_ffi_next:
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  next_interference mc_conf s1.ffi ms1 =
+    SOME (FfiApp index new_bytes ms_pre ms_post, mc', ffi') ∧
+  (s2:('a,'c,'ffi) labSem$state).io_regs = shift_seq 1 s1.io_regs ∧
+  s2.io_fp_regs = shift_seq 1 s1.io_fp_regs ∧
+  s2.cc_regs = s1.cc_regs ∧ s2.cc_fp_regs = s1.cc_fp_regs ∧
+  s2.ffi = ffi' ⇒
+  oracle_tie mc' ms_post s2
+Proof
+  strip_tac
+  \\ drule_all oracle_tie_ffi_step
+  \\ simp[oracle_tie_def]
+QED
+
+Theorem oracle_tie_ccache_next:
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  next_interference mc_conf s1.ffi ms1 =
+    SOME (CcApp a1 a2 ms_pre ms_post, mc', ffi') ∧
+  (s2:('a,'c,'ffi) labSem$state).cc_regs = shift_seq 1 s1.cc_regs ∧
+  s2.cc_fp_regs = shift_seq 1 s1.cc_fp_regs ∧
+  s2.io_regs = s1.io_regs ∧ s2.io_fp_regs = s1.io_fp_regs ∧
+  s2.ffi = ffi' ⇒
+  oracle_tie mc' ms_post s2
+Proof
+  strip_tac
+  \\ drule_all oracle_tie_ccache_step
+  \\ simp[oracle_tie_def]
+QED
+
+Theorem oracle_tie_ExtCall_residues:
+  ∀mc_conf ms1 s1 ms2 l index name bytes bytes2 new_ffi new_bytes t1.
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  (∀k. find_next_interference mc_conf s1.ffi (k + l) ms1 =
+       find_next_interference
+         (mc_conf with next_interfer := shift_seq l mc_conf.next_interfer)
+         s1.ffi k ms2) ∧
+  mc_conf.target.get_pc ms2 ∉ mc_conf.prog_addresses DIFF set mc_conf.ffi_entry_pcs ∧
+  mc_conf.target.get_pc ms2 ≠ mc_conf.halt_pc ∧
+  mc_conf.target.get_pc ms2 ≠ mc_conf.ccache_pc ∧
+  find_index (mc_conf.target.get_pc ms2) mc_conf.ffi_entry_pcs 0 = SOME index ∧
+  EL index mc_conf.ffi_names = ExtCall name ∧
+  ALOOKUP mc_conf.mmio_info index = NONE ∧
+  read_ffi_bytearrays mc_conf ms2 = (SOME bytes, SOME bytes2) ∧
+  call_FFI s1.ffi (ExtCall name) bytes bytes2 = FFI_return new_ffi new_bytes ⇒
+  (λa. get_reg_value (s1.io_regs 0 (ExtCall name) a) (t1.regs a) I) =
+    (λa. if MEM a mc_conf.callee_saved_regs ∨
+            ¬(a < mc_conf.target.config.reg_count) ∨
+            MEM a mc_conf.target.config.avoid_regs
+         then t1.regs a
+         else mc_conf.target.get_reg
+                (mc_conf.ffi_interfer 0 (index,new_bytes,ms2)) a) ∧
+  (λn. s1.io_fp_regs 0 n) =
+    (λn. mc_conf.target.get_fp_reg
+           (mc_conf.ffi_interfer 0 (index,new_bytes,ms2)) n)
+Proof
+  rpt gen_tac \\ strip_tac
+  \\ `next_interference mc_conf s1.ffi ms1 =
+      next_interference
+        (mc_conf with next_interfer := shift_seq l mc_conf.next_interfer)
+        s1.ffi ms2` by (irule next_interference_shift \\ metis_tac[])
+  \\ `(mc_conf with next_interfer := shift_seq l mc_conf.next_interfer).ffi_interfer =
+      mc_conf.ffi_interfer` by simp[]
+  \\ sg `next_interference mc_conf s1.ffi ms1 =
+      SOME (FfiApp index new_bytes ms2
+              (mc_conf.ffi_interfer 0 (index,new_bytes,ms2)),
+            (mc_conf with next_interfer := shift_seq l mc_conf.next_interfer)
+              with ffi_interfer := shift_seq 1 mc_conf.ffi_interfer, new_ffi)`
+  >- (pop_assum (fn th => rewrite_tac[GSYM th])
+      \\ pop_assum $ rewrite_tac o single
+      \\ irule next_interference_ExtCall
+      \\ simp[]
+      \\ conj_tac
+      >- gvs[]
+      \\ qexists_tac `bytes` \\ qexists_tac `bytes2`
+      \\ gvs[targetSemTheory.read_ffi_bytearrays_def,
+             targetSemTheory.read_ffi_bytearray_def])
+  \\ drule_all oracle_tie_ffi_step
+  \\ strip_tac
+  \\ conj_tac
+  >- (simp[FUN_EQ_THM] \\ rw[] \\ gvs[get_reg_value_def])
+  \\ simp[FUN_EQ_THM]
+QED
+
 (* The code buffer is set-up to immediately follow the current code:
   |---code---|---cb---|
 *)
@@ -805,24 +982,35 @@ Definition state_rel_def:
        target_state_rel mc_conf.target
          (t1 with pc := p - n2w ((3 + index) * ffi_offset)) ms2 /\
        aligned mc_conf.target.config.code_alignment (t1.regs s1.link_reg) ==>
-       target_state_rel mc_conf.target
-         (t1 with
-         <|regs := (\a. get_reg_value (s1.io_regs k (EL index mc_conf.ffi_names) a) (t1.regs a) I);
-           mem := asm_write_bytearray (t1.regs s1.ptr2_reg) new_bytes t1.mem;
-           pc := t1.regs s1.link_reg|>)
-        (mc_conf.ffi_interfer k (index,new_bytes,ms2))) /\
+       (let ms' = mc_conf.ffi_interfer k (index,new_bytes,ms2) in
+          target_state_rel mc_conf.target
+            (t1 with
+            <|regs := (\a. if MEM a mc_conf.callee_saved_regs ∨
+                              ¬(a < mc_conf.target.config.reg_count) ∨
+                              MEM a mc_conf.target.config.avoid_regs
+                           then t1.regs a
+                           else mc_conf.target.get_reg ms' a);
+              fp_regs := (\n. mc_conf.target.get_fp_reg ms' n);
+              mem := asm_write_bytearray (t1.regs s1.ptr2_reg) new_bytes t1.mem;
+              pc := t1.regs s1.link_reg|>)
+            ms')) /\
     (* clear cache behaves correctly *)
     (∀ms2 t1 k a1 a2.
       target_state_rel mc_conf.target
         (t1 with pc := p - n2w ((2 * ffi_offset))) ms2 /\
       aligned mc_conf.target.config.code_alignment (t1.regs s1.link_reg) ⇒
-      target_state_rel mc_conf.target
-        (t1 with
-          <|regs :=
-            (s1.ptr_reg =+ t1.regs s1.ptr_reg)
-              (λa. get_reg_value (s1.cc_regs k a) (t1.regs a) I);
-            pc := t1.regs s1.link_reg|>)
-        (mc_conf.ccache_interfer k (a1,a2,ms2))) /\
+      (let ms' = mc_conf.ccache_interfer k (a1,a2,ms2) in
+         target_state_rel mc_conf.target
+           (t1 with
+             <|regs := (\a. if MEM a mc_conf.callee_saved_regs ∨
+                               a = s1.ptr_reg ∨
+                               ¬(a < mc_conf.target.config.reg_count) ∨
+                               MEM a mc_conf.target.config.avoid_regs
+                            then t1.regs a
+                            else mc_conf.target.get_reg ms' a);
+               fp_regs := (\n. mc_conf.target.get_fp_reg ms' n);
+               pc := t1.regs s1.link_reg|>)
+           ms')) /\
     s1.compile = compile_lab mc_conf.target.config ∧
     (no_share_mem_inst code2 ==> (∀k. let (cfg,code) = s1.compile_oracle k in
             good_code mc_conf.target.config cfg.labels code ∧
@@ -906,6 +1094,13 @@ Definition state_rel_def:
     LENGTH mc_conf.ffi_names = LENGTH mc_conf.ffi_entry_pcs /\
     no_install_or_no_share_mem code2 mc_conf.ffi_names
 End
+
+Theorem oracle_tie_clock:
+  oracle_tie mc_conf ms s1 ⇒
+  oracle_tie mc_conf ms (s1 with clock := k)
+Proof
+  simp[oracle_tie_def]
+QED
 
 Theorem state_rel_clock:
   state_rel x s1 t1 ms ==>
@@ -7255,10 +7450,84 @@ Proof
   Cases_on ‘x’>>gvs[]
 QED
 
+Theorem oracle_tie_shift_gen:
+  ∀mc_conf mc2 ms1 s1 ms2 l.
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  (∀k. find_next_interference mc_conf s1.ffi (k + l) ms1 =
+       find_next_interference mc2 s1.ffi k ms2) ∧
+  mc2.target = mc_conf.target ∧
+  mc2.callee_saved_regs = mc_conf.callee_saved_regs ∧
+  mc2.ptr_reg = mc_conf.ptr_reg ⇒
+  oracle_tie mc2 ms2 s1
+Proof
+  rpt gen_tac \\ strip_tac
+  \\ `next_interference mc_conf s1.ffi ms1 = next_interference mc2 s1.ffi ms2`
+       by (irule next_interference_shift \\ metis_tac[])
+  \\ drule constructed_oracles_EQ
+  \\ simp[]
+  \\ strip_tac
+  \\ gvs[oracle_tie_def]
+QED
+
+Theorem oracle_tie_ccache_residues:
+  ∀mc_conf mc2 ms1 s1 ms2 l t1.
+  oracle_tie mc_conf ms1 (s1:('a,'c,'ffi) labSem$state) ∧
+  (∀k. find_next_interference mc_conf s1.ffi (k + l) ms1 =
+       find_next_interference mc2 s1.ffi k ms2) ∧
+  mc2.target = mc_conf.target ∧
+  mc2.ptr_reg = mc_conf.ptr_reg ∧
+  mc2.len_reg = mc_conf.len_reg ∧
+  mc2.ccache_interfer = mc_conf.ccache_interfer ∧
+  mc2.target.get_pc ms2 ∉ mc2.prog_addresses DIFF set mc2.ffi_entry_pcs ∧
+  mc2.target.get_pc ms2 ≠ mc2.halt_pc ∧
+  mc2.target.get_pc ms2 = mc2.ccache_pc ⇒
+  (λa. get_reg_value (s1.cc_regs 0 a) (t1.regs a) I) =
+    (λa. if MEM a mc_conf.callee_saved_regs ∨ a = mc_conf.ptr_reg ∨
+            ¬(a < mc_conf.target.config.reg_count) ∨
+            MEM a mc_conf.target.config.avoid_regs
+         then t1.regs a
+         else mc_conf.target.get_reg
+                (mc_conf.ccache_interfer 0
+                   (mc_conf.target.get_reg ms2 mc_conf.ptr_reg,
+                    mc_conf.target.get_reg ms2 mc_conf.len_reg, ms2)) a) ∧
+  (λn. s1.cc_fp_regs 0 n) =
+    (λn. mc_conf.target.get_fp_reg
+           (mc_conf.ccache_interfer 0
+              (mc_conf.target.get_reg ms2 mc_conf.ptr_reg,
+               mc_conf.target.get_reg ms2 mc_conf.len_reg, ms2)) n)
+Proof
+  rpt gen_tac \\ strip_tac
+  \\ `next_interference mc_conf s1.ffi ms1 = next_interference mc2 s1.ffi ms2`
+       by (irule next_interference_shift \\ metis_tac[])
+  \\ sg `next_interference mc2 s1.ffi ms2 =
+         SOME (CcApp (mc2.target.get_reg ms2 mc2.ptr_reg)
+                     (mc2.target.get_reg ms2 mc2.len_reg) ms2
+                 (mc2.ccache_interfer 0
+                    (mc2.target.get_reg ms2 mc2.ptr_reg,
+                     mc2.target.get_reg ms2 mc2.len_reg, ms2)),
+               mc2 with ccache_interfer := shift_seq 1 mc2.ccache_interfer,
+               s1.ffi)`
+  >- (irule next_interference_ccache \\ simp[])
+  \\ `next_interference mc_conf s1.ffi ms1 =
+      SOME (CcApp (mc_conf.target.get_reg ms2 mc_conf.ptr_reg)
+                  (mc_conf.target.get_reg ms2 mc_conf.len_reg) ms2
+              (mc_conf.ccache_interfer 0
+                 (mc_conf.target.get_reg ms2 mc_conf.ptr_reg,
+                  mc_conf.target.get_reg ms2 mc_conf.len_reg, ms2)),
+            mc2 with ccache_interfer := shift_seq 1 mc_conf.ccache_interfer,
+            s1.ffi)` by gvs[]
+  \\ drule_all oracle_tie_ccache_step
+  \\ strip_tac
+  \\ conj_tac
+  >- (simp[FUN_EQ_THM] \\ rw[] \\ gvs[get_reg_value_def])
+  \\ simp[FUN_EQ_THM]
+QED
+
 val say = say0 "compile_correct";
 
 Theorem compile_correct:
   !^s1 res (mc_conf: ('a,'state,'b) machine_config) s2 code2 labs t1 ms1.
+     oracle_tie mc_conf ms1 s1 /\
      (evaluate s1 = (res,s2)) /\ (res <> Error) /\
      encoder_correct mc_conf.target /\
      state_rel (mc_conf,code2,labs,p) s1 t1 ms1 ==>
@@ -7276,91 +7545,153 @@ Proof
   \\ Cases_on `asm_fetch s1` \\ full_simp_tac(srw_ss())[]
   \\ Cases_on `x` \\ full_simp_tac(srw_ss())[] \\ Cases_on `a` \\ full_simp_tac(srw_ss())[]
   \\ REPEAT (Q.PAT_X_ASSUM `T` (K ALL_TAC)) \\ full_simp_tac(srw_ss())[LET_DEF]
-  THEN1 (
-    fs[case_eq_thms]>>rw[]
-    THEN1 (* Asm Inst *) (
-       say "Asm Inst"
-       \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (Asm (Asmi(Inst i)) bytes len)`
-       \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-       \\ mp_tac IMP_bytes_in_memory_Inst
-       \\ full_simp_tac(srw_ss())[]
-       \\ impl_tac
-       THEN1 (full_simp_tac(srw_ss())[state_rel_def])
-       \\ rpt strip_tac \\ pop_assum mp_tac \\ pop_assum mp_tac
-       \\ qpat_abbrev_tac `jj = asm$Inst i` \\ rpt strip_tac
-       \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]MP_TAC
-            asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
-       \\ disch_then (mp_tac o Q.SPEC `bytes'`)
-       \\ impl_tac>-
-        (imp_res_tac Inst_lemma \\ pop_assum (K all_tac)
-         \\ full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF] \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
-         \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
-         \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
-         \\ conj_tac
-         >- (fs[asm_fetch_def] >>
-          `!op re a. Asmi (Inst i) <> ShareMem op re a` by simp[] >>
-          drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm >>
-          simp[])
-         \\ qpat_x_assum `bytes_in_mem ww bytes' t1.mem
-               t1.mem_domain s1.mem_domain` mp_tac
-         \\ match_mp_tac bytes_in_mem_IMP_memory \\ full_simp_tac(srw_ss())[])
-       \\ rpt strip_tac \\ full_simp_tac(srw_ss())[]
-       \\ rfs[] \\ fs[]
-       \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l mc_conf`,
-            `code2`,`labs`,
-            `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
-       \\ impl_tac THEN1
-        (unabbrev_all_tac \\ rpt strip_tac \\ full_simp_tac(srw_ss())[asm_def]
-         THEN1 (full_simp_tac(srw_ss())[shift_interfer_def])
-         \\ full_simp_tac(srw_ss())[GSYM PULL_FORALL]
-         \\ match_mp_tac state_rel_shift_interfer
-         \\ old_drule Inst_lemma \\ fs[])
-       \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
-       \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k` mp_tac)
-       \\ rpt strip_tac
-       \\ Q.EXISTS_TAC `k + l - 1` \\ full_simp_tac(srw_ss())[]
-       \\ `^s1.clock - 1 + k + l = ^s1.clock + (k + l - 1)` by decide_tac
-       \\ fs[asm_inst_consts])
-    THEN1 (* Asm JumpReg *) (
-      say "Asm JumpReg"
-      \\ qmatch_assum_rename_tac `read_reg r1 s1 = Loc l1 l2`
-      \\ Cases_on `loc_to_pc l1 l2 s1.code` \\ full_simp_tac(srw_ss())[]
-      \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`, `s1.ffi`, `JumpReg r1`]MP_TAC
-           asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]
-      \\ impl_tac >-
-       (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-        \\ conj_tac
-        >- (fs[asm_fetch_def]
-          \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-          \\ strip_tac
-          \\ fs[]
-          \\ `!op re a. Asmi (JumpReg r1) <> ShareMem op re a` by simp[]
-          \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm
-          \\ `LENGTH ((mc_conf.target.config.encode (JumpReg r1))) <=
-            LENGTH (line_bytes j)`
-            suffices_by metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
-          \\ Cases_on `j`
-          \\ fs[line_similar_def,line_ok_def]
-          \\ fs[enc_with_nop_thm,line_length_def]
-          \\ Cases_on `a` >> fs[]
-          \\ metis_tac[LENGTH_APPEND,LESS_EQ_ADD])
-        \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
-        \\ imp_res_tac bytes_in_mem_IMP
-        \\ full_simp_tac(srw_ss())[IMP_bytes_in_memory_JumpReg,asmSemTheory.upd_pc_def,
-               asmSemTheory.assert_def]
-        \\ imp_res_tac IMP_bytes_in_memory_JumpReg \\ full_simp_tac(srw_ss())[]
-        \\ full_simp_tac(srw_ss())[asmSemTheory.read_reg_def]
-        \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
-        \\ FIRST_X_ASSUM (kall_tac o Q.SPEC `r1:num`)
-        \\ qpat_x_assum `!n. n<s1.code_buffer.space_left ==> _` kall_tac
-        \\ qpat_x_assum `!r. word_loc_val _ _ (read_reg r _) = _` (MP_TAC o Q.SPEC `r1:num`)
-        \\ strip_tac \\ rev_full_simp_tac(srw_ss())[]
-        \\ full_simp_tac(srw_ss())[word_loc_val_def]
-        \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
-        \\ Q.PAT_X_ASSUM `xx = t1.regs r1` (fn th => full_simp_tac(srw_ss())[GSYM th])
-        \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
-        \\ (alignmentTheory.aligned_add_sub_cor
-            |> SPEC_ALL |> UNDISCH |> CONJUNCT1 |> DISCH_ALL |> irule)
+  THEN1 suspend "Asm"
+  THEN1 suspend "CBW"
+  THEN1 suspend "ShareMemOp"
+  THEN1 suspend "Jump"
+  THEN1 suspend "JumpCmp"
+  THEN1 suspend "Call"
+  THEN1 suspend "LocValue"
+  THEN1 suspend "CallFFI"
+  THEN1 suspend "Install"
+  THEN1 suspend "Halt"
+QED
+
+Resume compile_correct[Asm]:
+  fs[case_eq_thms]>>rw[]
+  THEN1 (* Asm Inst *) (
+     say "Asm Inst"
+     \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (Asm (Asmi(Inst i)) bytes len)`
+     \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+     \\ mp_tac IMP_bytes_in_memory_Inst
+     \\ full_simp_tac(srw_ss())[]
+     \\ impl_tac
+     THEN1 (full_simp_tac(srw_ss())[state_rel_def])
+     \\ rpt strip_tac \\ pop_assum mp_tac \\ pop_assum mp_tac
+     \\ qpat_abbrev_tac `jj = asm$Inst i` \\ rpt strip_tac
+     \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]MP_TAC
+          asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
+     \\ disch_then (mp_tac o Q.SPEC `bytes'`)
+     \\ impl_tac>-
+      (imp_res_tac Inst_lemma \\ pop_assum (K all_tac)
+       \\ full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF] \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
+       \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
+       \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
+       \\ conj_tac
+       >- (fs[asm_fetch_def] >>
+        `!op re a. Asmi (Inst i) <> ShareMem op re a` by simp[] >>
+        drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm >>
+        simp[])
+       \\ qpat_x_assum `bytes_in_mem ww bytes' t1.mem
+             t1.mem_domain s1.mem_domain` mp_tac
+       \\ match_mp_tac bytes_in_mem_IMP_memory \\ full_simp_tac(srw_ss())[])
+     \\ rpt strip_tac \\ full_simp_tac(srw_ss())[]
+     \\ rfs[] \\ fs[]
+     \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l mc_conf`,
+          `code2`,`labs`,
+          `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
+     \\ impl_tac THEN1
+      (conj_tac
+       >- (irule oracle_tie_step
+           \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+           \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                   labSemTheory.upd_pc_def,asm_inst_consts]
+           \\ metis_tac[])
+       \\ unabbrev_all_tac \\ rpt strip_tac \\ full_simp_tac(srw_ss())[asm_def]
+       THEN1 (full_simp_tac(srw_ss())[shift_interfer_def])
+       \\ full_simp_tac(srw_ss())[GSYM PULL_FORALL]
+       \\ match_mp_tac state_rel_shift_interfer
+       \\ old_drule Inst_lemma \\ fs[])
+     \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
+     \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k` mp_tac)
+     \\ rpt strip_tac
+     \\ Q.EXISTS_TAC `k + l - 1` \\ full_simp_tac(srw_ss())[]
+     \\ `^s1.clock - 1 + k + l = ^s1.clock + (k + l - 1)` by decide_tac
+     \\ fs[asm_inst_consts])
+  THEN1 (* Asm JumpReg *) (
+    say "Asm JumpReg"
+    \\ qmatch_assum_rename_tac `read_reg r1 s1 = Loc l1 l2`
+    \\ Cases_on `loc_to_pc l1 l2 s1.code` \\ full_simp_tac(srw_ss())[]
+    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`, `s1.ffi`, `JumpReg r1`]MP_TAC
+         asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]
+    \\ impl_tac >-
+     (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+      \\ conj_tac
+      >- (fs[asm_fetch_def]
+        \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+        \\ strip_tac
+        \\ fs[]
+        \\ `!op re a. Asmi (JumpReg r1) <> ShareMem op re a` by simp[]
+        \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm
+        \\ `LENGTH ((mc_conf.target.config.encode (JumpReg r1))) <=
+          LENGTH (line_bytes j)`
+          suffices_by metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
+        \\ Cases_on `j`
+        \\ fs[line_similar_def,line_ok_def]
+        \\ fs[enc_with_nop_thm,line_length_def]
+        \\ Cases_on `a` >> fs[]
+        \\ metis_tac[LENGTH_APPEND,LESS_EQ_ADD])
+      \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+      \\ imp_res_tac bytes_in_mem_IMP
+      \\ full_simp_tac(srw_ss())[IMP_bytes_in_memory_JumpReg,asmSemTheory.upd_pc_def,
+             asmSemTheory.assert_def]
+      \\ imp_res_tac IMP_bytes_in_memory_JumpReg \\ full_simp_tac(srw_ss())[]
+      \\ full_simp_tac(srw_ss())[asmSemTheory.read_reg_def]
+      \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
+      \\ FIRST_X_ASSUM (kall_tac o Q.SPEC `r1:num`)
+      \\ qpat_x_assum `!n. n<s1.code_buffer.space_left ==> _` kall_tac
+      \\ qpat_x_assum `!r. word_loc_val _ _ (read_reg r _) = _` (MP_TAC o Q.SPEC `r1:num`)
+      \\ strip_tac \\ rev_full_simp_tac(srw_ss())[]
+      \\ full_simp_tac(srw_ss())[word_loc_val_def]
+      \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
+      \\ Q.PAT_X_ASSUM `xx = t1.regs r1` (fn th => full_simp_tac(srw_ss())[GSYM th])
+      \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
+      \\ (alignmentTheory.aligned_add_sub_cor
+          |> SPEC_ALL |> UNDISCH |> CONJUNCT1 |> DISCH_ALL |> irule)
+      \\ conj_tac >- fs[alignmentTheory.aligned_bitwise_and]
+      \\ simp[aligned_w2n]
+      \\ qmatch_goalsub_abbrev_tac`pv MOD dw MOD _`
+      \\ `pv MOD dw = pv` by (
+        simp[Abbr`pv`,Abbr`dw`]
+        \\ irule LESS_EQ_LESS_TRANS
+        \\ qexists_tac`LENGTH (prog_to_bytes code2)`
+        \\ simp[]
+        \\ old_drule pos_val_bound
+        \\ disch_then(qspec_then`0`mp_tac o CONV_RULE SWAP_FORALL_CONV)
+        \\ simp[] )
+      \\ simp[]
+      \\ qunabbrev_tac`pv`
+      \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+      \\ match_mp_tac pos_val_MOD_0 \\ gvs[]
+      \\ metis_tac[has_odd_inst_alignment] )
+    \\ rpt strip_tac
+    \\ rfs[] \\ fs[] \\ rfs[]
+    \\ FIRST_X_ASSUM (qspecl_then [`shift_interfer l' mc_conf`,
+         `code2`,`labs`,`(asm (JumpReg r1)
+            (t1.pc + n2w (LENGTH (mc_conf.target.config.encode (JumpReg r1)))) t1)`,`ms2`] mp_tac)
+    \\ impl_tac >-
+     (conj_tac
+       >- (irule oracle_tie_step
+           \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+           \\ simp[labSemTheory.upd_pc_def,labSemTheory.dec_clock_def]
+           \\ metis_tac[])
+      \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
+      \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
+             asmSemTheory.read_reg_def,dec_clock_def,labSemTheory.upd_pc_def,
+             labSemTheory.assert_def]
+      \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
+      \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
+      \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
+      \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
+      \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `r1:num`)
+      \\ strip_tac \\ rev_full_simp_tac(srw_ss())[]
+      \\ full_simp_tac(srw_ss())[word_loc_val_def]
+      \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
+      \\ Q.PAT_X_ASSUM `xx = t1.regs r1` (fn th => full_simp_tac(srw_ss())[GSYM th])
+      \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
+      \\ RES_TAC \\ full_simp_tac(srw_ss())[] \\ rpt strip_tac \\ res_tac \\ srw_tac[][]
+      >- ((alignmentTheory.aligned_add_sub_cor
+          |> SPEC_ALL |> UNDISCH |> CONJUNCT1 |> DISCH_ALL |> irule)
         \\ conj_tac >- fs[alignmentTheory.aligned_bitwise_and]
         \\ simp[aligned_w2n]
         \\ qmatch_goalsub_abbrev_tac`pv MOD dw MOD _`
@@ -7374,301 +7705,378 @@ Proof
           \\ simp[] )
         \\ simp[]
         \\ qunabbrev_tac`pv`
-        \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-        \\ match_mp_tac pos_val_MOD_0 \\ gvs[]
-        \\ metis_tac[has_odd_inst_alignment] )
-      \\ rpt strip_tac
-      \\ rfs[] \\ fs[] \\ rfs[]
-      \\ FIRST_X_ASSUM (qspecl_then [`shift_interfer l' mc_conf`,
-           `code2`,`labs`,`(asm (JumpReg r1)
-              (t1.pc + n2w (LENGTH (mc_conf.target.config.encode (JumpReg r1)))) t1)`,`ms2`] mp_tac)
-      \\ impl_tac >-
-       (full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
-        \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
-               asmSemTheory.read_reg_def,dec_clock_def,labSemTheory.upd_pc_def,
-               labSemTheory.assert_def]
-        \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
-        \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
-        \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
-        \\ FIRST_X_ASSUM (K ALL_TAC o Q.SPEC `r1:num`)
-        \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `r1:num`)
-        \\ strip_tac \\ rev_full_simp_tac(srw_ss())[]
-        \\ full_simp_tac(srw_ss())[word_loc_val_def]
-        \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
-        \\ Q.PAT_X_ASSUM `xx = t1.regs r1` (fn th => full_simp_tac(srw_ss())[GSYM th])
-        \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
-        \\ RES_TAC \\ full_simp_tac(srw_ss())[] \\ rpt strip_tac \\ res_tac \\ srw_tac[][]
-        >- ((alignmentTheory.aligned_add_sub_cor
-            |> SPEC_ALL |> UNDISCH |> CONJUNCT1 |> DISCH_ALL |> irule)
-          \\ conj_tac >- fs[alignmentTheory.aligned_bitwise_and]
-          \\ simp[aligned_w2n]
-          \\ qmatch_goalsub_abbrev_tac`pv MOD dw MOD _`
-          \\ `pv MOD dw = pv` by (
-            simp[Abbr`pv`,Abbr`dw`]
-            \\ irule LESS_EQ_LESS_TRANS
-            \\ qexists_tac`LENGTH (prog_to_bytes code2)`
-            \\ simp[]
-            \\ old_drule pos_val_bound
-            \\ disch_then(qspec_then`0`mp_tac o CONV_RULE SWAP_FORALL_CONV)
-            \\ simp[] )
-          \\ simp[]
-          \\ qunabbrev_tac`pv`
-          \\ match_mp_tac $ Q.GEN `ffi_names` pos_val_MOD_0 \\ fs[]
-          \\ metis_tac[has_odd_inst_alignment])
-        >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
-        >- fs[share_mem_domain_code_rel_def] )
-      \\ rpt strip_tac
-      \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k`MP_TAC) \\ srw_tac[][]
-      \\ `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC
-      \\ Q.EXISTS_TAC `k + l' - 1` \\ full_simp_tac(srw_ss())[]
-      \\ Q.EXISTS_TAC `ms2'` \\ fs[state_rel_def,shift_interfer_def] ))
-  THEN1 ( (* CBW *)
-    say "CBW" >>
-    fs[case_eq_thms]>>
-    fs[dec_clock_def]>>
-    qmatch_asmsub_rename_tac `Asm (Cbw r1 r2) bytes len`>>
-    qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names` >>
-    mp_tac IMP_bytes_in_memory_Cbw>> impl_tac>-
-      fs[state_rel_def]>>
-    strip_tac>>
-    `t1.regs r1 = w1 ∧ t1.regs r2 = w2` by
-      (fs[state_rel_def]>>
-      qpat_assum`!r. word_loc_val _ _ _ = SOME _` (qspec_then`r1` mp_tac)>>
-      qpat_x_assum`!r. word_loc_val _ _ _ = SOME _` (qspec_then`r2` mp_tac)>>
-      simp[word_loc_val_def])>>
-    qpat_x_assum`buffer_write _ _ _ = _ `mp_tac>>
-    simp[buffer_write_def]>>
-    strip_tac>>
-    qmatch_asmsub_abbrev_tac`Inst jj`>>
-    (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`Inst jj`]MP_TAC
-            asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
-    \\ disch_then (mp_tac o Q.SPEC `bytes'`)
-    \\ fs[asm_def] >>
-    `inst jj t1 = t1 with mem := ((w1 =+ w2w w2) t1.mem)` by
-      (unabbrev_all_tac >>
-      simp[inst_def,mem_op_def,mem_store_def,alignmentTheory.aligned_0]>>
-      EVAL_TAC>> simp[asm_state_component_equality]>>
-      fs[state_rel_def]>>rw[]>>
-      first_x_assum old_drule>>simp[])
-    \\ impl_tac>-
-      (fs[state_rel_def]>>
-      conj_tac >- (
-        fs[asm_fetch_def]
-        \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-        \\ strip_tac
-        \\ fs[]
-        \\ `!op re a. Cbw r1 r2 <> ShareMem op re a` by simp[]
-        \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm
-        \\ `LENGTH bytes' <= LENGTH (line_bytes j)` suffices_by
-          metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
-        \\ Cases_on `j`
-        \\ fs[line_similar_def,line_ok_def]) >>
-      conj_tac>-
-        (match_mp_tac (GEN_ALL bytes_in_mem_IMP)>>
-        qexists_tac`s1.mem_domain`>>
-        match_mp_tac bytes_in_mem_UPDATE>>
-        rw[]>>
-        PURE_REWRITE_TAC [GSYM WORD_ADD_ASSOC]>>
-        `LENGTH bytes' + pos_val s1.pc 0 code2 <= LENGTH (prog_to_bytes code2)` by
-          (qpat_x_assum`pos_val _ _ _ = _` sym_sub_tac>>
-          old_drule pos_val_bound>>
-          disch_then(qspecl_then [`s1.pc+1`,`0`] assume_tac)>>
-          fs[])>>
-        rw[]>>
-        simp[word_add_n2w])>>
-      simp[asm_step_nop_def,asm_def]) >>
-    strip_tac>>
-    first_x_assum (qspecl_then [`shift_interfer l mc_conf`,
-          `code2`,`labs`,
-          `(asm (Inst jj) (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`] mp_tac)>>
-    impl_tac>-
-      (unabbrev_all_tac \\ rpt strip_tac \\ full_simp_tac(srw_ss())[asm_def]
-      >-
-        (full_simp_tac(srw_ss())[shift_interfer_def])
-      >>
-      qpat_x_assum`_ = new_cb` sym_sub_tac >> fs[]>>
-      match_mp_tac state_rel_shift_interfer>>
-      fs[state_rel_def]>>
-      rfs[]>>fs[]>>
-      conj_tac>- metis_tac[]>>
-      conj_tac>- metis_tac[]>>
-      conj_tac>-
-        (rw[APPLY_UPDATE_THM]>>
-        first_x_assum old_drule>>
-        fs[])
-      \\ conj_tac>-
-        (strip_tac>>
-        qpat_x_assum`!n. n <s1.code_buffer.space_left ⇒ _`
-          (qspec_then`n+1` assume_tac)>>
-        fs[])
-      \\ conj_tac >-
-        (* non-overlap of cb with code *)
-        (match_mp_tac bytes_in_mem_UPDATE>>rw[]>>
-        PURE_REWRITE_TAC [GSYM WORD_ADD_ASSOC]>>
-        simp[word_add_n2w])
-      \\ conj_tac >-
-        (simp[bytes_in_mem_APPEND]
-      \\ conj_tac >-
-        (* non-overlap of cb with itself *)
-        (match_mp_tac bytes_in_mem_UPDATE>>
-          rw[])
-      \\ simp[bytes_in_mem_def,APPLY_UPDATE_THM]>>
-         first_x_assum old_drule>>fs[])
-      \\ simp[GSYM word_add_n2w]
-       >> fs[upd_pc_def, inc_pc_def, share_mem_state_rel_def] >>
-        share_mem_state_rel_tac)
-    \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
-    \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k` mp_tac)
+        \\ match_mp_tac $ Q.GEN `ffi_names` pos_val_MOD_0 \\ fs[]
+        \\ metis_tac[has_odd_inst_alignment])
+      >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
+      >- fs[share_mem_domain_code_rel_def] )
     \\ rpt strip_tac
-    \\ Q.EXISTS_TAC `k + l - 1` \\ full_simp_tac(srw_ss())[]
-    \\ `^s1.clock - 1 + k + l = ^s1.clock + (k + l - 1)` by decide_tac
-    \\ fs[])
-  THEN1 ( (* share_mem_op *)
-    say "share_mem_op"
-    \\ Cases_on `m` >>
-    fs[share_mem_op_def,share_mem_load_def,share_mem_store_def]>>
-    gvs[pair_case_eq,option_case_eq, ffi_result_case_eq,CaseEq"word_loc"]>>
-    fs[asm_fetch_def,state_rel_def]>>
-    drule_all IMP_bytes_in_memory_ShareMem>>strip_tac>>
-    fs[share_mem_domain_code_rel_def]>>
-    qpat_assum `!pc op re a inst len i. asm_fetch_aux _ _ = SOME _ /\
-    mmio_pcs_min_index _ = SOME _ ==> _` drule_all>>strip_tac>>
-    fs[get_memop_info_def]>>
-    old_drule find_index_is_MEM>>strip_tac>>
-    simp[Once targetSemTheory.evaluate_def]>>
-    qpat_x_assum ‘target_state_rel _ _ _’ assume_tac>>
-    fs[target_state_rel_def]>>
+    \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k`MP_TAC) \\ srw_tac[][]
+    \\ `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC
+    \\ Q.EXISTS_TAC `k + l' - 1` \\ full_simp_tac(srw_ss())[]
+    \\ Q.EXISTS_TAC `ms2'` \\ fs[state_rel_def,shift_interfer_def] )
+QED
 
-    qpat_assum ‘share_mem_state_rel _ _ _ _ ’ assume_tac>>
-    fs[share_mem_state_rel_def]>>
-    qpat_assum `!index' i'. mmio_pcs_min_index _ = SOME i' /\ index' < _ /\
-    _ ==> _` $ qspecl_then [`index`, `i`] old_drule>>
+Resume compile_correct[CBW]:
+(* CBW *)
+  say "CBW" >>
+  fs[case_eq_thms]>>
+  fs[dec_clock_def]>>
+  qmatch_asmsub_rename_tac `Asm (Cbw r1 r2) bytes len`>>
+  qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names` >>
+  mp_tac IMP_bytes_in_memory_Cbw>> impl_tac>-
+    fs[state_rel_def]>>
+  strip_tac>>
+  `t1.regs r1 = w1 ∧ t1.regs r2 = w2` by
+    (fs[state_rel_def]>>
+    qpat_assum`!r. word_loc_val _ _ _ = SOME _` (qspec_then`r1` mp_tac)>>
+    qpat_x_assum`!r. word_loc_val _ _ _ = SOME _` (qspec_then`r2` mp_tac)>>
+    simp[word_loc_val_def])>>
+  qpat_x_assum`buffer_write _ _ _ = _ `mp_tac>>
+  simp[buffer_write_def]>>
+  strip_tac>>
+  qmatch_asmsub_abbrev_tac`Inst jj`>>
+  (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`Inst jj`]MP_TAC
+          asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
+  \\ disch_then (mp_tac o Q.SPEC `bytes'`)
+  \\ fs[asm_def] >>
+  `inst jj t1 = t1 with mem := ((w1 =+ w2w w2) t1.mem)` by
+    (unabbrev_all_tac >>
+    simp[inst_def,mem_op_def,mem_store_def,alignmentTheory.aligned_0]>>
+    EVAL_TAC>> simp[asm_state_component_equality]>>
+    fs[state_rel_def]>>rw[]>>
+    first_x_assum old_drule>>simp[])
+  \\ impl_tac>-
+    (fs[state_rel_def]>>
+    conj_tac >- (
+      fs[asm_fetch_def]
+      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+      \\ strip_tac
+      \\ fs[]
+      \\ `!op re a. Cbw r1 r2 <> ShareMem op re a` by simp[]
+      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_Asm
+      \\ `LENGTH bytes' <= LENGTH (line_bytes j)` suffices_by
+        metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
+      \\ Cases_on `j`
+      \\ fs[line_similar_def,line_ok_def]) >>
+    conj_tac>-
+      (match_mp_tac (GEN_ALL bytes_in_mem_IMP)>>
+      qexists_tac`s1.mem_domain`>>
+      match_mp_tac bytes_in_mem_UPDATE>>
+      rw[]>>
+      PURE_REWRITE_TAC [GSYM WORD_ADD_ASSOC]>>
+      `LENGTH bytes' + pos_val s1.pc 0 code2 <= LENGTH (prog_to_bytes code2)` by
+        (qpat_x_assum`pos_val _ _ _ = _` sym_sub_tac>>
+        old_drule pos_val_bound>>
+        disch_then(qspecl_then [`s1.pc+1`,`0`] assume_tac)>>
+        fs[])>>
+      rw[]>>
+      simp[word_add_n2w])>>
+    simp[asm_step_nop_def,asm_def]) >>
+  strip_tac>>
+  first_x_assum (qspecl_then [`shift_interfer l mc_conf`,
+        `code2`,`labs`,
+        `(asm (Inst jj) (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`] mp_tac)>>
+  impl_tac>-
+    (conj_tac
+      >- (irule oracle_tie_step
+          \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+          \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                  labSemTheory.upd_pc_def,labSemTheory.upd_reg_def,asm_inst_consts]
+          \\ metis_tac[])
+     \\ unabbrev_all_tac \\ rpt strip_tac \\ full_simp_tac(srw_ss())[asm_def]
+    >-
+      (full_simp_tac(srw_ss())[shift_interfer_def])
+    >>
+    qpat_x_assum`_ = new_cb` sym_sub_tac >> fs[]>>
+    match_mp_tac state_rel_shift_interfer>>
+    fs[state_rel_def]>>
+    rfs[]>>fs[]>>
+    conj_tac>- metis_tac[]>>
+    conj_tac>- metis_tac[]>>
+    conj_tac>-
+      (rw[APPLY_UPDATE_THM]>>
+      first_x_assum old_drule>>
+      fs[])
+    \\ conj_tac>-
+      (strip_tac>>
+      qpat_x_assum`!n. n <s1.code_buffer.space_left ⇒ _`
+        (qspec_then`n+1` assume_tac)>>
+      fs[])
+    \\ conj_tac >-
+      (* non-overlap of cb with code *)
+      (match_mp_tac bytes_in_mem_UPDATE>>rw[]>>
+      PURE_REWRITE_TAC [GSYM WORD_ADD_ASSOC]>>
+      simp[word_add_n2w])
+    \\ conj_tac >-
+      (simp[bytes_in_mem_APPEND]
+    \\ conj_tac >-
+      (* non-overlap of cb with itself *)
+      (match_mp_tac bytes_in_mem_UPDATE>>
+        rw[])
+    \\ simp[bytes_in_mem_def,APPLY_UPDATE_THM]>>
+       first_x_assum old_drule>>fs[])
+    \\ simp[GSYM word_add_n2w]
+     >> fs[upd_pc_def, inc_pc_def, share_mem_state_rel_def] >>
+      share_mem_state_rel_tac)
+  \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
+  \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k` mp_tac)
+  \\ rpt strip_tac
+  \\ Q.EXISTS_TAC `k + l - 1` \\ full_simp_tac(srw_ss())[]
+  \\ `^s1.clock - 1 + k + l = ^s1.clock + (k + l - 1)` by decide_tac
+  \\ fs[]
+QED
 
-    (impl_tac>-(old_drule find_index_LESS_LENGTH >> fs[]))>>
-    strip_tac>>
-    `mc_conf.target.get_pc ms1 <> mc_conf.ccache_pc /\
-    mc_conf.target.get_pc ms1 <> mc_conf.halt_pc` by (
-      irule ffi_entry_pcs_NOT_ccache_OR_halt_pc >> gvs[])>>
-    fs[]>>
+Resume compile_correct[ShareMemOp]:
+(* share_mem_op *)
+  say "share_mem_op"
+  \\ Cases_on `m` >>
+  fs[share_mem_op_def,share_mem_load_def,share_mem_store_def]>>
+  gvs[pair_case_eq,option_case_eq, ffi_result_case_eq,CaseEq"word_loc"]>>
+  fs[asm_fetch_def,state_rel_def]>>
+  drule_all IMP_bytes_in_memory_ShareMem>>strip_tac>>
+  fs[share_mem_domain_code_rel_def]>>
+  qpat_assum `!pc op re a inst len i. asm_fetch_aux _ _ = SOME _ /\
+  mmio_pcs_min_index _ = SOME _ ==> _` drule_all>>strip_tac>>
+  fs[get_memop_info_def]>>
+  old_drule find_index_is_MEM>>strip_tac>>
+  simp[Once targetSemTheory.evaluate_def]>>
+  qpat_x_assum ‘target_state_rel _ _ _’ assume_tac>>
+  fs[target_state_rel_def]>>
 
-    Cases_on ‘a'’>>
-    fs[labSemTheory.addr_def,CaseEq"word_loc"]>>
-    qpat_assum ‘∀r. word_loc_val _ _ _ = SOME _’ $ qspec_then ‘n''’ assume_tac>>
-    TRY (qpat_assum ‘∀r. word_loc_val _ _ _ = SOME _’ $ qspec_then ‘n'’ assume_tac)>>
-    fs[option_case_eq,CaseEq"word_loc"]>>
-    qpat_x_assum ‘read_reg n'' _ = _ ’ $ assume_tac>>
-    TRY (qpat_x_assum ‘read_reg n' _ = _ ’ $ assume_tac)>>
-    fs[word_loc_val_def]>>
-    qpat_x_assum ‘_ = v'’ $ assume_tac o GSYM>>
+  qpat_assum ‘share_mem_state_rel _ _ _ _ ’ assume_tac>>
+  fs[share_mem_state_rel_def]>>
+  qpat_assum `!index' i'. mmio_pcs_min_index _ = SOME i' /\ index' < _ /\
+  _ ==> _` $ qspecl_then [`index`, `i`] old_drule>>
 
-    qpat_assum ‘asm_ok _ _’ mp_tac>>
-    rewrite_tac[asm_ok_def,inst_ok_def,reg_ok_def]>>strip_tac>>
-    rfs[]>>
-    ‘∀x. word_to_bytes_aux 1n x F = [get_byte 0w x F]’
-      by (rewrite_tac[word_to_bytes_aux_def,ONE]>>simp[])>>
-    ‘∀x:'a word. TAKE 1 (word_to_bytes x F) = [get_byte 0w x F]’
-      by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
-          rw[good_dimindex_def] >>
-          rw[word_to_bytes_def,
-             CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
-    ‘∀x:'a word. TAKE 2 (word_to_bytes x F) = word_to_bytes_aux 2 x F’
-      by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
-          rw[good_dimindex_def] >>
-          rw[word_to_bytes_def,
-             CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
-    ‘∀x:'a word. TAKE 4 (word_to_bytes x F) = word_to_bytes_aux 4 x F’
-      by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
-          rw[good_dimindex_def] >>
-          rw[word_to_bytes_def,
-             CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
-    Cases_on ‘ALOOKUP mc_conf.mmio_info index’>>fs[]>>
-    fs[]
-    >>~- ([‘Halt (FFI_outcome _)’],
-          IF_CASES_TAC>>fs[]>>
-          pop_assum irule>>
-          enc_is_valid_mapped_access_tac>>fs[])>>
-    gvs[]>>
-    simp[bool_case_eq]>>
-    simp[GSYM PULL_EXISTS]>>
-    (conj_asm1_tac >-
-      enc_is_valid_mapped_access_tac)>>fs[]>>
-    pairarg_tac>>fs[inc_pc_def,dec_clock_def]>>
-    last_x_assum $ irule>>fs[]>>
-    (conj_tac >-
-     (rpt strip_tac>>
-      first_x_assum $ irule o cj 1>>
-      first_assum $ irule_at Any>>
-      metis_tac[]))>>
-      rename1 ‘apply_oracle _ _ = (ms1', new_oracle)’>>
-    (conj_tac >-
-     (rpt gen_tac>>strip_tac>>
-      fs[apply_oracle_def,shift_seq_def]>>
-      qpat_x_assum ‘_ = new_oracle’ $ assume_tac o GSYM>>fs[]>>
-      first_x_assum irule>>
-      fs[]>>
-      irule (cj 2 RTC_RULES)>>
-      rfs[evaluatePropsTheory.call_FFI_rel_def]>>
-      last_assum $ irule_at Any>>fs[]))>>
-    (conj_tac >-
-     (rpt gen_tac>>strip_tac>>
-      fs[apply_oracle_def,shift_seq_def]>>
-      qpat_x_assum ‘_ = new_oracle’ $ assume_tac o GSYM>>fs[]>>
-      first_x_assum irule>>fs[]>>
-      first_x_assum $ irule_at Any>>
-      irule (cj 2 RTC_RULES)>>
-      rfs[evaluatePropsTheory.call_FFI_rel_def]>>
-      last_assum $ irule_at Any>>fs[]))>>
+  (impl_tac>-(old_drule find_index_LESS_LENGTH >> fs[]))>>
+  strip_tac>>
+  `mc_conf.target.get_pc ms1 <> mc_conf.ccache_pc /\
+  mc_conf.target.get_pc ms1 <> mc_conf.halt_pc` by (
+    irule ffi_entry_pcs_NOT_ccache_OR_halt_pc >> gvs[])>>
+  fs[]>>
 
+  Cases_on ‘a'’>>
+  fs[labSemTheory.addr_def,CaseEq"word_loc"]>>
+  qpat_assum ‘∀r. word_loc_val _ _ _ = SOME _’ $ qspec_then ‘n''’ assume_tac>>
+  TRY (qpat_assum ‘∀r. word_loc_val _ _ _ = SOME _’ $ qspec_then ‘n'’ assume_tac)>>
+  fs[option_case_eq,CaseEq"word_loc"]>>
+  qpat_x_assum ‘read_reg n'' _ = _ ’ $ assume_tac>>
+  TRY (qpat_x_assum ‘read_reg n' _ = _ ’ $ assume_tac)>>
+  fs[word_loc_val_def]>>
+  qpat_x_assum ‘_ = v'’ $ assume_tac o GSYM>>
 
+  qpat_assum ‘asm_ok _ _’ mp_tac>>
+  rewrite_tac[asm_ok_def,inst_ok_def,reg_ok_def]>>strip_tac>>
+  rfs[]>>
+  ‘∀x. word_to_bytes_aux 1n x F = [get_byte 0w x F]’
+    by (rewrite_tac[word_to_bytes_aux_def,ONE]>>simp[])>>
+  ‘∀x:'a word. TAKE 1 (word_to_bytes x F) = [get_byte 0w x F]’
+    by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
+        rw[good_dimindex_def] >>
+        rw[word_to_bytes_def,
+           CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
+  ‘∀x:'a word. TAKE 2 (word_to_bytes x F) = word_to_bytes_aux 2 x F’
+    by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
+        rw[good_dimindex_def] >>
+        rw[word_to_bytes_def,
+           CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
+  ‘∀x:'a word. TAKE 4 (word_to_bytes x F) = word_to_bytes_aux 4 x F’
+    by (qhdtm_x_assum ‘good_dimindex’ mp_tac >>
+        rw[good_dimindex_def] >>
+        rw[word_to_bytes_def,
+           CONV_RULE numLib.SUC_TO_NUMERAL_DEFN_CONV word_to_bytes_aux_def]) >>
+  Cases_on ‘ALOOKUP mc_conf.mmio_info index’>>fs[]>>
+  fs[]
+  >>~- ([‘Halt (FFI_outcome _)’],
+        IF_CASES_TAC>>fs[]>>
+        pop_assum irule>>
+        enc_is_valid_mapped_access_tac>>fs[])>>
+  gvs[]>>
+  simp[bool_case_eq]>>
+  simp[GSYM PULL_EXISTS]>>
+  (conj_asm1_tac >-
+    enc_is_valid_mapped_access_tac)>>fs[]>>
+  pairarg_tac>>fs[inc_pc_def,dec_clock_def]>>
+  last_x_assum $ irule>>fs[]>>
+  (conj_tac >-
+   (rpt strip_tac>>
+    first_x_assum $ irule o cj 1>>
+    first_assum $ irule_at Any>>
+    metis_tac[]))>>
+    rename1 ‘apply_oracle _ _ = (ms1', new_oracle)’>>
+  (conj_tac >-
+   (rpt gen_tac>>strip_tac>>
     fs[apply_oracle_def,shift_seq_def]>>
-    qpat_x_assum ‘_ = ms1'’ $ assume_tac o GSYM>>fs[]>>
-    qpat_x_assum ‘∀a b c d e f g h i j k l. _ ⇒ _’ mp_tac>>
-    disch_then $ old_drule>>fs[]>>
-    old_drule find_index_LESS_LENGTH>>strip_tac>>
-    strip_tac>>
-    (conj_tac >-
-      (pop_assum mp_tac>>
-       simp[target_state_rel_def]>>strip_tac>>
-       pop_assum $ irule o cj 1>>
-       fs[find_index_INDEX_OF, INDEX_OF_eq_SOME]>>
-       rpt (last_x_assum $ irule_at Any)>>fs[]))>>
+    qpat_x_assum ‘_ = new_oracle’ $ assume_tac o GSYM>>fs[]>>
+    first_x_assum irule>>
+    fs[]>>
+    irule (cj 2 RTC_RULES)>>
+    rfs[evaluatePropsTheory.call_FFI_rel_def]>>
+    last_assum $ irule_at Any>>fs[]))>>
+  (conj_tac >-
+   (rpt gen_tac>>strip_tac>>
+    fs[apply_oracle_def,shift_seq_def]>>
+    qpat_x_assum ‘_ = new_oracle’ $ assume_tac o GSYM>>fs[]>>
+    first_x_assum irule>>fs[]>>
+    first_x_assum $ irule_at Any>>
+    irule (cj 2 RTC_RULES)>>
+    rfs[evaluatePropsTheory.call_FFI_rel_def]>>
+    last_assum $ irule_at Any>>fs[]))>>
 
-    qabbrev_tac ‘pc = p + n2w (LENGTH bytes + pos_val s1.pc 0n code2)’>>
-    qmatch_asmsub_abbrev_tac ‘call_FFI _ _ [nb] _ = _’>>
-    last_x_assum $ qspecl_then [‘ms1’, ‘0’, ‘new_bytes’, ‘t1’, ‘s1.ffi’, ‘new_ffi’] mp_tac>>
-    (impl_tac>-
-      fs[target_state_rel_def,find_index_INDEX_OF, INDEX_OF_eq_SOME])>>
-    strip_tac>>rfs[Abbr ‘nb’]>>
 
-    qmatch_asmsub_abbrev_tac ‘target_state_rel mc_conf.target t1_new’>>
+  fs[apply_oracle_def,shift_seq_def]>>
+  qpat_x_assum ‘_ = ms1'’ $ assume_tac o GSYM>>fs[]>>
+  qpat_x_assum ‘∀a b c d e f g h i j k l. _ ⇒ _’ mp_tac>>
+  disch_then $ old_drule>>fs[]>>
+  old_drule find_index_LESS_LENGTH>>strip_tac>>
+  strip_tac>>
+  (conj_tac >-
+    (pop_assum mp_tac>>
+     simp[target_state_rel_def]>>strip_tac>>
+     pop_assum $ irule o cj 1>>
+     fs[find_index_INDEX_OF, INDEX_OF_eq_SOME]>>
+     rpt (last_x_assum $ irule_at Any)>>fs[]))>>
+  (conj_tac >-
+    (qpat_x_assum `_ = new_oracle` (SUBST_ALL_TAC o SYM)
+     \\ irule (REWRITE_RULE [shift_seq_def] oracle_tie_ffi_next)
+     \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+     \\ simp[]
+     \\ irule_at Any (REWRITE_RULE [shift_seq_def] next_interference_SharedMem)
+     \\ gvs[]))>>
 
-    qexistsl [‘code2’, ‘labs’, ‘t1_new’] >> fs[]>>
-    fs[Abbr ‘t1_new’]>>
-    qpat_x_assum ‘∀a b c d e f. _ ⇒ _’ mp_tac>>
-    ‘call_FFI_rel꙳ s1.ffi s1.ffi’ by fs[cj 1 RTC_RULES]>>
-    rpt (disch_then $ drule_at Any)>>
-    fs[find_index_INDEX_OF, INDEX_OF_eq_SOME]>>
-    fs[target_state_rel_def,UPDATE_def]>>
-    rw[word_loc_val_def]>>
-    metis_tac[word_loc_val_def])
-  THEN1 ( (* Jump *)
-    say "Jump"
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (Jump jtarget) l1 l2 l3)`
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (Jump jtarget) l bytes n)`
-    \\ Cases_on `get_pc_value jtarget s1` \\ full_simp_tac(srw_ss())[]
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ mp_tac IMP_bytes_in_memory_Jump \\ full_simp_tac(srw_ss())[]
+  qabbrev_tac ‘pc = p + n2w (LENGTH bytes + pos_val s1.pc 0n code2)’>>
+  qmatch_asmsub_abbrev_tac ‘call_FFI _ _ [nb] _ = _’>>
+  last_x_assum $ qspecl_then [‘ms1’, ‘0’, ‘new_bytes’, ‘t1’, ‘s1.ffi’, ‘new_ffi’] mp_tac>>
+  (impl_tac>-
+    fs[target_state_rel_def,find_index_INDEX_OF, INDEX_OF_eq_SOME])>>
+  strip_tac>>rfs[Abbr ‘nb’]>>
+
+  qmatch_asmsub_abbrev_tac ‘target_state_rel mc_conf.target t1_new’>>
+
+  qexistsl [‘code2’, ‘labs’, ‘t1_new’] >> fs[]>>
+  fs[Abbr ‘t1_new’]>>
+  qpat_x_assum ‘∀a b c d e f. _ ⇒ _’ mp_tac>>
+  ‘call_FFI_rel꙳ s1.ffi s1.ffi’ by fs[cj 1 RTC_RULES]>>
+  rpt (disch_then $ drule_at Any)>>
+  fs[find_index_INDEX_OF, INDEX_OF_eq_SOME]>>
+  fs[target_state_rel_def,UPDATE_def]>>
+  rw[word_loc_val_def]>>
+  metis_tac[word_loc_val_def]
+QED
+
+Resume compile_correct[Jump]:
+(* Jump *)
+  say "Jump"
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (Jump jtarget) l1 l2 l3)`
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (Jump jtarget) l bytes n)`
+  \\ Cases_on `get_pc_value jtarget s1` \\ full_simp_tac(srw_ss())[]
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ mp_tac IMP_bytes_in_memory_Jump \\ full_simp_tac(srw_ss())[]
+  \\ match_mp_tac IMP_IMP \\ strip_tac
+  THEN1 (full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
+  \\ rpt strip_tac \\ pop_assum mp_tac
+  \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
+  \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]MP_TAC
+       asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+    \\ imp_res_tac bytes_in_mem_IMP
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,asmSemTheory.upd_pc_def]
+    \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,asmSemTheory.upd_pc_def,asm_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+    \\ strip_tac
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ `LENGTH
+          ((mc_conf.target.config.encode
+            (Jump
+               (n2w (find_pos jtarget labs) +
+                -n2w (pos_val s1.pc 0 code2)))))
+        <= LENGTH (line_bytes j)` suffices_by
+      metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
+    \\ fs[get_label_def]
+    \\ Cases_on `jtarget`
+    \\ fs[]
+    \\ Cases_on `lab_lookup n'' n0 labs`
+    \\ gvs[lab_inst_def,enc_with_nop_thm, LENGTH_APPEND]
+    \\ old_drule lab_lookup_IMP
+    \\ fs[]
+  )
+  \\ rpt strip_tac
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l' mc_conf`,
+       `code2`,`labs`,
+       `(asm jj (t1.pc + n2w (LENGTH (mc_conf.target.config.encode jj))) t1)`,`ms2`])
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (conj_tac
+     >- (irule oracle_tie_step
+         \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+         \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                 labSemTheory.upd_pc_def,labSemTheory.upd_reg_def,asm_inst_consts]
+         \\ metis_tac[])
+    \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
+           asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
+           labSemTheory.assert_def,asm_def,
+           jump_to_offset_def]
+    \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
+    \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+          WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
+    \\ Cases_on `jtarget` \\ full_simp_tac(srw_ss())[]
+    \\ qmatch_assum_rename_tac `loc_to_pc l1 l2 s1.code = SOME x`
+    \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
+    \\ imp_res_tac lab_lookup_IMP \\ full_simp_tac(srw_ss())[]
+    >- metis_tac[]
+    >- metis_tac[]
+    >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
+    >- fs[share_mem_domain_code_rel_def] )
+  \\ rpt strip_tac>>
+  irule_at Any EQ_TRANS>>
+  first_x_assum $ irule_at Any>>
+  irule_at Any EQ_TRANS>>
+  `!k. evaluate mc_conf s1.ffi (k + l') ms1 =
+       evaluate (shift_interfer l' mc_conf) s1.ffi k ms2` by metis_tac[]>>
+  first_x_assum $ irule_at (Pos last)>>
+  `l' <> 0` by metis_tac[]>>
+  `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC>>
+  metis_tac[]
+QED
+
+Resume compile_correct[JumpCmp]:
+(* JumpCmp *)
+  say "JumpCmp"
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l1 l2 l3)`
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)`
+  \\ `word_cmp cmp (read_reg rr s1) (labSem$reg_imm ri s1) =
+      SOME (asm$word_cmp cmp (read_reg rr t1) (reg_imm ri t1))` by
+   (Cases_on `word_cmp cmp (read_reg rr s1) (reg_imm ri s1)` \\ full_simp_tac(srw_ss())[]
+    \\ imp_res_tac word_cmp_lemma \\ full_simp_tac(srw_ss())[])
+  \\ full_simp_tac(srw_ss())[]
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ Cases_on `word_cmp cmp (read_reg rr t1) (reg_imm ri t1)` \\ full_simp_tac(srw_ss())[]
+
+
+  THEN1
+   (Cases_on `get_pc_value jtarget s1` \\ full_simp_tac(srw_ss())[]
+    \\ mp_tac IMP_bytes_in_memory_JumpCmp \\ full_simp_tac(srw_ss())[]
     \\ match_mp_tac IMP_IMP \\ strip_tac
     THEN1 (full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
     \\ rpt strip_tac \\ pop_assum mp_tac
-    \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
-    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]MP_TAC
-         asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]
+    \\ qpat_abbrev_tac `jj = asm$JumpCmp cmp rr ri lll` \\ rpt strip_tac
+    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+         asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]
     \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
      (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+      \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
       \\ imp_res_tac bytes_in_mem_IMP
       \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,asmSemTheory.upd_pc_def]
       \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
@@ -7678,13 +8086,10 @@ Proof
       \\ strip_tac
       \\ fs[]
       \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ `LENGTH
-            ((mc_conf.target.config.encode
-              (Jump
-                 (n2w (find_pos jtarget labs) +
-                  -n2w (pos_val s1.pc 0 code2)))))
-          <= LENGTH (line_bytes j)` suffices_by
-        metis_tac[ffi_entry_pcs_disjoint_LENGTH_shorter]
+      \\ ho_match_mp_tac (
+        PURE_REWRITE_RULE [satTheory.AND_IMP] o
+        PURE_REWRITE_RULE [Once CONJ_SYM] $
+        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
       \\ Cases_on `j`
       \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
       \\ fs[get_label_def]
@@ -7700,7 +8105,13 @@ Proof
          `code2`,`labs`,
          `(asm jj (t1.pc + n2w (LENGTH (mc_conf.target.config.encode jj))) t1)`,`ms2`])
     \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (unabbrev_all_tac
+     (conj_tac
+       >- (irule oracle_tie_step
+           \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+           \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                   labSemTheory.upd_pc_def,labSemTheory.upd_reg_def,asm_inst_consts]
+           \\ metis_tac[])
+      \\ unabbrev_all_tac
       \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
       \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
              asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
@@ -7713,949 +8124,1147 @@ Proof
       \\ qmatch_assum_rename_tac `loc_to_pc l1 l2 s1.code = SOME x`
       \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
       \\ imp_res_tac lab_lookup_IMP \\ full_simp_tac(srw_ss())[]
-      >- metis_tac[]
-      >- metis_tac[]
+      >- metis_tac []
+      >- metis_tac []
       >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
       >- fs[share_mem_domain_code_rel_def] )
     \\ rpt strip_tac>>
     irule_at Any EQ_TRANS>>
     first_x_assum $ irule_at Any>>
     irule_at Any EQ_TRANS>>
+    `!k. evaluate mc_conf s1.ffi (k + l') ms1 =
+         evaluate (shift_interfer l' mc_conf) s1.ffi k ms2` by metis_tac[]>>
     first_x_assum $ irule_at (Pos last)>>
+    `l' <> 0` by metis_tac[]>>
     `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC>>
     metis_tac[])
-  THEN1 (* JumpCmp *)
-   (say "JumpCmp"
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l1 l2 l3)`
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (JumpCmp cmp rr ri jtarget) l bytes n)`
-    \\ `word_cmp cmp (read_reg rr s1) (labSem$reg_imm ri s1) =
-        SOME (asm$word_cmp cmp (read_reg rr t1) (reg_imm ri t1))` by
-     (Cases_on `word_cmp cmp (read_reg rr s1) (reg_imm ri s1)` \\ full_simp_tac(srw_ss())[]
-      \\ imp_res_tac word_cmp_lemma \\ full_simp_tac(srw_ss())[])
-    \\ full_simp_tac(srw_ss())[]
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ Cases_on `word_cmp cmp (read_reg rr t1) (reg_imm ri t1)` \\ full_simp_tac(srw_ss())[]
-
-
-    THEN1
-     (Cases_on `get_pc_value jtarget s1` \\ full_simp_tac(srw_ss())[]
-      \\ mp_tac IMP_bytes_in_memory_JumpCmp \\ full_simp_tac(srw_ss())[]
-      \\ match_mp_tac IMP_IMP \\ strip_tac
-      THEN1 (full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-      \\ rpt strip_tac \\ pop_assum mp_tac
-      \\ qpat_abbrev_tac `jj = asm$JumpCmp cmp rr ri lll` \\ rpt strip_tac
-      \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-           asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]
-      \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-       (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-        \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
-        \\ imp_res_tac bytes_in_mem_IMP
-        \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,asmSemTheory.upd_pc_def]
-        \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
-        \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,asmSemTheory.upd_pc_def,asm_def]
-        \\ fs[asm_fetch_def]
-        \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-        \\ strip_tac
-        \\ fs[]
-        \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-        \\ ho_match_mp_tac (
-          PURE_REWRITE_RULE [satTheory.AND_IMP] o
-          PURE_REWRITE_RULE [Once CONJ_SYM] $
-          GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-        \\ Cases_on `j`
-        \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
-        \\ fs[get_label_def]
-        \\ Cases_on `jtarget`
-        \\ fs[]
-        \\ Cases_on `lab_lookup n'' n0 labs`
-        \\ gvs[lab_inst_def,enc_with_nop_thm, LENGTH_APPEND]
-        \\ old_drule lab_lookup_IMP
-        \\ fs[]
-      )
-      \\ rpt strip_tac
-      \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l' mc_conf`,
-           `code2`,`labs`,
-           `(asm jj (t1.pc + n2w (LENGTH (mc_conf.target.config.encode jj))) t1)`,`ms2`])
-      \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-       (unabbrev_all_tac
-        \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
-        \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
-               asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
-               labSemTheory.assert_def,asm_def,
-               jump_to_offset_def]
-        \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
-        \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-              WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
-        \\ Cases_on `jtarget` \\ full_simp_tac(srw_ss())[]
-        \\ qmatch_assum_rename_tac `loc_to_pc l1 l2 s1.code = SOME x`
-        \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`l1`,`l2`]) \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
-        \\ imp_res_tac lab_lookup_IMP \\ full_simp_tac(srw_ss())[]
-        >- metis_tac []
-        >- metis_tac []
-        >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
-        >- fs[share_mem_domain_code_rel_def] )
-      \\ rpt strip_tac>>
-      irule_at Any EQ_TRANS>>
-      first_x_assum $ irule_at Any>>
-      irule_at Any EQ_TRANS>>
-      first_x_assum $ irule_at (Pos last)>>
-      `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC>>
-      metis_tac[])
-    \\ mp_tac (IMP_bytes_in_memory_JumpCmp_1) \\ full_simp_tac(srw_ss())[]
-    \\ match_mp_tac IMP_IMP \\ strip_tac
-    THEN1 (full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-    \\ rpt strip_tac \\ pop_assum mp_tac \\ pop_assum mp_tac
-    \\ qpat_abbrev_tac `jj = asm$JumpCmp cmp rr ri lll` \\ rpt strip_tac
-    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-         asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
-    \\ strip_tac \\ pop_assum (mp_tac o Q.SPEC `bytes'`)
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF] \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
-      \\ fs[asm_fetch_def]
-      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-      \\ strip_tac
-      \\ fs[]
-      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ ho_match_mp_tac (
-        PURE_REWRITE_RULE [satTheory.AND_IMP] o
-        PURE_REWRITE_RULE [Once CONJ_SYM] $
-        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-      \\ Cases_on `j`
-      \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def] )
-    \\ rpt strip_tac
-    \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l' mc_conf`,
-         `code2`,`labs`,
-         `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
-             asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
-             labSemTheory.assert_def,asm_def,
-             jump_to_offset_def,inc_pc_def,asmSemTheory.upd_reg_def,
-             labSemTheory.upd_reg_def]
-      \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
-      \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-            WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
-      \\ rpt strip_tac \\ res_tac \\ full_simp_tac(srw_ss())[]
-      >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
-      >- fs[share_mem_domain_code_rel_def] )
-    \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
-    \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k`mp_tac)
-    \\ rpt strip_tac>>
-    irule_at Any EQ_TRANS>>
-    first_x_assum $ irule_at Any>>
-    irule_at Any EQ_TRANS>>
-    first_x_assum $ irule_at (Pos last)>>
-    `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC>>
-    metis_tac[])
-  THEN1 (* Call *)
-   (say "Call"
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (Call lab) x1 x2 x3)`
-    \\ Cases_on `lab`
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (Call (Lab l1 l2)) l bytes len)`
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ (Q.SPECL_THEN [`Lab l1 l2`,`len`]mp_tac
-            (Q.GENL[`ww`,`n`]IMP_bytes_in_memory_Call))
-    \\ match_mp_tac IMP_IMP \\ strip_tac \\ full_simp_tac(srw_ss())[]
-    \\ full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-  THEN1 (* LocValue *)
-   (say "LocValue"
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (LocValue reg lab) x1 x2 x3)`
-    \\ Cases_on `lab`
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (LocValue reg (Lab l1 l2)) ww bytes len)`
-    \\ full_simp_tac(srw_ss())[lab_to_loc_def]
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ mp_tac (Q.INST [`l`|->`ww`,`n`|->`len`]
-               IMP_bytes_in_memory_LocValue) \\ full_simp_tac(srw_ss())[]
-    \\ match_mp_tac IMP_IMP \\ strip_tac
-    THEN1 (full_simp_tac(srw_ss())[state_rel_def]
-           \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-    \\ rpt strip_tac \\ pop_assum mp_tac
-    \\ Cases_on `get_pc_value (Lab l1 l2) s1` \\ fs []
-    \\ qpat_abbrev_tac `jj = asm$Loc reg lll` \\ rpt strip_tac
-    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-         asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
-    \\ strip_tac \\ pop_assum (mp_tac o Q.SPEC `bytes'`)
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-      \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
-      \\ fs[asm_fetch_def]
-      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-      \\ strip_tac
-      \\ fs[]
-      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ ho_match_mp_tac (
-        PURE_REWRITE_RULE [satTheory.AND_IMP] o
-        PURE_REWRITE_RULE [Once CONJ_SYM] $
-        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-      \\ Cases_on `j`
-      \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def] )
-    \\ rpt strip_tac
-    \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l mc_conf`,
-         `code2`,`labs`,
-         `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF]
-      \\ rev_full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
-             asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
-             labSemTheory.assert_def,asm_def,
-             jump_to_offset_def,inc_pc_def,asmSemTheory.upd_reg_def,
-             labSemTheory.upd_reg_def]
-      \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
-      \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-            WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
-      \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][word_loc_val_def]
-      \\ res_tac \\ full_simp_tac(srw_ss())[]
-      >- (
-        Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
-        \\ imp_res_tac lab_lookup_IMP \\ srw_tac[][] )
-      >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
-      >- fs[share_mem_domain_code_rel_def] )
-    \\ rpt strip_tac>>
-    gvs[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]>>
-    irule_at Any EQ_TRANS>>
-    first_x_assum $ irule_at Any>>
-    first_x_assum $ qspec_then ‘k + s1.clock - 1’ assume_tac>>
-    fs[]>>
-    qpat_x_assum ‘evaluate _ _ _ _ = evaluate _ _ _ _’ mp_tac>>
-    `k + s1.clock - 1 + l = k + l - 1 + s1.clock` by DECIDE_TAC>>
-    pop_assum (fn h => rewrite_tac[h])>>strip_tac>>
-    first_assum $ irule_at Any)
-  THEN1 (* CallFFI *)
-   (say "CallFFI"
-    \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm (CallFFI s) l1 l2 l3)`
-    \\ qmatch_assum_rename_tac
-         `asm_fetch s1 = SOME (LabAsm (CallFFI s) l bytes n)`
-    \\ Cases_on `s1.regs s1.len_reg` \\ full_simp_tac(srw_ss())[]
-    \\ Cases_on `s1.regs s1.len2_reg` \\ full_simp_tac(srw_ss())[]
-    \\ Cases_on `s1.regs s1.link_reg` \\ full_simp_tac(srw_ss())[]
-    \\ Cases_on `s1.regs s1.ptr_reg` \\ full_simp_tac(srw_ss())[]
-    \\ Cases_on `s1.regs s1.ptr2_reg` \\ full_simp_tac(srw_ss())[]
-    \\ qmatch_assum_rename_tac `read_reg _.len2_reg _ = Word c2`
-    \\ qmatch_assum_rename_tac `read_reg _.ptr2_reg _ = Word c2'`
-    \\ qmatch_assum_rename_tac `read_reg _.ptr_reg _ = Word c'`
-    \\ Cases_on `read_bytearray c' (w2n c) (mem_load_byte_aux s1.mem s1.mem_domain s1.be)`
-    \\ full_simp_tac(srw_ss())[]
-    \\ Cases_on `read_bytearray c2' (w2n c2) (mem_load_byte_aux s1.mem s1.mem_domain s1.be)`
-    \\ full_simp_tac(srw_ss())[]
-    \\ qmatch_assum_rename_tac `s1.regs s1.link_reg = Loc n1 n2`
-    \\ qmatch_asmsub_abbrev_tac `loc_to_pc a1 a2 a3`
-    \\ Cases_on `loc_to_pc a1 a2 a3` >- fs[]
-    \\ unabbrev_all_tac \\ fs[]
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ mp_tac (Q.GEN `name` IMP_bytes_in_memory_CallFFI) \\ full_simp_tac(srw_ss())[]
-    \\ match_mp_tac IMP_IMP \\ strip_tac
-    THEN1 (full_simp_tac(srw_ss())[state_rel_def]
-           \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-    \\ rpt strip_tac \\ pop_assum mp_tac
-    \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
-    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-         asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
-      \\ imp_res_tac bytes_in_mem_IMP
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-           asmSemTheory.upd_pc_def]
-      \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-           asmSemTheory.upd_pc_def,asm_def]
-      \\ fs[asm_fetch_def]
-      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-      \\ strip_tac
-      \\ fs[]
-      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ ho_match_mp_tac (
-        PURE_REWRITE_RULE [satTheory.AND_IMP] o
-        PURE_REWRITE_RULE [Once CONJ_SYM] $
-        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-      \\ Cases_on `j`
-      \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
-      \\ gvs[lab_inst_def,enc_with_nop_thm, LENGTH_APPEND]
-    )
-    \\ rpt strip_tac
-    \\ Cases_on `loc_to_pc n1 n2 s1.code` \\ full_simp_tac(srw_ss())[]
-    \\ qmatch_assum_rename_tac `loc_to_pc n1 n2 s1.code = SOME new_pc`
-    \\ `mc_conf.target.get_pc ms2 = p - n2w ((3 + get_ffi_index ffi_names (ExtCall s)) * ffi_offset)` by
-     (full_simp_tac(srw_ss())[GSYM PULL_FORALL]
-      \\ full_simp_tac(srw_ss())[state_rel_def] \\ rev_full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())
-           [encoder_correct_def,target_ok_def,target_state_rel_def]
-      \\ unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[asm_def,asmSemTheory.jump_to_offset_def,
-           asmSemTheory.upd_pc_def]
-      \\ rewrite_tac [GSYM word_sub_def,WORD_SUB_PLUS,
-           GSYM word_add_n2w,WORD_ADD_SUB]) \\ full_simp_tac(srw_ss())[]
-    \\ `has_io_name s s1.code` by
-          (imp_res_tac IMP_has_io_name \\ NO_TAC)
-    \\ `MEM (ExtCall s) mc_conf.ffi_names` by (
-      imp_res_tac has_io_name_find_index>>
-      imp_res_tac find_index_is_MEM>>
-      gvs[list_subset_def,state_rel_def,EVERY_MEM,Abbr`ffi_names`]>>
-      drule_all mmio_pcs_min_index_is_SOME >>
-      strip_tac >>
-      gvs[MEM_FILTER] >>
-      `MEM s mc_conf.ffi_names` by (
-        first_x_assum irule >> gvs[]) >>
-      gvs[MEM_EL] >>
-      `n'' < i` by (
-        spose_not_then assume_tac >>
-        `i <= n''` by decide_tac >>
-        first_x_assum drule_all >>
-        gvs[]
-      ) >>
-      qexists `n''` >>
-      gvs[] >>
-      irule $ GSYM EL_TAKE >>
-      simp[]
-    )
-    \\ `~(mc_conf.target.get_pc ms2 IN mc_conf.prog_addresses) /\
-        ~(mc_conf.target.get_pc ms2 = mc_conf.halt_pc) /\
-        ~(mc_conf.target.get_pc ms2 = mc_conf.ccache_pc) /\
-        (find_index (mc_conf.target.get_pc ms2) mc_conf.ffi_entry_pcs 0 =
-           SOME (get_ffi_index mc_conf.ffi_names (ExtCall s))) /\
-        get_ffi_index mc_conf.ffi_names (ExtCall s) = get_ffi_index ffi_names (ExtCall s)` by (
-       full_simp_tac(srw_ss())[state_rel_def]>>
-       first_x_assum $ qspecl_then [`ExtCall s`, `i`] old_drule >>
-       gvs[] >>
-       impl_keep_tac
-       >- (irule ffi_name_NOT_Mapped >> fs[]) >>
-       `get_ffi_index mc_conf.ffi_names (ExtCall s) = get_ffi_index ffi_names (ExtCall s)`
-         suffices_by gvs[] >>
-       gvs[get_ffi_index_def,backendPropsTheory.the_eqn] >>
-       gvs[Abbr`ffi_names`] >>
-       imp_res_tac find_index_MEM >>
-       first_x_assum $ qspec_then `0` assume_tac >>fs[]>>
-       fs[CaseEq"option"]>>irule OR_INTRO_THM2>>
-       Cases_on ‘i ≤ LENGTH mc_conf.ffi_names’>>fs[]>-
-        (
-        old_drule LENGTH_TAKE>>strip_tac>>
-        irule find_index_APPEND1>>fs[]>>
-        qexists_tac `DROP i mc_conf.ffi_names` >>
-        fs[TAKE_DROP])>>
-       fs[NOT_LESS_EQUAL,TAKE_LENGTH_TOO_LONG])
-
-    \\ `EL (get_ffi_index mc_conf.ffi_names (ExtCall s)) mc_conf.ffi_names = (ExtCall s)` by (
-      irule EL_get_ffi_index_MEM >> simp[]
-    )
-    \\ `(mc_conf.target.get_reg ms2 mc_conf.ptr_reg = t1.regs mc_conf.ptr_reg) /\
-        (mc_conf.target.get_reg ms2 mc_conf.len_reg = t1.regs mc_conf.len_reg) /\
-        (mc_conf.target.get_reg ms2 mc_conf.ptr2_reg = t1.regs mc_conf.ptr2_reg) /\
-        (mc_conf.target.get_reg ms2 mc_conf.len2_reg = t1.regs mc_conf.len2_reg) /\
-        !a. a IN mc_conf.prog_addresses ==>
-            (mc_conf.target.get_byte ms2 a = t1.mem a)` by
-     (full_simp_tac(srw_ss())[GSYM PULL_FORALL]
-      \\ full_simp_tac(srw_ss())[state_rel_def] \\ rev_full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())
-           [encoder_correct_def,target_ok_def,target_state_rel_def]
-      \\ full_simp_tac(srw_ss())[encoder_correct_def |> REWRITE_RULE [GSYM reg_ok_def]]
-      \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[state_rel_def,asm_def,
-           jump_to_offset_def,asmSemTheory.upd_pc_def,AND_IMP_INTRO]
-      \\ rpt strip_tac \\ first_x_assum match_mp_tac
-      \\ full_simp_tac(srw_ss())[reg_ok_def] \\ NO_TAC)
-    \\ full_simp_tac(srw_ss())[]
-    \\ `(t1.regs mc_conf.ptr_reg = c') /\
-        (t1.regs mc_conf.len_reg = c) /\
-        (t1.regs mc_conf.ptr2_reg = c2') /\
-        (t1.regs mc_conf.len2_reg = c2)` by
-     (full_simp_tac(srw_ss())[state_rel_def]
-      \\ Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
-           (fn th =>
-          MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr_reg` th)
-          \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len_reg` th)
-          \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr2_reg` th)
-          \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len2_reg` th))
-      \\ Q.PAT_X_ASSUM `xx = s1.ptr_reg` (ASSUME_TAC o GSYM)
-      \\ Q.PAT_X_ASSUM `xx = s1.len_reg` (ASSUME_TAC o GSYM)
-      \\ Q.PAT_X_ASSUM `xx = s1.ptr2_reg` (ASSUME_TAC o GSYM)
-      \\ Q.PAT_X_ASSUM `xx = s1.len2_reg` (ASSUME_TAC o GSYM)
-      \\ full_simp_tac(srw_ss())[word_loc_val_def] \\ NO_TAC)
-    \\ full_simp_tac(srw_ss())[]
-    \\ imp_res_tac read_bytearray_state_rel \\ full_simp_tac(srw_ss())[]
-    \\ reverse(Cases_on `call_FFI s1.ffi (ExtCall s) x x'`) THEN1
-     ((* FFI_final *)
-     FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock`mp_tac) \\ rpt strip_tac
-     \\ fs[] \\ rveq \\ fs[]
-     \\ Q.EXISTS_TAC `l'` \\ full_simp_tac(srw_ss())[ADD_ASSOC]
-     \\ once_rewrite_tac [targetSemTheory.evaluate_def]
-     \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
-     \\ simp[]
-     \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
-     \\ simp[]
-     \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
-     \\ simp[]
-     \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
-     \\ simp[]
-     \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
-     \\ simp[]
-     >> ‘EL x'' (shift_interfer l' mc_conf).ffi_names = ExtCall s’
-       by gvs[shift_interfer_def]>>
-     first_assum (fn h => simp[h])
-     \\ rpt (PURE_TOP_CASE_TAC \\ simp[])>>
-     TRY (fs[shift_interfer_def,read_ffi_bytearrays_def,read_ffi_bytearray_def]>>
-          gvs[]>>NO_TAC)>>
-
-     fs[shift_interfer_def]>>
-     fs[state_rel_def]>>
-     old_drule mmio_pcs_min_index_is_SOME>>
-     strip_tac>>fs[]>>
-     last_x_assum $ qspec_then ‘x''’ assume_tac>>fs[]>>
-     Cases_on ‘x'' < i’>>fs[NOT_LESS]>>
-     old_drule find_index_LESS_LENGTH>>strip_tac>>fs[]>>
-     first_x_assum $ qspec_then ‘x''’ assume_tac>>gvs[])
-    (* FFI_return *)
-    \\ full_simp_tac(srw_ss())[]
-    \\ qmatch_assum_rename_tac
-         `call_FFI s1.ffi (ExtCall s) x x' = FFI_return new_ffi new_bytes`
-    \\ FIRST_X_ASSUM (Q.SPECL_THEN [
-         `shift_interfer l' mc_conf with
-          ffi_interfer := shift_seq 1 mc_conf.ffi_interfer`,
-         `code2`,`labs`,
-         `t1 with <| pc := p + n2w (pos_val new_pc 0 (code2:'a sec list)) ;
-                     mem := asm_write_bytearray c2' new_bytes t1.mem ;
-                     regs := \a. get_reg_value (s1.io_regs 0 (ExtCall s) a) (t1.regs a) I |>`,
-         `mc_conf.ffi_interfer 0 (get_ffi_index mc_conf.ffi_names (ExtCall s),new_bytes,ms2)`]mp_tac)
-    \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
-     (rpt strip_tac
-      THEN1 (full_simp_tac(srw_ss())[encoder_correct_def,shift_interfer_def]
-             \\ metis_tac [])
-      \\ unabbrev_all_tac
-      \\ imp_res_tac bytes_in_mem_asm_write_bytearray
-      \\ full_simp_tac(srw_ss())[state_rel_def,shift_interfer_def,
-             asm_def,jump_to_offset_def,
-             asmSemTheory.upd_pc_def] \\ rev_full_simp_tac(srw_ss())[]
-      \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-            WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
-      \\ full_simp_tac bool_ss [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-            WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
-      \\ `interference_ok (shift_seq l' mc_conf.next_interfer)
-            (mc_conf.target.proj t1.mem_domain)` by
-               (full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
-                \\ NO_TAC) \\ full_simp_tac(srw_ss())[]
-      \\ `p + n2w (pos_val new_pc 0 code2) = t1.regs s1.link_reg` by
-       (Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
-           (Q.SPEC_THEN `s1.link_reg`mp_tac)
-        \\ full_simp_tac(srw_ss())[word_loc_val_def]
-        \\ Cases_on `lab_lookup n1 n2 labs` \\ full_simp_tac(srw_ss())[]
-        \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ full_simp_tac(srw_ss())[]
-        \\ res_tac \\ full_simp_tac(srw_ss())[]) \\ full_simp_tac(srw_ss())[]
-      \\ `w2n c2 = LENGTH new_bytes` by
-       (imp_res_tac read_bytearray_LENGTH
-        \\ imp_res_tac evaluatePropsTheory.call_FFI_LENGTH \\ full_simp_tac(srw_ss())[])
-      \\ qmatch_goalsub_abbrev_tac`mc_conf.ffi_interfer _ (index,_,_)`
-      \\ `index < i` by (
-        imp_res_tac mmio_pcs_min_index_is_SOME>>gvs[]>>
-        simp[get_ffi_index_def,backendPropsTheory.the_eqn] >>
-       imp_res_tac find_index_MEM >>
-        first_x_assum $ qspec_then `0` assume_tac >>fs[]>>
-        Cases_on ‘i' < i’>>fs[NOT_LESS]>>
-        first_x_assum $ qspec_then `i'` assume_tac >>gvs[]
-      )
-      \\ `index < LENGTH mc_conf.ffi_names` by (
-        old_drule mmio_pcs_min_index_is_SOME >> gvs[]
-        )
-      \\ qunabbrev_tac`index`
-      \\ conj_tac
-      THEN1
-       (rw [] \\
-        qpat_x_assum `EL (get_ffi_index (TAKE i mc_conf.ffi_names) (ExtCall s)) mc_conf.ffi_names = ExtCall s` $ assume_tac o GSYM
-        \\ first_assum (fn th => CONV_TAC(LAND_CONV(ONCE_REWRITE_CONV[th])))
-        \\ first_x_assum match_mp_tac \\ simp []
-        \\ pop_assum(SUBST_ALL_TAC o SYM)
-        \\ `aligned mc_conf.target.config.code_alignment p` by fs [alignmentTheory.aligned_bitwise_and]
-        \\ qpat_x_assum `_ = t1.regs s1.link_reg` (fn th => rewrite_tac [GSYM th])
-        \\ simp [ONCE_REWRITE_RULE [WORD_ADD_COMM] alignmentTheory.aligned_add_sub]
-        \\ old_drule all_enc_ok_aligned_pos_val \\ simp []
-        \\ fs[read_ffi_bytearrays_def,read_ffi_bytearray_def]
-        \\ disch_then (qspec_then`new_pc`mp_tac)
-        \\ impl_tac >- metis_tac[has_odd_inst_alignment]
-        \\ rw[]
-        \\ imp_res_tac EL_get_ffi_index_MEM
-        \\ simp[]
-        \\ goal_assum(first_assum o mp_then Any mp_tac)
-        \\ simp[]
-        \\ irule ffi_name_NOT_Mapped
-        \\ gvs[]
-      )
-      \\ conj_tac
-      THEN1
-       (full_simp_tac(srw_ss())[shift_seq_def,PULL_FORALL,AND_IMP_INTRO,
-         read_ffi_bytearrays_def,read_ffi_bytearray_def]
-        \\ rw[]
-        \\ first_x_assum irule
-        \\ rw[]
-        \\ asm_exists_tac \\ simp[] \\ fs[]
-        \\ simp[Once RTC_CASES1]
-        \\ disj2_tac
-        \\ goal_assum(first_assum o mp_then Any mp_tac)
-        \\ simp[evaluatePropsTheory.call_FFI_rel_def]
-        \\ goal_assum(first_assum o mp_then Any mp_tac))
-      \\ conj_tac THEN1 metis_tac[]
-      \\ conj_tac THEN1
-       (Cases_on `s1.io_regs 0 (ExtCall s) r`
-        \\ full_simp_tac(srw_ss())[get_reg_value_def,word_loc_val_def])
-      \\ conj_tac THEN1
-       (rpt strip_tac \\ qpat_x_assum `!a.
-           byte_align a IN s1.mem_domain ==> bbb` (MP_TAC o Q.SPEC `a`)
-        \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
-        \\ match_mp_tac (SIMP_RULE std_ss [] (Q.INST [`x` |-> `x'`] CallFFI_bytearray_lemma))
-        \\ full_simp_tac(srw_ss())[])
-      \\ rw[]
-      >- (
-        match_mp_tac (MP_CANON (Q.INST [`x`|->`x'`] bytes_in_mem_asm_write_bytearray))
-        \\ simp[] \\ fs[])
-      >- (
-        match_mp_tac (MP_CANON (Q.INST [`x`|->`x'`] bytes_in_mem_asm_write_bytearray))
-        \\ simp[] \\ fs[])
-      >- (
-          fs[share_mem_state_rel_def] >>
-          gvs[]>>
-          rpt gen_tac>>strip_tac>>fs[]>>
-          gvs[IMP_CONJ_THM,AND_IMP_INTRO,shift_seq_def] >>
-          first_assum $ irule_at Any>>
-          fs[]>>
-          irule $ cj 2 RTC_RULES >>
-          qexists `new_ffi` >>
-          gvs[evaluatePropsTheory.call_FFI_rel_def] >>
-          metis_tac[]
-      )
-      >- fs[share_mem_domain_code_rel_def]
-    )
-    \\ rpt strip_tac
-    \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock + k`mp_tac) \\ rpt strip_tac
-    \\ Q.EXISTS_TAC `k + l'` \\ full_simp_tac(srw_ss())[ADD_ASSOC]
-    \\ Q.LIST_EXISTS_TAC [`ms2'`] \\ full_simp_tac(srw_ss())[]
-    \\ fs[]
-    \\ simp_tac std_ss [Once evaluate_def]
-    \\ full_simp_tac(srw_ss())[shift_interfer_def]
-    \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC,AC MULT_COMM MULT_ASSOC]
-    \\ rev_full_simp_tac(srw_ss())[LET_DEF]
-    \\ rewrite_tac[read_ffi_bytearrays_def, read_ffi_bytearray_def]
-    \\ TOP_CASE_TAC>>fs[]
-    \\ TRY (TOP_CASE_TAC>>fs[])
-    \\ TRY (TOP_CASE_TAC>>fs[])
-    >- (pairarg_tac>>fs[]>>
-        irule EQ_TRANS>>
-        first_x_assum $ irule_at (Pos last)>>
-        simp[]>>
-        fs[apply_oracle_def])>>
-    qabbrev_tac ‘j = get_ffi_index ffi_names (ExtCall s)’>>
-    fs[state_rel_def]>>
-    old_drule mmio_pcs_min_index_is_SOME>>
-    strip_tac>>fs[]>>
-    last_x_assum $ qspec_then ‘j’ assume_tac>>fs[]>>
-    Cases_on ‘j < i’>>fs[NOT_LESS]>>
-    old_drule find_index_LESS_LENGTH>>strip_tac>>fs[]>>
-    first_x_assum $ qspec_then ‘j’ assume_tac>>gvs[])
-  THEN1 (* Install *)
-    (say "Install" >>
-    qpat_x_assum`_ =(res,s2)` mp_tac >>
-    ntac 6 (TOP_CASE_TAC >> fs[])>>
-    pairarg_tac \\ fs[] \\
-    ntac 5 (TOP_CASE_TAC \\ fs[]) >>
-    strip_tac >> rfs[]>>
-    qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names` >>
-    mp_tac IMP_bytes_in_memory_Install>>
-    fs[]>>impl_tac>-
-      fs[state_rel_def]>>
-    strip_tac>>
-    pop_assum mp_tac >>
-    qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac>>
-    (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-         asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]>>
-    impl_tac>-
-      (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
-      \\ imp_res_tac bytes_in_mem_IMP
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-            asmSemTheory.upd_pc_def]
-      \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-            asmSemTheory.upd_pc_def,asm_def]
-      \\ fs[asm_fetch_def]
-      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-      \\ strip_tac
-      \\ fs[]
-      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ ho_match_mp_tac (
-        PURE_REWRITE_RULE [satTheory.AND_IMP] o
-        PURE_REWRITE_RULE [Once CONJ_SYM] $
-        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-      \\ Cases_on `j`
-      \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
-      \\ gvs[enc_with_nop_thm,LENGTH_APPEND] )>>
-    strip_tac
-    \\ `mc_conf.target.get_pc ms2 = mc_conf.ccache_pc` by
-     (
-      fs[Abbr`jj`,asm_def]>>
-      fs[encoder_correct_def,target_ok_def,target_state_rel_def]>>
-      fs[jump_to_offset_def,state_rel_def]>>
-      metis_tac[GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-           WORD_ADD_SUB])
-    \\ `~(mc_conf.target.get_pc ms2 IN t1.mem_domain)` by
-      (fs[state_rel_def]>>rfs[])
-    \\ `(t1.regs mc_conf.ptr_reg = c') /\
-        (t1.regs mc_conf.len_reg = c'')` by
-      (fs[state_rel_def]>>
-      Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
-           (fn th =>
-          MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr_reg` th)
-          \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len_reg` th))
-      \\ Q.PAT_X_ASSUM `xx = s1.ptr_reg` (ASSUME_TAC o GSYM)
-      \\ Q.PAT_X_ASSUM `xx = s1.len_reg` (ASSUME_TAC o GSYM)
-      \\ full_simp_tac(srw_ss())[word_loc_val_def])
-    \\ rfs[]
-    \\ qmatch_asmsub_abbrev_tac`evaluate mc_conf2 s1.ffi _ ms2`
-    \\ qmatch_assum_rename_tac`s1.compile cfg _ = SOME (bytes,new_cfg)`
-    \\ fs[asm_def,Abbr`jj`,jump_to_offset_def,upd_pc_def,FORALL_AND_THM]
-    \\ `target_state_rel mc_conf.target
-        (t1 with  <| regs := (s1.ptr_reg =+ t1.regs s1.ptr_reg)
-                              (λa. get_reg_value (s1.cc_regs 0 a) (t1.regs a) I);
-                      pc := t1.regs s1.link_reg |>)
-        (mc_conf.ccache_interfer 0 (t1.regs s1.ptr_reg, t1.regs s1.len_reg, ms2))`
-    by (
-      fs[state_rel_def]
-      \\ first_x_assum match_mp_tac
-      \\ conj_tac THEN1
-       (qmatch_abbrev_tac`_ _ t11 _`
-        \\ qmatch_assum_abbrev_tac`_ _ t12 _`
-        \\ `t11 = t12` by (
-          simp[Abbr`t11`,Abbr`t12`,asmSemTheory.asm_state_component_equality]
-          \\ simp[GSYM WORD_LITERAL_ADD]
-          \\ qpat_x_assum`_ = mc_conf.ccache_pc`(kall_tac)
-          \\ qpat_x_assum`_ = mc_conf.ccache_pc`(mp_tac o SYM)
-          \\ rw[]
-          \\ qmatch_abbrev_tac`p + b = p + e + b + -e`>>
-          `p+e+b = p+b+e` by
-            simp[]>>
-          simp[])
-        \\ rw[] )
-      \\ qpat_x_assum `∀r. word_loc_val p labs (read_reg r s1) = SOME (t1.regs r)`
-            (qspec_then `s1.link_reg` mp_tac) \\ simp [] \\ strip_tac
-      \\ rename [`word_loc_val p labs (Loc l1 l2) = SOME (t1.regs r1)`]
-      \\ full_simp_tac(srw_ss())[word_loc_val_def]
-      \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
-      \\ FIRST_X_ASSUM (qspecl_then [`l1`,`l2`] mp_tac) \\ fs [] \\ rw []
-      \\ `aligned mc_conf.target.config.code_alignment p` by
-             fs [alignmentTheory.aligned_bitwise_and]
-      \\ qpat_x_assum `_ = t1.regs r1` (fn th => rewrite_tac [GSYM th])
-      \\ simp [ONCE_REWRITE_RULE [WORD_ADD_COMM] alignmentTheory.aligned_add_sub]
-      \\ old_drule all_enc_ok_aligned_pos_val \\ simp []
-      \\ disch_then match_mp_tac \\ fs []
-      \\ metis_tac[has_odd_inst_alignment])
-    \\ qmatch_assum_abbrev_tac`target_state_rel _ t2 ms12`
-    \\ qpat_assum`s1.compile _ _ = _`mp_tac
-    \\ `s1.compile = compile_lab mc_conf.target.config` by fs[state_rel_def]
-    \\ pop_assum SUBST1_TAC
-    \\ simp[compile_lab_def]
-    \\ pairarg_tac \\ simp[]
-    \\ qmatch_assum_abbrev_tac`s1.compile cfg new_code = _`
-    \\ TOP_CASE_TAC
-    \\ split_pair_case_tac \\ fs[]
+  \\ mp_tac (IMP_bytes_in_memory_JumpCmp_1) \\ full_simp_tac(srw_ss())[]
+  \\ match_mp_tac IMP_IMP \\ strip_tac
+  THEN1 (full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
+  \\ rpt strip_tac \\ pop_assum mp_tac \\ pop_assum mp_tac
+  \\ qpat_abbrev_tac `jj = asm$JumpCmp cmp rr ri lll` \\ rpt strip_tac
+  \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+       asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
+  \\ strip_tac \\ pop_assum (mp_tac o Q.SPEC `bytes'`)
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF] \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
     \\ strip_tac
-    \\ first_x_assum(qspecl_then
-        [`mc_conf2 with ccache_interfer := shift_seq 1 mc_conf.ccache_interfer`,
-         `code2 ++ sec_list`,
-         `new_cfg.labels`,`t2`,`ms12`]mp_tac)
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ ho_match_mp_tac (
+      PURE_REWRITE_RULE [satTheory.AND_IMP] o
+      PURE_REWRITE_RULE [Once CONJ_SYM] $
+      GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def] )
+  \\ rpt strip_tac
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l' mc_conf`,
+       `code2`,`labs`,
+       `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (conj_tac
+     >- (irule oracle_tie_step
+         \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+         \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                 labSemTheory.upd_pc_def,labSemTheory.upd_reg_def,asm_inst_consts]
+         \\ metis_tac[])
+    \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF] \\ rev_full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
+           asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
+           labSemTheory.assert_def,asm_def,
+           jump_to_offset_def,inc_pc_def,asmSemTheory.upd_reg_def,
+           labSemTheory.upd_reg_def]
+    \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
+    \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+          WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
+    \\ rpt strip_tac \\ res_tac \\ full_simp_tac(srw_ss())[]
+    >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
+    >- fs[share_mem_domain_code_rel_def] )
+  \\ rpt strip_tac \\ full_simp_tac(srw_ss())[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]
+  \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock - 1 + k`mp_tac)
+  \\ rpt strip_tac>>
+  irule_at Any EQ_TRANS>>
+  first_x_assum $ irule_at Any>>
+  irule_at Any EQ_TRANS>>
+  first_x_assum $ irule_at (Pos last)>>
+  `s1.clock - 1 + k + l' = s1.clock + (k + l' - 1)` by DECIDE_TAC>>
+  metis_tac[]
+QED
+
+Resume compile_correct[Call]:
+(* Call *)
+  say "Call"
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (Call lab) x1 x2 x3)`
+  \\ Cases_on `lab`
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (Call (Lab l1 l2)) l bytes len)`
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ (Q.SPECL_THEN [`Lab l1 l2`,`len`]mp_tac
+          (Q.GENL[`ww`,`n`]IMP_bytes_in_memory_Call))
+  \\ match_mp_tac IMP_IMP \\ strip_tac \\ full_simp_tac(srw_ss())[]
+  \\ full_simp_tac(srw_ss())[state_rel_def] \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[]
+QED
+
+Resume compile_correct[LocValue]:
+(* LocValue *)
+  say "LocValue"
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (LocValue reg lab) x1 x2 x3)`
+  \\ Cases_on `lab`
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (LocValue reg (Lab l1 l2)) ww bytes len)`
+  \\ full_simp_tac(srw_ss())[lab_to_loc_def]
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ mp_tac (Q.INST [`l`|->`ww`,`n`|->`len`]
+             IMP_bytes_in_memory_LocValue) \\ full_simp_tac(srw_ss())[]
+  \\ match_mp_tac IMP_IMP \\ strip_tac
+  THEN1 (full_simp_tac(srw_ss())[state_rel_def]
+         \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
+  \\ rpt strip_tac \\ pop_assum mp_tac
+  \\ Cases_on `get_pc_value (Lab l1 l2) s1` \\ fs []
+  \\ qpat_abbrev_tac `jj = asm$Loc reg lll` \\ rpt strip_tac
+  \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+       asm_step_IMP_evaluate_step_nop) \\ full_simp_tac(srw_ss())[]
+  \\ strip_tac \\ pop_assum (mp_tac o Q.SPEC `bytes'`)
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+    \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[asm_step_nop_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_def,upd_pc_def,upd_reg_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+    \\ strip_tac
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ ho_match_mp_tac (
+      PURE_REWRITE_RULE [satTheory.AND_IMP] o
+      PURE_REWRITE_RULE [Once CONJ_SYM] $
+      GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def] )
+  \\ rpt strip_tac
+  \\ FIRST_X_ASSUM (MP_TAC o Q.SPECL [`shift_interfer l mc_conf`,
+       `code2`,`labs`,
+       `(asm jj (t1.pc + n2w (LENGTH (bytes':word8 list))) t1)`,`ms2`])
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1
+   (conj_tac
+     >- (irule oracle_tie_step
+         \\ qpat_assum `oracle_tie _ _ _` (irule_at Any)
+         \\ simp[labSemTheory.inc_pc_def,labSemTheory.dec_clock_def,
+                 labSemTheory.upd_pc_def,labSemTheory.upd_reg_def,asm_inst_consts]
+         \\ metis_tac[])
+    \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,asm_def,LET_DEF]
+    \\ rev_full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[asmSemTheory.upd_pc_def,asmSemTheory.assert_def,
+           asmSemTheory.read_reg_def, dec_clock_def,labSemTheory.upd_pc_def,
+           labSemTheory.assert_def,asm_def,
+           jump_to_offset_def,inc_pc_def,asmSemTheory.upd_reg_def,
+           labSemTheory.upd_reg_def]
+    \\ full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def,read_reg_def]
+    \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+          WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
+    \\ full_simp_tac(srw_ss())[APPLY_UPDATE_THM] \\ srw_tac[][word_loc_val_def]
+    \\ res_tac \\ full_simp_tac(srw_ss())[]
+    >- (
+      Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
+      \\ imp_res_tac lab_lookup_IMP \\ srw_tac[][] )
+    >- (fs[share_mem_state_rel_def] >> share_mem_state_rel_tac)
+    >- fs[share_mem_domain_code_rel_def] )
+  \\ rpt strip_tac>>
+  gvs[inc_pc_def,dec_clock_def,labSemTheory.upd_reg_def]>>
+  irule_at Any EQ_TRANS>>
+  first_x_assum $ irule_at Any>>
+  first_x_assum $ qspec_then ‘k + s1.clock - 1’ assume_tac>>
+  fs[]>>
+  qpat_x_assum ‘evaluate _ _ _ _ = evaluate _ _ _ _’ mp_tac>>
+  `k + s1.clock - 1 + l = k + l - 1 + s1.clock` by DECIDE_TAC>>
+  pop_assum (fn h => rewrite_tac[h])>>strip_tac>>
+  first_assum $ irule_at Any
+QED
+
+Resume compile_correct[CallFFI]:
+(* CallFFI *)
+  say "CallFFI"
+  \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm (CallFFI s) l1 l2 l3)`
+  \\ qmatch_assum_rename_tac
+       `asm_fetch s1 = SOME (LabAsm (CallFFI s) l bytes n)`
+  \\ Cases_on `s1.regs s1.len_reg` \\ full_simp_tac(srw_ss())[]
+  \\ Cases_on `s1.regs s1.len2_reg` \\ full_simp_tac(srw_ss())[]
+  \\ Cases_on `s1.regs s1.link_reg` \\ full_simp_tac(srw_ss())[]
+  \\ Cases_on `s1.regs s1.ptr_reg` \\ full_simp_tac(srw_ss())[]
+  \\ Cases_on `s1.regs s1.ptr2_reg` \\ full_simp_tac(srw_ss())[]
+  \\ qmatch_assum_rename_tac `read_reg _.len2_reg _ = Word c2`
+  \\ qmatch_assum_rename_tac `read_reg _.ptr2_reg _ = Word c2'`
+  \\ qmatch_assum_rename_tac `read_reg _.ptr_reg _ = Word c'`
+  \\ Cases_on `read_bytearray c' (w2n c) (mem_load_byte_aux s1.mem s1.mem_domain s1.be)`
+  \\ full_simp_tac(srw_ss())[]
+  \\ Cases_on `read_bytearray c2' (w2n c2) (mem_load_byte_aux s1.mem s1.mem_domain s1.be)`
+  \\ full_simp_tac(srw_ss())[]
+  \\ qmatch_assum_rename_tac `s1.regs s1.link_reg = Loc n1 n2`
+  \\ qmatch_asmsub_abbrev_tac `loc_to_pc a1 a2 a3`
+  \\ Cases_on `loc_to_pc a1 a2 a3` >- fs[]
+  \\ unabbrev_all_tac \\ fs[]
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ mp_tac (Q.GEN `name` IMP_bytes_in_memory_CallFFI) \\ full_simp_tac(srw_ss())[]
+  \\ match_mp_tac IMP_IMP \\ strip_tac
+  THEN1 (
+    full_simp_tac(srw_ss())[state_rel_def]
+    \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[]
+  )
+  \\ rpt strip_tac \\ pop_assum mp_tac
+  \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
+  \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+       asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1 (
+    full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+    \\ imp_res_tac bytes_in_mem_IMP
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+         asmSemTheory.upd_pc_def]
+    \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+         asmSemTheory.upd_pc_def,asm_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+    \\ strip_tac
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ ho_match_mp_tac (
+      PURE_REWRITE_RULE [satTheory.AND_IMP] o
+      PURE_REWRITE_RULE [Once CONJ_SYM] $
+      GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
+    \\ gvs[lab_inst_def,enc_with_nop_thm, LENGTH_APPEND]
+  )
+  \\ rpt strip_tac
+  \\ Cases_on `loc_to_pc n1 n2 s1.code` \\ full_simp_tac(srw_ss())[]
+  \\ qmatch_assum_rename_tac `loc_to_pc n1 n2 s1.code = SOME new_pc`
+  \\ `mc_conf.target.get_pc ms2 = p - n2w ((3 + get_ffi_index ffi_names (ExtCall s)) * ffi_offset)` by
+   (full_simp_tac(srw_ss())[GSYM PULL_FORALL]
+    \\ full_simp_tac(srw_ss())[state_rel_def] \\ rev_full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())
+         [encoder_correct_def,target_ok_def,target_state_rel_def]
+    \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[asm_def,asmSemTheory.jump_to_offset_def,
+         asmSemTheory.upd_pc_def]
+    \\ rewrite_tac [GSYM word_sub_def,WORD_SUB_PLUS,
+         GSYM word_add_n2w,WORD_ADD_SUB]) \\ full_simp_tac(srw_ss())[]
+  \\ `has_io_name s s1.code` by
+        (imp_res_tac IMP_has_io_name \\ NO_TAC)
+  \\ `MEM (ExtCall s) mc_conf.ffi_names` by (
+    imp_res_tac has_io_name_find_index>>
+    imp_res_tac find_index_is_MEM>>
+    gvs[list_subset_def,state_rel_def,EVERY_MEM,Abbr`ffi_names`]>>
+    drule_all mmio_pcs_min_index_is_SOME >>
+    strip_tac >>
+    gvs[MEM_FILTER] >>
+    `MEM s mc_conf.ffi_names` by (
+      first_x_assum irule >> gvs[]) >>
+    gvs[MEM_EL] >>
+    `n'' < i` by (
+      spose_not_then assume_tac >>
+      `i <= n''` by decide_tac >>
+      first_x_assum drule_all >>
+      gvs[]
+    ) >>
+    qexists `n''` >>
+    gvs[] >>
+    irule $ GSYM EL_TAKE >>
+    simp[]
+  )
+  \\ `~(mc_conf.target.get_pc ms2 IN mc_conf.prog_addresses) /\
+      ~(mc_conf.target.get_pc ms2 = mc_conf.halt_pc) /\
+      ~(mc_conf.target.get_pc ms2 = mc_conf.ccache_pc) /\
+      (find_index (mc_conf.target.get_pc ms2) mc_conf.ffi_entry_pcs 0 =
+         SOME (get_ffi_index mc_conf.ffi_names (ExtCall s))) /\
+      get_ffi_index mc_conf.ffi_names (ExtCall s) = get_ffi_index ffi_names (ExtCall s)` by (
+     full_simp_tac(srw_ss())[state_rel_def]>>
+     first_x_assum $ qspecl_then [`ExtCall s`, `i`] old_drule >>
+     gvs[] >>
+     impl_keep_tac
+     >- (irule ffi_name_NOT_Mapped >> fs[]) >>
+     `get_ffi_index mc_conf.ffi_names (ExtCall s) = get_ffi_index ffi_names (ExtCall s)`
+       suffices_by gvs[] >>
+     gvs[get_ffi_index_def,backendPropsTheory.the_eqn] >>
+     gvs[Abbr`ffi_names`] >>
+     imp_res_tac find_index_MEM >>
+     first_x_assum $ qspec_then `0` assume_tac >>fs[]>>
+     fs[CaseEq"option"]>>irule OR_INTRO_THM2>>
+     Cases_on ‘i ≤ LENGTH mc_conf.ffi_names’>>fs[]>-
+      (
+      old_drule LENGTH_TAKE>>strip_tac>>
+      irule find_index_APPEND1>>fs[]>>
+      qexists_tac `DROP i mc_conf.ffi_names` >>
+      fs[TAKE_DROP])>>
+     fs[NOT_LESS_EQUAL,TAKE_LENGTH_TOO_LONG])
+
+  \\ `EL (get_ffi_index mc_conf.ffi_names (ExtCall s)) mc_conf.ffi_names = (ExtCall s)` by (
+    irule EL_get_ffi_index_MEM >> simp[]
+  )
+  \\ sg `(mc_conf.target.get_reg ms2 mc_conf.ptr_reg = t1.regs mc_conf.ptr_reg) /\
+      (mc_conf.target.get_reg ms2 mc_conf.len_reg = t1.regs mc_conf.len_reg) /\
+      (mc_conf.target.get_reg ms2 mc_conf.ptr2_reg = t1.regs mc_conf.ptr2_reg) /\
+      (mc_conf.target.get_reg ms2 mc_conf.len2_reg = t1.regs mc_conf.len2_reg) /\
+      !a. a IN mc_conf.prog_addresses ==>
+          (mc_conf.target.get_byte ms2 a = t1.mem a)`
+  >- (
+    qpat_x_assum `!k. _` (strip_assume_tac o SPEC_ALL)
+    \\ gvs[asmPropsTheory.target_state_rel_def,asm_def,jump_to_offset_def,
+           asmSemTheory.upd_pc_def]
+    \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[state_rel_def,asm_def,
+         jump_to_offset_def,asmSemTheory.upd_pc_def,AND_IMP_INTRO]
+    \\ rpt strip_tac \\ first_x_assum match_mp_tac
+    \\ full_simp_tac(srw_ss())[reg_ok_def]
+  )
+  \\ full_simp_tac(srw_ss())[]
+  \\ `(t1.regs mc_conf.ptr_reg = c') /\
+      (t1.regs mc_conf.len_reg = c) /\
+      (t1.regs mc_conf.ptr2_reg = c2') /\
+      (t1.regs mc_conf.len2_reg = c2)` by
+   (full_simp_tac(srw_ss())[state_rel_def]
+    \\ Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
+         (fn th =>
+        MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr_reg` th)
+        \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len_reg` th)
+        \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr2_reg` th)
+        \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len2_reg` th))
+    \\ Q.PAT_X_ASSUM `xx = s1.ptr_reg` (ASSUME_TAC o GSYM)
+    \\ Q.PAT_X_ASSUM `xx = s1.len_reg` (ASSUME_TAC o GSYM)
+    \\ Q.PAT_X_ASSUM `xx = s1.ptr2_reg` (ASSUME_TAC o GSYM)
+    \\ Q.PAT_X_ASSUM `xx = s1.len2_reg` (ASSUME_TAC o GSYM)
+    \\ full_simp_tac(srw_ss())[word_loc_val_def] \\ NO_TAC)
+  \\ full_simp_tac(srw_ss())[]
+  \\ imp_res_tac read_bytearray_state_rel \\ full_simp_tac(srw_ss())[]
+  \\ reverse(Cases_on `call_FFI s1.ffi (ExtCall s) x x'`) THEN1
+   ((* FFI_final *)
+   FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock`mp_tac) \\ rpt strip_tac
+   \\ fs[] \\ rveq \\ fs[]
+   \\ Q.EXISTS_TAC `l'` \\ full_simp_tac(srw_ss())[ADD_ASSOC]
+   \\ once_rewrite_tac [targetSemTheory.evaluate_def]
+   \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
+   \\ simp[]
+   \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
+   \\ simp[]
+   \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
+   \\ simp[]
+   \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
+   \\ simp[]
+   \\ PURE_TOP_CASE_TAC >- (fs[shift_interfer_def])
+   \\ simp[]
+   >> ‘EL x'' (shift_interfer l' mc_conf).ffi_names = ExtCall s’
+     by gvs[shift_interfer_def]>>
+   first_assum (fn h => simp[h])
+   \\ rpt (PURE_TOP_CASE_TAC \\ simp[])>>
+   TRY (fs[shift_interfer_def,read_ffi_bytearrays_def,read_ffi_bytearray_def]>>
+        gvs[]>>NO_TAC)>>
+
+   fs[shift_interfer_def]>>
+   fs[state_rel_def]>>
+   old_drule mmio_pcs_min_index_is_SOME>>
+   strip_tac>>fs[]>>
+   last_x_assum $ qspec_then ‘x''’ assume_tac>>fs[]>>
+   Cases_on ‘x'' < i’>>fs[NOT_LESS]>>
+   old_drule find_index_LESS_LENGTH>>strip_tac>>fs[]>>
+   first_x_assum $ qspec_then ‘x''’ assume_tac>>gvs[])
+  (* FFI_return *)
+  \\ full_simp_tac(srw_ss())[]
+  \\ qmatch_assum_rename_tac
+       `call_FFI s1.ffi (ExtCall s) x x' = FFI_return new_ffi new_bytes`
+  \\ FIRST_X_ASSUM (Q.SPECL_THEN [
+       `shift_interfer l' mc_conf with
+        ffi_interfer := shift_seq 1 mc_conf.ffi_interfer`,
+       `code2`,`labs`,
+       `t1 with <| pc := p + n2w (pos_val new_pc 0 (code2:'a sec list)) ;
+                   mem := asm_write_bytearray c2' new_bytes t1.mem ;
+                   regs := \a. get_reg_value (s1.io_regs 0 (ExtCall s) a) (t1.regs a) I ;
+                   fp_regs := \n. s1.io_fp_regs 0 n |>`,
+       `mc_conf.ffi_interfer 0 (get_ffi_index mc_conf.ffi_names (ExtCall s),new_bytes,ms2)`]mp_tac)
+  \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1 (
+    (conj_tac
+      >- (
+        sg `oracle_tie (shift_interfer l' mc_conf) ms2 s1`
+        >- (
+          irule oracle_tie_shift_interfer
+          \\ qexists_tac `ms1`
+          \\ conj_tac
+          >- (gen_tac
+              \\ qpat_x_assum `!k. _ /\ _ /\ _ /\ _` (qspec_then `k` strip_assume_tac)
+              \\ first_assum ACCEPT_TAC)
+          \\ first_assum ACCEPT_TAC
+        )
+        \\ `(shift_interfer l' mc_conf).ffi_interfer = mc_conf.ffi_interfer` by
+             simp[shift_interfer_def]
+        \\ sg `next_interference (shift_interfer l' mc_conf) s1.ffi ms2 =
+            SOME (FfiApp (get_ffi_index mc_conf.ffi_names (ExtCall s)) new_bytes ms2
+                    (mc_conf.ffi_interfer 0
+                       (get_ffi_index mc_conf.ffi_names (ExtCall s),new_bytes,ms2)),
+                  shift_interfer l' mc_conf with
+                    ffi_interfer := shift_seq 1 mc_conf.ffi_interfer, new_ffi)`
+        >- (
+          qpat_x_assum `(shift_interfer l' mc_conf).ffi_interfer = mc_conf.ffi_interfer`
+            (fn th => rewrite_tac[GSYM th])
+          \\ irule next_interference_ExtCall
+          \\ full_simp_tac(srw_ss())[shift_interfer_def,state_rel_def,
+               read_ffi_bytearrays_def,read_ffi_bytearray_def]
+          \\ rpt conj_tac
+          >- (
+            qpat_x_assum `mc_conf.target.get_pc ms2 = _` (fn th => rewrite_tac[GSYM th])
+            \\ first_assum ACCEPT_TAC
+          )
+          >- (
+            qpat_x_assum `mc_conf.target.get_pc ms2 = _` (fn th => rewrite_tac[GSYM th])
+            \\ first_assum ACCEPT_TAC
+          )
+          >- (
+            disj1_tac
+            \\ qpat_x_assum `mc_conf.target.get_pc ms2 = _` (fn th => rewrite_tac[GSYM th])
+            \\ qpat_x_assum `mc_conf.prog_addresses = _` (fn th => rewrite_tac[GSYM th])
+            \\ first_assum ACCEPT_TAC
+          )
+          >- (
+            qpat_x_assum `mc_conf.target.get_pc ms2 = _` (fn th => rewrite_tac[GSYM th])
+            \\ first_assum ACCEPT_TAC
+          )
+          >- (
+            `get_ffi_index ffi_names (ExtCall s) < i` by
+               (qpat_x_assum `get_ffi_index mc_conf.ffi_names _ = _`
+                  (fn th => rewrite_tac[GSYM th])
+                \\ irule ffi_name_NOT_Mapped
+                \\ simp[]
+                \\ first_assum ACCEPT_TAC)
+            \\ qpat_x_assum `!index. if _ then _ else _`
+                 (qspec_then `get_ffi_index ffi_names (ExtCall s)` mp_tac)
+            \\ rw[]
+          )
+          >- (
+            qexists_tac `x` \\ qexists_tac `x'` \\ qexists_tac `s`
+            \\ full_simp_tac(srw_ss())[]
+            \\ rev_full_simp_tac(srw_ss())[]
+          )
+        )
+        >- (
+          irule oracle_tie_ffi_next
+          \\ qpat_assum `next_interference (shift_interfer l' mc_conf) _ _ = _`
+               (irule_at Any)
+          \\ simp[]
+          \\ first_assum ACCEPT_TAC
+        )
+      )
+     \\ rpt strip_tac
+     THEN1 (full_simp_tac(srw_ss())[encoder_correct_def,shift_interfer_def]
+            \\ metis_tac [])
+     >- (
+       unabbrev_all_tac
+       \\ imp_res_tac bytes_in_mem_asm_write_bytearray
+       \\ full_simp_tac(srw_ss())[state_rel_def,shift_interfer_def,
+              asm_def,jump_to_offset_def,
+              asmSemTheory.upd_pc_def] \\ rev_full_simp_tac(srw_ss())[]
+       \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+             WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
+       \\ full_simp_tac bool_ss [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+             WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[get_pc_value_def]
+       \\ `interference_ok (shift_seq l' mc_conf.next_interfer)
+             (mc_conf.target.proj t1.mem_domain)` by
+                (full_simp_tac(srw_ss())[interference_ok_def,shift_seq_def]
+                 \\ NO_TAC) \\ full_simp_tac(srw_ss())[]
+       \\ `p + n2w (pos_val new_pc 0 code2) = t1.regs s1.link_reg` by
+        (Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
+            (Q.SPEC_THEN `s1.link_reg`mp_tac)
+         \\ full_simp_tac(srw_ss())[word_loc_val_def]
+         \\ Cases_on `lab_lookup n1 n2 labs` \\ full_simp_tac(srw_ss())[]
+         \\ ONCE_REWRITE_TAC [EQ_SYM_EQ] \\ full_simp_tac(srw_ss())[]
+         \\ res_tac \\ full_simp_tac(srw_ss())[]) \\ full_simp_tac(srw_ss())[]
+       \\ `w2n c2 = LENGTH new_bytes` by
+        (imp_res_tac read_bytearray_LENGTH
+         \\ imp_res_tac evaluatePropsTheory.call_FFI_LENGTH \\ full_simp_tac(srw_ss())[])
+       \\ qmatch_goalsub_abbrev_tac`mc_conf.ffi_interfer _ (index,_,_)`
+       \\ `index < i` by (
+         imp_res_tac mmio_pcs_min_index_is_SOME>>gvs[]>>
+         simp[get_ffi_index_def,backendPropsTheory.the_eqn] >>
+        imp_res_tac find_index_MEM >>
+         first_x_assum $ qspec_then `0` assume_tac >>fs[]>>
+         Cases_on ‘i' < i’>>fs[NOT_LESS]>>
+         first_x_assum $ qspec_then `i'` assume_tac >>gvs[]
+       )
+       \\ `index < LENGTH mc_conf.ffi_names` by (
+         old_drule mmio_pcs_min_index_is_SOME >> gvs[]
+         )
+       \\ qunabbrev_tac`index`
+       \\ conj_tac >- (
+         `read_ffi_bytearrays mc_conf ms2 = (SOME x, SOME x')` by
+            full_simp_tac(srw_ss())[read_ffi_bytearrays_def,read_ffi_bytearray_def]
+         \\ qspecl_then [`mc_conf`,`ms1`,`s1`,`ms2`,`l'`,
+                         `get_ffi_index (TAKE i mc_conf.ffi_names) (ExtCall s)`,`s`,
+                         `x`,`x'`,`new_ffi`,`new_bytes`,`t1`] mp_tac
+              oracle_tie_ExtCall_residues
+         \\ impl_tac
+         >- (
+           qpat_assum `mc_conf.target.get_pc ms2 = _` $ rewrite_tac o single
+           \\ rpt conj_tac
+           >- first_assum ACCEPT_TAC
+           >- (gen_tac
+               \\ qpat_x_assum `!k. _ /\ _ /\ _ /\ _` (qspec_then `k` strip_assume_tac)
+               \\ first_assum ACCEPT_TAC)
+           >- (qpat_x_assum `mc_conf.prog_addresses = _` $ rewrite_tac o single
+               \\ rewrite_tac[pred_setTheory.IN_DIFF]
+               \\ qpat_x_assum `p + -n2w _ NOTIN t1.mem_domain` $ rewrite_tac o single)
+           >- first_assum ACCEPT_TAC
+           >- first_assum ACCEPT_TAC
+           >- first_assum ACCEPT_TAC
+           >- first_assum ACCEPT_TAC
+           >- (qpat_x_assum `!index. if _ then _ else _`
+                 (qspec_then `get_ffi_index (TAKE i mc_conf.ffi_names) (ExtCall s)` mp_tac)
+               \\ qpat_x_assum `get_ffi_index (TAKE i mc_conf.ffi_names) (ExtCall s) < i` mp_tac
+               \\ rw[])
+           >- first_assum ACCEPT_TAC
+           \\ first_assum ACCEPT_TAC
+         )
+         >- (
+           strip_tac
+           \\ pop_assum $ rewrite_tac o single
+           \\ pop_assum $ rewrite_tac o single
+           \\ qpat_x_assum `!ms2' k index new_bytes' t1' bytes' bytes2 st new_st. _`
+                (qspecl_then [`ms2`,`0`,
+                              `get_ffi_index (TAKE i mc_conf.ffi_names) (ExtCall s)`,
+                              `new_bytes`,`t1`,`x`,`x'`,`s1.ffi`,`new_ffi`] mp_tac)
+           \\ impl_tac
+           >- (
+             rpt conj_tac
+             >- first_assum ACCEPT_TAC
+             >- first_assum ACCEPT_TAC
+             >- MATCH_ACCEPT_TAC relationTheory.RTC_REFL
+             >- (qpat_x_assum `mc_conf.ffi_names❲_❳ = ExtCall s` $ rewrite_tac o single
+                 \\ first_assum ACCEPT_TAC)
+             >- rewrite_tac[]
+             >- (qpat_x_assum `!k. _ /\ _ /\ _ /\ _` (qspec_then `0` strip_assume_tac)
+                 \\ first_assum ACCEPT_TAC)
+             \\ `aligned mc_conf.target.config.code_alignment p` by
+                  fs [alignmentTheory.aligned_bitwise_and]
+             \\ qpat_x_assum `_ = t1.regs s1.link_reg` (fn th => rewrite_tac [GSYM th])
+             \\ simp [ONCE_REWRITE_RULE [WORD_ADD_COMM] alignmentTheory.aligned_add_sub]
+             \\ old_drule all_enc_ok_aligned_pos_val \\ simp []
+             \\ disch_then (qspec_then `new_pc` mp_tac)
+             \\ impl_tac >- metis_tac[has_odd_inst_alignment]
+             \\ rw[]
+           )
+           >- (
+             qpat_x_assum `t1.regs s1.ptr2_reg = c2'` (fn th => rewrite_tac[GSYM th])
+             \\ qpat_x_assum `new_pc = x''` (fn th => rewrite_tac[GSYM th])
+             \\ qpat_x_assum `p + n2w (pos_val new_pc 0 code2) = t1.regs s1.link_reg`
+                  $ rewrite_tac o single
+             \\ rewrite_tac[LET_THM]
+             \\ BETA_TAC
+             \\ disch_then ACCEPT_TAC
+           )
+         )
+       )
+       \\ conj_tac >- (
+         rpt gen_tac \\ strip_tac
+         \\ qpat_x_assum `!ms2'' k' index' new_bytes'' t1'' bytes'' bytes2' st' new_st'. _`
+              (qspecl_then [`ms2'`,`k+1`,`index`,`new_bytes'`,`t1'`,`bytes'`,`bytes2`,
+                            `st`,`new_st`] mp_tac)
+         \\ impl_tac
+         >- (
+           rpt conj_tac
+           >- first_assum ACCEPT_TAC
+           >- first_assum ACCEPT_TAC
+           >- (once_rewrite_tac[RTC_CASES1]
+               \\ disj2_tac
+               \\ qexists_tac `new_ffi`
+               \\ conj_tac
+               >- (rewrite_tac[evaluatePropsTheory.call_FFI_rel_def]
+                   \\ goal_assum (first_assum o mp_then Any mp_tac))
+               \\ first_assum ACCEPT_TAC)
+           \\ first_assum ACCEPT_TAC
+         )
+         >- (
+           rewrite_tac[shift_seq_def, LET_THM]
+           \\ BETA_TAC
+           \\ disch_then ACCEPT_TAC
+         )
+       )
+       \\ conj_tac THEN1 metis_tac[]
+       \\ conj_tac THEN1
+        (Cases_on `s1.io_regs 0 (ExtCall s) r`
+         \\ full_simp_tac(srw_ss())[get_reg_value_def,word_loc_val_def])
+       \\ conj_tac THEN1
+        (rpt strip_tac \\ qpat_x_assum `!a.
+            byte_align a IN s1.mem_domain ==> bbb` (MP_TAC o Q.SPEC `a`)
+         \\ full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
+         \\ match_mp_tac (SIMP_RULE std_ss [] (Q.INST [`x` |-> `x'`] CallFFI_bytearray_lemma))
+         \\ full_simp_tac(srw_ss())[])
+       \\ rw[]
+       >- (
+         match_mp_tac (MP_CANON (Q.INST [`x`|->`x'`] bytes_in_mem_asm_write_bytearray))
+         \\ simp[] \\ fs[])
+       >- (
+         match_mp_tac (MP_CANON (Q.INST [`x`|->`x'`] bytes_in_mem_asm_write_bytearray))
+         \\ simp[] \\ fs[])
+       >- (
+           fs[share_mem_state_rel_def] >>
+           gvs[]>>
+           rpt gen_tac>>strip_tac>>fs[]>>
+           gvs[IMP_CONJ_THM,AND_IMP_INTRO,shift_seq_def] >>
+           first_assum $ irule_at Any>>
+           fs[]>>
+           irule $ cj 2 RTC_RULES >>
+           qexists `new_ffi` >>
+           gvs[evaluatePropsTheory.call_FFI_rel_def] >>
+           metis_tac[]
+       )
+       >- fs[share_mem_domain_code_rel_def]
+     ))
+  )
+  \\ rpt strip_tac
+  \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock + k`mp_tac) \\ rpt strip_tac
+  \\ Q.EXISTS_TAC `k + l'` \\ full_simp_tac(srw_ss())[ADD_ASSOC]
+  \\ Q.LIST_EXISTS_TAC [`ms2'`] \\ full_simp_tac(srw_ss())[]
+  \\ fs[]
+  \\ simp_tac std_ss [Once evaluate_def]
+  \\ full_simp_tac(srw_ss())[shift_interfer_def]
+  \\ full_simp_tac(srw_ss())[AC ADD_COMM ADD_ASSOC,AC MULT_COMM MULT_ASSOC]
+  \\ rev_full_simp_tac(srw_ss())[LET_DEF]
+  \\ rewrite_tac[read_ffi_bytearrays_def, read_ffi_bytearray_def]
+  \\ TOP_CASE_TAC>>fs[]
+  \\ TRY (TOP_CASE_TAC>>fs[])
+  \\ TRY (TOP_CASE_TAC>>fs[])
+  >- (pairarg_tac>>fs[]>>
+      irule EQ_TRANS>>
+      first_x_assum $ irule_at (Pos last)>>
+      simp[]>>
+      fs[apply_oracle_def])>>
+  qabbrev_tac ‘j = get_ffi_index ffi_names (ExtCall s)’>>
+  fs[state_rel_def]>>
+  old_drule mmio_pcs_min_index_is_SOME>>
+  strip_tac>>fs[]>>
+  last_x_assum $ qspec_then ‘j’ assume_tac>>fs[]>>
+  Cases_on ‘j < i’>>fs[NOT_LESS]>>
+  old_drule find_index_LESS_LENGTH>>strip_tac>>fs[]>>
+  first_x_assum $ qspec_then ‘j’ assume_tac>>gvs[]
+QED
+
+Resume compile_correct[Install]:
+(* Install *)
+  say "Install" >>
+  qpat_x_assum`_ =(res,s2)` mp_tac >>
+  ntac 6 (TOP_CASE_TAC >> fs[])>>
+  pairarg_tac \\ fs[] \\
+  ntac 5 (TOP_CASE_TAC \\ fs[]) >>
+  strip_tac >> rfs[]>>
+  qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names` >>
+  mp_tac IMP_bytes_in_memory_Install>>
+  fs[]>>impl_tac>-
+    fs[state_rel_def]>>
+  strip_tac>>
+  pop_assum mp_tac >>
+  qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac>>
+  (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+       asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]>>
+  impl_tac>-
+    (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+    \\ imp_res_tac bytes_in_mem_IMP
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+          asmSemTheory.upd_pc_def]
+    \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+          asmSemTheory.upd_pc_def,asm_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+    \\ strip_tac
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ ho_match_mp_tac (
+      PURE_REWRITE_RULE [satTheory.AND_IMP] o
+      PURE_REWRITE_RULE [Once CONJ_SYM] $
+      GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
+    \\ gvs[enc_with_nop_thm,LENGTH_APPEND] )>>
+  strip_tac
+  \\ `mc_conf.target.get_pc ms2 = mc_conf.ccache_pc` by
+   (
+    fs[Abbr`jj`,asm_def]>>
+    fs[encoder_correct_def,target_ok_def,target_state_rel_def]>>
+    fs[jump_to_offset_def,state_rel_def]>>
+    metis_tac[GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+         WORD_ADD_SUB])
+  \\ `~(mc_conf.target.get_pc ms2 IN t1.mem_domain)` by
+    (fs[state_rel_def]>>rfs[])
+  \\ `(t1.regs mc_conf.ptr_reg = c') /\
+      (t1.regs mc_conf.len_reg = c'')` by
+    (fs[state_rel_def]>>
+    Q.PAT_X_ASSUM `!r. word_loc_val p labs (s1.regs r) = SOME (t1.regs r)`
+         (fn th =>
+        MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).ptr_reg` th)
+        \\ MP_TAC (Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).len_reg` th))
+    \\ Q.PAT_X_ASSUM `xx = s1.ptr_reg` (ASSUME_TAC o GSYM)
+    \\ Q.PAT_X_ASSUM `xx = s1.len_reg` (ASSUME_TAC o GSYM)
+    \\ full_simp_tac(srw_ss())[word_loc_val_def])
+  \\ rfs[]
+  \\ qmatch_asmsub_abbrev_tac`evaluate mc_conf2 s1.ffi _ ms2`
+  \\ qmatch_assum_rename_tac`s1.compile cfg _ = SOME (bytes,new_cfg)`
+  \\ fs[asm_def,Abbr`jj`,jump_to_offset_def,upd_pc_def,FORALL_AND_THM]
+  \\ sg `target_state_rel mc_conf.target
+      (t1 with  <| regs := (s1.ptr_reg =+ t1.regs s1.ptr_reg)
+                            (λa. get_reg_value (s1.cc_regs 0 a) (t1.regs a) I);
+                    fp_regs := (λn. s1.cc_fp_regs 0 n);
+                    pc := t1.regs s1.link_reg |>)
+      (mc_conf.ccache_interfer 0 (t1.regs s1.ptr_reg, t1.regs s1.len_reg, ms2))`
+  >- (
+    qspecl_then [`mc_conf`,`mc_conf2`,`ms1`,`s1`,`ms2`,`l''`,`t1`] mp_tac
+       oracle_tie_ccache_residues
     \\ impl_tac
     >- (
-       fs[Abbr`mc_conf2`,shift_interfer_def,ELIM_UNCURRY]
-       \\ pop_assum $ assume_tac o GSYM
-       \\ fs[state_rel_def,Abbr`t2`,Abbr`ms12`]
-       \\ reverse $ rfs[no_install_or_no_share_mem_def]
-       >- (
-         fs[no_install_def,asm_fetch_def] >>
-         old_drule code_similar_IMP_asm_fetch_aux_line_similar >>
-         disch_then $ qspec_then `s1.pc` assume_tac >>
-         gvs[DefnBase.one_line_ify NONE line_similar_def,OPTREL_def] >>
-         pop_assum mp_tac >>
-         TOP_CASE_TAC >>
-         strip_tac >>
-         gvs[]) >>
-       qpat_assum `_ ==> !k. _ (s1.compile_oracle k)`
-         (drule_then $ qspec_then`0` mp_tac)>>
-       qpat_assum`s1.compile_oracle 0 = _` SUBST1_TAC>>
-       SIMP_TAC (srw_ss()) [] >>
-       strip_tac>>
-       old_drule remove_labels_thm >> impl_tac>-
-         (fs[good_code_def]>>
-         rw[]>>fs[]>>
-         Cases_on`lab_lookup l1' l2 cfg.labels`>>
-         fs[]>>
-         metis_tac[])>>
-      strip_tac >>
-      fs[]>>rfs[] >>
-      drule_all code_similar_IMP_both_no_share_mem >>
-      strip_tac >>
-      `no_share_mem_inst (code2 ++ sec_list)` by (
-        irule no_share_mem_APPEND >>
-        simp[]) >>
-      simp[] >>
-      `~(no_install (code2 ++ sec_list))` by (
-        irule $ SRULE[Once $ DECIDE ``(B ==> A) <=> (~A ==> ~B)``] $
-          cj 1 no_install_APPEND_IMP >>
-        simp[no_install_def] >>
-        rev_drule code_similar_IMP_asm_fetch_aux_line_similar >>
-        disch_then $ qspec_then `s1.pc` (assume_tac o
-          SRULE[DefnBase.one_line_ify NONE OPTREL_def,
-            DefnBase.one_line_ify NONE line_similar_def]) >>
-        gvs[asm_fetch_def] >>
-        pop_assum mp_tac >>
-        TOP_CASE_TAC >>
-        strip_tac >>
-        var_eq_tac >>
-        metis_tac[])
-      \\ conj_tac >- (
-        fs[read_ffi_bytearrays_def, read_ffi_bytearray_def, shift_seq_def]
-        \\ rw[] \\ first_x_assum irule
-        \\ rw[] \\ asm_exists_tac \\ rw[]
-        \\ fs[])
-      \\ conj_tac >- fs[shift_seq_def]
-      \\ conj_tac
+      fs[Abbr`mc_conf2`,shift_interfer_def]
+      \\ rpt conj_tac
+      >- (disj1_tac \\ fs[state_rel_def])
+      \\ fs[state_rel_def]
+      \\ qpat_x_assum `p + -n2w (2 * ffi_offset) = _` (fn th => rewrite_tac[GSYM th])
+      \\ qpat_x_assum `p + -n2w ffi_offset = _` (fn th => rewrite_tac[GSYM th])
+      \\ rfs[good_dimindex_def,ffi_offset_def]
+      \\ EVAL_TAC
+      \\ simp[dimword_def]
+    )
+    >- (
+      sg `mc_conf.target.get_reg ms2 mc_conf.ptr_reg = t1.regs s1.ptr_reg ∧
+          mc_conf.target.get_reg ms2 mc_conf.len_reg = t1.regs s1.len_reg ∧
+          mc_conf.ptr_reg = s1.ptr_reg`
       >- (
-        fs[shift_seq_def]
-        \\ rw[]
-        \\ pairarg_tac \\ fs[]
+        fs[state_rel_def,asmPropsTheory.target_state_rel_def,reg_ok_def]
+        \\ rfs[]
+      )
+      >- (
+        qpat_x_assum `mc_conf.target.get_reg ms2 mc_conf.ptr_reg = _`
+          $ rewrite_tac o single
+        \\ qpat_x_assum `mc_conf.target.get_reg ms2 mc_conf.len_reg = _`
+          $ rewrite_tac o single
+        \\ qpat_x_assum `mc_conf.ptr_reg = s1.ptr_reg` $ rewrite_tac o single
+        \\ strip_tac
+        \\ pop_assum $ rewrite_tac o single
+        \\ pop_assum $ rewrite_tac o single
+        \\ `!(f:num -> 'a word).
+              (λa. if MEM a mc_conf.callee_saved_regs ∨ a = s1.ptr_reg ∨
+                      ¬(a < mc_conf.target.config.reg_count) ∨
+                      MEM a mc_conf.target.config.avoid_regs
+                   then t1.regs a else f a)⦇ s1.ptr_reg ↦ t1.regs s1.ptr_reg ⦈ =
+              (λa. if MEM a mc_conf.callee_saved_regs ∨ a = s1.ptr_reg ∨
+                      ¬(a < mc_conf.target.config.reg_count) ∨
+                      MEM a mc_conf.target.config.avoid_regs
+                   then t1.regs a else f a)` by
+             (gen_tac \\ simp[FUN_EQ_THM,APPLY_UPDATE_THM] \\ rw[])
+        \\ pop_assum $ rewrite_tac o single
+        \\ fs[state_rel_def]
+        \\ first_x_assum irule
         \\ conj_tac
         >- (
-          rpt(first_x_assum(qspec_then`k+1`mp_tac))
-          \\ simp[] ) \\
-        conj_tac
+          qpat_x_assum `∀r. word_loc_val p labs (read_reg r s1) = SOME (t1.regs r)`
+                (qspec_then `s1.link_reg` mp_tac) \\ simp [] \\ strip_tac
+          \\ rename [`word_loc_val p labs (Loc l1 l2) = SOME (t1.regs r1)`]
+          \\ full_simp_tac(srw_ss())[word_loc_val_def]
+          \\ Cases_on `lab_lookup l1 l2 labs` \\ full_simp_tac(srw_ss())[]
+          \\ first_x_assum (qspecl_then [`l1`,`l2`] mp_tac) \\ fs [] \\ rw []
+          \\ `aligned mc_conf.target.config.code_alignment p` by
+                 fs [alignmentTheory.aligned_bitwise_and]
+          \\ qpat_x_assum `_ = t1.regs r1` (fn th => rewrite_tac [GSYM th])
+          \\ simp [ONCE_REWRITE_RULE [WORD_ADD_COMM] alignmentTheory.aligned_add_sub]
+          \\ old_drule all_enc_ok_aligned_pos_val \\ simp []
+          \\ disch_then match_mp_tac \\ fs []
+          \\ metis_tac[has_odd_inst_alignment]
+        )
         >- (
-          rpt(first_x_assum(qspec_then`k+1`mp_tac))
-          \\ simp[] ) \\
-        strip_tac \\
-        rpt(first_x_assum(qspec_then`0` assume_tac))>>
-        rfs[]>>
-        fs[]>>
-        simp[prog_to_bytes_MAP,no_share_mem_IMP_get_shmem_info]
-      )
-      \\ conj_tac >- (
-        rw[]>>
-        metis_tac[])
-      \\ conj_tac >-(
-        fs[find_ffi_names_append,list_subset_def]>>
-        fs[EVERY_FILTER,EVERY_MEM])
-      \\ conj_tac >- (
-        fs[prog_to_bytes_APPEND,EVEN_ADD]>>
-        metis_tac[all_enc_ok_prog_to_bytes_EVEN])
-      \\ conj_tac >- ( fs[interference_ok_def,shift_seq_def] )
-      \\ conj_asm2_tac >- (
-        `EVERY sec_labels_ok (s1.code++new_code)` by
-          (fs[good_code_def]>>
-          metis_tac[code_similar_sym,code_similar_sec_labels_ok])>>
-        `EVERY sec_label_zero sec_list` by
-          metis_tac[all_enc_ok_imp_sec_label_zero]>>
-        simp[loc_to_pc_append]>>
-        ntac 3 strip_tac>>
-        reverse (TOP_CASE_TAC >> fs[])
-        >-
-          (rw[]>> first_x_assum old_drule>>
-          strip_tac>>
-          first_x_assum old_drule>>
-          simp[pos_val_append]>>
-          rw[]>>
-          metis_tac[code_similar_loc_to_pc,loc_to_pc_bound])
-        >>
-          TOP_CASE_TAC>>fs[]>>
-          first_x_assum old_drule>>rw[]>>
-          simp[pos_val_append]>>
-          rw[]
-          >-
-            (imp_res_tac code_similar_len_no_lab>>
-            fs[]>>
-            `x''=0` by fs[]>>
-            simp[]>>
-            simp[pos_val_acc]>>
-            imp_res_tac pos_val_0>>
-            simp[]>>
-            metis_tac[LENGTH_prog_to_bytes2])
-          >>
-            imp_res_tac code_similar_len_no_lab>>
-            simp[]>>
-            metis_tac[LENGTH_prog_to_bytes2])
-      \\ conj_tac >- (
-        rw[]
-        \\ reverse(rw[APPLY_UPDATE_THM])
-        \\ rfs[]
-        >- (
-          qmatch_goalsub_rename_tac`s1.cc_regs 0 reg`
-          \\ Cases_on`s1.cc_regs 0 reg`
+          sg `t1.pc + -n2w (2 * ffi_offset + pos_val s1.pc 0 code2) =
+              p + -n2w (2 * ffi_offset)`
           >- (
-            simp[get_reg_value_def]
-            \\ first_assum(qspec_then`reg`(CHANGED_TAC o SUBST1_TAC o SYM))
-            \\ Cases_on`read_reg reg s1` \\ simp[word_loc_val_def]
-            \\ match_mp_tac EQ_SYM
-            \\ TOP_CASE_TAC
-            >- (
-              rpt(first_x_assum(qspec_then`reg`mp_tac))
-              \\ simp[word_loc_val_def] )
-            \\ first_x_assum old_drule
-            \\ simp[])
-          \\ simp[get_reg_value_def]
-          \\ simp[word_loc_val_def] )
-        \\ simp[word_loc_val_def]
-        \\ fs[Abbr`new_code`]
-        \\ first_x_assum (qspecl_then [`n''`,`0`,`0`] mp_tac)
-        \\ simp[Once loc_to_pc_def]
-        \\ imp_res_tac pos_val_0
-        \\ rw[]
-        \\ qhdtm_x_assum`buffer_flush`mp_tac
-        \\ simp[buffer_flush_def]
-        \\ strip_tac
-        \\ rfs[])
-      \\ conj_tac >- (
-        rw[]
-        \\ res_tac
-        \\ fs[word_loc_val_byte_def]
-        \\ ntac 2 (pop_assum mp_tac)
-        \\ TOP_CASE_TAC \\ simp[]
-        \\ strip_tac
-        \\ qmatch_asmsub_abbrev_tac`word_loc_val p labs w = _`
-        \\ Cases_on`w` \\ fs[word_loc_val_def]
-        \\ ntac 4 (pop_assum mp_tac)
-        \\ TOP_CASE_TAC \\ simp[]
-        \\ ntac 4 strip_tac
-        \\ first_x_assum old_drule \\ simp[])
-      \\ conj_tac >- (
-        strip_tac \\
-        qhdtm_x_assum`buffer_flush`mp_tac \\
-        simp[buffer_flush_def] \\ ntac 2 strip_tac \\
-        qpat_x_assum `∀n. n < _ ⇒ _`(qspec_then`n'''` mp_tac)>>
-        rw[]>>rfs[] >> fs[GSYM word_add_n2w])
-      \\ conj_tac >- (
-        simp[prog_to_bytes_APPEND]
-        \\ fs[bytes_in_mem_APPEND]
-        \\ qhdtm_x_assum`buffer_flush`mp_tac
-        \\ simp[buffer_flush_def]
-        \\ rw[]
-        \\ fs[])
-      \\ conj_tac >- (
-        simp[prog_to_bytes_APPEND]
-        \\ fs[buffer_flush_def] \\ rw[]
-        \\ qpat_x_assum`_ = t1.regs s1.len_reg` sym_sub_tac
-        \\ simp[GSYM word_add_n2w])
-      \\ conj_tac >- (
-        fs[buffer_flush_def]>>rw[]>>
-        simp[bytes_in_mem_def])
-      \\ conj_tac >-
-        (fs[buffer_flush_def] \\ rw[] >>
-        fs[LENGTH_prog_to_bytes2,prog_to_bytes_APPEND])
-      \\ conj_tac >- (
-         gvs[buffer_flush_def] >>
-         rw[] >>
-         qpat_x_assum `!bn. bn < _ + _ ==> ~(MEM _ _)` $
-           qspec_then `bn + LENGTH (prog_to_bytes sec_list)` mp_tac >>
-         gvs[GSYM word_add_n2w] >>
-         metis_tac[WORD_ADD_ASSOC]
+            `t1.pc = p + n2w (pos_val s1.pc 0 code2)` by fs[state_rel_def]
+            \\ pop_assum $ rewrite_tac o single
+            \\ simp[GSYM word_add_n2w, WORD_NEG_ADD]
+            \\ qpat_x_assum `p + -n2w (2 * ffi_offset) = mc_conf.ccache_pc`
+                 (fn th => rewrite_tac[GSYM th])
+            \\ CONV_TAC wordsLib.WORD_ARITH_CONV
+            \\ rewrite_tac[WORD_ADD_RINV]
+          )
+          \\ pop_assum (fn th => rewrite_tac[GSYM th])
+          \\ first_assum ACCEPT_TAC
+        )
       )
-      \\ conj_tac>- (
-        `EVERY sec_label_zero sec_list` by
-          metis_tac[all_enc_ok_imp_sec_label_zero]>>
-        qmatch_assum_rename_tac `loc_to_pc ll1 ll2 s1.code = SOME xx`>>
-        rfs[]>>fs[]>>
-        `pos_val xx 0 (code2 ++ sec_list) = pos_val xx 0 code2` by
-          (simp[pos_val_append]>>
-          metis_tac[loc_to_pc_bound,code_similar_sec_labels_ok,code_similar_loc_to_pc])>>
-        simp[]>>
-        last_x_assum(qspecl_then[`ll1`,`ll2`,`xx`] assume_tac)>>
-        last_x_assum(qspecl_then[`ll1`,`ll2`,`xx`] assume_tac)>>
-        rfs[]>>
-        fs[]>>
-        qpat_x_assum`!r. word_loc_val _ _ _ = _` (qspec_then`s1.link_reg` assume_tac)>>
-        rfs[word_loc_val_def])
-      \\ conj_tac>-
-        (match_mp_tac all_enc_ok_append>>
-        rw[]>>fs[]>>
-        match_mp_tac all_enc_ok_labs_mono
-        >- metis_tac[] >>
-        (* TODO: remove qexists `l1` *)
-        (* irule (Pos hd) $ DECIDE``A ==> A`` *)
-        qexists `l1` >>
-        gvs[asm_fetch_def] >>
-        rev_drule code_similar_IMP_asm_fetch_aux_line_similar >>
-        simp[OPTREL_def,DefnBase.one_line_ify NONE line_similar_def,AllCaseEqs()] >>
-        disch_then $ qspec_then `s1.pc` assume_tac >>
-        gvs[] >>
-        first_x_assum mp_tac >>
-        TOP_CASE_TAC >>
-        strip_tac >>
-        var_eq_tac >>
-        old_drule $ GEN_ALL no_share_mem_lemma >>
-        rpt strip_tac >>
-        gvs[Abbr`ffi_names`] >>
-        pop_assum old_drule >>
-        impl_tac >-
-        simp[no_install_or_no_share_mem_def] >>
-        metis_tac[TAKE_LENGTH_ID] )
-      \\ conj_tac>-
-        (fs[good_code_def]>>
-        metis_tac[code_similar_sec_labels_ok])
-      \\ conj_tac >- metis_tac[code_similar_append]
-      \\ conj_tac >-
-        (gvs[share_mem_state_rel_def] >>
-         share_mem_state_rel_tac)
-      \\ gvs[share_mem_domain_code_rel_def] >>
-         conj_tac >- gvs[no_share_mem_inst_def] >>
-         rw[IN_DISJOINT] >>
-         spose_not_then assume_tac >>
-         gvs[asm_fetch_def] >>
-         Cases_on `pc < num_pcs code2`
-         >- (
-           gvs[asm_fetch_aux_APPEND1,pos_val_APPEND1] >>
-           first_x_assum drule_all >>
-           gvs[IN_DISJOINT] >>
-           metis_tac[]
-         ) >>
-         `?pc'. pc = num_pcs code2 + pc'` by (
-           irule LESS_EQUAL_ADD >>
-           decide_tac
-         ) >>
-         gvs[asm_fetch_aux_APPEND2] >>
-         rev_drule_then (qspecl_then [`sec_list`,`pc'`] assume_tac)
-           pos_val_APPEND2 >>
-         gvs[] >>
-         pop_assum kall_tac >>
-         drule_then old_drule $ GEN_ALL no_share_mem_lemma >>
-         impl_tac >- (
-           irule code_similar_IMP_both_no_install_or_no_share_mem >>
-           irule_at (Pos hd) code_similar_sym >>
-           first_x_assum $ irule_at (Pos hd) >>
-           simp[no_install_or_no_share_mem_def]) >>
-         strip_tac >>
-         gvs[buffer_flush_def] >>
-         drule_all $ GEN_ALL asm_fetch_aux_pos_val_SUC >>
-         disch_then $ qspec_then `0` assume_tac >>
-         drule_then (qspecl_then [`pc'+1`,`0`] (assume_tac o SIMP_RULE(srw_ss())[]))
-           pos_val_bound >>
-         qpat_x_assum `!bn. bn < _ + _ ==> ~(MEM _ _)` mp_tac >>
-         simp[] >>
-         qexists `a + pos_val pc' 0 sec_list` >>
-         simp[GSYM word_add_n2w] >>
-         metis_tac[word_add_n2w,WORD_ADD_ASSOC,WORD_ADD_COMM]
     )
-    \\ disch_then(qx_choose_then`k`strip_assume_tac)
-    \\ first_x_assum(qspec_then`s1.clock+k`assume_tac)
+  )
+  \\ qmatch_assum_abbrev_tac`target_state_rel _ t2 ms12`
+  \\ qpat_assum`s1.compile _ _ = _`mp_tac
+  \\ `s1.compile = compile_lab mc_conf.target.config` by fs[state_rel_def]
+  \\ pop_assum SUBST1_TAC
+  \\ simp[compile_lab_def]
+  \\ pairarg_tac \\ simp[]
+  \\ qmatch_assum_abbrev_tac`s1.compile cfg new_code = _`
+  \\ TOP_CASE_TAC
+  \\ split_pair_case_tac \\ fs[]
+  \\ strip_tac
+  \\ first_x_assum(qspecl_then
+      [`mc_conf2 with ccache_interfer := shift_seq 1 mc_conf.ccache_interfer`,
+       `code2 ++ sec_list`,
+       `new_cfg.labels`,`t2`,`ms12`]mp_tac)
+  \\ impl_tac
+  >- (
+     conj_tac >- (
+       sg `oracle_tie mc_conf2 ms2 s1`
+       >- (
+         qspecl_then [`mc_conf`,`mc_conf2`,`ms1`,`s1`,`ms2`,`l''`] mp_tac
+           oracle_tie_shift_gen
+         \\ impl_tac
+         >- (rpt conj_tac
+             >- first_assum ACCEPT_TAC
+             >- first_assum ACCEPT_TAC
+             \\ simp[Abbr`mc_conf2`,shift_interfer_def])
+         \\ disch_then ACCEPT_TAC
+       )
+       \\ sg `next_interference mc_conf2 s1.ffi ms2 =
+              SOME (CcApp (mc_conf2.target.get_reg ms2 mc_conf2.ptr_reg)
+                          (mc_conf2.target.get_reg ms2 mc_conf2.len_reg) ms2
+                      (mc_conf2.ccache_interfer 0
+                         (mc_conf2.target.get_reg ms2 mc_conf2.ptr_reg,
+                          mc_conf2.target.get_reg ms2 mc_conf2.len_reg, ms2)),
+                    mc_conf2 with ccache_interfer := shift_seq 1 mc_conf2.ccache_interfer,
+                    s1.ffi)`
+       >- (
+         irule next_interference_ccache
+         \\ simp[Abbr`mc_conf2`,shift_interfer_def]
+         \\ conj_tac
+         >- (fs[state_rel_def]
+             \\ qpat_x_assum `p + -n2w (2 * ffi_offset) = _`
+                  (fn th => rewrite_tac[GSYM th])
+             \\ qpat_x_assum `p + -n2w ffi_offset = _` (fn th => rewrite_tac[GSYM th])
+             \\ rfs[good_dimindex_def,ffi_offset_def]
+             \\ EVAL_TAC
+             \\ simp[dimword_def])
+         \\ disj1_tac \\ fs[state_rel_def]
+       )
+       >- (
+         `mc_conf2.ccache_interfer = mc_conf.ccache_interfer` by
+            simp[Abbr`mc_conf2`,shift_interfer_def]
+         \\ sg `mc_conf2.target.get_reg ms2 mc_conf2.ptr_reg = t1.regs s1.ptr_reg ∧
+                mc_conf2.target.get_reg ms2 mc_conf2.len_reg = t1.regs s1.len_reg`
+         >- (
+           simp[Abbr`mc_conf2`,shift_interfer_def]
+           \\ fs[state_rel_def,asmPropsTheory.target_state_rel_def,reg_ok_def]
+           \\ rfs[]
+         )
+         >- (
+           qpat_x_assum `next_interference mc_conf2 _ _ = _` mp_tac
+           \\ qpat_x_assum `mc_conf2.target.get_reg ms2 mc_conf2.ptr_reg = _`
+                $ rewrite_tac o single
+           \\ qpat_x_assum `mc_conf2.target.get_reg ms2 mc_conf2.len_reg = _`
+                $ rewrite_tac o single
+           \\ qpat_x_assum `mc_conf2.ccache_interfer = _` $ rewrite_tac o single
+           \\ strip_tac
+           \\ simp[Abbr`ms12`]
+           \\ irule oracle_tie_ccache_next
+           \\ qpat_assum `next_interference mc_conf2 _ _ = _` (irule_at Any)
+           \\ simp[]
+           \\ first_assum ACCEPT_TAC
+         )
+       )
+     )
+     \\ fs[Abbr`mc_conf2`,shift_interfer_def,ELIM_UNCURRY]
+     \\ pop_assum $ assume_tac o GSYM
+     \\ fs[state_rel_def,Abbr`t2`,Abbr`ms12`]
+     \\ reverse $ rfs[no_install_or_no_share_mem_def]
+     >- (
+       fs[no_install_def,asm_fetch_def] >>
+       old_drule code_similar_IMP_asm_fetch_aux_line_similar >>
+       disch_then $ qspec_then `s1.pc` assume_tac >>
+       gvs[DefnBase.one_line_ify NONE line_similar_def,OPTREL_def] >>
+       pop_assum mp_tac >>
+       TOP_CASE_TAC >>
+       strip_tac >>
+       gvs[]) >>
+     qpat_assum `_ ==> !k. _ (s1.compile_oracle k)`
+       (drule_then $ qspec_then`0` mp_tac)>>
+     qpat_assum`s1.compile_oracle 0 = _` SUBST1_TAC>>
+     SIMP_TAC (srw_ss()) [] >>
+     strip_tac>>
+     old_drule remove_labels_thm >> impl_tac>-
+       (fs[good_code_def]>>
+       rw[]>>fs[]>>
+       Cases_on`lab_lookup l1' l2 cfg.labels`>>
+       fs[]>>
+       metis_tac[])>>
+    strip_tac >>
+    fs[]>>rfs[] >>
+    drule_all code_similar_IMP_both_no_share_mem >>
+    strip_tac >>
+    `no_share_mem_inst (code2 ++ sec_list)` by (
+      irule no_share_mem_APPEND >>
+      simp[]) >>
+    simp[] >>
+    `~(no_install (code2 ++ sec_list))` by (
+      irule $ SRULE[Once $ DECIDE ``(B ==> A) <=> (~A ==> ~B)``] $
+        cj 1 no_install_APPEND_IMP >>
+      simp[no_install_def] >>
+      rev_drule code_similar_IMP_asm_fetch_aux_line_similar >>
+      disch_then $ qspec_then `s1.pc` (assume_tac o
+        SRULE[DefnBase.one_line_ify NONE OPTREL_def,
+          DefnBase.one_line_ify NONE line_similar_def]) >>
+      gvs[asm_fetch_def] >>
+      pop_assum mp_tac >>
+      TOP_CASE_TAC >>
+      strip_tac >>
+      var_eq_tac >>
+      metis_tac[])
+    \\ conj_tac >- (
+      fs[read_ffi_bytearrays_def, read_ffi_bytearray_def, shift_seq_def]
+      \\ rw[] \\ first_x_assum irule
+      \\ rw[] \\ asm_exists_tac \\ rw[]
+      \\ fs[]
+    )
+    \\ conj_tac >- (
+      fs[shift_seq_def]
+    )
+    \\ conj_tac
+    >- (
+      fs[shift_seq_def]
+      \\ rw[]
+      \\ pairarg_tac \\ fs[]
+      \\ conj_tac
+      >- (
+        rpt(first_x_assum(qspec_then`k+1`mp_tac))
+        \\ simp[] ) \\
+      conj_tac
+      >- (
+        rpt(first_x_assum(qspec_then`k+1`mp_tac))
+        \\ simp[] ) \\
+      strip_tac \\
+      rpt(first_x_assum(qspec_then`0` assume_tac))>>
+      rfs[]>>
+      fs[]>>
+      simp[prog_to_bytes_MAP,no_share_mem_IMP_get_shmem_info]
+    )
+    \\ conj_tac >- (
+      rw[]>>
+      metis_tac[])
+    \\ conj_tac >-(
+      fs[find_ffi_names_append,list_subset_def]>>
+      fs[EVERY_FILTER,EVERY_MEM])
+    \\ conj_tac >- (
+      fs[prog_to_bytes_APPEND,EVEN_ADD]>>
+      metis_tac[all_enc_ok_prog_to_bytes_EVEN])
+    \\ conj_tac >- ( fs[interference_ok_def,shift_seq_def] )
+    \\ conj_asm2_tac >- (
+      `EVERY sec_labels_ok (s1.code++new_code)` by
+        (fs[good_code_def]>>
+        metis_tac[code_similar_sym,code_similar_sec_labels_ok])>>
+      `EVERY sec_label_zero sec_list` by
+        metis_tac[all_enc_ok_imp_sec_label_zero]>>
+      simp[loc_to_pc_append]>>
+      ntac 3 strip_tac>>
+      reverse (TOP_CASE_TAC >> fs[])
+      >-
+        (rw[]>> first_x_assum old_drule>>
+        strip_tac>>
+        first_x_assum old_drule>>
+        simp[pos_val_append]>>
+        rw[]>>
+        metis_tac[code_similar_loc_to_pc,loc_to_pc_bound])
+      >>
+        TOP_CASE_TAC>>fs[]>>
+        first_x_assum old_drule>>rw[]>>
+        simp[pos_val_append]>>
+        rw[]
+        >-
+          (imp_res_tac code_similar_len_no_lab>>
+          fs[]>>
+          `x''=0` by fs[]>>
+          simp[]>>
+          simp[pos_val_acc]>>
+          imp_res_tac pos_val_0>>
+          simp[]>>
+          metis_tac[LENGTH_prog_to_bytes2])
+        >>
+          imp_res_tac code_similar_len_no_lab>>
+          simp[]>>
+          metis_tac[LENGTH_prog_to_bytes2])
+    \\ conj_tac >- (
+      rw[]
+      \\ reverse(rw[APPLY_UPDATE_THM])
+      \\ rfs[]
+      >- (
+        qmatch_goalsub_rename_tac`s1.cc_regs 0 reg`
+        \\ Cases_on`s1.cc_regs 0 reg`
+        >- (
+          simp[get_reg_value_def]
+          \\ first_assum(qspec_then`reg`(CHANGED_TAC o SUBST1_TAC o SYM))
+          \\ Cases_on`read_reg reg s1` \\ simp[word_loc_val_def]
+          \\ match_mp_tac EQ_SYM
+          \\ TOP_CASE_TAC
+          >- (
+            rpt(first_x_assum(qspec_then`reg`mp_tac))
+            \\ simp[word_loc_val_def] )
+          \\ first_x_assum old_drule
+          \\ simp[])
+        \\ simp[get_reg_value_def]
+        \\ simp[word_loc_val_def] )
+      \\ simp[word_loc_val_def]
+      \\ fs[Abbr`new_code`]
+      \\ first_x_assum (qspecl_then [`n''`,`0`,`0`] mp_tac)
+      \\ simp[Once loc_to_pc_def]
+      \\ imp_res_tac pos_val_0
+      \\ rw[]
+      \\ qhdtm_x_assum`buffer_flush`mp_tac
+      \\ simp[buffer_flush_def]
+      \\ strip_tac
+      \\ rfs[])
+    \\ conj_tac >- (
+      rw[]
+      \\ res_tac
+      \\ fs[word_loc_val_byte_def]
+      \\ ntac 2 (pop_assum mp_tac)
+      \\ TOP_CASE_TAC \\ simp[]
+      \\ strip_tac
+      \\ qmatch_asmsub_abbrev_tac`word_loc_val p labs w = _`
+      \\ Cases_on`w` \\ fs[word_loc_val_def]
+      \\ ntac 4 (pop_assum mp_tac)
+      \\ TOP_CASE_TAC \\ simp[]
+      \\ ntac 4 strip_tac
+      \\ first_x_assum old_drule \\ simp[])
+    \\ conj_tac >- (
+      strip_tac \\
+      qhdtm_x_assum`buffer_flush`mp_tac \\
+      simp[buffer_flush_def] \\ ntac 2 strip_tac \\
+      qpat_x_assum `∀n. n < _ ⇒ _`(qspec_then`n'''` mp_tac)>>
+      rw[]>>rfs[] >> fs[GSYM word_add_n2w])
+    \\ conj_tac >- (
+      simp[prog_to_bytes_APPEND]
+      \\ fs[bytes_in_mem_APPEND]
+      \\ qhdtm_x_assum`buffer_flush`mp_tac
+      \\ simp[buffer_flush_def]
+      \\ rw[]
+      \\ fs[])
+    \\ conj_tac >- (
+      simp[prog_to_bytes_APPEND]
+      \\ fs[buffer_flush_def] \\ rw[]
+      \\ qpat_x_assum`_ = t1.regs s1.len_reg` sym_sub_tac
+      \\ simp[GSYM word_add_n2w])
+    \\ conj_tac >- (
+      fs[buffer_flush_def]>>rw[]>>
+      simp[bytes_in_mem_def])
+    \\ conj_tac >-
+      (fs[buffer_flush_def] \\ rw[] >>
+      fs[LENGTH_prog_to_bytes2,prog_to_bytes_APPEND])
+    \\ conj_tac >- (
+       gvs[buffer_flush_def] >>
+       rw[] >>
+       qpat_x_assum `!bn. bn < _ + _ ==> ~(MEM _ _)` $
+         qspec_then `bn + LENGTH (prog_to_bytes sec_list)` mp_tac >>
+       gvs[GSYM word_add_n2w] >>
+       metis_tac[WORD_ADD_ASSOC]
+    )
+    \\ conj_tac>- (
+      `EVERY sec_label_zero sec_list` by
+        metis_tac[all_enc_ok_imp_sec_label_zero]>>
+      qmatch_assum_rename_tac `loc_to_pc ll1 ll2 s1.code = SOME xx`>>
+      rfs[]>>fs[]>>
+      `pos_val xx 0 (code2 ++ sec_list) = pos_val xx 0 code2` by
+        (simp[pos_val_append]>>
+        metis_tac[loc_to_pc_bound,code_similar_sec_labels_ok,code_similar_loc_to_pc])>>
+      simp[]>>
+      last_x_assum(qspecl_then[`ll1`,`ll2`,`xx`] assume_tac)>>
+      last_x_assum(qspecl_then[`ll1`,`ll2`,`xx`] assume_tac)>>
+      rfs[]>>
+      fs[]>>
+      qpat_x_assum`!r. word_loc_val _ _ _ = _` (qspec_then`s1.link_reg` assume_tac)>>
+      rfs[word_loc_val_def])
+    \\ conj_tac>-
+      (match_mp_tac all_enc_ok_append>>
+      rw[]>>fs[]>>
+      match_mp_tac all_enc_ok_labs_mono
+      >- metis_tac[] >>
+      (* TODO: remove qexists `l1` *)
+      (* irule (Pos hd) $ DECIDE``A ==> A`` *)
+      qexists `l1` >>
+      gvs[asm_fetch_def] >>
+      rev_drule code_similar_IMP_asm_fetch_aux_line_similar >>
+      simp[OPTREL_def,DefnBase.one_line_ify NONE line_similar_def,AllCaseEqs()] >>
+      disch_then $ qspec_then `s1.pc` assume_tac >>
+      gvs[] >>
+      first_x_assum mp_tac >>
+      TOP_CASE_TAC >>
+      strip_tac >>
+      var_eq_tac >>
+      old_drule $ GEN_ALL no_share_mem_lemma >>
+      rpt strip_tac >>
+      gvs[Abbr`ffi_names`] >>
+      pop_assum old_drule >>
+      impl_tac >-
+      simp[no_install_or_no_share_mem_def] >>
+      metis_tac[TAKE_LENGTH_ID] )
+    \\ conj_tac>-
+      (fs[good_code_def]>>
+      metis_tac[code_similar_sec_labels_ok])
+    \\ conj_tac >- metis_tac[code_similar_append]
+    \\ conj_tac >-
+      (gvs[share_mem_state_rel_def] >>
+       share_mem_state_rel_tac)
+    \\ gvs[share_mem_domain_code_rel_def] >>
+       conj_tac >- gvs[no_share_mem_inst_def] >>
+       rw[IN_DISJOINT] >>
+       spose_not_then assume_tac >>
+       gvs[asm_fetch_def] >>
+       Cases_on `pc < num_pcs code2`
+       >- (
+         gvs[asm_fetch_aux_APPEND1,pos_val_APPEND1] >>
+         first_x_assum drule_all >>
+         gvs[IN_DISJOINT] >>
+         metis_tac[]
+       ) >>
+       `?pc'. pc = num_pcs code2 + pc'` by (
+         irule LESS_EQUAL_ADD >>
+         decide_tac
+       ) >>
+       gvs[asm_fetch_aux_APPEND2] >>
+       rev_drule_then (qspecl_then [`sec_list`,`pc'`] assume_tac)
+         pos_val_APPEND2 >>
+       gvs[] >>
+       pop_assum kall_tac >>
+       drule_then old_drule $ GEN_ALL no_share_mem_lemma >>
+       impl_tac >- (
+         irule code_similar_IMP_both_no_install_or_no_share_mem >>
+         irule_at (Pos hd) code_similar_sym >>
+         first_x_assum $ irule_at (Pos hd) >>
+         simp[no_install_or_no_share_mem_def]) >>
+       strip_tac >>
+       gvs[buffer_flush_def] >>
+       drule_all $ GEN_ALL asm_fetch_aux_pos_val_SUC >>
+       disch_then $ qspec_then `0` assume_tac >>
+       drule_then (qspecl_then [`pc'+1`,`0`] (assume_tac o SIMP_RULE(srw_ss())[]))
+         pos_val_bound >>
+       qpat_x_assum `!bn. bn < _ + _ ==> ~(MEM _ _)` mp_tac >>
+       simp[] >>
+       qexists `a + pos_val pc' 0 sec_list` >>
+       simp[GSYM word_add_n2w] >>
+       metis_tac[word_add_n2w,WORD_ADD_ASSOC,WORD_ADD_COMM]
+  )
+  >- (
+    disch_then(qx_choose_then`k`strip_assume_tac)
+    \\ qpat_x_assum `!k'. evaluate mc_conf _ _ _ = _`
+         (qspec_then `s1.clock+k` assume_tac)
     \\ qmatch_asmsub_rename_tac`s1.clock + k + k0`
     \\ qexists_tac`k + k0` \\ fs[]
     \\ simp[Abbr`mc_conf2`,Abbr`ms12`]
     \\ simp[Once evaluate_def]
     \\ fs[shift_interfer_def]
-    \\ IF_CASES_TAC >- fs[state_rel_def]
     \\ IF_CASES_TAC >- (
+      fs[state_rel_def]
+    )
+    \\ IF_CASES_TAC
+    >- (
       fs[state_rel_def]
       \\ `F` suffices_by rw[]
       \\ pop_assum mp_tac
@@ -8664,84 +9273,94 @@ Proof
       \\ rpt(qpat_x_assum`_ = _.halt_pc`(mp_tac o SYM))
       \\ simp[]
       \\ EVAL_TAC
-      \\ simp[dimword_def] )
-    \\ rfs[apply_oracle_def,target_state_rel_def,state_rel_def,reg_ok_def])
-  THEN1 (* Halt *)
-   (say "Halt"
-    \\ srw_tac[][]
-    \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm Halt l1 l2 l3)`
-    \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm Halt l bytes n)`
-    \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
-    \\ mp_tac IMP_bytes_in_memory_Halt \\ full_simp_tac(srw_ss())[]
-    \\ match_mp_tac IMP_IMP \\ strip_tac
-    THEN1 (full_simp_tac(srw_ss())[state_rel_def]
-           \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
-    \\ rpt strip_tac \\ pop_assum mp_tac
-    \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
-    \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
-         asm_step_IMP_evaluate_step) \\ full_simp_tac(srw_ss())[]
-    \\ MATCH_MP_TAC IMP_IMP2 \\ STRIP_TAC THEN1
-     (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
-      \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
-      \\ imp_res_tac bytes_in_mem_IMP
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-            asmSemTheory.upd_pc_def]
-      \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
-      \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
-            asmSemTheory.upd_pc_def,asm_def]
-      \\ fs[asm_fetch_def]
-      \\ drule_all $ GEN_ALL IMP_bytes_in_memory
-      \\ strip_tac
-      \\ fs[]
-      \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
-      \\ ho_match_mp_tac (
-        PURE_REWRITE_RULE [satTheory.AND_IMP] o
-        PURE_REWRITE_RULE [Once CONJ_SYM] $
-        GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
-      \\ Cases_on `j`
-      \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
-      \\ gvs[enc_with_nop_thm,LENGTH_APPEND]
+      \\ simp[dimword_def]
     )
-    \\ rpt strip_tac
-    \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[asm_def]
-    \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock`mp_tac) \\ srw_tac[][]
-    \\ Q.EXISTS_TAC `l'` \\ full_simp_tac(srw_ss())[]
-    \\ once_rewrite_tac [evaluate_def] \\ full_simp_tac(srw_ss())[]
-    \\ full_simp_tac(srw_ss())[shift_interfer_def]
-    \\ `mc_conf.target.get_pc ms2 = mc_conf.halt_pc` by
-     (full_simp_tac(srw_ss())
-        [encoder_correct_def,target_ok_def,target_state_rel_def]
-      \\ res_tac
-      \\ full_simp_tac(srw_ss())[]
-      \\ full_simp_tac(srw_ss())[jump_to_offset_def,asmSemTheory.upd_pc_def]
-      \\ full_simp_tac(srw_ss())[state_rel_def]
-      \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
-           WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[])
-    \\ `~(mc_conf.target.get_pc ms2 IN t1.mem_domain)` by
-            full_simp_tac(srw_ss())[state_rel_def]
-    \\ full_simp_tac(srw_ss())[state_rel_def,jump_to_offset_def,
-          asmSemTheory.upd_pc_def]
-    \\ Cases_on `s1.regs s1.ptr_reg` \\ full_simp_tac(srw_ss())[]
-    \\ `word_loc_val p labs (s1.regs s1.ptr_reg) =
-         SOME (t1.regs s1.ptr_reg)` by full_simp_tac(srw_ss())[]
-    \\ Cases_on `s1.regs s1.ptr_reg`
-    \\ full_simp_tac(srw_ss())[word_loc_val_def] \\ srw_tac[][]
-    \\ `s1 = s2` by (Cases_on `t1.regs s1.ptr_reg = 0w`
-    \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]) \\ srw_tac[][]
-    \\ full_simp_tac(srw_ss())
-         [encoder_correct_def,target_ok_def,target_state_rel_def]
-    \\ first_x_assum (qspec_then `s1.ptr_reg` mp_tac)
-    \\ first_x_assum (qspec_then `s1.ptr_reg` mp_tac)
-    \\ full_simp_tac(srw_ss())[reg_ok_def]
-    \\ srw_tac[][] \\ full_simp_tac(srw_ss())[])
+    >- (
+      rfs[apply_oracle_def,target_state_rel_def,state_rel_def,reg_ok_def]
+    )
+  )
 QED
+
+Resume compile_correct[Halt]:
+(* Halt *)
+  say "Halt"
+  \\ srw_tac[][]
+  \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm Halt l1 l2 l3)`
+  \\ qmatch_assum_rename_tac `asm_fetch s1 = SOME (LabAsm Halt l bytes n)`
+  \\ qabbrev_tac `ffi_names = TAKE (THE (mmio_pcs_min_index mc_conf.ffi_names)) mc_conf.ffi_names`
+  \\ mp_tac IMP_bytes_in_memory_Halt \\ full_simp_tac(srw_ss())[]
+  \\ match_mp_tac IMP_IMP \\ strip_tac
+  THEN1 (full_simp_tac(srw_ss())[state_rel_def]
+         \\ imp_res_tac bytes_in_mem_IMP \\ full_simp_tac(srw_ss())[])
+  \\ rpt strip_tac \\ pop_assum mp_tac
+  \\ qpat_abbrev_tac `jj = asm$Jump lll` \\ rpt strip_tac
+  \\ (Q.ISPECL_THEN [`mc_conf`,`t1`,`ms1`,`s1.ffi`,`jj`]mp_tac
+       asm_step_IMP_evaluate_step_find_next) \\ full_simp_tac(srw_ss())[]
+  \\ MATCH_MP_TAC IMP_IMP2 \\ STRIP_TAC THEN1
+   (full_simp_tac(srw_ss())[state_rel_def,asm_def,LET_DEF]
+    \\ full_simp_tac(srw_ss())[asm_step_def,asm_def,LET_DEF]
+    \\ imp_res_tac bytes_in_mem_IMP
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+          asmSemTheory.upd_pc_def]
+    \\ rev_full_simp_tac(srw_ss())[] \\ unabbrev_all_tac
+    \\ full_simp_tac(srw_ss())[asmSemTheory.jump_to_offset_def,
+          asmSemTheory.upd_pc_def,asm_def]
+    \\ fs[asm_fetch_def]
+    \\ drule_all $ GEN_ALL IMP_bytes_in_memory
+    \\ strip_tac
+    \\ fs[]
+    \\ drule_all $ GEN_ALL IMP_ffi_entry_pcs_disjoint_LabAsm
+    \\ ho_match_mp_tac (
+      PURE_REWRITE_RULE [satTheory.AND_IMP] o
+      PURE_REWRITE_RULE [Once CONJ_SYM] $
+      GEN_ALL ffi_entry_pcs_disjoint_LENGTH_shorter )
+    \\ Cases_on `j`
+    \\ gvs[line_similar_def,line_ok_def,line_length_def,line_bytes_def]
+    \\ gvs[enc_with_nop_thm,LENGTH_APPEND]
+  )
+  \\ rpt strip_tac
+  \\ unabbrev_all_tac \\ full_simp_tac(srw_ss())[asm_def]
+  \\ FIRST_X_ASSUM (Q.SPEC_THEN `s1.clock`mp_tac) \\ srw_tac[][]
+  \\ Q.EXISTS_TAC `l'` \\ full_simp_tac(srw_ss())[]
+  \\ once_rewrite_tac [evaluate_def] \\ full_simp_tac(srw_ss())[]
+  \\ full_simp_tac(srw_ss())[shift_interfer_def]
+  \\ `mc_conf.target.get_pc ms2 = mc_conf.halt_pc` by
+   (full_simp_tac(srw_ss())
+      [encoder_correct_def,target_ok_def,target_state_rel_def]
+    \\ res_tac
+    \\ full_simp_tac(srw_ss())[]
+    \\ full_simp_tac(srw_ss())[jump_to_offset_def,asmSemTheory.upd_pc_def]
+    \\ full_simp_tac(srw_ss())[state_rel_def]
+    \\ rewrite_tac [GSYM word_add_n2w,GSYM word_sub_def,WORD_SUB_PLUS,
+         WORD_ADD_SUB] \\ full_simp_tac(srw_ss())[])
+  \\ `~(mc_conf.target.get_pc ms2 IN t1.mem_domain)` by
+          full_simp_tac(srw_ss())[state_rel_def]
+  \\ full_simp_tac(srw_ss())[state_rel_def,jump_to_offset_def,
+        asmSemTheory.upd_pc_def]
+  \\ Cases_on `s1.regs s1.ptr_reg` \\ full_simp_tac(srw_ss())[]
+  \\ `word_loc_val p labs (s1.regs s1.ptr_reg) =
+       SOME (t1.regs s1.ptr_reg)` by full_simp_tac(srw_ss())[]
+  \\ Cases_on `s1.regs s1.ptr_reg`
+  \\ full_simp_tac(srw_ss())[word_loc_val_def] \\ srw_tac[][]
+  \\ `s1 = s2` by (Cases_on `t1.regs s1.ptr_reg = 0w`
+  \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]) \\ srw_tac[][]
+  \\ full_simp_tac(srw_ss())
+       [encoder_correct_def,target_ok_def,target_state_rel_def]
+  \\ first_x_assum (qspec_then `s1.ptr_reg` mp_tac)
+  \\ first_x_assum (qspec_then `s1.ptr_reg` mp_tac)
+  \\ full_simp_tac(srw_ss())[reg_ok_def]
+  \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+QED
+
+Finalise compile_correct;
 
 (* relating observable semantics *)
 
 Definition init_ok_def:
   init_ok (mc_conf, p) s ms <=>
     ?code2 labs t1.
-      state_rel (mc_conf,code2,labs,p) s t1 ms
+      state_rel (mc_conf,code2,labs,p) s t1 ms ∧
+      oracle_tie mc_conf ms s
 End
 
 Theorem machine_sem_EQ_sem:
@@ -8758,124 +9377,154 @@ Proof
   DEEP_INTRO_TAC some_intro >>
   conj_tac
   >- (
-    qx_gen_tac`ffi`>>strip_tac>> full_simp_tac(srw_ss())[]
-    \\ old_drule compile_correct \\ full_simp_tac(srw_ss())[]
-    \\ disch_then old_drule
-    \\ imp_res_tac state_rel_clock
-    \\ pop_assum (qspec_then `k` assume_tac)
-    \\ disch_then old_drule \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
-    \\ full_simp_tac(srw_ss())[machine_sem_def,EXTENSION] \\ full_simp_tac(srw_ss())[IN_DEF]
-    \\ Cases \\ full_simp_tac(srw_ss())[machine_sem_def]
-    THEN1 (disj1_tac \\ qexists_tac `k+k'` \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
-    THEN1
-     (eq_tac THEN1
-       (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
-        \\ old_drule (GEN_ALL evaluate_ignore_clocks) \\ full_simp_tac(srw_ss())[]
-        \\ pop_assum (K all_tac)
-        \\ disch_then old_drule \\ full_simp_tac(srw_ss())[])
-      \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ asm_exists_tac \\ full_simp_tac(srw_ss())[])
-    \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[FST_EQ_EQUIV]
-    \\ PairCases_on `y`
-    \\ old_drule (GEN_ALL evaluate_ignore_clocks) \\ full_simp_tac(srw_ss())[]
-    \\ every_case_tac \\ full_simp_tac(srw_ss())[]
-    \\ pop_assum (K all_tac)
-    \\ asm_exists_tac \\ full_simp_tac(srw_ss())[])
+    (
+      qx_gen_tac`ffi`>>strip_tac>> full_simp_tac(srw_ss())[]
+      \\ imp_res_tac oracle_tie_clock
+      \\ pop_assum (qspec_then `k` assume_tac)
+      \\ old_drule compile_correct \\ full_simp_tac(srw_ss())[]
+      \\ imp_res_tac state_rel_clock
+      \\ pop_assum (qspec_then `k` assume_tac)
+      \\ disch_then old_drule \\ srw_tac[][] \\ full_simp_tac(srw_ss())[]
+      \\ full_simp_tac(srw_ss())[machine_sem_def,EXTENSION] \\ full_simp_tac(srw_ss())[IN_DEF]
+      \\ Cases \\ full_simp_tac(srw_ss())[machine_sem_def]
+      THEN1 (disj1_tac \\ qexists_tac `k+k'` \\ full_simp_tac(srw_ss())[] \\ every_case_tac \\ full_simp_tac(srw_ss())[])
+      THEN1
+       (eq_tac THEN1
+         (srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ srw_tac[][]
+          \\ old_drule (GEN_ALL evaluate_ignore_clocks) \\ full_simp_tac(srw_ss())[]
+          \\ pop_assum (K all_tac)
+          \\ disch_then old_drule \\ full_simp_tac(srw_ss())[])
+        \\ srw_tac[][] \\ every_case_tac \\ full_simp_tac(srw_ss())[] \\ asm_exists_tac \\ full_simp_tac(srw_ss())[])
+      \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[FST_EQ_EQUIV]
+      \\ PairCases_on `y`
+      \\ old_drule (GEN_ALL evaluate_ignore_clocks) \\ full_simp_tac(srw_ss())[]
+      \\ every_case_tac \\ full_simp_tac(srw_ss())[]
+      \\ pop_assum (K all_tac)
+      \\ asm_exists_tac \\ full_simp_tac(srw_ss())[])
+  )
   \\ full_simp_tac(srw_ss())[machine_sem_def,EXTENSION] \\ full_simp_tac(srw_ss())[IN_DEF]
   \\ strip_tac
   \\ Cases \\ full_simp_tac(srw_ss())[machine_sem_def]
   \\ imp_res_tac state_rel_clock
-  THEN1 (
-    qmatch_abbrev_tac`a ∧ b ⇔ c` >>
-    `a` by (
-      unabbrev_all_tac >> gen_tac >>
+  >- (
+    (
+      qmatch_abbrev_tac`a ∧ b ⇔ c` >>
+      sg `a`
+      >- (
+        (
+          unabbrev_all_tac >> gen_tac >>
+          `oracle_tie mc_conf ms (s1 with clock := k)` by
+            (irule oracle_tie_clock \\ first_assum ACCEPT_TAC) >>
+          qspec_then `s1 with clock := k` mp_tac compile_correct >>
+          Cases_on`evaluate (s1 with clock := k)`>>simp[]>>
+          last_assum(qspec_then`k`mp_tac)>>
+          pop_assum mp_tac >> simp_tac(srw_ss())[] >>
+          ntac 2 strip_tac >>
+          disch_then old_drule >>
+          disch_then old_drule >>
+          first_x_assum(qspec_then`k`strip_assume_tac) >>
+          disch_then old_drule >> strip_tac >>
+          first_x_assum(qspec_then`k`mp_tac)>>simp[]>>
+          strip_tac >>
+          spose_not_then strip_assume_tac >>
+          Cases_on`q`>>full_simp_tac(srw_ss())[]>>
+          `∃x y z. evaluate mc_conf s1.ffi k ms = (x,y,z)` by metis_tac[PAIR] >>
+          `x = TimeOut` by (
+            spose_not_then strip_assume_tac >>
+            old_drule (GEN_ALL evaluate_add_clock) >>
+            simp[] >> qexists_tac`k'`>>simp[] ) >>
+          full_simp_tac(srw_ss())[] >>
+          metis_tac[evaluate_add_clock_io_events_mono,SND,option_CASES,
+                    IS_SOME_EXISTS,LESS_EQ_EXISTS])
+      )
+      >- (
+        simp[] >> full_simp_tac(srw_ss())[Abbr`a`] >>
+        unabbrev_all_tac >> simp[] >>
+        qmatch_abbrev_tac`lprefix_lub l1 l ⇔ l = build_lprefix_lub l2` >>
+        `lprefix_chain l1 ∧ lprefix_chain l2` by (
+          unabbrev_all_tac >>
+          conj_tac >>
+          Ho_Rewrite.ONCE_REWRITE_TAC[GSYM o_DEF] >>
+          REWRITE_TAC[IMAGE_COMPOSE] >>
+          match_mp_tac prefix_chain_lprefix_chain >>
+          simp[prefix_chain_def,PULL_EXISTS] >>
+          qx_genl_tac[`k1`,`k2`] >>
+          qspecl_then[`k1`,`k2`]mp_tac LESS_EQ_CASES >>
+          metis_tac[
+            targetPropsTheory.evaluate_add_clock_io_events_mono,
+            labPropsTheory.evaluate_add_clock_io_events_mono
+            |> Q.SPEC`s with clock := k` |> SIMP_RULE (srw_ss())[],
+            LESS_EQ_EXISTS]) >>
+        `equiv_lprefix_chain l1 l2` by (
+          simp[equiv_lprefix_chain_thm] >>
+          unabbrev_all_tac >> simp[PULL_EXISTS] >>
+          ntac 2 (pop_assum kall_tac) >>
+          simp[LNTH_fromList,PULL_EXISTS] >>
+          simp[GSYM FORALL_AND_THM] >>
+          rpt gen_tac >>
+          `oracle_tie mc_conf ms (s1 with clock := k)` by
+            (irule oracle_tie_clock \\ first_assum ACCEPT_TAC) >>
+          qspec_then `s1 with clock := k` mp_tac compile_correct >>
+          Cases_on`evaluate (s1 with clock := k)`>>full_simp_tac(srw_ss())[] >>
+          last_assum(qspec_then`k`mp_tac)>>
+          pop_assum mp_tac >> simp_tac(srw_ss())[] >>
+          ntac 2 strip_tac >>
+          disch_then old_drule >>
+          disch_then old_drule >>
+          first_x_assum(qspec_then`k`(fn th => assume_tac th >> disch_then old_drule)) >>
+          strip_tac >>
+          reverse conj_tac >> strip_tac >- (
+            qexists_tac`k+k'`>>simp[] ) >>
+          qmatch_assum_abbrev_tac`n < (LENGTH (_ ffi))` >>
+          qexists_tac`k`>>simp[] >>
+          `ffi.io_events ≼ r.ffi.io_events` by (
+            qunabbrev_tac`ffi` >>
+            metis_tac[
+              targetPropsTheory.evaluate_add_clock_io_events_mono,
+              SND,LESS_EQ_EXISTS] ) >>
+          full_simp_tac(srw_ss())[IS_PREFIX_APPEND] >>
+          simp[EL_APPEND1]) >>
+        metis_tac[build_lprefix_lub_thm,unique_lprefix_lub,lprefix_lub_new_chain]
+      ))
+  )
+  >- (
+    (
+      spose_not_then strip_assume_tac >> var_eq_tac >>
+      `oracle_tie mc_conf ms (s1 with clock := k)` by
+        (irule oracle_tie_clock \\ first_assum ACCEPT_TAC) >>
       qspec_then `s1 with clock := k` mp_tac compile_correct >>
       Cases_on`evaluate (s1 with clock := k)`>>simp[]>>
       last_assum(qspec_then`k`mp_tac)>>
-      pop_assum mp_tac >> simp_tac(srw_ss())[] >>
-      ntac 2 strip_tac >>
-      disch_then old_drule >>
+      pop_assum mp_tac >> simp_tac(srw_ss())[] >> rpt strip_tac >>
+      asm_exists_tac >> simp[] >>
       first_x_assum(qspec_then`k`strip_assume_tac) >>
-      disch_then old_drule >> strip_tac >>
-      first_x_assum(qspec_then`k`mp_tac)>>simp[]>>
-      strip_tac >>
-      spose_not_then strip_assume_tac >>
-      Cases_on`q`>>full_simp_tac(srw_ss())[]>>
-      `∃x y z. evaluate mc_conf s1.ffi k ms = (x,y,z)` by metis_tac[PAIR] >>
-      `x = TimeOut` by (
-        spose_not_then strip_assume_tac >>
-        old_drule (GEN_ALL evaluate_add_clock) >>
-        simp[] >> qexists_tac`k'`>>simp[] ) >>
-      full_simp_tac(srw_ss())[] >>
-      metis_tac[evaluate_add_clock_io_events_mono,SND,option_CASES,
-                IS_SOME_EXISTS,LESS_EQ_EXISTS]) >>
-    simp[] >> full_simp_tac(srw_ss())[Abbr`a`] >>
-    unabbrev_all_tac >> simp[] >>
-    qmatch_abbrev_tac`lprefix_lub l1 l ⇔ l = build_lprefix_lub l2` >>
-    `lprefix_chain l1 ∧ lprefix_chain l2` by (
-      unabbrev_all_tac >>
-      conj_tac >>
-      Ho_Rewrite.ONCE_REWRITE_TAC[GSYM o_DEF] >>
-      REWRITE_TAC[IMAGE_COMPOSE] >>
-      match_mp_tac prefix_chain_lprefix_chain >>
-      simp[prefix_chain_def,PULL_EXISTS] >>
-      qx_genl_tac[`k1`,`k2`] >>
-      qspecl_then[`k1`,`k2`]mp_tac LESS_EQ_CASES >>
-      metis_tac[
-        targetPropsTheory.evaluate_add_clock_io_events_mono,
-        labPropsTheory.evaluate_add_clock_io_events_mono
-        |> Q.SPEC`s with clock := k` |> SIMP_RULE (srw_ss())[],
-        LESS_EQ_EXISTS]) >>
-    `equiv_lprefix_chain l1 l2` by (
-      simp[equiv_lprefix_chain_thm] >>
-      unabbrev_all_tac >> simp[PULL_EXISTS] >>
-      ntac 2 (pop_assum kall_tac) >>
-      simp[LNTH_fromList,PULL_EXISTS] >>
-      simp[GSYM FORALL_AND_THM] >>
+      asm_exists_tac >> simp[] >>
       rpt gen_tac >>
-      qspec_then `s1 with clock := k` mp_tac compile_correct >>
-      Cases_on`evaluate (s1 with clock := k)`>>full_simp_tac(srw_ss())[] >>
-      last_assum(qspec_then`k`mp_tac)>>
-      pop_assum mp_tac >> simp_tac(srw_ss())[] >>
-      ntac 2 strip_tac >>
-      disch_then old_drule >>
-      first_x_assum(qspec_then`k`(fn th => assume_tac th >> disch_then old_drule)) >>
-      strip_tac >>
-      reverse conj_tac >> strip_tac >- (
-        qexists_tac`k+k'`>>simp[] ) >>
-      qmatch_assum_abbrev_tac`n < (LENGTH (_ ffi))` >>
-      qexists_tac`k`>>simp[] >>
-      `ffi.io_events ≼ r.ffi.io_events` by (
-        qunabbrev_tac`ffi` >>
-        metis_tac[
-          targetPropsTheory.evaluate_add_clock_io_events_mono,
-          SND,LESS_EQ_EXISTS] ) >>
-      full_simp_tac(srw_ss())[IS_PREFIX_APPEND] >>
-      simp[EL_APPEND1]) >>
-    metis_tac[build_lprefix_lub_thm,unique_lprefix_lub,lprefix_lub_new_chain])
-  THEN1 (
-    spose_not_then strip_assume_tac >> var_eq_tac >>
-    qspec_then `s1 with clock := k` mp_tac compile_correct >>
-    Cases_on`evaluate (s1 with clock := k)`>>simp[]>>
-    last_assum(qspec_then`k`mp_tac)>>
-    pop_assum mp_tac >> simp_tac(srw_ss())[] >> rpt strip_tac >>
-    asm_exists_tac >> simp[] >>
-    first_x_assum(qspec_then`k`strip_assume_tac) >>
-    asm_exists_tac >> simp[] >>
-    rpt gen_tac >>
-    old_drule (GEN_ALL evaluate_add_clock) >> simp[] >>
-    disch_then kall_tac >>
-    first_x_assum(qspec_then`k`mp_tac) >> simp[])
-  \\ CCONTR_TAC \\ full_simp_tac(srw_ss())[FST_EQ_EQUIV]
-  \\ last_x_assum (qspec_then `k` mp_tac) \\ full_simp_tac(srw_ss())[]
-  \\ Cases_on `evaluate (s1 with clock := k)` \\ full_simp_tac(srw_ss())[]
-  \\ old_drule compile_correct
-  \\ Cases_on `q = Error` \\ full_simp_tac(srw_ss())[]
-  \\ asm_exists_tac \\ full_simp_tac(srw_ss())[]
-  \\ first_x_assum (qspec_then `k` assume_tac)
-  \\ asm_exists_tac \\ full_simp_tac(srw_ss())[] \\ gen_tac
-  \\ PairCases_on `y`
-  \\ old_drule (GEN_ALL evaluate_add_clock) \\ full_simp_tac(srw_ss())[]
-  \\ every_case_tac \\ full_simp_tac(srw_ss())[]
+      old_drule (GEN_ALL evaluate_add_clock) >> simp[] >>
+      disch_then kall_tac >>
+      first_x_assum(qspec_then`k`mp_tac) >> simp[] >>
+      metis_tac[])
+  )
+  >- (
+    CCONTR_TAC \\ full_simp_tac(srw_ss())[FST_EQ_EQUIV]
+    \\ last_x_assum (qspec_then `k` mp_tac) \\ full_simp_tac(srw_ss())[]
+    \\ Cases_on `evaluate (s1 with clock := k)` \\ full_simp_tac(srw_ss())[]
+    \\ CCONTR_TAC
+    \\ `oracle_tie mc_conf ms (s1 with clock := k)` by
+         (irule oracle_tie_clock \\ first_assum ACCEPT_TAC)
+    \\ old_drule compile_correct
+    \\ full_simp_tac(srw_ss())[]
+    \\ qexists_tac `code2` \\ qexists_tac `labs` \\ qexists_tac `t1`
+    \\ conj_tac
+    >- (
+      qpat_x_assum `!k'. state_rel _ _ _ _` (qspec_then `k` assume_tac)
+      \\ first_assum ACCEPT_TAC
+    )
+    \\ rpt gen_tac
+    \\ PairCases_on `y`
+    \\ old_drule (GEN_ALL evaluate_add_clock) \\ full_simp_tac(srw_ss())[]
+    \\ every_case_tac \\ full_simp_tac(srw_ss())[]
+  )
 QED
 
 (*
@@ -8900,7 +9549,7 @@ Definition make_word_def:
 End
 
 Definition make_init_def:
-  make_init mc_conf (ffi:'ffi ffi_state) io_regs cc_regs t m dm sdm (ms:'state) code
+  make_init mc_conf (ffi:'ffi ffi_state) t m dm sdm (ms:'state) code
     comp cbpos cbspace coracle =
     <| regs           := \k. Word ((t.regs k):'a word)
      ; fp_regs    := t.fp_regs
@@ -8910,8 +9559,10 @@ Definition make_init_def:
      ; pc             := 0
      ; be             := mc_conf.target.config.big_endian
      ; ffi            := ffi
-     ; io_regs        := \n i k. if MEM k mc_conf.callee_saved_regs then NONE else (io_regs n i k)
-     ; cc_regs        := \n k. if MEM k mc_conf.callee_saved_regs then NONE else (cc_regs n k)
+     ; io_regs        := target_io_regs mc_conf ffi ms
+     ; io_fp_regs     := target_io_fp_regs mc_conf ffi ms
+     ; cc_regs        := target_cc_regs mc_conf ffi ms
+     ; cc_fp_regs     := target_cc_fp_regs mc_conf ffi ms
      ; code           := code
      ; clock          := 0
      ; failed         := F
@@ -8926,6 +9577,13 @@ Definition make_init_def:
      ; compile_oracle := coracle
      |>
 End
+
+Theorem oracle_tie_make_init:
+  oracle_tie mc_conf ms
+    (make_init mc_conf ffi t m dm sdm ms code cmp cbpos cbspace coracle)
+Proof
+  simp[oracle_tie_def, make_init_def]
+QED
 
 val IMP_LEMMA = METIS_PROVE [] ``(a ==> b) ==> (b ==> c) ==> (a ==> c)``
 
@@ -9485,7 +10143,7 @@ Theorem IMP_state_rel_make_init[local]:
    remove_labels clock mc_conf.target.config 0 LN (TAKE i mc_conf.ffi_names) code =
       SOME (code2,labs) /\
    good_init_state mc_conf ms (prog_to_bytes code2)
-      cbspace t m dm sdm io_regs cc_regs /\
+      cbspace t m dm sdm /\
    get_shmem_info code2 0 [] [] = (new_ffi_names, shmem_info) /\
    new_shmem_info = MAP (\rec. rec with
     <|entry_pc:= w2n (mc_conf.target.get_pc ms) + rec.entry_pc
@@ -9504,7 +10162,7 @@ Theorem IMP_state_rel_make_init[local]:
    ==>
    state_rel ((mc_conf: ('a,'state,'b) machine_config),code2,labs,
        mc_conf.target.get_pc ms)
-     (make_init mc_conf (ffi:'ffi ffi_state) io_regs cc_regs t m dm sdm ms code
+     (make_init mc_conf (ffi:'ffi ffi_state) t m dm sdm ms code
       (compile_lab mc_conf.target.config)
       (mc_conf.target.get_pc ms+n2w(LENGTH(prog_to_bytes code2))) cbspace coracle) t ms
 Proof
@@ -9525,117 +10183,175 @@ Proof
         compiler_oracle_ok_def,
         target_configured_def,
         good_code_def,
-        start_pc_ok_def,
-        ffi_interfer_ok_def,
-        ccache_interfer_ok_def]
+        start_pc_ok_def]
   \\ rfs[]
-  \\ conj_tac >- (
-        fs[Abbr ‘new_shmem_info’]>>
-        fs[MAP_MAP_o,o_DEF]>>
-        qmatch_goalsub_abbrev_tac ‘ZIP (l1,MAP ff _)’>>
-        ‘LENGTH l1 = LENGTH (MAP ff shmem_info)’ by fs[Abbr ‘l1’,LENGTH_GENLIST]>>
-        fs[ALOOKUP_ZIP_MAP_SND]>>
-        `LENGTH shmem_info = LENGTH (DROP i (MAP w2n mc_conf.ffi_entry_pcs))`
-          by (qpat_assum `MAP _ shmem_info = DROP _ _` (fn h => assume_tac (Q.AP_TERM `LENGTH` h))>>
-              gvs[LENGTH_MAP,LENGTH_DROP])>>
-        rw[Abbr ‘l1’]
-        >- (‘shmem_info ≠ []’ by (strip_tac>>fs[])>>
-            irule_at Any ALOOKUP_ALL_DISTINCT_MEM>>
-            simp[MEM_ZIP,MAP_ZIP,ALL_DISTINCT_GENLIST,EL_GENLIST]>>
-            qexists_tac ‘index - i’>>
-            reverse conj_asm1_tac>- fs[EL_GENLIST]>>fs[LENGTH_MAP,LENGTH_DROP])>>
-        rewrite_tac[ALOOKUP_FAILS]>>
-        rpt strip_tac>>
-        gvs[NOT_LESS,NOT_LESS_EQUAL,MEM_ZIP])>>
-  conj_tac >- (
-    rw[]>>
-    gvs[IMP_CONJ_THM,AND_IMP_INTRO] >>
-    first_x_assum $ map_first_cj >>
-    simp[] >>
-    gvs[call_FFI_def, AllCaseEqs()] >>
-    old_drule mmio_pcs_min_index_is_SOME >>
-    rpt strip_tac >>
-    drule_all LESS_LESS_EQ_TRANS >>
-    gvs[]
-  )
-  \\ conj_tac >- (
-    ntac 2 strip_tac >>
-    pairarg_tac >> fs[]>>
-    drule_then assume_tac code_similar_sym >>
-    drule_all_then assume_tac code_similar_IMP_both_no_share_mem >>
-    fs[] >>
-    qpat_x_assum`!k. _ (coracle k)`(qspec_then`k` assume_tac)>>rfs[]>>
-    strip_tac>>fs[])
-  \\ conj_tac >- metis_tac[EVEN,all_enc_ok_prog_to_bytes_EVEN]
-  \\ conj_tac >- metis_tac[list_subset_TAKE,list_subset_trans]
-  \\ conj_tac >- metis_tac[EVEN,all_enc_ok_prog_to_bytes_EVEN]
-  \\ conj_tac >- (
-    imp_res_tac mmio_pcs_min_index_is_SOME>>
-    rpt strip_tac>>fs[]>>
-    fs[get_ffi_index_def,backendPropsTheory.the_eqn]>>
-    imp_res_tac find_index_MEM>>
-    first_x_assum $ qspecl_then [‘0’] assume_tac>>gvs[])
-  \\ conj_tac >- (
-    simp[word_loc_val_byte_def,case_eq_thms]
-    \\ metis_tac[SUBSET_DEF,word_loc_val_def] )
-  \\ conj_tac >- metis_tac[word_add_n2w]
-  \\ conj_tac >- simp[bytes_in_mem_def]
-  \\ conj_tac >- (
-    rpt strip_tac >>
-    `MAP (\rec. n2w rec.entry_pc) new_shmem_info = DROP i (mc_conf.ffi_entry_pcs : 'a word list)` by (
-      qpat_x_assum `MAP _ new_shmem_info = DROP i (MAP w2n _)` (fn h =>
-        mp_tac (AP_TERM ``MAP (n2w:num -> 'a word)`` h)) >>
-      simp[MAP_MAP_o, o_DEF, n2w_w2n, MAP_DROP]) >>
-    qpat_x_assum `!bn. bn < cbspace ==> _` $ imp_res_tac >>
-    gvs[MEM_EL] >>
-    drule_then assume_tac $ cj 1 mmio_pcs_min_index_is_SOME>>
-    gvs[LENGTH_TAKE] >>
-    first_x_assum $ qspec_then`n` assume_tac >>
-    Cases_on `n < i`
-    >- gvs[EL_TAKE] >>
-    `i <= n` by decide_tac >>
-    gvs[] >>
-    old_drule get_shmem_info_thm >>
-    disch_then $ qspecl_then [`0`,`[]`,`[]`] assume_tac >>
-    gvs[UNZIP_MAP,MAP_GENLIST,combinTheory.o_DEF,ZIP_MAP_FST_SND_EQ,MAP_MAP_o,
-      Abbr`new_shmem_info`,EL_MAP] >>
-    qspecl_then [`n - i`, `i`,`mc_conf.ffi_entry_pcs`]
-      assume_tac $ GSYM EL_DROP >>
-    gvs[] >>
-    pop_assum kall_tac >>
-    qpat_x_assum `_ = DROP i mc_conf.ffi_entry_pcs` $ assume_tac o GSYM >>
-    fs[GSYM word_add_n2w]>>
-    qmatch_assum_abbrev_tac `DROP i mc_conf.ffi_entry_pcs = MAP offset_func flatten_genlist` >>
-    gvs[] >>
-    `n - i < LENGTH (MAP offset_func flatten_genlist)` by (
-      qpat_x_assum `DROP i mc_conf.ffi_entry_pcs = _` $ assume_tac o GSYM >>
-      asm_rewrite_tac[LENGTH_DROP] >>
-      simp[]
-    ) >>
-    gvs[EL_MAP,Abbr`offset_func`] >>
-    drule_all genlist_line_to_info_entry_pc_max >>
-    strip_tac >>
-    drule_then (qspec_then `n-i` assume_tac) $ iffLR EVERY_EL >>
-    gvs[Abbr`flatten_genlist`] >>
-    qmatch_asmsub_abbrev_tac `entry_pc' < pos_val _ _ _` >>
-    drule_then (fn t =>
-      gvs[t,addressTheory.word_arith_lemma1]) $
-      GEN_ALL pos_val_num_pcs
-  )
-  \\ conj_tac>-
-    (old_drule pos_val_0 \\ simp[])
-  \\ conj_tac >- metis_tac[code_similar_sec_labels_ok]
-  \\ conj_tac >- (
-    gvs[share_mem_state_rel_def]
-    \\ rpt strip_tac
-    \\ gvs[IMP_CONJ_THM, AND_IMP_INTRO]
-    \\ first_x_assum $ qspecl_then [`ms2`, `k`, `index`, `new_bytes`, `t1`, `B`, `C`] mp_tac
-    \\ gvs[] >> strip_tac>>fs[]>>
-    old_drule mmio_pcs_min_index_is_SOME>>
-    strip_tac>>fs[]>>
-    first_x_assum $ qspec_then ‘index’ assume_tac>>gvs[]>>
-    TOP_CASE_TAC>>fs[])
-  \\ simp[share_mem_domain_code_rel_def]
+  \\ conj_tac >- suspend "ISR1"
+  \\ conj_tac >- suspend "ISR2"
+  \\ conj_tac >- suspend "ISR3"
+  \\ conj_tac >- suspend "ISR4"
+  \\ conj_tac >- suspend "ISR5"
+  \\ conj_tac >- suspend "ISR6"
+  \\ conj_tac >- suspend "ISR7"
+  \\ conj_tac >- suspend "ISR8"
+  \\ conj_tac >- suspend "ISR9"
+  \\ conj_tac >- suspend "ISR10"
+  \\ conj_tac >- suspend "ISR11"
+  \\ conj_tac >- suspend "ISR12"
+  \\ conj_tac >- suspend "ISR13"
+  \\ conj_tac >- suspend "ISR14"
+  \\ conj_tac >- suspend "ISR15"
+  \\ conj_tac >- suspend "ISR16" >- suspend "ISR17"
+QED
+
+Resume IMP_state_rel_make_init[ISR1]:
+  fs[Abbr ‘new_shmem_info’]>>
+  fs[MAP_MAP_o,o_DEF]>>
+  qmatch_goalsub_abbrev_tac ‘ZIP (l1,MAP ff _)’>>
+  ‘LENGTH l1 = LENGTH (MAP ff shmem_info)’ by fs[Abbr ‘l1’,LENGTH_GENLIST]>>
+  fs[ALOOKUP_ZIP_MAP_SND]>>
+  `LENGTH shmem_info = LENGTH (DROP i (MAP w2n mc_conf.ffi_entry_pcs))`
+    by (qpat_assum `MAP _ shmem_info = DROP _ _` (fn h => assume_tac (Q.AP_TERM `LENGTH` h))>>
+        gvs[LENGTH_MAP,LENGTH_DROP])>>
+  rw[Abbr ‘l1’]
+  >- (‘shmem_info ≠ []’ by (strip_tac>>fs[])>>
+      irule_at Any ALOOKUP_ALL_DISTINCT_MEM>>
+      simp[MEM_ZIP,MAP_ZIP,ALL_DISTINCT_GENLIST,EL_GENLIST]>>
+      qexists_tac ‘index - i’>>
+      reverse conj_asm1_tac>- fs[EL_GENLIST]>>fs[LENGTH_MAP,LENGTH_DROP])>>
+  rewrite_tac[ALOOKUP_FAILS]>>
+  rpt strip_tac>>
+  gvs[NOT_LESS,NOT_LESS_EQUAL,MEM_ZIP]
+QED
+
+Resume IMP_state_rel_make_init[ISR2]:
+  rpt strip_tac
+  \\ irule (REWRITE_RULE [post_ffi_asm_def] ffi_interfer_ok_post_ffi_asm)
+  \\ rpt conj_tac \\ fs[]
+  >- (old_drule mmio_pcs_min_index_is_SOME \\ gvs[])
+  >- (conj_tac
+      >- (imp_res_tac evaluatePropsTheory.call_FFI_LENGTH \\ simp[])
+      \\ strip_tac \\ gvs[call_FFI_def, AllCaseEqs()])
+  \\ qexists_tac `mc_conf.target.get_pc ms`
+  \\ simp[]
+QED
+
+Resume IMP_state_rel_make_init[ISR3]:
+  rpt strip_tac
+  \\ irule (REWRITE_RULE [post_ccache_asm_def] ccache_interfer_ok_post_ccache_asm)
+  \\ simp[]
+  \\ qexists_tac `mc_conf.target.get_pc ms`
+  \\ simp[]
+QED
+
+Resume IMP_state_rel_make_init[ISR4]:
+  ntac 2 strip_tac >>
+  pairarg_tac >> fs[]>>
+  drule_then assume_tac code_similar_sym >>
+  drule_all_then assume_tac code_similar_IMP_both_no_share_mem >>
+  fs[] >>
+  qpat_x_assum`!k. _ (coracle k)`(qspec_then`k` assume_tac)>>rfs[]>>
+  strip_tac>>fs[]
+QED
+
+Resume IMP_state_rel_make_init[ISR5]:
+  metis_tac[EVEN,all_enc_ok_prog_to_bytes_EVEN]
+QED
+
+Resume IMP_state_rel_make_init[ISR6]:
+  metis_tac[list_subset_TAKE,list_subset_trans]
+QED
+
+Resume IMP_state_rel_make_init[ISR7]:
+  metis_tac[EVEN,all_enc_ok_prog_to_bytes_EVEN]
+QED
+
+Resume IMP_state_rel_make_init[ISR8]:
+  imp_res_tac mmio_pcs_min_index_is_SOME>>
+  rpt strip_tac>>fs[]>>
+  fs[get_ffi_index_def,backendPropsTheory.the_eqn]>>
+  imp_res_tac find_index_MEM>>
+  first_x_assum $ qspecl_then [‘0’] assume_tac>>gvs[]
+QED
+
+Resume IMP_state_rel_make_init[ISR9]:
+  simp[word_loc_val_byte_def,case_eq_thms]
+  \\ metis_tac[SUBSET_DEF,word_loc_val_def]
+QED
+
+Resume IMP_state_rel_make_init[ISR10]:
+  metis_tac[word_add_n2w]
+QED
+
+Resume IMP_state_rel_make_init[ISR11]:
+  simp[bytes_in_mem_def]
+QED
+
+Resume IMP_state_rel_make_init[ISR12]:
+  rpt strip_tac >>
+  `MAP (\rec. n2w rec.entry_pc) new_shmem_info = DROP i (mc_conf.ffi_entry_pcs : 'a word list)` by (
+    qpat_x_assum `MAP _ new_shmem_info = DROP i (MAP w2n _)` (fn h =>
+      mp_tac (AP_TERM ``MAP (n2w:num -> 'a word)`` h)) >>
+    simp[MAP_MAP_o, o_DEF, n2w_w2n, MAP_DROP]) >>
+  qpat_x_assum `!bn. bn < cbspace ==> _` $ imp_res_tac >>
+  gvs[MEM_EL] >>
+  drule_then assume_tac $ cj 1 mmio_pcs_min_index_is_SOME>>
+  gvs[LENGTH_TAKE] >>
+  first_x_assum $ qspec_then`n` assume_tac >>
+  Cases_on `n < i`
+  >- gvs[EL_TAKE] >>
+  `i <= n` by decide_tac >>
+  gvs[] >>
+  old_drule get_shmem_info_thm >>
+  disch_then $ qspecl_then [`0`,`[]`,`[]`] assume_tac >>
+  gvs[UNZIP_MAP,MAP_GENLIST,combinTheory.o_DEF,ZIP_MAP_FST_SND_EQ,MAP_MAP_o,
+    Abbr`new_shmem_info`,EL_MAP] >>
+  qspecl_then [`n - i`, `i`,`mc_conf.ffi_entry_pcs`]
+    assume_tac $ GSYM EL_DROP >>
+  gvs[] >>
+  pop_assum kall_tac >>
+  qpat_x_assum `_ = DROP i mc_conf.ffi_entry_pcs` $ assume_tac o GSYM >>
+  fs[GSYM word_add_n2w]>>
+  qmatch_assum_abbrev_tac `DROP i mc_conf.ffi_entry_pcs = MAP offset_func flatten_genlist` >>
+  gvs[] >>
+  `n - i < LENGTH (MAP offset_func flatten_genlist)` by (
+    qpat_x_assum `DROP i mc_conf.ffi_entry_pcs = _` $ assume_tac o GSYM >>
+    asm_rewrite_tac[LENGTH_DROP] >>
+    simp[]
+  ) >>
+  gvs[EL_MAP,Abbr`offset_func`] >>
+  drule_all genlist_line_to_info_entry_pc_max >>
+  strip_tac >>
+  drule_then (qspec_then `n-i` assume_tac) $ iffLR EVERY_EL >>
+  gvs[Abbr`flatten_genlist`] >>
+  qmatch_asmsub_abbrev_tac `entry_pc' < pos_val _ _ _` >>
+  drule_then (fn t =>
+    gvs[t,addressTheory.word_arith_lemma1]) $
+    GEN_ALL pos_val_num_pcs
+QED
+
+Resume IMP_state_rel_make_init[ISR13]:
+  drule pos_val_0 \\ simp[]
+QED
+
+Resume IMP_state_rel_make_init[ISR14]:
+  metis_tac[code_similar_sec_labels_ok]
+QED
+
+Resume IMP_state_rel_make_init[ISR15]:
+  fs[ffi_interfer_ok_def]
+  \\ gvs[share_mem_state_rel_def]
+  \\ rpt strip_tac
+  \\ gvs[IMP_CONJ_THM, AND_IMP_INTRO]
+  \\ first_x_assum $ qspecl_then [`ms2`, `k`, `index`, `new_bytes`, `t1`, `B`, `C`] mp_tac
+  \\ gvs[] >> strip_tac>>fs[]>>
+  old_drule mmio_pcs_min_index_is_SOME>>
+  strip_tac>>fs[]>>
+  first_x_assum $ qspec_then ‘index’ assume_tac>>gvs[]>>
+  TOP_CASE_TAC>>fs[]
+QED
+
+Resume IMP_state_rel_make_init[ISR16]:
+  simp[share_mem_domain_code_rel_def]
   \\ fs[MAP_MAP_o,o_DEF,ELIM_UNCURRY]
   \\ old_drule $ GEN_ALL get_shmem_info_ok_lemma
   \\ disch_then $ qspecl_then [
@@ -9791,13 +10507,18 @@ Proof
       `a + (w2n (mc_conf.target.get_pc ms) + pos_val pc 0 code2) - dimword(:'a) < dimword(:'a)` by fs[] >>
       imp_res_tac LESS_MOD >> fs[])
     \\ simp[] >> fs[])
-  \\ drule_then (drule_then irule) $ GEN_ALL code_similar_IMP_both_no_install_or_no_share_mem
 QED
 
+Resume IMP_state_rel_make_init[ISR17]:
+  drule_then (drule_then irule) $ GEN_ALL code_similar_IMP_both_no_install_or_no_share_mem
+QED
+
+Finalise IMP_state_rel_make_init;
+
 Theorem make_init_simp[simp]:
-  (make_init a b d e f g h i j k l m n p).ffi = b ∧
-  (make_init a b d e f g h i j k l m n p).pc = 0 ∧
-  (make_init a b d e f g h i j k l m n p).code = k
+  (make_init a b f g h i j k l m n p).ffi = b ∧
+  (make_init a b f g h i j k l m n p).pc = 0 ∧
+  (make_init a b f g h i j k l m n p).code = k
 Proof
   EVAL_TAC
 QED
@@ -9810,19 +10531,20 @@ Theorem semantics_make_init =
   |> Q.GEN `t1` |> Q.SPEC `t`
   |> Q.SPEC `(mc_conf: ('a,'state,'b) machine_config).target.get_pc ms`
   |> Q.SPEC `make_init (mc_conf: ('a,'state,'b) machine_config)
-       ffi io_regs cc_regs t m dm sdm (ms:'state) code
+       ffi t m dm sdm (ms:'state) code
        (compile_lab mc_conf.target.config) (mc_conf.target.get_pc ms + (n2w (LENGTH (prog_to_bytes (code2:'a labLang$prog)))))
        cbspace coracle`
   |> SIMP_RULE std_ss [make_init_simp]
   |> MATCH_MP (MATCH_MP IMP_LEMMA IMP_state_rel_make_init)
   |> DISCH_ALL |> REWRITE_RULE [AND_IMP_INTRO,GSYM CONJ_ASSOC]
+  |> REWRITE_RULE [oracle_tie_make_init]
 
 Theorem make_init_filter_skip:
    semantics
-    (make_init mc_conf ffi io_regs cc_regs t m dm sdm ms (filter_skip code)
+    (make_init mc_conf ffi t m dm sdm ms (filter_skip code)
        (compile_lab mc_conf.target.config) cbpos cbspace((λ(a,b). (a,filter_skip b)) o coracle)) =
    semantics
-    (make_init mc_conf ffi io_regs cc_regs t m dm sdm ms code
+    (make_init mc_conf ffi t m dm sdm ms code
       (λc p. (compile_lab mc_conf.target.config) c (filter_skip p)) cbpos cbspace coracle)
 Proof
   match_mp_tac (filter_skip_semantics)>>
@@ -10301,7 +11023,7 @@ Theorem semantics_compile_lemma'[local]:
   lab_to_target$compile asm_conf (c:lab_to_target$config) code = SOME (bytes,c') /\
   (* FFI is either given or computed *)
   c'.ffi_names = SOME mc_conf.ffi_names /\
-  good_init_state mc_conf ms bytes cbspace t m dm sdm io_regs cc_regs /\
+  good_init_state mc_conf ms bytes cbspace t m dm sdm /\
   (* set up mmio_info and ffi_entry_pcs for mmio *)
   MAP (\rec. w2n (mc_conf.target.get_pc ms) + rec.entry_pc) c'.shmem_extra =
     DROP i (MAP w2n mc_conf.ffi_entry_pcs) /\
@@ -10315,12 +11037,12 @@ Theorem semantics_compile_lemma'[local]:
   cbspace + LENGTH bytes + ffi_offset * (i + 3) < dimword (:'a) /\
   (* the original ffi names provided does not contain MappedRead or MappedWrite *)
   (!ffis. c.ffi_names = SOME ffis ==> EVERY (λx. ∃s. x = ExtCall s) ffis) /\
-  semantics (make_init mc_conf ffi io_regs cc_regs t m dm sdm ms code
+  semantics (make_init mc_conf ffi t m dm sdm ms code
     (lab_to_target$compile asm_conf) (mc_conf.target.get_pc ms+n2w(LENGTH bytes)) cbspace
     coracle
   ) <> Fail ==>
   machine_sem mc_conf ffi ms =
-  {semantics (make_init mc_conf ffi io_regs cc_regs t m dm sdm ms code
+  {semantics (make_init mc_conf ffi t m dm sdm ms code
     (lab_to_target$compile asm_conf) (mc_conf.target.get_pc ms+n2w(LENGTH bytes)) cbspace
     coracle
   )}
@@ -10533,7 +11255,7 @@ Theorem semantics_compile:
   c.labels = LN ∧ c.pos = 0 ∧
   compile asm_conf c (code: 'a sec list) = SOME (bytes,c') ∧
   c'.ffi_names = SOME mc_conf.ffi_names /\
-  good_init_state mc_conf ms bytes cbspace t m dm sdm io_regs cc_regs /\
+  good_init_state mc_conf ms bytes cbspace t m dm sdm /\
   mmio_pcs_min_index mc_conf.ffi_names = SOME i /\
   MAP (\rec. w2n (mc_conf.target.get_pc ms) + rec.entry_pc) c'.shmem_extra =
    DROP i (MAP w2n mc_conf.ffi_entry_pcs) /\
@@ -10548,7 +11270,7 @@ Theorem semantics_compile:
   (!ffis. c.ffi_names = SOME ffis ==> EVERY (λx. ∃s. x = ExtCall s) ffis ) ⇒
    implements' T (machine_sem mc_conf ffi ms)
      {semantics
-        (make_init mc_conf ffi io_regs cc_regs t m (dm ∩ byte_aligned) (sdm ∩ byte_aligned) ms code
+        (make_init mc_conf ffi t m (dm ∩ byte_aligned) (sdm ∩ byte_aligned) ms code
            (compile asm_conf) (mc_conf.target.get_pc ms + n2w (LENGTH bytes))
            cbspace coracle)}
 Proof

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -2431,8 +2431,10 @@ Proof
               (λa.
                  get_reg_value (t1.cc_regs 0 a)
                    (if t1.link_reg = a then Loc n l
-                    else read_reg a t1) Word); pc := t1.pc+2;
+                    else read_reg a t1) Word);
+          fp_regs := (\n. t1.cc_fp_regs 0 n); pc := t1.pc+2;
           cc_regs := shift_seq 1 t1.cc_regs;
+          cc_fp_regs := shift_seq 1 t1.cc_fp_regs;
           code := t1.code ++ new_code;
           compile_oracle := shift_seq 1 t1.compile_oracle;
           code_buffer := cb;
@@ -2551,6 +2553,7 @@ Proof
                     qexists_tac ‘dec_clock t1
                     with <| regs := t1.regs⦇r ↦ Word (word_of_bytes F 0w new_bytes)⦈;
                             io_regs := shift_seq 1 t1.io_regs;
+                            io_fp_regs := shift_seq 1 t1.io_fp_regs;
                             pc:=t1.pc+1; ffi := new_ffi|>’ >>
          simp[]>>
          fs[code_installed_def,call_args_def] >>
@@ -2569,6 +2572,7 @@ Proof
                     qexists_tac ‘dec_clock t1
                     with <| regs := t1.regs⦇r ↦ Word (word_of_bytes F 0w new_bytes)⦈;
                             io_regs := shift_seq 1 t1.io_regs;
+                            io_fp_regs := shift_seq 1 t1.io_fp_regs;
                             pc:=t1.pc+1; ffi := new_ffi|>’ >>
          simp[]>>
          fs[code_installed_def,call_args_def] >>
@@ -2587,6 +2591,7 @@ Proof
                     qexists_tac ‘dec_clock t1
                     with <| regs := t1.regs⦇r ↦ Word (word_of_bytes F 0w new_bytes)⦈;
                             io_regs := shift_seq 1 t1.io_regs;
+                            io_fp_regs := shift_seq 1 t1.io_fp_regs;
                             pc:=t1.pc+1; ffi := new_ffi|>’ >>
          simp[]>>
          fs[code_installed_def,call_args_def] >>
@@ -2605,6 +2610,7 @@ Proof
                     qexists_tac ‘dec_clock t1
                     with <| regs := t1.regs⦇r ↦ Word (word_of_bytes F 0w new_bytes)⦈;
                             io_regs := shift_seq 1 t1.io_regs;
+                            io_fp_regs := shift_seq 1 t1.io_fp_regs;
                             pc:=t1.pc+1; ffi := new_ffi|>’ >>
          simp[]>>
          fs[code_installed_def,call_args_def] >>
@@ -2621,6 +2627,7 @@ Proof
     strip_tac>>
     qexists_tac`0` >>
     qexists_tac`dec_clock t1 with <| io_regs := shift_seq 1 t1.io_regs;
+                           io_fp_regs := shift_seq 1 t1.io_fp_regs;
                            pc:=t1.pc+1; ffi := new_ffi|>` >>
     fs[state_rel_def,stackSemTheory.dec_clock_def,dec_clock_def,inc_pc_def]>>
     fs[code_installed_def,call_args_def] >>

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -3027,7 +3027,7 @@ QED
 Definition make_init_def:
   make_init code coracle regs save_regs (s:('a,'c,'ffi) labSem$state) =
     <| regs    := FEMPTY |++ (MAP (\r. r, read_reg r s) regs)
-     ; fp_regs    := FEMPTY (*TODO: is this right? *)
+     ; fp_regs    := FEMPTY
      ; memory  := s.mem
      ; mdomain := s.mem_domain
      ; sh_mdomain := s.shared_mem_domain

--- a/compiler/backend/proofs/stack_to_labProofScript.sml
+++ b/compiler/backend/proofs/stack_to_labProofScript.sml
@@ -3158,16 +3158,6 @@ Proof
   \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs []
 QED
 
-(*
-Theorem FLOOKUP_fp_regs[local]:
-  !regs n v f s.
-      FLOOKUP (FEMPTY |++ MAP (λr. (r,read_fp_reg r s)) regs) n = SOME v ==>
-      s.fp_regs n = v
-Proof
-  recInduct SNOC_INDUCT \\ fs [FUPDATE_LIST,FOLDL_SNOC,MAP_SNOC]
-  \\ fs [FLOOKUP_UPDATE] \\ rw [] \\ Cases_on `x = n` \\ fs [read_fp_reg_def]
-QED*)
-
 Theorem state_rel_make_init:
    state_rel (make_init code coracle regs save_regs s) (s:('a,'c,'ffi) labSem$state) <=>
     (∀n prog.

--- a/compiler/backend/proofs/word_allocProofScript.sml
+++ b/compiler/backend/proofs/word_allocProofScript.sml
@@ -4358,6 +4358,7 @@ Resume evaluate_remove_dead[Install]:
   first_x_assum $ irule_at Any>> simp[]>>
   drule_at Any strong_locals_rel_I_cut_env>>
   disch_then $ irule_at Any>>
+  simp[state_component_equality]>>
   CONJ_TAC >- (
     irule_at Any strong_locals_rel_subset>>
     first_x_assum (irule_at Any)>>
@@ -4429,7 +4430,7 @@ Resume evaluate_remove_dead[FFI]:
     simp[SUBSET_DEF,domain_union])>>
   TOP_CASE_TAC>>gvs[]
   >-
-    fs[strong_locals_rel_def]
+    fs[state_component_equality,strong_locals_rel_def]
   >-
     fs[flush_state_def]
 QED
@@ -9948,8 +9949,8 @@ Resume ssa_cc_trans_correct[FFI]:
     reverse(Cases_on`call_FFI st.ffi (ExtCall s) x'' x'`)>>full_simp_tac(srw_ss())[]
     >- fs[call_env_def,flush_state_def] >>
     qpat_abbrev_tac`mem = write_bytearray A B C D E`>>
-    qabbrev_tac`rst = st with <|locals := x;memory:=mem;ffi:=f'|>`>>
-    qpat_abbrev_tac`rcstt = rcst with <|locals := A;memory:=B;ffi:=D|>`>>
+    qabbrev_tac`rst = st with <|locals := x;fp_regs:=FEMPTY;memory:=mem;ffi:=f'|>`>>
+    qpat_abbrev_tac`rcstt = rcst with <|locals := A;fp_regs:=FEMPTY;memory:=B;ffi:=D|>`>>
     `domain ssa_cut = domain x` by (
       fs[Abbr`ssa_cut`,domain_union,cut_env_def,AllCaseEqs()]>>
       drule cut_envs_domain_SUBSET>>

--- a/compiler/backend/semantics/labPropsScript.sml
+++ b/compiler/backend/semantics/labPropsScript.sml
@@ -167,7 +167,9 @@ Theorem update_simps[simp]:
     ((labSem$inc_pc s).mem_domain = s.mem_domain) ∧
     ((labSem$inc_pc s).shared_mem_domain = s.shared_mem_domain) ∧
     ((labSem$inc_pc s).io_regs = s.io_regs) ∧
+    ((labSem$inc_pc s).io_fp_regs = s.io_fp_regs) ∧
     ((labSem$inc_pc s).cc_regs = s.cc_regs) ∧
+    ((labSem$inc_pc s).cc_fp_regs = s.cc_fp_regs) ∧
     ((labSem$inc_pc s).compile = s.compile) ∧
     ((labSem$inc_pc s).compile_oracle = s.compile_oracle) ∧
     ((labSem$inc_pc s).code_buffer = s.code_buffer) ∧
@@ -192,7 +194,9 @@ Theorem binop_upd_consts[simp]:
    (labSem$binop_upd a b c d x).be = x.be ∧
    (labSem$binop_upd a b c d x).mem = x.mem ∧
    (labSem$binop_upd a b c d x).io_regs = x.io_regs ∧
+   (labSem$binop_upd a b c d x).io_fp_regs = x.io_fp_regs ∧
    (labSem$binop_upd a b c d x).cc_regs = x.cc_regs ∧
+   (labSem$binop_upd a b c d x).cc_fp_regs = x.cc_fp_regs ∧
    (labSem$binop_upd a b c d x).compile = x.compile ∧
    (labSem$binop_upd a b c d x).compile_oracle = x.compile_oracle ∧
    (labSem$binop_upd a b c d x).code_buffer = x.code_buffer ∧
@@ -214,7 +218,9 @@ Theorem arith_upd_consts[simp]:
    (labSem$arith_upd a x).be = x.be ∧
    (labSem$arith_upd a x).mem = x.mem ∧
    (labSem$arith_upd a x).io_regs = x.io_regs ∧
+   (labSem$arith_upd a x).io_fp_regs = x.io_fp_regs ∧
    (labSem$arith_upd a x).cc_regs = x.cc_regs ∧
+   (labSem$arith_upd a x).cc_fp_regs = x.cc_fp_regs ∧
    (labSem$arith_upd a x).compile = x.compile ∧
    (labSem$arith_upd a x).compile_oracle = x.compile_oracle ∧
    (labSem$arith_upd a x).code_buffer = x.code_buffer ∧
@@ -235,12 +241,14 @@ Theorem fp_upd_consts[simp]:
    (labSem$fp_upd f x).link_reg = x.link_reg ∧
    (labSem$fp_upd f x).code = x.code ∧
    (labSem$fp_upd f x).cc_regs = x.cc_regs ∧
+   (labSem$fp_upd f x).cc_fp_regs = x.cc_fp_regs ∧
    (labSem$fp_upd f x).code_buffer = x.code_buffer ∧
    (labSem$fp_upd f x).compile = x.compile ∧
    (labSem$fp_upd f x).compile_oracle = x.compile_oracle ∧
    (labSem$fp_upd f x).be = x.be ∧
    (labSem$fp_upd f x).mem = x.mem ∧
    (labSem$fp_upd f x).io_regs = x.io_regs ∧
+   (labSem$fp_upd f x).io_fp_regs = x.io_fp_regs ∧
    (labSem$fp_upd f x).pc = x.pc ∧
    (labSem$fp_upd f x).ffi = x.ffi
 Proof
@@ -448,6 +456,7 @@ Theorem align_dm_const[simp]:
    (align_dm s).ptr2_reg = s.ptr2_reg ∧
    (align_dm s).len2_reg = s.len2_reg ∧
    (align_dm s).io_regs = s.io_regs ∧
+   (align_dm s).io_fp_regs = s.io_fp_regs ∧
    (align_dm s).code_buffer = s.code_buffer ∧
    (align_dm s).compile = s.compile ∧
    (align_dm s).compile_oracle = s.compile_oracle ∧
@@ -876,6 +885,7 @@ Theorem align_sdm_const[simp]:
    (align_sdm s).ptr2_reg = s.ptr2_reg ∧
    (align_sdm s).len2_reg = s.len2_reg ∧
    (align_sdm s).io_regs = s.io_regs ∧
+   (align_sdm s).io_fp_regs = s.io_fp_regs ∧
    (align_sdm s).code_buffer = s.code_buffer ∧
    (align_sdm s).compile = s.compile ∧
    (align_sdm s).compile_oracle = s.compile_oracle ∧

--- a/compiler/backend/semantics/labSemScript.sml
+++ b/compiler/backend/semantics/labSemScript.sml
@@ -369,6 +369,10 @@ Theorem asm_inst_consts:
    ((asm_inst i s).code = s.code) /\
    ((asm_inst i s).clock = s.clock) /\
    ((asm_inst i s).ffi = s.ffi) ∧
+   ((asm_inst i s).io_regs = s.io_regs) ∧
+   ((asm_inst i s).io_fp_regs = s.io_fp_regs) ∧
+   ((asm_inst i s).cc_regs = s.cc_regs) ∧
+   ((asm_inst i s).cc_fp_regs = s.cc_fp_regs) ∧
    ((asm_inst i s).ptr_reg = s.ptr_reg) ∧
    ((asm_inst i s).len_reg = s.len_reg) ∧
    ((asm_inst i s).ptr2_reg = s.ptr2_reg) ∧

--- a/compiler/backend/semantics/labSemScript.sml
+++ b/compiler/backend/semantics/labSemScript.sml
@@ -24,6 +24,12 @@ Datatype:
                   (* oracle: sequence of havoc on registers at each FFI call *)
      ; io_regs    : num (* seq number *) -> ffiname (* ffi name *) -> num (* register *) -> 'a word option
      ; cc_regs    : num -> num -> 'a word option (* same as io_regs but for calling clear cache *)
+                  (* oracles: sequence of havoc on FP registers at each FFI
+                     call / clear-cache call; a SharedMem call consumes an
+                     io_fp_regs position without using it (the machine-level
+                     counter is shared with ExtCall) *)
+     ; io_fp_regs : num (* seq number *) -> num (* FP register *) -> word64
+     ; cc_fp_regs : num -> num -> word64
      ; code       : 'a labLang$prog
      ; compile    : 'c -> 'a labLang$prog -> (word8 list # 'c) option
      ; compile_oracle : num -> 'c # 'a labLang$prog
@@ -507,7 +513,9 @@ Definition evaluate_def:
     | SOME (Asm (ShareMem m r ad) _ _) =>
        (case share_mem_op m r ad s of
         | SOME (FFI_final outcome,s') => (Halt (FFI_outcome outcome),s')
-        | SOME (FFI_return _ _,s') => evaluate (s' with io_regs := shift_seq 1 s'.io_regs)
+        | SOME (FFI_return _ _,s') =>
+            evaluate (s' with <| io_regs := shift_seq 1 s'.io_regs ;
+                                 io_fp_regs := shift_seq 1 s'.io_fp_regs |>)
         | NONE => (Error, s))
     | SOME (LabAsm Halt _ _ _) =>
        (case s.regs s.ptr_reg of
@@ -555,9 +563,11 @@ Definition evaluate_def:
                               ; code_buffer := cb
                               ; code := s.code ++ prog
                               ; cc_regs := shift_seq 1 s.cc_regs
+                              ; cc_fp_regs := shift_seq 1 s.cc_fp_regs
                               ; regs := (s.ptr_reg =+ Loc k 0)
                                           (λa. get_reg_value  (s.cc_regs 0 a)
                                                    (s.regs a) Word)
+                              ; fp_regs := (λn. s.cc_fp_regs 0 n)
                               ; compile_oracle := new_oracle
                               ; clock := s.clock - 1
                               |>)
@@ -578,13 +588,16 @@ Definition evaluate_def:
               | FFI_final outcome => (Halt (FFI_outcome outcome),s)
               | FFI_return new_ffi new_bytes =>
                   let new_io_regs = shift_seq 1 s.io_regs in
+                  let new_io_fp_regs = shift_seq 1 s.io_fp_regs in
                   let new_m = write_bytearray w4 new_bytes s.mem s.mem_domain s.be in
                     evaluate (s with <|
                                    mem := new_m ;
                                    ffi := new_ffi ;
                                    io_regs := new_io_regs ;
+                                   io_fp_regs := new_io_fp_regs ;
                                    regs := (\a. get_reg_value (s.io_regs 0 (ExtCall ffi_index) a)
                                                   (s.regs a) Word);
+                                   fp_regs := (\n. s.io_fp_regs 0 n);
                                    pc := new_pc ;
                                    clock := s.clock - 1 |>))
           | _ => (Error,s))

--- a/compiler/backend/semantics/stackSemScript.sml
+++ b/compiler/backend/semantics/stackSemScript.sml
@@ -911,6 +911,7 @@ Definition evaluate_def:
                 (* This order is convenient because it means all of s.code's entries are preserved *)
                 (* TODO: this might need to be a new field, cc_save_regs *)
                 ; regs := (DRESTRICT s.regs s.ffi_save_regs) |+ (ptr,Loc k 0)
+                ; fp_regs := FEMPTY
                 ; compile_oracle := new_oracle
                 |> in
               (NONE,s')
@@ -953,6 +954,7 @@ Definition evaluate_def:
                   let new_m = write_bytearray w4 new_bytes s.memory s.mdomain s.be in
                     (NONE, s with <| memory := new_m ;
                                      regs := DRESTRICT s.regs s.ffi_save_regs;
+                                     fp_regs := FEMPTY;
                                      ffi := new_ffi |>))
           | _ => (SOME Error,s))
      | res => (SOME Error,s))) /\

--- a/compiler/backend/semantics/targetPropsScript.sml
+++ b/compiler/backend/semantics/targetPropsScript.sml
@@ -631,6 +631,18 @@ Proof
   \\ rpt (CASE_TAC \\ gvs[])
 QED
 
+Theorem target_io_regs_callee_saved:
+  MEM r mc.callee_saved_regs ⇒ target_io_regs mc ffi ms k name r = NONE
+Proof
+  rw[target_io_regs_def] \\ rpt (CASE_TAC \\ gvs[])
+QED
+
+Theorem target_cc_regs_callee_saved:
+  MEM r mc.callee_saved_regs ⇒ target_cc_regs mc ffi ms k r = NONE
+Proof
+  rw[target_cc_regs_def] \\ rpt (CASE_TAC \\ gvs[])
+QED
+
 Theorem next_interference_ExtCall:
   mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
   mc.target.get_pc ms ≠ mc.halt_pc ∧
@@ -668,6 +680,102 @@ Proof
   \\ irule next_interference_intro
   \\ qexists_tac ‘1’
   \\ simp[Once find_next_interference_def, apply_oracle_def]
+QED
+
+Theorem next_interference_MappedRead:
+  mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
+  mc.target.get_pc ms ≠ mc.halt_pc ∧
+  mc.target.get_pc ms ≠ mc.ccache_pc ∧
+  find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME index ∧
+  EL index mc.ffi_names = SharedMem MappedRead ∧
+  ALOOKUP mc.mmio_info index = SOME (nb,Addr r off,reg,pc') ∧
+  (nb = 0w ⇒
+   w2n (mc.target.get_reg ms r + off) MOD (dimindex (:'b) DIV 8) = 0) ∧
+  mc.target.get_reg ms r + off ∈ mc.shared_addresses ∧
+  is_valid_mapped_read (mc.target.get_pc ms) nb (Addr r off) reg pc'
+    mc.target ms mc.prog_addresses ∧
+  call_FFI ffi (EL index mc.ffi_names) [nb]
+    (word_to_bytes (mc.target.get_reg ms r + off) F) =
+    FFI_return new_ffi new_bytes ⇒
+  next_interference (mc:('b,'a,'c) machine_config) ffi ms =
+    SOME (FfiApp index new_bytes ms (mc.ffi_interfer 0 (index,new_bytes,ms)),
+          mc with ffi_interfer := shift_seq 1 mc.ffi_interfer,
+          new_ffi)
+Proof
+  rpt strip_tac
+  \\ irule next_interference_intro
+  \\ qexists_tac ‘1’
+  \\ simp[Once find_next_interference_def, apply_oracle_def]
+  \\ gvs[AC WORD_ADD_COMM WORD_ADD_ASSOC]
+QED
+
+Theorem next_interference_MappedWrite:
+  mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
+  mc.target.get_pc ms ≠ mc.halt_pc ∧
+  mc.target.get_pc ms ≠ mc.ccache_pc ∧
+  find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME index ∧
+  EL index mc.ffi_names = SharedMem MappedWrite ∧
+  ALOOKUP mc.mmio_info index = SOME (nb,Addr r off,reg,pc') ∧
+  (nb = 0w ⇒
+   w2n (mc.target.get_reg ms r + off) MOD (dimindex (:'b) DIV 8) = 0) ∧
+  mc.target.get_reg ms r + off ∈ mc.shared_addresses ∧
+  is_valid_mapped_write (mc.target.get_pc ms) nb (Addr r off) reg pc'
+    mc.target ms mc.prog_addresses ∧
+  call_FFI ffi (EL index mc.ffi_names) [nb]
+    ((let w = mc.target.get_reg ms reg in
+        if nb = 0w then word_to_bytes w F
+        else word_to_bytes_aux (w2n nb) w F) ++
+     word_to_bytes (mc.target.get_reg ms r + off) F) =
+    FFI_return new_ffi new_bytes ⇒
+  next_interference (mc:('b,'a,'c) machine_config) ffi ms =
+    SOME (FfiApp index new_bytes ms (mc.ffi_interfer 0 (index,new_bytes,ms)),
+          mc with ffi_interfer := shift_seq 1 mc.ffi_interfer,
+          new_ffi)
+Proof
+  rpt strip_tac
+  \\ irule next_interference_intro
+  \\ qexists_tac ‘1’
+  \\ simp[Once find_next_interference_def, apply_oracle_def]
+  \\ gvs[AC WORD_ADD_COMM WORD_ADD_ASSOC]
+QED
+
+Theorem next_interference_SharedMem:
+  mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
+  mc.target.get_pc ms ≠ mc.halt_pc ∧
+  mc.target.get_pc ms ≠ mc.ccache_pc ∧
+  find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME index ∧
+  EL index mc.ffi_names = SharedMem op ∧
+  ALOOKUP mc.mmio_info index = SOME (nb,Addr r off,reg,pc') ∧
+  (nb = 0w ⇒
+   w2n (mc.target.get_reg ms r + off) MOD (dimindex (:'b) DIV 8) = 0) ∧
+  mc.target.get_reg ms r + off ∈ mc.shared_addresses ∧
+  (op = MappedRead ⇒
+     is_valid_mapped_read (mc.target.get_pc ms) nb (Addr r off) reg pc'
+       mc.target ms mc.prog_addresses ∧
+     call_FFI ffi (EL index mc.ffi_names) [nb]
+       (word_to_bytes (mc.target.get_reg ms r + off) F) =
+       FFI_return new_ffi new_bytes) ∧
+  (op = MappedWrite ⇒
+     is_valid_mapped_write (mc.target.get_pc ms) nb (Addr r off) reg pc'
+       mc.target ms mc.prog_addresses ∧
+     call_FFI ffi (EL index mc.ffi_names) [nb]
+       ((let w = mc.target.get_reg ms reg in
+           if nb = 0w then word_to_bytes w F
+           else word_to_bytes_aux (w2n nb) w F) ++
+        word_to_bytes (mc.target.get_reg ms r + off) F) =
+       FFI_return new_ffi new_bytes) ⇒
+  next_interference (mc:('b,'a,'c) machine_config) ffi ms =
+    SOME (FfiApp index new_bytes ms (mc.ffi_interfer 0 (index,new_bytes,ms)),
+          mc with ffi_interfer := shift_seq 1 mc.ffi_interfer,
+          new_ffi)
+Proof
+  Cases_on ‘op’ \\ strip_tac
+  >- (gvs[] \\ irule next_interference_MappedRead
+      \\ gvs[AC WORD_ADD_COMM WORD_ADD_ASSOC]
+      \\ metis_tac[])
+  \\ gvs[] \\ irule next_interference_MappedWrite
+  \\ gvs[AC WORD_ADD_COMM WORD_ADD_ASSOC]
+  \\ metis_tac[]
 QED
 
 Theorem evaluate_EQ_evaluate_lemma:
@@ -1215,41 +1323,5 @@ Proof
   \\ strip_tac
   \\ gvs[target_state_rel_def, post_ccache_asm_def]
   \\ rw[] \\ gvs[]
-QED
-
-(* the old packaged conclusions imply the per-call clauses; used to
-   re-discharge verified-environment instantiations (e.g. ag32) *)
-
-Theorem target_state_rel_IMP_ffi_clauses:
-  target_state_rel t
-    (t1 with <|regs := (λa. get_reg_value
-                              (if MEM a cs then NONE else or a)
-                              (t1.regs a) I);
-               mem := m; pc := p|>) ms' ⇒
-  t.state_ok ms' ∧ t.get_pc ms' = p ∧
-  (∀a. a ∈ t1.mem_domain ⇒ t.get_byte ms' a = m a) ∧
-  (∀r. MEM r cs ∧ r < t.config.reg_count ∧ ¬MEM r t.config.avoid_regs ⇒
-       t.get_reg ms' r = t1.regs r)
-Proof
-  rw[target_state_rel_def]
-  \\ first_x_assum (qspec_then ‘r’ mp_tac)
-  \\ simp[get_reg_value_def]
-QED
-
-Theorem target_state_rel_IMP_ccache_clauses:
-  target_state_rel t
-    (t1 with <|regs := (r0 =+ t1.regs r0)
-                 (λa. get_reg_value (if MEM a cs then NONE else or a)
-                        (t1.regs a) I);
-               pc := p|>) ms' ⇒
-  t.state_ok ms' ∧ t.get_pc ms' = p ∧
-  (∀a. a ∈ t1.mem_domain ⇒ t.get_byte ms' a = t1.mem a) ∧
-  (∀r. (MEM r cs ∨ r = r0) ∧ r < t.config.reg_count ∧
-       ¬MEM r t.config.avoid_regs ⇒
-       t.get_reg ms' r = t1.regs r)
-Proof
-  rw[target_state_rel_def]
-  \\ first_x_assum (qspec_then ‘r’ mp_tac)
-  \\ rw[combinTheory.APPLY_UPDATE_THM, get_reg_value_def]
 QED
 

--- a/compiler/backend/semantics/targetPropsScript.sml
+++ b/compiler/backend/semantics/targetPropsScript.sml
@@ -88,6 +88,588 @@ Definition ffi_entry_pcs_disjoint_def:
     DISJOINT (set mc.ffi_entry_pcs) {s1.pc + n2w a | a < len}
 End
 
+(* -- the interference-application trace of a machine run -- *)
+
+Datatype:
+  interference_app =
+      FfiApp num (word8 list) 'state 'state
+    | CcApp ('a word) ('a word) 'state 'state
+End
+
+Definition is_ffi_app_def[simp]:
+  (is_ffi_app (FfiApp index new_bytes ms_pre ms_post) = T) ∧
+  (is_ffi_app (CcApp a1 a2 ms_pre ms_post) = F)
+End
+
+Definition app_post_def[simp]:
+  (app_post (FfiApp index new_bytes ms_pre ms_post) = ms_post) ∧
+  (app_post (CcApp a1 a2 ms_pre ms_post) = ms_post)
+End
+
+(* clocked clone of evaluate that stops at the first interference
+   application (FFI, shared-memory or cache-clear) and returns its data
+   together with the continuation configuration and ffi state *)
+Definition find_next_interference_def:
+  find_next_interference (mc:('b,'a,'c) machine_config) (ffi:'ffi ffi_state) k (ms:'a) =
+    if k = 0n then NONE
+    else
+      if (mc.target.get_pc ms) IN (mc.prog_addresses DIFF (set mc.ffi_entry_pcs)) then
+        if encoded_bytes_in_mem
+            mc.target.config (mc.target.get_pc ms)
+            (mc.target.get_byte ms) mc.prog_addresses then
+          let ms1 = mc.target.next ms in
+          let (ms2,new_oracle) = apply_oracle mc.next_interfer ms1 in
+          let mc = mc with next_interfer := new_oracle in
+            if EVERY mc.target.state_ok [ms;ms1;ms2] ∧
+               (∀x. x ∉ mc.prog_addresses ⇒
+                   mc.target.get_byte ms1 x =
+                   mc.target.get_byte ms x)
+            then
+              find_next_interference mc ffi (k - 1) ms2
+            else NONE
+        else NONE
+      else if mc.target.get_pc ms = mc.halt_pc then NONE
+      else if mc.target.get_pc ms = mc.ccache_pc then
+        let (ms1,new_oracle) =
+          apply_oracle mc.ccache_interfer
+            (mc.target.get_reg ms mc.ptr_reg,
+             mc.target.get_reg ms mc.len_reg,
+             ms) in
+          SOME (CcApp (mc.target.get_reg ms mc.ptr_reg)
+                      (mc.target.get_reg ms mc.len_reg) ms ms1,
+                mc with ccache_interfer := new_oracle, ffi)
+      else
+        case find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 of
+        | NONE => NONE
+        | SOME ffi_index =>
+            (case EL ffi_index mc.ffi_names of
+             | SharedMem op =>
+                 (case ALOOKUP mc.mmio_info ffi_index of
+                  | NONE => NONE
+                  | SOME (nb,a,reg,pc') =>
+                      (case op of
+                         | MappedRead =>
+                             (case a of
+                              | Addr r off =>
+                                  let ad = mc.target.get_reg ms r + off in
+                                    (if (if nb = 0w
+                                         then (w2n ad MOD (dimindex (:'b) DIV 8)) = 0 else T) ∧
+                                        (ad IN mc.shared_addresses) ∧
+                                        is_valid_mapped_read (mc.target.get_pc ms) nb a reg pc'
+                                                             mc.target ms mc.prog_addresses
+                                     then
+                                       (case call_FFI ffi (EL ffi_index mc.ffi_names) [nb]
+                                                      (word_to_bytes ad F) of
+                                        | FFI_final outcome => NONE
+                                        | FFI_return new_ffi new_bytes =>
+                                            let (ms1,new_oracle)
+                                                = apply_oracle mc.ffi_interfer
+                                                               (ffi_index,new_bytes,ms) in
+                                              SOME (FfiApp ffi_index new_bytes ms ms1,
+                                                    mc with ffi_interfer := new_oracle,
+                                                    new_ffi))
+                                     else NONE))
+                         | MappedWrite =>
+                             (case a of
+                              | Addr r off =>
+                                  let ad = (mc.target.get_reg ms r) + off in
+                                    (if (if nb = 0w
+                                         then (w2n ad MOD (dimindex (:'b) DIV 8)) = 0 else T) ∧
+                                        (ad IN mc.shared_addresses) ∧
+                                        is_valid_mapped_write (mc.target.get_pc ms) nb a reg pc'
+                                                              mc.target ms mc.prog_addresses
+                                     then
+                                       (case call_FFI ffi (EL ffi_index mc.ffi_names) [nb]
+                                                      ((let w = mc.target.get_reg ms reg in
+                                                          if nb = 0w then word_to_bytes w F
+                                                          else word_to_bytes_aux (w2n nb) w F)
+                                                       ++ (word_to_bytes ad F)) of
+                                        | FFI_final outcome => NONE
+                                        | FFI_return new_ffi new_bytes =>
+                                            let (ms1,new_oracle)
+                                                = apply_oracle mc.ffi_interfer
+                                                               (ffi_index,new_bytes,ms) in
+                                              SOME (FfiApp ffi_index new_bytes ms ms1,
+                                                    mc with ffi_interfer := new_oracle,
+                                                    new_ffi))
+                                     else NONE))))
+             | ExtCall _ =>
+                 (case ALOOKUP mc.mmio_info ffi_index of
+                  | SOME _ => NONE
+                  | NONE =>
+                      (case read_ffi_bytearrays mc ms of
+                       | (SOME bytes, SOME bytes2) =>
+                           (case call_FFI ffi (EL ffi_index mc.ffi_names) bytes bytes2 of
+                            | FFI_final outcome => NONE
+                            | FFI_return new_ffi new_bytes =>
+                                let (ms1,new_oracle)
+                                    = apply_oracle mc.ffi_interfer
+                                                   (ffi_index,new_bytes,ms) in
+                                  SOME (FfiApp ffi_index new_bytes ms ms1,
+                                        mc with ffi_interfer := new_oracle,
+                                        new_ffi))
+                       | _ => NONE)))
+End
+
+(* the limit of find_next_interference over all clocks *)
+Definition next_interference_def:
+  next_interference mc ffi ms =
+    some res. ∃k. find_next_interference mc ffi k ms = SOME res
+End
+
+(* the sequence of interference applications of a run *)
+Definition interference_app_seq_def:
+  (interference_app_seq mc ffi ms 0 = next_interference mc ffi ms) ∧
+  (interference_app_seq mc ffi ms (SUC n) =
+     case next_interference mc ffi ms of
+     | NONE => NONE
+     | SOME (app,mc',ffi') => interference_app_seq mc' ffi' (app_post app) n)
+End
+
+(* number of applications satisfying P among the first n applications *)
+Definition interference_count_def:
+  (interference_count P mc ffi ms 0 = 0n) ∧
+  (interference_count P mc ffi ms (SUC n) =
+     interference_count P mc ffi ms n +
+     case interference_app_seq mc ffi ms n of
+     | SOME (app,mc',ffi') => if P app then 1 else 0
+     | NONE => 0)
+End
+
+(* position in the application sequence of the k-th application
+   satisfying P *)
+Definition interference_pos_def:
+  interference_pos P mc ffi ms k =
+    some n. interference_count P mc ffi ms n = k ∧
+            ∃app mc' ffi'.
+              interference_app_seq mc ffi ms n = SOME (app,mc',ffi') ∧
+              P app
+End
+
+(* the lab-level oracle sequences, constructed from the machine run:
+   caller-saved register and FP-register residues are read off each
+   application's post state; callee-saved (and avoid / out-of-range)
+   registers are marked NONE, i.e. preserved *)
+Definition target_io_regs_def:
+  target_io_regs mc ffi ms k (name:ffiname) r =
+    case interference_pos is_ffi_app mc ffi ms k of
+    | NONE => NONE
+    | SOME n =>
+      (case interference_app_seq mc ffi ms n of
+       | SOME (FfiApp index new_bytes ms_pre ms_post, mc', ffi') =>
+           (if MEM r mc.callee_saved_regs ∨
+               ¬(r < mc.target.config.reg_count) ∨
+               MEM r mc.target.config.avoid_regs
+            then NONE
+            else SOME (mc.target.get_reg ms_post r))
+       | _ => NONE)
+End
+
+Definition target_io_fp_regs_def:
+  target_io_fp_regs mc ffi ms k (i:num) =
+    case interference_pos is_ffi_app mc ffi ms k of
+    | NONE => (0w:word64)
+    | SOME n =>
+      (case interference_app_seq mc ffi ms n of
+       | SOME (FfiApp index new_bytes ms_pre ms_post, mc', ffi') =>
+           mc.target.get_fp_reg ms_post i
+       | _ => 0w)
+End
+
+Definition target_cc_regs_def:
+  target_cc_regs mc ffi ms k r =
+    case interference_pos (λapp. ¬is_ffi_app app) mc ffi ms k of
+    | NONE => NONE
+    | SOME n =>
+      (case interference_app_seq mc ffi ms n of
+       | SOME (CcApp a1 a2 ms_pre ms_post, mc', ffi') =>
+           (if MEM r mc.callee_saved_regs ∨ r = mc.ptr_reg ∨
+               ¬(r < mc.target.config.reg_count) ∨
+               MEM r mc.target.config.avoid_regs
+            then NONE
+            else SOME (mc.target.get_reg ms_post r))
+       | _ => NONE)
+End
+
+Definition target_cc_fp_regs_def:
+  target_cc_fp_regs mc ffi ms k (i:num) =
+    case interference_pos (λapp. ¬is_ffi_app app) mc ffi ms k of
+    | NONE => (0w:word64)
+    | SOME n =>
+      (case interference_app_seq mc ffi ms n of
+       | SOME (CcApp a1 a2 ms_pre ms_post, mc', ffi') =>
+           mc.target.get_fp_reg ms_post i
+       | _ => 0w)
+End
+
+Theorem find_next_interference_mono:
+  ∀k mc ffi ms res i.
+    find_next_interference mc ffi k ms = SOME res ⇒
+    find_next_interference mc ffi (k + i) ms = SOME res
+Proof
+  Induct
+  >- simp[Once find_next_interference_def]
+  \\ rpt gen_tac
+  \\ once_rewrite_tac [find_next_interference_def]
+  \\ simp[apply_oracle_def]
+  \\ rpt (TOP_CASE_TAC \\ simp[])
+  \\ rw[] \\ fs[ADD_CLAUSES]
+QED
+
+Theorem find_next_interference_unique:
+  find_next_interference mc ffi k1 ms = SOME res1 ∧
+  find_next_interference mc ffi k2 ms = SOME res2 ⇒
+  res1 = res2
+Proof
+  rw[]
+  \\ ‘find_next_interference mc ffi (k1 + k2) ms = SOME res1’
+       by simp[find_next_interference_mono]
+  \\ ‘find_next_interference mc ffi (k2 + k1) ms = SOME res2’
+       by simp[find_next_interference_mono]
+  \\ ‘k2 + k1 = k1 + k2’ by decide_tac
+  \\ gvs[]
+QED
+
+Theorem next_interference_intro:
+  find_next_interference mc ffi k ms = SOME res ⇒
+  next_interference mc ffi ms = SOME res
+Proof
+  rw[next_interference_def]
+  \\ DEEP_INTRO_TAC some_intro
+  \\ rw[]
+  \\ metis_tac[find_next_interference_unique]
+QED
+
+Theorem next_interference_shift:
+  (∀k. find_next_interference mc1 ffi1 (k + l) ms1 =
+       find_next_interference mc2 ffi2 k ms2) ⇒
+  next_interference mc1 ffi1 ms1 = next_interference mc2 ffi2 ms2
+Proof
+  rw[next_interference_def]
+  \\ AP_TERM_TAC
+  \\ simp[FUN_EQ_THM]
+  \\ metis_tac[find_next_interference_mono]
+QED
+
+Theorem find_next_interference_const:
+  ∀k mc ffi ms app mc' ffi'.
+    find_next_interference mc ffi k ms = SOME (app,mc',ffi') ⇒
+    mc'.target = mc.target ∧
+    mc'.callee_saved_regs = mc.callee_saved_regs ∧
+    mc'.ptr_reg = mc.ptr_reg
+Proof
+  Induct
+  >- simp[Once find_next_interference_def]
+  \\ rpt gen_tac
+  \\ once_rewrite_tac [find_next_interference_def]
+  \\ simp[apply_oracle_def]
+  \\ rpt (TOP_CASE_TAC \\ simp[])
+  \\ rw[] \\ res_tac \\ simp[]
+QED
+
+Theorem next_interference_const:
+  next_interference mc ffi ms = SOME (app,mc',ffi') ⇒
+  mc'.target = mc.target ∧
+  mc'.callee_saved_regs = mc.callee_saved_regs ∧
+  mc'.ptr_reg = mc.ptr_reg
+Proof
+  rw[next_interference_def]
+  \\ qpat_x_assum ‘_ = SOME _’ mp_tac
+  \\ DEEP_INTRO_TAC some_intro
+  \\ rw[]
+  \\ metis_tac[find_next_interference_const]
+QED
+
+Theorem interference_app_seq_EQ:
+  next_interference mc1 ffi1 ms1 = next_interference mc2 ffi2 ms2 ⇒
+  ∀n. interference_app_seq mc1 ffi1 ms1 n =
+      interference_app_seq mc2 ffi2 ms2 n
+Proof
+  strip_tac \\ Cases \\ simp[interference_app_seq_def]
+QED
+
+Theorem interference_app_seq_tail:
+  next_interference mc ffi ms = SOME (app,mc',ffi') ⇒
+  ∀n. interference_app_seq mc ffi ms (SUC n) =
+      interference_app_seq mc' ffi' (app_post app) n
+Proof
+  simp[interference_app_seq_def]
+QED
+
+Theorem interference_count_mono:
+  ∀i m. interference_count P mc ffi ms m ≤
+        interference_count P mc ffi ms (m + i)
+Proof
+  Induct >- simp[]
+  \\ gen_tac
+  \\ first_x_assum (qspec_then ‘m’ assume_tac)
+  \\ fs[ADD_CLAUSES, interference_count_def]
+  \\ every_case_tac \\ fs[]
+  \\ qpat_x_assum ‘_ ≤ _’ mp_tac \\ decide_tac
+QED
+
+Theorem interference_count_lt:
+  interference_app_seq mc ffi ms n = SOME (app,mc',ffi') ∧ P app ∧ n < n2 ⇒
+  interference_count P mc ffi ms n < interference_count P mc ffi ms n2
+Proof
+  rw[]
+  \\ ‘interference_count P mc ffi ms (SUC n) =
+      interference_count P mc ffi ms n + 1’ by simp[interference_count_def]
+  \\ ‘∃i. n2 = SUC n + i’ by (qexists_tac ‘n2 - SUC n’ \\ decide_tac)
+  \\ ‘interference_count P mc ffi ms (SUC n) ≤
+      interference_count P mc ffi ms (SUC n + i)’
+        by simp[interference_count_mono]
+  \\ gvs[]
+QED
+
+Theorem interference_pos_unique:
+  interference_app_seq mc ffi ms n1 = SOME (app1,mc1',ffi1') ∧ P app1 ∧
+  interference_app_seq mc ffi ms n2 = SOME (app2,mc2',ffi2') ∧ P app2 ∧
+  interference_count P mc ffi ms n1 = interference_count P mc ffi ms n2 ⇒
+  n1 = n2
+Proof
+  rpt strip_tac
+  \\ CCONTR_TAC
+  \\ ‘n1 < n2 ∨ n2 < n1’ by decide_tac
+  \\ metis_tac[interference_count_lt, prim_recTheory.LESS_REFL]
+QED
+
+Theorem interference_count_tail:
+  next_interference mc ffi ms = SOME (app0,mcc,ffic) ⇒
+  ∀n. interference_count P mc ffi ms (SUC n) =
+      (if P app0 then 1 else 0) +
+      interference_count P mcc ffic (app_post app0) n
+Proof
+  strip_tac \\ Induct
+  >- simp[interference_count_def, interference_app_seq_def]
+  \\ simp[interference_count_def]
+  \\ drule interference_app_seq_tail \\ simp[]
+QED
+
+Theorem interference_pos_head:
+  next_interference mc ffi ms = SOME (app0,mcc,ffic) ∧ P app0 ⇒
+  interference_pos P mc ffi ms 0 = SOME 0
+Proof
+  rw[interference_pos_def]
+  \\ DEEP_INTRO_TAC some_intro
+  \\ rw[]
+  >- (rename1 ‘interference_count P mc ffi ms n = 0’
+      \\ CCONTR_TAC
+      \\ ‘interference_app_seq mc ffi ms 0 = SOME (app0,mcc,ffic)’
+           by simp[interference_app_seq_def]
+      \\ ‘0 < n’ by fs[]
+      \\ drule_all interference_count_lt
+      \\ simp[interference_count_def])
+  \\ qexists_tac ‘0’
+  \\ simp[interference_count_def, interference_app_seq_def]
+  \\ metis_tac[]
+QED
+
+Theorem interference_pos_tail_hit:
+  next_interference mc ffi ms = SOME (app0,mcc,ffic) ∧ P app0 ⇒
+  interference_pos P mc ffi ms (SUC k) =
+  OPTION_MAP SUC (interference_pos P mcc ffic (app_post app0) k)
+Proof
+  strip_tac
+  \\ ‘∀n. interference_app_seq mc ffi ms (SUC n) =
+          interference_app_seq mcc ffic (app_post app0) n’
+       by simp[interference_app_seq_tail]
+  \\ ‘∀n. interference_count P mc ffi ms (SUC n) =
+          1 + interference_count P mcc ffic (app_post app0) n’
+       by (drule interference_count_tail \\ simp[])
+  \\ simp[interference_pos_def]
+  \\ DEEP_INTRO_TAC some_intro \\ rw[]
+  >- (rename1 ‘interference_app_seq mc ffi ms n = SOME _’
+      \\ Cases_on ‘n’
+      >- fs[interference_count_def]
+      \\ rename1 ‘interference_app_seq mc ffi ms (SUC m) = SOME _’
+      \\ gvs[]
+      \\ ‘interference_count P mcc ffic (app_post app0) m = k’ by fs[]
+      \\ DEEP_INTRO_TAC some_intro \\ rw[]
+      >- metis_tac[interference_pos_unique]
+      \\ metis_tac[])
+  \\ DEEP_INTRO_TAC some_intro \\ rw[]
+  \\ rename1 ‘interference_app_seq mcc ffic (app_post app0) m = SOME _’
+  \\ first_x_assum (qspec_then ‘SUC m’ mp_tac)
+  \\ simp[]
+  \\ metis_tac[]
+QED
+
+Theorem interference_pos_tail_miss:
+  next_interference mc ffi ms = SOME (app0,mcc,ffic) ∧ ¬P app0 ⇒
+  interference_pos P mc ffi ms k =
+  OPTION_MAP SUC (interference_pos P mcc ffic (app_post app0) k)
+Proof
+  strip_tac
+  \\ ‘∀n. interference_app_seq mc ffi ms (SUC n) =
+          interference_app_seq mcc ffic (app_post app0) n’
+       by simp[interference_app_seq_tail]
+  \\ ‘∀n. interference_count P mc ffi ms (SUC n) =
+          interference_count P mcc ffic (app_post app0) n’
+       by (drule interference_count_tail \\ simp[])
+  \\ simp[interference_pos_def]
+  \\ DEEP_INTRO_TAC some_intro \\ rw[]
+  >- (rename1 ‘interference_app_seq mc ffi ms n = SOME _’
+      \\ Cases_on ‘n’
+      >- gvs[interference_app_seq_def]
+      \\ rename1 ‘interference_app_seq mc ffi ms (SUC m) = SOME _’
+      \\ gvs[]
+      \\ DEEP_INTRO_TAC some_intro \\ rw[]
+      >- metis_tac[interference_pos_unique]
+      \\ metis_tac[])
+  \\ DEEP_INTRO_TAC some_intro \\ rw[]
+  \\ rename1 ‘interference_app_seq mcc ffic (app_post app0) m = SOME _’
+  \\ first_x_assum (qspec_then ‘SUC m’ mp_tac)
+  \\ simp[]
+  \\ metis_tac[]
+QED
+
+Theorem constructed_oracles_ffi_step:
+  next_interference mc ffi ms =
+    SOME (FfiApp index new_bytes ms_pre ms_post, mc', ffi') ⇒
+  target_io_regs mc ffi ms 0 name r =
+    (if MEM r mc.callee_saved_regs ∨
+        ¬(r < mc.target.config.reg_count) ∨
+        MEM r mc.target.config.avoid_regs
+     then NONE else SOME (mc.target.get_reg ms_post r)) ∧
+  target_io_fp_regs mc ffi ms 0 i = mc.target.get_fp_reg ms_post i ∧
+  target_io_regs mc ffi ms (SUC k) name r =
+    target_io_regs mc' ffi' ms_post k name r ∧
+  target_io_fp_regs mc ffi ms (SUC k) i =
+    target_io_fp_regs mc' ffi' ms_post k i ∧
+  target_cc_regs mc ffi ms k r = target_cc_regs mc' ffi' ms_post k r ∧
+  target_cc_fp_regs mc ffi ms k i = target_cc_fp_regs mc' ffi' ms_post k i
+Proof
+  strip_tac
+  \\ imp_res_tac next_interference_const
+  \\ ‘interference_pos is_ffi_app mc ffi ms 0 = SOME 0’
+       by (drule interference_pos_head \\ simp[])
+  \\ ‘∀k. interference_pos is_ffi_app mc ffi ms (SUC k) =
+          OPTION_MAP SUC (interference_pos is_ffi_app mc' ffi' ms_post k)’
+       by (drule interference_pos_tail_hit \\ simp[])
+  \\ ‘∀k. interference_pos (λapp. ¬is_ffi_app app) mc ffi ms k =
+          OPTION_MAP SUC
+            (interference_pos (λapp. ¬is_ffi_app app) mc' ffi' ms_post k)’
+       by (drule interference_pos_tail_miss \\ simp[])
+  \\ ‘∀n. interference_app_seq mc ffi ms (SUC n) =
+          interference_app_seq mc' ffi' ms_post n’
+       by (drule interference_app_seq_tail \\ simp[])
+  \\ rw[target_io_regs_def, target_io_fp_regs_def, target_cc_regs_def,
+        target_cc_fp_regs_def]
+  \\ simp[Once interference_app_seq_def]
+  \\ rpt (CASE_TAC \\ gvs[])
+QED
+
+Theorem constructed_oracles_cc_step:
+  next_interference mc ffi ms =
+    SOME (CcApp a1 a2 ms_pre ms_post, mc', ffi') ⇒
+  target_cc_regs mc ffi ms 0 r =
+    (if MEM r mc.callee_saved_regs ∨ r = mc.ptr_reg ∨
+        ¬(r < mc.target.config.reg_count) ∨
+        MEM r mc.target.config.avoid_regs
+     then NONE else SOME (mc.target.get_reg ms_post r)) ∧
+  target_cc_fp_regs mc ffi ms 0 i = mc.target.get_fp_reg ms_post i ∧
+  target_cc_regs mc ffi ms (SUC k) r = target_cc_regs mc' ffi' ms_post k r ∧
+  target_cc_fp_regs mc ffi ms (SUC k) i =
+    target_cc_fp_regs mc' ffi' ms_post k i ∧
+  target_io_regs mc ffi ms k name r =
+    target_io_regs mc' ffi' ms_post k name r ∧
+  target_io_fp_regs mc ffi ms k i = target_io_fp_regs mc' ffi' ms_post k i
+Proof
+  strip_tac
+  \\ imp_res_tac next_interference_const
+  \\ ‘interference_pos (λapp. ¬is_ffi_app app) mc ffi ms 0 = SOME 0’
+       by (drule interference_pos_head \\ simp[])
+  \\ ‘∀k. interference_pos (λapp. ¬is_ffi_app app) mc ffi ms (SUC k) =
+          OPTION_MAP SUC
+            (interference_pos (λapp. ¬is_ffi_app app) mc' ffi' ms_post k)’
+       by (drule interference_pos_tail_hit \\ simp[])
+  \\ ‘∀k. interference_pos is_ffi_app mc ffi ms k =
+          OPTION_MAP SUC (interference_pos is_ffi_app mc' ffi' ms_post k)’
+       by (drule interference_pos_tail_miss \\ simp[])
+  \\ ‘∀n. interference_app_seq mc ffi ms (SUC n) =
+          interference_app_seq mc' ffi' ms_post n’
+       by (drule interference_app_seq_tail \\ simp[])
+  \\ rw[target_io_regs_def, target_io_fp_regs_def, target_cc_regs_def,
+        target_cc_fp_regs_def]
+  \\ simp[Once interference_app_seq_def]
+  \\ rpt (CASE_TAC \\ gvs[])
+QED
+
+Theorem interference_count_EQ:
+  next_interference mc1 ffi1 ms1 = next_interference mc2 ffi2 ms2 ⇒
+  ∀n. interference_count P mc1 ffi1 ms1 n =
+      interference_count P mc2 ffi2 ms2 n
+Proof
+  strip_tac \\ Induct
+  \\ simp[interference_count_def]
+  \\ drule interference_app_seq_EQ \\ simp[]
+QED
+
+Theorem constructed_oracles_EQ:
+  next_interference mc1 ffi1 ms1 = next_interference mc2 ffi2 ms2 ∧
+  mc1.target = mc2.target ∧
+  mc1.callee_saved_regs = mc2.callee_saved_regs ∧
+  mc1.ptr_reg = mc2.ptr_reg ⇒
+  target_io_regs mc1 ffi1 ms1 = target_io_regs mc2 ffi2 ms2 ∧
+  target_io_fp_regs mc1 ffi1 ms1 = target_io_fp_regs mc2 ffi2 ms2 ∧
+  target_cc_regs mc1 ffi1 ms1 = target_cc_regs mc2 ffi2 ms2 ∧
+  target_cc_fp_regs mc1 ffi1 ms1 = target_cc_fp_regs mc2 ffi2 ms2
+Proof
+  strip_tac
+  \\ ‘∀n. interference_app_seq mc1 ffi1 ms1 n =
+          interference_app_seq mc2 ffi2 ms2 n’
+       by simp[interference_app_seq_EQ]
+  \\ ‘∀P n. interference_count P mc1 ffi1 ms1 n =
+            interference_count P mc2 ffi2 ms2 n’
+       by simp[interference_count_EQ]
+  \\ ‘∀P k. interference_pos P mc1 ffi1 ms1 k =
+            interference_pos P mc2 ffi2 ms2 k’
+       by (rw[interference_pos_def] \\ AP_TERM_TAC \\ simp[FUN_EQ_THM])
+  \\ rw[FUN_EQ_THM, target_io_regs_def, target_io_fp_regs_def,
+        target_cc_regs_def, target_cc_fp_regs_def]
+  \\ rpt (CASE_TAC \\ gvs[])
+QED
+
+Theorem next_interference_ExtCall:
+  mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
+  mc.target.get_pc ms ≠ mc.halt_pc ∧
+  mc.target.get_pc ms ≠ mc.ccache_pc ∧
+  find_index (mc.target.get_pc ms) mc.ffi_entry_pcs 0 = SOME index ∧
+  EL index mc.ffi_names = ExtCall name ∧
+  ALOOKUP mc.mmio_info index = NONE ∧
+  read_ffi_bytearrays mc ms = (SOME bytes, SOME bytes2) ∧
+  call_FFI ffi (ExtCall name) bytes bytes2 = FFI_return new_ffi new_bytes ⇒
+  next_interference mc ffi ms =
+    SOME (FfiApp index new_bytes ms (mc.ffi_interfer 0 (index,new_bytes,ms)),
+          mc with ffi_interfer := shift_seq 1 mc.ffi_interfer,
+          new_ffi)
+Proof
+  rw[]
+  \\ irule next_interference_intro
+  \\ qexists_tac ‘1’
+  \\ simp[Once find_next_interference_def, apply_oracle_def]
+QED
+
+Theorem next_interference_ccache:
+  mc.target.get_pc ms ∉ mc.prog_addresses DIFF set mc.ffi_entry_pcs ∧
+  mc.target.get_pc ms ≠ mc.halt_pc ∧
+  mc.target.get_pc ms = mc.ccache_pc ⇒
+  next_interference mc ffi ms =
+    SOME (CcApp (mc.target.get_reg ms mc.ptr_reg)
+                (mc.target.get_reg ms mc.len_reg) ms
+                (mc.ccache_interfer 0
+                   (mc.target.get_reg ms mc.ptr_reg,
+                    mc.target.get_reg ms mc.len_reg, ms)),
+          mc with ccache_interfer := shift_seq 1 mc.ccache_interfer,
+          ffi)
+Proof
+  rw[]
+  \\ irule next_interference_intro
+  \\ qexists_tac ‘1’
+  \\ simp[Once find_next_interference_def, apply_oracle_def]
+QED
+
 Theorem evaluate_EQ_evaluate_lemma:
   !n ms1 c.
       c.target.get_pc ms1 IN (c.prog_addresses DIFF (set c.ffi_entry_pcs)) /\
@@ -118,12 +700,15 @@ Theorem evaluate_EQ_evaluate_lemma:
       ?ms2.
         !k. (evaluate c io (k + (n + 1)) ms1 =
              evaluate (shift_interfer (n+1) c) io k ms2) /\
+            (find_next_interference c io (k + (n + 1)) ms1 =
+             find_next_interference (shift_interfer (n+1) c) io k ms2) /\
             target_state_rel c.target s2 ms2
 Proof
   Induct THEN1
    (full_simp_tac(srw_ss())[] \\ REPEAT STRIP_TAC
     \\ full_simp_tac(srw_ss())[asserts_def,LET_DEF]
-    \\ SIMP_TAC std_ss [Once evaluate_def] \\ full_simp_tac(srw_ss())[LET_DEF]
+    \\ SIMP_TAC std_ss [Once evaluate_def, Once find_next_interference_def]
+    \\ full_simp_tac(srw_ss())[LET_DEF]
     \\ FIRST_X_ASSUM (MP_TAC o Q.SPEC `K (c.next_interfer 0)`)
     \\ full_simp_tac(srw_ss())[interference_ok_def] \\ RES_TAC \\ full_simp_tac(srw_ss())[]
     \\ REPEAT STRIP_TAC \\ RES_TAC \\ full_simp_tac(srw_ss())[shift_interfer_def,apply_oracle_def]
@@ -147,7 +732,8 @@ Proof
     \\ METIS_TAC [])
   \\ REPEAT STRIP_TAC \\ full_simp_tac(srw_ss())[]
   \\ full_simp_tac(srw_ss())[arithmeticTheory.ADD_CLAUSES]
-  \\ SIMP_TAC std_ss [Once evaluate_def] \\ full_simp_tac(srw_ss())[ADD1] \\ full_simp_tac(srw_ss())[LET_DEF]
+  \\ SIMP_TAC std_ss [Once evaluate_def, Once find_next_interference_def]
+  \\ full_simp_tac(srw_ss())[ADD1] \\ full_simp_tac(srw_ss())[LET_DEF]
   \\ Q.PAT_ASSUM `!i. bbb`(qspec_then`λi. c.next_interfer 0`mp_tac)
   \\ MATCH_MP_TAC IMP_IMP \\ STRIP_TAC THEN1 (full_simp_tac(srw_ss())[interference_ok_def])
   \\ full_simp_tac(srw_ss())[]
@@ -243,20 +829,23 @@ Proof
   METIS_TAC [listTheory.LENGTH_NIL,enc_ok_def]
 QED
 
-Theorem asm_step_IMP_evaluate_step = Q.prove(`
-  !c s1 ms1 io i s2.
+Theorem asm_step_IMP_evaluate_step_find_next:
+  !c s1 ms1 io i.
       encoder_correct c.target /\
       (c.prog_addresses = s1.mem_domain) /\
       ffi_entry_pcs_disjoint c s1 (LENGTH $ c.target.config.encode i) /\
       interference_ok c.next_interfer (c.target.proj s1.mem_domain) /\
-      asm_step c.target.config s1 i s2 /\
-      (* NOTE: Don't delete the following line although it is redundant,
-      * it is useful to simplify the lemma after SIMP_RULE *)
-      (s2 = asm i (s1.pc + n2w (LENGTH (c.target.config.encode i))) s1) /\
+      asm_step c.target.config s1 i
+        (asm i (s1.pc + n2w (LENGTH (c.target.config.encode i))) s1) /\
       target_state_rel c.target (s1:'a asm_state) (ms1:'state) ==>
       ?l ms2. !k. (evaluate c io (k + l) ms1 =
                    evaluate (shift_interfer l c) io k ms2) /\
-                  target_state_rel c.target s2 ms2 /\ l <> 0`,
+                  (find_next_interference c io (k + l) ms1 =
+                   find_next_interference (shift_interfer l c) io k ms2) /\
+                  target_state_rel c.target
+                    (asm i (s1.pc + n2w (LENGTH (c.target.config.encode i))) s1)
+                    ms2 /\ l <> 0
+Proof
   fs[encoder_correct_def,target_ok_def,LET_DEF,ffi_entry_pcs_disjoint_def]
   \\ rw[]
   \\ first_x_assum drule
@@ -335,8 +924,31 @@ Theorem asm_step_IMP_evaluate_step = Q.prove(`
     irule bytes_in_memory_DIFF
     \\ qexistsl [`s1.mem_domain`, `set c.ffi_entry_pcs`]
     \\ gvs[]
-  ))
-  |> SIMP_RULE std_ss [GSYM PULL_FORALL];
+  )
+QED
+
+Theorem asm_step_IMP_evaluate_step:
+  !c s1 ms1 io i.
+      encoder_correct c.target /\
+      (c.prog_addresses = s1.mem_domain) /\
+      ffi_entry_pcs_disjoint c s1 (LENGTH $ c.target.config.encode i) /\
+      interference_ok c.next_interfer (c.target.proj s1.mem_domain) /\
+      asm_step c.target.config s1 i
+        (asm i (s1.pc + n2w (LENGTH (c.target.config.encode i))) s1) /\
+      target_state_rel c.target (s1:'a asm_state) (ms1:'state) ==>
+      ?l ms2.
+        (!k. evaluate c io (k + l) ms1 =
+             evaluate (shift_interfer l c) io k ms2) /\
+        target_state_rel c.target
+          (asm i (s1.pc + n2w (LENGTH (c.target.config.encode i))) s1) ms2 /\
+        l <> 0
+Proof
+  rpt strip_tac
+  \\ drule_all asm_step_IMP_evaluate_step_find_next
+  \\ disch_then (qspec_then ‘io’ strip_assume_tac)
+  \\ qexistsl_tac [‘l’,‘ms2’]
+  \\ metis_tac[]
+QED
 
 (* basic properties *)
 
@@ -554,5 +1166,90 @@ Proof
   \\ disch_then drule
   \\ rw[GSYM FUNPOW_ADD]
   \\ asm_exists_tac \\ rw[]
+QED
+
+(* -- interface lemmas for the interference contracts -- *)
+
+Theorem ffi_interfer_ok_post_ffi_asm:
+  ffi_interfer_ok pc mc_conf ∧
+  index < LENGTH mc_conf.ffi_names ∧
+  mmio_pcs_min_index mc_conf.ffi_names = SOME i ∧
+  index < i ∧
+  mc_conf.prog_addresses = t1.mem_domain ∧
+  read_ffi_bytearrays mc_conf ms2 = (SOME bytes, SOME bytes2) ∧
+  LENGTH new_bytes = LENGTH bytes2 ∧
+  (EL index mc_conf.ffi_names = ExtCall «» ⇒ new_bytes = bytes2) ∧
+  target_state_rel mc_conf.target
+    (t1 with pc := -n2w ((3 + index) * ffi_offset) + pc) ms2 ∧
+  aligned mc_conf.target.config.code_alignment
+    (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n))
+  ⇒
+  target_state_rel mc_conf.target
+    (post_ffi_asm mc_conf t1 new_bytes
+       (mc_conf.ffi_interfer k (index,new_bytes,ms2)))
+    (mc_conf.ffi_interfer k (index,new_bytes,ms2))
+Proof
+  rw[ffi_interfer_ok_def]
+  \\ first_x_assum (qspecl_then
+       [‘ms2’,‘k’,‘index’,‘new_bytes’,‘t1’,‘bytes’,‘bytes2’,‘i’] mp_tac)
+  \\ simp[]
+  \\ strip_tac
+  \\ gvs[target_state_rel_def, post_ffi_asm_def]
+  \\ rw[] \\ gvs[]
+QED
+
+Theorem ccache_interfer_ok_post_ccache_asm:
+  ccache_interfer_ok pc mc_conf ∧
+  target_state_rel mc_conf.target
+    (t1 with pc := -n2w (2 * ffi_offset) + pc) ms2 ∧
+  aligned mc_conf.target.config.code_alignment
+    (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n))
+  ⇒
+  target_state_rel mc_conf.target
+    (post_ccache_asm mc_conf t1 (mc_conf.ccache_interfer k (a1,a2,ms2)))
+    (mc_conf.ccache_interfer k (a1,a2,ms2))
+Proof
+  rw[ccache_interfer_ok_def]
+  \\ first_x_assum (qspecl_then [‘ms2’,‘t1’,‘k’,‘a1’,‘a2’] mp_tac)
+  \\ simp[]
+  \\ strip_tac
+  \\ gvs[target_state_rel_def, post_ccache_asm_def]
+  \\ rw[] \\ gvs[]
+QED
+
+(* the old packaged conclusions imply the per-call clauses; used to
+   re-discharge verified-environment instantiations (e.g. ag32) *)
+
+Theorem target_state_rel_IMP_ffi_clauses:
+  target_state_rel t
+    (t1 with <|regs := (λa. get_reg_value
+                              (if MEM a cs then NONE else or a)
+                              (t1.regs a) I);
+               mem := m; pc := p|>) ms' ⇒
+  t.state_ok ms' ∧ t.get_pc ms' = p ∧
+  (∀a. a ∈ t1.mem_domain ⇒ t.get_byte ms' a = m a) ∧
+  (∀r. MEM r cs ∧ r < t.config.reg_count ∧ ¬MEM r t.config.avoid_regs ⇒
+       t.get_reg ms' r = t1.regs r)
+Proof
+  rw[target_state_rel_def]
+  \\ first_x_assum (qspec_then ‘r’ mp_tac)
+  \\ simp[get_reg_value_def]
+QED
+
+Theorem target_state_rel_IMP_ccache_clauses:
+  target_state_rel t
+    (t1 with <|regs := (r0 =+ t1.regs r0)
+                 (λa. get_reg_value (if MEM a cs then NONE else or a)
+                        (t1.regs a) I);
+               pc := p|>) ms' ⇒
+  t.state_ok ms' ∧ t.get_pc ms' = p ∧
+  (∀a. a ∈ t1.mem_domain ⇒ t.get_byte ms' a = t1.mem a) ∧
+  (∀r. (MEM r cs ∨ r = r0) ∧ r < t.config.reg_count ∧
+       ¬MEM r t.config.avoid_regs ⇒
+       t.get_reg ms' r = t1.regs r)
+Proof
+  rw[target_state_rel_def]
+  \\ first_x_assum (qspec_then ‘r’ mp_tac)
+  \\ rw[combinTheory.APPLY_UPDATE_THM, get_reg_value_def]
 QED
 

--- a/compiler/backend/semantics/targetSemScript.sml
+++ b/compiler/backend/semantics/targetSemScript.sml
@@ -307,9 +307,15 @@ Definition start_pc_ok_def:
 End
 
 (* ffi_interfer_ok: the FFI interference oracle is ok:
-   target_state_rel is preserved for any FFI behaviour *)
+   an ExtCall transition must satisfy the per-call promises of the
+   calling convention -- the machine invariants hold, control returns
+   to the link-register address, the byte array is written and no other
+   program memory changes, and callee-saved registers are preserved;
+   all other registers (including all FP registers) are unconstrained.
+   A SharedMem transition performs the mapped load/store and touches
+   nothing else. *)
 Definition ffi_interfer_ok_def:
-  ffi_interfer_ok pc io_regs mc_conf ⇔
+  ffi_interfer_ok pc mc_conf ⇔
     (∀ms2 k index new_bytes t1 bytes bytes2 i.
        index < LENGTH mc_conf.ffi_names ∧
        mmio_pcs_min_index mc_conf.ffi_names = SOME i /\
@@ -323,17 +329,18 @@ Definition ffi_interfer_ok_def:
            aligned mc_conf.target.config.code_alignment
             (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n))
         ⇒
-        target_state_rel mc_conf.target
-            (t1 with
-             <|regs :=
-                (λa.
-                 get_reg_value
-                   (if MEM a mc_conf.callee_saved_regs then NONE else io_regs k (EL index mc_conf.ffi_names) a)
-                   (t1.regs a) I);
-               mem := asm_write_bytearray (t1.regs mc_conf.ptr2_reg) new_bytes t1.mem;
-               pc := t1.regs (case mc_conf.target.config.link_reg of NONE => 0
-                      | SOME n => n)|>)
-            (mc_conf.ffi_interfer k (index,new_bytes,ms2))) /\
+        (let ms' = mc_conf.ffi_interfer k (index,new_bytes,ms2) in
+           mc_conf.target.state_ok ms' ∧
+           mc_conf.target.get_pc ms' =
+             t1.regs (case mc_conf.target.config.link_reg of NONE => 0
+                      | SOME n => n) ∧
+           (∀a. a ∈ t1.mem_domain ⇒
+                mc_conf.target.get_byte ms' a =
+                asm_write_bytearray (t1.regs mc_conf.ptr2_reg) new_bytes t1.mem a) ∧
+           (∀r. MEM r mc_conf.callee_saved_regs ∧
+                r < mc_conf.target.config.reg_count ∧
+                ¬MEM r mc_conf.target.config.avoid_regs ⇒
+                mc_conf.target.get_reg ms' r = t1.regs r))) /\
          (i <= index /\
            target_state_rel mc_conf.target
             (t1 with pc := EL index mc_conf.ffi_entry_pcs) ms2 ==>
@@ -358,25 +365,61 @@ Definition ffi_interfer_ok_def:
                  (mc_conf.ffi_interfer k (index,new_bytes,ms2))))))
 End
 
+(* ccache_interfer_ok: a cache-clear transition must satisfy the same
+   per-call promises, additionally preserving ptr_reg and leaving all
+   program memory unchanged *)
 Definition ccache_interfer_ok_def:
-  ccache_interfer_ok pc cc_regs mc_conf ⇔
+  ccache_interfer_ok pc mc_conf ⇔
     (!ms2 t1 k a1 a2.
        target_state_rel mc_conf.target
          (t1 with
           pc := -n2w (2 * ffi_offset) + pc)
        ms2 /\
        aligned mc_conf.target.config.code_alignment (t1.regs (case mc_conf.target.config.link_reg of NONE => 0 | SOME n => n)) ==>
-       target_state_rel mc_conf.target
-        (t1 with
-         <|regs :=
-            (mc_conf.ptr_reg =+ t1.regs mc_conf.ptr_reg)
-            (\a.
-             get_reg_value
-               (if MEM a mc_conf.callee_saved_regs then NONE else cc_regs k a)
-               (t1.regs a) I);
-           pc := t1.regs (case mc_conf.target.config.link_reg of NONE => 0
-                  | SOME n => n) |> )
-        (mc_conf.ccache_interfer k (a1,a2,ms2)))
+       (let ms' = mc_conf.ccache_interfer k (a1,a2,ms2) in
+          mc_conf.target.state_ok ms' ∧
+          mc_conf.target.get_pc ms' =
+            t1.regs (case mc_conf.target.config.link_reg of NONE => 0
+                     | SOME n => n) ∧
+          (∀a. a ∈ t1.mem_domain ⇒
+               mc_conf.target.get_byte ms' a = t1.mem a) ∧
+          (∀r. (MEM r mc_conf.callee_saved_regs ∨ r = mc_conf.ptr_reg) ∧
+               r < mc_conf.target.config.reg_count ∧
+               ¬MEM r mc_conf.target.config.avoid_regs ⇒
+               mc_conf.target.get_reg ms' r = t1.regs r)))
+End
+
+(* post_ffi_asm / post_ccache_asm: the canonical asm-level successor
+   state after an FFI / cache-clear transition -- caller-saved
+   registers and all FP registers are taken from the machine state *)
+Definition post_ffi_asm_def:
+  post_ffi_asm (mc_conf:('a,'state,'b) machine_config) (t1:'a asm_state)
+               new_bytes (ms':'state) =
+    t1 with
+      <|regs := (λa. if MEM a mc_conf.callee_saved_regs ∨
+                        ¬(a < mc_conf.target.config.reg_count) ∨
+                        MEM a mc_conf.target.config.avoid_regs
+                     then t1.regs a
+                     else mc_conf.target.get_reg ms' a);
+        fp_regs := (λi. mc_conf.target.get_fp_reg ms' i);
+        mem := asm_write_bytearray (t1.regs mc_conf.ptr2_reg) new_bytes t1.mem;
+        pc := t1.regs (case mc_conf.target.config.link_reg of NONE => 0
+                       | SOME n => n)|>
+End
+
+Definition post_ccache_asm_def:
+  post_ccache_asm (mc_conf:('a,'state,'b) machine_config) (t1:'a asm_state)
+                  (ms':'state) =
+    t1 with
+      <|regs := (λa. if MEM a mc_conf.callee_saved_regs ∨
+                        a = mc_conf.ptr_reg ∨
+                        ¬(a < mc_conf.target.config.reg_count) ∨
+                        MEM a mc_conf.target.config.avoid_regs
+                     then t1.regs a
+                     else mc_conf.target.get_reg ms' a);
+        fp_regs := (λi. mc_conf.target.get_fp_reg ms' i);
+        pc := t1.regs (case mc_conf.target.config.link_reg of NONE => 0
+                       | SOME n => n)|>
 End
 
 (*
@@ -384,7 +427,7 @@ End
     intermediate invariant describing how
     code (bytes) and ffi is installed in the machine (mc_conf, ms)
     using labLang (m, dm, cbspace) and
-    target semantics (t, io_regs, cc_regs) information as an intermediary
+    target semantics (t) information as an intermediary
   these are all destined to be assumptions on the top-level correctness theorem
 *)
 
@@ -393,7 +436,6 @@ Definition good_init_state_def:
     (mc_conf: ('a,'state,'b) machine_config) ms bytes
     cbspace
     t m dm sdm
-    io_regs cc_regs
     <=>
     target_state_rel mc_conf.target t ms /\
     target_configured t mc_conf ∧
@@ -404,8 +446,8 @@ Definition good_init_state_def:
     (n2w (2 ** t.align - 1) && t.pc) = 0w /\
 
     interference_ok mc_conf.next_interfer (mc_conf.target.proj mc_conf.prog_addresses) /\
-    ffi_interfer_ok t.pc io_regs mc_conf ∧
-    ccache_interfer_ok t.pc cc_regs mc_conf ∧
+    ffi_interfer_ok t.pc mc_conf ∧
+    ccache_interfer_ok t.pc mc_conf ∧
 
     (* code memory relation *)
     code_loaded bytes mc_conf ms /\
@@ -434,9 +476,9 @@ End
 *)
 Definition installed_def:
   installed bytes cbspace bitmaps data_sp ffi_names (r1,r2) (mc_conf:('a,'state,'b) machine_config) shmem_extra ms ⇔
-    ∃t m io_regs cc_regs bitmap_ptr bitmaps_dm sdm.
+    ∃t m bitmap_ptr bitmaps_dm sdm.
       let heap_stack_dm = { w | t.regs r1 <=+ w ∧ w <+ t.regs r2 } in
-      good_init_state mc_conf ms bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) sdm io_regs cc_regs ∧
+      good_init_state mc_conf ms bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) sdm ∧
       byte_aligned (t.regs r1) /\
       byte_aligned (t.regs r2) /\
       byte_aligned bitmap_ptr /\

--- a/compiler/backend/semantics/wordSemScript.sml
+++ b/compiler/backend/semantics/wordSemScript.sml
@@ -1136,6 +1136,7 @@ Definition evaluate_def:
                 ; code := union s.code (fromAList progs)
                 (* This order is convenient because it means all of s.code's entries are preserved *)
                 ; locals := insert ptr (Loc k 0) env
+                ; fp_regs := FEMPTY
                 ; compile_oracle := new_oracle
                 ; stack_max := NONE (* Install is not safe for space *)
                 ; stack_size := LN
@@ -1180,6 +1181,7 @@ Definition evaluate_def:
                 let new_m = write_bytearray w4 new_bytes s.memory s.mdomain s.be in
                   (NONE, s with <| memory := new_m ;
                                    locals := env ;
+                                   fp_regs := FEMPTY;
                                    ffi := new_ffi |>))
           | _ => (SOME Error,s)))
     | res => (SOME Error,s)) /\

--- a/developers/changes-since-release.md
+++ b/developers/changes-since-release.md
@@ -46,6 +46,10 @@ BVI now supports multi-arg calls/returns (with a separate constructor).
 
 Thunks can now be inlined by the GC (#1440).
 
+### targetSem
+
+targetSem is now more lax about the FFI/clear-cache havocs (#1458)
+
 ## Pancake
 
 ## Candle

--- a/examples/opentheory/compilation/ag32/README.md
+++ b/examples/opentheory/compilation/ag32/README.md
@@ -4,6 +4,6 @@ Compilation of the OpenTheory article checker to the Silver ISA.
 End-to-end correctness proofs that relate the OpenTheory article
 checker to the behaviour of the Silver machine code.
 
-[readerCompileScript.sml](readerCompileScript.sml):
+[readerCompile_ag32Script.sml](readerCompile_ag32Script.sml):
 In-logic compilation of the OpenTheory article checker to the
 Silver ISA.

--- a/examples/opentheory/compilation/ag32/proofs/README.md
+++ b/examples/opentheory/compilation/ag32/proofs/README.md
@@ -1,7 +1,7 @@
 End-to-end correctness proofs that relate the OpenTheory article
 checker to the behaviour of the Silver machine code.
 
-[readerProgProofScript.sml](readerProgProofScript.sml):
+[readerProgProof_ag32Script.sml](readerProgProof_ag32Script.sml):
 End-to-end correctness theorem for the OpenTheory article
 checker. The theorem reaches the next-state function of the
 verified hardware platform called Silver.

--- a/pancake/proofs/pan_to_targetProofScript.sml
+++ b/pancake/proofs/pan_to_targetProofScript.sml
@@ -289,10 +289,10 @@ QED
 
 Definition pan_installed_def:
   pan_installed bytes cbspace bitmaps data_sp ffi_names (r1,r2) (mc_conf:('a,'state,'b) machine_config) shmem_extra ms p_mem p_dom sdm' ⇔
-  ∃t m io_regs cc_regs bitmap_ptr bitmaps_dm sdm.
+  ∃t m bitmap_ptr bitmaps_dm sdm.
   let heap_stack_dm = { w | t.regs r1 <=+ w ∧ w <+ t.regs r2 } in
     (∀a. a ∈ p_dom ⇒ m a = p_mem a) ∧
-    good_init_state mc_conf ms bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) sdm io_regs cc_regs ∧ sdm' = sdm ∩ byte_aligned ∧
+    good_init_state mc_conf ms bytes cbspace t m (heap_stack_dm ∪ bitmaps_dm) sdm ∧ sdm' = sdm ∩ byte_aligned ∧
     byte_aligned (t.regs r1) /\
 
     byte_aligned (t.regs r2) /\
@@ -1478,7 +1478,9 @@ Proof
    (case mc.target.config.link_reg of NONE => 0 | SOME n => n) =
    labst.link_reg ∧ ¬labst.failed’
     by (gs[Abbr ‘labst’, Abbr ‘sp’,
-           lab_to_targetProofTheory.make_init_def]>>
+           lab_to_targetProofTheory.make_init_def,
+           targetPropsTheory.target_io_regs_callee_saved,
+           targetPropsTheory.target_cc_regs_callee_saved]>>
         gs[Abbr ‘lorac’]>>
         drule backendProofTheory.byte_aligned_MOD>>gs[]>>
         strip_tac>>
@@ -2170,7 +2172,7 @@ Proof
           rewrite_tac[lab_to_targetProofTheory.make_init_def]>>simp[]>>
           gs[wordSemTheory.theWord_def]>>
           gs[set_sepTheory.fun2set_eq]>>
-          qpat_x_assum ‘good_init_state _ _ _ _ _ _ _ _ _ _’ mp_tac >>
+          qpat_x_assum ‘good_init_state _ _ _ _ _ _ _ _’ mp_tac >>
           simp[targetSemTheory.good_init_state_def] >>
           ‘byte_aligned a’
             by(gs[stack_removeProofTheory.addresses_thm] >>


### PR DESCRIPTION
This changes `installed` to underspecify FP regs and non-callee-saved registers (they were prescribed too strictly before).