### PR TITLE
Remove duplicate mllist mapPartial definition

### DIFF
--- a/basis/pure/mllistScript.sml
+++ b/basis/pure/mllistScript.sml
@@ -384,17 +384,10 @@ Proof
   |> SIMP_RULE (srw_ss()++ETA_ss) [])]
 QED
 
-Definition mapPartial_def:
-  (mapPartial f [] = []) /\
-  (mapPartial f (h::t) = case (f h) of
-    NONE => mapPartial f t
-    |(SOME x) => x::mapPartial f t)
-End
-
 Theorem mapPartial_thm:
    !f l. mapPartial f l = MAP THE (FILTER IS_SOME (MAP f l))
 Proof
-  Induct_on `l` \\ rw [mapPartial_def] \\ Cases_on `f h` \\ rw [THE_DEF] \\ fs [IS_SOME_DEF]
+  Induct_on `l` \\ rw [listTheory.mapPartial_def] \\ Cases_on `f h` \\ rw [THE_DEF] \\ fs [IS_SOME_DEF]
 QED
 
 Theorem index_find_thm:


### PR DESCRIPTION
## Summary

- remove the duplicate `mapPartial` definition from `mllist`
- prove the existing `mapPartial_thm` against `listTheory.mapPartial_def`
- leave the public theorem available to downstream scripts

## Verification

- confirmed `basis/pure/mllistScript.sml` no longer defines `mapPartial`
- `git diff --check`
- full HOL build not run locally because `Holmake` is unavailable

Closes #1449
