### PR TITLE
Adding return type annotations to the concrete syntax

### DIFF
--- a/compiler/parsing/cmlPEGScript.sml
+++ b/compiler/parsing/cmlPEGScript.sml
@@ -335,7 +335,8 @@ Definition cmlPEG_def[nocompute]:
               (mkNT nAndFDecls,
                peg_linfix (mkNT nAndFDecls) (pnt nFDecl) (tokeq AndT));
               (mkNT nFDecl,
-               seql [pnt nV; pnt nPbaseList1; tokeq EqualsT; pnt nE]
+               seql [pnt nV; pnt nPbaseList1;
+                     try (seql [tokeq ColonT; pnt nType] I); tokeq EqualsT; pnt nE]
                     (bindNT nFDecl));
               (mkNT nPbaseList1,
                seql [pnt nPbase; try (pnt nPbaseList1)]

--- a/compiler/parsing/proofs/pegCompleteScript.sml
+++ b/compiler/parsing/proofs/pegCompleteScript.sml
@@ -3043,9 +3043,13 @@ Proof
            PULL_EXISTS] >>
       gvs[MAP_EQ_APPEND, MAP_EQ_CONS, DISJ_IMP_THM, FORALL_AND_THM] >>
       loseRK >> gs[SKOLEM_THM, GSYM RIGHT_EXISTS_IMP_THM] >>
+
       normlist >> first_assum $ irule_at Any >> simp[stoppers_def] >>
       normlist >> first_assum $ irule_at Any >> simp[stoppers_def] >>
-      first_x_assum $ irule_at Any >> gs[stoppers_def])
+
+      first_assum $ irule_at Any >> gs[stoppers_def] >>
+      simp[choicel_cons, seql_cons, peg_eval_tok] >> dsimp[] >>
+      normlist >> first_x_assum $ irule_at Any >> gs[stoppers_def])
   >- (print_tac "nEtyped" >>
       simp[Once peg_eval_NT_SOME, cmlpeg_rules_applied] >>
       rw[seql_cons_SOME, PULL_EXISTS] >>

--- a/compiler/parsing/proofs/pegSoundScript.sml
+++ b/compiler/parsing/proofs/pegSoundScript.sml
@@ -1072,11 +1072,26 @@ Proof
         (MATCH_MP not_peg0_LENGTH_decreases peg0_nV |> GEN_ALL) >>
       first_assum (erule strip_assume_tac) >> rveq >> dsimp[] >>
       first_assum (assume_tac o MATCH_MP length_no_greater o
-                   assert (free_in ``nPbaseList1`` o concl)) >> fs[] >>
+                              assert (free_in ``nPbaseList1`` o concl)) >> fs[] >>
+      simp[cmlG_FDOM, cmlG_applied] >~
+      [‘(TK ColonT, _)’]
+      >- (
+       first_assum (qpat_assum ‘peg_eval cmlPEG (_, nt (mkNT nType) _) _’ o
+                               mp_then Any mp_tac) >> simp[] >> strip_tac >> gvs[] >>
+       first_assum (qpat_assum ‘peg_eval cmlPEG (_, nt (mkNT nE) _) _’ o
+                               mp_then Any mp_tac) >> impl_tac
+       >- (
+         first_x_assum (mp_tac o Q.AP_TERM ‘LENGTH’) >> simp[]
+         )
+       >> strip_tac >> gvs[]
+       )
+                >>
+
+
       first_x_assum (fn patth =>
             first_assum (mp_tac o PART_MATCH (lhand o rand) patth o
                          assert (free_in ``nE``) o concl)) >>
-      simp[] >> strip_tac >> rveq >> simp[cmlG_FDOM, cmlG_applied])
+      simp[] >> strip_tac >> gvs[])
   >- (print_tac "nAndFDecls" >>
       disch_then (match_mp_tac o MATCH_MP peg_linfix_correct_lemma) >>
       dsimp[SUBSET_DEF, pegsym_to_sym_def, DISJ_IMP_THM, FORALL_AND_THM,

--- a/compiler/parsing/proofs/pegSoundScript.sml
+++ b/compiler/parsing/proofs/pegSoundScript.sml
@@ -1080,17 +1080,11 @@ Proof
                                mp_then Any mp_tac) >> simp[] >> strip_tac >> gvs[] >>
        first_assum (qpat_assum ‘peg_eval cmlPEG (_, nt (mkNT nE) _) _’ o
                                mp_then Any mp_tac) >> impl_tac
-       >- (
-         first_x_assum (mp_tac o Q.AP_TERM ‘LENGTH’) >> simp[]
-         )
-       >> strip_tac >> gvs[]
-       )
-                >>
-
-
+       >- (first_x_assum (mp_tac o Q.AP_TERM ‘LENGTH’) >> simp[])
+       >> strip_tac >> gvs[]) >>
       first_x_assum (fn patth =>
-            first_assum (mp_tac o PART_MATCH (lhand o rand) patth o
-                         assert (free_in ``nE``) o concl)) >>
+                       first_assum (mp_tac o PART_MATCH (lhand o rand) patth o
+                                    assert (free_in ``nE``) o concl)) >>
       simp[] >> strip_tac >> gvs[])
   >- (print_tac "nAndFDecls" >>
       disch_then (match_mp_tac o MATCH_MP peg_linfix_correct_lemma) >>

--- a/compiler/parsing/tests/cmlTestsScript.sml
+++ b/compiler/parsing/tests/cmlTestsScript.sml
@@ -143,6 +143,9 @@ val tytest = parsetest ``nType`` ``ptree_Type nType``
 val elab_decls = ``OPTION_MAP (elab_decs NONE [] []) o ptree_Decls``
  *)
 
