### PR TITLE
Variable length shifts for Pancake

### DIFF
--- a/compiler/bootstrap/translation/from_pancake32ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake32ProgScript.sml
@@ -513,8 +513,6 @@ val res = translate kw_def;
 
 val res = translate $ spec32 isSubOp_def;
 
-val res = translate $ preprocess $ spec32 conv_Shift_def;
-
 val res = translate $ conv_panop_def;
 
 

--- a/compiler/bootstrap/translation/from_pancake64ProgScript.sml
+++ b/compiler/bootstrap/translation/from_pancake64ProgScript.sml
@@ -520,8 +520,6 @@ val res = translate kw_def;
 
 val res = translate $ spec64 isSubOp_def;
 
-val res = translate $ preprocess $ spec64 conv_Shift_def;
-
 val res = translate $ conv_panop_def;
 
 

--- a/developers/changes-since-release.md
+++ b/developers/changes-since-release.md
@@ -52,6 +52,12 @@ targetSem is now more lax about the FFI/clear-cache havocs (#1458)
 
 ## Pancake
 
+A parser bug related to field accesses has been fixed (#1438).
+
+Exeception syntax has been improved (#1450)
+
+Variable length shifts are now supported (#1460).
+
 ## Candle
 
 ### Parser

--- a/pancake/NEWS.md
+++ b/pancake/NEWS.md
@@ -5,6 +5,19 @@ User-facing changes to the Pancake language and compiler are
 documented here when they are merged into `master`.
 
 
+Aug 20th 2026
+-------------------
+
+### Variable length shifts
+
+Pancake now supports variable length shifts.
+
+    fun 1 f() {
+      var a = 1 + 1 << 2;    // previously, the RHS of << only admitted numerical constants
+      a = 1 + 1 << a;        // this is now permitted
+      return 1 + 1 << a + 3; // shift lengths can be arbitrary expressions, so this too is permitted
+    }
+
 Aug 18th 2026
 -------------------
 

--- a/pancake/crepLangScript.sml
+++ b/pancake/crepLangScript.sml
@@ -34,7 +34,7 @@ Datatype:
       | Op binop (exp list)
       | Crepop crepop (exp list)
       | Cmp cmp exp exp
-      | Shift shift exp num
+      | Shift shift exp exp
       | BaseAddr
       | TopAddr
 End
@@ -135,7 +135,7 @@ Definition var_cexp_def:
   (var_cexp (Op bop es) = FLAT (MAP var_cexp es)) ∧
   (var_cexp (Crepop cop es) = FLAT (MAP var_cexp es)) ∧
   (var_cexp (Cmp c e1 e2) = var_cexp e1 ++ var_cexp e2) ∧
-  (var_cexp (Shift sh e num) = var_cexp e) ∧
+  (var_cexp (Shift sh e1 e2) = var_cexp e1 ++ var_cexp e2) ∧
   (var_cexp BaseAddr = []) ∧
   (var_cexp TopAddrl = [])
 Termination
@@ -206,7 +206,7 @@ Definition exps_def:
   (exps (Op bop es) = FLAT (MAP exps es)) ∧
   (exps (Crepop pop es) = FLAT (MAP exps es)) ∧
   (exps (Cmp c e1 e2) = exps e1 ++ exps e2) ∧
-  (exps (Shift sh e num) = exps e) ∧
+  (exps (Shift sh e1 e2) = exps e1 ++ exps e2) ∧
   (exps BaseAddr = [BaseAddr]) ∧
   (exps TopAddr = [TopAddr])
 Termination

--- a/pancake/crep_arithScript.sml
+++ b/pancake/crep_arithScript.sml
@@ -52,7 +52,7 @@ Definition mul_const_def:
     else if c = 1w then exp
     else (case dest_2exp 0n c of
       | NONE => Crepop Mul [exp; Const c]
-      | SOME i => Shift Lsl exp i
+      | SOME i => Shift Lsl exp (Const (n2w i))
     )
 End
 
@@ -74,7 +74,7 @@ Definition simp_exp_def:
   simp_exp (Load exp) = Load (simp_exp exp) /\
   simp_exp (Op bop exps) = Op bop (MAP simp_exp exps) /\
   simp_exp (Cmp cmp exp1 exp2) = Cmp cmp (simp_exp exp1) (simp_exp exp2) /\
-  simp_exp (Shift s exp n) = Shift s (simp_exp exp) n /\
+  simp_exp (Shift s exp1 exp2) = Shift s (simp_exp exp1) (simp_exp exp2) /\
   simp_exp exp = exp
 Termination
   WF_REL_TAC `measure (exp_size (K 0))`

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -78,7 +78,7 @@ Definition compile_exp_def:
   (compile_exp ctxt tmp l (Shift sh e e') =
    let (p, le, tmp, l) = compile_exp ctxt tmp l e in
    let (p', le', tmp', l) = compile_exp ctxt tmp l e' in
-     (p', Shift sh le le', tmp', l)) /\
+     (p ++ p', Shift sh le le', tmp', l)) /\
   (compile_exps ctxt tmp l cps = (* to generate ind thm *)
    case cps of
    | [] => ([], [], tmp, l)

--- a/pancake/crep_to_loopScript.sml
+++ b/pancake/crep_to_loopScript.sml
@@ -75,9 +75,10 @@ Definition compile_exp_def:
    let (p', le', tmp', l) = compile_exp ctxt tmp l e' in
      (prog_if cmp p p' le le' (tmp' + 1) (tmp' + 2) l, Var (tmp' + 1), tmp' + 3,
       list_insert [tmp' + 1; tmp' + 2] l)) /\
-  (compile_exp ctxt tmp l (Shift sh e n) =
-   let (p, le, tmp, l) = compile_exp ctxt tmp l e in (p, Shift sh le n, tmp, l)) /\
-
+  (compile_exp ctxt tmp l (Shift sh e e') =
+   let (p, le, tmp, l) = compile_exp ctxt tmp l e in
+   let (p', le', tmp', l) = compile_exp ctxt tmp l e' in
+     (p', Shift sh le le', tmp', l)) /\
   (compile_exps ctxt tmp l cps = (* to generate ind thm *)
    case cps of
    | [] => ([], [], tmp, l)

--- a/pancake/loopLangScript.sml
+++ b/pancake/loopLangScript.sml
@@ -18,7 +18,7 @@ Datatype:
       | Lookup (5 word)
       | Load exp
       | Op binop (exp list)
-      | Shift shift exp num
+      | Shift shift exp exp
       | BaseAddr
       | TopAddr
 End
@@ -80,7 +80,7 @@ Definition locals_touched_def:
   (locals_touched (Lookup name) = []) /\
   (locals_touched (Load addr) = locals_touched addr) /\
   (locals_touched (Op op wexps) = FLAT (MAP locals_touched wexps)) /\
-  (locals_touched (Shift sh wexp n) = locals_touched wexp) ∧
+  (locals_touched (Shift sh wexp1 wexp2) = locals_touched wexp1 ++ locals_touched wexp2) ∧
   (locals_touched BaseAddr = []) ∧
   (locals_touched TopAddr = [])
 Termination

--- a/pancake/loop_liveScript.sml
+++ b/pancake/loop_liveScript.sml
@@ -16,7 +16,7 @@ Definition vars_of_exp_def:
   vars_of_exp (Lookup _) l = l ∧
   vars_of_exp (Load a) l = vars_of_exp a l ∧
   vars_of_exp (Op x vs) l = vars_of_exp_list vs l ∧
-  vars_of_exp (Shift _ x y) l = vars_of_exp y (vars_of_exp x l) ∧
+  vars_of_exp (Shift _ x y) l = vars_of_exp x (vars_of_exp y l) ∧
   vars_of_exp_list xs l =
     (case xs of [] => l
      | (x::xs) => vars_of_exp x (vars_of_exp_list xs l))

--- a/pancake/loop_liveScript.sml
+++ b/pancake/loop_liveScript.sml
@@ -16,7 +16,7 @@ Definition vars_of_exp_def:
   vars_of_exp (Lookup _) l = l ∧
   vars_of_exp (Load a) l = vars_of_exp a l ∧
   vars_of_exp (Op x vs) l = vars_of_exp_list vs l ∧
-  vars_of_exp (Shift _ x _) l = vars_of_exp x l ∧
+  vars_of_exp (Shift _ x y) l = vars_of_exp y (vars_of_exp x l) ∧
   vars_of_exp_list xs l =
     (case xs of [] => l
      | (x::xs) => vars_of_exp x (vars_of_exp_list xs l))

--- a/pancake/loop_to_wordScript.sml
+++ b/pancake/loop_to_wordScript.sml
@@ -26,7 +26,7 @@ Definition comp_exp_def :
   (comp_exp ctxt (BaseAddr) = Lookup CurrHeap) /\
   (comp_exp ctxt (TopAddr) = Op Add [Lookup CurrHeap; Shift Lsl (Lookup HeapLength) (Const 1w)]) /\
   (comp_exp ctxt (Load exp) = Load (comp_exp ctxt exp)) /\
-  (comp_exp ctxt (Shift s exp n) = Shift s (comp_exp ctxt exp) (Const (n2w n))) /\
+  (comp_exp ctxt (Shift s exp1 exp2) = Shift s (comp_exp ctxt exp1) (comp_exp ctxt exp2)) /\
   (comp_exp ctxt (Op op wexps) =
    let wexps = MAP (comp_exp ctxt) wexps in
    Op op wexps)

--- a/pancake/panLangScript.sml
+++ b/pancake/panLangScript.sml
@@ -59,7 +59,7 @@ Datatype:
       | Op binop (exp list)
       | Panop panop (exp list)
       | Cmp cmp exp exp
-      | Shift shift exp num
+      | Shift shift exp exp
       | BaseAddr
       | TopAddr
       | BytesInWord
@@ -250,23 +250,6 @@ Definition size_of_eids_def:
   size_of_eids prog = LENGTH(FILTER is_exn_decl prog)
 End
 
-(*
-  for time_to_pancake compiler:
-
-Definition Assigns_def:
-  (Assigns [] n = Skip) ∧
-  (Assigns (v::vs) n =
-    Seq (Assign v n) (Assigns vs n))
-End
-
-Definition Decs_def:
-  (Decs [] p = p) /\
-  (Decs ((v,e)::es) p =
-    Dec v e (Decs es p))
-End
-
-*)
-
 Definition var_exp_def:
   (var_exp (Const w) = ([]:mlstring list)) ∧
   (var_exp (Var Local v) = [v]) ∧
@@ -281,7 +264,7 @@ Definition var_exp_def:
   (var_exp (Op bop es) = FLAT (MAP var_exp es)) ∧
   (var_exp (Panop op es) = FLAT (MAP var_exp es)) ∧
   (var_exp (Cmp c e1 e2) = var_exp e1 ++ var_exp e2) ∧
-  (var_exp (Shift sh e num) = var_exp e) ∧
+  (var_exp (Shift sh e1 e2) = var_exp e1 ++ var_exp e2) ∧
   (var_exp BaseAddr = []) ∧
   (var_exp TopAddr = []) ∧
   (var_exp BytesInWord = [])
@@ -305,7 +288,7 @@ Definition global_var_exp_def:
   (global_var_exp (Op bop es) = FLAT (MAP global_var_exp es)) ∧
   (global_var_exp (Panop op es) = FLAT (MAP global_var_exp es)) ∧
   (global_var_exp (Cmp c e1 e2) = global_var_exp e1 ++ global_var_exp e2) ∧
-  (global_var_exp (Shift sh e num) = global_var_exp e)
+  (global_var_exp (Shift sh e1 e2) = global_var_exp e1 ++ global_var_exp e2)
 Termination
   wf_rel_tac `measure (\e. exp_size ARB e)` >>
   rpt strip_tac >>

--- a/pancake/panStaticScript.sml
+++ b/pancake/panStaticScript.sml
@@ -991,18 +991,23 @@ Definition static_check_exp_def:
       (* return exp info *)
       return <| sh_bd := WordB NotBased |>
     od ∧
-  static_check_exp ctxt (Shift sop exp n) =
+  static_check_exp ctxt (Shift sop exp1 exp2) =
     do
-      (* check shifted exp *)
-      eret <- static_check_exp ctxt exp;
+      (* check shifted exps *)
+      eret1 <- static_check_exp ctxt exp1;
+      eret2 <- static_check_exp ctxt exp2;
       (* check exp shape *)
-      if ~(sh_bd_has_shape One eret.sh_bd) then
+      if ~(sh_bd_has_shape One eret1.sh_bd) then
         error (ShapeErr $ get_non_word_msg
           (strlit "shifted expression")
-          (sh_bd_to_str eret.sh_bd) ctxt.loc ctxt.scope)
+          (sh_bd_to_str eret1.sh_bd) ctxt.loc ctxt.scope)
+      else if ~(sh_bd_has_shape One eret2.sh_bd) then
+        error (ShapeErr $ get_non_word_msg
+          (strlit "shift expression")
+          (sh_bd_to_str eret2.sh_bd) ctxt.loc ctxt.scope)
       else return ();
       (* return exp info *)
-      return eret
+      return eret2
     od ∧
   static_check_exp ctxt BaseAddr =
     (* return exp info *)

--- a/pancake/pan_globalsScript.sml
+++ b/pancake/pan_globalsScript.sml
@@ -40,8 +40,8 @@ Definition compile_exp_def:
    Panop pop (MAP (compile_exp ctxt) es)) ∧
   (compile_exp ctxt (Cmp cmp e e') =
    Cmp cmp (compile_exp ctxt e) (compile_exp ctxt e')) ∧
-  (compile_exp ctxt (Shift sh e n) =
-   Shift sh (compile_exp ctxt e) n) ∧
+  (compile_exp ctxt (Shift sh e e') =
+   Shift sh (compile_exp ctxt e) (compile_exp ctxt e')) ∧
   (compile_exp ctxt TopAddr = Op Sub [TopAddr; Const ctxt.max_globals_size]) ∧
   (compile_exp ctxt e = e)
 Termination

--- a/pancake/pan_passesScript.sml
+++ b/pancake/pan_passesScript.sml
@@ -171,8 +171,8 @@ Definition pan_exp_to_display_def:
     = Item NONE (strlit "RawField") [num_to_display n; pan_exp_to_display e]) ∧
   (pan_exp_to_display (NField f e) (*#!TEST*)
     = Item NONE (strlit "NamedField") [String f; pan_exp_to_display e]) ∧
-  (pan_exp_to_display (Shift sh e n)
-    = insert_es (shift_to_display sh) [pan_exp_to_display e; num_to_display n])
+  (pan_exp_to_display (Shift sh e e')
+    = insert_es (shift_to_display sh) [pan_exp_to_display e; pan_exp_to_display e'])
 End
 
 Definition dest_annot_def:
@@ -370,8 +370,8 @@ Definition crep_exp_to_display_def:
   (crep_exp_to_display (Crepop p xs)
     = case p of
       | Mul => Item NONE «Mul» (MAP crep_exp_to_display xs)) ∧
-  (crep_exp_to_display (Shift sh e n)
-    = insert_es (shift_to_display sh) [crep_exp_to_display e; num_to_display n])
+  (crep_exp_to_display (Shift sh e e')
+    = insert_es (shift_to_display sh) [crep_exp_to_display e; crep_exp_to_display e'])
 End
 
 Definition crep_seqs_def:
@@ -523,11 +523,11 @@ Definition loop_exp_to_display_def:
   (loop_exp_to_display (Op bop exs)
     = Item NONE «Op» (asm_binop_to_display bop
         :: MAP loop_exp_to_display exs)) /\
-  (loop_exp_to_display (Shift sh exp num)
+  (loop_exp_to_display (Shift sh exp exp')
     = Item NONE «Shift» [
       shift_to_display sh;
       loop_exp_to_display exp;
-      num_to_display num
+      loop_exp_to_display exp';
     ])
 End
 

--- a/pancake/pan_structsScript.sml
+++ b/pancake/pan_structsScript.sml
@@ -142,8 +142,8 @@ Definition compile_exp_def:
     Panop pop (compile_exps ctxt es)) ∧
   (compile_exp ctxt (Cmp cmp e1 e2) =
     Cmp cmp (compile_exp ctxt e1) (compile_exp ctxt e2)) ∧
-  (compile_exp ctxt (Shift sh e n) =
-    Shift sh (compile_exp ctxt e) n) ∧
+  (compile_exp ctxt (Shift sh e e') =
+    Shift sh (compile_exp ctxt e) (compile_exp ctxt e')) ∧
   (compile_exp ctxt e = e) ∧
   (compile_exps ctxt [] = []) ∧
   (compile_exps ctxt (e::es) =

--- a/pancake/pan_to_crepScript.sml
+++ b/pancake/pan_to_crepScript.sml
@@ -86,10 +86,12 @@ Definition compile_exp_def:
    case (ce, ce') of
    | (e::es, e'::es') => ([Cmp cmp e e'], One)
    | (_, _) => ([Const 0w], One)) /\
-  (compile_exp ctxt (Shift sh e n) =
-   case FST (compile_exp ctxt e) of
-   | [] => ([Const 0w], One)
-   | e::es => ([Shift sh e n], One)) /\
+  (compile_exp ctxt (Shift sh e e') =
+   let ce  = FST (compile_exp ctxt e);
+       ce' = FST (compile_exp ctxt e') in
+   case (ce,ce') of
+   | (e::es, e'::es') => ([Shift sh e e'], One)
+   | _ => ([Const 0w], One)) /\
   (compile_exp ctxt BaseAddr = ([BaseAddr], One)) /\
   (compile_exp ctxt TopAddr = ([TopAddr], One)) /\
   (compile_exp ctxt BytesInWord = ([Const bytes_in_word], One))

--- a/pancake/parser/panConcreteExamplesScript.sml
+++ b/pancake/parser/panConcreteExamplesScript.sml
@@ -249,7 +249,18 @@ val ex9 = ‘
    return @top;
  }’;
 
-val treeEx10 = check_success $ parse_pancake ex9;
+val treeEx9 = check_success $ parse_pancake ex9;
+
+(** Shifts *)
+val ex10 = ‘
+ fun testfun() {
+   var a = 1 << 2;
+   a = a >>> 1 + 1;
+   a = a << a #>> 2 >> 3;
+   return 1;
+ }’;
+
+val treeEx10 = check_success $ parse_pancake ex10;
 
 (** Function call syntax. *)
 

--- a/pancake/parser/panPEGScript.sml
+++ b/pancake/parser/panPEGScript.sml
@@ -318,7 +318,7 @@ Definition pancake_peg_def[nocompute]:
                                FLAT]
                           (mksubtree EAndNT));
         (INL EShiftNT, seql [mknt EAddNT;
-                             rpt (seql [mknt ShiftOpsNT; keep_nat] I)
+                             rpt (seql [mknt ShiftOpsNT; mknt EAddNT] I)
                                  FLAT]
                             (mksubtree EShiftNT));
         (INL EAddNT, seql [mknt EMulNT;

--- a/pancake/parser/panPtreeConversionScript.sml
+++ b/pancake/parser/panPtreeConversionScript.sml
@@ -235,16 +235,6 @@ Definition conv_params_def:
   | _ => NONE
 End
 
-Definition conv_Shift_def:
-  conv_Shift [] e = SOME e ∧
-  conv_Shift [x] e = NONE ∧
-  (conv_Shift (t1::t2::ts) e =
-    do op <- conv_shift t1;
-       n <- conv_nat t2;
-       conv_Shift ts (Shift op e n)
-    od)
-End
-
 (** Convert a expression parse tree into the corresponding AST.
   *
   * The definition is slightly complicated by the requirement that
@@ -340,7 +330,7 @@ Definition conv_Exp_def:
       | _ => NONE
     else if isNT nodeNT EShiftNT then
       case args of
-        (e::es) => conv_Shift es ' (conv_Exp e)
+        e::es => conv_shifts es ' (conv_Exp e)
       | _ => NONE
     else if EXISTS (isNT nodeNT) binaryExps then
       case args of
@@ -376,7 +366,14 @@ Definition conv_Exp_def:
          Panop bop es => conv_panops ts (Panop op [res; e])
        | e' => conv_panops ts (Panop op [e'; e])
     od) ∧
-  conv_panops _ _ = NONE (* Impossible: ruled out by grammar. *)
+  conv_panops _ _ = NONE ∧ (* Impossible: ruled out by grammar. *)
+  conv_shifts [] e = SOME e ∧
+  (conv_shifts (t1::t2::ts) res =
+    do op <- conv_shift t1;
+       e <- conv_Exp t2;
+       conv_shifts ts (Shift op res e)
+    od) ∧
+  conv_shifts _ _ = NONE (* Impossible: ruled out by grammar. *)
 Termination
   WF_REL_TAC ‘measure (λx. case x of
                            | INL x => ptree_size x
@@ -384,7 +381,8 @@ Termination
                            | INR(INR(INL x)) => ptree_size x
                            | INR(INR(INR(INL x))) => ptree_size x
                            | INR(INR(INR(INR(INL x)))) => list_size ptree_size (FST x)
-                           | INR(INR(INR(INR(INR x)))) => list_size ptree_size (FST x))’ >> rw[]
+                           | INR(INR(INR(INR(INR(INL x))))) => list_size ptree_size (FST x)
+                           | INR(INR(INR(INR(INR(INR x))))) => list_size ptree_size (FST x))’ >> rw[]
   >> simp[]
   >- (
     drule MEM_list_size
@@ -837,7 +835,7 @@ Definition localise_exp_def:
   localise_exp ls (Op binop exps) = Op binop (localise_exps ls exps) ∧
   localise_exp ls (Panop panop exps) = Panop panop (localise_exps ls exps) ∧
   localise_exp ls (Cmp cmp exp1 exp2) = Cmp cmp (localise_exp ls exp1) (localise_exp ls exp2) ∧
-  localise_exp ls (Shift shift exp num) = Shift shift (localise_exp ls exp) num ∧
+  localise_exp ls (Shift shift exp1 exp2) = Shift shift (localise_exp ls exp1) (localise_exp ls exp2) ∧
   localise_exp ls e = e ∧
   localise_exps ls [] = [] ∧
   localise_exps ls (e::es) = localise_exp ls e::localise_exps ls es

--- a/pancake/proofs/crep_arithProofScript.sml
+++ b/pancake/proofs/crep_arithProofScript.sml
@@ -7,6 +7,59 @@ Ancestors
 Libs
   preamble
 
+Theorem dest_2exp_bound:
+  ∀n w m.
+    dest_2exp n (w:'a word) = SOME m ⇒
+    m ≤ n + w2n(word_log2 w)
+Proof
+  recInduct dest_2exp_ind >>
+  rw[] >>
+  pop_assum mp_tac >>
+  rw[Once dest_2exp_def] >>
+  first_x_assum dxrule >>
+  rw[] >>
+  irule LESS_EQ_TRANS >>
+  first_x_assum $ irule_at $ Pos hd >>
+  gvs [wordLangTheory.word_sh_def, wordsTheory.WORD_MUL_LSL,
+       word_log2_def,w2n_lsr] >>
+  Cases_on ‘w’ >> gvs[] >>
+  rename1 ‘k DIV 2’ >>
+  Cases_on ‘k = 0’ >- gvs[Once dest_2exp_def] >>
+  PURE_ONCE_REWRITE_TAC[bitTheory.LOG2_def] >>
+  CONV_TAC (RAND_CONV (PURE_ONCE_REWRITE_CONV [numeral_bitTheory.LOG_compute])) >>
+  simp[] >> rw[ADD1] >>
+  dep_rewrite.DEP_REWRITE_TAC[LESS_MOD] >>
+  simp[] >>
+  conj_asm2_tac >- intLib.COOPER_TAC >>
+  irule LESS_LESS_EQ_TRANS >>
+  irule_at (Pos hd) LESS_MONO_ADD >>
+  irule_at (Pos hd) logrootTheory.LOG2_LT_SELF >>
+  intLib.COOPER_TAC
+QED
+
+Theorem dest_2exp_bound':
+  ∀n w m.
+    dest_2exp 0 (w:'a word) = SOME m ⇒
+    m < dimindex(:'a)
+Proof
+  rpt strip_tac >>
+  ‘w ≠ 0w’ by gvs[Once dest_2exp_def] >>
+  drule dest_2exp_bound >>
+  simp[word_log2_def] >>
+  dep_rewrite.DEP_REWRITE_TAC[LESS_MOD] >>
+  conj_tac
+  >- (irule LESS_LESS_EQ_TRANS >>
+      PURE_ONCE_REWRITE_TAC[bitTheory.LOG2_def] >>
+      irule_at (Pos hd) logrootTheory.LOG2_LT_SELF >>
+      conj_tac >- (Cases_on ‘w’ >> gvs[]) >>
+      irule LT_IMP_LE >>
+      irule w2n_lt) >>
+  strip_tac >>
+  irule LESS_EQ_LESS_TRANS >>
+  first_x_assum $ irule_at $ Pos last >>
+  irule LOG2_w2n_lt >>
+  simp[]
+QED
 
 Theorem dest_const_thm:
   dest_const exp = SOME v ==> exp = Const v
@@ -22,8 +75,19 @@ Proof
   \\ every_case_tac
   \\ fs [eval_def, crep_op_def]
   \\ imp_res_tac dest_2exp_thm
-  \\ simp [wordLangTheory.word_sh_def, wordsTheory.WORD_MUL_LSL]
-  \\ CCONTR_TAC \\ fs []
+  \\ imp_res_tac dest_2exp_bound'
+  \\ dep_rewrite.DEP_REWRITE_TAC[LESS_MOD]
+  \\ conj_tac
+  >- (irule LESS_LESS_EQ_TRANS >>
+      first_x_assum $ irule_at $ Pos hd >>
+      simp[dimword_def] >>
+      irule LT_IMP_LE >>
+      irule X_LT_EXP_X >>
+      simp[])
+  \\ rename1 ‘dest_2exp _ _ = SOME x’
+  \\ Cases_on ‘x = 0’ >- gvs[Once dest_2exp_def]
+  \\ gvs [wordLangTheory.word_sh_def, wordsTheory.WORD_MUL_LSL]
+  \\ rw[GE,NOT_LE]
 QED
 
 Theorem OPT_MMAP_EQ_SOME_MONO[local]:
@@ -147,4 +211,3 @@ Proof
   \\ rw [] \\ fs []
   \\ fs [sh_mem_op_code]
 QED
-

--- a/pancake/proofs/crep_to_loopProofScript.sml
+++ b/pancake/proofs/crep_to_loopProofScript.sml
@@ -429,11 +429,10 @@ Proof
   ho_match_mp_tac compile_exp_ind >>
   rpt conj_tac >> rpt gen_tac >> strip_tac >>
   TRY (
-  fs [Once compile_exp_def] >> rveq >>
-  TRY (pairarg_tac >> fs [] >> rveq >> NO_TAC) >>
-  fs [nested_seq_def, comp_syntax_ok_def, cut_sets_def] >> NO_TAC)
-  >- (
-   rename [‘compile_exp _ _ _ (Load32 e)’] >>
+    fs [Once compile_exp_def] >> rveq >>
+    TRY (pairarg_tac >> fs [] >> rveq >> NO_TAC) >>
+    fs [nested_seq_def, comp_syntax_ok_def, cut_sets_def] >> NO_TAC)
+  >~ [‘compile_exp _ _ _ (Load32 e)’] >- (
    rpt gen_tac >> strip_tac >>
    conj_asm1_tac
    >- (
@@ -454,8 +453,7 @@ Proof
    fs [cut_sets_nested_seq] >>
    fs [Abbr ‘np’] >> pop_assum kall_tac >>
    fs [nested_seq_def, cut_sets_def, Once insert_insert])
-  >- (
-   rename [‘compile_exp _ _ _ (LoadByte e)’] >>
+  >~ [‘compile_exp _ _ _ (LoadByte e)’] >- (
    rpt gen_tac >> strip_tac >>
    conj_asm1_tac
    >- (
@@ -476,16 +474,19 @@ Proof
    fs [cut_sets_nested_seq] >>
    fs [Abbr ‘np’] >> pop_assum kall_tac >>
    fs [nested_seq_def, cut_sets_def, Once insert_insert])
-  >- (
-   rename [‘compile_exp _ _ _ (Op _ _)’] >>
+  >~ [‘compile_exp _ _ _ (Op _ _)’] >- (
    fs [Once compile_exp_def] >>
    pairarg_tac >> fs [] >> rveq >>
    cases_on ‘e’
    >- fs [compile_exp_def] >>
    fs [] >>
    fs [Once compile_exp_def])
-  >- (
-   rename [‘compile_exp _ _ _ (Crepop _ _)’] >>
+  >~ [‘compile_exp _ _ _ (Shift sh e e')’] >- (
+   fs [Once compile_exp_def] >>
+   pairarg_tac >> fs [] >> rveq >>
+   pairarg_tac >> fs [] >> rveq >>
+   gvs[cut_sets_nested_seq,comp_syn_ok_nested_seq])
+  >~ [‘compile_exp _ _ _ (Crepop _ _)’] >- (
    simp [Once compile_exp_def] >>
    pairarg_tac >> fs [] >> rveq >>
    rpt gen_tac >> disch_then strip_assume_tac >>
@@ -648,7 +649,14 @@ Proof
    >- (res_tac >> fs [])
    >- (res_tac >> fs []) >>
    fs [nested_seq_def] >>
-   fs [assigned_vars_seq_split, assigned_vars_def]) >>
+   fs [assigned_vars_seq_split, assigned_vars_def])
+  >- (rw[compile_exp_def] >>
+      rpt(pairarg_tac >> gvs[]) >>
+      imp_res_tac compile_exp_out_rel >>
+      fs [assigned_vars_nested_seq_split] >>
+      gvs[] >>
+      res_tac >>
+      intLib.COOPER_TAC) >>
   rpt gen_tac >> strip_tac >>
   pop_assum mp_tac >> fs [] >>
   once_rewrite_tac [compile_exp_def] >>
@@ -703,6 +711,23 @@ Proof
      rpt(pairarg_tac >> fs [] >> rveq) >>
      fs [locals_touched_def, crepLangTheory.var_cexp_def, ETA_AX,AllCaseEqs()]
      )
+  >~ [‘Shift sh e e'’] >-
+    (rw[Once compile_exp_def] >>
+     rpt(pairarg_tac >> gvs[]) >>
+     gvs[locals_touched_def,crepLangTheory.var_cexp_def, SF DNF_ss] >>
+     imp_res_tac compile_exp_out_rel_cases >>
+     res_tac >>
+     gvs[comp_syn_cut_sets_mem_domain]
+     >- (last_x_assum $ drule_at (Pat ‘MEM _ (locals_touched _)’) >>
+         intLib.COOPER_TAC)
+     >- (last_x_assum $ drule_at (Pat ‘MEM _ (locals_touched _)’) >>
+         impl_tac
+         >- (rw[] >> res_tac >>
+             gvs[comp_syn_cut_sets_mem_domain]) >>
+         intLib.COOPER_TAC) >>
+     first_x_assum irule >>
+     rw[] >> res_tac >>
+     gvs[comp_syn_cut_sets_mem_domain])
   >~ [‘compile_exps’] >-
    (rpt gen_tac >>
     strip_tac >>
@@ -1060,13 +1085,46 @@ Proof
    (rw [] >>
     fs [crepSemTheory.eval_def, CaseEq "option", CaseEq "word_lab",
         compile_exp_def] >>
-    rveq >> fs [] >>
-    pairarg_tac >> fs [] >> rveq >>
-    fs [loopSemTheory.evaluate_def] >>
-    last_x_assum drule_all >>
-    strip_tac >> rfs [] >>
-    qexists_tac ‘ck’ >> fs [] >>
-    fs [loopSemTheory.eval_def, wlab_wloc_def])
+    rpt(pairarg_tac >> gvs []) >>
+    first_x_assum drule_all >>
+    strip_tac >>
+    first_x_assum $ drule_at (Pat ‘_ = _’) >>
+    rpt $ disch_then drule >>
+    impl_tac >- (imp_res_tac compile_exp_out_rel >> gvs[]) >>
+    strip_tac >>
+    rev_drule evaluate_add_clock_eq >>
+    disch_then $ qspec_then ‘ck'’ assume_tac >>
+    gvs[] >>
+    FULL_SIMP_TAC std_ss [ADD_ASSOC] >>
+    irule_at (Pos hd) EQ_TRANS >>
+    irule_at (Pos hd) evaluate_none_nested_seq_append >>
+    first_assum $ irule_at $ (Pat ‘evaluate _ = _’) >>
+    simp[loopSemTheory.eval_def] >>
+    rev_drule_at (Pos last) nested_seq_pure_evaluation >>
+    ntac 2 $ disch_then drule >>
+    simp[GSYM PULL_EXISTS] >>
+    impl_tac
+    >- (simp[PULL_EXISTS] >>
+        imp_res_tac compile_exp_out_rel_cases >>
+        gvs[] >>
+        first_x_assum $ irule_at $ Pos hd >>
+        simp[] >>
+        imp_res_tac comp_exp_assigned_vars_tmp_bound_cases >>
+        qexists ‘tmp'’ >>
+        simp[] >>
+        strip_tac >> strip_tac >>
+        irule compile_exp_le_tmp_domain >>
+        first_x_assum $ irule_at (Pat ‘_ = _’) >>
+        simp[] >>
+        conj_tac
+        >- (rpt strip_tac >>
+            drule_all eval_some_var_cexp_local_lookup >>
+            strip_tac >>
+            gvs[locals_rel_def] >>
+            res_tac >>
+            gvs[]) >>
+        gvs[locals_rel_def]) >>
+    simp[wlab_wloc_def])
   >~ [‘Cmp’] >-
    (rw [] >>
     fs [crepSemTheory.eval_def, CaseEq "option", CaseEq "word_lab"] >>
@@ -1335,7 +1393,14 @@ Proof
    rw [] >>
    pop_assum mp_tac >>
    rw [Once compile_exp_def, AllCaseEqs()] >> rveq >>
-   pairarg_tac >> fs []) >>
+   rpt(pairarg_tac >> gvs []) >>
+   match_mp_tac survives_nested_seq_intro >>
+   res_tac >> simp[] >>
+   imp_res_tac compile_exp_out_rel >> rveq >>
+   fs [] >>
+   imp_res_tac cut_sets_union_domain_subset >>
+   fs [SUBSET_DEF]
+  ) >>
   rpt gen_tac >> strip_tac >>
   cases_on ‘e’ >> fs []
   >- (
@@ -1465,7 +1530,11 @@ Proof
    rw [] >>
    qpat_x_assum ‘compile_exp _ _ _ (Shift _ _ _) = _’ mp_tac >>
    rw [Once compile_exp_def, AllCaseEqs()] >> rveq >>
-   pairarg_tac >> fs []) >>
+   rpt(pairarg_tac >> gvs []) >>
+   fs [assigned_vars_nested_seq_split] >>
+   imp_res_tac compile_exp_out_rel >>
+   fs []
+  ) >>
   rpt gen_tac >> strip_tac >>
   cases_on ‘e’ >> fs []
   >- (
@@ -4222,4 +4291,3 @@ Proof
   rpt strip_tac>>gvs[MEM_MAP,MEM_ZIP]>>
   pairarg_tac>>gs[crep_to_loopTheory.first_name_def]
 QED
-

--- a/pancake/proofs/loop_liveProofScript.sml
+++ b/pancake/proofs/loop_liveProofScript.sml
@@ -366,7 +366,11 @@ Proof
   >- (* Op *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
                \\ metis_tac [])
   >- (* Shift *) (rpt strip_tac \\ once_rewrite_tac [vars_of_exp_def]
-                  \\ metis_tac [])
+                  \\ PURE_ONCE_REWRITE_TAC[domain_union]
+                  \\ last_x_assum $ PURE_ONCE_REWRITE_TAC o single
+                  \\ PURE_ONCE_REWRITE_TAC[domain_union]
+                  \\ last_x_assum $ PURE_ONCE_REWRITE_TAC o single
+                  \\ gvs[domain_union,UNION_ASSOC])
   >- suspend "list_case"
 QED
 
@@ -469,7 +473,18 @@ Proof
     \\ fs [domain_union])
   THEN1
    (fs [CaseEq"option",CaseEq"word_loc",vars_of_exp_def,PULL_EXISTS] \\ rveq
-    \\ res_tac \\ fs[] \\ fs [mem_load_def])
+    \\ res_tac \\ fs[]
+    \\ first_x_assum $ irule_at $ Pos hd
+    \\ simp[]
+    \\ pop_assum kall_tac
+    \\ qexists ‘vars_of_exp exp l’
+    \\ fs [subspt_lookup,lookup_inter_alt]
+    \\ pop_assum mp_tac
+    \\ once_rewrite_tac [vars_of_exp_acc]
+    \\ fs[domain_union]
+    \\ once_rewrite_tac [vars_of_exp_acc]
+    \\ fs[domain_union]
+    \\ metis_tac[])
 QED
 
 Resume compile_correct[Assign]:

--- a/pancake/proofs/pan_to_crepProofScript.sml
+++ b/pancake/proofs/pan_to_crepProofScript.sml
@@ -372,18 +372,18 @@ Proof
     fs [eval_def] >>
     every_case_tac >> fs [] >> EVAL_TAC)
   >~ [‘Shift’] >-
-   (rpt gen_tac >> rpt strip_tac >>
-    fs [panSemTheory.eval_def] >>
-    fs [option_case_eq, v_case_eq, word_lab_case_eq] >> rveq >>
-    fs [compile_exp_def,localised_exp_simps] >>
+   (rpt strip_tac >>
+    gvs[panSemTheory.eval_def,AllCaseEqs(),
+        compile_exp_def,localised_exp_simps,
+        panLangTheory.size_of_shape_def, shape_of_def, flatten_def,
+        eval_def, PULL_EXISTS
+       ] >>
     cases_on ‘compile_exp ct e’ >>
-    first_x_assum drule_all >>
-    rpt strip_tac >> fs [] >>
-    fs [panLangTheory.size_of_shape_def, shape_of_def, flatten_def] >>
-    rveq >>
-    fs [panLangTheory.size_of_shape_def, shape_of_def] >> rveq >>
-    fs [eval_def] >>  every_case_tac >>
-    fs [panLangTheory.size_of_shape_def, shape_of_def])>>
+    cases_on ‘compile_exp ct e'’ >>
+    gvs[] >>
+    res_tac >>
+    gvs[] >>
+    metis_tac[])>>
   rpt strip_tac >>
   fs [panSemTheory.eval_def] >>
   fs [option_case_eq, v_case_eq, word_lab_case_eq] >> rveq >>
@@ -860,7 +860,17 @@ Proof
     cases_on ‘compile_exp ct e’ >> fs []) >>
    first_x_assum drule >>
    disch_then (qspec_then ‘ct’ mp_tac) >>
-   cases_on ‘compile_exp ct e'’ >> fs []) >>
+   cases_on ‘compile_exp ct e'’ >> fs [])
+  >- (
+   rename [‘eval s (Shift sh e e')’] >>
+   rpt strip_tac >>
+   gvs[panSemTheory.eval_def,AllCaseEqs(),compile_exp_def,
+       localised_exp_simps,var_cexp_def] >>
+   cases_on ‘compile_exp ct e’ >>
+   cases_on ‘compile_exp ct e'’ >>
+   gvs[] >>
+   res_tac >>
+   gvs[MEM_FLAT,MEM_MAP]) >>
   rpt gen_tac >> strip_tac >>
   fs [panSemTheory.eval_def, option_case_eq, v_case_eq,
       CaseEq "word_lab"] >> rveq >>

--- a/pancake/proofs/pan_to_wordProofScript.sml
+++ b/pancake/proofs/pan_to_wordProofScript.sml
@@ -830,7 +830,7 @@ Proof
   rw $ [loopPropsTheory.every_prog_def,loop_inst_ok_def,crep_to_loopTheory.prog_if_def,crepPropsTheory.every_exp_def] @ butlast(CONJUNCTS crep_to_loopTheory.compile_exp_def) \\
   rpt(pairarg_tac \\ gvs[]) \\
   gvs[loopPropsTheory.every_prog_def,loop_inst_ok_def,crep_to_loopTheory.prog_if_def]
-  THEN1 (gvs[DefnBase.one_line_ify NONE crep_to_loopTheory.compile_crepop_def,AllCaseEqs(),
+  THEN1 (gvs[oneline crep_to_loopTheory.compile_crepop_def,AllCaseEqs(),
              loopPropsTheory.every_prog_def,loop_inst_ok_def] \\
          rw[EVERY_MEM,MEM_MAPi] \\
          rw[loopPropsTheory.every_prog_def,loop_inst_ok_def] \\
@@ -838,7 +838,7 @@ Proof
                               crep_to_loopProofTheory.compile_exps_alt] \\
          rpt(pairarg_tac \\ gvs[]) \\
          metis_tac[EVERY_MEM])
-  THEN1 (gvs[DefnBase.one_line_ify NONE crep_to_loopTheory.compile_crepop_def,AllCaseEqs(),
+  THEN1 (gvs[oneline crep_to_loopTheory.compile_crepop_def,AllCaseEqs(),
              loopPropsTheory.every_prog_def,loop_inst_ok_def] \\
          rw[EVERY_MEM,MEM_MAPi] \\
          rw[loopPropsTheory.every_prog_def,loop_inst_ok_def] \\

--- a/pancake/semantics/crepPropsScript.sml
+++ b/pancake/semantics/crepPropsScript.sml
@@ -1271,7 +1271,7 @@ Definition every_exp_def:
   (every_exp P (Op bop es) = (P(Op bop es) ∧ EVERY (every_exp P) es)) ∧
   (every_exp P (Crepop op es) = (P(Crepop op es) ∧ EVERY (every_exp P) es)) ∧
   (every_exp P (Cmp c e1 e2) = (P(Cmp c e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
-  (every_exp P (Shift sh e num) = (P(Shift sh e num) ∧ every_exp P e)) ∧
+  (every_exp P (Shift sh e1 e2) = (P(Shift sh e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
   (every_exp P (BaseAddr) = P BaseAddr) ∧
   (every_exp P (TopAddr) = P TopAddr)
 Termination

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -129,7 +129,7 @@ Definition eval_def:
      | _ => NONE) /\
   (eval s (Shift sh e1 e2) =
     case (eval s e1, eval s e2) of
-     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 w2)
+     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 (w2n w2))
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (Word s.base_addr)) /\

--- a/pancake/semantics/crepSemScript.sml
+++ b/pancake/semantics/crepSemScript.sml
@@ -127,9 +127,9 @@ Definition eval_def:
     case (eval s e1, eval s e2) of
      | (SOME (Word w1), SOME (Word w2)) => SOME (Word (bitstring$v2w [word_cmp cmp w1 w2]))
      | _ => NONE) /\
-  (eval s (Shift sh e n) =
-    case eval s e of
-     | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
+  (eval s (Shift sh e1 e2) =
+    case (eval s e1, eval s e2) of
+     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 w2)
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (Word s.base_addr)) /\

--- a/pancake/semantics/loopSemScript.sml
+++ b/pancake/semantics/loopSemScript.sml
@@ -82,7 +82,7 @@ Definition eval_def:
      | _ => NONE) /\
   (eval s (Shift sh wexp1 wexp2) =
      case (eval s wexp1, eval s wexp2) of
-     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 w2)
+     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 (w2n w2))
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (Word s.base_addr)) /\

--- a/pancake/semantics/loopSemScript.sml
+++ b/pancake/semantics/loopSemScript.sml
@@ -80,9 +80,9 @@ Definition eval_def:
      case the_words (MAP (eval s) wexps) of
      | SOME ws => (OPTION_MAP Word (word_op op ws))
      | _ => NONE) /\
-  (eval s (Shift sh wexp n) =
-     case eval s wexp of
-     | SOME (Word w) => OPTION_MAP Word (word_sh sh w n)
+  (eval s (Shift sh wexp1 wexp2) =
+     case (eval s wexp1, eval s wexp2) of
+     | (SOME (Word w1), SOME (Word w2)) => OPTION_MAP Word (word_sh sh w1 w2)
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (Word s.base_addr)) /\

--- a/pancake/semantics/panPropsScript.sml
+++ b/pancake/semantics/panPropsScript.sml
@@ -1297,7 +1297,7 @@ Definition every_exp_def:
   (every_exp P (Op bop es) = (P(Op bop es) ∧ EVERY (every_exp P) es)) ∧
   (every_exp P (Panop op es) = (P(Panop op es) ∧ EVERY (every_exp P) es)) ∧
   (every_exp P (Cmp c e1 e2) = (P(Cmp c e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
-  (every_exp P (Shift sh e num) = (P(Shift sh e num) ∧ every_exp P e)) ∧
+  (every_exp P (Shift sh e1 e2) = (P(Shift sh e1 e2) ∧ every_exp P e1 ∧ every_exp P e2)) ∧
   (every_exp P BaseAddr = P BaseAddr) ∧
   (every_exp P TopAddr = P TopAddr) ∧
   (every_exp P BytesInWord = P BytesInWord)

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -282,7 +282,7 @@ Definition eval_def:
      | _ => NONE) /\
   (eval s (Shift sh e1 e2) =
     case (eval s e1, eval s e2) of
-     | (SOME (ValWord w1), SOME (ValWord w2)) => OPTION_MAP ValWord (word_sh sh w1 w2)
+     | (SOME (ValWord w1), SOME (ValWord w2)) => OPTION_MAP ValWord (word_sh sh w1 (w2n w2))
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (ValWord s.base_addr)) /\

--- a/pancake/semantics/panSemScript.sml
+++ b/pancake/semantics/panSemScript.sml
@@ -280,9 +280,9 @@ Definition eval_def:
      | (SOME (ValWord w1), SOME (ValWord w2)) =>
           SOME (ValWord (if word_cmp cmp w1 w2 then 1w else 0w))
      | _ => NONE) /\
-  (eval s (Shift sh e n) =
-    case eval s e of
-     | SOME (ValWord w) => OPTION_MAP ValWord (word_sh sh w n)
+  (eval s (Shift sh e1 e2) =
+    case (eval s e1, eval s e2) of
+     | (SOME (ValWord w1), SOME (ValWord w2)) => OPTION_MAP ValWord (word_sh sh w1 w2)
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (ValWord s.base_addr)) /\

--- a/pancake/semantics/pan_itreeSemScript.sml
+++ b/pancake/semantics/pan_itreeSemScript.sml
@@ -150,9 +150,9 @@ Definition eval_def:
      | (SOME (ValWord w1), SOME (ValWord w2)) =>
           SOME (ValWord (if word_cmp cmp w1 w2 then 1w else 0w))
      | _ => NONE) /\
-  (eval s (Shift sh e n) =
-    case eval s e of
-     | SOME (ValWord w) => OPTION_MAP ValWord (word_sh sh w n)
+  (eval s (Shift sh e1 e2) =
+    case (eval s e1, eval s e2) of
+     | (SOME (ValWord w1), SOME (ValWord w2)) => OPTION_MAP ValWord (word_sh sh w1 (w2n w2))
      | _ => NONE) /\
   (eval s BaseAddr =
         SOME (ValWord s.base_addr)) /\


### PR DESCRIPTION
This PR make the variable length shifts that have been available in `wordLang` since #1341, available in Pancake.