+val _ = parsetest0 ``nDecl`` ``ARB``
+  "fun f x : int = x + 1" NONE
+
 val _ = parsetest0 ``nE`` ``ptree_Expr nE``
          "let val _ = print \"foo\"\
             \ val z = 10\

--- a/compiler/parsing/tests/cmlTestsScript.sml
+++ b/compiler/parsing/tests/cmlTestsScript.sml
@@ -143,8 +143,8 @@ val tytest = parsetest ``nType`` ``ptree_Type nType``
 val elab_decls = ``OPTION_MAP (elab_decs NONE [] []) o ptree_Decls``
  *)
 
-val _ = parsetest0 ``nDecl`` ``ARB``
-  "fun f x : int = x + 1" NONE
+val _ = parsetest0 ``nDecl`` ``ptree_Decl``
+  "fun f x : int = x + 1" (SOME “Dletrec locs [(«f», «x», Tannot (vbinop (Short «+») (V «x») (Lit (IntLit 1))) (Atapp [] (Short «int»)))]”)
 
 val _ = parsetest0 ``nE`` ``ptree_Expr nE``
          "let val _ = print \"foo\"\

--- a/semantics/cmlPtreeConversionScript.sml
+++ b/semantics/cmlPtreeConversionScript.sml
@@ -1116,7 +1116,17 @@ Definition ptree_Expr_def[nocompute]:
                 body0 <- ptree_Expr nE body_pt;
                 SOME(fname,dePat p1 (FOLDR mkFun body0 (TL ps)))
               od
-            | _ => NONE
+          | [fname_pt; pats_pt; colont; typept; eqt; body_pt] =>
+              do
+                assert(tokcheckl [colont; eqt] [ColonT; EqualsT]);
+                fname <- ptree_V fname_pt;
+                ps <- ptree_PbaseList1 pats_pt;
+                p1 <- oHD ps;
+                body0 <- ptree_Expr nE body_pt;
+                ty <- ptree_Type nType typept;
+                SOME(fname,dePat p1 (FOLDR mkFun (Tannot body0 ty) (TL ps)))
+              od
+          | _ => NONE
         else NONE) ∧
   (ptree_LetDecs ptree =
     case ptree of

--- a/semantics/gramScript.sml
+++ b/semantics/gramScript.sml
@@ -182,7 +182,7 @@ val cmlG_def = mk_grammar_def ginfo
     | "raise" E |  Ehandle;
 
  (* function and value declarations *)
- FDecl ::= V PbaseList1 "=" E ;
+ FDecl ::= V PbaseList1 "=" E | V PbaseList1 ":" Type "=" E;
  AndFDecls ::= FDecl | AndFDecls "and" FDecl;
  LetDec ::= "val" Pattern "=" E | "fun" AndFDecls ;
  LetDecs ::= LetDec LetDecs | ";" LetDecs | ;

--- a/semantics/grammar.txt
+++ b/semantics/grammar.txt
@@ -108,8 +108,8 @@ E ::=
  | "raise" E
  | ElogicOR
 
-Fdecl ::= V V "=" E                    // (V,V,E)
-                                       // second V is parameter
+Fdecl ::= V Pattern+ "=" E
+        | V Pattern+ ":" Type "=" E
 
 AndFDecls ::= FDecl                    // ([FDecl])
            |  FDecl "and" AndFDecls    // FDecl :: AndFDecls

--- a/semantics/proofs/cmlPtreeConversionPropsScript.sml
+++ b/semantics/proofs/cmlPtreeConversionPropsScript.sml
@@ -591,6 +591,10 @@ Proof
       asm_match `0 < LENGTH pl` >> Cases_on `pl` >> fs[oHD_def] >> std) >~
   [‘(λ(e,pes). SOME (Raise e, pes)) pe (* sg *)’]
   >- (Cases_on ‘pe’ >> simp[]) >~
+  [‘ptree_Type’]
+  >- (dsimp[] >> map_every (erule strip_assume_tac o n) [V_OK, PbaseList1_OK, Type_OK] >>
+      qexistsl [‘i’, ‘pl’, ‘HD pl’, ‘t'’] >> fs[oHD_def] >> simp[]
+      >> Cases_on ‘pl’ >> fs[] >> simp[]) >~
   [‘_ ++ _ = SOME _’]
   >- (dsimp[OPTION_CHOICE_EQUALS_OPTION, UNCURRY_EQ, PULL_EXISTS,
             AllCaseEqs()] >>


### PR DESCRIPTION
Fixes parsing errors with type annotations in the return position like the following:

```
fun swap (x : int, y : int): int = x + y
```

